### PR TITLE
fix(logging): disable Logback scanning in packaged config

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration scan="true" scanPeriod="30 seconds">
+<configuration>
   <!-- Log directory comes from LoggingConfigHandler via system property. -->
   <property name="LOG_DIR" value="${crypta.log.dir:-${user.dir}/logs}"/>
 


### PR DESCRIPTION
This fixes two Logback warnings on startup when the configuration is loaded from the classpath inside the JAR (non‑watchable URL):

- "Missing watchable .xml or .properties files."
- "Watching .xml files requires that the main configuration file is reachable as a URL."

Change
- Remove `scan="true"` and `scanPeriod` from the packaged `src/main/resources/logback.xml` so the runtime config is not watched.
- Keep Test config hot‑reload: `src/test/resources/logback-test.xml` still uses `scan="true"` for local/dev runs.

Rationale
- The runtime config is read from within `cryptad.jar` during normal operation; Logback cannot watch that resource. Disabling scanning avoids noisy warnings without affecting functionality.

No functional logging changes beyond disabling scan. Rolling policy, thresholds, and async file appender remain unchanged.
