### PR TITLE
Distribution + startup hardening: reproducible tar/zip, robust wrapper detection, and data-dir free space check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,18 +28,6 @@ When operating as an autonomous or semi-autonomous agent, proactively leverage s
 current task (e.g., context management, Kotlin/Java expertise, debugging, performance/security review, search, and
 architecture review).
 
-### apply_patch — REQUIRED (important)
-
-- Virtual tool: `apply_patch` is implemented inside the Codex executable (invoked via `--codex-run-as-apply-patch`). There is no standalone `apply_patch` binary on `PATH`.
-- Preferred invocation (structured command array):
-    - `["apply_patch", "*** Begin Patch\n*** Update File: path/to/file\n@@\n- old\n+ new\n*** End Patch\n"]`
-    - Explanation: pass the full patch text as the second element (including `*** Begin Patch`/`*** End Patch`).
-- If you must use a heredoc, wrap it with `bash -lc` so the runner interprets the heredoc as shell would:
-    - `["bash","-lc","apply_patch <<'EOF'\n*** Begin Patch\n...\n*** End Patch\nEOF\n"]`
-    - Avoid passing the heredoc markers as a literal argv string (e.g. `["apply_patch","<<'EOF'...EOF"]`) because that may be interpreted literally and is not reliably parsed.
-- Command name variants: do not use `apply-patch` (with a hyphen) or other unapproved variants; detection expects `apply_patch` (and in limited cases `applypatch`).
-- If you need to run a small script that includes `apply_patch` (for example `cd repo && apply_patch <<'EOF'...EOF`), prefer wrapping the entire script in `bash -lc`, or pass the patch text directly as the second argument.
-
 ## Development Commands
 
 ### Building

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,18 @@ When operating as an autonomous or semi-autonomous agent, proactively leverage s
 current task (e.g., context management, Kotlin/Java expertise, debugging, performance/security review, search, and
 architecture review).
 
+### apply_patch — REQUIRED (important)
+
+- Virtual tool: `apply_patch` is implemented inside the Codex executable (invoked via `--codex-run-as-apply-patch`). There is no standalone `apply_patch` binary on `PATH`.
+- Preferred invocation (structured command array):
+    - `["apply_patch", "*** Begin Patch\n*** Update File: path/to/file\n@@\n- old\n+ new\n*** End Patch\n"]`
+    - Explanation: pass the full patch text as the second element (including `*** Begin Patch`/`*** End Patch`).
+- If you must use a heredoc, wrap it with `bash -lc` so the runner interprets the heredoc as shell would:
+    - `["bash","-lc","apply_patch <<'EOF'\n*** Begin Patch\n...\n*** End Patch\nEOF\n"]`
+    - Avoid passing the heredoc markers as a literal argv string (e.g. `["apply_patch","<<'EOF'...EOF"]`) because that may be interpreted literally and is not reliably parsed.
+- Command name variants: do not use `apply-patch` (with a hyphen) or other unapproved variants; detection expects `apply_patch` (and in limited cases `applypatch`).
+- If you need to run a small script that includes `apply_patch` (for example `cd repo && apply_patch <<'EOF'...EOF`), prefer wrapping the entire script in `bash -lc`, or pass the patch text directly as the second argument.
+
 ## Development Commands
 
 ### Building

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,3 +30,12 @@ dependencies {
 
   runtimeOnly(files("libs/db4o-7.4.58.jar"))
 }
+
+// Utility task to print the project version
+tasks.register("printVersion") {
+  group = "help"
+  description = "Prints the project version"
+  doLast {
+    println(project.version.toString())
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,5 @@ dependencies {
 tasks.register("printVersion") {
   group = "help"
   description = "Prints the project version"
-  doLast {
-    println(project.version.toString())
-  }
+  doLast { println(project.version.toString()) }
 }

--- a/src/main/templates/cryptad.sh.tpl
+++ b/src/main/templates/cryptad.sh.tpl
@@ -28,10 +28,14 @@ OS_RAW=$(uname -s 2>/dev/null || echo unknown)
 ARCH_RAW=$(uname -m 2>/dev/null || echo unknown)
 
 normalize_os() {
-  case "${1,,}" in
+  # Lowercase argument in a Bash-3 compatible way (macOS ships Bash 3.2)
+  # Avoids ${var,,} which is Bash 4+ only.
+  local in
+  in=$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]')
+  case "$in" in
     darwin) echo macosx ;;
     linux|gnu/linux|linux-gnu) echo linux ;;
-    *) echo "$1" ;;
+    *) echo "$in" ;;
   esac
 }
 

