### PR TITLE
support(MediaType): robust charset parsing + API cleanup (getParameters returns Map) + docs

### DIFF
--- a/src/main/java/network/crypta/support/MediaType.java
+++ b/src/main/java/network/crypta/support/MediaType.java
@@ -7,15 +7,18 @@ import java.util.Map.Entry;
 import network.crypta.client.DefaultMIMETypes;
 
 /**
- * A media type denotes the content type of a document. A media consists of a top-level type, a
- * subtype, and an optional list of key-value pairs. An example would be “audio/ogg” or “text/html;
- * charset=utf-8.”
+ * Represents a media (MIME) type.
  *
- * <p>{@link MediaType}s are immutable. The setter methods (e.g. {@link #setType(String)} and {@link
- * #setSubtype(String)}) return new {@link MediaType} objects with the requested part changed and
- * all other parts copied.
+ * <p>A media type consists of a top-level type, a subtype, and optional parameters. Examples
+ * include {@code "audio/ogg"} and {@code "text/html; charset=utf-8"}.
  *
- * <p>Media types are defined in <a href="http://www.ietf.org/rfc/rfc2046.txt">RFC 2046</a>.
+ * <p>Instances are immutable and therefore thread-safe. "Setter" methods such as {@link
+ * #setType(String)} and {@link #setSubtype(String)} return new {@link MediaType} instances with the
+ * requested part changed while copying all other parts. Parameter names are normalized to lowercase
+ * and values are trimmed; quoted values are unquoted during parsing.
+ *
+ * <p>Media types are defined by <a href="http://www.ietf.org/rfc/rfc2046.txt">RFC&nbsp;2046</a> and
+ * related documents.
  *
  * @author <a href="mailto:bombe@pterodactylus.net">David ‘Bombe’ Roden</a>
  */
