### PR TITLE
refactor(support): encapsulate BandwidthStatsContainer fields, update callers, and add tests

### DIFF
--- a/src/main/java/network/crypta/client/async/PersistentStatsPutter.java
+++ b/src/main/java/network/crypta/client/async/PersistentStatsPutter.java
@@ -35,9 +35,11 @@ public class PersistentStatsPutter implements Serializable {
     // Update our values
     // 0 : total bytes out, 1 : total bytes in
     final long[] nodeBW = n.getCollector().getTotalIO();
-    this.latestBW.totalBytesOut += nodeBW[0] - this.latestNodeBytesOut;
-    this.latestBW.totalBytesIn += nodeBW[1] - this.latestNodeBytesIn;
-    this.latestBW.creationTime = System.currentTimeMillis();
+    this.latestBW.setTotalBytesOut(
+        this.latestBW.getTotalBytesOut() + nodeBW[0] - this.latestNodeBytesOut);
+    this.latestBW.setTotalBytesIn(
+        this.latestBW.getTotalBytesIn() + nodeBW[1] - this.latestNodeBytesIn);
+    this.latestBW.setCreationTime(System.currentTimeMillis());
     this.latestNodeBytesOut = nodeBW[0];
     this.latestNodeBytesIn = nodeBW[1];
 

--- a/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
@@ -506,8 +506,8 @@ public class DiagnosticToadlet extends Toadlet {
         if (stats == null) {
           throw new NullPointerException();
         }
-        long overall_total_out = stats.totalBytesOut;
-        long overall_total_in = stats.totalBytesIn;
+        long overall_total_out = stats.getTotalBytesOut();
+        long overall_total_in = stats.getTotalBytesIn();
         int percent = (int) (100 * totalPayload / total[0]);
         long[] rate = node.getNodeStats().getNodeIOStats();
         long delta = (rate[5] - rate[2]) / 1000;

--- a/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
@@ -1348,8 +1348,8 @@ public class StatisticsToadlet extends Toadlet {
     BandwidthStatsContainer stats =
         node.getClientCore().getBandwidthStatsPutter().getLatestBWData();
     if (stats == null) throw new NullPointerException();
-    long overall_total_out = stats.totalBytesOut;
-    long overall_total_in = stats.totalBytesIn;
+    long overall_total_out = stats.getTotalBytesOut();
+    long overall_total_in = stats.getTotalBytesIn();
     int percent = (int) (100 * totalPayload / total[0]);
     long[] rate = node.getNodeStats().getNodeIOStats();
     long delta = (rate[5] - rate[2]) / 1000;

--- a/src/main/java/network/crypta/support/BandwidthStatsContainer.java
+++ b/src/main/java/network/crypta/support/BandwidthStatsContainer.java
@@ -4,16 +4,44 @@ import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * Contains bandwidth statistics.
+ * Holds cumulative bandwidth totals and a creation timestamp.
  *
- * @author Artefact2
+ * <p>This is a simple, mutable value object used to aggregate bandwidth figures over time. The
+ * totals are expressed in bytes, and {@code creationTime} stores the millisecond time since the
+ * Unix epoch when the values were last updated or created.
+ *
+ * <p>Thread-safety: This class is not thread-safe. If an instance is shared across threads, callers
+ * must provide external synchronization.
+ *
+ * <p>Overflow: All counters are {@code long}. Arithmetic follows two's-complement semantics and may
+ * wrap on overflow; no saturation or checks are performed.
+ *
+ * <p>Equality: {@link #equals(Object)} compares the three fields and requires the argument to be of
+ * the exact same runtime class (no {@code instanceof} check). As a result, equality can be
+ * asymmetric with subclasses.
  */
 public class BandwidthStatsContainer implements Serializable {
   @Serial private static final long serialVersionUID = 1L;
-  public long creationTime = 0;
-  public long totalBytesOut = 0;
-  public long totalBytesIn = 0;
 
+  private long creationTime = 0L;
+  private long totalBytesOut = 0L;
+  private long totalBytesIn = 0L;
+
+  /**
+   * Indicates whether some other object is equal to this one.
+   *
+   * <p>Two containers are equal when and only when the other object is a {@code
+   * BandwidthStatsContainer} (exact runtime class match) and their {@code creationTime}, {@code
+   * totalBytesIn}, and {@code totalBytesOut} fields are all equal.
+   *
+   * <p>Note: The strict class check ({@code o.getClass() == BandwidthStatsContainer.class}) means a
+   * subclass instance is not considered equal to a base instance, even if all field values match.
+   * Consequently, equality may be asymmetric with respect to subclasses.
+   *
+   * @param o object to compare against; may be {@code null}
+   * @return {@code true} if {@code o} is an equal {@code BandwidthStatsContainer}; {@code false}
+   *     otherwise
+   */
   @Override
   public boolean equals(Object o) {
     if (o == null) return false;
@@ -25,17 +53,97 @@ public class BandwidthStatsContainer implements Serializable {
     } else return false;
   }
 
+  /**
+   * Returns a hash code value for the object consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash is derived from the three fields using simple mixing and a multiplier.
+   *
+   * @return a hash code consistent with the equality definition
+   */
   @Override
   public int hashCode() {
     int hash = 3;
-    hash = 41 * hash + (int) (this.creationTime ^ (this.creationTime >>> 32));
-    hash = 41 * hash + (int) (this.totalBytesOut ^ (this.totalBytesOut >>> 32));
-    hash = 41 * hash + (int) (this.totalBytesIn ^ (this.totalBytesIn >>> 32));
+    hash = 41 * hash + Long.hashCode(this.creationTime);
+    hash = 41 * hash + Long.hashCode(this.totalBytesOut);
+    hash = 41 * hash + Long.hashCode(this.totalBytesIn);
     return hash;
   }
 
+  /**
+   * Adds the byte totals from another instance into this instance.
+   *
+   * <p>Only {@code totalBytesIn} and {@code totalBytesOut} are added; {@code creationTime} of this
+   * instance remains unchanged. Arithmetic uses Java {@code long} addition and can wrap on
+   * overflow.
+   *
+   * <p>Side effects: Mutates this instance. No synchronization is performed.
+   *
+   * @param latestBW the source of additional byte totals; must not be {@code null}
+   * @throws NullPointerException if {@code latestBW} is {@code null}
+   */
   public void addFrom(BandwidthStatsContainer latestBW) {
     this.totalBytesIn += latestBW.totalBytesIn;
     this.totalBytesOut += latestBW.totalBytesOut;
+  }
+
+  /**
+   * Returns the creation timestamp.
+   *
+   * @return milliseconds since the Unix epoch representing when this container was created or last
+   *     updated by the caller
+   */
+  public long getCreationTime() {
+    return creationTime;
+  }
+
+  /**
+   * Sets the creation timestamp.
+   *
+   * <p>No validation is performed.
+   *
+   * @param creationTime milliseconds since the Unix epoch
+   */
+  public void setCreationTime(long creationTime) {
+    this.creationTime = creationTime;
+  }
+
+  /**
+   * Returns the cumulative total of bytes sent.
+   *
+   * @return total bytes transmitted (may be negative if overflow occurred)
+   */
+  public long getTotalBytesOut() {
+    return totalBytesOut;
+  }
+
+  /**
+   * Sets the cumulative total of bytes sent.
+   *
+   * <p>No validation or saturation is performed. The value may be any {@code long}.
+   *
+   * @param totalBytesOut total bytes transmitted
+   */
+  public void setTotalBytesOut(long totalBytesOut) {
+    this.totalBytesOut = totalBytesOut;
+  }
+
+  /**
+   * Returns the cumulative total of bytes received.
+   *
+   * @return total bytes received (may be negative if overflow occurred)
+   */
+  public long getTotalBytesIn() {
+    return totalBytesIn;
+  }
+
+  /**
+   * Sets the cumulative total of bytes received.
+   *
+   * <p>No validation or saturation is performed. The value may be any {@code long}.
+   *
+   * @param totalBytesIn total bytes received
+   */
+  public void setTotalBytesIn(long totalBytesIn) {
+    this.totalBytesIn = totalBytesIn;
   }
 }

--- a/src/test/java/network/crypta/support/BandwidthStatsContainerTest.java
+++ b/src/test/java/network/crypta/support/BandwidthStatsContainerTest.java
@@ -1,0 +1,211 @@
+package network.crypta.support;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+// Mockito is available for I/O/time mocking; not needed here.
+
+/** Tests for {@link BandwidthStatsContainer}. */
+class BandwidthStatsContainerTest {
+
+  private static BandwidthStatsContainer newContainer(long ct, long out, long in) {
+    BandwidthStatsContainer b = new BandwidthStatsContainer();
+    b.setCreationTime(ct);
+    b.setTotalBytesOut(out);
+    b.setTotalBytesIn(in);
+    return b;
+  }
+
+  @Test
+  void equalsWhenDefaultsExpectTrue() {
+    // Arrange
+    BandwidthStatsContainer a = new BandwidthStatsContainer();
+    BandwidthStatsContainer b = new BandwidthStatsContainer();
+
+    // Act & Assert
+    assertEquals(a, b);
+    assertEquals(b, a);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void equalsWhenComparedWithNullExpectFalse() {
+    // Arrange
+    BandwidthStatsContainer a = new BandwidthStatsContainer();
+
+    // Act & Assert
+    assertNotEquals(null, a);
+  }
+
+  @Test
+  void equalsWhenComparedWithDifferentClassExpectFalse() {
+    // Arrange
+    BandwidthStatsContainer a = new BandwidthStatsContainer();
+    Object other = new Object();
+
+    // Act & Assert
+    assertNotEquals(a, other);
+  }
+
+  static class BWSubclass extends BandwidthStatsContainer {}
+
+  @Test
+  void equalsWhenComparedWithSubclassExpectAsymmetricEquality() {
+    // Arrange
+    BandwidthStatsContainer a = new BandwidthStatsContainer();
+    BandwidthStatsContainer sub = new BWSubclass();
+
+    // Act & Assert
+    // equals checks the argument's runtime class against BandwidthStatsContainer.class.
+    // Therefore a.equals(sub) is false, but sub.equals(a) becomes true (asymmetric).
+    assertNotEquals(a, sub);
+    assertEquals(sub, a);
+  }
+
+  @Test
+  void equalsWhenReflexiveSymmetricTransitiveExpectAllHold() {
+    // Arrange
+    BandwidthStatsContainer a = newContainer(10L, 20L, 30L);
+    BandwidthStatsContainer b = newContainer(10L, 20L, 30L);
+    BandwidthStatsContainer c = newContainer(10L, 20L, 30L);
+
+    // Assert reflexive
+    //noinspection EqualsWithItself
+    assertEquals(a, a);
+    // Assert symmetric
+    assertEquals(a, b);
+    assertEquals(b, a);
+    // Assert transitive
+    assertEquals(a, b);
+    assertEquals(b, c);
+    assertEquals(a, c);
+  }
+
+  static Stream<Arguments> unequalFieldProvider() {
+    return Stream.of(
+        Arguments.of(newContainer(1L, 0L, 0L), newContainer(2L, 0L, 0L), "creationTime"),
+        Arguments.of(newContainer(0L, 1L, 0L), newContainer(0L, 2L, 0L), "totalBytesOut"),
+        Arguments.of(newContainer(0L, 0L, 1L), newContainer(0L, 0L, 2L), "totalBytesIn"));
+  }
+
+  @ParameterizedTest(name = "equals false when {2} differs")
+  @MethodSource("unequalFieldProvider")
+  void equalsWhenAnyFieldDiffersExpectFalse(
+      BandwidthStatsContainer a, BandwidthStatsContainer b, String differingField) {
+    // Act & Assert
+    assertNotEquals(a, b, () -> "Expected inequality when " + differingField + " differs");
+    assertNotEquals(
+        b, a, () -> "Expected inequality when " + differingField + " differs (symmetry)");
+  }
+
+  @Test
+  void hashCodeWhenObjectsEqualExpectSameHash() {
+    // Arrange
+    BandwidthStatsContainer a = newContainer(111L, 222L, 333L);
+    BandwidthStatsContainer b = newContainer(111L, 222L, 333L);
+
+    // Act & Assert
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void hashCodeWhenCalledRepeatedlyExpectConsistentValue() {
+    // Arrange
+    BandwidthStatsContainer a = newContainer(7L, 8L, 9L);
+
+    // Act
+    int first = a.hashCode();
+    int second = a.hashCode();
+    int third = a.hashCode();
+
+    // Assert
+    assertEquals(first, second);
+    assertEquals(second, third);
+  }
+
+  @Test
+  void addFromWhenAddingTypicalValuesExpectTotalsAddedAndCreationUnchanged() {
+    // Arrange
+    BandwidthStatsContainer base = newContainer(1000L, 10L, 20L);
+    BandwidthStatsContainer inc = newContainer(2000L, 5L, 7L);
+
+    // Act
+    base.addFrom(inc);
+
+    // Assert
+    assertEquals(1000L, base.getCreationTime(), "creationTime must not change");
+    assertEquals(15L, base.getTotalBytesOut());
+    assertEquals(27L, base.getTotalBytesIn());
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void addFromWhenLatestIsNullExpectNullPointerException() {
+    // Arrange
+    BandwidthStatsContainer base = newContainer(0L, 1L, 1L);
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> base.addFrom(null));
+  }
+
+  @Test
+  void addFromWhenBoundaryOverflowExpectWrapAround() {
+    // Arrange
+    BandwidthStatsContainer base = newContainer(0L, Long.MAX_VALUE, Long.MAX_VALUE);
+    BandwidthStatsContainer inc = newContainer(0L, 1L, 1L);
+
+    // Act
+    base.addFrom(inc);
+
+    // Assert (Java long overflow wraps per two's complement)
+    assertEquals(Long.MIN_VALUE, base.getTotalBytesOut());
+    assertEquals(Long.MIN_VALUE, base.getTotalBytesIn());
+  }
+
+  @Nested
+  @DisplayName("Serialization")
+  class SerializationTests {
+    @Test
+    void serializationWhenRoundTrippedExpectEqualObject() throws Exception {
+      // Arrange
+      BandwidthStatsContainer original = newContainer(123L, 456L, 789L);
+
+      // Act
+      byte[] bytes;
+      try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+          ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+        oos.writeObject(original);
+        oos.flush();
+        bytes = bos.toByteArray();
+      }
+      BandwidthStatsContainer restored;
+      try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+          ObjectInputStream ois = new ObjectInputStream(bis)) {
+        restored = (BandwidthStatsContainer) ois.readObject();
+      }
+
+      // Assert
+      assertEquals(original, restored);
+      assertEquals(original.hashCode(), restored.hashCode());
+      assertThat(restored.getCreationTime(), is(123L));
+      assertThat(restored.getTotalBytesOut(), is(456L));
+      assertThat(restored.getTotalBytesIn(), is(789L));
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Encapsulates fields in `BandwidthStatsContainer` (creationTime, totalBytesOut, totalBytesIn) and adds getters/setters to satisfy Sonar rule S1104 (no public mutable fields).
- Updates callers to use the new accessors in:
  - `network.crypta.client.async.PersistentStatsPutter`
  - `network.crypta.clients.http.StatisticsToadlet`
  - `network.crypta.clients.http.DiagnosticToadlet`
- Adds comprehensive unit tests for `BandwidthStatsContainer` (JUnit 6, Mockito available). Tests cover:
  - equals/hashCode contracts (strict class equality semantics)
  - null/different-class/subclass asymmetry
  - addFrom aggregation (including overflow wrap-around)
  - serialization round-trip
- Improves Javadoc for `BandwidthStatsContainer` (thread-safety, overflow behavior, equality semantics, parameter/return tags).

Rationale
- Addresses maintainability and encapsulation concerns flagged by SonarLint (S1104).
- Improves API documentation clarity and test coverage without changing runtime behavior.

Compatibility
- Behavior is unchanged. Binary/API change: public fields are now private with accessors. All internal call sites have been updated. Plugins or external code that accessed the fields directly must switch to getters/setters.

Testing
- Local build with Java 21+.
- Commands executed:
  - `./gradlew --parallel test` → all tests pass.
  - `./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/support/BandwidthStatsContainer.java` → clean.

Change Details
- src/main/java/network/crypta/support/BandwidthStatsContainer.java
  - Encapsulate fields; add getters/setters
  - Javadoc: thread-safety, overflow, equality semantics
  - Keep equals/hashCode logic unchanged
- src/main/java/network/crypta/client/async/PersistentStatsPutter.java
  - Use accessors, preserve timestamp update
- src/main/java/network/crypta/clients/http/StatisticsToadlet.java
  - Use accessors for totals
- src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
  - Use accessors for totals
- src/test/java/network/crypta/support/BandwidthStatsContainerTest.java
  - New tests (AAA style, deterministic)

Commits
- 4976617 refactor(support): encapsulate BandwidthStatsContainer fields and update callers

Request
- Please review and merge into `develop`. I can separate tests/docs into a follow-up commit if desired.