### PR TITLE
test(math): Add TrivialRunningAverage tests and expand math test coverage

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -76,6 +76,8 @@ tasks.withType<Test>().configureEach {
     jvmArgs("--add-opens=java.base/java.io=ALL-UNNAMED")
     jvmArgs("--add-opens=java.base/java.util.zip=ALL-UNNAMED")
   }
+  // Allow dynamic agent loading for Mockito inline mock-maker (JEP 451).
+  jvmArgs("-XX:+EnableDynamicAgentLoading")
   minHeapSize = "128m"
   maxHeapSize = "512m"
   include("network/crypta/**/*Test.class")

--- a/src/main/java/network/crypta/support/transport/ip/HostnameSyntaxException.java
+++ b/src/main/java/network/crypta/support/transport/ip/HostnameSyntaxException.java
@@ -6,9 +6,9 @@ import java.io.Serial;
  * Signals that a host name (or, when permitted, an IP literal) does not conform to the expected
  * syntax.
  *
- * <p>This checked exception is raised by hostname/IP parsers and validators when the supplied
- * input fails basic syntactic checks. It does not imply that a DNS lookup was attempted or that a
- * host is unreachable; it strictly represents a formatting problem with the value.
+ * <p>This checked exception is raised by hostname/IP parsers and validators when the supplied input
+ * fails basic syntactic checks. It does not imply that a DNS lookup was attempted or that a host is
+ * unreachable; it strictly represents a formatting problem with the value.
  *
  * <p>Typical sources include:
  *

--- a/src/main/java/network/crypta/support/transport/ip/package-info.java
+++ b/src/main/java/network/crypta/support/transport/ip/package-info.java
@@ -12,9 +12,9 @@
  *   <li>{@link network.crypta.support.transport.ip.IPUtil} — IP address classification helpers
  *       (IPv4/IPv6). Notably:
  *       <ul>
- *         <li>{@code isSiteLocalAddress(...)} recognizes IPv6 Unique Local Addresses
- *             ({@code fc00::/7}) and the deprecated site-local range ({@code fec0::/10}), and
- *             otherwise delegates to the JDK for non-IPv6 addresses.
+ *         <li>{@code isSiteLocalAddress(...)} recognizes IPv6 Unique Local Addresses ({@code
+ *             fc00::/7}) and the deprecated site-local range ({@code fec0::/10}), and otherwise
+ *             delegates to the JDK for non-IPv6 addresses.
  *         <li>{@code isValidAddress(...)} rejects wildcard and multicast addresses, and optionally
  *             rejects local-only addresses (loopback, link-local, site/unique-local). For IPv4, it
  *             also rejects {@code 0.0.0.0/8}.
@@ -53,8 +53,8 @@
  *   <li>Bracketed IPv6 literals such as {@code [::1]} are not recognized by the hostname validator;
  *       supply raw address literals.
  *   <li>Top-level domains longer than six ASCII letters are rejected by {@code HostnameUtil}.
- *   <li>TODO: Clarify classification for IPv6-mapped IPv4 addresses to ensure consistent
- *       treatment across utilities.
+ *   <li>TODO: Clarify classification for IPv6-mapped IPv4 addresses to ensure consistent treatment
+ *       across utilities.
  * </ul>
  */
 package network.crypta.support.transport.ip;

--- a/src/test/java/network/crypta/support/math/BootstrappingDecayingRunningAverageTest.java
+++ b/src/test/java/network/crypta/support/math/BootstrappingDecayingRunningAverageTest.java
@@ -1,100 +1,270 @@
 package network.crypta.support.math;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
