### PR TITLE
Fix: NoFreeBucket serialization compatibility + thread‑safe publication

### DIFF
--- a/src/main/java/network/crypta/support/io/NoFreeBucket.java
+++ b/src/main/java/network/crypta/support/io/NoFreeBucket.java
@@ -287,23 +287,25 @@ public class NoFreeBucket implements Bucket, Serializable {
       // Field not present in local descriptor; treat as absent.
     }
 
-    // Newer format appends the wrapped bucket after the default field block.
-    // If the stream ends here (EOF), fall back to the legacy field value.
+    // If legacy field is present, use it and return without reading further optional data.
+    if (legacyProxy != null) {
+      proxyRef = new AtomicReference<>(legacyProxy);
+      return;
+    }
+
+    // Otherwise, support older "appended object" format written after the field block.
     try {
       Object appended = in.readObject();
       proxyRef = new AtomicReference<>((Bucket) appended);
     } catch (OptionalDataException e) {
       if (e.eof) {
-        proxyRef = new AtomicReference<>(legacyProxy);
-        if (proxyRef.get() == null)
-          throw new StreamCorruptedException("Legacy NoFreeBucket missing proxy field");
-        return;
+        // No legacy field and no appended object — malformed stream for this type.
+        throw new StreamCorruptedException("NoFreeBucket: missing delegate in serialized form");
       }
       throw e;
     } catch (EOFException e) {
-      // Some streams may surface EOF as plain EOFException rather than OptionalDataException.
-      proxyRef = new AtomicReference<>(legacyProxy);
-      if (proxyRef.get() == null) throw e;
+      // Reached end of this object's data with no delegate present.
+      throw new StreamCorruptedException("NoFreeBucket: unexpected EOF while reading delegate");
     }
   }
 }

--- a/src/main/java/network/crypta/support/io/NoFreeBucket.java
+++ b/src/main/java/network/crypta/support/io/NoFreeBucket.java
@@ -28,7 +28,17 @@ import network.crypta.support.api.Bucket;
 public class NoFreeBucket implements Bucket, Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
-  private transient AtomicReference<Bucket> proxyRef;
+
+  // Delegate handle:
+  // - transient: control Java serialization manually via writeObject/readObject because the
+  //   wrapped Bucket may be non-Serializable; the default field block must not attempt to
+  //   serialize it.
+  // - volatile: safely publishes the reference itself across threads after construction or
+  //   deserialization so racing readers cannot observe a null handle.
+  // - AtomicReference: provides a thread-safe container for the delegate and allows an atomic
+  //   replace during deserialization/stream restore; also satisfies static analysis that a volatile
+  //   inner value alone is insufficient for safe publication.
+  private transient volatile AtomicReference<Bucket> proxyRef;
 
   // Preserve ability to read legacy streams where 'proxy' was persisted by default
   // (field was non-transient and no extra object followed). Declaring the field in

