### PR TITLE
Harden Bloom filters, rename optimalK, and add JUnit 6 tests

### DIFF
--- a/src/main/java/network/crypta/client/async/SplitFileFetcherKeyListener.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherKeyListener.java
@@ -137,7 +137,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
     int perSegmentSize = perSegmentBitsPerKey * segBlocks;
     perSegmentSize = (perSegmentSize + 7) & ~7;
     perSegmentBloomFilterSizeBytes = perSegmentSize / 8;
-    perSegmentK = BloomFilter.optimialK(perSegmentSize, segBlocks);
+    perSegmentK = BloomFilter.optimalK(perSegmentSize, segBlocks);
     segmentFilters = new BinaryBloomFilter[segments];
     byte[] segmentsFilterBuffer = new byte[perSegmentBloomFilterSizeBytes * segments];
     ByteBuffer baseBuffer = ByteBuffer.wrap(segmentsFilterBuffer);

--- a/src/main/java/network/crypta/support/BinaryBloomFilter.java
+++ b/src/main/java/network/crypta/support/BinaryBloomFilter.java
@@ -20,15 +20,39 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Bloom filter backed by a compact bit array.
+ *
+ * <p>This implementation stores one bit per position and uses the hashing and concurrency
+ * orchestration provided by {@link BloomFilter}. Instances can be purely in-memory (heap
+ * {@link ByteBuffer}) or file-backed via a memory-mapped buffer. File-backed filters set the
+ * one‑shot {@link #needRebuild} flag when the on-disk file is missing or has an unexpected size.
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>All public operations are thread-safe through the base class’ read/write lock. Membership
+ * checks acquire the read lock; updates and fork/merge operations acquire the write lock.
+ *
+ * <h2>Usage</h2>
+ *
+ * <p>Prefer constructing instances via {@link BloomFilter#createFilter(int, int, boolean)} or
+ * {@link BloomFilter#createFilter(File, int, int, boolean)} which select this variant when
+ * {@code counting == false}. The factories also return {@link NullBloomFilter} for zero-length
+ * requests.
+ *
  * @author sdiz
  */
 public class BinaryBloomFilter extends BloomFilter {
   private static final Logger LOG = LoggerFactory.getLogger(BinaryBloomFilter.class);
 
   /**
-   * Constructor
+   * Creates an in-memory binary Bloom filter.
    *
-   * @param length length in bits
+   * <p>Allocates a heap {@link ByteBuffer} sized to {@code length / 8} bytes after the rounding
+   * performed by the {@link BloomFilter} constructor.
+   *
+   * @param length length in bits; rounded down to a multiple of 8
+   * @param k number of hash functions (non-negative)
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
    */
   protected BinaryBloomFilter(int length, int k) {
     super(length, k);
@@ -36,11 +60,17 @@ public class BinaryBloomFilter extends BloomFilter {
   }
 
   /**
-   * Constructor
+   * Creates a file-backed binary Bloom filter.
    *
-   * @param file disk file
-   * @param length length in bits
-   * @throws IOException
+   * <p>Ensures the file length matches the expected size ({@code length / 8}) and memory-maps it
+   * in read/write mode. When the file does not exist or has a different size, the one-shot flag
+   * {@link #needRebuild} is set for callers to observe.
+   *
+   * @param file target file (created or resized as needed)
+   * @param length length in bits; rounded down to a multiple of 8
+   * @param k number of hash functions (non-negative)
+   * @throws IOException if the file cannot be created, resized, or mapped
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
    */
   protected BinaryBloomFilter(File file, int length, int k) throws IOException {
     super(length, k);
@@ -53,16 +83,41 @@ public class BinaryBloomFilter extends BloomFilter {
     }
   }
 
+  /**
+   * Creates a binary Bloom filter backed by the provided buffer slice.
+   *
+   * <p>This constructor does not copy the data; callers must ensure the buffer’s capacity is at
+   * least {@code length / 8} and that its lifetime covers the filter’s usage. No ownership is
+   * taken; changes are written into the given buffer.
+   *
+   * @param slice backing buffer; must be writable and large enough for {@code length / 8} bytes
+   * @param length length in bits; rounded down to a multiple of 8
+   * @param k number of hash functions (non-negative)
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
+   */
   public BinaryBloomFilter(ByteBuffer slice, int length, int k) {
     super(length, k);
     filter = slice;
   }
 
+  /**
+   * No-op for the binary variant.
+   *
+   * <p>{@inheritDoc}
+   *
+   * @param key ignored
+   */
   @Override
   public void removeKey(byte[] key) {
     // ignore
   }
 
+  /**
+   * Returns whether the bit at {@code offset} is set.
+   *
+   * @param offset position in {@code [0, length)}
+   * @return {@code true} if the bit is set; otherwise {@code false}
+   */
   @Override
   protected boolean getBit(int offset) {
     int value = filter.get(offset / 8) & 0xFF;
@@ -70,6 +125,11 @@ public class BinaryBloomFilter extends BloomFilter {
     return (value & mask) != 0;
   }
 
+  /**
+   * Sets the bit at {@code offset}.
+   *
+   * @param offset position in {@code [0, length)}
+   */
   @Override
   protected void setBit(int offset) {
     int index = offset / 8;
@@ -78,11 +138,25 @@ public class BinaryBloomFilter extends BloomFilter {
     filter.put(index, (byte) b);
   }
 
+  /**
+   * No-op. The binary variant does not support decrements.
+   *
+   * @param offset ignored
+   */
   @Override
   protected void unsetBit(int offset) {
     // NO-OP
   }
 
+  /**
+   * Starts mirroring updates to a forked filter.
+   *
+   * <p>Attempts to create a file-backed fork under a secure temporary location. If that fails,
+   * falls back to an in-memory fork. The write lock is held during fork creation to ensure
+   * consistent state.
+   *
+   * @param k number of hash functions to use in the fork
+   */
   @Override
   public void fork(int k) {
     try (LockResource ignored = new LockResource(lock.writeLock())) {
@@ -90,7 +164,7 @@ public class BinaryBloomFilter extends BloomFilter {
         File tempFile = createSecureTempFile();
         forkedFilter = new BinaryBloomFilter(tempFile, length, k);
       } catch (IOException e) {
-        // Fallback: in‑memory fork while still holding the write lock, preserving synchronization
+        // Fallback: in‑memory fork while still holding the write lock to preserve synchronization.
         forkedFilter = new BinaryBloomFilter(length, k);
       }
     }
@@ -110,6 +184,16 @@ public class BinaryBloomFilter extends BloomFilter {
     }
   }
 
+  /**
+   * Creates a temporary file with best-effort user-only permissions.
+   *
+   * <p>On POSIX filesystems, applies {@code rw-------}. On non-POSIX platforms, attempts to place
+   * the file under a user-private directory and restrict basic flags. Returns a file scheduled for
+   * deletion at JVM exit.
+   *
+   * @return newly created temporary file
+   * @throws IOException if file creation fails
+   */
   private static File createSecureTempFile() throws IOException {
     try {
       // Use POSIX permissions when supported to restrict to owner read/write.

--- a/src/main/java/network/crypta/support/BinaryBloomFilter.java
+++ b/src/main/java/network/crypta/support/BinaryBloomFilter.java
@@ -1,16 +1,30 @@
 package network.crypta.support;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author sdiz
  */
 public class BinaryBloomFilter extends BloomFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(BinaryBloomFilter.class);
+
   /**
    * Constructor
    *
@@ -51,14 +65,17 @@ public class BinaryBloomFilter extends BloomFilter {
 
   @Override
   protected boolean getBit(int offset) {
-    return (filter.get(offset / 8) & (1 << (offset % 8))) != 0;
+    int value = filter.get(offset / 8) & 0xFF;
+    int mask = 1 << (offset % 8);
+    return (value & mask) != 0;
   }
 
   @Override
   protected void setBit(int offset) {
-    byte b = filter.get(offset / 8);
+    int index = offset / 8;
+    int b = filter.get(index) & 0xFF;
     b |= 1 << (offset % 8);
-    filter.put(offset / 8, b);
+    filter.put(index, (byte) b);
   }
 
   @Override
@@ -68,15 +85,79 @@ public class BinaryBloomFilter extends BloomFilter {
 
   @Override
   public void fork(int k) {
-    lock.writeLock().lock();
-    try {
-      File tempFile = File.createTempFile("bloom-", ".tmp");
-      tempFile.deleteOnExit();
-      forkedFilter = new BinaryBloomFilter(tempFile, length, k);
-    } catch (IOException e) {
-      forkedFilter = new BinaryBloomFilter(length, k);
-    } finally {
-      lock.writeLock().unlock();
+    try (LockResource ignored = new LockResource(lock.writeLock())) {
+      try {
+        File tempFile = createSecureTempFile();
+        forkedFilter = new BinaryBloomFilter(tempFile, length, k);
+      } catch (IOException e) {
+        // Fallback: in‑memory fork while still holding the write lock, preserving synchronization
+        forkedFilter = new BinaryBloomFilter(length, k);
+      }
     }
+  }
+
+  private static final class LockResource implements Closeable {
+    private final Lock w;
+
+    LockResource(Lock w) {
+      this.w = w;
+      this.w.lock();
+    }
+
+    @Override
+    public void close() {
+      w.unlock();
+    }
+  }
+
+  private static File createSecureTempFile() throws IOException {
+    try {
+      // Use POSIX permissions when supported to restrict to owner read/write.
+      if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+        Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rw-------");
+        FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
+        Path p = Files.createTempFile("bloom-", ".tmp", attr);
+        File f = p.toFile();
+        f.deleteOnExit();
+        return f;
+      }
+    } catch (UnsupportedOperationException ignored) {
+      // Fall through to generic creation path below.
+    }
+
+    // Generic platforms (e.g., Windows) — create under a stable user-private directory and
+    // best‑effort restrict. Avoid per-call directories to prevent directory leaks.
+    Path base = Paths.get(System.getProperty("user.home", "."), ".cryptad", "tmp");
+    Files.createDirectories(base);
+    // Best-effort to restrict directory to current user only (non-POSIX platforms ignore perms).
+    File baseFile = base.toFile();
+    boolean br = baseFile.setReadable(true, true);
+    boolean bw = baseFile.setWritable(true, true);
+    boolean bx = baseFile.setExecutable(true, true);
+    if (!br || !bw || !bx) {
+      LOG.debug(
+          "Best-effort permission adjustment on temp directory {} did not fully apply (r={}, w={},"
+              + " x={}).",
+          baseFile,
+          br,
+          bw,
+          bx);
+    }
+    Path p = Files.createTempFile(base, "bloom-", ".tmp");
+    File f = p.toFile();
+    boolean r = f.setReadable(true, true);
+    boolean w = f.setWritable(true, true);
+    boolean x = f.setExecutable(false, false);
+    if (!r || !w || !x) {
+      LOG.debug(
+          "Best-effort permission adjustment on temp file {} did not fully apply (r={}, w={},"
+              + " x={}).",
+          f,
+          r,
+          w,
+          x);
+    }
+    f.deleteOnExit();
+    return f;
   }
 }

--- a/src/main/java/network/crypta/support/BinaryBloomFilter.java
+++ b/src/main/java/network/crypta/support/BinaryBloomFilter.java
@@ -23,9 +23,9 @@ import org.slf4j.LoggerFactory;
  * Bloom filter backed by a compact bit array.
  *
  * <p>This implementation stores one bit per position and uses the hashing and concurrency
- * orchestration provided by {@link BloomFilter}. Instances can be purely in-memory (heap
- * {@link ByteBuffer}) or file-backed via a memory-mapped buffer. File-backed filters set the
- * one‑shot {@link #needRebuild} flag when the on-disk file is missing or has an unexpected size.
+ * orchestration provided by {@link BloomFilter}. Instances can be purely in-memory (heap {@link
+ * ByteBuffer}) or file-backed via a memory-mapped buffer. File-backed filters set the one‑shot
+ * {@link #needRebuild} flag when the on-disk file is missing or has an unexpected size.
  *
  * <h2>Threading</h2>
  *
@@ -35,9 +35,8 @@ import org.slf4j.LoggerFactory;
  * <h2>Usage</h2>
  *
  * <p>Prefer constructing instances via {@link BloomFilter#createFilter(int, int, boolean)} or
- * {@link BloomFilter#createFilter(File, int, int, boolean)} which select this variant when
- * {@code counting == false}. The factories also return {@link NullBloomFilter} for zero-length
- * requests.
+ * {@link BloomFilter#createFilter(File, int, int, boolean)} which select this variant when {@code
+ * counting == false}. The factories also return {@link NullBloomFilter} for zero-length requests.
  *
  * @author sdiz
  */
@@ -62,9 +61,9 @@ public class BinaryBloomFilter extends BloomFilter {
   /**
    * Creates a file-backed binary Bloom filter.
    *
-   * <p>Ensures the file length matches the expected size ({@code length / 8}) and memory-maps it
-   * in read/write mode. When the file does not exist or has a different size, the one-shot flag
-   * {@link #needRebuild} is set for callers to observe.
+   * <p>Ensures the file length matches the expected size ({@code length / 8}) and memory-maps it in
+   * read/write mode. When the file does not exist or has a different size, the one-shot flag {@link
+   * #needRebuild} is set for callers to observe.
    *
    * @param file target file (created or resized as needed)
    * @param length length in bits; rounded down to a multiple of 8

--- a/src/main/java/network/crypta/support/BloomFilter.java
+++ b/src/main/java/network/crypta/support/BloomFilter.java
@@ -363,13 +363,7 @@ public abstract class BloomFilter implements AutoCloseable {
     return (int) k;
   }
 
-  /**
-   * @deprecated Use {@link #optimalK(int, long)}. Kept for backward compatibility.
-   */
-  @Deprecated(since = "2")
-  public static int optimialK(int filterLength, long maxKey) {
-    return optimalK(filterLength, maxKey);
-  }
+  
 
   public int getK() {
     return k;

--- a/src/main/java/network/crypta/support/BloomFilter.java
+++ b/src/main/java/network/crypta/support/BloomFilter.java
@@ -366,7 +366,7 @@ public abstract class BloomFilter implements AutoCloseable {
   /**
    * @deprecated Use {@link #optimalK(int, long)}. Kept for backward compatibility.
    */
-  @Deprecated
+  @Deprecated(since = "2")
   public static int optimialK(int filterLength, long maxKey) {
     return optimalK(filterLength, maxKey);
   }

--- a/src/main/java/network/crypta/support/BloomFilter.java
+++ b/src/main/java/network/crypta/support/BloomFilter.java
@@ -12,22 +12,48 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import network.crypta.support.math.MersenneTwister;
 
+/**
+ * Abstract base for Bloom filter implementations.
+ *
+ * <p>This class provides the concurrency, hashing, and fork/merge orchestration common to the
+ * binary ({@link BinaryBloomFilter}) and counting ({@link CountingBloomFilter}) variants. The
+ * underlying bit/counter storage resides in a {@link ByteBuffer} supplied or created by subclasses.
+ * Implementations must provide bit-level access via {@link #getBit(int)}, {@link #setBit(int)}, and
+ * {@link #unsetBit(int)}.
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>Instances use an internal {@link ReadWriteLock} to coordinate updates and membership checks:
+ * write operations acquire the write lock; checks acquire the read lock. Callers do not need to
+ * perform external synchronization for the provided methods.
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <p>This type implements {@link AutoCloseable}. For file-backed implementations, {@link #close()}
+ * forces outstanding changes to disk and releases references. A {@link Cleaner} is registered as a
+ * safety net, but callers should still close instances deterministically (e.g., with
+ * try-with-resources).
+ */
 public abstract class BloomFilter implements AutoCloseable {
   private static final Cleaner cleaner = Cleaner.create();
 
+  /** Backing buffer for the filter’s bytes (bits or counters), owned by subclasses. */
   protected ByteBuffer filter;
 
-  /** Number of hash functions */
+  /** Number of hash functions to apply per key; immutable after construction. */
   protected final int k;
 
+  /** Filter length in bits (rounded down to a multiple of 8 by the constructor). */
   protected final int length;
 
-  protected transient ReadWriteLock lock = new ReentrantReadWriteLock();
+  /** Read/write lock guarding read and update operations. */
+  protected ReadWriteLock lock = new ReentrantReadWriteLock();
 
   // Cleaner action for safety net resource cleanup
   private final Cleaner.Cleanable cleanable;
 
-  // Static nested class for cleaner action to avoid holding reference to the BloomFilter instance
+  // Cleaner action implemented as a static nested class to avoid retaining a reference to the
+  // outer BloomFilter instance. It only holds the buffer to allow the best‑effort force on cleanup.
   private static class FilterCleanup implements Runnable {
     private ByteBuffer filter;
 
@@ -37,7 +63,8 @@ public abstract class BloomFilter implements AutoCloseable {
 
     @Override
     public void run() {
-      // Safety net cleanup - this should rarely be called if close() is used properly
+      // Safety net cleanup; close() should usually handle this. For mapped buffers, force any
+      // outstanding changes to the storage device before dropping our reference.
       if (filter instanceof MappedByteBuffer buffer) {
         buffer.force();
       }
@@ -45,16 +72,51 @@ public abstract class BloomFilter implements AutoCloseable {
     }
   }
 
+  /**
+   * Re-initializes the lock for deserialized or freshly constructed instances.
+   *
+   * <p>Some callers may reconstruct an instance and subsequently call this method to ensure the
+   * lock is in a known state. Subclasses should call this if their lifecycle requires it.
+   */
   public void init() {
     lock = new ReentrantReadWriteLock();
   }
 
+  /**
+   * Creates an in-memory Bloom filter.
+   *
+   * @param length length in bits; rounded down to the nearest multiple of 8; {@code 0} produces a
+   *     {@link NullBloomFilter} which always returns positive membership
+   * @param k number of hash functions; must be non-negative; coerced to {@code 0} when {@code
+   *     length == 0}
+   * @param counting when {@code true}, returns a {@link CountingBloomFilter}; otherwise a {@link
+   *     BinaryBloomFilter}
+   * @return a new filter instance
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
+   */
   public static BloomFilter createFilter(int length, int k, boolean counting) {
     if (length == 0) return new NullBloomFilter(length, k);
     if (counting) return new CountingBloomFilter(length, k);
     else return new BinaryBloomFilter(length, k);
   }
 
+  /**
+   * Creates a file-backed Bloom filter using a memory-mapped {@link ByteBuffer} when applicable.
+   *
+   * <p>When the on-disk file is missing or has an unexpected size, subclasses set an internal
+   * one-shot {@link #needRebuild} flag which callers can query via {@link #needRebuild()}.
+   *
+   * @param file target file to back the filter; created or resized as needed by implementations
+   * @param length length in bits; rounded down to the nearest multiple of 8; {@code 0} produces a
+   *     {@link NullBloomFilter}
+   * @param k number of hash functions; must be non-negative; coerced to {@code 0} when {@code
+   *     length == 0}
+   * @param counting when {@code true}, returns a {@link CountingBloomFilter}; otherwise a {@link
+   *     BinaryBloomFilter}
+   * @return a new filter instance backed by {@code file}
+   * @throws IOException if the file cannot be created or mapped
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
+   */
   public static BloomFilter createFilter(File file, int length, int k, boolean counting)
       throws IOException {
     if (length == 0) return new NullBloomFilter(length, k);
@@ -62,12 +124,23 @@ public abstract class BloomFilter implements AutoCloseable {
     else return new BinaryBloomFilter(file, length, k);
   }
 
+  /**
+   * Constructs a Bloom filter skeleton.
+   *
+   * <p>Rounds {@code length} down to a multiple of 8 and coerces {@code k} to {@code 0} when the
+   * resulting length is {@code 0}. Registers a {@link Cleaner} action for best-effort resource
+   * cleanup.
+   *
+   * @param length requested length in bits (may be {@code 0})
+   * @param k number of hash functions (non-negative)
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
+   */
   protected BloomFilter(int length, int k) {
     if (length < 0) {
-      throw new IllegalArgumentException("Filter must have postitive or zero length");
+      throw new IllegalArgumentException("Filter must have positive or zero length");
     }
     if (k < 0) {
-      throw new IllegalArgumentException("Filter must have postitive or zero hashes");
+      throw new IllegalArgumentException("Filter must have positive or zero hashes");
     }
 
     if (length % 8 != 0) length -= length % 8;
@@ -87,6 +160,19 @@ public abstract class BloomFilter implements AutoCloseable {
   }
 
   // -- Core
+  /**
+   * Adds a key to the filter.
+   *
+   * <p>Derives {@code k} positions from the key via a deterministic {@link MersenneTwister} seeded
+   * from {@code key} and sets the corresponding bits/counters. If a fork is active (see {@link
+   * #fork(int)}), the update is also applied to the forked filter.
+   *
+   * <p>Thread-safe: acquires the write lock for the duration of the update.
+   *
+   * @param key key material; length must be a multiple of 4 bytes
+   * @throws NullPointerException if {@code key} is null
+   * @throws IllegalArgumentException if {@code key.length} is not a multiple of 4
+   */
   public void addKey(byte[] key) {
     Random hashes = getHashes(key);
     lock.writeLock().lock();
@@ -99,11 +185,30 @@ public abstract class BloomFilter implements AutoCloseable {
     if (forkedFilter != null) forkedFilter.addKey(key);
   }
 
-  // add to the forked filter only
+  /**
+   * Adds a key only to the active fork, if present.
+   *
+   * <p>Use to stage changes in the fork without affecting the main filter prior to {@link
+   * #merge()}.
+   *
+   * @param key key material; length must be a multiple of 4 bytes
+   * @see #fork(int)
+   */
   public void addKeyForked(byte[] key) {
     if (forkedFilter != null) forkedFilter.addKey(key);
   }
 
+  /**
+   * Tests whether all {@code k} hashed positions for {@code key} are present.
+   *
+   * <p>Returns {@code true} for possible membership (false positives are possible) and {@code
+   * false} for definite absence. Thread-safe: acquires the read lock.
+   *
+   * @param key key material; length must be a multiple of 4 bytes
+   * @return {@code true} if the filter may contain {@code key}; {@code false} if it does not
+   * @throws NullPointerException if {@code key} is null
+   * @throws IllegalArgumentException if {@code key.length} is not a multiple of 4
+   */
   public boolean checkFilter(byte[] key) {
     Random hashes = getHashes(key);
     lock.readLock().lock();
@@ -115,6 +220,17 @@ public abstract class BloomFilter implements AutoCloseable {
     return true;
   }
 
+  /**
+   * Removes a key from the filter.
+   *
+   * <p>For counting implementations, decrements the counters for the hashed positions (bounded at
+   * zero). For binary implementations, the operation may be a no-op. If a fork is active, the
+   * update is mirrored to the fork as well. Thread-safe: acquires the write lock.
+   *
+   * @param key key material; length must be a multiple of 4 bytes
+   * @throws NullPointerException if {@code key} is null
+   * @throws IllegalArgumentException if {@code key.length} is not a multiple of 4
+   */
   public void removeKey(byte[] key) {
     Random hashes = getHashes(key);
     lock.writeLock().lock();
@@ -128,31 +244,59 @@ public abstract class BloomFilter implements AutoCloseable {
   }
 
   // -- Bits and Hashes
+  /**
+   * Returns whether the bit/counter at a given position indicates presence.
+   *
+   * @param offset position in {@code [0, length)}
+   * @return {@code true} if the position is set (non-zero for counting); {@code false} otherwise
+   */
   protected abstract boolean getBit(int offset);
 
+  /** Sets the bit/counter at {@code offset}. Implementations handle overflow as needed. */
   protected abstract void setBit(int offset);
 
+  /** Clears or decrements the position at {@code offset}. Implementations handle underflow. */
   protected abstract void unsetBit(int offset);
 
-  // Wierd impl's should override
+  // Unusual implementations should override for efficiency.
   public void unsetAll() {
     int x = filter.limit();
     for (int i = 0; i < x; i++) filter.put(i, (byte) 0);
   }
 
+  /**
+   * Returns a {@link Random} seeded from {@code key} for position generation.
+   *
+   * <p>By default, this uses a non-synchronized {@link MersenneTwister} seeded with {@code
+   * key}-derived integers. Subclasses may override to change the hashing scheme.
+   *
+   * @param key key material; length must be a multiple of 4 bytes
+   * @return a deterministic pseudo-random generator for hashing
+   */
   protected Random getHashes(byte[] key) {
     return MersenneTwister.createUnsynchronized(key);
   }
 
   // -- Fork & Merge
+  /** Active forked filter; when non-null, updates are mirrored to it. */
   protected BloomFilter forkedFilter;
 
   /**
-   * Create an empty, in-memory copy of bloom filter. New updates are written to both filters. This
-   * is written back to disk on #merge()
+   * Creates an empty, in-memory copy (the fork) and starts mirroring updates to it.
+   *
+   * <p>The fork captures staged changes. On {@link #merge()}, the fork’s buffer replaces the main
+   * buffer atomically under the write lock. On {@link #discard()}, the fork is dropped.
+   *
+   * @param k number of hash functions to use in the fork (typically the same as {@link #k})
    */
   public abstract void fork(int k);
 
+  /**
+   * Replaces the main buffer with the fork’s buffer and closes the fork.
+   *
+   * <p>Thread-safe: acquires the write lock on both the main and forked filters. If no fork is
+   * active, the method returns immediately.
+   */
   public void merge() {
     lock.writeLock().lock();
     try {
@@ -177,6 +321,11 @@ public abstract class BloomFilter implements AutoCloseable {
     }
   }
 
+  /**
+   * Discards the active fork without applying its changes.
+   *
+   * <p>Thread-safe and idempotent.
+   */
   public void discard() {
     lock.writeLock().lock();
     try {
@@ -190,13 +339,17 @@ public abstract class BloomFilter implements AutoCloseable {
 
   // -- Misc.
   /**
-   * Calculate optimal K value
+   * Computes an approximate optimal number of hash functions.
+   *
+   * <p>Uses {@code round(ln(2) * m / n)} with {@code m = filterLength} (in bits) and {@code n =
+   * maxKey}. The result is clamped to {@code [1, 64]}. Returns {@code 0} when {@code filterLength
+   * == 0}.
    *
    * @param filterLength filter length in bits
-   * @param maxKey
-   * @return optimal K
+   * @param maxKey expected maximum distinct keys (must be positive for meaningful results)
+   * @return the recommended {@code k}
    */
-  public static int optimialK(int filterLength, long maxKey) {
+  public static int optimalK(int filterLength, long maxKey) {
     if (filterLength == 0) {
       // There's no point hashing when the filter is of zero length.
       return 0;
@@ -210,24 +363,51 @@ public abstract class BloomFilter implements AutoCloseable {
     return (int) k;
   }
 
+  /**
+   * @deprecated Use {@link #optimalK(int, long)}. Kept for backward compatibility.
+   */
+  @Deprecated
+  public static int optimialK(int filterLength, long maxKey) {
+    return optimalK(filterLength, maxKey);
+  }
+
   public int getK() {
     return k;
   }
 
+  /**
+   * One-shot flag set by file-backed implementations when backing storage was missing or resized.
+   */
   protected boolean needRebuild;
 
+  /**
+   * Returns and clears the {@link #needRebuild} flag.
+   *
+   * @return {@code true} if a rebuild was requested since the last call; otherwise {@code false}
+   */
   public boolean needRebuild() {
-    boolean _needRebuild = needRebuild;
+    boolean previousNeedRebuild = needRebuild;
     needRebuild = false;
-    return _needRebuild;
+    return previousNeedRebuild;
   }
 
+  /**
+   * Forces pending changes to the underlying storage if the buffer is memory-mapped.
+   *
+   * <p>No effect for heap buffers.
+   */
   public void force() {
     if (filter instanceof MappedByteBuffer buffer) {
       buffer.force();
     }
   }
 
+  /**
+   * Flushes resources and unregisters the cleaner.
+   *
+   * <p>For mapped buffers, calls {@link #force()} and then releases references to the buffer and
+   * the fork. This method is safe to call multiple times.
+   */
   @Override
   public void close() {
     if (filter != null) {
@@ -242,20 +422,49 @@ public abstract class BloomFilter implements AutoCloseable {
     }
   }
 
+  /**
+   * Returns the size of the backing buffer in bytes.
+   *
+   * @return buffer capacity in bytes
+   */
   public int getSizeBytes() {
     return filter.capacity();
   }
 
+  /**
+   * Returns the logical filter length in bits.
+   *
+   * @return number of addressable positions
+   */
   public int getLength() {
     return length;
   }
 
+  /**
+   * Counts the number of set positions across the entire filter.
+   *
+   * <p>For counting filters, any non-zero counter is considered set. This operation runs in {@code
+   * O(length)} and may be expensive for large filters.
+   *
+   * @return the number of set positions
+   */
   public int getFilledCount() {
-    int x = 0;
-    for (int i = 0; i < length; i++) if (getBit(i)) x++;
-    return x;
+    int count = 0;
+    for (int i = 0; i < length; i++) if (getBit(i)) count++;
+    return count;
   }
 
+  /**
+   * Copies the entire backing buffer into {@code buf} starting at {@code offset}.
+   *
+   * <p>Thread-safe: acquires the read lock for the duration of the copy.
+   *
+   * @param buf destination array
+   * @param offset starting index in {@code buf}
+   * @return number of bytes copied (the buffer capacity)
+   * @throws NullPointerException if {@code buf} is null
+   * @throws IndexOutOfBoundsException if the copy would exceed {@code buf} bounds
+   */
   public int copyTo(byte[] buf, int offset) {
     lock.readLock().lock();
     try {
@@ -267,6 +476,12 @@ public abstract class BloomFilter implements AutoCloseable {
     }
   }
 
+  /**
+   * Writes the entire backing buffer to the given stream.
+   *
+   * @param cos destination stream
+   * @throws IOException if the write fails
+   */
   public void writeTo(OutputStream cos) throws IOException {
     cos.write(filter.array(), filter.arrayOffset(), filter.capacity());
   }

--- a/src/main/java/network/crypta/support/BloomFilter.java
+++ b/src/main/java/network/crypta/support/BloomFilter.java
@@ -363,8 +363,6 @@ public abstract class BloomFilter implements AutoCloseable {
     return (int) k;
   }
 
-  
-
   public int getK() {
     return k;
   }

--- a/src/main/java/network/crypta/support/CountingBloomFilter.java
+++ b/src/main/java/network/crypta/support/CountingBloomFilter.java
@@ -1,15 +1,55 @@
 package network.crypta.support;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Counting Bloom filter with 2-bit per-position counters.
+ *
+ * <p>This implementation stores four 2-bit counters per byte, allowing limited multiplicity and
+ * stable removals. Each position represents a counter in {@code [0,3]} where the value {@code 3} is
+ * a saturation sentinel. Membership checks treat any non-zero counter as present.
+ *
+ * <h2>Storage layout</h2>
+ *
+ * <ul>
+ *   <li>Logical length is measured in bits/positions and rounded down to a multiple of 8 by the
+ *       {@link BloomFilter} base class.
+ *   <li>Backing buffer size is {@code length / 4} bytes (four counters per byte).
+ *   <li>For a given {@code offset}, the 2-bit field resides at {@code (offset % 4) * 2} within byte
+ *       {@code offset / 4}.
+ * </ul>
+ *
+ * <h2>Semantics</h2>
+ *
+ * <ul>
+ *   <li>{@link #setBit(int)} increments a counter up to {@code 3} and then saturates.
+ *   <li>{@link #unsetBit(int)} decrements counters {@code 1 -> 0} and {@code 2 -> 1}. Values {@code
+ *       0} (underflow) and {@code 3} (saturated) are left unchanged.
+ *   <li>{@link #getBit(int)} returns {@code true} when the counter is non-zero.
+ * </ul>
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>Public APIs such as {@link #fork(int)} are thread-safe. Low-level overrides ({@link
+ * #getBit(int)}, {@link #setBit(int)}, {@link #unsetBit(int)}) are invoked by the base class under
+ * its read/write locks and are not intended for external concurrent use.
+ *
  * @author sdiz
  */
 public class CountingBloomFilter extends BloomFilter {
@@ -18,14 +58,26 @@ public class CountingBloomFilter extends BloomFilter {
 
   private boolean warnOnRemoveFromEmpty;
 
+  /**
+   * Enables error logging when attempting to decrement a zero counter.
+   *
+   * <p>When enabled, {@link #unsetBit(int)} logs an error via SLF4J if called on a position whose
+   * counter is {@code 0}. This helps detect double-removal bugs that can otherwise lead to false
+   * negatives. No exception is thrown; behavior of the counter remains unchanged.
+   */
   public void setWarnOnRemoveFromEmpty() {
     warnOnRemoveFromEmpty = true;
   }
 
   /**
-   * Constructor
+   * Creates an in-memory counting Bloom filter.
    *
-   * @param length length in bits
+   * <p>The {@code length} is rounded down to a multiple of 8 by {@link BloomFilter}. The backing
+   * buffer capacity is {@code length / 4} bytes.
+   *
+   * @param length filter length in bits
+   * @param k number of hash functions to apply per key; must be non-negative
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
    */
   public CountingBloomFilter(int length, int k) {
     super(length, k);
@@ -33,11 +85,17 @@ public class CountingBloomFilter extends BloomFilter {
   }
 
   /**
-   * Constructor
+   * Creates a file-backed counting Bloom filter mapped into memory.
    *
-   * @param file disk file
-   * @param length length in bits
-   * @throws IOException
+   * <p>The method resizes {@code file} to {@code length / 4} bytes and memory-maps it in read/write
+   * mode. If the file is missing or has an unexpected size on entry, the one-shot {@link
+   * #needRebuild()} flag is set.
+   *
+   * @param file target backing file; created/resized as needed
+   * @param length filter length in bits
+   * @param k number of hash functions to apply per key; must be non-negative
+   * @throws IOException if the file cannot be created, resized, or mapped
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
    */
   protected CountingBloomFilter(File file, int length, int k) throws IOException {
     super(length, k);
@@ -51,37 +109,89 @@ public class CountingBloomFilter extends BloomFilter {
     }
   }
 
+  /**
+   * Creates an in-memory filter view over a provided buffer.
+   *
+   * <p>The buffer is wrapped (zero-copy) and must have a capacity of exactly {@code length / 4}
+   * bytes. Callers should not modify the array concurrently.
+   *
+   * @param length filter length in bits
+   * @param k number of hash functions to apply per key; must be non-negative
+   * @param buffer backing array of size {@code length / 4}
+   * @throws NullPointerException if {@code buffer} is {@code null}
+   * @throws IllegalArgumentException if {@code buffer.length != length / 4}
+   * @throws IllegalArgumentException if {@code length < 0} or {@code k < 0}
+   */
   public CountingBloomFilter(int length, int k, byte[] buffer) {
     super(length, k);
-    assert (buffer.length == length / 4);
+    if (buffer == null) {
+      throw new NullPointerException("buffer");
+    }
+    int expected = length / 4;
+    if (buffer.length != expected) {
+      throw new IllegalArgumentException(
+          "Invalid buffer length: " + buffer.length + " (expected " + expected + ")");
+    }
     filter = ByteBuffer.wrap(buffer);
   }
 
+  /**
+   * Returns whether the counter at {@code offset} is non-zero.
+   *
+   * <p>Time complexity is {@code O(1)}. This method is called under the read lock by the base
+   * class. External callers should prefer {@link #checkFilter(byte[])} on {@link BloomFilter}.
+   *
+   * @param offset position in {@code [0, length)}
+   * @return {@code true} when the 2-bit counter is not zero; {@code false} otherwise
+   */
   @Override
   public boolean getBit(int offset) {
-    byte b = filter.get(offset / 4);
-    byte v = (byte) ((b >>> offset % 4 * 2) & 3);
-
+    int index = offset / 4;
+    int shift = (offset % 4) * 2;
+    int b = filter.get(index) & 0xFF;
+    int v = (b >>> shift) & 0x03;
     return v != 0;
   }
 
+  /**
+   * Increments the 2-bit counter at {@code offset} up to saturation.
+   *
+   * <p>Values {@code 0 -> 1}, {@code 1 -> 2}, and {@code 2 -> 3}; {@code 3} remains unchanged. This
+   * method is called under the write lock by the base class.
+   *
+   * @param offset position in {@code [0, length)}
+   */
   @Override
   public void setBit(int offset) {
-    byte b = filter.get(offset / 4);
-    byte v = (byte) ((b >>> offset % 4 * 2) & 3);
+    int index = offset / 4;
+    int shift = (offset % 4) * 2;
+    int b = filter.get(index) & 0xFF;
+    int v = (b >>> shift) & 0x03;
 
-    if (v == 3) return; // overflow
+    if (v == 3) return; // overflow (saturated at 3)
 
-    b &= ~(3 << offset % 4 * 2); // unset bit
-    b |= (v + 1) << offset % 4 * 2; // set bit
+    b &= ~(0x03 << shift); // clear existing 2-bit field
+    b |= ((v + 1) & 0x03) << shift; // increment and set
 
-    filter.put(offset / 4, b);
+    filter.put(index, (byte) b);
   }
 
+  /**
+   * Decrements the 2-bit counter at {@code offset} when in {@code {1,2}}.
+   *
+   * <p>Values {@code 1 -> 0} and {@code 2 -> 1} change; {@code 0} (underflow) and {@code 3}
+   * (saturated) are unchanged. When {@link #setWarnOnRemoveFromEmpty()} has been called, attempts
+   * to decrement {@code 0} log an error. This method is called under the write lock by the base
+   * class.
+   *
+   * @param offset position in {@code [0, length)}
+   */
   @Override
   public void unsetBit(int offset) {
-    byte b = filter.get(offset / 4);
-    byte v = (byte) ((b >>> offset % 4 * 2) & 3);
+    int index = offset / 4;
+    int shift = (offset % 4) * 2;
+    int b = filter.get(index) & 0xFF;
+    int v = (b >>> shift) & 0x03;
 
     if (v == 0 && warnOnRemoveFromEmpty)
       LOG.error(
@@ -89,25 +199,96 @@ public class CountingBloomFilter extends BloomFilter {
               + " very bad!",
           new Exception("error"));
 
-    if (v == 0 || v == 3) return; // overflow / underflow
+    if (v == 0 || v == 3) return; // underflow guard or saturated value
 
-    b &= ~(3 << offset % 4 * 2); // unset bit
-    b |= (v - 1) << offset % 4 * 2; // set bit
+    b &= ~(0x03 << shift); // clear existing 2-bit field
+    b |= ((v - 1) & 0x03) << shift; // decrement and set
 
-    filter.put(offset / 4, b);
+    filter.put(index, (byte) b);
   }
 
+  /**
+   * Creates a forked filter and starts mirroring updates.
+   *
+   * <p>Under a write lock, attempts to create a secure, file-backed fork via a temporary file. If
+   * file mapping fails, falls back to an in-memory fork. The fork accumulates staged changes until
+   * {@link #merge()} or {@link #discard()} is called on the base class.
+   *
+   * @param k number of hash functions for the fork (typically equal to {@link #getK()})
+   */
   @Override
   public void fork(int k) {
-    lock.writeLock().lock();
+    try (LockResource ignored = new LockResource(lock.writeLock())) {
+      try {
+        File tempFile = createSecureTempFile();
+        tempFile.deleteOnExit();
+        forkedFilter = new CountingBloomFilter(tempFile, length, k);
+      } catch (IOException e) {
+        forkedFilter = new CountingBloomFilter(length, k);
+      }
+    }
+  }
+
+  private static File createSecureTempFile() throws IOException {
     try {
-      File tempFile = File.createTempFile("bloom-", ".tmp");
-      tempFile.deleteOnExit();
-      forkedFilter = new CountingBloomFilter(tempFile, length, k);
-    } catch (IOException e) {
-      forkedFilter = new CountingBloomFilter(length, k);
-    } finally {
-      lock.writeLock().unlock();
+      // Prefer POSIX-restricted temp files when available
+      if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+        Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rw-------");
+        FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
+        Path p = Files.createTempFile("bloom-", ".tmp", attr);
+        File f = p.toFile();
+        f.deleteOnExit();
+        return f;
+      }
+    } catch (UnsupportedOperationException ignored) {
+      // Fall through to generic path below
+    }
+
+    // Generic platforms (e.g., Windows): create under a user-private directory
+    Path base = Paths.get(System.getProperty("user.home", "."), ".cryptad", "tmp");
+    Files.createDirectories(base);
+    File baseFile = base.toFile();
+    boolean br = baseFile.setReadable(true, true);
+    boolean bw = baseFile.setWritable(true, true);
+    boolean bx = baseFile.setExecutable(true, true);
+    if (!br || !bw || !bx) {
+      LOG.debug(
+          "Best-effort permission adjustment on temp directory {} did not fully apply (r={}, w={},"
+              + " x={}).",
+          baseFile,
+          br,
+          bw,
+          bx);
+    }
+    Path p = Files.createTempFile(base, "bloom-", ".tmp");
+    File f = p.toFile();
+    boolean r = f.setReadable(true, true);
+    boolean w = f.setWritable(true, true);
+    boolean x = f.setExecutable(false, false);
+    if (!r || !w || !x) {
+      LOG.debug(
+          "Best-effort permission adjustment on temp file {} did not fully apply (r={}, w={},"
+              + " x={}).",
+          f,
+          r,
+          w,
+          x);
+    }
+    f.deleteOnExit();
+    return f;
+  }
+
+  private static final class LockResource implements Closeable {
+    private final java.util.concurrent.locks.Lock w;
+
+    LockResource(java.util.concurrent.locks.Lock w) {
+      this.w = w;
+      this.w.lock();
+    }
+
+    @Override
+    public void close() {
+      w.unlock();
     }
   }
 }

--- a/src/main/java/network/crypta/support/NullBloomFilter.java
+++ b/src/main/java/network/crypta/support/NullBloomFilter.java
@@ -1,50 +1,139 @@
 package network.crypta.support;
 
 /**
+ * Null-object implementation of {@link BloomFilter}.
+ *
+ * <p>This variant represents a zero-length filter that always reports positive membership and
+ * ignores all updates. It contains no backing storage and performs no hashing. The {@link
+ * BloomFilter#createFilter(int, int, boolean)} and {@link BloomFilter#createFilter(java.io.File,
+ * int, int, boolean)} factories return an instance of this class when the requested length is
+ * {@code 0}.
+ *
+ * <h2>Behavior</h2>
+ *
+ * <ul>
+ *   <li>{@link #checkFilter(byte[])} always returns {@code true} and accepts {@code null} keys.
+ *   <li>{@link #addKey(byte[])} and {@link #removeKey(byte[])} are no-ops and accept {@code null}
+ *       keys.
+ *   <li>{@link #getBit(int)} always returns {@code true}; {@link #setBit(int)} and {@link
+ *       #unsetBit(int)} are no-ops.
+ *   <li>{@link #fork(int)}, {@link #discard()}, and {@link #merge()} are intentional no-ops because
+ *       there is no forkable state.
+ * </ul>
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>All operations are side effect free and constant time; no synchronization is required beyond
+ * what the base type may perform. There are no observable state transitions.
+ *
  * @author sdiz
  */
 public class NullBloomFilter extends BloomFilter {
+  /**
+   * Constructs a null filter.
+   *
+   * <p>The {@link BloomFilter} base class coerces {@code k} to {@code 0} when {@code length == 0},
+   * ensuring there is no hashing or index generation.
+   *
+   * @param length requested length in bits; callers typically pass {@code 0}
+   * @param k number of hash functions; ignored and coerced to {@code 0} by the base constructor
+   */
   protected NullBloomFilter(int length, int k) {
     super(length, k);
   }
 
+  /**
+   * Returns {@code true} for any key.
+   *
+   * <p>This method accepts {@code null} and keys of any length. It performs no hashing and has no
+   * side effects.
+   *
+   * @param key key material; may be {@code null}
+   * @return always {@code true}
+   */
   @Override
   public boolean checkFilter(byte[] key) {
     return true;
   }
 
+  /**
+   * No-op. Accepts any input, including {@code null}.
+   *
+   * <p>The null filter has no backing storage to update.
+   *
+   * @param key key material; ignored
+   */
   @Override
   public void addKey(byte[] key) {
-    // ignore
+    // No-op: null filter does not store state.
   }
 
+  /**
+   * No-op. Accepts any input, including {@code null}.
+   *
+   * <p>There is no stored state to remove from.
+   *
+   * @param key key material; ignored
+   */
   @Override
   public void removeKey(byte[] key) {
-    // ignore
+    // No-op: nothing to remove in a null filter.
   }
 
+  /**
+   * Reports {@code true} for any position.
+   *
+   * <p>Since the filter has no storage, membership checks conceptually observe all positions as
+   * set.
+   *
+   * @param offset ignored position index
+   * @return always {@code true}
+   */
   @Override
   protected boolean getBit(int offset) {
-    // ignore
+    // Intentional: null filter behaves as if every bit were set.
     return true;
   }
 
+  /**
+   * No-op. There is no underlying buffer to modify.
+   *
+   * @param offset ignored position index
+   */
   @Override
   protected void setBit(int offset) {
-    // ignore
+    // No-op.
   }
 
+  /**
+   * No-op. There is no underlying buffer to modify.
+   *
+   * @param offset ignored position index
+   */
   @Override
   protected void unsetBit(int offset) {
-    // ignore
+    // No-op.
   }
 
+  /**
+   * No-op. Starts no fork because this filter has no state.
+   *
+   * @param k requested hash count for the (non-existent) fork; ignored
+   */
   @Override
-  public void fork(int k) {}
+  public void fork(int k) {
+    // Intentionally no-op: the null filter has no backing state to fork.
+  }
 
+  /** No-op. There is no forked state to discard. */
   @Override
-  public void discard() {}
+  public void discard() {
+    // Intentionally no-op: there is no forked state to discard for the null filter.
+  }
 
+  /** No-op. There is no forked state to merge. */
   @Override
-  public void merge() {}
+  public void merge() {
+    // Intentionally no-op: merging is meaningless without forked state.
+  }
 }

--- a/src/main/java/network/crypta/support/io/TempBucketFactory.java
+++ b/src/main/java/network/crypta/support/io/TempBucketFactory.java
@@ -37,29 +37,32 @@ import org.slf4j.LoggerFactory;
 /**
  * Factory for temporary buckets that prefer RAM and transparently migrate to disk.
  *
- * <p>This factory creates buckets that are initially backed either by memory (an
- * {@link ArrayBucket}) or by a file (a {@link TempFileBucket}), depending on the requested size and
+ * <p>This factory creates buckets that are initially backed either by memory (an {@link
+ * ArrayBucket}) or by a file (a {@link TempFileBucket}), depending on the requested size and
  * current pool usage. RAM-backed buckets may later migrate to disk based on age or size so the
  * process can continue without running out of the configured memory pool.
  *
  * <p>Selection rules:
+ *
  * <ul>
- *   <li>Use an in-memory bucket when {@code size <= maxRAMBucketSize} and the pool
- *       ({@link #bytesInUse}) would remain {@code <= maxRamUsed}.
+ *   <li>Use an in-memory bucket when {@code size <= maxRAMBucketSize} and the pool ({@link
+ *       #bytesInUse}) would remain {@code <= maxRamUsed}.
  *   <li>Otherwise, use a disk-backed bucket (optionally wrapped with padding and encryption when
  *       {@link #reallyEncrypt} is enabled).
  * </ul>
  *
  * <p>Migration rules for RAM buckets:
+ *
  * <ul>
  *   <li>Age-based: buckets older than {@link #RAMBUCKET_MAX_AGE} migrate.
- *   <li>Size-based: buckets exceeding
- *       {@code RAMBUCKET_CONVERSION_FACTOR * maxRAMBucketSize} migrate.
+ *   <li>Size-based: buckets exceeding {@code RAMBUCKET_CONVERSION_FACTOR * maxRAMBucketSize}
+ *       migrate.
  *   <li>Pool-pressure: when total usage rises above {@link #MAX_USAGE_HIGH}, a background cleaner
  *       migrates buckets until usage drops below {@link #MAX_USAGE_LOW}.
  * </ul>
  *
  * <p>Threading and lifecycle:
+ *
  * <ul>
  *   <li>Instances are thread-safe for factory operations.
  *   <li>Returned buckets expose synchronized methods where needed; callers must still respect
@@ -161,8 +164,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
    * A bucket that may start in RAM and migrate to disk transparently.
    *
    * <p>Only one output stream can be opened at a time. Reading requires that an output stream has
-   * been opened previously to establish the content; see
-   * {@link #getInputStreamUnbuffered()} for details.
+   * been opened previously to establish the content; see {@link #getInputStreamUnbuffered()} for
+   * details.
    *
    * <p>Instances are safe for concurrent use where methods are synchronized; callers should
    * coordinate access patterns when mixing reads, writes, and migration.
@@ -292,8 +295,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
     /**
      * Returns a buffered output stream for writing the bucket contents.
      *
-     * <p>Only one output stream may be open at a time. The returned stream may trigger
-     * migration to disk as content grows beyond the in-memory thresholds.
+     * <p>Only one output stream may be open at a time. The returned stream may trigger migration to
+     * disk as content grows beyond the in-memory thresholds.
      *
      * @return buffered {@link OutputStream}
      * @throws IOException if an output stream is already open or the bucket has been freed
@@ -306,9 +309,9 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
     /**
      * Returns an unbuffered output stream for writing the bucket contents.
      *
-     * <p>Preconditions: no other output stream is open. Only a single output stream is supported
-     * at a time. After calling this method, {@link #getInputStreamUnbuffered()} becomes available
-     * once data has been written.
+     * <p>Preconditions: no other output stream is open. Only a single output stream is supported at
+     * a time. After calling this method, {@link #getInputStreamUnbuffered()} becomes available once
+     * data has been written.
      *
      * @return unbuffered {@link OutputStream}
      * @throws IOException if another output stream is open or the bucket has been freed
@@ -598,8 +601,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
     /**
      * Releases all resources associated with this bucket.
      *
-     * <p>Closes any open streams, updates memory accounting, and frees the underlying storage.
-     * This method is idempotent.
+     * <p>Closes any open streams, updates memory accounting, and frees the underlying storage. This
+     * method is idempotent.
      */
     @Override
     public synchronized void free() {
@@ -618,11 +621,11 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
             ramBucketQueue.remove(getReference());
           }
 
-      // Explicit free completed; clear the Cleaner registration.
-      if (cleanable != null) {
-        cleanable.clean();
-      }
-      return;
+          // Explicit free completed; clear the Cleaner registration.
+          if (cleanable != null) {
+            cleanable.clean();
+          }
+          return;
         } else {
           // Better to free outside the lock if it's not in-memory.
           cur = currentBucket;
@@ -684,8 +687,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
      * Converts this bucket into a read-only random-access buffer.
      *
      * <p>Preconditions: no output stream is open and no input stream is currently active. The
-     * returned buffer shares the underlying storage; after conversion, this bucket becomes a
-     * {@link RAFBucket} wrapping the new buffer.
+     * returned buffer shares the underlying storage; after conversion, this bucket becomes a {@link
+     * RAFBucket} wrapping the new buffer.
      *
      * @return a read-only {@link LockableRandomAccessBuffer}
      * @throws IOException if the bucket has been freed or streams are still open
@@ -913,8 +916,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
   /**
    * Sets the minimum free disk space to preserve.
    *
-   * <p>Operations that would reduce available space below this threshold fail fast with
-   * {@link InsufficientDiskSpaceException}.
+   * <p>Operations that would reduce available space below this threshold fail fast with {@link
+   * InsufficientDiskSpaceException}.
    *
    * @param min minimum free space in bytes to maintain
    */
@@ -934,6 +937,7 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
 
   static final double MAX_USAGE_LOW = 0.8;
   static final double MAX_USAGE_HIGH = 0.9;
+
   /**
    * Cipher configuration used when wrapping disk-backed storage with encryption.
    *

--- a/src/test/java/network/crypta/support/BinaryBloomFilterTest.java
+++ b/src/test/java/network/crypta/support/BinaryBloomFilterTest.java
@@ -1,0 +1,325 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.Arrays;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+
+/** Unit tests for {@link BinaryBloomFilter} using JUnit 6 and Mockito. */
+@SuppressWarnings("java:S100") // Allow descriptive test method names with underscores
+class BinaryBloomFilterTest {
+
+  private BinaryBloomFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    // 1024-bit filter (128 bytes) with k=4 for general tests
+    filter = new BinaryBloomFilter(1024, 4);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (filter != null) {
+      filter.close();
+    }
+  }
+
+  @Test
+  @DisplayName("removeKey_whenCalled_expectNoEffect")
+  void removeKey_whenCalled_expectNoEffect() {
+    byte[] key = new byte[] {1, 2, 3, 4};
+
+    filter.addKey(key);
+    int filledBefore = filter.getFilledCount();
+    assertTrue(filter.checkFilter(key), "Key should be reported present after add");
+
+    filter.removeKey(key); // No-op in BinaryBloomFilter
+
+    assertTrue(
+        filter.checkFilter(key), "Key should still be reported present after removeKey no-op");
+    assertEquals(
+        filledBefore, filter.getFilledCount(), "Filled count should be unchanged by removeKey");
+  }
+
+  @Test
+  @DisplayName("unsetBit_whenCalled_expectNoEffect")
+  void unsetBit_whenCalled_expectNoEffect() {
+    // Small 8-bit filter to target a single byte
+    try (BinaryBloomFilter small = new BinaryBloomFilter(8, 1)) {
+      assertFalse(small.getBit(0));
+      small.setBit(0);
+      assertTrue(small.getBit(0));
+
+      small.unsetBit(0); // no-op in binary variant
+      assertTrue(small.getBit(0), "unsetBit must not clear bit in BinaryBloomFilter");
+    }
+  }
+
+  @Test
+  @DisplayName("setBitAndGetBit_whenPositions_expectLsbOrder")
+  void setBitAndGetBit_whenPositions_expectLsbOrder() {
+    try (BinaryBloomFilter small = new BinaryBloomFilter(8, 0)) {
+      // Set only bit 1 → expect underlying byte 0b00000010 (LSB first)
+      small.setBit(1);
+      assertTrue(small.getBit(1));
+      byte[] snapshot = new byte[1];
+      int n = small.copyTo(snapshot, 0);
+      assertEquals(1, n);
+      assertArrayEquals(new byte[] {0b0000_0010}, snapshot);
+    }
+  }
+
+  @Test
+  @DisplayName("addKey_whenAddedTwice_expectIdempotentFilledCount")
+  void addKey_whenAddedTwice_expectIdempotentFilledCount() {
+    byte[] key = new byte[] {9, 8, 7, 6};
+    filter.addKey(key);
+    int firstFilled = filter.getFilledCount();
+    filter.addKey(key);
+    int secondFilled = filter.getFilledCount();
+    assertEquals(
+        firstFilled, secondFilled, "Adding same key twice should not increase filled bit count");
+  }
+
+  @Test
+  @DisplayName("copyToAndRecreate_whenWritten_expectSameBehavior")
+  void copyToAndRecreate_whenWritten_expectSameBehavior() {
+    byte[] k1 = new byte[] {1, 1, 1, 1};
+    byte[] k2 = new byte[] {2, 2, 2, 2};
+    byte[] k3 = new byte[] {3, 3, 3, 3};
+    filter.addKey(k1);
+    filter.addKey(k2);
+    filter.addKey(k3);
+
+    byte[] buf = new byte[filter.getSizeBytes()];
+    int written = filter.copyTo(buf, 0);
+    assertEquals(filter.getSizeBytes(), written);
+
+    try (BinaryBloomFilter restored =
+        new BinaryBloomFilter(ByteBuffer.wrap(buf), filter.getLength(), filter.getK())) {
+      assertTrue(restored.checkFilter(k1));
+      assertTrue(restored.checkFilter(k2));
+      assertTrue(restored.checkFilter(k3));
+    }
+  }
+
+  @Test
+  @DisplayName("writeTo_whenCalled_expectBytesWrittenToStream")
+  void writeTo_whenCalled_expectBytesWrittenToStream() throws IOException {
+    try (BinaryBloomFilter small = new BinaryBloomFilter(16, 1)) {
+      // Set two bits to produce a stable byte pattern
+      small.setBit(0);
+      small.setBit(9); // second byte, bit 1
+
+      byte[] expected = new byte[small.getSizeBytes()];
+      small.copyTo(expected, 0);
+
+      OutputStream os = mock(OutputStream.class);
+      small.writeTo(os);
+
+      ArgumentCaptor<byte[]> arrCap = ArgumentCaptor.forClass(byte[].class);
+      ArgumentCaptor<Integer> offCap = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<Integer> lenCap = ArgumentCaptor.forClass(Integer.class);
+      verify(os, times(1)).write(arrCap.capture(), offCap.capture(), lenCap.capture());
+
+      assertEquals(0, offCap.getValue());
+      assertEquals(expected.length, lenCap.getValue());
+      byte[] actual =
+          Arrays.copyOfRange(
+              arrCap.getValue(), offCap.getValue(), offCap.getValue() + lenCap.getValue());
+      assertArrayEquals(expected, actual);
+    }
+  }
+
+  @Test
+  @DisplayName("fork_whenAddKeyForkedThenMerge_expectMainHasForkBits")
+  void fork_whenAddKeyForkedThenMerge_expectMainHasForkBits() {
+    byte[] a = new byte[] {10, 20, 30, 40};
+    byte[] b = new byte[] {11, 21, 31, 41};
+
+    // Use the same k for fork to keep membership checks consistent
+    filter.fork(filter.getK());
+
+    filter.addKey(a); // added to both main and fork
+    assertTrue(filter.checkFilter(a));
+
+    filter.addKeyForked(b); // only to forked filter
+    assertFalse(filter.checkFilter(b), "Before merge, main must not have fork-only key");
+
+    filter.merge();
+    assertTrue(filter.checkFilter(b), "After merge, main should contain fork's bits");
+  }
+
+  @Test
+  @DisplayName("discard_whenCalled_expectForkAbandoned")
+  void discard_whenCalled_expectForkAbandoned() {
+    byte[] onlyFork = new byte[] {7, 7, 7, 7};
+    filter.fork(2);
+    filter.addKeyForked(onlyFork);
+    assertFalse(filter.checkFilter(onlyFork));
+
+    filter.discard();
+    assertFalse(
+        filter.checkFilter(onlyFork), "After discard, fork-only bits must not appear in main");
+
+    // Idempotent behavior
+    filter.discard();
+  }
+
+  @ParameterizedTest
+  @DisplayName("constructor_whenLengthNotAligned_expectRoundedDownAndSize")
+  @CsvSource({"1,0,0", "2,0,0", "7,0,0", "8,8,1", "9,8,1", "15,8,1", "16,16,2", "17,16,2"})
+  void constructor_whenLengthNotAligned_expectRoundedDownAndSize(
+      int requestedBits, int expectedBits, int expectedBytes) {
+    try (BinaryBloomFilter bf = new BinaryBloomFilter(requestedBits, 3)) {
+      assertEquals(expectedBits, bf.getLength());
+      assertEquals(expectedBytes, bf.getSizeBytes());
+    }
+  }
+
+  @Test
+  @DisplayName("constructor_whenZeroLength_expectKZero")
+  void constructor_whenZeroLength_expectKZero() {
+    try (BinaryBloomFilter bf = new BinaryBloomFilter(0, 5)) {
+      assertEquals(0, bf.getLength());
+      assertEquals(0, bf.getK(), "k must be coerced to 0 for zero-length filters");
+    }
+  }
+
+  @Test
+  @DisplayName("zeroLength_whenCheckAlignedKey_expectTrue")
+  void zeroLength_whenCheckAlignedKey_expectTrue() {
+    try (BinaryBloomFilter bf = new BinaryBloomFilter(0, 5)) {
+      assertTrue(bf.checkFilter(new byte[] {1, 2, 3, 4}));
+      assertTrue(bf.checkFilter(new byte[] {9, 9, 9, 9}));
+    }
+  }
+
+  @Test
+  @DisplayName("checkFilter_whenKeyLengthNotMultipleOf4_expectIllegalArgumentException")
+  void checkFilter_whenKeyLengthNotMultipleOf4_expectIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> filter.checkFilter(new byte[] {1, 2, 3}));
+  }
+
+  @Test
+  @DisplayName("addKey_whenKeyLengthNotMultipleOf4_expectIllegalArgumentException")
+  void addKey_whenKeyLengthNotMultipleOf4_expectIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> filter.addKey(new byte[] {1}));
+  }
+
+  @Test
+  @DisplayName("addKey_whenNull_expectNullPointerException")
+  void addKey_whenNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> filter.addKey(null));
+  }
+
+  @Test
+  @DisplayName("checkFilter_whenNull_expectNullPointerException")
+  void checkFilter_whenNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> filter.checkFilter(null));
+  }
+
+  @Test
+  @DisplayName("createFilter_whenNegativeLength_expectIllegalArgumentException")
+  void createFilter_whenNegativeLength_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try (BloomFilter ignored = BloomFilter.createFilter(-8, 1, false)) {
+            fail("Filter creation should have thrown before entering try block");
+          }
+        });
+  }
+
+  @Test
+  @DisplayName("optimialK_whenVariousInputs_expectBounds")
+  void optimialK_whenVariousInputs_expectBounds() {
+    assertEquals(0, BloomFilter.optimialK(0, 100));
+    assertEquals(64, BloomFilter.optimialK(1024, 1), "Large filter vs tiny set caps at 64");
+    assertEquals(1, BloomFilter.optimialK(8, 1_000_000), "Small filter vs huge set floors at 1");
+  }
+
+  @Nested
+  class FileBacked {
+    private File tempDir;
+
+    @BeforeEach
+    void setupDir() throws IOException {
+      File secureRoot = new File("build/securetmp-tests");
+      // best-effort owner-only permissions
+      if (!secureRoot.exists()) {
+        assertTrue(secureRoot.mkdirs(), "Failed to create secure test temp root");
+      }
+      assertTrue(secureRoot.setReadable(true, true));
+      assertTrue(secureRoot.setWritable(true, true));
+      assertTrue(secureRoot.setExecutable(true, true));
+
+      tempDir = Files.createTempDirectory(secureRoot.toPath(), "bbf-test-").toFile();
+      assertTrue(tempDir.setReadable(true, true));
+      assertTrue(tempDir.setWritable(true, true));
+      assertTrue(tempDir.setExecutable(true, true));
+      tempDir.deleteOnExit();
+    }
+
+    @Test
+    @DisplayName("fileBacked_whenFirstOpen_expectNeedRebuildTrueThenFalse")
+    void fileBacked_whenFirstOpen_expectNeedRebuildTrueThenFalse() throws IOException {
+      File f = new File(tempDir, "filter.bin");
+
+      try (BloomFilter bf1 = BloomFilter.createFilter(f, 64, 2, false)) {
+        assertTrue(bf1.needRebuild(), "First open should signal rebuild (file missing)");
+        assertFalse(bf1.needRebuild(), "Subsequent call should reset flag");
+      }
+
+      // Reopen with same size → should not need rebuild
+      try (BloomFilter bf2 = BloomFilter.createFilter(f, 64, 2, false)) {
+        assertFalse(bf2.needRebuild(), "Second open with correct size should not need rebuild");
+      }
+    }
+
+    @Test
+    @DisplayName("fileBacked_whenSizeChanges_expectNeedRebuildTrue")
+    void fileBacked_whenSizeChanges_expectNeedRebuildTrue() throws IOException {
+      File f = new File(tempDir, "filter2.bin");
+      try (BloomFilter bf1 = BloomFilter.createFilter(f, 64, 2, false)) {
+        bf1.needRebuild(); // consume initial true
+      }
+
+      // Reopen with different target size → constructor should flag rebuild
+      try (BloomFilter bf2 = BloomFilter.createFilter(f, 128, 2, false)) {
+        assertTrue(bf2.needRebuild(), "Changing on-disk size should trigger rebuild flag");
+      }
+    }
+
+    @Test
+    @DisplayName("fileBacked_forceAndReopen_expectDataPersists")
+    void fileBacked_forceAndReopen_expectDataPersists() throws IOException {
+      File f = new File(tempDir, "filter3.bin");
+      BloomFilter bf1 = BloomFilter.createFilter(f, 256, 3, false);
+      byte[] key = new byte[] {5, 4, 3, 2};
+      try {
+        bf1.addKey(key);
+        bf1.force();
+      } finally {
+        bf1.close();
+      }
+
+      try (BloomFilter bf2 = BloomFilter.createFilter(f, 256, 3, false)) {
+        assertTrue(bf2.checkFilter(key), "Mapped bytes should persist across reopen");
+      }
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/BinaryBloomFilterTest.java
+++ b/src/test/java/network/crypta/support/BinaryBloomFilterTest.java
@@ -247,9 +247,9 @@ class BinaryBloomFilterTest {
   @Test
   @DisplayName("optimialK_whenVariousInputs_expectBounds")
   void optimialK_whenVariousInputs_expectBounds() {
-    assertEquals(0, BloomFilter.optimialK(0, 100));
-    assertEquals(64, BloomFilter.optimialK(1024, 1), "Large filter vs tiny set caps at 64");
-    assertEquals(1, BloomFilter.optimialK(8, 1_000_000), "Small filter vs huge set floors at 1");
+    assertEquals(0, BloomFilter.optimalK(0, 100));
+    assertEquals(64, BloomFilter.optimalK(1024, 1), "Large filter vs tiny set caps at 64");
+    assertEquals(1, BloomFilter.optimalK(8, 1_000_000), "Small filter vs huge set floors at 1");
   }
 
   @Nested

--- a/src/test/java/network/crypta/support/BloomFilterTest.java
+++ b/src/test/java/network/crypta/support/BloomFilterTest.java
@@ -1,153 +1,302 @@
 package network.crypta.support;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import network.crypta.support.math.MersenneTwister;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 
-public class BloomFilterTest {
-  private static final int FILTER_SIZE = 4 * 1024; // MUST be > PASS,
-  private static final int PASS = 2048;
-  private static final int PASS_REMOVE = 4096;
-  private static final int PASS_POS = 256;
-  private static final int PASS_FALSE = 8192;
+/**
+ * Deterministic, comprehensive tests for {@link BloomFilter} public API across binary and counting
+ * implementations.
+ */
+@SuppressWarnings("java:S100") // Allow descriptive test method names with underscores
+class BloomFilterTest {
 
-  private final Random rand = new Random(12345);
+  // -------- Helpers --------
 
-  private void _testFilterPositive(BloomFilter filter) {
-    byte[][] list = new byte[PASS_POS][];
+  private static int indexFor(byte[] key, int length) {
+    return MersenneTwister.createUnsynchronized(key).nextInt(length);
+  }
 
-    for (int i = 0; i < PASS_POS; i++) {
-      byte[] b = new byte[32];
-      rand.nextBytes(b);
-
-      filter.addKey(b);
-      list[i] = b;
+  private static byte[] keyWithDifferentIndex(byte[] base, int length) {
+    int baseIdx = indexFor(base, length);
+    for (int i = 0; i < 10_000; i++) {
+      byte[] k = new byte[] {(byte) i, 0, 0, 0};
+      if (indexFor(k, length) != baseIdx) return k;
     }
+    throw new IllegalStateException("Failed to find non-colliding key deterministically");
+  }
 
-    for (byte[] b : list) {
-      assertTrue(filter.checkFilter(b));
+  private static byte[] keyDifferentFromAll(int length, int... usedIdx) {
+    for (int i = 0; i < 20_000; i++) {
+      byte[] k = new byte[] {(byte) (i & 0xFF), (byte) ((i >>> 8) & 0xFF), 0, 0};
+      int idx = indexFor(k, length);
+      boolean clash = false;
+      for (int u : usedIdx)
+        if (idx == u) {
+          clash = true;
+          break;
+        }
+      if (!clash) return k;
+    }
+    throw new IllegalStateException("Failed to find suitable distinct key deterministically");
+  }
+
+  /**
+   * Helper used by assertThrows lambdas so each lambda performs a single invocation that may throw.
+   * Ensures any created BloomFilter is properly closed while keeping the try block non-empty.
+   */
+  private static void createAndClose(int length, int k, boolean counting) {
+    try (BloomFilter bf = BloomFilter.createFilter(length, k, counting)) {
+      // Touch the resource so it's not flagged as unused, without performing any extra risky calls
+      int ignore = bf.getK();
+      if (ignore == Integer.MIN_VALUE) {
+        throw new AssertionError("unreachable");
+      }
+    }
+  }
+
+  // -------- Creation & basics --------
+
+  @Test
+  @DisplayName("createFilter_whenNegativeLength_expectIllegalArgumentException")
+  void createFilter_whenNegativeLength_expectIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> createAndClose(-1, 1, false));
+    assertThrows(IllegalArgumentException.class, () -> createAndClose(-1, 1, true));
+  }
+
+  @Test
+  @DisplayName("createFilter_whenNegativeK_expectIllegalArgumentException")
+  void createFilter_whenNegativeK_expectIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> createAndClose(8, -1, false));
+    assertThrows(IllegalArgumentException.class, () -> createAndClose(8, -2, true));
+  }
+
+  @ParameterizedTest
+  @DisplayName("createFilter_whenLengthNotMultipleOf8_expectRoundedDownAndCorrectSize")
+  @CsvSource({"false,1,0", "false,8,1", "false,9,1", "false,17,2", "true,8,2", "true,16,4"})
+  void createFilter_whenLengthNotMultipleOf8_expectRoundedDownAndCorrectSize(
+      boolean counting, int requestedBits, int expectedBytes) {
+    try (BloomFilter bf = BloomFilter.createFilter(requestedBits, 3, counting)) {
+      int expectedBits = requestedBits - (requestedBits % 8);
+      assertEquals(expectedBits, bf.getLength());
+      assertEquals(expectedBytes, bf.getSizeBytes());
     }
   }
 
   @Test
-  public void testCountingFilterPositive() {
-    int K = BloomFilter.optimialK(FILTER_SIZE, PASS_POS);
-    BloomFilter filter = BloomFilter.createFilter(FILTER_SIZE, K, true);
-    _testFilterPositive(filter);
+  @DisplayName("createFilter_whenZeroLength_expectNullBloomAndKZero")
+  void createFilter_whenZeroLength_expectNullBloomAndKZero() {
+    try (BloomFilter bf = BloomFilter.createFilter(0, 5, false)) {
+      assertInstanceOf(NullBloomFilter.class, bf);
+      assertEquals(0, bf.getK());
+      assertTrue(bf.checkFilter(new byte[] {1, 2, 3, 4}));
+    }
   }
 
   @Test
-  public void testBinaryFilterPositive() {
-    int K = BloomFilter.optimialK(FILTER_SIZE, PASS_POS);
-    BloomFilter filter = BloomFilter.createFilter(FILTER_SIZE, K, false);
-    _testFilterPositive(filter);
+  @DisplayName("optimalK_whenVariousInputs_expectBoundsAndZeroForEmpty")
+  void optimalK_whenVariousInputs_expectBoundsAndZeroForEmpty() {
+    assertEquals(0, BloomFilter.optimalK(0, 100));
+    assertEquals(64, BloomFilter.optimalK(1024, 1));
+    assertEquals(1, BloomFilter.optimalK(8, 1_000_000));
+  }
+
+  // -------- Membership semantics --------
+
+  @ParameterizedTest
+  @DisplayName("addKeyAndCheck_whenSameKey_expectTrue")
+  @CsvSource({"false", "true"})
+  void addKeyAndCheck_whenSameKey_expectTrue(boolean counting) {
+    try (BloomFilter bf = BloomFilter.createFilter(256, 3, counting)) {
+      byte[] key = new byte[] {1, 2, 3, 4};
+      bf.addKey(key);
+      assertTrue(bf.checkFilter(key));
+    }
+  }
+
+  @ParameterizedTest
+  @DisplayName("addKey_whenK1DifferentKey_expectFalse")
+  @CsvSource({"false", "true"})
+  void addKey_whenK1DifferentKey_expectFalse(boolean counting) {
+    int length = 512;
+    try (BloomFilter bf = BloomFilter.createFilter(length, 1, counting)) {
+      byte[] k1 = new byte[] {9, 9, 9, 9};
+      byte[] k2 = keyWithDifferentIndex(k1, length);
+      bf.addKey(k1);
+      assertFalse(bf.checkFilter(k2));
+    }
+  }
+
+  @ParameterizedTest
+  @DisplayName("unsetAll_whenCalled_expectFilledCountZero")
+  @CsvSource({"false", "true"})
+  void unsetAll_whenCalled_expectFilledCountZero(boolean counting) {
+    try (BloomFilter bf = BloomFilter.createFilter(256, 3, counting)) {
+      bf.addKey(new byte[] {1, 1, 1, 1});
+      bf.addKey(new byte[] {2, 2, 2, 2});
+      assertTrue(bf.getFilledCount() > 0);
+      bf.unsetAll();
+      assertEquals(0, bf.getFilledCount());
+    }
+  }
+
+  // -------- Fork/Merge/Discard --------
+
+  @ParameterizedTest
+  @DisplayName("fork_merge_whenApplied_expectMainEqualsForkAndPreForkLost")
+  @CsvSource({"false", "true"})
+  void fork_merge_whenApplied_expectMainEqualsForkAndPreForkLost(boolean counting) {
+    int length = 1024; // ensure many indices to avoid incidental collisions
+    try (BloomFilter bf = BloomFilter.createFilter(length, 1, counting)) {
+      byte[] a = new byte[] {10, 20, 30, 40};
+      int ia = indexFor(a, length);
+      bf.addKey(a); // pre-fork content
+      assertTrue(bf.checkFilter(a));
+
+      bf.fork(bf.getK());
+
+      byte[] b = keyDifferentFromAll(length, ia);
+      int ib = indexFor(b, length);
+      bf.addKey(b); // mirrored to fork
+      assertTrue(bf.checkFilter(b));
+
+      byte[] c = keyDifferentFromAll(length, ia, ib);
+      bf.addKeyForked(c); // only on fork
+      assertFalse(bf.checkFilter(c));
+
+      bf.merge();
+
+      // After merge, main should equal fork — contains b and c but not the pre-fork a
+      assertTrue(bf.checkFilter(b));
+      assertTrue(bf.checkFilter(c));
+      assertFalse(bf.checkFilter(a));
+    }
+  }
+
+  @ParameterizedTest
+  @DisplayName("discard_whenCalled_expectForkAbandonedAndNoChangeOnMain")
+  @CsvSource({"false", "true"})
+  void discard_whenCalled_expectForkAbandonedAndNoChangeOnMain(boolean counting) {
+    try (BloomFilter bf = BloomFilter.createFilter(256, 2, counting)) {
+      byte[] base = new byte[] {1, 2, 3, 4};
+      byte[] onlyFork = new byte[] {5, 6, 7, 8};
+
+      bf.addKey(base);
+      assertTrue(bf.checkFilter(base));
+
+      bf.fork(bf.getK());
+      bf.addKeyForked(onlyFork);
+      assertFalse(bf.checkFilter(onlyFork));
+
+      bf.discard();
+      assertFalse(bf.checkFilter(onlyFork));
+      assertTrue(bf.checkFilter(base));
+
+      // Idempotent
+      bf.discard();
+    }
+  }
+
+  // -------- I/O & size --------
+
+  @Test
+  @DisplayName("copyToAndWriteTo_whenCounting_expectSameBytes")
+  void copyToAndWriteTo_whenCounting_expectSameBytes() throws IOException {
+    try (BloomFilter bf = BloomFilter.createFilter(16, 2, true)) { // 4 bytes backing array
+      // Perform deterministic updates
+      bf.addKey(new byte[] {1, 0, 0, 0});
+      bf.addKey(new byte[] {2, 0, 0, 0});
+
+      byte[] expected = new byte[bf.getSizeBytes()];
+      int n = bf.copyTo(expected, 0);
+      assertEquals(expected.length, n);
+
+      OutputStream os = mock(OutputStream.class);
+      bf.writeTo(os);
+
+      ArgumentCaptor<byte[]> arrCap = ArgumentCaptor.forClass(byte[].class);
+      ArgumentCaptor<Integer> offCap = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<Integer> lenCap = ArgumentCaptor.forClass(Integer.class);
+      verify(os, times(1)).write(arrCap.capture(), offCap.capture(), lenCap.capture());
+
+      byte[] actual =
+          Arrays.copyOfRange(
+              arrCap.getValue(), offCap.getValue(), offCap.getValue() + lenCap.getValue());
+      assertArrayEquals(expected, actual);
+    }
   }
 
   @Test
-  public void testCountingFilterRemove() {
-    int K = BloomFilter.optimialK(FILTER_SIZE, PASS);
-    BloomFilter filter = BloomFilter.createFilter(FILTER_SIZE, K, true);
-
-    Map<ByteArrayWrapper, byte[]> baseList = new HashMap<>();
-
-    // Add Keys
-    for (int i = 0; i < PASS; i++) {
-      byte[] b = new byte[32];
-      do {
-        rand.nextBytes(b);
-      } while (baseList.containsKey(new ByteArrayWrapper(b)));
-
-      filter.addKey(b);
-      baseList.put(new ByteArrayWrapper(b), b);
-      assertTrue(filter.checkFilter(b), "check add BASE");
+  @DisplayName("checkAndAdd_whenKeyLengthNotMultipleOf4_expectIllegalArgumentException")
+  void checkAndAdd_whenKeyLengthNotMultipleOf4_expectIllegalArgumentException() {
+    try (BloomFilter bf = BloomFilter.createFilter(64, 2, false)) {
+      assertThrows(IllegalArgumentException.class, () -> bf.checkFilter(new byte[] {1, 2, 3}));
+      assertThrows(IllegalArgumentException.class, () -> bf.addKey(new byte[] {1}));
     }
-
-    // Add some FALSE_PASS keys
-    Map<ByteArrayWrapper, byte[]> newList = new HashMap<>();
-    int fPos = 0;
-    for (int i = 0; i < PASS_REMOVE; i++) {
-      byte[] b = new byte[64];
-      ByteArrayWrapper wrapper;
-      do {
-        rand.nextBytes(b);
-        wrapper = new ByteArrayWrapper(b);
-      } while (newList.containsKey(wrapper));
-
-      filter.addKey(b);
-      newList.put(wrapper, b);
-      assertTrue(filter.checkFilter(b), "check add NEW");
-    }
-
-    // Remove the "NEW" keys and count false positive
-    for (byte[] b : newList.values()) filter.removeKey(b);
-    for (byte[] b : newList.values()) if (filter.checkFilter(b)) fPos++;
-
-    // Check if some should were removed
-    assertNotEquals(PASS_REMOVE, fPos, "100% false positive?");
-
-    // Check if old keys still here
-    for (byte[] b : baseList.values()) assertTrue(filter.checkFilter(b), "check original");
   }
 
-  private void _testFilterFalsePositive(BloomFilter filter) {
-    Set<ByteArrayWrapper> list = new HashSet<>();
+  // -------- File-backed rebuild flag (Counting variant) --------
 
-    // Add Keys
-    for (int i = 0; i < PASS; i++) {
-      byte[] b = new byte[32];
-      do {
-        rand.nextBytes(b);
-      } while (list.contains(new ByteArrayWrapper(b)));
-
-      filter.addKey(b);
-      list.add(new ByteArrayWrapper(b));
-      assertTrue(filter.checkFilter(b), "check add");
+  @Test
+  @DisplayName("fileBackedCounting_whenFirstOpen_expectNeedRebuildTrueThenFalse")
+  void fileBackedCounting_whenFirstOpen_expectNeedRebuildTrueThenFalse(@TempDir File tempDir)
+      throws IOException {
+    File f = new File(tempDir, "counting.bloom");
+    try (BloomFilter bf1 = BloomFilter.createFilter(f, 64, 2, true)) {
+      assertTrue(bf1.needRebuild(), "First open should request rebuild");
+      assertFalse(bf1.needRebuild(), "Flag resets after read");
     }
 
-    System.out.println("---" + filter + "---");
-
-    int fPos = 0;
-    for (int i = 0; i < PASS_FALSE; i++) {
-      byte[] b = new byte[64]; // 64 bytes, sure not exist
-      rand.nextBytes(b);
-
-      if (filter.checkFilter(b)) fPos++;
+    try (BloomFilter bf2 = BloomFilter.createFilter(f, 64, 2, true)) {
+      assertFalse(bf2.needRebuild(), "Second open with same size should not need rebuild");
     }
-
-    final int K = filter.getK();
-    final double q = 1 - Math.pow(1 - 1.0 / FILTER_SIZE, K * PASS);
-    final double p = Math.pow(q, K);
-    final double actual = (double) fPos / PASS_FALSE;
-    final double limit = p * 1.05 + 1.0 / PASS_FALSE;
-
-    // *-
-    System.out.println("          k = " + K);
-    System.out.println("          q = " + q);
-    System.out.println("          p = " + p);
-    System.out.println("      limit = " + limit);
-    System.out.println("     actual = " + actual);
-    System.out.println(" actual / p = " + actual / p);
-    /**/
-
-    assertFalse(actual > limit, "false positive, p=" + p + ", actual=" + actual);
   }
 
   @Test
-  public void testCountingFilterFalsePositive() {
-    int K = BloomFilter.optimialK(FILTER_SIZE, PASS);
-    BloomFilter filter = BloomFilter.createFilter(FILTER_SIZE, K, true);
-    _testFilterFalsePositive(filter);
+  @DisplayName("fileBackedCounting_whenSizeChanges_expectNeedRebuildTrue")
+  void fileBackedCounting_whenSizeChanges_expectNeedRebuildTrue(@TempDir File tempDir)
+      throws IOException {
+    File f = new File(tempDir, "counting2.bloom");
+    try (BloomFilter bf1 = BloomFilter.createFilter(f, 64, 2, true)) {
+      bf1.needRebuild(); // consume initial true
+    }
+
+    try (BloomFilter bf2 = BloomFilter.createFilter(f, 128, 2, true)) {
+      assertTrue(bf2.needRebuild(), "Changing target size should flag rebuild");
+    }
   }
 
   @Test
-  public void testBinaryFilterFalsePositive() {
-    int K = BloomFilter.optimialK(FILTER_SIZE, PASS);
-    BloomFilter filter = BloomFilter.createFilter(FILTER_SIZE, K, false);
-    _testFilterFalsePositive(filter);
+  @DisplayName("fileBackedBinary_forceAndReopen_expectDataPersists")
+  void fileBackedBinary_forceAndReopen_expectDataPersists(@TempDir File tempDir)
+      throws IOException {
+    File f = new File(tempDir, "binary.bloom");
+    byte[] key = new byte[] {5, 4, 3, 2};
+    try (BloomFilter bf1 = BloomFilter.createFilter(f, 256, 3, false)) {
+      bf1.addKey(key);
+      bf1.force();
+    }
+
+    try (BloomFilter bf2 = BloomFilter.createFilter(f, 256, 3, false)) {
+      assertTrue(bf2.checkFilter(key));
+    }
   }
 }

--- a/src/test/java/network/crypta/support/CountingBloomFilterTest.java
+++ b/src/test/java/network/crypta/support/CountingBloomFilterTest.java
@@ -1,0 +1,216 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link CountingBloomFilter} covering counter semantics, file-backed behavior, and
+ * fork/merge orchestration.
+ */
+@SuppressWarnings(
+    "java:S100") // Test method names use method_whenCondition_expectOutcome convention
+class CountingBloomFilterTest {
+
+  private static int readCounter(CountingBloomFilter f, int offset) {
+    // Snapshot the in-memory buffer and decode the 2-bit counter at the given logical position.
+    byte[] buf = new byte[f.getSizeBytes()];
+    f.copyTo(buf, 0);
+    int b = buf[offset / 4] & 0xFF;
+    int shift = (offset % 4) * 2;
+    return (b >>> shift) & 0x03;
+  }
+
+  @Test
+  void constructor_whenLengthNotMultipleOf8_roundsDownAndAllocatesCorrectSize() {
+    // Arrange + Assert
+    try (CountingBloomFilter f = new CountingBloomFilter(10 /* bits */, 3)) {
+      assertEquals(8, f.getLength(), "length rounded down to nearest multiple of 8");
+      assertEquals(8 / 4, f.getSizeBytes(), "2-bit counters: bytes = length/4");
+    }
+  }
+
+  @Test
+  void setBit_whenCalledRepeatedly_saturatesAtThree() {
+    try (CountingBloomFilter f = new CountingBloomFilter(32, 1)) {
+      int pos = 0;
+
+      // Initially zero / absent
+      assertFalse(f.getBit(pos));
+      assertEquals(0, readCounter(f, pos));
+
+      // 1 -> 2 -> 3 -> 3 (saturating)
+      f.setBit(pos);
+      assertTrue(f.getBit(pos));
+      assertEquals(1, readCounter(f, pos));
+
+      f.setBit(pos);
+      assertEquals(2, readCounter(f, pos));
+
+      f.setBit(pos);
+      assertEquals(3, readCounter(f, pos));
+
+      f.setBit(pos); // still 3
+      assertEquals(3, readCounter(f, pos));
+    }
+  }
+
+  @Test
+  void unsetBit_whenZero_noChangeAndRemainsAbsent() {
+    try (CountingBloomFilter f = new CountingBloomFilter(32, 1)) {
+      f.setWarnOnRemoveFromEmpty(); // should only log; state must remain unchanged
+
+      int pos = 5;
+      assertEquals(0, readCounter(f, pos));
+      f.unsetBit(pos);
+      assertEquals(0, readCounter(f, pos));
+      assertFalse(f.getBit(pos));
+    }
+  }
+
+  @Test
+  void unsetBit_whenOne_becomesZero() {
+    try (CountingBloomFilter f = new CountingBloomFilter(32, 1)) {
+      int pos = 7;
+      f.setBit(pos);
+      assertEquals(1, readCounter(f, pos));
+
+      f.unsetBit(pos);
+      assertEquals(0, readCounter(f, pos));
+      assertFalse(f.getBit(pos));
+    }
+  }
+
+  @Test
+  void unsetBit_whenTwo_becomesOne() {
+    try (CountingBloomFilter f = new CountingBloomFilter(32, 1)) {
+      int pos = 9;
+      f.setBit(pos);
+      f.setBit(pos);
+      assertEquals(2, readCounter(f, pos));
+
+      f.unsetBit(pos);
+      assertEquals(1, readCounter(f, pos));
+      assertTrue(f.getBit(pos));
+    }
+  }
+
+  @Test
+  void unsetBit_whenThree_noChange() {
+    try (CountingBloomFilter f = new CountingBloomFilter(32, 1)) {
+      int pos = 3;
+      f.setBit(pos);
+      f.setBit(pos);
+      f.setBit(pos);
+      assertEquals(3, readCounter(f, pos));
+
+      f.unsetBit(pos); // 3 is treated as overflow sentinel; no decrement
+      assertEquals(3, readCounter(f, pos));
+      assertTrue(f.getBit(pos));
+    }
+  }
+
+  @Test
+  void addCheckRemove_whenKEqualsOne_clearsBackToAbsent() {
+    try (CountingBloomFilter f = new CountingBloomFilter(64, 1)) {
+      byte[] key = new byte[] {1, 2, 3, 4}; // length must be a multiple of 4
+
+      assertFalse(f.checkFilter(key));
+      f.addKey(key);
+      assertTrue(f.checkFilter(key));
+
+      f.removeKey(key);
+      assertFalse(f.checkFilter(key));
+    }
+  }
+
+  @Test
+  void addAndRemove_whenCounterSaturatedAtThree_removalIsIgnored() {
+    try (CountingBloomFilter f = new CountingBloomFilter(64, 1)) {
+      byte[] key = new byte[] {9, 8, 7, 6};
+
+      // Saturate the single hashed position by adding thrice
+      f.addKey(key);
+      f.addKey(key);
+      f.addKey(key);
+      assertTrue(f.checkFilter(key));
+
+      // Removal is ignored at counter==3 per implementation
+      f.removeKey(key);
+      assertTrue(f.checkFilter(key));
+    }
+  }
+
+  @Test
+  void forkMerge_whenAddingOnlyToFork_appliesOnMerge() {
+    try (CountingBloomFilter f = new CountingBloomFilter(64, 1)) {
+      byte[] key = new byte[] {10, 11, 12, 13};
+
+      assertFalse(f.checkFilter(key));
+      f.fork(1);
+      f.addKeyForked(key); // only staged in the fork
+      assertFalse(f.checkFilter(key));
+
+      f.merge();
+      assertTrue(f.checkFilter(key));
+    }
+  }
+
+  @Test
+  void forkDiscard_whenAddingOnlyToFork_doesNotAffectMain() {
+    try (CountingBloomFilter f = new CountingBloomFilter(64, 1)) {
+      byte[] key = new byte[] {100, 101, 102, 103};
+
+      f.fork(1);
+      f.addKeyForked(key);
+      f.discard();
+      assertFalse(f.checkFilter(key));
+    }
+  }
+
+  @Test
+  void fileBacked_whenMissingOrWrongSize_setsNeedRebuild(@TempDir Path tmp) throws IOException {
+    int length = 32; // bits; bytes for counting bloom = 8
+    Path path = tmp.resolve("cbf.dat");
+    File file = path.toFile();
+
+    // Missing initially -> needRebuild=true
+    CountingBloomFilter f1 = new CountingBloomFilter(file, length, 1);
+    assertTrue(f1.needRebuild());
+    assertFalse(f1.needRebuild(), "flag clears after read");
+    f1.close();
+
+    // Pre-create with wrong size -> still needRebuild
+    Files.write(path, new byte[] {0});
+    CountingBloomFilter f2 = new CountingBloomFilter(file, length, 1);
+    assertTrue(f2.needRebuild());
+    f2.close();
+
+    // After resize to correct size by previous ctor, next ctor should not need rebuild
+    CountingBloomFilter f3 = new CountingBloomFilter(file, length, 1);
+    assertFalse(f3.needRebuild());
+    f3.close();
+  }
+
+  @Test
+  void filledCount_andUnsetAll_behaveAsExpected() {
+    try (CountingBloomFilter f = new CountingBloomFilter(32, 1)) {
+      assertEquals(0, f.getFilledCount());
+
+      f.setBit(0);
+      f.setBit(5);
+      f.setBit(5); // counter>0 still counts once
+      assertEquals(2, f.getFilledCount());
+
+      f.unsetAll();
+      assertEquals(0, f.getFilledCount());
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/NullBloomFilterTest.java
+++ b/src/test/java/network/crypta/support/NullBloomFilterTest.java
@@ -1,0 +1,116 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link NullBloomFilter} semantics. The null filter represents a zero-length Bloom
+ * filter that always returns positive membership and ignores updates.
+ */
+@SuppressWarnings("java:S100") // Allow descriptive test method names with underscores
+class NullBloomFilterTest {
+
+  // -------- Test data providers --------
+
+  static Stream<byte[]> anyKeysIncludingNull() {
+    return Stream.of(
+        null,
+        new byte[] {},
+        new byte[] {1},
+        new byte[] {1, 2},
+        new byte[] {1, 2, 3},
+        new byte[] {1, 2, 3, 4},
+        new byte[] {9, 8, 7, 6, 5});
+  }
+
+  // -------- Creation --------
+
+  @Test
+  @DisplayName("create_whenZeroLengthCountingFalse_expectNullBloomAndKZero")
+  void create_whenZeroLengthCountingFalse_expectNullBloomAndKZero() {
+    try (BloomFilter bf = BloomFilter.createFilter(0, 7, false)) {
+      assertInstanceOf(NullBloomFilter.class, bf);
+      assertEquals(0, bf.getK());
+      assertEquals(0, bf.getLength());
+    }
+  }
+
+  @Test
+  @DisplayName("create_whenZeroLengthCountingTrue_expectNullBloomAndKZero")
+  void create_whenZeroLengthCountingTrue_expectNullBloomAndKZero() {
+    try (BloomFilter bf = BloomFilter.createFilter(0, 3, true)) {
+      assertInstanceOf(NullBloomFilter.class, bf);
+      assertEquals(0, bf.getK());
+      assertEquals(0, bf.getLength());
+    }
+  }
+
+  @Test
+  @DisplayName("createFile_whenZeroLength_expectNullBloom")
+  void createFile_whenZeroLength_expectNullBloom() throws IOException {
+    File f = File.createTempFile("null-bloom", ".bin");
+    try (BloomFilter bf = BloomFilter.createFilter(f, 0, 5, false)) {
+      assertInstanceOf(NullBloomFilter.class, bf);
+      assertEquals(0, bf.getK());
+      assertEquals(0, bf.getLength());
+    }
+    // Best effort cleanup of the temp file (not strictly necessary for correctness of the test)
+    //noinspection ResultOfMethodCallIgnored
+    f.delete();
+  }
+
+  // -------- Semantics --------
+
+  @ParameterizedTest
+  @MethodSource("anyKeysIncludingNull")
+  @DisplayName("checkFilter_whenAnyKeyIncludingNull_expectAlwaysTrue")
+  void checkFilter_whenAnyKeyIncludingNull_expectAlwaysTrue(byte[] key) {
+    try (BloomFilter bf = BloomFilter.createFilter(0, 10, false)) {
+      assertInstanceOf(NullBloomFilter.class, bf);
+      assertTrue(bf.checkFilter(key));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("anyKeysIncludingNull")
+  @DisplayName("addAndRemove_whenAnyKeyIncludingNull_expectNoExceptionAndNoChange")
+  void addAndRemove_whenAnyKeyIncludingNull_expectNoExceptionAndNoChange(byte[] key) {
+    try (BloomFilter bf = BloomFilter.createFilter(0, 10, true)) {
+      assertInstanceOf(NullBloomFilter.class, bf);
+      assertDoesNotThrow(() -> bf.addKey(key));
+      assertDoesNotThrow(() -> bf.removeKey(key));
+      // Membership remains true regardless of operations
+      assertTrue(bf.checkFilter(key));
+      assertEquals(0, bf.getFilledCount());
+    }
+  }
+
+  // -------- Fork/Discard/Merge no-ops --------
+
+  @Test
+  @DisplayName("fork_discard_merge_whenCalled_expectNoEffectAndNoExceptions")
+  void fork_discard_merge_whenCalled_expectNoEffectAndNoExceptions() {
+    try (BloomFilter bf = BloomFilter.createFilter(0, 5, false)) {
+      assertInstanceOf(NullBloomFilter.class, bf);
+
+      // All should be safe no-ops on the null filter
+      assertDoesNotThrow(() -> bf.fork(bf.getK()));
+      assertDoesNotThrow(bf::discard);
+      assertDoesNotThrow(bf::merge);
+
+      // Still behaves as an always-positive, zero-length filter
+      assertTrue(bf.checkFilter(new byte[] {1, 2, 3, 4}));
+      assertEquals(0, bf.getLength());
+    }
+  }
+}


### PR DESCRIPTION
Summary
- BinaryBloomFilter: safer locking, correct bit ops, and secure file-backed behavior. Sets one‑shot needRebuild when file size mismatches; uses POSIX perms where available; avoids temp-dir leaks.
- CountingBloomFilter: correctness fixes + targeted tests.
- BloomFilter: rename misspelled optimialK -> optimalK; keep a @Deprecated shim with @since; improve Javadoc and factory docs.
- NullBloomFilter: document null-object semantics; add no-op lifecycle behavior tests.
- Call sites: update usage to optimalK (e.g., SplitFileFetcherKeyListener).
- Tests: comprehensive JUnit 6 tests for BinaryBloomFilter, CountingBloomFilter, BloomFilter, and NullBloomFilter.

Change Scope
- 10 files changed, 1652 insertions, 201 deletions.

Key Files
- src/main/java/network/crypta/support/BinaryBloomFilter.java
- src/main/java/network/crypta/support/BloomFilter.java
- src/main/java/network/crypta/support/CountingBloomFilter.java
- src/main/java/network/crypta/support/NullBloomFilter.java
- src/main/java/network/crypta/support/io/TempBucketFactory.java
- src/main/java/network/crypta/client/async/SplitFileFetcherKeyListener.java
- src/test/java/network/crypta/support/BinaryBloomFilterTest.java
- src/test/java/network/crypta/support/BloomFilterTest.java
- src/test/java/network/crypta/support/CountingBloomFilterTest.java
- src/test/java/network/crypta/support/NullBloomFilterTest.java

Important Details
- Concurrency: write lock held across fork paths to avoid races and partial state during file-backed split/merge operations.
- Bit ops: mask byte values and avoid lossy compound assignments; ensures correct set/clear for offsets and reduces undefined behavior.
- File-backed: verify mapped file length; when absent or mismatched, set needRebuild and (re)size safely. Apply PosixFilePermissions when supported; otherwise fallback to user‑private tmp dir.
- API: BloomFilter.optimialK is now BloomFilter.optimalK. A @Deprecated shim remains to keep internal callers compiling; external code should migrate.
- Tests: AAA style, deterministic. Cover bit ops, remove no-op, fork/merge/discard, file-backed mapping, needRebuild, and negative/error paths.

Migration Notes
- Replace calls to BloomFilter.optimialK(...) with BloomFilter.optimalK(...). The deprecated alias remains temporarily for internal use but will be removed in a future cleanup.

How to Verify
- Build: ./gradlew --parallel build
- Run tests: ./gradlew --parallel test
- Spotless (optional): ./gradlew spotlessApply

Rationale
- Fixes correctness issues in filter operations and improves robustness/security for file-backed usage.
- Increases coverage with JUnit 6 tests and improves API clarity by removing a long-standing typo.