+import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-public class BootstrappingDecayingRunningAverageTest {
+/**
+ * Tests for {@link BootstrappingDecayingRunningAverage}.
+ *
+ * <p>Style: AAA (Arrange-Act-Assert), deterministic, and parameterized where helpful.
+ */
+class BootstrappingDecayingRunningAverageTest {
+  private static final double EPS = 1e-9;
+
+  // --- Utilities
+
+  private static BootstrappingDecayingRunningAverage newAvg(
+      double def, double min, double max, int maxReports) {
+    return new BootstrappingDecayingRunningAverage(def, min, max, maxReports, null);
+  }
+
+  private static double arithmeticMean(double... vals) {
+    return DoubleStream.of(vals).average().orElse(Double.NaN);
+  }
+
+  // --- Step 1: API surface and invariants (documented as tests below)
+
   @Test
-  public void decaysOverSubsequentReports() {
-    BootstrappingDecayingRunningAverage average =
-        new BootstrappingDecayingRunningAverage(0, 0, 1, 2, null);
-    average.report(1);
-    assertThat(average.currentValue(), equalTo(1.0));
-    average.report(0);
-    assertThat(average.currentValue(), equalTo(0.5));
-    average.report(0);
-    assertThat(average.currentValue(), equalTo(0.25));
-    average.report(0);
-    assertThat(average.currentValue(), equalTo(0.125));
+  void currentValue_whenNoReports_expectDefault() {
+    // Arrange
+    var avg = newAvg(42.25, 0, 100, 8);
+    // Act
+    double cv = avg.currentValue();
+    // Assert
+    assertEquals(42.25, cv, EPS);
+    assertEquals(0L, avg.countReports());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1, -10})
+  void constructor_whenMaxReportsNonPositive_expectIllegalArgument(int badMaxReports) {
+    // Arrange / Act / Assert
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BootstrappingDecayingRunningAverage(0.0, 0, 100, badMaxReports, null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("validBoundaryValues")
+  void report_whenAtInclusiveBoundaries_expectAccepted(double min, double max, double value) {
+    // Arrange
+    var avg = newAvg(1000.0, min, max, 10);
+    // Act
+    avg.report(value);
+    // Assert - first valid report uses weight 1 and becomes the value
+    assertEquals(value, avg.currentValue(), EPS);
+    assertEquals(1L, avg.countReports());
+  }
+
+  static Stream<Arguments> validBoundaryValues() {
+    return Stream.of(
+        Arguments.of(0.0, 100.0, 0.0), // min boundary
+        Arguments.of(0.0, 100.0, 100.0), // max boundary
+        Arguments.of(-5.0, -1.0, -5.0), // negative min boundary
+        Arguments.of(-5.0, -1.0, -1.0)); // negative max boundary
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidValues")
+  void report_whenInvalidInput_expectIgnored(double invalid) {
+    // Arrange
+    var avg = newAvg(10.0, 0.0, 100.0, 4);
+    // Act
+    avg.report(invalid);
+    // Assert
+    assertEquals(10.0, avg.currentValue(), EPS);
+    assertEquals(0L, avg.countReports());
+  }
+
+  static Stream<Arguments> invalidValues() {
+    return Stream.of(
+        Arguments.of(Double.NaN),
+        Arguments.of(Double.POSITIVE_INFINITY),
+        Arguments.of(Double.NEGATIVE_INFINITY),
+        Arguments.of(-1.0), // below min
+        Arguments.of(101.0) // above max
+        );
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidValues")
+  void valueIfReported_whenInvalidInput_expectUnchanged(double invalid) {
+    // Arrange
+    var avg = newAvg(7.5, 0.0, 100.0, 3);
+    // Act
+    double predicted = avg.valueIfReported(invalid);
+    // Assert
+    assertEquals(7.5, predicted, EPS);
+    assertEquals(7.5, avg.currentValue(), EPS);
+    assertEquals(0L, avg.countReports());
   }
 
   @Test
-  public void newInstanceHasDefaultValue() {
-    BootstrappingDecayingRunningAverage average =
-        new BootstrappingDecayingRunningAverage(1, 0, 1, 2, null);
-    assertThat(average.currentValue(), equalTo(1.0));
+  void reportLong_whenWithinRange_expectAcceptedAndCountIncremented() {
+    // Arrange
+    var avg = newAvg(0.0, 0.0, 1000.0, 5);
+    // Act
+    avg.report(200L);
+    // Assert
+    assertEquals(200.0, avg.currentValue(), EPS);
+    assertEquals(1L, avg.countReports());
   }
 
   @Test
-  public void countsNumberOfValidReports() {
-    BootstrappingDecayingRunningAverage average =
-        new BootstrappingDecayingRunningAverage(0, 0, 1, 2, null);
-    assertThat(average.countReports(), equalTo(0L));
-
-    // Valid report
-    average.report(0);
-    assertThat(average.countReports(), equalTo(1L));
-
-    // Invalid reports
-    average.report(-1000);
-    average.report(1000);
-    average.report(Double.NEGATIVE_INFINITY);
-    average.report(Double.POSITIVE_INFINITY);
-    average.report(Double.NaN);
-    assertThat(average.countReports(), equalTo(1L));
+  void report_whenBootstrapping_expectArithmeticMeanOverEarlyReports() {
+    // Arrange
+    var avg = newAvg(999.0, -100.0, 1000.0, 10); // maxReports > number of values
+    double[] vals = {10.0, 20.0, 30.0, 40.0, 50.0};
+    // Act
+    for (double v : vals) avg.report(v);
+    // Assert
+    assertEquals(arithmeticMean(vals), avg.currentValue(), EPS);
+    assertEquals(vals.length, avg.countReports());
   }
 
   @Test
-  public void writesStateToSimpleFieldSet() {
-    BootstrappingDecayingRunningAverage average =
-        new BootstrappingDecayingRunningAverage(0, 0, 1, 2, null);
-    average.report(0.5);
+  void report_whenBeyondMaxReports_expectExponentialDecayWeight() {
+    // Arrange: maxReports = 3 => steady weight = 1/3 after 3 reports
+    var avg = newAvg(0.0, 0.0, 100.0, 3);
+    avg.report(9.0); // cv = 9
+    avg.report(9.0); // cv = 9
+    avg.report(9.0); // cv = 9
+    assertEquals(3L, avg.countReports());
+    assertEquals(9.0, avg.currentValue(), EPS);
 
-    SimpleFieldSet sfs = average.exportFieldSet(true);
-    assertThat(
-        sfs.directKeyValues(),
-        allOf(
-            hasEntry("Type", "BootstrappingDecayingRunningAverage"),
-            hasEntry("Reports", "1"),
-            hasEntry("CurrentValue", "0.5")));
+    // Act: next report uses decayFactor = 1 / min(4, 3) = 1/3
+    double predicted = avg.valueIfReported(12.0);
+    avg.report(12.0);
+
+    // Assert
+    double expected = (12.0 * (1.0 / 3.0)) + (9.0 * (1.0 - (1.0 / 3.0)));
+    assertEquals(expected, predicted, EPS);
+    assertEquals(expected, avg.currentValue(), EPS);
+    assertEquals(4L, avg.countReports());
   }
 
   @Test
-  public void canBeRestoredFromSimpleFieldSet() {
-    SimpleFieldSet sfs = new SimpleFieldSet(true);
-    sfs.putSingle("Type", "BootstrappingDecayingRunningAverage");
-    sfs.putSingle("Reports", "1");
-    sfs.putSingle("CurrentValue", "0.5");
-
-    BootstrappingDecayingRunningAverage average =
-        new BootstrappingDecayingRunningAverage(0, 0, 1, 2, sfs);
-    assertThat(average.currentValue(), equalTo(0.5));
-    assertThat(average.countReports(), equalTo(1L));
-
-    average.report(0);
-    assertThat(average.currentValue(), equalTo(0.25));
-    assertThat(average.countReports(), equalTo(2L));
+  void valueIfReported_whenCalled_expectMatchesSubsequentReport() {
+    // Arrange
+    var avg = newAvg(5.0, 0.0, 100.0, 4);
+    avg.report(9.0);
+    avg.report(13.0);
+    // Act
+    double predicted = avg.valueIfReported(17.0);
+    avg.report(17.0);
+    // Assert
+    assertEquals(predicted, avg.currentValue(), EPS);
   }
 
   @Test
-  public void cloneCreatesIndependentInstance() {
-    BootstrappingDecayingRunningAverage first =
-        new BootstrappingDecayingRunningAverage(0, 0, 1, 2, null);
-    BootstrappingDecayingRunningAverage second = new BootstrappingDecayingRunningAverage(first);
-    second.report(0);
-    second.report(1);
+  void constructor_whenFieldSetHasValidStoredValues_expectInitializesFromFieldSet() {
+    // Arrange
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.put("CurrentValue", 42.5);
+    fs.put("Reports", 10L);
+    // Act
+    var avg = new BootstrappingDecayingRunningAverage(0.0, 0.0, 100.0, 8, fs);
+    // Assert
+    assertEquals(42.5, avg.currentValue(), EPS);
+    assertEquals(10L, avg.countReports());
+  }
 
-    // Cloned instance should remain untouched
-    assertThat(first.currentValue(), equalTo(0.0));
-    assertThat(first.countReports(), equalTo(0L));
+  @Test
+  void constructor_whenFieldSetHasInvalidCurrentValue_expectIgnoresAndUsesDefault() {
+    // Arrange
+    SimpleFieldSet fs = mock(SimpleFieldSet.class);
+    when(fs.getDouble(eq("CurrentValue"), anyDouble())).thenReturn(Double.NaN);
+    // If code were to call getLong, it's a bug in this path; make it obvious if it happens
+    when(fs.getLong(eq("Reports"), anyLong()))
+        .thenAnswer(
+            inv -> {
+              fail("getLong should not be called when CurrentValue is invalid");
+              return 99L;
+            });
 
-    // New instance should be updated
-    assertThat(second.currentValue(), equalTo(0.5));
-    assertThat(second.countReports(), equalTo(2L));
+    // Act
+    var avg = new BootstrappingDecayingRunningAverage(7.0, 0.0, 100.0, 8, fs);
+
+    // Assert
+    assertEquals(7.0, avg.currentValue(), EPS); // default retained
+    assertEquals(0L, avg.countReports()); // reports not overridden
+    verify(fs, times(1)).getDouble(eq("CurrentValue"), anyDouble());
+    verify(fs, never()).getLong(eq("Reports"), anyLong());
+  }
+
+  @Test
+  void exportFieldSet_whenCalled_expectContainsTypeAndValues() {
+    // Arrange
+    var avg = newAvg(3.0, 0.0, 100.0, 5);
+    avg.report(5.0);
+    avg.report(7.0);
+    // Act
+    SimpleFieldSet out = avg.exportFieldSet(true);
+    // Assert
+    assertEquals("BootstrappingDecayingRunningAverage", out.get("Type"));
+    assertEquals(avg.currentValue(), out.getDouble("CurrentValue", -1.0), EPS);
+    assertEquals(avg.countReports(), out.getLong("Reports", -1));
+  }
+
+  @Test
+  void copyConstructor_whenSourceMutatesLater_expectSnapshotIndependence() {
+    // Arrange
+    var original = newAvg(0.0, 0.0, 100.0, 4);
+    original.report(10.0);
+    original.report(20.0);
+    var copy = new BootstrappingDecayingRunningAverage(original);
+
+    // Act - mutate original further
+    original.report(30.0);
+
+    // Assert - copy remains as it was at snapshot time
+    assertNotEquals(original.currentValue(), copy.currentValue(), EPS);
+    assertEquals(2L, copy.countReports());
+  }
+
+  @Test
+  void changeMaxReports_whenSetToSmaller_expectHeavierWeightOnNextObservation() {
+    // Arrange
+    var avg = newAvg(0.0, 0.0, 100.0, 5);
+    avg.report(10.0); // n=1, cv=10
+    avg.report(20.0); // n=2, cv=15
+    double predictedBefore = avg.valueIfReported(100.0); // would use 1/3
+
+    // Act - reduce maxReports so next uses weight 1/2 instead of 1/3
+    avg.changeMaxReports(2);
+    double predictedAfter = avg.valueIfReported(100.0);
+
+    // Assert
+    double expectedBefore = (100.0 * (1.0 / 3.0)) + (15.0 * (1.0 - (1.0 / 3.0)));
+    double expectedAfter = (100.0 * (1.0 / 2.0)) + (15.0 * (1.0 - (1.0 / 2.0)));
+    assertEquals(expectedBefore, predictedBefore, EPS);
+    assertEquals(expectedAfter, predictedAfter, EPS);
+    assertTrue(
+        predictedAfter > predictedBefore, "Smaller maxReports should increase weight of new value");
+  }
+
+  @Test
+  void changeMaxReports_whenSetToZero_expectNaNOnNextPredictionAndUpdate() {
+    // Arrange
+    var avg = newAvg(1.0, 0.0, 100.0, 5);
+    avg.report(5.0); // one valid report
+    assertEquals(1L, avg.countReports());
+    // Act
+    avg.changeMaxReports(0);
+    double predicted = avg.valueIfReported(10.0);
+    avg.report(10.0);
+    // Assert
+    assertTrue(Double.isNaN(predicted));
+    assertTrue(Double.isNaN(avg.currentValue()));
   }
 }

--- a/src/test/java/network/crypta/support/math/DecayingKeyspaceAverageTest.java
+++ b/src/test/java/network/crypta/support/math/DecayingKeyspaceAverageTest.java
@@ -1,36 +1,252 @@
 package network.crypta.support.math;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.stream.Stream;
+import network.crypta.node.Location;
+import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class DecayingKeyspaceAverageTest {
-  private final DecayingKeyspaceAverage average = new DecayingKeyspaceAverage(0.5, 2, null);
+/**
+ * Tests for {@link DecayingKeyspaceAverage} in AAA style.
+ *
+ * <p>Deterministic, no time/I-O dependencies. We use Mockito to mock {@link SimpleFieldSet} when
+ * exercising persistence-based construction paths.
+ */
+class DecayingKeyspaceAverageTest {
+
+  private static final double EPS = 1e-12;
+
+  // -------- Helpers / sources --------
+
+  static Stream<Double> invalidDoubles() {
+    return Stream.of(-0.1, 1.1, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+  }
+
+  static Stream<Double> boundaryDoubles() {
+    return Stream.of(0.0, 1.0);
+  }
+
+  // -------- Tests --------
 
   @Test
-  public void wrapsAround() {
-    average.report(0.5);
-    assertThat(average.currentValue(), equalTo(0.5));
-    average.report(1.0);
-    assertThat(average.currentValue(), equalTo(0.75));
-    average.report(0.25);
-    assertThat(average.currentValue(), equalTo(0.0));
-    average.report(0.25);
-    assertThat(average.currentValue(), equalTo(0.125));
-    average.report(0.875);
-    assertThat(average.currentValue(), equalTo(0.0));
-    average.report(0.75);
-    assertThat(average.currentValue(), equalTo(0.875));
+  void currentValue_whenConstructedWithDefault_expectDefault() {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.5, 2, null);
+
+    // Act
+    double value = avg.currentValue();
+
+    // Assert
+    assertThat(value, equalTo(0.5));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidDoubles")
+  void report_whenInvalid_expectIllegalArgumentException(Double invalid) {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.5, 2, null);
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> avg.report(invalid));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidDoubles")
+  void valueIfReported_whenInvalid_expectIllegalArgumentException(Double invalid) {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.5, 2, null);
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> avg.valueIfReported(invalid));
+  }
+
+  @ParameterizedTest
+  @MethodSource("boundaryDoubles")
+  void report_whenBoundaryValues_expectAccepted(Double boundary) {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.5, 2, null);
+    assertEquals(0, avg.countReports());
+
+    // Act
+    assertDoesNotThrow(() -> avg.report(boundary));
+
+    // Assert
+    assertEquals(1, avg.countReports());
+    // For boundary=1.0, the stored value normalizes to 0.0; for 0.0, it's 0.0 directly.
+    assertThat(avg.currentValue(), closeTo(0.0, EPS));
   }
 
   @Test
-  public void rejectsInvalidInput() {
-    assertThrows(IllegalArgumentException.class, () -> average.report(1.1));
-    assertThrows(IllegalArgumentException.class, () -> average.report(-0.1));
-    assertThrows(IllegalArgumentException.class, () -> average.report(Double.NaN));
-    assertThrows(IllegalArgumentException.class, () -> average.report(Double.POSITIVE_INFINITY));
-    assertThrows(IllegalArgumentException.class, () -> average.report(Double.NEGATIVE_INFINITY));
+  void valueIfReported_whenCalled_doesNotMutateState() {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.25, 2, null);
+    avg.report(0.25); // anchor first sample; decay=1.0
+    double beforeValue = avg.currentValue();
+    long beforeCount = avg.countReports();
+
+    // Act
+    double predicted = avg.valueIfReported(0.75);
+
+    // Assert
+    // Expect normalize(s + 0.5 * change(s, d)) with s=0.25, d=0.75, change=0.5
+    double expected = Location.normalize(beforeValue + 0.5 * Location.change(beforeValue, 0.75));
+    assertThat(predicted, closeTo(expected, EPS));
+    assertThat(avg.currentValue(), closeTo(beforeValue, EPS));
+    assertEquals(beforeCount, avg.countReports());
+  }
+
+  @Test
+  void report_whenWrapsAcrossBoundary_expectShortestPath() {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.5, 2, null);
+
+    // Act + Assert (anchor at 0.5)
+    avg.report(0.5);
+    assertThat(avg.currentValue(), equalTo(0.5));
+
+    // Act + Assert (0.5 -> 1.0 wraps at boundary; expected 0.75 due to 0.5 decay)
+    avg.report(1.0);
+    assertThat(avg.currentValue(), equalTo(0.75));
+
+    // Act + Assert (0.75 -> 0.25 across wrap, expected 0.0)
+    avg.report(0.25);
+    assertThat(avg.currentValue(), equalTo(0.0));
+
+    // Act + Assert (continue sequence as regression coverage)
+    avg.report(0.25);
+    assertThat(avg.currentValue(), equalTo(0.125));
+    avg.report(0.875);
+    assertThat(avg.currentValue(), equalTo(0.0));
+    avg.report(0.75);
+    assertThat(avg.currentValue(), equalTo(0.875));
+  }
+
+  @Test
+  void reportLong_whenCalled_expectIllegalArgumentException() {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.5, 2, null);
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> avg.report(1L));
+  }
+
+  @Test
+  void changeMaxReports_whenSetToOne_nextReportReplacesCurrent() {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.0, 2, null);
+    avg.report(0.9); // anchor: s=0.9
+
+    // Act: with maxReports=2, reporting 0.1 moves halfway across shortest path
+    avg.report(0.1);
+    double expectedHalf = Location.normalize(0.9 + 0.5 * Location.change(0.9, 0.1));
+    assertThat(avg.currentValue(), closeTo(expectedHalf, EPS));
+
+    // Act: increase decay by setting maxReports=1 so next report fully replaces current
+    avg.changeMaxReports(1);
+    avg.report(0.2);
+
+    // Assert: new value equals the unwrapped target (normalized)
+    double expectedFull = Location.normalize(expectedHalf + Location.change(expectedHalf, 0.2));
+    assertThat(avg.currentValue(), closeTo(expectedFull, EPS));
+  }
+
+  @Test
+  void copyConstructor_whenCopied_modifyingCopyDoesNotAffectOriginal() {
+    // Arrange
+    DecayingKeyspaceAverage original = new DecayingKeyspaceAverage(0.5, 2, null);
+    original.report(0.5);
+    original.report(0.75);
+    DecayingKeyspaceAverage copy = new DecayingKeyspaceAverage(original);
+    double originalBefore = original.currentValue();
+    long reportsBefore = original.countReports();
+
+    // Act
+    copy.report(0.875); // mutate copy only
+
+    // Assert
+    assertThat(original.currentValue(), closeTo(originalBefore, EPS));
+    assertEquals(reportsBefore, original.countReports());
+  }
+
+  @Test
+  void copyOf_whenCalled_returnsDeepCopy() {
+    // Arrange
+    DecayingKeyspaceAverage original = new DecayingKeyspaceAverage(0.5, 2, null);
+    original.report(0.5);
+    original.report(1.0);
+    double snapValue = original.currentValue();
+    long snapReports = original.countReports();
+
+    // Act: take a snapshot using the interface helper and then mutate original
+    RunningAverage snapshot = RunningAverage.copyOf(original);
+    original.report(0.25);
+
+    // Assert: snapshot is independent
+    assertThat(snapshot.currentValue(), closeTo(snapValue, EPS));
+    assertEquals(snapReports, snapshot.countReports());
+  }
+
+  @Test
+  void constructorWithBaseAverage_whenBaseMutatedAfterConstruction_doesNotAffectInstance() {
+    // Arrange (prepare a base underlying average with some state)
+    BootstrappingDecayingRunningAverage base =
+        new BootstrappingDecayingRunningAverage(0.25, -2.0, 2.0, 4, null);
+    base.report(0.75);
+    double snapshot = base.currentValue();
+    long snapReports = base.countReports();
+
+    // Act: construct instance from base (takes snapshot) and then mutate base
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(base);
+    base.report(0.0); // mutate base after construction
+
+    // Assert: the new instance reflects the snapshot, not later mutations
+    assertThat(avg.currentValue(), closeTo(snapshot, EPS));
+    assertEquals(snapReports, avg.countReports());
+  }
+
+  @Test
+  void exportFieldSet_whenCalled_containsTypeAndCurrentValueAndReports() {
+    // Arrange
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.5, 2, null);
+    avg.report(0.5);
+    avg.report(1.0); // normalizes to 0.75 internally then to [0,1)
+    double current = avg.currentValue();
+    long reports = avg.countReports();
+
+    // Act
+    SimpleFieldSet sfs = avg.exportFieldSet(false);
+
+    // Assert
+    assertThat(sfs.get("Type"), equalTo("BootstrappingDecayingRunningAverage"));
+    assertThat(Double.parseDouble(sfs.get("CurrentValue")), closeTo(current, EPS));
+    assertEquals(reports, Long.parseLong(sfs.get("Reports")));
+  }
+
+  @Test
+  void constructor_whenFsProvided_usesPersistedValues() {
+    // Arrange: mock SimpleFieldSet to simulate persisted state
+    SimpleFieldSet fs = mock(SimpleFieldSet.class);
+    when(fs.getDouble(eq("CurrentValue"), anyDouble())).thenReturn(1.75);
+    when(fs.getLong(eq("Reports"), anyLong())).thenReturn(13L);
+
+    // Act
+    DecayingKeyspaceAverage avg = new DecayingKeyspaceAverage(0.5, 4, fs);
+
+    // Assert: the underlying snapshot is picked up from fs
+    assertThat(avg.currentValue(), equalTo(1.75));
+    assertEquals(13L, avg.countReports());
   }
 }

--- a/src/test/java/network/crypta/support/math/MersenneTwisterTest.java
+++ b/src/test/java/network/crypta/support/math/MersenneTwisterTest.java
@@ -9,10 +9,10 @@ import java.util.stream.Stream;
 import network.crypta.support.Fields;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.function.ThrowingSupplier;
 
 /**
  * Unit tests for {@link MersenneTwister} wrapper.

--- a/src/test/java/network/crypta/support/math/MersenneTwisterTest.java
+++ b/src/test/java/network/crypta/support/math/MersenneTwisterTest.java
@@ -1,202 +1,346 @@
 package network.crypta.support.math;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.util.stream.Stream;
 import network.crypta.support.Fields;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 
-public class MersenneTwisterTest {
+/**
+ * Unit tests for {@link MersenneTwister} wrapper.
+ *
+ * <p>Tests compare sequences against the upstream implementation {@link
+ * org.spaceroots.mantissa.random.MersenneTwister} to ensure behavioral compatibility. All seeds are
+ * deterministic; tests avoid the time-based constructors to prevent flakiness.
+ */
+class MersenneTwisterTest {
 
-  // Should be sufficient for testing MT
-  private static final int SEED_SIZE = 624;
-  private static final int[] INT_SEED = new int[SEED_SIZE];
-  private static final byte[] BYTE_SEED;
-  private static final int[] INPUT_1 = new int[] {123456789, 123456789, 123456789, 123456789};
-  private static final byte[] OUTPUT_1 =
-      new byte[] {
-        (byte) 0x15,
-        (byte) 0xCD,
-        (byte) 0x5B,
-        (byte) 0x7,
-        (byte) 0x15,
-        (byte) 0xCD,
-        (byte) 0x5B,
-        (byte) 0x7,
-        (byte) 0x15,
-        (byte) 0xCD,
-        (byte) 0x5B,
-        (byte) 0x7,
-        (byte) 0x15,
-        (byte) 0xCD,
-        (byte) 0x5B,
-        (byte) 0x7
-      };
-  private static final byte[] EXPECTED_OUTPUT_MT_INT =
-      new byte[] {
-        (byte) 0x9a,
-        (byte) 0x6,
-        (byte) 0xab,
-        (byte) 0x8c,
-        (byte) 0x2b,
-        (byte) 0xf3,
-        (byte) 0x3d,
-        (byte) 0x7f,
-        (byte) 0x6,
-        (byte) 0x4,
-        (byte) 0x5b,
-        (byte) 0x20ac,
-        (byte) 0x46,
-        (byte) 0xdd,
-        (byte) 0xdf,
-        (byte) 0x47,
-        (byte) 0x28,
-        (byte) 0xc0,
-        (byte) 0xb7,
-        (byte) 0x74
-      };
-  private static final byte[] EXPECTED_OUTPUT_MT_LONG =
-      new byte[] {
-        (byte) 0x4f,
-        (byte) 0x75,
-        (byte) 0xda,
-        (byte) 0x52,
-        (byte) 0xe2,
-        (byte) 0x40,
-        (byte) 0xf0,
-        (byte) 0x1,
-        (byte) 0x8a,
-        (byte) 0x69,
-        (byte) 0xf6,
-        (byte) 0xcb,
-        (byte) 0x1a,
-        (byte) 0xe3,
-        (byte) 0x1,
-        (byte) 0xb6,
-        (byte) 0x21,
-        (byte) 0x1f,
-        (byte) 0x73,
-        (byte) 0xec
-      };
-  private static final byte[] EXPECTED_OUTPUT_MT_INTS =
-      new byte[] {
-        (byte) 0x1C,
-        (byte) 0x58,
-        (byte) 0xB0,
-        (byte) 0x47,
-        (byte) 0x92,
-        (byte) 0xC7,
-        (byte) 0xBE,
-        (byte) 0xC4,
-        (byte) 0x25,
-        (byte) 0x64,
-        (byte) 0x31,
-        (byte) 0x27,
-        (byte) 0x12,
-        (byte) 0x14,
-        (byte) 0xDB,
-        (byte) 0xF,
-        (byte) 0x61,
-        (byte) 0xA6,
-        (byte) 0x73,
-        (byte) 0x32
-      };
-  private static final byte[] EXPECTED_OUTPUT_MT_BYTES =
-      new byte[] {
-        (byte) 0x5C,
-        (byte) 0x6,
-        (byte) 0xAD,
-        (byte) 0x71,
-        (byte) 0x56,
-        (byte) 0xDB,
-        (byte) 0xBE,
-        (byte) 0x69,
-        (byte) 0x87,
-        (byte) 0xDF,
-        (byte) 0xC4,
-        (byte) 0x3B,
-        (byte) 0xCB,
-        (byte) 0x71,
-        (byte) 0x73,
-        (byte) 0xF1,
-        (byte) 0x9B,
-        (byte) 0xED,
-        (byte) 0x9,
-        (byte) 0x2D,
-      };
+  // Generate a moderate number of values to validate sequence equality while keeping tests fast.
+  private static final int SEQ_LEN = 128;
 
-  static {
-    ByteBuffer bb = ByteBuffer.allocate(INT_SEED.length * 4);
-    for (int i = 0; i < INT_SEED.length; i++) {
-      INT_SEED[i] = i;
-      bb.putInt(i);
-    }
-    BYTE_SEED = bb.array();
+  // ----- Parameter sources -----
+
+  private static Stream<Integer> intSeeds() {
+    return Stream.of(0, 1, -1, 123456789, Integer.MIN_VALUE, Integer.MAX_VALUE);
   }
 
-  private static String bytesToString(byte[] bytes) {
-    return new String(bytes, StandardCharsets.UTF_8);
+  private static Stream<Long> longSeeds() {
+    return Stream.of(0L, 1L, -1L, 0x0123456789ABCDEFL, Long.MIN_VALUE, Long.MAX_VALUE);
   }
 
-  @Test
-  public void testBytesToInts() {
-    // Test the consistency in order to avoid the freenet-ext #24 fiasco
-    int[] output = Fields.bytesToInts(OUTPUT_1, 0, OUTPUT_1.length);
+  private static Stream<Arguments> intArraySeeds() {
+    return Stream.of(
+        Arguments.of((Object) new int[] {42}),
+        Arguments.of((Object) new int[] {0xCAFEBABE}),
+        Arguments.of((Object) new int[] {1, 2}),
+        Arguments.of((Object) new int[] {0, -1, Integer.MIN_VALUE, Integer.MAX_VALUE}));
+  }
 
-    assertEquals(INPUT_1.length, output.length);
-    for (int i = 0; i < INPUT_1.length; i++) {
-      assertEquals(INPUT_1[i], output[i]);
+  private static Stream<Arguments> validByteArraySeeds() {
+    // Use Fields.intsToBytes() to create byte[] that reversibly maps to int[] via bytesToInts().
+    return Stream.of(
+        Arguments.of((Object) Fields.intsToBytes(new int[] {42})),
+        Arguments.of((Object) Fields.intsToBytes(new int[] {0xCAFEBABE})),
+        Arguments.of((Object) Fields.intsToBytes(new int[] {1, 2})),
+        Arguments.of(
+            (Object) Fields.intsToBytes(new int[] {0, -1, Integer.MIN_VALUE, Integer.MAX_VALUE})));
+  }
+
+  private static Stream<byte[]> invalidLengthByteArraySeeds() {
+    return Stream.of(
+        new byte[] {1}, new byte[] {1, 2}, new byte[] {1, 2, 3}, new byte[] {1, 2, 3, 4, 5});
+  }
+
+  // ----- Tests comparing against upstream implementation -----
+
+  @ParameterizedTest
+  @MethodSource("intSeeds")
+  @DisplayName("nextInt_whenSeededWithInt_sameSequenceAsUpstream")
+  void nextInt_whenSeededWithInt_sameSequenceAsUpstream(int seed) {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(seed);
+    org.spaceroots.mantissa.random.MersenneTwister upstream =
+        new org.spaceroots.mantissa.random.MersenneTwister(seed);
+
+    // Act & Assert
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(upstream.nextInt(), ours.nextInt(), "Mismatch at index " + i);
     }
   }
 
-  @Test
-  public void testConsistencySeedFromInts() throws NoSuchAlgorithmException {
-    MessageDigest md = MessageDigest.getInstance("SHA-1");
-    MersenneTwister mt = new MersenneTwister(INT_SEED);
-    byte[] bytes = new byte[SEED_SIZE];
+  @ParameterizedTest
+  @MethodSource("longSeeds")
+  @DisplayName("nextInt_whenSeededWithLong_sameSequenceAsUpstream")
+  void nextInt_whenSeededWithLong_sameSequenceAsUpstream(long seed) {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(seed);
+    org.spaceroots.mantissa.random.MersenneTwister upstream =
+        new org.spaceroots.mantissa.random.MersenneTwister(seed);
 
-    mt.nextBytes(bytes);
-    md.update(bytes);
+    // Act & Assert
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(upstream.nextInt(), ours.nextInt(), "Mismatch at index " + i);
+    }
+  }
 
-    assertEquals(bytesToString(EXPECTED_OUTPUT_MT_INTS), bytesToString(md.digest()));
+  @ParameterizedTest
+  @MethodSource("intArraySeeds")
+  @DisplayName("nextInt_whenSeededWithIntArray_sameSequenceAsUpstream")
+  void nextInt_whenSeededWithIntArray_sameSequenceAsUpstream(int[] seed) {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(seed);
+    org.spaceroots.mantissa.random.MersenneTwister upstream =
+        new org.spaceroots.mantissa.random.MersenneTwister(seed);
+
+    // Act & Assert
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(upstream.nextInt(), ours.nextInt(), "Mismatch at index " + i);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("validByteArraySeeds")
+  @DisplayName("nextInt_whenSeededWithByteArray_sameSequenceAsUpstreamConvertedInts")
+  void nextInt_whenSeededWithByteArray_sameSequenceAsUpstreamConvertedInts(byte[] seed) {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(123); // placeholder seed, will be replaced
+    ours.setSeed(seed);
+
+    int[] ints = Fields.bytesToInts(seed);
+    org.spaceroots.mantissa.random.MersenneTwister upstream =
+        new org.spaceroots.mantissa.random.MersenneTwister(ints);
+
+    // Act & Assert
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(upstream.nextInt(), ours.nextInt(), "Mismatch at index " + i);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("validByteArraySeeds")
+  @DisplayName("nextInt_whenCreatedUnsynchronizedByteSeed_matchesSynchronized")
+  void nextInt_whenCreatedUnsynchronizedByteSeed_matchesSynchronized(byte[] seed) {
+    // Arrange
+    MersenneTwister sync = MersenneTwister.createSynchronized(seed);
+    MersenneTwister unsync = MersenneTwister.createUnsynchronized(seed);
+
+    // Act & Assert
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(sync.nextInt(), unsync.nextInt(), "Mismatch at index " + i);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("intSeeds")
+  @DisplayName("nextGaussian_whenSameIntSeed_matchesUpstream")
+  void nextGaussian_whenSameIntSeed_matchesUpstream(int seed) {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(seed);
+    org.spaceroots.mantissa.random.MersenneTwister upstream =
+        new org.spaceroots.mantissa.random.MersenneTwister(seed);
+
+    // Act & Assert
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(upstream.nextGaussian(), ours.nextGaussian(), 0.0, "Mismatch at index " + i);
+    }
   }
 
   @Test
-  public void testConsistencySeedFromBytes() throws NoSuchAlgorithmException {
-    MessageDigest md = MessageDigest.getInstance("SHA-1");
-    MersenneTwister mt = MersenneTwister.createUnsynchronized(BYTE_SEED);
-    byte[] bytes = new byte[SEED_SIZE];
+  @DisplayName("nextBytes_whenSameSeed_equalOutput")
+  void nextBytes_whenSameSeed_equalOutput() {
+    // Arrange
+    int seed = 987654321;
+    MersenneTwister ours = new MersenneTwister(seed);
+    org.spaceroots.mantissa.random.MersenneTwister upstream =
+        new org.spaceroots.mantissa.random.MersenneTwister(seed);
+    byte[] b1 = new byte[64];
+    byte[] b2 = new byte[64];
 
-    mt.nextBytes(bytes);
-    md.update(bytes);
+    // Act
+    ours.nextBytes(b1);
+    upstream.nextBytes(b2);
 
-    assertEquals(bytesToString(EXPECTED_OUTPUT_MT_BYTES), bytesToString(md.digest()));
+    // Assert
+    assertArrayEquals(b2, b1);
   }
 
   @Test
-  public void testConsistencySeedFromInteger() throws NoSuchAlgorithmException {
-    MessageDigest md = MessageDigest.getInstance("SHA-1");
-    MersenneTwister mt = new MersenneTwister(Integer.MAX_VALUE);
-    byte[] bytes = new byte[SEED_SIZE];
+  @DisplayName("nextBytes_whenZeroLength_noChangeAndNoException")
+  void nextBytes_whenZeroLength_noChangeAndNoException() {
+    // Arrange
+    int seed = 13579;
+    MersenneTwister ours = new MersenneTwister(seed);
+    byte[] empty = new byte[0];
 
-    mt.nextBytes(bytes);
-    md.update(bytes);
-
-    assertEquals(bytesToString(EXPECTED_OUTPUT_MT_INT), bytesToString(md.digest()));
+    // Act & Assert
+    assertDoesNotThrow(() -> ours.nextBytes(empty));
+    assertEquals(0, empty.length);
   }
 
   @Test
-  public void testConsistencySeedFromLong() throws NoSuchAlgorithmException {
-    MessageDigest md = MessageDigest.getInstance("SHA-1");
-    MersenneTwister mt = new MersenneTwister(Long.MAX_VALUE);
-    byte[] bytes = new byte[SEED_SIZE];
+  @DisplayName("setSeed_whenCalledTwiceWithSameIntSeed_resetsSequence")
+  void setSeed_whenCalledTwiceWithSameIntSeed_resetsSequence() {
+    // Arrange
+    int seed = 424242;
+    MersenneTwister ours = new MersenneTwister(seed);
 
-    mt.nextBytes(bytes);
-    md.update(bytes);
+    int firstA = ours.nextInt();
+    int secondA = ours.nextInt();
 
-    assertEquals(bytesToString(EXPECTED_OUTPUT_MT_LONG), bytesToString(md.digest()));
+    // Act
+    ours.setSeed(seed);
+
+    int firstB = ours.nextInt();
+    int secondB = ours.nextInt();
+
+    // Assert
+    assertEquals(firstA, firstB);
+    assertEquals(secondA, secondB);
+  }
+
+  // ----- Null and invalid input paths -----
+
+  @Test
+  @DisplayName("setSeed_whenIntArrayNull_doesNotThrow")
+  void setSeed_whenIntArrayNull_doesNotThrow() {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(123);
+
+    // Act & Assert: Upstream supports null -> time-based seed; wrapper forwards to super.
+    assertDoesNotThrow(() -> ours.setSeed((int[]) null));
+    // Also exercise that generator remains usable.
+    assertDoesNotThrow((ThrowingSupplier<Integer>) ours::nextInt);
+  }
+
+  @Test
+  @DisplayName("setSeed_whenByteArrayNull_throwsNullPointerException")
+  void setSeed_whenByteArrayNull_throwsNullPointerException() {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(123);
+
+    // Act + Assert
+    assertThrows(NullPointerException.class, () -> ours.setSeed((byte[]) null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidLengthByteArraySeeds")
+  @DisplayName("setSeed_whenByteArrayNotMultipleOf4_throwsIllegalArgumentException")
+  void setSeed_whenByteArrayNotMultipleOf4_throwsIllegalArgumentException(byte[] badSeed) {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(123);
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> ours.setSeed(badSeed));
+  }
+
+  @Test
+  @DisplayName("setSeed_whenEmptyByteArray_throwsArrayIndexOutOfBoundsException")
+  void setSeed_whenEmptyByteArray_throwsArrayIndexOutOfBoundsException() {
+    // Arrange
+    MersenneTwister ours = new MersenneTwister(123);
+    byte[] empty = new byte[0];
+
+    // Act + Assert: bytesToInts(empty) -> empty int[], upstream setSeed(int[]) will access seed[0]
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ours.setSeed(empty));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidLengthByteArraySeeds")
+  @DisplayName("createSynchronized_whenByteArrayNotMultipleOf4_throwsIllegalArgumentException")
+  void createSynchronized_whenByteArrayNotMultipleOf4_throwsIllegalArgumentException(
+      byte[] badSeed) {
+    assertThrows(IllegalArgumentException.class, () -> MersenneTwister.createSynchronized(badSeed));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidLengthByteArraySeeds")
+  @DisplayName("createUnsynchronized_whenByteArrayNotMultipleOf4_throwsIllegalArgumentException")
+  void createUnsynchronized_whenByteArrayNotMultipleOf4_throwsIllegalArgumentException(
+      byte[] badSeed) {
+    assertThrows(
+        IllegalArgumentException.class, () -> MersenneTwister.createUnsynchronized(badSeed));
+  }
+
+  @Test
+  @DisplayName("createSynchronized_whenEmptyByteArray_throwsArrayIndexOutOfBoundsException")
+  void createSynchronized_whenEmptyByteArray_throwsArrayIndexOutOfBoundsException() {
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class,
+        () -> MersenneTwister.createSynchronized(new byte[0]));
+  }
+
+  @Test
+  @DisplayName("createUnsynchronized_whenEmptyByteArray_throwsArrayIndexOutOfBoundsException")
+  void createUnsynchronized_whenEmptyByteArray_throwsArrayIndexOutOfBoundsException() {
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class,
+        () -> MersenneTwister.createUnsynchronized(new byte[0]));
+  }
+
+  @Test
+  @DisplayName("createMethods_whenByteArrayNull_throwsNullPointerException")
+  void createMethods_whenByteArrayNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> MersenneTwister.createSynchronized(null));
+    assertThrows(NullPointerException.class, () -> MersenneTwister.createUnsynchronized(null));
+  }
+
+  // ----- Byte/int conversions and cross-API consistency -----
+
+  @Test
+  @DisplayName("setSeed_whenByteArrayEqualsIntsConversion_sameSequence")
+  void setSeed_whenByteArrayEqualsIntsConversion_sameSequence() {
+    // Arrange
+    int[] ints = new int[] {0x01234567, 0x89ABCDEF};
+    byte[] bytes = Fields.intsToBytes(ints);
+    MersenneTwister viaBytes = new MersenneTwister(0);
+    viaBytes.setSeed(bytes);
+
+    MersenneTwister viaInts = new MersenneTwister(0);
+    viaInts.setSeed(ints);
+
+    // Act & Assert
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(viaInts.nextLong(), viaBytes.nextLong(), "Mismatch at index " + i);
+    }
+  }
+
+  @Test
+  @DisplayName("unsynchronizedAndSynchronized_whenSameSeed_produceIdenticalSequence")
+  void unsynchronizedAndSynchronized_whenSameSeed_produceIdenticalSequence() {
+    // Arrange
+    byte[] seed = Fields.intsToBytes(new int[] {123456789});
+    MersenneTwister sync = MersenneTwister.createSynchronized(seed);
+    MersenneTwister unsync = MersenneTwister.createUnsynchronized(seed);
+
+    // Act & Assert
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(sync.nextLong(), unsync.nextLong(), "Mismatch at index " + i);
+    }
+  }
+
+  @Test
+  @DisplayName("randomApiParity_whenSameSeed_matchesForAllPrimitives")
+  void randomApiParity_whenSameSeed_matchesForAllPrimitives() {
+    // Arrange
+    int seed = 2468;
+    MersenneTwister ours = new MersenneTwister(seed);
+    org.spaceroots.mantissa.random.MersenneTwister upstream =
+        new org.spaceroots.mantissa.random.MersenneTwister(seed);
+
+    // Act & Assert across various Random methods
+    for (int i = 0; i < SEQ_LEN; i++) {
+      assertEquals(upstream.nextBoolean(), ours.nextBoolean(), "boolean @" + i);
+      assertEquals(upstream.nextFloat(), ours.nextFloat(), 0.0f, "float @" + i);
+      assertEquals(upstream.nextDouble(), ours.nextDouble(), 0.0, "double @" + i);
+      assertEquals(upstream.nextLong(), ours.nextLong(), "long @" + i);
+    }
   }
 }

--- a/src/test/java/network/crypta/support/math/SimpleRunningAverageTest.java
+++ b/src/test/java/network/crypta/support/math/SimpleRunningAverageTest.java
@@ -1,47 +1,291 @@
 package network.crypta.support.math;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class SimpleRunningAverageTest {
-  private final SimpleRunningAverage average = new SimpleRunningAverage(4, 100.0);
+class SimpleRunningAverageTest {
+  private static final double EPS = 1e-9;
 
   @Test
-  public void returnsInitialValue() {
-    assertThat(average.currentValue(), equalTo(100.0));
+  void currentValue_whenNoReports_returnsInitValue() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(4, 100.0);
+
+    // Act
+    double value = avg.currentValue();
+
+    // Assert
+    assertEquals(100.0, value, EPS);
   }
 
   @Test
-  public void returnsLinearMeanOfLastReports() {
-    average.report(10);
-    assertThat(average.currentValue(), equalTo(10.0));
-    average.report(40);
-    assertThat(average.currentValue(), equalTo(25.0));
-    average.report(40);
-    assertThat(average.currentValue(), equalTo(30.0));
-    average.report(110);
-    assertThat(average.currentValue(), equalTo(50.0));
+  void report_whenWithinWindow_updatesCurrentValue() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(4, 100.0);
 
-    // Values should start dropping out now
-    average.report(40);
-    assertThat(average.currentValue(), equalTo(57.5));
-    average.report(10);
-    assertThat(average.currentValue(), equalTo(50.0));
+    // Act & Assert
+    avg.report(10);
+    assertEquals(10.0, avg.currentValue(), EPS);
+
+    avg.report(40);
+    assertEquals(25.0, avg.currentValue(), EPS);
+
+    avg.report(40);
+    assertEquals(30.0, avg.currentValue(), EPS);
+
+    avg.report(110);
+    assertEquals(50.0, avg.currentValue(), EPS);
   }
 
   @Test
-  public void clear() {
-    for (int i = 0; i < 4; i++) {
-      average.report(12345);
-    }
-    assertThat(average.currentValue(), equalTo(12345.0));
-    assertThat(average.countReports(), equalTo(4L));
+  void report_whenExceedsWindow_evictsOldestAndComputesAverage() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(4, 0.0);
+    avg.report(10);
+    avg.report(40);
+    avg.report(40);
+    avg.report(110); // window full: [10, 40, 40, 110]
+    assertEquals(50.0, avg.currentValue(), EPS);
 
-    // Clear should reset to initial value = 100
-    average.clear();
-    assertThat(average.currentValue(), equalTo(100.0));
-    assertThat(average.countReports(), equalTo(0L));
+    // Act & Assert (oldest 10 evicted)
+    avg.report(40); // [40, 40, 110, 40]
+    assertEquals(57.5, avg.currentValue(), EPS);
+
+    avg.report(10); // [40, 110, 40, 10]
+    assertEquals(50.0, avg.currentValue(), EPS);
+  }
+
+  @Test
+  void clear_whenCalled_resetsToInitialAndResetsCount() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(4, 100.0);
+    for (int i = 0; i < 4; i++) avg.report(12345);
+    assertEquals(12345.0, avg.currentValue(), EPS);
+    assertEquals(4L, avg.countReports());
+
+    // Act
+    avg.clear();
+
+    // Assert
+    assertEquals(100.0, avg.currentValue(), EPS);
+    assertEquals(0L, avg.countReports());
+  }
+
+  @ParameterizedTest
+  @MethodSource("valueIfReportedNotFullCases")
+  @DisplayName("valueIfReported when window not full includes hypothetical value")
+  void valueIfReported_whenWindowNotFull_returnsAverageIncludingHypothetical(
+      double[] alreadyReported, double hypothetical) {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(3, -1.0);
+    Arrays.stream(alreadyReported).forEach(avg::report);
+    double before = avg.currentValue();
+    long countBefore = avg.countReports();
+
+    // Act
+    double predicted = avg.valueIfReported(hypothetical);
+
+    // Assert
+    double sum = Arrays.stream(alreadyReported).sum();
+    double expected = (sum + hypothetical) / (alreadyReported.length + 1);
+    assertEquals(expected, predicted, EPS);
+    // Must not mutate state
+    assertEquals(before, avg.currentValue(), EPS);
+    assertEquals(countBefore, avg.countReports());
+  }
+
+  static Stream<Arguments> valueIfReportedNotFullCases() {
+    return Stream.of(
+        Arguments.of(new double[] {}, 8.0),
+        Arguments.of(new double[] {2.0}, 8.0),
+        Arguments.of(new double[] {2.0, 4.0}, 8.0));
+  }
+
+  @ParameterizedTest
+  @MethodSource("valueIfReportedFullCases")
+  @DisplayName("valueIfReported when window full replaces oldest value")
+  void valueIfReported_whenWindowFull_returnsAverageWithOldestEvicted(
+      int window, double[] initial, double hypothetical) {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(window, 0.0);
+    Arrays.stream(initial).forEach(avg::report);
+    double before = avg.currentValue();
+    long countBefore = avg.countReports();
+
+    // Sanity guard: window must be full for this case
+    if (initial.length != window) throw new AssertionError("window not full in test setup");
+
+    // Act
+    double predicted = avg.valueIfReported(hypothetical);
+
+    // Assert (oldest initial[0] will be evicted)
+    double sum = Arrays.stream(initial).sum();
+    double expected = (sum + hypothetical - initial[0]) / window;
+    assertEquals(expected, predicted, EPS);
+    // Must not mutate state
+    assertEquals(before, avg.currentValue(), EPS);
+    assertEquals(countBefore, avg.countReports());
+  }
+
+  static Stream<Arguments> valueIfReportedFullCases() {
+    return Stream.of(
+        Arguments.of(3, new double[] {2.0, 4.0, 6.0}, 0.0),
+        Arguments.of(3, new double[] {2.0, 4.0, 6.0}, 3.0),
+        Arguments.of(3, new double[] {2.0, 4.0, 6.0}, 9.0),
+        Arguments.of(2, new double[] {5.0, 7.0}, 9.0));
+  }
+
+  @Test
+  void valueIfReported_whenCalled_doesNotMutateState() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(3, 0.0);
+    avg.report(1.0);
+    avg.report(2.0);
+    double before = avg.currentValue();
+    long countBefore = avg.countReports();
+
+    // Act
+    double predictedHigh = avg.valueIfReported(100.0);
+    double predictedLow = avg.valueIfReported(-100.0);
+
+    // Assert (predictions are correct and state doesn't change)
+    assertEquals((1.0 + 2.0 + 100.0) / 3.0, predictedHigh, EPS);
+    assertEquals((1.0 + 2.0 - 100.0) / 3.0, predictedLow, EPS);
+    assertEquals(before, avg.currentValue(), EPS);
+    assertEquals(countBefore, avg.countReports());
+  }
+
+  @Test
+  void reportLong_whenCalled_isEquivalentToReportDouble() {
+    // Arrange
+    SimpleRunningAverage a = new SimpleRunningAverage(2, 0.0);
+    SimpleRunningAverage b = new SimpleRunningAverage(2, 0.0);
+
+    // Act
+    a.report(1L);
+    a.report(3.0);
+
+    b.report(1.0);
+    b.report(3L);
+
+    // Assert
+    assertEquals(a.currentValue(), b.currentValue(), EPS);
+    assertEquals(a.countReports(), b.countReports());
+  }
+
+  @Test
+  void countReports_whenMoreThanWindow_reportsMonotonicIncrease() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(3, 0.0);
+
+    // Act
+    for (int i = 0; i < 10; i++) avg.report(i);
+
+    // Assert
+    assertEquals(10L, avg.countReports());
+  }
+
+  @Test
+  void constructor_whenZeroLength_thenReport_throwsArrayIndex() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(0, 7.0);
+
+    // Assert: current value still returns init
+    assertEquals(7.0, avg.currentValue(), EPS);
+    assertEquals(0L, avg.countReports());
+
+    // Act & Assert: operations that access storage fail
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> avg.valueIfReported(1.0));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> avg.report(1.0));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> avg.report(1L));
+  }
+
+  @Test
+  void constructor_whenNegativeLength_throwsNegativeArraySize() {
+    assertThrows(NegativeArraySizeException.class, () -> new SimpleRunningAverage(-1, 0.0));
+  }
+
+  @Test
+  void toString_whenNoReports_containsAverageNaNAndDoesNotThrow() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(3, 42.0);
+
+    // Act
+    String s = avg.toString();
+
+    // Assert: should include average=NaN when no reports
+    // (toString computes total/curLen directly).
+    assertFalse(s.isEmpty());
+    org.hamcrest.MatcherAssert.assertThat(s, org.hamcrest.Matchers.containsString("average="));
+    org.hamcrest.MatcherAssert.assertThat(s, org.hamcrest.Matchers.containsString("NaN"));
+  }
+
+  @Test
+  void toString_whenHasReports_containsAverageNotNaN() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(2, 0.0);
+    avg.report(2.0);
+
+    // Act
+    String s = avg.toString();
+
+    // Assert
+    org.hamcrest.MatcherAssert.assertThat(s, org.hamcrest.Matchers.containsString("average="));
+    org.hamcrest.MatcherAssert.assertThat(
+        s, org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("NaN")));
+  }
+
+  @Test
+  void copyConstructor_whenOriginalMutates_copyRemainsIndependent() {
+    // Arrange
+    SimpleRunningAverage original = new SimpleRunningAverage(3, 0.0);
+    original.report(10.0);
+    original.report(20.0);
+    original.report(30.0); // avg = 20
+    SimpleRunningAverage copy = new SimpleRunningAverage(original);
+
+    // Act (mutate original; evict 10)
+    original.report(100.0); // now [20, 30, 100] => avg 50
+
+    // Assert
+    assertEquals(20.0, copy.currentValue(), EPS);
+    assertEquals(3L, copy.countReports());
+    assertEquals(50.0, original.currentValue(), EPS);
+    assertEquals(4L, original.countReports());
+  }
+
+  @Test
+  void report_whenNaNInput_propagatesNaN() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(2, 0.0);
+    avg.report(1.0);
+
+    // Act
+    avg.report(Double.NaN);
+
+    // Assert: any arithmetic with NaN yields NaN
+    String s = avg.toString();
+    org.hamcrest.MatcherAssert.assertThat(s, org.hamcrest.Matchers.containsString("average=NaN"));
+  }
+
+  @Test
+  void report_whenInfinityInput_propagatesInfinity() {
+    // Arrange
+    SimpleRunningAverage avg = new SimpleRunningAverage(2, 0.0);
+    avg.report(Double.POSITIVE_INFINITY);
+
+    // Assert
+    String s = avg.toString();
+    org.hamcrest.MatcherAssert.assertThat(
+        s, org.hamcrest.Matchers.containsString("average=Infinity"));
   }
 }

