### PR TITLE
Fix Windows-only test failures; normalize EOL in M3U filter

### DIFF
--- a/src/main/java/network/crypta/client/filter/M3UFilter.java
+++ b/src/main/java/network/crypta/client/filter/M3UFilter.java
@@ -155,10 +155,10 @@ public class M3UFilter implements ContentDataFilter {
                 } catch (Exception e) {
                   dos.write(badUriReplacement.getBytes(StandardCharsets.UTF_8));
                 }
-              }
-              // write the newline if we're not at EOF
-              if (readcount != -1) {
-                dos.write(nextbyte);
+                // write a canonical newline for non-empty lines (normalize EOL)
+                if (readcount != -1) {
+                  dos.write(CHAR_NEWLINE);
+                }
               }
             }
           }

--- a/src/test/java/network/crypta/client/filter/M3UFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/M3UFilterTest.java
@@ -41,7 +41,7 @@ public class M3UFilterTest {
             null,
             SCHEME_HOST_PORT,
             new GenericReadFilterCallback(new URI(BASE_URI), null, null, null));
-        String result = ibprocessed.toString();
+        String result = normalizeEol(ibprocessed.toString());
 
         assertEquals(
             original
@@ -62,6 +62,10 @@ public class M3UFilterTest {
   }
 
   protected String bucketToString(ArrayBucket bucket) throws IOException {
-    return new String(bucket.toByteArray());
+    return normalizeEol(new String(bucket.toByteArray()));
+  }
+
+  private static String normalizeEol(String s) {
+    return s.replace("\r\n", "\n");
   }
 }

--- a/src/test/java/network/crypta/clients/http/utils/PebbleUtilsTest.java
+++ b/src/test/java/network/crypta/clients/http/utils/PebbleUtilsTest.java
@@ -20,7 +20,7 @@ public class PebbleUtilsTest {
   @Test
   public void addChildAddsCorrectlyEvaluatedSimpleTemplateToHtmlNode() throws IOException {
     PebbleUtils.addChild(emptyParentNode, "pebble-utils-test-simple", model, null);
-    assertThat(emptyParentNode.generate(), equalTo("Test!\n"));
+    assertThat(normalizeEol(emptyParentNode.generate()), equalTo("Test!\n"));
   }
 
   @Test
@@ -32,4 +32,9 @@ public class PebbleUtilsTest {
 
   private final HTMLNode emptyParentNode = new HTMLNode("#");
   private final Map<String, Object> model = new HashMap<>();
+
+  private static String normalizeEol(String s) {
+    // Make assertions robust across Windows/Unix newlines
+    return s.replace("\r\n", "\n");
+  }
 }

--- a/src/test/java/network/crypta/config/CryptadConfigExpandTest.java
+++ b/src/test/java/network/crypta/config/CryptadConfigExpandTest.java
@@ -12,6 +12,6 @@ public class CryptadConfigExpandTest {
     Map<String, String> base = new HashMap<>();
     base.put("configDir", "/tmp/cfg");
     String out = CryptadConfig.expandValue("${configDir}", base);
-    assertEquals("/tmp/cfg", out);
+    assertEquals("/tmp/cfg", out.replace('\\', '/'));
   }
 }

--- a/src/test/java/network/crypta/fs/AppDirsTest.java
+++ b/src/test/java/network/crypta/fs/AppDirsTest.java
@@ -300,8 +300,9 @@ public class AppDirsTest {
     ServiceDirs svc = new ServiceDirs(env, new AppEnv(env, "Mac OS X", "root"));
     Resolved r = svc.resolve();
     assertTrue(
-        r.getConfigDir().toString().startsWith("/Library/Application Support/Cryptad/config"));
-    assertTrue(r.getLogsDir().toString().startsWith("/Library/Logs/Cryptad"));
+        norm(r.getConfigDir().toString())
+            .startsWith("/Library/Application Support/Cryptad/config"));
+    assertTrue(norm(r.getLogsDir().toString()).startsWith("/Library/Logs/Cryptad"));
   }
 
   @Test

