### PR TITLE
fix(io): clarify and harden LineReadingInputStream buffer growth; expand Javadoc; add tests

### DIFF
--- a/src/main/java/network/crypta/support/io/LineReader.java
+++ b/src/main/java/network/crypta/support/io/LineReader.java
@@ -2,8 +2,45 @@ package network.crypta.support.io;
 
 import java.io.IOException;
 
+/**
+ * Minimal abstraction for reading a single text line from a byte-oriented source.
+ *
+ * <p>Implementations read a line terminated by LF ({@code '\n'}) or CRLF ({@code "\r\n"}), decode
+ * it using either UTF-8 or ISO-8859-1 as directed, and return the line content without the
+ * line-termination characters. At end of stream, if no bytes were read for the next line, {@code
+ * null} is returned; otherwise the remaining bytes are decoded and returned as the final line.
+ *
+ * <p>The primary purpose of this interface is to allow components to consume lines from different
+ * sources consistently (e.g., {@link java.io.BufferedReader} via an adapter, or {@link
+ * LineReadingInputStream}). Implementations may enforce a maximum line length to bound memory
+ * usage.
+ *
+ * <p>Thread-safety: Implementations are not required to be thread-safe unless stated otherwise by
+ * the concrete type.
+ */
 public interface LineReader {
 
-  /** Read a \n or \r\n terminated line of UTF-8 or ISO-8859-1. */
+  /**
+   * Reads one LF or CRLF-terminated line and decodes it as UTF-8 or ISO-8859-1.
+   *
+   * <p>The returned string never includes the line-termination characters. If end-of-stream is
+   * reached before any byte is read for the next line, this method returns {@code null}; if some
+   * bytes were read but no terminator was found before EOF, the decoded bytes are returned as the
+   * final line.
+   *
+   * @param maxLength Upper bound on the number of bytes to consume before the terminator (not
+   *     including the terminator). Implementations should throw {@link TooLongException} when this
+   *     limit is exceeded to prevent unbounded buffering; adapters may ignore the limit.
+   * @param bufferSize Hint for the initial internal buffer capacity; implementations may clamp or
+   *     ignore this value.
+   * @param utf When {@code true}, decode as UTF-8; when {@code false}, decode as ISO-8859-1. No
+   *     other encodings are supported.
+   * @return The decoded line text without the line-termination characters, or {@code null} at
+   *     end-of-stream when no byte was read for the next line.
+   * @throws TooLongException if the line exceeds {@code maxLength} (subclass of {@link
+   *     IOException}).
+   * @throws IOException on I/O errors or if the underlying stream violates its contract (e.g.,
+   *     returning zero from a blocking read).
+   */
   String readLine(int maxLength, int bufferSize, boolean utf) throws IOException;
 }

--- a/src/main/java/network/crypta/support/io/LineReadingInputStream.java
+++ b/src/main/java/network/crypta/support/io/LineReadingInputStream.java
@@ -267,7 +267,7 @@ public class LineReadingInputStream extends FilterInputStream implements LineRea
               + HexUtil.bytesToHex(s.buf, 0, s.ctr)
               + "\n"
               + decode(s.buf, s.ctr, cs));
-    // Safe to append: on entry we have s.ctr < s.buf.length. If this write fills the buffer,
+    // Safe to append: on entry we have s.ctr < s.buf.length. If this writing fills the buffer,
     // the caller grows capacity before the next iteration (see growth check in the loop above).
     s.buf[s.ctr++] = (byte) x;
   }

--- a/src/main/java/network/crypta/support/io/LineReadingInputStream.java
+++ b/src/main/java/network/crypta/support/io/LineReadingInputStream.java
@@ -4,117 +4,279 @@ import java.io.EOFException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import network.crypta.support.HexUtil;
+import org.jetbrains.annotations.NotNull;
 
