### PR TITLE
Improve DelayedFree wrappers: add Java serialization hooks, expand Javadoc, and add targeted unit tests

### DIFF
--- a/src/main/java/network/crypta/support/io/DelayedFree.java
+++ b/src/main/java/network/crypta/support/io/DelayedFree.java
@@ -1,9 +1,45 @@
 package network.crypta.support.io;
 
-/** A Bucket or RandomAccessBuffer that will be freed only after client.dat* is written. */
+/**
+ * Contract for resources that participate in deferred freeing after a successful persistence
+ * commit.
+ *
+ * <p>Implementations typically wrap storage primitives (for example, a {@code Bucket} or a
+ * random-access buffer) so that their {@code free()} is not executed immediately but is scheduled
+ * by a {@link PersistentFileTracker}. The tracker records the deletion in the persistent state and
+ * then calls {@link #realFree()} only after the corresponding transaction has been durably written
+ * (e.g., after the client layer state file has been updated). This reduces the risk of losing
+ * bookkeeping in the event of an unclean shutdown between mutation and checkpointing.
+ *
+ * <p>Implementations are expected to be used only by the persistence subsystem; typical callers
+ * should use the normal {@code free()}/close methods on the wrapped types and let the tracker
+ * coordinate the actual release.
+ */
 public interface DelayedFree {
 
+  /**
+   * Indicates whether the resource has been marked for deferred freeing.
+   *
+   * <p>Trackers use this signal to confirm that {@link #realFree()} should actually release the
+   * underlying storage when processing a batch that was scheduled earlier.
+   *
+   * @return {@code true} if a prior call requested freeing (for example, via a wrapper's {@code
+   *     free()}), otherwise {@code false}
+   */
   boolean toFree();
 
+  /**
+   * Performs the immediate release of the underlying resource.
+   *
+   * <p>This method is invoked by {@link PersistentFileTracker} after the transaction recording the
+   * deletion has been successfully written to disk, or immediately when no commit barrier is
+   * required. It must not rely on external state that is only present before the commit.
+   *
+   * <p>Threading: callers may invoke this from a background thread owned by the persistence layer.
+   * Implementations should avoid long blocking operations.
+   *
+   * <p>Idempotency: TODO: Clarify whether repeated calls must be tolerated. Current usage expects a
+   * single call per lifecycle.
+   */
   void realFree();
 }

--- a/src/main/java/network/crypta/support/io/DelayedFreeBucket.java
+++ b/src/main/java/network/crypta/support/io/DelayedFreeBucket.java
@@ -1,6 +1,14 @@
 package network.crypta.support.io;
 
