### PR TITLE
fix(dist): robust Windows wrapper asset detection and inclusion

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -250,10 +250,8 @@ val extractWindowsWrapperAmd64 by
     doFirst {
       // Configure sources just-in-time to account for the actual downloaded format
       val f = wrapperWindowsAmd64Archive.get().asFile
-      println("[dist][debug] Extracting AMD64 from ${f.absolutePath}")
       fromAutoArchive(f)
     }
-    doLast { println("[dist][debug] Extracted AMD64 into ${wrapperWindowsAmd64Extract.get().asFile.absolutePath}") }
   }
 
 val extractWindowsWrapperArm64 by
@@ -266,10 +264,8 @@ val extractWindowsWrapperArm64 by
     into(wrapperWindowsArm64Extract)
     doFirst {
       val f = wrapperWindowsArm64Archive.get().asFile
-      println("[dist][debug] Extracting ARM64 from ${f.absolutePath}")
       fromAutoArchive(f)
     }
-    doLast { println("[dist][debug] Extracted ARM64 into ${wrapperWindowsArm64Extract.get().asFile.absolutePath}") }
   }
 
 // Copy Windows wrapper binaries into dist:
@@ -289,8 +285,6 @@ val copyWindowsWrapperBinaries by
 
       val amd64Archive = wrapperWindowsAmd64Archive.get().asFile
       val arm64Archive = wrapperWindowsArm64Archive.get().asFile
-      println("[dist][debug] AMD64 archive: ${amd64Archive.absolutePath} (exists=${amd64Archive.exists()}, size=${amd64Archive.length()} bytes)")
-      println("[dist][debug] ARM64 archive: ${arm64Archive.absolutePath} (exists=${arm64Archive.exists()}, size=${arm64Archive.length()} bytes)")
 
       fun fileTreeFromArchive(file: File): FileTree {
         val magic = ByteArray(2)
@@ -336,8 +330,7 @@ val copyWindowsWrapperBinaries by
           val listing = firstN(tree, 64)
           throw GradleException("No DLL found inside amd64 archive. Entries (first 64):\n$listing")
         }
-        println("[dist][debug] Selected amd64 exe: ${exe}")
-        println("[dist][debug] Selected amd64 dll: ${dll}")
+        
         exe.copyTo(binDir.resolve("wrapper-windows-x86-64.exe"), overwrite = true)
         dll.copyTo(libDir.resolve("wrapper-windows-x86-64.dll"), overwrite = true)
       }
@@ -353,8 +346,7 @@ val copyWindowsWrapperBinaries by
           val listing = firstN(tree, 64)
           throw GradleException("No DLL found inside arm64 archive. Entries (first 64):\n$listing")
         }
-        println("[dist][debug] Selected arm64 exe: ${exe}")
-        println("[dist][debug] Selected arm64 dll: ${dll}")
+        
         exe.copyTo(binDir.resolve("wrapper-windows-arm-64.exe"), overwrite = true)
         dll.copyTo(libDir.resolve("wrapper-windows-arm-64.dll"), overwrite = true)
       }

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -243,11 +243,17 @@ val extractWindowsWrapperAmd64 by
     group = "distribution"
     description = "Extracts Windows amd64 wrapper archive"
     dependsOn(downloadWindowsWrapper)
+    // Declare inputs/outputs so Gradle executes even when sources are configured late
+    inputs.file(wrapperWindowsAmd64Archive)
+    outputs.dir(wrapperWindowsAmd64Extract)
     into(wrapperWindowsAmd64Extract)
     doFirst {
       // Configure sources just-in-time to account for the actual downloaded format
-      fromAutoArchive(wrapperWindowsAmd64Archive.get().asFile)
+      val f = wrapperWindowsAmd64Archive.get().asFile
+      println("[dist][debug] Extracting AMD64 from ${f.absolutePath}")
+      fromAutoArchive(f)
     }
+    doLast { println("[dist][debug] Extracted AMD64 into ${wrapperWindowsAmd64Extract.get().asFile.absolutePath}") }
   }
 
 val extractWindowsWrapperArm64 by
@@ -255,10 +261,15 @@ val extractWindowsWrapperArm64 by
     group = "distribution"
     description = "Extracts Windows arm64 wrapper archive"
     dependsOn(downloadWindowsWrapper)