--- a/src/main/templates/cryptad.sh.tpl
+++ b/src/main/templates/cryptad.sh.tpl
@@ -24,26 +24,72 @@ fi
 
 # Resolve native wrapper
 WRAPPER="$BIN_DIR/wrapper"
-OS=$(uname -s || echo unknown)
-ARCH=$(uname -m || echo unknown)
+OS_RAW=$(uname -s 2>/dev/null || echo unknown)
+ARCH_RAW=$(uname -m 2>/dev/null || echo unknown)
 
-# Normalize identifiers
-case "$OS" in
-  Darwin) DIST_OS=macosx ;;
-  Linux)  DIST_OS=linux ;;
-  *) DIST_OS=$OS ;;
-esac
-case "$ARCH" in
-  x86_64|amd64) DIST_ARCH=x86 ; DIST_BIT=64 ;;
-  aarch64|arm64) DIST_ARCH=aarch64 ; DIST_BIT=64 ;;
-  *) DIST_ARCH=$ARCH ; DIST_BIT=64 ;;
-esac
+normalize_os() {
+  case "${1,,}" in
+    darwin) echo macosx ;;
+    linux|gnu/linux|linux-gnu) echo linux ;;
+    *) echo "$1" ;;
+  esac
+}
+
+# Prefer Snap and distro hints when available
+detect_arch() {
+  local snap_arch="$SNAP_ARCH"  # set by Snap: amd64, arm64, armhf, ppc64el, s390x, riscv64
+  local dpkg_arch=""
+  if command -v dpkg >/dev/null 2>&1; then
+    dpkg_arch=$(dpkg --print-architecture 2>/dev/null || true)
+  fi
+  local raw="$ARCH_RAW"
+
+  local src=""
+  local a=""
+  if [ -n "$snap_arch" ]; then
+    a="$snap_arch"; src="SNAP_ARCH"
+  elif [ -n "$dpkg_arch" ]; then
+    a="$dpkg_arch"; src="dpkg"
+  else
+    a="$raw"; src="uname"
+  fi
+
+  local dist_arch=""; local dist_bit=""
+  case "$a" in
+    x86_64|amd64) dist_arch=x86 ; dist_bit=64 ;;
+    i386|i486|i586|i686) dist_arch=x86 ; dist_bit=32 ;;
+    aarch64|arm64) dist_arch=aarch64 ; dist_bit=64 ;;
+    armv8*) dist_arch=aarch64 ; dist_bit=64 ;;
+    armv7*|armhf) dist_arch=armhf ; dist_bit=32 ;;
+    armv6*) dist_arch=armhf ; dist_bit=32 ;;
+    ppc64le|ppc64el) dist_arch=ppc64le ; dist_bit=64 ;;
+    s390x) dist_arch=s390x ; dist_bit=64 ;;
+    riscv64) dist_arch=riscv64 ; dist_bit=64 ;;
+    *)
+      # Fallback: keep raw arch, infer bits from getconf if possible
+      dist_arch="$a"
+      if command -v getconf >/dev/null 2>&1; then
+        dist_bit=$(getconf LONG_BIT 2>/dev/null || echo 64)
+      else
+        dist_bit=64
+      fi
+      ;;
+  esac
+
+  echo "$dist_arch:$dist_bit:$src:$a"
+}
+
+DIST_OS=$(normalize_os "$OS_RAW")
+IFS=":" read -r DIST_ARCH DIST_BIT ARCH_SRC ARCH_INPUT < <(detect_arch)
 
 # Try generic wrapper first
 if [ ! -x "$WRAPPER" ]; then
   CANDIDATES=(
     "$BIN_DIR/wrapper-$DIST_OS-$DIST_ARCH-$DIST_BIT"
     "$BIN_DIR/wrapper-$DIST_OS-universal-$DIST_BIT"
+    # Common alternate spellings for some platforms
+    "$BIN_DIR/wrapper-$DIST_OS-arm64-$DIST_BIT"
+    "$BIN_DIR/wrapper-$DIST_OS-amd64-$DIST_BIT"
   )
   for c in "${CANDIDATES[@]}"; do
     if [ -x "$c" ]; then WRAPPER="$c"; break; fi
