### PR TITLE
docs: correct AGENTS.md and README.md to match repo behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,14 +169,14 @@ Refactoring guidance
 
 #### Windows details
 
-- The distribution includes Windows-native wrapper binaries built from the latest release of `crypta-network/wrapper-windows-build`:
+- The distribution includes Windows‑native wrapper binaries built from the latest release of `crypta-network/wrapper-windows-build`:
   - `bin/wrapper-windows-x86-64.exe` and `bin/wrapper-windows-arm-64.exe`.
   - DLLs are placed directly in `lib/` as `wrapper-windows-x86-64.dll` and `wrapper-windows-arm-64.dll`.
 - The main Windows launcher is `bin/cryptad.bat`:
   - Detects `AMD64` vs `ARM64` and runs the matching `wrapper-windows-x86-64.exe` or `wrapper-windows-arm-64.exe`.
   - Passes a per‑user anchor on the command line so the GUI can stop gracefully by deleting it:
     - `"wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor"` (command‑line property overrides any value in `wrapper.conf`).
-  - Temporarily prepends `lib/windows/<arch>` to `PATH` so `wrapper.dll` is found consistently.
+  - Native DLL resolution uses `wrapper.java.library.path=lib` in `wrapper.conf`. No `PATH` edits are required.
   - Accepts the same arguments as the Unix script and uses `conf/wrapper.conf`.
   - The GUI launcher is `bin/cryptad-launcher.bat`.
   
@@ -256,7 +256,7 @@ Tip: If GitHub API rate limits are hit during builds, set `GITHUB_TOKEN` in the 
 
 ## Key Tools and Instructions for Them
 
-- Kotlin lint: ktlint has been installed
+- Formatting: Spotless is configured (Kotlin via ktfmt; Java via google‑java‑format).
 - Build: ./gradlew build
 - Test: ./gradlew :test --tests [replace with TestClassName]
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Choose one of the following options.
 
 ### A) Install via Packages (recommended)
 
-- Windows (.exe)
-  - Download the Crypta installer from the Releases page.
-  - Double‑click to install. If Windows SmartScreen blocks it, click “More info” → “Run anyway”.
-  - Launch “Crypta” from the Start Menu.
+- Windows
+  - This repository does not build Windows installers. Use the portable distribution or the
+    jpackage app image below. If a Windows installer is published on the project’s Releases page,
+    you can install it by double‑clicking; if SmartScreen warns, click “More info” → “Run anyway”.
 
 - macOS (.dmg)
   - Download the DMG from the Releases page and open it.
@@ -163,8 +163,9 @@ Clean build:
 ./gradlew clean buildJar
 ```
 
-The wrapper is configured to [verify the distribution checksum](gradle/wrapper/gradle-wrapper.properties) from
-`https://services.gradle.org`.
+The wrapper validates the distribution URL (`validateDistributionUrl=true` in
+`gradle/wrapper/gradle-wrapper.properties`). To also verify the download by checksum, add
+`distributionSha256Sum=<sha256>` for the chosen Gradle distribution.
 
 ## Testing
 
@@ -429,8 +430,10 @@ cd build/jpackage/Crypta.app/Contents
 - Runtime: Java 21+
 - Language/Tooling: Kotlin 2.2.20+, Gradle Wrapper (provided in this repo)
 - External libraries are managed via Gradle.
-- Dependency verification is enabled; update both the `dependencies` and `dependencyVerification` blocks in
-  `build.gradle.kts` when adding libraries.
+- Dependency verification is enabled. When adding or updating libraries:
+  - Declare versions in `gradle/libs.versions.toml` and add usages in `build.gradle.kts`.
+  - Update verification metadata so `gradle/verification-metadata.xml` and keyrings reflect the new
+    artifacts; use the commands in “Spotless + Dependency Verification” below.
 
 Launcher adds:
 - `org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2` for Swing + coroutine integration.


### PR DESCRIPTION
Summary
- Fix Windows wrapper DLL note: DLLs are resolved via `wrapper.java.library.path=lib` (no PATH edits required).
- Replace outdated "ktlint" mention with actual formatting setup (Spotless: ktfmt for Kotlin, google-java-format for Java).
- Clarify Gradle Wrapper behavior: URL validation is enabled; recommend `distributionSha256Sum` for checksum verification.
- README: clarify that this repo does not build Windows installers; point users to portable distribution/jpackage.
- README: align dependency verification guidance with `gradle/libs.versions.toml` + `gradle/verification-metadata.xml` workflow.

Why
These statements drifted from the current build logic (`build-logic/*`) and templates under `src/main/templates`. This PR brings docs in sync to avoid confusing contributors and users.

Scope
- Only documentation changes (`AGENTS.md`, `README.md`).
- No code or build changes.

Validation
- Verified task names with `./gradlew tasks`.
- Cross-checked wrapper templates, jpackage tasks, and updater endpoints in source.

Requested merge: develop