+    inputs.file(wrapperWindowsArm64Archive)
+    outputs.dir(wrapperWindowsArm64Extract)
     into(wrapperWindowsArm64Extract)
     doFirst {
-      fromAutoArchive(wrapperWindowsArm64Archive.get().asFile)
+      val f = wrapperWindowsArm64Archive.get().asFile
+      println("[dist][debug] Extracting ARM64 from ${f.absolutePath}")
+      fromAutoArchive(f)
     }
+    doLast { println("[dist][debug] Extracted ARM64 into ${wrapperWindowsArm64Extract.get().asFile.absolutePath}") }
   }
 
 // Copy Windows wrapper binaries into dist:

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -213,7 +213,7 @@ val downloadWindowsWrapper by
   }
 
 // Helper to detect archive type and configure extraction dynamically at execution time.
-fun org.gradle.api.tasks.Copy.fromAutoArchive(file: File) {
+fun Copy.fromAutoArchive(file: File) {
   // Detect by magic bytes: ZIP starts with 'PK', GZIP starts with 0x1F 0x8B.
   val magic = ByteArray(2)
   file.inputStream().use { it.read(magic) }

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -1,16 +1,7 @@
-import java.io.File
 import java.net.HttpURLConnection
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import javax.inject.Inject
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.TaskAction
 
 plugins { java }
 
@@ -187,7 +178,7 @@ abstract class DownloadWindowsWrapper @Inject constructor() : DefaultTask() {
     val json = httpGet(apiUrl)
     // Very small JSON picker: find the first browser_download_url for Windows and the arch hints
     // We avoid adding a JSON parser dependency here.
-    val re = Regex("""\"browser_download_url\"\s*:\s*\"([^\"]+)\"""", RegexOption.IGNORE_CASE)
+    val re = Regex(""""browser_download_url"\s*:\s*"([^"]+)"""", RegexOption.IGNORE_CASE)
     val all = re.findAll(json).map { it.groupValues[1] }.toList()
     val candidate =
       all.firstOrNull { u ->
@@ -305,16 +296,19 @@ val copyWindowsWrapperBinaries by
         val exeFiles = tree.matching { include("**/*.exe") }.files.toList()
         if (exeFiles.isEmpty()) return null
         val lower = exeFiles.associateBy { it.name.lowercase() }
-        val prefs = listOf("wrapper-windows-x86-64.exe", "wrapper-windows-arm-64.exe", "wrapper.exe")
+        val prefs =
+          listOf("wrapper-windows-x86-64.exe", "wrapper-windows-arm-64.exe", "wrapper.exe")
         for (p in prefs) if (p in lower) return lower[p]
-        return exeFiles.firstOrNull { it.name.lowercase().startsWith("wrapper") } ?: exeFiles.first()
+        return exeFiles.firstOrNull { it.name.lowercase().startsWith("wrapper") }
+          ?: exeFiles.first()
       }
 
       fun pickDll(tree: FileTree): File? {
         val dllFiles = tree.matching { include("**/*.dll") }.files.toList()
         if (dllFiles.isEmpty()) return null
         val lower = dllFiles.associateBy { it.name.lowercase() }
-        val prefs = listOf("wrapper.dll", "wrapper-windows-x86-64.dll", "wrapper-windows-arm-64.dll")
+        val prefs =
+          listOf("wrapper.dll", "wrapper-windows-x86-64.dll", "wrapper-windows-arm-64.dll")
         for (p in prefs) if (p in lower) return lower[p]
         return dllFiles.firstOrNull { it.name.lowercase().contains("wrapper") } ?: dllFiles.first()
       }
@@ -322,15 +316,23 @@ val copyWindowsWrapperBinaries by
       // amd64
       run {
         val tree = fileTreeFromArchive(amd64Archive)
-        val exe = pickExe(tree) ?: run {
-          val listing = firstN(tree, 64)
-          throw GradleException("No .exe found inside amd64 archive. Entries (first 64):\n$listing")
-        }
-        val dll = pickDll(tree) ?: run {
-          val listing = firstN(tree, 64)
-          throw GradleException("No DLL found inside amd64 archive. Entries (first 64):\n$listing")
-        }
-        
+        val exe =
+          pickExe(tree)
+            ?: run {
+              val listing = firstN(tree, 64)
+              throw GradleException(
+                "No .exe found inside amd64 archive. Entries (first 64):\n$listing"
+              )
+            }
+        val dll =
+          pickDll(tree)
+            ?: run {
+              val listing = firstN(tree, 64)
+              throw GradleException(
+                "No DLL found inside amd64 archive. Entries (first 64):\n$listing"
+              )
+            }
+
         exe.copyTo(binDir.resolve("wrapper-windows-x86-64.exe"), overwrite = true)
         dll.copyTo(libDir.resolve("wrapper-windows-x86-64.dll"), overwrite = true)
       }
@@ -338,15 +340,23 @@ val copyWindowsWrapperBinaries by
       // arm64
       run {
         val tree = fileTreeFromArchive(arm64Archive)
-        val exe = pickExe(tree) ?: run {
-          val listing = firstN(tree, 64)
-          throw GradleException("No .exe found inside arm64 archive. Entries (first 64):\n$listing")
-        }
-        val dll = pickDll(tree) ?: run {
-          val listing = firstN(tree, 64)
-          throw GradleException("No DLL found inside arm64 archive. Entries (first 64):\n$listing")
-        }
-        
+        val exe =
+          pickExe(tree)
+            ?: run {
+              val listing = firstN(tree, 64)
+              throw GradleException(
+                "No .exe found inside arm64 archive. Entries (first 64):\n$listing"
+              )
+            }
+        val dll =
+          pickDll(tree)
+            ?: run {
+              val listing = firstN(tree, 64)
+              throw GradleException(
+                "No DLL found inside arm64 archive. Entries (first 64):\n$listing"
+              )
+            }
+
         exe.copyTo(binDir.resolve("wrapper-windows-arm-64.exe"), overwrite = true)
         dll.copyTo(libDir.resolve("wrapper-windows-arm-64.dll"), overwrite = true)
       }


### PR DESCRIPTION
Summary
- Make Windows wrapper asset handling in the distribution more robust and format-agnostic.
- Ensure wrapper executables/DLLs are reliably included in `cryptad-dist` for both AMD64 and ARM64.

Key Changes
- Download GitHub release assets to neutral filenames (`*.bin`) and auto‑detect archive type (ZIP vs TAR.GZ) via magic bytes.
- Add `fromAutoArchive` helper and use lazy configuration (`doFirst`) to set `Copy` sources based on detected type.
- Declare `inputs.file`/`outputs.dir` for extract/copy tasks so Gradle executes them correctly and supports incremental builds.
- Rework `copyWindowsWrapperBinaries` to read directly from the downloaded archive trees; no pre‑extraction directories required.
- Resilient selection of `*.exe` and `*.dll`:
  - Prefer stable names: `wrapper-windows-{x86-64,arm-64}.exe`, fallback to any `wrapper*.exe` or first `*.exe`.
  - Accept `wrapper.dll` and arch‑suffixed DLLs (`wrapper-windows-{x86-64,arm-64}.dll`).
  - On failure, include a short listing of entries to aid debugging.
- Cleanup: remove redundant qualifier, minor reformatting, and drop leftover debug prints.

Files Changed
- `build-logic/src/main/kotlin/cryptad.distribution.gradle.kts` (±118/−40)

Motivation & Impact
- Fix cases where Windows assets switch between `.zip` and `.tar.gz` without notice.
- Avoid brittle assumptions about extracted directory shapes.
- Improve diagnostics when assets are missing or layouts change.
- Should stabilize Windows distribution assembly on CI and local machines.

Testing Notes
- Locally: `./gradlew assembleCryptadDist -PuseDummyCryptad=true` (requests dummy wrapper; good for quick iteration).
- Inspect `build/cryptad-dist/bin/` and `build/cryptad-dist/lib/` for the expected `wrapper-windows-*.exe` and DLLs.

Compatibility
- No runtime behavior changes to Cryptad itself; build‑logic only.
- No breaking API changes.

Checklist
- [x] Builds locally on Java 21+
- [x] Covers AMD64 and ARM64 Windows assets
- [x] Adds clear diagnostic messages for missing assets
- [ ] CI green (will validate in PR)
