### PR TITLE
fix(launcher,windows): graceful quit via wrapper anchor; taskkill fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ The launcher automatically starts the daemon, streams live logs, detects the FPr
 `Starting FProxy on ...:<port>`, and opens `http://localhost:<port>/` on the first successful start.
 
 Top‑row buttons and shortcuts:
-- Start/Stop: toggles the daemon (Stop sends SIGINT; waits up to 20s before forcing).
+- Start/Stop: toggles the daemon.
+  - Unix/macOS: sends SIGINT to the wrapper/JVM; waits up to ~20s before escalating (TERM→KILL).
+  - Windows: requests a graceful stop by deleting an anchor file and waits up to ~25s; only then falls back to `taskkill`.
 - Launch in Browser: enabled after the port is known (parsed from logs).
 - Quit: exits the launcher immediately (shutdown continues in background).
 
@@ -95,6 +97,13 @@ Notes
 - Live output combines the wrapper’s console with tailing of the wrapper log file when configured, so JVM logs appear
   while the wrapper is running.
 - On Unix/macOS the launcher uses a pseudo‑tty (via `script`) when available to reduce buffering.
+
+### Windows shutdown behavior
+
+- The Windows batch launcher (`bin/cryptad.bat`) passes a per‑user anchor location to the wrapper: `"wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor"`.
+- The Swing launcher requests a graceful stop by deleting that file; the Java Service Wrapper notices and shuts down the JVM cleanly (running shutdown hooks, flushing logs, etc.).
+- If the process tree is still alive after ~25 seconds, the launcher escalates to `taskkill` (first without `/F`, then with `/F`).
+- Advanced: If you need to change the anchor path, you can customize the batch file or pass a different property on the command line; a value in `wrapper.conf` (if present) is overridden by the batch property.
 
 ### Launcher script resolution
 

--- a/src/main/kotlin/network/crypta/launcher/LauncherUtils.kt
+++ b/src/main/kotlin/network/crypta/launcher/LauncherUtils.kt
@@ -87,6 +87,25 @@ fun computeWrapperLogPath(confPath: Path, logSpec: String?): Path {
 }
 
 /**
+ * Compute an effective file path declared in `wrapper.conf` taking into account
+ * `wrapper.working.dir` when the specification is relative. If `fileSpec` is null or blank, returns
+ * null.
+ */
+fun computeWrapperFilePath(confPath: Path, fileSpec: String?, workingDirSpec: String?): Path? {
+  val spec = fileSpec?.takeUnless { it.isBlank() } ?: return null
+  val p = Paths.get(spec)
+  if (p.isAbsolute) return p.normalize()
+  val base =
+    workingDirSpec
+      ?.takeUnless { it.isBlank() }
+      ?.let { wdRaw ->
+        val wd = Paths.get(wdRaw)
+        if (wd.isAbsolute) wd.normalize() else confPath.parent.resolve(wd).normalize()
+      } ?: confPath.parent
+  return base.resolve(p).normalize()
+}
+
+/**
  * Guess wrapper.conf path for a `cryptad` wrapper script path. Tries `../conf/wrapper.conf` and
  * also scans the script for an explicit `-c ".../wrapper.conf"` or `CONF=".../wrapper.conf"`.
  */

--- a/src/main/templates/cryptad.bat.tpl
+++ b/src/main/templates/cryptad.bat.tpl
@@ -38,5 +38,6 @@ REM  - wrapper-windows-x86-64.dll
 REM  - wrapper-windows-arm-64.dll
 REM They are resolved via wrapper.java.library.path=lib in wrapper.conf.
 
-REM Run Tanuki wrapper with our config
-"%WRAPPER_EXE%" -c "%CONF%" %*
+REM Run Tanuki wrapper with our config and set anchorfile to a per-user path
+REM (Command-line properties override wrapper.conf and handle spaces if quoted as one arg.)
+"%WRAPPER_EXE%" -c "%CONF%" "wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor" %*

