### PR TITLE
io: PrependLengthOutputStream — unit tests + improved Javadoc

### DIFF
--- a/src/main/java/network/crypta/support/io/PrependLengthOutputStream.java
+++ b/src/main/java/network/crypta/support/io/PrependLengthOutputStream.java
@@ -6,10 +6,36 @@ import java.io.IOException;
 import java.io.OutputStream;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * Write to a temporary Bucket. On close, if not abort()'ed, write length and then copy the data.
- * Does not close the underlying Bucket.
+ * Output stream that buffers into a temporary {@link network.crypta.support.api.Bucket} and, on
+ * close, prepends an 8-byte length header before copying the payload to a caller-provided {@link
+ * OutputStream}.
+ *
+ * <p>Data written to this stream is accumulated in a temporary {@code Bucket}. When {@link
+ * #close()} is called:
+ *
+ * <ol>
+ *   <li>If {@link #abort()} was invoked earlier, the stream writes a {@code long} value of {@code
+ *       0} to the underlying stream and writes no payload bytes.
+ *   <li>Otherwise, it writes a {@code long} header equal to {@code temp.size() - offset} and then
+ *       copies the entire buffered payload from the temporary {@code Bucket} to the underlying
+ *       stream.
+ * </ol>
+ *
+ * The temporary {@code Bucket} is always freed. The underlying stream is closed only when the
+ * {@code closeUnderlying} flag is set at construction time (see {@link #create(OutputStream,
+ * BucketFactory, int, boolean)}).
+ *
+ * <p>Header format: the 8-byte value is written via {@link
+ * java.io.DataOutputStream#writeLong(long)} (big-endian). The value is computed as the buffered
+ * size minus {@code offset}; if {@code offset} exceeds the buffered size, a negative value is
+ * written. Note: confirm with callers whether negative lengths are acceptable before relying on
+ * this behavior.
+ *
+ * <p>Thread-safety: instances are not thread-safe. Callers must serialize access and ensure that
+ * {@link #close()} is not invoked concurrently with {@link #write(byte[], int, int)}.
  */
 public class PrependLengthOutputStream extends FilterOutputStream {
 
@@ -21,8 +47,20 @@ public class PrependLengthOutputStream extends FilterOutputStream {
   private boolean closed;
 
   /**
-   * Create a stream which writes to temporary space and then on a non-aborted close() will write
-   * the length (minus the offset) followed by the data.
+   * Creates a stream that buffers to a temporary {@link Bucket} and, on non-aborted close, writes
+   * an 8-byte length header followed by the payload to the provided underlying stream.
+   *
+   * <p>The returned stream writes only to temporary storage until {@link #close()} is called.
+   *
+   * @param out the underlying stream that receives the header and payload on close; must not be
+   *     {@code null}
+   * @param bf the factory used to allocate a temporary {@code Bucket}; must not be {@code null}
+   * @param offset the value subtracted from the buffered size to compute the length header; may be
+   *     negative or greater than the buffered size
+   * @param closeUnderlying whether to close {@code out} after writing
+   * @return a new {@code PrependLengthOutputStream}
+   * @throws IOException if the temporary bucket cannot be created or its output stream cannot be
+   *     obtained
    */
   public static PrependLengthOutputStream create(
       OutputStream out, BucketFactory bf, int offset, boolean closeUnderlying) throws IOException {
@@ -40,22 +78,45 @@ public class PrependLengthOutputStream extends FilterOutputStream {
     this.closeUnderlying = closeUnderlying;
   }
 
+  /**
+   * Writes {@code length} bytes from {@code buf}, starting at {@code offset}, to the temporary
+   * buffer.
+   *
+   * <p>This override forwards the bulk operation directly to the wrapped stream to avoid {@link
+   * FilterOutputStream}'s default per-byte delegation.
+   *
+   * @param buf the source buffer; must not be {@code null}
+   * @param offset the starting index in {@code buf}
+   * @param length the number of bytes to write
+   * @throws IOException if an I/O error occurs while writing to the temporary bucket
+   */
   @Override
-  public void write(byte[] buf, int offset, int length) throws IOException {
-    // Unfortunately this is necessary because FilterOutputStream passes everything through
-    // write(int).
+  public void write(byte @NotNull [] buf, int offset, int length) throws IOException {
+    // Prefer bulk write over FilterOutputStream's default one-byte-at-a-time path.
     out.write(buf, offset, length);
   }
 
+  /**
+   * Writes the entire {@code buf} to the temporary buffer.
+   *
+   * @param buf the source buffer; must not be {@code null}
+   * @throws IOException if an I/O error occurs while writing to the temporary bucket
+   */
   @Override
-  public void write(byte[] buf) throws IOException {
+  public void write(byte @NotNull [] buf) throws IOException {
     write(buf, 0, buf.length);
   }
 
   /**
-   * Abort the stream. Will write a length of 0 when close()'ed.
+   * Aborts the stream so that {@link #close()} writes only an eight-byte zero length header and no
+   * payload.
    *
-   * @return False if the stream has already been closed.
+   * <p>If already closed, the method does nothing and returns {@code false}; otherwise it marks the
+   * stream aborted and returns {@code true}.
+   *
+   * @return {@code false} if already closed; {@code true} otherwise
+   * @throws IOException declared for historical compatibility; this implementation performs no I/O
+   *     and does not throw it
    */
   public boolean abort() throws IOException {
     if (closed) return false;
@@ -63,6 +124,18 @@ public class PrependLengthOutputStream extends FilterOutputStream {
     return true;
   }
 
+  /**
+   * Flushes the buffered content to the underlying stream with a prepended length header, frees the
+   * temporary bucket, and optionally closes the underlying stream.
+   *
+   * <p>If aborted, writes {@code 0L} as the header and no payload. Otherwise, writes the header
+   * {@code temp.size() - offset} and copies all buffered data.
+   *
+   * <p>This method is idempotent: repeated calls after the first have no effect.
+   *
+   * @throws IOException if writing the header or payload fails, if freeing resources triggers an
+   *     I/O error, or if closing the underlying stream fails when configured to do so
+   */
   @Override
   public void close() throws IOException {
     if (closed) return;
@@ -72,6 +145,7 @@ public class PrependLengthOutputStream extends FilterOutputStream {
       dos.writeLong(0);
     } else {
       dos.writeLong(temp.size() - offset);
+      /* Copy the entire payload. Using Long.MAX_VALUE signals “no explicit limit” to copyTo(). */
       BucketTools.copyTo(temp, dos, Long.MAX_VALUE);
     }
     temp.free();

--- a/src/test/java/network/crypta/support/io/PrependLengthOutputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/PrependLengthOutputStreamTest.java
@@ -1,0 +1,309 @@
+package network.crypta.support.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Tests for {@link PrependLengthOutputStream}.
+ *
+ * <p>AAA style, Mockito for I/O, deterministic inputs. Covers normal, abort, boundary and error
+ * paths.
+ */
+@SuppressWarnings("java:S100") // Allow underscore-based test method names per project guidelines
+class PrependLengthOutputStreamTest {
+
+  private PrependLengthOutputStream underTest; // closed in @AfterEach when created
+
+  @AfterEach
+  void tearDown() {
+    if (underTest != null) {
+      // Safe double-close to assert idempotency across tests
+      try {
+        underTest.close();
+      } catch (Throwable ignore) {
+        // Some tests intentionally provoke errors during close; ignore here
+      }
+    }
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  @DisplayName("create_whenBucketFactoryNull_expectNullPointerException")
+  void create_whenBucketFactoryNull_expectNullPointerException() throws IOException {
+    // Arrange
+    try (OutputStream out = mock(OutputStream.class)) {
+      // Act + Assert
+      assertThrows(
+          NullPointerException.class, () -> PrependLengthOutputStream.create(out, null, 0, true));
+    }
+  }
+
+  @Test
+  @DisplayName("close_whenOutputStreamNull_expectNullPointerException")
+  void close_whenOutputStreamNull_expectNullPointerException() throws IOException {
+    // Arrange: bucket factory returning a mock temp bucket with working streams
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(new ByteArrayOutputStream());
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+
+    // Create with null original OutputStream
+    underTest = PrependLengthOutputStream.create(null, bf, 0, true);
+
+    // Act + Assert: NPE arises when close() tries to write to DataOutputStream(null)
+    assertThrows(NullPointerException.class, () -> underTest.close());
+  }
+
+  @Test
+  @DisplayName("write_whenByteArray_expectSingleBulkWriteToTemp")
+  void write_whenByteArray_expectSingleBulkWriteToTemp() throws IOException {
+    // Arrange
+    ByteArrayOutputStream tempBaos = spy(new ByteArrayOutputStream());
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(tempBaos);
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    ByteArrayOutputStream origSpy = spy(new ByteArrayOutputStream());
+
+    underTest = PrependLengthOutputStream.create(origSpy, bf, 0, false);
+
+    byte[] data = "abcdef".getBytes(StandardCharsets.US_ASCII);
+
+    // Act
+    underTest.write(data);
+
+    // Assert: PrependLengthOutputStream delegates to underlying out.write(byte[],off,len)
+    verify(tempBaos, times(1)).write(data, 0, data.length);
+    // Ensure no per-byte writes happened
+    verify(tempBaos, never()).write(anyInt());
+  }
+
+  @ParameterizedTest(name = "offset={0}")
+  @MethodSource("offsetProvider")
+  @DisplayName("close_whenNotAborted_writesHeaderAsSizeMinusOffset_andCopiesAllData")
+  void close_whenNotAborted_writesHeaderAsSizeMinusOffset_andCopiesAllData(int offset)
+      throws IOException {
+    // Arrange
+    byte[] payload = "hello world".getBytes(StandardCharsets.US_ASCII); // 11 bytes
+    ByteArrayOutputStream tempBaos = new ByteArrayOutputStream();
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(tempBaos);
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    ByteArrayOutputStream origSpy = spy(new ByteArrayOutputStream());
+    underTest = PrependLengthOutputStream.create(origSpy, bf, offset, false);
+
+    // Act
+    underTest.write(payload);
+    underTest.close();
+
+    // Assert
+    byte[] written = origSpy.toByteArray();
+    assertTrue(written.length >= 8, "Must have at least 8 bytes for the length header");
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(written))) {
+      long header = dis.readLong();
+      assertThat(header, is((long) payload.length - offset));
+      byte[] copied = dis.readAllBytes();
+      assertArrayEquals(payload, copied, "All payload bytes must be copied");
+    }
+
+    // temp.free() must be called
+    verify(tempBucket, times(1)).free();
+
+    // Underlying should not be closed when closeUnderlying=false
+    verify(origSpy, never()).close();
+  }
+
+  static Stream<Arguments> offsetProvider() {
+    return Stream.of(
+        Arguments.of(0), // equal
+        Arguments.of(5), // positive smaller than size
+        Arguments.of(100), // larger than size (negative header)
+        Arguments.of(-2) // negative offset (header larger than size)
+        );
+  }
+
+  @Test
+  @DisplayName("close_whenCloseUnderlyingTrue_expectUnderlyingClosed")
+  void close_whenCloseUnderlyingTrue_expectUnderlyingClosed() throws IOException {
+    // Arrange
+    ByteArrayOutputStream tempBaos = new ByteArrayOutputStream();
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(tempBaos);
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    ByteArrayOutputStream origSpy = spy(new ByteArrayOutputStream());
+    underTest = PrependLengthOutputStream.create(origSpy, bf, 0, true);
+
+    underTest.write("123".getBytes(StandardCharsets.US_ASCII));
+
+    // Act
+    underTest.close();
+
+    // Assert
+    verify(origSpy, times(1)).close();
+    verify(tempBucket, times(1)).free();
+  }
+
+  @Test
+  @DisplayName("close_whenAborted_expectZeroLengthHeaderAndNoPayload")
+  void close_whenAborted_expectZeroLengthHeaderAndNoPayload() throws IOException {
+    // Arrange
+    ByteArrayOutputStream tempBaos = new ByteArrayOutputStream();
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(tempBaos);
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    ByteArrayOutputStream origSpy = spy(new ByteArrayOutputStream());
+    underTest = PrependLengthOutputStream.create(origSpy, bf, 3, false);
+
+    underTest.write("ignored".getBytes(StandardCharsets.US_ASCII));
+    assertTrue(underTest.abort());
+
+    // Act
+    underTest.close();
+
+    // Assert
+    byte[] written = origSpy.toByteArray();
+    assertThat("Only header expected when aborted", written.length, is(8));
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(written))) {
+      assertThat(dis.readLong(), is(0L));
+      assertEquals(0, dis.available(), "No payload after aborted header");
+    }
+    verify(tempBucket, times(1)).free();
+  }
+
+  @Test
+  @DisplayName("abort_whenClosed_expectFalse")
+  void abort_whenClosed_expectFalse() throws IOException {
+    // Arrange
+    ByteArrayOutputStream tempBaos = new ByteArrayOutputStream();
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(tempBaos);
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    OutputStream orig = new ByteArrayOutputStream();
+    underTest = PrependLengthOutputStream.create(orig, bf, 0, false);
+    underTest.close();
+
+    // Act + Assert
+    assertFalse(underTest.abort());
+  }
+
+  @Test
+  @DisplayName("abort_whenOpen_expectTrue")
+  void abort_whenOpen_expectTrue() throws IOException {
+    // Arrange
+    ByteArrayOutputStream tempBaos = new ByteArrayOutputStream();
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(tempBaos);
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    OutputStream orig = new ByteArrayOutputStream();
+    underTest = PrependLengthOutputStream.create(orig, bf, 0, false);
+
+    // Act + Assert
+    assertTrue(underTest.abort());
+  }
+
+  @Test
+  @DisplayName("close_whenCalledTwice_expectIdempotentBehavior")
+  void close_whenCalledTwice_expectIdempotentBehavior() throws IOException {
+    // Arrange
+    ByteArrayOutputStream tempBaos = new ByteArrayOutputStream();
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(tempBaos);
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    ByteArrayOutputStream origSpy = spy(new ByteArrayOutputStream());
+    underTest = PrependLengthOutputStream.create(origSpy, bf, 1, true);
+
+    underTest.write("xyz".getBytes(StandardCharsets.US_ASCII));
+
+    // Act
+    underTest.close();
+    byte[] first = origSpy.toByteArray();
+    underTest.close();
+    byte[] second = origSpy.toByteArray();
+
+    // Assert: identical bytes, no second write
+    assertArrayEquals(first, second);
+    verify(origSpy, times(1)).close();
+  }
+
+  @Test
+  @DisplayName("write_whenNullArray_expectNullPointerException")
+  @SuppressWarnings("DataFlowIssue")
+  void write_whenNullArray_expectNullPointerException() throws IOException {
+    // Arrange
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(new ByteArrayOutputStream());
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    OutputStream orig = new ByteArrayOutputStream();
+    underTest = PrependLengthOutputStream.create(orig, bf, 0, false);
+
+    // Act + Assert
+    assertThrows(NullPointerException.class, () -> underTest.write(null));
+  }
+
+  @Test
+  @DisplayName("write_whenLengthOutOfBounds_expectIndexOutOfBoundsException")
+  void write_whenLengthOutOfBounds_expectIndexOutOfBoundsException() throws IOException {
+    // Arrange
+    RandomAccessBucket tempBucket = mockTempBucketBackedBy(new ByteArrayOutputStream());
+    BucketFactory bf = mock(BucketFactory.class);
+    when(bf.makeBucket(anyLong())).thenReturn(tempBucket);
+    OutputStream orig = new ByteArrayOutputStream();
+    underTest = PrependLengthOutputStream.create(orig, bf, 0, false);
+
+    byte[] data = new byte[5];
+
+    // Act + Assert
+    assertThrows(IndexOutOfBoundsException.class, () -> underTest.write(data, 0, 6));
+  }
+
+  // Helpers
+
+  /**
+   * Creates a Mockito-backed {@link RandomAccessBucket} whose contents are stored in the provided
+   * {@link ByteArrayOutputStream}.
+   */
+  private static RandomAccessBucket mockTempBucketBackedBy(ByteArrayOutputStream backingBaos)
+      throws IOException {
+    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
+
+    // Output side: writes go into the provided BAOS (the stream instance must be stable)
+    when(bucket.getOutputStream()).thenReturn(backingBaos);
+    when(bucket.getOutputStreamUnbuffered()).thenReturn(backingBaos);
+
+    // Size reflects current content of the BAOS
+    when(bucket.size()).thenAnswer((Answer<Long>) invocation -> (long) backingBaos.size());
+
+    // Input side used during close(): produce a fresh InputStream over the current bytes
+    when(bucket.getInputStream())
+        .thenAnswer(
+            (Answer<java.io.InputStream>)
+                invocation -> new ByteArrayInputStream(backingBaos.toByteArray()));
+    when(bucket.getInputStreamUnbuffered())
+        .thenAnswer(
+            (Answer<java.io.InputStream>)
+                invocation -> new ByteArrayInputStream(backingBaos.toByteArray()));
+
+    // free() is verified in tests
+    doNothing().when(bucket).free();
+
+    return bucket;
+  }
+}


### PR DESCRIPTION
Summary
- Add comprehensive unit tests for PrependLengthOutputStream (JUnit 6 + Mockito) and improve its API documentation.
- No functional changes to production code; comments/Javadoc only.

Changes
1) Tests (AAA, deterministic)
- src/test/java/network/crypta/support/io/PrependLengthOutputStreamTest.java
  - Parameterized offsets: verifies header = size - offset for {0,5,100,-2} and that full payload is copied.
  - Abort path: close writes 0-length header and no payload.
  - closeUnderlying: when true, underlying OutputStream is closed; otherwise it remains open.
  - Idempotent close(): calling twice produces identical output and no extra close.
  - Delegation: write(byte[]) goes through bulk write, not per-byte.
  - Error/edge: abort() after close returns false; null array throws NPE; OOB length throws IndexOutOfBoundsException.
  - Mockito used to isolate external I/O; temp Bucket mocked and backed by ByteArrayOutputStream.

2) Documentation
- src/main/java/network/crypta/support/io/PrependLengthOutputStream.java
  - Class-level Javadoc explains temporary buffering, 8-byte big-endian header, and payload copy.
  - Notes that written length is temp.size() - offset and may be negative if offset > size.
  - Thread-safety note: not thread-safe; caller must serialize access.
  - Method Javadocs for create(), write(byte[],int,int), write(byte[]), abort(), close().
  - Inline rationale comments (e.g., bulk write, copyTo with Long.MAX_VALUE).

Rationale
- Clarifies behavior contract for callers/consumers and prevents misuse around header format and close semantics.
- Tests provide stable coverage and guard against regressions.

Validation
- Spotless applied: ./gradlew --quiet spotlessApply
- Focused tests: ./gradlew --parallel test --tests 'network.crypta.support.io.PrependLengthOutputStreamTest'
- SonarLint (single-file):
  - ./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/support/io/PrependLengthOutputStream.java
  - ./gradlew --quiet sonarlintFile -Psonarlint.file=src/test/java/network/crypta/support/io/PrependLengthOutputStreamTest.java
- Both files are SonarLint clean.

Commits
- f2fb4e432d docs(io): improve Javadoc for PrependLengthOutputStream (header format, behavior, threading)
- bce5b3f7e0 test(io): add unit tests for PrependLengthOutputStream (JUnit 6, Mockito)

Scope & Risk
- Production behavior unchanged; only documentation added.
- Tests exercise current semantics without modifying runtime code.

Checklist
- [x] Tests added/updated
- [x] Builds locally (Java 21) and tests pass
- [x] Spotless formatting
- [x] SonarLint clean on touched files

How to run locally
- ./gradlew --parallel test --tests 'network.crypta.support.io.PrependLengthOutputStreamTest'