-import java.io.*;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.support.api.Bucket;
@@ -8,32 +16,74 @@ import network.crypta.support.api.RandomAccessBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A {@link Bucket} wrapper that defers deletion of its underlying resources until the next
+ * successful persistence commit.
+ *
+ * <p>This class marks buckets for deferred freeing via {@link PersistentFileTracker#delayedFree}.
+ * The tracker will actually call {@link #realFree()} only after the transaction that recorded the
+ * deletion has been written to disk. This avoids data loss when the process stops between marking
+ * and checkpointing.
+ *
+ * <p>Thread-safety: methods that change or read the lifecycle state synchronize on {@code this}.
+ * Once {@code freed} is set, stream accessors throw {@link IOException}. After a successful
+ * migration to a random-access variant, stream accessors also throw to avoid using the old wrapper
+ * concurrently with the new one.
+ *
+ * <p>Serialization: this class is {@link Serializable}, but the wrapped {@link Bucket} is kept
+ * {@code transient} and is persisted through {@link #storeTo(DataOutputStream)} / the matching
+ * restoring constructor. The {@code createdCommitID} recorded at construction is transient on
+ * purpose; when an instance is restored, it is 0, which signals “created before the last restart”
+ * to {@link PersistentFileTracker#delayedFree(DelayedFree, long)}.
+ */
 public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
   private static final Logger LOG = LoggerFactory.getLogger(DelayedFreeBucket.class);
 
   @Serial private static final long serialVersionUID = 1L;
-  // Only set on construction and on onResume() on startup. So shouldn't need locking.
+  // Set on construction and when resuming; access is guarded by outer synchronization when needed.
   private transient PersistentFileTracker factory;
-  private final Bucket bucket;
+  // Wrapped bucket may not be java.io.Serializable; persisted via Java serialization hooks.
+  private transient Bucket bucket;
+  // True once free() is requested; gating flag for stream accessors and getUnderlying().
   private boolean freed;
 
   /**
-   * Has the bucket been migrated to a RandomAccessBucket? If so it should not be accessed again,
-   * and in particular it should not be freed, since the new DelayedFreeRandomAccessBucket will
-   * share share the underlying RandomAccessBucket.
+   * Set to {@code true} after a successful {@link #toRandomAccessBucket()} migration. When true the
+   * old wrapper must no longer expose streams or be freed, because the new {@link
+   * DelayedFreeRandomAccessBucket} shares the underlying random-access storage.
    */
   private boolean migrated;
 
+  // Commit id captured at construction. Transient by design: restored instances use 0 which
+  // means “pre-restart” for the tracker and allows immediate freeing when appropriate.
   private transient long createdCommitID;
 
-  static {
-  }
+  // No static initialization required.
 
+  /**
+   * Indicates whether this wrapper has been marked for deferred freeing.
+   *
+   * <p>When {@code true}, the {@link PersistentFileTracker} will call {@link #realFree()} after the
+   * next successful commit. Until then, the underlying bucket is still present but stream accessors
+   * will throw.
+   *
+   * @return {@code true} if {@link #free()} has been called; {@code false} otherwise
+   */
   @Override
   public synchronized boolean toFree() {
     return freed;
   }
 
+  /**
+   * Creates a wrapper over a bucket that will be freed after a commit.
+   *
+   * <p>The constructor captures {@link PersistentFileTracker#commitID()} to decide later whether
+   * freeing can happen immediately or must be delayed until a subsequent commit.
+   *
+   * @param factory tracker that schedules and performs the eventual free
+   * @param bucket wrapped bucket; must be non-{@code null}
+   * @throws NullPointerException if {@code bucket} is {@code null}
+   */
   public DelayedFreeBucket(PersistentFileTracker factory, Bucket bucket) {
     this.factory = factory;
     this.bucket = bucket;
@@ -41,6 +91,16 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
     if (bucket == null) throw new NullPointerException();
   }
 
+  /**
+   * Opens a buffered output stream positioned at offset 0.
+   *
+   * <p>Delegates to the wrapped bucket. Fails if the wrapper was freed or migrated to a
+   * random-access variant.
+   *
+   * @return buffered {@link OutputStream}
+   * @throws IOException if the wrapper is freed or migrated, or if the underlying bucket fails to
+   *     provide a stream
+   */
   @Override
   public OutputStream getOutputStream() throws IOException {
     synchronized (this) {
@@ -50,6 +110,13 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
     return bucket.getOutputStream();
   }
 
+  /**
+   * Opens an unbuffered output stream positioned at offset 0.
+   *
+   * @return unbuffered {@link OutputStream}
+   * @throws IOException if the wrapper is freed or migrated, or if the underlying bucket fails to
+   *     provide a stream
+   */
   @Override
   public OutputStream getOutputStreamUnbuffered() throws IOException {
     synchronized (this) {
@@ -59,6 +126,13 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
     return bucket.getOutputStreamUnbuffered();
   }
 
+  /**
+   * Opens a buffered input stream to read the bucket contents from the beginning.
+   *
+   * @return buffered {@link InputStream}
+   * @throws IOException if the wrapper is freed or migrated, or if the underlying bucket fails to
+   *     provide a stream
+   */
   @Override
   public InputStream getInputStream() throws IOException {
     synchronized (this) {
@@ -68,6 +142,13 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
     return bucket.getInputStream();
   }
 
+  /**
+   * Opens an unbuffered input stream to read the bucket contents from the beginning.
+   *
+   * @return unbuffered {@link InputStream}
+   * @throws IOException if the wrapper is freed or migrated, or if the underlying bucket fails to
+   *     provide a stream
+   */
   @Override
   public InputStream getInputStreamUnbuffered() throws IOException {
     synchronized (this) {
@@ -77,32 +158,63 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
     return bucket.getInputStreamUnbuffered();
   }
 
+  /**
+   * Returns the name of the wrapped bucket.
+   *
+   * @return name reported by the underlying bucket
+   */
   @Override
   public String getName() {
     return bucket.getName();
   }
 
+  /**
+   * Returns the number of bytes currently stored in the wrapped bucket.
+   *
+   * @return size in bytes
+   */
   @Override
   public long size() {
     return bucket.size();
   }
 
+  /**
+   * Indicates whether the wrapped bucket is read-only.
+   *
+   * @return {@code true} when further writes are disallowed
+   */
   @Override
   public boolean isReadOnly() {
     return bucket.isReadOnly();
   }
 
+  /** Makes the wrapped bucket read-only. */
   @Override
   public void setReadOnly() {
     bucket.setReadOnly();
   }
 
+  /**
+   * Returns the wrapped bucket if it is still usable.
+   *
+   * <p>Returns {@code null} if this wrapper has already been freed or migrated to a random-access
+   * variant. The reference is not a stable capability across threads and should be used immediately
+   * by the caller.
+   *
+   * @return the underlying bucket, or {@code null} if freed or migrated
+   */
   public synchronized Bucket getUnderlying() {
     if (freed) return null;
     if (migrated) return null;
     return bucket;
   }
 
+  /**
+   * Marks this wrapper to be freed after the next successful commit.
+   *
+   * <p>This method is idempotent. If the wrapper has already migrated to a random-access variant,
+   * the call is ignored because the new wrapper is responsible for freeing shared resources.
+   */
   @Override
   public void free() {
     synchronized (this) {
@@ -114,30 +226,64 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
     this.factory.delayedFree(this, createdCommitID);
   }
 
+  /** Returns a debug-oriented string including the wrapped bucket. */
   @Override
   public String toString() {
     return super.toString() + ":" + bucket;
   }
 
+  /**
+   * Creates a read-only shallow copy of the wrapped bucket.
+   *
+   * <p>Delegates directly to the underlying bucket.
+   *
+   * @return a shadow bucket, or {@code null} if the underlying implementation cannot provide one
+   */
   @Override
   public Bucket createShadow() {
     return bucket.createShadow();
   }
 
+  /**
+   * Immediately frees the underlying bucket.
+   *
+   * <p>Called by {@link PersistentFileTracker} after a successful commit. Do not call directly
+   * unless you are implementing the tracker.
+   */
   @Override
   public void realFree() {
     bucket.free();
   }
 
+  /**
+   * Reattaches runtime state after a restart.
+   *
+   * <p>Wires the tracker from {@link ClientContext#persistentBucketFactory} and delegates {@link
+   * Bucket#onResume(ClientContext)} to the wrapped bucket so it can register itself and avoid
+   * premature collection.
+   *
+   * @param context runtime context providing the persistent bucket factory
+   * @throws ResumeFailedException if the wrapped bucket cannot be resumed
+   */
   @Override
   public void onResume(ClientContext context) throws ResumeFailedException {
     this.factory = context.persistentBucketFactory;
     bucket.onResume(context);
   }
 
+  // Persistence marker and on-disk schema version for this wrapper.
   static final int MAGIC = 0x4e9c9a03;
   static final int VERSION = 1;
 
+  /**
+   * Writes the minimal state required to reconstruct this wrapper.
+   *
+   * <p>Format: {@link #MAGIC} (int), {@link #VERSION} (int), followed by the wrapped bucket's
+   * serialized form via {@link Bucket#storeTo(DataOutputStream)}.
+   *
+   * @param dos destination stream
+   * @throws IOException if writing fails
+   */
   @Override
   public void storeTo(DataOutputStream dos) throws IOException {
     dos.writeInt(MAGIC);
@@ -145,6 +291,20 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
     bucket.storeTo(dos);
   }
 
+  /**
+   * Reconstructs an instance from {@link #storeTo(DataOutputStream)} output.
+   *
+   * <p>The caller must have already consumed {@link #MAGIC}. This constructor validates the stored
+   * {@link #VERSION} and restores the wrapped bucket via {@link BucketTools#restoreFrom}.
+   *
+   * @param dis source positioned at the version field
+   * @param fg filename generator for nested bucket reconstruction
+   * @param persistentFileTracker tracker used by nested bucket types
+   * @param masterKey master secret used by encrypted buckets if present
+   * @throws StorageFormatException if the stored format version is unknown or malformed
+   * @throws IOException on I/O errors
+   * @throws ResumeFailedException if nested buckets cannot be resumed
+   */
   protected DelayedFreeBucket(
       DataInputStream dis,
       FilenameGenerator fg,
@@ -157,9 +317,15 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
   }
 
   /**
-   * Convert to a RandomAccessBucket if it can be done quickly. Otherwise return null.
+   * Attempts to convert the wrapped bucket to a {@link RandomAccessBucket} without copying.
    *
-   * @throws IOException If the bucket has already been freed.
+   * <p>If the underlying implementation already is a {@link RandomAccessBucket}, this method marks
+   * the wrapper as migrated and returns a {@link DelayedFreeRandomAccessBucket} that shares the
+   * same storage. Otherwise, it returns {@code null} to signal that a copy-based conversion is
+   * required by callers.
+   *
+   * @return a delayed-free random-access wrapper, or {@code null} when not directly convertible
+   * @throws IOException if this wrapper was already freed
    */
   public synchronized RandomAccessBucket toRandomAccessBucket() throws IOException {
     if (freed) throw new IOException("Already freed");
@@ -169,5 +335,38 @@ public class DelayedFreeBucket implements Bucket, Serializable, DelayedFree {
       // Underlying file is already registered.
     }
     return null;
+  }
+
+  /* ===== Java serialization support ===== */
+
+  /**
+   * Writes default state and the wrapped bucket so that Java serialization can restore it.
+   *
+   * @param out destination stream
+   * @throws IOException on I/O errors
+   */
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    if (bucket instanceof Serializable serializable) {
+      out.writeObject(serializable);
+    } else {
+      // Do not attempt to serialize non-serializable implementations.
+      throw new java.io.NotSerializableException(
+          bucket == null ? "nullBucket" : bucket.getClass().getName());
+    }
+  }
+
+  /**
+   * Restores default state and the wrapped bucket written by {@link #writeObject}.
+   *
+   * @param in source stream
+   * @throws IOException on I/O errors
+   * @throws ClassNotFoundException if the bucket class is unavailable
+   */
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    bucket = (Bucket) in.readObject();
   }
 }

--- a/src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBucket.java
+++ b/src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBucket.java
@@ -1,6 +1,14 @@
 package network.crypta.support.io;
 
-import java.io.*;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.support.api.Bucket;
@@ -9,26 +17,67 @@ import network.crypta.support.api.RandomAccessBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A {@link RandomAccessBucket} wrapper whose {@link #free()} operation is deferred until after the
+ * next successful persistence commit.
+ *
+ * <p>This class collaborates with a {@link PersistentFileTracker}: when {@link #free()} is called,
+ * the wrapper is marked to be freed and the tracker is notified via {@link
+ * PersistentFileTracker#delayedFree(DelayedFree, long)}. The underlying storage is only released
+ * once the transaction that recorded the deletion is durably written. This avoids data loss when
+ * the process stops between bookkeeping and checkpointing.
+ *
+ * <h2>Thread-safety</h2>
+ *
+ * Lifecycle flags are guarded by synchronization on {@code this}. Stream accessors check the {@code
+ * freed} flag and throw {@link IOException} after the wrapper is freed.
+ *
+ * <h2>Persistence</h2>
+ *
+ * The wrapper is {@link Serializable}. The wrapped bucket is kept {@code transient} and is
+ * serialized explicitly by Java serialization hooks ({@code writeObject}/{@code readObject}) and by
+ * the project-specific mechanism {@link #storeTo(DataOutputStream)} / the restoring constructor
+ * (identified by {@link #MAGIC} and {@link #VERSION}). The {@code createdCommitID} captured at
+ * construction is {@code transient} by design; after Java deserialization it is {@code 0}, which
+ * signals “pre-restart” to the tracker.
+ *
+ * @since 2
+ */
 public class DelayedFreeRandomAccessBucket
     implements Bucket, Serializable, RandomAccessBucket, DelayedFree {
 
   private static final Logger LOG = LoggerFactory.getLogger(DelayedFreeRandomAccessBucket.class);
 
   @Serial private static final long serialVersionUID = 1L;
-  // Only set on construction and on onResume() on startup. So shouldn't need locking.
+  // Set on construction and re-wired on onResume(); set once per lifecycle stage.
   private transient PersistentFileTracker factory;
-  private final RandomAccessBucket bucket;
+  // Wrapped bucket may not be java.io.Serializable; handled via writeObject/readObject.
+  private transient RandomAccessBucket bucket;
+  // True once free() is requested; gates further stream operations and getUnderlying().
   private boolean freed;
+  // Commit id captured at construction; 0 after Java deserialization means “pre-restart”.
   private transient long createdCommitID;
 
-  static {
-  }
-
+  /**
+   * Indicates whether this wrapper has been marked for deferred freeing.
+   *
+   * @return {@code true} if {@link #free()} has been called; {@code false} otherwise
+   */
   @Override
   public boolean toFree() {
     return freed;
   }
 
+  /**
+   * Creates a wrapper over a random-access bucket that will be freed after a commit.
+   *
+   * <p>The constructor captures {@link PersistentFileTracker#commitID()} to decide later whether
+   * freeing can happen immediately or must be delayed until a subsequent commit.
+   *
+   * @param factory tracker that schedules and performs the eventual free
+   * @param bucket wrapped bucket; must be non-{@code null}
+   * @throws NullPointerException if {@code bucket} is {@code null}
+   */
   public DelayedFreeRandomAccessBucket(PersistentFileTracker factory, RandomAccessBucket bucket) {
     this.factory = factory;
     this.bucket = bucket;
@@ -36,6 +85,15 @@ public class DelayedFreeRandomAccessBucket
     if (bucket == null) throw new NullPointerException();
   }
 
+  /**
+   * Opens a buffered output stream positioned at offset 0.
+   *
+   * <p>Delegates to the wrapped bucket.
+   *
+   * @return buffered {@link OutputStream}
+   * @throws IOException if this wrapper has already been freed, or if the underlying bucket fails
+   *     to provide a stream
+   */
   @Override
   public OutputStream getOutputStream() throws IOException {
     synchronized (this) {
@@ -44,6 +102,13 @@ public class DelayedFreeRandomAccessBucket
     return bucket.getOutputStream();
   }
 
+  /**
+   * Opens an unbuffered output stream positioned at offset 0.
+   *
+   * @return unbuffered {@link OutputStream}
+   * @throws IOException if this wrapper has already been freed, or if the underlying bucket fails
+   *     to provide a stream
+   */
   @Override
   public OutputStream getOutputStreamUnbuffered() throws IOException {
     synchronized (this) {
@@ -52,6 +117,13 @@ public class DelayedFreeRandomAccessBucket
     return bucket.getOutputStreamUnbuffered();
   }
 
+  /**
+   * Opens a buffered input stream to read the bucket contents from the beginning.
+   *
+   * @return buffered {@link InputStream}
+   * @throws IOException if this wrapper has already been freed, or if the underlying bucket fails
+   *     to provide a stream
+   */
   @Override
   public InputStream getInputStream() throws IOException {
     synchronized (this) {
@@ -60,6 +132,13 @@ public class DelayedFreeRandomAccessBucket
     return bucket.getInputStream();
   }
 
+  /**
+   * Opens an unbuffered input stream to read the bucket contents from the beginning.
+   *
+   * @return unbuffered {@link InputStream}
+   * @throws IOException if this wrapper has already been freed, or if the underlying bucket fails
+   *     to provide a stream
+   */
   @Override
   public InputStream getInputStreamUnbuffered() throws IOException {
     synchronized (this) {
@@ -68,31 +147,61 @@ public class DelayedFreeRandomAccessBucket
     return bucket.getInputStreamUnbuffered();
   }
 
+  /**
+   * Returns the name of the wrapped bucket.
+   *
+   * @return name reported by the underlying bucket
+   */
   @Override
   public String getName() {
     return bucket.getName();
   }
 
+  /**
+   * Returns the number of bytes currently stored in the wrapped bucket.
+   *
+   * @return size in bytes
+   */
   @Override
   public long size() {
     return bucket.size();
   }
 
+  /**
+   * Indicates whether the wrapped bucket is read-only.
+   *
+   * @return {@code true} when further writes are disallowed
+   */
   @Override
   public boolean isReadOnly() {
     return bucket.isReadOnly();
   }
 
+  /** Makes the wrapped bucket read-only. */
   @Override
   public void setReadOnly() {
     bucket.setReadOnly();
   }
 
+  /**
+   * Returns the wrapped bucket if it is still usable.
+   *
+   * <p>Returns {@code null} if this wrapper has already been freed. The reference is not a stable
+   * capability across threads and should be used immediately by the caller.
+   *
+   * @return the underlying bucket, or {@code null} if freed
+   */
   public synchronized Bucket getUnderlying() {
     if (freed) return null;
     return bucket;
   }
 
+  /**
+   * Marks this wrapper to be freed after the next successful commit.
+   *
+   * <p>This method is idempotent. It notifies the {@link PersistentFileTracker}, which will call
+   * {@link #realFree()} after the commit.
+   */
   @Override
   public void free() {
     synchronized (this) {
@@ -103,21 +212,45 @@ public class DelayedFreeRandomAccessBucket
     this.factory.delayedFree(this, createdCommitID);
   }
 
+  /** Returns a debug-oriented string including the wrapped bucket. */
   @Override
   public String toString() {
     return super.toString() + ":" + bucket;
   }
 
+  /**
+   * Creates a read-only shallow copy of the wrapped bucket.
+   *
+   * <p>Delegates directly to the underlying bucket.
+   *
+   * @return a shadow bucket, or {@code null} if the underlying implementation cannot provide one
+   */
   @Override
   public RandomAccessBucket createShadow() {
     return bucket.createShadow();
   }
 
+  /**
+   * Immediately frees the underlying bucket.
+   *
+   * <p>Called by {@link PersistentFileTracker} after a successful commit. Do not call directly
+   * unless you are implementing the tracker.
+   */
   @Override
   public void realFree() {
     bucket.free();
   }
 
+  /**
+   * Reattaches runtime state after a restart.
+   *
+   * <p>Wires the tracker from {@link ClientContext#persistentBucketFactory} and delegates {@link
+   * Bucket#onResume(ClientContext)} to the wrapped bucket so it can register itself and avoid
+   * premature collection.
+   *
+   * @param context runtime context providing the persistent bucket factory
+   * @throws ResumeFailedException if the wrapped bucket cannot be resumed
+   */
   @Override
   public void onResume(ClientContext context) throws ResumeFailedException {
     this.factory = context.persistentBucketFactory;
@@ -127,6 +260,15 @@ public class DelayedFreeRandomAccessBucket
   static final int MAGIC = 0xa28f2a2d;
   static final int VERSION = 1;
 
+  /**
+   * Writes the minimal state required to reconstruct this wrapper.
+   *
+   * <p>Format: {@link #MAGIC} (int), {@link #VERSION} (int), followed by the wrapped bucket's
+   * serialized form via {@link Bucket#storeTo(DataOutputStream)}.
+   *
+   * @param dos destination stream
+   * @throws IOException if writing fails
+   */
   @Override
   public void storeTo(DataOutputStream dos) throws IOException {
     dos.writeInt(MAGIC);
@@ -134,6 +276,20 @@ public class DelayedFreeRandomAccessBucket
     bucket.storeTo(dos);
   }
 
+  /**
+   * Reconstructs an instance from {@link #storeTo(DataOutputStream)} output.
+   *
+   * <p>The caller must have already consumed {@link #MAGIC}. This constructor validates the stored
+   * {@link #VERSION} and restores the wrapped bucket via {@link BucketTools#restoreFrom}.
+   *
+   * @param dis source positioned at the version field
+   * @param fg filename generator for nested bucket reconstruction
+   * @param persistentFileTracker tracker used by nested bucket types
+   * @param masterKey master secret used by encrypted buckets if present
+   * @throws StorageFormatException if the stored format version is unknown or malformed
+   * @throws IOException on I/O errors
+   * @throws ResumeFailedException if nested buckets cannot be resumed
+   */
   protected DelayedFreeRandomAccessBucket(
       DataInputStream dis,
       FilenameGenerator fg,
@@ -146,6 +302,17 @@ public class DelayedFreeRandomAccessBucket
         (RandomAccessBucket) BucketTools.restoreFrom(dis, fg, persistentFileTracker, masterKey);
   }
 
+  /**
+   * Converts this bucket to a lockable random-access buffer without copying.
+   *
+   * <p>This method sets the wrapped bucket read-only before converting. The returned buffer is
+   * wrapped in {@link DelayedFreeRandomAccessBuffer} so its {@link
+   * DelayedFreeRandomAccessBuffer#free()} is also deferred until the next commit.
+   *
+   * @return a lockable random-access buffer sharing the same storage
+   * @throws IOException if this wrapper has already been freed, or if the underlying conversion
+   *     fails
+   */
   @Override
   public LockableRandomAccessBuffer toRandomAccessBuffer() throws IOException {
     synchronized (this) {
@@ -153,5 +320,24 @@ public class DelayedFreeRandomAccessBucket
     }
     setReadOnly();
     return new DelayedFreeRandomAccessBuffer(bucket.toRandomAccessBuffer(), factory);
+  }
+
+  /* ===== Java serialization support ===== */
+
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    if (bucket instanceof Serializable serializable) {
+      out.writeObject(serializable);
+    } else {
+      throw new java.io.NotSerializableException(
+          bucket == null ? "nullBucket" : bucket.getClass().getName());
+    }
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    bucket = (RandomAccessBucket) in.readObject();
   }
 }

--- a/src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBuffer.java
@@ -5,14 +5,53 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 
+/**
+ * A {@link LockableRandomAccessBuffer} wrapper whose {@link #free()} is deferred until after the
+ * next successful persistence commit.
+ *
+ * <p>When {@link #free()} is requested, this wrapper notifies a {@link PersistentFileTracker},
+ * which will call {@link #realFree()} only after the transaction recording the deletion has been
+ * durably written. This reduces the risk of losing bookkeeping during crashes between mutation and
+ * checkpointing.
+ *
+ * <h2>Thread-safety</h2>
+ *
+ * Access to the {@code freed} lifecycle flag is synchronized on {@code this}. All I/O methods check
+ * the flag and throw {@link IOException} once the wrapper is freed. Otherwise, operations delegate
+ * directly to the underlying buffer.
+ *
+ * <h2>Persistence</h2>
+ *
+ * This class is {@link Serializable}. It also supports project-level persistence via {@link
+ * #storeTo(DataOutputStream)} and the restoring constructor that uses {@link
+ * BucketTools#restoreRAFFrom(DataInputStream, FilenameGenerator, PersistentFileTracker,
+ * MasterSecret)}. The {@code createdCommitID} captured at construction is transient by design and
+ * becomes {@code 0} after Java deserialization, which the tracker interprets as "pre-restart".
+ *
+ * @since 2
+ */
 public class DelayedFreeRandomAccessBuffer
     implements LockableRandomAccessBuffer, Serializable, DelayedFree {
   @Serial private static final long serialVersionUID = 1L;
-  final LockableRandomAccessBuffer underlying;
+  // Underlying random-access buffer being wrapped and delegated to. Not always Serializable; we
+  // handle it via Java serialization hooks below.
+  private transient LockableRandomAccessBuffer underlying;
+  // Set to true after free() is requested; guards further I/O and query methods.
   private boolean freed;
+  // Re-wired on onResume(); not part of the serialized state.
   private transient PersistentFileTracker factory;
+  // Commit id captured at construction; transient so restored instances are treated as pre-restart.
   private transient long createdCommitID;
 
+  /**
+   * Creates a wrapper around a lockable random-access buffer that will be freed after a commit.
+   *
+   * <p>The constructor captures {@link PersistentFileTracker#commitID()} to decide later whether
+   * the free can happen immediately or must be delayed until a subsequent commit.
+   *
+   * @param raf underlying buffer; must be non-{@code null}
+   * @param factory tracker responsible for deferred freeing
+   */
   public DelayedFreeRandomAccessBuffer(
       LockableRandomAccessBuffer raf, PersistentFileTracker factory) {
     underlying = raf;
@@ -20,11 +59,27 @@ public class DelayedFreeRandomAccessBuffer
     this.factory = factory;
   }
 
+  /**
+   * Returns the current size of the underlying buffer in bytes.
+   *
+   * @return size in bytes
+   */
   @Override
   public long size() {
     return underlying.size();
   }
 
+  /**
+   * Reads {@code length} bytes starting at {@code fileOffset} into {@code buf}.
+   *
+   * <p>Throws if the wrapper has been freed; otherwise delegates to the underlying buffer.
+   *
+   * @param fileOffset absolute byte offset within the buffer (0-based)
+   * @param buf destination array
+   * @param bufOffset offset into {@code buf}
+   * @param length number of bytes to read
+   * @throws IOException if this wrapper is freed or if the underlying read fails
+   */
   @Override
   public void pread(long fileOffset, byte[] buf, int bufOffset, int length) throws IOException {
     synchronized (this) {
@@ -33,6 +88,17 @@ public class DelayedFreeRandomAccessBuffer
     underlying.pread(fileOffset, buf, bufOffset, length);
   }
 
+  /**
+   * Writes {@code length} bytes from {@code buf} at {@code fileOffset}.
+   *
+   * <p>Throws if the wrapper has been freed; otherwise delegates to the underlying buffer.
+   *
+   * @param fileOffset absolute byte offset within the buffer (0-based)
+   * @param buf source array
+   * @param bufOffset offset into {@code buf}
+   * @param length number of bytes to write
+   * @throws IOException if this wrapper is freed or if the underlying write fails
+   */
   @Override
   public void pwrite(long fileOffset, byte[] buf, int bufOffset, int length) throws IOException {
     synchronized (this) {
@@ -41,6 +107,12 @@ public class DelayedFreeRandomAccessBuffer
     underlying.pwrite(fileOffset, buf, bufOffset, length);
   }
 
+  /**
+   * Closes the underlying buffer if not already freed.
+   *
+   * <p>If {@link #free()} has been called, the close is ignored to avoid racing with deferred
+   * freeing.
+   */
   @Override
   public void close() {
     synchronized (this) {
@@ -49,6 +121,12 @@ public class DelayedFreeRandomAccessBuffer
     underlying.close();
   }
 
+  /**
+   * Marks this wrapper to be freed after the next successful commit.
+   *
+   * <p>This method is idempotent. It notifies the tracker, which will call {@link #realFree()}
+   * after the commit.
+   */
   @Override
   public void free() {
     synchronized (this) {
@@ -58,6 +136,14 @@ public class DelayedFreeRandomAccessBuffer
     this.factory.delayedFree(this, createdCommitID);
   }
 
+  /**
+   * Locks the underlying buffer open for a short period.
+   *
+   * <p>Throws if the wrapper has been freed; otherwise delegates to the underlying buffer.
+   *
+   * @return a lock handle that must be released by calling {@link RAFLock#unlock()}
+   * @throws IOException if this wrapper is freed or if the underlying allocation fails
+   */
   @Override
   public RAFLock lockOpen() throws IOException {
     synchronized (this) {
@@ -66,20 +152,54 @@ public class DelayedFreeRandomAccessBuffer
     return underlying.lockOpen();
   }
 
+  /**
+   * Reattaches runtime state after a restart.
+   *
+   * <p>Wires the tracker from {@link ClientContext#persistentBucketFactory} and delegates to the
+   * underlying buffer so it can register itself and avoid premature collection.
+   *
+   * @param context runtime context providing the persistent bucket factory
+   * @throws ResumeFailedException if the underlying buffer cannot be resumed
+   */
   @Override
   public void onResume(ClientContext context) throws ResumeFailedException {
     this.factory = context.persistentBucketFactory;
     underlying.onResume(context);
   }
 
+  /** Persistence marker for this wrapper when using {@link #storeTo(DataOutputStream)}. */
   static final int MAGIC = 0x3fb645de;
 
+  /**
+   * Writes the minimal state required to reconstruct this wrapper.
+   *
+   * <p>Format: {@link #MAGIC} (int) followed by the underlying buffer's serialized form via {@link
+   * LockableRandomAccessBuffer#storeTo(DataOutputStream)}.
+   *
+   * @param dos destination stream
+   * @throws IOException if writing fails
+   */
   @Override
   public void storeTo(DataOutputStream dos) throws IOException {
     dos.writeInt(MAGIC);
     underlying.storeTo(dos);
   }
 
+  /**
+   * Reconstructs an instance from the output of {@link #storeTo(DataOutputStream)}.
+   *
+   * <p>The caller must have already consumed {@link #MAGIC}. The underlying buffer is restored via
+   * {@link BucketTools#restoreRAFFrom(DataInputStream, FilenameGenerator, PersistentFileTracker,
+   * MasterSecret)} and the tracker is set to the provided {@code persistentFileTracker}.
+   *
+   * @param dis source stream positioned after {@link #MAGIC}
+   * @param fg filename generator for nested reconstruction
+   * @param persistentFileTracker tracker passed along to nested types
+   * @param masterSecret node's master secret when required by encrypted buffers
+   * @throws IOException on I/O errors
+   * @throws StorageFormatException if the stored format is unknown or malformed
+   * @throws ResumeFailedException if nested buffers cannot be resumed
+   */
   public DelayedFreeRandomAccessBuffer(
       DataInputStream dis,
       FilenameGenerator fg,
@@ -90,29 +210,55 @@ public class DelayedFreeRandomAccessBuffer
     factory = persistentFileTracker;
   }
 
+  /**
+   * Indicates whether this wrapper has been marked for deferred freeing.
+   *
+   * @return {@code true} if {@link #free()} has been called; {@code false} otherwise
+   */
   @Override
   public boolean toFree() {
     return freed;
   }
 
+  /**
+   * Returns the wrapped buffer if it is still usable.
+   *
+   * <p>Returns {@code null} after {@link #free()} has been called. The returned reference is not a
+   * stable capability across threads and should be used immediately by the caller.
+   *
+   * @return the underlying buffer, or {@code null} if freed
+   */
   public LockableRandomAccessBuffer getUnderlying() {
     if (freed) return null;
     return underlying;
   }
 
+  /**
+   * Immediately frees the underlying buffer.
+   *
+   * <p>Called by {@link PersistentFileTracker} after a successful commit. Do not call directly
+   * unless you are implementing the tracker.
+   */
   @Override
   public void realFree() {
     underlying.free();
   }
 
+  /**
+   * Returns the hash code of the underlying buffer.
+   *
+   * @return hash code derived from the wrapped buffer
+   */
   @Override
   public int hashCode() {
     return underlying.hashCode();
   }
 
   /**
-   * Two DelayedFreeBucket's for the same underlying can only happen on resume, in which case we DO
-   * want them to compare as equal.
+   * Compares wrappers by the identity of their underlying buffers.
+   *
+   * <p>Two delayed-free wrappers may reference the same restored buffer after a resume; they should
+   * then compare as equal.
    */
   @Override
   public boolean equals(Object obj) {
@@ -127,5 +273,24 @@ public class DelayedFreeRandomAccessBuffer
     }
     DelayedFreeRandomAccessBuffer other = (DelayedFreeRandomAccessBuffer) obj;
     return underlying.equals(other.underlying);
+  }
+
+  /* ===== Java serialization support ===== */
+
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    if (underlying instanceof Serializable serializable) {
+      out.writeObject(serializable);
+    } else {
+      throw new NotSerializableException(
+          underlying == null ? "nullUnderlying" : underlying.getClass().getName());
+    }
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    underlying = (LockableRandomAccessBuffer) in.readObject();
   }
 }

--- a/src/test/java/network/crypta/support/io/DelayedFreeBucketTest.java
+++ b/src/test/java/network/crypta/support/io/DelayedFreeBucketTest.java
@@ -1,0 +1,342 @@
+package network.crypta.support.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.*;
+import java.util.stream.Stream;
+import network.crypta.client.async.ClientContext;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit tests for {@link DelayedFreeBucket}.
+ *
+ * <p>Tests follow AAA style and mock external I/O with Mockito.
+ */
+class DelayedFreeBucketTest {
+
+  private static DelayedFreeBucket newSut(PersistentFileTracker tracker, Bucket underlying) {
+    return new DelayedFreeBucket(tracker, underlying);
+  }
+
+  @Test
+  @DisplayName("constructor_nullBucket_throwsNPE")
+  void constructor_nullBucket_throwsNPE() {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          try (DelayedFreeBucket ignored = new DelayedFreeBucket(pft, null)) {
+            fail("constructor should have thrown before entering try block");
+          }
+        });
+  }
+
+  @Test
+  @DisplayName("toFree_initiallyFalse_thenTrueAfterFree")
+  void toFree_initiallyFalse_thenTrueAfterFree() {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    when(pft.commitID()).thenReturn(123L);
+    Bucket underlying = mock(Bucket.class);
+
+    DelayedFreeBucket sut = newSut(pft, underlying);
+    assertFalse(sut.toFree());
+
+    sut.free();
+    assertTrue(sut.toFree());
+  }
+
+  @Test
+  @DisplayName("getUnderlying_beforeFreeAndMigration_returnsUnderlying")
+  void getUnderlying_beforeFreeAndMigration_returnsUnderlying() {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    Bucket underlying = mock(Bucket.class);
+    DelayedFreeBucket sut = newSut(pft, underlying);
+    assertSame(underlying, sut.getUnderlying());
+  }
+
+  @Test
+  @DisplayName("getUnderlying_afterFree_returnsNull")
+  void getUnderlying_afterFree_returnsNull() {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    when(pft.commitID()).thenReturn(1L);
+    Bucket underlying = mock(Bucket.class);
+    DelayedFreeBucket sut = newSut(pft, underlying);
+    sut.free();
+    assertNull(sut.getUnderlying());
+  }
+
+  @Test
+  @DisplayName("getUnderlying_afterMigration_returnsNull")
+  void getUnderlying_afterMigration_returnsNull() throws IOException {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    RandomAccessBucket rab = mock(RandomAccessBucket.class);
+    DelayedFreeBucket sut = newSut(pft, rab);
+    assertNotNull(sut.toRandomAccessBucket());
+    assertNull(sut.getUnderlying());
+  }
+
+  // Parameter set: method names of the four stream getters
+  private static Stream<String> streamGetters() {
+    return Stream.of(
+        "getOutputStream",
+        "getOutputStreamUnbuffered",
+        "getInputStream",
+        "getInputStreamUnbuffered");
+  }
+
+  @ParameterizedTest(name = "{0}_whenNotFreedOrMigrated_delegates")
+  @MethodSource("streamGetters")
+  void streamGetter_whenNotFreedOrMigrated_delegates(String name) throws Exception {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    Bucket b = mock(Bucket.class);
+    when(b.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+    when(b.getOutputStreamUnbuffered()).thenReturn(new ByteArrayOutputStream());
+    when(b.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    when(b.getInputStreamUnbuffered()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    DelayedFreeBucket sut = newSut(pft, b);
+
+    // Act & Assert: no exception and not null
+    switch (name) {
+      case "getOutputStream" -> assertNotNull(sut.getOutputStream());
+      case "getOutputStreamUnbuffered" -> assertNotNull(sut.getOutputStreamUnbuffered());
+      case "getInputStream" -> assertNotNull(sut.getInputStream());
+      case "getInputStreamUnbuffered" -> assertNotNull(sut.getInputStreamUnbuffered());
+      default -> fail("unexpected parameter: " + name);
+    }
+  }
+
+  @ParameterizedTest(name = "{0}_whenFreed_throwsIOException")
+  @MethodSource("streamGetters")
+  void streamGetter_whenFreed_throwsIOException(String name) throws Exception {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    when(pft.commitID()).thenReturn(77L);
+    Bucket b = mock(Bucket.class);
+    when(b.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+    when(b.getOutputStreamUnbuffered()).thenReturn(new ByteArrayOutputStream());
+    when(b.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    when(b.getInputStreamUnbuffered()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    DelayedFreeBucket sut = newSut(pft, b);
+    sut.free();
+
+    IOException ex;
+    switch (name) {
+      case "getOutputStream" -> ex = assertThrows(IOException.class, sut::getOutputStream);
+      case "getOutputStreamUnbuffered" ->
+          ex = assertThrows(IOException.class, sut::getOutputStreamUnbuffered);
+      case "getInputStream" -> ex = assertThrows(IOException.class, sut::getInputStream);
+      case "getInputStreamUnbuffered" ->
+          ex = assertThrows(IOException.class, sut::getInputStreamUnbuffered);
+      default -> throw new AssertionError("unexpected parameter: " + name);
+    }
+    assertThat(ex.getMessage(), containsString("Already freed"));
+  }
+
+  @ParameterizedTest(name = "{0}_whenMigrated_throwsIOException")
+  @MethodSource("streamGetters")
+  void streamGetter_whenMigrated_throwsIOException(String name) throws Exception {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    RandomAccessBucket rab = mock(RandomAccessBucket.class);
+    when(rab.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    when(rab.getInputStreamUnbuffered()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    when(rab.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+    when(rab.getOutputStreamUnbuffered()).thenReturn(new ByteArrayOutputStream());
+    DelayedFreeBucket sut = newSut(pft, rab);
+    assertNotNull(sut.toRandomAccessBucket()); // triggers migrated=true
+
+    IOException ex;
+    switch (name) {
+      case "getOutputStream" -> ex = assertThrows(IOException.class, sut::getOutputStream);
+      case "getOutputStreamUnbuffered" ->
+          ex = assertThrows(IOException.class, sut::getOutputStreamUnbuffered);
+      case "getInputStream" -> ex = assertThrows(IOException.class, sut::getInputStream);
+      case "getInputStreamUnbuffered" ->
+          ex = assertThrows(IOException.class, sut::getInputStreamUnbuffered);
+      default -> throw new AssertionError("unexpected parameter: " + name);
+    }
+    assertThat(ex.getMessage(), containsString("Already migrated to a RandomAccessBucket"));
+  }
+
+  @Test
+  @DisplayName("free_whenCalled_callsDelayedFreeOnceWithCreatedCommitID")
+  void free_whenCalled_callsDelayedFreeOnceWithCreatedCommitID() {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    when(pft.commitID()).thenReturn(42L);
+    Bucket underlying = mock(Bucket.class);
+    DelayedFreeBucket sut = newSut(pft, underlying);
+
+    sut.free();
+    sut.free(); // idempotent; still exactly one call
+
+    verify(pft, times(1)).delayedFree(sut, 42L);
+  }
+
+  @Test
+  @DisplayName("free_afterMigration_noopDoesNotCallFactory")
+  void free_afterMigration_noopDoesNotCallFactory() throws IOException {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    RandomAccessBucket rab = mock(RandomAccessBucket.class);
+    DelayedFreeBucket sut = newSut(pft, rab);
+    assertNotNull(sut.toRandomAccessBucket());
+    sut.free();
+    verify(pft, never()).delayedFree(any(), anyLong());
+  }
+
+  @Test
+  @DisplayName("toRandomAccessBucket_whenUnderlyingNotRAB_returnsNull")
+  void toRandomAccessBucket_whenUnderlyingNotRAB_returnsNull() throws IOException {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    Bucket plain = mock(Bucket.class);
+    DelayedFreeBucket sut = newSut(pft, plain);
+    assertNull(sut.toRandomAccessBucket());
+    // Still usable after null return
+    when(plain.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    assertNotNull(sut.getInputStream());
+  }
+
+  @Test
+  @DisplayName("toRandomAccessBucket_whenFreed_thenThrows")
+  void toRandomAccessBucket_whenFreed_thenThrows() {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    when(pft.commitID()).thenReturn(33L);
+    Bucket underlying = mock(Bucket.class);
+    DelayedFreeBucket sut = newSut(pft, underlying);
+    sut.free();
+    assertThrows(IOException.class, sut::toRandomAccessBucket);
+  }
+
+  @Test
+  @DisplayName("toRandomAccessBucket_whenUnderlyingIsRAB_returnsWrapperAndBlocksStreams")
+  void toRandomAccessBucket_whenUnderlyingIsRAB_returnsWrapperAndBlocksStreams() throws Exception {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    RandomAccessBucket rab = mock(RandomAccessBucket.class);
+    DelayedFreeBucket sut = newSut(pft, rab);
+
+    Bucket wrapped = sut.toRandomAccessBucket();
+    assertNotNull(wrapped);
+    assertInstanceOf(DelayedFreeRandomAccessBucket.class, wrapped);
+
+    IOException ex = assertThrows(IOException.class, sut::getInputStream);
+    assertThat(ex.getMessage(), containsString("Already migrated"));
+
+    // Free after migration: no call to delayedFree
+    sut.free();
+    verify(pft, never()).delayedFree(any(), anyLong());
+  }
+
+  @Test
+  @DisplayName("onResume_whenCalled_delegatesToUnderlying")
+  void onResume_whenCalled_delegatesToUnderlying() throws ResumeFailedException {
+    PersistentFileTracker original = mock(PersistentFileTracker.class);
+    Bucket underlying = mock(Bucket.class);
+    DelayedFreeBucket sut = newSut(original, underlying);
+    ClientContext ctx = mock(ClientContext.class);
+    // Act
+    sut.onResume(ctx);
+    // Assert
+    verify(underlying, times(1)).onResume(ctx);
+  }
+
+  @Test
+  @DisplayName("free_afterFactorySwap_usesOriginalCreatedCommitID")
+  void free_afterFactorySwap_usesOriginalCreatedCommitID() throws Exception {
+    // Arrange original factory (commitID captured at construction)
+    PersistentFileTracker original = mock(PersistentFileTracker.class);
+    when(original.commitID()).thenReturn(11L);
+    Bucket underlying = mock(Bucket.class);
+    DelayedFreeBucket sut = newSut(original, underlying);
+
+    // Swap the factory field to a new instance via reflection (simulates onResume wiring)
+    PersistentTempBucketFactory newFactory = mock(PersistentTempBucketFactory.class);
+    var field = DelayedFreeBucket.class.getDeclaredField("factory");
+    field.setAccessible(true);
+    field.set(sut, newFactory);
+
+    // Act
+    sut.free();
+
+    // Assert: delayedFree called on the new factory with the original createdCommitID (11)
+    verify(newFactory, times(1)).delayedFree(sut, 11L);
+    verify(original, never()).delayedFree(any(), anyLong());
+  }
+
+  @Test
+  @DisplayName("storeTo_writesMagicVersionThenDelegates")
+  void storeTo_writesMagicVersionThenDelegates() throws Exception {
+    PersistentFileTracker pft = mock(PersistentFileTracker.class);
+    Bucket underlying = mock(Bucket.class);
+
+    // Make underlying write a known marker so we can assert ordering
+    doAnswer(
+            inv -> {
+              DataOutputStream dos = inv.getArgument(0);
+              dos.writeInt(0xCAFEBABE);
+              return null;
+            })
+        .when(underlying)
+        .storeTo(org.mockito.ArgumentMatchers.any(DataOutputStream.class));
+
+    DelayedFreeBucket sut = newSut(pft, underlying);
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+
+    sut.storeTo(dos);
+    dos.flush();
+
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()));
+    assertEquals(DelayedFreeBucket.MAGIC, dis.readInt());
+    assertEquals(1, dis.readInt());
+    assertEquals(0xCAFEBABE, dis.readInt());
+    verify(underlying, times(1)).storeTo(org.mockito.ArgumentMatchers.any(DataOutputStream.class));
+  }
+
+  @Nested
+  class DelegationTests {
+    @Test
+    @DisplayName("createShadow_delegates")
+    void createShadow_delegates() {
+      PersistentFileTracker pft = mock(PersistentFileTracker.class);
+      Bucket underlying = mock(Bucket.class);
+      Bucket shadow = mock(Bucket.class);
+      when(underlying.createShadow()).thenReturn(shadow);
+      DelayedFreeBucket sut = newSut(pft, underlying);
+      assertSame(shadow, sut.createShadow());
+    }
+
+    @Test
+    @DisplayName("realFree_delegatesToBucketFree")
+    void realFree_delegatesToBucketFree() {
+      PersistentFileTracker pft = mock(PersistentFileTracker.class);
+      Bucket underlying = mock(Bucket.class);
+      DelayedFreeBucket sut = newSut(pft, underlying);
+      sut.realFree();
+      verify(underlying, times(1)).free();
+    }
+
+    @Test
+    @DisplayName("nameSizeReadOnly_delegates")
+    void nameSizeReadOnly_delegates() {
+      PersistentFileTracker pft = mock(PersistentFileTracker.class);
+      Bucket underlying = mock(Bucket.class);
+      when(underlying.getName()).thenReturn("test-bucket");
+      when(underlying.size()).thenReturn(123L);
+      when(underlying.isReadOnly()).thenReturn(false).thenReturn(true);
+      DelayedFreeBucket sut = newSut(pft, underlying);
+
+      assertEquals("test-bucket", sut.getName());
+      assertEquals(123L, sut.size());
+      assertFalse(sut.isReadOnly());
+      sut.setReadOnly();
+      verify(underlying, times(1)).setReadOnly();
+      assertTrue(sut.isReadOnly());
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBucketTest.java
+++ b/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBucketTest.java
@@ -1,0 +1,342 @@
+package network.crypta.support.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Random;
+import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.RandomAccessBucket;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
+
+class DelayedFreeRandomAccessBucketTest {
+
+  private PersistentFileTracker factory;
+  private RandomAccessBucket underlying;
+
+  @BeforeEach
+  void setup() {
+    factory = mock(PersistentFileTracker.class);
+    when(factory.commitID()).thenReturn(101L);
+    underlying = mock(RandomAccessBucket.class);
+  }
+
+  @Test
+  void constructor_whenBucketIsNull_expectNPE() {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          try (DelayedFreeRandomAccessBucket ignored =
+              new DelayedFreeRandomAccessBucket(factory, null)) {
+            fail("unreachable");
+          }
+        });
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void constructor_whenFactoryIsNull_expectNPE() {
+    // NPE occurs when reading commitID() on null factory
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          try (DelayedFreeRandomAccessBucket ignored =
+              new DelayedFreeRandomAccessBucket(null, underlying)) {
+            fail("unreachable");
+          }
+        });
+  }
+
+  @Test
+  void getUnderlying_whenFreed_returnsNull() {
+    // Arrange
+    DelayedFreeRandomAccessBucket bucket = new DelayedFreeRandomAccessBucket(factory, underlying);
+
+    // Act: before free
+    assertSame(underlying, bucket.getUnderlying());
+
+    // Act: free
+    bucket.free();
+
+    // Assert
+    assertNull(bucket.getUnderlying());
+  }
+
+  @Test
+  void free_whenCalledTwice_idempotent() {
+    // Arrange
+    when(factory.commitID()).thenReturn(777L); // commit captured at construction
+    DelayedFreeRandomAccessBucket bucket = new DelayedFreeRandomAccessBucket(factory, underlying);
+
+    // Act
+    bucket.free();
+    bucket.free();
+
+    // Assert
+    assertTrue(bucket.toFree());
+    verify(factory, times(1)).delayedFree(bucket, 777L);
+  }
+
+  @Test
+  void free_whenResumed_usesNewFactoryButOriginalCommitID() throws ResumeFailedException {
+    // Arrange: factory at creation time (commit captured)
+    PersistentFileTracker factoryAtCreate = mock(PersistentFileTracker.class);
+    when(factoryAtCreate.commitID()).thenReturn(42L);
+    DelayedFreeRandomAccessBucket bucket =
+        new DelayedFreeRandomAccessBucket(factoryAtCreate, underlying);
+
+    // Underlying should receive onResume()
+    doNothing().when(underlying).onResume(any());
+
+    // New factory after resume
+    PersistentTempBucketFactory newFactory = mock(PersistentTempBucketFactory.class);
+
+    // Build a minimal ClientContext with the new factory; other args can be mocks/nulls where safe
+    Random fastWeak = mock(Random.class);
+    ClientContext ctx =
+        new ClientContext(
+            1L,
+            mock(network.crypta.client.async.ClientLayerPersister.class),
+            mock(network.crypta.support.Executor.class),
+            mock(network.crypta.client.ArchiveManager.class),
+            newFactory, // persistentBucketFactory
+            mock(TempBucketFactory.class),
+            mock(PersistentFileTracker.class),
+            mock(network.crypta.client.async.HealingQueue.class),
+            mock(network.crypta.client.async.USKManager.class),
+            mock(network.crypta.crypt.RandomSource.class),
+            fastWeak,
+            mock(network.crypta.support.Ticker.class),
+            mock(network.crypta.support.MemoryLimitedJobRunner.class),
+            mock(FilenameGenerator.class),
+            mock(FilenameGenerator.class),
+            mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
+            mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
+            mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
+            mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
+            mock(network.crypta.support.compress.RealCompressor.class),
+            mock(network.crypta.client.async.DatastoreChecker.class),
+            mock(network.crypta.clients.fcp.PersistentRequestRoot.class),
+            mock(MasterSecret.class),
+            mock(network.crypta.client.filter.LinkFilterExceptionProvider.class),
+            mock(network.crypta.client.FetchContext.class),
+            mock(network.crypta.client.InsertContext.class),
+            mock(network.crypta.config.Config.class));
+
+    // Act: resume then free
+    bucket.onResume(ctx);
+    bucket.free();
+
+    // Assert: delayedFree invoked on the NEW factory with the ORIGINAL commit id
+    verify(newFactory, times(1)).delayedFree(bucket, 42L);
+    verify(factoryAtCreate, never()).delayedFree(any(), anyLong());
+    verify(underlying, times(1)).onResume(ctx);
+  }
+
+  static StreamAction[] streamActions() {
+    return new StreamAction[] {
+      new StreamAction(
+          "getOutputStream",
+          (w, u) -> {
+            OutputStream os = new ByteArrayOutputStream();
+            when(u.getOutputStream()).thenReturn(os);
+            return w.getOutputStream();
+          }),
+      new StreamAction(
+          "getOutputStreamUnbuffered",
+          (w, u) -> {
+            OutputStream os = new ByteArrayOutputStream();
+            when(u.getOutputStreamUnbuffered()).thenReturn(os);
+            return w.getOutputStreamUnbuffered();
+          }),
+      new StreamAction(
+          "getInputStream",
+          (w, u) -> {
+            InputStream is = new ByteArrayInputStream(new byte[0]);
+            when(u.getInputStream()).thenReturn(is);
+            return w.getInputStream();
+          }),
+      new StreamAction(
+          "getInputStreamUnbuffered",
+          (w, u) -> {
+            InputStream is = new ByteArrayInputStream(new byte[0]);
+            when(u.getInputStreamUnbuffered()).thenReturn(is);
+            return w.getInputStreamUnbuffered();
+          })
+    };
+  }
+
+  @ParameterizedTest(name = "{0} when freed throws IOException")
+  @MethodSource("streamActions")
+  void ioMethods_whenFreed_expectIOException(StreamAction action) {
+    // Arrange
+    DelayedFreeRandomAccessBucket bucket = new DelayedFreeRandomAccessBucket(factory, underlying);
+    bucket.free();
+
+    // Act + Assert
+    IOException ex = assertThrows(IOException.class, () -> action.invoke(bucket, underlying));
+    assertThat(ex.getMessage(), containsString("Already freed"));
+  }
+
+  @ParameterizedTest(name = "{0} delegates to underlying when not freed")
+  @MethodSource("streamActions")
+  void ioMethods_whenNotFreed_delegate(StreamAction action) throws IOException {
+    // Arrange
+    DelayedFreeRandomAccessBucket bucket = new DelayedFreeRandomAccessBucket(factory, underlying);
+
+    // Act
+    Closeable stream = action.invoke(bucket, underlying);
+
+    // Assert
+    assertNotNull(stream);
+  }
+
+  @Test
+  void toRandomAccessBuffer_whenNotFreed_wrapsAndSetsReadOnly() throws IOException {
+    // Arrange
+    DelayedFreeRandomAccessBucket bucket = new DelayedFreeRandomAccessBucket(factory, underlying);
+    LockableRandomAccessBuffer raf = mock(LockableRandomAccessBuffer.class);
+    when(underlying.toRandomAccessBuffer()).thenReturn(raf);
+
+    // Act
+    LockableRandomAccessBuffer out = bucket.toRandomAccessBuffer();
+
+    // Assert
+    assertNotNull(out);
+    assertThat(out, instanceOf(DelayedFreeRandomAccessBuffer.class));
+    InOrder order = inOrder(underlying);
+    order.verify(underlying, times(1)).setReadOnly();
+    order.verify(underlying, times(1)).toRandomAccessBuffer();
+  }
+
+  @Test
+  void toRandomAccessBuffer_whenFreed_expectIOException() {
+    // Arrange
+    DelayedFreeRandomAccessBucket bucket = new DelayedFreeRandomAccessBucket(factory, underlying);
+    bucket.free();
+
+    // Act + Assert
+    assertThrows(IOException.class, bucket::toRandomAccessBuffer);
+  }
+
+  @Test
+  void basicDelegations_whenCalled_delegateToUnderlying() {
+    // Arrange
+    when(underlying.getName()).thenReturn("n");
+    when(underlying.size()).thenReturn(0L, 123L);
+    when(underlying.isReadOnly()).thenReturn(false, true);
+    RandomAccessBucket shadow = mock(RandomAccessBucket.class);
+    when(underlying.createShadow()).thenReturn(shadow);
+
+    DelayedFreeRandomAccessBucket bucket = new DelayedFreeRandomAccessBucket(factory, underlying);
+
+    // Act + Assert
+    assertEquals("n", bucket.getName());
+    assertEquals(0L, bucket.size());
+    assertFalse(bucket.isReadOnly());
+
+    bucket.setReadOnly();
+    verify(underlying, times(1)).setReadOnly();
+
+    assertTrue(bucket.isReadOnly());
+    assertSame(shadow, bucket.createShadow());
+
+    bucket.realFree();
+    verify(underlying, times(1)).free();
+  }
+
+  @Test
+  void storeTo_whenCalled_writesHeaderAndDelegates() throws IOException {
+    // Arrange
+    DelayedFreeRandomAccessBucket bucket = new DelayedFreeRandomAccessBucket(factory, underlying);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+
+    // Act
+    bucket.storeTo(dos);
+    dos.flush();
+
+    // Assert bytes
+    byte[] data = baos.toByteArray();
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
+      assertEquals(DelayedFreeRandomAccessBucket.MAGIC, dis.readInt());
+      assertEquals(DelayedFreeRandomAccessBucket.VERSION, dis.readInt());
+    }
+    verify(underlying, times(1)).storeTo(ArgumentMatchers.any(DataOutputStream.class));
+  }
+
+  // Helper types for parameterized stream tests
+  private interface IOSupplier {
+    Closeable get(DelayedFreeRandomAccessBucket wrapper, RandomAccessBucket underlying)
+        throws IOException;
+  }
+
+  private record StreamAction(String name, IOSupplier supplier)
+      implements Comparable<StreamAction> {
+
+    Closeable invoke(DelayedFreeRandomAccessBucket wrapper, RandomAccessBucket underlying)
+        throws IOException {
+      return supplier.get(wrapper, underlying);
+    }
+
+    @Override
+    public @NotNull String toString() {
+      return name;
+    }
+
+    @Override
+    public int compareTo(StreamAction o) {
+      return this.name.compareTo(o.name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      StreamAction other = (StreamAction) obj;
+      return name.equals(other.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return name.hashCode();
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java
+++ b/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java
@@ -1,0 +1,266 @@
+package network.crypta.support.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.LockableRandomAccessBuffer.RAFLock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DelayedFreeRandomAccessBufferTest {
+
+  private PersistentFileTracker factory;
+  private LockableRandomAccessBuffer underlying;
+
+  @BeforeEach
+  void setup() {
+    factory = mock(PersistentFileTracker.class);
+    when(factory.commitID()).thenReturn(101L);
+    underlying = mock(LockableRandomAccessBuffer.class);
+  }
+
+  @Test
+  void toFree_whenInitiallyFalse_afterFreeTrue() {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    assertFalse(buf.toFree());
+    buf.free();
+    assertTrue(buf.toFree());
+  }
+
+  @Test
+  void free_whenCalledTwice_idempotent() {
+    when(factory.commitID()).thenReturn(777L);
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+
+    buf.free();
+    buf.free();
+
+    assertTrue(buf.toFree());
+    verify(factory, times(1)).delayedFree(buf, 777L);
+  }
+
+  @Test
+  void free_whenResumed_usesNewFactoryButOriginalCommitID()
+      throws IOException, ResumeFailedException {
+    PersistentFileTracker factoryAtCreate = mock(PersistentFileTracker.class);
+    when(factoryAtCreate.commitID()).thenReturn(42L);
+    DelayedFreeRandomAccessBuffer buf =
+        new DelayedFreeRandomAccessBuffer(underlying, factoryAtCreate);
+
+    doNothing().when(underlying).onResume(any());
+
+    PersistentTempBucketFactory newFactory = mock(PersistentTempBucketFactory.class);
+    Random fastWeak = mock(Random.class);
+    ClientContext ctx =
+        new ClientContext(
+            1L,
+            mock(network.crypta.client.async.ClientLayerPersister.class),
+            mock(network.crypta.support.Executor.class),
+            mock(network.crypta.client.ArchiveManager.class),
+            newFactory,
+            mock(TempBucketFactory.class),
+            mock(PersistentFileTracker.class),
+            mock(network.crypta.client.async.HealingQueue.class),
+            mock(network.crypta.client.async.USKManager.class),
+            mock(network.crypta.crypt.RandomSource.class),
+            fastWeak,
+            mock(network.crypta.support.Ticker.class),
+            mock(network.crypta.support.MemoryLimitedJobRunner.class),
+            mock(FilenameGenerator.class),
+            mock(FilenameGenerator.class),
+            mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
+            mock(network.crypta.support.api.LockableRandomAccessBufferFactory.class),
+            mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
+            mock(network.crypta.support.io.FileRandomAccessBufferFactory.class),
+            mock(network.crypta.support.compress.RealCompressor.class),
+            mock(network.crypta.client.async.DatastoreChecker.class),
+            mock(network.crypta.clients.fcp.PersistentRequestRoot.class),
+            mock(MasterSecret.class),
+            mock(network.crypta.client.filter.LinkFilterExceptionProvider.class),
+            mock(network.crypta.client.FetchContext.class),
+            mock(network.crypta.client.InsertContext.class),
+            mock(network.crypta.config.Config.class));
+
+    buf.onResume(ctx);
+    buf.free();
+
+    verify(newFactory, times(1)).delayedFree(buf, 42L);
+    verify(factoryAtCreate, never()).delayedFree(any(), anyLong());
+    verify(underlying, times(1)).onResume(ctx);
+  }
+
+  static OpAction[] freeGuardedOps() {
+    return new OpAction[] {
+      new OpAction(
+          "pread",
+          (b, u) -> {
+            byte[] dst = new byte[8];
+            b.pread(4L, dst, 1, 3);
+          }),
+      new OpAction(
+          "pwrite",
+          (b, u) -> {
+            byte[] src = new byte[8];
+            b.pwrite(6L, src, 2, 4);
+          }),
+      new OpAction("lockOpen", (b, u) -> b.lockOpen())
+    };
+  }
+
+  @ParameterizedTest(name = "{0} when freed throws IOException")
+  @MethodSource("freeGuardedOps")
+  void ops_whenFreed_expectIOException(OpAction action) throws IOException {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    buf.free();
+    IOException ex = assertThrows(IOException.class, () -> action.run(buf, underlying));
+    assertThat(ex.getMessage(), containsString("Already freed"));
+  }
+
+  @Test
+  void pread_whenNotFreed_delegatesWithSameArgs() throws IOException {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    byte[] dst = new byte[16];
+
+    buf.pread(5L, dst, 3, 7);
+
+    verify(underlying, times(1)).pread(5L, dst, 3, 7);
+  }
+
+  @Test
+  void pwrite_whenNotFreed_delegatesWithSameArgs() throws IOException {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    byte[] src = new byte[16];
+
+    buf.pwrite(9L, src, 2, 6);
+
+    verify(underlying, times(1)).pwrite(9L, src, 2, 6);
+  }
+
+  @Test
+  void close_whenFreed_noDelegateClose() {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    buf.free();
+    buf.close();
+    verify(underlying, never()).close();
+  }
+
+  @Test
+  void close_whenNotFreed_delegatesClose() {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    buf.close();
+    verify(underlying, times(1)).close();
+  }
+
+  @Test
+  void lockOpen_whenNotFreed_delegatesAndReturnsRafLock() throws IOException {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    RAFLock lock =
+        new RAFLock() {
+          @Override
+          protected void innerUnlock() {
+            // No-op for tests: we only need a concrete RAFLock instance.
+          }
+        };
+    when(underlying.lockOpen()).thenReturn(lock);
+
+    RAFLock out = buf.lockOpen();
+    assertSame(lock, out);
+    verify(underlying, times(1)).lockOpen();
+  }
+
+  @Test
+  void size_whenCalled_delegates() {
+    when(underlying.size()).thenReturn(123L);
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    assertEquals(123L, buf.size());
+  }
+
+  @Test
+  void getUnderlying_whenFreed_returnsNull() {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    assertSame(underlying, buf.getUnderlying());
+    buf.free();
+    assertNull(buf.getUnderlying());
+  }
+
+  @Test
+  void realFree_whenCalled_delegatesToUnderlying() {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    buf.realFree();
+    verify(underlying, times(1)).free();
+  }
+
+  @Test
+  void equalsAndHashCode_whenSameUnderlying_areEqual() {
+    LockableRandomAccessBuffer same = underlying;
+    DelayedFreeRandomAccessBuffer a = new DelayedFreeRandomAccessBuffer(same, factory);
+    DelayedFreeRandomAccessBuffer b = new DelayedFreeRandomAccessBuffer(same, factory);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void equals_whenDifferentUnderlying_notEqual() {
+    LockableRandomAccessBuffer other = mock(LockableRandomAccessBuffer.class);
+    DelayedFreeRandomAccessBuffer a = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    DelayedFreeRandomAccessBuffer b = new DelayedFreeRandomAccessBuffer(other, factory);
+    assertNotEquals(a, b);
+    assertNotEquals(a, null);
+    assertNotEquals(a, new Object());
+  }
+
+  @Test
+  void storeTo_whenCalled_writesMagicAndDelegates() throws IOException {
+    DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+
+    buf.storeTo(dos);
+    dos.flush();
+
+    byte[] data = baos.toByteArray();
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
+      assertEquals(DelayedFreeRandomAccessBuffer.MAGIC, dis.readInt());
+    }
+    verify(underlying, times(1)).storeTo(org.mockito.ArgumentMatchers.any(DataOutputStream.class));
+  }
+
+  // Helper types for parameterized freed-guard tests
+  private interface Op {
+    void accept(DelayedFreeRandomAccessBuffer wrapper, LockableRandomAccessBuffer underlying)
+        throws IOException;
+  }
+
+  private static final class OpAction {
+    final String name;
+    final Op op;
+
+    OpAction(String name, Op op) {
+      this.name = name;
+      this.op = op;
+    }
+
+    void run(DelayedFreeRandomAccessBuffer wrapper, LockableRandomAccessBuffer underlying)
+        throws IOException {
+      op.accept(wrapper, underlying);
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java
+++ b/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java
@@ -1,9 +1,22 @@
 package network.crypta.support.io;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -15,6 +28,7 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.LockableRandomAccessBuffer.RAFLock;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,8 +67,7 @@ class DelayedFreeRandomAccessBufferTest {
   }
 
   @Test
-  void free_whenResumed_usesNewFactoryButOriginalCommitID()
-      throws IOException, ResumeFailedException {
+  void free_whenResumed_usesNewFactoryButOriginalCommitID() throws ResumeFailedException {
     PersistentFileTracker factoryAtCreate = mock(PersistentFileTracker.class);
     when(factoryAtCreate.commitID()).thenReturn(42L);
     DelayedFreeRandomAccessBuffer buf =
@@ -122,7 +135,7 @@ class DelayedFreeRandomAccessBufferTest {
 
   @ParameterizedTest(name = "{0} when freed throws IOException")
   @MethodSource("freeGuardedOps")
-  void ops_whenFreed_expectIOException(OpAction action) throws IOException {
+  void ops_whenFreed_expectIOException(OpAction action) {
     DelayedFreeRandomAccessBuffer buf = new DelayedFreeRandomAccessBuffer(underlying, factory);
     buf.free();
     IOException ex = assertThrows(IOException.class, () -> action.run(buf, underlying));
@@ -244,14 +257,7 @@ class DelayedFreeRandomAccessBufferTest {
         throws IOException;
   }
 
-  private static final class OpAction {
-    final String name;
-    final Op op;
-
-    OpAction(String name, Op op) {
-      this.name = name;
-      this.op = op;
-    }
+  private record OpAction(String name, Op op) {
 
     void run(DelayedFreeRandomAccessBuffer wrapper, LockableRandomAccessBuffer underlying)
         throws IOException {
@@ -259,7 +265,7 @@ class DelayedFreeRandomAccessBufferTest {
     }
 
     @Override
-    public String toString() {
+    public @NotNull String toString() {
       return name;
     }
   }

--- a/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java
+++ b/src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java
@@ -217,9 +217,9 @@ class DelayedFreeRandomAccessBufferTest {
     LockableRandomAccessBuffer other = mock(LockableRandomAccessBuffer.class);
     DelayedFreeRandomAccessBuffer a = new DelayedFreeRandomAccessBuffer(underlying, factory);
     DelayedFreeRandomAccessBuffer b = new DelayedFreeRandomAccessBuffer(other, factory);
-    assertNotEquals(a, b);
-    assertNotEquals(a, null);
-    assertNotEquals(a, new Object());
+    assertNotEquals(b, a);
+    assertNotEquals(null, a);
+    assertNotEquals(new Object(), a);
   }
 
   @Test


### PR DESCRIPTION
Summary
- Serialization hooks for delayed-free wrappers (`writeObject`/`readObject`), guarding non-serializable delegates and persisting required fields safely.
- Expanded Javadoc for `DelayedFree`, `DelayedFreeBucket`, `DelayedFreeRandomAccessBucket`, and `DelayedFreeRandomAccessBuffer` to clarify semantics and lifecycle.
- Added targeted, non-flaky unit tests covering free guards, delegation, idempotency, equals/hashCode, and resume wiring.
- Spotless formatting and minor SonarLint cleanups; no functional behavior changes to the delayed-free mechanism.

Scope of changes
- src/main/java/network/crypta/support/io/DelayedFree.java
- src/main/java/network/crypta/support/io/DelayedFreeBucket.java
- src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBucket.java
- src/main/java/network/crypta/support/io/DelayedFreeRandomAccessBuffer.java
- src/test/java/network/crypta/support/io/DelayedFreeBucketTest.java
- src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBucketTest.java
- src/test/java/network/crypta/support/io/DelayedFreeRandomAccessBufferTest.java

Why
- Ensure wrappers are Java-serialization-safe for persistence/transfer scenarios without changing runtime behavior.
- Clarify API/contract to reduce misuse and ease maintenance.
- Increase test coverage and confidence in delayed-free semantics.

Compatibility & risk
- No behavior change intended; wrappers continue to delay freeing until tracker commit.
- Tests validate previous semantics; only documentation and serialization mechanics were added.

Notes
- Verified commits vs origin/develop and summarized diffs locally.
- Reviewer model noted: documentation expansion, targeted unit tests, and serialization helpers without semantic changes.

Checklist
- [ ] Unit tests pass in CI
- [x] Spotless formatting
- [x] No public API breaks

Please review. Once approved, we can merge into `develop`.