### PR TITLE
dist: ensure Windows wrapper binaries persist; fix task ordering and outputs

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -1,4 +1,3 @@
-import java.io.File
 import java.net.HttpURLConnection
 import java.net.URI
 import java.nio.file.Files
@@ -592,12 +591,13 @@ val cleanCryptadDist by
     group = "distribution"
     description = "Cleans the Cryptad distribution directory"
     delete(wrapperDistDir)
-    delete(layout.buildDirectory.dir("wrapper-dist"))
   }
 
-tasks.named("assembleCryptadDist") { dependsOn(cleanCryptadDist) }
+assembleCryptadDist { dependsOn(cleanCryptadDist) }
 
 copyWrapperBinaries { dependsOn(cleanCryptadDist) }
+
+copyWindowsWrapperBinaries { dependsOn(cleanCryptadDist) }
 
 prepareWrapperLibs { dependsOn(cleanCryptadDist) }
 

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -558,7 +558,25 @@ val assembleCryptadDist by
       generateWrapperLaunchers,
     )
     doLast {
-      println("Cryptad distribution assembled at: ${wrapperDistDir.get().asFile.absolutePath}")
+      val distRoot = wrapperDistDir.get().asFile
+      println("Cryptad distribution assembled at: ${distRoot.absolutePath}")
+
+      if (!distRoot.exists()) {
+        println("[dist] WARNING: distribution directory not found: ${distRoot.absolutePath}")
+        return@doLast
+      }
+
+      // Recursively list all files under build/cryptad-dist with paths relative to the root
+      val files =
+        distRoot
+          .walkTopDown()
+          .filter { it.isFile }
+          .map { it.relativeTo(distRoot).invariantSeparatorsPath }
+          .toList()
+          .sorted()
+
+      println("[dist] cryptad-dist contents (" + files.size + " files):")
+      files.forEach { rel -> println("  $rel") }
     }
   }
 

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -14,23 +14,6 @@ val wrapperWorkDir = layout.buildDirectory.dir("wrapper")
 val wrapperExtractDir = layout.buildDirectory.dir("wrapper/extracted")
 val wrapperDistDir = layout.buildDirectory.dir("cryptad-dist")
 
-// Common: recursively list files under the distribution directory
-fun printCryptadDistContents(distRoot: File, label: String) {
-  if (!distRoot.exists()) {
-    println("[dist] $label: WARNING: distribution directory not found: ${distRoot.absolutePath}")
-    return
-  }
-  val files =
-    distRoot
-      .walkTopDown()
-      .filter { it.isFile }
-      .map { it.relativeTo(distRoot).invariantSeparatorsPath }
-      .toList()
-      .sorted()
-  println("[dist] $label: cryptad-dist contents (" + files.size + " files):")
-  files.forEach { rel -> println("  $rel") }
-}
-
 // Windows wrapper binaries are not present in the delta pack. We fetch them from the latest
 // release of crypta-network/wrapper-windows-build.
 val wrapperWindowsRepo = "crypta-network/wrapper-windows-build"
@@ -151,7 +134,6 @@ val copyWrapperBinaries by
       // Drop 32-bit binaries
       exclude("*-x86-32*", "*-universal-32*", "*-armel-32*", "*-armhf-32*")
     }
-    doLast { printCryptadDistContents(wrapperDistDir.get().asFile, "after copyWrapperBinaries") }
   }
 
 // --- Windows wrapper: locate asset URLs (newest GitHub release) and download ---
@@ -444,9 +426,6 @@ val copyWindowsWrapperBinaries by
         println("[dist] arm64: copied exe -> ${exeOut.absolutePath}")
         println("[dist] arm64: copied dll -> ${dllOut.absolutePath}")
       }
-      // After copying both amd64 and arm64 binaries, print a recursive listing
-      printCryptadDistContents(wrapperDistDir.get().asFile, "after copyWindowsWrapperBinaries")
-
       println("[dist] copyWindowsWrapperBinaries: done")
     }
   }
@@ -485,7 +464,6 @@ val prepareWrapperLibs by
       include("wrapper*.jar")
       rename { "wrapper.jar" }
     }
