### PR TITLE
docs: Rebrand to Crypta, refresh README, and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ debian/seednodes.fref
 .idea
 output.*
 /split-file-inserter-storage-test
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@
 - After editing a Java or Kotlin file, please check for any missing or poorly written JavaDoc/KDoc comments. Add or
   improve them as needed.
 - Do not use "--no-daemon" for Gradle
+- If the Java Runtime cannot be located, or if any other errors occur when running a command, request approval to
+  proceed. Do not skip the command.
 
 ## Repository Etiquette
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,285 +1,626 @@
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.)  You can apply it to
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-  To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
   For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
-rights.
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-  Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-		    GNU GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+                       TERMS AND CONDITIONS
 
-  0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term "modification".)  Each licensee is addressed as "you".
+  0. Definitions.
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+  "This License" refers to version 3 of the GNU General Public License.
 
-  1. You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-  2. You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any
-    part thereof, to be licensed as a whole at no charge to all third
-    parties under the terms of this License.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-    c) If the modified program normally reads commands interactively
-    when run, you must cause it, when started running for such
-    interactive use in the most ordinary way, to print or display an
-    announcement including an appropriate copyright notice and a
-    notice that there is no warranty (or else, saying that you provide
-    a warranty) and that users may redistribute the program under
-    these conditions, and telling the user how to view a copy of this
-    License.  (Exception: if the Program itself is interactive but
-    does not normally print such an announcement, your work based on
-    the Program is not required to print an announcement.)
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+  1. Source Code.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-  3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections
-    1 and 2 above on a medium customarily used for software interchange; or,
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-    b) Accompany it with a written offer, valid for at least three
-    years, to give any third party, for a charge no more than your
-    cost of physically performing source distribution, a complete
-    machine-readable copy of the corresponding source code, to be
-    distributed under the terms of Sections 1 and 2 above on a medium
-    customarily used for software interchange; or,
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-    c) Accompany it with the information you received as to the offer
-    to distribute corresponding source code.  (This alternative is
-    allowed only for noncommercial distribution and only if you
-    received the program in object code or executable form with such
-    an offer, in accord with Subsection b above.)
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
+  2. Basic Permissions.
 
-  4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
-parties remain in full compliance.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-  5. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-  6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
 this License.
 
-  7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
+  13. Use with the GNU Affero General Public License.
 
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
+  14. Revised Versions of this License.
 
-  8. If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
-
-  9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and "any
-later version", you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
 
-  10. If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
 
-			    NO WARRANTY
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
 
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
+  15. Disclaimer of Warranty.
 
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-		     END OF TERMS AND CONDITIONS
+  16. Limitation of Liability.
 
-	    How to Apply These Terms to Your New Programs
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
@@ -287,15 +628,15 @@ free software which everyone can redistribute and change under these terms.
 
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
+state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
     Copyright (C) <year>  <name of author>
 
-    This program is free software; you can redistribute it and/or modify
+    This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
@@ -303,37 +644,31 @@ the "copyright" line and a pointer to where the full notice is found.
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
 The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
 
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Crypta
 
-Crypta is a platform for censorship-resistant communication and publishing. It is a peer‑to‑peer network that provides a
-distributed, encrypted, and decentralized datastore. Applications such as forums, chat, micro‑blogs, and websites run on
-top of Crypta without central servers.
+Crypta is a platform for censorship-resistant communication and publishing. It is a fork of Hyphanet (formerly known as
+Freenet), building upon its principles and technology. It is a peer‑to‑peer network that provides a distributed,
+encrypted, and decentralized datastore. Applications such as forums, chat, micro‑blogs, and websites run on top of
+Crypta without central servers.
 
 Inspired by the goals of Hyphanet, Crypta focuses on privacy, resilience, and free expression:
 
@@ -10,6 +11,9 @@ Inspired by the goals of Hyphanet, Crypta focuses on privacy, resilience, and fr
 - Decentralized and censorship‑resistant: no central point of control or failure.
 - Publishing and discovery: content is addressed by keys and can be versioned and replicated across the network.
 - Extensible platform: build apps that leverage the content store and routing to deliver interactive experiences.
+
+Crypta plans to evolve with new technologies such as Kotlin Multiplatform, a modern frontend stack, improved
+scalability, enhanced security measures, better developer tooling, and significantly improved user experiences.
 
 This repository contains the reference node (the "Crypta reference daemon") that participates in the network, stores
 data, and serves applications.