-/** A FilterInputStream which provides readLine(). */
+/**
+ * InputStream wrapper that reads a single LF or CRLF-terminated line.
+ *
+ * <p>This class implements {@link LineReader} on top of a byte-oriented {@link InputStream} and
+ * returns decoded text lines without the line-termination characters. It supports two encodings:
+ * UTF-8 and ISO-8859-1. A line terminates on LF ({@code '\n'}). If the byte immediately preceding
+ * the LF is CR ({@code '\r'}), that CR is stripped, thus supporting ordinary CRLF sequences.
+ *
+ * <p>When the underlying stream supports marking (see {@link InputStream#markSupported()}), the
+ * implementation uses {@link #mark(int)} and {@link #reset()} to probe for a terminator and then
+ * repositions the stream so that, on return, the next byte to read is the one immediately after the
+ * line terminator. When marking is not supported, it falls back to reading one byte at a time and
+ * stops once a terminator is encountered or the stream ends. In both cases, the underlying stream
+ * is advanced to just after the terminator (or to end-of-stream if no terminator is found).
+ *
+ * <p>Limits and safety: callers provide an upper bound for the number of bytes that may be consumed
+ * for a single line (exclusive of the terminator). If the bound is exceeded, a {@link
+ * TooLongException} is thrown to avoid unbounded buffering. The method returns {@code null} at
+ * end-of-stream when zero bytes are available for the next line; otherwise any remaining bytes are
+ * decoded and returned as the final line, even if they are not terminated.
+ *
+ * <p>Thread-safety: instances are not thread-safe. Synchronize externally if multiple threads may
+ * read concurrently.
+ */
 public class LineReadingInputStream extends FilterInputStream implements LineReader {
 
+  /**
+   * Creates a new line-reading wrapper over the given stream.
+   *
+   * <p>The provided stream may or may not support marking. If it does, this class uses mark/reset
+   * to detect the line terminator efficiently while leaving the stream positioned just after the
+   * line. Otherwise, the implementation reads byte-by-byte until a terminator is found or the end
+   * of the stream is reached.
+   *
+   * @param in the underlying input stream. The constructor does not buffer or change the stream's
+   *     configuration.
+   */
   public LineReadingInputStream(InputStream in) {
     super(in);
   }
 
   /**
-   * Read a \n or \r\n terminated line of UTF-8 or ISO-8859-1.
+   * Reads one LF or CRLF-terminated line and decodes it as UTF-8 or ISO-8859-1.
    *
-   * @param maxLength The maximum length of a line. If a line is longer than this, we throw
-   *     IOException rather than keeping on reading it forever.
-   * @param bufferSize The initial size of the read buffer.
-   * @param utf If true, read as UTF-8, if false, read as ISO-8859-1.
+   * <p>The returned string never includes the line-termination characters. If end-of-stream is
+   * reached before any byte is available for the next line, this method returns {@code null}; if
+   * some bytes were read but no terminator was found before EOF, the decoded bytes are returned as
+   * the final line.
+   *
+   * <p>Special case: when {@code maxLength < 1}, this method returns {@code null} without reading
+   * from the stream.
+   *
+   * @param maxLength maximum number of bytes to buffer for the line content (excludes the
+   *     terminator). Exceeding this limit causes a {@link TooLongException}.
+   * @param bufferSize hint for the initial internal buffer capacity. The implementation clamps the
+   *     actual initial capacity between {@code min(128, maxLength)} and {@code 1024} bytes and, if
+   *     {@code bufferSize >= maxLength}, sets it to {@code maxLength + 1} to account for an
+   *     optional trailing CR.
+   * @param utf when {@code true}, decode as UTF-8; when {@code false}, decode as ISO-8859-1.
+   * @return decoded line text without the terminator, or {@code null} at end-of-stream when no
+   *     bytes were available for a new line.
+   * @throws TooLongException if the line exceeds {@code maxLength}.
+   * @throws EOFException if a blocking read unexpectedly returns zero bytes (prevents busy loops).
+   * @throws IOException on I/O errors.
    */
   @Override
   public String readLine(int maxLength, int bufferSize, boolean utf) throws IOException {
     if (maxLength < 1) return null;
     if (maxLength <= bufferSize)
-      bufferSize = maxLength + 1; // Buffer too big, shrink it (add 1 for the optional \r)
+      bufferSize =
+          maxLength + 1; // If requested buffer covers or exceeds maxLength, cap to maxLength+1
+    // (extra 1 accounts for a possible preceding CR before LF).
 
     if (!markSupported()) return readLineWithoutMarking(maxLength, bufferSize, utf);
 
-    byte[] buf = new byte[Math.max(Math.min(128, maxLength), Math.min(1024, bufferSize))];
+    byte[] buf = new byte[initialBufferSize(maxLength, bufferSize)];
     int ctr = 0;
-    mark(maxLength + 2); // in case we have both a \r and a \n
+    final Charset cs = utf ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
+    mark(maxLength + 2); // Allow room for both CR and LF following up to maxLength content.
+    return readMarkedLoop(buf, ctr, maxLength, bufferSize, cs);
+  }
+
+  /**
+   * Non-marking variant used when {@link #markSupported()} is {@code false}.
+   *
+   * <p>Behavior matches {@link #readLine(int, int, boolean)} with the difference that the
+   * implementation does not rely on {@code mark}/{@code reset}. Exposed as {@code protected} to
+   * facilitate testing and reuse in subclasses.
+   *
+   * @param maxLength maximum number of bytes to buffer (excludes the terminator)
+   * @param bufferSize initial buffer size hint (subject to clamping)
+   * @param utf when {@code true}, decode as UTF-8; when {@code false}, decode as ISO-8859-1
+   * @return decoded line without the terminator, or {@code null} at end-of-stream when no byte was
+   *     available for a new line
+   * @throws TooLongException if the line exceeds {@code maxLength}
+   * @throws IOException on I/O errors
+   */
+  protected String readLineWithoutMarking(int maxLength, int bufferSize, boolean utf)
+      throws IOException {
+    if (maxLength < bufferSize)
+      bufferSize =
+          maxLength + 1; // If buffer exceeds maxLength, cap to maxLength+1 (allow for optional CR).
+    byte[] buf = new byte[initialBufferSize(maxLength, bufferSize)];
+    int ctr = 0;
+    final Charset cs = utf ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
+    NonMarkedState s = new NonMarkedState(buf, ctr);
     while (true) {
-      assert (buf.length - ctr > 0);
-      int x = read(buf, ctr, buf.length - ctr);
-      if (x < 0) {
-        if (ctr == 0) return null;
-        return new String(buf, 0, ctr, utf ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1);
-      }
-      if (x == 0) {
-        // Don't busy-loop. Probably a socket closed or something.
-        // If not, it's not a salavageable situation; either way throw.
-        throw new EOFException();
-      }
-      // REDFLAG this is definitely safe with the above charsets, it may not be safe with some wierd
-      // ones.
-      int end = ctr + x;
-      for (; ctr < end; ctr++) {
-        if (buf[ctr] == '\n') {
-          String toReturn = "";
-          if (ctr != 0) {
-            boolean removeCR = (buf[ctr - 1] == '\r');
-            toReturn =
-                new String(
-                    buf,
-                    0,
-                    (removeCR ? ctr - 1 : ctr),
-                    utf ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1);
-          }
-          reset();
-          skip(ctr + 1);
-          return toReturn;
-        }
-        if (ctr >= maxLength)
-          throw new TooLongException(
-              "We reached maxLength="
-                  + maxLength
-                  + " parsing\n "
-                  + HexUtil.bytesToHex(buf, 0, ctr)
-                  + "\n"
-                  + new String(
-                      buf, 0, ctr, utf ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1));
-      }
-      if ((buf.length < maxLength) && (buf.length - ctr < bufferSize)) {
-        byte[] newBuf = new byte[Math.min(buf.length * 2, maxLength)];
-        System.arraycopy(buf, 0, newBuf, 0, ctr);
-        buf = newBuf;
+      processChunkNonMarked(s, maxLength, cs);
+      if (s.done) return s.line;
+      if (s.ctr >= s.buf.length) {
+        s.buf = Arrays.copyOf(s.buf, Math.min(s.buf.length * 2, maxLength));
       }
     }
   }
 
-  protected String readLineWithoutMarking(int maxLength, int bufferSize, boolean utf)
+  /**
+   * Delegates bulk reads to the underlying stream.
+   *
+   * <p>Returns {@code 0} immediately when {@code len == 0}; otherwise forwards to {@link
+   * InputStream#read(byte[], int, int)} on the wrapped stream.
+   *
+   * @param b destination buffer
+   * @param off offset within {@code b}
+   * @param len maximum number of bytes to read
+   * @return number of bytes read, or {@code -1} on end-of-stream
+   * @throws IOException on I/O errors
+   */
+  @Override
+  public int read(byte @NotNull [] b, int off, int len) throws IOException {
+    if (len == 0) return 0;
+    return in.read(b, off, len);
+  }
+
+  private String readMarkedLoop(byte[] buf, int ctr, int maxLength, int bufferSize, Charset cs)
       throws IOException {
-    if (maxLength < bufferSize)
-      bufferSize = maxLength + 1; // Buffer too big, shrink it (add 1 for the optional \r)
-    byte[] buf = new byte[Math.max(Math.min(128, maxLength), Math.min(1024, bufferSize))];
-    int ctr = 0;
+    MarkedState s = new MarkedState(buf, ctr);
     while (true) {
-      int x = read();
-      if (x == -1) {
-        if (ctr == 0) return null;
-        return new String(buf, 0, ctr, utf ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1);
-      }
-      // REDFLAG this is definitely safe with the above charsets, it may not be safe with some wierd
-      // ones.
-      if (x == '\n') {
-        if (ctr == 0) return "";
-        if (buf[ctr - 1] == '\r') ctr--;
-        return new String(buf, 0, ctr, utf ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1);
-      }
-      if (ctr >= maxLength)
-        throw new TooLongException(
-            "We reached maxLength="
-                + maxLength
-                + " parsing\n "
-                + HexUtil.bytesToHex(buf, 0, ctr)
-                + "\n"
-                + new String(
-                    buf, 0, ctr, utf ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1));
-      if (ctr >= buf.length) {
-        buf = Arrays.copyOf(buf, Math.min(buf.length * 2, maxLength));
-      }
-      buf[ctr++] = (byte) x;
+      processChunkMarked(s, maxLength, bufferSize, cs);
+      if (s.done) return s.line;
+    }
+  }
+
+  private void processChunkMarked(MarkedState s, int maxLength, int bufferSize, Charset cs)
+      throws IOException {
+    assert (s.buf.length - s.ctr > 0);
+    int x = read(s.buf, s.ctr, s.buf.length - s.ctr);
+    if (x < 0) {
+      s.done = true;
+      s.line = (s.ctr == 0) ? null : decode(s.buf, s.ctr, cs);
+      return;
+    }
+    if (x == 0) {
+      // Prevent busy-looping when a blocking read yields 0 bytes; treat as terminal.
+      throw new EOFException();
+    }
+    int end = s.ctr + x;
+
+    int lf = indexOfLF(s.buf, s.ctr, end);
+    if (lf >= 0) {
+      s.done = true;
+      s.line = buildLineToReturn(s.buf, lf, cs);
+      // Rewind to the last mark and advance past the terminator so the caller observes
+      // the stream positioned immediately after the line just returned.
+      reset();
+      skipNBytes(lf + 1L);
+      return;
+    }
+
+    // No LF found in the bytes just read; update counter and enforce maxLength.
+    s.ctr = end;
+    if (s.ctr > maxLength) {
+      // Include up to maxLength bytes in the message to aid diagnostics.
+      throw new TooLongException(
+          "We reached maxLength="
+              + maxLength
+              + " parsing\n "
+              + HexUtil.bytesToHex(s.buf, 0, maxLength)
+              + "\n"
+              + decode(s.buf, maxLength, cs));
+    }
+
+    if (shouldGrow(s.buf.length, s.ctr, bufferSize, maxLength)) {
+      s.buf = grow(s.buf, s.ctr, maxLength);
+    }
+  }
+
+  private static final class MarkedState {
+    byte[] buf;
+    int ctr;
+    boolean done;
+    String line;
+
+    MarkedState(byte[] buf, int ctr) {
+      this.buf = buf;
+      this.ctr = ctr;
+    }
+  }
+
+  private static int indexOfLF(byte[] buf, int start, int end) {
+    for (int i = start; i < end; i++) {
+      if (buf[i] == '\n') return i;
+    }
+    return -1;
+  }
+
+  private static String decode(byte[] buf, int len, Charset cs) {
+    return new String(buf, 0, len, cs);
+  }
+
+  private static int initialBufferSize(int maxLength, int bufferSize) {
+    int low = Math.min(128, maxLength);
+    return Math.clamp(bufferSize, low, 1024);
+  }
+
+  private static boolean shouldGrow(int currentLength, int used, int bufferSize, int maxLength) {
+    return (currentLength < maxLength) && (currentLength - used < bufferSize);
+  }
+
+  private static byte[] grow(byte[] buf, int used, int maxLength) {
+    byte[] newBuf = new byte[Math.min(buf.length * 2, maxLength)];
+    System.arraycopy(buf, 0, newBuf, 0, used);
+    return newBuf;
+  }
+
+  private static String buildLineToReturn(byte[] buf, int lfIndex, Charset cs) {
+    if (lfIndex == 0) return "";
+    boolean removeCR = (buf[lfIndex - 1] == '\r');
+    int end = removeCR ? lfIndex - 1 : lfIndex;
+    return decode(buf, end, cs);
+  }
+
+  private void processChunkNonMarked(NonMarkedState s, int maxLength, Charset cs)
+      throws IOException {
+    int x = read();
+    if (x == -1) {
+      s.done = true;
+      s.line = (s.ctr == 0) ? null : decode(s.buf, s.ctr, cs);
+      return;
+    }
+    // Checking for LF by byte value is safe for UTF-8 and ISO-8859-1 (LF is ASCII in both).
+    if (x == '\n') {
+      s.done = true;
+      int len = (s.ctr > 0 && s.buf[s.ctr - 1] == '\r') ? s.ctr - 1 : s.ctr;
+      s.line = decode(s.buf, len, cs);
+      return;
+    }
+    if (s.ctr >= maxLength)
+      // Enforce the maximum length before appending the next byte.
+      throw new TooLongException(
+          "We reached maxLength="
+              + maxLength
+              + " parsing\n "
+              + HexUtil.bytesToHex(s.buf, 0, s.ctr)
+              + "\n"
+              + decode(s.buf, s.ctr, cs));
+    s.buf[s.ctr++] = (byte) x;
+  }
+
+  private static final class NonMarkedState {
+    byte[] buf;
+    int ctr;
+    boolean done;
+    String line;
+
+    NonMarkedState(byte[] buf, int ctr) {
+      this.buf = buf;
+      this.ctr = ctr;
     }
   }
 }

--- a/src/main/java/network/crypta/support/io/LineReadingInputStream.java
+++ b/src/main/java/network/crypta/support/io/LineReadingInputStream.java
@@ -119,6 +119,8 @@ public class LineReadingInputStream extends FilterInputStream implements LineRea
     while (true) {
       processChunkNonMarked(s, maxLength, cs);
       if (s.done) return s.line;
+      // Grow after append: processChunkNonMarked writes one byte at index s.ctr.
+      // If that write filled the buffer (s.ctr == length), we expand here before next append.
       if (s.ctr >= s.buf.length) {
         s.buf = Arrays.copyOf(s.buf, Math.min(s.buf.length * 2, maxLength));
       }
@@ -257,7 +259,7 @@ public class LineReadingInputStream extends FilterInputStream implements LineRea
       return;
     }
     if (s.ctr >= maxLength)
-      // Enforce the maximum length before appending the next byte.
+      // Enforce maximum length before appending the next byte.
       throw new TooLongException(
           "We reached maxLength="
               + maxLength
@@ -265,6 +267,8 @@ public class LineReadingInputStream extends FilterInputStream implements LineRea
               + HexUtil.bytesToHex(s.buf, 0, s.ctr)
               + "\n"
               + decode(s.buf, s.ctr, cs));
+    // Safe to append: on entry we have s.ctr < s.buf.length. If this write fills the buffer,
+    // the caller grows capacity before the next iteration (see growth check in the loop above).
     s.buf[s.ctr++] = (byte) x;
   }
 

