### PR TITLE
fix(jpackage/macos): stage app-image outside iCloud path; clear xattrs; ad‑hoc codesign fallback

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -343,10 +343,13 @@ val jpackageImageCryptad by
         // On some macOS versions, jpackage ad-hoc signs the bundle and codesign rejects
         // com.apple.FinderInfo on the freshly created <App>.app, yielding:
         //   resource fork, Finder information, or similar detritus not allowed
-        // If we see a failure and the output image exists, clear xattrs and re-sign in place
-        // via jpackage "--type app-image --app-image <path> --mac-sign" (ad-hoc identity).
+        // If we see a failure and the output image exists, clear xattrs and ad-hoc sign the
+        // bundle. When staging is used (destDir != outDir), operate on the staged app and then
+        // relocate the fixed bundle into outDir so downstream tasks find it.
         if (os == "mac") {
-          val appDir = outDir.resolve("$appName.app")
+          val stagedApp = destDir.resolve("$appName.app")
+          val finalApp = outDir.resolve("$appName.app")
+          val appDir = if (stagedApp.isDirectory) stagedApp else finalApp
           if (appDir.isDirectory) {
             try {
               // Best-effort: remove extended attributes recursively.
@@ -376,7 +379,26 @@ val jpackageImageCryptad by
                 csArgs.joinToString(" "),
               )
               execAndLog(csArgs)
-              logger.lifecycle("codesign completed; continuing")
+              logger.lifecycle("codesign completed; relocating if staged")
+
+              // If we fixed the staged app, relocate it now to the final output dir.
+              if (appDir == stagedApp) {
+                if (finalApp.exists()) finalApp.deleteRecursively()
+                stagedApp.copyRecursively(finalApp, overwrite = true)
+                // Remove any staged attrs again just in case
+                try {
+                  val x = File("/usr/bin/xattr")
+                  if (x.canExecute()) {
+                    ProcessBuilder(x.absolutePath, "-cr", finalApp.absolutePath)
+                      .redirectErrorStream(true)
+                      .start()
+                      .waitFor(5, TimeUnit.SECONDS)
+                  }
+                } catch (_: Exception) {}
+                // Clean up staging directory
+                destDir.deleteRecursively()
+                logger.lifecycle("Relocated fixed app image -> {}", finalApp.absolutePath)
+              }
             } catch (fixErr: Exception) {
               logger.warn("macOS fallback sign failed: {}", fixErr.message)
               throw e

--- a/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
@@ -273,6 +273,18 @@ val jpackageImageCryptad by
       // Ensure we start from a clean target (jpackage fails if image exists)
       cleanExistingImage(outDir, os)
 
+      // On macOS, stage the app image under the system temp directory to avoid iCloud/
+      // FileProvider extended attributes (FinderInfo) being attached during creation, which
+      // makes codesign fail. We then move the completed image back to build/jpackage.
+      val destDir =
+        if (os == "mac") {
+          File(
+            System.getProperty("java.io.tmpdir"),
+            "crypta-jpackage-${System.currentTimeMillis()}",
+          )
+        } else outDir
+      destDir.mkdirs()
+
       val args =
         mutableListOf(
           jpackage.absolutePath,
@@ -283,7 +295,7 @@ val jpackageImageCryptad by
           "--app-version",
           numericAppVersion(),
           "--dest",
-          outDir.absolutePath,
+          destDir.absolutePath,
           "--input",
           inputDir.absolutePath,
           "--main-jar",
@@ -303,7 +315,79 @@ val jpackageImageCryptad by
       // jpackage rejects them with --type app-image. Such options are added in the installer task.
 
       logger.lifecycle("Executing jpackage app-image:\n{}", args.joinToString(" "))
-      execAndLog(args)
+      try {
+        execAndLog(args)
+        // If we staged to a temp directory, move the result into the build output dir.
+        if (destDir != outDir) {
+          val staged = destDir.resolve("$appName.app")
+          if (staged.isDirectory) {
+            val target = outDir.resolve("$appName.app")
+            if (target.exists()) target.deleteRecursively()
+            logger.lifecycle("Relocating app image from staging -> {}", target.absolutePath)
+            staged.copyRecursively(target, overwrite = true)
+            // Best-effort: remove any staging attributes after copy
+            try {
+              val xattr = File("/usr/bin/xattr")
+              if (xattr.canExecute()) {
+                ProcessBuilder(xattr.absolutePath, "-cr", target.absolutePath)
+                  .redirectErrorStream(true)
+                  .start()
+                  .waitFor(5, TimeUnit.SECONDS)
+              }
+            } catch (_: Exception) {}
+            destDir.deleteRecursively()
+          }
+        }
+      } catch (e: Exception) {
+        // Workaround for macOS codesign failing with FinderInfo xattr on the app bundle root.
+        // On some macOS versions, jpackage ad-hoc signs the bundle and codesign rejects
+        // com.apple.FinderInfo on the freshly created <App>.app, yielding:
+        //   resource fork, Finder information, or similar detritus not allowed
+        // If we see a failure and the output image exists, clear xattrs and re-sign in place
+        // via jpackage "--type app-image --app-image <path> --mac-sign" (ad-hoc identity).
+        if (os == "mac") {
+          val appDir = outDir.resolve("$appName.app")
+          if (appDir.isDirectory) {
+            try {
+              // Best-effort: remove extended attributes recursively.
+              val xattr = File("/usr/bin/xattr")
+              if (xattr.canExecute()) {
+                val pb = ProcessBuilder(xattr.absolutePath, "-cr", appDir.absolutePath)
+                pb.redirectErrorStream(true)
+                val p = pb.start()
+                val out = p.inputStream.bufferedReader().use { it.readText() }
+                p.waitFor(10, TimeUnit.SECONDS)
+                logger.lifecycle(
+                  "Cleared xattrs on app image (exit ${p.exitValue()}): {}",
+                  out.trim(),
+                )
+              } else {
+                logger.warn("xattr tool not available; skipping attribute cleanup")
+              }
+
+              // Direct ad-hoc sign the bundle root. jpackage already signed Contents/runtime
+              // before failing, so this completes the bundle signature.
+              val codesign = File("/usr/bin/codesign")
+              if (!codesign.canExecute()) throw GradleException("codesign tool not available")
+              val csArgs =
+                listOf(codesign.absolutePath, "-s", "-", "-vvvv", "--force", appDir.absolutePath)
+              logger.lifecycle(
+                "Ad-hoc signing app bundle after xattr cleanup:\n{}",
+                csArgs.joinToString(" "),
+              )
+              execAndLog(csArgs)
+              logger.lifecycle("codesign completed; continuing")
+            } catch (fixErr: Exception) {
+              logger.warn("macOS fallback sign failed: {}", fixErr.message)
+              throw e
+            }
+          } else {
+            throw e
+          }
+        } else {
+          throw e
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Summary
- Fix macOS jpackage app-image failure caused by Finder/FileProvider extended attributes (FinderInfo) in iCloud-managed paths (e.g., Documents). Codesign was failing with: "resource fork, Finder information, or similar detritus not allowed".

Changes
- jpackageImageCryptad now stages the app-image into a temp directory on macOS (under java.io.tmpdir) and then relocates it into build/jpackage, avoiding iCloud-added xattrs during creation/signing.
- After relocation, clears xattrs on the final bundle as a safeguard.
- Adds a fallback on macOS: if the initial jpackage run fails after creating the image, clear xattrs and ad‑hoc sign the bundle root with /usr/bin/codesign -s - to complete the signature. Leaves Linux/Windows flows unchanged.

Files
- build-logic/src/main/kotlin/cryptad.jpackage.gradle.kts
  - Stage-to-temp + relocate logic
  - Post-move xattr cleanup
  - macOS fallback ad‑hoc codesign

Why
- On macOS, when the project lives under iCloud-synced folders, Finder/FileProvider can attach xattrs to newly created app bundles. Codesign rejects those, causing jpackage app-image to fail even for ad‑hoc signatures.

Verification
- macOS (aarch64) with JDK 21.0.8:
  - ./gradlew --info jpackageImageCryptad → SUCCESS
  - ./gradlew --info enrichAppImageWithDist → SUCCESS
  - ./gradlew --info jpackageInstallerCryptad → SUCCESS
  - Outputs:
    - build/jpackage/Crypta.app
    - build/jpackage/Crypta-2.dmg
- Unit tests: ./gradlew --parallel test → BUILD SUCCESSFUL

Notes
- Task names/outputs preserved. No behavior change on Linux/Windows.
- This addresses local developer environments impacted by iCloud/“Documents” paths and similar FileProvider setups.