@@ -59,6 +105,8 @@ echo "  CONF_DIR=$CONF_DIR"
 echo "  LIB_DIR=$LIB_DIR"
 echo "  TMP_DIR=$TMP_DIR"
 echo "  WRAPPER=$WRAPPER"
+echo "  DETECTED_OS=$DIST_OS (raw=$OS_RAW)"
+echo "  DETECTED_ARCH=$DIST_ARCH (bits=$DIST_BIT source=$ARCH_SRC input=$ARCH_INPUT raw=$ARCH_RAW)"
 
 if [ -x "$WRAPPER" ]; then
   exec "$WRAPPER" -c "$CONF" "$@"

--- a/src/main/templates/cryptad.sh.tpl
+++ b/src/main/templates/cryptad.sh.tpl
@@ -4,8 +4,12 @@ set -euo pipefail
 # Resolve installation root (../ from bin)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR/.."
+BIN_DIR="$ROOT_DIR/bin"
+CONF_DIR="$ROOT_DIR/conf"
+LIB_DIR="$ROOT_DIR/lib"
+TMP_DIR="$ROOT_DIR/tmp"
 
-CONF="$ROOT_DIR/conf/wrapper.conf"
+CONF="$CONF_DIR/wrapper.conf"
 if [ ! -f "$CONF" ]; then
   echo "Missing configuration at $CONF" >&2
   exit 1
@@ -18,13 +22,8 @@ if [ "$EUID" -eq 0 ] && [ -z "$CRYPTAD_ALLOW_ROOT" ]; then
   exit 1
 fi
 
-# If CRYPTAD_NO_WRAPPER=1, or no wrapper binary is available, run with plain java.
-USE_WRAPPER=1
-if [ "${CRYPTAD_NO_WRAPPER:-0}" = "1" ]; then
-  USE_WRAPPER=0
-fi
-
-WRAPPER="$ROOT_DIR/bin/wrapper"
+# Resolve native wrapper
+WRAPPER="$BIN_DIR/wrapper"
 OS=$(uname -s || echo unknown)
 ARCH=$(uname -m || echo unknown)
 
@@ -43,42 +42,29 @@ esac
 # Try generic wrapper first
 if [ ! -x "$WRAPPER" ]; then
   CANDIDATES=(
-    "$ROOT_DIR/bin/wrapper-$DIST_OS-$DIST_ARCH-$DIST_BIT"
-    "$ROOT_DIR/bin/wrapper-$DIST_OS-universal-$DIST_BIT"
+    "$BIN_DIR/wrapper-$DIST_OS-$DIST_ARCH-$DIST_BIT"
+    "$BIN_DIR/wrapper-$DIST_OS-universal-$DIST_BIT"
   )
   for c in "${CANDIDATES[@]}"; do
     if [ -x "$c" ]; then WRAPPER="$c"; break; fi
   done
 fi
 
-if [ "$USE_WRAPPER" = "1" ] && [ -x "$WRAPPER" ]; then
+# Print directory diagnostics to help users verify paths
+echo "[cryptad] Directory layout"
+echo "  SCRIPT_DIR=$SCRIPT_DIR"
+echo "  ROOT_DIR=$ROOT_DIR"
+echo "  BIN_DIR=$BIN_DIR"
+echo "  CONF_DIR=$CONF_DIR"
+echo "  LIB_DIR=$LIB_DIR"
+echo "  TMP_DIR=$TMP_DIR"
+echo "  WRAPPER=$WRAPPER"
+
+if [ -x "$WRAPPER" ]; then
   exec "$WRAPPER" -c "$CONF" "$@"
 fi
 
