### PR TITLE
io: counting streams tests + docs; annotate LZMA read/write byte[] as @NotNull

### DIFF
--- a/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
+++ b/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
@@ -260,7 +260,7 @@ public class NewLZMACompressor extends AbstractCompressor {
     }
 
     @Override
-    public void write(byte[] b, int off, int len) throws IOException {
+    public void write(byte @NotNull [] b, int off, int len) throws IOException {
       if (len < 0) throw new ArrayIndexOutOfBoundsException(len);
       if (written() + len > max) throw new CompressionOutputSizeException(written() + len);
       super.write(b, off, len);

--- a/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
+++ b/src/main/java/network/crypta/support/compress/NewLZMACompressor.java
@@ -11,6 +11,7 @@ import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.CountedInputStream;
 import network.crypta.support.io.CountedOutputStream;
+import org.jetbrains.annotations.NotNull;
 import org.sevenzip.ICodeProgress;
 import org.sevenzip.compression.lzma.Decoder;
 import org.sevenzip.compression.lzma.Encoder;
@@ -213,7 +214,7 @@ public class NewLZMACompressor extends AbstractCompressor {
     }
 
     @Override
-    public int read(byte[] b, int off, int len) throws IOException {
+    public int read(byte @NotNull [] b, int off, int len) throws IOException {
       long remaining = max - count();
       if (remaining > 0) {
         int toRead = (int) Math.min(len, remaining);
@@ -228,7 +229,7 @@ public class NewLZMACompressor extends AbstractCompressor {
     }
 
     @Override
-    public int read(byte[] b) throws IOException {
+    public int read(byte @NotNull [] b) throws IOException {
       long remaining = max - count();
       if (remaining > 0) {
         int toRead = (int) Math.min(b.length, remaining);

--- a/src/main/java/network/crypta/support/io/CountedInputStream.java
+++ b/src/main/java/network/crypta/support/io/CountedInputStream.java
@@ -3,44 +3,122 @@ package network.crypta.support.io;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * An {@link InputStream} wrapper that counts bytes consumed from the underlying stream.
+ *
+ * <p>The counter increases for every successfully read byte and for bytes skipped via {@link
+ * #skip(long)}. End-of-stream indicators (for example, {@code -1} from {@link #read()}) do not
+ * increment the count. The count is monotonic and does not decrease on {@code reset()} — if the
+ * underlying stream supports mark/reset and the caller rewinds the position, the counter continues
+ * to reflect the total bytes that have been delivered or skipped through this wrapper over its
+ * lifetime.
+ *
+ * <p>Thread-safety: like most {@link InputStream} implementations, this class is not inherently
+ * thread-safe. If multiple threads access the same instance, external synchronization is required.
+ */
 public class CountedInputStream extends FilterInputStream {
 
+  /**
+   * Cumulative number of bytes observed by this wrapper.
+   *
+   * <p>Units are bytes. The value increases on successful reads and positive {@link #skip(long)}
+   * operations and never decreases. It is not automatically adjusted by {@code reset()} on the
+   * underlying stream.
+   */
   protected long count = 0;
 
+  /**
+   * Creates a counting wrapper around the given input stream.
+   *
+   * @param in the underlying stream to read from; must not be {@code null}
+   * @throws IllegalStateException if {@code in} is {@code null}
+   */
   public CountedInputStream(InputStream in) {
     super(in);
+    // Guard against accidental null wiring. Use IllegalStateException to match historical
+    // behavior in this codebase.
     if (in == null) throw new IllegalStateException("null fed to CountedInputStream");
   }
 
+  /**
+   * Returns the number of bytes consumed so far.
+   *
+   * <p>The value includes both bytes returned by {@code read(...)} and bytes successfully skipped
+   * via {@link #skip(long)}. It does not include unread bytes after {@code mark/reset} and does not
+   * decrease.
+   *
+   * @return the cumulative byte count (never negative)
+   */
   public final long count() {
     return count;
   }
 
+  /**
+   * Reads one byte and increments the counter if successful.
+   *
+   * @return the next byte as an unsigned {@code 0..255} value, or {@code -1} if end of stream
+   * @throws IOException if an I/O error occurs in the underlying stream
+   */
   @Override
   public int read() throws IOException {
     int ret = super.read();
+    // Increment only when a real byte is obtained; -1 means EOF.
     if (ret != -1) ++count;
     return ret;
   }
 
+  /**
+   * Reads up to {@code len} bytes into the buffer and increments the counter by the number of bytes
+   * actually read.
+   *
+   * <p>Note: This implementation calls the underlying {@code in.read(...)} directly to avoid any
+   * double-counting and then updates the counter based on the returned length.
+   *
+   * @param buf destination buffer; must not be {@code null}
+   * @param off offset in {@code buf} at which to start storing bytes
+   * @param len maximum number of bytes to read
+   * @return the number of bytes read, or {@code -1} if end of stream
+   * @throws IOException if an I/O error occurs in the underlying stream
+   * @throws IndexOutOfBoundsException if {@code off < 0}, {@code len < 0}, or {@code off + len >}
+   *     {@code buf.length}
+   */
   @Override
-  public int read(byte[] buf, int off, int len) throws IOException {
+  public int read(byte @NotNull [] buf, int off, int len) throws IOException {
     int ret = in.read(buf, off, len);
     if (ret != -1) count += ret;
     return ret;
   }
 
+  /**
+   * Reads some bytes into the buffer and increments the counter by the number of bytes read.
+   *
+   * @param buf destination buffer; must not be {@code null}
+   * @return the number of bytes read, or {@code -1} if end of stream
+   * @throws IOException if an I/O error occurs in the underlying stream
+   */
   @Override
-  public int read(byte[] buf) throws IOException {
+  public int read(byte @NotNull [] buf) throws IOException {
     int ret = in.read(buf);
     if (ret != -1) count += ret;
     return ret;
   }
 
+  /**
+   * Skips up to {@code n} bytes and increments the counter by the number of bytes actually skipped.
+   *
+   * <p>Some {@link InputStream} implementations may skip fewer bytes than requested or return
+   * {@code 0} if no bytes can be skipped at the moment.
+   *
+   * @param n the number of bytes to attempt to skip
+   * @return the actual number of bytes skipped, which may be less than {@code n}
+   * @throws IOException if an I/O error occurs in the underlying stream
+   */
   @Override
   public long skip(long n) throws IOException {
     long l = in.skip(n);
+    // Count only positive progress; some streams return 0 to indicate no-op.
     if (l > 0) count += l;
     return l;
   }

--- a/src/main/java/network/crypta/support/io/CountedOutputStream.java
+++ b/src/main/java/network/crypta/support/io/CountedOutputStream.java
@@ -3,32 +3,91 @@ package network.crypta.support.io;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * An {@link OutputStream} wrapper that counts the number of bytes successfully written.
+ *
+ * <p>All write operations delegate to the wrapped stream and, on success, increment an internal
+ * counter. The current total can be queried via {@link #written()} and starts at {@code 0} when the
+ * instance is constructed.
+ *
+ * <p>Thread-safety: This class is not thread-safe. If used by multiple threads, synchronize
+ * externally.
+ *
+ * <p>Overflow: The counter is a {@code long}. No overflow checks are performed; if more than {@link
+ * Long#MAX_VALUE} bytes are written, the value wraps according to two's-complement rules.
+ */
 public class CountedOutputStream extends FilterOutputStream {
 
+  // Tracks the total number of bytes successfully written to 'out'. Not thread-safe. No overflow
+  // checks are performed; extremely large totals may wrap.
   private long written;
 
+  /**
+   * Creates a counting output stream that forwards to the given stream.
+   *
+   * @param arg0 the underlying stream to which data is written; may be {@code null}, but any
+   *     subsequent write will throw {@link NullPointerException}
+   */
   public CountedOutputStream(OutputStream arg0) {
     super(arg0);
   }
 
+  /**
+   * Writes a single byte and increments the counter by one on success.
+   *
+   * @param x the byte value to write; only the low eight bits are used
+   * @throws IOException if the underlying stream throws an I/O error
+   * @throws NullPointerException if the underlying stream is {@code null}
+   */
   @Override
   public void write(int x) throws IOException {
     super.write(x);
     written++;
   }
 
+  /**
+   * Writes the entire array and increments the counter by {@code buf.length} on success.
+   *
+   * <p>This method is equivalent to {@code write(buf, 0, buf.length)}.
+   *
+   * @param buf the data to write; must not be {@code null}
+   * @throws IOException if the underlying stream throws an I/O error
+   * @throws NullPointerException if {@code buf} is {@code null} or the underlying stream is {@code
+   *     null}
+   */
   @Override
-  public void write(byte[] buf) throws IOException {
+  public void write(byte @NotNull [] buf) throws IOException {
     write(buf, 0, buf.length);
   }
 
+  /**
+   * Writes {@code length} bytes from {@code buf} starting at {@code offset} and increments the
+   * counter by {@code length} on success.
+   *
+   * <p>As with {@link OutputStream#write(byte[], int, int)}, providing an invalid range typically
+   * results in {@link IndexOutOfBoundsException}.
+   *
+   * @param buf the source buffer; must not be {@code null}
+   * @param offset the starting index within {@code buf}
+   * @param length the number of bytes to write; may be {@code 0}
+   * @throws IOException if the underlying stream throws an I/O error
+   * @throws NullPointerException if {@code buf} is {@code null} or the underlying stream is {@code
+   *     null}
+   * @throws IndexOutOfBoundsException if {@code offset} or {@code length} are out of range
+   */
   @Override
-  public void write(byte[] buf, int offset, int length) throws IOException {
+  public void write(byte @NotNull [] buf, int offset, int length) throws IOException {
     out.write(buf, offset, length);
     written += length;
   }
 
+  /**
+   * Returns the number of bytes successfully written since construction.
+   *
+   * @return the total number of bytes written (may wrap on overflow)
+   */
   public long written() {
     return written;
   }

--- a/src/test/java/network/crypta/support/io/CountedInputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/CountedInputStreamTest.java
@@ -1,0 +1,154 @@
+package network.crypta.support.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CountedInputStreamTest {
+
+  @Test
+  void constructor_whenNullInput_expectIllegalStateException() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          try (CountedInputStream ignored = new CountedInputStream(null)) {
+            fail("unreachable");
+          }
+        });
+  }
+
+  @Test
+  void count_whenNoOperations_expectZero() throws IOException {
+    InputStream in = mock(InputStream.class);
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      assertEquals(0L, cis.count());
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"-1,0", "0,1", "42,1"})
+  void read_whenSingleByteVariousReturn_expectCountAccumulates(int delegateReturn, long expectedInc)
+      throws IOException {
+    InputStream in = mock(InputStream.class);
+    when(in.read()).thenReturn(delegateReturn);
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      int ret = cis.read();
+      assertEquals(delegateReturn, ret);
+      assertEquals(expectedInc, cis.count());
+    }
+    verify(in, times(1)).read();
+  }
+
+  @ParameterizedTest
+  @CsvSource({"-1,0", "0,0", "5,5"})
+  void read_whenByteArrayVariousReturn_expectCountAccumulates(int delegateReturn, long expectedInc)
+      throws IOException {
+    byte[] buf = new byte[8];
+    InputStream in = mock(InputStream.class);
+    when(in.read(any(byte[].class))).thenReturn(delegateReturn);
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      int ret = cis.read(buf);
+      assertEquals(delegateReturn, ret);
+      assertEquals(expectedInc, cis.count());
+    }
+    verify(in, times(1)).read(same(buf));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"-1,0", "0,0", "4,4"})
+  void read_whenByteArrayWithOffsetVariousReturn_expectCountAccumulates(
+      int delegateReturn, long expectedInc) throws IOException {
+    byte[] buf = new byte[16];
+    int off = 3;
+    int len = 7;
+    InputStream in = mock(InputStream.class);
+    when(in.read(any(byte[].class), eq(off), eq(len))).thenReturn(delegateReturn);
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      int ret = cis.read(buf, off, len);
+      assertEquals(delegateReturn, ret);
+      assertEquals(expectedInc, cis.count());
+    }
+    verify(in, times(1)).read(same(buf), eq(off), eq(len));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"-5,0", "0,0", "7,7"})
+  void skip_whenDelegateReturnsVarious_expectCountAccumulates(long delegateReturn, long expectedInc)
+      throws IOException {
+    InputStream in = mock(InputStream.class);
+    when(in.skip(anyLong())).thenReturn(delegateReturn);
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      long ret = cis.skip(10L);
+      assertEquals(delegateReturn, ret);
+      assertEquals(expectedInc, cis.count());
+    }
+    verify(in, times(1)).skip(10L);
+  }
+
+  @Test
+  void read_whenNullBuffer_expectNPEAndNoCountChange() throws IOException {
+    InputStream in = mock(InputStream.class);
+    when(in.read((byte[]) isNull())).thenThrow(new NullPointerException("buf"));
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      assertThrows(NullPointerException.class, () -> cis.read(null));
+      assertEquals(0L, cis.count());
+    }
+  }
+
+  @Test
+  void read_whenInvalidOffsetLength_delegateThrows_expectNoCountChange() throws IOException {
+    byte[] buf = new byte[4];
+    InputStream in = mock(InputStream.class);
+    when(in.read(same(buf), eq(-1), eq(2))).thenThrow(new IndexOutOfBoundsException("off < 0"));
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      assertThrows(IndexOutOfBoundsException.class, () -> cis.read(buf, -1, 2));
+      assertEquals(0L, cis.count());
+    }
+  }
+
+  @Test
+  void skip_whenDelegateSkipsLessThanRequested_expectCountByReturned() throws IOException {
+    InputStream in = mock(InputStream.class);
+    when(in.skip(5L)).thenReturn(2L);
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      long ret = cis.skip(5L);
+      assertEquals(2L, ret);
+      assertEquals(2L, cis.count());
+    }
+    verify(in, times(1)).skip(5L);
+  }
+
+  @Test
+  void count_whenMultipleOperations_expectSum() throws IOException {
+    InputStream in = mock(InputStream.class);
+    try (CountedInputStream cis = new CountedInputStream(in)) {
+      when(in.read()).thenReturn(0); // one byte read (value 0)
+      int b = cis.read();
+      assertEquals(0, b);
+
+      byte[] buf1 = new byte[10];
+      when(in.read(same(buf1), eq(1), eq(3))).thenReturn(3);
+      int r1 = cis.read(buf1, 1, 3);
+      assertEquals(3, r1);
+
+      byte[] buf2 = new byte[5];
+      when(in.read(same(buf2))).thenReturn(2);
+      int r2 = cis.read(buf2);
+      assertEquals(2, r2);
+
+      when(in.skip(5L)).thenReturn(4L);
+      long s = cis.skip(5L);
+      assertEquals(4L, s);
+
+      assertEquals(1L + 3L + 2L + 4L, cis.count());
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/io/CountedOutputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/CountedOutputStreamTest.java
@@ -1,0 +1,180 @@
+package network.crypta.support.io;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CountedOutputStreamTest {
+
+  @Test
+  void written_whenNoWrites_expectZero() {
+    // Arrange
+    OutputStream mockOut = mock(OutputStream.class);
+    try (CountedOutputStream counted = new CountedOutputStream(mockOut)) {
+      // Act & Assert
+      assertEquals(0L, counted.written());
+    } catch (IOException e) {
+      fail(e);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 127, 255})
+  void writeInt_whenAnyByte_expectCountIncrementByOne(int value) throws IOException {
+    // Arrange
+    OutputStream mockOut = mock(OutputStream.class);
+    try (CountedOutputStream counted = new CountedOutputStream(mockOut)) {
+      // Act
+      counted.write(value);
+      // Assert
+      assertEquals(1L, counted.written());
+      verify(mockOut, times(1)).write(value);
+    }
+  }
+
+  @Test
+  void writeInt_whenUnderlyingThrows_expectCountUnchanged() throws IOException {
+    // Arrange
+    OutputStream mockOut = mock(OutputStream.class);
+    doThrow(new IOException("boom")).when(mockOut).write(anyInt());
+    try (CountedOutputStream counted = new CountedOutputStream(mockOut)) {
+      // Act
+      IOException ex = assertThrows(IOException.class, () -> counted.write(42));
+      assertEquals("boom", ex.getMessage());
+      // Assert
+      assertEquals(0L, counted.written());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 3, 16})
+  void writeByteArray_whenWholeArray_expectCountEqualsLength(int len) throws IOException {
+    // Arrange
+    OutputStream mockOut = mock(OutputStream.class);
+    byte[] data = new byte[len];
+    try (CountedOutputStream counted = new CountedOutputStream(mockOut)) {
+      // Act
+      counted.write(data);
+      // Assert
+      assertEquals(len, counted.written());
+      verify(mockOut, times(1)).write(data, 0, len);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0,0", "0,3", "1,2", "2,3"})
+  @DisplayName("write(byte[],off,len) counts exactly len and delegates")
+  void writeByteArray_whenOffsetAndLength_expectCountEqualsLength(int off, int len)
+      throws IOException {
+    // Arrange
+    int total = Math.max(off + len, 0);
+    byte[] data = new byte[total];
+    OutputStream mockOut = mock(OutputStream.class);
+    try (CountedOutputStream counted = new CountedOutputStream(mockOut)) {
+      // Act
+      counted.write(data, off, len);
+      // Assert
+      assertEquals(len, counted.written());
+      verify(mockOut, times(1)).write(data, off, len);
+    }
+  }
+
+  @Test
+  void writeByteArray_whenZeroLength_expectNoChange() throws IOException {
+    // Arrange
+    byte[] data = new byte[5];
+    OutputStream mockOut = mock(OutputStream.class);
+    try (CountedOutputStream counted = new CountedOutputStream(mockOut)) {
+      // Act
+      counted.write(data, 2, 0);
+      // Assert
+      assertEquals(0L, counted.written());
+      verify(mockOut, times(1)).write(data, 2, 0);
+    }
+  }
+
+  @Test
+  void writeByteArray_whenNull_expectNullPointerException() {
+    // Arrange
+    OutputStream mockOut = mock(OutputStream.class);
+    try (CountedOutputStream counted = new CountedOutputStream(mockOut)) {
+      // Act & Assert
+      //noinspection DataFlowIssue
+      assertThrows(NullPointerException.class, () -> counted.write(null));
+      assertEquals(0L, counted.written());
+    } catch (IOException e) {
+      fail(e);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "-1,1", // negative offset
+    "0,-1", // negative length
+    "2,4" // offset+length > array length
+  })
+  void writeByteArray_whenInvalidRange_expectIndexOutOfBoundsException(int off, int len) {
+    // Arrange: use a real OutputStream with default range checks
+    OutputStream realOut =
+        new OutputStream() {
+          @Override
+          public void write(int b) {
+            // no-op
+          }
+        };
+    try (CountedOutputStream cos = new CountedOutputStream(realOut)) {
+      byte[] data = new byte[4];
+      // Act & Assert
+      assertThrows(IndexOutOfBoundsException.class, () -> cos.write(data, off, len));
+      assertEquals(0L, cos.written());
+    } catch (IOException e) {
+      fail(e);
+    }
+  }
+
+  @Test
+  void constructor_whenNullStream_expectNpeOnWriteAndCountUnchanged() {
+    // Arrange
+    try (CountedOutputStream cos =
+        new CountedOutputStream(null) {
+          @Override
+          public void close() {
+            // Do nothing: underlying is null
+          }
+        }) {
+      // Act & Assert
+      assertThrows(NullPointerException.class, () -> cos.write(1));
+      assertEquals(0L, cos.written());
+    } catch (IOException e) {
+      fail(e);
+    }
+  }
+
+  @Test
+  void multipleWrites_whenMixedCalls_expectAccumulatedCount() throws IOException {
+    // Arrange
+    OutputStream mockOut = mock(OutputStream.class);
+    byte[] a = new byte[4];
+    byte[] b = new byte[3];
+
+    try (CountedOutputStream counted = new CountedOutputStream(mockOut)) {
+      // Act
+      counted.write(0x7F); // +1
+      counted.write(a); // +4
+      counted.write(b, 1, 2); // +2
+
+      // Assert
+      assertEquals(1 + 4 + 2, counted.written());
+      verify(mockOut, times(1)).write(0x7F);
+      verify(mockOut, times(1)).write(a, 0, 4);
+      verify(mockOut, times(1)).write(b, 1, 2);
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Add comprehensive JUnit 6 tests for CountedInputStream and CountedOutputStream (AAA style, parameterized, Mockito, try‑with‑resources, deterministic).
- Improve Javadoc for CountedOutputStream (purpose, threading, overflow, exceptions, parameters).
- Nullability cleanup in NewLZMACompressor: annotate byte[] parameters on read/write methods with @NotNull to match surrounding APIs and static analysis.

Changes (relative to develop)
- src/main/java/network/crypta/support/io/CountedInputStream.java: enrich class and method docs; add @NotNull annotations to byte[] overloads; clarify skip/read counting semantics.
- src/main/java/network/crypta/support/io/CountedOutputStream.java: enrich class and method docs; add @NotNull annotations to byte[] overloads; clarify overflow/thread‑safety.
- src/main/java/network/crypta/support/compress/NewLZMACompressor.java: add org.jetbrains.annotations.NotNull on byte[] parameters for read(byte[],off,len), read(byte[]), and write(byte[],off,len).
- src/test/java/network/crypta/support/io/CountedInputStreamTest.java: new tests (154 LOC): constructor, read() variants, skip(), error paths, accumulation.
- src/test/java/network/crypta/support/io/CountedOutputStreamTest.java: new tests (180 LOC): write() variants, delegation, zero‑length, error paths, accumulation.

Why
- Strengthen correctness guarantees with focused unit tests for small I/O wrappers used widely in the codebase.
- Address static analysis guidance (avoid redundant eq(...), use try‑with‑resources, clarify nullability).
- Improve API documentation for downstream maintainability.

Notes
- Behavior is unchanged; tests codify existing semantics. @NotNull type annotations on array parameters do not alter runtime method signatures.
- Thread‑safety remains external (documented). Counters may wrap at Long.MAX_VALUE (documented).

Validation
- Local: ./gradlew --parallel test passes on Java 21.
- No distribution or runtime behavior changes.

Commits
- b4f55ceba5 fix(io): update write method signature in NewLZMACompressor to include @NotNull annotation
- fee2234ec8 docs(io): improve Javadoc for CountedOutputStream
- 2fc0c76008 test(io): add unit tests for CountedOutputStream
- 291c232aaa fix(io): CountedInputStream; add unit tests; adjust NewLZMACompressor

Request
- Please review. If approved, merge into develop. Labels: area:io, tests, documentation.