### PR TITLE
test(io): harden disk-space tests and extract factory helper

### DIFF
--- a/src/test/java/network/crypta/support/io/TempBucketFactoryTempBucketTest.java
+++ b/src/test/java/network/crypta/support/io/TempBucketFactoryTempBucketTest.java
@@ -311,8 +311,11 @@ class TempBucketFactoryTempBucketTest {
     @DisplayName("makeBucket_whenMinDiskSpaceExceededOnCreate_throwsInsufficientDiskSpace")
     void makeBucket_whenMinDiskSpaceExceededOnCreate_throwsInsufficientDiskSpace() {
       // Arrange
-      long usable = fg.getDir().getUsableSpace();
-      long minDisk = usable + 8192 + 1; // force failure on pre-check
+      long initialUsable = fg.getDir().getUsableSpace();
+      long guard = 64L * 1024 * 1024; // 64 MiB safety margin against CI free-space fluctuations
+      long currentUsable = fg.getDir().getUsableSpace();
+      long baseUsable = Math.max(initialUsable, currentUsable);
+      long minDisk = baseUsable + guard + 8192; // force failure on pre-check robustly
       TempBucketFactory tbf =
           new TempBucketFactory(
               exec, fg, /*maxRamBucket*/ 1, /*maxRamUsed*/ 1, false, minDisk, SECRET);
@@ -331,8 +334,11 @@ class TempBucketFactoryTempBucketTest {
     @DisplayName("write_whenDiskBucketAndBelowUsableSpace_throwsInsufficientDiskSpace")
     void write_whenDiskBucketAndBelowUsableSpace_throwsInsufficientDiskSpace() throws IOException {
       // Arrange
-      long usable = fg.getDir().getUsableSpace();
-      long minDisk = usable + 4096 + 1; // fail the per-write disk check on first 4K flush
+      long initialUsable = fg.getDir().getUsableSpace();
+      long guard = 64L * 1024 * 1024; // 64 MiB safety margin against CI free-space fluctuations
+      long currentUsable = fg.getDir().getUsableSpace();
+      long baseUsable = Math.max(initialUsable, currentUsable);
+      long minDisk = baseUsable + guard + 4096; // fail per-write check on first 4K flush robustly
       TempBucketFactory tbf =
           new TempBucketFactory(
               exec, fg, /*maxRamBucket*/ 0, /*maxRamUsed*/ 0, false, minDisk, SECRET);

--- a/src/test/java/network/crypta/support/io/TempBucketFactoryTempBucketTest.java
+++ b/src/test/java/network/crypta/support/io/TempBucketFactoryTempBucketTest.java
@@ -307,6 +307,17 @@ class TempBucketFactoryTempBucketTest {
   @Nested
   @SuppressWarnings("java:S100")
   class DiskSpaceChecks {
+    /**
+     * Helper to create a TempBucketFactory with a specific minimum free-disk threshold.
+     *
+     * <p>Parameters {@code maxRamBucket} and {@code maxRamUsed} are used to steer selection toward
+     * a disk-backed bucket when needed for these disk-space tests.
+     */
+    private TempBucketFactory newFactoryWithMinDisk(
+        long minDisk, long maxRamBucket, long maxRamUsed) {
+      return new TempBucketFactory(exec, fg, maxRamBucket, maxRamUsed, false, minDisk, SECRET);
+    }
+
     @Test
     @DisplayName("makeBucket_whenMinDiskSpaceExceededOnCreate_throwsInsufficientDiskSpace")
     void makeBucket_whenMinDiskSpaceExceededOnCreate_throwsInsufficientDiskSpace() {
@@ -316,9 +327,7 @@ class TempBucketFactoryTempBucketTest {
       long currentUsable = fg.getDir().getUsableSpace();
       long baseUsable = Math.max(initialUsable, currentUsable);
       long minDisk = baseUsable + guard + 8192; // force failure on pre-check robustly
-      TempBucketFactory tbf =
-          new TempBucketFactory(
-              exec, fg, /*maxRamBucket*/ 1, /*maxRamUsed*/ 1, false, minDisk, SECRET);
+      TempBucketFactory tbf = newFactoryWithMinDisk(minDisk, /*maxRamBucket*/ 1, /*maxRamUsed*/ 1);
 
       // Act + Assert (ensure resource would be closed if unexpectedly created)
       assertThrows(
@@ -339,9 +348,7 @@ class TempBucketFactoryTempBucketTest {
       long currentUsable = fg.getDir().getUsableSpace();
       long baseUsable = Math.max(initialUsable, currentUsable);
       long minDisk = baseUsable + guard + 4096; // fail per-write check on first 4K flush robustly
-      TempBucketFactory tbf =
-          new TempBucketFactory(
-              exec, fg, /*maxRamBucket*/ 0, /*maxRamUsed*/ 0, false, minDisk, SECRET);
+      TempBucketFactory tbf = newFactoryWithMinDisk(minDisk, /*maxRamBucket*/ 0, /*maxRamUsed*/ 0);
 
       try (RandomAccessBucket bucket = tbf.makeBucket(-1);
           OutputStream os = bucket.getOutputStreamUnbuffered()) {


### PR DESCRIPTION
Summary
- Harden disk-space checks in TempBucketFactoryTempBucketTest against CI free-space fluctuations by adding a 64 MiB guard to minDisk calculations.
- Extract factory construction into a small helper inside DiskSpaceChecks to clarify intent and satisfy extraction heuristics (single output, ≤3 inputs, no non-local control flow).

Details
- makeBucket_whenMinDiskSpaceExceededOnCreate_throwsInsufficientDiskSpace:
  - Use baseUsable = max(initialUsable, currentUsable) + 64 MiB + 8192 to force preflight failure deterministically.
- write_whenDiskBucketAndBelowUsableSpace_throwsInsufficientDiskSpace:
  - Use baseUsable + 64 MiB + 4096 to fail the per-write check robustly.
- Add newFactoryWithMinDisk(minDisk, maxRamBucket, maxRamUsed) helper to de-duplicate TempBucketFactory setup.

Motivation
- CI runners can reclaim space or report usable space with coarse granularity between consecutive calls, causing sporadic false negatives when the margin is only +1 byte.
- The guard preserves the original test intent (force InsufficientDiskSpaceException) while keeping tests deterministic.

Validation
- Targeted test run: ./gradlew --parallel test --tests *TempBucketFactoryTempBucketTest → PASS

Scope
- Test-only changes. No production code modified.

Please review and merge. After this, the previously observed CI failure should be eliminated.