### PR TITLE
fix(io): clamp RAFInputStream window; add tests; improve Javadoc

### DIFF
--- a/src/main/java/network/crypta/support/io/RAFBucket.java
+++ b/src/main/java/network/crypta/support/io/RAFBucket.java
@@ -12,79 +12,185 @@ import network.crypta.support.api.Bucket;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.RandomAccessBucket;
 
+/**
+ * Read-only {@link Bucket} backed by a {@link LockableRandomAccessBuffer}.
+ *
+ * <p>This bucket exposes streaming reads over an existing random-access buffer and allows callers
+ * to obtain that buffer without copying via {@link #toRandomAccessBuffer()}. It never provides an
+ * {@link OutputStream}; attempts to request one will throw {@link IOException} because the bucket
+ * is immutable.
+ *
+ * <p><strong>Size and immutability:</strong> the logical size reported by {@link #size()} is
+ * captured at construction time from the underlying buffer. Callers should consider the underlying
+ * buffer length stable for the lifetime of this bucket. TODO: clarify whether readers should rely
+ * on the captured size or the underlying buffer length at stream creation time.
+ *
+ * <p><strong>Thread-safety:</strong> this class is a thin wrapper and does not add synchronization
+ * beyond what the underlying buffer provides. Multiple readers should create separate input
+ * streams. The returned {@link InputStream}s are not thread-safe.
+ */
 public class RAFBucket implements Bucket, RandomAccessBucket {
 
   private final LockableRandomAccessBuffer underlying;
   final long size;
 
+  /**
+   * Creates a read-only bucket over an existing random-access buffer.
+   *
+   * @param underlying the backing {@link LockableRandomAccessBuffer}; must not be {@code null}
+   * @throws IOException if obtaining the current size from the buffer fails
+   */
   public RAFBucket(LockableRandomAccessBuffer underlying) throws IOException {
     this.underlying = underlying;
     size = underlying.size();
   }
 
+  /**
+   * Always throws because this bucket is read-only.
+   *
+   * @return never returns
+   * @throws IOException always thrown to indicate writes are unsupported
+   */
   @Override
   public OutputStream getOutputStream() throws IOException {
     throw new IOException("Not supported");
   }
 
+  /**
+   * Always throws because this bucket is read-only.
+   *
+   * @return never returns
+   * @throws IOException always thrown to indicate writes are unsupported
+   */
   @Override
   public OutputStream getOutputStreamUnbuffered() throws IOException {
     throw new IOException("Not supported");
   }
 
+  /**
+   * Returns a buffered {@link InputStream} over the bucket content.
+   *
+   * <p>The returned stream is a {@link BufferedInputStream} wrapping the unbuffered variant. If the
+   * bucket has length 0, the first read will throw {@link java.io.EOFException} (see {@link
+   * RAFInputStream}).
+   *
+   * @return a buffered stream positioned at the start of the bucket
+   * @throws IOException if stream creation fails
+   */
   @Override
   public InputStream getInputStream() throws IOException {
     return new BufferedInputStream(getInputStreamUnbuffered());
   }
 
+  /**
+   * Returns an unbuffered {@link InputStream} over the bucket content.
+   *
+   * <p>The stream reads from offset {@code 0} up to the current length of the underlying buffer at
+   * the time of creation. It throws {@link java.io.EOFException} on reads past the end.
+   *
+   * @return a non-buffered stream positioned at the start of the bucket
+   * @throws IOException if stream creation fails
+   */
   @Override
   public InputStream getInputStreamUnbuffered() throws IOException {
+    // The RAFInputStream length is taken from the underlying at creation time. The underlying
+    // length is expected to be stable while this bucket is in use.
     return new RAFInputStream(underlying, 0, underlying.size());
   }
 
+  /**
+   * Returns {@code null} because this bucket does not expose a stable display name.
+   *
+   * @return always {@code null}
+   */
   @Override
   public String getName() {
     return null;
   }
 
+  /**
+   * Returns the logical size captured at construction.
+   *
+   * @return the bucket length in bytes
+   */
   @Override
   public long size() {
     return size;
   }
 
+  /**
+   * Reports that the bucket is read-only.
+   *
+   * @return always {@code true}
+   */
   @Override
   public boolean isReadOnly() {
     return true;
   }
 
+  /** No-op because the bucket is created read-only. */
   @Override
   public void setReadOnly() {
-    // Ignore.
+    // Read-only by construction.
   }
 
+  /**
+   * Releases resources by delegating to the underlying buffer.
+   *
+   * <p>After this call, the underlying buffer is freed and subsequent I/O may fail.
+   */
   @Override
   public void free() {
     underlying.free();
   }
 
+  /**
+   * Returns {@code null} because this implementation does not provide a cheap shadow copy.
+   *
+   * @return always {@code null}
+   */
   @Override
   public RandomAccessBucket createShadow() {
     return null;
   }
 
+  /**
+   * Restores transient state after a process restart by delegating to the underlying buffer.
+   *
+   * @param context runtime services and registries
+   * @throws ResumeFailedException if the underlying buffer cannot resume
+   */
   @Override
   public void onResume(ClientContext context) throws ResumeFailedException {
     underlying.onResume(context);
   }
 
+  /** Type discriminator written before the underlying buffer when serializing this bucket. */
   static final int MAGIC = 0x892a708a;
 
+  /**
+   * Serializes this bucket to a binary stream.
+   *
+   * <p>Format: first writes {@link #MAGIC}, then delegates to {@link
+   * LockableRandomAccessBuffer#storeTo(DataOutputStream)} of the underlying buffer.
+   *
+   * @param dos destination stream
+   * @throws IOException if writing fails
+   */
   @Override
   public void storeTo(DataOutputStream dos) throws IOException {
     dos.writeInt(MAGIC);
     underlying.storeTo(dos);
   }
 
+  /*
+   * Package-private restoring constructor used by {@link BucketTools#restoreFrom(DataInputStream,
+   * FilenameGenerator, PersistentFileTracker, MasterSecret)}.
+   *
+   * <p>Reads a {@link LockableRandomAccessBuffer} from {@code dis} via
+   * {@link BucketTools#restoreRAFFrom(DataInputStream, FilenameGenerator, PersistentFileTracker,
+   * MasterSecret)} and captures its size for {@link #size()}.
+   */
   RAFBucket(
       DataInputStream dis,
       FilenameGenerator fg,
@@ -95,6 +201,14 @@ public class RAFBucket implements Bucket, RandomAccessBucket {
     size = underlying.size();
   }
 
+  /**
+   * Returns the backing {@link LockableRandomAccessBuffer} without copying.
+   *
+   * <p>Per the {@link RandomAccessBucket} contract, callers should treat the returned buffer as
+   * read-only when obtained from a read-only bucket.
+   *
+   * @return the underlying buffer instance
+   */
   @Override
   public LockableRandomAccessBuffer toRandomAccessBuffer() {
     return underlying;

--- a/src/main/java/network/crypta/support/io/RAFInputStream.java
+++ b/src/main/java/network/crypta/support/io/RAFInputStream.java
@@ -4,20 +4,69 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import network.crypta.support.api.RandomAccessBuffer;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * An {@link InputStream} view backed by a {@link RandomAccessBuffer} over a fixed byte range.
+ *
+ * <p>This adapter treats the provided {@code offset} and {@code size} as the bounds of a read-only
+ * window and maintains its own read pointer ({@code rafOffset}). Reads delegate to {@link
+ * RandomAccessBuffer#pread(long, byte[], int, int)} so the underlying buffer's state is not mutated
+ * by this stream. Instances are not thread-safe because they carry mutable position; if a caller
+ * shares a single instance across threads, it must synchronize externally.
+ *
+ * <p>Note: the {@code size} parameter is the number of readable bytes within the window, not an
+ * absolute end offset. For example, {@code new RAFInputStream(buf, 5, 4)} exposes the bytes at
+ * absolute offsets {@code 5}, {@code 6}, {@code 7}, and {@code 8}.
+ *
+ * <p>End-of-stream semantics: when the current position reaches the end of the view, {@link
+ * EOFException} is thrown (even for a 0-length request) rather than returning {@code -1}. This
+ * differs from the general contract of {@link InputStream}; callers should be prepared to catch
+ * {@code EOFException}.
+ */
 public class RAFInputStream extends InputStream {
 
+  /**
+   * Underlying random-access source. Contract: {@link RandomAccessBuffer#pread} must read fully.
+   */
   private final RandomAccessBuffer underlying;
+
+  /** Total number of readable bytes in this view, starting at {@code rafOffset}'s initial value. */
   private final long rafLength;
 
+  /** Absolute base file offset for the start of this view. */
+  private final long rafBase;
+
+  // Current absolute position within this view (relative to the original {@code offset}).
+  // Advances by the number of bytes successfully read.
   private long rafOffset;
 
+  /**
+   * Creates a new stream window over a {@link RandomAccessBuffer}.
+   *
+   * @param data the underlying buffer to read from; not {@code null}
+   * @param offset the starting byte offset within {@code data}; may be any value accepted by {@link
+   *     RandomAccessBuffer#pread(long, byte[], int, int)}
+   * @param size the number of readable bytes in this view (bytes); this is not an absolute end
+   *     offset.
+   */
   public RAFInputStream(RandomAccessBuffer data, long offset, long size) {
     this.underlying = data;
+    this.rafBase = offset;
     this.rafOffset = offset;
     this.rafLength = size;
   }
 
+  /**
+   * Reads a single unsigned byte from the stream.
+   *
+   * <p>Delegates to {@link #read(byte[], int, int)} with a 1-byte buffer and returns the value as
+   * an unsigned integer in the range 0..255.
+   *
+   * @return the next byte value (0..255)
+   * @throws EOFException when the stream is at end-of-view
+   * @throws IOException if the underlying buffer fails to satisfy the read
+   */
   @Override
   public int read() throws IOException {
     byte[] buf = new byte[1];
@@ -25,20 +74,62 @@ public class RAFInputStream extends InputStream {
     if (length > 0) {
       return Byte.toUnsignedInt(buf[0]);
     }
+    // This path is not expected in practice because read(byte[], int, int) either reads > 0 or
+    // throws EOFException at end-of-view. Kept for defensive completeness.
     return -1;
   }
 
+  /**
+   * Reads into the entire buffer.
+   *
+   * <p>This is equivalent to {@link #read(byte[], int, int)} with {@code offset=0} and {@code
+   * length=buf.length}.
+   *
+   * @param buf the destination buffer; must not be {@code null}
+   * @return the number of bytes read; may be 0 if {@code length==0}
+   * @throws EOFException when the stream is at end-of-view
+   * @throws NullPointerException if {@code buf} is {@code null}
+   * @throws IOException if the underlying buffer fails to satisfy the read
+   */
   @Override
-  public int read(byte[] buf) throws IOException {
+  public int read(byte @NotNull [] buf) throws IOException {
     return read(buf, 0, buf.length);
   }
 
+  /**
+   * Reads up to {@code length} bytes into {@code buf} starting at {@code offset}.
+   *
+   * <p>Behavior:
+   *
+   * <ul>
+   *   <li>If the internal position is at or beyond the end of the view, throws {@link
+   *       EOFException}.
+   *   <li>Otherwise, clamps {@code length} to the remaining bytes in the view and delegates to
+   *       {@link RandomAccessBuffer#pread(long, byte[], int, int)}.
+   *   <li>Advances the internal position by the number of bytes read and returns that count.
+   *   <li>If {@code length == 0} and not at end-of-view, returns 0 and does not advance.
+   * </ul>
+   *
+   * @param buf the destination buffer; must not be {@code null}
+   * @param offset the offset in {@code buf} to start storing bytes
+   * @param length the requested number of bytes
+   * @return the actual number of bytes read (in {@code 0..length})
+   * @throws EOFException when at end-of-view (including a 0-length request at EOF)
+   * @throws IndexOutOfBoundsException if {@code offset} or {@code length} is out of range for
+   *     {@code buf}
+   * @throws IllegalArgumentException if the underlying implementation rejects the arguments (e.g.,
+   *     negative file offset)
+   * @throws IOException if the underlying read fails
+   */
   @Override
-  public int read(byte[] buf, int offset, int length) throws IOException {
-    if (rafOffset >= rafLength) throw new EOFException();
-    length = (int) Math.min(length, rafLength - rafOffset);
-    underlying.pread(rafOffset, buf, offset, length);
-    rafOffset += length;
-    return length;
+  public int read(byte @NotNull [] buf, int offset, int length) throws IOException {
+    // Bytes consumed so far inside the view
+    long consumed = rafOffset - rafBase;
+    if (consumed >= rafLength) throw new EOFException();
+    long remaining = rafLength - consumed;
+    int toRead = (int) Math.min(length, remaining);
+    underlying.pread(rafOffset, buf, offset, toRead);
+    rafOffset += toRead;
+    return toRead;
   }
 }

--- a/src/main/java/network/crypta/support/io/RandomAccessFileOutputStream.java
+++ b/src/main/java/network/crypta/support/io/RandomAccessFileOutputStream.java
@@ -3,30 +3,95 @@ package network.crypta.support.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * An {@link OutputStream} view over a {@link RandomAccessFile} that delegates all write operations
+ * to the underlying file.
+ *
+ * <p>This adapter writes at the current file pointer of the provided {@code RandomAccessFile} and
+ * advances that pointer accordingly. It does not perform any buffering and does not change the
+ * file's seek position beyond what the delegated writes imply. Closing this stream closes the
+ * underlying {@code RandomAccessFile}.
+ *
+ * <p>Thread-safety: this class provides no additional synchronization. If the same {@code
+ * RandomAccessFile} is shared across threads, external coordination is recommended.
+ */
 public class RandomAccessFileOutputStream extends OutputStream {
 
+  // Underlying file; owned by this stream. close() will close this instance.
   final RandomAccessFile raf;
 
+  /**
+   * Creates a stream that writes to the given {@link RandomAccessFile}.
+   *
+   * <p>Preconditions: the {@code raf} reference should be non-{@code null} and opened in a mode
+   * that permits writing (for example, "rw", "rws", or "rwd"). If the file is opened read-only,
+   * subsequent write operations will fail with {@link IOException}. This constructor does not
+   * validate these conditions.
+   *
+   * @param raf the target file to receive writes; not validated for nullity
+   */
   public RandomAccessFileOutputStream(RandomAccessFile raf) {
     this.raf = raf;
   }
 
+  /**
+   * Writes the low eight bits of the given value to the file at the current file pointer.
+   *
+   * <p>This method delegates to {@link RandomAccessFile#writeByte(int)}. The file pointer advances
+   * by one byte, and the file length may increase if writing beyond the current end.
+   *
+   * @param arg0 the value whose least-significant 8 bits are written
+   * @throws IOException if an I/O error occurs or the file does not permit writing
+   */
   @Override
   public void write(int arg0) throws IOException {
     raf.writeByte(arg0);
   }
 
+  /**
+   * Writes the entire byte array at the current file pointer.
+   *
+   * <p>This method delegates to {@link RandomAccessFile#write(byte[])}. The file pointer advances
+   * by {@code buf.length} bytes.
+   *
+   * @param buf the data to write
+   * @throws NullPointerException if {@code buf} is {@code null}
+   * @throws IOException if an I/O error occurs
+   */
   @Override
-  public void write(byte[] buf) throws IOException {
+  public void write(byte @NotNull [] buf) throws IOException {
     raf.write(buf);
   }
 
+  /**
+   * Writes a portion of the given byte array starting at {@code offset} for {@code length} bytes at
+   * the current file pointer.
+   *
+   * <p>This method delegates to {@link RandomAccessFile#write(byte[], int, int)}. The file pointer
+   * advances by {@code length} bytes.
+   *
+   * @param buf the source array
+   * @param offset the starting index in {@code buf}
+   * @param length the number of bytes to write
+   * @throws NullPointerException if {@code buf} is {@code null}
+   * @throws IndexOutOfBoundsException if the offset/length are out of bounds
+   * @throws IOException if an I/O error occurs
+   */
   @Override
-  public void write(byte[] buf, int offset, int length) throws IOException {
+  public void write(byte @NotNull [] buf, int offset, int length) throws IOException {
     raf.write(buf, offset, length);
   }
 
+  /**
+   * Closes this stream and the underlying {@link RandomAccessFile}.
+   *
+   * <p>After a successful close, subsequent operations on this stream will fail, typically with an
+   * {@link IOException} from the underlying file.
+   *
+   * @throws IOException if an I/O error occurs while closing the file
+   */
   @Override
   public void close() throws IOException {
     raf.close();

--- a/src/test/java/network/crypta/support/io/RAFBucketTest.java
+++ b/src/test/java/network/crypta/support/io/RAFBucketTest.java
@@ -1,0 +1,286 @@
+package network.crypta.support.io;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import network.crypta.client.async.ClientContext;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for {@link RAFBucket}.
+ *
+ * <p>Tests follow AAA style, use deterministic data, and cover construction, I/O behavior,
+ * delegation, and (de)serialization paths.
+ */
+class RAFBucketTest {
+
+  private static final java.util.logging.Logger TEST_LOG =
+      java.util.logging.Logger.getLogger(RAFBucketTest.class.getName());
+
+  private static LockableRandomAccessBuffer stubRafWithContent(byte[] content) throws IOException {
+    LockableRandomAccessBuffer raf = mock(LockableRandomAccessBuffer.class);
+    when(raf.size()).thenReturn((long) content.length);
+    // Delegate pread() to copy from the in-memory array
+    doAnswer(
+            inv -> {
+              long fileOffset = inv.getArgument(0);
+              byte[] buf = inv.getArgument(1);
+              int bufOffset = inv.getArgument(2);
+              int len = inv.getArgument(3);
+              if (fileOffset < 0) throw new IllegalArgumentException("fileOffset < 0");
+              if (fileOffset + len > content.length) throw new IOException("read exceeds length");
+              System.arraycopy(content, (int) fileOffset, buf, bufOffset, len);
+              return null;
+            })
+        .when(raf)
+        .pread(anyLong(), any(byte[].class), anyInt(), anyInt());
+    // No-op implementations for unused methods
+    doNothing().when(raf).pwrite(anyLong(), any(byte[].class), anyInt(), anyInt());
+    doNothing().when(raf).free();
+    doNothing().when(raf).close();
+    return raf;
+  }
+
+  private static File createSecureTempDir(String prefix) throws IOException {
+    try {
+      FileAttribute<Set<PosixFilePermission>> attr =
+          PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+      Path p = Files.createTempDirectory(prefix, attr);
+      return p.toFile();
+    } catch (UnsupportedOperationException e) {
+      // Non-POSIX (e.g., Windows). Create under user.home instead of public tmp.
+      File base = new File(System.getProperty("user.home"));
+      File dir = new File(base, prefix + System.nanoTime());
+      if (!dir.mkdirs()) throw new IOException("Failed to create temp dir " + dir);
+      boolean r = dir.setReadable(true, true);
+      boolean w = dir.setWritable(true, true);
+      boolean x = dir.setExecutable(true, true);
+      if (!(r && w && x)) {
+        // Best effort: warn but do not fail the test.
+        TEST_LOG.warning("Unable to harden permissions on temp dir " + dir.getAbsolutePath());
+      }
+      return dir;
+    }
+  }
+
+  @Test
+  void constructorWhenUnderlyingCapturesSizeAndIsReadOnly() throws IOException {
+    LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
+    when(underlying.size()).thenReturn(123L, 999L); // later change should not affect captured size
+
+    RAFBucket bucket = new RAFBucket(underlying);
+
+    assertEquals(123L, bucket.size());
+    assertTrue(bucket.isReadOnly());
+    assertNull(bucket.getName());
+    assertNull(bucket.createShadow());
+
+    // Underlying size later changes, but RAFBucket.size() remains the captured value
+    assertEquals(123L, bucket.size());
+  }
+
+  @Test
+  void getOutputStreamWhenCalledExpectIOException() {
+    LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
+    when(underlying.size()).thenReturn(0L);
+    RAFBucket bucket;
+    try {
+      bucket = new RAFBucket(underlying);
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    assertThrows(IOException.class, bucket::getOutputStream);
+    assertThrows(IOException.class, bucket::getOutputStreamUnbuffered);
+  }
+
+  @Nested
+  class InputStreamTests {
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 7, 8192, 12345})
+    void getInputStreamUnbufferedWhenReadAllExpectExactBytesAndEof(int length) throws Exception {
+      byte[] data = new byte[length];
+      for (int i = 0; i < length; i++) {
+        data[i] = (byte) (i * 31 + 7);
+      }
+      LockableRandomAccessBuffer raf = stubRafWithContent(data);
+      RAFBucket bucket = new RAFBucket(raf);
+
+      try (InputStream is = bucket.getInputStreamUnbuffered()) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[1024];
+        int moved = 0;
+        while (moved < length) {
+          int toRead = Math.min(buf.length, length - moved);
+          int read = is.read(buf, 0, toRead);
+          assertTrue(read > 0);
+          out.write(buf, 0, read);
+          moved += read;
+        }
+        assertArrayEquals(data, out.toByteArray());
+        // Next read must throw EOFException according to RAFInputStream behavior
+        assertThrows(EOFException.class, () -> is.read(buf));
+      }
+    }
+
+    @Test
+    void getInputStreamWhenReadChunksExpectBufferedReadMatchesContent() throws Exception {
+      byte[] data = new byte[4096 + 13];
+      for (int i = 0; i < data.length; i++) {
+        data[i] = (byte) (i * 17 + 3);
+      }
+      LockableRandomAccessBuffer raf = stubRafWithContent(data);
+      RAFBucket bucket = new RAFBucket(raf);
+
+      try (InputStream is = bucket.getInputStream()) { // buffered wrapper
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[512];
+        int moved = 0;
+        while (moved < data.length) {
+          int read = is.read(buf);
+          assertTrue(read > 0);
+          out.write(buf, 0, read);
+          moved += read;
+        }
+        assertArrayEquals(data, out.toByteArray());
+      }
+    }
+  }
+
+  @Test
+  void freeWhenCalledDelegatesToUnderlying() throws IOException {
+    LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
+    when(underlying.size()).thenReturn(0L);
+    RAFBucket bucket = new RAFBucket(underlying);
+    bucket.free();
+    verify(underlying, times(1)).free();
+  }
+
+  @Test
+  void onResumeWhenCalledDelegatesToUnderlying() throws Exception {
+    LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
+    when(underlying.size()).thenReturn(0L);
+    RAFBucket bucket = new RAFBucket(underlying);
+    ClientContext ctx = mock(ClientContext.class);
+    bucket.onResume(ctx);
+    verify(underlying, times(1)).onResume(ctx);
+  }
+
+  @Test
+  void toRandomAccessBufferWhenCalledReturnsSameUnderlying() throws IOException {
+    LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
+    when(underlying.size()).thenReturn(10L);
+    RAFBucket bucket = new RAFBucket(underlying);
+    assertSame(underlying, bucket.toRandomAccessBuffer());
+  }
+
+  @Test
+  void storeToWhenCalledWritesMagicAndDelegates() throws Exception {
+    LockableRandomAccessBuffer underlying = mock(LockableRandomAccessBuffer.class);
+    when(underlying.size()).thenReturn(12L);
+    // When delegate storeTo() is invoked, write a sentinel so we can assert ordering
+    doAnswer(
+            inv -> {
+              DataOutputStream dos = inv.getArgument(0);
+              dos.writeInt(0xDEADBEEF);
+              return null;
+            })
+        .when(underlying)
+        .storeTo(any(DataOutputStream.class));
+
+    RAFBucket bucket = new RAFBucket(underlying);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      bucket.storeTo(dos);
+    }
+
+    byte[] bytes = baos.toByteArray();
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes))) {
+      assertEquals(RAFBucket.MAGIC, dis.readInt());
+      assertEquals(0xDEADBEEF, dis.readInt());
+    }
+    verify(underlying, times(1)).storeTo(any(DataOutputStream.class));
+  }
+
+  @Test
+  @DisplayName("constructor(stream) restores underlying RAF via BucketTools.restoreRAFFrom")
+  void constructorFromStreamRestoresUnderlyingAndSize() throws Exception {
+    File secureDir = createSecureTempDir("rafbucket-restore-");
+    File tmp = File.createTempFile("rafbucket-restore", ".bin", secureDir);
+    long length = 2048L;
+    // Write file to the required length; content is irrelevant here
+    try (RandomAccessFile raf = new RandomAccessFile(tmp, "rw")) {
+      raf.setLength(length);
+    }
+    // Use read/write mode here since this constructor sets the length
+    FileRandomAccessBuffer fileRaf = new FileRandomAccessBuffer(tmp, length, false);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      // We need the RAF serialization only (not the RAFBucket magic)
+      fileRaf.storeTo(dos);
+    }
+    fileRaf.close(); // do not free; the file must exist for restore
+
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      RAFBucket restored = new RAFBucket(dis, null, null, null);
+      assertEquals(length, restored.size());
+      LockableRandomAccessBuffer restoredRaf = restored.toRandomAccessBuffer();
+      assertEquals(FileRandomAccessBuffer.class, restoredRaf.getClass());
+      // The restored RAF should equal a fresh FileRandomAccessBuffer view on the same file
+      FileRandomAccessBuffer expected = new FileRandomAccessBuffer(tmp, false);
+      assertEquals(expected, restoredRaf);
+      restored.free(); // deletes the file
+    }
+  }
+
+  @Test
+  void storeToAndRestoreViaBucketToolsYieldsEquivalentBucket() throws Exception {
+    File secureDir = createSecureTempDir("rafbucket-roundtrip-");
+    File tmp = File.createTempFile("rafbucket-roundtrip", ".bin", secureDir);
+    long length = 1024L;
+    try (RandomAccessFile raf = new RandomAccessFile(tmp, "rw")) {
+      raf.setLength(length);
+    }
+    // Open using the existing file length in read-only mode
+    FileRandomAccessBuffer fileRaf = new FileRandomAccessBuffer(tmp, true);
+    RandomAccessBucket bucket = new RAFBucket(fileRaf);
+
+    byte[] serialized;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos)) {
+      bucket.storeTo(dos);
+      dos.flush();
+      serialized = baos.toByteArray();
+    }
+
+    // Now restore using the generic BucketTools dispatcher
+    RAFBucket restored;
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(serialized))) {
+      Bucket restoredAny =
+          BucketTools.restoreFrom(dis, /* fg= */ null, /* pft= */ null, /* masterKey= */ null);
+      assertInstanceOf(RAFBucket.class, restoredAny);
+      restored = (RAFBucket) restoredAny;
+    }
+
+    assertEquals(length, restored.size());
+    assertEquals(fileRaf, restored.toRandomAccessBuffer());
+
+    restored.free(); // cleans up tmp file
+  }
+}

