### PR TITLE
tests/docs(support): Add comprehensive Histogram2 tests and improve Javadoc

### DIFF
--- a/src/main/java/network/crypta/support/Histogram2.java
+++ b/src/main/java/network/crypta/support/Histogram2.java
@@ -20,7 +20,7 @@ import network.crypta.support.math.TrivialRunningAverage;
  */
 public class Histogram2 {
 
-  private final double MAX;
+  private final double max;
   private final RunningAverage[] bars;
 
   /**
@@ -41,7 +41,7 @@ public class Histogram2 {
    *     positive for meaningful results
    */
   public Histogram2(final int numBars, final double maxValue) {
-    this.MAX = maxValue;
+    this.max = maxValue;
     this.bars = new RunningAverage[numBars];
     for (int i = 0; i < numBars; i++) {
       this.bars[i] = new TrivialRunningAverage();
@@ -71,10 +71,10 @@ public class Histogram2 {
    *     implementation is propagated
    */
   public void report(final double key, final double value) {
-    if (key < 0.0 || key >= MAX) return;
+    if (key < 0.0 || key >= max) return;
     // Compute bar index by scaling key into [0, bars.length) and truncating toward zero (floor for
     // non‑negative inputs). This yields a uniform partition of [0, MAX) into equal-width bins.
-    int n = (int) (bars.length * key / MAX);
+    int n = (int) (bars.length * key / max);
     bars[n].report(value);
   }
 
@@ -103,7 +103,7 @@ public class Histogram2 {
     int[] retval = new int[bars.length];
     for (int i = 0; i < retval.length; i++) {
       // Scale the current average from [0, MAX] into [0, localMax], then truncate to an int.
-      int val = (int) (bars[i].currentValue() * localMax / MAX);
+      int val = (int) (bars[i].currentValue() * localMax / max);
       retval[i] = val;
     }
     return retval;

--- a/src/main/java/network/crypta/support/Histogram2.java
+++ b/src/main/java/network/crypta/support/Histogram2.java
@@ -4,14 +4,42 @@ import network.crypta.support.math.RunningAverage;
 import network.crypta.support.math.TrivialRunningAverage;
 
 /**
- * Similiar to a standard histogram, but each bar is reasoned independently. Pretty much just an
- * array of running averages. Used for tracking success rates per-location.
+ * A lightweight, bucketed aggregator built from independent running averages.
+ *
+ * <p>This class partitions the key space {@code [0, MAX)} into a fixed number of equally sized bins
+ * ("bars"). Each bar holds a {@link RunningAverage} that is updated when {@link #report} receives a
+ * key within that bar's interval. Unlike a conventional histogram that counts occurrences, each bar
+ * tracks an average of caller-provided values. A common use case is tracking success rates per
+ * location or key range.
+ *
+ * <p>Thread-safety: The instance performs no explicit synchronization. The bars are created as
+ * {@link TrivialRunningAverage}, whose implementation is synchronized. Concurrent calls are safe in
+ * practice because the array contents are final after construction and each bar's implementation is
+ * thread-safe; however this class itself does not enforce additional memory barriers beyond final
+ * field publication.
  */
 public class Histogram2 {
 
   private final double MAX;
   private final RunningAverage[] bars;
 
+  /**
+   * Creates a histogram with {@code numBars} equally sized buckets spanning {@code [0, maxValue)}.
+   *
+   * <p>Each bar is initialized with a fresh {@link TrivialRunningAverage}. The number of bars and
+   * {@code maxValue} are fixed for the lifetime of the instance.
+   *
+   * <p>Preconditions (not enforced):
+   *
+   * <ul>
+   *   <li>{@code numBars > 0}
+   *   <li>{@code maxValue > 0} (avoids division by zero in scaling operations)
+   * </ul>
+   *
+   * @param numBars total number of bars; must be positive
+   * @param maxValue exclusive upper bound of the key domain ({@code [0, maxValue)}); must be
+   *     positive for meaningful results
+   */
   public Histogram2(final int numBars, final double maxValue) {
     this.MAX = maxValue;
     this.bars = new RunningAverage[numBars];
@@ -20,15 +48,61 @@ public class Histogram2 {
     }
   }
 
+  /**
+   * Reports a value to the bar that corresponds to {@code key}.
+   *
+   * <p>Behavior:
+   *
+   * <ul>
+   *   <li>Keys outside {@code [0, MAX)} are ignored.
+   *   <li>Valid keys map to a bar via {@code floor(bars.length * key / MAX)}. This is equivalent to
+   *       dividing the key range into equal-width intervals and choosing the corresponding index.
+   *   <li>The chosen bar's running average incorporates {@code value}.
+   * </ul>
+   *
+   * <p>Complexity: O(1).
+   *
+   * <p>Threading: See class-level notes. This method does not synchronize; it delegates to the
+   * thread-safe {@link RunningAverage} held by the selected bar.
+   *
+   * @param key location in {@code [0, MAX)} that selects the bar
+   * @param value observation to feed to that bar's running average; units are caller-defined
+   * @throws RuntimeException any exception thrown by the underlying {@link RunningAverage}
+   *     implementation is propagated
+   */
   public void report(final double key, final double value) {
     if (key < 0.0 || key >= MAX) return;
+    // Compute bar index by scaling key into [0, bars.length) and truncating toward zero (floor for
+    // non‑negative inputs). This yields a uniform partition of [0, MAX) into equal-width bins.
     int n = (int) (bars.length * key / MAX);
     bars[n].report(value);
   }
 
+  /**
+   * Returns a snapshot of per-bar averages scaled to {@code localMax} and truncated to integers.
+   *
+   * <p>For each bar {@code i}, the returned array contains {@code (int) (bars[i].currentValue() *
+   * localMax / MAX)}. This provides a linear mapping from the bar's average (assumed to be in the
+   * range {@code [0, MAX]} for percentage-like data) into {@code [0, localMax]}.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Values are truncated toward zero due to the explicit cast to {@code int}.
+   *   <li>If a bar's average is negative, the corresponding entry will be negative.
+   *   <li>Precondition (not enforced): {@code MAX > 0}; otherwise the scale factor is undefined
+   *       (division by zero). TODO: consider validating {@code maxValue > 0} at construction time.
+   * </ul>
+   *
+   * <p>Complexity: O(number of bars).
+   *
+   * @param localMax target scale for the output values; typically a non-negative display height
+   * @return an array of length {@code numBars} with the scaled averages (never {@code null})
+   */
   public int[] getPercentageArray(int localMax) {
     int[] retval = new int[bars.length];
     for (int i = 0; i < retval.length; i++) {
+      // Scale the current average from [0, MAX] into [0, localMax], then truncate to an int.
       int val = (int) (bars[i].currentValue() * localMax / MAX);
       retval[i] = val;
     }

--- a/src/main/java/network/crypta/support/Histogram2.java
+++ b/src/main/java/network/crypta/support/Histogram2.java
@@ -6,7 +6,7 @@ import network.crypta.support.math.TrivialRunningAverage;
 /**
  * A lightweight, bucketed aggregator built from independent running averages.
  *
- * <p>This class partitions the key space {@code [0, MAX)} into a fixed number of equally sized bins
+ * <p>This class partitions the key space {@code [0, max)} into a fixed number of equally sized bins
  * ("bars"). Each bar holds a {@link RunningAverage} that is updated when {@link #report} receives a
  * key within that bar's interval. Unlike a conventional histogram that counts occurrences, each bar
  * tracks an average of caller-provided values. A common use case is tracking success rates per
@@ -54,8 +54,8 @@ public class Histogram2 {
    * <p>Behavior:
    *
    * <ul>
-   *   <li>Keys outside {@code [0, MAX)} are ignored.
-   *   <li>Valid keys map to a bar via {@code floor(bars.length * key / MAX)}. This is equivalent to
+   *   <li>Keys outside {@code [0, max)} are ignored.
+   *   <li>Valid keys map to a bar via {@code floor(bars.length * key / max)}. This is equivalent to
    *       dividing the key range into equal-width intervals and choosing the corresponding index.
    *   <li>The chosen bar's running average incorporates {@code value}.
    * </ul>
@@ -65,7 +65,7 @@ public class Histogram2 {
    * <p>Threading: See class-level notes. This method does not synchronize; it delegates to the
    * thread-safe {@link RunningAverage} held by the selected bar.
    *
-   * @param key location in {@code [0, MAX)} that selects the bar
+   * @param key location in {@code [0, max)} that selects the bar
    * @param value observation to feed to that bar's running average; units are caller-defined
    * @throws RuntimeException any exception thrown by the underlying {@link RunningAverage}
    *     implementation is propagated
@@ -73,7 +73,7 @@ public class Histogram2 {
   public void report(final double key, final double value) {
     if (key < 0.0 || key >= max) return;
     // Compute bar index by scaling key into [0, bars.length) and truncating toward zero (floor for
-    // non‑negative inputs). This yields a uniform partition of [0, MAX) into equal-width bins.
+    // non‑negative inputs). This yields a uniform partition of [0, max) into equal-width bins.
     int n = (int) (bars.length * key / max);
     bars[n].report(value);
   }
@@ -82,15 +82,15 @@ public class Histogram2 {
    * Returns a snapshot of per-bar averages scaled to {@code localMax} and truncated to integers.
    *
    * <p>For each bar {@code i}, the returned array contains {@code (int) (bars[i].currentValue() *
-   * localMax / MAX)}. This provides a linear mapping from the bar's average (assumed to be in the
-   * range {@code [0, MAX]} for percentage-like data) into {@code [0, localMax]}.
+   * localMax / max)}. This provides a linear mapping from the bar's average (assumed to be in the
+   * range {@code [0, max]} for percentage-like data) into {@code [0, localMax]}.
    *
    * <p>Notes:
    *
    * <ul>
    *   <li>Values are truncated toward zero due to the explicit cast to {@code int}.
    *   <li>If a bar's average is negative, the corresponding entry will be negative.
-   *   <li>Precondition (not enforced): {@code MAX > 0}; otherwise the scale factor is undefined
+   *   <li>Precondition (not enforced): {@code max > 0}; otherwise the scale factor is undefined
    *       (division by zero). TODO: consider validating {@code maxValue > 0} at construction time.
    * </ul>
    *
@@ -102,7 +102,7 @@ public class Histogram2 {
   public int[] getPercentageArray(int localMax) {
     int[] retval = new int[bars.length];
     for (int i = 0; i < retval.length; i++) {
-      // Scale the current average from [0, MAX] into [0, localMax], then truncate to an int.
+      // Scale the current average from [0, max] into [0, localMax], then truncate to an int.
       int val = (int) (bars[i].currentValue() * localMax / max);
       retval[i] = val;
     }

--- a/src/test/java/network/crypta/support/Histogram2Test.java
+++ b/src/test/java/network/crypta/support/Histogram2Test.java
@@ -1,0 +1,150 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Tests for {@link Histogram2}.
+ *
+ * <p>Focus areas: - Bin selection across boundary values and typical inputs. - Per-bin averaging
+ * via the underlying running averages. - Scaling behavior of {@link
+ * Histogram2#getPercentageArray(int)}.
+ */
+@SuppressWarnings("java:S100") // Allow method names like method_whenCondition_expectOutcome
+class Histogram2Test {
+
+  @Test
+  @DisplayName("constructor_whenCreated_expectZeroedBars")
+  void constructor_whenCreated_expectZeroedBars() {
+    // Arrange
+    int bars = 5;
+    int max = 100;
+    Histogram2 h = new Histogram2(bars, max);
+
+    // Act
+    int[] percentages = h.getPercentageArray(100);
+
+    // Assert
+    assertEquals(bars, percentages.length, "array length = numBars");
+    assertArrayEquals(new int[bars], percentages, "all bars start at 0");
+  }
+
+  @Test
+  @DisplayName("report_whenKeyOutOfRange_expectIgnored")
+  void report_whenKeyOutOfRange_expectIgnored() {
+    // Arrange
+    Histogram2 h = new Histogram2(4, 100);
+
+    // Act: keys < 0 and >= MAX are ignored
+    h.report(-0.0001, 50);
+    h.report(100.0, 50);
+    h.report(1234.56, 50);
+
+    // Assert: still all zeros
+    assertArrayEquals(new int[] {0, 0, 0, 0}, h.getPercentageArray(100));
+  }
+
+  @ParameterizedTest(name = "key={0} -> bin={1}")
+  @CsvSource({
+    // Lower edges
+    "0.0, 0",
+    "0.1, 0",
+    "24.9999, 0",
+    // Exact cutoffs for 4 equally-sized bins across [0,100)
+    "25.0, 1",
+    "49.9999, 1",
+    "50.0, 2",
+    "74.9999, 2",
+    "75.0, 3",
+    "99.9999, 3"
+  })
+  @DisplayName("report_whenKeyWithinRange_expectCorrectBin")
+  void report_whenKeyWithinRange_expectCorrectBin(double key, int expectedBin) {
+    // Arrange
+    Histogram2 h = new Histogram2(4, 100);
+
+    // Act
+    h.report(key, 50.0);
+    int[] out = h.getPercentageArray(100);
+
+    // Assert: only expected bin is non-zero and equals value (50)
+    int[] expected = new int[] {0, 0, 0, 0};
+    expected[expectedBin] = 50; // 50 * 100 / 100 = 50
+    assertArrayEquals(expected, out);
+  }
+
+  @Test
+  @DisplayName("report_whenMultipleReportsPerBin_expectPerBinAverages")
+  void report_whenMultipleReportsPerBin_expectPerBinAverages() {
+    // Arrange
+    Histogram2 h = new Histogram2(4, 100);
+
+    // Act: populate bin 0 with values -> average should be (20 + 40) / 2 = 30
+    h.report(0.0, 20);
+    h.report(10.0, 40);
+
+    // Populate bin 2 with three values -> average = (30 + 60 + 90) / 3 = 60
+    h.report(50.0, 30);
+    h.report(60.0, 60);
+    h.report(70.0, 90);
+
+    int[] out = h.getPercentageArray(100);
+
+    // Assert: scaled by localMax=100 and MAX=100, so equals the averages
+    assertArrayEquals(new int[] {30, 0, 60, 0}, out);
+  }
+
+  @Test
+  @DisplayName("getPercentageArray_whenScaled_expectUsesLocalMax")
+  void getPercentageArray_whenScaled_expectUsesLocalMax() {
+    // Arrange
+    Histogram2 h = new Histogram2(3, 100);
+
+    // Act: put a single report with value = MAX into bin 0
+    h.report(0.0, 100.0);
+
+    // Scale to a small localMax; with average == MAX, the scaled value should equal localMax
+    int[] out = h.getPercentageArray(7);
+
+    // Assert
+    assertArrayEquals(new int[] {7, 0, 0}, out);
+  }
+
+  @Test
+  @DisplayName("getPercentageArray_whenLocalMaxIsZero_expectAllZero")
+  void getPercentageArray_whenLocalMaxIsZero_expectAllZero() {
+    // Arrange
+    Histogram2 h = new Histogram2(2, 100);
+    h.report(10.0, 100.0); // non-zero value to ensure scaling by 0 zeros it out
+
+    // Act
+    int[] out = h.getPercentageArray(0);
+
+    // Assert
+    assertArrayEquals(new int[] {0, 0}, out);
+  }
+
+  @Test
+  @DisplayName("report_whenSingleBin_expectAllKeysMapToThatBin")
+  void report_whenSingleBin_expectAllKeysMapToThatBin() {
+    // Arrange
+    Histogram2 h = new Histogram2(1, 100);
+
+    // Act
+    h.report(0.0, 10);
+    h.report(50.0, 20);
+    h.report(99.9999, 30);
+
+    // Average for the single bin = (10 + 20 + 30) / 3 = 20
+    int[] out = h.getPercentageArray(100);
+
+    // Assert
+    assertAll(() -> assertEquals(1, out.length), () -> assertEquals(20, out[0]));
+  }
+}


### PR DESCRIPTION
Summary
- Add comprehensive tests for Histogram2 (JUnit 6).
- Improve API documentation and inline comments in Histogram2.java.

Details
- Tests (Histogram2Test):
  - Validate bin selection at boundaries across [0, MAX) for 4 bins.
  - Confirm out-of-range keys (<0 or >=MAX) are ignored.
  - Verify per-bin averaging behavior using TrivialRunningAverage.
  - Ensure getPercentageArray() scaling and truncation semantics, including localMax=0.
  - Deterministic, no mocks required; isolated, AAA structure; explicit imports.
- Docs (Histogram2.java):
  - Clarify purpose: bucketed aggregator of independent running averages.
  - Document key range semantics, bin mapping formula, and scaling formula.
  - Add threading notes (delegates to synchronized TrivialRunningAverage) and big-O hints.
  - No functional code changes.

Why
- Strengthen coverage and clarity of a support utility used for tracking per-location success rates and similar metrics.
- Aid future maintenance and onboarding with explicit behavior and constraints.

Testing
- Local: `./gradlew --parallel test` passes.
- Formatting: `./gradlew --parallel spotlessApply` applied.
- SonarLint (single file): clean for the test file.

Risks
- None; tests and documentation only, no production logic changes.

Scope
- Files:
  - src/test/java/network/crypta/support/Histogram2Test.java (new)
  - src/main/java/network/crypta/support/Histogram2.java (docs only)

Checklist
- [x] Tests added/updated
- [x] Spotless formatting
- [x] No functional changes
- [x] Targets `develop`
