### PR TITLE
docs(io): clarify PersistentFileTracker Javadoc and semantics

### DIFF
--- a/src/main/java/network/crypta/support/io/NoFreeBucket.java
+++ b/src/main/java/network/crypta/support/io/NoFreeBucket.java
@@ -36,7 +36,8 @@ public class NoFreeBucket implements Bucket, Serializable {
   // - volatile: safely publishes the reference itself across threads after construction or
   //   deserialization so racing readers cannot observe a null handle.
   // - AtomicReference: provides a thread-safe container for the delegate and allows an atomic
-  //   replacement during deserialization/stream restore; also satisfies static analysis that a volatile
+  //   replacement during deserialization/stream restore; also satisfies static analysis that a
+  // volatile
   //   inner value alone is insufficient for safe publication.
   @SuppressWarnings("java:S3077") // AtomicReference is used for safe publication
   private transient volatile AtomicReference<Bucket> proxyRef;

--- a/src/main/java/network/crypta/support/io/PersistentFileTracker.java
+++ b/src/main/java/network/crypta/support/io/PersistentFileTracker.java
@@ -2,31 +2,92 @@ package network.crypta.support.io;
 
 import java.io.File;
 
+/**
+ * Coordinates persistent temporary files and deferred resource freeing across restarts and commit
+ * boundaries.
+ *
+ * <p>This contract is used by the persistence subsystem to:
+ *
+ * <ul>
+ *   <li>Claim pre-existing temporary files discovered during startup so they are not removed by the
+ *       post-startup cleanup.
+ *   <li>Expose a monotonic commit barrier identifier via {@link #commitID()} that callers record at
+ *       creation time and later present back to {@link #delayedFree(DelayedFree, long)} when a
+ *       resource is being freed.
+ *   <li>Schedule actual deletion of resources implementing {@link DelayedFree} only after the
+ *       transaction recording their deletion has been durably persisted, to avoid data loss on
+ *       unclean shutdowns.
+ *   <li>Provide access to the persistent temporary directory and its {@link FilenameGenerator}.
+ * </ul>
+ *
+ * <p>This interface also extends {@link DiskSpaceChecker}; implementations should use the same
+ * directory context when evaluating free-space policies.
+ *
+ * <p><strong>Threading:</strong> Callers may invoke methods from multiple threads. Implementations
+ * should be thread-safe and avoid long blocking operations on hot paths.
+ *
+ * <p><strong>Exceptions:</strong> None of the methods declare checked exceptions. Implementations
+ * should prefer returning normally (or logging) for expected conditions and only throw for fatal
+ * errors unrelated to low disk space or routine cleanup.
+ */
 public interface PersistentFileTracker extends DiskSpaceChecker {
 
   /**
-   * While resuming, register a file with the garbage collector so that it doesn't get deleted when
-   * startup has finished and we cleanup the persistent-temp dir. We will only delete files which
-   * were present at startup and have not been claimed; new files are fine.
+   * Claims an existing temporary file during startup so it is not deleted by the one-time cleanup
+   * that follows initialization.
+   *
+   * <p>Typical usage: while restoring state at node startup, components that reconstruct buckets or
+   * buffers call this method to mark files they own. After initialization completes, the
+   * implementation removes any unclaimed files that match its naming scheme. Files created after
+   * startup do not need to be registered.
+   *
+   * @param file file under the persistent temporary directory to retain; must be non-{@code null}
    */
   void register(File file);
 
-  /** A positive number incremented on every transaction. */
+  /**
+   * Returns the current commit barrier identifier.
+   *
+   * <p>The value is strictly positive and monotonically increases when the implementation advances
+   * to a new persistence window (for example, after handing off a batch of deletions to be freed
+   * post-commit). Callers capture this value when creating a resource and pass it back to {@link
+   * #delayedFree(DelayedFree, long)} when releasing that resource so the tracker can decide whether
+   * freeing is safe immediately or must be deferred until after the next successful commit.
+   *
+   * @return a positive, monotonically increasing identifier
+   */
   long commitID();
 
   /**
-   * Notify that we have finished with a bucket and it should be freed after the next serialization
-   * to disk.
+   * Requests that a resource be freed, deferring the actual release until it is safe to do so.
    *
-   * @param bucket The bucket to free.
-   * @param createdCommitID 0 if the bucket was created before the last node restart, otherwise the
-   *     return value of commitID() when it was created. If there hasn't been a commit, we can free
-   *     the bucket immediately...
+   * <p>If {@code createdCommitID} equals the current {@link #commitID()}, implementations may call
+   * {@link DelayedFree#realFree()} immediately because no commit barrier is required. Otherwise,
+   * they queue the resource and perform the release only after the next successful persistence
+   * commit. Implementations also typically treat {@code createdCommitID == 0} as “created before
+   * the last restart”, which always requires deferral until after a commit. TODO: Confirm the exact
+   * semantics for {@code 0} across all implementations.
+   *
+   * <p>Concurrency: callers may invoke this from I/O threads. Implementations should synchronize
+   * their internal state as needed.
+   *
+   * @param bucket resource to free after the appropriate commit barrier
+   * @param createdCommitID the {@link #commitID()} value captured when the resource was created; 0
+   *     indicates creation before the last restart in typical implementations
    */
   void delayedFree(DelayedFree bucket, long createdCommitID);
 
-  /** Get the persistent temp files directory. */
+  /**
+   * Returns the directory used to store persistent temporary files.
+   *
+   * @return the canonical temporary directory managed by this tracker
+   */
   File getDir();
 
+  /**
+   * Returns the filename generator bound to the persistent temporary directory.
+   *
+   * @return the generator used for naming and migration of temp files
+   */
   FilenameGenerator getGenerator();
 }


### PR DESCRIPTION
Summary
- Clarifies and expands the Javadoc for PersistentFileTracker and adjusts a minor comment wrap in NoFreeBucket. No functional code changes.

Why
- Make the contract around commit barriers, delayed free semantics, threading, and error handling explicit for implementers and callers.

Scope
- src/main/java/network/crypta/support/io/PersistentFileTracker.java: expanded Javadoc, added threading/exception guidance.
- src/main/java/network/crypta/support/io/NoFreeBucket.java: minor Spotless reflow of a wrapped comment.

Commits on this branch since origin/develop
- e19aaefe75 docs(io): clarify PersistentFileTracker Javadoc and semantics
  - Expand interface-level overview and threading notes
  - Document register(), commitID(), delayedFree() behavior and commit barrier
  - Add TODO on createdCommitID==0 semantics
  - Run Spotless (minor comment wrap in NoFreeBucket)

Diff Summary (src)
- 2 files changed, 74 insertions(+), 12 deletions(-)

Notes
- No runtime behavior changes; tests and coverage unaffected.
- Ready for review; happy to split further if desired.