### PR TITLE
build(jpackage): make build also produce Linux DEB/RPM installers when tools exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ image bundles a minimal runtime (from our jlink flow) and the portable `cryptad-
 start/stop the wrapper reliably.
 
 - Tasks:
-  - `./gradlew build` → builds the jpackage app image and enriches it with `cryptad-dist` (does not build installers).
+  - `./gradlew build` → builds the jpackage app image and enriches it with `cryptad-dist`. On Linux, it also builds native installers (DEB/RPM) when `dpkg-deb`/`rpmbuild` are available; missing tools cause those installer tasks to be skipped, not failed.
   - `./gradlew jpackageImageCryptad` → builds only the app image under `build/jpackage/`.
   - `./gradlew jpackageInstallerCryptad` → builds a native installer for the current OS (macOS: `.dmg`; Linux: `.deb` or `.rpm` when `dpkg-deb`/`rpmbuild` is available). Not available on Windows.
   - Linux type override: pass `-PlinuxInstaller=<deb|rpm>` (or set env `CRYPTA_LINUX_INSTALLER`) to force installer type. When both are available, RPM is preferred by default.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ bundles the portable distribution under `app/cryptad-dist/` so the GUI can invok
 Commands
 
 ```bash
-# Build includes the jpackage app image (no installer by default)
+# Build includes the jpackage app image.
+# On Linux, it also builds native installers (DEB/RPM) when tooling is present
+# (`dpkg-deb` and/or `rpmbuild`). On macOS, installers are not built by `build`.
 ./gradlew build
 
 # App image only
@@ -292,6 +294,8 @@ Linux notes
 - RPM builds require `rpmbuild` to be installed and on PATH.
 - When both `dpkg-deb` and `rpmbuild` are installed, the default task prefers RPM. You can force DEB/RPM using the
   tasks above or `-PlinuxInstaller=<deb|rpm>`.
+- The `build` task on Linux now depends on building all available Linux installers (DEB/RPM) and will skip any
+  installer type whose tool is missing.
 
 Linux behavior and service
 

--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -108,7 +108,15 @@ val prepareJpackageResources by
       // Ensure Linux maintainer scripts are executable when present
       if (currentOs() == "linux") {
         val res = jpackageResourcesDir.get().asFile
-        listOf("preinst", "prerm", "postinst", "postrm", "postinstall", "postuninstall", "lib/crypta-common.sh")
+        listOf(
+            "preinst",
+            "prerm",
+            "postinst",
+            "postrm",
+            "postinstall",
+            "postuninstall",
+            "lib/crypta-common.sh",
+          )
           .map { File(res, it) }
           .filter { it.isFile }
           .forEach { it.setExecutable(true, true) }
@@ -558,4 +566,10 @@ val jpackageInstallerLinuxAll by
 
 // Ensure the built app image is fully usable by default builds
 // (copies cryptad-dist into the image and patches launcher cfg).
-tasks.named("build") { dependsOn(enrichAppImageWithDist) }
+tasks.named("build") {
+  dependsOn(enrichAppImageWithDist)
+  // On Linux, also build native installers (DEB/RPM) when the host has the tools.
+  if (currentOs() == "linux") {
+    dependsOn(jpackageInstallerLinuxAll)
+  }
+}


### PR DESCRIPTION
Summary
- Wire `build` to also run `jpackageInstallerLinuxAll` on Linux hosts.
- Keeps existing behavior on macOS/Windows: `build` produces the app image only; installers are opt-in (`jpackageInstallerCryptad`).
- Updates README and AGENTS to document the new behavior and Linux expectations.

Details
- Task changes (in build-logic/cryptad.jpackage.gradle.kts):
  - `tasks.named("build")` now depends on `enrichAppImageWithDist` (unchanged) and, when `currentOs()=="linux"`, on `jpackageInstallerLinuxAll`.
  - `jpackageInstallerLinuxAll` chains `jpackageInstallerDeb` and `jpackageInstallerRpm`. Each task `onlyIf` checks for required tooling (`dpkg-deb` or `rpmbuild`), so missing tools skip rather than fail the build.
- No Windows installer tasks are introduced; Windows builds continue to produce only the app image.
- Docs clarify outputs and how to force a specific Linux type via `-PlinuxInstaller=<deb|rpm>`.

Why
- Improves developer/CI ergonomics on Linux by producing installable packages in a single step.
- Keeps cross-platform behavior predictable and non-breaking (installers remain Linux-only).

Testing
- macOS: Verified `./gradlew build` builds the app image and patches `Crypta.cfg` (no installer built on macOS). SHA-256 printed for `cryptad.jar` as before.
- Linux: Expected outputs under `build/jpackage/` when tools are present:
  - `Crypta-<version>.deb` (requires `dpkg-deb`)
  - `Crypta-<version>.rpm` (requires `rpmbuild`)
- Both packages are built when both tools exist; otherwise only those with available tools.

Risk/Compatibility
- No impact to runtime code or Windows builds.
- Installer tasks are guarded by tooling presence; no-op on unsupported hosts.

Follow-ups (optional)
- Add a CI Linux matrix job to exercise DEB and RPM builds.
- Consider an explicit `:release:packagers` task that aggregates all dist + installer outputs for release cut.
