### PR TITLE
fix(io): honor FileChannel.write() result in Fallocate; complete API docs; add tests

### DIFF
--- a/src/main/java/network/crypta/support/io/Fallocate.java
+++ b/src/main/java/network/crypta/support/io/Fallocate.java
@@ -11,9 +11,35 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provides access to operating system-specific {@code fallocate} and {@code posix_fallocate}
- * functions.
- * https://stackoverflow.com/questions/18031841/pre-allocating-drive-space-for-file-storage
+ * Pre-allocates file space using platform facilities and falls back to a portable writer.
+ *
+ * <p>This utility wraps native {@code fallocate(2)} on Linux and {@code posix_fallocate(3)} on
+ * other POSIX platforms when possible. If a native call is unsupported or fails, it performs a
+ * legacy fill that extends the file by writing zeros. On Windows, where sparse files are not
+ * created by default, the legacy behavior writes a single byte at {@code newLength - 1} to extend
+ * the file.
+ *
+ * <p>Usage is a small fluent builder:
+ *
+ * <pre>{@code
+ * Fallocate.forChannel(channel, sizeBytes)
+ *          .fromOffset(0)
+ *          .execute();
+ * }</pre>
+ *
+ * <p>Notes and constraints:
+ *
+ * <ul>
+ *   <li>Instances are not thread-safe. Use a separate instance per file/channel.
+ *   <li>{@link FileChannel} must be open and writable. Behavior is undefined if the channel is
+ *       closed during execution.
+ *   <li>The implementation uses reflection to obtain the underlying file descriptor. If the
+ *       descriptor cannot be accessed, the code silently falls back to the legacy fill path.
+ *   <li>Native calls are made via JNA to the platform C library.
+ * </ul>
+ *
+ * <p>External reference: “Pre-allocating drive space for file storage” — <a
+ * href="https://stackoverflow.com/questions/18031841/pre-allocating-drive-space-for-file-storage">...</a>
  */
 public final class Fallocate {
   private static final Logger LOG = LoggerFactory.getLogger(Fallocate.class);
@@ -29,38 +55,81 @@ public final class Fallocate {
   private final int fd;
   private int mode;
   private long offset;
-  private final long final_filesize;
+  private final long finalFilesize;
   private final FileChannel channel;
 
-  private Fallocate(FileChannel channel, int fd, long final_filesize) {
+  /**
+   * Constructs a new instance bound to a channel and a resolved file descriptor.
+   *
+   * @param channel target channel to operate on; must be open and writable
+   * @param fd platform file descriptor number; a value {@code <= 2} forces legacy behavior
+   * @param finalFilesize desired file size in bytes after allocation completes
+   */
+  private Fallocate(FileChannel channel, int fd, long finalFilesize) {
     this.fd = fd;
-    this.final_filesize = final_filesize;
+    this.finalFilesize = finalFilesize;
     this.channel = channel;
   }
 
-  public static Fallocate forChannel(FileChannel channel, long final_filesize) {
-    return new Fallocate(channel, getDescriptor(channel), final_filesize);
-  }
-
-  public static Fallocate forChannel(FileChannel channel, FileDescriptor fd, long final_filesize) {
-    return new Fallocate(channel, getDescriptor(fd), final_filesize);
+  /**
+   * Creates an instance for the given channel and desired final size.
+   *
+   * <p>Attempts to discover the native file descriptor behind the channel via reflection. If this
+   * discovery fails due to platform or security restrictions, subsequent execution falls back to
+   * the legacy writer.
+   *
+   * @param channel target channel; must be open and writable
+   * @param finalFilesize desired file size in bytes after allocation completes
+   * @return a new {@link Fallocate} bound to {@code channel}
+   */
+  public static Fallocate forChannel(FileChannel channel, long finalFilesize) {
+    return new Fallocate(channel, getDescriptor(channel), finalFilesize);
   }
 
   /**
-   * @throws IllegalArgumentException
+   * Creates an instance using an explicit file descriptor when available.
+   *
+   * <p>If {@code fd} is {@code null} or cannot be accessed, the instance behaves as if the
+   * descriptor were unavailable and will fall back to the legacy writer.
+   *
+   * @param channel target channel; must be open and writable
+   * @param fd optional descriptor; when inaccessible, legacy behavior is used
+   * @param finalFilesize desired file size in bytes after allocation completes
+   * @return a new {@link Fallocate} bound to {@code channel}
+   */
+  public static Fallocate forChannel(FileChannel channel, FileDescriptor fd, long finalFilesize) {
+    return new Fallocate(channel, getDescriptor(fd), finalFilesize);
+  }
+
+  /**
+   * Sets the starting byte offset for allocation.
+   *
+   * <p>The offset must be within {@code [0, finalFilesize]}. The default offset is {@code 0}.
+   *
+   * @param offset first byte to allocate (inclusive)
+   * @return this instance for fluent chaining
+   * @throws IllegalArgumentException if {@code offset < 0} or {@code offset > finalFilesize}
    */
   public Fallocate fromOffset(long offset) {
-    if (offset < 0 || offset > final_filesize) throw new IllegalArgumentException();
+    if (offset < 0 || offset > finalFilesize) throw new IllegalArgumentException();
     this.offset = offset;
     return this;
   }
 
   /**
-   * This method only works for Linux, do not use it.
+   * Requests Linux {@code FALLOC_FL_KEEP_SIZE} mode.
    *
-   * @throws UnsupportedOperationException
+   * <p>This flag preallocates blocks without extending the apparent file length. The mode is only
+   * supported on Linux; calling it on other platforms throws an exception.
+   *
+   * @deprecated Linux-only; on non-Linux systems this method throws {@link
+   *     UnsupportedOperationException}. Prefer the default behavior or simply call {@link
+   *     #execute()} without keep-size mode.
+   * @since 2
+   * @return this instance for fluent chaining
+   * @throws UnsupportedOperationException when invoked on non-Linux platforms
    */
-  @Deprecated
+  @Deprecated(since = "2")
   public Fallocate keepSize() {
     if (!IS_LINUX) {
       throw new UnsupportedOperationException(
@@ -70,15 +139,36 @@ public final class Fallocate {
     return this;
   }
 
+  /**
+   * Performs the allocation using the best available strategy on the current platform.
+   *
+   * <p>Behavior by platform:
+   *
+   * <ul>
+   *   <li><strong>Linux</strong>: Calls native {@code fallocate(fd, mode, offset, length)}. When
+   *       the call fails (non-zero errno), falls back to the legacy writer.
+   *   <li><strong>Other POSIX</strong>: Calls native {@code posix_fallocate(fd, offset, length)}.
+   *       On failure, falls back to the legacy writer.
+   *   <li><strong>Non-POSIX / missing descriptor</strong>: Uses the legacy writer directly.
+   * </ul>
+   *
+   * <p>The legacy writer extends the file to {@code finalFilesize}. On Windows it writes a single
+   * byte at {@code newLength - 1}. On other platforms it writes zero-filled blocks in chunks,
+   * retrying partial writes until the full range is covered.
+   *
+   * <p>Side effects: may extend the underlying file; may log a message when a native call fails.
+   *
+   * @throws IOException if I/O fails during the legacy fill path
+   */
   public void execute() throws IOException {
     int errno = 0;
     boolean isUnsupported = false;
     if (fd > 2) {
       if (IS_LINUX) {
-        final int result = FallocateHolder.fallocate(fd, mode, offset, final_filesize - offset);
+        final int result = FallocateHolder.fallocate(fd, mode, offset, finalFilesize - offset);
         errno = result == 0 ? 0 : Native.getLastError();
       } else if (IS_POSIX) {
-        errno = FallocateHolderPOSIX.posix_fallocate(fd, offset, final_filesize - offset);
+        errno = FallocateHolderPOSIX.posix_fallocate(fd, offset, finalFilesize - offset);
       } else {
         isUnsupported = true;
       }
@@ -89,14 +179,15 @@ public final class Fallocate {
     if (isUnsupported || errno != 0) {
       if (errno != 0) {
         // OS supports fallocate() but it failed. Do not log if the OS does not support fallocate().
-        LOG.info("fallocate() failed; using legacy method; errno=" + errno);
+        LOG.info("fallocate() failed; using legacy method; errno={}", errno);
       }
-      legacyFill(channel, final_filesize, offset);
+      legacyFill(channel, finalFilesize, offset);
     }
   }
 
   private static class FallocateHolder {
     static {
+      // Bind this class to the platform C library so JNA can resolve fallocate.
       Native.register(FallocateHolder.class, Platform.C_LIBRARY_NAME);
     }
 
@@ -105,49 +196,88 @@ public final class Fallocate {
 
   private static class FallocateHolderPOSIX {
     static {
+      // Bind POSIX variant to resolve posix_fallocate on non-Linux platforms.
       Native.register(FallocateHolderPOSIX.class, Platform.C_LIBRARY_NAME);
     }
 
+    @SuppressWarnings("java:S100")
     private static native int posix_fallocate(int fd, long offset, long length);
   }
 
+  /**
+   * Best-effort extraction of a channel's {@link FileDescriptor} to obtain its native fd value.
+   *
+   * <p>Returns {@code 0} when the descriptor is inaccessible (e.g., different JDK implementation or
+   * insufficient permissions) which forces legacy behavior for allocation.
+   */
   private static int getDescriptor(FileChannel channel) {
     try {
-      // sun.nio.ch.FileChannelImpl declares private final java.io.FileDescriptor fd
+      // FileChannel implementations typically declare a private 'fd' field holding a
+      // java.io.FileDescriptor. Use reflection as a last resort to access it.
       final Field field = channel.getClass().getDeclaredField("fd");
-      field.setAccessible(true);
+      // Attempt to make the field accessible; fall back to legacy when forbidden.
+      if (!field.canAccess(channel) && !field.trySetAccessible()) {
+        return 0; // Trigger legacy path when descriptor is not accessible
+      }
       return getDescriptor((FileDescriptor) field.get(channel));
     } catch (final Exception e) {
-      // File descriptor is not supported: fd is null and unavailable, return 0
+      // Intentionally fall back: descriptor is unavailable (e.g., different JDK implementation).
       return 0;
     }
   }
 
+  /**
+   * Best-effort extraction of the integer fd from a {@link FileDescriptor}.
+   *
+   * <p>Different VMs use different field names ({@code fd}, {@code descriptor}). When extraction
+   * fails, returns {@code 0} to signal that native allocation should not be attempted.
+   */
   private static int getDescriptor(FileDescriptor descriptor) {
     try {
-      // Oracle java.io.FileDescriptor declares private int fd
+      // Oracle/OpenJDK typically declare 'fd'; Android sometimes uses 'descriptor'.
       final Field field = descriptor.getClass().getDeclaredField(IS_ANDROID ? "descriptor" : "fd");
-      field.setAccessible(true);
+      // Attempt to make the field accessible; fall back to legacy when forbidden.
+      if (!field.canAccess(descriptor) && !field.trySetAccessible()) {
+        return 0; // Trigger legacy path when descriptor is not accessible
+      }
       return (int) field.get(descriptor);
     } catch (final Exception e) {
-      // File descriptor is not supported: fd is null and unavailable, return 0
+      // Intentionally fall back: descriptor is unavailable or null; return 0 for legacy path.
       return 0;
     }
   }
 
+  /**
+   * Portable fallback writer used when native allocation is unavailable or fails.
+   *
+   * <p>On Windows, extends the file by writing a single byte at {@code newLength - 1}. On other
+   * platforms, writes zero-filled blocks (4 MiB) from {@code offset} to {@code newLength}, handling
+   * partial writes by retrying until the requested range is fully written.
+   *
+   * @param fc target channel
+   * @param newLength desired file size in bytes after the operation
+   * @param offset starting position (inclusive)
+   * @throws IOException if any channel write fails
+   */
   private static void legacyFill(FileChannel fc, long newLength, long offset) throws IOException {
     if (IS_WINDOWS) {
-      // Windows do not create sparse files by default, so just write a byte at the end.
-      fc.write(ByteBuffer.allocate(1), newLength - 1);
+      // Windows does not create sparse files by default; extend by writing the last byte.
+      ByteBuffer one = ByteBuffer.allocate(1);
+      long pos = newLength - 1;
+      int written = fc.write(one, pos);
+      while (written == 0 && one.hasRemaining()) {
+        one.clear();
+        written = fc.write(one, pos);
+      }
     } else {
-      // fill fc with zeros (4MiB each time)
+      // Write zeros in 4 MiB chunks to reduce the number of IO calls.
       byte[] b = new byte[4096 * 1024];
       ByteBuffer bb = ByteBuffer.wrap(b);
       while ((offset < newLength) && (newLength - offset >= b.length)) {
         bb.rewind();
         offset += fc.write(bb, offset);
       }
-      // Remaining data can be written at once. If less bytes are written then try again.
+      // Write any remaining tail in one buffer. Retry until all bytes are written.
       while (offset < newLength) {
         offset += fc.write(ByteBuffer.wrap(new byte[Math.toIntExact(newLength - offset)]), offset);
       }

--- a/src/test/java/network/crypta/support/io/FallocateTest.java
+++ b/src/test/java/network/crypta/support/io/FallocateTest.java
@@ -1,0 +1,218 @@
+package network.crypta.support.io;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+import com.sun.jna.Platform;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link Fallocate} in AAA style. These tests avoid native calls by providing a
+ * mocked {@link FileChannel} which forces the fallback path regardless of OS (descriptor becomes
+ * 0). OS-specific expectations are guarded with assumptions.
+ */
+class FallocateTest {
+
+  // region fromOffset()
+
+  @ParameterizedTest
+  @DisplayName("fromOffset_whenOutOfRange_expectIllegalArgumentException")
+  @ValueSource(longs = {-1L, 11L})
+  void fromOffset_whenOutOfRange_expectIllegalArgumentException(long badOffset) {
+    // Arrange
+    FileChannel channel = mock(FileChannel.class);
+    Fallocate f = Fallocate.forChannel(channel, 10L);
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> f.fromOffset(badOffset));
+  }
+
+  @ParameterizedTest
+  @DisplayName("fromOffset_whenWithinBounds_expectSameInstance")
+  @ValueSource(longs = {0L, 10L})
+  void fromOffset_whenWithinBounds_expectSameInstance(long okOffset) {
+    // Arrange
+    FileChannel channel = mock(FileChannel.class);
+    Fallocate f = Fallocate.forChannel(channel, 10L);
+
+    // Act
+    Fallocate result = f.fromOffset(okOffset);
+
+    // Assert
+    assertSame(f, result);
+  }
+
+  // endregion
+
+  // region execute() -> legacy path (fd <= 2)
+
+  @Test
+  void execute_whenUnsupportedAndNonWindows_writesExactRemainingFromOffset() throws IOException {
+    // Arrange
+    assumeFalse(Platform.isWindows(), "This test targets the non-Windows legacy path.");
+    FileChannel channel = mock(FileChannel.class);
+    // Make write() return the full buffer size in one go
+    when(channel.write(any(ByteBuffer.class), anyLong()))
+        .thenAnswer(
+            inv -> {
+              ByteBuffer buf = inv.getArgument(0);
+              return buf.remaining();
+            });
+
+    long finalSize = 10L;
+    long offset = 7L;
+    Fallocate f = Fallocate.forChannel(channel, finalSize).fromOffset(offset);
+
+    // Act
+    f.execute();
+
+    // Assert
+    ArgumentCaptor<ByteBuffer> bufCap = ArgumentCaptor.forClass(ByteBuffer.class);
+    ArgumentCaptor<Long> posCap = ArgumentCaptor.forClass(Long.class);
+    verify(channel, times(1)).write(bufCap.capture(), posCap.capture());
+    assertEquals(3, bufCap.getValue().remaining());
+    assertEquals(offset, posCap.getValue());
+  }
+
+  @Test
+  void execute_whenUnsupportedAndNonWindowsAndPartialWrites_retriesUntilDone() throws IOException {
+    // Arrange
+    assumeFalse(Platform.isWindows(), "This test targets the non-Windows legacy path.");
+    FileChannel channel = mock(FileChannel.class);
+    // Simulate partial writes of 1 byte each time
+    when(channel.write(any(ByteBuffer.class), anyLong())).thenReturn(1, 1, 1);
+
+    long finalSize = 10L;
+    long offset = 7L;
+    Fallocate f = Fallocate.forChannel(channel, finalSize).fromOffset(offset);
+
+    // Act
+    f.execute();
+
+    // Assert
+    ArgumentCaptor<Long> posCap = ArgumentCaptor.forClass(Long.class);
+    verify(channel, times(3)).write(any(ByteBuffer.class), posCap.capture());
+    assertEquals(3, posCap.getAllValues().size());
+    assertEquals(7L, posCap.getAllValues().get(0));
+    assertEquals(8L, posCap.getAllValues().get(1));
+    assertEquals(9L, posCap.getAllValues().get(2));
+  }
+
+  @Test
+  void execute_whenUnsupportedAndWindows_writesSingleByteAtEnd() throws IOException {
+    // Arrange
+    assumeTrue(Platform.isWindows(), "This test targets the Windows legacy path.");
+    FileChannel channel = mock(FileChannel.class);
+    when(channel.write(any(ByteBuffer.class), anyLong())).thenReturn(1);
+
+    long finalSize = 10L;
+    long offset = 7L; // ignored on Windows path
+    Fallocate f = Fallocate.forChannel(channel, finalSize).fromOffset(offset);
+
+    // Act
+    f.execute();
+
+    // Assert
+    ArgumentCaptor<ByteBuffer> bufCap = ArgumentCaptor.forClass(ByteBuffer.class);
+    ArgumentCaptor<Long> posCap = ArgumentCaptor.forClass(Long.class);
+    verify(channel, times(1)).write(bufCap.capture(), posCap.capture());
+    assertEquals(1, bufCap.getValue().remaining());
+    assertEquals(finalSize - 1, posCap.getValue());
+  }
+
+  @Test
+  void execute_whenOffsetEqualsFinalSize_expectNoWriteOnNonWindowsOrSingleByteOnWindows()
+      throws IOException {
+    // Arrange
+    FileChannel channel = mock(FileChannel.class);
+    long finalSize = 10L;
+    long offset = 10L; // zero remaining
+    Fallocate f = Fallocate.forChannel(channel, finalSize).fromOffset(offset);
+
+    // Act
+    f.execute();
+
+    // Assert
+    if (Platform.isWindows()) {
+      // On Windows, legacy writes a single byte at finalSize-1
+      verify(channel, times(1)).write(any(ByteBuffer.class), eq(finalSize - 1));
+    } else {
+      // On non-Windows, zero remaining => no writes
+      verify(channel, never()).write(any(ByteBuffer.class), anyLong());
+    }
+  }
+
+  // endregion
+
+  // region keepSize()
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void keepSize_whenNotLinux_expectUnsupportedOperationException() {
+    // Arrange
+    assumeFalse(Platform.isLinux(), "Skip when Linux; covered by the Linux test.");
+    FileChannel channel = mock(FileChannel.class);
+    Fallocate f = Fallocate.forChannel(channel, 10L);
+
+    // Act + Assert
+    assertThrows(UnsupportedOperationException.class, f::keepSize);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void keepSize_whenLinux_doesNotThrowAndReturnsSame() {
+    // Arrange
+    assumeTrue(Platform.isLinux(), "Linux-only behavior under test.");
+    FileChannel channel = mock(FileChannel.class);
+    Fallocate f = Fallocate.forChannel(channel, 10L);
+
+    // Act
+    Fallocate result = f.keepSize();
+
+    // Assert
+    assertSame(f, result);
+  }
+
+  // endregion
+
+  // region forChannel(FileDescriptor) null/reflective fallback
+
+  @Test
+  void execute_whenProvidedFileDescriptorIsNull_fallsBackToLegacy() throws IOException {
+    // Arrange
+    FileChannel channel = mock(FileChannel.class);
+    when(channel.write(any(ByteBuffer.class), anyLong()))
+        .thenAnswer(inv -> ((ByteBuffer) inv.getArgument(0)).remaining());
+
+    long finalSize = 10L;
+    long offset = 7L;
+    Fallocate f = Fallocate.forChannel(channel, null, finalSize).fromOffset(offset);
+
+    // Act
+    f.execute();
+
+    // Assert
+    if (Platform.isWindows()) {
+      verify(channel, times(1)).write(any(ByteBuffer.class), eq(finalSize - 1));
+    } else {
+      ArgumentCaptor<ByteBuffer> bufCap = ArgumentCaptor.forClass(ByteBuffer.class);
+      ArgumentCaptor<Long> posCap = ArgumentCaptor.forClass(Long.class);
+      verify(channel, times(1)).write(bufCap.capture(), posCap.capture());
+      assertEquals(3, bufCap.getValue().remaining());
+      assertEquals(offset, posCap.getValue());
+    }
+  }
+
+  // endregion
+}


### PR DESCRIPTION
Summary
- Fix: Windows legacy path in Fallocate honors FileChannel.write() return value and retries on zero/short write (no behavior change otherwise).
- Docs: Complete Javadoc for the Fallocate API (class and public methods), clarify native vs legacy behavior, reflection rationale, and error handling.
- Code health: Replace string concatenation logging with SLF4J parameterized logging; avoid setAccessible(true) by using canAccess/trySetAccessible (addresses Sonar rule S3011 without changing behavior).
- Tests: Add deterministic JUnit 6 + Mockito tests in AAA style for bounds, Windows/non-Windows legacy paths, partial write retry, and deprecated keepSize() behavior (guarded with OS assumptions).

Motivation
- Prevent “ignored result” on FileChannel.write() (static analysis finding), ensuring the legacy path is robust under zero/short writes.
- Improve maintainability and clarity of platform-specific behavior via comprehensive documentation.
- Reduce reflective access risks while keeping the same fallback behavior when descriptors are not accessible.

Implementation Notes
- Windows legacy path now writes a single byte at newLength-1 and loops until at least one byte is written, using the return value of write().
- Non-Windows legacy path is unchanged: 4MiB zero-chunk writes plus a tail write with retries until the requested range is fully written.
- Native fallocate/posix_fallocate paths are unchanged; errno is logged with LOG.info using parameterized placeholders.
- Reflection helpers: use trySetAccessible() when needed; if not accessible, return 0 to force legacy path.
- Deprecation: keepSize() has doc block placed above the @Deprecated annotation, includes @since and @deprecated tags.

Testing
- Ran: ./gradlew --parallel test → PASS
- SonarLint (file-scoped): ./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/support/io/Fallocate.java → no warnings/errors (only an INFO reminder about deprecated code).
- Tests are deterministic, OS-behavior validated via com.sun.jna.Platform assumptions.

Affected Files (this commit)
- src/main/java/network/crypta/support/io/Fallocate.java
- src/test/java/network/crypta/support/io/FallocateTest.java

Risk & Compatibility
- Minimal risk. Behavior changes only affect the Windows legacy extension path by checking the write() result. Linux/POSIX native calls and non-Windows legacy zero-fill remain unchanged.

How to Validate Locally
- ./gradlew --parallel test jacocoTestReport
- (Optional) ./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/support/io/Fallocate.java

Notes
- Base: develop. Head: feature/fix-fallocate.