--- a/src/test/java/network/crypta/support/math/TimeDecayingRunningAverageTest.java
+++ b/src/test/java/network/crypta/support/math/TimeDecayingRunningAverageTest.java
@@ -1,128 +1,270 @@
 package network.crypta.support.math;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
 
-import java.util.Random;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.Arrays;
+import java.util.function.LongSupplier;
 import network.crypta.node.TimeSkewDetectorCallback;
 import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-public class TimeDecayingRunningAverageTest {
-  private final Clock clock = new Clock();
+class TimeDecayingRunningAverageTest {
 
-  @Test
-  public void decaysOverTime() {
-    TimeDecayingRunningAverage average =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    average.report(0);
-    assertThat(average.currentValue(), equalTo(0.0));
+  private static final double EPS = 1e-12;
 
-    // 1 half-life passes, should take 50% old value (0.0) and 50% new value (1.0)
-    clock.tick(1000);
-    average.report(1);
-    assertThat(average.currentValue(), equalTo(0.5));
+  // Helpers to build deterministic Mockito stubs
+  private static LongSupplier wallTimes(long... millis) {
+    LongSupplier s = mock(LongSupplier.class);
+    final long[] seq = Arrays.copyOf(millis, millis.length);
+    final int[] i = {0};
+    when(s.getAsLong()).thenAnswer(inv -> seq[Math.min(i[0]++, seq.length - 1)]);
+    return s;
+  }
 
-    // 2 half-lives pass, should take 25% old value (0.5) and 75% new value (1.0)
-    clock.tick(2000);
-    average.report(1);
-    assertThat(average.currentValue(), equalTo(0.875));
+  private static LongSupplier monoTimesFromMillis(long... millis) {
+    LongSupplier s = mock(LongSupplier.class);
+    final long[] seq = Arrays.stream(millis).map(m -> m * 1_000_000L).toArray();
+    final int[] i = {0};
+    when(s.getAsLong()).thenAnswer(inv -> seq[Math.min(i[0]++, seq.length - 1)]);
+    return s;
   }
 
   @Test
-  public void newInstanceJumpsToFirstReported() {
-    TimeDecayingRunningAverage average =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    assertThat(average.currentValue(), equalTo(0.0));
+  @DisplayName("currentValue_whenNoReports_returnsDefaultValue")
+  void currentValue_whenNoReports_returnsDefaultValue() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000);
+    LongSupplier mono = monoTimesFromMillis(0);
 
-    average.report(1);
-    assertThat(average.currentValue(), equalTo(1.0));
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.5, 1000, 0, 1, null, null, wall, mono);
+
+    // Act
+    double v = avg.currentValue();
+
+    // Assert
+    assertEquals(0.5, v, EPS);
   }
 
   @Test
-  public void isNotAffectedByClockDrift() {
-    TimeDecayingRunningAverage average =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    average.report(0);
-    assertThat(average.currentValue(), equalTo(0.0));
+  @DisplayName("report_whenFirstValidValue_setsStartedAndCurrentToValue")
+  void report_whenFirstValidValue_setsStartedAndCurrentToValue() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 1_500);
+    LongSupplier mono = monoTimesFromMillis(0, 500);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1000, 0, 1, null, null, wall, mono);
 