--- a/README.md
+++ b/README.md
@@ -1,117 +1,83 @@
-[![Build status](https://img.shields.io/github/check-runs/hyphanet/fred/next?label=build)](https://github.com/hyphanet/fred/actions)
-[![Coverity status](https://scan.coverity.com/projects/2316/badge.svg?flat=1)](https://scan.coverity.com/projects/freenet-fred)
+# Crypta
 
-# Freenet
+Crypta is a platform for censorship-resistant communication and publishing. It is a peer‑to‑peer network that provides a
+distributed, encrypted, and decentralized datastore. Applications such as forums, chat, micro‑blogs, and websites run on
+top of Crypta without central servers.
 
-Freenet is a platform for censorship-resistant communication and publishing. It is peer-to-peer
-software which provides a distributed, encrypted, decentralized datastore. Websites and applications
-providing things like forums and chat are built on top of it.
+Inspired by the goals of Hyphanet, Crypta focuses on privacy, resilience, and free expression:
 
-Fred stands for Freenet REference Daemon.
+- Privacy by design: data is encrypted end‑to‑end and routed through multiple peers.
+- Decentralized and censorship‑resistant: no central point of control or failure.
+- Publishing and discovery: content is addressed by keys and can be versioned and replicated across the network.
+- Extensible platform: build apps that leverage the content store and routing to deliver interactive experiences.
+
+This repository contains the reference node (the "Crypta reference daemon") that participates in the network, stores
+data, and serves applications.
 
 ## Building
 
-We've included the [Gradle Wrapper](https://docs.gradle.org/8.11/userguide/gradle_wrapper.html) as
-recommended by the Gradle project. If you trust the version we've committed you can build
-immediately:
+We use the [Gradle Wrapper](https://docs.gradle.org/8.11/userguide/gradle_wrapper.html). If you trust the committed
+wrapper, you can build immediately.
 
-#### POSIX / Windows PowerShell:
+Prerequisites:
 
-    $ ./gradlew jar
+- Java 21 or newer
+- A POSIX shell or Windows terminal
 
-#### Windows cmd:
+Build the node JAR:
 
-    > gradlew jar
+    ./gradlew jar
 
-We've [configured it](gradle/wrapper/gradle-wrapper.properties) to [verify the checksum](https://docs.gradle.org/8.11/userguide/gradle_wrapper.html#wrapper_checksum_verification)
-of the archive it downloads from `https://services.gradle.org`.
+On Windows `cmd`:
 
-### Build with ant
+    gradlew jar
 
-    $ mkdir -p lib; cd lib && grep -o CHK.* ../dependencies.properties  | xargs -P16 -I {} bash -c 'fcpget -v {} "$(echo {} | sed s,^.*/,,)"'
-    $ ant -propertyfile build.properties -f build-clean.xml -Dtest.skip=true -Dfindbugs.skip=true
-
-## Building the installers
-
-The installers are built from specialized repositories:
-
-- The GNU/Linux, macOS and *nix installer is built from [hyphanet/java_installer](https://github.com/hyphanet/java_installer).
-- The Windows installer is built from [hyphanet/wininstaller-innosetup](https://github.com/hyphanet/wininstaller-innosetup) and signed with [hyphanet/sign-windows-installer](https://github.com/hyphanet/sign-windows-installer).
-
-Free code signing for the Windows installer is provided by [SignPath.io](https://about.signpath.io/), the certificate by the [SignPath Foundation](https://signpath.org/).
-
+The wrapper is configured to [verify the distribution checksum](gradle/wrapper/gradle-wrapper.properties) from
+`https://services.gradle.org`.
 
 ## Testing
 
-### Run Tests
+- Run all tests:
 
-To run all unit tests, use
+  ./gradlew --parallel test
 
-    ./gradlew --parallel test
+- Run a specific test class or method:
 
-You can run specifics tests with a test filter similar to the following:
+  ./gradlew --parallel test --tests *M3UFilterTest
 
-    ./gradlew --parallel test --tests *M3UFilterTest
+## Running Your Build
 
-TODO: how to run integration tests.
+To try your local build of Crypta:
 
-### Run your changes as node
+1. Build it with `./gradlew jar`.
+2. Stop your running node.
+3. Replace the existing node JAR with `build/libs/cryptad.jar` produced by the build.
+4. Start your node again.
 
-To test your version of Freenet, build it with ,./gradlew jar`,
-stop your node, replace `freenet.jar` in your
-Freenet directory with `build/libs/freenet.jar`, and start your node again.
+To override Gradle settings, create `gradle.properties` (see
+the [Gradle docs](https://docs.gradle.org/8.11/userguide/build_environment.html)) and add entries like:
 
-To override values set in `build.gradle.kts` put them into [the file](https://docs.gradle.org/8.11/userguide/build_environment.html)
-`gradle.properties` in the format `variable = value`. For instance:
-
-    org.gradle.parallel = true
-    org.gradle.daemon = true
+    org.gradle.parallel=true
+    org.gradle.daemon=true
     org.gradle.jvmargs=-Xms256m -Xmx1024m
     org.gradle.configureondemand=true
 
-    tasks.withType(Test)  {
-      maxParallelForks = Runtime.runtime.availableProcessors()
-    }
+## Dependencies
 
-## Contributing
+- Runtime: Java 21+
+- Language/Tooling: Kotlin 2.2+, Gradle Wrapper (provided in this repo)
+- External libraries: managed via Gradle; for offline distribution and installer integration, see
+  `dependencies.properties`.
+- Dependency verification is enabled; update both the `dependencies` and `dependencyVerification` blocks in
+  `build.gradle.kts` when adding libraries.
 
-See our [contributor guidelines](CONTRIBUTING.md).
+You generally do not need to install libraries manually; Gradle resolves them. When preparing installer assets or
+offline bundles, ensure artifacts are listed in `dependencies.properties` and available through the project’s
+distribution process.
 
-### Get in contact
+## License
 
-* Ask the [development mailing list](https://www.hyphanet.org/pages/help.html#mailing-lists)
-  or join us in [IRC](https://web.libera.chat/?nick=Rabbit|?#freenet) - `#freenet` on
-  `irc.libera.chat`.
-* You can file problems in the [bug tracker](https://freenet.mantishub.io/my_view_page.php).
+Crypta is free software licensed under the GNU General Public License, version 3 only. See `LICENSE` for the full text.
 
-## Add a new dependency
-
-All dependencies must be available via Freenet, so it must be added to
-dependencies.properties.
-
-- Add it to build.gradle.kts dependencies *and* dependencyVerification.
-  Run `./gradlew jar --debug` to find files that fail the
-  verification.
-- fcpupload {dependencyfile.jar}
-- add it to all installers: wininstaller-innosetup, java_installer, mactray. Search for `jna-platform` to find out where to put and register the dependency.
-- add dependency and the CHK to `dependencies.properties`.
-- update `scripts/update.sh` and `res/wrapper.conf` and `res/unix/run.sh` in java_installer to include the dependency.
-
-With the example of pebble: The filename is just the jarfile. The key is what fcpupload returns. Size is `wc -c filename.jar`, sha256 is `sha256sum filename.jar`, order is where it should be put in `wrapper.conf` in wrapper.java.classpath.
-
-```
-pebble.version=3.1.5
-pebble.filename=pebble-3.1.5.jar
-pebble.filename-regex=pebble-*.jar
-pebble.key=CHK@y~p8HMUVXmVgfSnrmUyu2UNXMO9uMDHS5nwo2YuOKvw,yzwLFP0GXa8RjwRpicQCPFKNggDXLkTQKH8nISe0qUY,AAMC--8/pebble-3.1.5.jar
-pebble.size=318169
-pebble.sha256=85e77f9fd64c0a1f85569db8f95c1fb8e6ef8b296f4d6206440dc6306140c1a1
-pebble.type=CLASSPATH
-pebble.order=4
-```
-
-## Licensing
-Freenet is under the GPL, version 2 or later - see LICENSE.Freenet. We use some
-code under the Apache license version 2 (mostly apache commons stuff), and some
-modified BSD code (Mantissa). All of which is compatible with the GPL, although
-arguably ASL2 is only compatible with GPL3. Some plugins are GPL3.
+Some bundled components may be under permissive licenses (e.g., Apache‑2.0, BSD‑3‑Clause). These are compatible with
+GPLv3 and included under their respective terms.

--- a/src/network/crypta/client/ArchiveContext.java
+++ b/src/network/crypta/client/ArchiveContext.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.Serializable;

--- a/src/network/crypta/client/ArchiveFailureException.java
+++ b/src/network/crypta/client/ArchiveFailureException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 /**

--- a/src/network/crypta/client/ArchiveHandler.java
+++ b/src/network/crypta/client/ArchiveHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;

--- a/src/network/crypta/client/ArchiveKey.java
+++ b/src/network/crypta/client/ArchiveKey.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import network.crypta.keys.FreenetURI;

--- a/src/network/crypta/client/ArchiveManager.java
+++ b/src/network/crypta/client/ArchiveManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.BufferedOutputStream;

--- a/src/network/crypta/client/ArchiveRestartException.java
+++ b/src/network/crypta/client/ArchiveRestartException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 /**

--- a/src/network/crypta/client/ArchiveStoreContext.java
+++ b/src/network/crypta/client/ArchiveStoreContext.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.util.LinkedList;

--- a/src/network/crypta/client/ArchiveStoreItem.java
+++ b/src/network/crypta/client/ArchiveStoreItem.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import network.crypta.support.api.Bucket;

--- a/src/network/crypta/client/ClientMetadata.java
+++ b/src/network/crypta/client/ClientMetadata.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/client/DefaultMIMETypes.java
+++ b/src/network/crypta/client/DefaultMIMETypes.java
@@ -1,8 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. 
- * Note that the mime type list is from the debian mime-types package,
- * which is public information and public domain software. */
 package network.crypta.client;
 
 import java.util.HashMap;

--- a/src/network/crypta/client/ErrorArchiveStoreItem.java
+++ b/src/network/crypta/client/ErrorArchiveStoreItem.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import network.crypta.keys.FreenetURI;

--- a/src/network/crypta/client/FailureCodeTracker.java
+++ b/src/network/crypta/client/FailureCodeTracker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/client/FetchContext.java
+++ b/src/network/crypta/client/FetchContext.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/client/FetchException.java
+++ b/src/network/crypta/client/FetchException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.util.HashMap;

--- a/src/network/crypta/client/FetchResult.java
+++ b/src/network/crypta/client/FetchResult.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.IOException;

--- a/src/network/crypta/client/FetchWaiter.java
+++ b/src/network/crypta/client/FetchWaiter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/client/HighLevelSimpleClient.java
+++ b/src/network/crypta/client/HighLevelSimpleClient.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.util.HashMap;

--- a/src/network/crypta/client/HighLevelSimpleClientImpl.java
+++ b/src/network/crypta/client/HighLevelSimpleClientImpl.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.IOException;

--- a/src/network/crypta/client/InsertBlock.java
+++ b/src/network/crypta/client/InsertBlock.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.Serializable;

--- a/src/network/crypta/client/InsertContext.java
+++ b/src/network/crypta/client/InsertContext.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.Serializable;

--- a/src/network/crypta/client/InsertException.java
+++ b/src/network/crypta/client/InsertException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.util.HashMap;

--- a/src/network/crypta/client/Metadata.java
+++ b/src/network/crypta/client/Metadata.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import java.io.ByteArrayInputStream;

--- a/src/network/crypta/client/MetadataParseException.java
+++ b/src/network/crypta/client/MetadataParseException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 /** Thrown when Metadata parse fails. */

--- a/src/network/crypta/client/MetadataUnresolvedException.java
+++ b/src/network/crypta/client/MetadataUnresolvedException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 public class MetadataUnresolvedException extends Exception {

--- a/src/network/crypta/client/RealArchiveStoreItem.java
+++ b/src/network/crypta/client/RealArchiveStoreItem.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client;
 
 import network.crypta.keys.FreenetURI;

--- a/src/network/crypta/client/async/BaseClientGetter.java
+++ b/src/network/crypta/client/async/BaseClientGetter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.node.RequestClient;

--- a/src/network/crypta/client/async/BaseClientPutter.java
+++ b/src/network/crypta/client/async/BaseClientPutter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.node.RequestClient;

--- a/src/network/crypta/client/async/BaseManifestPutter.java
+++ b/src/network/crypta/client/async/BaseManifestPutter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.IOException;

--- a/src/network/crypta/client/async/BaseSingleFileFetcher.java
+++ b/src/network/crypta/client/async/BaseSingleFileFetcher.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.FetchContext;

--- a/src/network/crypta/client/async/BinaryBlobWriter.java
+++ b/src/network/crypta/client/async/BinaryBlobWriter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.DataOutputStream;

--- a/src/network/crypta/client/async/BlockSet.java
+++ b/src/network/crypta/client/async/BlockSet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.util.Set;

--- a/src/network/crypta/client/async/ClientBaseCallback.java
+++ b/src/network/crypta/client/async/ClientBaseCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.node.RequestClient;

--- a/src/network/crypta/client/async/ClientContext.java
+++ b/src/network/crypta/client/async/ClientContext.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.util.Random;

--- a/src/network/crypta/client/async/ClientGetCallback.java
+++ b/src/network/crypta/client/async/ClientGetCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.FetchException;

--- a/src/network/crypta/client/async/ClientGetState.java
+++ b/src/network/crypta/client/async/ClientGetState.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.FetchException;

--- a/src/network/crypta/client/async/ClientGetWorkerThread.java
+++ b/src/network/crypta/client/async/ClientGetWorkerThread.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.async;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/client/async/ClientGetter.java
+++ b/src/network/crypta/client/async/ClientGetter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/client/async/ClientPutCallback.java
+++ b/src/network/crypta/client/async/ClientPutCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.InsertException;

--- a/src/network/crypta/client/async/ClientPutState.java
+++ b/src/network/crypta/client/async/ClientPutState.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.InsertException;

--- a/src/network/crypta/client/async/ClientPutter.java
+++ b/src/network/crypta/client/async/ClientPutter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.IOException;

--- a/src/network/crypta/client/async/ClientRequestScheduler.java
+++ b/src/network/crypta/client/async/ClientRequestScheduler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.FetchException;

--- a/src/network/crypta/client/async/ClientRequester.java
+++ b/src/network/crypta/client/async/ClientRequester.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.ByteArrayOutputStream;

--- a/src/network/crypta/client/async/ContainerInserter.java
+++ b/src/network/crypta/client/async/ContainerInserter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.BufferedOutputStream;

--- a/src/network/crypta/client/async/DefaultManifestPutter.java
+++ b/src/network/crypta/client/async/DefaultManifestPutter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.util.HashMap;

--- a/src/network/crypta/client/async/GetCompletionCallback.java
+++ b/src/network/crypta/client/async/GetCompletionCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.util.List;

--- a/src/network/crypta/client/async/HealingQueue.java
+++ b/src/network/crypta/client/async/HealingQueue.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.support.api.Bucket;

--- a/src/network/crypta/client/async/KeyListenerTracker.java
+++ b/src/network/crypta/client/async/KeyListenerTracker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import static java.lang.String.format;

--- a/src/network/crypta/client/async/ManifestElement.java
+++ b/src/network/crypta/client/async/ManifestElement.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.IOException;

--- a/src/network/crypta/client/async/ManifestPutter.java
+++ b/src/network/crypta/client/async/ManifestPutter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.node.RequestClient;

--- a/src/network/crypta/client/async/OfferedKeysList.java
+++ b/src/network/crypta/client/async/OfferedKeysList.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.util.ArrayList;

--- a/src/network/crypta/client/async/PersistentStatsPutter.java
+++ b/src/network/crypta/client/async/PersistentStatsPutter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.Serializable;

--- a/src/network/crypta/client/async/PlainManifestPutter.java
+++ b/src/network/crypta/client/async/PlainManifestPutter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.util.HashMap;

--- a/src/network/crypta/client/async/SimpleHealingQueue.java
+++ b/src/network/crypta/client/async/SimpleHealingQueue.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.util.HashMap;

--- a/src/network/crypta/client/async/SimpleSingleFileFetcher.java
+++ b/src/network/crypta/client/async/SimpleSingleFileFetcher.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.IOException;

--- a/src/network/crypta/client/async/SingleBlockInserter.java
+++ b/src/network/crypta/client/async/SingleBlockInserter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.IOException;

--- a/src/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/network/crypta/client/async/SingleFileFetcher.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/client/async/SingleFileStreamGenerator.java
+++ b/src/network/crypta/client/async/SingleFileStreamGenerator.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.async;
 
 import java.io.IOException;

--- a/src/network/crypta/client/async/SnoopBucket.java
+++ b/src/network/crypta/client/async/SnoopBucket.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.support.api.Bucket;

--- a/src/network/crypta/client/async/SnoopMetadata.java
+++ b/src/network/crypta/client/async/SnoopMetadata.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.Metadata;

--- a/src/network/crypta/client/async/StreamGenerator.java
+++ b/src/network/crypta/client/async/StreamGenerator.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.async;
 
 import java.io.IOException;

--- a/src/network/crypta/client/async/USKCallback.java
+++ b/src/network/crypta/client/async/USKCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.keys.USK;

--- a/src/network/crypta/client/async/USKChecker.java
+++ b/src/network/crypta/client/async/USKChecker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.FetchContext;

--- a/src/network/crypta/client/async/USKCheckerCallback.java
+++ b/src/network/crypta/client/async/USKCheckerCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.keys.ClientSSKBlock;

--- a/src/network/crypta/client/async/USKFetcher.java
+++ b/src/network/crypta/client/async/USKFetcher.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import static java.util.concurrent.TimeUnit.HOURS;

--- a/src/network/crypta/client/async/USKFetcherCallback.java
+++ b/src/network/crypta/client/async/USKFetcherCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.keys.USK;

--- a/src/network/crypta/client/async/USKFetcherWrapper.java
+++ b/src/network/crypta/client/async/USKFetcherWrapper.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.util.List;

--- a/src/network/crypta/client/async/USKInserter.java
+++ b/src/network/crypta/client/async/USKInserter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.IOException;

--- a/src/network/crypta/client/async/USKManager.java
+++ b/src/network/crypta/client/async/USKManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/src/network/crypta/client/async/USKProxyCompletionCallback.java
+++ b/src/network/crypta/client/async/USKProxyCompletionCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.Serializable;

--- a/src/network/crypta/client/async/USKRetriever.java
+++ b/src/network/crypta/client/async/USKRetriever.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/client/async/USKRetrieverCallback.java
+++ b/src/network/crypta/client/async/USKRetrieverCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.async;
 
 import network.crypta.client.FetchResult;

--- a/src/network/crypta/client/events/ClientEvent.java
+++ b/src/network/crypta/client/events/ClientEvent.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 /**

--- a/src/network/crypta/client/events/ClientEventListener.java
+++ b/src/network/crypta/client/events/ClientEventListener.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/client/events/ClientEventProducer.java
+++ b/src/network/crypta/client/events/ClientEventProducer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/client/events/EventDumper.java
+++ b/src/network/crypta/client/events/EventDumper.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 import java.io.IOException;

--- a/src/network/crypta/client/events/EventLogger.java
+++ b/src/network/crypta/client/events/EventLogger.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/client/events/FinishedCompressionEvent.java
+++ b/src/network/crypta/client/events/FinishedCompressionEvent.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 public class FinishedCompressionEvent implements ClientEvent {

--- a/src/network/crypta/client/events/SimpleEventProducer.java
+++ b/src/network/crypta/client/events/SimpleEventProducer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 import java.io.Serializable;

--- a/src/network/crypta/client/events/SplitfileProgressEvent.java
+++ b/src/network/crypta/client/events/SplitfileProgressEvent.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 import java.util.Date;

--- a/src/network/crypta/client/events/StartedCompressionEvent.java
+++ b/src/network/crypta/client/events/StartedCompressionEvent.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.events;
 
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;

--- a/src/network/crypta/client/filter/BMPFilter.java
+++ b/src/network/crypta/client/filter/BMPFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/client/filter/CSSParser.java
+++ b/src/network/crypta/client/filter/CSSParser.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.Reader;

--- a/src/network/crypta/client/filter/CSSReadFilter.java
+++ b/src/network/crypta/client/filter/CSSReadFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.BufferedReader;

--- a/src/network/crypta/client/filter/CSSTokenizerFilter.java
+++ b/src/network/crypta/client/filter/CSSTokenizerFilter.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.filter;
 
 import java.io.IOException;

--- a/src/network/crypta/client/filter/CharsetExtractor.java
+++ b/src/network/crypta/client/filter/CharsetExtractor.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.IOException;

--- a/src/network/crypta/client/filter/CodecPacket.java
+++ b/src/network/crypta/client/filter/CodecPacket.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.filter;
 
 import java.util.Arrays;

--- a/src/network/crypta/client/filter/CodecPacketFilter.java
+++ b/src/network/crypta/client/filter/CodecPacketFilter.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.filter;
 
 import java.io.IOException;

--- a/src/network/crypta/client/filter/CommentException.java
+++ b/src/network/crypta/client/filter/CommentException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 /**

--- a/src/network/crypta/client/filter/ContentDataFilter.java
+++ b/src/network/crypta/client/filter/ContentDataFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.IOException;

--- a/src/network/crypta/client/filter/ContentFilter.java
+++ b/src/network/crypta/client/filter/ContentFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/client/filter/DataFilterException.java
+++ b/src/network/crypta/client/filter/DataFilterException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import network.crypta.client.FetchException;

--- a/src/network/crypta/client/filter/FilterMIMEType.java
+++ b/src/network/crypta/client/filter/FilterMIMEType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 /**

--- a/src/network/crypta/client/filter/FoundURICallback.java
+++ b/src/network/crypta/client/filter/FoundURICallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.net.URI;

--- a/src/network/crypta/client/filter/GIFFilter.java
+++ b/src/network/crypta/client/filter/GIFFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/client/filter/GenericReadFilterCallback.java
+++ b/src/network/crypta/client/filter/GenericReadFilterCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import network.crypta.client.filter.HTMLFilter.ParsedTag;

--- a/src/network/crypta/client/filter/JPEGFilter.java
+++ b/src/network/crypta/client/filter/JPEGFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.ByteArrayOutputStream;

--- a/src/network/crypta/client/filter/KnownUnsafeContentTypeException.java
+++ b/src/network/crypta/client/filter/KnownUnsafeContentTypeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.util.LinkedList;

--- a/src/network/crypta/client/filter/LinkFilterExceptionProvider.java
+++ b/src/network/crypta/client/filter/LinkFilterExceptionProvider.java
@@ -1,20 +1,3 @@
-/*
- * fred - LinkFilterExceptionProvider.java - Copyright © 2011 David Roden
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package network.crypta.client.filter;
 
 import java.net.URI;

--- a/src/network/crypta/client/filter/M3UFilter.java
+++ b/src/network/crypta/client/filter/M3UFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/client/filter/NullFilterCallback.java
+++ b/src/network/crypta/client/filter/NullFilterCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import network.crypta.client.filter.HTMLFilter.ParsedTag;

--- a/src/network/crypta/client/filter/OggBitstreamFilter.java
+++ b/src/network/crypta/client/filter/OggBitstreamFilter.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.filter;
 
 import java.io.IOException;

--- a/src/network/crypta/client/filter/OggFilter.java
+++ b/src/network/crypta/client/filter/OggFilter.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.filter;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/client/filter/OggPage.java
+++ b/src/network/crypta/client/filter/OggPage.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.filter;
 
 import java.io.ByteArrayOutputStream;

--- a/src/network/crypta/client/filter/PNGFilter.java
+++ b/src/network/crypta/client/filter/PNGFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.ByteArrayOutputStream;

--- a/src/network/crypta/client/filter/UnknownContentTypeException.java
+++ b/src/network/crypta/client/filter/UnknownContentTypeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import network.crypta.client.FetchException.FetchExceptionMode;

--- a/src/network/crypta/client/filter/UnsafeContentTypeException.java
+++ b/src/network/crypta/client/filter/UnsafeContentTypeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import java.io.IOException;

--- a/src/network/crypta/client/filter/VorbisBitstreamFilter.java
+++ b/src/network/crypta/client/filter/VorbisBitstreamFilter.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.filter;
 
 import java.io.IOException;

--- a/src/network/crypta/client/filter/VorbisPacketFilter.java
+++ b/src/network/crypta/client/filter/VorbisPacketFilter.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.client.filter;
 
 import java.io.ByteArrayInputStream;

--- a/src/network/crypta/clients/fcp/AddPeer.java
+++ b/src/network/crypta/clients/fcp/AddPeer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.BufferedReader;

--- a/src/network/crypta/clients/fcp/AllDataMessage.java
+++ b/src/network/crypta/clients/fcp/AllDataMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/ClientGet.java
+++ b/src/network/crypta/clients/fcp/ClientGet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/clients/fcp/ClientGetMessage.java
+++ b/src/network/crypta/clients/fcp/ClientGetMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/ClientHelloMessage.java
+++ b/src/network/crypta/clients/fcp/ClientHelloMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/ClientPut.java
+++ b/src/network/crypta/clients/fcp/ClientPut.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/src/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/network/crypta/clients/fcp/ClientPutDir.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/ClientPutDirMessage.java
+++ b/src/network/crypta/clients/fcp/ClientPutDirMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.net.MalformedURLException;

--- a/src/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
+++ b/src/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/ClientPutMessage.java
+++ b/src/network/crypta/clients/fcp/ClientPutMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/CloseConnectionDuplicateClientNameMessage.java
+++ b/src/network/crypta/clients/fcp/CloseConnectionDuplicateClientNameMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/ConfigData.java
+++ b/src/network/crypta/clients/fcp/ConfigData.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.config.Config;

--- a/src/network/crypta/clients/fcp/DataCarryingMessage.java
+++ b/src/network/crypta/clients/fcp/DataCarryingMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/fcp/DataFoundMessage.java
+++ b/src/network/crypta/clients/fcp/DataFoundMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.client.FetchResult;

--- a/src/network/crypta/clients/fcp/DirPutFile.java
+++ b/src/network/crypta/clients/fcp/DirPutFile.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.client.ClientMetadata;

--- a/src/network/crypta/clients/fcp/DisconnectMessage.java
+++ b/src/network/crypta/clients/fcp/DisconnectMessage.java
@@ -1,8 +1,3 @@
-/*
- * This code is part of Freenet. It is distributed under the GNU General Public
- * License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL.
- */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/DiskDirPutFile.java
+++ b/src/network/crypta/clients/fcp/DiskDirPutFile.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/EndListPeerNotesMessage.java
+++ b/src/network/crypta/clients/fcp/EndListPeerNotesMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/EndListPeersMessage.java
+++ b/src/network/crypta/clients/fcp/EndListPeersMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/EndListPersistentRequestsMessage.java
+++ b/src/network/crypta/clients/fcp/EndListPersistentRequestsMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/FCPConnectionInputHandler.java
+++ b/src/network/crypta/clients/fcp/FCPConnectionInputHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/clients/fcp/FCPConnectionOutputHandler.java
+++ b/src/network/crypta/clients/fcp/FCPConnectionOutputHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.BufferedOutputStream;

--- a/src/network/crypta/clients/fcp/FCPPluginClientMessage.java
+++ b/src/network/crypta/clients/fcp/FCPPluginClientMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/fcp/FCPPluginConnection.java
+++ b/src/network/crypta/clients/fcp/FCPPluginConnection.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/fcp/FCPPluginConnectionImpl.java
+++ b/src/network/crypta/clients/fcp/FCPPluginConnectionImpl.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/fcp/FCPPluginConnectionTracker.java
+++ b/src/network/crypta/clients/fcp/FCPPluginConnectionTracker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/fcp/FCPPluginMessage.java
+++ b/src/network/crypta/clients/fcp/FCPPluginMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.util.UUID;

--- a/src/network/crypta/clients/fcp/FCPPluginServerMessage.java
+++ b/src/network/crypta/clients/fcp/FCPPluginServerMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/FCPServer.java
+++ b/src/network/crypta/clients/fcp/FCPServer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/FinishedCompressionMessage.java
+++ b/src/network/crypta/clients/fcp/FinishedCompressionMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.client.events.FinishedCompressionEvent;

--- a/src/network/crypta/clients/fcp/GenerateSSKMessage.java
+++ b/src/network/crypta/clients/fcp/GenerateSSKMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;

--- a/src/network/crypta/clients/fcp/GetConfig.java
+++ b/src/network/crypta/clients/fcp/GetConfig.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/GetFailedMessage.java
+++ b/src/network/crypta/clients/fcp/GetFailedMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/clients/fcp/GetNode.java
+++ b/src/network/crypta/clients/fcp/GetNode.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/GetPluginInfo.java
+++ b/src/network/crypta/clients/fcp/GetPluginInfo.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/GetRequestStatusMessage.java
+++ b/src/network/crypta/clients/fcp/GetRequestStatusMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/clients/fcp/IdentifierCollisionException.java
+++ b/src/network/crypta/clients/fcp/IdentifierCollisionException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 /**

--- a/src/network/crypta/clients/fcp/IdentifierCollisionMessage.java
+++ b/src/network/crypta/clients/fcp/IdentifierCollisionMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/ListPeerMessage.java
+++ b/src/network/crypta/clients/fcp/ListPeerMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/ListPeerNotesMessage.java
+++ b/src/network/crypta/clients/fcp/ListPeerNotesMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.DarknetPeerNode;

--- a/src/network/crypta/clients/fcp/ListPeersMessage.java
+++ b/src/network/crypta/clients/fcp/ListPeersMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/ListPersistentRequestsMessage.java
+++ b/src/network/crypta/clients/fcp/ListPersistentRequestsMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/clients/fcp/LoadPlugin.java
+++ b/src/network/crypta/clients/fcp/LoadPlugin.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/MessageInvalidException.java
+++ b/src/network/crypta/clients/fcp/MessageInvalidException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 /**

--- a/src/network/crypta/clients/fcp/ModifyConfig.java
+++ b/src/network/crypta/clients/fcp/ModifyConfig.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.config.Config;

--- a/src/network/crypta/clients/fcp/ModifyPeer.java
+++ b/src/network/crypta/clients/fcp/ModifyPeer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.DarknetPeerNode;

--- a/src/network/crypta/clients/fcp/ModifyPeerNote.java
+++ b/src/network/crypta/clients/fcp/ModifyPeerNote.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.DarknetPeerNode;

--- a/src/network/crypta/clients/fcp/ModifyPersistentRequest.java
+++ b/src/network/crypta/clients/fcp/ModifyPersistentRequest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/clients/fcp/NodeData.java
+++ b/src/network/crypta/clients/fcp/NodeData.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/NodeHelloMessage.java
+++ b/src/network/crypta/clients/fcp/NodeHelloMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.l10n.NodeL10n;

--- a/src/network/crypta/clients/fcp/NotAllowedException.java
+++ b/src/network/crypta/clients/fcp/NotAllowedException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 /** Thrown when a client tries to upload a file it's not allowed to upload (or otherwise read it), or 

--- a/src/network/crypta/clients/fcp/PeerMessage.java
+++ b/src/network/crypta/clients/fcp/PeerMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/PeerNote.java
+++ b/src/network/crypta/clients/fcp/PeerNote.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/PeerRemoved.java
+++ b/src/network/crypta/clients/fcp/PeerRemoved.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/PersistentGet.java
+++ b/src/network/crypta/clients/fcp/PersistentGet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/PersistentPut.java
+++ b/src/network/crypta/clients/fcp/PersistentPut.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/PersistentPutDir.java
+++ b/src/network/crypta/clients/fcp/PersistentPutDir.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.util.HashMap;

--- a/src/network/crypta/clients/fcp/PersistentRequestModifiedMessage.java
+++ b/src/network/crypta/clients/fcp/PersistentRequestModifiedMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/PersistentRequestRemovedMessage.java
+++ b/src/network/crypta/clients/fcp/PersistentRequestRemovedMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/PersistentRequestRoot.java
+++ b/src/network/crypta/clients/fcp/PersistentRequestRoot.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.util.ArrayList;

--- a/src/network/crypta/clients/fcp/PluginInfoMessage.java
+++ b/src/network/crypta/clients/fcp/PluginInfoMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/PluginRemovedMessage.java
+++ b/src/network/crypta/clients/fcp/PluginRemovedMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/ProtocolErrorMessage.java
+++ b/src/network/crypta/clients/fcp/ProtocolErrorMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.Serializable;

--- a/src/network/crypta/clients/fcp/PutFailedMessage.java
+++ b/src/network/crypta/clients/fcp/PutFailedMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.Serializable;

--- a/src/network/crypta/clients/fcp/PutFetchableMessage.java
+++ b/src/network/crypta/clients/fcp/PutFetchableMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;

--- a/src/network/crypta/clients/fcp/PutSuccessfulMessage.java
+++ b/src/network/crypta/clients/fcp/PutSuccessfulMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;

--- a/src/network/crypta/clients/fcp/ReloadPlugin.java
+++ b/src/network/crypta/clients/fcp/ReloadPlugin.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/RemovePeer.java
+++ b/src/network/crypta/clients/fcp/RemovePeer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/RemovePersistentRequest.java
+++ b/src/network/crypta/clients/fcp/RemovePersistentRequest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/clients/fcp/RemovePlugin.java
+++ b/src/network/crypta/clients/fcp/RemovePlugin.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/SSKKeypairMessage.java
+++ b/src/network/crypta/clients/fcp/SSKKeypairMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;

--- a/src/network/crypta/clients/fcp/ShutdownMessage.java
+++ b/src/network/crypta/clients/fcp/ShutdownMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/SimpleProgressMessage.java
+++ b/src/network/crypta/clients/fcp/SimpleProgressMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.util.Date;

--- a/src/network/crypta/clients/fcp/StartedCompressionMessage.java
+++ b/src/network/crypta/clients/fcp/StartedCompressionMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/SubscribeUSK.java
+++ b/src/network/crypta/clients/fcp/SubscribeUSK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/clients/fcp/SubscribeUSKMessage.java
+++ b/src/network/crypta/clients/fcp/SubscribeUSKMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.net.MalformedURLException;

--- a/src/network/crypta/clients/fcp/SubscribedUSKMessage.java
+++ b/src/network/crypta/clients/fcp/SubscribedUSKMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/SubscribedUSKUpdate.java
+++ b/src/network/crypta/clients/fcp/SubscribedUSKUpdate.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.USK;

--- a/src/network/crypta/clients/fcp/TestDDACompleteMessage.java
+++ b/src/network/crypta/clients/fcp/TestDDACompleteMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import java.io.File;

--- a/src/network/crypta/clients/fcp/TestDDAReplyMessage.java
+++ b/src/network/crypta/clients/fcp/TestDDAReplyMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.clients.fcp.FCPConnectionHandler.DDACheckJob;

--- a/src/network/crypta/clients/fcp/TestDDARequestMessage.java
+++ b/src/network/crypta/clients/fcp/TestDDARequestMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.clients.fcp.FCPConnectionHandler.DDACheckJob;

--- a/src/network/crypta/clients/fcp/TestDDAResponseMessage.java
+++ b/src/network/crypta/clients/fcp/TestDDAResponseMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.clients.fcp.FCPConnectionHandler.DDACheckJob;

--- a/src/network/crypta/clients/fcp/URIGeneratedMessage.java
+++ b/src/network/crypta/clients/fcp/URIGeneratedMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;

--- a/src/network/crypta/clients/fcp/UnknownNodeIdentifierMessage.java
+++ b/src/network/crypta/clients/fcp/UnknownNodeIdentifierMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/UnknownPeerNoteTypeMessage.java
+++ b/src/network/crypta/clients/fcp/UnknownPeerNoteTypeMessage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/fcp/WatchGlobal.java
+++ b/src/network/crypta/clients/fcp/WatchGlobal.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;

--- a/src/network/crypta/clients/http/ConfigToadlet.java
+++ b/src/network/crypta/clients/http/ConfigToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/http/ConnectivityToadlet.java
+++ b/src/network/crypta/clients/http/ConnectivityToadlet.java
@@ -1,18 +1,3 @@
-/* Copyright 2007 Freenet Project Inc.
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.clients.http;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/http/Cookie.java
+++ b/src/network/crypta/clients/http/Cookie.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.net.URI;

--- a/src/network/crypta/clients/http/FirstTimeWizardToadlet.java
+++ b/src/network/crypta/clients/http/FirstTimeWizardToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/http/HTTPRangeException.java
+++ b/src/network/crypta/clients/http/HTTPRangeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import network.crypta.support.LightweightException;

--- a/src/network/crypta/clients/http/HTTPRequestImpl.java
+++ b/src/network/crypta/clients/http/HTTPRequestImpl.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/clients/http/LinkFilterExceptedToadlet.java
+++ b/src/network/crypta/clients/http/LinkFilterExceptedToadlet.java
@@ -1,20 +1,3 @@
-/*
- * fred - LinkFilteExceptedToadlet.java - Copyright © 2011 David Roden
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package network.crypta.clients.http;
 
 import java.net.URI;

--- a/src/network/crypta/clients/http/LocalFileBrowserToadlet.java
+++ b/src/network/crypta/clients/http/LocalFileBrowserToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import network.crypta.client.HighLevelSimpleClient;

--- a/src/network/crypta/clients/http/LocalFileInsertToadlet.java
+++ b/src/network/crypta/clients/http/LocalFileInsertToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.File;

--- a/src/network/crypta/clients/http/LocalFileN2NMToadlet.java
+++ b/src/network/crypta/clients/http/LocalFileN2NMToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.File;

--- a/src/network/crypta/clients/http/N2NTMToadlet.java
+++ b/src/network/crypta/clients/http/N2NTMToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.File;

--- a/src/network/crypta/clients/http/QueueToadlet.java
+++ b/src/network/crypta/clients/http/QueueToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/clients/http/ReceivedCookie.java
+++ b/src/network/crypta/clients/http/ReceivedCookie.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.net.URI;

--- a/src/network/crypta/clients/http/RedirectException.java
+++ b/src/network/crypta/clients/http/RedirectException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.net.URI;

--- a/src/network/crypta/clients/http/SecurityLevelsToadlet.java
+++ b/src/network/crypta/clients/http/SecurityLevelsToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/http/SessionManager.java
+++ b/src/network/crypta/clients/http/SessionManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import static java.util.concurrent.TimeUnit.HOURS;

--- a/src/network/crypta/clients/http/SimpleHelpToadlet.java
+++ b/src/network/crypta/clients/http/SimpleHelpToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/network/crypta/clients/http/SimpleToadletServer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import org.tanukisoftware.wrapper.WrapperManager;

--- a/src/network/crypta/clients/http/Toadlet.java
+++ b/src/network/crypta/clients/http/Toadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import network.crypta.client.*;

--- a/src/network/crypta/clients/http/ToadletContainer.java
+++ b/src/network/crypta/clients/http/ToadletContainer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.File;

--- a/src/network/crypta/clients/http/ToadletContextClosedException.java
+++ b/src/network/crypta/clients/http/ToadletContextClosedException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 public class ToadletContextClosedException extends Exception {

--- a/src/network/crypta/clients/http/TranslationToadlet.java
+++ b/src/network/crypta/clients/http/TranslationToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/http/UserAlertsToadlet.java
+++ b/src/network/crypta/clients/http/UserAlertsToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.IOException;

--- a/src/network/crypta/clients/http/WelcomeToadlet.java
+++ b/src/network/crypta/clients/http/WelcomeToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import java.io.File;

--- a/src/network/crypta/clients/http/annotation/AllowData.java
+++ b/src/network/crypta/clients/http/annotation/AllowData.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http.annotation;
 
 import static java.lang.annotation.ElementType.METHOD;

--- a/src/network/crypta/clients/http/bookmark/BookmarkItem.java
+++ b/src/network/crypta/clients/http/bookmark/BookmarkItem.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http.bookmark;
 
 import java.net.MalformedURLException;

--- a/src/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http.bookmark;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/config/BooleanOption.java
+++ b/src/network/crypta/config/BooleanOption.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 import network.crypta.l10n.NodeL10n;

--- a/src/network/crypta/config/Config.java
+++ b/src/network/crypta/config/Config.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 import java.io.IOException;

--- a/src/network/crypta/config/ConfigCallback.java
+++ b/src/network/crypta/config/ConfigCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 public abstract class ConfigCallback<T> {

--- a/src/network/crypta/config/ConfigException.java
+++ b/src/network/crypta/config/ConfigException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 /**

--- a/src/network/crypta/config/EnumerableOptionCallback.java
+++ b/src/network/crypta/config/EnumerableOptionCallback.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.config;
 
 public interface EnumerableOptionCallback {

--- a/src/network/crypta/config/FilePersistentConfig.java
+++ b/src/network/crypta/config/FilePersistentConfig.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 import network.crypta.support.LogThresholdCallback;

--- a/src/network/crypta/config/IntOption.java
+++ b/src/network/crypta/config/IntOption.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 import network.crypta.l10n.NodeL10n;

--- a/src/network/crypta/config/InvalidConfigValueException.java
+++ b/src/network/crypta/config/InvalidConfigValueException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 /**

--- a/src/network/crypta/config/LongOption.java
+++ b/src/network/crypta/config/LongOption.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 import network.crypta.l10n.NodeL10n;

--- a/src/network/crypta/config/NodeNeedRestartException.java
+++ b/src/network/crypta/config/NodeNeedRestartException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 /**

--- a/src/network/crypta/config/Option.java
+++ b/src/network/crypta/config/Option.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 import network.crypta.l10n.BaseL10n;

--- a/src/network/crypta/config/StringOption.java
+++ b/src/network/crypta/config/StringOption.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 import network.crypta.support.api.StringCallback;

--- a/src/network/crypta/config/SubConfig.java
+++ b/src/network/crypta/config/SubConfig.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.config;
 
 import java.util.LinkedHashMap;

--- a/src/network/crypta/crypt/BlockCipher.java
+++ b/src/network/crypta/crypt/BlockCipher.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 /**

--- a/src/network/crypta/crypt/CryptByteBuffer.java
+++ b/src/network/crypta/crypt/CryptByteBuffer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.Serializable;

--- a/src/network/crypta/crypt/CryptByteBufferType.java
+++ b/src/network/crypta/crypt/CryptByteBufferType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.Serializable;

--- a/src/network/crypta/crypt/CryptoElement.java
+++ b/src/network/crypta/crypt/CryptoElement.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 /**

--- a/src/network/crypta/crypt/CryptoKey.java
+++ b/src/network/crypta/crypt/CryptoKey.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/crypt/DSAGroup.java
+++ b/src/network/crypta/crypt/DSAGroup.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.IOException;

--- a/src/network/crypta/crypt/DSAPrivateKey.java
+++ b/src/network/crypta/crypt/DSAPrivateKey.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.IOException;

--- a/src/network/crypta/crypt/DummyRandomSource.java
+++ b/src/network/crypta/crypt/DummyRandomSource.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 /**

--- a/src/network/crypta/crypt/Ed2MessageDigest.java
+++ b/src/network/crypta/crypt/Ed2MessageDigest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.security.MessageDigest;

--- a/src/network/crypta/crypt/EncryptedRandomAccessBuffer.java
+++ b/src/network/crypta/crypt/EncryptedRandomAccessBuffer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/crypt/EncryptedRandomAccessBufferType.java
+++ b/src/network/crypta/crypt/EncryptedRandomAccessBufferType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.util.HashMap;

--- a/src/network/crypta/crypt/EntropySource.java
+++ b/src/network/crypta/crypt/EntropySource.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 /**

--- a/src/network/crypta/crypt/Global.java
+++ b/src/network/crypta/crypt/Global.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import org.bouncycastle.crypto.params.DSAParameters;

--- a/src/network/crypta/crypt/HMAC.java
+++ b/src/network/crypta/crypt/HMAC.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.security.InvalidKeyException;

--- a/src/network/crypta/crypt/Hash.java
+++ b/src/network/crypta/crypt/Hash.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import network.crypta.support.HexUtil;

--- a/src/network/crypta/crypt/HashResult.java
+++ b/src/network/crypta/crypt/HashResult.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/crypt/HashType.java
+++ b/src/network/crypta/crypt/HashType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.security.MessageDigest;

--- a/src/network/crypta/crypt/KeyAgreementSchemeContext.java
+++ b/src/network/crypta/crypt/KeyAgreementSchemeContext.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 public abstract class KeyAgreementSchemeContext {

--- a/src/network/crypta/crypt/KeyGenUtils.java
+++ b/src/network/crypta/crypt/KeyGenUtils.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.nio.ByteBuffer;

--- a/src/network/crypta/crypt/KeyPairType.java
+++ b/src/network/crypta/crypt/KeyPairType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.security.spec.ECGenParameterSpec;

--- a/src/network/crypta/crypt/KeyType.java
+++ b/src/network/crypta/crypt/KeyType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 /**

--- a/src/network/crypta/crypt/MACType.java
+++ b/src/network/crypta/crypt/MACType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.security.NoSuchAlgorithmException;

--- a/src/network/crypta/crypt/MasterSecret.java
+++ b/src/network/crypta/crypt/MasterSecret.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.Serializable;

--- a/src/network/crypta/crypt/MessageAuthCode.java
+++ b/src/network/crypta/crypt/MessageAuthCode.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.nio.ByteBuffer;

--- a/src/network/crypta/crypt/PCFBMode.java
+++ b/src/network/crypta/crypt/PCFBMode.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.io.IOException;

--- a/src/network/crypta/crypt/PersistentRandomSource.java
+++ b/src/network/crypta/crypt/PersistentRandomSource.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 

--- a/src/network/crypta/crypt/RandomSource.java
+++ b/src/network/crypta/crypt/RandomSource.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import java.util.Random;

--- a/src/network/crypta/crypt/SHA256.java
+++ b/src/network/crypta/crypt/SHA256.java
@@ -1,36 +1,3 @@
-/**
-Cryptix General Licence
-Copyright (C) 1995, 1996, 1997, 1998, 1999, 2000 
-The Cryptix Foundation Limited. All rights reserved.
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions 
-are met:
-1. Redistributions of source code must retain the copyright notice, 
-this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright 
-notice, this list of conditions and the following disclaimer in 
-the documentation and/or other materials provided with the 
-distribution.
-THIS SOFTWARE IS PROVIDED BY THE CRYPTIX FOUNDATION LIMITED ``AS IS'' 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR 
-OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF 
-USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED 
-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-THE POSSIBILITY OF SUCH DAMAGE.
- *
- * Copyright (C) 2000 The Cryptix Foundation Limited. All rights reserved.
- *
- * Use, modification, copying and distribution of this software is subject to
- * the terms and conditions of the Cryptix General Licence. You should have
- * received a copy of the Cryptix General Licence along with this library;
- * if not, you can download a copy from http://www.cryptix.org/ .
- */
 package network.crypta.crypt;
 
 import java.io.IOException;

--- a/src/network/crypta/crypt/SSL.java
+++ b/src/network/crypta/crypt/SSL.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.crypt;
 
 import java.io.FileInputStream;

--- a/src/network/crypta/crypt/UnsupportedTypeException.java
+++ b/src/network/crypta/crypt/UnsupportedTypeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 /**

--- a/src/network/crypta/crypt/Util.java
+++ b/src/network/crypta/crypt/Util.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import network.crypta.crypt.ciphers.Rijndael;

--- a/src/network/crypta/crypt/Yarrow.java
+++ b/src/network/crypta/crypt/Yarrow.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import static java.util.concurrent.TimeUnit.HOURS;

--- a/src/network/crypta/crypt/ciphers/Rijndael_Algorithm.java
+++ b/src/network/crypta/crypt/ciphers/Rijndael_Algorithm.java
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 1997, 1998 Systemics Ltd on behalf of
- * the Cryptix Development Team. All rights reserved.
- */
 package network.crypta.crypt.ciphers;
 
 import java.security.InvalidKeyException;

--- a/src/network/crypta/io/AddressIdentifier.java
+++ b/src/network/crypta/io/AddressIdentifier.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import java.util.regex.Pattern;

--- a/src/network/crypta/io/AddressMatcher.java
+++ b/src/network/crypta/io/AddressMatcher.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import java.net.InetAddress;

--- a/src/network/crypta/io/AddressTracker.java
+++ b/src/network/crypta/io/AddressTracker.java
@@ -1,18 +1,3 @@
-/* Copyright 2007 Freenet Project Inc.
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.io;
 
 import static java.util.concurrent.TimeUnit.HOURS;

--- a/src/network/crypta/io/AddressTrackerItem.java
+++ b/src/network/crypta/io/AddressTrackerItem.java
@@ -1,18 +1,3 @@
-/* Copyright 2007 Freenet Project Inc.
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.io;
 
 import network.crypta.node.FSParseException;

--- a/src/network/crypta/io/AllowedHosts.java
+++ b/src/network/crypta/io/AllowedHosts.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.io;
 
 import java.net.InetAddress;

--- a/src/network/crypta/io/Inet4AddressMatcher.java
+++ b/src/network/crypta/io/Inet4AddressMatcher.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import java.net.Inet4Address;

--- a/src/network/crypta/io/Inet6AddressMatcher.java
+++ b/src/network/crypta/io/Inet6AddressMatcher.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import java.net.Inet6Address;

--- a/src/network/crypta/io/InetAddressAddressTrackerItem.java
+++ b/src/network/crypta/io/InetAddressAddressTrackerItem.java
@@ -1,18 +1,3 @@
-/* Copyright 2007 Freenet Project Inc.
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.io;
 
 import java.net.InetAddress;

--- a/src/network/crypta/io/NetworkInterface.java
+++ b/src/network/crypta/io/NetworkInterface.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import java.io.Closeable;

--- a/src/network/crypta/io/PeerAddressTrackerItem.java
+++ b/src/network/crypta/io/PeerAddressTrackerItem.java
@@ -1,18 +1,3 @@
-/* Copyright 2007 Freenet Project Inc.
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.io;
 
 import java.net.UnknownHostException;

--- a/src/network/crypta/io/SSLNetworkInterface.java
+++ b/src/network/crypta/io/SSLNetworkInterface.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import java.io.IOException;

--- a/src/network/crypta/io/WritableToDataOutputStream.java
+++ b/src/network/crypta/io/WritableToDataOutputStream.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.io;
 
 import java.io.DataOutputStream;

--- a/src/network/crypta/io/comm/AsyncMessageCallback.java
+++ b/src/network/crypta/io/comm/AsyncMessageCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 /**

--- a/src/network/crypta/io/comm/AsyncMessageFilterCallback.java
+++ b/src/network/crypta/io/comm/AsyncMessageFilterCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 /**

--- a/src/network/crypta/io/comm/ByteCounter.java
+++ b/src/network/crypta/io/comm/ByteCounter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 /**

--- a/src/network/crypta/io/comm/DMT.java
+++ b/src/network/crypta/io/comm/DMT.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.io.comm;
 
 import network.crypta.crypt.DSAPublicKey;

--- a/src/network/crypta/io/comm/DisconnectedException.java
+++ b/src/network/crypta/io/comm/DisconnectedException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import network.crypta.support.LightweightException;

--- a/src/network/crypta/io/comm/Dispatcher.java
+++ b/src/network/crypta/io/comm/Dispatcher.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 public interface Dispatcher {

--- a/src/network/crypta/io/comm/FreenetInetAddress.java
+++ b/src/network/crypta/io/comm/FreenetInetAddress.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import java.io.DataInput;

--- a/src/network/crypta/io/comm/IOStatisticCollector.java
+++ b/src/network/crypta/io/comm/IOStatisticCollector.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import java.net.InetAddress;

--- a/src/network/crypta/io/comm/IncomingPacketFilter.java
+++ b/src/network/crypta/io/comm/IncomingPacketFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import network.crypta.node.OutgoingPacketMangler;

--- a/src/network/crypta/io/comm/IncomingPacketFilterException.java
+++ b/src/network/crypta/io/comm/IncomingPacketFilterException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import network.crypta.support.LightweightException;

--- a/src/network/crypta/io/comm/IncomingPacketFilterImpl.java
+++ b/src/network/crypta/io/comm/IncomingPacketFilterImpl.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/src/network/crypta/io/comm/IncorrectTypeException.java
+++ b/src/network/crypta/io/comm/IncorrectTypeException.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.io.comm;
 
 /**

--- a/src/network/crypta/io/comm/Message.java
+++ b/src/network/crypta/io/comm/Message.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.io.comm;
 
 import java.io.ByteArrayOutputStream;

--- a/src/network/crypta/io/comm/MessageCore.java
+++ b/src/network/crypta/io/comm/MessageCore.java
@@ -1,21 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
 package network.crypta.io.comm;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/io/comm/MessageFilter.java
+++ b/src/network/crypta/io/comm/MessageFilter.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.io.comm;
 
 import java.util.ArrayList;

--- a/src/network/crypta/io/comm/MessageType.java
+++ b/src/network/crypta/io/comm/MessageType.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.io.comm;
 
 import java.util.HashMap;

--- a/src/network/crypta/io/comm/NotConnectedException.java
+++ b/src/network/crypta/io/comm/NotConnectedException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import network.crypta.support.LightweightException;

--- a/src/network/crypta/io/comm/PacketSocketHandler.java
+++ b/src/network/crypta/io/comm/PacketSocketHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import network.crypta.io.AddressTracker.Status;

--- a/src/network/crypta/io/comm/Peer.java
+++ b/src/network/crypta/io/comm/Peer.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.io.comm;
 
 import java.io.DataInput;

--- a/src/network/crypta/io/comm/PeerContext.java
+++ b/src/network/crypta/io/comm/PeerContext.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 import java.lang.ref.WeakReference;

--- a/src/network/crypta/io/comm/PeerParseException.java
+++ b/src/network/crypta/io/comm/PeerParseException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 /**

--- a/src/network/crypta/io/comm/ReferenceSignatureVerificationException.java
+++ b/src/network/crypta/io/comm/ReferenceSignatureVerificationException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 /**

--- a/src/network/crypta/io/comm/RetrievalException.java
+++ b/src/network/crypta/io/comm/RetrievalException.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.io.comm;
 
 

--- a/src/network/crypta/io/comm/SocketHandler.java
+++ b/src/network/crypta/io/comm/SocketHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.comm;
 
 /**

--- a/src/network/crypta/io/xfer/AbortedException.java
+++ b/src/network/crypta/io/xfer/AbortedException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.xfer;
 
 /**

--- a/src/network/crypta/io/xfer/BlockReceiver.java
+++ b/src/network/crypta/io/xfer/BlockReceiver.java
@@ -1,21 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
 package network.crypta.io.xfer;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/src/network/crypta/io/xfer/BlockTransmitter.java
+++ b/src/network/crypta/io/xfer/BlockTransmitter.java
@@ -1,21 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
 package network.crypta.io.xfer;
 
 import java.util.ArrayList;

--- a/src/network/crypta/io/xfer/BulkReceiver.java
+++ b/src/network/crypta/io/xfer/BulkReceiver.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.xfer;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/src/network/crypta/io/xfer/BulkTransmitter.java
+++ b/src/network/crypta/io/xfer/BulkTransmitter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.xfer;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/io/xfer/PacketThrottle.java
+++ b/src/network/crypta/io/xfer/PacketThrottle.java
@@ -1,21 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
 package network.crypta.io.xfer;
 
 import network.crypta.support.LogThresholdCallback;

--- a/src/network/crypta/io/xfer/PartiallyReceivedBlock.java
+++ b/src/network/crypta/io/xfer/PartiallyReceivedBlock.java
@@ -1,21 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
 package network.crypta.io.xfer;
 
 import java.util.ArrayList;

--- a/src/network/crypta/io/xfer/PartiallyReceivedBulk.java
+++ b/src/network/crypta/io/xfer/PartiallyReceivedBulk.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.xfer;
 
 import java.io.IOException;

--- a/src/network/crypta/io/xfer/WaitedTooLongException.java
+++ b/src/network/crypta/io/xfer/WaitedTooLongException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.io.xfer;
 
 /**

--- a/src/network/crypta/keys/BaseClientKey.java
+++ b/src/network/crypta/keys/BaseClientKey.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.Serializable;

--- a/src/network/crypta/keys/CHKBlock.java
+++ b/src/network/crypta/keys/CHKBlock.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.security.MessageDigest;

--- a/src/network/crypta/keys/CHKDecodeException.java
+++ b/src/network/crypta/keys/CHKDecodeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 /**

--- a/src/network/crypta/keys/CHKEncodeException.java
+++ b/src/network/crypta/keys/CHKEncodeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 /**

--- a/src/network/crypta/keys/CHKVerifyException.java
+++ b/src/network/crypta/keys/CHKVerifyException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 /**

--- a/src/network/crypta/keys/ClientCHK.java
+++ b/src/network/crypta/keys/ClientCHK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/keys/ClientCHKBlock.java
+++ b/src/network/crypta/keys/ClientCHKBlock.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.IOException;

--- a/src/network/crypta/keys/ClientKSK.java
+++ b/src/network/crypta/keys/ClientKSK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 /** A KSK. We know the private key from the keyword, so this can be both 

--- a/src/network/crypta/keys/ClientKeyBlock.java
+++ b/src/network/crypta/keys/ClientKeyBlock.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.IOException;

--- a/src/network/crypta/keys/ClientSSK.java
+++ b/src/network/crypta/keys/ClientSSK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.net.MalformedURLException;

--- a/src/network/crypta/keys/ClientSSKBlock.java
+++ b/src/network/crypta/keys/ClientSSKBlock.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.IOException;

--- a/src/network/crypta/keys/FreenetURI.java
+++ b/src/network/crypta/keys/FreenetURI.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.ByteArrayInputStream;

--- a/src/network/crypta/keys/InsertableClientSSK.java
+++ b/src/network/crypta/keys/InsertableClientSSK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.IOException;

--- a/src/network/crypta/keys/InsertableUSK.java
+++ b/src/network/crypta/keys/InsertableUSK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.net.MalformedURLException;

--- a/src/network/crypta/keys/Key.java
+++ b/src/network/crypta/keys/Key.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.DataInput;

--- a/src/network/crypta/keys/KeyBlock.java
+++ b/src/network/crypta/keys/KeyBlock.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import network.crypta.store.StorableBlock;

--- a/src/network/crypta/keys/KeyDecodeException.java
+++ b/src/network/crypta/keys/KeyDecodeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 /**

--- a/src/network/crypta/keys/KeyEncodeException.java
+++ b/src/network/crypta/keys/KeyEncodeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 public class KeyEncodeException extends Exception {

--- a/src/network/crypta/keys/KeyVerifyException.java
+++ b/src/network/crypta/keys/KeyVerifyException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 public class KeyVerifyException extends Exception {

--- a/src/network/crypta/keys/NodeCHK.java
+++ b/src/network/crypta/keys/NodeCHK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.DataInput;

--- a/src/network/crypta/keys/NodeSSK.java
+++ b/src/network/crypta/keys/NodeSSK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.DataInput;

--- a/src/network/crypta/keys/SSKBlock.java
+++ b/src/network/crypta/keys/SSKBlock.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.math.BigInteger;

--- a/src/network/crypta/keys/SSKDecodeException.java
+++ b/src/network/crypta/keys/SSKDecodeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 public class SSKDecodeException extends KeyDecodeException {

--- a/src/network/crypta/keys/SSKEncodeException.java
+++ b/src/network/crypta/keys/SSKEncodeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 public class SSKEncodeException extends KeyEncodeException {

--- a/src/network/crypta/keys/SSKVerifyException.java
+++ b/src/network/crypta/keys/SSKVerifyException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 /**

--- a/src/network/crypta/keys/USK.java
+++ b/src/network/crypta/keys/USK.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.keys;
 
 import java.io.Serializable;

--- a/src/network/crypta/l10n/BaseL10n.java
+++ b/src/network/crypta/l10n/BaseL10n.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.l10n;
 
 import java.io.File;

--- a/src/network/crypta/l10n/ISO639_3.java
+++ b/src/network/crypta/l10n/ISO639_3.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.l10n;
 
 import java.io.BufferedReader;

--- a/src/network/crypta/l10n/NodeL10n.java
+++ b/src/network/crypta/l10n/NodeL10n.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.l10n;
 
 import network.crypta.l10n.BaseL10n.LANGUAGE;

--- a/src/network/crypta/l10n/PluginL10n.java
+++ b/src/network/crypta/l10n/PluginL10n.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.l10n;
 
 import network.crypta.l10n.BaseL10n.LANGUAGE;

--- a/src/network/crypta/node/AnnounceSender.java
+++ b/src/network/crypta/node/AnnounceSender.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.util.HashSet;

--- a/src/network/crypta/node/Announcer.java
+++ b/src/network/crypta/node/Announcer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/node/AnyInsertSender.java
+++ b/src/network/crypta/node/AnyInsertSender.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 public interface AnyInsertSender {

--- a/src/network/crypta/node/BaseRequestThrottle.java
+++ b/src/network/crypta/node/BaseRequestThrottle.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/src/network/crypta/node/CHKInsertHandler.java
+++ b/src/network/crypta/node/CHKInsertHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/src/network/crypta/node/CHKInsertSender.java
+++ b/src/network/crypta/node/CHKInsertSender.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/DNSRequester.java
+++ b/src/network/crypta/node/DNSRequester.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.util.ArrayDeque;

--- a/src/network/crypta/node/FNPPacketMangler.java
+++ b/src/network/crypta/node/FNPPacketMangler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/src/network/crypta/node/FSParseException.java
+++ b/src/network/crypta/node/FSParseException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /**

--- a/src/network/crypta/node/FailureTable.java
+++ b/src/network/crypta/node/FailureTable.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/FastRunnable.java
+++ b/src/network/crypta/node/FastRunnable.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /**

--- a/src/network/crypta/node/HandlePortTuple.java
+++ b/src/network/crypta/node/HandlePortTuple.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /** Used to associate a port with a node database handle */

--- a/src/network/crypta/node/HighHtlAware.java
+++ b/src/network/crypta/node/HighHtlAware.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /**

--- a/src/network/crypta/node/Location.java
+++ b/src/network/crypta/node/Location.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.support.Logger;

--- a/src/network/crypta/node/LocationManager.java
+++ b/src/network/crypta/node/LocationManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.DAYS;

--- a/src/network/crypta/node/LoggingConfigHandler.java
+++ b/src/network/crypta/node/LoggingConfigHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.io.File;

--- a/src/network/crypta/node/LowLevelGetException.java
+++ b/src/network/crypta/node/LowLevelGetException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.support.LightweightException;

--- a/src/network/crypta/node/LowLevelPutException.java
+++ b/src/network/crypta/node/LowLevelPutException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.keys.KeyBlock;

--- a/src/network/crypta/node/MasterKeysFileSizeException.java
+++ b/src/network/crypta/node/MasterKeysFileSizeException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 public class MasterKeysFileSizeException extends Exception {

--- a/src/network/crypta/node/MessageFragment.java
+++ b/src/network/crypta/node/MessageFragment.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 class MessageFragment {

--- a/src/network/crypta/node/MessageItem.java
+++ b/src/network/crypta/node/MessageItem.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.io.comm.AsyncMessageCallback;

--- a/src/network/crypta/node/MessageWrapper.java
+++ b/src/network/crypta/node/MessageWrapper.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.util.Arrays;

--- a/src/network/crypta/node/NPFPacket.java
+++ b/src/network/crypta/node/NPFPacket.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.util.Arrays;

--- a/src/network/crypta/node/NewPacketFormat.java
+++ b/src/network/crypta/node/NewPacketFormat.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/Node.java
+++ b/src/network/crypta/node/Node.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 /* Freenet 0.7 node. */
 package network.crypta.node;
 

--- a/src/network/crypta/node/NodeCrypto.java
+++ b/src/network/crypta/node/NodeCrypto.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.io.ByteArrayOutputStream;

--- a/src/network/crypta/node/NodeCryptoConfig.java
+++ b/src/network/crypta/node/NodeCryptoConfig.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.net.UnknownHostException;

--- a/src/network/crypta/node/NodeDispatcher.java
+++ b/src/network/crypta/node/NodeDispatcher.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.crypt.HMAC;

--- a/src/network/crypta/node/NodeIPPortDetector.java
+++ b/src/network/crypta/node/NodeIPPortDetector.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.util.ArrayList;

--- a/src/network/crypta/node/NodePinger.java
+++ b/src/network/crypta/node/NodePinger.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.DAYS;

--- a/src/network/crypta/node/NodeStarter.java
+++ b/src/network/crypta/node/NodeStarter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import freenet.node.ExtVersion;

--- a/src/network/crypta/node/OpennetDisabledException.java
+++ b/src/network/crypta/node/OpennetDisabledException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /**

--- a/src/network/crypta/node/OpennetManager.java
+++ b/src/network/crypta/node/OpennetManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.DAYS;

--- a/src/network/crypta/node/OutgoingPacketMangler.java
+++ b/src/network/crypta/node/OutgoingPacketMangler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.io.AddressTracker.Status;

--- a/src/network/crypta/node/PacketSender.java
+++ b/src/network/crypta/node/PacketSender.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/src/network/crypta/node/PeerManager.java
+++ b/src/network/crypta/node/PeerManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.io.BufferedReader;

--- a/src/network/crypta/node/PeerNodeStatus.java
+++ b/src/network/crypta/node/PeerNodeStatus.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
  
 import java.net.InetAddress;

--- a/src/network/crypta/node/Persistable.java
+++ b/src/network/crypta/node/Persistable.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.support.SimpleFieldSet;

--- a/src/network/crypta/node/PrioRunnable.java
+++ b/src/network/crypta/node/PrioRunnable.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /**

--- a/src/network/crypta/node/ProgramDirectory.java
+++ b/src/network/crypta/node/ProgramDirectory.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.config.InvalidConfigValueException;

--- a/src/network/crypta/node/RequestClient.java
+++ b/src/network/crypta/node/RequestClient.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /**

--- a/src/network/crypta/node/RequestHandler.java
+++ b/src/network/crypta/node/RequestHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.crypt.DSAPublicKey;

--- a/src/network/crypta/node/RequestScheduler.java
+++ b/src/network/crypta/node/RequestScheduler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/RequestSender.java
+++ b/src/network/crypta/node/RequestSender.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/RequestStarter.java
+++ b/src/network/crypta/node/RequestStarter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/RequestStarterGroup.java
+++ b/src/network/crypta/node/RequestStarterGroup.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/node/SSKInsertHandler.java
+++ b/src/network/crypta/node/SSKInsertHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.crypt.CryptFormatException;

--- a/src/network/crypta/node/SSKInsertSender.java
+++ b/src/network/crypta/node/SSKInsertSender.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/src/network/crypta/node/SecurityLevels.java
+++ b/src/network/crypta/node/SecurityLevels.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.util.ArrayList;

--- a/src/network/crypta/node/SeedClientPeerNode.java
+++ b/src/network/crypta/node/SeedClientPeerNode.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.io.comm.PeerParseException;

--- a/src/network/crypta/node/SeedServerPeerNode.java
+++ b/src/network/crypta/node/SeedServerPeerNode.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.net.InetAddress;

--- a/src/network/crypta/node/SeedServerTestPeerNode.java
+++ b/src/network/crypta/node/SeedServerTestPeerNode.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.io.comm.PeerParseException;

--- a/src/network/crypta/node/SendMessageOnErrorCallback.java
+++ b/src/network/crypta/node/SendMessageOnErrorCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.io.comm.AsyncMessageCallback;

--- a/src/network/crypta/node/SendableGet.java
+++ b/src/network/crypta/node/SendableGet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.client.FetchContext;

--- a/src/network/crypta/node/SendableInsert.java
+++ b/src/network/crypta/node/SendableInsert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.client.InsertException;

--- a/src/network/crypta/node/SessionKey.java
+++ b/src/network/crypta/node/SessionKey.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.crypt.BlockCipher;

--- a/src/network/crypta/node/SimpleSendableInsert.java
+++ b/src/network/crypta/node/SimpleSendableInsert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.client.InsertException;

--- a/src/network/crypta/node/TextModeClientInterfaceServer.java
+++ b/src/network/crypta/node/TextModeClientInterfaceServer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.io.File;

--- a/src/network/crypta/node/ThrottleWindowManager.java
+++ b/src/network/crypta/node/ThrottleWindowManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.support.LogThresholdCallback;

--- a/src/network/crypta/node/TimeSkewDetectorCallback.java
+++ b/src/network/crypta/node/TimeSkewDetectorCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /*

--- a/src/network/crypta/node/TimedOutNodesList.java
+++ b/src/network/crypta/node/TimedOutNodesList.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /**

--- a/src/network/crypta/node/UnqueueMessageOnAckCallback.java
+++ b/src/network/crypta/node/UnqueueMessageOnAckCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import network.crypta.io.comm.AsyncMessageCallback;

--- a/src/network/crypta/node/UptimeEstimator.java
+++ b/src/network/crypta/node/UptimeEstimator.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/Version.kt
+++ b/src/network/crypta/node/Version.kt
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 @file:JvmName("Version")
 
 package network.crypta.node

--- a/src/network/crypta/node/VersionParseException.java
+++ b/src/network/crypta/node/VersionParseException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 /**

--- a/src/network/crypta/node/diagnostics/DefaultNodeDiagnostics.java
+++ b/src/network/crypta/node/diagnostics/DefaultNodeDiagnostics.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.diagnostics;
 
 import network.crypta.node.NodeStats;

--- a/src/network/crypta/node/diagnostics/NodeDiagnostics.java
+++ b/src/network/crypta/node/diagnostics/NodeDiagnostics.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.diagnostics;
 
 public interface NodeDiagnostics {

--- a/src/network/crypta/node/diagnostics/ThreadDiagnostics.java
+++ b/src/network/crypta/node/diagnostics/ThreadDiagnostics.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.diagnostics;
 
 import network.crypta.node.diagnostics.threads.NodeThreadSnapshot;

--- a/src/network/crypta/node/diagnostics/threads/DefaultThreadDiagnostics.java
+++ b/src/network/crypta/node/diagnostics/threads/DefaultThreadDiagnostics.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.diagnostics.threads;
 
 import network.crypta.node.NodeStats;

--- a/src/network/crypta/node/diagnostics/threads/NodeThreadInfo.java
+++ b/src/network/crypta/node/diagnostics/threads/NodeThreadInfo.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.diagnostics.threads;
 
 /**

--- a/src/network/crypta/node/diagnostics/threads/NodeThreadSnapshot.java
+++ b/src/network/crypta/node/diagnostics/threads/NodeThreadSnapshot.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.diagnostics.threads;
 
 import java.util.ArrayList;

--- a/src/network/crypta/node/simulator/RealNodeBusyNetworkTest.java
+++ b/src/network/crypta/node/simulator/RealNodeBusyNetworkTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import network.crypta.client.HighLevelSimpleClient;

--- a/src/network/crypta/node/simulator/RealNodePingTest.java
+++ b/src/network/crypta/node/simulator/RealNodePingTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import network.crypta.crypt.RandomSource;

--- a/src/network/crypta/node/simulator/RealNodePitchBlackMitigationTest.java
+++ b/src/network/crypta/node/simulator/RealNodePitchBlackMitigationTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/simulator/RealNodeProbeTest.java
+++ b/src/network/crypta/node/simulator/RealNodeProbeTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import network.crypta.config.SubConfig;

--- a/src/network/crypta/node/simulator/RealNodeRequestInsertTest.java
+++ b/src/network/crypta/node/simulator/RealNodeRequestInsertTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import java.io.File;

--- a/src/network/crypta/node/simulator/RealNodeRoutingTest.java
+++ b/src/network/crypta/node/simulator/RealNodeRoutingTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import java.io.File;

--- a/src/network/crypta/node/simulator/RealNodeTest.java
+++ b/src/network/crypta/node/simulator/RealNodeTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import network.crypta.crypt.RandomSource;

--- a/src/network/crypta/node/simulator/RealNodeULPRTest.java
+++ b/src/network/crypta/node/simulator/RealNodeULPRTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import network.crypta.crypt.DummyRandomSource;

--- a/src/network/crypta/node/simulator/SeednodePingTest.java
+++ b/src/network/crypta/node/simulator/SeednodePingTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.simulator;
 
 import static java.util.concurrent.TimeUnit.DAYS;

--- a/src/network/crypta/node/stats/DataStoreKeyType.java
+++ b/src/network/crypta/node/stats/DataStoreKeyType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.stats;
 
 /**

--- a/src/network/crypta/node/stats/DataStoreStats.java
+++ b/src/network/crypta/node/stats/DataStoreStats.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.stats;
 
 /**

--- a/src/network/crypta/node/stats/DataStoreType.java
+++ b/src/network/crypta/node/stats/DataStoreType.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.stats;
 
 /**

--- a/src/network/crypta/node/stats/NotAvailNodeStoreStats.java
+++ b/src/network/crypta/node/stats/NotAvailNodeStoreStats.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.stats;
 
 /**

--- a/src/network/crypta/node/stats/StatsNotAvailableException.java
+++ b/src/network/crypta/node/stats/StatsNotAvailableException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.stats;
 
 /**

--- a/src/network/crypta/node/stats/StoreCallbackStats.java
+++ b/src/network/crypta/node/stats/StoreCallbackStats.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.stats;
 
 import network.crypta.store.StoreCallback;

--- a/src/network/crypta/node/stats/StoreLocationStats.java
+++ b/src/network/crypta/node/stats/StoreLocationStats.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.stats;
 
 /**

--- a/src/network/crypta/node/updater/MainJarDependenciesChecker.java
+++ b/src/network/crypta/node/updater/MainJarDependenciesChecker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.updater;
 
 import network.crypta.client.FetchException;

--- a/src/network/crypta/node/updater/UpdateOverMandatoryManager.java
+++ b/src/network/crypta/node/updater/UpdateOverMandatoryManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.updater;
 
 import static java.util.concurrent.TimeUnit.HOURS;

--- a/src/network/crypta/node/updater/UpdaterParserException.java
+++ b/src/network/crypta/node/updater/UpdaterParserException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.updater;
 
 public class UpdaterParserException extends Exception {

--- a/src/network/crypta/node/useralerts/AbstractUserAlert.java
+++ b/src/network/crypta/node/useralerts/AbstractUserAlert.java
@@ -1,21 +1,3 @@
-/*
- * freenet - AbstractUserAlert.java Copyright © 2007 David Roden
- * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * 
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.node.useralerts;
 
 import network.crypta.clients.fcp.FCPMessage;

--- a/src/network/crypta/node/useralerts/IPUndetectedUserAlert.java
+++ b/src/network/crypta/node/useralerts/IPUndetectedUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/node/useralerts/InvalidAddressOverrideUserAlert.java
+++ b/src/network/crypta/node/useralerts/InvalidAddressOverrideUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import network.crypta.config.Option;

--- a/src/network/crypta/node/useralerts/MeaningfulNodeNameUserAlert.java
+++ b/src/network/crypta/node/useralerts/MeaningfulNodeNameUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import network.crypta.config.Option;

--- a/src/network/crypta/node/useralerts/N2NTMUserAlert.java
+++ b/src/network/crypta/node/useralerts/N2NTMUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import java.lang.ref.WeakReference;

--- a/src/network/crypta/node/useralerts/NotEnoughNiceLevelsUserAlert.java
+++ b/src/network/crypta/node/useralerts/NotEnoughNiceLevelsUserAlert.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.node.useralerts;
 
 import network.crypta.l10n.NodeL10n;

--- a/src/network/crypta/node/useralerts/PeerManagerUserAlert.java
+++ b/src/network/crypta/node/useralerts/PeerManagerUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import static java.util.concurrent.TimeUnit.DAYS;

--- a/src/network/crypta/node/useralerts/RevocationKeyFoundUserAlert.java
+++ b/src/network/crypta/node/useralerts/RevocationKeyFoundUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import network.crypta.l10n.NodeL10n;

--- a/src/network/crypta/node/useralerts/SimpleUserAlert.java
+++ b/src/network/crypta/node/useralerts/SimpleUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import network.crypta.l10n.NodeL10n;

--- a/src/network/crypta/node/useralerts/TimeSkewDetectedUserAlert.java
+++ b/src/network/crypta/node/useralerts/TimeSkewDetectedUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import network.crypta.l10n.NodeL10n;

--- a/src/network/crypta/node/useralerts/UpdatedVersionAvailableUserAlert.java
+++ b/src/network/crypta/node/useralerts/UpdatedVersionAvailableUserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import java.io.File;

--- a/src/network/crypta/node/useralerts/UserAlert.java
+++ b/src/network/crypta/node/useralerts/UserAlert.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import network.crypta.clients.fcp.FCPMessage;

--- a/src/network/crypta/node/useralerts/UserAlertManager.java
+++ b/src/network/crypta/node/useralerts/UserAlertManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node.useralerts;
 
 import static java.util.Arrays.stream;

--- a/src/network/crypta/pluginmanager/AccessDeniedPluginHTTPException.java
+++ b/src/network/crypta/pluginmanager/AccessDeniedPluginHTTPException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 /**

--- a/src/network/crypta/pluginmanager/DetectedIP.java
+++ b/src/network/crypta/pluginmanager/DetectedIP.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import java.net.InetAddress;

--- a/src/network/crypta/pluginmanager/DownloadPluginHTTPException.java
+++ b/src/network/crypta/pluginmanager/DownloadPluginHTTPException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 /**

--- a/src/network/crypta/pluginmanager/FredPlugin.java
+++ b/src/network/crypta/pluginmanager/FredPlugin.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 /**

--- a/src/network/crypta/pluginmanager/FredPluginBandwidthIndicator.java
+++ b/src/network/crypta/pluginmanager/FredPluginBandwidthIndicator.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 public interface FredPluginBandwidthIndicator {

--- a/src/network/crypta/pluginmanager/FredPluginBaseL10n.java
+++ b/src/network/crypta/pluginmanager/FredPluginBaseL10n.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.l10n.BaseL10n.LANGUAGE;

--- a/src/network/crypta/pluginmanager/FredPluginConfigurable.java
+++ b/src/network/crypta/pluginmanager/FredPluginConfigurable.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.config.SubConfig;

--- a/src/network/crypta/pluginmanager/FredPluginFCP.java
+++ b/src/network/crypta/pluginmanager/FredPluginFCP.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.support.SimpleFieldSet;

--- a/src/network/crypta/pluginmanager/FredPluginFCPMessageHandler.java
+++ b/src/network/crypta/pluginmanager/FredPluginFCPMessageHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import java.io.IOException;

--- a/src/network/crypta/pluginmanager/FredPluginHTTP.java
+++ b/src/network/crypta/pluginmanager/FredPluginHTTP.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.support.api.HTTPRequest;

--- a/src/network/crypta/pluginmanager/FredPluginIPDetector.java
+++ b/src/network/crypta/pluginmanager/FredPluginIPDetector.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 public interface FredPluginIPDetector {

--- a/src/network/crypta/pluginmanager/FredPluginL10n.java
+++ b/src/network/crypta/pluginmanager/FredPluginL10n.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.l10n.BaseL10n.LANGUAGE;

--- a/src/network/crypta/pluginmanager/FredPluginMultiple.java
+++ b/src/network/crypta/pluginmanager/FredPluginMultiple.java
@@ -1,21 +1,3 @@
-/*
- * freenet - FredPluginMultiple.java Copyright © 2007 David Roden
- * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * 
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.pluginmanager;
 
 /**

--- a/src/network/crypta/pluginmanager/FredPluginTalker.java
+++ b/src/network/crypta/pluginmanager/FredPluginTalker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.support.SimpleFieldSet;

--- a/src/network/crypta/pluginmanager/FredPluginThemed.java
+++ b/src/network/crypta/pluginmanager/FredPluginThemed.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.clients.http.PageMaker.THEME;

--- a/src/network/crypta/pluginmanager/FredPluginThreadless.java
+++ b/src/network/crypta/pluginmanager/FredPluginThreadless.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 /** Implement this if you do not need to do anything in 

--- a/src/network/crypta/pluginmanager/NotFoundPluginHTTPException.java
+++ b/src/network/crypta/pluginmanager/NotFoundPluginHTTPException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 /**

--- a/src/network/crypta/pluginmanager/PluginDownLoader.java
+++ b/src/network/crypta/pluginmanager/PluginDownLoader.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import java.io.IOException;

--- a/src/network/crypta/pluginmanager/PluginDownLoaderFile.java
+++ b/src/network/crypta/pluginmanager/PluginDownLoaderFile.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import java.io.File;

--- a/src/network/crypta/pluginmanager/PluginDownLoaderFreenet.java
+++ b/src/network/crypta/pluginmanager/PluginDownLoaderFreenet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import java.io.IOException;

--- a/src/network/crypta/pluginmanager/PluginDownLoaderURL.java
+++ b/src/network/crypta/pluginmanager/PluginDownLoaderURL.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import java.io.File;

--- a/src/network/crypta/pluginmanager/PluginHTTPException.java
+++ b/src/network/crypta/pluginmanager/PluginHTTPException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 /**

--- a/src/network/crypta/pluginmanager/PluginManager.java
+++ b/src/network/crypta/pluginmanager/PluginManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/pluginmanager/PluginNotFoundException.java
+++ b/src/network/crypta/pluginmanager/PluginNotFoundException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 public class PluginNotFoundException extends Exception {

--- a/src/network/crypta/pluginmanager/PluginReplySender.java
+++ b/src/network/crypta/pluginmanager/PluginReplySender.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.clients.fcp.FCPConnectionInputHandler;

--- a/src/network/crypta/pluginmanager/PluginReplySenderDirect.java
+++ b/src/network/crypta/pluginmanager/PluginReplySenderDirect.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.clients.fcp.FCPPluginConnection;

--- a/src/network/crypta/pluginmanager/PluginReplySenderFCP.java
+++ b/src/network/crypta/pluginmanager/PluginReplySenderFCP.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import network.crypta.clients.fcp.FCPConnectionHandler;

--- a/src/network/crypta/pluginmanager/PluginStore.java
+++ b/src/network/crypta/pluginmanager/PluginStore.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import java.util.HashMap;

--- a/src/network/crypta/pluginmanager/PluginTalker.java
+++ b/src/network/crypta/pluginmanager/PluginTalker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 import java.lang.ref.WeakReference;

--- a/src/network/crypta/pluginmanager/RedirectPluginHTTPException.java
+++ b/src/network/crypta/pluginmanager/RedirectPluginHTTPException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.pluginmanager;
 
 /**

--- a/src/network/crypta/store/KeyCollisionException.java
+++ b/src/network/crypta/store/KeyCollisionException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.store;
 
 import network.crypta.support.LightweightException;

--- a/src/network/crypta/store/StoreCallback.java
+++ b/src/network/crypta/store/StoreCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.store;
 
 import java.io.IOException;

--- a/src/network/crypta/store/saltedhash/CipherManager.java
+++ b/src/network/crypta/store/saltedhash/CipherManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.store.saltedhash;
 
 import java.security.MessageDigest;

--- a/src/network/crypta/store/saltedhash/LockManager.java
+++ b/src/network/crypta/store/saltedhash/LockManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.store.saltedhash;
 
 import java.util.HashMap;

--- a/src/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/network/crypta/store/saltedhash/SaltedHashFreenetStore.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.store.saltedhash;
 
 import network.crypta.crypt.BlockCipher;

--- a/src/network/crypta/support/BandwidthStatsContainer.java
+++ b/src/network/crypta/support/BandwidthStatsContainer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.io.Serializable;

--- a/src/network/crypta/support/BinaryBloomFilter.java
+++ b/src/network/crypta/support/BinaryBloomFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import network.crypta.support.io.Closer;

--- a/src/network/crypta/support/BitArray.java
+++ b/src/network/crypta/support/BitArray.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.support;
 
 import java.io.DataInput;

--- a/src/network/crypta/support/Buffer.java
+++ b/src/network/crypta/support/Buffer.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.support;
 
 import java.io.DataInput;

--- a/src/network/crypta/support/ByteArrayWrapper.java
+++ b/src/network/crypta/support/ByteArrayWrapper.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.util.Arrays;

--- a/src/network/crypta/support/ByteBufferInputStream.java
+++ b/src/network/crypta/support/ByteBufferInputStream.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.io.DataInput;

--- a/src/network/crypta/support/ContainerSizeEstimator.java
+++ b/src/network/crypta/support/ContainerSizeEstimator.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.util.HashMap;

--- a/src/network/crypta/support/CountingBloomFilter.java
+++ b/src/network/crypta/support/CountingBloomFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import network.crypta.support.io.Closer;

--- a/src/network/crypta/support/CurrentTimeUTC.java
+++ b/src/network/crypta/support/CurrentTimeUTC.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.time.LocalDate;

--- a/src/network/crypta/support/Executor.java
+++ b/src/network/crypta/support/Executor.java
@@ -1,9 +1,3 @@
-/**
- * @author toad
- * To the extent that this is copyrightable, it's part of Freenet and licensed
- * under GPL2 or later. However, it's a trivial interface taken from Sun/Oracle JDK 1.5,
- * and we will use that when we migrate to 1.5.
- */
 package network.crypta.support;
 
 /**

--- a/src/network/crypta/support/HTMLDecoder.java
+++ b/src/network/crypta/support/HTMLDecoder.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 //import java.util.HashMap;

--- a/src/network/crypta/support/HTMLEncoder.java
+++ b/src/network/crypta/support/HTMLEncoder.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.util.HashMap;

--- a/src/network/crypta/support/HTMLEntities.java
+++ b/src/network/crypta/support/HTMLEntities.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import java.util.HashMap;

--- a/src/network/crypta/support/JarClassLoader.java
+++ b/src/network/crypta/support/JarClassLoader.java
@@ -1,21 +1,3 @@
-/*
- * freenet - JarClassLoader.java Copyright © 2007 David Roden
- * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * 
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.support;
 
 import java.io.ByteArrayOutputStream;

--- a/src/network/crypta/support/LRUCache.java
+++ b/src/network/crypta/support/LRUCache.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 

--- a/src/network/crypta/support/LightweightException.java
+++ b/src/network/crypta/support/LightweightException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 /**

--- a/src/network/crypta/support/ListUtils.java
+++ b/src/network/crypta/support/ListUtils.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.support;
 import java.util.List;
 import java.util.Random;

--- a/src/network/crypta/support/LogThresholdCallback.java
+++ b/src/network/crypta/support/LogThresholdCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- *  * Public License, version 2 (or at your option any later version). See
- *   * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 public class LogThresholdCallback {

--- a/src/network/crypta/support/MediaType.java
+++ b/src/network/crypta/support/MediaType.java
@@ -1,20 +1,3 @@
-/*
- * fred - MediaType.java - Copyright © 2011 David Roden
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package network.crypta.support;
 
 import java.net.MalformedURLException;

--- a/src/network/crypta/support/MutableBoolean.java
+++ b/src/network/crypta/support/MutableBoolean.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 /**

--- a/src/network/crypta/support/NullBloomFilter.java
+++ b/src/network/crypta/support/NullBloomFilter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 /**

--- a/src/network/crypta/support/PooledExecutor.java
+++ b/src/network/crypta/support/PooledExecutor.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/support/ProcessPriority.java
+++ b/src/network/crypta/support/ProcessPriority.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.support;
 
 import com.sun.jna.Native;

--- a/src/network/crypta/support/RandomGrabArrayItemExclusionList.java
+++ b/src/network/crypta/support/RandomGrabArrayItemExclusionList.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import network.crypta.client.async.ClientContext;

--- a/src/network/crypta/support/SentTimeCache.java
+++ b/src/network/crypta/support/SentTimeCache.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.util.LinkedHashMap;

--- a/src/network/crypta/support/Serializer.java
+++ b/src/network/crypta/support/Serializer.java
@@ -1,22 +1,3 @@
-/*
-Dijjer - A Peer to Peer HTTP Cache
-Copyright (C) 2004,2005  Change.Tv, Inc
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-*/
-
 package network.crypta.support;
 
 import java.io.DataInput;

--- a/src/network/crypta/support/ShortBuffer.java
+++ b/src/network/crypta/support/ShortBuffer.java
@@ -1,22 +1,3 @@
-/*
- * Dijjer - A Peer to Peer HTTP Cache
- * Copyright (C) 2004,2005 Change.Tv, Inc
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package network.crypta.support;
 
 import java.io.DataInput;

--- a/src/network/crypta/support/StringCounter.java
+++ b/src/network/crypta/support/StringCounter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.util.Arrays;

--- a/src/network/crypta/support/Ticker.java
+++ b/src/network/crypta/support/Ticker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 

--- a/src/network/crypta/support/TimeUtil.java
+++ b/src/network/crypta/support/TimeUtil.java
@@ -1,21 +1,3 @@
-/*
-  TimeUtil.java / Freenet
-  Copyright (C) 2005-2006 The Free Network project
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License as
-  published by the Free Software Foundation; either version 2 of
-  the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-*/
-
 package network.crypta.support;
 
 import static java.util.concurrent.TimeUnit.DAYS;

--- a/src/network/crypta/support/TransferThread.java
+++ b/src/network/crypta/support/TransferThread.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/src/network/crypta/support/URLDecoder.java
+++ b/src/network/crypta/support/URLDecoder.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.io.ByteArrayOutputStream;

--- a/src/network/crypta/support/URLEncodedFormatException.java
+++ b/src/network/crypta/support/URLEncodedFormatException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 /**

--- a/src/network/crypta/support/URLEncoder.java
+++ b/src/network/crypta/support/URLEncoder.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.nio.charset.StandardCharsets;

--- a/src/network/crypta/support/UptimeContainer.java
+++ b/src/network/crypta/support/UptimeContainer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import java.io.Serializable;

--- a/src/network/crypta/support/XMLCharacterClasses.java
+++ b/src/network/crypta/support/XMLCharacterClasses.java
@@ -1,21 +1,3 @@
-/*
- * freenet - XMLCharacterClasses.java Copyright © 2007 David Roden
- * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * 
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.support;
 
 import java.util.regex.Matcher;

--- a/src/network/crypta/support/api/BooleanCallback.java
+++ b/src/network/crypta/support/api/BooleanCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import java.util.function.Supplier;

--- a/src/network/crypta/support/api/Bucket.java
+++ b/src/network/crypta/support/api/Bucket.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/src/network/crypta/support/api/BucketFactory.java
+++ b/src/network/crypta/support/api/BucketFactory.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import java.io.IOException;

--- a/src/network/crypta/support/api/HTTPRequest.java
+++ b/src/network/crypta/support/api/HTTPRequest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import java.util.Collection;

--- a/src/network/crypta/support/api/HTTPUploadedFile.java
+++ b/src/network/crypta/support/api/HTTPUploadedFile.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 public interface HTTPUploadedFile {

--- a/src/network/crypta/support/api/IntCallback.java
+++ b/src/network/crypta/support/api/IntCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import network.crypta.config.ConfigCallback;

--- a/src/network/crypta/support/api/LongCallback.java
+++ b/src/network/crypta/support/api/LongCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import network.crypta.config.ConfigCallback;

--- a/src/network/crypta/support/api/ManifestElement.java
+++ b/src/network/crypta/support/api/ManifestElement.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import java.io.Serializable;

--- a/src/network/crypta/support/api/RandomAccessBuffer.java
+++ b/src/network/crypta/support/api/RandomAccessBuffer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import java.io.Closeable;

--- a/src/network/crypta/support/api/StringArrCallback.java
+++ b/src/network/crypta/support/api/StringArrCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import network.crypta.config.ConfigCallback;

--- a/src/network/crypta/support/api/StringCallback.java
+++ b/src/network/crypta/support/api/StringCallback.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.api;
 
 import network.crypta.config.ConfigCallback;

--- a/src/network/crypta/support/codeshortification/IfNotEquals.java
+++ b/src/network/crypta/support/codeshortification/IfNotEquals.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.codeshortification;
 
 /**

--- a/src/network/crypta/support/codeshortification/IfNull.java
+++ b/src/network/crypta/support/codeshortification/IfNull.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.codeshortification;
 
 import java.util.Objects;

--- a/src/network/crypta/support/compress/Bzip2Compressor.java
+++ b/src/network/crypta/support/compress/Bzip2Compressor.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
-* Public License, version 2 (or at your option any later version). See
-* http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import java.io.ByteArrayInputStream;

--- a/src/network/crypta/support/compress/Compressor.java
+++ b/src/network/crypta/support/compress/Compressor.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
-* Public License, version 2 (or at your option any later version). See
-* http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import java.io.IOException;

--- a/src/network/crypta/support/compress/DecompressorThreadManager.java
+++ b/src/network/crypta/support/compress/DecompressorThreadManager.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
-* Public License, version 2 (or at your option any later version). See
-* http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/support/compress/InvalidCompressionCodecException.java
+++ b/src/network/crypta/support/compress/InvalidCompressionCodecException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 /**

--- a/src/network/crypta/support/compress/NewLZMACompressor.java
+++ b/src/network/crypta/support/compress/NewLZMACompressor.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
-* Public License, version 2 (or at your option any later version). See
-* http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import java.io.ByteArrayInputStream;

--- a/src/network/crypta/support/compress/OldLZMACompressor.java
+++ b/src/network/crypta/support/compress/OldLZMACompressor.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
-* Public License, version 2 (or at your option any later version). See
-* http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import java.io.ByteArrayInputStream;

--- a/src/network/crypta/support/compress/RealCompressor.java
+++ b/src/network/crypta/support/compress/RealCompressor.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import java.util.concurrent.ExecutorService;

--- a/src/network/crypta/support/io/ArrayBucketFactory.java
+++ b/src/network/crypta/support/io/ArrayBucketFactory.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.IOException;

--- a/src/network/crypta/support/io/Closer.java
+++ b/src/network/crypta/support/io/Closer.java
@@ -1,21 +1,3 @@
-/*
- * freenet - Closer.java Copyright © 2007 David Roden
- * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * 
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.support.io;
 
 import java.io.Closeable;

--- a/src/network/crypta/support/io/DelayedFreeBucket.java
+++ b/src/network/crypta/support/io/DelayedFreeBucket.java
@@ -1,8 +1,3 @@
-/**
- * This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL.
- */
 package network.crypta.support.io;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/support/io/DelayedFreeRandomAccessBucket.java
+++ b/src/network/crypta/support/io/DelayedFreeRandomAccessBucket.java
@@ -1,8 +1,3 @@
-/**
- * This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL.
- */
 package network.crypta.support.io;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/support/io/FileBucket.java
+++ b/src/network/crypta/support/io/FileBucket.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/support/io/FileUtil.java
+++ b/src/network/crypta/support/io/FileUtil.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/support/io/HeaderStreams.java
+++ b/src/network/crypta/support/io/HeaderStreams.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.InputStream;

--- a/src/network/crypta/support/io/LineReader.java
+++ b/src/network/crypta/support/io/LineReader.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.IOException;

--- a/src/network/crypta/support/io/LineReadingInputStream.java
+++ b/src/network/crypta/support/io/LineReadingInputStream.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import network.crypta.support.HexUtil;

--- a/src/network/crypta/support/io/MultiReaderBucket.java
+++ b/src/network/crypta/support/io/MultiReaderBucket.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.DataOutputStream;

--- a/src/network/crypta/support/io/NativeThread.java
+++ b/src/network/crypta/support/io/NativeThread.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.support.io;
 
 import com.sun.jna.Native;

--- a/src/network/crypta/support/io/NullBucket.java
+++ b/src/network/crypta/support/io/NullBucket.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/src/network/crypta/support/io/NullInputStream.java
+++ b/src/network/crypta/support/io/NullInputStream.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 import java.io.InputStream;
 

--- a/src/network/crypta/support/io/NullOutputStream.java
+++ b/src/network/crypta/support/io/NullOutputStream.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 import java.io.OutputStream;
 

--- a/src/network/crypta/support/io/NullWriter.java
+++ b/src/network/crypta/support/io/NullWriter.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.IOException;

--- a/src/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
+++ b/src/network/crypta/support/io/PaddedEphemerallyEncryptedBucket.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/support/io/PersistentFileTracker.java
+++ b/src/network/crypta/support/io/PersistentFileTracker.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.File;

--- a/src/network/crypta/support/io/PersistentTempBucketFactory.java
+++ b/src/network/crypta/support/io/PersistentTempBucketFactory.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.File;

--- a/src/network/crypta/support/io/ReadOnlyFileSliceBucket.java
+++ b/src/network/crypta/support/io/ReadOnlyFileSliceBucket.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.BufferedInputStream;

--- a/src/network/crypta/support/io/Readers.java
+++ b/src/network/crypta/support/io/Readers.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.BufferedReader;

--- a/src/network/crypta/support/io/SkipShieldingInputStream.java
+++ b/src/network/crypta/support/io/SkipShieldingInputStream.java
@@ -1,20 +1,3 @@
-/*
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- */
 package network.crypta.support.io;
 
 import java.io.FilterInputStream;

--- a/src/network/crypta/support/io/TempBucketFactory.java
+++ b/src/network/crypta/support/io/TempBucketFactory.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/network/crypta/support/io/TooLongException.java
+++ b/src/network/crypta/support/io/TooLongException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.IOException;

--- a/src/network/crypta/support/math/BootstrappingDecayingRunningAverage.java
+++ b/src/network/crypta/support/math/BootstrappingDecayingRunningAverage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.math;
 
 import network.crypta.support.LogThresholdCallback;

--- a/src/network/crypta/support/math/DecayingKeyspaceAverage.java
+++ b/src/network/crypta/support/math/DecayingKeyspaceAverage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.math;
 
 import network.crypta.node.Location;

--- a/src/network/crypta/support/math/RunningAverage.java
+++ b/src/network/crypta/support/math/RunningAverage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.math;
 
 import java.io.Serializable;

--- a/src/network/crypta/support/math/SimpleRunningAverage.java
+++ b/src/network/crypta/support/math/SimpleRunningAverage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.math;
 
 import java.io.DataOutputStream;

--- a/src/network/crypta/support/math/TimeDecayingRunningAverage.java
+++ b/src/network/crypta/support/math/TimeDecayingRunningAverage.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.math;
 
 import java.io.DataInputStream;

--- a/src/network/crypta/support/plugins/helpers1/AbstractFCPHandler.java
+++ b/src/network/crypta/support/plugins/helpers1/AbstractFCPHandler.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.plugins.helpers1;
 
 import java.io.PrintWriter;

--- a/src/network/crypta/support/plugins/helpers1/InvisibleWebInterfaceToadlet.java
+++ b/src/network/crypta/support/plugins/helpers1/InvisibleWebInterfaceToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.plugins.helpers1;
 
 import java.io.IOException;

--- a/src/network/crypta/support/plugins/helpers1/PluginContext.java
+++ b/src/network/crypta/support/plugins/helpers1/PluginContext.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.plugins.helpers1;
 
 import network.crypta.client.HighLevelSimpleClient;

--- a/src/network/crypta/support/plugins/helpers1/URISanitizer.java
+++ b/src/network/crypta/support/plugins/helpers1/URISanitizer.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.plugins.helpers1;
 
 import java.net.MalformedURLException;

--- a/src/network/crypta/support/plugins/helpers1/WebInterface.java
+++ b/src/network/crypta/support/plugins/helpers1/WebInterface.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.plugins.helpers1;
 
 import java.util.Vector;

--- a/src/network/crypta/support/plugins/helpers1/WebInterfaceToadlet.java
+++ b/src/network/crypta/support/plugins/helpers1/WebInterfaceToadlet.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.plugins.helpers1;
 
 import java.util.List;

--- a/src/network/crypta/support/transport/ip/HostnameSyntaxException.java
+++ b/src/network/crypta/support/transport/ip/HostnameSyntaxException.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.transport.ip;
 
 /**

--- a/src/network/crypta/support/transport/ip/HostnameUtil.java
+++ b/src/network/crypta/support/transport/ip/HostnameUtil.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.transport.ip;
 
 import network.crypta.io.AddressIdentifier;

--- a/src/network/crypta/support/transport/ip/IPUtil.java
+++ b/src/network/crypta/support/transport/ip/IPUtil.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.transport.ip;
 
 import java.net.InetAddress;

--- a/src/network/crypta/tools/AddRef.java
+++ b/src/network/crypta/tools/AddRef.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.tools;
 
 import java.io.File;

--- a/test/network/crypta/client/filter/ContentFilterTest.java
+++ b/test/network/crypta/client/filter/ContentFilterTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import network.crypta.client.filter.ContentFilter.FilterStatus;

--- a/test/network/crypta/client/filter/TagVerifierTest.java
+++ b/test/network/crypta/client/filter/TagVerifierTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.client.filter;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/clients/fcp/FCPPluginConnectionImplTest.java
+++ b/test/network/crypta/clients/fcp/FCPPluginConnectionImplTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/clients/fcp/FCPPluginMessageEncodeDecodeTest.java
+++ b/test/network/crypta/clients/fcp/FCPPluginMessageEncodeDecodeTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.fcp;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/clients/http/CookieTest.java
+++ b/test/network/crypta/clients/http/CookieTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/clients/http/FilterCSSIdentifierTest.java
+++ b/test/network/crypta/clients/http/FilterCSSIdentifierTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/clients/http/ReceivedCookieTest.java
+++ b/test/network/crypta/clients/http/ReceivedCookieTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.clients.http;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/config/ConfigTest.java
+++ b/test/network/crypta/config/ConfigTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.config;
 
 import network.crypta.test.UTFUtil;

--- a/test/network/crypta/crypt/CryptByteBufferTest.java
+++ b/test/network/crypta/crypt/CryptByteBufferTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/test/network/crypta/crypt/CryptUtilTest.java
+++ b/test/network/crypta/crypt/CryptUtilTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/crypt/EncryptedRandomAccessBufferTest.java
+++ b/test/network/crypta/crypt/EncryptedRandomAccessBufferTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/crypt/HMAC_legacy.java
+++ b/test/network/crypta/crypt/HMAC_legacy.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import network.crypta.crypt.SHA256;

--- a/test/network/crypta/crypt/HashTest.java
+++ b/test/network/crypta/crypt/HashTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/crypt/KeyGenUtilsTest.java
+++ b/test/network/crypta/crypt/KeyGenUtilsTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import network.crypta.support.HexUtil;

--- a/test/network/crypta/crypt/MasterSecretTest.java
+++ b/test/network/crypta/crypt/MasterSecretTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/crypt/MessageAuthCodeTest.java
+++ b/test/network/crypta/crypt/MessageAuthCodeTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import network.crypta.crypt.MACType;

--- a/test/network/crypta/crypt/YarrowTest.java
+++ b/test/network/crypta/crypt/YarrowTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/crypt/ciphers/RijndaelTest.java
+++ b/test/network/crypta/crypt/ciphers/RijndaelTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.crypt.ciphers;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/io/AddressIdentifierTest.java
+++ b/test/network/crypta/io/AddressIdentifierTest.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/io/Inet4AddressMatcherTest.java
+++ b/test/network/crypta/io/Inet4AddressMatcherTest.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/io/Inet6AddressMatcherTest.java
+++ b/test/network/crypta/io/Inet6AddressMatcherTest.java
@@ -1,22 +1,3 @@
-/*
- * freenet0.7 - 
- * Copyright (C) 2006 David Roden
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.io;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/node/NPFPacketTest.java
+++ b/test/network/crypta/node/NPFPacketTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/node/NewPacketFormatTest.java
+++ b/test/network/crypta/node/NewPacketFormatTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import java.net.UnknownHostException;

--- a/test/network/crypta/node/NodeTest.java
+++ b/test/network/crypta/node/NodeTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/node/PeerMessageQueueTest.java
+++ b/test/network/crypta/node/PeerMessageQueueTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.node;
 
 import static org.junit.Assert.assertEquals;

--- a/test/network/crypta/support/Base64Test.java
+++ b/test/network/crypta/support/Base64Test.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/BitArrayTest.java
+++ b/test/network/crypta/support/BitArrayTest.java
@@ -1,17 +1,3 @@
-/* This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/BufferTest.java
+++ b/test/network/crypta/support/BufferTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/ByteArrayWrapperTest.java
+++ b/test/network/crypta/support/ByteArrayWrapperTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/FieldsTest.java
+++ b/test/network/crypta/support/FieldsTest.java
@@ -1,7 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
-
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/HTMLEncoderDecoderTest.java
+++ b/test/network/crypta/support/HTMLEncoderDecoderTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import network.crypta.test.UTFUtil;

--- a/test/network/crypta/support/HTMLNodeTest.java
+++ b/test/network/crypta/support/HTMLNodeTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/HexUtilTest.java
+++ b/test/network/crypta/support/HexUtilTest.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/LRUMapTest.java
+++ b/test/network/crypta/support/LRUMapTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/LRUQueueTest.java
+++ b/test/network/crypta/support/LRUQueueTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/ListUtilsTest.java
+++ b/test/network/crypta/support/ListUtilsTest.java
@@ -1,17 +1,3 @@
-/* This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/LoaderTest.java
+++ b/test/network/crypta/support/LoaderTest.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/MultiValueTableTest.java
+++ b/test/network/crypta/support/MultiValueTableTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/test/network/crypta/support/MutableBooleanTest.java
+++ b/test/network/crypta/support/MutableBooleanTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/SentTimeCacheTest.java
+++ b/test/network/crypta/support/SentTimeCacheTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/ShortBufferTest.java
+++ b/test/network/crypta/support/ShortBufferTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/SimpleFieldSetTest.java
+++ b/test/network/crypta/support/SimpleFieldSetTest.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.support;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/test/network/crypta/support/SizeUtilTest.java
+++ b/test/network/crypta/support/SizeUtilTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/SparseBitmapTest.java
+++ b/test/network/crypta/support/SparseBitmapTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/TestProperty.java
+++ b/test/network/crypta/support/TestProperty.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support;
 
 /**

--- a/test/network/crypta/support/TimeUtilTest.java
+++ b/test/network/crypta/support/TimeUtilTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import static java.util.Calendar.MILLISECOND;

--- a/test/network/crypta/support/URIPreEncoderTest.java
+++ b/test/network/crypta/support/URIPreEncoderTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import network.crypta.test.UTFUtil;

--- a/test/network/crypta/support/URLEncoderDecoderTest.java
+++ b/test/network/crypta/support/URLEncoderDecoderTest.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.support;
 
 import network.crypta.test.UTFUtil;

--- a/test/network/crypta/support/compress/Bzip2CompressorTest.java
+++ b/test/network/crypta/support/compress/Bzip2CompressorTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/compress/GzipCompressorTest.java
+++ b/test/network/crypta/support/compress/GzipCompressorTest.java
@@ -1,19 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
-
 package network.crypta.support.compress;
 
 import static network.crypta.support.compress.Compressor.COMPRESSOR_TYPE.GZIP;

--- a/test/network/crypta/support/compress/NewLzmaCompressorTest.java
+++ b/test/network/crypta/support/compress/NewLzmaCompressorTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/compress/OldLZMACompressorTest.java
+++ b/test/network/crypta/support/compress/OldLZMACompressorTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.compress;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/io/ArrayBucketTest.java
+++ b/test/network/crypta/support/io/ArrayBucketTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.IOException;

--- a/test/network/crypta/support/io/BucketTestBase.java
+++ b/test/network/crypta/support/io/BucketTestBase.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import network.crypta.support.ByteArrayWrapper;

--- a/test/network/crypta/support/io/HeaderStreamsTest.java
+++ b/test/network/crypta/support/io/HeaderStreamsTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import org.junit.After;

--- a/test/network/crypta/support/io/LineReadingInputStreamTest.java
+++ b/test/network/crypta/support/io/LineReadingInputStreamTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/io/MockInputStream.java
+++ b/test/network/crypta/support/io/MockInputStream.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.InputStream;

--- a/test/network/crypta/support/io/PaddedEphemerallyEncryptedBucketTest.java
+++ b/test/network/crypta/support/io/PaddedEphemerallyEncryptedBucketTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import java.io.IOException;

--- a/test/network/crypta/support/io/TempBucketTest.java
+++ b/test/network/crypta/support/io/TempBucketTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/support/io/TempFileBucketTest.java
+++ b/test/network/crypta/support/io/TempFileBucketTest.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.support.io;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/test/Asserts.java
+++ b/test/network/crypta/test/Asserts.java
@@ -1,6 +1,3 @@
-/* This code is part of Freenet. It is distributed under the GNU General
- * Public License, version 2 (or at your option any later version). See
- * http://www.gnu.org/ for further details of the GPL. */
 package network.crypta.test;
 
 import static org.junit.Assert.*;

--- a/test/network/crypta/test/UTFUtil.java
+++ b/test/network/crypta/test/UTFUtil.java
@@ -1,18 +1,3 @@
-/*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- */
 package network.crypta.test;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
Summary
- Rebrand documentation to Crypta and refresh README and project docs
- Clarify project origin, scope, and roadmap
- Remove top-of-file copyright headers from Java sources
- Add .DS_Store to .gitignore

Changes (since origin/develop)
- 8c8b62baa: Add instructions for Codex Cli to always try to run a command in a sandbox
- f784a39c7: remove top-of-file copyright headers from Java
- 255782386: Ignore macOS .DS_Store artifacts
- af45883e0: clarify project origin, scope, and roadmap
- 76ada4220: Rebrand to Crypta and refresh documentation

Notes
- No functional runtime changes expected; primarily docs/housekeeping
- Target branch: develop (GitFlow)
- CI will verify builds and tests