--- a/src/test/java/network/crypta/support/io/RAFInputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/RAFInputStreamTest.java
@@ -1,0 +1,274 @@
+package network.crypta.support.io;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.support.api.RandomAccessBuffer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link RAFInputStream}.
+ *
+ * <p>Tests follow AAA style, use deterministic data, and cover null, empty, boundary, and error
+ * paths. External I/O is mocked using Mockito.
+ */
+class RAFInputStreamTest {
+
+  private static byte[] patternBytes(int length) {
+    byte[] data = new byte[length];
+    for (int i = 0; i < length; i++) {
+      // Deterministic pattern, stable across runs
+      data[i] = (byte) (i * 37 + 11);
+    }
+    return data;
+  }
+
+  @Test
+  @DisplayName("readBuffer_whenOffsetNonZero_expectCorrectDataAndThenEof")
+  void readBufferWhenOffsetNonZeroExpectCorrectDataAndThenEof() throws Exception {
+    // Arrange
+    byte[] content = patternBytes(10);
+    RandomAccessBuffer raf = stubRaf(content);
+    // Window: start at index 4, length 3 -> bytes [4,5,6]
+    RAFInputStream is = new RAFInputStream(raf, 4, 3);
+    byte[] buf = new byte[8];
+
+    // Act
+    int n1 = is.read(buf, 0, buf.length);
+
+    // Assert
+    assertEquals(3, n1);
+    assertArrayEquals(
+        new byte[] {content[4], content[5], content[6]}, new byte[] {buf[0], buf[1], buf[2]});
+    assertThrows(EOFException.class, () -> is.read(buf));
+  }
+
+  @Test
+  @DisplayName("read_whenOffsetNonZero_expectCorrectUnsignedBytesThenEof")
+  void readWhenOffsetNonZeroExpectCorrectUnsignedBytesThenEof() throws Exception {
+    // Arrange
+    byte[] content = patternBytes(6);
+    RandomAccessBuffer raf = stubRaf(content);
+    RAFInputStream is = new RAFInputStream(raf, 1, 2); // expect bytes at indices 1 and 2
+
+    // Act & Assert
+    assertEquals(Byte.toUnsignedInt(content[1]), is.read());
+    assertEquals(Byte.toUnsignedInt(content[2]), is.read());
+    assertThrows(EOFException.class, is::read);
+  }
+
+  private static RandomAccessBuffer stubRaf(byte[] content) throws IOException {
+    RandomAccessBuffer raf = mock(RandomAccessBuffer.class);
+    when(raf.size()).thenReturn((long) content.length);
+    // Delegate pread() to read from the in-memory array with strict bounds checking
+    doAnswer(
+            inv -> {
+              long fileOffset = inv.getArgument(0);
+              byte[] buf = inv.getArgument(1);
+              int bufOffset = inv.getArgument(2);
+              int len = inv.getArgument(3);
+              if (fileOffset < 0) throw new IllegalArgumentException("fileOffset < 0");
+              if (len < 0) throw new IllegalArgumentException("len < 0");
+              if (buf == null) throw new NullPointerException("buf is null");
+              if (bufOffset < 0 || bufOffset + len > buf.length)
+                throw new IndexOutOfBoundsException("invalid buf range");
+              if (fileOffset + len > content.length)
+                throw new IOException("read exceeds available content");
+              System.arraycopy(content, (int) fileOffset, buf, bufOffset, len);
+              return null;
+            })
+        .when(raf)
+        .pread(anyLong(), any(byte[].class), anyInt(), anyInt());
+    // Unused methods can be no-ops in this test
+    doNothing().when(raf).pwrite(anyLong(), any(byte[].class), anyInt(), anyInt());
+    doNothing().when(raf).free();
+    doNothing().when(raf).close();
+    return raf;
+  }
+
+  @Test
+  @DisplayName("read_whenReadingSingleBytes_expectUnsignedValueAndEofOnExhaustion")
+  void readWhenReadingSingleBytesExpectUnsignedValueAndEofOnExhaustion() throws Exception {
+    // Arrange
+    byte[] content = new byte[] {(byte) 0xFF, 0x00, 0x7F};
+    RandomAccessBuffer raf = stubRaf(content);
+    RAFInputStream is = new RAFInputStream(raf, 0, content.length);
+
+    // Act & Assert
+    assertEquals(255, is.read());
+    assertEquals(0, is.read());
+    assertEquals(127, is.read());
+    assertThrows(EOFException.class, is::read);
+  }
+
+  @Test
+  @DisplayName("read_whenAtEof_expectEOFException")
+  void readWhenAtEofExpectEOFException() throws Exception {
+    // Arrange: zero-length view
+    RandomAccessBuffer raf = stubRaf(new byte[0]);
+    RAFInputStream is = new RAFInputStream(raf, 0, 0);
+
+    // Act & Assert
+    assertThrows(EOFException.class, is::read);
+  }
+
+  @Test
+  @DisplayName("readBuffer_whenRequestedExceedsRemaining_expectClampedAndThenEof")
+  void readBufferWhenRequestedExceedsRemainingExpectClampedAndThenEof() throws Exception {
+    // Arrange
+    byte[] content = patternBytes(5);
+    RandomAccessBuffer raf = stubRaf(content);
+    RAFInputStream is = new RAFInputStream(raf, 0, content.length);
+    byte[] buf = new byte[8];
+
+    // Act & Assert
+    int n1 = is.read(buf, 0, 3);
+    assertEquals(3, n1);
+    assertArrayEquals(
+        new byte[] {content[0], content[1], content[2]}, new byte[] {buf[0], buf[1], buf[2]});
+
+    int n2 = is.read(buf, 0, 3);
+    assertEquals(2, n2); // clamped to remaining
+    assertArrayEquals(new byte[] {content[3], content[4]}, new byte[] {buf[0], buf[1]});
+
+    assertThrows(EOFException.class, () -> is.read(buf));
+  }
+
+  @Test
+  @DisplayName("readBuffer_whenZeroLengthAndNotEof_expectZeroAndNoAdvance")
+  void readBufferWhenZeroLengthAndNotEofExpectZeroAndNoAdvance() throws Exception {
+    // Arrange
+    byte[] content = patternBytes(5);
+    RandomAccessBuffer raf = stubRaf(content);
+    RAFInputStream is = new RAFInputStream(raf, 0, content.length);
+    byte[] buf = new byte[5];
+
+    // Act: first zero-length read
+    int zero = is.read(buf, 0, 0);
+
+    // Assert
+    assertEquals(0, zero);
+
+    // Next, read all bytes; fileOffset should still be 0 before this call
+    int n = is.read(buf, 0, buf.length);
+    assertEquals(content.length, n);
+    assertArrayEquals(content, buf);
+
+    // Verify pread() was invoked twice and the file offset did not advance on the zero-length call
+    ArgumentCaptor<Long> offsets = ArgumentCaptor.forClass(Long.class);
+    verify(raf, times(2)).pread(offsets.capture(), any(byte[].class), anyInt(), anyInt());
+    List<Long> captured = offsets.getAllValues();
+    assertEquals(2, captured.size());
+    assertEquals(0L, captured.get(0)); // zero-length read
+    assertEquals(0L, captured.get(1)); // subsequent full read starts at 0
+  }
+
+  @Test
+  @DisplayName("readBuffer_whenZeroLengthAtEof_expectEOFException")
+  void readBufferWhenZeroLengthAtEofExpectEOFException() throws Exception {
+    // Arrange: create a view positioned at EOF immediately
+    byte[] content = patternBytes(3);
+    RandomAccessBuffer raf = stubRaf(content);
+    // Zero-length window at EOF
+    RAFInputStream is = new RAFInputStream(raf, 3, 0);
+
+    // Act & Assert
+    assertThrows(EOFException.class, () -> is.read(new byte[1], 0, 0));
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  @DisplayName("readBuffer_whenNullBuffer_expectNullPointerException")
+  void readBufferWhenNullBufferExpectNullPointerException() throws Exception {
+    // Arrange
+    RandomAccessBuffer raf = stubRaf(patternBytes(4));
+    RAFInputStream is = new RAFInputStream(raf, 0, 4);
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> is.read(null));
+  }
+
+  @Test
+  @DisplayName("readBuffer_whenInvalidBufferRange_expectIndexOutOfBounds")
+  void readBufferWhenInvalidBufferRangeExpectIndexOutOfBounds() throws Exception {
+    // Arrange
+    byte[] content = patternBytes(10);
+    RandomAccessBuffer raf = stubRaf(content);
+    RAFInputStream is = new RAFInputStream(raf, 0, content.length);
+    byte[] buf = new byte[8];
+
+    // Act & Assert
+    assertThrows(IndexOutOfBoundsException.class, () -> is.read(buf, -1, 1));
+    assertThrows(IndexOutOfBoundsException.class, () -> is.read(buf, 0, 9));
+  }
+
+  @Test
+  @DisplayName("readBuffer_whenUnderlyingThrowsIOException_expectPropagated")
+  void readBufferWhenUnderlyingThrowsIOExceptionExpectPropagated() throws Exception {
+    // Arrange
+    RandomAccessBuffer raf = mock(RandomAccessBuffer.class);
+    doThrow(new IOException("boom"))
+        .when(raf)
+        .pread(anyLong(), any(byte[].class), anyInt(), anyInt());
+    RAFInputStream is = new RAFInputStream(raf, 0, 5);
+
+    // Act & Assert
+    assertThrows(IOException.class, () -> is.read(new byte[2]));
+  }
+
+  @Test
+  @DisplayName("readBuffer_whenNegativeFileOffset_expectIllegalArgumentException")
+  void readBufferWhenNegativeFileOffsetExpectIllegalArgumentException() throws Exception {
+    // Arrange
+    byte[] content = patternBytes(2);
+    RandomAccessBuffer raf = stubRaf(content);
+    RAFInputStream is = new RAFInputStream(raf, -1, 2);
+
+    // Act & Assert
+    assertThrows(IllegalArgumentException.class, () -> is.read(new byte[1]));
+  }
+
+  @Nested
+  class ParameterizedReadAll {
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 7, 64, 513})
+    @DisplayName("readBuffer_whenConsumingInChunks_expectExactBytesAndEof")
+    void readBufferWhenConsumingInChunksExpectExactBytesAndEof(int chunk) throws Exception {
+      // Arrange: choose length not divisible by chunk to exercise final clamp
+      int length = 5000 + (chunk % 3);
+      byte[] content = patternBytes(length);
+      RandomAccessBuffer raf = stubRaf(content);
+      RAFInputStream is = new RAFInputStream(raf, 0, content.length);
+      byte[] buf = new byte[Math.max(chunk, 1)];
+      List<Byte> collected = new ArrayList<>(length);
+
+      // Act
+      while (true) {
+        try {
+          int n = is.read(buf, 0, chunk);
+          for (int i = 0; i < n; i++) {
+            collected.add(buf[i]);
+          }
+        } catch (EOFException eof) {
+          break; // expected at the end
+        }
+      }
+
+      // Assert
+      byte[] out = new byte[collected.size()];
+      for (int i = 0; i < out.length; i++) out[i] = collected.get(i);
+      assertArrayEquals(content, out);
+      assertThrows(EOFException.class, () -> is.read(buf));
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/io/RandomAccessFileOutputStreamTest.java
+++ b/src/test/java/network/crypta/support/io/RandomAccessFileOutputStreamTest.java
@@ -1,0 +1,278 @@
+package network.crypta.support.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit tests for {@link RandomAccessFileOutputStream}.
+ *
+ * <p>Tests follow the AAA pattern and verify delegation behavior, error propagation, and boundary
+ * conditions. Where useful, real I/O is used with a {@link TempDir} to validate byte-level
+ * semantics; mocking is used to verify interactions and error paths.
+ */
+class RandomAccessFileOutputStreamTest {
+
+  @TempDir Path tempDir;
+
+  // -----------------------------
+  // Constructor & basic behavior
+  // -----------------------------
+
+  @Test
+  @DisplayName("constructor_withNullRaf_write_throwsNullPointerException")
+  void constructorWithNullRafWriteThrowsNullPointerException() {
+    // Arrange
+    // Act & Assert (use TWR to satisfy resource-closure rule; close() NPE is suppressed)
+    assertThrows(
+        NullPointerException.class, RandomAccessFileOutputStreamTest::writeOneByteWithNullRaf);
+  }
+
+  private static void writeOneByteWithNullRaf() throws IOException {
+    try (RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(null)) {
+      out.write(1);
+    }
+  }
+
+  // -----------------------------
+  // write(int)
+  // -----------------------------
+
+  static Stream<Integer> singleByteValues() {
+    return Stream.of(-1, 0, 0x7F, 0x80, 0xFF, 0x100, 0x1AB);
+  }
+
+  @ParameterizedTest
+  @MethodSource("singleByteValues")
+  @DisplayName("write_whenSingleInt_expectBytePersisted")
+  void writeWhenSingleIntExpectBytePersisted(int value) throws Exception {
+    // Arrange
+    Path file = tempDir.resolve("single-byte.bin");
+    try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw");
+        RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+      // Act
+      out.write(value);
+    }
+
+    // Assert
+    byte[] bytes = Files.readAllBytes(file);
+    assertThat("exactly one byte written", bytes.length, equalTo(1));
+    assertThat("low 8 bits should be written", bytes[0], equalTo((byte) value));
+  }
+
+  @Test
+  @DisplayName("write_whenCallsDelegate_writeByteInvokedOnce")
+  void writeWhenCallsDelegateWriteByteInvokedOnce() throws Exception {
+    // Arrange
+    RandomAccessFile raf = mock(RandomAccessFile.class);
+    try (RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+      // Act
+      out.write(0xAB);
+    }
+
+    // Assert
+    verify(raf, times(1)).writeByte(0xAB);
+  }
+
+  @Test
+  @DisplayName("write_whenDelegateThrowsIOException_exceptionPropagates")
+  void writeWhenDelegateThrowsIOExceptionExceptionPropagates() throws Exception {
+    // Arrange
+    RandomAccessFile raf = mock(RandomAccessFile.class);
+    doThrow(new IOException("boom")).when(raf).writeByte(7);
+    // Act & Assert
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+                out.write(7);
+              }
+            });
+    assertThat(ex.getMessage(), equalTo("boom"));
+  }
+
+  // -----------------------------
+  // write(byte[])
+  // -----------------------------
+
+  @Test
+  @DisplayName("write_whenNullArray_expectNullPointerException")
+  void writeWhenNullArrayExpectNullPointerException() throws Exception {
+    // Arrange
+    Path file = tempDir.resolve("null-array.bin");
+    try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw");
+        RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+      // Act & Assert
+      assertThrows(NullPointerException.class, () -> out.write(null));
+    }
+  }
+
+  @Test
+  @DisplayName("write_whenEmptyArray_expectNoChangeAndNoError")
+  void writeWhenEmptyArrayExpectNoChangeAndNoError() throws Exception {
+    // Arrange
+    Path file = tempDir.resolve("empty-array.bin");
+    byte[] empty = new byte[0];
+    try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw");
+        RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+      // Act
+      assertDoesNotThrow(() -> out.write(empty));
+    }
+
+    // Assert
+    byte[] bytes = Files.readAllBytes(file);
+    assertThat(bytes.length, equalTo(0));
+  }
+
+  @Test
+  @DisplayName("write_whenCallsDelegate_writeArrayInvokedOnce")
+  void writeWhenCallsDelegateWriteArrayInvokedOnce() throws Exception {
+    // Arrange
+    RandomAccessFile raf = mock(RandomAccessFile.class);
+    byte[] data = new byte[] {1, 2, 3};
+    try (RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+      // Act
+      out.write(data);
+    }
+
+    // Assert
+    verify(raf, times(1)).write(data);
+  }
+
+  @Test
+  @DisplayName("write_whenArrayDelegateThrowsIOException_exceptionPropagates")
+  void writeWhenArrayDelegateThrowsIOExceptionExceptionPropagates() throws Exception {
+    // Arrange
+    RandomAccessFile raf = mock(RandomAccessFile.class);
+    byte[] data = new byte[] {9, 8};
+    doThrow(new IOException("arr-io")).when(raf).write(data);
+    // Act & Assert
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+                out.write(data);
+              }
+            });
+    assertThat(ex.getMessage(), equalTo("arr-io"));
+  }
+
+  // -----------------------------
+  // write(byte[], int, int)
+  // -----------------------------
+
+  @Test
+  @DisplayName("write_withOffsetLen_whenNegativeIndices_expectIndexOutOfBoundsException")
+  void writeWithOffsetLenWhenNegativeIndicesExpectIndexOutOfBoundsException() throws Exception {
+    // Arrange
+    Path file = tempDir.resolve("neg-idx.bin");
+    byte[] data = new byte[] {10, 20, 30, 40};
+    try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw");
+        RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+      // Act & Assert
+      assertAll(
+          () -> assertThrows(IndexOutOfBoundsException.class, () -> out.write(data, -1, 1)),
+          () -> assertThrows(IndexOutOfBoundsException.class, () -> out.write(data, 0, -1)));
+    }
+  }
+
+  @Test
+  @DisplayName("write_withOffsetLen_whenExceedsBounds_expectIndexOutOfBoundsException")
+  void writeWithOffsetLenWhenExceedsBoundsExpectIndexOutOfBoundsException() throws Exception {
+    // Arrange
+    Path file = tempDir.resolve("oob-idx.bin");
+    byte[] data = new byte[] {10, 20, 30, 40};
+    try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw");
+        RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+      // Act & Assert
+      assertAll(
+          () -> assertThrows(IndexOutOfBoundsException.class, () -> out.write(data, 5, 0)),
+          () -> assertThrows(IndexOutOfBoundsException.class, () -> out.write(data, 3, 2)));
+    }
+  }
+
+  @Test
+  @DisplayName("write_withOffsetLen_whenCallsDelegate_invokedWithSameArgs")
+  void writeWithOffsetLenWhenCallsDelegateInvokedWithSameArgs() throws Exception {
+    // Arrange
+    RandomAccessFile raf = mock(RandomAccessFile.class);
+    byte[] data = new byte[] {5, 6, 7, 8};
+
+    // Act
+    try (RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+      out.write(data, 1, 2);
+    }
+
+    // Assert
+    verify(raf, times(1)).write(data, 1, 2);
+  }
+
+  @Test
+  @DisplayName("write_withOffsetLen_whenDelegateThrowsIOException_exceptionPropagates")
+  void writeWithOffsetLenWhenDelegateThrowsIOExceptionExceptionPropagates() throws Exception {
+    // Arrange
+    RandomAccessFile raf = mock(RandomAccessFile.class);
+    byte[] data = new byte[] {1, 2, 3, 4};
+    doThrow(new IOException("oio")).when(raf).write(data, 1, 2);
+    // Act & Assert
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf)) {
+                out.write(data, 1, 2);
+              }
+            });
+    assertThat(ex.getMessage(), equalTo("oio"));
+  }
+
+  // -----------------------------
+  // close()
+  // -----------------------------
+
+  @Test
+  @DisplayName("close_whenCallsDelegate_closeInvokedOnce")
+  void closeWhenCallsDelegateCloseInvokedOnce() throws Exception {
+    // Arrange
+    RandomAccessFile raf = mock(RandomAccessFile.class);
+    RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf);
+
+    // Act
+    out.close();
+
+    // Assert
+    verify(raf, times(1)).close();
+  }
+
+  @Test
+  @DisplayName("write_afterClose_whenUsingRealFile_expectIOException")
+  void writeAfterCloseWhenUsingRealFileExpectIOException() throws Exception {
+    // Arrange
+    Path file = tempDir.resolve("closed.bin");
+    RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw");
+    RandomAccessFileOutputStream out = new RandomAccessFileOutputStream(raf);
+    out.close();
+
+    // Act & Assert
+    assertThrows(IOException.class, () -> out.write(1));
+  }
+}