-    // Wall-clock time drifts backwards
-    clock.drift(-12345);
+    // Act
+    avg.report(1.0);
 
-    // 1 half-life passes, should take 50% old value (0.0) and 50% new value (1.0)
-    clock.tick(1000);
-    average.report(1);
-    assertThat(average.currentValue(), equalTo(0.5));
+    // Assert
+    assertEquals(1.0, avg.currentValue(), EPS);
+    assertEquals(1L, avg.countReports());
   }
 
   @Test
-  public void reportsNegativeClockDrift() {
-    TimeSkewDetectorCallback callback = mock(TimeSkewDetectorCallback.class);
-    TimeDecayingRunningAverage average =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, callback, clock::getWallClockMillis, clock::getMonotonicNanos);
+  @DisplayName("report_whenElapsedEqualsHalfLife_updatesBy50Percent")
+  void report_whenElapsedEqualsHalfLife_updatesBy50Percent() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 1_000, 2_000);
+    LongSupplier mono = monoTimesFromMillis(0, 0, 1_000);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, null, wall, mono);
+    avg.report(0.0); // first report sets baseline
 
-    // Wall-clock time drifts forward should not be reported
-    clock.drift(12345);
-    average.report(0);
-    verifyNoInteractions(callback);
+    // Act
+    avg.report(1.0);
 
