### PR TITLE
macOS DMG build + test-safe service dirs + Dirs.kt cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ image bundles a minimal runtime (from our jlink flow) and the portable `cryptad-
 start/stop the wrapper reliably.
 
 - Tasks:
-  - `./gradlew build` → builds the jpackage app image and enriches it with `cryptad-dist`. On Linux, it also builds native installers (DEB/RPM) when `dpkg-deb`/`rpmbuild` are available; missing tools cause those installer tasks to be skipped, not failed.
+  - `./gradlew build` → builds the jpackage app image and enriches it with `cryptad-dist`. On Linux and macOS, it also builds native installers (`.deb`/`.rpm` on Linux when `dpkg-deb`/`rpmbuild` are available; `.dmg` on macOS). Missing tools cause those installer tasks to be skipped, not failed. Windows builds do not produce installers by default.
   - `./gradlew jpackageImageCryptad` → builds only the app image under `build/jpackage/`.
   - `./gradlew jpackageInstallerCryptad` → builds a native installer for the current OS (macOS: `.dmg`; Linux: `.deb` or `.rpm` when `dpkg-deb`/`rpmbuild` is available). Not available on Windows.
   - Linux type override: pass `-PlinuxInstaller=<deb|rpm>` (or set env `CRYPTA_LINUX_INSTALLER`) to force installer type. When both are available, RPM is preferred by default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ architecture review).
 - Merge strategy: GitFlow
 - Commit format: Conventional commits
 - PR requirements: Tests pass, approved review
+- PR creation: Always ask before creating a GitHub pull request. Do not open PRs without explicit approval from a maintainer/requester.
 
 ## Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ Commands
 
 ```bash
 # Build includes the jpackage app image.
-# On Linux, it also builds native installers (DEB/RPM) when tooling is present
-# (`dpkg-deb` and/or `rpmbuild`). On macOS, installers are not built by `build`.
+# On Linux and macOS, it also builds native installers when tooling is present
+# (Linux: DEB/RPM via `dpkg-deb`/`rpmbuild`; macOS: DMG). On Windows, installers
+# are not built by `build`.
 ./gradlew build
 
 # App image only
@@ -296,6 +297,12 @@ Linux notes
   tasks above or `-PlinuxInstaller=<deb|rpm>`.
 - The `build` task on Linux now depends on building all available Linux installers (DEB/RPM) and will skip any
   installer type whose tool is missing.
+
+macOS notes
+
+- The `build` task on macOS now also builds a `.dmg` via `jpackage`.
+- Unsigned DMGs are fine for local testing; macOS may require right‑click → Open
+  or removing quarantine to run the app the first time.
 
 Linux behavior and service
 

--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -572,4 +572,8 @@ tasks.named("build") {
   if (currentOs() == "linux") {
     dependsOn(jpackageInstallerLinuxAll)
   }
+  // On macOS, also build a DMG installer.
+  if (currentOs() == "mac") {
+    dependsOn(jpackageInstallerCryptad)
+  }
 }

--- a/src/main/java/network/crypta/fs/Dirs.kt
+++ b/src/main/java/network/crypta/fs/Dirs.kt
@@ -31,6 +31,7 @@ const val PERM_GROUP_RX = "rwxr-x---"
 const val PERM_USER_RWX = "rwx------"
 const val MACOS_LIBRARY_PATH = "Library"
 const val APP_RUNTIME_SUBPATH = "network/crypta"
+const val LINUX_RUN_USER_PREFIX = "/run/user"
 const val USER_HOME = "user.home"
 
 /** Ensure a directory exists with best-effort POSIX permissions when supported. */
@@ -75,9 +76,7 @@ private fun isUnitTestRuntime(): Boolean {
     } catch (_: Throwable) {
       false
     }
-  if (hasClass("org.junit.Test") || hasClass("org.junit.jupiter.api.Test")) return true
-
-  return false
+  return hasClass("org.junit.Test") || hasClass("org.junit.jupiter.api.Test")
 }
 
 // --- Dedup helpers -----------------------------------------------------------
