### PR TITLE
fix: quote l10n placeholders to avoid regex errors in CoreUpdater UI

### DIFF
--- a/src/main/java/network/crypta/config/CryptadConfig.kt
+++ b/src/main/java/network/crypta/config/CryptadConfig.kt
@@ -2,8 +2,6 @@
 
 package network.crypta.config
 
-import network.crypta.fs.Resolved
-import network.crypta.support.SimpleFieldSet
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -12,6 +10,8 @@ import java.nio.file.StandardCopyOption
 import java.util.*
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
+import network.crypta.fs.Resolved
+import network.crypta.support.SimpleFieldSet
 
 @Throws(IOException::class)
 fun loadExpandingPlaceholders(

--- a/src/main/java/network/crypta/l10n/BaseL10n.java
+++ b/src/main/java/network/crypta/l10n/BaseL10n.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.NoSuchElementException;
+import java.util.regex.Pattern;
 import network.crypta.clients.http.TranslationToadlet;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
@@ -686,7 +687,12 @@ public class BaseL10n {
     String result = getDefaultString(key);
 
     for (int i = 0; i < patterns.length; i++) {
-      result = result.replaceAll("\\$\\{" + patterns[i] + "\\}", quoteReplacement(values[i]));
+      String pattern = patterns[i];
+      if (pattern == null) {
+        continue;
+      }
+      result =
+          result.replaceAll("\\$\\{" + Pattern.quote(pattern) + "\\}", quoteReplacement(values[i]));
     }
 
     return result;
@@ -705,7 +711,12 @@ public class BaseL10n {
     String result = getString(key);
 
     for (int i = 0; i < patterns.length; i++) {
-      result = result.replaceAll("\\$\\{" + patterns[i] + "\\}", quoteReplacement(values[i]));
+      String pattern = patterns[i];
+      if (pattern == null) {
+        continue;
+      }
+      result =
+          result.replaceAll("\\$\\{" + Pattern.quote(pattern) + "\\}", quoteReplacement(values[i]));
     }
 
     return result;
@@ -766,7 +777,12 @@ public class BaseL10n {
     String result = HTMLEncoder.encode(getString(key));
     assert (patterns.length == values.length);
     for (int i = 0; i < patterns.length; i++) {
-      result = result.replaceAll("\\$\\{" + patterns[i] + "\\}", quoteReplacement(values[i]));
+      String pattern = patterns[i];
+      if (pattern == null) {
+        continue;
+      }
+      result =
+          result.replaceAll("\\$\\{" + Pattern.quote(pattern) + "\\}", quoteReplacement(values[i]));
     }
     node.addChild("%", result);
   }

--- a/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
+++ b/src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt
@@ -38,7 +38,7 @@ class CoreActionToadlet(client: HighLevelSimpleClient, private val node: Node) :
   private fun t(key: String, replacements: Map<String, String> = emptyMap()): String {
     if (replacements.isEmpty()) return l10n.getString("CoreActionToadlet.$key")
     val entries = replacements.entries.toList()
-    val patterns = entries.map { "$" + "{${it.key}}" }.toTypedArray()
+    val patterns = entries.map { it.key }.toTypedArray()
     val values = entries.map { it.value }.toTypedArray()
     return l10n.getString("CoreActionToadlet.$key", patterns, values)
   }


### PR DESCRIPTION
Summary
- Fixes a PatternSyntaxException thrown while rendering CoreUpdater install guidance when a localized string contains placeholders.
- Error observed: java.util.regex.PatternSyntaxException: Illegal repetition near index 6 \$\{${path}\}.

Root Cause
- CoreActionToadlet passed replacement patterns as already-wrapped tokens ("${key}") to BaseL10n, which itself wraps them again as "${...}", producing `${${key}}` and breaking the regex used by String.replaceAll.
- BaseL10n fed raw placeholder names into replaceAll without quoting, so any regex metacharacters in keys would break substitution.

Changes
- CoreActionToadlet: pass raw keys as patterns; BaseL10n performs the `${...}` wrapping (src/main/kotlin/network/crypta/node/updater/CoreActionToadlet.kt).
- BaseL10n: quote placeholder names with Pattern.quote() in all substitution paths and guard null pattern entries (src/main/java/network/crypta/l10n/BaseL10n.java).
- Spotless import reorder in CryptadConfig.kt (no functional change).

Risk / Impact
- Low. Affects only l10n placeholder substitution and CoreUpdater UI rendering. No change to placeholder format in translation files.

Validation
- `./gradlew compileJava compileKotlin` succeeds locally.
- Manual sanity checked the CoreUpdater strings to ensure `${path}` and similar placeholders render with provided values.

Reproduction Note (pre-fix)
- Hitting POST /core-update?action=install on Linux Snap guidance path triggered PatternSyntaxException during l10n substitution.

Changelog
- Fix: prevent regex errors in l10n substitutions that broke CoreUpdater install guidance.

Requested Target
- Base: release/1
- Head: bugfix/snap-install-page-reset

Please let me know if you want additional validation steps or a backport to other maintenance branches.