### PR TITLE
docs(io): Improve API docs for support.io exceptions

### DIFF
--- a/src/main/java/network/crypta/support/io/ResumeFailedException.java
+++ b/src/main/java/network/crypta/support/io/ResumeFailedException.java
@@ -2,13 +2,39 @@ package network.crypta.support.io;
 
 import java.io.Serial;
 
+/**
+ * Signals that resuming a previously persisted or paused I/O resource failed.
+ *
+ * <p>This checked exception is used by I/O abstractions in this package (for example, buckets and
+ * random-access buffers) when reloading on-disk state or reconstructing in-memory structures from
+ * persistent metadata does not succeed. Typical causes include missing files, mismatched or
+ * truncated lengths, or corruption detected during format checks. Callers should treat this as a
+ * failure of the specific artifact being resumed and decide whether to recreate it or abandon the
+ * operation depending on context.
+ */
 public class ResumeFailedException extends Exception {
+  /** Serialization version for compatibility across releases. */
   @Serial private static final long serialVersionUID = 4332224721883071870L;
 
+  /**
+   * Creates an exception with a detail message describing the resume failure.
+   *
+   * @param message human-readable description of why resuming failed; may be {@code null}.
+   */
   public ResumeFailedException(String message) {
     super(message);
   }
 
+  /**
+   * Creates an exception that wraps an underlying cause.
+   *
+   * <p>The detail message is set to {@code cause.toString()} and the cause is attached using {@link
+   * Throwable#initCause(Throwable)} so the original stack trace is preserved.
+   *
+   * @param e non-{@code null} cause of the resume failure.
+   * @throws NullPointerException if {@code e} is {@code null} (due to {@code e.toString()}).
+   */
+  // Use cause.toString() for the message and attach the cause to preserve its stack trace.
   public ResumeFailedException(Throwable e) {
     super(e.toString());
     this.initCause(e);

--- a/src/main/java/network/crypta/support/io/StorageFormatException.java
+++ b/src/main/java/network/crypta/support/io/StorageFormatException.java
@@ -3,14 +3,39 @@ package network.crypta.support.io;
 import java.io.IOException;
 import java.io.Serial;
 
-/** Thrown when the file being loaded appears not to be a stored splitfile or other request. */
+/**
+ * Indicates that persisted data does not match the expected on-disk format.
+ *
+ * <p>This checked exception is used when loading a stored artifact (for example, a splitfile,
+ * bucket, or request state) and the bytes cannot be parsed or validated according to the expected
+ * storage format. Typical causes include missing or corrupt headers, unsupported or mismatched
+ * version identifiers, truncated content, or length fields that disagree with the actual file size.
+ * I/O failures that are not format-related should propagate as {@link IOException} and may
+ * optionally be wrapped as the cause of this exception when the boundary between I/O and validation
+ * is crossed.
+ */
 public class StorageFormatException extends Exception {
+  /** Serialization version for compatibility across releases. */
   @Serial private static final long serialVersionUID = 6953756148374736258L;
 
+  /**
+   * Creates an exception with a detail message describing the format violation.
+   *
+   * @param message human-readable description of the detected format problem; may be {@code null}.
+   */
   public StorageFormatException(String message) {
     super(message);
   }
 
+  /**
+   * Creates an exception with a detail message and an underlying {@link IOException} cause.
+   *
+   * <p>Use this when an I/O error occurs while attempting to validate or parse the storage format,
+   * and you want to signal a format-level failure to callers while preserving the original cause.
+   *
+   * @param message human-readable description of the detected problem; may be {@code null}.
+   * @param e the I/O cause; may be {@code null} if unavailable.
+   */
   public StorageFormatException(String message, IOException e) {
     super(message, e);
   }

--- a/src/main/java/network/crypta/support/io/TooLongException.java
+++ b/src/main/java/network/crypta/support/io/TooLongException.java
@@ -3,10 +3,27 @@ package network.crypta.support.io;
 import java.io.IOException;
 import java.io.Serial;
 
-/** Exception thrown by a LineReadingInputStream when a line is too long. */
+/**
+ * Signals that a line read from a stream exceeds the configured maximum length.
+ *
+ * <p>This checked {@link IOException} is thrown by {@link LineReadingInputStream} when the number
+ * of bytes accumulated for a single logical line (excluding the line terminator) grows beyond the
+ * caller-specified bound. The limit applies to raw bytes, not Unicode code points, so multibyte
+ * characters in UTF-8 count toward the limit by their encoded length.
+ *
+ * <p>Callers can catch this exception to abort parsing of the current artifact while keeping the
+ * underlying stream in a well-defined position. See {@link LineReadingInputStream#readLine(int,
+ * int, boolean)} for details on how the stream is advanced on success and on failure.
+ */
 public class TooLongException extends IOException {
+  /** Serialization version for compatibility across releases. */
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates the exception with a detail message describing the length violation.
+   *
+   * @param s human-readable description of the error; may be {@code null}.
+   */
   TooLongException(String s) {
     super(s);
   }


### PR DESCRIPTION
This PR improves and completes API documentation for three exception types under `network.crypta.support.io`.

Summary
- Add comprehensive class- and constructor-level Javadoc to:
  - `ResumeFailedException`
  - `StorageFormatException`
  - `TooLongException`
- Clarify purpose, typical causes, and usage guidance.
- Document thrown conditions and serialization semantics (UID notes).
- No code, signatures, or logic changes — comments only.
- Ran `./gradlew spotlessApply` to keep formatting consistent.

Rationale
These exceptions are part of public/protected APIs used across I/O components (e.g., `LineReadingInputStream`, RandomAccess* utilities). Clear documentation helps downstream callers understand failure modes (format errors, resume failures, and length limits) and appropriate handling.

Scope & Risk
- Scope: comments/Javadoc only. No behavior changes. Low risk.
- Verified with Spotless; build unaffected.

Diffstat
- 3 files changed, 70 insertions(+), 2 deletions(-).

Notes
- Followed project docs style: US English, ~100 col wrapping, and placed docs above annotations as required.

Please let me know if you’d like any phrasing or tag changes before merge.