### PR TITLE
fix(windows): ensure launcher finds bundled Java in Windows launcher (cryptad.bat.tpl)

### DIFF
--- a/src/main/templates/cryptad.bat.tpl
+++ b/src/main/templates/cryptad.bat.tpl
@@ -13,6 +13,24 @@ if not exist "%CONF%" (
   exit /b 1
 )
 
+REM Use bundled runtime when running from a jpackage app image
+set "JPACKAGE_RUNTIME=%ROOT_DIR%\..\..\runtime"
+if exist "%JPACKAGE_RUNTIME%\bin\java.exe" (
+  if not defined JAVA_HOME (
+    for %%I in ("%JPACKAGE_RUNTIME%") do set "JAVA_HOME=%%~fI"
+  ) else (
+    if not exist "%JAVA_HOME%\bin\java.exe" (
+      for %%I in ("%JPACKAGE_RUNTIME%") do set "JAVA_HOME=%%~fI"
+    )
+  )
+)
+
+if defined JAVA_HOME (
+  if exist "%JAVA_HOME%\bin\java.exe" (
+    set "PATH=%JAVA_HOME%\bin;%PATH%"
+  )
+)
+
 REM Detect architecture (normalize to amd64/arm64)
 set "ARCH=%PROCESSOR_ARCHITECTURE%"
 if /I "%ARCH%"=="AMD64" set "ARCH=amd64"


### PR DESCRIPTION
Summary
- Windows launcher template now uses the jpackage-bundled runtime when available by probing "%ROOT_DIR%\..\..\runtime" and setting JAVA_HOME and PATH accordingly.
- Ensures Tanuki Wrapper can always find a compatible Java without requiring a system-wide JRE/JDK.

Details
- File: src/main/templates/cryptad.bat.tpl
- Added detection for the app image runtime: sets `JAVA_HOME` to the resolved jpackage runtime and prepends `%JAVA_HOME%\bin` to `PATH` only when `%JAVA_HOME%\bin\java.exe` exists.
- Preserves prior behavior when JAVA_HOME is already valid or when no bundled runtime is present (portable/zip layouts remain unaffected).

Why
- Fixes cases where the Windows launcher failed to find Java when running the jpackage image, or picked an unintended system Java (wrong bitness or missing), causing start failures.

Scope
- Only affects Windows `.bat` launcher generated from the template. No changes to non-Windows scripts.

Diff summary
- 1 file changed, +18 insertions: adds `JPACKAGE_RUNTIME` detection and safe PATH override.

How to test (Windows)
- Build the app image: `./gradlew build`.
- Launch: `build\\jpackage\\Crypta\\Crypta.exe` (or from a console to view logs).
- Verify Java resolution:
  - `where java` should include `...\\app\\runtime\\bin\\java.exe` ahead of any system Java.
  - Node starts normally; wrapper logs show Java detected without errors.

Notes
- Matches our documented Windows image layout where `app/` contains the app and `runtime/` sits alongside; from `cryptad-dist`, the bundled runtime resolves via `..\\..\\runtime`.
- No behavior change for users who launch the portable distribution outside the jpackage image.
