### PR TITLE
feat(windows): native wrapper support and require Java 21

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,10 +96,10 @@ architecture review).
 #### Windows details
 
 - The distribution includes Windows-native wrapper binaries built from the latest release of `crypta-network/wrapper-windows-build`:
-  - `bin/wrapper-windows-amd64.exe` and `bin/wrapper-windows-arm64.exe`.
+  - `bin/wrapper-windows-x86-64.exe` and `bin/wrapper-windows-arm-64.exe`.
   - DLLs are placed directly in `lib/` as `wrapper-windows-x86-64.dll` and `wrapper-windows-arm-64.dll`.
 - The main Windows launcher is `bin/cryptad.bat`:
-  - Detects `AMD64` vs `ARM64` and runs the matching `wrapper-windows-<arch>.exe`.
+  - Detects `AMD64` vs `ARM64` and runs the matching `wrapper-windows-x86-64.exe` or `wrapper-windows-arm-64.exe`.
   - Temporarily prepends `lib/windows/<arch>` to `PATH` so `wrapper.dll` is found consistently.
   - Accepts the same arguments as the Unix script and uses `conf/wrapper.conf`.
   - The GUI launcher is `bin/cryptad-launcher.bat`.

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -239,8 +239,8 @@ val extractWindowsWrapperArm64 by
   }
 
 // Copy Windows wrapper binaries into dist:
-//  - bin/wrapper-windows-amd64.exe and bin/wrapper-windows-arm64.exe
-//  - lib/windows/amd64/wrapper.dll and lib/windows/arm64/wrapper.dll
+//  - bin/wrapper-windows-x86-64.exe and bin/wrapper-windows-arm-64.exe
+//  - lib/wrapper-windows-x86-64.dll and lib/wrapper-windows-arm-64.dll
 val copyWindowsWrapperBinaries by
   tasks.registering {
     group = "distribution"
@@ -266,12 +266,12 @@ val copyWindowsWrapperBinaries by
         return files.firstOrNull()
       }
 
-      // amd64
+      // x86_64 (amd64)
       run {
         val from = wrapperWindowsAmd64Extract.get().asFile
         val exe = pickExe(from) ?: throw GradleException("No .exe found in $from")
         val dll = pickDll(from) ?: throw GradleException("No wrapper.dll found in $from")
-        exe.copyTo(binDir.resolve("wrapper-windows-amd64.exe"), overwrite = true)
+        exe.copyTo(binDir.resolve("wrapper-windows-x86-64.exe"), overwrite = true)
         dll.copyTo(libDir.resolve("wrapper-windows-x86-64.dll"), overwrite = true)
       }
 
@@ -280,7 +280,7 @@ val copyWindowsWrapperBinaries by
         val from = wrapperWindowsArm64Extract.get().asFile
         val exe = pickExe(from) ?: throw GradleException("No .exe found in $from")
         val dll = pickDll(from) ?: throw GradleException("No wrapper.dll found in $from")
-        exe.copyTo(binDir.resolve("wrapper-windows-arm64.exe"), overwrite = true)
+        exe.copyTo(binDir.resolve("wrapper-windows-arm-64.exe"), overwrite = true)
         dll.copyTo(libDir.resolve("wrapper-windows-arm-64.dll"), overwrite = true)
       }
     }

--- a/src/main/templates/cryptad.bat.tpl
+++ b/src/main/templates/cryptad.bat.tpl
@@ -24,7 +24,9 @@ if /I "%ARCH%"=="x86" (
 )
 
 REM Prefer arch-specific wrapper exe; fallback to wrapper.exe if present