@@ -114,7 +113,7 @@ private fun computeStandardXdgRuntime(
   return when {
     appEnv.isFlatpak() -> {
       val appId = env["FLATPAK_ID"] ?: "network.crypta.Cryptad"
-      (xdgRuntime ?: Paths.get("/run/user", (systemProperties["user.name"] ?: "0")))
+      (xdgRuntime ?: Paths.get(LINUX_RUN_USER_PREFIX, (systemProperties["user.name"] ?: "0")))
         .resolve("app")
         .resolve(appId)
         .resolve(APP_RUNTIME_SUBPATH)
@@ -122,7 +121,7 @@ private fun computeStandardXdgRuntime(
     xdgRuntime != null -> xdgRuntime.resolve(APP_RUNTIME_SUBPATH)
     else -> {
       val uidBased =
-        Paths.get("/run/user")
+        Paths.get(LINUX_RUN_USER_PREFIX)
           .resolve(System.getProperty("user.name") ?: "0")
           .resolve(APP_RUNTIME_SUBPATH)
       if (Files.isWritable(uidBased.parent)) uidBased else cacheBase.resolve("rt")
@@ -138,11 +137,11 @@ private fun computeSnapRuntime(env: Map<String, String>, cacheBase: Path): Path 
     uidEnv
       ?: run {
         val rd = env["XDG_RUNTIME_DIR"] ?: ""
-        val m = Regex("^/run/user/(\\d+)/").find(rd)
+        val m = Regex("^" + Regex.escape(LINUX_RUN_USER_PREFIX) + "/(\\d+)/").find(rd)
         m?.groupValues?.getOrNull(1) ?: "0"
       }
   val snapInstance = inst ?: "cryptad"
-  val candidate = Paths.get("/run/user", uid, "snap.$snapInstance")
+  val candidate = Paths.get(LINUX_RUN_USER_PREFIX, uid, "snap.$snapInstance")
   return try {
     val parent = candidate.parent
     if (parent != null && Files.isWritable(parent)) candidate else cacheBase.resolve("rt")
@@ -251,39 +250,47 @@ class AppDirs(
     val appDirName =
       if (appEnv.isWindows() || (appEnv.isMac() && !osxPrefersXdg)) "Cryptad" else "cryptad"
     val home = systemProperties[USER_HOME] ?: System.getProperty(USER_HOME)
-    if (appEnv.isWindows()) {
-      val appData = env["APPDATA"] ?: Paths.get(home, "AppData", "Roaming").toString()
-      val localAppData = env["LOCALAPPDATA"] ?: Paths.get(home, "AppData", "Local").toString()
-      val bases =
-        Bases(Paths.get(appData), Paths.get(localAppData), Paths.get(localAppData, "Cache"))
-      val runtimeBase = Paths.get(localAppData, "Cryptad", "Run")
-      val logsBase = Paths.get(localAppData, "Cryptad", "Logs")
-      return buildResolved(bases, appDirName, runtimeBase, logsBase)
-    } else if (appEnv.isMac() && !osxPrefersXdg) {
-      // macOS native (GUI/Homebrew default w/o XDG)
-      val appSupport = Paths.get(home, MACOS_LIBRARY_PATH, "Application Support")
-      val bases = Bases(appSupport, appSupport, Paths.get(home, MACOS_LIBRARY_PATH, "Caches"))
-      val runtimeBase = bases.cache.resolve("Cryptad").resolve("run")
-      val logsBase = Paths.get(home, MACOS_LIBRARY_PATH, "Logs", "Cryptad")
-      return buildResolved(bases, appDirName, runtimeBase, logsBase)
-    } else {
-      // Linux/XDG and macOS when XDG_* set
-      var bases = xdgBases(env, home)
-      if (appEnv.isSnap()) {
-        val snapCommon = env["SNAP_USER_COMMON"]
-        if (!snapCommon.isNullOrBlank()) {
-          bases =
-            Bases(Paths.get(snapCommon), Paths.get(snapCommon), Paths.get(snapCommon, ".cache"))
-          val runtimeBase = computeSnapRuntime(env, bases.cache)
+
+    val result: Resolved =
+      if (appEnv.isWindows()) {
+        val appData = env["APPDATA"] ?: Paths.get(home, "AppData", "Roaming").toString()
+        val localAppData = env["LOCALAPPDATA"] ?: Paths.get(home, "AppData", "Local").toString()
+        val bases =
+          Bases(Paths.get(appData), Paths.get(localAppData), Paths.get(localAppData, "Cache"))
+        val runtimeBase = Paths.get(localAppData, "Cryptad", "Run")
+        val logsBase = Paths.get(localAppData, "Cryptad", "Logs")
+        buildResolved(bases, appDirName, runtimeBase, logsBase)
+      } else if (appEnv.isMac() && !osxPrefersXdg) {
+        // macOS native (GUI/Homebrew default w/o XDG)
+        val appSupport = Paths.get(home, MACOS_LIBRARY_PATH, "Application Support")
+        val bases = Bases(appSupport, appSupport, Paths.get(home, MACOS_LIBRARY_PATH, "Caches"))
+        val runtimeBase = bases.cache.resolve("Cryptad").resolve("run")
+        val logsBase = Paths.get(home, MACOS_LIBRARY_PATH, "Logs", "Cryptad")
+        buildResolved(bases, appDirName, runtimeBase, logsBase)
+      } else {
+        // Linux/XDG and macOS when XDG_* set
+        var bases = xdgBases(env, home)
+        if (appEnv.isSnap()) {
+          val snapCommon = env["SNAP_USER_COMMON"]
+          if (!snapCommon.isNullOrBlank()) {
+            bases =
+              Bases(Paths.get(snapCommon), Paths.get(snapCommon), Paths.get(snapCommon, ".cache"))
+            val runtimeBase = computeSnapRuntime(env, bases.cache)
+            val logsBase = bases.data.resolve(appDirName).resolve("logs")
+            buildResolved(bases, appDirName, runtimeBase, logsBase)
+          } else {
+            val runtimeBase = computeStandardXdgRuntime(env, systemProperties, appEnv, bases.cache)
+            val logsBase = bases.data.resolve(appDirName).resolve("logs")
+            buildResolved(bases, appDirName, runtimeBase, logsBase)
+          }
+        } else {
+          val runtimeBase = computeStandardXdgRuntime(env, systemProperties, appEnv, bases.cache)
           val logsBase = bases.data.resolve(appDirName).resolve("logs")
-          return buildResolved(bases, appDirName, runtimeBase, logsBase)
+          buildResolved(bases, appDirName, runtimeBase, logsBase)
         }
       }
 
-      val runtimeBase = computeStandardXdgRuntime(env, systemProperties, appEnv, bases.cache)
-      val logsBase = bases.data.resolve(appDirName).resolve("logs")
-      return buildResolved(bases, appDirName, runtimeBase, logsBase)
-    }
+    return result
   }
 
   override fun envOverrides(): Overrides {

--- a/src/main/java/network/crypta/fs/Dirs.kt
+++ b/src/main/java/network/crypta/fs/Dirs.kt
@@ -54,6 +54,32 @@ private fun ensureDir(path: Path, perms: String) {
   }
 }
 
+/** Returns true when running under a unit test runtime (Gradle/JUnit). */
+private fun isUnitTestRuntime(): Boolean {
+  // Opt-in property for explicit control
+  if ((System.getProperty("cryptad.test") ?: "").equals("true", ignoreCase = true)) return true
+
+  // Gradle test workers often set identifying properties/commands
+  val cmd = System.getProperty("sun.java.command") ?: ""
+  if (cmd.contains("Gradle Test Executor") || cmd.contains("org.gradle.test")) return true
+  if (!System.getProperty("org.gradle.test.worker", "").isNullOrEmpty()) return true
+
+  // Maven Surefire/Failsafe indicators (harmless if absent)
+  if (System.getProperty("surefire.test.class.path") != null) return true
+
+  // Presence of common test-only classes (junit4/junit5)
+  fun hasClass(name: String): Boolean =
+    try {
+      Class.forName(name)
+      true
+    } catch (_: Throwable) {
+      false
+    }
+  if (hasClass("org.junit.Test") || hasClass("org.junit.jupiter.api.Test")) return true
+
+  return false
+}
+
 // --- Dedup helpers -----------------------------------------------------------
 
 /** Base XDG or platform roots before app subdirectories are applied. */
@@ -377,9 +403,12 @@ class ServiceDirs(
   }
 
   override fun shouldEnsureDirectories(): Boolean {
+    // Skip creation when running unit tests to avoid touching system directories.
+    if (isUnitTestRuntime()) return false
+
     // Only ensure directories when the target platform matches the host OS. This avoids attempts
     // to create system-level paths like "/Library/..." on Linux or \\ProgramData on Unix during
-    // cross-platform testing where we simulate another OS via AppEnv.
+    // cross-platform execution where we simulate another OS via AppEnv.
     val hostOs = (systemProperties["os.name"] ?: System.getProperty("os.name") ?: "").lowercase()
     val hostIsWindows = hostOs.contains("win")
     val hostIsMac = hostOs.contains("mac") || hostOs.contains("darwin")


### PR DESCRIPTION
Summary
- Build now produces a macOS DMG when building on macOS via jpackage.
- Filesystem safety in tests: skip creating system service directories under unit-test runtimes.
- Style/cleanup in Dirs.kt per Sonar recommendations.
- Docs updated to require explicit approval before creating PRs.

Change Details
- build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
  - On macOS, wire `build` to depend on `jpackageInstallerCryptad` so a DMG is emitted.
- src/main/java/network/crypta/fs/Dirs.kt (≈ +70 / −34)
  - Add `isUnitTestRuntime()` and gate `ServiceDirs.shouldEnsureDirectories()` to avoid touching system paths during tests (e.g., preventing writes under `/Library` on CI).
  - Extract `LINUX_RUN_USER_PREFIX` and use it for snap runtime computation.
  - Refactor `AppDirs.computeBase()` to a single-return structure for clarity.
- AGENTS.md, README.md
  - Document PR approval policy and installer outputs.

Commits
1) style(fs): address SonarLint issues in Dirs.kt
2) docs(agents): require explicit approval before creating GitHub PRs
3) fix(fs): skip creating service dirs during unit tests
4) build(jpackage): have build produce macOS DMG on macOS

Impact/Risks
- DMG build path only affects macOS builders; other platforms unchanged.
- Test-only gating avoids unintended system directory creation during CI/unit tests; no change at runtime on user systems.

Validation
- Compare vs origin/develop: 4 commits
- Affected sources: Dirs.kt (+70, −34)

How to Build/Test
- Build: `./gradlew build` (macOS will produce a DMG)
- Build node jar: `./gradlew buildJar`
- Tests: `./gradlew --parallel test`

Notes
- No protocol or API changes.
- No migration required.