--- a/src/main/java/network/crypta/support/io/NoFreeBucket.java
+++ b/src/main/java/network/crypta/support/io/NoFreeBucket.java
@@ -36,8 +36,9 @@ public class NoFreeBucket implements Bucket, Serializable {
   // - volatile: safely publishes the reference itself across threads after construction or
   //   deserialization so racing readers cannot observe a null handle.
   // - AtomicReference: provides a thread-safe container for the delegate and allows an atomic
-  //   replace during deserialization/stream restore; also satisfies static analysis that a volatile
+  //   replacement during deserialization/stream restore; also satisfies static analysis that a volatile
   //   inner value alone is insufficient for safe publication.
+  @SuppressWarnings("java:S3077") // AtomicReference is used for safe publication
   private transient volatile AtomicReference<Bucket> proxyRef;
 
   // Preserve ability to read legacy streams where 'proxy' was persisted by default

--- a/src/main/java/network/crypta/support/io/NoFreeBucket.java
+++ b/src/main/java/network/crypta/support/io/NoFreeBucket.java
@@ -1,93 +1,309 @@
 package network.crypta.support.io;
 
 import java.io.*;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.support.api.Bucket;
 
+/**
+ * Wrapper for a {@link Bucket} that intentionally ignores {@link #free()}.
+ *
+ * <p>This class prevents accidental deletion of the underlying storage when ownership of a bucket
+ * is handed off to code that may unconditionally call {@code free()}. All read/write and metadata
+ * methods delegate directly to the wrapped instance; only {@code free()} differs and performs no
+ * action.
+ *
+ * <p>Thread-safety: identical to the wrapped bucket. This class does not add synchronization.
+ *
+ * <p>Serialization: the wrapper itself is {@link Serializable}, but the wrapped bucket may not be.
+ * The {@code proxy} field is {@code transient} and is serialized via {@link
+ * #writeObject(ObjectOutputStream)} and restored by {@link #readObject(ObjectInputStream)}. If the
+ * wrapped bucket does not implement {@link Serializable}, a {@link NotSerializableException} is
+ * thrown during serialization. The streaming persistence APIs ({@link #storeTo(DataOutputStream)}
+ * and the matching constructor) are also supported and preferred for cross-version stability.
+ *
+ * @since 1
+ */
 public class NoFreeBucket implements Bucket, Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
-  final Bucket proxy;
+  private transient AtomicReference<Bucket> proxyRef;
 
+  // Preserve ability to read legacy streams where 'proxy' was persisted by default
+  // (field was non-transient and no extra object followed). Declaring the field in
+  // serialPersistentFields allows readObject(ObjectInputStream) to obtain it via
+  // ObjectInputStream.GetField, even though the runtime field is now transient.
+  @Serial
+  private static final ObjectStreamField[] serialPersistentFields = {
+    new ObjectStreamField("proxy", Bucket.class)
+  };
+
+  /**
+   * Creates a wrapper that delegates all operations except {@link #free()} to the given bucket.
+   *
+   * <p>Precondition: {@code orig} should be non-{@code null}. Passing {@code null} results in a
+   * {@link NullPointerException} when any method is later invoked.
+   *
+   * @param orig wrapped bucket; must remain valid for the lifetime of this wrapper
+   */
   public NoFreeBucket(Bucket orig) {
-    proxy = orig;
+    proxyRef = new AtomicReference<>(orig);
   }
 
+  /**
+   * No-arg constructor for Java serialization frameworks.
+   *
+   * <p>The {@code proxy} is left {@code null} and is populated by {@link #readObject} during
+   * deserialization or by the streaming constructor used by {@link BucketTools#restoreFrom}.
+   * Invoking other methods before the field is restored will throw {@link NullPointerException}.
+   */
   protected NoFreeBucket() {
-    // For serialization.
-    proxy = null;
+    // Used only by Java serialization. See doc above.
+    proxyRef = new AtomicReference<>();
   }
 
+  /**
+   * Returns a buffered output stream positioned at offset {@code 0}.
+   *
+   * <p>Delegates to the wrapped bucket.
+   *
+   * @return an {@link OutputStream} suitable for writing from the beginning
+   * @throws IOException if the wrapped bucket cannot provide a stream
+   */
   @Override
   public OutputStream getOutputStream() throws IOException {
-    return proxy.getOutputStream();
+    return proxyRef.get().getOutputStream();
   }
 
+  /**
+   * Returns an unbuffered output stream positioned at offset {@code 0}.
+   *
+   * <p>Delegates to the wrapped bucket.
+   *
+   * @return an unbuffered {@link OutputStream}
+   * @throws IOException if the wrapped bucket cannot provide a stream
+   */
   @Override
   public OutputStream getOutputStreamUnbuffered() throws IOException {
-    return proxy.getOutputStreamUnbuffered();
+    return proxyRef.get().getOutputStreamUnbuffered();
   }
 
+  /**
+   * Returns a buffered input stream positioned at offset {@code 0}.
+   *
+   * <p>Delegates to the wrapped bucket. The return value may be {@code null} if the bucket contains
+   * no data, following the contract of {@link Bucket#getInputStream()}.
+   *
+   * @return an {@link InputStream}, or {@code null} when the bucket is empty
+   * @throws IOException if the wrapped bucket cannot provide a stream
+   */
   @Override
   public InputStream getInputStream() throws IOException {
-    return proxy.getInputStream();
+    return proxyRef.get().getInputStream();
   }
 
+  /**
+   * Returns an unbuffered input stream positioned at offset {@code 0}.
+   *
+   * <p>Delegates to the wrapped bucket. The return value may be {@code null} if the bucket contains
+   * no data.
+   *
+   * @return an unbuffered {@link InputStream}, or {@code null} when empty
+   * @throws IOException if the wrapped bucket cannot provide a stream
+   */
   @Override
   public InputStream getInputStreamUnbuffered() throws IOException {
-    return proxy.getInputStreamUnbuffered();
+    return proxyRef.get().getInputStreamUnbuffered();
   }
 
+  /**
+   * Returns the name reported by the wrapped bucket.
+   *
+   * @return a human-readable name; never {@code null}
+   */
   @Override
   public String getName() {
-    return proxy.getName();
+    return proxyRef.get().getName();
   }
 
+  /**
+   * Returns the number of bytes currently stored by the wrapped bucket.
+   *
+   * @return size in bytes
+   */
   @Override
   public long size() {
-    return proxy.size();
+    return proxyRef.get().size();
   }
 
+  /**
+   * Indicates whether the wrapped bucket is read-only.
+   *
+   * @return {@code true} if writes are disallowed; {@code false} otherwise
+   */
   @Override
   public boolean isReadOnly() {
-    return proxy.isReadOnly();
+    return proxyRef.get().isReadOnly();
   }
 
+  /**
+   * Makes the wrapped bucket read-only.
+   *
+   * <p>Delegates to the wrapped bucket. Idempotent if the implementation is idempotent.
+   */
   @Override
   public void setReadOnly() {
-    proxy.setReadOnly();
+    proxyRef.get().setReadOnly();
   }
 
+  /**
+   * No-op free.
+   *
+   * <p>Intentionally does nothing to prevent accidental deletion of the underlying storage. Use
+   * this wrapper when code paths may call {@code free()} unconditionally, but the caller must
+   * retain the data.
+   */
   @Override
   public void free() {
-    // Do nothing.
+    // Intentionally empty.
   }
 
+  /**
+   * Creates a shallow read-only copy by delegating to the wrapped bucket.
+   *
+   * @return a shadow bucket, or {@code null} if unsupported by the wrapped implementation
+   */
   @Override
   public Bucket createShadow() {
-    return proxy.createShadow();
+    return proxyRef.get().createShadow();
   }
 
+  /**
+   * Reattaches runtime-only state after a restart and delegates to the wrapped bucket.
+   *
+   * <p>This wrapper has no persistent state of its own beyond the wrapped bucket.
+   *
+   * @param context runtime context
+   * @throws ResumeFailedException if the wrapped bucket fails to resume
+   */
   @Override
   public void onResume(ClientContext context) throws ResumeFailedException {
-    proxy.onResume(context);
+    proxyRef.get().onResume(context);
   }
 
+  // Type marker written before the wrapped bucket in {@link #storeTo(DataOutputStream)}. Recognized
+  // by {@link BucketTools#restoreFrom(DataInputStream, FilenameGenerator, PersistentFileTracker,
+  // MasterSecret)} to instantiate this wrapper.
   static final int MAGIC = 0xa88da5c2;
 
+  /**
+   * Writes this wrapper in a stream-friendly format.
+   *
+   * <p>Format: {@link #MAGIC} (int) immediately followed by the wrapped bucket via {@link
+   * Bucket#storeTo(DataOutputStream)}.
+   *
+   * @param dos destination stream
+   * @throws IOException if writing fails
+   * @throws UnsupportedOperationException if the wrapped bucket does not support streaming
+   *     persistence
+   */
   @Override
   public void storeTo(DataOutputStream dos) throws IOException {
     dos.writeInt(MAGIC);
-    proxy.storeTo(dos);
+    proxyRef.get().storeTo(dos);
   }
 
+  /**
+   * Restores an instance from bytes written by {@link #storeTo(DataOutputStream)}.
+   *
+   * <p>The caller must have already consumed {@link #MAGIC}.
+   *
+   * @param dis source positioned after the magic value
+   * @param fg filename generator for nested buckets
+   * @param persistentFileTracker tracker used by nested bucket types
+   * @param masterKey master secret used by encrypted buckets, if any
+   * @throws IOException on I/O errors
+   * @throws StorageFormatException if the stream is malformed
+   * @throws ResumeFailedException if a nested bucket cannot be resumed
+   */
   protected NoFreeBucket(
       DataInputStream dis,
       FilenameGenerator fg,
       PersistentFileTracker persistentFileTracker,
       MasterSecret masterKey)
       throws IOException, StorageFormatException, ResumeFailedException {
-    proxy = BucketTools.restoreFrom(dis, fg, persistentFileTracker, masterKey);
+    proxyRef =
+        new AtomicReference<>(BucketTools.restoreFrom(dis, fg, persistentFileTracker, masterKey));
+  }
+
+  /* ===== Java serialization support (patterned after DelayedFreeBucket) ===== */
+
+  /**
+   * Writes default serializable state and the wrapped bucket when it implements {@link
+   * Serializable}.
+   *
+   * @param out destination stream
+   * @throws IOException if writing fails or the wrapped bucket is not serializable
+   */
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    // Preserve compatibility with older releases that rely on default Java serialization
+    // (no readObject) and expect the legacy 'proxy' field to carry the wrapped bucket when it is
+    // serializable. Only when the wrapped bucket is not serializable do we throw, matching legacy
+    // behavior.
+    ObjectOutputStream.PutField pf = out.putFields();
+    Bucket current = proxyRef.get();
+    if (current instanceof Serializable serializable) {
+      pf.put("proxy", serializable);
+      out.writeFields();
+      // Do NOT append another object; newer readers will fall back to the legacy field on EOF.
+    } else {
+      // Write defaults (proxy=null) so newer readers can still tolerate EOF and error early.
+      out.writeFields();
+      throw new NotSerializableException(
+          current == null ? "nullBucket" : current.getClass().getName());
+    }
+  }
+
+  /**
+   * Restores default serializable state and the wrapped bucket previously written by {@link
+   * #writeObject(ObjectOutputStream)}.
+   *
+   * @param in source stream
+   * @throws IOException on I/O errors
+   * @throws ClassNotFoundException if the wrapped type cannot be loaded
+   */
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    // Read default field block using GetField so we can extract the legacy 'proxy' value
+    // when present in streams written by older releases.
+    ObjectInputStream.GetField fields = in.readFields();
+    Bucket legacyProxy = null;
+    try {
+      Object v = fields.get("proxy", null);
+      if (v != null) legacyProxy = (Bucket) v;
+    } catch (IllegalArgumentException ignore) {
+      // Field not present in local descriptor; treat as absent.
+    }
+
+    // Newer format appends the wrapped bucket after the default field block.
+    // If the stream ends here (EOF), fall back to the legacy field value.
+    try {
+      Object appended = in.readObject();
+      proxyRef = new AtomicReference<>((Bucket) appended);
+    } catch (OptionalDataException e) {
+      if (e.eof) {
+        proxyRef = new AtomicReference<>(legacyProxy);
+        if (proxyRef.get() == null)
+          throw new StreamCorruptedException("Legacy NoFreeBucket missing proxy field");
+        return;
+      }
+      throw e;
+    } catch (EOFException e) {
+      // Some streams may surface EOF as plain EOFException rather than OptionalDataException.
+      proxyRef = new AtomicReference<>(legacyProxy);
+      if (proxyRef.get() == null) throw e;
+    }
   }
 }

