### PR TITLE
io: clarify disk-space checks; add tests; improve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ debhelper-build-stamp
 *.substvars
 /debian/freenet/*
 .gradle
+.gradle-home
 gradle
 /.gradle-user-home
 debian/seednodes.fref

--- a/src/main/java/network/crypta/support/io/DiskSpaceChecker.java
+++ b/src/main/java/network/crypta/support/io/DiskSpaceChecker.java
@@ -2,16 +2,40 @@ package network.crypta.support.io;
 
 import java.io.File;
 
+/**
+ * Contract for validating that sufficient free space exists before writing more data.
+ *
+ * <p>Callers use this interface to decide whether a pending write should proceed based on the
+ * available space of the filesystem containing the target file. Implementations define the specific
+ * policy (for example, reserving a minimum amount of free bytes, or allowing writes only when a
+ * threshold is met) and may incorporate additional context such as write buffering or throttling
+ * intervals.
+ *
+ * <p><strong>Units:</strong> All sizes are in bytes.
+ *
+ * <p><strong>Threading:</strong> Implementations may be invoked from multiple threads. Any
+ * thread-safety guarantees should be documented by the implementing class.
+ */
 public interface DiskSpaceChecker {
 
   /**
-   * Is there enough space to extend the file?
+   * Determines whether a proposed write should be allowed given current free space.
    *
-   * @param file The current filename
-   * @param toWrite Length of the proposed write
-   * @param bufferSize The caller only checks disk space when the number of bytes written since the
-   *     last check exceeds this value.
-   * @return True if there is sufficient disk space
+   * <p>The {@code file} identifies the destination whose containing filesystem is evaluated. The
+   * file may or may not already exist (implementation-dependent). The {@code toWrite} value
+   * represents the number of additional bytes the caller intends to write next. {@code bufferSize}
+   * can be used by implementations to incorporate the amount written since the last check, enabling
+   * periodic rather than per-byte evaluation.
+   *
+   * <p>This method does not declare checked exceptions. Implementations should return {@code false}
+   * to signal insufficient space rather than throwing, unless a fatal error unrelated to low disk
+   * space occurs.
+   *
+   * @param file target file; used to determine the filesystem to check; must be non-null
+   * @param toWrite number of additional bytes the caller intends to write (bytes; non-negative)
+   * @param bufferSize number of bytes written since the last check (bytes; non-negative)
+   * @return {@code true} if the write is allowed under the implementation's policy; {@code false}
+   *     otherwise
    */
   boolean checkDiskSpace(File file, int toWrite, int bufferSize);
 }