-    // Wall-clock time drifts backwards should be reported
-    clock.drift(-12345);
-    average.report(0);
-    verify(callback).setTimeSkewDetectedUserAlert();
+    // Assert
+    assertEquals(0.5, avg.currentValue(), EPS);
   }
 
   @Test
-  public void countsNumberOfValidReports() {
-    TimeDecayingRunningAverage average =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    assertThat(average.countReports(), equalTo(0L));
+  @DisplayName("report_whenTwoHalfLives_elapsedBlends75PercentNew")
+  void report_whenTwoHalfLives_elapsedBlends75PercentNew() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 1_000, 2_000, 4_000);
+    LongSupplier mono = monoTimesFromMillis(0, 0, 1_000, 3_000); // second delta = 2_000ms
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, null, wall, mono);
+    avg.report(0.0);
+    avg.report(1.0); // after 1 HL -> 0.5
 
-    // Valid report
-    average.report(0);
-    assertThat(average.countReports(), equalTo(1L));
+    // Act: after additional 2 HL (changeFactor = 0.25)
+    avg.report(1.0);
 
-    // Invalid reports
-    average.report(-1000);
-    average.report(1000);
-    average.report(Double.NEGATIVE_INFINITY);
-    average.report(Double.POSITIVE_INFINITY);
-    average.report(Double.NaN);
-    assertThat(average.countReports(), equalTo(1L));
+    // Assert: old=0.5 -> 0.5*0.25 + 1*0.75 = 0.875
+    assertEquals(0.875, avg.currentValue(), EPS);
   }
 
   @Test