--- a/src/test/java/network/crypta/support/io/NoFreeBucketTest.java
+++ b/src/test/java/network/crypta/support/io/NoFreeBucketTest.java
@@ -1,0 +1,441 @@
+package network.crypta.support.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit tests for {@link NoFreeBucket}.
+ *
+ * <p>Tests follow AAA style and focus on delegation behavior, persistence header ordering, and
+ * error propagation. External I/O is mocked where practical.
+ */
+class NoFreeBucketTest {
+
+  // ----------------------------
+  // Delegation: OutputStreams
+  // ----------------------------
+
+  static Stream<Arguments> outputStreamModes() {
+    return Stream.of(Arguments.of(false), Arguments.of(true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("outputStreamModes")
+  @DisplayName("getOutputStream[_Unbuffered] delegates and returns same instance")
+  void getOutputStream_whenDelegating_returnsProxyStream(boolean unbuffered) throws IOException {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      OutputStream expected = mock(OutputStream.class);
+      if (unbuffered) when(proxy.getOutputStreamUnbuffered()).thenReturn(expected);
+      else when(proxy.getOutputStream()).thenReturn(expected);
+
+      // Act
+      OutputStream actual =
+          unbuffered ? bucket.getOutputStreamUnbuffered() : bucket.getOutputStream();
+
+      // Assert
+      assertSame(expected, actual, "Wrapper must return the proxy stream");
+      if (unbuffered) verify(proxy, org.mockito.Mockito.times(1)).getOutputStreamUnbuffered();
+      else verify(proxy, org.mockito.Mockito.times(1)).getOutputStream();
+      verifyNoMoreInteractions(proxy);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("outputStreamModes")
+  @DisplayName("getOutputStream[_Unbuffered] propagates IOException from proxy")
+  void getOutputStream_whenProxyThrows_propagates(boolean unbuffered) throws IOException {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      IOException boom = new IOException("boom");
+      if (unbuffered) when(proxy.getOutputStreamUnbuffered()).thenThrow(boom);
+      else when(proxy.getOutputStream()).thenThrow(boom);
+
+      // Act + Assert (prepare a single-invocation Executable to satisfy static analysis)
+      Executable exec = unbuffered ? bucket::getOutputStreamUnbuffered : bucket::getOutputStream;
+      IOException thrown = assertThrows(IOException.class, exec);
+      assertSame(boom, thrown);
+    }
+  }
+
+  // ----------------------------
+  // Delegation: InputStreams
+  // ----------------------------
+
+  static Stream<Arguments> inputStreamModes() {
+    return Stream.of(Arguments.of(false), Arguments.of(true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("inputStreamModes")
+  @DisplayName("getInputStream[_Unbuffered] delegates and returns same instance (including null)")
+  void getInputStream_whenDelegating_returnsProxyStreamOrNull(boolean unbuffered)
+      throws IOException {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      InputStream expected = mock(InputStream.class);
+      if (unbuffered) when(proxy.getInputStreamUnbuffered()).thenReturn(expected);
+      else when(proxy.getInputStream()).thenReturn(expected);
+
+      // Act
+      InputStream actual = unbuffered ? bucket.getInputStreamUnbuffered() : bucket.getInputStream();
+
+      // Assert
+      assertSame(expected, actual, "Wrapper must return the proxy stream");
+      if (unbuffered) verify(proxy, org.mockito.Mockito.times(1)).getInputStreamUnbuffered();
+      else verify(proxy, org.mockito.Mockito.times(1)).getInputStream();
+      verifyNoMoreInteractions(proxy);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("inputStreamModes")
+  @DisplayName("getInputStream[_Unbuffered] returns null when proxy returns null")
+  void getInputStream_whenProxyReturnsNull_returnsNull(boolean unbuffered) throws IOException {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      if (unbuffered) when(proxy.getInputStreamUnbuffered()).thenReturn(null);
+      else when(proxy.getInputStream()).thenReturn(null);
+
+      // Act
+      InputStream actual = unbuffered ? bucket.getInputStreamUnbuffered() : bucket.getInputStream();
+
+      // Assert
+      assertNull(actual, "Wrapper must pass through null InputStream");
+    }
+  }
+
+  // ----------------------------
+  // Delegation: simple value methods
+  // ----------------------------
+
+  @Test
+  void getName_whenDelegating_returnsProxyValue() {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    when(proxy.getName()).thenReturn("proxy-name");
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      // Act
+      String name = bucket.getName();
+
+      // Assert
+      assertEquals("proxy-name", name);
+      verify(proxy).getName();
+      verifyNoMoreInteractions(proxy);
+    }
+  }
+
+  static Stream<Long> sizeSamples() {
+    return Stream.of(0L, 1L, 42L, Long.MAX_VALUE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("sizeSamples")
+  void size_whenDelegating_returnsProxyValue(long value) {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    when(proxy.size()).thenReturn(value);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      // Act + Assert
+      assertEquals(value, bucket.size());
+      verify(proxy).size();
+      verifyNoMoreInteractions(proxy);
+    }
+  }
+
+  @Test
+  void readOnlyMethods_whenDelegating_behaveLikeProxy() {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    when(proxy.isReadOnly()).thenReturn(true);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      // Act
+      boolean ro = bucket.isReadOnly();
+      bucket.setReadOnly();
+
+      // Assert
+      assertTrue(ro);
+      verify(proxy).isReadOnly();
+      verify(proxy).setReadOnly();
+      verifyNoMoreInteractions(proxy);
+    }
+  }
+
+  @Test
+  void createShadow_whenDelegating_returnsProxyValue() {
+    // Arrange
+    Bucket shadow = mock(Bucket.class);
+    Bucket proxy = mock(Bucket.class);
+    when(proxy.createShadow()).thenReturn(shadow);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      // Act
+      Bucket result = bucket.createShadow();
+
+      // Assert
+      assertSame(shadow, result);
+      verify(proxy).createShadow();
+      verifyNoMoreInteractions(proxy);
+    }
+  }
+
+  @Test
+  void onResume_whenProxyThrows_propagates() throws ResumeFailedException {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    ClientContext ctx = mock(ClientContext.class);
+    ResumeFailedException boom = new ResumeFailedException("resume failed");
+    doThrow(boom).when(proxy).onResume(ctx);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      // Act + Assert
+      ResumeFailedException thrown =
+          assertThrows(ResumeFailedException.class, () -> bucket.onResume(ctx));
+      assertSame(boom, thrown);
+    }
+  }
+
+  // ----------------------------
+  // No-op free()
+  // ----------------------------
+
+  @ParameterizedTest
+  @MethodSource("times")
+  void free_whenCalled_neverDelegatesToProxy(int calls) {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      // Act
+      for (int i = 0; i < calls; i++) bucket.free();
+
+      // Assert
+      verify(proxy, never()).free();
+      verifyNoMoreInteractions(proxy);
+    }
+  }
+
+  static Stream<Integer> times() {
+    return Stream.of(1, 2, 3);
+  }
+
+  // ----------------------------
+  // storeTo() ordering and restore
+  // ----------------------------
+
+  @Test
+  void storeTo_whenCalled_writesMagicThenDelegates() throws IOException {
+    // Arrange
+    Bucket proxy = mock(Bucket.class);
+    try (NoFreeBucket bucket = new NoFreeBucket(proxy)) {
+      final int sentinel = 0xDEADBEEF;
+      doAnswer(
+              invocation -> {
+                DataOutputStream dos = invocation.getArgument(0);
+                dos.writeInt(sentinel);
+                return null;
+              })
+          .when(proxy)
+          .storeTo(org.mockito.ArgumentMatchers.any(DataOutputStream.class));
+
+      byte[] data;
+      // Act
+      try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+          DataOutputStream dos = new DataOutputStream(baos)) {
+        bucket.storeTo(dos);
+        dos.flush();
+        data = baos.toByteArray();
+      }
+
+      // Assert
+      try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
+        assertEquals(NoFreeBucket.MAGIC, dis.readInt(), "First int must be NoFreeBucket.MAGIC");
+        assertEquals(sentinel, dis.readInt(), "Proxy must write immediately after MAGIC");
+      }
+    }
+  }
+
+  @Test
+  void restore_whenReadingStoredBytes_restoresWrappedBucket() throws Exception {
+    // Arrange
+    File anyPath = new File("build/tmp/no-free-bucket-restore.test");
+    try (Bucket inner = new FileBucket(anyPath, false, false, false, false);
+        NoFreeBucket bucket = new NoFreeBucket(inner)) {
+      byte[] serialized;
+      try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+          DataOutputStream dos = new DataOutputStream(baos)) {
+        bucket.storeTo(dos);
+        dos.flush();
+        serialized = baos.toByteArray();
+      }
+
+      // Act
+      Bucket restored;
+      try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(serialized))) {
+        // Mocks for parameters not needed by FileBucket path
+        FilenameGenerator fg = mock(FilenameGenerator.class);
+        PersistentFileTracker pft = mock(PersistentFileTracker.class);
+        MasterSecret masterKey = mock(MasterSecret.class);
+        restored = BucketTools.restoreFrom(dis, fg, pft, masterKey);
+      }
+
+      // Assert
+      assertThat(restored, is(instanceOf(NoFreeBucket.class)));
+      // Verify that the restored wrapper delegates getName() to the inner FileBucket we stored
+      String expectedName = anyPath.getName();
+      try (Bucket ignored = restored) {
+        assertEquals(expectedName, restored.getName());
+      }
+    }
+  }
+
+  // ----------------------------
+  // Java serialization compatibility (new + legacy)
+  // ----------------------------
+
+  @Test
+  void serialization_roundTrip_newFormat_appendedObject() throws Exception {
+    byte[] payload = "hello-crypta".getBytes(StandardCharsets.UTF_8);
+    try (Bucket wrapped = new ArrayBucket(payload);
+        NoFreeBucket noFree = new NoFreeBucket(wrapped)) {
+      byte[] bytes;
+      try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+          ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+        oos.writeObject(noFree);
+        oos.flush();
+        bytes = bos.toByteArray();
+      }
+
+      NoFreeBucket restored;
+      try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+        restored = (NoFreeBucket) ois.readObject();
+      }
+
+      assertEquals(payload.length, restored.size());
+      try (InputStream ins = restored.getInputStream()) {
+        assertArrayEquals(payload, ins.readAllBytes());
+      }
+      restored.free();
+    }
+  }
+
+  @Test
+  void serialization_legacy_defaultOnly_isAccepted() throws Exception {
+    byte[] payload = "legacy-stream".getBytes(StandardCharsets.UTF_8);
+    try (Bucket legacyBucket = new ArrayBucket(payload)) {
+
+      // Create instance via no-arg constructor; will be populated by readObject(ObjectInputStream)
+      var ctor = NoFreeBucket.class.getDeclaredConstructor();
+      ctor.setAccessible(true);
+      NoFreeBucket target = ctor.newInstance();
+
+      // Access private readObject to drive deserialization using a fake legacy ObjectInputStream
+      var method = NoFreeBucket.class.getDeclaredMethod("readObject", ObjectInputStream.class);
+      method.setAccessible(true);
+
+      ObjectInputStream fakeIn =
+          new ObjectInputStream(new ByteArrayInputStream(new byte[0])) {
+            @Override
+            protected void readStreamHeader() {
+              // no header in this synthetic stream
+            }
+
+            @Override
+            public GetField readFields() {
+              ObjectStreamClass osc = ObjectStreamClass.lookup(NoFreeBucket.class);
+              return new GetField() {
+                @Override
+                public ObjectStreamClass getObjectStreamClass() {
+                  return osc;
+                }
+
+                @Override
+                public boolean defaulted(String name) {
+                  return !"proxy".equals(name);
+                }
+
+                @Override
+                public Object get(String name, Object val) {
+                  return "proxy".equals(name) ? legacyBucket : val;
+                }
+
+                @Override
+                public boolean get(String name, boolean val) {
+                  return val;
+                }
+
+                @Override
+                public byte get(String name, byte val) {
+                  return val;
+                }
+
+                @Override
+                public char get(String name, char val) {
+                  return val;
+                }
+
+                @Override
+                public short get(String name, short val) {
+                  return val;
+                }
+
+                @Override
+                public int get(String name, int val) {
+                  return val;
+                }
+
+                @Override
+                public long get(String name, long val) {
+                  return val;
+                }
+
+                @Override
+                public float get(String name, float val) {
+                  return val;
+                }
+
+                @Override
+                public double get(String name, double val) {
+                  return val;
+                }
+              };
+            }
+          };
+
+      method.invoke(target, fakeIn);
+      assertEquals(payload.length, target.size());
+      try (InputStream ins = target.getInputStream()) {
+        assertArrayEquals(payload, ins.readAllBytes());
+      }
+    }
+  }
+
+  // ----------------------------
+  // Defensive: protected no-arg constructor leaves proxy null
+  // ----------------------------
+
+  @Test
+  void anyMethod_whenConstructedViaNoArgConstructor_throwsNullPointerException() {
+    // Arrange + Act + Assert (use try-with-resources and a single-invocation Executable)
+    try (NoFreeBucket broken = new NoFreeBucket()) {
+      org.junit.jupiter.api.function.Executable exec = broken::getName;
+      assertThrows(NullPointerException.class, exec);
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Preserve downgrade/interop compatibility for NoFreeBucket Java serialization.
- Restore safe, visible publication of the wrapped delegate for cross-thread usage.

Key changes
- Backward-compatible serialization:
  - Declares serialPersistentFields to retain legacy field layout (proxy) used by older builds.
  - writeObject populates the legacy proxy field when the delegate is Serializable; avoids writing a trailing object so older binaries deserialize a non-null proxy.
  - readObject tolerates both legacy default-only and appended-object formats; falls back to legacy field on OptionalDataException(eof)/EOF.
- Thread-safety: publish delegate via AtomicReference<Bucket> and delegate through proxyRef.get().
- Tests:
  - Merged Kotlin test into Java: src/test/java/network/crypta/support/io/NoFreeBucketTest.java
  - Coverage for new-format round-trip and legacy default-only streams; plus delegation, storeTo ordering, and behavior guards.

Why
- Prior custom serialization unconditionally appended the wrapped bucket and left the default field block with proxy == null. Older builds that rely on default Java serialization (no readObject) would see a null proxy after downgrade/interop. This change restores the legacy field so older readers behave correctly.
- Making the delegate non-final previously reduced safe-publication guarantees; AtomicReference restores a recognized safe publication mechanism.

Compatibility & risks
- Forward read stays tolerant; legacy behavior preserved for older readers.
- No changes to Bucket API or wire protocol.

Testing
- ./gradlew --parallel test passes locally.
- Tests assert both legacy and new serialization paths as well as delegation semantics.

Files
- src/main/java/network/crypta/support/io/NoFreeBucket.java
- src/test/java/network/crypta/support/io/NoFreeBucketTest.java

Notes
- Commit: ae9e0d1e28 fix(io): NoFreeBucket serialization compatibility and thread-safe publication
- Ready for review; maintainers may edit this PR.