-set "WRAPPER_EXE=%BIN_DIR%\wrapper-windows-%ARCH%.exe"
+set "WRAPPER_EXE="
+if /I "%ARCH%"=="amd64" set "WRAPPER_EXE=%BIN_DIR%\wrapper-windows-x86-64.exe"
+if /I "%ARCH%"=="arm64" set "WRAPPER_EXE=%BIN_DIR%\wrapper-windows-arm-64.exe"
 if not exist "%WRAPPER_EXE%" set "WRAPPER_EXE=%BIN_DIR%\wrapper.exe"
 if not exist "%WRAPPER_EXE%" (
   echo No Windows native wrapper found in "%BIN_DIR%" for arch %ARCH% 1>&2

--- a/src/main/templates/cryptad.bat.tpl
+++ b/src/main/templates/cryptad.bat.tpl
@@ -1,0 +1,40 @@
+@echo off
+setlocal enableextensions
+REM Resolve installation root (.. from bin)
+set "SCRIPT_DIR=%~dp0"
+set "ROOT_DIR=%SCRIPT_DIR%.."
+set "BIN_DIR=%ROOT_DIR%\bin"
+set "CONF_DIR=%ROOT_DIR%\conf"
+set "LIB_DIR=%ROOT_DIR%\lib"
+
+set "CONF=%CONF_DIR%\wrapper.conf"
+if not exist "%CONF%" (
+  echo Missing configuration at "%CONF%" 1>&2
+  exit /b 1
+)
+
+REM Detect architecture (normalize to amd64/arm64)
+set "ARCH=%PROCESSOR_ARCHITECTURE%"
+if /I "%ARCH%"=="AMD64" set "ARCH=amd64"
+if /I "%ARCH%"=="ARM64" set "ARCH=arm64"
+REM Wow64 case: 32-bit process on 64-bit OS
+if /I "%ARCH%"=="x86" (
+  if /I "%PROCESSOR_ARCHITEW6432%"=="AMD64" set "ARCH=amd64"
+  if /I "%PROCESSOR_ARCHITEW6432%"=="ARM64" set "ARCH=arm64"
+)
+
+REM Prefer arch-specific wrapper exe; fallback to wrapper.exe if present
+set "WRAPPER_EXE=%BIN_DIR%\wrapper-windows-%ARCH%.exe"
+if not exist "%WRAPPER_EXE%" set "WRAPPER_EXE=%BIN_DIR%\wrapper.exe"
+if not exist "%WRAPPER_EXE%" (
+  echo No Windows native wrapper found in "%BIN_DIR%" for arch %ARCH% 1>&2
+  exit /b 1
+)
+
+REM Native DLLs are placed directly in lib as:
+REM  - wrapper-windows-x86-64.dll
+REM  - wrapper-windows-arm-64.dll
+REM They are resolved via wrapper.java.library.path=lib in wrapper.conf.
+
+REM Run Tanuki wrapper with our config
+"%WRAPPER_EXE%" -c "%CONF%" %*

--- a/src/main/templates/wrapper.conf.tpl
+++ b/src/main/templates/wrapper.conf.tpl
@@ -1,5 +1,7 @@
 # Cryptad Wrapper configuration (generated from template)
 
+wrapper.java.version.min=21
+
 # Classpath: load all jars from ../lib relative to this conf file
 wrapper.java.classpath.1=lib/*
 


### PR DESCRIPTION
Summary
- Add Windows-native wrapper support (amd64 + arm64) to Cryptad distributions.
- Introduce `bin/cryptad.bat` and update the Kotlin launcher to resolve Windows paths.
- Set minimum Java runtime to 21 in `wrapper.conf`.

What changed
- build-logic (`build-logic/src/main/kotlin/cryptad.distribution.gradle.kts`):
  - New tasks to fetch the latest Windows wrapper binaries from the newest `crypta-network/wrapper-windows-build` release, with optional `-PwrapperWinApiUrl`, `-PwrapperWinAmd64Url`, `-PwrapperWinArm64Url` overrides.
  - Extraction and copy tasks to place executables and DLLs into the dist layout:
    - `bin/wrapper-windows-x86-64.exe`, `bin/wrapper-windows-arm-64.exe`.
    - `lib/wrapper-windows-x86-64.dll`, `lib/wrapper-windows-arm-64.dll`.
  - Generate `bin/cryptad.bat` alongside existing Unix scripts during `assembleCryptadDist`.
- Launcher (`src/main/kotlin/network/crypta/launcher/LauncherUtils.kt`):
  - Path resolution now accounts for Windows: checks `cryptad.bat` near `cryptad.jar`, within `../bin/`, and fallbacks from `cwd`.
  - Updated KDoc to document Windows resolution order.
- Templates:
  - Added `src/main/templates/cryptad.bat.tpl` implementing the Windows launcher that selects the correct wrapper exe (`amd64`/`arm64`) and runs with `conf/wrapper.conf`.
  - Updated `src/main/templates/wrapper.conf.tpl` with `wrapper.java.version.min=21`.
- Docs (`AGENTS.md`):
  - Expanded Swing Launcher section with explicit Windows details and distribution packaging notes.
  - Clarified Windows executable naming to use `x86-64` / `arm-64` consistently across EXEs and DLLs.

Commits on this branch
- 4eef3ac3e1 — feat(wrapper): set minimum Java version to 21 in configuration
- f176d3011f — feat(distribution): add Windows x86_64/arm64 wrapper support
- ec976d8827 — chore(windows): rename wrapper exes to wrapper-windows-{x86-64,arm-64}.exe for consistency

Why
- Provide a first-class Windows distribution using native Tanuki wrapper binaries and architecture-aware launcher.
- Align runtime requirements with project baseline (Java 21+).

Notes for reviewers
- Windows path detection is guarded by `os.name` checks and preserves existing Unix paths.
- Distribution tasks avoid adding JSON parser dependencies; a minimal regex extracts the asset URL. Overrides are available if needed.

Testing plan (suggested)
- Build dist: `./gradlew buildJar assembleCryptadDist` (with Java 21+).
- On Windows:
  - Run `bin/cryptad.bat -c conf/wrapper.conf` from the assembled dist.
  - Verify the correct exe is selected for `AMD64` vs `ARM64`.
- On Unix:
  - Confirm no regressions to existing `bin/cryptad` and `cryptad-launcher` flows.

Checklist
- [ ] CI passes on Java 21.
- [ ] Manual smoke test on Windows amd64.
- [ ] Optional: verify ARM64 on Windows via emulator/device.