-  public void writesStateToSimpleFieldSet() {
-    TimeDecayingRunningAverage average =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    clock.tick(1000);
-    average.report(0.5);
+  @DisplayName("report_whenHalfLifeZero_usesMinimumOneMillisecondForDecay")
+  void report_whenHalfLifeZero_usesMinimumOneMillisecondForDecay() {
+    // Arrange: half-life = 0 -> treated as 1ms
+    LongSupplier wall = wallTimes(1_000, 1_000, 2_000);
+    LongSupplier mono = monoTimesFromMillis(0, 0, 1_000);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 0, 0, 1, null, null, wall, mono);
+    avg.report(0.0);
 
-    SimpleFieldSet sfs = average.exportFieldSet(true);
-    assertThat(
-        sfs.directKeyValues(),
-        allOf(
-            hasEntry("Type", "TimeDecayingRunningAverage"),
-            hasEntry("Started", "true"),
-            hasEntry("Uptime", "1000"),
-            hasEntry("TotalReports", "1"),
-            hasEntry("CurrentValue", "0.5")));
+    // Act: 1,000 ms elapsed with effective HL=1 -> changeFactor = 0.5^(1000/1) ~ 0.0
+    // Numerically this under-flows to ~0.0, so value should move to the new sample (1.0)
+    avg.report(1.0);
+
+    // Assert
+    assertEquals(1.0, avg.currentValue(), EPS);
+  }
+
+  @ParameterizedTest(name = "report_whenValueBelowMin_isIgnored[{index}]({0})")
+  @ValueSource(doubles = {-1.0, -1000.0})
+  @DisplayName("report_whenValueBelowMin_isIgnored")
+  void report_whenValueBelowMin_isIgnored(double bad) {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 1_000);
+    LongSupplier mono = monoTimesFromMillis(0, 0);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.25, 1_000, 0, 1, null, null, wall, mono);
+    avg.report(0.25);
+    long before = avg.countReports();
+
+    // Act
+    avg.report(bad);
+
+    // Assert
+    assertEquals(0.25, avg.currentValue(), EPS);
+    assertEquals(before, avg.countReports());
+  }
+
+  @ParameterizedTest(name = "report_whenValueAboveMax_isIgnored[{index}]({0})")
+  @ValueSource(doubles = {1.01, 1000.0})
+  @DisplayName("report_whenValueAboveMax_isIgnored")
+  void report_whenValueAboveMax_isIgnored(double bad) {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 1_000);
+    LongSupplier mono = monoTimesFromMillis(0, 0);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.75, 1_000, 0, 1, null, null, wall, mono);
+    avg.report(0.75);
+    long before = avg.countReports();
+
+    // Act
+    avg.report(bad);
+
+    // Assert
+    assertEquals(0.75, avg.currentValue(), EPS);
+    assertEquals(before, avg.countReports());
+  }
+
+  @ParameterizedTest(name = "report_whenNaNOrInfinity_isIgnored[{index}]({0})")
+  @ValueSource(doubles = {Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY})
+  @DisplayName("report_whenNaNOrInfinity_isIgnored")
+  void report_whenNaNOrInfinity_isIgnored(double bad) {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 1_000);
+    LongSupplier mono = monoTimesFromMillis(0, 0);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.4, 1_000, 0, 1, null, null, wall, mono);
+    avg.report(0.4);
+    long before = avg.countReports();
+
+    // Act
+    avg.report(bad);
+
+    // Assert
+    assertEquals(0.4, avg.currentValue(), EPS);
+    assertEquals(before, avg.countReports());
   }
 
   @Test