-# Fallback: run Java main directly (no native wrapper). Set CRYPTAD_JAVA_OPTS to override.
-JAVA_BIN="${JAVA:-}"
-if [ -z "$JAVA_BIN" ] && [ -n "$JAVA_HOME" ]; then
-  JAVA_BIN="$JAVA_HOME/bin/java"
-fi
-if [ -z "$JAVA_BIN" ]; then
-  JAVA_BIN="java"
-fi
-
-JAVA_OPTS_DEFAULT=(
-  "-Dnetworkaddress.cache.ttl=0"
-  "-Dnetworkaddress.cache.negative.ttl=0"
-  "-Djava.io.tmpdir=$ROOT_DIR/tmp/"
-  "--enable-native-access=ALL-UNNAMED"
-  "--add-opens=java.base/java.lang=ALL-UNNAMED"
-  "--add-opens=java.base/java.util=ALL-UNNAMED"
-  "--add-opens=java.base/java.io=ALL-UNNAMED"
-  "--illegal-access=permit"
-)
-
-# Allow user overrides (e.g., -Xms64m -Xmx1536m etc.)
-read -r -a JAVA_OPTS_USER <<< "${CRYPTAD_JAVA_OPTS:-}"
-
-exec "$JAVA_BIN" "${JAVA_OPTS_DEFAULT[@]}" "${JAVA_OPTS_USER[@]:-}" \
-  -cp "$ROOT_DIR/lib/*" \
-  network.crypta.node.NodeStarter "$@"
-
+echo "No native wrapper found or not executable: $WRAPPER" >&2
+echo "Searched in: $BIN_DIR" >&2
+echo "Please install the appropriate native wrapper for $DIST_OS/$DIST_ARCH or rebuild the distribution." >&2
+exit 1

--- a/src/main/templates/cryptad.sh.tpl
+++ b/src/main/templates/cryptad.sh.tpl
@@ -16,7 +16,7 @@ if [ ! -f "$CONF" ]; then
 fi
 
 # Friendly warning when running as root in interactive mode
-if [ "$EUID" -eq 0 ] && [ -z "$CRYPTAD_ALLOW_ROOT" ]; then
+if [ "$EUID" -eq 0 ] && [ -z "${CRYPTAD_ALLOW_ROOT:-}" ]; then
   echo "Refusing to run as root. Create a service or use a non-root user." >&2
   echo "Set CRYPTAD_ALLOW_ROOT=1 to override." >&2
   exit 1
