### PR TITLE
support: Refactor and document DoublyLinkedListImpl; harden tests

### DIFF
--- a/src/main/java/network/crypta/support/DoublyLinkedList.java
+++ b/src/main/java/network/crypta/support/DoublyLinkedList.java
@@ -3,130 +3,271 @@ package network.crypta.support;
 import java.util.Enumeration;
 
 /**
- * Framework for managing a doubly linked list. The purpose of DoublyLinkedList is simply and solely
- * so that we can override the entries with our own classes. This makes removal for example
- * extremely fast: O(1) not O(n). In any other case we can use LinkedList.
+ * Intrusive doubly linked list interface.
  *
+ * <p>This interface defines a lightweight, allocation-free ("intrusive") doubly linked list in
+ * which each element stores links to its neighbors and remembers which list it belongs to. Compared
+ * to {@link java.util.LinkedList}, this enables constant-time ({@code O(1)}) removal when the
+ * element to remove is already known, because no search is required. For general-purpose use cases
+ * where intrusive storage is not needed, prefer standard JDK collections.
+ *
+ * <p>Concurrency: implementations are not required to be thread-safe.
+ *
+ * @param <T> the concrete {@link Item} type stored in this list
  * @author tavin
  */
 public interface DoublyLinkedList<T extends DoublyLinkedList.Item<?>> extends Iterable<T> {
-  // public abstract DoublyLinkedList<T> clone();
 
-  /** List element */
+  /**
+   * Node stored in a {@link DoublyLinkedList}. Implementations maintain neighbor links and a
+   * reference to the parent list.
+   *
+   * <p>Nullability: for the first element, {@link #getPrev()} may return {@code null}; for the last
+   * element, {@link #getNext()} may return {@code null}.
+   *
+   * @param <T> the concrete, self-referential item type (typically {@code T extends Item<T>})
+   */
   interface Item<T extends DoublyLinkedList.Item<?>> {
     /**
-     * Get next {@link Item}. May or may not return <code>null</code> if this is the last <code>Item
-     * </code>.
+     * Returns the next item in the list, or {@code null} if this is the last item.
      *
-     * @see DoublyLinkedList#hasNext()
+     * @return the next item, or {@code null} if none
+     * @see DoublyLinkedList#hasNext
      */
     T getNext();
 
-    /** Set next {@link Item} */
+    /**
+     * Sets the next item reference.
+     *
+     * <p>Preconditions: {@code i} is {@code null} or an item compatible with this list's generic
+     * type. Implementations may perform sanity checks; behavior on incompatible items is
+     * implementation-defined.
+     *
+     * @param i the next item, or {@code null}
+     * @return the previously linked next item, or {@code null} if none
+     */
     T setNext(Item<?> i);
 
     /**
-     * Get previous {@link Item}. May or may not return <code>null</code> if this is the first
-     * <code>Item</code>.
+     * Returns the previous item in the list, or {@code null} if this is the first item.
      *
-     * @see DoublyLinkedList#hasNext()
+     * @return the previous item, or {@code null} if none
+     * @see DoublyLinkedList#hasPrev
      */
     T getPrev();
 
-    /** Get previous {@link Item} */
+    /**
+     * Sets the previous item reference.
+     *
+     * <p>Preconditions: {@code i} is {@code null} or an item compatible with this list's generic
+     * type. Implementations may perform sanity checks; behavior on incompatible items is
+     * implementation-defined.
+     *
+     * @param i the previous item, or {@code null}
+     * @return the previously linked previous item, or {@code null} if none
+     */
     T setPrev(Item<?> i);
 
-    /** Return the contained list. <strong>For sanity checking only.</strong> */
-    DoublyLinkedList<? super T> getParent();
+    /**
+     * Returns the parent list that currently contains this item.
+     *
+     * @return the parent list, or {@code null} if not in any list
+     */
+    DoublyLinkedList<T> getParent();
 
-    /** Set the contained list. <strong>For sanity checking only.</strong> */
-    DoublyLinkedList<? super T> setParent(DoublyLinkedList<? super T> l);
+    /**
+     * Sets the parent list reference. Intended for use by list implementations for sanity checking.
+     * Calling this does not by itself add or remove the item from a list.
+     *
+     * @param l the new parent list, or {@code null} to mark the item as detached
+     * @return the previous parent list, or {@code null} if none
+     */
+    DoublyLinkedList<T> setParent(DoublyLinkedList<T> l);
   }
 
-  /** Clear this list */
+  /**
+   * Removes all items from this list and detaches their neighbor links.
+   *
+   * <p>Postconditions: {@link #size()} returns 0; {@link #head()} and {@link #tail()} return {@code
+   * null}. Complexity: {@code O(n)}.
+   */
   void clear();
 
-  /** Return the size of this list */
+  /**
+   * Returns the number of items in this list.
+   *
+   * @return the item count, never negative
+   */
   int size();
 
   /**
-   * Check if this list is empty. @return <code>true</code> if this list is empty, <code>false
-   * </code> otherwise.
+   * Returns whether this list is empty.
+   *
+   * @return {@code true} if empty; {@code false} otherwise
    */
   boolean isEmpty();
 
-  /** Get a {@link Enumeration} of {@link DoublyLinkedList.Item}. */
-  Enumeration<T> elements(); // for consistency w/ typical Java API
+  /**
+   * Returns an {@link Enumeration} over items from head to tail.
+   *
+   * <p>Iteration semantics during concurrent modification are implementation-defined and may vary
+   * by implementation.
+   *
+   * @return an enumeration of items in forward order
+   */
+  Enumeration<T> elements(); // Provided for consistency with typical Java APIs.
 
-  /** Returns true if the list contains an item i where <code>i.equals(item)</code> is true. */
+  /**
+   * Returns whether the list contains an item equal to {@code item}.
+   *
+   * <p>Equality is determined by {@link Object#equals(Object)}.
+   *
+   * @param item the item to compare against existing elements (may be {@code null})
+   * @return {@code true} if an equal item exists; {@code false} otherwise
+   */
   boolean contains(T item);
 
   /**
    * Returns the first item.
    *
-   * @return the item at the head of the list, or <code>null</code> if empty
+   * @return the item at the head, or {@code null} if empty
    */
   T head();
 
   /**
    * Returns the last item.
    *
-   * @return the item at the tail of the list, or <code>null</code> if empty
+   * @return the item at the tail, or {@code null} if empty
    */
   T tail();
 
-  /** Puts the item before the first item. */
+  /**
+   * Inserts {@code i} as the new head (before the current first item).
+   *
+   * <p>Preconditions: {@code i} is not already linked into a list. Implementations may validate
+   * this and throw a runtime exception if violated.
+   *
+   * @param i the item to insert
+   */
   void unshift(T i);
 
-  /** Removes and returns the first item. */
+  /**
+   * Removes and returns the first item.
+   *
+   * @return the removed head, or {@code null} if empty
+   */
   T shift();
 
-  /** Remove <tt>n</tt> elements from head and return them as a <code>DoublyLinkedList</code>. */
+  /**
+   * Removes up to {@code n} items from the head and returns them as a new list.
+   *
+   * <p>If {@code n} is greater than the current size, all items are removed. If {@code n} is less
+   * than 1, an empty list is returned. Complexity: {@code O(n)} in the number of removed items.
+   *
+   * @param n number of items to remove from the head
+   * @return a new list containing the removed items in their original order
+   */
   DoublyLinkedList<T> shift(int n);
 
-  /** Puts the item after the last item. */
+  /**
+   * Inserts {@code i} as the new tail (after the current last item).
+   *
+   * <p>Preconditions: {@code i} is not already linked into a list. Implementations may validate
+   * this and throw a runtime exception if violated.
+   *
+   * @param i the item to insert
+   */
   void push(T i);
 
-  /** Removes and returns the last item. */
+  /**
+   * Removes and returns the last item.
+   *
+   * @return the removed tail, or {@code null} if empty
+   */
   T pop();
 
-  /** Remove <tt>n</tt> elements from tail and return them as a <code>DoublyLinkedList</code>. */
+  /**
+   * Removes up to {@code n} items from the tail and returns them as a new list.
+   *
+   * <p>If {@code n} is greater than the current size, all items are removed. If {@code n} is less
+   * than 1, an empty list is returned. Complexity: {@code O(n)} in the number of removed items.
+   *
+   * @param n number of items to remove from the tail
+   * @return a new list containing the removed items in their original order
+   */
   DoublyLinkedList<T> pop(int n);
 
   /**
-   * @return <code>true</code> if <code>i</code> has next item. (ie. not the last item); <code>false
-   *     </code> otherwise
+   * Returns whether {@code i} has a successor.
+   *
+   * @param i the item to inspect
+   * @return {@code true} if {@code i} is not the last item; {@code false} otherwise
    */
   boolean hasNext(T i);
 
   /**
-   * @return <code>true</code> if <code>i</code> has previous item. (ie. not the first item); <code>
-   *     false</code> otherwise
+   * Returns whether {@code i} has a predecessor.
+   *
+   * @param i the item to inspect
+   * @return {@code true} if {@code i} is not the first item; {@code false} otherwise
    */
   boolean hasPrev(T i);
 
   /**
-   * @return next item of <code>i</code>. If this is the last element, return <code>null</code>
+   * Returns the successor of {@code i}.
+   *
+   * @param i the item to inspect
+   * @return the next item, or {@code null} if {@code i} is last
    */
   T next(T i);
 
   /**
-   * @return previous item of <code>i</code>. If this is the first element, return <code>null</code>
+   * Returns the predecessor of {@code i}.
+   *
+   * @param i the item to inspect
+   * @return the previous item, or {@code null} if {@code i} is first
    */
   T prev(T i);
 
   /**
-   * Remove and return a element
+   * Removes {@code i} from this list.
    *
-   * @return this item, or <code>null</code> if the item was not in the list
+   * <p>If {@code i} is not in any list, this method returns {@code null}. If {@code i} belongs to a
+   * different {@link DoublyLinkedList}, a runtime exception is thrown.
+   *
+   * @param i the item to remove
+   * @return the same item, or {@code null} if it was not contained
+   * @throws network.crypta.support.PromiscuousItemException if {@code i} belongs to another list
    */
   T remove(T i);
 
-  /** Inserts item <code>j</code> before item <code>i</code>. */
+  /**
+   * Inserts item {@code j} immediately before item {@code i}.
+   *
+   * <p>If {@code i} is {@code null}, {@code j} is inserted as the new tail. The item {@code j} must
+   * not already be linked into any list.
+   *
+   * @param i the anchor item before which to insert, or {@code null} for tail insertion
+   * @param j the item to insert
+   * @throws network.crypta.support.PromiscuousItemException if {@code j} is already linked or if
+   *     {@code i} belongs to another list
+   * @throws network.crypta.support.VirginItemException if internal invariants indicate that {@code
+   *     i} is not positioned as expected (diagnostic guard)
+   */
   void insertPrev(T i, T j);
 
   /**
-   * Inserts item <code>j</code> after item <code>i</code.
+   * Inserts item {@code j} immediately after item {@code i}.
+   *
+   * <p>If {@code i} is {@code null}, {@code j} is inserted as the new head. The item {@code j} must
+   * not already be linked into any list.
+   *
+   * @param i the anchor item after which to insert, or {@code null} for head insertion
+   * @param j the item to insert
+   * @throws network.crypta.support.PromiscuousItemException if {@code j} is already linked or if
+   *     {@code i} belongs to another list
+   * @throws network.crypta.support.VirginItemException if internal invariants indicate that {@code
+   *     i} is not positioned as expected (diagnostic guard)
    */
   void insertNext(T i, T j);
 }

