### PR TITLE
docs(support): document DummyJobRunner API and add focused unit tests

### DIFF
--- a/src/main/java/network/crypta/support/DummyJobRunner.java
+++ b/src/main/java/network/crypta/support/DummyJobRunner.java
@@ -9,32 +9,57 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A PersistentJobRunner that isn't persistent. Convenient for transient requests, code doesn't need
- * messy if(persistent) everywhere.
+ * Non-persistent implementation of {@link PersistentJobRunner}.
+ *
+ * <p>This runner submits jobs directly to a provided {@link Executor} and does not coordinate
+ * checkpointing, persistence, or loading phases. It is useful for transient or best-effort work
+ * where saving client-layer state is unnecessary. Using this avoids sprinkling callers with {@code
+ * if (persistent) ...} checks.
+ *
+ * <p>Threading: Jobs are executed on the given executor and therefore usually run off the calling
+ * thread. Jobs are wrapped in a {@link PrioRunnable} so priority-aware executors can read the
+ * requested priority. No internal queueing or locking is performed beyond the executor submission.
+ *
+ * <p>Persistence: Methods related to checkpointing and lifecycle (e.g., {@link #setCheckpointASAP}
+ * and {@link #lock()}) are effectively no-ops; {@link #hasLoaded()} always returns {@code true}.
  */
 public class DummyJobRunner implements PersistentJobRunner {
   private static final Logger LOG = LoggerFactory.getLogger(DummyJobRunner.class);
 
-  static {
-  }
-
   final Executor executor;
   final ClientContext context;
 
+  /**
+   * Create a dummy job runner.
+   *
+   * @param executor executor used to run submitted jobs; must tolerate {@link PrioRunnable}
+   *     instances
+   * @param context {@link ClientContext} passed to each job's {@link
+   *     PersistentJob#run(ClientContext)}; may be {@code null}
+   */
   public DummyJobRunner(Executor executor, ClientContext context) {
     this.executor = executor;
     this.context = context;
   }
 
+  /**
+   * Submit a job immediately to the executor.
+   *
+   * <p>No persistence checks occur. The job is executed in the executor's thread and the supplied
+   * {@code priority} is exposed via {@link PrioRunnable#getPriority()}.
+   *
+   * @param job task to run; must be non-null
+   * @param priority priority hint for the executor
+   */
   @Override
   public void queue(final PersistentJob job, final int priority) {
-    if (LOG.isDebugEnabled()) LOG.debug("Running job off thread: " + job);
+    if (LOG.isDebugEnabled()) LOG.debug("Running job off thread: {}", job);
     executor.execute(
         new PrioRunnable() {
 
           @Override
           public void run() {
-            if (LOG.isDebugEnabled()) LOG.debug("Starting job " + job);
+            if (LOG.isDebugEnabled()) LOG.debug("Starting job {}", job);
             job.run(context);
           }
 
@@ -45,43 +70,93 @@ public class DummyJobRunner implements PersistentJobRunner {
         });
   }
 
+  /**
+   * Submit a job at {@link NativeThread.PriorityLevel#NORM_PRIORITY}.
+   *
+   * <p>This dummy implementation never drops jobs; it simply forwards to {@link #queue} with normal
+   * priority.
+   *
+   * @param job task to run
+   */
   @Override
   public void queueNormalOrDrop(PersistentJob job) {
     queue(job, NativeThread.PriorityLevel.NORM_PRIORITY.value);
   }
 
+  /**
+   * No-op.
+   *
+   * <p>Persistent implementations would request an immediate checkpoint; this runner does not
+   * checkpoint.
+   */
   @Override
   public void setCheckpointASAP() {
-    // Ignore.
+    // Intentionally ignored: there is no checkpointing in this implementation.
   }
 
+  /**
+   * The dummy runner is always considered loaded.
+   *
+   * @return {@code true}
+   */
   @Override
   public boolean hasLoaded() {
     return true;
   }
 
+  /**
+   * Submit an internal job with the given priority.
+   *
+   * <p>For the dummy runner, internal jobs behave the same as regular jobs.
+   *
+   * @param job task to run
+   * @param threadPriority priority hint for the executor
+   */
   @Override
   public void queueInternal(PersistentJob job, int threadPriority) {
     queue(job, threadPriority);
   }
 
+  /**
+   * Submit an internal job at {@link NativeThread.PriorityLevel#NORM_PRIORITY}.
+   *
+   * @param job task to run
+   */
   @Override
   public void queueInternal(PersistentJob job) {
     queueInternal(job, NativeThread.PriorityLevel.NORM_PRIORITY.value);
   }
 
+  /**
+   * Return a lock whose {@code unlock(...)} method is a no-op.
+   *
+   * <p>Persistent implementations would use this to defer checkpointing while a job updates state.
+   * The dummy runner never checkpoints and therefore the returned lock does nothing.
+   *
+   * @return a no-op {@link CheckpointLock}
+   */
   @Override
   public CheckpointLock lock() {
     return (forceWrite, threadPriority) -> {
-      // Do nothing.
+      // No-op: checkpointing is not supported here.
     };
   }
 
+  /**
+   * Always returns {@code false}; the dummy runner does not load persistent requests.
+   *
+   * @return {@code false}
+   */
   @Override
   public boolean newSalt() {
     return false;
   }
 
+  /**
+   * Always returns {@code false}; the dummy runner does not manage shutdown state.
+   *
+   * @return {@code false}
+   */
   @Override
   public boolean shuttingDown() {
     return false;

--- a/src/test/java/network/crypta/support/DummyJobRunnerTest.java
+++ b/src/test/java/network/crypta/support/DummyJobRunnerTest.java
@@ -1,0 +1,179 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.node.PrioRunnable;
+import network.crypta.support.io.NativeThread;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+@SuppressWarnings("java:S100") // test method naming: method_whenCondition_expectOutcome
+class DummyJobRunnerTest {
+  private static final String PRIO_RUNNABLE_MSG = "Runnable should implement PrioRunnable";
+
+  @Test
+  @DisplayName("queue schedules PrioRunnable and runs job with provided context")
+  void queue_whenCalled_executesJobWithContextAndPriorityPreserved() {
+    Executor executor = Mockito.mock(Executor.class);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    PersistentJob job = Mockito.mock(PersistentJob.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, context);
+    int priority = NativeThread.PriorityLevel.HIGH_PRIORITY.value;
+
+    runner.queue(job, priority);
+
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor, times(1)).execute(captor.capture());
+
+    Runnable r = captor.getValue();
+    assertNotNull(r, "Executor should receive a runnable");
+    assertInstanceOf(PrioRunnable.class, r, PRIO_RUNNABLE_MSG);
+    PrioRunnable pr = (PrioRunnable) r;
+    // Assert priority is preserved
+    org.junit.jupiter.api.Assertions.assertEquals(priority, pr.getPriority());
+
+    // When run, the job executes with the exact context instance
+    pr.run();
+    verify(job, times(1)).run(context);
+  }
+
+  @Test
+  @DisplayName("queueNormalOrDrop uses NORM priority and runs job")
+  void queueNormalOrDrop_whenCalled_usesNormPriority() {
+    Executor executor = Mockito.mock(Executor.class);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    PersistentJob job = Mockito.mock(PersistentJob.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, context);
+
+    runner.queueNormalOrDrop(job);
+
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor, times(1)).execute(captor.capture());
+
+    Runnable r = captor.getValue();
+    assertInstanceOf(PrioRunnable.class, r, PRIO_RUNNABLE_MSG);
+    PrioRunnable pr = (PrioRunnable) r;
+    org.junit.jupiter.api.Assertions.assertEquals(
+        NativeThread.PriorityLevel.NORM_PRIORITY.value, pr.getPriority());
+
+    pr.run();
+    verify(job, times(1)).run(context);
+  }
+
+  @Test
+  @DisplayName("queueInternal(priority) delegates to queue and preserves priority")
+  void queueInternal_withPriority_delegatesToQueue() {
+    Executor executor = Mockito.mock(Executor.class);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    PersistentJob job = Mockito.mock(PersistentJob.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, context);
+    int priority = NativeThread.PriorityLevel.LOW_PRIORITY.value;
+
+    runner.queueInternal(job, priority);
+
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor, times(1)).execute(captor.capture());
+
+    Runnable r = captor.getValue();
+    assertInstanceOf(PrioRunnable.class, r, PRIO_RUNNABLE_MSG);
+    PrioRunnable pr = (PrioRunnable) r;
+    org.junit.jupiter.api.Assertions.assertEquals(priority, pr.getPriority());
+
+    pr.run();
+    verify(job, times(1)).run(context);
+  }
+
+  @Test
+  @DisplayName("queueInternal() uses NORM priority")
+  void queueInternal_withoutPriority_usesNormPriority() {
+    Executor executor = Mockito.mock(Executor.class);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    PersistentJob job = Mockito.mock(PersistentJob.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, context);
+
+    runner.queueInternal(job);
+
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor, times(1)).execute(captor.capture());
+
+    Runnable r = captor.getValue();
+    assertInstanceOf(PrioRunnable.class, r, PRIO_RUNNABLE_MSG);
+    PrioRunnable pr = (PrioRunnable) r;
+    org.junit.jupiter.api.Assertions.assertEquals(
+        NativeThread.PriorityLevel.NORM_PRIORITY.value, pr.getPriority());
+
+    pr.run();
+    verify(job, times(1)).run(context);
+  }
+
+  @Test
+  @DisplayName("lock returns a no-op CheckpointLock")
+  void lock_whenUnlockCalled_doesNothing() {
+    Executor executor = Mockito.mock(Executor.class);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, context);
+    PersistentJobRunner.CheckpointLock lock = runner.lock();
+    assertNotNull(lock, "lock() must return a CheckpointLock instance");
+    assertDoesNotThrow(
+        () -> lock.unlock(true, NativeThread.PriorityLevel.MAX_PRIORITY.value),
+        "Unlocking the dummy lock should not throw");
+  }
+
+  @Test
+  @DisplayName("hasLoaded always returns true")
+  void hasLoaded_whenCalled_returnsTrue() {
+    Executor executor = Mockito.mock(Executor.class);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, context);
+    assertTrue(runner.hasLoaded());
+  }
+
+  @Test
+  @DisplayName("newSalt always returns false")
+  void newSalt_whenCalled_returnsFalse() {
+    Executor executor = Mockito.mock(Executor.class);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, context);
+    assertFalse(runner.newSalt());
+  }
+
+  @Test
+  @DisplayName("shuttingDown always returns false")
+  void shuttingDown_whenCalled_returnsFalse() {
+    Executor executor = Mockito.mock(Executor.class);
+    ClientContext context = Mockito.mock(ClientContext.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, context);
+    assertFalse(runner.shuttingDown());
+  }
+
+  @Test
+  @DisplayName("queue passes null context through to job.run")
+  void queue_whenContextIsNull_jobReceivesNull() {
+    Executor executor = Mockito.mock(Executor.class);
+    PersistentJob job = Mockito.mock(PersistentJob.class);
+    DummyJobRunner runner = new DummyJobRunner(executor, null);
+
+    runner.queue(job, NativeThread.PriorityLevel.NORM_PRIORITY.value);
+
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor, times(1)).execute(captor.capture());
+
+    Runnable r = captor.getValue();
+    assertInstanceOf(PrioRunnable.class, r, PRIO_RUNNABLE_MSG);
+    r.run();
+
+    verify(job, times(1)).run(isNull());
+  }
+}


