### PR TITLE
build(coverage): source JaCoCo toolVersion from version catalog

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -1,4 +1,6 @@
 import java.math.BigDecimal
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 import org.gradle.testing.jacoco.tasks.JacocoReport
@@ -87,9 +89,10 @@ tasks.withType<Test>().configureEach {
 tasks.withType<Test>().configureEach { enableAssertions = false }
 
 // JaCoCo setup: use a recent agent and produce XML for Sonar
+// Version is sourced from the version catalog (gradle/libs.versions.toml: [versions].jacoco)
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 extensions.configure<JacocoPluginExtension>("jacoco") {
-  // Use a version available on Maven Central (0.8.13 as of Apr 2025)
-  toolVersion = "0.8.13"
+  toolVersion = libs.findVersion("jacoco").get().requiredVersion
 }
 
 // Generate XML + HTML reports; ensure reports run after tests

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ junitJupiter = "5.13.4"
 junitPlatform = "1.13.4"
 sonarqube = "6.3.1.5724"
 remalSonarlint = "7.0.0-rc-2"
+jacoco = "0.8.13"
 
 [libraries]
 bcprov = { group = "org.bouncycastle", name = "bcprov-lts8on", version.ref = "bcprov" }


### PR DESCRIPTION
Summary
- Move JaCoCo toolVersion to the version catalog and read it in the build-logic convention plugin.

Changes
- gradle/libs.versions.toml: add versions.jacoco = "0.8.13".
- build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts: use VersionCatalogsExtension to resolve jacoco.toolVersion from libs.versions.jacoco.

Rationale
- Centralizes the JaCoCo version with other tool versions for consistency and easier bumping.
- Keeps convention plugin free of hardcoded versions.

Verification
- Compiled the convention plugin: `./gradlew :build-logic:compileKotlin` (Gradle 9.1) – successful.
- No functional change beyond sourcing the version; reported XML/HTML outputs and coverage gating remain as configured.

Notes
- AGENTS.md documents 0.8.13 in the "JaCoCo & SonarCloud Coverage — Oct 2025" section.

Request
- Please review and merge into `develop`. If desired, I can follow up with a small CI task to run `jacocoTestReport` explicitly in coverage jobs.