--- a/src/main/java/network/crypta/support/io/DiskSpaceCheckingOutputStream.java
+++ b/src/main/java/network/crypta/support/io/DiskSpaceCheckingOutputStream.java
@@ -4,9 +4,37 @@ import java.io.File;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * Output stream that periodically checks available disk space before writing.
+ *
+ * <p>This class delegates all writes to an underlying {@link OutputStream} but consults a {@link
+ * DiskSpaceChecker} at configurable intervals. A disk-space check is performed only when the number
+ * of bytes written since the last successful check plus the size of the pending write is greater
+ * than or equal to {@code bufferSize}. If the check fails, the current write does not proceed and
+ * an {@link InsufficientDiskSpaceException} is thrown.
+ *
+ * <p>The supplied {@link File} identifies the file being created or extended and is passed to the
+ * checker. Implementations typically use it to resolve the containing directory or filesystem.
+ *
+ * <p>Thread-safety: {@link #write(byte[], int, int)} is {@code synchronized}. The other overloads
+ * delegate to it, so writes are serialized per instance.
+ */
 public class DiskSpaceCheckingOutputStream extends FilterOutputStream {
 
+  /**
+   * Creates a stream that performs periodic disk-space checks during writes.
+   *
+   * @param out the underlying stream to write to; must not be {@code null}.
+   * @param checker the strategy used to decide whether a write may proceed; must not be {@code
+   *     null}.
+   * @param file the path of the file being written. It is passed to the checker, which may use it
+   *     to locate the target directory or filesystem; must not be {@code null}.
+   * @param bufferSize the threshold in bytes that controls how often checks are performed. This
+   *     value is also passed to {@link DiskSpaceChecker#checkDiskSpace(File, int, int)}; see that
+   *     contract for details on its interpretation.
+   */
   public DiskSpaceCheckingOutputStream(
       OutputStream out, DiskSpaceChecker checker, File file, int bufferSize) {
     super(out);
@@ -18,24 +46,59 @@ public class DiskSpaceCheckingOutputStream extends FilterOutputStream {
   private final File file;
   private final DiskSpaceChecker checker;
   private final int bufferSize;
+  // Total number of bytes successfully written through this stream so far.
   private long written;
+  // Value of {@code written} at the time of the last successful disk-space check.
   private long lastChecked;
 
+  /**
+   * Writes the entire buffer, performing a disk-space check when required.
+   *
+   * @param buf the data to write; must not be {@code null}.
+   * @throws InsufficientDiskSpaceException if the checker reports insufficient free space for the
+   *     pending write.
+   * @throws IOException if the underlying stream throws an I/O error.
+   */
   @Override
-  public void write(byte[] buf) throws IOException {
+  public void write(byte @NotNull [] buf) throws IOException {
     write(buf, 0, buf.length);
   }
 
+  /**
+   * Writes a single byte, delegating to the array-based overload.
+   *
+   * @param i the byte to write, as an {@code int}.
+   * @throws InsufficientDiskSpaceException if the checker reports insufficient free space for the
+   *     pending write.
+   * @throws IOException if the underlying stream throws an I/O error.
+   */
   @Override
   public void write(int i) throws IOException {
     write(new byte[] {(byte) i});
   }
 
+  /**
+   * Writes a subrange of the given array, checking disk space at most once per threshold interval.
+   *
+   * <p>A check is triggered when {@code written + length - lastChecked >= bufferSize}. When a check
+   * occurs and {@link DiskSpaceChecker#checkDiskSpace(File, int, int)} returns {@code false}, no
+   * bytes are written and an {@link InsufficientDiskSpaceException} is thrown.
+   *
+   * @param buf the source buffer; must not be {@code null}.
+   * @param offset the start offset in the data.
+   * @param length the number of bytes to write.
+   * @throws InsufficientDiskSpaceException if there is not enough free space to allow to write.
+   * @throws IOException if the underlying stream throws an I/O error.
+   */
   @Override
-  public synchronized void write(byte[] buf, int offset, int length) throws IOException {
+  public synchronized void write(byte @NotNull [] buf, int offset, int length) throws IOException {
+    // Trigger a check when the next write would push the distance since the last check
+    // to at least the configured threshold.
     if (written + length - lastChecked >= bufferSize) {
       if (!checker.checkDiskSpace(file, length, bufferSize))
         throw new InsufficientDiskSpaceException();
+      // Record the position at which the check was performed so the threshold comparison includes
+      // the size of the pending write. This biases checks conservatively.
       lastChecked = written;
     }
     out.write(buf, offset, length);

--- a/src/main/java/network/crypta/support/io/DiskSpaceCheckingRandomAccessBufferFactory.java
+++ b/src/main/java/network/crypta/support/io/DiskSpaceCheckingRandomAccessBufferFactory.java
@@ -2,6 +2,7 @@ package network.crypta.support.io;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Random;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -10,6 +11,22 @@ import network.crypta.support.api.LockableRandomAccessBufferFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Factory that enforces free‑space checks before creating random‑access buffers.
+ *
+ * <p>This wrapper queries {@link File#getUsableSpace()} on a configured directory and requires that
+ * enough space remains after an allocation to meet a caller‑defined reserve. When the check passes,
+ * calls delegate to the underlying {@link LockableRandomAccessBufferFactory}. It also implements
+ * {@link DiskSpaceChecker} for incremental write checks and {@link FileRandomAccessBufferFactory}
+ * for file‑backed buffer creation.
+ *
+ * <p><strong>Threading:</strong> A single fair {@link java.util.concurrent.locks.ReentrantLock}
+ * serializes free‑space checks with allocation to keep observations consistent and reduce
+ * fragmentation. The lock does not provide any per‑file concurrency guarantees for returned
+ * buffers.
+ *
+ * <p><strong>Units:</strong> All sizes are bytes.
+ */
 public class DiskSpaceCheckingRandomAccessBufferFactory
     implements LockableRandomAccessBufferFactory, DiskSpaceChecker, FileRandomAccessBufferFactory {
 
@@ -20,13 +37,20 @@ public class DiskSpaceCheckingRandomAccessBufferFactory
   private final File dir;
   private volatile long minDiskSpace;
 
-  /**
-   * LOCKING: We synchronize throughout the whole operation to prevent fragmentation and to have an
-   * accurate free space estimate. FIXME ideally this would be per-filesystem. It might be possible
-   * to get that information from Java (1.7) via java.nio.file.
+  /*
+   * LOCKING: Serialize space checks and allocations under one fair lock to make the free‑space
+   * snapshot representative for the following allocation. Per‑filesystem granularity could be
+   * considered in the future if needed.
    */
   private static final Lock lock = new ReentrantLock(true);
 
+  /**
+   * Creates a factory that validates free space before delegating to the underlying factory.
+   *
+   * @param underlying delegate for actual buffer creation when checks pass
+   * @param dir directory whose filesystem is queried via {@link File#getUsableSpace()}
+   * @param minDiskSpace minimum free bytes that must remain after allocation (reserve)
+   */
   public DiskSpaceCheckingRandomAccessBufferFactory(
       LockableRandomAccessBufferFactory underlying, File dir, long minDiskSpace) {
     this.underlying = underlying;
@@ -34,11 +58,28 @@ public class DiskSpaceCheckingRandomAccessBufferFactory
     this.minDiskSpace = minDiskSpace;
   }
 
+  /**
+   * Sets the minimum free‑space reserve (bytes) required to remain after allocations.
+   *
+   * @param min non‑negative reserve in bytes
+   * @throws IllegalArgumentException if {@code min < 0}
+   */
   public void setMinDiskSpace(long min) {
     if (min < 0) throw new IllegalArgumentException();
     this.minDiskSpace = min;
   }
 
+  /**
+   * Creates a fixed‑size buffer after verifying free space.
+   *
+   * <p>Requires {@code dir.getUsableSpace() > size + minDiskSpace}. The method holds the internal
+   * lock while checking and delegating to avoid races between threads.
+   *
+   * @param size requested length in bytes
+   * @return a new {@link LockableRandomAccessBuffer}
+   * @throws InsufficientDiskSpaceException if the free‑space requirement is not met
+   * @throws IOException if the delegate fails with an I/O error
+   */
   @Override
   public LockableRandomAccessBuffer makeRAF(long size) throws IOException {
     lock.lock();
@@ -50,6 +91,21 @@ public class DiskSpaceCheckingRandomAccessBufferFactory
     }
   }
 
+  /**
+   * Creates a buffer initialized from a byte array after verifying free space.
+   *
+   * <p>Requires {@code dir.getUsableSpace() > size + minDiskSpace}. This method is synchronized and
+   * also uses the internal lock for a consistent check‑then‑allocate sequence.
+   *
+   * @param initialContents source array; data from {@code offset} with length {@code size} is
+   *     copied
+   * @param offset index of the first byte to copy
+   * @param size number of bytes to copy; also the resulting buffer length
+   * @param readOnly whether the returned buffer is read‑only if supported by the delegate
+   * @return a new {@link LockableRandomAccessBuffer} containing the copied data
+   * @throws InsufficientDiskSpaceException if the free‑space requirement is not met
+   * @throws IOException if the delegate fails with an I/O error
+   */
   @Override
   public synchronized LockableRandomAccessBuffer makeRAF(
       byte[] initialContents, int offset, int size, boolean readOnly) throws IOException {
@@ -63,25 +119,41 @@ public class DiskSpaceCheckingRandomAccessBufferFactory
     }
   }
 
+  /**
+   * Returns a diagnostic string that includes the delegate factory.
+   *
+   * @return {@code super.toString() + ":" + underlying.toString()}
+   */
+  @Override
   public String toString() {
     return super.toString() + ":" + underlying.toString();
   }
 
   /**
-   * Create a new RAF for a specified file, which must exist but be 0 bytes long. Will delete the
-   * file if an RAF cannot be created.
+   * Creates a file‑backed buffer for an existing empty file.
    *
-   * @throws InsufficientDiskSpaceException If there is not enough disk space.
-   * @throws IOException If some other disk I/O error occurs.
+   * <p>The file must exist and have length {@code 0}. Requires {@code dir.getUsableSpace() > size +
+   * minDiskSpace}. On success, returns a {@link PooledFileRandomAccessBuffer}. If any step fails
+   * before returning a buffer, the method deletes the file in the best‑effort manner.
+   *
+   * <p><strong>Ownership:</strong> The caller owns the returned buffer and must close or free it.
+   *
+   * @param file target file; must exist and be empty
+   * @param size desired length in bytes
+   * @param random randomness source used by the buffer implementation when pre‑allocating
+   * @return a newly created file‑backed buffer
+   * @throws IOException if the file preconditions are not met or another I/O error occurs
+   * @throws InsufficientDiskSpaceException if the free‑space requirement is not met
    */
+  @SuppressWarnings("java:S2093")
   public PooledFileRandomAccessBuffer createNewRAF(File file, long size, Random random)
       throws IOException {
-    lock.lock();
     PooledFileRandomAccessBuffer ret = null;
+    lock.lock();
     try {
       if (!file.exists()) throw new IOException("File does not exist");
       if (file.length() != 0) throw new IOException("File is wrong length");
-      // FIXME ideally we would have separate locks for each filesystem ...
+      // Keep check and allocation under the same lock for a consistent space snapshot.
       if (dir.getUsableSpace() > size + minDiskSpace) {
         ret = new PooledFileRandomAccessBuffer(file, false, size, random, -1, true);
         return ret;
@@ -89,15 +161,35 @@ public class DiskSpaceCheckingRandomAccessBufferFactory
         throw new InsufficientDiskSpaceException();
       }
     } finally {
-      if (ret == null) file.delete();
+      if (ret == null) { // Best‑effort cleanup when no buffer was returned.
+        try {
+          Files.delete(file.toPath());
+        } catch (IOException e) {
+          // Preserve original failure; deletion failure here is non‑fatal.
+          LOG.debug("Unable to delete {} after RAF creation failed", file, e);
+        }
+      }
       lock.unlock();
     }
   }
 
+  /**
+   * Checks whether writing more data would violate the configured free‑space reserve.
+   *
+   * <p>If {@code file} is not a descendant of {@code dir}, the method logs an error and returns
+   * {@code true} (i.e., it does not block the writing). Otherwise, it evaluates {@code
+   * dir.getUsableSpace() - (toWrite + bufferSize) >= minDiskSpace} under the internal lock.
+   *
+   * @param file file being extended; used to validate directory relationship
+   * @param toWrite number of additional bytes intended to be written
+   * @param bufferSize number of bytes written since the last check; callers use this to throttle
+   *     check frequency
+   * @return {@code true} if the writing is allowed, {@code false} if it would violate the reserve
+   */
   @Override
   public boolean checkDiskSpace(File file, int toWrite, int bufferSize) {
     if (!FileUtil.isParent(dir, file)) {
-      LOG.error("Not checking disk space because " + file + " is not child of " + dir);
+      LOG.error("Not checking disk space because {} is not child of {}", file, dir);
       return true;
     }
     lock.lock();

--- a/src/test/java/network/crypta/support/io/DiskSpaceCheckingOutputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/DiskSpaceCheckingOutputStreamTest.java
@@ -1,0 +1,277 @@
+package network.crypta.support.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Tests for {@link DiskSpaceCheckingOutputStream}.
+ *
+ * <p>- Uses AAA style - Mocks external I/O using Mockito - Covers null, empty, boundary and error
+ * paths
+ */
+class DiskSpaceCheckingOutputStreamTest {
+
+  // Helpers
+  private static DiskSpaceCheckingOutputStream newStream(
+      OutputStream out, DiskSpaceChecker checker, File file, int bufferSize) {
+    return new DiskSpaceCheckingOutputStream(out, checker, file, bufferSize);
+  }
+
+  @Test
+  @DisplayName("write_whenBelowBuffer_doesNotCheckSpace")
+  void write_whenBelowBuffer_doesNotCheckSpace() throws IOException {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    File file = new File("/tmp/dummy");
+    int bufferSize = 8;
+    byte[] data = new byte[5];
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, file, bufferSize);
+
+    // Act
+    stream.write(data);
+
+    // Assert
+    verifyNoInteractions(checker);
+    verify(out).write(data, 0, 5);
+    verifyNoMoreInteractions(out);
+  }
+
+  @Test
+  @DisplayName("write_whenCrossesThreshold_callsCheckerOnceAndWrites")
+  void write_whenCrossesThreshold_callsCheckerOnceAndWrites() throws IOException {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    when(checker.checkDiskSpace(any(), anyInt(), anyInt())).thenReturn(true);
+    File file = new File("/tmp/dummy");
+    int bufferSize = 10;
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, file, bufferSize);
+
+    byte[] a = new byte[5];
+    byte[] b = new byte[4];
+    byte[] c = new byte[1]; // This write crosses the threshold (5+4 -> 9; +1 -> 10)
+
+    // Act
+    stream.write(a);
+    stream.write(b);
+    stream.write(c);
+
+    // Assert
+    // Only the last write should trigger the first check
+    verify(checker, times(1)).checkDiskSpace(file, 1, bufferSize);
+    verify(out).write(a, 0, a.length);
+    verify(out).write(b, 0, b.length);
+    verify(out).write(c, 0, c.length);
+    verifyNoMoreInteractions(out);
+  }
+
+  @Test
+  @DisplayName("write_whenEqualToBuffer_callsCheckerOnce")
+  void write_whenEqualToBuffer_callsCheckerOnce() throws IOException {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    when(checker.checkDiskSpace(any(), anyInt(), anyInt())).thenReturn(true);
+    File file = new File("/tmp/dummy");
+    int bufferSize = 6;
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, file, bufferSize);
+    byte[] data = new byte[6];
+
+    // Act
+    stream.write(data);
+
+    // Assert
+    verify(checker, times(1)).checkDiskSpace(file, 6, bufferSize);
+    verify(out).write(data, 0, 6);
+  }
+
+  @Test
+  @DisplayName("write_whenLargeSingleWrite_callsCheckerOnceWithToWriteLength")
+  void write_whenLargeSingleWrite_callsCheckerOnceWithToWriteLength() throws IOException {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    when(checker.checkDiskSpace(any(), anyInt(), anyInt())).thenReturn(true);
+    File file = new File("/tmp/file");
+    int bufferSize = 10;
+    byte[] data = new byte[25];
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, file, bufferSize);
+
+    // Act
+    stream.write(data);
+
+    // Assert
+    verify(checker, times(1)).checkDiskSpace(file, 25, bufferSize);
+    verify(out).write(data, 0, 25);
+  }
+
+  @Test
+  @DisplayName("write_whenCheckerReturnsFalse_throwsAndDoesNotWrite")
+  void write_whenCheckerReturnsFalse_throwsAndDoesNotWrite() throws IOException {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    when(checker.checkDiskSpace(any(), anyInt(), anyInt())).thenReturn(false);
+    File file = new File("/tmp/file");
+    int bufferSize = 4;
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, file, bufferSize);
+
+    byte[] small = new byte[3]; // below threshold, shouldn't check
+    byte[] trigger = new byte[2]; // this writing crosses threshold and should throw
+
+    // Act
+    stream.write(small);
+
+    // Assert (first write)
+    verifyNoInteractions(checker); // no check yet
+    verify(out).write(small, 0, 3);
+
+    // Act & Assert (second write triggers failure before writing to 'out')
+    InsufficientDiskSpaceException ex =
+        assertThrows(InsufficientDiskSpaceException.class, () -> stream.write(trigger));
+    assertNotNull(ex);
+
+    // The failing chunk must not be written to the underlying stream
+    verify(out, never()).write(same(trigger), anyInt(), anyInt());
+    // And the checker must have been called once with the second chunk's length
+    verify(checker, times(1)).checkDiskSpace(file, 2, bufferSize);
+  }
+
+  @Test
+  @DisplayName("writeInt_whenBufferIsOne_callsCheckerAndWritesOneByte")
+  void writeInt_whenBufferIsOne_callsCheckerAndWritesOneByte() throws IOException {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    when(checker.checkDiskSpace(any(), anyInt(), anyInt())).thenReturn(true);
+    File file = new File("/tmp/any");
+    int bufferSize = 1;
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, file, bufferSize);
+
+    // Act
+    stream.write(42);
+
+    // Assert
+    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+    verify(checker).checkDiskSpace(file, 1, bufferSize);
+    ArgumentCaptor<Integer> offCap = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> lenCap = ArgumentCaptor.forClass(Integer.class);
+    verify(out).write(captor.capture(), offCap.capture(), lenCap.capture());
+    byte[] written = captor.getValue();
+    assertThat(written.length, equalTo(1));
+    assertThat(written[0], equalTo((byte) 42));
+    assertThat(offCap.getValue(), equalTo(0));
+    assertThat(lenCap.getValue(), equalTo(1));
+  }
+
+  @Test
+  @DisplayName("write_withZeroLength_callsOutButDoesNotCheck")
+  void write_withZeroLength_callsOutButDoesNotCheck() throws IOException {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    File file = new File("/tmp/zero");
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, file, 8);
+    byte[] empty = new byte[0];
+
+    // Act
+    stream.write(empty);
+
+    // Assert
+    verifyNoInteractions(checker);
+    verify(out).write(empty, 0, 0);
+  }
+
+  @Test
+  @DisplayName("write_withNullBuffer_throwsNPE")
+  @SuppressWarnings("DataFlowIssue")
+  void write_withNullBuffer_throwsNPE() {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, null, 8);
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> stream.write(null));
+  }
+
+  @ParameterizedTest(name = "buffer={0}: sequence triggers {1} checks")
+  @MethodSource("seqProvider")
+  @DisplayName("write_whenSequentialThresholds_checkCalledExpectedTimes")
+  void write_whenSequentialThresholds_checkCalledExpectedTimes(int bufferSize, int expectedChecks)
+      throws IOException {
+    // Arrange
+    OutputStream out = mock(OutputStream.class);
+    DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+    when(checker.checkDiskSpace(any(), anyInt(), anyInt())).thenReturn(true);
+    DiskSpaceCheckingOutputStream stream = newStream(out, checker, new File("/tmp/x"), bufferSize);
+
+    // Writes: 5, 6, 4, 1
+    // With buffer=10, checks on 6 and 4 => 2 checks
+    // With buffer=5, checks on 5 (first), 6, 4, 1 => 3 checks (first write = exactly 5)
+    // With buffer=20, checks on 6 (5+6 >=20? no), after adding 4: 5+6+4 >=20? no, +1: 5+6+4+1=16<20
+    // => 0 checks
+    // But due to algorithm (checks based on lastChecked before the chunk), calculations:
+    // We'll assert via invocation count, not recompute here.
+    int[] writes = new int[] {5, 6, 4, 1};
+
+    // Act
+    for (int w : writes) stream.write(new byte[w]);
+
+    // Assert
+    ArgumentCaptor<Integer> bufSizeCap = ArgumentCaptor.forClass(Integer.class);
+    verify(checker, times(expectedChecks)).checkDiskSpace(any(), anyInt(), bufSizeCap.capture());
+    for (Integer v : bufSizeCap.getAllValues()) {
+      assertThat(v, equalTo(bufferSize));
+    }
+  }
+
+  static Stream<Arguments> seqProvider() {
+    return Stream.of(
+        Arguments.of(10, 2), // threshold crossed by 6 and later by 4
+        Arguments.of(5, 4),
+        Arguments.of(20, 0));
+  }
+
+  @Nested
+  class OffsetWrite {
+    @Test
+    @DisplayName("write_withOffset_writesExactRangeToOut")
+    void write_withOffset_writesExactRangeToOut() throws IOException {
+      // Arrange
+      OutputStream out = mock(OutputStream.class);
+      DiskSpaceChecker checker = mock(DiskSpaceChecker.class);
+      when(checker.checkDiskSpace(any(), anyInt(), anyInt())).thenReturn(true);
+      DiskSpaceCheckingOutputStream stream = newStream(out, checker, new File("/tmp/y"), 2);
+
+      byte[] buf = new byte[] {10, 20, 30, 40, 50};
+
+      // Act
+      stream.write(buf, 1, 3); // [20,30,40]
+
+      // Assert
+      ArgumentCaptor<Integer> toWriteCap = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<Integer> bufSizeCap = ArgumentCaptor.forClass(Integer.class);
+      verify(checker, times(1)).checkDiskSpace(any(), toWriteCap.capture(), bufSizeCap.capture());
+      assertThat(toWriteCap.getValue(), equalTo(3));
+      assertThat(bufSizeCap.getValue(), equalTo(2));
+      verify(out).write(buf, 1, 3);
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/io/DiskSpaceCheckingRandomAccessBufferFactoryTest.java
+++ b/src/test/java/network/crypta/support/io/DiskSpaceCheckingRandomAccessBufferFactoryTest.java
@@ -1,0 +1,341 @@
+package network.crypta.support.io;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiskSpaceCheckingRandomAccessBufferFactoryTest {
+
+  @TempDir Path tmp;
+
+  @Test
+  void makeRAF_whenEnoughSpace_returnsUnderlyingResult() throws IOException {
+    // Arrange
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    File dir = mock(File.class);
+    long min = 100L;
+    long size = 50L;
+    when(dir.getUsableSpace()).thenReturn(1_000L);
+    LockableRandomAccessBuffer expected = mock(LockableRandomAccessBuffer.class);
+    when(underlying.makeRAF(size)).thenReturn(expected);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, min);
+
+    // Act
+    try (LockableRandomAccessBuffer raf = factory.makeRAF(size)) {
+      // Assert
+      assertSame(expected, raf);
+      try (LockableRandomAccessBuffer ignored = verify(underlying).makeRAF(size)) {
+        assertTrue(true);
+      }
+      verifyNoMoreInteractions(underlying);
+    }
+  }
+
+  @Test
+  void makeRAF_whenInsufficientSpace_throwsInsufficientDiskSpaceException() {
+    // Arrange
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    File dir = mock(File.class);
+    long min = 100L;
+    long size = 50L;
+    when(dir.getUsableSpace()).thenReturn(min + size); // equality is not enough (strict >)
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, min);
+
+    // Act + Assert
+    assertThrows(
+        InsufficientDiskSpaceException.class,
+        () -> {
+          try (LockableRandomAccessBuffer ignored = factory.makeRAF(size)) {
+            assertNotNull(ignored);
+          }
+        });
+    verifyNoInteractions(underlying);
+  }
+
+  @Test
+  void makeRAFWithInitialContents_whenEnoughSpace_callsUnderlying() throws IOException {
+    // Arrange
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    File dir = mock(File.class);
+    when(dir.getUsableSpace()).thenReturn(10_000L);
+    byte[] data = new byte[] {0, 1, 2, 3, 4, 5};
+    int offset = 2;
+    int size = 3;
+    boolean readOnly = false;
+    LockableRandomAccessBuffer expected = mock(LockableRandomAccessBuffer.class);
+    when(underlying.makeRAF(data, offset, size, readOnly)).thenReturn(expected);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, 100L);
+
+    // Act
+    try (LockableRandomAccessBuffer raf = factory.makeRAF(data, offset, size, readOnly)) {
+      // Assert
+      assertSame(expected, raf);
+      try (LockableRandomAccessBuffer ignored =
+          verify(underlying).makeRAF(data, offset, size, readOnly)) {
+        assertTrue(true);
+      }
+      verifyNoMoreInteractions(underlying);
+    }
+  }
+
+  @Test
+  void makeRAFWithInitialContents_whenInsufficientSpace_throwsInsufficientDiskSpaceException() {
+    // Arrange
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    File dir = mock(File.class);
+    int size = 5;
+    long min = 100L;
+    when(dir.getUsableSpace()).thenReturn(min + size); // not strictly greater
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, min);
+
+    // Act + Assert
+    assertThrows(
+        InsufficientDiskSpaceException.class,
+        () -> {
+          try (LockableRandomAccessBuffer ignored = factory.makeRAF(new byte[10], 0, size, false)) {
+            assertNotNull(ignored);
+          }
+        });
+    verifyNoInteractions(underlying);
+  }
+
+  @Test
+  void makeRAFWithInitialContents_whenNullInitialContents_callsUnderlying() throws IOException {
+    // Arrange
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    File dir = mock(File.class);
+    when(dir.getUsableSpace()).thenReturn(10_000L);
+    LockableRandomAccessBuffer expected = mock(LockableRandomAccessBuffer.class);
+    when(underlying.makeRAF(null, 0, 0, true)).thenReturn(expected);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, 0L);
+
+    // Act
+    try (LockableRandomAccessBuffer raf = factory.makeRAF(null, 0, 0, true)) {
+      // Assert
+      assertSame(expected, raf);
+      try (LockableRandomAccessBuffer ignored = verify(underlying).makeRAF(null, 0, 0, true)) {
+        assertTrue(true);
+      }
+    }
+  }
+
+  @Test
+  void setMinDiskSpace_whenNegative_throwsIllegalArgumentException() {
+    // Arrange
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    File dir = mock(File.class);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, 0L);
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> factory.setMinDiskSpace(-1L));
+  }
+
+  @Test
+  void setMinDiskSpace_whenReduced_allowsSubsequentMakeRAF() throws IOException {
+    // Arrange
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    File dir = mock(File.class);
+    when(dir.getUsableSpace()).thenReturn(600L);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, 1_000L);
+    long size = 550L;
+
+    // Act + Assert (first call should fail)
+    assertThrows(
+        InsufficientDiskSpaceException.class,
+        () -> {
+          try (LockableRandomAccessBuffer ignored = factory.makeRAF(size)) {
+            assertNotNull(ignored);
+          }
+        });
+
+    // Reduce min and retry
+    LockableRandomAccessBuffer expected = mock(LockableRandomAccessBuffer.class);
+    when(underlying.makeRAF(size)).thenReturn(expected);
+    factory.setMinDiskSpace(0L);
+    try (LockableRandomAccessBuffer raf = factory.makeRAF(size)) {
+      assertSame(expected, raf);
+    }
+  }
+
+  @Test
+  void toString_whenCalled_containsUnderlyingToString() {
+    // Arrange
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    when(underlying.toString()).thenReturn("UNDER");
+    File dir = mock(File.class);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, 0L);
+
+    // Act
+    String s = factory.toString();
+
+    // Assert
+    assertTrue(s.endsWith(":UNDER"), "toString should suffix underlying toString");
+  }
+
+  @Test
+  void createNewRAF_whenFileDoesNotExist_throwsIOException() {
+    // Arrange
+    File dir = mock(File.class);
+    when(dir.getUsableSpace()).thenReturn(10_000L);
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, 0L);
+    File missing = tmp.resolve("missing.bin").toFile();
+    long size = 123L;
+
+    // Act + Assert
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (PooledFileRandomAccessBuffer ignored =
+                  factory.createNewRAF(missing, size, new Random(1))) {
+                assertNotNull(ignored);
+              }
+            });
+    assertTrue(ex.getMessage().contains("does not exist"));
+    assertFalse(missing.exists());
+  }
+
+  @Test
+  void createNewRAF_whenFileHasNonZeroLength_throwsIOExceptionAndDeletesFile() throws IOException {
+    // Arrange
+    File dir = mock(File.class);
+    when(dir.getUsableSpace()).thenReturn(10_000L);
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, 0L);
+    Path p = tmp.resolve("nonzero.dat");
+    Files.write(p, new byte[] {42}); // create with one byte
+    File f = p.toFile();
+
+    // Act + Assert
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (PooledFileRandomAccessBuffer ignored =
+                  factory.createNewRAF(f, 10L, new Random(7))) {
+                assertNotNull(ignored);
+              }
+            });
+    assertTrue(ex.getMessage().contains("wrong length"));
+    assertFalse(f.exists(), "File should be deleted on failure");
+  }
+
+  @Test
+  void createNewRAF_whenInsufficientSpace_throwsAndDeletesFile() throws IOException {
+    // Arrange
+    File dir = mock(File.class);
+    long min = 500L;
+    long size = 500L;
+    when(dir.getUsableSpace()).thenReturn(min + size); // equality not sufficient
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, min);
+    Path p = tmp.resolve("insufficient.dat");
+    Files.createFile(p); // zero length
+    File f = p.toFile();
+
+    // Act + Assert
+    assertThrows(
+        InsufficientDiskSpaceException.class,
+        () -> {
+          try (PooledFileRandomAccessBuffer ignored =
+              factory.createNewRAF(f, size, new Random(1234))) {
+            assertNotNull(ignored);
+          }
+        });
+    assertFalse(f.exists(), "File should be deleted when creation fails");
+  }
+
+  @Test
+  void createNewRAF_whenEnoughSpace_constructsPooledFileRandomAccessBufferAndKeepsFile()
+      throws IOException {
+    // Arrange
+    File dir = mock(File.class);
+    long min = 10L;
+    long size = 123L;
+    when(dir.getUsableSpace()).thenReturn(min + size + 1); // strictly greater
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, min);
+    Path p = tmp.resolve("ok.dat");
+    Files.createFile(p); // zero length file
+    File f = p.toFile();
+    Random rnd = new Random(42L);
+
+    // Act
+    try (PooledFileRandomAccessBuffer raf = factory.createNewRAF(f, size, rnd)) {
+      // Assert
+      assertNotNull(raf);
+      assertTrue(f.exists(), "File should remain after successful creation");
+      assertEquals(size, f.length(), "File should be preallocated to requested size");
+    }
+  }
+
+  @Test
+  void checkDiskSpace_whenFileNotChild_returnsTrue() throws IOException {
+    // Arrange: real directories so FileUtil.isParent() returns false
+    Path dirPath = tmp.resolve("parent");
+    Files.createDirectories(dirPath);
+    Path otherDir = tmp.resolve("other");
+    Files.createDirectories(otherDir);
+
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dirPath.toFile(), /*min*/ 100L);
+    File notChild = otherDir.resolve("file.bin").toFile();
+
+    // Act
+    boolean ok = factory.checkDiskSpace(notChild, 10, 20);
+
+    // Assert
+    assertTrue(ok, "Should not block when file is outside monitored dir");
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {0L, Long.MAX_VALUE})
+  void checkDiskSpace_whenFileChild_respectsThreshold(long min) throws IOException {
+    // Arrange: real parent/child to exercise FileUtil.isParent(); choose inputs with deterministic
+    // outcomes regardless of available space.
+    Path dirPath = tmp.resolve("child-parent");
+    Files.createDirectories(dirPath);
+    File dir = dirPath.toFile();
+    File child = dirPath.resolve("child.bin").toFile();
+    LockableRandomAccessBufferFactory underlying = mock(LockableRandomAccessBufferFactory.class);
+
+    // toWrite=0, buffer=0 so condition reduces to (usableSpace >= min)
+    int toWrite = 0;
+    int buffer = 0;
+
+    DiskSpaceCheckingRandomAccessBufferFactory factory =
+        new DiskSpaceCheckingRandomAccessBufferFactory(underlying, dir, min);
+
+    // Act
+    boolean ok = factory.checkDiskSpace(child, toWrite, buffer);
+
+    // Assert
+    boolean expected = (min == 0L); // true for 0, false for Long.MAX_VALUE
+    assertEquals(expected, ok);
+  }
+}


