### PR TITLE
docs: clarify Javadoc for InsufficientDiskSpaceException

### DIFF
--- a/src/main/java/network/crypta/support/io/InsufficientDiskSpaceException.java
+++ b/src/main/java/network/crypta/support/io/InsufficientDiskSpaceException.java
@@ -3,6 +3,26 @@ package network.crypta.support.io;
 import java.io.IOException;
 import java.io.Serial;
 
+/**
+ * Signals that an I/O operation cannot proceed because there is not enough free disk space on
+ * the target filesystem.
+ *
+ * <p>This checked exception refines {@link IOException}. Code that allocates or grows files,
+ * expands on-disk data structures, or writes temporary data may throw this type to indicate that
+ * the operation should be aborted until additional space is made available.
+ *
+ * <p>Notes
+ * <ul>
+ *   <li>No additional state is carried by this exception; callers should include path and
+ *       capacity details in their own logs or error messages at the throw site if needed.</li>
+ *   <li>The class is immutable and thread-safe.</li>
+ *   <li>Typical recovery strategies include freeing disk space and retrying the operation.</li>
+ * </ul>
+ *
+ * <p>TODO: Document concrete thresholds/units used by callers (e.g., required bytes vs. free
+ * space percentage) once standardized.
+ */
 public class InsufficientDiskSpaceException extends IOException {
+  // Serialization compatibility identifier.
   @Serial private static final long serialVersionUID = 1795900904922247498L;
 }


### PR DESCRIPTION
Summary
- Add comprehensive Javadoc to `InsufficientDiskSpaceException` describing purpose, usage scenarios, recovery strategies, and immutability/thread-safety notes. No code changes.

Rationale
- Improves API clarity for callers that allocate/grow files or write temporary data. Encourages consistent handling and logging when disk space is insufficient.

Scope / Risk
- Comments only; no behavior, signatures, or formatting changed. Zero risk to runtime or ABI.

Testing & CI
- No functional changes. Usual build and tests should pass unchanged. Coverage unaffected.

Commits on this branch (relative to origin/develop)
```
1 0e7bbab7f2 docs(support/io): clarify Javadoc for InsufficientDiskSpaceException
```

Diffstat (src/ only)
```
src/main/java/network/crypta/support/io/InsufficientDiskSpaceException.java | 20 ++++++++++++++++++++
1 file changed, 20 insertions(+)
```

Notes
- Added a short inline comment for `serialVersionUID` purpose.
- Left a TODO in the Javadoc for documenting standardized thresholds/units once agreed.

Checklist
- [x] Follows repo coding/documentation guidelines
- [x] No public API/behavior change (docs only)
- [x] Builds locally
- [x] Ready for review