@@ -31,12 +34,23 @@ public class MediaType {
   private final LinkedHashMap<String, String> parameters = new LinkedHashMap<>();
 
   /**
-   * Creates a new media type by parsing the given string.
+   * Parses a media type string into a new instance.
    *
-   * @param mediaType The media type to parse
+   * <p>Accepts inputs like {@code "text/html"} and {@code "text/html; charset=UTF-8; q=0.9"}. The
+   * parser is strict about basic structure:
+   *
+   * <ul>
+   *   <li>Type/subtype must contain a {@code '/'} separator.
+   *   <li>Parameters are separated by semicolons; each parameter must contain a single {@code '='}.
+   *   <li>Parameter names are normalized to lowercase; quoted values are unquoted.
+   * </ul>
+   *
+   * <p>On success, the resulting instance preserves parameter insertion order.
+   *
+   * @param mediaType media type string; must not be {@code null}
    * @throws NullPointerException if {@code mediaType} is {@code null}
-   * @throws MalformedURLException if {@code mediaType} is incorrectly formatted, i.e. does not
-   *     contain a slash, or a parameter does not contain an equals sign
+   * @throws MalformedURLException if {@code mediaType} is not plausibly a MIME type, does not
+   *     contain a slash, or a parameter lacks an equals sign
    */
   public MediaType(String mediaType) throws NullPointerException, MalformedURLException {
     if (mediaType == null) {
@@ -44,6 +58,7 @@ public class MediaType {
     }
     if (!DefaultMIMETypes.isPlausibleMIMEType(mediaType))
       throw new MalformedURLException("Doesn't look like a MIME type");
+    // Basic structural parsing: split type/subtype first, then parameters.
     int slash = mediaType.indexOf('/');
     if (slash == -1) {
       throw new MalformedURLException("mediaType does not contain ‘/’!");
@@ -55,12 +70,13 @@ public class MediaType {
       return;
     }
     subtype = mediaType.substring(slash + 1, semicolon).trim();
-    String[] parameters = mediaType.substring(semicolon + 1).split(";");
-    for (String parameter : parameters) {
+    String[] parsedParameters = mediaType.substring(semicolon + 1).split(";");
+    for (String parameter : parsedParameters) {
       int equals = parameter.indexOf('=');
       if (equals == -1) {
         throw new MalformedURLException("Illegal parameter: “%s”".formatted(parameter));
       }
+      // Normalize parameter names to lowercase and unquote quoted values.
       String name = parameter.substring(0, equals).trim().toLowerCase();
       String value = parameter.substring(equals + 1).trim();
       if (value.startsWith("\"") && value.endsWith("\""))
@@ -70,14 +86,15 @@ public class MediaType {
   }
 
   /**
-   * Creates a new media type.
+   * Constructs a new instance from explicit parts.
    *
-   * @param type The top-level type
-   * @param subtype The subtype
-   * @param parameters The parameters in key-value pairs, in the order {@code key1}, {@code value1},
-   *     {@code key2}, {@code value2}, …
-   * @throws IllegalArgumentException if an invalid number of parameters is given (i.e. the number
-   *     of parameters is odd)
+   * <p>Parameter varargs are interpreted as key-value pairs in order: {@code key1, value1, key2,
+   * value2, ...}. Parameter names are stored as-is and are not validated here.
+   *
+   * @param type top-level type (e.g., {@code "text"})
+   * @param subtype subtype (e.g., {@code "html"})
+   * @param parameters alternating parameter keys and values
+   * @throws IllegalArgumentException if the number of {@code parameters} is odd
    */
   public MediaType(String type, String subtype, String... parameters)
       throws IllegalArgumentException {
@@ -92,11 +109,15 @@ public class MediaType {
   }
 
   /**
-   * Creates a new media type.
+   * Constructs a new instance from explicit parts and a parameter map.
    *
-   * @param type The top-level type
-   * @param subtype The subtype
-   * @param parameters The parameters of the media type
+   * <p>The provided map is defensively copied. Insertion order of the map is preserved in the
+   * resulting instance if the map is an ordered implementation such as {@link LinkedHashMap}.
+   * Parameter keys are copied as-is and not validated.
+   *
+   * @param type top-level type
+   * @param subtype subtype
+   * @param parameters parameter map to copy (may be empty but not {@code null})
    */
   public MediaType(String type, String subtype, Map<String, String> parameters) {
     this.type = type;
@@ -109,63 +130,68 @@ public class MediaType {
   //
 
   /**
-   * Returns the top-level type of this media type.
+   * Returns the top-level type.
    *
-   * @return The top-level type
+   * @return top-level type string (never {@code null})
    */
   public String getType() {
     return type;
   }
 
   /**
-   * Creates a new media type that has the same subtype and parameters as this media type and the
-   * given type as top-level type.
+   * Returns a new instance with the given top-level type.
    *
-   * @param type The top-level type of the new media type
-   * @return The new media type
+   * <p>All other parts (subtype and parameters) are copied unchanged.
+   *
+   * @param type new top-level type
+   * @return a new {@link MediaType} with {@code type} applied
    */
   public MediaType setType(String type) {
     return new MediaType(type, subtype, parameters);
   }
 
   /**
-   * Returns the subtype of this media type.
+   * Returns the subtype.
    *
-   * @return The subtype
+   * @return subtype string (never {@code null})
    */
   public String getSubtype() {
     return subtype;
   }
 
   /**
-   * Creates a new media type that has the same top-level type and parameters as this media type and
-   * the given subtype as subtype.
+   * Returns a new instance with the given subtype.
    *
-   * @param subtype The subtype of the new media type
-   * @return The new media type
+   * <p>All other parts (top-level type and parameters) are copied unchanged.
+   *
+   * @param subtype new subtype
+   * @return a new {@link MediaType} with {@code subtype} applied
    */
   public MediaType setSubtype(String subtype) {
     return new MediaType(type, subtype, parameters);
   }
 
   /**
-   * Returns the value of the parameter with the given name.
+   * Returns the value of a parameter.
    *
-   * @param name The name of the parameter
-   * @return The value of the parameter (or {@code null} if the media type does not have a parameter
-   *     with the given name)
+   * <p>Lookup is case-insensitive because parameter names are normalized to lowercase for storage.
+   *
+   * @param name parameter name (case-insensitive)
+   * @return parameter value, or {@code null} if not present
    */
   public String getParameter(String name) {
     return parameters.get(name.toLowerCase());
   }
 
   /**
-   * Creates a new media type that has the same top-level type, subtype, and parameters as this
-   * media type but has the parameter with the given name changed to the given value.
+   * Returns a new instance with the parameter updated.
    *
-   * @param name The name of the parameter to change
-   * @param value The new value of the parameter. Null = delete parameter.
-   * @return The new media type
+   * <p>If {@code value} is {@code null}, the parameter is removed. The {@code name} is normalized
+   * to lowercase for storage.
+   *
+   * @param name parameter name (case-insensitive)
+   * @param value new value, or {@code null} to remove the parameter
+   * @return a new {@link MediaType} reflecting the change
    */
   public MediaType setParameter(String name, String value) {
     MediaType newMediaType = new MediaType(type, subtype, parameters);
@@ -175,11 +201,10 @@ public class MediaType {
   }
 
   /**
-   * Creates a new media type that has the same top-level type, subtype, and parameters as this
-   * media type but has the parameter with the given name removed.
+   * Returns a new instance with the parameter removed, if present.
    *
-   * @param name The name of the parameter to remove
-   * @return The new media type
+   * @param name parameter name (case-insensitive)
+   * @return {@code this} if the parameter was absent; otherwise a new {@link MediaType}
    */
   public MediaType removeParameter(String name) {
     if (!parameters.containsKey(name.toLowerCase())) {
@@ -194,7 +219,12 @@ public class MediaType {
   // OBJECT METHODS
   //
 
-  /** {@inheritDoc} */
+  /**
+   * Returns the RFC-style string representation.
+   *
+   * <p>The format is {@code type/subtype} followed by semicolon-separated parameters in insertion
+   * order. Parameter values are quoted. Parameters with {@code null} values are omitted.
+   */
   @Override
   public String toString() {
     StringBuilder mediaType = new StringBuilder();
@@ -213,32 +243,61 @@ public class MediaType {
     return mediaType.toString();
   }
 
+  /**
+   * Best-effort extraction of the {@code charset} parameter from a media type string.
+   *
+   * <p>Returns {@code null} when the input is {@code null}, malformed, or when parsing triggers any
+   * throwable (including {@link Error}) due to extreme or malicious inputs. This preserves the
+   * historical "robust" contract: callers dealing with untrusted headers should not be taken down
+   * by parse-time failures.
+   *
+   * @param expectedMimeType content type string such as {@code "text/html; charset=UTF-8"}
+   * @return the charset value if present; otherwise {@code null}
+   */
+  @SuppressWarnings("java:S1181") // Intentionally catch Throwable to uphold robustness contract.
   public static String getCharsetRobust(String expectedMimeType) {
     try {
       if (expectedMimeType == null) return null;
       MediaType type = new MediaType(expectedMimeType);
       return type.getParameter("charset");
-    } catch (MalformedURLException e) {
-      return null;
     } catch (Throwable t) {
       // Could be malicious, hence "Robust".
       return null;
     }
   }
 
+  /**
+   * Returns the {@code charset} parameter or {@code "UTF-8"} when absent.
+   *
+   * <p>Falls back to {@code "UTF-8"} if the input is {@code null}, invalid, or lacks an explicit
+   * charset parameter. This is a convenience wrapper around {@link #getCharsetRobust(String)}.
+   *
+   * @param expectedMimeType content type string to inspect
+   * @return the parsed charset or {@code "UTF-8"} when unavailable
+   */
   public static String getCharsetRobustOrUTF(String expectedMimeType) {
     String charset = getCharsetRobust(expectedMimeType);
     if (charset == null) return "UTF-8";
     return charset;
   }
 
+  /**
+   * Returns a defensive copy of the parameters map.
+   *
+   * <p>The returned map preserves insertion order and may be modified by the caller without
+   * affecting this instance.
+   *
+   * @return new {@link LinkedHashMap} containing all parameters
+   */
   public LinkedHashMap<String, String> getParameters() {
-    LinkedHashMap<String, String> map = new LinkedHashMap<>();
-    map.putAll(parameters);
-    return map;
+    return new LinkedHashMap<>(parameters);
   }
 
-  /** Get the base type without any parameters */
+  /**
+   * Returns the base type without parameters.
+   *
+   * @return {@code type + "/" + subtype}
+   */
   public String getPlainType() {
     return type + '/' + subtype;
   }

--- a/src/main/java/network/crypta/support/MediaType.java
+++ b/src/main/java/network/crypta/support/MediaType.java
@@ -289,7 +289,7 @@ public class MediaType {
    *
    * @return new {@link LinkedHashMap} containing all parameters
    */
-  public LinkedHashMap<String, String> getParameters() {
+  public Map<String, String> getParameters() {
     return new LinkedHashMap<>(parameters);
   }
 

--- a/src/test/java/network/crypta/support/MediaTypeTest.java
+++ b/src/test/java/network/crypta/support/MediaTypeTest.java
@@ -1,0 +1,296 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.MalformedURLException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Tests for {@link MediaType}. */
+@SuppressWarnings("java:S100") // Allow method names like method_whenCondition_expectOutcome
+class MediaTypeTest {
+
+  private static final String MIME_TEXT_HTML = "text/html";
+  private static final String PARAM_CHARSET = "charset";
+  private static final String CHARSET_UTF8 = "utf-8";
+  private static final String CHARSET_UTF8_UPPER = "UTF-8";
+  private static final String MIME_TEXT_HTML_CHARSET_UTF8 =
+      MIME_TEXT_HTML + "; " + PARAM_CHARSET + "=" + CHARSET_UTF8;
+
+  @Test
+  @DisplayName("parse constructor: simple type/subtype without parameters")
+  void constructor_whenSimpleType_expectParsedCorrectly() throws Exception {
+    // Arrange & Act
+    MediaType mt = new MediaType(MIME_TEXT_HTML);
+
+    // Assert
+    assertEquals("text", mt.getType());
+    assertEquals("html", mt.getSubtype());
+    assertEquals(MIME_TEXT_HTML, mt.getPlainType());
+    assertEquals(MIME_TEXT_HTML, mt.toString());
+    assertNull(mt.getParameter(PARAM_CHARSET));
+  }
+
+  @Test
+  @DisplayName("parse constructor: parameters with whitespace and quotes are normalized")
+  void constructor_whenParamsWithWhitespaceAndQuotes_expectNormalized() throws Exception {
+    // Arrange
+    String input =
+        MIME_TEXT_HTML
+            + "; "
+            + PARAM_CHARSET
+            + "="
+            + CHARSET_UTF8
+            + "; foo=\"bar baz\" ; QuUx = \" spaced \"";
+
+    // Act
+    MediaType mt = new MediaType(input);
+
+    // Assert
+    assertEquals(CHARSET_UTF8, mt.getParameter(PARAM_CHARSET));
+    assertEquals("bar baz", mt.getParameter("foo"));
+    assertEquals("spaced", mt.getParameter("quux"));
+    assertEquals(
+        MIME_TEXT_HTML
+            + "; "
+            + PARAM_CHARSET
+            + "=\""
+            + CHARSET_UTF8
+            + "\"; foo=\"bar baz\"; quux=\"spaced\"",
+        mt.toString());
+  }
+
+  @Test
+  @SuppressWarnings("ConstantValue")
+  @DisplayName("parse constructor: null input throws NPE with message")
+  void constructor_whenNull_expectNullPointerException() {
+    // Arrange
+    String input = null;
+
+    // Act + Assert
+    NullPointerException ex = assertThrows(NullPointerException.class, () -> new MediaType(input));
+    assertEquals("contentType must not be null", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("parse constructor: missing slash throws MalformedURLException")
+  void constructor_whenNoSlash_expectMalformedURLException() {
+    // Arrange
+    String input = "texthtml";
+
+    // Act + Assert
+    MalformedURLException ex =
+        assertThrows(MalformedURLException.class, () -> new MediaType(input));
+    assertEquals("Doesn't look like a MIME type", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("parse constructor: parameter without equals throws MalformedURLException")
+  void constructor_whenParamWithoutEquals_expectMalformedURLException() {
+    // Arrange
+    // This matches DefaultMIMETypes' legacy compatibility pattern and reaches the equals-check.
+    String input = "application/mercurial-bundle;123";
+
+    // Act + Assert
+    MalformedURLException ex =
+        assertThrows(MalformedURLException.class, () -> new MediaType(input));
+    // Message includes the illegal parameter string that lacked '='
+    assertEquals("Illegal parameter: “123”", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("varargs constructor: even number of parameters accepted and ordered")
+  void varargsConstructor_whenEvenParamCount_expectAccepted() {
+    // Arrange + Act
+    MediaType mt = new MediaType("text", "html", PARAM_CHARSET, CHARSET_UTF8, "q", "1");
+
+    // Assert
+    assertEquals("text", mt.getType());
+    assertEquals("html", mt.getSubtype());
+    assertEquals(CHARSET_UTF8, mt.getParameter(PARAM_CHARSET));
+    assertEquals(
+        MIME_TEXT_HTML + "; " + PARAM_CHARSET + "=\"" + CHARSET_UTF8 + "\"; q=\"1\"",
+        mt.toString());
+  }
+
+  @Test
+  @DisplayName("varargs constructor: odd number of parameters throws IAE")
+  void varargsConstructor_whenOddParamCount_expectIllegalArgumentException() {
+    // Arrange + Act + Assert
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new MediaType("text", "html", PARAM_CHARSET, CHARSET_UTF8, "lonelyKey"));
+  }
+
+  @Test
+  @DisplayName(
+      "map constructor: copies parameters and preserves insertion order while skipping null")
+  void mapConstructor_whenGivenMap_expectCopiedAndOrderedAndSkipsNull() {
+    // Arrange
+    LinkedHashMap<String, String> params = new LinkedHashMap<>();
+    params.put("q", "0.8");
+    params.put("foo", null); // should be skipped in toString()
+    params.put(PARAM_CHARSET, CHARSET_UTF8);
+
+    // Act
+    MediaType mt = new MediaType("text", "html", params);
+
+    // Mutate the original map to verify defensive copy
+    params.put("another", "x");
+
+    // Assert
+    assertEquals("0.8", mt.getParameter("q"));
+    assertEquals(CHARSET_UTF8, mt.getParameter(PARAM_CHARSET));
+    assertNull(mt.getParameter("foo"));
+    assertEquals(
+        MIME_TEXT_HTML + "; q=\"0.8\"; " + PARAM_CHARSET + "=\"" + CHARSET_UTF8 + "\"",
+        mt.toString());
+  }
+
+  @Test
+  @DisplayName("getParameters returns a copy not backed by internal map")
+  void getParameters_whenMutated_expectOriginalUnaffected() throws Exception {
+    // Arrange
+    MediaType mt = new MediaType(MIME_TEXT_HTML_CHARSET_UTF8 + "; q=0.9");
+
+    // Act
+    Map<String, String> copy = mt.getParameters();
+    copy.put("newparam", "value");
+
+    // Assert
+    assertNull(mt.getParameter("newparam"));
+    assertEquals(
+        MIME_TEXT_HTML + "; " + PARAM_CHARSET + "=\"" + CHARSET_UTF8 + "\"; q=\"0.9\"",
+        mt.toString());
+  }
+
+  @Test
+  @DisplayName("setType returns new instance with updated type and preserves others")
+  void setType_whenCalled_expectNewWithChangedType() throws Exception {
+    // Arrange
+    MediaType original = new MediaType(MIME_TEXT_HTML_CHARSET_UTF8);
+
+    // Act
+    MediaType changed = original.setType("application");
+
+    // Assert
+    assertNotSame(original, changed);
+    assertEquals("text", original.getType());
+    assertEquals("application", changed.getType());
+    assertEquals("html", changed.getSubtype());
+    assertEquals(CHARSET_UTF8, changed.getParameter(PARAM_CHARSET));
+  }
+
+  @Test
+  @DisplayName("setSubtype returns new instance with updated subtype and preserves others")
+  void setSubtype_whenCalled_expectNewWithChangedSubtype() throws Exception {
+    // Arrange
+    MediaType original = new MediaType(MIME_TEXT_HTML_CHARSET_UTF8);
+
+    // Act
+    MediaType changed = original.setSubtype("plain");
+
+    // Assert
+    assertNotSame(original, changed);
+    assertEquals("html", original.getSubtype());
+    assertEquals("plain", changed.getSubtype());
+    assertEquals("text", changed.getType());
+    assertEquals(CHARSET_UTF8, changed.getParameter(PARAM_CHARSET));
+  }
+
+  @Test
+  @DisplayName(
+      "setParameter with non-null value updates or adds parameter (normalized to lowercase)")
+  void setParameter_whenNonNull_expectUpdatedAndNormalized() throws Exception {
+    // Arrange
+    MediaType original = new MediaType(MIME_TEXT_HTML_CHARSET_UTF8);
+
+    // Act
+    MediaType changed = original.setParameter("Charset", "latin-1");
+
+    // Assert
+    assertNotSame(original, changed);
+    assertEquals(CHARSET_UTF8, original.getParameter(PARAM_CHARSET));
+    assertEquals("latin-1", changed.getParameter(PARAM_CHARSET));
+    assertEquals(MIME_TEXT_HTML + "; " + PARAM_CHARSET + "=\"latin-1\"", changed.toString());
+  }
+
+  @Test
+  @DisplayName("setParameter with null value removes parameter")
+  void setParameter_whenNull_expectRemoval() throws Exception {
+    // Arrange
+    MediaType original =
+        new MediaType(MIME_TEXT_HTML + "; q=0.5; " + PARAM_CHARSET + "=" + CHARSET_UTF8);
+
+    // Act
+    MediaType changed = original.setParameter("q", null);
+
+    // Assert
+    assertNotSame(original, changed);
+    assertNull(changed.getParameter("q"));
+    assertEquals(
+        MIME_TEXT_HTML + "; " + PARAM_CHARSET + "=\"" + CHARSET_UTF8 + "\"", changed.toString());
+  }
+
+  @Test
+  @DisplayName("removeParameter for missing key returns same instance; for existing returns new")
+  void removeParameter_whenMissingOrPresent_expectSameOrNew() throws Exception {
+    // Arrange
+    MediaType withoutParams = new MediaType(MIME_TEXT_HTML);
+    MediaType withCharset = new MediaType(MIME_TEXT_HTML_CHARSET_UTF8);
+
+    // Act
+    MediaType same = withoutParams.removeParameter(PARAM_CHARSET);
+    MediaType removed = withCharset.removeParameter("Charset"); // case-insensitive by normalization
+
+    // Assert
+    assertSame(withoutParams, same);
+    assertNotSame(withCharset, removed);
+    assertEquals(MIME_TEXT_HTML, removed.toString());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "invalid, UTF-8", // invalid MIME → default
+    MIME_TEXT_HTML + ", UTF-8" // valid MIME without charset → default
+  })
+  @DisplayName("getCharsetRobustOrUTF returns UTF-8 when charset is missing or input invalid")
+  void getCharsetRobustOrUTF_whenMissingOrInvalid_expectUTF8(String input, String expected) {
+    // Arrange + Act
+    String result = MediaType.getCharsetRobustOrUTF(input);
+
+    // Assert
+    assertEquals(expected, result);
+  }
+
+  @Test
+  @DisplayName("getCharsetRobustOrUTF returns UTF-8 for null input")
+  void getCharsetRobustOrUTF_whenNull_expectUTF8() {
+    // Arrange + Act
+    String result = MediaType.getCharsetRobustOrUTF(null);
+
+    // Assert
+    assertEquals(CHARSET_UTF8_UPPER, result);
+  }
+
+  @Test
+  @DisplayName("getCharsetRobust returns charset value when present (any case in input)")
+  void getCharsetRobust_whenValidWithCharset_expectValue() {
+    // Arrange
+    String input = "Text/Html; Charset=\"" + CHARSET_UTF8_UPPER + "\"";
+
+    // Act
+    String charset = MediaType.getCharsetRobust(input);
+
+    // Assert
+    assertEquals(CHARSET_UTF8_UPPER, charset);
+  }
+}


### PR DESCRIPTION
Summary
- Strengthens MediaType robustness when parsing untrusted Content-Type values and improves API docs.
- Makes return type of MediaType.getParameters Map<String, String> (intentional API cleanup).
- Branch also contains Loader/LoaderTest changes; please verify intent (see notes below).

Changes (by file)
- src/main/java/network/crypta/support/MediaType.java
  - Javadoc: comprehensive class and method documentation; clarifies immutability, normalization, and string format.
  - getCharsetRobust: catches Throwable again to uphold the historical “robust” contract for untrusted inputs.
  - getCharsetRobustOrUTF: documented fallback semantics (UTF-8 default) and relation to getCharsetRobust.
  - getParameters: signature now returns Map<String, String> (still returns a defensive LinkedHashMap copy under the hood).
  - Minor inline comments for clarity; no logic changes beyond the Throwable catch restoration.

- src/test/java/network/crypta/support/MediaTypeTest.java
  - New/expanded tests for parsing, parameter normalization, immutability, and robust charset helpers.

- src/main/java/network/crypta/support/Loader.java and src/test/java/network/crypta/support/LoaderTest.java
  - This branch includes changes replacing ConcurrentHashMap with Hashtable and simplifying tests. These differ notably from origin/develop’s current implementation style (e.g., removal of computeIfAbsent, reduced Javadoc/test coverage). Please confirm if these loader changes are intended to be part of this PR.

Breaking change
- API: MediaType.getParameters now returns Map<String, String> instead of LinkedHashMap<String, String>.
  - Source impact: callers assigning to LinkedHashMap will need to target Map instead.
  - Binary impact: callers compiled against the old descriptor Ljava/util/LinkedHashMap; must recompile.
  - Rationale: expose the interface type to decouple implementation while still returning a defensive LinkedHashMap copy.
  - Migration: change variable/field types to Map<String, String>; behavior remains identical for iteration order.

Rationale
- Robustness: getCharsetRobust swallows all Throwable to avoid crashing on malicious or extreme inputs (e.g., OOM or stack overflows from pathological strings). This matches the prior contract and common project patterns in untrusted paths.
- API surface: returning Map narrows the surface to the interface; implementation remains a LinkedHashMap copy so insertion order is preserved.
- Documentation: Public APIs now have clear behavior/exception/note sections.

Testing
- Local: gradle compileJava; targeted MediaType tests (MediaTypeTest) passing.
- Formatting: Spotless applied.

Risks & mitigations
- ABI/source break for getParameters: documented above with migration guidance.
- Loader changes: appear to revert modern code to older patterns (Hashtable; reduced tests). Flagging for reviewer confirmation before merge.

Commits
- 90ef820a66 refactor(api): return type of MediaType.getParameters is Map again (intentional)
- 0d9300e568 fix(support): restore robust Throwable catch in MediaType.getCharsetRobust; preserve ABI by returning LinkedHashMap in getParameters

Reviewer notes
- If Loader changes are not intended here, I can split them into a separate branch/PR or rebase this branch to include only MediaType changes.

Checklist
- [x] Builds locally
- [x] Spotless formatting
- [x] Tests updated/run (targeted)
- [x] PR does not target main or develop directly (uses feature/fix-MediaType into develop)