### PR DESCRIPTION
Summary
- Improve and complete Javadoc for network.crypta.support.DummyJobRunner.
- Add deterministic unit tests for DummyJobRunner covering all public methods.
- Format with Spotless.

Context
DummyJobRunner is used by transient request code paths where persistence is not required. The class previously had minimal documentation. This PR documents behavior and clarifies that checkpoint-related APIs are no-ops. It also adds tests to ensure behavior remains stable.

Changes
- src/main/java/network/crypta/support/DummyJobRunner.java
  - Expand class and method Javadoc (purpose, threading, priority, persistence semantics).
  - Replace concatenated debug logs with parameterized logging.
  - No functional changes to logic, signatures, or visibility.
- src/test/java/network/crypta/support/DummyJobRunnerTest.java (new)
  - Tests for: queue(priority), queueNormalOrDrop, queueInternal (with/without priority), lock(), hasLoaded(), newSalt(), shuttingDown(), null-context pass-through.
  - Uses Mockito; no sleeps or threads; captures and runs the PrioRunnable inline.

Validation
- ./gradlew --parallel test → PASS (BUILD SUCCESSFUL).
- SonarLint (file-scoped) → No issues in DummyJobRunner.java or the new test file after deduplicating strings.
- Spotless applied.

Risk / Compatibility
- No behavior changes. Only documentation and tests. Priority and execution semantics are preserved.

Checklist
- [x] Tests added and passing
- [x] Spotless/formatting
- [x] No public API or behavior change

Requested reviewers
- @crypta-network/maintainers

