### PR TITLE
build(coverage): JaCoCo + SonarCloud coverage wiring (non-failing verification)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -519,3 +519,28 @@ Note: `dependencies.properties` has been removed (Sep 2025). It is no longer pac
 - Memory
   - Increased Gradle daemon heap to reduce OOM risk during SonarLint indexing:
     - `gradle.properties`: `org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8`.
+
+## JaCoCo & SonarCloud Coverage — Oct 2025
+
+- Plugin & wiring
+  - JaCoCo is applied via the build-logic convention plugin `cryptad.java-kotlin-conventions` (toolVersion `0.8.13`).
+  - XML and HTML reports are enabled; XML lives at `build/reports/jacoco/test/jacocoTestReport.xml`.
+  - The `check` lifecycle depends on both `jacocoTestReport` and `jacocoTestCoverageVerification`.
+  - Coverage verification rule: 80% line coverage (LINE/COVEREDRATIO >= 0.80).
+  - Builds do not fail on coverage by default: `isFailOnViolation = false` (violations are logged).
+
+- SonarCloud
+  - Sonar is configured via the `cryptad.sonar` convention plugin.
+  - Host: `https://sonarcloud.io` with project `crypta-network_cryptad` and organization `crypta-network`.
+  - Coverage is read from the JaCoCo XML path above (`sonar.coverage.jacoco.xmlReportPaths`).
+  - The `sonarqube` task depends on `jacocoTestReport` to ensure XML is generated. If present, the optional `sonar` alias also depends on it.
+  - Authentication: set `SONAR_TOKEN` in the environment; the convention maps it to `sonar.token`. No CLI flag is required.
+
+- How to run locally
+  - Tests + coverage: `./gradlew --parallel test jacocoTestReport`
+  - Enforced check (non-failing gate): `./gradlew check`
+  - Upload to SonarCloud: `export SONAR_TOKEN=<token>` then `./gradlew --parallel sonarqube`
+
+- CI tips
+  - Minimal job step: `./gradlew --parallel test jacocoTestReport sonarqube`
+  - Provide the token securely (env `SONAR_TOKEN`).

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -1,8 +1,13 @@
+import java.math.BigDecimal
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
+import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   java
   id("org.jetbrains.kotlin.jvm")