### PR DESCRIPTION
Summary
- Clarifies and documents the disk-space checking behavior in the IO layer.
- Adds focused unit tests for OutputStream and factory paths.
- Tightens logging/cleanup and keeps check+allocation under one lock for consistent snapshots.

Motivation
- Make the semantics of when and how disk space is checked explicit for maintainers and plugin authors.
- Cover critical paths with unit tests to prevent regressions when adjusting thresholds/locking.

Changes
- src/main/java/network/crypta/support/io/DiskSpaceChecker.java
  - Expanded Javadoc for contract, units (bytes), threading expectations, and parameter semantics.
- src/main/java/network/crypta/support/io/DiskSpaceCheckingOutputStream.java
  - Comprehensive Javadoc for constructor and write methods.
  - Adds `@NotNull` on array parameter in the synchronized `write(byte[], int, int)` overload.
  - Documents threshold logic: a check occurs when `written + length - lastChecked >= bufferSize`; throws `InsufficientDiskSpaceException` if checker rejects.
- src/main/java/network/crypta/support/io/DiskSpaceCheckingRandomAccessBufferFactory.java
  - Holds the internal lock across the space check and RAF allocation for a consistent state.
  - Uses parameterized logging and best-effort cleanup via `Files.delete(...)` with debug logging on failure.
  - Adds Javadoc for the checker helper describing reserve rule: `dir.getUsableSpace() - (toWrite + bufferSize) >= minDiskSpace`.
  - Suppresses S2093 where intentional (lifecycle handled by returned buffer).
