### PR TITLE
refactor(support): harden Loader and add documentation + tests

### DIFF
--- a/src/main/java/network/crypta/support/Loader.java
+++ b/src/main/java/network/crypta/support/Loader.java
@@ -2,36 +2,68 @@ package network.crypta.support;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
+ * Reflection utilities for loading classes and instantiating objects.
+ *
+ * <p>This utility caches {@link Class} lookups by fully qualified name and provides convenience
+ * methods to create new instances using public constructors selected by parameter types. It does
+ * not implement or delegate to a custom {@code ClassLoader}; it relies on the standard {@link
+ * Class#forName(String)} semantics provided by the platform.
+ *
+ * <p>Thread-safety: {@link #load(String)} maintains an internal concurrent cache and is safe for
+ * concurrent use. Cached entries are not evicted for the lifetime of the JVM.
+ *
  * @author <a href=mailto:blanu@uts.cc.utexas.edu>Brandon Wiley</a>
  * @author oskar (I made this a generic loader, not just for messages).
  */
 public class Loader {
 
-  private static final Hashtable<String, Class<?>> classes = new Hashtable<>();
+  private static final Map<String, Class<?>> classes = new ConcurrentHashMap<>();
 
-  //  static final public String prefix="freenet.message.";
-
-  /**
-   * This is a caching Class loader.
-   *
-   * @param name The name of the class to load.
-   */
-  public static Class<?> load(String name) throws ClassNotFoundException {
-    Class<?> c = classes.get(name);
-    if (c == null) {
-      c = Class.forName(name);
-      classes.put(name, c);
-    }
-    return c;
+  private Loader() {
+    // Prevent instantiation of a utility class.
   }
 
   /**
-   * Creates a new object of given classname.
+   * Loads a class by fully qualified name with caching.
    *
-   * @param classname Name of class to instantiate.
+   * <p>On the first call for a given name this method delegates to {@link Class#forName(String)}
+   * and stores the resulting {@link Class} in an internal concurrent cache. Subsequent calls with
+   * the same name return the cached instance, avoiding the overhead of repeated lookups.
+   *
+   * <p>This method is thread-safe. Entries are kept for the duration of the process.
+   *
+   * @param name fully qualified binary name of the desired class; must not be {@code null}
+   * @return the resolved {@link Class}
+   * @throws ClassNotFoundException if the class cannot be located
+   * @throws NullPointerException if {@code name} is {@code null}
+   */
+  public static Class<?> load(String name) throws ClassNotFoundException {
+    try {
+      return classes.computeIfAbsent(name, Loader::loadClassUnchecked);
+    } catch (UncheckedClassNotFoundException e) {
+      throw (ClassNotFoundException) e.getCause();
+    }
+  }
+
+  /**
+   * Creates an instance of the named class using its public no-argument constructor.
+   *
+   * <p>The target class is resolved via {@link #load(String)} and then instantiated with its public
+   * no-arg constructor. The class must expose such a constructor.
+   *
+   * @param classname fully qualified name of the class to instantiate; must not be {@code null}
+   * @return a new instance of the requested class
+   * @throws ClassNotFoundException if the class cannot be located
+   * @throws NoSuchMethodException if no public no-arg constructor exists
+   * @throws InstantiationException if the class represents an abstract class or cannot be
+   *     instantiated
+   * @throws IllegalAccessException if the no-arg constructor is not accessible
+   * @throws InvocationTargetException if the constructor itself throws an exception
+   * @throws NullPointerException if {@code classname} is {@code null}
    */
   public static Object getInstance(String classname)
       throws InvocationTargetException,
@@ -43,11 +75,25 @@ public class Loader {
   }
 
   /**
-   * Creates a new object of given classname.
+   * Creates an instance of the named class using a matching public constructor.
    *
-   * @param classname Name of class to instantiate.
-   * @param argtypes The classes of the arguments.
-   * @param args The arguments. Since this uses the reflect methods it's ok to wrap primitives.
+   * <p>The class is resolved via {@link #load(String)} and instantiated by locating a public
+   * constructor whose parameter types exactly match {@code argtypes}. Note that constructor
+   * selection is exact; primitive types (for example, {@code int.class}) do not match their boxed
+   * counterparts (for example, {@link Integer}).
+   *
+   * @param classname fully qualified name of the class to instantiate; must not be {@code null}
+   * @param argtypes parameter types for constructor selection; must not be {@code null}
+   * @param args constructor arguments; the array length must match {@code argtypes}
+   * @return a new instance created by the selected constructor
+   * @throws ClassNotFoundException if the class cannot be located
+   * @throws NoSuchMethodException if no public constructor with the exact signature exists
+   * @throws InstantiationException if the class represents an abstract class or cannot be
+   *     instantiated
+   * @throws IllegalAccessException if the constructor is not accessible
+   * @throws InvocationTargetException if the constructor itself throws an exception
+   * @throws NullPointerException if {@code classname}, {@code argtypes}, or {@code args} is {@code
+   *     null}
    */
   public static Object getInstance(String classname, Class<?>[] argtypes, Object[] args)
       throws InvocationTargetException,
@@ -59,11 +105,20 @@ public class Loader {
   }
 
   /**
-   * Creats a new object of a given class.
+   * Creates an instance of the given class using a matching public constructor.
    *
-   * @param c The class to instantiate.
-   * @param argtypes The classes of the arguments.
-   * @param args The arguments. Since this uses the reflect methods it's ok to wrap primitives.
+   * <p>Constructor selection is exact. Primitive parameter types must be declared explicitly in
+   * {@code argtypes}; autoboxing does not apply when locating the constructor via reflection.
+   *
+   * @param c class to instantiate; must not be {@code null}
+   * @param argtypes parameter types for constructor selection; must not be {@code null}
+   * @param args constructor arguments; the array length must match {@code argtypes}
+   * @return a new instance created by the selected constructor
+   * @throws NoSuchMethodException if no public constructor with the exact signature exists
+   * @throws InstantiationException if {@code c} is abstract or cannot be instantiated
+   * @throws IllegalAccessException if the constructor is not accessible
+   * @throws InvocationTargetException if the constructor itself throws an exception
+   * @throws NullPointerException if any argument is {@code null}
    */
   public static Object getInstance(Class<?> c, Class<?>[] argtypes, Object[] args)
       throws InvocationTargetException,
@@ -72,5 +127,24 @@ public class Loader {
           IllegalAccessException {
     Constructor<?> con = c.getConstructor(argtypes);
     return con.newInstance(args);
+  }
+
+  // Bridge {@link ClassNotFoundException} through {@code computeIfAbsent}, which requires a
+  // function that does not declare checked exceptions. The caller unwraps and rethrows it to
+  // preserve the public API.
+  private static Class<?> loadClassUnchecked(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new UncheckedClassNotFoundException(e);
+    }
+  }
+
+  // Internal runtime wrapper used solely to transport a checked exception through lambdas that do
+  // not permit checked throws.
+  private static final class UncheckedClassNotFoundException extends RuntimeException {
+    UncheckedClassNotFoundException(ClassNotFoundException cause) {
+      super(cause);
+    }
   }
 }

--- a/src/main/java/network/crypta/support/PooledExecutor.java
+++ b/src/main/java/network/crypta/support/PooledExecutor.java
@@ -61,9 +61,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
     this.ticker = ticker;
   }
 
-  /**
-   * Construct a new executor with empty per‑priority pools and counters.
-   */
+  /** Construct a new executor with empty per‑priority pools and counters. */
   public PooledExecutor() {
     for (int i = 0; i < runningThreads.length; i++) {
       waitingThreads.add(new ArrayList<>());
@@ -126,8 +124,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
   public void execute(Runnable runnable, String jobName, boolean fromTicker) {
     final int prio = priorityOf(runnable);
 
-    if (LOG.isDebugEnabled())
-      LOG.debug("Executing {} as {} at prio {}", runnable, jobName, prio);
+    if (LOG.isDebugEnabled()) LOG.debug("Executing {} as {} at prio {}", runnable, jobName, prio);
     validatePriority(prio);
 
     final Job job = new Job(runnable, jobName);
@@ -176,8 +173,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
     if (!list.isEmpty()) {
       MyThread t = list.removeLast();
       if (t != null) waitingThreadsCount.decrementAndGet();
-      if (LOG.isDebugEnabled())
-        LOG.debug("Reusing thread {}", t);
+      if (LOG.isDebugEnabled()) LOG.debug("Reusing thread {}", t);
       return t;
     }
     return null;
@@ -215,7 +211,10 @@ public class PooledExecutor implements PriorityAwareExecutor {
   private void logNotStarting(String jobName) {
     if (LOG.isDebugEnabled())
       synchronized (this) {
-        LOG.debug("Not starting: Jobs: {} misses of {} starting urgently {}", jobMisses, jobCount,
+        LOG.debug(
+            "Not starting: Jobs: {} misses of {} starting urgently {}",
+            jobMisses,
+            jobCount,
             jobName);
       }
   }
@@ -300,9 +299,7 @@ public class PooledExecutor implements PriorityAwareExecutor {
       nextJob = firstJob;
     }
 
-    /**
-     * Execute the worker loop and decrement pool counters on exit.
-     */
+    /** Execute the worker loop and decrement pool counters on exit. */
     @Override
     public void realRun() {
       int nativePriority = getNativePriority();

--- a/src/main/java/network/crypta/support/SerialExecutor.java
+++ b/src/main/java/network/crypta/support/SerialExecutor.java
@@ -13,15 +13,15 @@ import org.slf4j.LoggerFactory;
 /**
  * Executor that guarantees tasks execute one after another on a single worker thread.
  *
- * <p>This executor queues submitted {@link Runnable} instances and processes them strictly in
- * FIFO order. It uses a real, backing {@link PriorityAwareExecutor} supplied via {@link #start} to
- * run a single long-lived "runner" task which drains the internal queue. The runner thread is not
- * created until {@link #start(PriorityAwareExecutor, String)} is called; submissions prior to that
- * point are queued and will run once started.
+ * <p>This executor queues submitted {@link Runnable} instances and processes them strictly in FIFO
+ * order. It uses a real, backing {@link PriorityAwareExecutor} supplied via {@link #start} to run a
+ * single long-lived "runner" task which drains the internal queue. The runner thread is not created
+ * until {@link #start(PriorityAwareExecutor, String)} is called; submissions prior to that point
+ * are queued and will run once started.
  *
- * <p>Priority: the runner implements {@link network.crypta.node.PrioRunnable} and reports the
- * fixed priority passed to this executor's constructor. Individual jobs do not influence the
- * runner's priority.
+ * <p>Priority: the runner implements {@link network.crypta.node.PrioRunnable} and reports the fixed
+ * priority passed to this executor's constructor. Individual jobs do not influence the runner's
+ * priority.
  *
  * <p>Queueing and capacity: jobs are stored in a {@link LinkedBlockingQueue}. When constructed with
  * a positive {@code bound}, the queue is bounded; additional submissions beyond capacity are
@@ -29,8 +29,8 @@ import org.slf4j.LoggerFactory;
  * submissions are only limited by memory.
  *
  * <p>Errors and exceptions thrown by jobs are caught and logged; processing continues with the next
- * job. The runner thread will exit when no job arrives for {@link #NEWJOB_TIMEOUT} milliseconds.
- * A new runner will be created automatically by future submissions.
+ * job. The runner thread will exit when no job arrives for {@link #NEWJOB_TIMEOUT} milliseconds. A
+ * new runner will be created automatically by future submissions.
  *
  * <p>Thread-safety: All public methods are thread-safe. Introspection methods return snapshots that
  * may become stale immediately after return and are intended for diagnostics only.
@@ -42,11 +42,13 @@ public class SerialExecutor implements PriorityAwareExecutor {
 
   /** Queue of submitted tasks. May be bounded or unbounded depending on constructor. */
   private final LinkedBlockingQueue<Runnable> jobs;
+
   private final Object syncLock;
   private final int priority;
 
   /** True when the runner is currently waiting for work (for introspection only). */
   private volatile boolean threadWaiting;
+
   /** True after a runner has been submitted to the backing executor (for introspection only). */
   private volatile boolean threadStarted;
 
@@ -130,8 +132,8 @@ public class SerialExecutor implements PriorityAwareExecutor {
   /**
    * Construct an executor with an unbounded queue.
    *
-   * @param priority runner priority reported to the backing executor; usually one of
-   *     {@link NativeThread.PriorityLevel} values
+   * @param priority runner priority reported to the backing executor; usually one of {@link
+   *     NativeThread.PriorityLevel} values
    */
   public SerialExecutor(int priority) {
     this(priority, 0);
@@ -140,8 +142,8 @@ public class SerialExecutor implements PriorityAwareExecutor {
   /**
    * Construct an executor with an optional queue capacity.
    *
-   * @param priority runner priority reported to the backing executor; usually one of
-   *     {@link NativeThread.PriorityLevel} values
+   * @param priority runner priority reported to the backing executor; usually one of {@link
+   *     NativeThread.PriorityLevel} values
    * @param bound maximum number of queued jobs; {@code <= 0} creates an unbounded queue
    */
   public SerialExecutor(int priority, int bound) {
@@ -179,8 +181,7 @@ public class SerialExecutor implements PriorityAwareExecutor {
     synchronized (syncLock) {
       threadStarted = true;
     }
-    if (LOG.isDebugEnabled())
-      LOG.debug("Starting thread... {} : {}", name, runner);
+    if (LOG.isDebugEnabled()) LOG.debug("Starting thread... {} : {}", name, runner);
     realExecutor.execute(runner, name);
   }
 
@@ -201,8 +202,8 @@ public class SerialExecutor implements PriorityAwareExecutor {
   /**
    * Submit a task with a label for diagnostics.
    *
-   * <p>The task is queued and will execute serially on the runner thread. When the queue is
-   * bounded and full, the task is dropped and a warning is logged.
+   * <p>The task is queued and will execute serially on the runner thread. When the queue is bounded
+   * and full, the task is dropped and a warning is logged.
    *
    * @param job task to execute; must be non-{@code null}
    * @param jobName descriptive label used in logs; may be {@code null} or empty
@@ -210,8 +211,8 @@ public class SerialExecutor implements PriorityAwareExecutor {
   @Override
   public void execute(Runnable job, String jobName) {
     if (LOG.isDebugEnabled())
-      LOG.debug("Running {} : {} started={} waiting={}", jobName, job, threadStarted,
-          threadWaiting);
+      LOG.debug(
+          "Running {} : {} started={} waiting={}", jobName, job, threadStarted, threadWaiting);
     boolean offered = jobs.offer(job);
     if (!offered && LOG.isWarnEnabled()) {
       LOG.warn("SerialExecutor queue is full; dropping job {} ({})", jobName, job);
@@ -238,8 +239,8 @@ public class SerialExecutor implements PriorityAwareExecutor {
    * Return a snapshot of running worker counts per priority.
    *
    * <p>For {@code SerialExecutor} the value is either {@code 0} or {@code 1} at the configured
-   * priority, depending on whether the runner is executing a job as opposed to waiting for one.
-   * The array length equals {@code NativeThread.JAVA_PRIORITY_RANGE + 1}.
+   * priority, depending on whether the runner is executing a job as opposed to waiting for one. The
+   * array length equals {@code NativeThread.JAVA_PRIORITY_RANGE + 1}.
    *
    * @return array of running counts per priority (never {@code null})
    */

--- a/src/test/java/network/crypta/support/LoaderTest.java
+++ b/src/test/java/network/crypta/support/LoaderTest.java
@@ -1,36 +1,193 @@
 package network.crypta.support;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.InvocationTargetException;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link Loader} class.
+ * Unit tests for {@link Loader}.
  *
- * @author stuart martin &lt;wavey@freenetproject.org&gt;
+ * <p>These tests exercise happy paths and error paths of class loading and reflective
+ * instantiation, including constructor selection, primitive/boxed argument handling, and exception
+ * propagation.
  */
-public class LoaderTest {
+@SuppressWarnings("java:S100") // allow method names with underscores per project test naming rules
+class LoaderTest {
+  private static final String JLS = "java.lang.String";
+
+  // -------- load(String) --------
 
   @Test
-  public void testLoader() {
-    Object o = null;
+  @DisplayName("load when called twice returns same Class instance")
+  void load_whenCalledTwice_returnsSameClassObject() throws ClassNotFoundException {
+    Class<?> first = Loader.load(JLS);
+    Class<?> second = Loader.load(JLS);
+    assertSame(first, second);
+  }
 
-    try {
-      o = Loader.getInstance("java.lang.String");
-    } catch (InvocationTargetException e) {
-      fail("unexpected exception" + e.getMessage());
-    } catch (NoSuchMethodException e) {
-      fail("unexpected exception" + e.getMessage());
-    } catch (InstantiationException e) {
-      fail("unexpected exception" + e.getMessage());
-    } catch (IllegalAccessException e) {
-      fail("unexpected exception" + e.getMessage());
-    } catch (ClassNotFoundException e) {
-      fail("unexpected exception" + e.getMessage());
+  @Test
+  @DisplayName("load with null throws NullPointerException")
+  void load_whenNameNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> Loader.load(null));
+  }
+
+  // -------- getInstance(String) (no-args) --------
+
+  @Test
+  @DisplayName("getInstance(String) for java.lang.String creates a String")
+  void getInstanceString_whenClassExistsWithNoArgCtor_returnsInstance()
+      throws InvocationTargetException,
+          NoSuchMethodException,
+          InstantiationException,
+          IllegalAccessException,
+          ClassNotFoundException {
+    Object instance = Loader.getInstance(JLS);
+    assertInstanceOf(String.class, instance);
+  }
+
+  @Test
+  @DisplayName("getInstance(String) for non-existent class throws ClassNotFoundException")
+  void getInstanceString_whenClassDoesNotExist_throwsClassNotFoundException() {
+    assertThrows(
+        ClassNotFoundException.class,
+        () -> Loader.getInstance("network.crypta.support.DoesNotExist_____"));
+  }
+
+  @Test
+  @DisplayName("getInstance(String) with no default constructor throws NoSuchMethodException")
+  void getInstanceString_whenNoNoArgCtor_throwsNoSuchMethodException() {
+    String name = "network.crypta.support.LoaderTest$NoDefaultCtor";
+    assertThrows(
+        NoSuchMethodException.class,
+        () ->
+            Loader.getInstance(
+                name // no-arg variant must fail
+                ));
+  }
+
+  @Test
+  @DisplayName("getInstance(String) when constructor throws wraps in InvocationTargetException")
+  void getInstanceString_whenCtorThrows_throwsInvocationTargetException() {
+    String name = "network.crypta.support.LoaderTest$CtorThrows";
+    InvocationTargetException ex =
+        assertThrows(InvocationTargetException.class, () -> Loader.getInstance(name));
+    assertNotNull(ex.getCause());
+    assertInstanceOf(IllegalStateException.class, ex.getCause());
+    assertEquals("boom", ex.getCause().getMessage());
+  }
+
+  // -------- getInstance(String, Class[], Object[]) --------
+
+  @Test
+  @DisplayName("getInstance(String, ...) with primitive arg types succeeds and sets fields")
+  void getInstanceStringWithArgs_whenArgsMatchPrimitives_constructsCorrectly()
+      throws InvocationTargetException,
+          NoSuchMethodException,
+          InstantiationException,
+          IllegalAccessException,
+          ClassNotFoundException {
+    String name = "network.crypta.support.LoaderTest$ArgCtor";
+    Object o =
+        Loader.getInstance(
+            name, new Class<?>[] {int.class, String.class}, new Object[] {123, "abc"});
+    ArgCtor inst = (ArgCtor) o;
+    assertEquals(123, inst.a);
+    assertEquals("abc", inst.b);
+  }
+
+  @Test
+  @DisplayName(
+      "getInstance(String, ...) with boxed types in argtypes (Integer) does not match primitive"
+          + " ctor")
+  void getInstanceStringWithArgs_whenWrapperTypesInArgtypes_throwsNoSuchMethodException() {
+    String name = "network.crypta.support.LoaderTest$ArgCtor";
+    assertThrows(
+        NoSuchMethodException.class,
+        () ->
+            Loader.getInstance(
+                name, new Class<?>[] {Integer.class, String.class}, new Object[] {123, "x"}));
+  }
+
+  // -------- getInstance(Class, Class[], Object[]) --------
+
+  @Test
+  @DisplayName("getInstance(Class, ...) for abstract class throws InstantiationException")
+  void getInstanceClassWithArgs_whenAbstract_throwsInstantiationException() {
+    assertThrows(
+        InstantiationException.class,
+        () -> Loader.getInstance(AbstractType.class, new Class<?>[] {}, new Object[] {}));
+  }
+
+  @Test
+  @DisplayName("getInstance(Class, ...) with wrong signature throws NoSuchMethodException")
+  void getInstanceClassWithArgs_whenWrongSignature_throwsNoSuchMethodException() {
+    assertThrows(
+        NoSuchMethodException.class,
+        () -> Loader.getInstance(ArgCtor.class, new Class<?>[] {String.class}, new Object[] {"x"}));
+  }
+
+  @Test
+  @DisplayName("getInstance(Class, ...) with args length mismatch throws IllegalArgumentException")
+  void getInstanceClassWithArgs_whenArgsLengthMismatch_throwsIllegalArgumentException() {
+    // Correct signature is (int, String) but we pass only one argument.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            Loader.getInstance(
+                ArgCtor.class, new Class<?>[] {int.class, String.class}, new Object[] {42}));
+  }
+
+  @Test
+  @DisplayName("getInstance(Class, ...) with wrong arg type throws IllegalArgumentException")
+  void getInstanceClassWithArgs_whenWrongArgType_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            Loader.getInstance(
+                ArgCtor.class,
+                new Class<?>[] {int.class, String.class},
+                new Object[] {"notInt", "ok"}));
+  }
+
+  // ---------- Helper classes used only by these tests ----------
+
+  /**
+   * Helper type used by reflective-name tests.
+   *
+   * <p>This class intentionally lacks a no-arg constructor so that {@code
+   * Loader.getInstance(String)} fails with {@link NoSuchMethodException} when invoked with the
+   * fully qualified name of this nested type. It is referenced by name (not by direct symbol use)
+   * to exercise the string-based code path; therefore it appears unused to static analysis but must
+   * remain in this file.
+   */
+  @SuppressWarnings("unused")
+  public record NoDefaultCtor(int x) {}
+
+  /**
+   * Helper type used by reflective-name tests.
+   *
+   * <p>Its constructor throws to validate that {@code Loader.getInstance(String)} propagates the
+   * failure as an {@link InvocationTargetException}. Like {@link NoDefaultCtor}, it is resolved by
+   * fully qualified name in tests and thus looks unused to static analysis, but it is required to
+   * cover this error path deterministically.
+   */
+  @SuppressWarnings("unused")
+  public static class CtorThrows {
+    public CtorThrows() {
+      throw new IllegalStateException("boom");
     }
+  }
 
-    assertTrue(o instanceof String);
+  public record ArgCtor(int a, String b) {}
+
+  @SuppressWarnings("java:S5993") // public ctor is intentional to reach InstantiationException path
+  public abstract static class AbstractType {
+    public AbstractType() {}
   }
 }

--- a/src/test/java/network/crypta/support/SerialExecutorTest.java
+++ b/src/test/java/network/crypta/support/SerialExecutorTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import network.crypta.support.io.NativeThread;
 import org.junit.jupiter.api.Test;
- 
+
 @SuppressWarnings("java:S100") // test method names follow method_whenCondition_expectOutcome style
 class SerialExecutorTest {
 
@@ -189,14 +189,16 @@ class SerialExecutorTest {
     CountDownLatch job2Done = new CountDownLatch(1);
     AtomicInteger ranCount = new AtomicInteger();
 
-    Runnable job1 = () -> {
-      ranCount.incrementAndGet();
-      job1Done.countDown();
-    };
-    Runnable job2 = () -> {
-      ranCount.incrementAndGet();
-      job2Done.countDown();
-    };
+    Runnable job1 =
+        () -> {
+          ranCount.incrementAndGet();
+          job1Done.countDown();
+        };
+    Runnable job2 =
+        () -> {
+          ranCount.incrementAndGet();
+          job2Done.countDown();
+        };
 
     // Fill to capacity before starting; the second offer() should be dropped silently
     exec.execute(job1, "first");


### PR DESCRIPTION
Summary
- Convert Loader to a proper utility with a private constructor and a concurrent cache.
- Replace legacy Hashtable with ConcurrentHashMap and use computeIfAbsent for class caching.
- Preserve public API and behavior (checked ClassNotFoundException contract, exact constructor matching).
- Add comprehensive Javadoc and clarify inline rationale for exception-bridging through computeIfAbsent.
- Expand LoaderTest to cover happy paths and error paths deterministically (no I/O, no randomness).
- Apply Spotless formatting (which updated a few nearby files).

Motivation
SonarLint flagged several maintainability issues in Loader.java (S1118, S1149, S125, S3824). This refactor fixes them without changing external behavior:
- Utility class: add private constructor (S1118).
- Replace Hashtable with ConcurrentHashMap (S1149) to keep thread-safety with better performance.
- Remove commented-out code (S125).
- Use computeIfAbsent for the cache (S3824). Because it does not permit checked exceptions, internally wrap ClassNotFoundException in a private runtime exception and unwrap it in load(String), preserving API semantics.

Behavioral notes
- Class loading: same Class object is returned for the same name across calls within the same ClassLoader (now cached).
- Exceptions: load(String) still throws ClassNotFoundException; getInstance methods continue to throw the same checked exceptions and wrap constructor errors in InvocationTargetException.
- Constructor selection remains exact (primitive vs boxed types don’t auto-match), as documented and tested.

Testing
- Tests pass locally: `./gradlew --parallel test`
- SonarLint (file-scoped) clean: `./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/support/Loader.java`
- Spotless applied: `./gradlew spotlessApply`

Files changed (high-level)
- src/main/java/network/crypta/support/Loader.java
  - Javadoc overhaul and inline comments.
  - Hashtable -> ConcurrentHashMap.
  - computeIfAbsent + internal wrapper to carry checked exception.
  - Private no-op constructor.
- src/test/java/network/crypta/support/LoaderTest.java
  - Added tests for: cache behavior, null input, missing no-arg ctor, ctor throws, primitive vs boxed mismatch, abstract type instantiation, wrong signatures/arg lengths/types.
  - Deterministic and isolated.
- Spotless reflowed: PooledExecutor.java, SerialExecutor.java, SerialExecutorTest.java (formatting only).

Risk & impact
- Low risk. Pure refactor with tests and SonarLint coverage. No runtime behavior changes intended beyond using a concurrent map for the cache.

Checklist
- [x] Tests pass locally
- [x] Spotless applied
- [x] SonarLint clean for Loader.java
- [x] No API changes

Please review. Happy to split the Spotless-only changes into a separate commit if desired.