--- a/src/main/java/network/crypta/support/DoublyLinkedListImpl.java
+++ b/src/main/java/network/crypta/support/DoublyLinkedListImpl.java
@@ -6,24 +6,55 @@ import java.util.NoSuchElementException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * DoublyLinkedList implementation. See DoublyLinkedList for an explanation when to use this.
+ * Intrusive doubly linked list implementation.
  *
- * <p>Note: Some methods remain unimplemented; they may not be needed.
+ * <p>This class provides a lightweight, allocation-free list in which each element stores
+ * references to its neighbors and to the parent list (see {@link DoublyLinkedList.Item}). It is
+ * designed for constant-time ({@code O(1)}) insertions and removals when the target node is
+ * already known. It does not allocate wrapper nodes and therefore avoids GC pressure compared to
+ * non-intrusive structures.
  *
+ * <p>Concurrency: Instances are not thread-safe. External synchronization is required for
+ * concurrent use.
+ *
+ * <p>Nullability: Methods such as {@link #head()} and {@link #tail()} return {@code null} for an
+ * empty list. Accessors on {@link Item} may also return {@code null} at the boundaries.
+ *
+ * <p>Iteration: {@link #elements()} and {@link #reverseElements()} return simple enumerations over
+ * the current structure. They are not fail-fast and have unspecified behavior if the list is
+ * structurally modified during iteration.
+ *
+ * @param <T> concrete intrusive item type stored in this list
  * @author tavin
  */
 public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     implements DoublyLinkedList<T> {
 
+  /** Current number of items in the list. Never negative. */
   protected int size;
+
+  /** Reference to the first item (head) or {@code null} when empty. */
   protected T firstItem;
+
+  /** Reference to the last item (tail) or {@code null} when empty. */
   protected T lastItem;
 
-  /** A new list with no items. */
+  /** Creates an empty list with no items. */
   public DoublyLinkedListImpl() {
     clear();
   }
 
+  /**
+   * Creates a list that adopts an existing intrusive chain.
+   *
+   * <p>The items from {@code head} through {@code tail} (via {@link Item#getNext()}) are assumed
+   * to form a valid chain. This constructor sets their parent to this list and records the
+   * provided size without validation.
+   *
+   * @param head first item in the chain; may be {@code null} when {@code size} is 0
+   * @param tail last item in the chain; may be {@code null} when {@code size} is 0
+   * @param size number of items contained in the chain
+   */
   protected DoublyLinkedListImpl(T head, T tail, int size) {
     firstItem = head;
     lastItem = tail;
@@ -42,9 +73,9 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
   /** {@inheritDoc} */
   @Override
   public void clear() {
-    // Help to detect removal after clear().
-    // The check in remove() is enough, strictly,
-    // as long as people don't add elements afterward.
+    // Help detect later misuse: detach and null all neighbor links and clear parent pointers.
+    // Note: {@link #remove(Object)} separately guards against removing after clear; we keep
+    // this full unlinking pass to avoid accidental retention.
     if (firstItem == null) return;
 
     T pos = firstItem;
@@ -76,16 +107,20 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     return size == 0;
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @see #forwardElements()
-   */
+  /** Returns a forward {@link Enumeration} over list items. See {@link #forwardElements()}. */
   @Override
   public final Enumeration<T> elements() {
     return forwardElements();
   }
 
+  /**
+   * Returns whether an equal item is present.
+   *
+   * <p>Equality uses {@link Object#equals(Object)} on elements already in the list.
+   *
+   * @param item item to search for; may be {@code null}
+   * @return {@code true} if an equal item exists; {@code false} otherwise
+   */
   @Override
   public boolean contains(T item) {
     for (T i : this) {
@@ -94,32 +129,40 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     return false;
   }
 
-  /** {@inheritDoc} */
+  /** Returns the first item or {@code null} when empty. */
   @Override
   public final T head() {
     return size == 0 ? null : firstItem;
   }
 
-  /** {@inheritDoc} */
+  /** Returns the last item or {@code null} when empty. */
   @Override
   public final T tail() {
     return size == 0 ? null : lastItem;
   }
 
   // === methods that add/remove items at the head of the list ================
-  /** {@inheritDoc} */
+  /** Inserts {@code i} at the head in {@code O(1)} time. */
   @Override
   public final void unshift(T i) {
     insertNext(null, i);
   }
 
-  /** {@inheritDoc} */
+  /** Removes and returns the head in {@code O(1)} time, or {@code null} if empty. */
   @Override
   public final T shift() {
     return size == 0 ? null : remove(firstItem);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Removes up to {@code n} items from the head and returns them as a new list.
+   *
+   * <p>If {@code n} exceeds the current size, all items are removed. If {@code n} is less than 1,
+   * this returns an empty list and does not modify this list.
+   *
+   * @param n number of items to remove; non-positive values yield an empty result
+   * @return a list containing the removed prefix, preserving original order
+   */
   @Override
   public DoublyLinkedList<T> shift(int n) {
     if (n > size) n = size;
@@ -146,19 +189,27 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
   }
 
   // === methods that add/remove items at the tail of the list ================
-  /** {@inheritDoc} */
+  /** Appends {@code i} at the tail in {@code O(1)} time. */
   @Override
   public final void push(T i) {
     insertPrev(null, i);
   }
 
-  /** {@inheritDoc} */
+  /** Removes and returns the tail in {@code O(1)} time, or {@code null} if empty. */
   @Override
   public final T pop() {
     return size == 0 ? null : remove(lastItem);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Removes up to {@code n} items from the tail and returns them as a new list.
+   *
+   * <p>If {@code n} exceeds the current size, all items are removed. If {@code n} is less than 1,
+   * this returns an empty list and does not modify this list.
+   *
+   * @param n number of items to remove; non-positive values yield an empty result
+   * @return a list containing the removed suffix, preserving original order
+   */
   @Override
   public DoublyLinkedList<T> pop(int n) {
     if (n > size) n = size;
@@ -183,27 +234,27 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
   }
 
   // === testing/looking at neighbor items ====================================
-  /** {@inheritDoc} */
+  /** Returns whether {@code i} has a successor (not the tail). */
   @Override
   public final boolean hasNext(T i) {
     T next = i.getNext();
     return next != null;
   }
 
-  /** {@inheritDoc} */
+  /** Returns whether {@code i} has a predecessor (not the head). */
   @Override
   public final boolean hasPrev(T i) {
     T prev = i.getPrev();
     return prev != null;
   }
 
-  /** {@inheritDoc} */
+  /** Returns the successor of {@code i}, or {@code null} if {@code i} is the tail. */
   @Override
   public final T next(T i) {
     return i.getNext();
   }
 
-  /** {@inheritDoc} */
+  /** Returns the predecessor of {@code i}, or {@code null} if {@code i} is the head. */
   @Override
   public final T prev(T i) {
     return i.getPrev();
@@ -211,7 +262,18 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
 
   // === insertion and removal of items =======================================
 
-  /** {@inheritDoc} */
+  /**
+   * Removes {@code i} from this list.
+   *
+   * <p>Returns {@code null} if {@code i} is not in any list. If {@code i} belongs to a different
+   * list, a {@link PromiscuousItemException} is thrown. Internal invariants are validated and may
+   * raise {@link IllegalStateException} if corrupted links are detected.
+   *
+   * @param i item to remove
+   * @return the same item, or {@code null} if not contained
+   * @throws PromiscuousItemException if {@code i} belongs to another list
+   * @throws IllegalStateException if neighbor links do not match expected invariants
+   */
   @Override
   public T remove(T i) {
     if (i.getParent() == null || isEmpty()) return null; // not in list
@@ -265,7 +327,18 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     }
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Inserts {@code j} immediately before {@code i}.
+   *
+   * <p>When {@code i} is {@code null}, {@code j} is appended as the new tail. The item {@code j}
+   * must not already be linked into any list.
+   *
+   * @param i anchor item to insert before, or {@code null} for tail insertion
+   * @param j item to insert (must be unlinked)
+   * @throws PromiscuousItemException if {@code j} is already linked or {@code i} belongs to another
+   *     list
+   * @throws VirginItemException if invariants indicate {@code i} is not positioned as expected
+   */
   @Override
   public void insertPrev(T i, T j) {
     if (j.getParent() != null) throw new PromiscuousItemException(j, j.getParent());
@@ -278,8 +351,8 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     }
   }
 
+  /** Inserts {@code j} as the new tail. Precondition: {@code j} is not linked. */
   private void insertAsTail(T j) {
-    // insert as tail
     j.setPrev(lastItem);
     j.setNext(null);
     j.setParent(this);
@@ -292,8 +365,8 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     ++size;
   }
 
+  /** Inserts {@code j} before {@code i}. Precondition: {@code i} belongs to this list. */
   private void insertBefore(T i, T j) {
-    // insert in middle (before 'i')
     if (i.getParent() == null)
       throw new PromiscuousItemException(
           i, i.getParent()); // different trace to make easier debugging
@@ -312,7 +385,18 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     ++size;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Inserts {@code j} immediately after {@code i}.
+   *
+   * <p>When {@code i} is {@code null}, {@code j} becomes the new head. The item {@code j} must not
+   * already be linked into any list.
+   *
+   * @param i anchor item to insert after, or {@code null} for head insertion
+   * @param j item to insert (must be unlinked)
+   * @throws PromiscuousItemException if {@code j} is already linked or {@code i} belongs to another
+   *     list
+   * @throws VirginItemException if invariants indicate {@code i} is not positioned as expected
+   */
   @Override
   public void insertNext(T i, T j) {
     if (j.getParent() != null) throw new PromiscuousItemException(j, j.getParent());
@@ -325,8 +409,8 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     }
   }
 
+  /** Inserts {@code j} as the new head. Precondition: {@code j} is not linked. */
   private void insertAsHead(T j) {
-    // insert as head
     j.setPrev(null);
     j.setNext(firstItem);
     j.setParent(this);
@@ -341,6 +425,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     ++size;
   }
 
+  /** Inserts {@code j} after {@code i}. Precondition: {@code i} belongs to this list. */
   private void insertAfter(T i, T j) {
     if (i.getParent() != this) throw new PromiscuousItemException(i, i.getParent());
     T next = i.getNext();
@@ -360,9 +445,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
 
   // === Walkable implementation ==============================================
 
-  /**
-   * @return an Enumeration of list elements from head to tail
-   */
+  /** Returns an {@link Enumeration} over items from head to tail. */
   private Enumeration<T> forwardElements() {
     return new Enumeration<>() {
       private T next = firstItem;
@@ -382,9 +465,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     };
   }
 
-  /**
-   * @return an Enumeration of list elements from tail to head
-   */
+  /** Returns an {@link Enumeration} over items from tail to head. */
   public Enumeration<T> reverseElements() {
     return new Enumeration<>() {
       private T next = lastItem;
@@ -406,37 +487,69 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
 
   // === list element ====================================================
 
+  /**
+   * Base implementation of an intrusive list item.
+   *
+   * <p>Implementations typically extend this class to inherit neighbor link management and a
+   * reference to the parent list.
+   *
+   * @param <T> the concrete self-referential item type (e.g., {@code T extends Item<T>})
+   */
   public static class Item<T extends DoublyLinkedListImpl.Item<?>>
       implements DoublyLinkedList.Item<T> {
     private T prev;
     private T next;
     private DoublyLinkedList<T> list;
 
+    /** Returns the next item, or {@code null} if this is the tail. */
     @Override
     public final T getNext() {
       return next;
     }
 
+    /**
+     * Sets the next link.
+     *
+     * @param i next item or {@code null}
+     * @return the previously linked next item (may be {@code null})
+     */
     @Override
     public final T setNext(DoublyLinkedList.Item<?> i) {
       return nextAndSet(castItem(i));
     }
 
+    /** Returns the previous item, or {@code null} if this is the head. */
     @Override
     public final T getPrev() {
       return prev;
     }
 
+    /**
+     * Sets the previous link.
+     *
+     * @param i previous item or {@code null}
+     * @return the previously linked previous item (may be {@code null})
+     */
     @Override
     public final T setPrev(DoublyLinkedList.Item<?> i) {
       return prevAndSet(castItem(i));
     }
 
+    /** Returns the parent list, or {@code null} if not linked. */
     @Override
     public DoublyLinkedList<T> getParent() {
       return list;
     }
 
+    /**
+     * Sets the parent list reference.
+     *
+     * <p>Intended for use by list implementations to support sanity checks. Changing this value
+     * does not by itself insert or remove the item.
+     *
+     * @param l new parent list or {@code null}
+     * @return the previous parent list
+     */
     @Override
     public DoublyLinkedList<T> setParent(DoublyLinkedList<T> l) {
       return parentAndSet(l);
@@ -467,14 +580,18 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     }
 
     @SuppressWarnings("unchecked")
+    /**
+     * Casts an {@link Item} to the concrete type {@code T}.
+     *
+     * <p>Safe by construction: items in a {@code DoublyLinkedList<T>} are always of type {@code T}.
+     */
     private T castItem(DoublyLinkedList.Item<?> i) {
-      // Safe by construction: this Item<T> only participates in lists of T, and callers
-      // use the same T throughout DoublyLinkedList<T>. We localize the unchecked cast here.
       return (T) i;
     }
   }
 
   @Override
+  /** Returns an {@link Iterator} that traverses from head to tail. */
   public @NotNull Iterator<T> iterator() {
     final Enumeration<T> e = forwardElements();
     return new Iterator<>() {

--- a/src/main/java/network/crypta/support/DoublyLinkedListImpl.java
+++ b/src/main/java/network/crypta/support/DoublyLinkedListImpl.java
@@ -3,35 +3,32 @@ package network.crypta.support;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * DoublyLinkedList implementation. See DoublyLinkedList for an explanation when to use this.
  *
+ * <p>Note: Some methods remain unimplemented; they may not be needed.
+ *
  * @author tavin
- *     <p>TODO: there are still some unimplemented methods -- it remains to be seen if they are
- *     needed at all
  */
-public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
+public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
     implements DoublyLinkedList<T> {
 
   protected int size;
-  protected T _firstItem, _lastItem;
-
-  // @Override
-  // public final DoublyLinkedListImpl<T> clone() {
-  //    return new DoublyLinkedListImpl<T>(this);
-  // }
+  protected T firstItem;
+  protected T lastItem;
 
   /** A new list with no items. */
   public DoublyLinkedListImpl() {
     clear();
   }
 
-  protected DoublyLinkedListImpl(T _h, T _t, int size) {
-    _firstItem = _h;
-    _lastItem = _t;
+  protected DoublyLinkedListImpl(T head, T tail, int size) {
+    firstItem = head;
+    lastItem = tail;
 
-    T i = _firstItem;
+    T i = firstItem;
     while (i != null) {
       i.setParent(this);
       i = i.getNext();
@@ -40,30 +37,6 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
     this.size = size;
   }
 
-  //	/**
-  //	 *
-  //	 * XXX: FIXME this doesn't really work. it use .clone() method
-  //	 *
-  //	 * @param impl
-  //	 */
-  //    protected DoublyLinkedListImpl(DoublyLinkedListImpl<T> impl) {
-  //        this();
-  //        Enumeration<T> e = impl.forwardElements();
-  //        boolean checked = false;
-  //        for(;e.hasMoreElements();) {
-  //			DoublyLinkedListImpl.Item oi = (DoublyLinkedListImpl.Item) e.nextElement();
-  //			T i = (T) oi.clone();
-  //            if(!checked) {
-  //                checked = true;
-  //                if(!i.getClass().getName().equals(oi.getClass().getName())) {
-  //                    System.err.println("Clone constructor failed for "+oi+": "+i);
-  //                    new Exception("error").printStackTrace();
-  //                }
-  //            }
-  //            this.push(i);
-  //        }
-  //    }
-
   // === DoublyLinkedList implementation ======================================
 
   /** {@inheritDoc} */
@@ -71,10 +44,10 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
   public void clear() {
     // Help to detect removal after clear().
     // The check in remove() is enough, strictly,
-    // as long as people don't add elements afterwards.
-    if (_firstItem == null) return;
+    // as long as people don't add elements afterward.
+    if (firstItem == null) return;
 
-    T pos = _firstItem;
+    T pos = firstItem;
     T opos;
 
     while (pos != null) {
@@ -85,21 +58,21 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
       opos.setNext(null);
     }
 
-    _firstItem = _lastItem = null;
+    firstItem = lastItem = null;
     size = 0;
   }
 
   /** {@inheritDoc} */
   @Override
   public final int size() {
-    assert size != 0 || (_firstItem == null && _lastItem == null);
+    assert size != 0 || (firstItem == null && lastItem == null);
     return size;
   }
 
   /** {@inheritDoc} */
   @Override
   public final boolean isEmpty() {
-    assert size != 0 || (_firstItem == null && _lastItem == null);
+    assert size != 0 || (firstItem == null && lastItem == null);
     return size == 0;
   }
 
@@ -124,13 +97,13 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
   /** {@inheritDoc} */
   @Override
   public final T head() {
-    return size == 0 ? null : _firstItem;
+    return size == 0 ? null : firstItem;
   }
 
   /** {@inheritDoc} */
   @Override
   public final T tail() {
-    return size == 0 ? null : _lastItem;
+    return size == 0 ? null : lastItem;
   }
 
   // === methods that add/remove items at the head of the list ================
@@ -143,7 +116,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
   /** {@inheritDoc} */
   @Override
   public final T shift() {
-    return size == 0 ? null : remove(_firstItem);
+    return size == 0 ? null : remove(firstItem);
   }
 
   /** {@inheritDoc} */
@@ -152,20 +125,20 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
     if (n > size) n = size;
     if (n < 1) return new DoublyLinkedListImpl<>();
 
-    T i = _firstItem;
+    T i = firstItem;
     for (int m = 0; m < n - 1; ++m) i = i.getNext();
 
     T newTailItem = i;
     T newFirstItem = newTailItem.getNext();
     newTailItem.setNext(null);
 
-    DoublyLinkedList<T> newlist = new DoublyLinkedListImpl<>(_firstItem, newTailItem, n);
+    DoublyLinkedList<T> newlist = new DoublyLinkedListImpl<>(firstItem, newTailItem, n);
 
     if (newFirstItem != null) {
       newFirstItem.setPrev(null);
-      _firstItem = newFirstItem;
+      firstItem = newFirstItem;
     } else {
-      _firstItem = _lastItem = null;
+      firstItem = lastItem = null;
     }
     size -= n;
 
@@ -182,7 +155,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
   /** {@inheritDoc} */
   @Override
   public final T pop() {
-    return size == 0 ? null : remove(_lastItem);
+    return size == 0 ? null : remove(lastItem);
   }
 
   /** {@inheritDoc} */
@@ -191,19 +164,19 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
     if (n > size) n = size;
     if (n < 1) return new DoublyLinkedListImpl<>();
 
-    T i = _lastItem;
+    T i = lastItem;
     for (int m = 0; m < n - 1; ++m) i = i.getPrev();
 
     T newFirstItem = i;
     T newLastItem = newFirstItem.getPrev();
     newFirstItem.setPrev(null);
 
-    DoublyLinkedList<T> newlist = new DoublyLinkedListImpl<>(newFirstItem, _lastItem, n);
+    DoublyLinkedList<T> newlist = new DoublyLinkedListImpl<>(newFirstItem, lastItem, n);
 
     if (newLastItem != null) {
       newLastItem.setNext(null);
-      _lastItem = newLastItem;
-    } else _firstItem = _lastItem = null;
+      lastItem = newLastItem;
+    } else firstItem = lastItem = null;
     size -= n;
 
     return newlist;
@@ -247,29 +220,49 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
     T next = i.getNext();
     T prev = i.getPrev();
 
-    assert (next != null) || (prev != null) || size == 1;
-
-    if (next == null) { // last item
-      assert _lastItem == i;
-      _lastItem = prev;
-    } else {
-      assert next.getPrev() == i;
-      next.setPrev(prev);
-    }
-
-    if (prev == null) { // first item
-      assert _firstItem == i;
-      _firstItem = next;
-    } else {
-      assert prev.getNext() == i;
-      prev.setNext(next);
-    }
+    ensureLinkedOrSingle(next, prev);
+    unlinkNextSide(i, next, prev);
+    unlinkPrevSide(i, next, prev);
 
     i.setNext(null);
     i.setPrev(null);
     --size;
     i.setParent(null);
     return i;
+  }
+
+  private void ensureLinkedOrSingle(T next, T prev) {
+    if (!((next != null) || (prev != null) || size == 1)) {
+      throw new IllegalStateException("Corrupted list: isolated node");
+    }
+  }
+
+  private void unlinkNextSide(T i, T next, T prev) {
+    if (next == null) { // last item
+      if (lastItem != i) {
+        throw new IllegalStateException("Corrupted list: tail mismatch");
+      }
+      lastItem = prev;
+    } else {
+      if (next.getPrev() != i) {
+        throw new IllegalStateException("Corrupted list: next.prev mismatch");
+      }
+      next.setPrev(prev);
+    }
+  }
+
+  private void unlinkPrevSide(T i, T next, T prev) {
+    if (prev == null) { // first item
+      if (firstItem != i) {
+        throw new IllegalStateException("Corrupted list: head mismatch");
+      }
+      firstItem = next;
+    } else {
+      if (prev.getNext() != i) {
+        throw new IllegalStateException("Corrupted list: prev.next mismatch");
+      }
+      prev.setNext(next);
+    }
   }
 
   /** {@inheritDoc} */
@@ -279,72 +272,90 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
     if ((j.getNext() != null) || (j.getPrev() != null)) throw new PromiscuousItemException(j);
 
     if (i == null) {
-      // insert as tail
-      j.setPrev(_lastItem);
-      j.setNext(null);
-      j.setParent(this);
-      if (_lastItem != null) {
-        _lastItem.setNext(j);
-        _lastItem = j;
-      } else {
-        _firstItem = _lastItem = j;
-      }
-
-      ++size;
+      insertAsTail(j);
     } else {
-      // insert in middle
-      if (i.getParent() == null)
-        throw new PromiscuousItemException(
-            i, i.getParent()); // different trace to make easier debugging
-      if (i.getParent() != this) throw new PromiscuousItemException(i, i.getParent());
-      T prev = i.getPrev();
-      if (prev == null) {
-        if (i != _firstItem) throw new VirginItemException(i);
-        _firstItem = j;
-      } else prev.setNext(j);
-      j.setPrev(prev);
-      i.setPrev(j);
-      j.setNext(i);
-      j.setParent(this);
-
-      ++size;
+      insertBefore(i, j);
     }
+  }
+
+  private void insertAsTail(T j) {
+    // insert as tail
+    j.setPrev(lastItem);
+    j.setNext(null);
+    j.setParent(this);
+    if (lastItem != null) {
+      lastItem.setNext(j);
+      lastItem = j;
+    } else {
+      firstItem = lastItem = j;
+    }
+    ++size;
+  }
+
+  private void insertBefore(T i, T j) {
+    // insert in middle (before 'i')
+    if (i.getParent() == null)
+      throw new PromiscuousItemException(
+          i, i.getParent()); // different trace to make easier debugging
+    if (i.getParent() != this) throw new PromiscuousItemException(i, i.getParent());
+    T prev = i.getPrev();
+    if (prev == null) {
+      if (i != firstItem) throw new VirginItemException(i);
+      firstItem = j;
+    } else {
+      prev.setNext(j);
+    }
+    j.setPrev(prev);
+    i.setPrev(j);
+    j.setNext(i);
+    j.setParent(this);
+    ++size;
   }
 
   /** {@inheritDoc} */
   @Override
   public void insertNext(T i, T j) {
-    if (j.getParent() != null) throw new PromiscuousItemException(j, i.getParent());
+    if (j.getParent() != null) throw new PromiscuousItemException(j, j.getParent());
     if ((j.getNext() != null) || (j.getPrev() != null)) throw new PromiscuousItemException(j);
 
     if (i == null) {
-      // insert as head
-      j.setPrev(null);
-      j.setNext(_firstItem);
-      j.setParent(this);
-
-      if (_firstItem != null) {
-        _firstItem.setPrev(j);
-        _firstItem = j;
-      } else {
-        _firstItem = _lastItem = j;
-      }
-
-      ++size;
+      insertAsHead(j);
     } else {
-      if (i.getParent() != this) throw new PromiscuousItemException(i, i.getParent());
-      T next = i.getNext();
-      if (next == null) {
-        if (i != _lastItem) throw new VirginItemException(i);
-        _lastItem = j;
-      } else next.setPrev(j);
-      j.setNext(next);
-      i.setNext(j);
-      j.setPrev(i);
-      j.setParent(this);
-
-      ++size;
+      insertAfter(i, j);
     }
+  }
+
+  private void insertAsHead(T j) {
+    // insert as head
+    j.setPrev(null);
+    j.setNext(firstItem);
+    j.setParent(this);
+
+    if (firstItem != null) {
+      firstItem.setPrev(j);
+      firstItem = j;
+    } else {
+      firstItem = lastItem = j;
+    }
+
+    ++size;
+  }
+
+  private void insertAfter(T i, T j) {
+    if (i.getParent() != this) throw new PromiscuousItemException(i, i.getParent());
+    T next = i.getNext();
+    if (next == null) {
+      if (i != lastItem) throw new VirginItemException(i);
+      lastItem = j;
+    } else {
+      next.setPrev(j);
+    }
+    j.setNext(next);
+    i.setNext(j);
+    j.setPrev(i);
+    j.setParent(this);
+
+    ++size;
   }
 
   // === Walkable implementation ==============================================
@@ -353,57 +364,44 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
    * @return an Enumeration of list elements from head to tail
    */
   private Enumeration<T> forwardElements() {
-    return new ForwardWalker();
+    return new Enumeration<>() {
+      private T next = firstItem;
+
+      @Override
+      public boolean hasMoreElements() {
+        return next != null;
+      }
+
+      @Override
+      public T nextElement() {
+        if (next == null) throw new NoSuchElementException();
+        T result = next;
+        next = next.getNext();
+        return result;
+      }
+    };
   }
 
   /**
    * @return an Enumeration of list elements from tail to head
    */
   public Enumeration<T> reverseElements() {
-    return new ReverseWalker();
-  }
+    return new Enumeration<>() {
+      private T next = lastItem;
 
-  private class ForwardWalker implements Enumeration<T> {
-    protected T next;
+      @Override
+      public boolean hasMoreElements() {
+        return next != null;
+      }
 
-    protected ForwardWalker() {
-      next = _firstItem;
-    }
-
-    @Override
-    public final boolean hasMoreElements() {
-      return next != null;
-    }
-
-    @Override
-    public T nextElement() {
-      if (next == null) throw new NoSuchElementException();
-      T result = next;
-      next = next.getNext();
-      return result;
-    }
-  }
-
-  private class ReverseWalker implements Enumeration<T> {
-    protected T next;
-
-    protected ReverseWalker() {
-      next = _lastItem;
-    }
-
-    @Override
-    public final boolean hasMoreElements() {
-      return next != null;
-    }
-
-    @Override
-    public T nextElement() {
-      if (next == null) throw new NoSuchElementException();
-      T result = next;
-      if (next == null) throw new IllegalStateException("next==null");
-      next = next.getPrev();
-      return result;
-    }
+      @Override
+      public T nextElement() {
+        if (next == null) throw new NoSuchElementException();
+        T result = next;
+        next = next.getPrev();
+        return result;
+      }
+    };
   }
 
   // === list element ====================================================
@@ -412,14 +410,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
       implements DoublyLinkedList.Item<T> {
     private T prev;
     private T next;
-    private DoublyLinkedList<? super T> list;
-
-    //		@Override
-    //		public T clone() {
-    //            if(getClass() != Item.class)
-    //                throw new RuntimeException("Must implement clone() for "+getClass());
-    //			return (T) new Item<T>();
-    //        }
+    private DoublyLinkedList<T> list;
 
     @Override
     public final T getNext() {
@@ -428,9 +419,7 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
 
     @Override
     public final T setNext(DoublyLinkedList.Item<?> i) {
-      T old = next;
-      next = castItem(i);
-      return old;
+      return nextAndSet(castItem(i));
     }
 
     @Override
@@ -440,21 +429,41 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
 
     @Override
     public final T setPrev(DoublyLinkedList.Item<?> i) {
-      T old = prev;
-      prev = castItem(i);
-      return old;
+      return prevAndSet(castItem(i));
     }
 
     @Override
-    public DoublyLinkedList<? super T> getParent() {
+    public DoublyLinkedList<T> getParent() {
       return list;
     }
 
     @Override
-    public DoublyLinkedList<? super T> setParent(DoublyLinkedList<? super T> l) {
-      DoublyLinkedList<? super T> old = list;
-      list = l;
-      return old;
+    public DoublyLinkedList<T> setParent(DoublyLinkedList<T> l) {
+      return parentAndSet(l);
+    }
+
+    private T nextAndSet(T newNext) {
+      try {
+        return next;
+      } finally {
+        next = newNext;
+      }
+    }
+
+    private T prevAndSet(T newPrev) {
+      try {
+        return prev;
+      } finally {
+        prev = newPrev;
+      }
+    }
+
+    private DoublyLinkedList<T> parentAndSet(DoublyLinkedList<T> newList) {
+      try {
+        return list;
+      } finally {
+        list = newList;
+      }
     }
 
     @SuppressWarnings("unchecked")
@@ -466,10 +475,9 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
   }
 
   @Override
-  public Iterator<T> iterator() {
+  public @NotNull Iterator<T> iterator() {
+    final Enumeration<T> e = forwardElements();
     return new Iterator<>() {
-      private final Enumeration<T> e = forwardElements();
-
       @Override
       public boolean hasNext() {
         return e.hasMoreElements();
@@ -480,7 +488,6 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<? extends T>>
         if (!hasNext()) {
           throw new NoSuchElementException();
         }
-
         return e.nextElement();
       }
 

--- a/src/main/java/network/crypta/support/DoublyLinkedListImpl.java
+++ b/src/main/java/network/crypta/support/DoublyLinkedListImpl.java
@@ -10,8 +10,8 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p>This class provides a lightweight, allocation-free list in which each element stores
  * references to its neighbors and to the parent list (see {@link DoublyLinkedList.Item}). It is
- * designed for constant-time ({@code O(1)}) insertions and removals when the target node is
- * already known. It does not allocate wrapper nodes and therefore avoids GC pressure compared to
+ * designed for constant-time ({@code O(1)}) insertions and removals when the target node is already
+ * known. It does not allocate wrapper nodes and therefore avoids GC pressure compared to
  * non-intrusive structures.
  *
  * <p>Concurrency: Instances are not thread-safe. External synchronization is required for
@@ -47,9 +47,9 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
   /**
    * Creates a list that adopts an existing intrusive chain.
    *
-   * <p>The items from {@code head} through {@code tail} (via {@link Item#getNext()}) are assumed
-   * to form a valid chain. This constructor sets their parent to this list and records the
-   * provided size without validation.
+   * <p>The items from {@code head} through {@code tail} (via {@link Item#getNext()}) are assumed to
+   * form a valid chain. This constructor sets their parent to this list and records the provided
+   * size without validation.
    *
    * @param head first item in the chain; may be {@code null} when {@code size} is 0
    * @param tail last item in the chain; may be {@code null} when {@code size} is 0
@@ -579,19 +579,19 @@ public class DoublyLinkedListImpl<T extends DoublyLinkedList.Item<T>>
       }
     }
 
-    @SuppressWarnings("unchecked")
     /**
      * Casts an {@link Item} to the concrete type {@code T}.
      *
      * <p>Safe by construction: items in a {@code DoublyLinkedList<T>} are always of type {@code T}.
      */
+    @SuppressWarnings("unchecked")
     private T castItem(DoublyLinkedList.Item<?> i) {
       return (T) i;
     }
   }
 
-  @Override
   /** Returns an {@link Iterator} that traverses from head to tail. */
+  @Override
   public @NotNull Iterator<T> iterator() {
     final Enumeration<T> e = forwardElements();
     return new Iterator<>() {

--- a/src/test/java/network/crypta/support/DoublyLinkedListImplTest.java
+++ b/src/test/java/network/crypta/support/DoublyLinkedListImplTest.java
@@ -2,19 +2,22 @@ package network.crypta.support;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
 import network.crypta.support.DoublyLinkedListImpl.Item;
 import org.junit.jupiter.api.Test;
 
-public class DoublyLinkedListImplTest {
+@SuppressWarnings("java:S100") // test method naming with underscores per project conventions
+class DoublyLinkedListImplTest {
   @Test
-  public void testForwardPushPop() {
+  void push_and_pop_whenAddedInOrder_expectLIFOFromTail() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
     list.push(new T(0));
     list.push(new T(1));
@@ -22,29 +25,41 @@ public class DoublyLinkedListImplTest {
     list.push(new T(3));
 
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.pop().assertV(3);
+    T r1 = list.pop();
+    assertNotNull(r1);
+    r1.assertV(3);
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.pop().assertV(2);
+    T r2 = list.pop();
+    assertNotNull(r2);
+    r2.assertV(2);
     assertFalse(list.isEmpty(), "isEmpty()");
 
     // add again
     list.push(new T(4));
     list.push(new T(5));
 
-    list.pop().assertV(5);
+    T r3 = list.pop();
+    assertNotNull(r3);
+    r3.assertV(5);
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.pop().assertV(4);
+    T r4 = list.pop();
+    assertNotNull(r4);
+    r4.assertV(4);
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.pop().assertV(1);
+    T r5 = list.pop();
+    assertNotNull(r5);
+    r5.assertV(1);
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.pop().assertV(0);
+    T r6 = list.pop();
+    assertNotNull(r6);
+    r6.assertV(0);
 
     assertTrue(list.isEmpty(), "isEmpty()");
     assertNull(list.pop(), "pop()");
   }
 
   @Test
-  public void testForwardShiftUnshift() {
+  void unshift_and_shift_whenAddedInOrder_expectFIFOFromHead() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
     list.unshift(new T(0));
     list.unshift(new T(1));
@@ -52,29 +67,41 @@ public class DoublyLinkedListImplTest {
     list.unshift(new T(3));
 
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.shift().assertV(3);
+    T s1 = list.shift();
+    assertNotNull(s1);
+    s1.assertV(3);
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.shift().assertV(2);
+    T s2 = list.shift();
+    assertNotNull(s2);
+    s2.assertV(2);
     assertFalse(list.isEmpty(), "isEmpty()");
 
     // add again
     list.unshift(new T(4));
     list.unshift(new T(5));
 
-    list.shift().assertV(5);
+    T s3 = list.shift();
+    assertNotNull(s3);
+    s3.assertV(5);
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.shift().assertV(4);
+    T s4 = list.shift();
+    assertNotNull(s4);
+    s4.assertV(4);
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.shift().assertV(1);
+    T s5 = list.shift();
+    assertNotNull(s5);
+    s5.assertV(1);
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.shift().assertV(0);
+    T s6 = list.shift();
+    assertNotNull(s6);
+    s6.assertV(0);
 
     assertTrue(list.isEmpty(), "isEmpty()");
     assertNull(list.shift(), "shift()");
   }
 
   @Test
-  public void testClearSize() {
+  void clear_whenListHasElements_expectSizeZeroAndEmpty() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
     list.unshift(new T(0));
     list.unshift(new T(1));
@@ -83,10 +110,14 @@ public class DoublyLinkedListImplTest {
 
     assertEquals(4, list.size(), "size()");
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.shift().assertV(3);
+    T cs1 = list.shift();
+    assertNotNull(cs1);
+    cs1.assertV(3);
     assertEquals(3, list.size(), "size()");
     assertFalse(list.isEmpty(), "isEmpty()");
-    list.shift().assertV(2);
+    T cs2 = list.shift();
+    assertNotNull(cs2);
+    cs2.assertV(2);
     assertEquals(2, list.size(), "size()");
     assertFalse(list.isEmpty(), "isEmpty()");
 
@@ -101,15 +132,19 @@ public class DoublyLinkedListImplTest {
     assertEquals(2, list.size(), "size()");
     assertFalse(list.isEmpty(), "isEmpty()");
 
-    list.shift().assertV(5);
-    list.shift().assertV(4);
+    T cs3 = list.shift();
+    assertNotNull(cs3);
+    cs3.assertV(5);
+    T cs4 = list.shift();
+    assertNotNull(cs4);
+    cs4.assertV(4);
 
     assertEquals(0, list.size(), "size()");
     assertTrue(list.isEmpty(), "isEmpty()");
   }
 
   @Test
-  public void testShiftN() {
+  void shift_whenNWithinAndBeyondBounds_expectCorrectPartitioning() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
 
     for (int i = 0; i < 5; i++) {
@@ -118,44 +153,35 @@ public class DoublyLinkedListImplTest {
 
     DoublyLinkedList<T> list2 = list.shift(2);
     assertEquals(2, list2.size(), "list2.size()");
-    list2.shift().assertV(0);
-    list2.shift().assertV(1);
+    T s2a = list2.shift();
+    assertNotNull(s2a);
+    s2a.assertV(0);
+    T s2b = list2.shift();
+    assertNotNull(s2b);
+    s2b.assertV(1);
     assertTrue(list2.isEmpty(), "list2.isEmpty()");
 
     assertEquals(3, list.size(), "list.size()");
-    list.shift().assertV(2);
+    T sRemain = list.shift();
+    assertNotNull(sRemain);
+    sRemain.assertV(2);
 
     list2 = list.shift(20);
     assertTrue(list.isEmpty(), "list.isEmpty()");
-    list2.shift().assertV(3);
-    list2.shift().assertV(4);
+    T s2c = list2.shift();
+    assertNotNull(s2c);
+    s2c.assertV(3);
+    T s2d = list2.shift();
+    assertNotNull(s2d);
+    s2d.assertV(4);
     assertTrue(list2.isEmpty(), "list2.isEmpty()");
 
     list2 = list.shift(20);
     assertTrue(list2.isEmpty(), "list2.isEmpty()");
   }
 
-  //	public void testClone() {
-  //		DoublyLinkedList<T> list = new DoublyLinkedListImpl<T>();
-  //		for (int i = 0; i < 3; i++) {
-  //			list.unshift(new T(i));
-  //		}
-  //
-  //		DoublyLinkedList<T> listClone = list.clone();
-  //
-  //		for (int i = 2; i >= 0; i--) {
-  //			T t = (T) list.shift();
-  //			t.assertV(i);
-  //			t.assertIsNotClone();
-  //
-  //			T tc = (T) listClone.shift();
-  //			tc.assertV(i);
-  //			tc.assertIsClone();
-  //		}
-  //	}
-
   @Test
-  public void testPopN() {
+  void pop_whenNWithinAndBeyondBounds_expectCorrectPartitioning() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
 
     for (int i = 0; i < 5; i++) {
@@ -164,17 +190,27 @@ public class DoublyLinkedListImplTest {
 
     DoublyLinkedList<T> list2 = list.pop(2);
     assertEquals(2, list2.size(), "list2.size()");
-    list2.pop().assertV(0);
-    list2.pop().assertV(1);
+    T p2a = list2.pop();
+    assertNotNull(p2a);
+    p2a.assertV(0);
+    T p2b = list2.pop();
+    assertNotNull(p2b);
+    p2b.assertV(1);
     assertTrue(list2.isEmpty(), "list2.isEmpty()");
 
     assertEquals(3, list.size(), "list.size()");
-    list.pop().assertV(2);
+    T pRemain = list.pop();
+    assertNotNull(pRemain);
+    pRemain.assertV(2);
 
     list2 = list.pop(20);
     assertTrue(list.isEmpty(), "list.isEmpty()");
-    list2.pop().assertV(3);
-    list2.pop().assertV(4);
+    T p2c = list2.pop();
+    assertNotNull(p2c);
+    p2c.assertV(3);
+    T p2d = list2.pop();
+    assertNotNull(p2d);
+    p2d.assertV(4);
     assertTrue(list2.isEmpty(), "list2.isEmpty()");
 
     list2 = list.pop(20);
@@ -182,7 +218,7 @@ public class DoublyLinkedListImplTest {
   }
 
   @Test
-  public void testHeadTail() {
+  void head_and_tail_whenListChanges_expectUpdatedEnds() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
 
     assertNull(list.head(), "head() == null");
@@ -212,7 +248,7 @@ public class DoublyLinkedListImplTest {
   }
 
   @Test
-  public void testIternator() {
+  void iterator_manualForwardAndReverse_expectOrder() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
     T[] array = new T[5];
 
@@ -224,11 +260,11 @@ public class DoublyLinkedListImplTest {
     // manual, forward
     T h = list.head();
     for (int i = 0; i < 5; i++) {
-      assertEquals(array[i], h, "manual iternate, forward");
-      // assertEquals(h.getNext(), list.next(h), "DoublyLinkedList.next() == Item.next()");
+      assertEquals(array[i], h, "manual iterate, forward");
       assertEquals(i != 4, list.hasNext(h), "hasNext()");
       assertEquals(i != 0, list.hasPrev(h), "hasPrev()");
 
+      assertNotNull(h);
       h.assertV(i);
 
       h = list.next(h);
@@ -238,11 +274,11 @@ public class DoublyLinkedListImplTest {
     // manual, reverse
     T t = list.tail();
     for (int i = 4; i >= 0; i--) {
-      assertEquals(array[i], t, "manual iternate, reverse");
-      // assertEquals(tail.getPrev(), list.prev(tail), "DoublyLinkedList.prev() == Item.getPrev()");
+      assertEquals(array[i], t, "manual iterate, reverse");
       assertEquals(i != 4, list.hasNext(t), "hasNext()");
       assertEquals(i != 0, list.hasPrev(t), "hasPrev()");
 
+      assertNotNull(t);
       t.assertV(i);
 
       t = list.prev(t);
@@ -254,19 +290,16 @@ public class DoublyLinkedListImplTest {
       assertTrue(e.hasMoreElements(), "hasMoreElements()");
 
       T n = e.nextElement();
+      assertNotNull(n);
       n.assertV(i);
 
       assertEquals(i != 4, e.hasMoreElements(), "hasMoreElements()");
     }
-    try {
-      e.nextElement();
-      fail("NoSuchElementException");
-    } catch (NoSuchElementException nsee) {
-    }
+    assertThrows(NoSuchElementException.class, e::nextElement);
   }
 
   @Test
-  public void testRandomRemovePush() {
+  void remove_whenRemovingFromMiddle_thenPushBack_expectOrderPreserved() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
     T[] array = new T[5];
 
@@ -284,17 +317,27 @@ public class DoublyLinkedListImplTest {
     // Remove non-identical (but equal) item -> give null
     assertNull(list.remove(new T(2)));
 
-    list.shift().assertV(0);
-    list.shift().assertV(1);
-    list.shift().assertV(2);
-    list.shift().assertV(4);
-    list.shift().assertV(3);
+    T rr0 = list.shift();
+    assertNotNull(rr0);
+    rr0.assertV(0);
+    T rr1 = list.shift();
+    assertNotNull(rr1);
+    rr1.assertV(1);
+    T rr2 = list.shift();
+    assertNotNull(rr2);
+    rr2.assertV(2);
+    T rr3 = list.shift();
+    assertNotNull(rr3);
+    rr3.assertV(4);
+    T rr4 = list.shift();
+    assertNotNull(rr4);
+    rr4.assertV(3);
 
     assertNull(list.remove(new T(-1)));
   }
 
   @Test
-  public void testRandomShiftPush() {
+  void shift_and_push_whenInterleaved_expectDeterministicOrder() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
     list.push(new T(0));
     list.push(new T(1));
@@ -303,16 +346,28 @@ public class DoublyLinkedListImplTest {
     list.unshift(new T(4));
     list.unshift(new T(5));
 
-    list.shift().assertV(5);
-    list.pop().assertV(3);
-    list.pop().assertV(1);
-    list.pop().assertV(0);
-    list.shift().assertV(4);
-    list.shift().assertV(2);
+    T rsp0 = list.shift();
+    assertNotNull(rsp0);
+    rsp0.assertV(5);
+    T rpp0 = list.pop();
+    assertNotNull(rpp0);
+    rpp0.assertV(3);
+    T rpp1 = list.pop();
+    assertNotNull(rpp1);
+    rpp1.assertV(1);
+    T rpp2 = list.pop();
+    assertNotNull(rpp2);
+    rpp2.assertV(0);
+    T rsp1 = list.shift();
+    assertNotNull(rsp1);
+    rsp1.assertV(4);
+    T rsp2 = list.shift();
+    assertNotNull(rsp2);
+    rsp2.assertV(2);
   }
 
   @Test
-  public void testRandomInsert() {
+  void insertPrev_and_insertNext_whenAnchored_expectOrderAndGuards() {
     DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
     T[] array = new T[5];
 
@@ -329,70 +384,150 @@ public class DoublyLinkedListImplTest {
     DoublyLinkedList<T> list2 = new DoublyLinkedListImpl<>();
     T l2 = new T(9999);
     list2.push(l2);
-    try {
-      // already exist
-      list2.insertNext(l2, l2);
-      fail("PromiscuousItemException");
-    } catch (PromiscuousItemException pie) {
-    }
-    try {
-      // already exist
-      list2.insertNext(l2, l2);
-      fail("PromiscuousItemException");
-    } catch (PromiscuousItemException pie) {
-    }
-    try {
-      // bad position
-      list2.insertPrev(array[3], new T(8888));
-      fail("PromiscuousItemException");
-    } catch (PromiscuousItemException pie) {
-    }
-    try {
-      // bad position
-      list2.insertNext(array[3], new T(8888));
-      fail("PromiscuousItemException");
-    } catch (PromiscuousItemException pie) {
-    }
-
-    try {
-      // item in other list
-      list2.insertPrev(l2, array[3]);
-      fail("PromiscuousItemException");
-    } catch (PromiscuousItemException pie) {
-    }
-    try {
-      // item in other list
-      list2.insertNext(l2, array[3]);
-      fail("PromiscuousItemException");
-    } catch (PromiscuousItemException pie) {
-    }
+    assertThrows(PromiscuousItemException.class, () -> list2.insertNext(l2, l2));
+    assertThrows(PromiscuousItemException.class, () -> list2.insertNext(l2, l2));
+    T notInListForPrev = new T(8888);
+    T notInListForNext = new T(8888);
+    assertThrows(
+        PromiscuousItemException.class, () -> list2.insertPrev(array[3], notInListForPrev));
+    assertThrows(
+        PromiscuousItemException.class, () -> list2.insertNext(array[3], notInListForNext));
+    assertThrows(PromiscuousItemException.class, () -> list2.insertPrev(l2, array[3]));
+    assertThrows(PromiscuousItemException.class, () -> list2.insertNext(l2, array[3]));
 
     T l3 = new T(9999);
     list2.push(l3);
-    try {
-      // VirginItemException
-      l3.setPrev(null); // corrupt it
-      list2.insertPrev(l3, new T(8888));
-      fail("VirginItemException");
-    } catch (VirginItemException vie) {
+    l3.setPrev(null); // corrupt it
+    T virginPrev = new T(8888);
+    assertThrows(VirginItemException.class, () -> list2.insertPrev(l3, virginPrev));
+    l2.setNext(null); // corrupt it
+    T virginNext = new T(8888);
+    assertThrows(VirginItemException.class, () -> list2.insertNext(l2, virginNext));
+
+    int[] expected = {100, 0, 1, 102, 2, 3, 4, 105, 104};
+    int[] actual = new int[expected.length];
+    for (int i = 0; i < expected.length; i++) {
+      T node = list.shift();
+      assertNotNull(node);
+      actual[i] = node.value;
     }
-    try {
-      // VirginItemException
-      l2.setNext(null); // corrupt it
-      list2.insertNext(l2, new T(8888));
-      fail("VirginItemException");
-    } catch (VirginItemException vie) {
+    org.junit.jupiter.api.Assertions.assertArrayEquals(expected, actual);
+  }
+
+  @Test
+  void contains_whenEquivalentItemPresent_expectTrue() {
+    DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
+    list.push(new T(1));
+    list.push(new T(2));
+    list.push(new T(3));
+
+    assertTrue(list.contains(new T(2)));
+    assertFalse(list.contains(new T(99)));
+  }
+
+  @Test
+  void iterator_whenExhausted_expectNoSuchElementException() {
+    DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
+    list.push(new T(1));
+    Iterator<T> it = list.iterator();
+    assertTrue(it.hasNext());
+    assertNotNull(it.next());
+    assertFalse(it.hasNext());
+    assertThrows(NoSuchElementException.class, it::next);
+  }
+
+  @Test
+  void iterator_remove_expectUnsupportedOperation() {
+    DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
+    list.push(new T(1));
+    Iterator<T> it = list.iterator();
+    assertThrows(UnsupportedOperationException.class, it::remove);
+  }
+
+  @Test
+  void reverseElements_whenIterated_expectReverseOrder() {
+    DoublyLinkedListImpl<T> list = new DoublyLinkedListImpl<>();
+    T[] array = new T[4];
+    for (int i = 0; i < array.length; i++) {
+      array[i] = new T(i);
+      list.push(array[i]);
     }
 
-    list.shift().assertV(100);
-    list.shift().assertV(0);
-    list.shift().assertV(1);
-    list.shift().assertV(102);
-    list.shift().assertV(2);
-    list.shift().assertV(3);
-    list.shift().assertV(4);
-    list.shift().assertV(105);
-    list.shift().assertV(104);
+    Enumeration<T> rev = list.reverseElements();
+    for (int i = array.length - 1; i >= 0; i--) {
+      assertTrue(rev.hasMoreElements());
+      assertSame(array[i], rev.nextElement());
+    }
+    assertFalse(rev.hasMoreElements());
+    assertThrows(NoSuchElementException.class, rev::nextElement);
+  }
+
+  @Test
+  void shift_whenNLessThanOne_expectEmptyReturnedAndListUnchanged() {
+    DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
+    list.push(new T(1));
+    list.push(new T(2));
+    int before = list.size();
+    DoublyLinkedList<T> out = list.shift(0);
+    assertTrue(out.isEmpty());
+    assertEquals(before, list.size());
+  }
+
+  @Test
+  void pop_whenNLessThanOne_expectEmptyReturnedAndListUnchanged() {
+    DoublyLinkedList<T> list = new DoublyLinkedListImpl<>();
+    list.push(new T(1));
+    list.push(new T(2));
+    int before = list.size();
+    DoublyLinkedList<T> out = list.pop(0);
+    assertTrue(out.isEmpty());
+    assertEquals(before, list.size());
+  }
+
+  @Test
+  void remove_whenItemBelongsToOtherList_expectPromiscuousItemException() {
+    DoublyLinkedListImpl<T> l1 = new DoublyLinkedListImpl<>();
+    DoublyLinkedList<T> l2 = new DoublyLinkedListImpl<>();
+    T x = new T(10);
+    l2.push(x);
+    // ensure l1 is non-empty so remove() does not return null early
+    l1.push(new T(-1));
+    assertThrows(PromiscuousItemException.class, () -> l1.remove(x));
+  }
+
+  @Test
+  void clear_whenCalled_expectNodesDetached() {
+    DoublyLinkedListImpl<T> list = new DoublyLinkedListImpl<>();
+    T a = new T(1);
+    T b = new T(2);
+    T c = new T(3);
+    list.push(a);
+    list.push(b);
+    list.push(c);
+
+    list.clear();
+    assertEquals(0, list.size());
+    assertNull(list.head());
+    assertNull(list.tail());
+    // All nodes detached
+    assertNull(a.getParent());
+    assertNull(b.getParent());
+    assertNull(c.getParent());
+    assertNull(a.getNext());
+    assertNull(b.getNext());
+    assertNull(c.getNext());
+    assertNull(a.getPrev());
+    assertNull(b.getPrev());
+    assertNull(c.getPrev());
+  }
+
+  @Test
+  void remove_whenItemClearedFromList_expectNullOnSecondRemoval() {
+    DoublyLinkedListImpl<T> list = new DoublyLinkedListImpl<>();
+    T a = new T(1);
+    list.push(a);
+    assertSame(a, list.remove(a));
+    assertNull(list.remove(a));
   }
 
   private static class T extends Item<T> {
@@ -400,12 +535,7 @@ public class DoublyLinkedListImplTest {
       value = v;
     }
 
-    @Override
-    public T clone() {
-      T c = new T(value);
-      c.isClone = true;
-      return c;
-    }
+    // No clone() override needed for tests; avoid Sonar S1182 on super.clone().
 
     @Override
     public String toString() {


### PR DESCRIPTION
Summary
- Refactors DoublyLinkedListImpl to reduce cognitive complexity and improve maintainability without changing external behavior.
- Expands and tidies Javadoc for the intrusive list implementation and its Item type.
- Hardens and modernizes DoublyLinkedListImplTest (JUnit 6): clearer AAA-style names, null-safety before method invocations, and reduced assertion count via array comparison.
- Applies Spotless formatting.

Motivation
- Bring the intrusive doubly-linked list to project standards (naming, invariants, documentation) and resolve SonarLint findings.
- Make tests deterministic and easier to maintain.

Key Changes
- Internal field renames to follow conventions: _firstItem/_lastItem -> firstItem/lastItem.
- Extracted helpers to lower complexity:
  - insertPrev -> insertAsTail() / insertBefore().
  - insertNext -> insertAsHead() / insertAfter().
  - remove -> ensureLinkedOrSingle(), unlinkNextSide(), unlinkPrevSide().
- Replaced asserts used as runtime checks with explicit IllegalStateException on invariant violations.
- Simplified Enumeration implementations via local anonymous classes; kept public iterator() behavior.
- Comprehensive Javadoc for class, constructors, public/protected methods, and Item API; clarified nullability, complexity, and exceptions.
- Tests: eliminated try/catch+fail anti-patterns in favor of assertThrows, avoided potential NPEs by introducing assertNotNull guards, and renamed tests to method_whenCondition_expectOutcome.

Behavior & Compatibility
- Public API signatures unchanged. Semantics remain the same; refactor only moves logic into private helpers and improves error messages for corrupt state.
- Note: protected fields were renamed to align with conventions. If there are subclasses outside the repo relying on the old names, please flag for discussion.

Quality Gates
- Local: ./gradlew --parallel test → all tests pass.
- Spotless applied.
- SonarLint (scoped to this file) reports no remaining issues.

Testing Instructions
- Build & run tests: `./gradlew --parallel test`.
- Optional static analysis (scoped): `./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/support/DoublyLinkedListImpl.java`.

Risks & Rollback
- Low risk; refactor limited to internal structure and documentation. If issues arise, revert this branch or back out the individual commits.

Commits
- 6b17f392cd docs(support): tidy Javadoc wrapping and annotation order in DoublyLinkedListImpl
- 65f4052b2b docs(support): expand Javadoc for DoublyLinkedListImpl and intrusive items
- 2f6db67bc1 refactor(support): reduce complexity and resolve SonarLint in DoublyLinkedListImpl; test(support): harden DoublyLinkedListImplTest; style: apply Spotless

Branch
- Source: feature/fix-DoublyLinkedList
- Target: develop

Please review. I am happy to split the PR (refactor vs docs vs tests) if you prefer smaller changesets.