@@ -41,7 +41,8 @@ normalize_os() {
 
 # Prefer Snap and distro hints when available
 detect_arch() {
-  local snap_arch="$SNAP_ARCH"  # set by Snap: amd64, arm64, armhf, ppc64el, s390x, riscv64
+  # Use default expansion to be compatible with 'set -u' when SNAP_ARCH is not set
+  local snap_arch="${SNAP_ARCH:-}"  # set by Snap: amd64, arm64, armhf, ppc64el, s390x, riscv64
   local dpkg_arch=""
   if command -v dpkg >/dev/null 2>&1; then
     dpkg_arch=$(dpkg --print-architecture 2>/dev/null || true)

--- a/src/main/templates/wrapper.conf.tpl
+++ b/src/main/templates/wrapper.conf.tpl
@@ -19,6 +19,10 @@ wrapper.java.mainclass=network.crypta.node.NodeStarter
 # Console and log
 wrapper.console.format=PM
 wrapper.console.loglevel=INFO
+wrapper.console.error_to_stderr=FALSE
+wrapper.console.fatal_to_stderr=FALSE
+wrapper.console.warn_to_stderr=FALSE
+
 wrapper.logfile=
 wrapper.logfile.format=LPTM
 wrapper.logfile.loglevel=INFO

--- a/src/main/templates/wrapper.conf.tpl
+++ b/src/main/templates/wrapper.conf.tpl
@@ -19,7 +19,7 @@ wrapper.java.mainclass=network.crypta.node.NodeStarter
 # Console and log
 wrapper.console.format=PM
 wrapper.console.loglevel=INFO
-wrapper.logfile=wrapper.log
+wrapper.logfile=
 wrapper.logfile.format=LPTM
 wrapper.logfile.loglevel=INFO
 wrapper.logfile.maxsize=2M
@@ -40,7 +40,6 @@ wrapper.java.library.path.1=lib
 
 # Lifecycle
 wrapper.restart.reload_configuration=TRUE
-wrapper.anchorfile=Crypta.anchor
 wrapper.anchor.poll_interval=1
 
 # Backend type


### PR DESCRIPTION
Summary
- Improve distribution packaging and startup reliability across Linux/macOS, including Snap environments.
- Make archive names predictable, reproducible, and provide both .tar.gz and .zip variants.
- Align datastore sizing with the actual target volume rather than the current working directory.

Key Changes
- Packaging (Gradle build logic)
  - Produce `cryptad-v<version>.tar.gz` and `cryptad-v<version>.zip` (drop `-dist` suffix).
  - Reproducible archives: preserve timestamps and file order.
  - Add aggregate `dist` task; wire it into `build` so standard builds emit distributables.
  - Add `printVersion` helper task.

- Startup script (`src/main/templates/cryptad.sh.tpl`)
  - Robust OS/arch detection: normalize OS; prefer `SNAP_ARCH`, then `dpkg`, then `uname` for arch.
  - Map arch names to distribution wrapper targets (e.g., Linux arm → `wrapper-linux-arm-64`, macOS universal/arm logic).
  - Guard env checks with default expansion for `set -u` compatibility (e.g., `CRYPTAD_ALLOW_ROOT`).
  - Print directory and detection diagnostics for easier support.
  - Remove plain-Java fallback; require the native wrapper (consistent with how we ship distribs).

- Wrapper configuration (`src/main/templates/wrapper.conf.tpl`)
  - Disable anchor file and explicit log file; keep console logging under wrapper control.
  - Avoid sending WARN/ERROR/FATAL to stderr by default (cleaner service logs).

- Datastore sizing (`src/main/java/network/crypta/support/io/DatastoreUtil.java`)
  - Check free space on the resolved data directory’s FileStore (via `AppEnv` + `AppDirs`/`ServiceDirs`) instead of the CWD.
  - Add JavaDoc; preserve memory-based cap.

Rationale
- Users running under Snap, system services, or non-standard shells hit brittle OS/arch and path logic. This hardens detection and makes failures actionable.
- Predictable artifact names and reproducible archives simplify release automation and downstream packaging.
- Datastore size must reflect the actual data volume; otherwise we may over- or under-provision space.

Compatibility Notes
- Requires native wrapper present for the detected `WRAP_OS-WRAP_ARCH-WRAP_BIT` target. Builds already include these; the script now fails fast with guidance if missing.
- Artifact file names change from `cryptad-dist-<ver>.tar.gz` to `cryptad-v<ver>.tar.gz` (and a new zip variant). Release/release-automation should be updated accordingly.

Testing
- Built distributables locally and launched on macOS Terminal (Bash 3.2); verified wrapper detection and diagnostics.
- Verified script behavior with `SNAP_ARCH` set and via `dpkg --print-architecture` on Linux.
- Confirmed `maxDatastoreSize()` chooses the data directory’s FileStore in both service and user modes.

Risks & Mitigations
- Environments relying on the old plain-Java fallback will now need the native wrapper installed; the script outputs targeted guidance when not found.
- Archive name change may require minor adjustments to packaging and CI release scripts.

Change Scope
- build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
- build.gradle.kts
- src/main/java/network/crypta/support/io/DatastoreUtil.java
- src/main/templates/cryptad.sh.tpl
- src/main/templates/wrapper.conf.tpl

Requested Reviews
- Distribution/Release automation
- Startup/runtime on Linux (Snap/Ubuntu and non-Snap) and macOS
- Storage/IO implications of the data-dir free space check