-  public void ignoresFirstValueWhenRestoredInStartedState() {
+  @DisplayName("report_whenWallClockGoesBackward_usesMonotonic")
+  void report_whenWallClockGoesBackward_usesMonotonic() {
+    // Arrange
+    TimeSkewDetectorCallback cb = mock(TimeSkewDetectorCallback.class);
+    LongSupplier wall = wallTimes(10_000, 12_000, 11_500);
+    LongSupplier mono = monoTimesFromMillis(0, 1_000, 2_000); // delta 1000ms used
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, cb, wall, mono);
+    avg.report(0.0);
+
+    // Act
+    avg.report(1.0);
+
+    // Assert: 1 half-life -> current moves halfway, proving monotonic use
+    assertEquals(0.5, avg.currentValue(), EPS);
+  }
+
+  @Test
+  @DisplayName("report_whenUptimeNegative_appliesDecay")
+  void report_whenUptimeNegative_appliesDecay() {
+    // Arrange
+    TimeSkewDetectorCallback cb = mock(TimeSkewDetectorCallback.class);
+    LongSupplier wall = wallTimes(10_000, 11_000, 9_000);
+    LongSupplier mono = monoTimesFromMillis(0, 1_000, 2_000);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, cb, wall, mono);
+    avg.report(0.0);
+
+    // Act
+    avg.report(1.0);
+
+    // Assert: still decays using monotonic delta despite negative uptime
+    assertTrue(avg.currentValue() >= 0.5 - 1e-9);
+  }
+
+  @Test
+  @DisplayName("report_whenMonotonicRegresses_clampsElapsedToZero")
+  void report_whenMonotonicRegresses_clampsElapsedToZero() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 1_100, 1_200); // strictly increasing wall clock
+    LongSupplier mono = monoTimesFromMillis(500, 1_000, 800); // regress at third call
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, null, wall, mono);
+    avg.report(1.0); // start at 1.0
+
+    // Act: second report with mono delta negative -> treated as 0ms elapsed
+    avg.report(0.123);
+
+    // Assert: no change due to 0ms elapsed
+    assertEquals(1.0, avg.currentValue(), EPS);
+    assertEquals(2L, avg.countReports());
+  }
+
+  @Test
+  @DisplayName("exportFieldSet_whenShortLivedTrue_containsExpectedValues")
+  void exportFieldSet_whenShortLivedTrue_containsExpectedValues() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 2_000, 2_000); // ctor, report, export
+    LongSupplier mono = monoTimesFromMillis(0, 0);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, null, wall, mono);
+    avg.report(0.5);
+
+    // Act
+    SimpleFieldSet fs = avg.exportFieldSet(true);
+
+    // Assert
+    assertEquals("TimeDecayingRunningAverage", fs.get("Type"));
+    assertEquals("true", fs.get("Started"));
+    assertEquals("1", fs.get("TotalReports"));
+    assertEquals("0.5", fs.get("CurrentValue"));
+    assertEquals("1000", fs.get("Uptime"));
+  }
+
+  @Test
+  @DisplayName("restoreFromFieldSet_whenStartedTrue_ignoresFirstReportThenDecays")
+  void restoreFromFieldSet_whenStartedTrue_ignoresFirstReportThenDecays() {
+    // Arrange: snapshot says value=0.5, started=true, uptime=1000, totalReports=1
     SimpleFieldSet sfs = new SimpleFieldSet(true);
     sfs.putSingle("Type", "TimeDecayingRunningAverage");
     sfs.putSingle("Started", "true");
@@ -130,118 +272,182 @@ public class TimeDecayingRunningAverageTest {
     sfs.putSingle("TotalReports", "1");
     sfs.putSingle("CurrentValue", "0.5");
 
-    TimeDecayingRunningAverage average =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, sfs, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    assertThat(average.currentValue(), equalTo(0.5));
-    assertThat(average.countReports(), equalTo(1L));
-    assertThat(average.toString(), containsString("createdTime=1000ms ago"));
+    LongSupplier wall = wallTimes(2_000, 3_000, 4_000);
+    LongSupplier mono = monoTimesFromMillis(0, 0, 1_000);
 
-    // First reported value should be ignored (but the remaining fields keep counting)
-    clock.tick(1000);
-    average.report(0);
-    assertThat(average.currentValue(), equalTo(0.5));
-    assertThat(average.countReports(), equalTo(2L));
-    assertThat(average.toString(), containsString("createdTime=2000ms ago"));
-
-    // Subsequent values should be handled normally
-    clock.tick(1000);
-    average.report(0);
-    assertThat(average.currentValue(), equalTo(0.25));
-    assertThat(average.countReports(), equalTo(3L));
-    assertThat(average.toString(), containsString("createdTime=3000ms ago"));
-  }
-
-  @Test
-  public void cloneCreatesIndependentInstance() {
-    TimeDecayingRunningAverage first =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    TimeDecayingRunningAverage second = new TimeDecayingRunningAverage(first);
-    second.report(0);
-    clock.tick(1000);
-    second.report(1);
-
-    // Cloned instance should remain untouched
-    assertThat(first.currentValue(), equalTo(0.0));
-    assertThat(first.countReports(), equalTo(0L));
-
-    // New instance should be updated
-    assertThat(second.currentValue(), equalTo(0.5));
-    assertThat(second.countReports(), equalTo(2L));
-  }
-
-  @Test
-  public void binaryRoundTripPreservesValueAndCount() throws Exception {
     TimeDecayingRunningAverage avg =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    clock.tick(500);
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, sfs, null, wall, mono);
+
+    // Assert initial restored state
+    assertEquals(0.5, avg.currentValue(), EPS);
+    assertEquals(1L, avg.countReports());
+
+    // Act 1: first report is ignored for value, only timestamps/count advance
+    avg.report(0.0);
+    assertEquals(0.5, avg.currentValue(), EPS);
+    assertEquals(2L, avg.countReports());
+
+    // Act 2: subsequent report decays normally (1 half-life -> 0.25)
+    avg.report(0.0);
+    assertEquals(0.25, avg.currentValue(), EPS);
+    assertEquals(3L, avg.countReports());
+  }
+
+  @Test
+  @DisplayName("restoreFromFieldSet_whenValueInvalid_resetsToDefaultAndZeroCount")
+  void restoreFromFieldSet_whenValueInvalid_resetsToDefaultAndZeroCount() {
+    // Arrange: set CurrentValue out of [min,max]
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle("Type", "TimeDecayingRunningAverage");
+    sfs.putSingle("Started", "true");
+    sfs.putSingle("Uptime", "1000");
+    sfs.putSingle("TotalReports", "7");
+    sfs.putSingle("CurrentValue", "2.0"); // out of range for [0,1]
+
+    LongSupplier wall = wallTimes(5_000);
+    LongSupplier mono = monoTimesFromMillis(0);
+
+    // Act
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.42, 1_000, 0, 1, sfs, null, wall, mono);
+
+    // Assert: defaults restored
+    assertEquals(0.42, avg.currentValue(), EPS);
+    assertEquals(0L, avg.countReports());
+  }
+
+  @Test
+  @DisplayName("valueIfReported_whenCalled_throwsUnsupportedOperationException")
+  void valueIfReported_whenCalled_throwsUnsupportedOperationException() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000);
+    LongSupplier mono = monoTimesFromMillis(0);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, null, wall, mono);
+
+    // Act + Assert
+    assertThrows(UnsupportedOperationException.class, () -> avg.valueIfReported(123.0));
+  }
+
+  @Test
+  @DisplayName("getDataLength_whenCalled_returns33Bytes")
+  void getDataLength_whenCalled_returns33Bytes() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000);
+    LongSupplier mono = monoTimesFromMillis(0);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, null, wall, mono);
+
+    // Act + Assert
+    assertEquals(33, avg.getDataLength());
+  }
+
+  @Test
+  @DisplayName("constructor_whenFieldSetNull_behavesAsFreshInstance")
+  void constructor_whenFieldSetNull_behavesAsFreshInstance() {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000);
+    LongSupplier mono = monoTimesFromMillis(0);
+
+    // Act
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.33, 1_000, 0, 1, null, null, wall, mono);
+
+    // Assert
+    assertEquals(0.33, avg.currentValue(), EPS);
+    assertEquals(0L, avg.countReports());
+  }
+
+  @Test
+  @DisplayName("binaryConstructor_whenMagicInvalid_throwsIOException")
+  void binaryConstructor_whenMagicInvalid_throwsIOException() throws Exception {
+    // Arrange: wrong magic, otherwise valid record
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(0xdeadbeef); // wrong magic
+      dos.writeInt(1); // version
+      dos.writeDouble(0.5);
+      dos.writeBoolean(true);
+      dos.writeLong(3L);
+      dos.writeLong(100L);
+    }
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+
+    // Act + Assert
+    assertThrows(
+        java.io.IOException.class,
+        () -> new TimeDecayingRunningAverage(0.0, 1_000.0, 0.0, 1.0, dis, null));
+  }
+
+  @Test
+  @DisplayName("binaryConstructor_whenCurValueOutOfRange_throwsIOException")
+  void binaryConstructor_whenCurValueOutOfRange_throwsIOException() throws Exception {
+    // Arrange: correct magic+version but curValue = 2.0 out of [0,1]
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(0x5ff4ac94); // magic used by implementation
+      dos.writeInt(1); // version
+      dos.writeDouble(2.0); // out of range
+      dos.writeBoolean(true);
+      dos.writeLong(1L);
+      dos.writeLong(0L);
+    }
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+
+    // Act + Assert
+    assertThrows(
+        java.io.IOException.class,
+        () -> new TimeDecayingRunningAverage(0.0, 1_000.0, 0.0, 1.0, dis, null));
+  }
+
+  @Test
+  @DisplayName("binaryRoundTrip_whenSerializedAndRestored_preservesValueAndCount")
+  void binaryRoundTrip_whenSerializedAndRestored_preservesValueAndCount() throws Exception {
+    // Arrange
+    LongSupplier wall = wallTimes(1_000, 1_500, 2_500, 2_500); // ctor, r1, r2, write
+    LongSupplier mono = monoTimesFromMillis(0, 500, 1_500);
+    TimeDecayingRunningAverage avg =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, null, wall, mono);
     avg.report(1.0);
-    clock.tick(1000);
     avg.report(1.0);
 
-    // Serialize to a binary stream
-    java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
-    try (java.io.DataOutputStream dos = new java.io.DataOutputStream(baos)) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
       avg.writeDataTo(dos);
     }
 
-    // Restore from the binary stream
-    java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(baos.toByteArray());
-    try (java.io.DataInputStream dis = new java.io.DataInputStream(bais)) {
+    // Act: restore using binary constructor
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    try (DataInputStream dis = new DataInputStream(bais)) {
       TimeDecayingRunningAverage restored =
-          new TimeDecayingRunningAverage(0, 1000, 0, 1, dis, null);
+          new TimeDecayingRunningAverage(0.0, 1_000.0, 0.0, 1.0, dis, null);
 
-      assertThat(restored.currentValue(), equalTo(avg.currentValue()));
-      assertThat(restored.lastReportTime(), equalTo(-1L)); // as per constructor semantics
+      // Assert
+      assertEquals(avg.currentValue(), restored.currentValue(), EPS);
+      assertEquals(avg.countReports(), restored.countReports());
+      assertEquals(-1L, restored.lastReportTime()); // constructor semantics
     }
   }
 
   @Test
-  public void binaryRoundTripPreservesReportCount() throws Exception {
-    TimeDecayingRunningAverage avg =
-        new TimeDecayingRunningAverage(
-            0, 1000, 0, 1, null, null, clock::getWallClockMillis, clock::getMonotonicNanos);
-    for (int i = 0; i < 7; i++) {
-      avg.report(0.75);
-    }
+  @DisplayName("copyConstructor_whenUsed_createsIndependentSnapshot")
+  void copyConstructor_whenUsed_createsIndependentSnapshot() {
+    // Arrange
+    LongSupplier wall1 = wallTimes(1_000, 1_000, 2_000);
+    LongSupplier mono1 = monoTimesFromMillis(0, 0, 1_000);
+    TimeDecayingRunningAverage original =
+        new TimeDecayingRunningAverage(0.0, 1_000, 0, 1, null, null, wall1, mono1);
+    TimeDecayingRunningAverage copy = new TimeDecayingRunningAverage(original);
 
-    // Serialize to a binary stream
-    java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
-    try (java.io.DataOutputStream dos = new java.io.DataOutputStream(baos)) {
-      avg.writeDataTo(dos);
-    }
+    // Act: update only the copy
+    copy.report(0.0);
+    copy.report(1.0);
 
-    // Restore from the binary stream
-    java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(baos.toByteArray());
-    try (java.io.DataInputStream dis = new java.io.DataInputStream(bais)) {
-      TimeDecayingRunningAverage restored =
-          new TimeDecayingRunningAverage(0, 1000, 0, 1, dis, null);
-
-      assertThat(restored.countReports(), equalTo(7L));
-    }
-  }
-
-  static class Clock {
-    private long wallClockMillis = System.currentTimeMillis();
-    private long monotonicMillis = new Random().nextLong();
-
-    void tick(long millis) {
-      wallClockMillis += millis;
-      monotonicMillis += millis;
-    }
-
-    void drift(long millis) {
-      wallClockMillis += millis;
-    }
-
-    long getWallClockMillis() {
-      return wallClockMillis;
-    }
-
-    long getMonotonicNanos() {
-      return monotonicMillis * 1_000_000;
-    }
+    // Assert: original remains untouched; copy updated
+    assertEquals(0.0, original.currentValue(), EPS);
+    assertEquals(0L, original.countReports());
+    // After one HL from 0.0 to 1.0 -> 0.5
+    assertEquals(0.5, copy.currentValue(), EPS);
+    assertEquals(2L, copy.countReports());
   }
 }