- Tests
  - src/test/java/network/crypta/support/io/DiskSpaceCheckingOutputStreamTest.java
  - src/test/java/network/crypta/support/io/DiskSpaceCheckingRandomAccessBufferFactoryTest.java

Stats
- Ahead of `origin/develop` by the following commits (newest first):
  - 610adeb6be docs(io): improve Javadoc for DiskSpaceChecker interface
  - d6c90708b3 refactor(io): clarify locking and cleanup in DiskSpaceCheckingRandomAccessBufferFactory
  - 5be40fa4e4 test(io): add unit tests for DiskSpaceCheckingOutputStream
  - 8dbb8ea0a7 docs(io): improve Javadoc for DiskSpaceCheckingOutputStream
- Diff summary: 6 files changed, 818 insertions(+), 20 deletions(-).

Behavioral impact
- No breaking changes intended. Runtime logic remains conservative: checks are performed at a configurable threshold and must pass before writes proceed.
- Logging and cleanup become clearer and safer; locking keeps check+allocation atomic relative to other threads.

Verification
- New unit tests cover the threshold-triggered check and the factory path; run:
  - `./gradlew --parallel test --tests *DiskSpaceChecking*`
- Full tests (optional): `./gradlew --parallel test`

Notes
- Please review the Javadoc changes for correctness and completeness.
- If you’d like, I can run the full test suite and attach results here.