-    doLast { printCryptadDistContents(wrapperDistDir.get().asFile, "after prepareWrapperLibs") }
   }
 
 // Generate conf/wrapper.conf from template
@@ -505,7 +483,6 @@ val generateWrapperConf by
       val confFile = confDirFile.resolve("wrapper.conf")
       confFile.writeText(template)
       println("Generated " + confFile.absolutePath)
-      printCryptadDistContents(wrapperDistDir.get().asFile, "after generateWrapperConf")
     }
   }
 
@@ -570,7 +547,6 @@ val generateWrapperLaunchers by
           println("WARNING: -PuseDummyCryptad was set but tools/cryptad-dummy.sh not found")
         }
       }
-      printCryptadDistContents(wrapperDistDir.get().asFile, "after generateWrapperLaunchers")
     }
   }
 
@@ -588,7 +564,6 @@ val assembleCryptadDist by
     )
     doLast {
       println("Cryptad distribution assembled at: ${wrapperDistDir.get().asFile.absolutePath}")
-      printCryptadDistContents(wrapperDistDir.get().asFile, "after assembleCryptadDist")
     }
   }
 

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -317,6 +317,12 @@ val copyWindowsWrapperBinaries by
     description = "Copies Windows wrapper executables and DLLs into the distribution"
     // Only need downloads; we parse archives directly (no pre-extract step required)
     dependsOn(downloadWindowsWrapper)
+    // Declare outputs so other Copy/Sync tasks don’t treat these as unknown files
+    val binExeX64 = wrapperDistDir.map { it.file("bin/wrapper-windows-x86-64.exe") }
+    val binExeArm = wrapperDistDir.map { it.file("bin/wrapper-windows-arm-64.exe") }
+    val libDllX64 = wrapperDistDir.map { it.file("lib/wrapper-windows-x86-64.dll") }
+    val libDllArm = wrapperDistDir.map { it.file("lib/wrapper-windows-arm-64.dll") }
+    outputs.files(binExeX64, binExeArm, libDllX64, libDllArm)
     doLast {
       val binDir = wrapperDistDir.get().dir("bin").asFile
       val libDir = wrapperDistDir.get().dir("lib").asFile

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -599,6 +599,15 @@ copyWrapperBinaries { dependsOn(cleanCryptadDist) }
 
 copyWindowsWrapperBinaries { dependsOn(cleanCryptadDist) }
 
+// Ensure Windows binaries are copied after other bin/lib population tasks,
+// so they are not inadvertently removed/overwritten by later copies.
+copyWindowsWrapperBinaries {
+  mustRunAfter(copyWrapperBinaries)
+  mustRunAfter(prepareWrapperLibs)
+  mustRunAfter(generateWrapperConf)
+  mustRunAfter(generateWrapperLaunchers)
+}
+
 prepareWrapperLibs { dependsOn(cleanCryptadDist) }
 
 generateWrapperConf { dependsOn(cleanCryptadDist) }

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -421,6 +421,22 @@ val copyWindowsWrapperBinaries by
         println("[dist] arm64: copied exe -> ${exeOut.absolutePath}")
         println("[dist] arm64: copied dll -> ${dllOut.absolutePath}")
       }
+      // After copying both amd64 and arm64 binaries, print a recursive listing
+      val distRoot = wrapperDistDir.get().asFile
+      if (distRoot.exists()) {
+        val files =
+          distRoot
+            .walkTopDown()
+            .filter { it.isFile }
+            .map { it.relativeTo(distRoot).invariantSeparatorsPath }
+            .toList()
+            .sorted()
+        println("[dist] cryptad-dist contents (" + files.size + " files):")
+        files.forEach { rel -> println("  $rel") }
+      } else {
+        println("[dist] WARNING: distribution directory not found: ${distRoot.absolutePath}")
+      }
+
       println("[dist] copyWindowsWrapperBinaries: done")
     }
   }
@@ -557,27 +573,7 @@ val assembleCryptadDist by
       generateWrapperConf,
       generateWrapperLaunchers,
     )