--- a/src/test/java/network/crypta/fs/AppDirsTest.java
+++ b/src/test/java/network/crypta/fs/AppDirsTest.java
@@ -19,6 +19,10 @@ public class AppDirsTest {
 
   @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
+  private static String norm(String s) {
+    return s.replace('\\', '/');
+  }
+
   private Map<String, String> sysProps(Path home, Path tmpdir) {
     Map<String, String> p = new HashMap<>();
     p.put("user.home", home.toString());
@@ -37,8 +41,8 @@ public class AppDirsTest {
     AppEnv ae = new AppEnv(env, "Linux", "tester");
     AppDirs dirs = new AppDirs(env, sysProps(home, t), new HashMap<>(), ae);
     Resolved r = dirs.resolve();
-    assertTrue(r.getConfigDir().toString().contains(".config/cryptad/config"));
-    assertTrue(r.getDataDir().toString().contains(".local/share/cryptad/data"));
+    assertTrue(norm(r.getConfigDir().toString()).contains(".config/cryptad/config"));
+    assertTrue(norm(r.getDataDir().toString()).contains(".local/share/cryptad/data"));
     assertTrue(Files.exists(r.getConfigDir()));
   }
 
@@ -77,8 +81,9 @@ public class AppDirsTest {
     sp.put("os.name", "Mac OS X");
     AppDirs dirs = new AppDirs(env, sp, new HashMap<>(), ae);
     Resolved r = dirs.resolve();
-    assertTrue(r.getConfigDir().toString().contains("Library/Application Support/Cryptad/config"));
-    assertTrue(r.getCacheDir().toString().contains("Library/Caches/Cryptad"));
+    assertTrue(
+        norm(r.getConfigDir().toString()).contains("Library/Application Support/Cryptad/config"));
+    assertTrue(norm(r.getCacheDir().toString()).contains("Library/Caches/Cryptad"));
   }
 
   @Test
@@ -185,7 +190,7 @@ public class AppDirsTest {
     sp.put("os.name", "Mac OS X");
     AppDirs dirs = new AppDirs(env, sp, new HashMap<>(), ae);
     Resolved r = dirs.resolve();
-    assertTrue(r.getConfigDir().toString().contains("/cryptad/config"));
+    assertTrue(norm(r.getConfigDir().toString()).contains("/cryptad/config"));
   }
 
   @Test
@@ -204,10 +209,8 @@ public class AppDirsTest {
     sp.put("os.name", "Windows 10");
     AppDirs dirs = new AppDirs(env, sp, new HashMap<>(), ae);
     Resolved r = dirs.resolve();
-    assertTrue(
-        r.getConfigDir().toString().contains("Cryptad\\/config".replace("\\/", "/"))
-            || r.getConfigDir().toString().contains("Cryptad/config"));
-    assertTrue(r.getCacheDir().toString().contains("Cryptad"));
+    assertTrue(norm(r.getConfigDir().toString()).contains("/Cryptad/config"));
+    assertTrue(norm(r.getCacheDir().toString()).contains("/Cryptad"));
   }
 
   @Test
@@ -243,8 +246,7 @@ public class AppDirsTest {
     Resolved r = dirs.resolve();
     assertTrue(r.getConfigDir().startsWith(xdgConfig));
     assertTrue(
-        r.getRunDir()
-            .toString()
+        norm(r.getRunDir().toString())
             .contains("/app/org.example.Cryptad/" + network.crypta.fs.DirsKt.APP_RUNTIME_SUBPATH));
   }
 


### PR DESCRIPTION
Summary
- Fix Windows-only failures by making assertions OS-agnostic and normalizing line endings where appropriate.
- Normalize EOL handling in M3UFilter output to write a canonical LF for non-empty lines and avoid emitting a newline for CRLF-only empty lines. This prevents extra blank lines on Windows and makes output deterministic across platforms.

Changes
- test(fs): normalize separators and expectations in AppDirsTest (mac daemon path, Windows casing checks)
- test(http): normalize CRLF to LF in PebbleUtilsTest simple template assertion
- test(filter): normalize EOL in M3UFilterTest expected/actual comparison
- test(config): normalize separators in CryptadConfigExpandTest assertion
- fix(m3u): emit LF for non-empty lines and skip newline for empty CRLF lines; no behavior change to URLs themselves

Validation
- Local run on Java 21: all tests passed (`./gradlew --parallel test`).
- Verified failures were Windows-only before; confirmed green locally after changes.

Notes
- The M3U filter change standardizes playlist EOLs to LF, independent of host OS. External behavior: clients reading playlists must tolerate LF (most do). This eliminates duplicate blank lines on Windows.

Request
- Please review and merge into `develop`. CI should validate across environments.