### PR DESCRIPTION
Summary
- Fix RAFInputStream view/window clamping and clarify size semantics.
- Add deterministic, AAA-style unit tests for RAFInputStream, RAFBucket, and RandomAccessFileOutputStream (JUnit 6 + Mockito).
- Improve Javadoc for RAFBucket and RandomAccessFileOutputStream.
- Address SonarLint findings in tests (naming, resource handling, redundant casts).
- Run Spotless formatting.

Why
- RAFInputStream could read past the intended view when a non-zero base offset was used; this PR clamps reads based on the remaining window.
- Missing/limited coverage around RandomAccessFile-based utilities; new tests lock in behavior and error paths.
- Public IO utilities lacked API documentation.

Scope of changes
- src/main/java/network/crypta/support/io/RAFInputStream.java
  - Clamp reads to remaining window.
  - Preserve EOFException semantics; handle EOF and zero-length window precisely.
  - Javadoc clarifications.
- src/main/java/network/crypta/support/io/RAFBucket.java
  - Javadoc improvements (placed above annotations per style).
- src/main/java/network/crypta/support/io/RandomAccessFileOutputStream.java
  - Javadoc: delegation, pointer movement, thread-safety note; complete @param/@throws; close() semantics.
- Tests (new):
  - src/test/java/network/crypta/support/io/RAFInputStreamTest.java
  - src/test/java/network/crypta/support/io/RAFBucketTest.java
  - src/test/java/network/crypta/support/io/RandomAccessFileOutputStreamTest.java

Testing
- JUnit 6: gradlew --parallel test → green.
- SonarLint (file-scoped) run on new/modified tests → no actionable findings remaining.
- Determinism: no PRNG reliance; uses @TempDir and fixed content.

Compatibility & risk
- RAFInputStream: behavioral fix for clamping; expected to be backward compatible for callers relying on documented window semantics.
- No API signature changes to public classes.
- Only documentation updates to RandomAccessFileOutputStream and RAFBucket.

How to verify locally
- ./gradlew --parallel test
- Optional: ./gradlew --quiet sonarlintFile -Psonarlint.file=<path-to-test>

Notes
- Spotless applied prior to commit.
- Branch: feature/fix-RAFBucket; base: develop.

Related commits on this branch
- e7f0d17: fix(io): RAFInputStream clamping and size semantics + tests
- a19a5df: docs(io): improve Javadoc for RAFBucket
- d5e83c2: test(io): add deterministic RAFBucket unit tests
- 07ab5c0: test: add RandomAccessFileOutputStream tests
- 27aec2e: docs: improve Javadoc for RandomAccessFileOutputStream