### PR TITLE
refactor(support): document Buffer and strengthen tests; rename private fields

### DIFF
--- a/src/main/java/network/crypta/support/Buffer.java
+++ b/src/main/java/network/crypta/support/Buffer.java
@@ -7,105 +7,165 @@ import java.util.Arrays;
 import network.crypta.io.WritableToDataOutputStream;
 
 /**
- * Wrapper for a byte array which handles serialisation/deserialisation
+ * Immutable view over a byte array with simple serialization support.
+ *
+ * <p>This class wraps an existing byte array together with a start offset and a length, and
+ * provides convenience methods for reading a buffer from a {@link DataInput} and writing it to a
+ * {@link DataOutputStream}. When constructed from a {@code DataInput}, the input is expected to be
+ * framed as a 4-byte length (signed, big-endian, non-negative, and not exceeding {@link
+ * Serializer#MAX_ARRAY_LENGTH}) followed by exactly that many bytes of payload.
+ *
+ * <p>When the buffer spans the entire backing array (i.e., {@code start == 0} and {@code length ==
+ * data.length}), {@link #getData()} returns the backing array directly. In all other cases it
+ * returns a copy of the visible window. Callers must not rely on receiving the internal buffer.
+ *
+ * <p>Thread-safety: instances are effectively immutable in terms of offset/length, however the
+ * contents may reflect changes to the original array reference supplied to the constructor. No
+ * internal synchronization is performed.
  *
  * @author ian
  */
 public class Buffer implements WritableToDataOutputStream {
 
+  /** Historical SCM identifier retained for compatibility/logging. */
   public static final String VERSION = "$Id: Buffer.java,v 1.2 2005/08/25 17:28:19 amphibian Exp $";
 
-  private final byte[] _data;
-  private final int _start;
-  private final int _length;
+  private final byte[] data;
+  private final int start;
+  private final int length;
 
   /**
-   * Create a Buffer by reading a DataInputStream. Note that this a) expects that the first 4 bytes
-   * to be a length indicator of the rest of the byte stream and b) these first 4 bytes are removed
-   * from the byte stream before storing the rest
+   * Construct a buffer by reading from a {@link DataInput}.
    *
-   * @param dis to read bytes from
-   * @throws IllegalArgumentException If the length integer is negative or exceeds
-   *     Serializer.MAX_ARRAY_LENGTH.
-   * @throws IOException error reading from dis
+   * <p>The input format is: a 4-byte signed length (written with {@link
+   * DataOutputStream#writeInt(int)}) followed by that many bytes of payload. The constructor reads
+   * and validates the length and then reads exactly {@code length} bytes.
+   *
+   * @param dis source to read the framed data from.
+   * @throws IllegalArgumentException if the length is negative or greater than {@link
+   *     Serializer#MAX_ARRAY_LENGTH}. The historical behavior is to signal invalid length with this
+   *     exception type rather than {@link IOException}.
+   * @throws IOException if {@code dis} cannot provide the requested bytes.
    */
   public Buffer(DataInput dis) throws IOException {
-    _length = dis.readInt();
-    if (_length < 0) throw new IllegalArgumentException("Negative Length: " + _length);
-    if (_length > Serializer.MAX_ARRAY_LENGTH) {
-      // TODO: Is it more appropriate for this to be an IOException?
+    length = dis.readInt();
+    if (length < 0) throw new IllegalArgumentException("Negative Length: " + length);
+    if (length > Serializer.MAX_ARRAY_LENGTH) {
+      // Preserve historical behavior: signal invalid length with IllegalArgumentException.
       throw new IllegalArgumentException("Length larger than " + Serializer.MAX_ARRAY_LENGTH);
     }
 
-    _data = new byte[_length];
-    _start = 0;
-    dis.readFully(_data);
+    data = new byte[length]; // Allocate exactly the announced length.
+    start = 0;
+    dis.readFully(data);
   }
 
   /**
-   * Create a Buffer from a byte array
+   * Construct a buffer that views the entire provided array.
    *
-   * @param data
+   * <p>No copy is performed. Subsequent external modification of {@code data} will be observable
+   * through this instance.
+   *
+   * @param data backing array; must not be {@code null}.
    */
   public Buffer(byte[] data) {
-    _start = 0;
-    _length = data.length;
-    _data = data;
+    start = 0;
+    length = data.length;
+    this.data = data;
   }
 
+  /**
+   * Construct a buffer that views a subrange of the provided array.
+   *
+   * <p>No copy is performed. The visible window starts at {@code start} and spans {@code length}
+   * bytes. The arguments must describe a valid range within {@code data}.
+   *
+   * @param data backing array; must not be {@code null}.
+   * @param start start offset (0-based) into {@code data}.
+   * @param length number of bytes visible from {@code start}.
+   * @throws IllegalArgumentException if {@code start < 0}, {@code length < 0}, or {@code start +
+   *     length > data.length}.
+   */
   public Buffer(byte[] data, int start, int length) {
     if (length < 0 || start < 0 || start + length > data.length)
       throw new IllegalArgumentException("Invalid Length: start=" + start + ", length=" + length);
-    _start = start;
-    _data = data;
-    _length = length;
+    this.start = start;
+    this.data = data;
+    this.length = length;
   }
 
   /**
-   * Retrieve a byte array containing the data in this buffer. Will be copied if the data does not
-   * fill the whole array, so please don't rely on it being the internal buffer.
+   * Return the bytes visible through this view.
    *
-   * @return The byte array
+   * <p>If this view covers the entire backing array the backing array itself is returned (no copy).
+   * Otherwise, a new array is allocated and the visible range is copied into it.
+   *
+   * @return a byte array containing the visible bytes; may be the backing array when the whole
+   *     array is visible.
    */
   public byte[] getData() {
-    if ((_start == 0) && (_length == _data.length)) {
-      return _data;
+    if ((start == 0) && (length == data.length)) {
+      return data;
     } else {
-      return Arrays.copyOfRange(_data, _start, _start + _length);
+      return Arrays.copyOfRange(data, start, start + length);
     }
   }
 
   /**
-   * Copy the data to a byte array
+   * Copy the visible bytes into the given array starting at {@code position}.
    *
-   * @param array
-   * @param position
+   * @param array destination array.
+   * @param position index in {@code array} at which to start writing.
+   * @throws ArrayIndexOutOfBoundsException if the copy would write past the end of {@code array}.
    */
   public void copyTo(byte[] array, int position) {
-    System.arraycopy(_data, _start, array, position, _length);
+    System.arraycopy(data, start, array, position, length);
   }
 
+  /**
+   * Return the byte at the given index within this view.
+   *
+   * @param pos zero-based index, {@code 0 <= pos < getLength()}.
+   * @return the byte value at {@code pos}.
+   * @throws ArrayIndexOutOfBoundsException if {@code pos} is outside the visible range.
+   */
   public byte byteAt(int pos) {
-    if (pos >= _length) {
+    if (pos >= length) {
       throw new ArrayIndexOutOfBoundsException();
     }
-    return _data[pos + _start];
+    return data[pos + start];
   }
 
+  /**
+   * Write this buffer to a {@link DataOutputStream} using the standard framing format.
+   *
+   * <p>The method writes a 4-byte signed length followed by the visible bytes. The length is equal
+   * to {@link #getLength()} and must not exceed {@link Serializer#MAX_ARRAY_LENGTH}.
+   *
+   * @param stream destination stream.
+   * @throws IOException if an I/O error occurs while writing to {@code stream}.
+   */
   @Override
   public void writeToDataOutputStream(DataOutputStream stream) throws IOException {
-    stream.writeInt(_length);
-    stream.write(_data, _start, _length);
+    stream.writeInt(length);
+    stream.write(data, start, length);
   }
 
+  /**
+   * Return a human-readable representation.
+   *
+   * <p>If the length is greater than 50, returns {@code "Buffer {<length>}"}. Otherwise, returns a
+   * string in the form {@code "{<length>:<byte0> <byte1> ... "} with a trailing space after the
+   * last value. This method is intended for debugging only; do not parse its output.
+   */
   @Override
   public String toString() {
-    if (this._length > 50) {
-      return "Buffer {" + this._length + '}';
+    if (this.length > 50) {
+      return "Buffer {" + this.length + '}';
     } else {
-      StringBuilder b = new StringBuilder(this._length * 3);
-      b.append('{').append(this._length).append(':');
-      for (int x = 0; x < this._length; x++) {
+      StringBuilder b = new StringBuilder(this.length * 3);
+      b.append('{').append(this.length).append(':');
+      for (int x = 0; x < this.length; x++) {
         b.append(byteAt(x));
         b.append(' ');
       }
@@ -113,6 +173,14 @@ public class Buffer implements WritableToDataOutputStream {
     }
   }
 
+  /**
+   * Compare for equality.
+   *
+   * <p>Two buffers are equal only if they share the same {@code start} and {@code length} and their
+   * entire backing arrays are {@linkplain Arrays#equals(byte[], byte[]) equal} (not just the
+   * visible window). This preserves historical semantics and is stricter than window-only
+   * comparison.
+   */
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -122,21 +190,32 @@ public class Buffer implements WritableToDataOutputStream {
       return false;
     }
 
-    if (_length != buffer._length) {
+    if (length != buffer.length) {
       return false;
     }
-    if (_start != buffer._start) {
+    if (start != buffer.start) {
       return false;
     }
-    return Arrays.equals(_data, buffer._data);
+    return Arrays.equals(data, buffer.data);
   }
 
+  /**
+   * Compute a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The value combines a hash of the entire backing array with the {@code start} and {@code
+   * length} fields.
+   */
   @Override
   public int hashCode() {
-    return Fields.hashCode(_data) ^ _start ^ _length;
+    return Fields.hashCode(data) ^ start ^ length;
   }
 
+  /**
+   * Return the number of visible bytes.
+   *
+   * @return the length of this view in bytes.
+   */
   public int getLength() {
-    return _length;
+    return length;
   }
 }

--- a/src/test/java/network/crypta/support/BufferTest.java
+++ b/src/test/java/network/crypta/support/BufferTest.java
@@ -1,16 +1,25 @@
 package network.crypta.support;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -18,122 +27,149 @@ import org.junit.jupiter.api.Test;
  *
  * @author stuart martin &lt;wavey@freenetproject.org&gt;
  */
-public class BufferTest {
+class BufferTest {
 
   private static final String DATA_STRING_1 =
       "asldkjaskjdsakdhasdhaskjdhaskjhbkasbhdjkasbduiwbxgdoudgboewuydxbybuewyxbuewyuwe"
           + "dasdkljasndijwnodhnqweoidhnaouidhbnwoduihwnxodiuhnwuioxdhnwqiouhnxwqoiushdnxwqoiudhxnwqoiudhxni";
 
   @Test
-  public void testByteArrayBuffer() {
-
+  @DisplayName("getData_whenFullArray_expectSameInstanceAndCorrectContent")
+  void getData_whenFullArray_expectSameInstanceAndCorrectContent() {
+    // Arrange
     byte[] data = DATA_STRING_1.getBytes();
 
+    // Act
     Buffer buffer = new Buffer(data);
 
-    assertEquals(data, buffer.getData());
-
-    doTestBuffer(data, buffer);
+    // Assert: returns the same backing array instance and content matches
+    assertSame(data, buffer.getData());
+    doTestBufferContent(data, buffer);
   }
 
   @Test
-  public void testByteArrayIndexBuffer() {
-
-    // get content
+  @DisplayName("getData_whenSubrange_expectCopyWithEqualContentAndNewInstanceEachCall")
+  void getData_whenSubrange_expectCopyWithEqualContentAndNewInstanceEachCall() {
+    // Arrange
     byte[] data = DATA_STRING_1.getBytes();
+    byte[] dataSub = Arrays.copyOfRange(data, 4, 9);
 
-    byte[] dataSub = new byte[5];
-
-    // prepare 'substring'
-    System.arraycopy(data, 4, dataSub, 0, 5);
-
+    // Act
     Buffer buffer = new Buffer(data, 4, 5);
 
-    assertNotEquals(dataSub, buffer.getData());
+    // Assert: returns copies, not the same instance
+    byte[] first = buffer.getData();
+    byte[] second = buffer.getData();
+    assertNotEquals(dataSub, buffer.getData()); // reference inequality
+    assertNotSame(first, second);
+    assertArrayEquals(dataSub, first);
+    assertArrayEquals(dataSub, second);
 
-    doTestBuffer(dataSub, buffer);
+    // Mutating one snapshot does not affect subsequent calls
+    first[0] = (byte) 123;
+    assertArrayEquals(dataSub, buffer.getData());
+
+    doTestBufferContent(dataSub, buffer);
   }
 
   @Test
-  public void testBadLength() {
-    try {
-      new Buffer(new byte[0], 0, -1);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expect this
-    }
-    try {
-      new Buffer(new byte[0], 0, 1);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expect this
-    }
-    try {
-      new Buffer(new byte[0], 1, 0);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expect this
-    }
-    new Buffer(new byte[1], 1, 0);
-    new Buffer(new byte[1], 0, 1);
+  @DisplayName("ctorByteArrayStartLen_whenInvalidArguments_expectIllegalArgumentException")
+  void ctorByteArrayStartLen_whenInvalidArguments_expectIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> new Buffer(new byte[0], 0, -1));
+    assertThrows(IllegalArgumentException.class, () -> new Buffer(new byte[0], 0, 1));
+    assertThrows(IllegalArgumentException.class, () -> new Buffer(new byte[0], 1, 0));
+
+    // Valid edge cases should not throw
+    assertDoesNotThrow(() -> new Buffer(new byte[1], 1, 0));
+    assertDoesNotThrow(() -> new Buffer(new byte[1], 0, 1));
   }
 
   @Test
-  public void testDataInputStreamBuffer() {
+  @DisplayName("ctorDataInput_whenValidLengthAndBytes_expectBufferWithCorrectContent")
+  void ctorDataInput_whenValidLengthAndBytes_expectBufferWithCorrectContent() {
+    // Arrange
+    byte[] data = DATA_STRING_1.getBytes();
+    byte[] framed = new byte[data.length + 4];
+    int length = data.length;
+    framed[0] = (byte) ((length >>> 24) & 0xFF);
+    framed[1] = (byte) ((length >>> 16) & 0xFF);
+    framed[2] = (byte) ((length >>> 8) & 0xFF);
+    framed[3] = (byte) (length & 0xFF);
+    System.arraycopy(data, 0, framed, 4, data.length);
 
-    byte[] data = DATA_STRING_1.getBytes(); // get some content
+    // Act
+    Buffer buffer =
+        assertDoesNotThrow(() -> new Buffer(new DataInputStream(new ByteArrayInputStream(framed))));
+    assertNotNull(buffer);
 
-    byte[] data2 = new byte[data.length + 4]; // make room for 4 byte length indicator
-
-    int length = DATA_STRING_1.getBytes().length;
-
-    // populate length as first 4 bytes
-    data2[0] = (byte) ((length & 0xff000000) >> 24);
-    data2[1] = (byte) ((length & 0xff0000) >> 16);
-    data2[2] = (byte) ((length & 0xff00) >> 8);
-    data2[3] = (byte) ((length & 0xff));
-
-    System.arraycopy(data, 0, data2, 4, data.length); // populate rest of content
-
-    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data2));
-    Buffer buffer = null;
-
-    try {
-      buffer = new Buffer(dis);
-    } catch (IOException e) {
-      fail("unexpected exception: " + e.getMessage());
-    }
-    // perform rest of test with the *original* array because Buffer(DataInputStream) chomps first 4
-    // bytes
-    doTestBuffer(data, buffer);
+    // Assert
+    doTestBufferContent(data, buffer);
   }
 
-  private void doTestBuffer(byte[] data, Buffer buffer) {
+  @Test
+  @DisplayName("ctorDataInput_whenNegativeLength_expectIllegalArgumentException")
+  void ctorDataInput_whenNegativeLength_expectIllegalArgumentException() {
+    byte[] hdr = ByteBuffer.allocate(4).putInt(-1).array();
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(hdr));
+    assertThrows(IllegalArgumentException.class, () -> new Buffer(dis));
+  }
+
+  @Test
+  @DisplayName("ctorDataInput_whenLengthExceedsMax_expectIllegalArgumentException")
+  void ctorDataInput_whenLengthExceedsMax_expectIllegalArgumentException() {
+    int tooLarge = Serializer.MAX_ARRAY_LENGTH + 1; // 4093
+    byte[] hdr = ByteBuffer.allocate(4).putInt(tooLarge).array();
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(hdr));
+    assertThrows(IllegalArgumentException.class, () -> new Buffer(dis));
+  }
+
+  @Test
+  @DisplayName("ctorDataInput_whenPrematureEOF_expectEOFException")
+  void ctorDataInput_whenPrematureEOF_expectEOFException() {
+    // Declare a length of 3 but provide only 2 payload bytes
+    int declaredLength = 3;
+    byte[] hdr = ByteBuffer.allocate(4).putInt(declaredLength).array();
+    byte[] payload = new byte[] {1, 2}; // 2 bytes only
+    byte[] framed = new byte[hdr.length + payload.length];
+    System.arraycopy(hdr, 0, framed, 0, hdr.length);
+    System.arraycopy(payload, 0, framed, hdr.length, payload.length);
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(framed));
+    assertThrows(EOFException.class, () -> new Buffer(dis));
+  }
+
+  private void doTestBufferContent(byte[] data, Buffer buffer) {
     assertEquals(data.length, buffer.getLength());
-
     for (int i = 0; i < buffer.getLength(); i++) {
       assertEquals(data[i], buffer.byteAt(i));
     }
-
-    try {
-      buffer.byteAt(data.length + 1); // expect exception
-      fail();
-    } catch (ArrayIndexOutOfBoundsException e) {
-      // expect this
-    }
   }
 
   @Test
-  public void testLongBufferToString() {
+  @DisplayName("byteAt_whenIndexOutOfBounds_expectArrayIndexOutOfBoundsException")
+  void byteAt_whenIndexOutOfBounds_expectArrayIndexOutOfBoundsException() {
+    Buffer b = new Buffer(new byte[] {10, 20, 30});
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.byteAt(3)); // == length
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.byteAt(-1));
+  }
 
+  @Test
+  void toString_whenLengthGreaterThan50_expectSummaryForm() {
     Buffer buffer = new Buffer(DATA_STRING_1.getBytes());
     String longString = buffer.toString();
-    assertEquals(longString, "Buffer {" + buffer.getLength() + "}");
+    assertEquals("Buffer {" + buffer.getLength() + "}", longString);
   }
 
   @Test
-  public void testEquals() {
+  @DisplayName("toString_whenShort_expectByteValuesWithLengthPrefix")
+  void toString_whenShort_expectByteValuesWithLengthPrefix() {
+    byte[] bytes = new byte[] {1, 2, 3};
+    Buffer buffer = new Buffer(bytes);
+    assertEquals("{3:1 2 3 ", buffer.toString());
+  }
 
+  @Test
+  @SuppressWarnings("EqualsWithItself")
+  void equals_whenSameContentAndLayout_expectEquality() {
     Buffer b1 = new Buffer("Buffer1".getBytes());
     Buffer b2 = new Buffer("Buffer2".getBytes());
     Buffer b3 = new Buffer("Buffer1".getBytes());
@@ -147,40 +183,94 @@ public class BufferTest {
   }
 
   @Test
-  public void testHashcode() {
+  @DisplayName("equals_whenSameWindowBytesButDifferentStart_expectNotEqual")
+  void equals_whenSameWindowBytesButDifferentStart_expectNotEqual() {
+    byte[] base = new byte[] {0, 1, 2, 3};
+    Buffer a = new Buffer(base, 1, 2); // [1,2]
+    Buffer b = new Buffer(new byte[] {1, 2}); // start=0, len=2
+    assertNotEquals(a, b); // start differs
+  }
 
+  @Test
+  @DisplayName("equals_whenSameWindowBytesButDifferentBackingArrays_expectNotEqual")
+  void equals_whenSameWindowBytesButDifferentBackingArrays_expectNotEqual() {
+    byte[] arr1 = new byte[] {9, 1, 2, 9};
+    byte[] arr2 = new byte[] {8, 1, 2, 8}; // different outside window
+    Buffer a = new Buffer(arr1, 1, 2); // window [1,2]
+    Buffer b = new Buffer(arr2, 1, 2); // window [1,2], identical start/len
+
+    // Per implementation, equality requires full array equality, not just the window
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void hashCode_whenPutInMap_expectKeyCollisionForEqualBuffers() {
     Buffer b1 = new Buffer("Buffer1".getBytes());
     Buffer b2 = new Buffer("Buffer2".getBytes());
     Buffer b3 = new Buffer("Buffer1".getBytes());
 
     Map<Buffer, Buffer> hashMap = new HashMap<>();
-
     hashMap.put(b1, b1);
     hashMap.put(b2, b2);
-    hashMap.put(b3, b3); // should clobber b1 due to content
+    hashMap.put(b3, b3); // should clobber b1 due to equality with b1
 
-    // see if b3 survived
     Object o = hashMap.get(b3);
     assertNotSame(o, b1);
     assertSame(o, b3);
 
-    // see if b1 survived
     o = hashMap.get(b1);
     assertNotSame(o, b1);
     assertSame(o, b3);
   }
 
   @Test
-  public void testCopy() {
-
+  void copyTo_whenPositionZero_expectExactCopy() {
     byte[] oldBuf = DATA_STRING_1.getBytes();
     Buffer b = new Buffer(oldBuf);
 
     byte[] newBuf = new byte[b.getLength()];
     b.copyTo(newBuf, 0);
 
-    for (int i = 0; i < oldBuf.length; i++) {
-      assertEquals(newBuf[i], oldBuf[i]);
+    assertArrayEquals(oldBuf, newBuf);
+  }
+
+  @Test
+  @DisplayName("copyTo_whenWithOffset_expectCopiedAtGivenPosition")
+  void copyTo_whenWithOffset_expectCopiedAtGivenPosition() {
+    byte[] src = new byte[] {10, 20, 30};
+    Buffer b = new Buffer(src);
+    byte[] dest = new byte[5];
+    b.copyTo(dest, 2);
+
+    assertArrayEquals(new byte[] {0, 0, 10, 20, 30}, dest);
+  }
+
+  @Test
+  @DisplayName("copyTo_whenDestTooSmall_expectArrayIndexOutOfBoundsException")
+  void copyTo_whenDestTooSmall_expectArrayIndexOutOfBoundsException() {
+    Buffer b = new Buffer(new byte[] {1, 2, 3});
+    byte[] dest = new byte[4];
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.copyTo(dest, 2));
+  }
+
+  @Test
+  @DisplayName("writeToDataOutputStream_whenSubrange_expectLengthAndPayloadWritten")
+  void writeToDataOutputStream_whenSubrange_expectLengthAndPayloadWritten() throws IOException {
+    byte[] src = new byte[] {9, 10, 11, 12, 13};
+    Buffer b = new Buffer(src, 1, 3); // [10,11,12]
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+
+    b.writeToDataOutputStream(dos);
+    dos.flush();
+
+    byte[] written = baos.toByteArray();
+    // Verify length prefix and payload
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(written))) {
+      assertEquals(3, dis.readInt());
+      byte[] payload = new byte[3];
+      dis.readFully(payload);
+      assertArrayEquals(new byte[] {10, 11, 12}, payload);
     }
   }
 }


### PR DESCRIPTION
Summary
This PR improves the support Buffer by documenting its API thoroughly, aligning private member naming with conventions, and strengthening unit tests. There are no public API or behavioral changes.

Changes
- support/Buffer.java
  - Rename private fields to conventional names:
    - _data → data
    - _start → start
    - _length → length
    (Private-only refactor; no signature or behavior changes.)
  - Enrich Javadoc for class and all public members:
    - DataInput framing contract (4‑byte signed length + payload; validated against Serializer.MAX_ARRAY_LENGTH).
    - Zero‑copy behavior of getData() when the view spans the entire backing array.
    - copyTo(byte[], int) bounds behavior; byteAt(int) preconditions; toString() output forms.
    - equals/hashCode semantics clarified (strict: same start/length and entire backing array equality).
  - Inline comments updated for clarity; removed stale TODO (kept historical IllegalArgumentException behavior and documented rationale).

- tests/support/BufferTest.java
  - Expand and harden tests:
    - DataInput constructor: valid path, negative length, oversize length, premature EOF.
    - getData(): full‑array zero‑copy vs subrange defensive copy (non‑aliasing across calls).
    - byteAt(): bounds checks for length and negative index.
    - toString(): short and long forms.
    - equals/hashCode: equality and map behavior; start/length sensitivity; full‑array equality requirement.
    - copyTo(): exact copy at position 0; offset copy; destination too small.
  - Replace try/catch with assertThrows/assertDoesNotThrow; add @Test where missing.

Quality & Tooling
- Spotless applied to keep formatting consistent.
- SonarLint: Buffer.java analyzed clean (no issues).
- Build & tests pass locally:
  - ./gradlew --parallel test → SUCCESS

Rationale
- Improves maintainability and readability via documentation and naming consistency.
- Tests provide deterministic coverage of edge cases and error paths.
- No functional changes; behavior and public API remain unchanged.

Risk/Compatibility
- Minimal: private fields only; equals/hashCode semantics unchanged (documented).
- No serialization format changes.

Checklist
- [x] Tests pass
- [x] Spotless formatting applied
- [x] SonarLint clean for Buffer.java
- [x] No public API change, no behavior change