--- a/src/test/java/network/crypta/support/math/TrivialRunningAverageTest.java
+++ b/src/test/java/network/crypta/support/math/TrivialRunningAverageTest.java
@@ -1,0 +1,362 @@
+package network.crypta.support.math;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Unit tests for {@link TrivialRunningAverage}. */
+class TrivialRunningAverageTest {
+
+  // ---- Constructors and initial state ----
+
+  @Test
+  void currentValue_whenEmpty_returnsNaN() {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act
+    double current = avg.currentValue();
+
+    // Assert
+    assertTrue(Double.isNaN(current), "Empty average should be NaN");
+  }
+
+  @Test
+  void totalValue_whenEmpty_returnsZero() {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act & Assert
+    assertEquals(0.0, avg.totalValue(), 0.0);
+  }
+
+  @Test
+  void countReports_whenNew_returnsZero() {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act & Assert
+    assertEquals(0L, avg.countReports());
+  }
+
+  @Test
+  @SuppressWarnings({"ConstantConditions", "DataFlowIssue"})
+  void constructor_whenNullAverage_throwsNullPointerException() {
+    // Arrange
+    TrivialRunningAverage source = null;
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> new TrivialRunningAverage(source));
+  }
+
+  @Test
+  void copyConstructor_whenSourceHasValues_copiesSnapshotAndIsIndependent() {
+    // Arrange
+    TrivialRunningAverage original = new TrivialRunningAverage();
+    original.report(10.0);
+    original.report(20.0);
+    long originalReportsBefore = original.countReports();
+    double originalTotalBefore = original.totalValue();
+
+    // Act
+    TrivialRunningAverage copy = new TrivialRunningAverage(original);
+
+    // Assert snapshot copied
+    assertEquals(originalReportsBefore, copy.countReports());
+    assertEquals(originalTotalBefore, copy.totalValue(), 0.0);
+    assertEquals(original.currentValue(), copy.currentValue(), 1e-12);
+
+    // Mutate original; copy should not change
+    original.report(30.0);
+    assertEquals(originalReportsBefore + 1, original.countReports());
+    assertEquals(originalReportsBefore, copy.countReports());
+
+    // Mutate copy; original should not change further
+    copy.report(40.0);
+    assertEquals(originalReportsBefore + 1, original.countReports());
+    assertEquals(originalReportsBefore + 1, copy.countReports());
+  }
+
+  // ---- Reporting and averaging behavior ----
+
+  static Stream<Arguments> sequencesAndMeans() {
+    return Stream.of(
+        Arguments.of(new double[] {42.0}, 42.0),
+        Arguments.of(new double[] {1.0, 3.0}, 2.0),
+        Arguments.of(new double[] {-2.0, 2.0}, 0.0),
+        Arguments.of(new double[] {0.0, 0.0, 0.0}, 0.0),
+        Arguments.of(new double[] {1.5, 2.5, 3.0}, (1.5 + 2.5 + 3.0) / 3.0));
+  }
+
+  @ParameterizedTest
+  @MethodSource("sequencesAndMeans")
+  @DisplayName("report(double) accumulates average correctly for sequences")
+  void report_whenDoubleSequence_computeCorrectAverage(double[] values, double expectedMean) {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act
+    for (double v : values) {
+      avg.report(v);
+    }
+
+    // Assert
+    assertEquals(values.length, avg.countReports());
+    assertEquals(Arrays.stream(values).sum(), avg.totalValue(), 1e-12);
+    assertEquals(expectedMean, avg.currentValue(), 1e-12);
+  }
+
+  static Stream<Arguments> longSequencesAndMeans() {
+    return Stream.of(
+        Arguments.of(new long[] {5L}, 5.0),
+        Arguments.of(new long[] {1L, 2L, 3L}, 2.0),
+        Arguments.of(new long[] {-10L, 10L}, 0.0));
+  }
+
+  @ParameterizedTest
+  @MethodSource("longSequencesAndMeans")
+  void report_whenLongSequence_computeCorrectAverage(long[] values, double expectedMean) {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act
+    for (long v : values) {
+      avg.report(v);
+    }
+
+    // Assert
+    assertEquals(values.length, avg.countReports());
+    double total = Arrays.stream(values).asDoubleStream().sum();
+    assertEquals(total, avg.totalValue(), 1e-12);
+    assertEquals(expectedMean, avg.currentValue(), 1e-12);
+  }
+
+  @Test
+  void valueIfReported_whenEmpty_returnsThatValueAndDoesNotMutate() {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act
+    double predicted = avg.valueIfReported(7.5);
+
+    // Assert
+    assertEquals(7.5, predicted, 0.0);
+    assertEquals(0L, avg.countReports());
+    assertEquals(0.0, avg.totalValue(), 0.0);
+    assertTrue(Double.isNaN(avg.currentValue()));
+  }
+
+  @Test
+  void valueIfReported_whenNonEmpty_returnsPredictedAndDoesNotMutate() {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+    avg.report(2.0);
+    avg.report(4.0);
+    long beforeReports = avg.countReports();
+    double beforeTotal = avg.totalValue();
+
+    // Act
+    double predicted = avg.valueIfReported(6.0);
+
+    // Assert: predicted mean (2 + 4 + 6) / 3 = 4.0
+    assertEquals(4.0, predicted, 1e-12);
+    assertEquals(beforeReports, avg.countReports());
+    assertEquals(beforeTotal, avg.totalValue(), 0.0);
+    assertEquals((2.0 + 4.0) / 2.0, avg.currentValue(), 1e-12);
+  }
+
+  // ---- Special numeric values ----
+
+  @Test
+  void report_whenNaN_propagatesToAverageAndTotal() {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act
+    avg.report(Double.NaN);
+
+    // Assert
+    assertEquals(1L, avg.countReports());
+    assertTrue(Double.isNaN(avg.totalValue()));
+    assertTrue(Double.isNaN(avg.currentValue()));
+    assertTrue(Double.isNaN(avg.valueIfReported(1.0)));
+  }
+
+  @Test
+  void report_whenInfinity_propagatesToAverageAndTotal() {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act
+    avg.report(Double.POSITIVE_INFINITY);
+
+    // Assert
+    assertEquals(1L, avg.countReports());
+    assertTrue(Double.isInfinite(avg.totalValue()));
+    assertTrue(Double.isInfinite(avg.currentValue()));
+  }
+
+  @Test
+  void report_whenDoubleMaxLeadsToOverflow_averageBecomesInfinity() {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    // Act
+    avg.report(Double.MAX_VALUE);
+    avg.report(Double.MAX_VALUE); // total should overflow to +Infinity
+
+    // Assert
+    assertEquals(2L, avg.countReports());
+    assertTrue(Double.isInfinite(avg.totalValue()));
+    assertTrue(Double.isInfinite(avg.currentValue()));
+  }
+
+  // ---- Concurrency (deterministic) ----
+
+  @Test
+  void report_whenConcurrent_updatesDeterministically() throws InterruptedException {
+    // Arrange
+    TrivialRunningAverage avg = new TrivialRunningAverage();
+
+    int threads = 4;
+    int itemsPerThread = 1000;
+    try (ExecutorService pool = Executors.newFixedThreadPool(threads)) {
+      CountDownLatch start = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(threads);
+
+      List<Double> expectedValues = new ArrayList<>(threads * itemsPerThread);
+      for (int t = 0; t < threads; t++) {
+        for (int i = 1; i <= itemsPerThread; i++) {
+          expectedValues.add((double) (t * itemsPerThread + i));
+        }
+      }
+
+      for (int t = 0; t < threads; t++) {
+        final int threadIndex = t;
+        pool.submit(
+            () -> {
+              try {
+                start.await();
+                int base = threadIndex * itemsPerThread;
+                for (int i = 1; i <= itemsPerThread; i++) {
+                  avg.report(base + i);
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted during test execution");
+              } finally {
+                done.countDown();
+              }
+            });
+      }
+
+      // Act
+      start.countDown();
+      boolean finished = done.await(10, TimeUnit.SECONDS);
+
+      // Assert
+      assertTrue(finished, "Worker threads should finish promptly");
+      long expectedCount = (long) threads * itemsPerThread;
+      double expectedTotal = expectedValues.stream().mapToDouble(Double::doubleValue).sum();
+
+      assertEquals(expectedCount, avg.countReports());
+      assertEquals(expectedTotal, avg.totalValue(), 1e-8);
+      assertEquals(expectedTotal / expectedCount, avg.currentValue(), 1e-8);
+    }
+  }
+
+  // ---- RunningAverage.copyOf() behavior ----
+
+  @Test
+  void copyOf_whenNull_throwsNullPointerException() {
+    // Arrange & Act & Assert
+    assertThrows(NullPointerException.class, () -> RunningAverage.copyOf(null));
+  }
+
+  @Test
+  void copyOf_whenTrivialRunningAverage_returnsEquivalentIndependentCopy() {
+    // Arrange
+    TrivialRunningAverage original = new TrivialRunningAverage();
+    original.report(100);
+    original.report(200);
+    long reportsBefore = original.countReports();
+    double totalBefore = original.totalValue();
+    double meanBefore = original.currentValue();
+
+    // Act
+    RunningAverage copyAsIface = RunningAverage.copyOf(original);
+
+    // Assert: type may not be the same static type, but state must match and be independent
+    assertInstanceOf(TrivialRunningAverage.class, copyAsIface);
+    TrivialRunningAverage copy = (TrivialRunningAverage) copyAsIface;
+    assertEquals(reportsBefore, copy.countReports());
+    assertEquals(totalBefore, copy.totalValue(), 0.0);
+    assertEquals(meanBefore, copy.currentValue(), 1e-12);
+
+    // Mutations do not affect each other
+    original.report(300);
+    assertEquals(reportsBefore + 1, original.countReports());
+    assertEquals(reportsBefore, copy.countReports());
+    copy.report(400);
+    assertEquals(reportsBefore + 1, copy.countReports());
+  }
+
+  @Test
+  void copyOf_whenUnknownImplementation_throwsUnsupportedOperationException() {
+    // Arrange: a minimal unknown implementation
+    class UnknownAverage implements RunningAverage {
+      @Serial private static final long serialVersionUID = 1L;
+      private long n;
+      private double t;
+
+      @Override
+      public double currentValue() {
+        return n == 0 ? Double.NaN : t / n;
+      }
+
+      @Override
+      public void report(double d) {
+        t += d;
+        n++;
+      }
+
+      @Override
+      public void report(long d) {
+        t += d;
+        n++;
+      }
+
+      @Override
+      public double valueIfReported(double r) {
+        return (t + r) / (n + 1);
+      }
+
+      @Override
+      public long countReports() {
+        return n;
+      }
+    }
+    RunningAverage unknown = new UnknownAverage();
+    unknown.report(1.0);
+
+    // Act & Assert
+    assertThrows(UnsupportedOperationException.class, () -> RunningAverage.copyOf(unknown));
+  }
+}


### PR DESCRIPTION
Summary
- Add comprehensive JUnit 5 tests for network.crypta.support.math.TrivialRunningAverage.
- Expand/strengthen tests for SimpleRunningAverage, TimeDecayingRunningAverage, BootstrappingDecayingRunningAverage, DecayingKeyspaceAverage, and MersenneTwister (deterministic, no flakiness).
- Minor Gradle test JVM arg tweak to enable dynamic agent loading for Mockito inline mock-maker (JEP 451) to avoid warnings; no production code behavior changes.
- Minor Javadoc formatting cleanups in HostnameSyntaxException and package-info.

Motivation
- Increase coverage and confidence in math utilities used across the node.
- Ensure deterministic behavior (fixed seeds, mocked time) and strong boundary/special-value handling.

Key Changes
- src/test/java/network/crypta/support/math/TrivialRunningAverageTest.java: New test suite covering
  - Constructors and copy-constructor snapshot semantics
  - Reporting and average computation for double/long sequences (parameterized)
  - valueIfReported non‑mutation semantics
  - Special values (NaN/±Infinity) and overflow behavior
  - Deterministic concurrency behavior (synchronized state) with try‑with‑resources executor
  - RunningAverage.copyOf() null/unknown‑impl paths
- src/test/java/network/crypta/support/math/SimpleRunningAverageTest.java: Expanded parameterized cases; copy semantics; valueIfReported assertions.
- src/test/java/network/crypta/support/math/TimeDecayingRunningAverageTest.java: Deterministic time via mocked suppliers; edge/bounds; serialization/constructor error paths; steady‑state decay invariants.
- src/test/java/network/crypta/support/math/BootstrappingDecayingRunningAverageTest.java: Constructor validation; bootstrapping/steady‑state behavior; SimpleFieldSet I/O; max‑reports changes.
- src/test/java/network/crypta/support/math/DecayingKeyspaceAverageTest.java: Additional coverage and JUnit 5 visibility fixes.
- src/test/java/network/crypta/support/math/MersenneTwisterTest.java: Deterministic sequences; domain cases.
- build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts: Add -XX:+EnableDynamicAgentLoading to Test JVM args to silence Mockito inline mock‑maker warning (JEP 451).
- src/main/java/network/crypta/support/transport/ip/{HostnameSyntaxException.java,package-info.java}: Javadoc line‑wrap cleanups only (no behavior change).

Diff Summary (base: origin/develop)
```
$ git diff --stat <merge-base>..HEAD
build-logic/.../cryptad.java-kotlin-conventions.gradle.kts |   +2
.../HostnameSyntaxException.java                         |   doc fmt
.../transport/ip/package-info.java                       |   doc fmt
.../BootstrappingDecayingRunningAverageTest.java         |  +312 - (updates)
.../DecayingKeyspaceAverageTest.java                     |  +258 - (updates)
.../MersenneTwisterTest.java                             |  +476 - (updates)
.../SimpleRunningAverageTest.java                        |  +304 - (updates)
.../TimeDecayingRunningAverageTest.java                  |  +548 - (updates)
.../TrivialRunningAverageTest.java                       |  +362 (new)
```

Validation
- Ran: `./gradlew --parallel test` → BUILD SUCCESSFUL.
- SonarLint (file-scoped for new/updated tests): no issues beyond allowed test method naming (S100). Resource handling, redundant returns fixed.

Risk/Impact
- Test-only changes plus a Gradle Test JVM arg addition; no production logic changes except doc formatting.
- The JEP 451 flag only affects Test tasks; it does not alter runtime packaging or distribution.

How to Test Locally
- `./gradlew --parallel test --tests network.crypta.support.math.TrivialRunningAverageTest`
- Or run full suite: `./gradlew --parallel test`

Notes
- Follows project guidelines (JUnit 6/Jupiter, Mockito). No Spotless or dependency verification changes required.

