### PR TITLE
support: Add comprehensive tests and improve Javadoc for BooleanLastTrueTracker

### DIFF
--- a/src/main/java/network/crypta/support/BooleanLastTrueTracker.java
+++ b/src/main/java/network/crypta/support/BooleanLastTrueTracker.java
@@ -1,9 +1,29 @@
 package network.crypta.support;
 
-/** Tracks when a condition was last true, e.g. whether a peer is connected. Self-synchronized. */
+/**
+ * Tracks when a boolean condition was last {@code true}.
+ *
+ * <p>This utility records the instant at which the tracked condition transitions from {@code false}
+ * to {@code true}. While the condition remains {@code true}, callers can query using the current
+ * time to obtain a view that the last-true moment is effectively "now". Once the condition becomes
+ * {@code false} again, the stored timestamp reflects the most recent {@code false -> true}
+ * transition.
+ *
+ * <p>Thread-safety: All public methods are synchronized on {@code this}, so instances are safe for
+ * concurrent use by multiple threads without external locking.
+ *
+ * <p>Time base: The class does not mandate a specific time unit or epoch for the {@code long}
+ * timestamps (typically milliseconds since the epoch from {@link System#currentTimeMillis()} or a
+ * monotonic source). Callers must use a consistent time base for all interactions with a given
+ * instance.
+ *
+ * <p>Sentinel: If the condition has never been {@code true}, {@link #getTimeLastTrue(long)} returns
+ * {@code -1} (when the no-arg constructor is used).
+ */
 public class BooleanLastTrueTracker {
-
+  // Guarded by 'this'. Holds the current state of the tracked condition.
   private boolean isTrue;
+  // Guarded by 'this'. Timestamp of the most recent false->true transition; -1 if never true.
   private long timeLastTrue;
 
   public BooleanLastTrueTracker() {
@@ -11,16 +31,53 @@ public class BooleanLastTrueTracker {
     timeLastTrue = -1;
   }
 
-  /** Initialise with a time last connected */
+  /**
+   * Creates a tracker with a predefined "last true" timestamp while starting in the {@code false}
+   * state.
+   *
+   * <p>This is useful when the last-true moment is known from persisted state, and callers want to
+   * continue tracking from that point.
+   *
+   * @param lastTrue the timestamp to report as the most recent {@code false -> true} transition
+   *     until the state next becomes {@code true}. The unit/epoch is defined by the caller but must
+   *     be consistent with subsequent {@code now} values supplied to this instance.
+   */
   public BooleanLastTrueTracker(long lastTrue) {
     isTrue = false;
     timeLastTrue = lastTrue;
   }
 
+  /**
+   * Returns the current value of the tracked condition.
+   *
+   * <p>Thread-safe: synchronized on {@code this}.
+   *
+   * @return {@code true} if the condition is currently true; otherwise {@code false}.
+   */
   public synchronized boolean isTrue() {
     return isTrue;
   }
 
+  /**
+   * Updates the tracked condition and optionally records a new "last true" timestamp.
+   *
+   * <p>When transitioning from {@code false} to {@code true}, this method stores {@code now} as the
+   * time the condition last became true. For all other cases (no change, or {@code true -> false})
+   * the stored timestamp is left unchanged.
+   *
+   * <p>Return value: This method returns the previous state (i.e., the value of {@link #isTrue()}
+   * before applying the update). This is intentionally useful to detect whether a transition
+   * occurred without an extra read.
+   *
+   * <p>Thread-safe: synchronized on {@code this}.
+   *
+   * @param value the new state to set.
+   * @param now the caller-supplied current time, used only when transitioning {@code false ->
+   *     true}. The unit/epoch is not enforced by this class; callers must supply values consistent
+   *     with those used elsewhere for the same instance. TODO: Clarify required time base across
+   *     the codebase (epoch vs. monotonic).
+   * @return the previous state of the condition.
+   */
   public synchronized boolean set(boolean value, long now) {
     if (value == isTrue) return value;
     if (!isTrue) timeLastTrue = now;
@@ -28,6 +85,22 @@ public class BooleanLastTrueTracker {
     return !value;
   }
 
+  /**
+   * Returns when the condition was last {@code true} according to the provided time base.
+   *
+   * <p>If the condition is currently {@code true}, the method returns the supplied {@code now}
+   * value. If it is currently {@code false}, it returns the timestamp recorded the last time the
+   * condition became {@code true}. If the condition has never been {@code true}, it returns {@code
+   * -1} (when this instance was created via the no-arg constructor).
+   *
+   * <p>Thread-safe: synchronized on {@code this}.
+   *
+   * @param now the caller-supplied current time; only used to echo back when the condition is
+   *     currently {@code true}. The unit/epoch must match the one used with {@link #set(boolean,
+   *     long)} for meaningful comparisons.
+   * @return {@code now} if currently true; otherwise the timestamp of the most recent {@code false
+   *     -> true} transition, or {@code -1} if never true.
+   */
   public synchronized long getTimeLastTrue(long now) {
     if (isTrue) return now;
     else return timeLastTrue;

--- a/src/test/java/network/crypta/support/BooleanLastTrueTrackerTest.java
+++ b/src/test/java/network/crypta/support/BooleanLastTrueTrackerTest.java
@@ -1,0 +1,183 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link BooleanLastTrueTracker}.
+ *
+ * <p>Focus: state transitions, returned values, and time reporting semantics.
+ */
+class BooleanLastTrueTrackerTest {
+
+  @Test
+  @DisplayName("defaultState_whenConstructed_expectFalseAndMinusOne")
+  void defaultState_whenConstructed_expectFalseAndMinusOne() {
+    // Arrange
+    BooleanLastTrueTracker tracker = new BooleanLastTrueTracker();
+
+    // Act
+    boolean isTrue = tracker.isTrue();
+    long time = tracker.getTimeLastTrue(1000L);
+
+    // Assert
+    assertFalse(isTrue, "New tracker should start false");
+    assertEquals(-1L, time, "Time should be -1 when never true");
+  }
+
+  @Test
+  @DisplayName("constructor_withInitialLastTrue_expectTimeReturnedWhileFalse")
+  void constructor_withInitialLastTrue_expectTimeReturnedWhileFalse() {
+    // Arrange
+    long initial = 42L;
+    BooleanLastTrueTracker tracker = new BooleanLastTrueTracker(initial);
+
+    // Act
+    boolean isTrue = tracker.isTrue();
+    long time = tracker.getTimeLastTrue(999L);
+
+    // Assert
+    assertFalse(isTrue, "Tracker constructed with lastTrue remains false initially");
+    assertEquals(initial, time, "Should return provided lastTrue while state is false");
+  }
+
+  @Test
+  @DisplayName("set_whenFalseToTrue_updatesTimeAndReturnsPreviousFalse")
+  void set_whenFalseToTrue_updatesTimeAndReturnsPreviousFalse() {
+    // Arrange
+    BooleanLastTrueTracker tracker = new BooleanLastTrueTracker();
+    long tTrue = 100L;
+
+    // Act
+    boolean returnedPrev = tracker.set(true, tTrue);
+
+    // Assert
+    assertFalse(returnedPrev, "set(true) should return previous state (false)");
+    assertTrue(tracker.isTrue(), "State should be true after transition");
+
+    // While true, getTimeLastTrue(now) must return the provided 'now'.
+    long nowWhileTrue = 200L;
+    assertEquals(
+        nowWhileTrue,
+        tracker.getTimeLastTrue(nowWhileTrue),
+        "When currently true, getTimeLastTrue(now) must echo 'now'");
+
+    // Transition to false should not change the stored last-true time (which is tTrue).
+    boolean prevOnFalse = tracker.set(false, 300L);
+    assertTrue(prevOnFalse, "set(false) should return previous state (true)");
+    assertFalse(tracker.isTrue(), "State should be false after transition");
+    assertEquals(
+        tTrue,
+        tracker.getTimeLastTrue(400L),
+        "When false, last-true time should be the time of the most recent false->true transition");
+  }
+
+  @Test
+  @DisplayName("set_whenTrueToFalse_keepsLastTrueTime")
+  void set_whenTrueToFalse_keepsLastTrueTime() {
+    // Arrange
+    BooleanLastTrueTracker tracker = new BooleanLastTrueTracker();
+    long t1 = 123L;
+    tracker.set(true, t1); // becomes true at t1
+
+    // Act
+    boolean returnedPrev = tracker.set(false, 200L); // back to false
+
+    // Assert
+    assertTrue(returnedPrev, "set(false) should return previous state (true)");
+    assertFalse(tracker.isTrue(), "State should be false after transition");
+    assertEquals(
+        t1,
+        tracker.getTimeLastTrue(999L),
+        "While false, last-true time should remain the time we became true (t1)");
+  }
+
+  @Test
+  @DisplayName("set_whenSettingSameValue_returnsSameValueAndNoTimeChange_falseCase")
+  void set_whenSettingSameValue_returnsSameValueAndNoTimeChange_falseCase() {
+    // Arrange
+    BooleanLastTrueTracker tracker = new BooleanLastTrueTracker();
+
+    // Act
+    boolean returnedPrev = tracker.set(false, 50L); // no state change
+
+    // Assert
+    assertFalse(returnedPrev, "Unchanged set(false) should return false (previous state)");
+    assertFalse(tracker.isTrue(), "State remains false");
+    assertEquals(-1L, tracker.getTimeLastTrue(999L), "Last-true time remains -1 when never true");
+  }
+
+  @Test
+  @DisplayName("set_whenSettingSameValueTrue_doesNotUpdateLastTrueTime")
+  void set_whenSettingSameValueTrue_doesNotUpdateLastTrueTime() {
+    // Arrange: become true at t1
+    BooleanLastTrueTracker tracker = new BooleanLastTrueTracker();
+    long t1 = 100L;
+    tracker.set(true, t1);
+
+    // Act: set(true) again with a later time; method should not overwrite the stored last-true
+    // moment
+    boolean returnedPrev = tracker.set(true, 200L); // unchanged
+
+    // Assert current behavior and then flip to false to read the stored last-true time
+    assertTrue(returnedPrev, "Unchanged set(true) should return true (previous state)");
+    assertTrue(tracker.isTrue(), "State remains true");
+
+    // Move to false to observe the stored last-true time (should still be t1, not 200)
+    tracker.set(false, 300L);
+    assertEquals(
+        t1,
+        tracker.getTimeLastTrue(350L),
+        "Unchanged set(true) must not update stored last-true time");
+  }
+
+  @Test
+  @DisplayName("getTimeLastTrue_whenCurrentlyTrue_returnsProvidedNow")
+  void getTimeLastTrue_whenCurrentlyTrue_returnsProvidedNow() {
+    // Arrange
+    BooleanLastTrueTracker tracker = new BooleanLastTrueTracker();
+    tracker.set(true, 10L);
+
+    // Act
+    long now = 777L;
+    long reported = tracker.getTimeLastTrue(now);
+
+    // Assert
+    assertEquals(now, reported, "While true, getTimeLastTrue should return the provided 'now'");
+  }
+
+  @Test
+  @DisplayName("multipleTransitions_onlyFalseToTrueUpdatesStoredTime")
+  void multipleTransitions_onlyFalseToTrueUpdatesStoredTime() {
+    // Arrange: start with a seed last-true value (pretend last known event)
+    BooleanLastTrueTracker tracker = new BooleanLastTrueTracker(5L);
+
+    // Become true at 100
+    tracker.set(true, 100L);
+    assertEquals(250L, tracker.getTimeLastTrue(250L), "While true, getTimeLastTrue mirrors 'now'");
+
+    // Back to false at 150; stored last-true time should be 100
+    tracker.set(false, 150L);
+    assertEquals(
+        100L,
+        tracker.getTimeLastTrue(151L),
+        "After true->false, last-true remains when it became true");
+
+    // Repeated false has no effect
+    tracker.set(false, 200L);
+    assertEquals(
+        100L,
+        tracker.getTimeLastTrue(201L),
+        "Repeated false should not change stored last-true time");
+
+    // Become true again at 250; this should update the stored time
+    tracker.set(true, 250L);
+    tracker.set(false, 300L);
+    assertEquals(
+        250L, tracker.getTimeLastTrue(301L), "The most recent false->true time should be recorded");
+  }
+}


### PR DESCRIPTION
Summary
- Add deterministic JUnit 6 tests for BooleanLastTrueTracker covering state transitions, timestamp semantics, unchanged sets, and sentinel behavior (-1).
- Improve Javadoc and inline comments: document thread-safety, time-base expectations, and precise method contracts for set(...) and getTimeLastTrue(...).

Why
- Increase confidence in a small but concurrency-sensitive utility that is used to represent connectivity/health conditions.
- Clarify API expectations to prevent misuse around the caller-supplied time base.

Changes
- src/test/java/network/crypta/support/BooleanLastTrueTrackerTest.java (new): 8 focused tests, AAA style. No external I/O, deterministic.
- src/main/java/network/crypta/support/BooleanLastTrueTracker.java (docs only): class/method Javadoc and brief field intent comments (no code changes).

Notes
- Thread safety: tests assert observable behavior while avoiding concurrency; the class remains fully synchronized.
- No production logic changed, names/signatures preserved, formatting left intact aside from Spotless.
- Branch rebased/merged with latest develop to avoid unrelated diffs; PR now contains only the two files listed above.

Validation
- Local: `./gradlew --parallel test --tests *BooleanLastTrueTrackerTest` passed.
- Spotless: `./gradlew spotlessApply` ran cleanly.

Risk
- Low. Pure documentation + new tests. No runtime behavior changes.

Checklist
- [x] Tests added and passing locally
- [x] Spotless formatting applied
- [x] No changes to public API behavior
- [x] Based on latest develop