--- a/src/test/kotlin/network/crypta/launcher/LauncherUtilsPathTest.kt
+++ b/src/test/kotlin/network/crypta/launcher/LauncherUtilsPathTest.kt
@@ -1,0 +1,29 @@
+package network.crypta.launcher
+
+import java.nio.file.Paths
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LauncherUtilsPathTest {
+  @Test
+  fun computeWrapperFilePath_resolves_relative_to_working_dir() {
+    val conf = Paths.get("/opt/cryptad/conf/wrapper.conf")
+    val p = computeWrapperFilePath(conf, "Cryptad.anchor", "..")
+    assertEquals(Paths.get("/opt/cryptad/Cryptad.anchor"), p)
+  }
+
+  @Test
+  fun computeWrapperFilePath_falls_back_to_conf_dir_when_no_working_dir() {
+    val conf = Paths.get("/opt/cryptad/conf/wrapper.conf")
+    val p = computeWrapperFilePath(conf, "../logs/wrapper.log", null)
+    assertEquals(Paths.get("/opt/cryptad/logs/wrapper.log"), p)
+  }
+
+  @Test
+  fun computeWrapperFilePath_returns_null_on_blank_spec() {
+    val conf = Paths.get("/opt/cryptad/conf/wrapper.conf")
+    val p = computeWrapperFilePath(conf, "  ", "..")
+    assertNull(p)
+  }
+}


### PR DESCRIPTION
Problem
- The Swing launcher on Windows was timing out and force-killing the batch wrapper process (cryptad.bat), which can bypass the Java Service Wrapper’s clean shutdown and lead to ungraceful exits.

Summary of changes
- cryptad.bat.tpl: Passes an anchor file path to the wrapper via CLI property:
  - "wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor"
  - Command-line property overrides any value in wrapper.conf, and handles spaces when quoted as one argument.
- LauncherController (Kotlin):
  - On stop() / shutdown(), attempts a graceful stop on Windows by deleting the anchor file, then waits up to ~25s for the wrapper/JVM to exit.
  - If the process tree is still alive after the grace period, falls back to taskkill (first without /F, then with /F) to avoid hangs.
  - Keeps Unix logic intact (SIGINT → TERM → KILL) with the existing timeouts.
  - Caches wrapper.conf path for property lookups.
- LauncherUtils (Kotlin):
  - Add computeWrapperFilePath(confPath, fileSpec, workingDirSpec) to resolve wrapper.conf-relative paths with respect to wrapper.working.dir.
- Docs:
  - README.md and AGENTS.md updated to describe Windows shutdown behavior and the command-line anchor override.
- Tests:
  - Add LauncherUtilsPathTest for computeWrapperFilePath resolution cases.

Why this approach
- The Tanuki Java Service Wrapper supports an "anchor file" contract on Windows; removing the file requests a controlled shutdown, allowing the JVM to run shutdown hooks and flush logs.
- Passing the anchor path on the command line makes it per-user and avoids hardcoding in wrapper.conf. It also ensures a known location the GUI can target and works even if wrapper.conf changes during updates.

Notes / Compatibility
- wrapper.conf no longer hardcodes wrapper.anchorfile; behavior is driven by the batch file argument. Any value written by the updater to wrapper.conf is overridden by the CLI property from cryptad.bat.
- Unix/macOS behavior unchanged.

Validation
- Built and ran the test suite locally (JUnit + kotlin-test); added unit tests for new path resolution helper.
- Manual check: launcher picks up wrapper.conf path, resolves anchor (or falls back to %LOCALAPPDATA%\Cryptad.anchor), deletes it, and waits for exit before falling back.

Follow-ups (optional)
- If desired, expose an env override for the anchor location and document it for service/deployment scenarios.
- Consider logging the resolved anchor path at start on Windows for easier diagnostics.
