### PR TITLE
docs(Base64): complete Javadoc; tests: rewrite Base64Test (AAA, parameterized)

### DIFF
--- a/src/main/java/network/crypta/support/Base64.java
+++ b/src/main/java/network/crypta/support/Base64.java
@@ -4,20 +4,30 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**
- * This class provides encoding of byte arrays into Base64-encoded strings, and decoding the other
- * way.
+ * Base64 utilities for encoding bytes/strings and decoding Base64 text.
  *
- * <p>NOTE! This is modified Base64 with slightly different characters than usual, so it won't
- * require escaping when used in URLs.
+ * <p>This class supports two alphabets:
  *
- * <p>NOTE! This class only does the padding that's normal in Base64 if the 'true' flag is given to
- * the encode() method. This is because Base64 requires that the length of the encoded text be a
- * multiple of four characters, padded with '='. Without the 'true' flag, we don't add these '='
- * characters.
+ * <ul>
+ *   <li>A modified, URL‑friendly alphabet using {@code '~'} and {@code '-'} for indices 62 and 63;
+ *       this is <strong>not</strong> RFC&nbsp;4648 nor the common URL‑safe variant.
+ *   <li>The standard Base64 alphabet using {@code '+'} and {@code '/'}, compatible with
+ *       RFC&nbsp;4648.
+ * </ul>
+ *
+ * <p>Padding: The standard alphabet encoders always pad with {@code '='} to a length that is a
+ * multiple of four characters. Modified alphabet encoders allow the caller to request padding; the
+ * unpadded form omits trailing {@code '='}. Decoders accept both padded and unpadded input and
+ * ignore trailing {@code '='}.
+ *
+ * <p>All methods are {@code static} and thread‑safe. Passing {@code null} to any method results in
+ * a {@link NullPointerException}. Encoding/decoding runs in O(n) time.
  *
  * @author Stephen Blackheath
  */
 public class Base64 {
+  private Base64() {}
+
   static final Charset UTF8 = StandardCharsets.UTF_8;
 
   private static final char[] base64Alphabet =
@@ -26,18 +36,17 @@ public class Base64 {
   private static final char[] base64StandardAlphabet =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
 
-  /** A reverse lookup table to convert base64 letters back into the a 6-bit sequence. */
+  /** A reverse lookup table to convert Base64 characters back into 6‑bit values. */
   private static final byte[] base64Reverse;
 
   private static final byte[] base64StandardReverse;
 
-  // Populate the base64Reverse lookup table from the base64Alphabet table.
+  // Populate reverse lookup tables from both alphabets.
   static {
     base64Reverse = new byte[128];
     base64StandardReverse = new byte[base64Reverse.length];
 
-    // Set all entries to 0xFF, which means that that particular letter
-    // is not a legal base64 letter.
+    // Initialize entries to 0xFF to mark illegal Base64 characters.
     for (int i = 0; i < base64Reverse.length; i++) {
       base64Reverse[i] = (byte) 0xFF;
       base64StandardReverse[i] = (byte) 0xFF;
@@ -48,64 +57,80 @@ public class Base64 {
     }
   }
 
-  /** Encode to our shortened (non-standards-compliant) format. */
+  /**
+   * Encodes bytes using the modified (non‑standard) Base64 alphabet without padding.
+   *
+   * @param in source bytes; must not be {@code null}
+   * @return Base64 text using the modified alphabet with no trailing {@code '='}
+   */
   public static String encode(byte[] in) {
     return encode(in, false);
   }
 
-  /* FIXME: Figure out where this function is used and maybe remove it if its not
-   * used. Its old javadoc which has been here for a while fools the user into believing
-   * that the format is standard compliant */
-
+  /* Overload that allows callers to request '=' padding when using the modified alphabet. */
   /**
-   * Caller should specify equalsPad=true if they want a standards compliant padding, but not
-   * standard compliant encoding.
+   * Encodes bytes using the modified (non‑standard) Base64 alphabet with optional padding.
+   *
+   * <p>When {@code equalsPad} is {@code true}, the result is padded to a length that is a multiple
+   * of four characters. When {@code false}, no padding is added and the length may not be a
+   * multiple of four.
+   *
+   * @param in source bytes; must not be {@code null}
+   * @param equalsPad whether to append {@code '='} padding
+   * @return Base64 text using the modified alphabet
    */
   public static String encode(byte[] in, boolean equalsPad) {
     return encode(in, equalsPad, base64Alphabet);
   }
 
   /**
-   * Convenience method to encode a string, in our shortened format.
+   * Encodes a UTF‑8 {@link String} using the modified alphabet without padding.
    *
-   * <p>Please use this to encode a string, rather than trying to encode the string yourself using
-   * the 0-arg String.getBytes() which is not deterministic.
+   * @param in text to encode; must not be {@code null}
+   * @return Base64 text using the modified alphabet with no trailing {@code '='}
    */
   public static String encodeUTF8(String in) {
     return encodeUTF8(in, false);
   }
 
   /**
-   * Convenience method to encode a string.
+   * Encodes a UTF‑8 {@link String} using the modified alphabet with optional padding.
    *
-   * <p>Please use this to encode a string, rather than trying to encode the string yourself using
-   * the 0-arg String.getBytes() which is not deterministic.
+   * @param in text to encode; must not be {@code null}
+   * @param equalsPad whether to append {@code '='} padding
+   * @return Base64 text using the modified alphabet
    */
   public static String encodeUTF8(String in, boolean equalsPad) {
     return encode(in.getBytes(UTF8), equalsPad, base64Alphabet);
   }
 
   /**
-   * Convenience method to encode a string.
+   * Encodes a UTF‑8 {@link String} using the standard Base64 alphabet with padding.
    *
-   * <p>Please use this to encode a string, rather than trying to encode the string yourself using
-   * the 0-arg String.getBytes() which is not deterministic.
+   * @param in text to encode; must not be {@code null}
+   * @return Base64 text using the standard alphabet padded with {@code '='}
    */
   public static String encodeStandardUTF8(String in) {
     return encodeStandard(in.getBytes(UTF8));
   }
 
-  /** Standard compliant encoding. */
+  /**
+   * Encodes bytes using the standard Base64 alphabet with padding.
+   *
+   * @param in source bytes; must not be {@code null}
+   * @return Base64 text using the standard alphabet padded with {@code '='}
+   */
   public static String encodeStandard(byte[] in) {
     return encode(in, true, base64StandardAlphabet);
   }
 
-  /** Caller should specify equalsPad=true if they want a standards compliant encoding. */
+  /* Core encoder used by both alphabets. {@code equalsPad} toggles '=' padding. */
   private static String encode(byte[] in, boolean equalsPad, char[] alphabet) {
     char[] out = new char[((in.length + 2) / 3) * 4];
     int rem = in.length % 3;
     int o = 0;
-    for (int i = 0; i < in.length; ) {
+    int i = 0;
+    while (i < in.length) {
       int val = (in[i++] & 0xFF) << 16;
       if (i < in.length) val |= (in[i++] & 0xFF) << 8;
       if (i < in.length) val |= (in[i++] & 0xFF);
@@ -122,6 +147,8 @@ public class Base64 {
       case 2:
         outLen -= 1;
         break;
+      default:
+        break;
     }
     // Pad with '=' signs up to a multiple of four if requested.
     if (equalsPad) while (outLen < out.length) out[outLen++] = '=';
@@ -129,42 +156,63 @@ public class Base64 {
   }
 
   /**
-   * Handles the standards-compliant padding (padded with '=' signs) as well as our shortened form.
+   * Decodes Base64 text using the modified alphabet.
    *
-   * @throws IllegalBase64Exception
+   * <p>Accepts both padded and unpadded input. Trailing {@code '='} is ignored.
+   *
+   * @param inStr Base64 text using the modified alphabet; must not be {@code null}
+   * @return decoded bytes
+   * @throws IllegalBase64Exception if the input contains illegal characters or the effective length
+   *     (after trimming trailing {@code '='}) is invalid (length mod 4 == 1)
    */
   public static byte[] decode(String inStr) throws IllegalBase64Exception {
     return decode(inStr, base64Reverse);
   }
 
   /**
-   * Convenience method to decode into a string, in our shortened format.
+   * Decodes Base64 text (modified alphabet) and returns a UTF‑8 {@link String}.
    *
-   * <p>Please use this to decode into a string, rather than trying to decode the string yourself
-   * using new String(bytes[]) which is not deterministic.
+   * @param inStr Base64 text using the modified alphabet; must not be {@code null}
+   * @return decoded text as UTF‑8
+   * @throws IllegalBase64Exception if the input is not valid Base64 in the modified alphabet
    */
   public static String decodeUTF8(String inStr) throws IllegalBase64Exception {
     return new String(decode(inStr), UTF8);
   }
 
-  /** Handles the standards-compliant base64 encoding. */
+  /**
+   * Decodes Base64 text using the standard alphabet.
+   *
+   * <p>Accepts both padded and unpadded input. Trailing {@code '='} is ignored.
+   *
+   * @param inStr Base64 text using the standard alphabet; must not be {@code null}
+   * @return decoded bytes
+   * @throws IllegalBase64Exception if the input contains illegal characters or the effective length
+   *     (after trimming trailing {@code '='}) is invalid (length mod 4 == 1)
+   */
   public static byte[] decodeStandard(String inStr) throws IllegalBase64Exception {
     return decode(inStr, base64StandardReverse);
   }
 
-  /** Handles the standards-compliant (padded with '=' signs) as well as our shortened form. */
+  /*
+   * Core decoder shared by both alphabets.
+   *
+   * Implementation detail: Trims trailing '=' padding, then processes full 4‑character blocks. The
+   * remainder determines how many output bytes follow. Any character that does not map to a 6‑bit
+   * value in the selected alphabet yields an IllegalBase64Exception. When the (unpadded) length
+   * mod 4 == 1, the length is illegal and an exception is thrown.
+   */
   private static byte[] decode(String inStr, byte[] reverseAlphabet) throws IllegalBase64Exception {
     try {
       char[] in = inStr.toCharArray();
       int inLength = in.length;
 
-      // Strip trailing equals signs.
+      // Strip trailing '=' padding ignored by the decoder.
       while ((inLength > 0) && (in[inLength - 1] == '=')) inLength--;
 
       int blocks = inLength / 4;
       int remainder = inLength & 3;
-      // wholeInLen and wholeOutLen are the the length of the input and output
-      // sequences respectively, not including any partial block at the end.
+      // wholeInLen/wholeOutLen exclude any partial block at the end.
       int wholeInLen = blocks * 4;
       int wholeOutLen = blocks * 3;
       int outLen = wholeOutLen;
@@ -178,12 +226,12 @@ public class Base64 {
           outLen = wholeOutLen + 2;
           break;
         default:
-          outLen = wholeOutLen;
+          break;
       }
       byte[] out = new byte[outLen];
       int o = 0;
-      int i;
-      for (i = 0; i < wholeInLen; ) {
+      int i = 0;
+      while (i < wholeInLen) {
         int in1 = reverseAlphabet[in[i]];
         int in2 = reverseAlphabet[in[i + 1]];
         int in3 = reverseAlphabet[in[i + 2]];

--- a/src/main/java/network/crypta/support/io/TempBucketFactory.java
+++ b/src/main/java/network/crypta/support/io/TempBucketFactory.java
@@ -37,29 +37,32 @@ import org.slf4j.LoggerFactory;
 /**
  * Factory for temporary buckets that prefer RAM and transparently migrate to disk.
  *
- * <p>This factory creates buckets that are initially backed either by memory (an
- * {@link ArrayBucket}) or by a file (a {@link TempFileBucket}), depending on the requested size and
+ * <p>This factory creates buckets that are initially backed either by memory (an {@link
+ * ArrayBucket}) or by a file (a {@link TempFileBucket}), depending on the requested size and
  * current pool usage. RAM-backed buckets may later migrate to disk based on age or size so the
  * process can continue without running out of the configured memory pool.
  *
  * <p>Selection rules:
+ *
  * <ul>
- *   <li>Use an in-memory bucket when {@code size <= maxRAMBucketSize} and the pool
- *       ({@link #bytesInUse}) would remain {@code <= maxRamUsed}.
+ *   <li>Use an in-memory bucket when {@code size <= maxRAMBucketSize} and the pool ({@link
+ *       #bytesInUse}) would remain {@code <= maxRamUsed}.
  *   <li>Otherwise, use a disk-backed bucket (optionally wrapped with padding and encryption when
  *       {@link #reallyEncrypt} is enabled).
  * </ul>
  *
  * <p>Migration rules for RAM buckets:
+ *
  * <ul>
  *   <li>Age-based: buckets older than {@link #RAMBUCKET_MAX_AGE} migrate.
- *   <li>Size-based: buckets exceeding
- *       {@code RAMBUCKET_CONVERSION_FACTOR * maxRAMBucketSize} migrate.
+ *   <li>Size-based: buckets exceeding {@code RAMBUCKET_CONVERSION_FACTOR * maxRAMBucketSize}
+ *       migrate.
  *   <li>Pool-pressure: when total usage rises above {@link #MAX_USAGE_HIGH}, a background cleaner
  *       migrates buckets until usage drops below {@link #MAX_USAGE_LOW}.
  * </ul>
  *
  * <p>Threading and lifecycle:
+ *
  * <ul>
  *   <li>Instances are thread-safe for factory operations.
  *   <li>Returned buckets expose synchronized methods where needed; callers must still respect
@@ -161,8 +164,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
    * A bucket that may start in RAM and migrate to disk transparently.
    *
    * <p>Only one output stream can be opened at a time. Reading requires that an output stream has
-   * been opened previously to establish the content; see
-   * {@link #getInputStreamUnbuffered()} for details.
+   * been opened previously to establish the content; see {@link #getInputStreamUnbuffered()} for
+   * details.
    *
    * <p>Instances are safe for concurrent use where methods are synchronized; callers should
    * coordinate access patterns when mixing reads, writes, and migration.
@@ -292,8 +295,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
     /**
      * Returns a buffered output stream for writing the bucket contents.
      *
-     * <p>Only one output stream may be open at a time. The returned stream may trigger
-     * migration to disk as content grows beyond the in-memory thresholds.
+     * <p>Only one output stream may be open at a time. The returned stream may trigger migration to
+     * disk as content grows beyond the in-memory thresholds.
      *
      * @return buffered {@link OutputStream}
      * @throws IOException if an output stream is already open or the bucket has been freed
@@ -306,9 +309,9 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
     /**
      * Returns an unbuffered output stream for writing the bucket contents.
      *
-     * <p>Preconditions: no other output stream is open. Only a single output stream is supported
-     * at a time. After calling this method, {@link #getInputStreamUnbuffered()} becomes available
-     * once data has been written.
+     * <p>Preconditions: no other output stream is open. Only a single output stream is supported at
+     * a time. After calling this method, {@link #getInputStreamUnbuffered()} becomes available once
+     * data has been written.
      *
      * @return unbuffered {@link OutputStream}
      * @throws IOException if another output stream is open or the bucket has been freed
@@ -598,8 +601,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
     /**
      * Releases all resources associated with this bucket.
      *
-     * <p>Closes any open streams, updates memory accounting, and frees the underlying storage.
-     * This method is idempotent.
+     * <p>Closes any open streams, updates memory accounting, and frees the underlying storage. This
+     * method is idempotent.
      */
     @Override
     public synchronized void free() {
@@ -618,11 +621,11 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
             ramBucketQueue.remove(getReference());
           }
 
-      // Explicit free completed; clear the Cleaner registration.
-      if (cleanable != null) {
-        cleanable.clean();
-      }
-      return;
+          // Explicit free completed; clear the Cleaner registration.
+          if (cleanable != null) {
+            cleanable.clean();
+          }
+          return;
         } else {
           // Better to free outside the lock if it's not in-memory.
           cur = currentBucket;
@@ -684,8 +687,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
      * Converts this bucket into a read-only random-access buffer.
      *
      * <p>Preconditions: no output stream is open and no input stream is currently active. The
-     * returned buffer shares the underlying storage; after conversion, this bucket becomes a
-     * {@link RAFBucket} wrapping the new buffer.
+     * returned buffer shares the underlying storage; after conversion, this bucket becomes a {@link
+     * RAFBucket} wrapping the new buffer.
      *
      * @return a read-only {@link LockableRandomAccessBuffer}
      * @throws IOException if the bucket has been freed or streams are still open
@@ -913,8 +916,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
   /**
    * Sets the minimum free disk space to preserve.
    *
-   * <p>Operations that would reduce available space below this threshold fail fast with
-   * {@link InsufficientDiskSpaceException}.
+   * <p>Operations that would reduce available space below this threshold fail fast with {@link
+   * InsufficientDiskSpaceException}.
    *
    * @param min minimum free space in bytes to maintain
    */
@@ -934,6 +937,7 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
 
   static final double MAX_USAGE_LOW = 0.8;
   static final double MAX_USAGE_HIGH = 0.9;
+
   /**
    * Cipher configuration used when wrapping disk-backed storage with encryption.
    *

--- a/src/test/java/network/crypta/support/Base64Test.java
+++ b/src/test/java/network/crypta/support/Base64Test.java
@@ -1,191 +1,387 @@
 package network.crypta.support;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import java.util.function.LongSupplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 /**
- * Test case for {@link Base64} class.
- *
- * @author Alberto Bacchelli &lt;sback@freenetproject.org&gt;
+ * Tests for {@link Base64}. AAA style, deterministic, parameterized where useful. Includes Mockito
+ * for simple I/O and time mocking without changing production code.
  */
-public class Base64Test {
+class Base64Test {
 
-  // data from http://www.alanwood.net/unicode/unicode_samples.html
-  static final String testSample =
-      "!5Aa¥¼ÑñĄąĲĳƏƐƕƺɖɞɫɷʱʬ˕˨o̕o̚ơo͡oΎΔδϠЉЩщӃԀԆԈԎԱԲաբסֶאבױ؟بحٍ۳܀ܐܠܘ݉ހސޤހި߄ߐ߰ߋ߹ࠀࠎࠏࠪ࠽ठःअठी३তঃঅ৩৵ਠਂਅਉਠੱઠઃઅઠૌ૩ଆଐଠୗ୩பஂஅபூ௩అఃఓఅౌ౩ಲಃಅಲೋ೩ഠഃഅഠൃ൩ෆංඑඣෆූกญกั๓ກຜໄ໓༣ཁངཱུངྵကဂု၄၍აზჵ჻ᄀᅙᇧᇸሀቻ፧፬ᎠᎫᏎᏴᐁᑦᕵᙧᚁᚈᚕ᚜ᚠᚳᛦᛰᜀᜄᜌᜊᜒᜠᜫᜪᜭᜯᝁᝊᝐᝊᝒᝠᝦᝮᝪᝲកឣខា៤᠀᠔ᡎᢥᢰᣇᣠᣴᤁᤥ᥅᥉ᥐᥞᥨᥲ᧠᧪᧴᧾ᨀᨁᨖᨔᨗᨠᨣᩯ᪁᪭ᬧᬀᬊᬧᭀ᭪ᮗᮀᮋᮗᮦ᮵ᰁᰘᰓᰯ᱅᱕ᱝᱰ᱿o᳐o᳢ᳩᳱᴂᴥᴽᵫḀẀẶỳἀὂᾑῼ—“‰※⁴⁾₃₌₢₣₪€o⃐o⃕o⃚o⃠℀℃№™⅛Ⅳⅸↂ←↯↻⇈∀∰⊇⋩⌂⌆⌣⌽␂␊␢␣⑀⑃⑆⑊③⑷⒌ⓦ┍┝╤╳▀▃▏░□▨◎◮☂☺♀♪✃✈❄➓⟐⟟⟥⟫⟰⟶⟺⟿⠀⠲⢖⣿⤄⤽⥈⥻⦀⦝⧰⧻⨇⨋⫚⫸⬀⬄⬉⬍ⰀⰉⰍⱙⱠⱥⱶⱺⲀⲑⲶⳂⴀⴆⴝⴢⴲⴶⵟⵥⶀⶆⶐⷖоⷠоⷩоⷶоⷿ⸁⸎⸨⸭⺀⺘⻂⻱⼀⼽⽺⿔⿰⿳⿷⿻々〒〣〰あぐるゞアヅヨヾㄆㄓㄝㄩㄱㄸㅪㆍ㆐㆕㆚㆟ㆠㆧㆯㆷㇰㇵㇺㇿ㈔㈲㊧㋮㌃㍻㎡㏵㐅㒅㝬㿜䷂䷫䷴䷾一憨田龥ꀀꅴꊩꒌ꒐꒡꒰꓆ꓐꓫꓻ꓿ꔁꔂꕝꕢꙂꙉꙮꚖꚠꛠꛕ꛰꛷꜁꜉ꜜꜟꜢꜮꝿꟿꠀꠇꠠꠤ꠪꠰꠶꠸꠹ꡁꡧꡳ꡷ꢝꢁꢍꢳ꣕ठ꣠ठ꣮ꣳꣻ꤅ꤎꤍꤪ꤮ꤰꤸꤷꥐ꥟ꥠꥪꥴꥼꦮꦀꦣꦮꦺ꧙ꨅꨍꨂꨬ꩖ꩠꩮꩴဂꩻꪀꪙꪒꪷ꫟ꯀꯌꯁꯧ꯹가뮀윸힣ힰퟎퟡퟻ豈朗歷館ﬀﬁﬗﭏﭐﰡﲼﷻo︠o︡o︢o︣︴︵﹃﹌﹖﹠﹩﹫ﹰﺗﺺﻼ３Ｆｶﾺ￹￺￼�𐀀𐀢𐁀𐁝𐂀𐂚𐃃𐃺𐄀𐄎𐄱𐄸𐅃𐅉𐅓𐆉𐆐𐆔𐆘𐆚𐇐𐇛𐇯𐇹𐊀𐊉𐊕𐊚𐊡𐊨𐊾𐋋𐌀𐌊𐌜𐌢𐌰𐌸𐍂𐍊𐎀𐎇𐎖𐎟𐐂𐐉𐐯𐑉𐑐𐑝𐑫𐑿𐒀𐒎𐒝𐒨𐠀𐠓𐠦𐠿𐡀𐡋𐡓𐡟𐤀𐤈𐤔𐤕𐤠𐤩𐤰𐤿𐨀𐨨𐨍𐨲𐩅𐩠𐩯𐩽𐩿𐬀𐬟𐬩𐬿𐭀𐭉𐭚𐭟𐭠𐭬𐭹𐭿𐰀𐰕𐰯𐱈𐹠𐹮𐹵𐹻𑂞𑂀𑂚𑂞𑂴𑃁𒀀𒀞𒅑𒍦𒐁𒐌𒐥𒑳𓀀𓅸𓉀𓐮𝁆𝂋𝃩𝃰𝄁𝄫𝅘𝅥𝅮𝇇𝌀𝌃𝌑𝍊𝍠𝍨𝍬𝍱𝓐𝕬𝝃𝟽🀀🀍🀒🀝🀴🁓🁮🂈🄀🄖🄭🆐🈐🈖🈪🉈𠀧𠤩𡨺𡽫𪜀𪮘𪾀𫜴勺卉善爨";
-  static final String testSampleStandardEncoding =
-      "ITVBYcKlwrzDkcOxxITEhcSyxLPGj8aQxpXGusmWyZ7Jq8m3yrHKrMuVy6hvzJVvzJpvzJtvzaFvzo7OlM60z6DQidCp0YnTg9SA1IbUiNSO1LHUstWh1aLXoda215DXkdex2J/YqNit2Y3bs9yA3JDcoNyY3YnegN6Q3qTegN6o34TfkN+w34vfueCggOCgjuCgj+CgquCgveCkoOCkg+CkheCkoOClgOClqeCmpOCmg+CmheCnqeCnteCooOCoguCoheCoieCooOCpseCqoOCqg+CqheCqoOCrjOCrqeCshuCskOCsoOCtl+CtqeCuquCuguCuheCuquCvguCvqeCwheCwg+Cwk+CwheCxjOCxqeCysuCyg+CyheCysuCzi+CzqeC0oOC0g+C0heC0oOC1g+C1qeC3huC2guC2keC2o+C3huC3luC4geC4jeC4geC4seC5k+C6geC6nOC7hOC7k+C8o+C9geC9hOC9teC9hOC+teGAgOGAguGAr+GBhOGBjeGDkOGDluGDteGDu+GEgOGFmeGHp+GHuOGIgOGJu+GNp+GNrOGOoOGOq+GPjuGPtOGQgeGRpuGVteGZp+GageGaiOGaleGanOGaoOGas+GbpuGbsOGcgOGchOGcjOGciuGckuGcoOGcq+GcquGcreGcr+GdgeGdiuGdkOGdiuGdkuGdoOGdpuGdruGdquGdsuGegOGeo+GegeGetuGfpOGggOGglOGhjuGipeGisOGjh+GjoOGjtOGkgeGkpeGlheGlieGlkOGlnuGlqOGlsuGnoOGnquGntOGnvuGogOGogeGoluGolOGol+GooOGoo+Gpr+GqgeGqreGsp+GsgOGsiuGsp+GtgOGtquGul+GugOGui+Gul+GupuGuteGwgeGwmOGwk+Gwr+GxheGxleGxneGxsOGxv2/hs5Bv4bOi4bOp4bOx4bSC4bSl4bS94bWr4biA4bqA4bq24buz4byA4b2C4b6R4b+84oCU4oCc4oCw4oC74oG04oG+4oKD4oKM4oKi4oKj4oKq4oKsb+KDkG/ig5Vv4oOab+KDoOKEgOKEg+KEluKEouKFm+KFo+KFuOKGguKGkOKGr+KGu+KHiOKIgOKIsOKKh+KLqeKMguKMhuKMo+KMveKQguKQiuKQouKQo+KRgOKRg+KRhuKRiuKRouKRt+KSjOKTpuKUjeKUneKVpOKVs+KWgOKWg+KWj+KWkeKWoeKWqOKXjuKXruKYguKYuuKZgOKZquKcg+KciOKdhOKek+KfkOKfn+KfpeKfq+KfsOKftuKfuuKfv+KggOKgsuKiluKjv+KkhOKkveKliOKlu+KmgOKmneKnsOKnu+Koh+Koi+KrmuKruOKsgOKshOKsieKsjeKwgOKwieKwjeKxmeKxoOKxpeKxtuKxuuKygOKykeKytuKzguK0gOK0huK0neK0ouK0suK0tuK1n+K1peK2gOK2huK2kOK3ltC+4reg0L7it6nQvuK3ttC+4re/4riB4riO4rio4rit4rqA4rqY4ruC4rux4ryA4ry94r264r+U4r+w4r+z4r+34r+744CF44CS44Cj44Cw44GC44GQ44KL44Ke44Ki44OF44Oo44O+44SG44ST44Sd44Sp44Sx44S444Wq44aN44aQ44aV44aa44af44ag44an44av44a344ew44e144e644e/44iU44iy44qn44uu44yD4427446h44+145CF45KF452s47+c5LeC5Ler5Le05Le+5LiA5oao55Sw6b6l6oCA6oW06oqp6pKM6pKQ6pKh6pKw6pOG6pOQ6pOr6pO76pO/6pSB6pSC6pWd6pWi6pmC6pmJ6pmu6pqW6pqg6pug6puV6puw6pu36pyB6pyJ6pyc6pyf6pyi6pyu6p2/6p+/6qCA6qCH6qCg6qCk6qCq6qCw6qC26qC46qC56qGB6qGn6qGz6qG36qKd6qKB6qKN6qKz6qOV4KSg6qOg4KSg6qOu6qOz6qO76qSF6qSO6qSN6qSq6qSu6qSw6qS46qS36qWQ6qWf6qWg6qWq6qW06qW86qau6qaA6qaj6qau6qa66qeZ6qiF6qiN6qiC6qis6qmW6qmg6qmu6qm04YCC6qm76qqA6qqZ6qqS6qq36quf6q+A6q+M6q+B6q+n6q+56rCA666A7Jy47Z6j7Z6w7Z+O7Z+h7Z+77oCA7pm474iw76O/76SA76Sp76aM76is76yA76yB76yX762P762Q77Ch77K877e7b++4oG/vuKFv77iib++4o++4tO+4te+5g++5jO+5lu+5oO+5qe+5q++5sO+6l++6uu+7vO+8k++8pu+9tu++uu+/ue+/uu+/vO+/vfCQgIDwkICi8JCBgPCQgZ3wkIKA8JCCmvCQg4PwkIO68JCEgPCQhI7wkISx8JCEuPCQhYPwkIWJ8JCFk/CQhonwkIaQ8JCGlPCQhpjwkIaa8JCHkPCQh5vwkIev8JCHufCQioDwkIqJ8JCKlfCQiprwkIqh8JCKqPCQir7wkIuL8JCMgPCQjIrwkIyc8JCMovCQjLDwkIy48JCNgvCQjYrwkI6A8JCOh/CQjpbwkI6f8JCQgvCQkInwkJCv8JCRifCQkZDwkJGd8JCRq/CQkb/wkJKA8JCSjvCQkp3wkJKo8JCggPCQoJPwkKCm8JCgv/CQoYDwkKGL8JChk/CQoZ/wkKSA8JCkiPCQpJTwkKSV8JCkoPCQpKnwkKSw8JCkv/CQqIDwkKio8JCojfCQqLLwkKmF8JCpoPCQqa/wkKm98JCpv/CQrIDwkKyf8JCsqfCQrL/wkK2A8JCtifCQrZrwkK2f8JCtoPCQrazwkK258JCtv/CQsIDwkLCV8JCwr/CQsYjwkLmg8JC5rvCQubXwkLm78JGCnvCRgoDwkYKa8JGCnvCRgrTwkYOB8JKAgPCSgJ7wkoWR8JKNpvCSkIHwkpCM8JKQpfCSkbPwk4CA8JOFuPCTiYDwk5Cu8J2BhvCdgovwnYOp8J2DsPCdhIHwnYSr8J2FoPCdh4fwnYyA8J2Mg/CdjJHwnY2K8J2NoPCdjajwnY2s8J2NsfCdk5DwnZWs8J2dg/Cdn73wn4CA8J+AjfCfgJLwn4Cd8J+AtPCfgZPwn4Gu8J+CiPCfhIDwn4SW8J+ErfCfhpDwn4iQ8J+IlvCfiKrwn4mI8KCAp/CgpKnwoai68KG9q/CqnIDwqq6Y8Kq+gPCrnLTwr6Co8K+grPCvoYbwr6Sg";
+  private static final String ILLEGAL_CHAR_MSG = "illegal Base64 character";
 
-  static final String toEncode =
-      "Man is distinguished, not only by his reason, but by this singular "
-          + "passion from other animals, which is a lust of the mind, that by a perseverance "
-          + "of delight in the continued and indefatigable generation of knowledge, exceeds "
-          + "the short vehemence of any carnal pleasure.";
-  static final String toDecode =
-      "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ"
-          + "1dCBieSB0aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIG"
-          + "x1c3Qgb2YgdGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY"
-          + "29udGludWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRz"
-          + "IHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4";
+  // ----------------------------
+  // Happy-path round trips
+  // ----------------------------
 
-  /**
-   * Test the encode(byte[]) method against a well-known example (see
-   * http://en.wikipedia.org/wiki/Base_64 as reference) to verify if it encode works correctly.
-   */
   @Test
-  public void testEncode() {
-    byte[] aByteArrayToEncode = toEncode.getBytes(StandardCharsets.UTF_8);
-    assertEquals(Base64.encode(aByteArrayToEncode), toDecode);
+  @DisplayName("encode_whenEmpty_expectEmptyString")
+  void encodeWhenEmptyExpectEmptyString() {
+    // Arrange
+    byte[] input = new byte[0];
+
+    // Act
+    String modified = Base64.encode(input);
+    String standard = Base64.encodeStandard(input);
+
+    // Assert
+    assertEquals("", modified);
+    assertEquals("", standard);
   }
 
-  /**
-   * Test the decode(String) method against a well-known example (see
-   * http://en.wikipedia.org/wiki/Base_64 as reference) to verify if it decode an already encoded
-   * string correctly.
-   */
   @Test
-  public void testDecode() throws Exception {
-    String decodedString = new String(Base64.decode(toDecode));
-    assertEquals(decodedString, toEncode);
+  @DisplayName("decode_whenEmpty_expectEmptyArray")
+  void decodeWhenEmptyExpectEmptyArray() throws IllegalBase64Exception {
+    // Arrange
+    String empty = "";
+
+    // Act
+    byte[] modified = Base64.decode(empty);
+    byte[] standard = Base64.decodeStandard(empty);
+
+    // Assert
+    assertArrayEquals(new byte[0], modified);
+    assertArrayEquals(new byte[0], standard);
   }
 
-  /**
-   * Test the encodeStandard(byte[]) method This is the same as encode() from
-   * generator/js/src/freenet/client/tools/Base64.java
-   */
   @Test
-  public void testEncodeStandard() {
-    byte[] aByteArrayToEncode = testSample.getBytes(StandardCharsets.UTF_8);
-    assertEquals(Base64.encodeStandard(aByteArrayToEncode), testSampleStandardEncoding);
+  @DisplayName("encodeUTF8_whenRoundTripUnicode_expectOriginalString")
+  void encodeUtf8WhenRoundTripUnicodeExpectOriginalString() throws IllegalBase64Exception {
+    // Arrange
+    String original = "Hello, 世界 🌍 — Crypta";
+
+    // Act
+    String enc = Base64.encodeUTF8(original);
+    String dec = Base64.decodeUTF8(enc);
+
+    // Assert
+    assertEquals(original, dec);
   }
 
-  /**
-   * Test the decodeStandard(byte[]) method. This is the same as decode() from
-   * generator/js/src/freenet/client/tools/Base64.java
-   */
-  @Test
-  public void testDecodeStandard() throws Exception {
-    String decodedString =
-        new String(Base64.decodeStandard(testSampleStandardEncoding), StandardCharsets.UTF_8);
-    assertEquals(decodedString, testSample);
-  }
+  @ParameterizedTest(name = "len={0}, equalsPad={1}, standardAlphabet={2}")
+  @MethodSource("lengthsAndAlphabetsData")
+  @DisplayName("encode_whenVariousLengths_expectRoundTrip")
+  void encodeWhenVariousLengthsExpectRoundTrip(
+      int length, boolean equalsPad, boolean standardAlphabet) throws IllegalBase64Exception {
+    // Arrange
+    byte[] input = generate(length, 42);
 
-  /**
-   * Test encode(byte[] in) and decode(String inStr) methods, to verify if they work correctly
-   * together. It compares the string before encoding and with the one after decoding.
-   */
-  @Test
-  public void testEncodeDecode() {
-    byte[] bytesDecoded;
-    byte[] bytesToEncode = new byte[5];
-
-    // byte upper bound
-    bytesToEncode[0] = 127;
-    bytesToEncode[1] = 64;
-    bytesToEncode[2] = 0;
-    bytesToEncode[3] = -64;
-    // byte lower bound
-    bytesToEncode[4] = -128;
-
-    String aBase64EncodedString = Base64.encode(bytesToEncode);
-
-    try {
-      bytesDecoded = Base64.decode(aBase64EncodedString);
-      assertArrayEquals(bytesToEncode, bytesDecoded);
-    } catch (IllegalBase64Exception aException) {
-      fail("Not expected exception thrown : " + aException.getMessage());
-    }
-  }
-
-  /**
-   * Test the encode(String,boolean) method to verify if the padding character '=' is correctly
-   * placed.
-   */
-  @Test
-  public void testEncodePadding() {
-    byte[][] methodBytesArray = {
-      // three byte Array -> no padding char expected
-      {4, 4, 4},
-      // two byte Array -> one padding char expected
-      {4, 4},
-      // one byte Array -> two padding-chars expected
-      {4}
-    };
+    // Act
     String encoded;
+    byte[] decoded;
+    if (standardAlphabet) {
+      encoded = Base64.encodeStandard(input);
+      decoded = Base64.decodeStandard(encoded);
+    } else {
+      encoded = Base64.encode(input, equalsPad);
+      decoded = Base64.decode(encoded);
+    }
 
-    for (int i = 0; i < methodBytesArray.length; i++) {
-      encoded = Base64.encode(methodBytesArray[i], true);
-      if (i == 0)
-        // no occurrences expected
-        assertEquals(-1, encoded.indexOf('='));
-      else assertEquals(encoded.length() - i, encoded.indexOf('='));
+    // Assert
+    assertArrayEquals(input, decoded);
+    if (!standardAlphabet && equalsPad) {
+      assertEquals(0, encoded.length() % 4, "Padded output must be multiple of 4");
     }
   }
 
-  /**
-   * Test if the decode(String) method raise correctly an exception when providing a string with
-   * non-Base64 characters.
-   */
-  @Test
-  public void testIllegalBaseCharacter() {
-    //		TODO: check many other possible cases!
-    String illegalCharString = "abcd=fghilmn";
-    try {
-      Base64.decode(illegalCharString);
-      fail("Expected IllegalBase64Exception not thrown");
-    } catch (IllegalBase64Exception exception) {
-      assertSame(exception.getMessage(), "illegal Base64 character");
-    }
+  static Stream<Arguments> lengthsAndAlphabetsData() {
+    // lengths 0..5; both alphabets; equalsPad true/false for modified alphabet
+    Stream<Arguments> modified =
+        IntStream.rangeClosed(0, 5)
+            .boxed()
+            .flatMap(
+                len -> Stream.of(Arguments.of(len, false, false), Arguments.of(len, true, false)));
+    Stream<Arguments> standard =
+        IntStream.rangeClosed(0, 5).mapToObj(len -> Arguments.of(len, true, true));
+    return Stream.concat(modified, standard);
   }
 
-  /**
-   * Test if the decode(String) method raise correctly an exception when providing a string with a
-   * wrong Base64 length. (as we can consider not-padded strings too, the only wrong lengths are the
-   * ones where -> number MOD 4 = 1).
-   */
+  // ----------------------------
+  // Alphabet-specific expectations
+  // ----------------------------
+
   @Test
-  public void testIllegalBaseLength() {
-    // most interesting case
-    String illegalLengthString = "a";
-    try {
-      Base64.decode(illegalLengthString);
-      fail("Expected IllegalBase64Exception not thrown");
-    } catch (IllegalBase64Exception exception) {
-      assertSame(exception.getMessage(), "illegal Base64 length");
-    }
+  @DisplayName("encodeStandard_whenAllFF_expectSlashes")
+  void encodeStandardWhenAllFFExpectSlashes() throws IllegalBase64Exception {
+    // Arrange
+    byte[] input = new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+
+    // Act
+    String encoded = Base64.encodeStandard(input);
+    byte[] decoded = Base64.decodeStandard(encoded);
+
+    // Assert
+    assertEquals("////", encoded);
+    assertArrayEquals(input, decoded);
   }
 
-  /**
-   * Random test
-   *
-   * @throws IllegalBase64Exception
-   */
   @Test
-  public void testRandom() throws IllegalBase64Exception {
-    int iter;
-    Random r = new Random(1234);
-    for (iter = 0; iter < 1000; iter++) {
-      byte[] b = new byte[r.nextInt(64)];
-      for (int i = 0; i < b.length; i++) b[i] = (byte) (r.nextInt(256));
-      String encoded = Base64.encode(b);
-      byte[] decoded = Base64.decode(encoded);
-      assertEquals(decoded.length, b.length, "length mismatch");
+  @DisplayName("encodeNonStandard_whenAllFF_expectDashes")
+  void encodeNonStandardWhenAllFFExpectDashes() throws IllegalBase64Exception {
+    // Arrange
+    byte[] input = new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
 
-      for (int i = 0; i < b.length; i++)
-        assertEquals(
-            b[i],
-            decoded[i],
-            "data mismatch: index "
-                + i
-                + " of "
-                + b.length
-                + " should be 0x"
-                + Integer.toHexString(b[i] & 0xFF)
-                + " was 0x"
-                + Integer.toHexString(decoded[i] & 0xFF));
-    }
+    // Act
+    String encoded = Base64.encode(input);
+    byte[] decoded = Base64.decode(encoded);
+
+    // Assert
+    assertEquals("----", encoded);
+    assertArrayEquals(input, decoded);
+  }
+
+  // ----------------------------
+  // Padding behavior
+  // ----------------------------
+
+  @ParameterizedTest(name = "len={0}")
+  @ValueSource(ints = {1, 2, 3, 4, 5})
+  @DisplayName("encode_whenEqualsPadTrue_expectMultipleOfFour")
+  void encodeWhenEqualsPadTrueExpectMultipleOfFour(int len) {
+    // Arrange
+    byte[] input = generate(len, 7);
+
+    // Act
+    String encoded = Base64.encode(input, true);
+
+    // Assert
+    assertEquals(0, encoded.length() % 4);
+  }
+
+  @Test
+  @DisplayName("encode_whenEqualsPadTrue_singleByte_expectTwoCharsPlusPadding")
+  void encodeWhenEqualsPadTrueSingleByteExpectTwoCharsPlusPadding() throws IllegalBase64Exception {
+    // Arrange
+    byte[] input = new byte[] {0x4D}; // 'M'
+
+    // Act
+    String modifiedPadded = Base64.encode(input, true);
+    String modifiedUnpadded = Base64.encode(input, false);
+
+    // Assert
+    assertEquals(4, modifiedPadded.length());
+    assertEquals(2, modifiedUnpadded.length());
+    assertEquals(modifiedUnpadded + "==", modifiedPadded);
+    assertArrayEquals(input, Base64.decode(modifiedPadded));
+    assertArrayEquals(input, Base64.decode(modifiedUnpadded));
+  }
+
+  @Test
+  @DisplayName("decodeStandard_whenKnownExamples_expectManFamily")
+  void decodeStandardWhenKnownExamplesExpectManFamily() throws IllegalBase64Exception {
+    // Arrange
+    String man = "TWFu"; // "Man"
+    String ma = "TWE="; // "Ma"
+    String m = "TQ=="; // "M"
+
+    // Act
+    byte[] outMan = Base64.decodeStandard(man);
+    byte[] outMa = Base64.decodeStandard(ma);
+    byte[] outM = Base64.decodeStandard(m);
+
+    // Assert
+    assertEquals("Man", new String(outMan, StandardCharsets.UTF_8));
+    assertEquals("Ma", new String(outMa, StandardCharsets.UTF_8));
+    assertEquals("M", new String(outM, StandardCharsets.UTF_8));
+  }
+
+  // ----------------------------
+  // Error paths
+  // ----------------------------
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abcd=fgh", "abcd=fghilmn", "YW*J", "YW_J"})
+  @DisplayName("decode_whenIllegalCharacters_expectIllegalBase64Character")
+  void decodeWhenIllegalCharactersExpectIllegalBase64Character(String illegal) {
+    // Arrange & Act
+    IllegalBase64Exception ex =
+        assertThrows(IllegalBase64Exception.class, () -> Base64.decode(illegal));
+    // Assert
+    assertEquals(ILLEGAL_CHAR_MSG, ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("decode_whenLengthModFourIsOne_expectIllegalBase64Length")
+  void decodeWhenLengthModFourIsOneExpectIllegalBase64Length() {
+    // Arrange
+    String illegalLength = "a";
+
+    // Act
+    IllegalBase64Exception ex =
+        assertThrows(IllegalBase64Exception.class, () -> Base64.decode(illegalLength));
+
+    // Assert
+    assertEquals("illegal Base64 length", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("decodeStandard_whenWhitespacePresent_expectIllegalBase64Length")
+  void decodeStandardWhenWhitespacePresentExpectIllegalBase64Length() {
+    // Arrange
+    String withSpace = "Y WJj"; // spaces in base64 are illegal here
+
+    // Act & Assert
+    IllegalBase64Exception ex =
+        assertThrows(IllegalBase64Exception.class, () -> Base64.decodeStandard(withSpace));
+    assertEquals("illegal Base64 length", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("decodeNonStandard_whenStandardAlphabetString_expectIllegalBase64Character")
+  void decodeNonStandardWhenStandardAlphabetStringExpectIllegalBase64Character() {
+    // Arrange
+    String standardEncoded = "////"; // index 63 is '/'
+
+    // Act & Assert
+    IllegalBase64Exception ex =
+        assertThrows(IllegalBase64Exception.class, () -> Base64.decode(standardEncoded));
+    assertEquals(ILLEGAL_CHAR_MSG, ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("decodeStandard_whenModifiedAlphabetString_expectIllegalBase64Character")
+  void decodeStandardWhenModifiedAlphabetStringExpectIllegalBase64Character() {
+    // Arrange
+    String modifiedEncoded = "----"; // index 63 is '-'
+
+    // Act & Assert
+    IllegalBase64Exception ex =
+        assertThrows(IllegalBase64Exception.class, () -> Base64.decodeStandard(modifiedEncoded));
+    assertEquals(ILLEGAL_CHAR_MSG, ex.getMessage());
+  }
+
+  // ----------------------------
+  // Null handling
+  // ----------------------------
+
+  @Test
+  @DisplayName("encode_whenNullBytes_expectNullPointerException")
+  void encodeWhenNullBytesExpectNullPointerException() {
+    // Arrange & Act & Assert
+    assertThrows(NullPointerException.class, () -> Base64.encode(null));
+  }
+
+  @Test
+  @DisplayName("encodeUTF8_whenNull_expectNullPointerException")
+  void encodeUtf8WhenNullExpectNullPointerException() {
+    // Arrange & Act & Assert
+    assertThrows(NullPointerException.class, () -> Base64.encodeUTF8(null));
+  }
+
+  @Test
+  @DisplayName("decode_whenNull_expectNullPointerException")
+  void decodeWhenNullExpectNullPointerException() {
+    // Arrange & Act & Assert
+    assertThrows(NullPointerException.class, () -> Base64.decode(null));
+  }
+
+  @Test
+  @DisplayName("decodeStandard_whenNull_expectNullPointerException")
+  void decodeStandardWhenNullExpectNullPointerException() {
+    // Arrange & Act & Assert
+    assertThrows(NullPointerException.class, () -> Base64.decodeStandard(null));
+  }
+
+  @Test
+  @DisplayName("decodeUTF8_whenNull_expectNullPointerException")
+  void decodeUtf8WhenNullExpectNullPointerException() {
+    // Arrange & Act & Assert
+    assertThrows(NullPointerException.class, () -> Base64.decodeUTF8(null));
+  }
+
+  // ----------------------------
+  // Mockito: I/O and time
+  // ----------------------------
+
+  @Test
+  @DisplayName("encode_whenBytesProvidedByInputStream_expectCorrectOutput")
+  void encodeWhenBytesProvidedByInputStreamExpectCorrectOutput()
+      throws IOException, IllegalBase64Exception {
+    // Arrange
+    byte[] data = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05};
+    InputStream is = mock(InputStream.class);
+    when(is.read(any(byte[].class)))
+        .thenAnswer(
+            new Answer<Integer>() {
+              int offset = 0;
+
+              @Override
+              public Integer answer(InvocationOnMock inv) {
+                byte[] dst = inv.getArgument(0);
+                if (offset >= data.length) return -1;
+                int len = Math.min(dst.length, data.length - offset);
+                System.arraycopy(data, offset, dst, 0, len);
+                offset += len;
+                return len;
+              }
+            });
+
+    // Act
+    byte[] readAll = readAll(is);
+    String encoded = Base64.encode(readAll, true);
+    byte[] decoded = Base64.decode(encoded);
+
+    // Assert
+    assertArrayEquals(data, readAll);
+    assertArrayEquals(data, decoded);
+    verify(is, atLeastOnce()).read(any(byte[].class));
+  }
+
+  @Test
+  @DisplayName("random_whenSeededByMockedTime_expectDeterministicRoundTrip")
+  @SuppressWarnings("java:S2245")
+  void randomWhenSeededByMockedTimeExpectDeterministicRoundTrip() throws IllegalBase64Exception {
+    // Arrange
+    LongSupplier time = mock(LongSupplier.class);
+    when(time.getAsLong()).thenReturn(987654321L);
+    Random r = new Random(time.getAsLong());
+    byte[] input = new byte[32];
+    for (int i = 0; i < input.length; i++) input[i] = (byte) r.nextInt(256);
+
+    // Act
+    String encoded = Base64.encode(input);
+    byte[] decoded = Base64.decode(encoded);
+
+    // Assert
+    assertArrayEquals(input, decoded);
+    verify(time, times(1)).getAsLong();
+  }
+
+  // ----------------------------
+  // Helpers
+  // ----------------------------
+
+  @SuppressWarnings("java:S2245")
+  private static byte[] generate(int length, long seed) {
+    Random r = new Random(seed + length);
+    byte[] out = new byte[length];
+    for (int i = 0; i < length; i++) out[i] = (byte) r.nextInt(256);
+    return out;
+  }
+
+  private static byte[] readAll(InputStream in) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    byte[] buf = new byte[4];
+    int n;
+    while ((n = in.read(buf)) != -1) baos.write(buf, 0, n);
+    return baos.toByteArray();
   }
 }


### PR DESCRIPTION
Summary
- Complete and clarify Javadoc for Base64 (modified vs standard alphabets, padding rules, decoder behavior, thread-safety, complexity).
- Address SonarLint findings in Base64 with behavior-preserving tweaks (private utility ctor, convert for-loops to while to avoid counter updates, add default no-op branches).
- Rewrite Base64Test in AAA style with parameterized cases; deterministic seeds; Mockito for simple I/O/time mocking; merged additional edge/error cases.
- Applied Spotless formatting.

Details
- src/main/java/network/crypta/support/Base64.java
  - Add comprehensive Javadoc for all public APIs and refine inline comments.
  - Minor refactors to satisfy SonarLint without changing behavior: private ctor; while-loops in encode/decode to avoid in-body counter updates; explicit default branches with no-ops.
- src/test/java/network/crypta/support/Base64Test.java
  - Replace legacy tests with AAA-style, parameterized tests covering null/empty/boundary/error paths across both alphabets and padding modes.
  - Deterministic random data; Mockito used to mock InputStream and a time supplier; no changes to production code.

Validation
- Full suite: ./gradlew --parallel cleanTest test (Spotless tasks excluded during runs) — PASS.
- SonarLint: single-file check for Base64 — clean after refactors.
- Spotless: ./gradlew spotlessApply — completed; committed.

Notes
- Changes are behavior-preserving; public API signatures unchanged.
- If desired, I can split out or rebase to drop any unrelated formatting from the earlier chore commit shown in the diff vs develop.

Diff overview vs develop (selected):
- Base64.java (+Javadoc/refactor) and Base64Test.java (+AAA tests). Other files listed by the diff come from a prior formatting commit and are not functionally related to Base64.

Checklist
- [x] Tests pass locally
- [x] No production behavior changes intended
- [x] Spotless applied
- [x] SonarLint clean for Base64
