### PR TITLE
CoreUpdater fixes + safer Windows store opener; docs/build updates

### DIFF
--- a/.spotlessignore
+++ b/.spotlessignore
@@ -4,3 +4,4 @@ repo/
 tools/flatpak/work/
 tools/flatpak/local/
 build/
+build-logic/build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,28 @@ architecture review).
 - Launcher code style guardrails
   - Use the `APP_NAME` constant for window titles; prefer logging via `LauncherLog` over silent catches; keep Desktop integration hooks inside `try/catch` with debug logs.
 
+### CoreUpdater Migration (Sep 2025)
+
+- Core package-based updates
+  - Replaces self-updating of `cryptad.jar` with a package-based updater (“CoreUpdater”).
+  - Fetches `info/<N>` JSON from the existing update USK, selects an OS/arch-specific installer (deb/rpm/dmg/exe/flatpak/snap), and downloads to `nodeDir/updates/core/<version>/`.
+  - Plugin updates are unchanged.
+- Update system changes
+  - `MainJarUpdater` removed; `NodeUpdateManager` now wires and coordinates `CoreUpdater` for core and `PluginJarUpdater` for plugins.
+  - JAR Update-over-Mandatory (UOM) is disabled; `supportsJarUOM()` returns false and legacy jar UOM paths are gated or no-ops.
+- New endpoint and UI
+  - HTTP endpoint: `/core-update/` with actions `download`, `install`, and `openStore`.
+  - Alerts panel shows progress percent when available; failures surface clear retry guidance (non‑fatal errors relabel to “Retry”).
+- Platform specifics
+  - Linux: prefers GUI handoff (gio/xdg-open) or PackageKit; in Flatpak uses the portal/`flatpak-spawn` to bridge to host tools. `.snap` files are never GUI-opened; installs use `snap install --dangerous`.
+  - macOS: adds Gatekeeper guidance for unsigned builds.
+  - Windows: adds SmartScreen guidance and SHA‑256 verification tips.
+- Environment detection
+  - `AppEnv` is the single source of truth for OS/arch/sandbox/service detection; launcher and updater code paths were refactored to use it.
+- Descriptor format & integrity
+  - JSON includes `version`, `packages` keyed by `<arch>.<ext>`, and optional `changelog_chk`/`fullchangelog_chk`.
+  - CHK integrity covers content; any historical `sha256` fields in descriptors are ignored.
+
 ### Environment detection (AppEnv)
 
 AppEnv is the SINGLE source of truth for runtime environment detection across the codebase. Do not read `System.getProperty("os.name")`, `os.arch`, or parse PATH directly in new code; use `AppEnv` instead.
@@ -220,10 +242,11 @@ Tip: If GitHub API rate limits are hit during builds, set `GITHUB_TOKEN` in the 
 
 ### Update System
 
-- `NodeUpdateManager` coordinates updates
-- `MainJarUpdater` updates the main application
-- `PluginJarUpdater` manages plugin updates
-- Update-over-Mandatory (UOM) for network-wide updates
+- `NodeUpdateManager` coordinates updates.
+- Core updates: `CoreUpdater` fetches `info/<N>` JSON from the update USK, selects an OS/arch package, downloads under `nodeDir/updates/core/<version>/`, and exposes actions via `/core-update/`.
+- Plugin updates: `PluginJarUpdater` continues to manage plugin downloads and deploys.
+- JAR UOM: disabled for the core; jar UOM handlers are gated (`supportsJarUOM() == false`).
+- Config keys: `node.updater.enabled`, `node.updater.autoupdate` remain (autoupdate downloads packages; OS installation is manual or guided).
 
 ### Security Model
 