+  jacoco
 }
 
 java {
@@ -80,3 +85,41 @@ tasks.withType<Test>().configureEach {
 
 // Match prior behavior: disable assertions in tests
 tasks.withType<Test>().configureEach { enableAssertions = false }
+
+// JaCoCo setup: use a recent agent and produce XML for Sonar
+extensions.configure<JacocoPluginExtension>("jacoco") {
+  // Use a version available on Maven Central (0.8.13 as of Apr 2025)
+  toolVersion = "0.8.13"
+}
+
+// Generate XML + HTML reports; ensure reports run after tests
+tasks.withType<JacocoReport>().configureEach {
+  dependsOn(tasks.withType<Test>())
+  reports {
+    xml.required.set(true)
+    csv.required.set(false)
+    html.required.set(true)
+  }
+}
+
+// Enforce coverage threshold (80% minimum)
+tasks.withType<JacocoCoverageVerification>().configureEach {
+  dependsOn(tasks.withType<Test>())
+  violationRules {
+    // Do not fail the build on coverage violations; still log them
+    isFailOnViolation = false
+    rule {
+      limit {
+        counter = "LINE"
+        value = "COVEREDRATIO"
+        minimum = BigDecimal("0.80")
+      }
+    }
+  }
+}
+
+// Integrate coverage checks with the standard lifecycle
+tasks.named("check") {
+  dependsOn(tasks.withType<JacocoReport>())
+  dependsOn(tasks.withType<JacocoCoverageVerification>())
+}

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -24,7 +24,7 @@ sonar {
         .absolutePath
     property("sonar.coverage.jacoco.xmlReportPaths", jacocoXml)
 
-    // Read token from environment if provided to avoid passing on CLI
+    // Read token from environment if provided to avoid passing on CLI (modern scanners read sonar.token)
     providers.environmentVariable("SONAR_TOKEN").orNull?.let { token ->
       if (token.isNotBlank()) property("sonar.token", token)
     }

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -112,7 +112,7 @@ tasks.named("sonarlintTest", SonarLint::class.java).configure {
   }
 }
 
-// Ensure coverage reports exist before publishing analysis
-tasks
-  .matching { it.name == "sonar" || it.name == "sonarqube" }
-  .configureEach { dependsOn(tasks.withType(JacocoReport::class.java)) }
+// Ensure coverage reports exist before publishing analysis.
+// Explicitly depend on jacocoTestReport for the SonarQube task; guard optional 'sonar' alias.
+tasks.named("sonarqube").configure { dependsOn("jacocoTestReport") }
+tasks.findByName("sonar")?.dependsOn("jacocoTestReport")

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -1,7 +1,5 @@
 import name.remal.gradle_plugins.sonarlint.SonarLint
 import name.remal.gradle_plugins.sonarlint.SonarLintSettings
-import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.testing.jacoco.tasks.JacocoReport
 
 plugins {
   // Apply SonarQube/SonarCloud and SonarLint centrally via convention plugin

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -1,5 +1,6 @@
 import name.remal.gradle_plugins.sonarlint.SonarLint
 import name.remal.gradle_plugins.sonarlint.SonarLintSettings
+import org.gradle.api.tasks.SourceSetContainer
 
 plugins {
   // Apply SonarQube/SonarCloud and SonarLint centrally via convention plugin

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -1,6 +1,7 @@
 import name.remal.gradle_plugins.sonarlint.SonarLint
 import name.remal.gradle_plugins.sonarlint.SonarLintSettings
 import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.testing.jacoco.tasks.JacocoReport
 
 plugins {
   // Apply SonarQube/SonarCloud and SonarLint centrally via convention plugin
@@ -13,6 +14,21 @@ sonar {
   properties {
     property("sonar.projectKey", "crypta-network_cryptad")
     property("sonar.organization", "crypta-network")
+    property("sonar.host.url", "https://sonarcloud.io")
+
+    // Point Sonar to the JaCoCo XML report produced by jacocoTestReport
+    val jacocoXml =
+      layout.buildDirectory
+        .file("reports/jacoco/test/jacocoTestReport.xml")
+        .get()
+        .asFile
+        .absolutePath
+    property("sonar.coverage.jacoco.xmlReportPaths", jacocoXml)
+
+    // Read token from environment if provided to avoid passing on CLI
+    providers.environmentVariable("SONAR_TOKEN").orNull?.let { token ->
+      if (token.isNotBlank()) property("sonar.token", token)
+    }
   }
 }
 
@@ -95,3 +111,8 @@ tasks.named("sonarlintTest", SonarLint::class.java).configure {
     explicitlyRequested
   }
 }
+
+// Ensure coverage reports exist before publishing analysis
+tasks
+  .matching { it.name == "sonar" || it.name == "sonarqube" }
+  .configureEach { dependsOn(tasks.withType(JacocoReport::class.java)) }

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -93,6 +93,7 @@
             <trusting group="org.eclipse.platform" name="org.eclipse.osgi" version="3.23.200"/>
          </trusted-key>
          <trusted-key id="A31DDE881C3E3C4C985BD0D02C7F998F4272C851" group="com.diffplug.spotless"/>
+         <trusted-key id="A413F67D71BEEC23ADD0CE0ACB43338E060CF9FA" group="org.jacoco"/>
          <trusted-key id="A4FACCFE5AFA1EB5FA3F4155A41774F54142A24C" group="de.jangassen" name="jfa" version="1.2.0"/>
          <trusted-key id="A58D5AF54809A8A63F458BBD56CD8D5D24452160" group="org.codehaus.sonar"/>
          <trusted-key id="A5BD02B93E7A40482EB1D66A5F69AD087600B22C" group="org.ow2.asm"/>


### PR DESCRIPTION
Summary
- Apply JaCoCo via convention plugin across the project (toolVersion 0.8.13).
- Generate XML + HTML reports; wire SonarCloud to use the XML (`build/reports/jacoco/test/jacocoTestReport.xml`).
- Configure SonarCloud: host url, org/project keys, and env token passthrough via `SONAR_TOKEN` -> `sonar.token`.
- Add 80% line coverage rule (LINE/COVEREDRATIO >= 0.80) but do not fail the build (`isFailOnViolation = false`).
- Make `sonarqube` depend on `jacocoTestReport` (and guard optional `sonar` alias) so coverage XML exists before analysis.
- Refresh dependency verification metadata for JaCoCo artifacts (strict mode remains enabled after the refresh).
- Fixes: Kotlin DSL property syntax (`isFailOnViolation`), missing `BigDecimal` import, and restored `SourceSetContainer` import.

How to run locally
- Tests + coverage: `./gradlew --parallel test jacocoTestReport`
- Enforced check (non-failing gate): `./gradlew check`
- Upload to SonarCloud: `export SONAR_TOKEN=<token>` then `./gradlew --parallel sonarqube`

CI tip
- Minimal step: `./gradlew --parallel test jacocoTestReport sonarqube` with `SONAR_TOKEN` set in the environment.

Docs
- Added "JaCoCo & SonarCloud Coverage — Oct 2025" to `AGENTS.md` with usage and CI notes.

Notes
- Coverage violations are logged but do not fail builds to allow incremental improvements.
- If we want to fail CI on low coverage later, we can switch `isFailOnViolation` to `true` in the convention plugin or introduce a Gradle property gate.