-    doLast {
-      val distRoot = wrapperDistDir.get().asFile
-      println("Cryptad distribution assembled at: ${distRoot.absolutePath}")
-
-      if (!distRoot.exists()) {
-        println("[dist] WARNING: distribution directory not found: ${distRoot.absolutePath}")
-        return@doLast
-      }
-
-      // Recursively list all files under build/cryptad-dist with paths relative to the root
-      val files =
-        distRoot
-          .walkTopDown()
-          .filter { it.isFile }
-          .map { it.relativeTo(distRoot).invariantSeparatorsPath }
-          .toList()
-          .sorted()
-
-      println("[dist] cryptad-dist contents (" + files.size + " files):")
-      files.forEach { rel -> println("  $rel") }
-    }
+    doLast { println("Cryptad distribution assembled at: ${wrapperDistDir.get().asFile.absolutePath}") }
   }
 
 val cleanCryptadDist by

--- a/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
@@ -309,6 +309,33 @@ val copyWindowsWrapperBinaries by
       val amd64Archive = wrapperWindowsAmd64Archive.get().asFile
       val arm64Archive = wrapperWindowsArm64Archive.get().asFile
 
+      println("[dist] copyWindowsWrapperBinaries: starting")
+      fun humanSize(bytes: Long): String {
+        val units = arrayOf("B", "KB", "MB", "GB")
+        var b = bytes.toDouble()
+        var i = 0
+        while (b >= 1024 && i < units.lastIndex) {
+          b /= 1024
+          i++
+        }
+        return String.format("%.1f %s", b, units[i])
+      }
+      try {
+        val amdType = detectArchiveType(amd64Archive)
+        val armType = detectArchiveType(arm64Archive)
+        println(
+          "[dist] windows archives:\n" +
+            "  amd64: ${amd64Archive.absolutePath} (" +
+            humanSize(amd64Archive.length()) +
+            ", type=$amdType)\n" +
+            "  arm64: ${arm64Archive.absolutePath} (" +
+            humanSize(arm64Archive.length()) +
+            ", type=$armType)"
+        )
+      } catch (e: Exception) {
+        println("[dist] archive detection warning: ${e.message}")
+      }
+
       fun firstN(tree: FileTree, n: Int): String =
         tree.files.take(n).joinToString("\n") { f -> f.toString() }
 
@@ -336,6 +363,7 @@ val copyWindowsWrapperBinaries by
       // amd64
       run {
         val tree = fileTreeFromArchive(amd64Archive)
+        println("[dist] amd64: sample entries:\n" + firstN(tree, 12))
         val exe =
           pickExe(tree)
             ?: run {
@@ -353,13 +381,20 @@ val copyWindowsWrapperBinaries by
               )
             }
 
-        exe.copyTo(binDir.resolve("wrapper-windows-x86-64.exe"), overwrite = true)
-        dll.copyTo(libDir.resolve("wrapper-windows-x86-64.dll"), overwrite = true)
+        println("[dist] amd64: selected exe=${exe.absolutePath}")
+        println("[dist] amd64: selected dll=${dll.absolutePath}")
+        val exeOut = binDir.resolve("wrapper-windows-x86-64.exe")
+        val dllOut = libDir.resolve("wrapper-windows-x86-64.dll")
+        exe.copyTo(exeOut, overwrite = true)
+        dll.copyTo(dllOut, overwrite = true)
+        println("[dist] amd64: copied exe -> ${exeOut.absolutePath}")
+        println("[dist] amd64: copied dll -> ${dllOut.absolutePath}")
       }
 
       // arm64
       run {
         val tree = fileTreeFromArchive(arm64Archive)
+        println("[dist] arm64: sample entries:\n" + firstN(tree, 12))
         val exe =
           pickExe(tree)
             ?: run {
@@ -377,9 +412,16 @@ val copyWindowsWrapperBinaries by
               )
             }
 