@@ -326,7 +349,10 @@ start/stop the wrapper reliably.
   - RPM: `src/jpackage/linux/crypta.spec` handles conditional service/desktop logic and also creates the `cryptad` user. The systemd unit is staged under the image at `lib/systemd/system/cryptad.service` and installed to `/etc/systemd/system/` by the spec. Desktop entry removal happens in `%postun` only on final erase (`$1=0`) so upgrades do not delete `/usr/share/applications/crypta.desktop`.
 - Icon and desktop entry:
   - A full‑size Linux icon is embedded; a `.desktop` file is prewritten into the image and patched on install so GNOME and other DEs display the correct icon. WM_CLASS is set to match the Swing window class.
-- Script library: common installer logic lives in `src/jpackage/linux/crypta-common.sh` (installed under `lib/` in the app image). Maintainer scripts and spec sections source it when present and include safe fallbacks to keep uninstall idempotent after files are removed. Do not duplicate `is_desktop`, `ensure_user`, or service control snippets elsewhere.
+ - Script library: common installer logic lives in `src/jpackage/linux/crypta-common.sh` (installed under `lib/` in the app image). Maintainer scripts and spec sections source it when present and include safe fallbacks to keep uninstall idempotent after files are removed. Do not duplicate `is_desktop`, `ensure_user`, or service control snippets elsewhere.
+- Headless helper: DEB/RPM install a privileged, least‑privilege helper for non‑interactive core package installs:
+  - Systemd oneshot unit `cryptad-core-install@.service` and script `cryptad-core-install.sh` (installed under the app image) validate paths under `/var/lib/cryptad/updates/core` and perform the install via PackageKit/native tools.
+  - A polkit rule restricts starting only this unit and only to the `cryptad` user. When unavailable, the UI shows manual admin commands instead.
 
 Debugging installers (Linux)
 - Set `CRYPTA_DEBUG=1` in the environment to enable verbose logging from maintainer scripts. Logs append to `/var/log/crypta-installer.log`.
@@ -356,6 +382,12 @@ Uninstall semantics
     - Warn the user and ask them to set their identity (agents must not set it themselves). Example:
       - "Git identity is not configured. Please run: git config --global user.name "<Your Name>" && git config --global user.email "<you@example.com>""
     - After the user confirms identity is set, resume the commit.
+
+### Temporary Working Notes
+
+- `tmp_changes.md` is for local, short‑lived notes and is ignored by Git. Do not commit it or include it in PRs.
+- If accidentally staged: `git restore --staged tmp_changes.md` (and optionally `git checkout -- tmp_changes.md`).
+- Copy any relevant, permanent information into this `AGENTS.md`, PR descriptions, or proper docs under `docs/`.
 
 ## Desktop & Theme Handling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Authoritative release notes and the full changelog are published on GitHub Releases.
+
+- View the latest releases and notes:
+  https://github.com/crypta-network/cryptad/releases
+
+Why no long-form changelog file?
+- We keep a single source of truth in Releases to avoid duplication and ensure release notes match tagged artifacts.
+- PRs should include clear, user-facing summaries; maintainers aggregate notable changes into each release entry.
+

