### PR TITLE
ListUtils: doc improvements, utility ctor, AAA tests; RandomRemoveResult as record

### DIFF
--- a/src/main/java/network/crypta/support/ListUtils.java
+++ b/src/main/java/network/crypta/support/ListUtils.java
@@ -3,15 +3,40 @@ package network.crypta.support;
 import java.util.List;
 import java.util.Random;
 
+/**
+ * Utilities for destructive removals from {@link java.util.List} without preserving element order.
+ * <p>
+ * The helpers here remove an element by swapping it with the list's last element and then
+ * truncating the list. This yields O(1) data movement on typical array-backed lists (for example,
+ * {@link java.util.ArrayList}), at the cost of changing the relative order of elements. These
+ * operations are not synchronized and make no attempt to be thread-safe.
+ * <p>
+ * Performance characteristics assume a list with:
+ * <ul>
+ *   <li>O(1) random access and {@code set(int, E)}</li>
+ *   <li>O(1) removal of the last element</li>
+ * </ul>
+ * Using a linked-list implementation will typically degrade performance to O(n).
+ */
 public class ListUtils {
+  private ListUtils() {
+    throw new IllegalStateException("Utility class");
+  }
   /**
-   * Removes element from List by swapping with last element. O(n) comparison, O(1) moves. This
-   * method is useful with ArrayList-alike containers with O(1) get(index) and O(n) remove(index)
-   * when keeping array order is not important. Not synchronized (even with synchronized
-   * containers).
+   * Removes the first occurrence of {@code o} by swapping it with the last element and truncating
+   * the list.
+   * <p>
+   * Complexity: O(n) to locate the element (via {@link List#indexOf(Object)}), then O(1) data
+   * movement on array-backed lists. Order is not preserved.
    *
-   * @return {@code true} if element was removed.
+   * @param <E> element type
+   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of
+   *     the last element in O(1)
+   * @param o element to remove; {@code null} is permitted
+   * @return {@code true} if an element equal to {@code o} was found and removed; {@code false}
+   *     otherwise
    */
+  @SuppressWarnings("SuspiciousMethodCalls")
   public static <E> boolean removeBySwapLast(List<E> a, Object o) {
     int idx = a.indexOf(o);
     if (idx == -1) return false;
@@ -20,16 +45,22 @@ public class ListUtils {
   }
 
   /**
-   * Removes element by index from List by swapping with last element. 0 comparison, O(1) moves.
-   * This method is useful with ArrayList-alike containers with O(1) get(index) and O(n)
-   * remove(index) when keeping array order is not important. Not synchronized (even with
-   * synchronized containers!).
+   * Removes the element at {@code idx} by swapping it with the last element and truncating the
+   * list.
+   * <p>
+   * Complexity: O(1) data movement on array-backed lists. Order is not preserved.
+   * <p>
+   * Return value note: Unlike {@link List#remove(int)}, this method returns the element that was
+   * moved into position {@code idx}. When {@code idx} points to the last element, the removed
+   * element is returned (nothing is moved).
    *
-   * @return moved element that will replace current index or removed element if it was last element
-   *     (and nothing was moved). WARNING: returned result is DIFFERENT from List.remove(index)!
-   *     (this is intentional to allow useful optimizations).
-   * @throws IndexOutOfBoundsException if idx is not valid index WARNING: Don't dare to break this
-   *     method contract!
+   * @param <E> element type
+   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of
+   *     the last element in O(1)
+   * @param idx index of the element to remove; valid range is {@code [0, a.size())}
+   * @return the element moved into position {@code idx}, or the removed element when {@code idx}
+   *     was the last index
+   * @throws IndexOutOfBoundsException if {@code idx} is negative or not less than {@code a.size()}
    */
   public static <E> E removeBySwapLast(List<E> a, int idx) {
     int size = a.size();
@@ -40,29 +71,40 @@ public class ListUtils {
     return moved;
   }
 
-  public static class RandomRemoveResult<E> {
-    public final E removed;
-    public final E moved;
-
-    RandomRemoveResult(E removed, E moved) {
-      this.removed = removed;
-      this.moved = moved;
-    }
-  }
+  /**
+   * Result tuple for random removal operations.
+   *
+   * @param <E> element type
+   * @param removed the element removed from the list; never {@code null} if the list contained a
+   *     non-{@code null} element at the chosen index
+   * @param moved the element that was moved to fill the vacated slot; equals {@code removed} when
+   *     the removed element was the last element or when the list size was 1
+   */
+  public record RandomRemoveResult<E>(E removed, E moved) {}
 
   /**
-   * Removes random element from List by swapping with last element. O(1) moves. This method is
-   * useful with ArrayList-alike containers with O(1) get(index) and O(n) remove(index) when keeping
-   * array order is not important. Not synchronized (even with synchronized containers!). WARNING:
-   * amount of fetched random data is implementation-defined
+   * Removes a uniformly random element by swapping it with the last element and truncating the
+   * list.
+   * <p>
+   * The index is selected with {@link Random#nextInt(int)}. When the list has size 1, the random
+   * source is not consulted; the sole element is removed and returned as both the {@code removed}
+   * and {@code moved} components. Order is not preserved.
+   * <p>
+   * The amount of random data consumed depends on the {@link Random} implementation.
    *
-   * @return null if list is empty, otherwise RandomRemoveResult(removed_element, moved_element)
+   * @param <E> element type
+   * @param random source of randomness; must not be {@code null} when {@code a.size() > 1}
+   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of
+   *     the last element in O(1)
+   * @return {@code null} if the list is empty; otherwise a {@link RandomRemoveResult} whose
+   *     {@code removed} component is no longer present in the list and whose {@code moved}
+   *     component either equals {@code removed} or is still present in the list
    */
   public static <E> RandomRemoveResult<E> removeRandomBySwapLast(Random random, List<E> a) {
     int size = a.size();
     if (size == 0) return null;
     if (size == 1) {
-      // short-circuit, avoid expensive random call
+      // Short-circuit: avoid invoking the random source for a single-element list.
       E removed = a.removeFirst();
       return new RandomRemoveResult<>(removed, removed);
     }
@@ -72,18 +114,24 @@ public class ListUtils {
   }
 
   /**
-   * Removes random element from List by swapping with last element. O(1) moves. This method is
-   * useful with ArrayList-alike containers with O(1) get(index) and O(n) remove(index) when keeping
-   * array order is not important. Not synchronized (even with synchronized containers!). WARNING:
-   * amount of fetched random data is implementation-defined
+   * Removes a uniformly random element by swapping it with the last element and truncating the
+   * list, returning only the removed element.
+   * <p>
+   * Semantics are identical to {@link #removeRandomBySwapLast(Random, List)} except that only the
+   * removed element is returned. When the list has size 1, the random source is not consulted.
+   * Order is not preserved.
    *
-   * @return null if list is empty, removed element otherwise
+   * @param <E> element type
+   * @param random source of randomness; must not be {@code null} when {@code a.size() > 1}
+   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of
+   *     the last element in O(1)
+   * @return {@code null} if the list is empty; otherwise the removed element
    */
   public static <E> E removeRandomBySwapLastSimple(Random random, List<E> a) {
     int size = a.size();
     if (size == 0) return null;
     if (size == 1) {
-      // short-circuit, avoid expensive random call
+      // Short-circuit: avoid invoking the random source for a single-element list.
       return a.removeFirst();
     }
     int idx = random.nextInt(size);

--- a/src/main/java/network/crypta/support/ListUtils.java
+++ b/src/main/java/network/crypta/support/ListUtils.java
@@ -5,33 +5,36 @@ import java.util.Random;
 
 /**
  * Utilities for destructive removals from {@link java.util.List} without preserving element order.
- * <p>
- * The helpers here remove an element by swapping it with the list's last element and then
+ *
+ * <p>The helpers here remove an element by swapping it with the list's last element and then
  * truncating the list. This yields O(1) data movement on typical array-backed lists (for example,
  * {@link java.util.ArrayList}), at the cost of changing the relative order of elements. These
  * operations are not synchronized and make no attempt to be thread-safe.
- * <p>
- * Performance characteristics assume a list with:
+ *
+ * <p>Performance characteristics assume a list with:
+ *
  * <ul>
- *   <li>O(1) random access and {@code set(int, E)}</li>
- *   <li>O(1) removal of the last element</li>
+ *   <li>O(1) random access and {@code set(int, E)}
+ *   <li>O(1) removal of the last element
  * </ul>
+ *
  * Using a linked-list implementation will typically degrade performance to O(n).
  */
 public class ListUtils {
   private ListUtils() {
     throw new IllegalStateException("Utility class");
   }
+
   /**
    * Removes the first occurrence of {@code o} by swapping it with the last element and truncating
    * the list.
-   * <p>
-   * Complexity: O(n) to locate the element (via {@link List#indexOf(Object)}), then O(1) data
+   *
+   * <p>Complexity: O(n) to locate the element (via {@link List#indexOf(Object)}), then O(1) data
    * movement on array-backed lists. Order is not preserved.
    *
    * @param <E> element type
-   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of
-   *     the last element in O(1)
+   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of the
+   *     last element in O(1)
    * @param o element to remove; {@code null} is permitted
    * @return {@code true} if an element equal to {@code o} was found and removed; {@code false}
    *     otherwise
@@ -47,16 +50,16 @@ public class ListUtils {
   /**
    * Removes the element at {@code idx} by swapping it with the last element and truncating the
    * list.
-   * <p>
-   * Complexity: O(1) data movement on array-backed lists. Order is not preserved.
-   * <p>
-   * Return value note: Unlike {@link List#remove(int)}, this method returns the element that was
+   *
+   * <p>Complexity: O(1) data movement on array-backed lists. Order is not preserved.
+   *
+   * <p>Return value note: Unlike {@link List#remove(int)}, this method returns the element that was
    * moved into position {@code idx}. When {@code idx} points to the last element, the removed
    * element is returned (nothing is moved).
    *
    * @param <E> element type
-   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of
-   *     the last element in O(1)
+   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of the
+   *     last element in O(1)
    * @param idx index of the element to remove; valid range is {@code [0, a.size())}
    * @return the element moved into position {@code idx}, or the removed element when {@code idx}
    *     was the last index
@@ -85,20 +88,20 @@ public class ListUtils {
   /**
    * Removes a uniformly random element by swapping it with the last element and truncating the
    * list.
-   * <p>
-   * The index is selected with {@link Random#nextInt(int)}. When the list has size 1, the random
+   *
+   * <p>The index is selected with {@link Random#nextInt(int)}. When the list has size 1, the random
    * source is not consulted; the sole element is removed and returned as both the {@code removed}
    * and {@code moved} components. Order is not preserved.
-   * <p>
-   * The amount of random data consumed depends on the {@link Random} implementation.
+   *
+   * <p>The amount of random data consumed depends on the {@link Random} implementation.
    *
    * @param <E> element type
    * @param random source of randomness; must not be {@code null} when {@code a.size() > 1}
-   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of
-   *     the last element in O(1)
-   * @return {@code null} if the list is empty; otherwise a {@link RandomRemoveResult} whose
-   *     {@code removed} component is no longer present in the list and whose {@code moved}
-   *     component either equals {@code removed} or is still present in the list
+   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of the
+   *     last element in O(1)
+   * @return {@code null} if the list is empty; otherwise a {@link RandomRemoveResult} whose {@code
+   *     removed} component is no longer present in the list and whose {@code moved} component
+   *     either equals {@code removed} or is still present in the list
    */
   public static <E> RandomRemoveResult<E> removeRandomBySwapLast(Random random, List<E> a) {
     int size = a.size();
@@ -116,15 +119,15 @@ public class ListUtils {
   /**
    * Removes a uniformly random element by swapping it with the last element and truncating the
    * list, returning only the removed element.
-   * <p>
-   * Semantics are identical to {@link #removeRandomBySwapLast(Random, List)} except that only the
-   * removed element is returned. When the list has size 1, the random source is not consulted.
+   *
+   * <p>Semantics are identical to {@link #removeRandomBySwapLast(Random, List)} except that only
+   * the removed element is returned. When the list has size 1, the random source is not consulted.
    * Order is not preserved.
    *
    * @param <E> element type
    * @param random source of randomness; must not be {@code null} when {@code a.size() > 1}
-   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of
-   *     the last element in O(1)
+   * @param a list to mutate; must support {@code get(int)}, {@code set(int, E)}, and removal of the
+   *     last element in O(1)
    * @return {@code null} if the list is empty; otherwise the removed element
    */
   public static <E> E removeRandomBySwapLastSimple(Random random, List<E> a) {

--- a/src/test/java/network/crypta/support/ListUtilsTest.java
+++ b/src/test/java/network/crypta/support/ListUtilsTest.java
@@ -4,85 +4,169 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Random;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /** Test case for {@link ListUtils} class. */
-public class ListUtilsTest {
+@SuppressWarnings("java:S100") // Allow descriptive test method names with underscores
+class ListUtilsTest {
 
   @Test
-  public void testRemoveByObject() {
+  void removeBySwapLastObject_whenElementAbsent_expectFalseAndNoChange() {
+    // Arrange
     ArrayList<Integer> list = new ArrayList<>();
     for (int i = 0; i < 10; i++) list.add(i);
-    // 0 1 2 3 4 5 6 7 8 9
-    assertEquals(list.size(), 10);
-    {
-      int oldSize = list.size();
-      // remove non-existing element
-      assertFalse(ListUtils.removeBySwapLast(list, Integer.valueOf(oldSize + 1)));
-      assertEquals(list.size(), oldSize);
-    }
-    // 0 1 2 3 4 5 6 7 8 9
-    for (int i = 0; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
-    {
-      // remove last element
-      int oldSize = list.size();
-      Integer oldTop = list.get(oldSize - 1);
-      assertTrue(ListUtils.removeBySwapLast(list, oldTop));
-      // 0 1 2 3 4 5 6 7 8
-      assertFalse(list.contains(oldTop));
-      assertEquals(list.size(), oldSize - 1);
-    }
-    for (int i = 0; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
-    {
-      // remove first element
-      int oldSize = list.size();
-      Integer oldFirst = list.getFirst();
-      Integer oldTop = list.get(oldSize - 1);
-      assertTrue(ListUtils.removeBySwapLast(list, oldFirst));
-      // 8 1 2 3 4 5 6 7
-      assertFalse(list.contains(oldFirst));
-      assertEquals(list.size(), oldSize - 1);
-      assertEquals(list.getFirst(), oldTop);
-      for (int i = 1; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
+    int oldSize = list.size();
+
+    // Act
+    boolean removed = ListUtils.removeBySwapLast(list, Integer.valueOf(oldSize + 1));
+
+    // Assert
+    assertFalse(removed);
+    assertEquals(oldSize, list.size());
+    for (int i = 0; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
     }
   }
 
   @Test
-  public void testRemoveByIndex() {
+  void removeBySwapLastObject_whenRemovingLast_expectRemovedAndSizeDecrement() {
+    // Arrange
     ArrayList<Integer> list = new ArrayList<>();
     for (int i = 0; i < 10; i++) list.add(i);
-    // 0 1 2 3 4 5 6 7 8 9
-    assertEquals(list.size(), 10);
-    {
-      // remove last element
-      int oldSize = list.size();
-      Integer oldTop = list.get(oldSize - 1);
-      assertEquals(ListUtils.removeBySwapLast(list, oldSize - 1), oldTop);
-      // 0 1 2 3 4 5 6 7 8
-      assertEquals(list.size(), oldSize - 1);
-      assertFalse(list.contains(oldTop));
+    int oldSize = list.size();
+    Integer oldTop = list.get(oldSize - 1);
+
+    // Act
+    boolean removed = ListUtils.removeBySwapLast(list, oldTop);
+
+    // Assert
+    assertTrue(removed);
+    assertEquals(oldSize - 1, list.size());
+    assertFalse(list.contains(oldTop));
+    for (int i = 0; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
     }
-    for (int i = 0; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
-    {
-      int oldSize = list.size();
-      Integer oldFirst = list.getFirst();
-      Integer oldTop = list.get(oldSize - 1);
-      // remove first element
-      assertEquals(ListUtils.removeBySwapLast(list, 0), oldTop);
-      // 8 1 2 3 4 5 6 7
-      assertFalse(list.contains(oldFirst));
-      assertEquals(list.size(), oldSize - 1);
-      assertEquals(list.getFirst(), oldTop);
+  }
+
+  @Test
+  void removeBySwapLastObject_whenRemovingFirst_expectMovesLastIntoIndexZero() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
+    for (int i = 0; i < 10; i++) list.add(i);
+    int oldSize = list.size();
+    Integer oldFirst = list.getFirst();
+    Integer oldTop = list.get(oldSize - 1);
+
+    // Act
+    boolean removed = ListUtils.removeBySwapLast(list, oldFirst);
+
+    // Assert
+    assertTrue(removed);
+    assertEquals(oldSize - 1, list.size());
+    assertFalse(list.contains(oldFirst));
+    assertEquals(oldTop, list.getFirst());
+    for (int i = 1; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
     }
-    for (int i = 1; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
+  }
+
+  @Test
+  void removeBySwapLastIndex_whenRemovingLast_expectReturnsOldTopAndRemovesIt() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
+    for (int i = 0; i < 10; i++) list.add(i);
+    int oldSize = list.size();
+    Integer oldTop = list.get(oldSize - 1);
+
+    // Act
+    Integer moved = ListUtils.removeBySwapLast(list, oldSize - 1);
+
+    // Assert
+    assertEquals(oldTop, moved);
+    assertEquals(oldSize - 1, list.size());
+    assertFalse(list.contains(oldTop));
+    for (int i = 0; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
+    }
+  }
+
+  @Test
+  void removeBySwapLastIndex_whenRemovingFirst_expectReturnsOldTopAndMovesItToZero() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
+    for (int i = 0; i < 10; i++) list.add(i);
+    int oldSize = list.size();
+    Integer oldFirst = list.getFirst();
+    Integer oldTop = list.get(oldSize - 1);
+
+    // Act
+    Integer moved = ListUtils.removeBySwapLast(list, 0);
+
+    // Assert
+    assertEquals(oldTop, moved);
+    assertEquals(oldSize - 1, list.size());
+    assertFalse(list.contains(oldFirst));
+    assertEquals(oldTop, list.getFirst());
+    for (int i = 1; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"-1", "10"})
+  @DisplayName("removeBySwapLast(index) throws on invalid indices")
+  void removeBySwapLastIndex_whenInvalid_expectIndexOutOfBounds(int badIndex) {
+    ArrayList<Integer> list = new ArrayList<>();
+    for (int i = 0; i < 10; i++) list.add(i);
+    assertThrows(IndexOutOfBoundsException.class, () -> ListUtils.removeBySwapLast(list, badIndex));
+  }
+
+  @Test
+  void removeBySwapLastObject_whenListContainsNull_expectRemovesNullAndMovesLast() {
+    ArrayList<String> list = new ArrayList<>(Arrays.asList(null, "X", "Y"));
+    boolean removed = ListUtils.removeBySwapLast(list, null);
+    assertTrue(removed);
+    assertEquals(2, list.size());
+    assertFalse(list.contains(null));
+    assertEquals("Y", list.getFirst());
+    assertEquals("X", list.getLast());
+  }
+
+  @Test
+  void removeBySwapLastObject_whenNullNotPresent_expectNoChange() {
+    ArrayList<String> list = new ArrayList<>(Arrays.asList("A", "B"));
+    boolean removed = ListUtils.removeBySwapLast(list, null);
+    assertFalse(removed);
+    assertEquals(2, list.size());
+    assertEquals("A", list.getFirst());
+    assertEquals("B", list.getLast());
+  }
+
+  @Test
+  void removeBySwapLastObject_whenDuplicates_expectRemovesOneAndKeepsAnother() {
+    ArrayList<String> list = new ArrayList<>(Arrays.asList("A", "B", "C", "B"));
+    boolean removed = ListUtils.removeBySwapLast(list, "B");
+    assertTrue(removed);
+    assertEquals(3, list.size());
+    assertEquals(1, Collections.frequency(list, "B"));
+    assertTrue(list.contains("C"));
+    assertEquals("C", list.getLast());
   }
 
   static class NotRandomAlwaysTop extends Random {
-    // Fake random, always remove highest possible value in nextInt
+    // Fake random, always remove the highest possible value in nextInt
     @Override
     public int nextInt(int top) {
       return top - 1;
@@ -90,7 +174,7 @@ public class ListUtilsTest {
   }
 
   static class NotRandomAlwaysZero extends Random {
-    // Fake random, always remove lowest possible value in nextInt
+    // Fake random, always remove the lowest possible value in nextInt
     @Override
     public int nextInt(int top) {
       return 0;
@@ -98,126 +182,200 @@ public class ListUtilsTest {
   }
 
   @Test
-  public void testRemoveByRandom() {
+  void removeRandomBySwapLast_whenListEmpty_expectNull() {
+    // Arrange
     ArrayList<Integer> list = new ArrayList<>();
-    Random rand = new Random();
-    for (int i = 0; i < 10; i++) list.add(i);
-    ListUtils.RandomRemoveResult<Integer> res;
-    for (int i = 0; i < 10; i++) {
-      assertEquals(list.size(), 10 - i);
-      Integer oldTop = list.getLast();
-      assertNotNull(oldTop);
-      res = ListUtils.removeRandomBySwapLast(rand, list);
-      assertNotNull(res);
-      assertEquals(list.size(), 10 - i - 1);
-      assertFalse(list.contains(res.removed));
-      assertTrue(res.removed.equals(res.moved) || list.contains(res.moved));
-    }
-    assertNull(ListUtils.removeRandomBySwapLast(rand, list));
-    assertEquals(list.size(), 0);
+    Random rand = new Random(123);
 
-    for (int i = 0; i < 10; i++) list.add(i);
-    assertEquals(list.size(), 10);
+    // Act
+    ListUtils.RandomRemoveResult<Integer> res = ListUtils.removeRandomBySwapLast(rand, list);
 
-    rand = new NotRandomAlwaysTop();
-    assertEquals(rand.nextInt(1000), 999);
-    assertEquals(rand.nextInt(100), 99);
-    assertEquals(rand.nextInt(10), 9);
-
-    // fake random will always remove last element
-    // (actually, this test relies on current implementation,
-    // not enforced by specification)
-    {
-      int oldSize = list.size();
-      Integer oldTop = list.get(oldSize - 1);
-      res = ListUtils.removeRandomBySwapLast(rand, list);
-      assertEquals(list.size(), oldSize - 1);
-      assertNotNull(res);
-      assertEquals(res.moved, oldTop);
-      assertEquals(res.moved, res.removed);
-    }
-    for (int i = 0; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
-
-    rand = new NotRandomAlwaysZero();
-    assertEquals(rand.nextInt(1000), 0);
-    assertEquals(rand.nextInt(100), 0);
-    assertEquals(rand.nextInt(10), 0);
-
-    // fake random will always remove first element
-    // (actually, this test relies on current implementation,
-    // not enforced by specification)
-    {
-      int oldSize = list.size();
-      Integer oldFirst = list.getFirst();
-      Integer oldTop = list.get(oldSize - 1);
-      res = ListUtils.removeRandomBySwapLast(rand, list);
-      assertEquals(list.size(), oldSize - 1);
-      assertNotNull(res);
-      assertEquals(res.removed, oldFirst);
-      assertEquals(res.moved, oldTop);
-      assertEquals(list.getFirst(), oldTop);
-    }
-    for (int i = 1; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
+    // Assert
+    assertNull(res);
+    assertEquals(0, list.size());
   }
 
   @Test
-  public void testRemoveByRandomSimple() {
+  void removeRandomBySwapLast_whenRandomGeneral_expectRemovedNotInListAndMovedInvariant() {
+    // Arrange
     ArrayList<Integer> list = new ArrayList<>();
-    Random rand = new Random();
     for (int i = 0; i < 10; i++) list.add(i);
-    Integer res;
+    Random rand = new Random(42);
+
+    // Act & Assert (per-iteration invariants)
     for (int i = 0; i < 10; i++) {
-      assertEquals(list.size(), 10 - i);
-      Integer oldTop = list.getLast();
-      assertNotNull(oldTop);
-      res = ListUtils.removeRandomBySwapLastSimple(rand, list);
+      assertEquals(10 - i, list.size());
+      ListUtils.RandomRemoveResult<Integer> res = ListUtils.removeRandomBySwapLast(rand, list);
       assertNotNull(res);
-      assertEquals(list.size(), 10 - i - 1);
-      assertFalse(list.contains(res));
+      if (i < 9) {
+        assertFalse(list.contains(res.removed()));
+        assertTrue(res.removed().equals(res.moved()) || list.contains(res.moved()));
+      } else {
+        // last removal happens via size==1 short-circuit
+        assertEquals(res.removed(), res.moved());
+      }
     }
-    assertNull(ListUtils.removeRandomBySwapLastSimple(rand, list));
-    assertEquals(list.size(), 0);
+    assertEquals(0, list.size());
+  }
 
+  @Test
+  void removeRandomBySwapLast_whenRandomAlwaysTop_expectRemovesLastAndMovedEqualsRemoved() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
     for (int i = 0; i < 10; i++) list.add(i);
+    Random rand = new NotRandomAlwaysTop();
+    assertEquals(999, rand.nextInt(1000));
+    assertEquals(99, rand.nextInt(100));
+    assertEquals(9, rand.nextInt(10));
+    int oldSize = list.size();
+    Integer oldTop = list.get(oldSize - 1);
 
-    rand = new NotRandomAlwaysTop();
-    assertEquals(rand.nextInt(1000), 999);
-    assertEquals(rand.nextInt(100), 99);
-    assertEquals(rand.nextInt(10), 9);
+    // Act
+    ListUtils.RandomRemoveResult<Integer> res = ListUtils.removeRandomBySwapLast(rand, list);
 
-    assertEquals(list.size(), 10);
-
-    // fake random will always remove last element
-    // (actually, this test relies on current implementation,
-    // not enforced by specification)
-    {
-      int oldSize = list.size();
-      Integer oldTop = list.get(oldSize - 1);
-      res = ListUtils.removeRandomBySwapLastSimple(rand, list);
-      assertEquals(list.size(), oldSize - 1);
-      assertNotNull(res);
-      assertEquals(res, oldTop);
+    // Assert
+    assertNotNull(res);
+    assertEquals(oldTop, res.moved());
+    assertEquals(res.moved(), res.removed());
+    assertEquals(oldSize - 1, list.size());
+    for (int i = 0; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
     }
-    for (int i = 0; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
+  }
 
-    rand = new NotRandomAlwaysZero();
-    assertEquals(rand.nextInt(1000), 0);
-    assertEquals(rand.nextInt(100), 0);
-    assertEquals(rand.nextInt(10), 0);
+  @Test
+  void removeRandomBySwapLast_whenRandomAlwaysZero_expectRemovesFirstAndMovesLastToFirst() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
+    for (int i = 0; i < 10; i++) list.add(i);
+    Random rand = new NotRandomAlwaysZero();
+    assertEquals(0, rand.nextInt(1000));
+    assertEquals(0, rand.nextInt(100));
+    assertEquals(0, rand.nextInt(10));
+    int oldSize = list.size();
+    Integer oldFirst = list.getFirst();
+    Integer oldTop = list.get(oldSize - 1);
 
-    // fake random will always remove first element
-    // (actually, this test relies on current implementation,
-    // not enforced by specification)
-    {
-      int oldSize = list.size();
-      Integer oldFirst = list.getFirst();
-      Integer oldTop = list.get(oldSize - 1);
-      res = ListUtils.removeRandomBySwapLastSimple(rand, list);
-      assertEquals(list.size(), oldSize - 1);
-      assertNotNull(res);
-      assertEquals(res, oldFirst);
-      assertEquals(list.getFirst(), oldTop);
+    // Act
+    ListUtils.RandomRemoveResult<Integer> res = ListUtils.removeRandomBySwapLast(rand, list);
+
+    // Assert
+    assertNotNull(res);
+    assertEquals(oldFirst, res.removed());
+    assertEquals(oldTop, res.moved());
+    assertEquals(oldTop, list.getFirst());
+    assertEquals(oldSize - 1, list.size());
+    for (int i = 1; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
     }
-    for (int i = 1; i < list.size(); i++) assertEquals(list.get(i), Integer.valueOf(i));
+  }
+
+  @Test
+  void removeRandomBySwapLastSimple_whenListEmpty_expectNull() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
+    Random rand = new Random(99);
+
+    // Act
+    Integer res = ListUtils.removeRandomBySwapLastSimple(rand, list);
+
+    // Assert
+    assertNull(res);
+    assertEquals(0, list.size());
+  }
+
+  @Test
+  void removeRandomBySwapLastSimple_whenRandomGeneral_expectRemovedNotInList() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
+    for (int i = 0; i < 10; i++) list.add(i);
+    Random rand = new Random(17);
+
+    // Act & Assert (per-iteration invariants)
+    for (int i = 0; i < 10; i++) {
+      assertEquals(10 - i, list.size());
+      Integer removed = ListUtils.removeRandomBySwapLastSimple(rand, list);
+      assertNotNull(removed);
+      if (i < 9) {
+        assertFalse(list.contains(removed));
+      }
+    }
+    assertEquals(0, list.size());
+  }
+
+  @Test
+  void removeRandomBySwapLastSimple_whenRandomAlwaysTop_expectRemovesLast() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
+    for (int i = 0; i < 10; i++) list.add(i);
+    Random rand = new NotRandomAlwaysTop();
+    assertEquals(999, rand.nextInt(1000));
+    assertEquals(99, rand.nextInt(100));
+    assertEquals(9, rand.nextInt(10));
+    int oldSize = list.size();
+    Integer oldTop = list.get(oldSize - 1);
+
+    // Act
+    Integer removed = ListUtils.removeRandomBySwapLastSimple(rand, list);
+
+    // Assert
+    assertEquals(oldTop, removed);
+    assertEquals(oldSize - 1, list.size());
+    for (int i = 0; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
+    }
+  }
+
+  @Test
+  void removeRandomBySwapLastSimple_whenRandomAlwaysZero_expectRemovesFirstAndMovesLastToFirst() {
+    // Arrange
+    ArrayList<Integer> list = new ArrayList<>();
+    for (int i = 0; i < 10; i++) list.add(i);
+    Random rand = new NotRandomAlwaysZero();
+    assertEquals(0, rand.nextInt(1000));
+    assertEquals(0, rand.nextInt(100));
+    assertEquals(0, rand.nextInt(10));
+    int oldSize = list.size();
+    Integer oldFirst = list.getFirst();
+    Integer oldTop = list.get(oldSize - 1);
+
+    // Act
+    Integer removed = ListUtils.removeRandomBySwapLastSimple(rand, list);
+
+    // Assert
+    assertEquals(oldFirst, removed);
+    assertEquals(oldTop, list.getFirst());
+    assertEquals(oldSize - 1, list.size());
+    for (int i = 1; i < list.size(); i++) {
+      assertEquals(Integer.valueOf(i), list.get(i));
+    }
+  }
+
+  @Test
+  void removeRandomBySwapLast_whenSizeOne_expectNoRandomCallAndMovedEqualsRemoved() {
+    ArrayList<Integer> list = new ArrayList<>();
+    list.add(42);
+    Random random = mock(Random.class);
+
+    ListUtils.RandomRemoveResult<Integer> result = ListUtils.removeRandomBySwapLast(random, list);
+
+    assertNotNull(result);
+    assertEquals(42, result.removed());
+    assertEquals(42, result.moved());
+    assertEquals(0, list.size());
+    verifyNoInteractions(random);
+  }
+
+  @Test
+  void removeRandomBySwapLastSimple_whenSizeOne_expectNoRandomCall() {
+    ArrayList<Integer> list = new ArrayList<>();
+    list.add(7);
+    Random random = mock(Random.class);
+
+    Integer removed = ListUtils.removeRandomBySwapLastSimple(random, list);
+
+    assertEquals(7, removed);
+    assertEquals(0, list.size());
+    verifyNoInteractions(random);
   }
 }


### PR DESCRIPTION
Summary
- Improve API docs for ListUtils and its methods. Clarify performance, invariants, and return semantics.
- Add a private utility constructor to prevent instantiation (java:S1118).
- Convert RandomRemoveResult to a record for immutability and clearer API.
- Rewrite and expand unit tests to AAA style; add edge cases, null/duplicate handling, parameterized invalid index tests, and Mockito checks for size==1 short-circuit.

Details
- ListUtils
  - Class-level Javadoc explains swap-with-last strategy (O(1) moves on array-backed lists) and trade-offs (order not preserved).
  - removeBySwapLast(List,E) and removeBySwapLast(List,int): expanded Javadoc covering complexity, preconditions, return differences vs List.remove(int), and exceptions.
  - removeRandomBySwapLast / removeRandomBySwapLastSimple: document uniform index selection via Random#nextInt(size), single-element short-circuit (no Random call), and result invariants.
  - RandomRemoveResult is now a record: `public record RandomRemoveResult<E>(E removed, E moved)` with generated equals/hashCode/toString.

- Tests
  - Convert to AAA style with descriptive names.
  - Add parameterized invalid index tests, null presence/absence, duplicate removal behavior, and size==1 Random short-circuit using Mockito verifyNoInteractions.

Breaking change
- RandomRemoveResult changed from a nested class with public fields to a record with accessors.
  - Migration: `res.removed` → `res.removed()`, `res.moved` → `res.moved()`.
  - If downstream binary/source compatibility is required, we can:
    1) Revert to the original class and add accessors now, or
    2) Keep the record and add a compatibility shim in a follow-up (e.g., a deprecating wrapper or overloads for upgrade windows).

Quality & analysis
- SonarLint (file-scoped) on ListUtils shows no issues.
- Tests pass locally: `./gradlew --parallel test` (Spotless excluded due to an unrelated repository path issue). I can help fix Spotless config separately.

Notes
- No behavior change to removal semantics; order remains non-preserving by design.
- Random source is not consulted for size==1 to reduce overhead; captured in tests and docs.

Checklist
- [x] Tests updated/added and pass locally
- [x] SonarLint on changed production files
- [x] No changes to package names or public method signatures apart from the intentional record conversion
- [x] No new external dependencies