-        exe.copyTo(binDir.resolve("wrapper-windows-arm-64.exe"), overwrite = true)
-        dll.copyTo(libDir.resolve("wrapper-windows-arm-64.dll"), overwrite = true)
+        println("[dist] arm64: selected exe=${exe.absolutePath}")
+        println("[dist] arm64: selected dll=${dll.absolutePath}")
+        val exeOut = binDir.resolve("wrapper-windows-arm-64.exe")
+        val dllOut = libDir.resolve("wrapper-windows-arm-64.dll")
+        exe.copyTo(exeOut, overwrite = true)
+        dll.copyTo(dllOut, overwrite = true)
+        println("[dist] arm64: copied exe -> ${exeOut.absolutePath}")
+        println("[dist] arm64: copied dll -> ${dllOut.absolutePath}")
       }
+      println("[dist] copyWindowsWrapperBinaries: done")
     }
   }
 


### PR DESCRIPTION
Summary
- Prevents Windows wrapper EXEs/DLLs from being removed during assemble.
- Fixes ordering and declares explicit task outputs so Copy cleanup won’t delete Windows assets.
- Removes temporary debug listings added during investigation.

Background
On GitHub Actions (Windows), after copyWindowsWrapperBinaries wrote:
- bin/wrapper-windows-x86-64.exe
- bin/wrapper-windows-arm-64.exe
(and DLLs into lib/)

copyWrapperBinaries subsequently ran and the two EXEs disappeared from build/cryptad-dist/bin, while the DLLs remained. This did not reproduce consistently on a local Windows 11 ARM box.

Root cause
Gradle’s Copy task may perform stale output cleanup in its destination. Files not tracked as outputs of the running task can be removed when the destination is reconciled. Because copyWindowsWrapperBinaries previously wrote EXE/DLLs without declaring them as outputs, a later Copy into bin/ could treat them as foreign and delete them on CI (fresh state). Locally, prior state often prevents cleanup from biting, hence the discrepancy.

What’s changed
- Task outputs (new):
  - copyWindowsWrapperBinaries now declares outputs:
    - bin/wrapper-windows-x86-64.exe
    - bin/wrapper-windows-arm-64.exe
    - lib/wrapper-windows-x86-64.dll
    - lib/wrapper-windows-arm-64.dll
- Ordering (new):
  - copyWindowsWrapperBinaries mustRunAfter:
    - copyWrapperBinaries
    - prepareWrapperLibs
    - generateWrapperConf
    - generateWrapperLaunchers
  - copyWindowsWrapperBinaries dependsOn(cleanCryptadDist) so clean cannot interleave afterward and wipe files.
- Debug clean-up:
  - Removed the temporary "printCryptadDistContents" helper and all call sites that were added to understand the CI behavior.

Why this works
- Declaring outputs makes Gradle treat the Windows EXE/DLLs as legitimate artifacts of a task; downstream Copy tasks won’t wipe them as stale.
- Placing Windows copies last ensures no subsequent Copy will overwrite or reinitialize bin/ afterward.

Scope
- Only build-logic is touched: build-logic/src/main/kotlin/cryptad.distribution.gradle.kts
- No runtime behavior changes to the daemon; only distribution assembly is affected.

Testing
- CI: In run 17479417507 the EXEs vanished after copyWrapperBinaries; with these changes they should persist through assemble. A follow-up workflow run in crypta-network/wininstaller-innosetup should show the EXEs present in build/cryptad-dist/bin at the end.
- Local: Verified sequence on Windows behaves as expected.

Commits
- 1ab1b9d07d: chore(dist): remove printCryptadDistContents and all call sites
- 1cac0921c7: fix(dist): declare Windows exe/dll as task outputs to prevent Copy cleanup from deleting them
- b50222c11a: fix(dist): enforce ordering so copyWindowsWrapperBinaries runs last (mustRunAfter bin/lib population)
- 1003d005a9: fix(dist): ensure copyWindowsWrapperBinaries runs after cleanCryptadDist to prevent asset loss
- 0f0429814d: chore(dist): factor file listing into helper and print after key dist tasks
- 6f07355509: chore(dist): move cryptad-dist listing to copyWindowsWrapperBinaries
- f51a36b57b: chore(dist): list cryptad-dist contents after assembly
- 10c3d48477: chore(dist): add debug prints in copyWindowsWrapperBinaries

Notes
- If a future task needs to write to the same destination, consider using Sync with a preserve clause for cross-task assets, or consolidate into a single Sync that assembles bin/ and lib/ in one pass.