--- a/src/test/java/network/crypta/support/io/LineReadingInputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/LineReadingInputStreamTest.java
@@ -2,32 +2,45 @@ package network.crypta.support.io;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class LineReadingInputStreamTest {
-  public static final String BLOCK = "\ntesting1\ntesting2\r\ntesting3\n\n";
-  public static final String[] LINES = new String[] {"", "testing1", "testing2", "testing3", ""};
+class LineReadingInputStreamTest {
+  private static final String BLOCK = "\ntesting1\ntesting2\r\ntesting3\n\n";
+  private static final String[] LINES = new String[] {"", "testing1", "testing2", "testing3", ""};
 
-  public static final String STRESSED_LINE = "\nĔ\n";
-  public static final String NULL_LINE = "a\u0000\u0000\u0000\u0000\n";
-  public static final String LENGTH_CHECKING_LINE = "a\u0000a\n";
-  public static final int LENGTH_CHECKING_LINE_LF = 3;
+  private static final String STRESSED_LINE = "\nĔ\n";
+  private static final String NULL_LINE = "a\u0000\u0000\u0000\u0000\n";
+  private static final String LENGTH_CHECKING_LINE = "a\u0000a\n";
+  private static final int LENGTH_CHECKING_LINE_LF = 3;
 
-  public static final int MAX_LENGTH = 128;
-  public static final int BUFFER_SIZE = 128;
+  private static final int MAX_LENGTH = 128;
+  private static final int BUFFER_SIZE = 128;
 
   @Test
-  public void testReadLineWithoutMarking() throws Exception {
+  void testReadLineWithoutMarking() throws Exception {
     // try utf8
     InputStream is = new ByteArrayInputStream(STRESSED_LINE.getBytes(StandardCharsets.UTF_8));
     LineReadingInputStream instance = new LineReadingInputStream(is);
-    assertEquals(instance.readLineWithoutMarking(MAX_LENGTH, BUFFER_SIZE, true), "");
-    assertEquals(instance.readLineWithoutMarking(MAX_LENGTH, BUFFER_SIZE, true), "Ĕ");
+    assertEquals("", instance.readLineWithoutMarking(MAX_LENGTH, BUFFER_SIZE, true));
+    assertEquals("Ĕ", instance.readLineWithoutMarking(MAX_LENGTH, BUFFER_SIZE, true));
     assertNull(instance.readLineWithoutMarking(MAX_LENGTH, BUFFER_SIZE, true));
 
     // try ISO-8859-1
@@ -47,11 +60,12 @@ public class LineReadingInputStreamTest {
     // is it throwing?
     is = new ByteArrayInputStream(LENGTH_CHECKING_LINE.getBytes());
     instance = new LineReadingInputStream(is);
-    try {
-      instance.readLineWithoutMarking(LENGTH_CHECKING_LINE_LF - 1, BUFFER_SIZE, true);
-      fail();
-    } catch (TooLongException e) {
-    }
+    final LineReadingInputStream throwingInstance1 = instance;
+    assertThrows(
+        TooLongException.class,
+        () ->
+            throwingInstance1.readLineWithoutMarking(
+                LENGTH_CHECKING_LINE_LF - 1, BUFFER_SIZE, true));
 
     // Same test shouldn't throw
     is = new ByteArrayInputStream(LENGTH_CHECKING_LINE.getBytes());
@@ -67,12 +81,12 @@ public class LineReadingInputStreamTest {
   }
 
   @Test
-  public void testReadLine() throws Exception {
+  void testReadLine() throws Exception {
     // try utf8
     InputStream is = new ByteArrayInputStream(STRESSED_LINE.getBytes(StandardCharsets.UTF_8));
     LineReadingInputStream instance = new LineReadingInputStream(is);
-    assertEquals(instance.readLine(MAX_LENGTH, BUFFER_SIZE, true), "");
-    assertEquals(instance.readLine(MAX_LENGTH, BUFFER_SIZE, true), "Ĕ");
+    assertEquals("", instance.readLine(MAX_LENGTH, BUFFER_SIZE, true));
+    assertEquals("Ĕ", instance.readLine(MAX_LENGTH, BUFFER_SIZE, true));
     assertNull(instance.readLine(MAX_LENGTH, BUFFER_SIZE, true));
 
     // try ISO-8859-1
@@ -92,11 +106,10 @@ public class LineReadingInputStreamTest {
     // is it throwing?
     is = new ByteArrayInputStream(LENGTH_CHECKING_LINE.getBytes());
     instance = new LineReadingInputStream(is);
-    try {
-      instance.readLine(LENGTH_CHECKING_LINE_LF - 1, BUFFER_SIZE, true);
-      fail();
-    } catch (TooLongException e) {
-    }
+    final LineReadingInputStream throwingInstance2 = instance;
+    assertThrows(
+        TooLongException.class,
+        () -> throwingInstance2.readLine(LENGTH_CHECKING_LINE_LF - 1, BUFFER_SIZE, true));
 
     // Same test shouldn't throw
     is = new ByteArrayInputStream(LENGTH_CHECKING_LINE.getBytes());
@@ -112,7 +125,7 @@ public class LineReadingInputStreamTest {
   }
 
   @Test
-  public void testBothImplementation() throws Exception {
+  void testBothImplementation() throws Exception {
     ByteArrayInputStream bis1 =
         new ByteArrayInputStream(BLOCK.getBytes(StandardCharsets.ISO_8859_1));
     ByteArrayInputStream bis2 =
@@ -127,5 +140,99 @@ public class LineReadingInputStreamTest {
     }
     assertNull(lris1.readLine(MAX_LENGTH, BUFFER_SIZE, true));
     assertNull(lris2.readLineWithoutMarking(MAX_LENGTH, BUFFER_SIZE, true));
+  }
+
+  // ---- Merged advanced tests ----
+
+  @Test
+  @DisplayName("readLine_whenMaxLengthLessThanOne_returnNull")
+  void readLineWhenMaxLengthLessThanOneReturnNull() throws Exception {
+    byte[] data = "hello\n".getBytes(StandardCharsets.UTF_8);
+    try (LineReadingInputStream in = new LineReadingInputStream(new ByteArrayInputStream(data))) {
+      String line = in.readLine(0, BUFFER_SIZE, true);
+      assertNull(line);
+    }
+  }
+
+  @Test
+  @DisplayName("readLine_whenReadReturnsZero_throwEOFException")
+  void readLineWhenReadReturnsZeroThrowEOFException() throws Exception {
+    InputStream mocked = mock(InputStream.class);
+    when(mocked.markSupported()).thenReturn(true);
+    when(mocked.read(any(byte[].class), anyInt(), anyInt())).thenReturn(0);
+
+    LineReadingInputStream in = new LineReadingInputStream(mocked);
+    assertThrows(EOFException.class, () -> in.readLine(MAX_LENGTH, BUFFER_SIZE, true));
+    verify(mocked, atLeastOnce()).read(any(byte[].class), anyInt(), anyInt());
+    verify(mocked, never()).read();
+  }
+
+  @Test
+  @DisplayName("readLine_whenLineEqualsMaxLength_returnsLine")
+  void readLineWhenLineEqualsMaxLengthReturnsLine() throws Exception {
+    int maxLen = 100;
+    String line = "x".repeat(maxLen);
+    byte[] data = (line + "\n").getBytes(StandardCharsets.UTF_8);
+    try (LineReadingInputStream in = new LineReadingInputStream(new ByteArrayInputStream(data))) {
+      String result = in.readLine(maxLen, maxLen + 8, true);
+      assertEquals(line, result);
+    }
+  }
+
+  @Test
+  @DisplayName("readLineWithoutMarking_whenLongerThanMaxLength_throwTooLongException")
+  void readLineWithoutMarkingWhenLongerThanMaxLengthThrowTooLongException() throws Exception {
+    int maxLen = 10;
+    String line = "a".repeat(maxLen + 1);
+    try (LineReadingInputStream in =
+        new LineReadingInputStream(
+            new NonMarkingInputStream((line).getBytes(StandardCharsets.UTF_8)))) {
+      assertThrows(TooLongException.class, () -> in.readLineWithoutMarking(maxLen, 4, true));
+    }
+  }
+
+  @ParameterizedTest(name = "{index}: term=''{1}''")
+  @MethodSource("terminatorCases")
+  @DisplayName("readLine_whenDifferentTerminators_expectCorrectContent")
+  void readLineWhenDifferentTerminatorsExpectCorrectContent(String content, String term)
+      throws Exception {
+    byte[] data = (content + term).getBytes(StandardCharsets.ISO_8859_1);
+    try (LineReadingInputStream in = new LineReadingInputStream(new ByteArrayInputStream(data))) {
+      String result = in.readLine(MAX_LENGTH, BUFFER_SIZE, false);
+      String eof = in.readLine(MAX_LENGTH, BUFFER_SIZE, false);
+      assertEquals(content, result);
+      assertNull(eof);
+    }
+  }
+
+  static Stream<Arguments> terminatorCases() {
+    return Stream.of(
+        Arguments.of("", "\n"),
+        Arguments.of("abc", "\n"),
+        Arguments.of("abc", "\r\n"),
+        Arguments.of("only", ""));
+  }
+
+  @Test
+  @DisplayName("readLineWithoutMarking_whenBufferGrows_correctlyReturnsLongLine")
+  void readLineWithoutMarkingWhenBufferGrowsCorrectlyReturnsLongLine() throws Exception {
+    String line = "y".repeat(300);
+    byte[] data = (line + "\n").getBytes(StandardCharsets.UTF_8);
+    try (LineReadingInputStream in = new LineReadingInputStream(new NonMarkingInputStream(data))) {
+      String result = in.readLineWithoutMarking(512, 4, true);
+      assertEquals(line, result);
+    }
+  }
+
+  /** ByteArrayInputStream that disables mark/reset support to force non-marking path. */
+  private static final class NonMarkingInputStream extends ByteArrayInputStream {
+    NonMarkingInputStream(byte[] buf) {
+      super(buf);
+    }
+
+    @Override
+    public boolean markSupported() {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Summary
- LineReader: add comprehensive Javadoc describing line termination, decoding (UTF‑8/ISO‑8859‑1), return semantics at EOF, and TooLongException behavior.
- LineReadingInputStream:
  - Expand class/method Javadoc and document mark/reset behavior and limits.
  - Clamp initial buffer sizing and cap to maxLength+1 where appropriate; introduce helpers: initialBufferSize(), shouldGrow(), grow().
  - Make CRLF handling explicit (mark(maxLength+2) to allow CR + LF) and decode using supplied charset.
  - Refactor marked path into readMarkedLoop()/processChunkMarked() for clarity.
  - Clarify and enforce safe growth-after-append ordering so writes never overflow the current buffer (grow only before next append when needed).
- Tests (JUnit 6):
  - Convert legacy try/catch assertions to assertThrows.
  - Add edge-case tests: maxLength==0 returns null; read() returning 0 with markSupported() throws EOFException; exact-length line equals maxLength; non-marking path length overflow; parameterized terminator coverage ("", "\n", "\r\n").

Commits
- f3fdcb65b4 fix(LineReadingInputStream): correct comment for buffer writing safety
- 14afefee6b docs: clarify non-marking buffer growth invariants
- 5023a81304 docs: improve Javadoc and inline comments in LineReadingInputStream

Motivation & Context
- The previous comments around buffer growth could be misread to allow an off-by-one write. This PR clarifies and formalizes the ordering: append at index ctr is safe when ctr < buf.length; if the write fills the buffer, capacity is grown before the subsequent append.
- Javadoc across the reader/stream pair was sparse; this consolidates expected behavior, encoding choices, and error handling.

Compatibility & Risk
- No public API changes; behavior is unchanged except for clearer limits and error reporting in edge cases. CR/LF handling remains compatible.
- Targets Java 21+. Tests use JUnit 6 APIs already configured in the build.

How to test locally
- ./gradlew --parallel test --tests *LineReadingInputStreamTest

Notes
- Branch already exists on origin (feature/fix-LineReader).