--- a/README.md
+++ b/README.md
@@ -66,27 +66,64 @@ data, and serves applications.
 - [Spotless + Dependency Verification](#spotless--dependency-verification)
 - [Versioning](#versioning)
 - [Branching & Releases](#branching--releases)
+- [Update System](#update-system)
 - [Architecture Overview](#architecture-overview)
 - [License](#license)
 
 ## Quick Start
 
-Build the portable distribution and run the Swing launcher:
+Choose one of the following options.
+
+### A) Install via Packages (recommended)
+
+- Windows (.exe)
+  - Download the Crypta installer from the Releases page.
+  - Double‑click to install. If Windows SmartScreen blocks it, click “More info” → “Run anyway”.
+  - Launch “Crypta” from the Start Menu.
+
+- macOS (.dmg)
+  - Download the DMG from the Releases page and open it.
+  - Drag “Crypta.app” to Applications. If Gatekeeper blocks it, right‑click → Open (or allow in Settings → Privacy & Security).
+  - Launch “Crypta” from Applications/Launchpad.
+
+- Debian/Ubuntu (.deb)
+  - Install from a local .deb:
+    ```bash
+    sudo apt install ./Crypta-<version>_amd64.deb   # adjust arch/version
+    ```
+
+- Fedora/RHEL/openSUSE (.rpm)
+  - Install from a local .rpm:
+    ```bash
+    sudo dnf install ./Crypta-<version>.x86_64.rpm  # or: sudo zypper install ./...
+    ```
+
+- Snap (.snap)
+  - Local snap install (not from store):
+    ```bash
+    sudo snap install --dangerous ./crypta-<version>.snap
+    ```
+
+- Flatpak (.flatpak or .flatpakref)
+  - Local Flatpak bundle:
+    ```bash
+    flatpak install --user ./crypta-<version>-amd64.flatpak
+    flatpak run network.crypta.cryptad//v1
+    ```
+
+After installation, start Crypta from your OS application launcher. The app starts the daemon, opens the UI in your browser on the first successful start, and manages start/stop for you.
+
+### B) Portable Distribution (for developers)
+
+Build the portable distribution and run the Swing launcher without installing system packages:
 
 ```bash
 ./gradlew assembleCryptadDist
 build/cryptad-dist/bin/cryptad-launcher    # Windows: cryptad-launcher.bat
 ```
 
-The launcher automatically starts the daemon, streams live logs, detects the FProxy port from lines like
+The launcher starts the daemon, streams live logs, detects the FProxy port from lines like
 `Starting FProxy on ...:<port>`, and opens `http://localhost:<port>/` on the first successful start.
-
-Top‑row buttons and shortcuts:
-- Start/Stop: toggles the daemon.
-  - Unix/macOS: sends SIGINT to the wrapper/JVM; waits up to ~20s before escalating (TERM→KILL).
-  - Windows: requests a graceful stop by deleting an anchor file and waits up to ~25s; only then falls back to `taskkill`.
-- Launch in Browser: enabled after the port is known (parsed from logs).
-- Quit: exits the launcher immediately (shutdown continues in background).
 
 Shortcuts (global):
 - ↑/↓ one row; PgUp/PgDn one page.
@@ -94,24 +131,8 @@ Shortcuts (global):
 - Enter/Space click focused button; s start/stop; q quit.
 
 Notes
-- Live output combines the wrapper’s console with tailing of the wrapper log file when configured, so JVM logs appear
-  while the wrapper is running.
+- Live output combines the wrapper’s console with tailing of the wrapper log file when configured, so JVM logs appear while the wrapper is running.
 - On Unix/macOS the launcher uses a pseudo‑tty (via `script`) when available to reduce buffering.
-
-### Windows shutdown behavior
-
-- The Windows batch launcher (`bin/cryptad.bat`) passes a per‑user anchor location to the wrapper: `"wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor"`.
-- The Swing launcher requests a graceful stop by deleting that file; the Java Service Wrapper notices and shuts down the JVM cleanly (running shutdown hooks, flushing logs, etc.).
-- If the process tree is still alive after ~25 seconds, the launcher escalates to `taskkill` (first without `/F`, then with `/F`).
-- Advanced: If you need to change the anchor path, you can customize the batch file or pass a different property on the command line; a value in `wrapper.conf` (if present) is overridden by the batch property.
-
-### Launcher script resolution
-
-- Env override: set `CRYPTAD_PATH` to an absolute path or a path relative to your current working directory to force a specific wrapper script, e.g. `export CRYPTAD_PATH=bin/cryptad`.
-- Default resolution order (first match wins):
-  - From the running `cryptad.jar` directory: `<jarDir>/cryptad`.
-  - From the assembled distribution layout: `<jarDir>/../bin/cryptad`.
-  - Fallbacks from `user.dir`: `./bin/cryptad`, then `./cryptad`.
 
 ## Building
 
@@ -324,13 +345,14 @@ Linux behavior and service
 
 Manual service control (Linux)
 
-Service management (Linux)
+Service management (Linux):
 
 ```bash
 sudo systemctl status cryptad
 sudo systemctl start cryptad   # start explicitly after installation
 sudo systemctl stop cryptad
 sudo systemctl disable --now cryptad
+```
 
 Package removal behavior (Linux)
 
@@ -345,7 +367,6 @@ sudo rm -f /etc/systemd/system/cryptad.service && sudo systemctl daemon-reload
 sudo rm -rf /var/lib/cryptad
 sudo userdel cryptad 2>/dev/null || true
 sudo groupdel cryptad 2>/dev/null || true
-```
 ```
 
 Troubleshooting (macOS)
@@ -368,6 +389,23 @@ build/jpackage/Crypta.app/Contents/MacOS/Crypta 2>&1 | tee /tmp/crypta-run.log
 cd build/jpackage/Crypta.app/Contents
 ./runtime/bin/java -cp "app/cryptad-dist/lib/*" network.crypta.launcher.LauncherKt
 ```
+
+## Launcher Details
+
+### Windows shutdown behavior
+
+- The Windows batch launcher (`bin/cryptad.bat`) passes a per‑user anchor location to the wrapper: `"wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor"`.
+- The Swing launcher requests a graceful stop by deleting that file; the Java Service Wrapper notices and shuts down the JVM cleanly (running shutdown hooks, flushing logs, etc.).
+- If the process tree is still alive after ~25 seconds, the launcher escalates to `taskkill` (first without `/F`, then with `/F`).
+- Advanced: To change the anchor path, customize the batch file or pass a different property on the command line; a value in `wrapper.conf` is overridden by the batch property.
+
+### Launcher script resolution
+
+- Env override: set `CRYPTAD_PATH` to an absolute path or a path relative to your current working directory to force a specific wrapper script, e.g. `export CRYPTAD_PATH=bin/cryptad`.
+- Default resolution order (first match wins):
+  - From the running `cryptad.jar` directory: `<jarDir>/cryptad`.
+  - From the assembled distribution layout: `<jarDir>/../bin/cryptad`.
+  - Fallbacks from `user.dir`: `./bin/cryptad`, then `./cryptad`.
 
 ## Development Guidelines
 
@@ -420,8 +458,16 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 
 ## Branching & Releases
 
-- [Standard branching and release workflow](https://github.com/crypta-network/cryptad/wiki/Standard-Git-Branching-and-Release-Workflow-for-Cryptad)
+- Standard branching and release workflow: see `docs/standard-git-branching-and-release-workflow.md` (validated copy). The original wiki page is also available: https://github.com/crypta-network/cryptad/wiki/Standard-Git-Branching-and-Release-Workflow-for-Cryptad
 - [Release workflow and operations runbook](https://github.com/crypta-network/cryptad/wiki/Cryptad-Release-Workflow-and-Runbook)
+
+## Update System
+
+- Core updates use a package‑based updater (“CoreUpdater”). It subscribes to an `info/<N>` JSON descriptor via the existing update USK, selects an OS/arch‑specific installer (deb/rpm/dmg/exe/flatpak/snap), and downloads to `nodeDir/updates/core/<version>/`.
+- Installing the OS package is a user/OS action. On Linux, the UI may hand off to the system’s software center or PackageKit. On macOS/Windows, follow the platform guidance shown in the UI.
+- Plugin updates continue to be downloaded and deployed in‑app.
+- JAR Update‑over‑Mandatory (UOM) for the core is disabled in favor of the package flow.
+- For developer testing, replacing `build/libs/cryptad.jar` manually (as noted above) is fine; for production use CoreUpdater and platform packages.
 
 ## Architecture Overview
 

--- a/docs/standard-git-branching-and-release-workflow.md
+++ b/docs/standard-git-branching-and-release-workflow.md
@@ -1,0 +1,116 @@
+# Standard Git Branching and Release Workflow for Cryptad
+
+Last validated: 2025-09-18
+
+This document captures the Cryptad team’s standard Git branching and release workflow, validated against the project wiki and aligned with repository policies found in `AGENTS.md`.
+
+## Goals
+
+- Keep `main` always releasable and matching the latest production build.
+- Use a simple, predictable versioning model driven by a single integer build number.
+- Allow parallel feature development while keeping release and hotfix flows safe and auditable.
+
+## Versioning System
+
+- Single integer build number set in `build.gradle.kts` (e.g., `version = 2`).
+- Tags use `v<build-number>` (e.g., `v2`).
+- Generated artifacts and installers use this integer where a numeric version is required (e.g., jpackage `--app-version`).
+- Compatibility: The build number is used in Cryptad/Fred version strings and for update compatibility checks.
+
+Rationale: Using a single, monotonically increasing integer keeps updater compatibility straightforward (USK subscriptions, minimum build checks) and avoids semantic-version drift.
+
+## Branching Model (GitFlow‑inspired)
+
+- Primary branches
+  - `main`: latest production-ready code; every commit on `main` must be release-quality.
+  - `develop`: integration branch for upcoming work that will land in the next release.
+
+- Supporting branches
+  - `feature/<name>`: new features or refactors targeting the next release.
+  - `bugfix/<name>`: fixes for work on `develop` before a release branch is cut.
+  - `release/<build-number>`: release stabilization for the numbered build; only critical changes.
+  - `hotfix/<build-number>`: emergency fix for production; based on `main`.
+
+Notes
+- Use Conventional Commits in messages (e.g., `feat:`, `fix:`, `docs:`). Squash & merge for feature/bugfix PRs is encouraged. Do not squash `release/*` or `hotfix/*` merges.
+- PR creation policy: open PRs only with maintainer/requester approval; all PRs require at least one approval and green CI.
+
+## Common Workflows
+
+### 1) Feature Development
+
+1. Branch from `develop`:
+   - `git checkout develop && git pull`
+   - `git checkout -b feature/<name>`
+2. Commit with Conventional Commit messages.
+3. Open PR to `develop`. Enable “squash and merge”.
+4. After merge, delete the feature branch.
+
+### 2) Bugfix on Develop (pre‑release)
+
+1. Branch from `develop`:
+   - `git checkout -b bugfix/<name>`
+2. Open PR to `develop` (squash & merge).
+
+### 3) Release Workflow (stabilization)
+
+1. Prepare the build number in `build.gradle.kts` (e.g., bump to `version = 2`).
+2. Create release branch:
+   - `git checkout develop && git pull`
+   - `git checkout -b release/2`
+3. Stabilize: only fixes, docs, and release tasks. Avoid large refactors.
+4. Tag the release on `release/2`:
+   - `git tag v2`
+5. Merge forward to `main` (no squash), then back‑merge to `develop`:
+   - `git checkout main && git merge --no-ff release/2`
+   - `git checkout develop && git merge --no-ff release/2`
+6. Push branches and tags:
+   - `git push origin main develop release/2`
+   - `git push origin v2`
+
+Outcome: `main` now reflects release `v2`. `develop` includes the same changes so future work starts from the released state.
+
+### 4) Hotfix Workflow (production)
+
+1. Branch from `main`:
+   - `git checkout main && git pull`
+   - `git checkout -b hotfix/3`
+2. Fix the issue. Update the build number to the next integer if the hotfix changes the shipped build (e.g., `version = 3`).
+3. Tag the hotfix on `hotfix/3`:
+   - `git tag v3`
+4. Merge to `main` and back‑merge to `develop` (no squash):
+   - `git checkout main && git merge --no-ff hotfix/3`
+   - `git checkout develop && git merge --no-ff hotfix/3`
+5. Push branches and tags:
+   - `git push origin main develop hotfix/3`
+   - `git push origin v3`
+
+Outcome: Production receives `v3`; `develop` is updated to include the hotfix.
+
+## Do/Don’t
+
+- Do
+  - Keep `main` releasable; use `develop` for integration.
+  - Use squash merges for `feature/*` and `bugfix/*` to keep history clean.
+  - Use `--no-ff` merges for `release/*` and `hotfix/*` to preserve branch context.
+  - Tag every release/hotfix with `v<build-number>`.
+  - After releasing or hotfixing, always back‑merge to `develop`.
+
+- Don’t
+  - Don’t rebase or squash `release/*` and `hotfix/*` branches when merging into `main`/`develop`.
+  - Don’t skip bumping the build number when a release/hotfix changes the shipped build.
+  - Don’t open PRs without maintainer/requester approval.
+
+## Release/Hotfix Checklist
+
+- [ ] `build.gradle.kts` has the intended numeric `version` (build number).
+- [ ] CI is green on the release/hotfix branch.
+- [ ] Tag created: `v<build-number>`.
+- [ ] Merged to `main` (no squash), then back‑merged to `develop`.
+- [ ] Pushed tags and branches.
+- [ ] Release notes updated (if applicable).
+
+## Notes on Updater Compatibility
+
+- The integer build number participates in network compatibility checks and update gating.
+- Update-over-Mandatory (UOM) for the core JAR is disabled in favor of the package‑based CoreUpdater. Tags and build numbers still identify releases for packaging and distribution.

--- a/src/main/java/network/crypta/node/Version.kt
+++ b/src/main/java/network/crypta/node/Version.kt
@@ -71,11 +71,10 @@ const val MIN_ACCEPTABLE_FRED_BUILD_NUMBER: Int = 1475
 private const val BUILD_NUMBER_STRING: String = "@build_number@"
 
 /**
- * Historical wire identifier used in version strings for compatibility
- * with upstream Freenet nodes. Many peers and tools expect the first
- * component of the comma-separated Version field to be exactly "Fred". We
- * therefore keep using this value on the wire while retaining [NODE_NAME]
- * for human-readable contexts (logs, UI, etc.).
+ * Historical identifier used by legacy Freenet tooling. Modern Cryptad peers
+ * advertise [NODE_NAME] as the first component of their primary version array,
+ * but we still expose this value for compatibility surfaces (for example,
+ * minimum-acceptable strings and older helpers that key off "Fred").
  */
 private const val WIRE_NAME: String = "Fred"
 

--- a/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
@@ -155,7 +155,7 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
           if (url.isNotBlank())
             InstallerDelegate.Spawn(
               ProcessBuilder("rundll32", "url.dll,FileProtocolHandler", url),
-              msg("store.openingPage")
+              msg("store.openingPage"),
             )
           else InstallerDelegate.Manual(msg("store.invalidUrl.windows"))
         else -> InstallerDelegate.Manual(msg("store.unsupportedPlatform"))

--- a/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
@@ -153,7 +153,10 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
           else InstallerDelegate.Manual(msg("store.invalidUrl.mac"))
         AppEnv.OsKind.WINDOWS ->
           if (url.isNotBlank())
-            InstallerDelegate.Spawn(ProcessBuilder("cmd", "/c", url), msg("store.openingPage"))
+            InstallerDelegate.Spawn(
+              ProcessBuilder("rundll32", "url.dll,FileProtocolHandler", url),
+              msg("store.openingPage")
+            )
           else InstallerDelegate.Manual(msg("store.invalidUrl.windows"))
         else -> InstallerDelegate.Manual(msg("store.unsupportedPlatform"))
       }

--- a/src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
@@ -555,13 +555,19 @@ class CoreUpdater(
           "download started (listener attached): target=${outFile.absolutePath}"
         )
       } catch (e: FetchException) {
+        markStartFailure(e.message ?: e.javaClass.simpleName, fatalFlag = safeIsFatal(e))
+        ctx.eventProducer.removeEventListener(this)
+        getter = null
         this@CoreUpdater.logError(
-          "Failed to start package download: ${e.message ?: e.javaClass.simpleName}",
+          "Failed to start package download: ${errorMsg ?: e.javaClass.simpleName}",
           e,
         )
       } catch (e: Exception) {
+        markStartFailure(e.message ?: e.javaClass.simpleName, fatalFlag = false)
+        ctx.eventProducer.removeEventListener(this)
+        getter = null
         this@CoreUpdater.logError(
-          "Error starting package download: ${e.message ?: e.javaClass.simpleName}",
+          "Error starting package download: ${errorMsg ?: e.javaClass.simpleName}",
           e,
         )
       }
@@ -657,6 +663,23 @@ class CoreUpdater(
       } catch (_: Throwable) {
         // ignore
       }
+    }
+
+    /** Guarded read of fatal status for FetchException instances. */
+    private fun safeIsFatal(e: FetchException): Boolean =
+      try {
+        e.isFatal
+      } catch (_: Throwable) {
+        false
+      }
+
+    /** Marks the fetcher as failed during startup, exposing the error to the UI. */
+    private fun markStartFailure(message: String?, fatalFlag: Boolean) {
+      complete = true
+      successFile = null
+      failed = true
+      fatal = fatalFlag
+      errorMsg = message ?: "Failed to start download"
     }
   }
 }


### PR DESCRIPTION
Summary
- Fix CoreUpdater download-start failure handling and error propagation to UI.
- Use safer URL opener on Windows for Core Store handoff.
- Clarify legacy "Fred" identifier comment in Version.
- Housekeeping: README/CHANGELOG/doc additions; Spotless ignore tweak.

Source Code Changes
- CoreUpdater: reset state and detach listener on FetchException during start; compute fatal flag via guarded read; improve error message fallback.
  - src/main/kotlin/network/crypta/node/updater/CoreUpdater.kt
    - Added `safeIsFatal(e: FetchException)` and `markStartFailure(message: String?, fatalFlag: Boolean)`.
    - On start failures, now calls `markStartFailure(...)`, removes the event listener, and nulls `getter`.
    - Error strings now use `errorMsg` fallback instead of only `e.message`.
- CoreActionToadlet (Windows): open Store/URL via `rundll32 url.dll,FileProtocolHandler <url>` instead of `cmd /c <url>` to avoid shell quirks and improve handler selection.
  - src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
- Version: comment-only clarification around legacy Freenet identifier usage; no runtime behavior change.
  - src/main/java/network/crypta/node/Version.kt

Docs & Build
- .spotlessignore: exclude build-logic outputs.
- README.md: simplify Quick Start; add package install guidance.
- CHANGELOG.md: new file pointing to GitHub Releases.
- docs/standard-git-branching-and-release-workflow.md: document validated workflow.

Why
- CoreUpdater was leaving partial state (e.g., non-null getter, listener attached) when start() failed, causing stale UI state and potential memory leaks. Fix ensures consistent UI and retry behavior.
- Windows opener change avoids quoting/space issues and relies on system URL handler consistently.

Testing Notes
- Manual: simulate a failing package fetch start and verify the Alerts panel surfaces the error and that a Retry works (no lingering listener; progress resets).
- Suggest adding unit tests around `markStartFailure()` and the start() failure branches.

Commits
- 6c914c7420 docs: clarify legacy Fred wire identifier comment
- 446b19f195 build: ignore build-logic outputs for spotless
- a4c954b038 fix: reset core package download state on start failure
- 947004d147 fix: use safe Windows URL opener for core store
- 0be1df021c docs(changelog): add CHANGELOG.md redirecting to GitHub Releases
- 0c9fdd1e71 docs(readme): simplify Quick Start and add package install instructions
- e6f1aebd9b docs(workflow): add validated standard branching and release workflow
- c5f4ce15e9 docs(agents): document CoreUpdater migration and tmp_changes policy

Risk/Impact
- No API changes; limited to updater UI/behavior and Windows launcher interaction. Low risk; improves failure hygiene.

Checklist
- [x] Builds locally
- [x] No breaking changes
- [ ] Tests updated/added where appropriate (follow-up ok)
