### PR TITLE
Support/LRU: improve LRUQueue docs, snapshot iteration in LRUMap, and extend tests

### DIFF
--- a/src/main/java/network/crypta/support/LRUCache.java
+++ b/src/main/java/network/crypta/support/LRUCache.java
@@ -10,22 +10,22 @@ package network.crypta.support;
  * the entry were absent.
  *
  * <p>Expiration is evaluated against {@link System#currentTimeMillis()} when entries are created
- * and when they are retrieved via {@link #get}. Expired entries are only purged on access
- * (or when they are evicted for capacity reasons); there is no background or periodic garbage
- * collection in this implementation. This cache is therefore intended for small capacities (or for
- * holding many small items) where opportunistic cleanup is acceptable. If a larger cache is
- * required, consider an alternative that includes scheduled cleanup.
+ * and when they are retrieved via {@link #get}. Expired entries are only purged on access (or when
+ * they are evicted for capacity reasons); there is no background or periodic garbage collection in
+ * this implementation. This cache is therefore intended for small capacities (or for holding many
+ * small items) where opportunistic cleanup is acceptable. If a larger cache is required, consider
+ * an alternative that includes scheduled cleanup.
  *
  * <p>Operations delegate to {@link LRUMap}, which uses a tree-based map to avoid hash-collision
- * denial-of-service scenarios. Typical {@code put} and {@code get} are {@code O(log N)} due to
- * the underlying {@code TreeMap}.
+ * denial-of-service scenarios. Typical {@code put} and {@code get} are {@code O(log N)} due to the
+ * underlying {@code TreeMap}.
  *
  * <p>Thread-safety: this class does not provide external synchronization guarantees. Callers should
  * synchronize externally if using the same instance from multiple threads.
  *
- * <p>Nullability: keys must be non-null (a {@link NullPointerException} is thrown by
- * {@link LRUMap}); values may be null. A stored {@code null} value is indistinguishable from an
- * absent or expired entry when using {@link #get}.
+ * <p>Nullability: keys must be non-null (a {@link NullPointerException} is thrown by {@link
+ * LRUMap}); values may be null. A stored {@code null} value is indistinguishable from an absent or
+ * expired entry when using {@link #get}.
  *
  * @param <K> key type; must be {@link Comparable}
  * @param <V> value type
@@ -86,9 +86,9 @@ public final class LRUCache<K extends Comparable<K>, V> {
   /**
    * Constructs a cache with the given capacity and expiration policy.
    *
-   * <p>Each inserted or updated entry receives a deadline equal to
-   * {@code System.currentTimeMillis() + expirationDelay}. The deadline is checked on retrieval.
-   * Negative delays cause entries to be considered expired immediately.
+   * <p>Each inserted or updated entry receives a deadline equal to {@code
+   * System.currentTimeMillis() + expirationDelay}. The deadline is checked on retrieval. Negative
+   * delays cause entries to be considered expired immediately.
    *
    * @param sizeLimit maximum number of entries held at once
    * @param expirationDelay delay in milliseconds from insertion/update until an entry expires; use

--- a/src/main/java/network/crypta/support/LRUCache.java
+++ b/src/main/java/network/crypta/support/LRUCache.java
@@ -1,32 +1,48 @@
 package network.crypta.support;
 
 /**
- * A key-value cache with a fixed size and optional expiration time. The least recently used item is
- * removed if the cache is full and a new entry is added.
+ * A small, fixed-capacity, least-recently-used (LRU) cache with an optional per-entry expiration
+ * time.
  *
- * <p>Existing entries are only returned if they are not expired.
+ * <p>On insertion or update, the entry becomes most-recently-used. When the cache exceeds its size
+ * limit, the least-recently-used entries are evicted to make room. Lookups that find a live entry
+ * promote it to most-recently-used; lookups that find an expired entry remove it and behave as if
+ * the entry were absent.
  *
- * <p>Notice that expired items are ONLY removed when trying to get() them or when they fall out
- * during push() because they are the least-recently-used. Therefore, this cache is intended for
- * small sizes (or large amounts of small items).
+ * <p>Expiration is evaluated against {@link System#currentTimeMillis()} when entries are created
+ * and when they are retrieved via {@link #get}. Expired entries are only purged on access
+ * (or when they are evicted for capacity reasons); there is no background or periodic garbage
+ * collection in this implementation. This cache is therefore intended for small capacities (or for
+ * holding many small items) where opportunistic cleanup is acceptable. If a larger cache is
+ * required, consider an alternative that includes scheduled cleanup.
  *
- * <p>If you want to do a large cache and therefore need periodical garbage collection, please email
- * me and I might implement it.
+ * <p>Operations delegate to {@link LRUMap}, which uses a tree-based map to avoid hash-collision
+ * denial-of-service scenarios. Typical {@code put} and {@code get} are {@code O(log N)} due to
+ * the underlying {@code TreeMap}.
  *
- * <p>Pushing and getting are executed in O(lg N) using a tree, to avoid hash collision DoS'es.
+ * <p>Thread-safety: this class does not provide external synchronization guarantees. Callers should
+ * synchronize externally if using the same instance from multiple threads.
  *
+ * <p>Nullability: keys must be non-null (a {@link NullPointerException} is thrown by
+ * {@link LRUMap}); values may be null. A stored {@code null} value is indistinguishable from an
+ * absent or expired entry when using {@link #get}.
+ *
+ * @param <K> key type; must be {@link Comparable}
+ * @param <V> value type
  * @author xor (xor@freenetproject.org)
  */
-public final class LRUCache<Key extends Comparable<Key>, Value> {
+public final class LRUCache<K extends Comparable<K>, V> {
 
   private final int mSizeLimit;
   private final long mExpirationDelay;
 
+  // Holds the cached value and its absolute expiration deadline (in epoch milliseconds).
   private final class Entry {
-    private final Value mValue;
+    private final V mValue;
     private final long mExpirationDate;
 
-    public Entry(final Value myValue) {
+    /** Records the value and computes the absolute expiration deadline. */
+    public Entry(final V myValue) {
       mValue = myValue;
       mExpirationDate =
           (mExpirationDelay < Long.MAX_VALUE)
@@ -34,25 +50,32 @@ public final class LRUCache<Key extends Comparable<Key>, Value> {
               : (Long.MAX_VALUE);
     }
 
+    /** Returns whether the entry is expired at the given wall-clock time. */
     public boolean expired(final long time) {
       return mExpirationDate < time;
     }
 
+    /** Returns whether the entry is expired at the current wall-clock time. */
     public boolean expired() {
       return expired(System.currentTimeMillis());
     }
 
-    public Value getValue() {
+    public V getValue() {
       return mValue;
     }
   }
 
-  private final LRUMap<Key, Entry> mCache;
+  private final LRUMap<K, Entry> mCache;
 
   /**
-   * Creates a cache without an expiration time.
+   * Constructs a cache with the given capacity and no expiration.
    *
-   * @param sizeLimit The maximal amount of items which the cache should hold.
+   * <p>Entries never expire (unless evicted for capacity) because the expiration delay is set to
+   * {@link Long#MAX_VALUE}.
+   *
+   * @param sizeLimit maximum number of entries held at once. Values greater than zero store up to
+   *     that many entries; zero means every insertion immediately evicts and the cache remains
+   *     effectively empty.
    */
   public LRUCache(final int sizeLimit) {
     mCache = LRUMap.createSafeMap();
@@ -61,8 +84,15 @@ public final class LRUCache<Key extends Comparable<Key>, Value> {
   }
 
   /**
-   * @param sizeLimit The maximal amount of items which the cache should hold.
-   * @param expirationDelay The amount of milliseconds after which an entry expires.
+   * Constructs a cache with the given capacity and expiration policy.
+   *
+   * <p>Each inserted or updated entry receives a deadline equal to
+   * {@code System.currentTimeMillis() + expirationDelay}. The deadline is checked on retrieval.
+   * Negative delays cause entries to be considered expired immediately.
+   *
+   * @param sizeLimit maximum number of entries held at once
+   * @param expirationDelay delay in milliseconds from insertion/update until an entry expires; use
+   *     {@link Long#MAX_VALUE} for no expiration
    */
   public LRUCache(final int sizeLimit, final long expirationDelay) {
     mCache = LRUMap.createSafeMap();
@@ -70,7 +100,10 @@ public final class LRUCache<Key extends Comparable<Key>, Value> {
     mExpirationDelay = expirationDelay;
   }
 
-  /** Removes the least recently used items until a free space of the given capacity is available */
+  // Evicts least-recently-used entries until there is at least {@code capacity} free space.
+  // Precondition: capacity <= size limit (asserted below). The loop removes from the tail (LRU)
+  // until the size invariant is restored.
+  @SuppressWarnings("SameParameterValue")
   private void freeCapacity(final int capacity) {
     assert (capacity <= mSizeLimit);
 
@@ -79,22 +112,34 @@ public final class LRUCache<Key extends Comparable<Key>, Value> {
   }
 
   /**
-   * Puts a value in the cache. If an entry for the key already exists, its value is updated and its
-   * expiration time is increased.
+   * Inserts or updates an entry and promotes it to most-recently-used.
    *
-   * <p>If the size limit of this cache is exceeded the least recently used entry is removed.
+   * <p>If the key already exists, the value is replaced and the expiration deadline is recomputed
+   * from the current wall-clock time using this cache's expiration delay. If inserting causes the
+   * size limit to be exceeded, the least-recently-used entries are evicted.
+   *
+   * @param key non-null key
+   * @param value value to store (may be null)
+   * @throws NullPointerException if {@code key} is null
    */
-  public void put(final Key key, final Value value) {
+  public void put(final K key, final V value) {
     mCache.push(key, new Entry(value));
     freeCapacity(0);
   }
 
   /**
-   * Gets a value from the cache and moves it to top. Returns null if there is no entry for the
-   * given key or if the entry is expired. If an expired entry was found, it is removed from the
-   * cache.
+   * Retrieves the value for a key and promotes the entry to most-recently-used.
+   *
+   * <p>If the key has no mapping or if the mapping is expired at retrieval time, this returns
+   * {@code null}. When an expired entry is encountered, it is removed. If a {@code null} value was
+   * stored, this method also returns {@code null} and the result is indistinguishable from the
+   * "absent or expired" case.
+   *
+   * @param key non-null key
+   * @return the stored value, or {@code null} if absent or expired
+   * @throws NullPointerException if {@code key} is null
    */
-  public Value get(final Key key) {
+  public V get(final K key) {
     final Entry entry = mCache.get(key);
     if (entry == null) return null;
 
@@ -103,11 +148,18 @@ public final class LRUCache<Key extends Comparable<Key>, Value> {
       return null;
     }
 
-    mCache.push(key, entry); // Move the key to top.
+    // Promote to most-recently-used ordering.
+    mCache.push(key, entry);
 
     return entry.getValue();
   }
 
+  /**
+   * Removes all entries from the cache.
+   *
+   * <p>This clears current contents but does not change the size limit or expiration policy; future
+   * operations use the same configuration.
+   */
   public void clear() {
     mCache.clear();
   }

--- a/src/main/java/network/crypta/support/LRUMap.java
+++ b/src/main/java/network/crypta/support/LRUMap.java
@@ -1,64 +1,114 @@
 package network.crypta.support;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An LRU map from K to V. That is, when a mapping is added, it is pushed to the top of the queue,
- * even if it was already present, and pop/peek operate from the bottom of the queue i.e. the least
- * recently pushed. The caller must implement any size limit needed. FIXME most callers should be
- * switched to LinkedHashMap. Does not support null keys.
+ * Least-recently-used (LRU) map from keys to values.
  *
- * @param <K> The key type.
- * @param <V> The value type.
+ * <p>When a mapping is {@linkplain #push(Object, Object) pushed}, the entry becomes the most
+ * recently used, even if the key already exists. Removal and peeking operations work from the
+ * least-recently-used side (i.e., the entry that was pushed furthest in the past). The caller is
+ * responsible for enforcing any size limits or eviction policies on top of this primitive.
+ *
+ * <p>In many cases, a {@link java.util.LinkedHashMap} configured for access order can offer similar
+ * behavior, but this implementation avoids rehashing and uses an intrusive list for predictable
+ * constant-time operations.
+ *
+ * <h3>Threading</h3>
+ *
+ * Most mutating and order-sensitive methods are {@code synchronized}. Methods such as {@link
+ * #size()} and {@link #isEmpty()} are not synchronized and may reflect a momentarily stale view
+ * under concurrent access.
+ *
+ * <h3>Nullability</h3>
+ *
+ * Null keys are not permitted and cause a {@link NullPointerException}. Null values are allowed.
+ *
+ * <h3>Iteration</h3>
+ *
+ * {@link #keys()} and {@link #values()} return snapshot enumerations in LRU→MRU order. The snapshot
+ * is created under synchronization and is not affected by later modifications.
+ *
+ * @param <K> the key type (non-null)
+ * @param <V> the value type (may be null)
  */
 public class LRUMap<K, V> {
   private static final Logger LOG = LoggerFactory.getLogger(LRUMap.class);
-
-  static {
-  }
+  private static final String NULL_KEY_IN_QITEM = "LRUMap invariant violated: null key in QItem";
 
   /**
-   * We use our own DoublyLinkedList implementation because it improves performance to be able to
-   * inherit from and refer to QItem's directly.
+   * Intrusive list of entries, ordered MRU→LRU (head is MRU, tail is LRU). We use an intrusive
+   * structure to store neighbor links in the nodes themselves for {@code O(1)} moves and removals.
    */
   private final DoublyLinkedListImpl<QItem<K, V>> list = new DoublyLinkedListImpl<>();
 
   private final Map<K, QItem<K, V>> hash;
 
+  /**
+   * Creates an instance backed by a {@link HashMap}. This variant is fast but not resilient to
+   * adversarial hash collisions; prefer {@link #createSafeMap()} when keys may be
+   * attacker-controlled.
+   */
   public LRUMap() {
     hash = new HashMap<>();
   }
 
-  /** Takes an arbitrary map */
+  /**
+   * Creates an instance reusing the provided backing map.
+   *
+   * <p>Implementation detail: used by safe factory methods to switch map type.
+   */
   private LRUMap(Map<K, QItem<K, V>> map) {
     hash = map;
   }
 
   /**
-   * Create a LRUMap that is safe to use with keys that can be controlled by an attacker. Meaning
-   * one based on a TreeMap, not a HashMap (think hash collision DoS's).
+   * Creates a variant that is safer for attacker-controlled keys.
+   *
+   * <p>Backed by a {@link TreeMap} to avoid pathological {@link HashMap} collision attacks.
+   *
+   * @param <K> comparable key type
+   * @param <V> value type
+   * @return a new map using {@link TreeMap} as the backing map
    */
   public static <K extends Comparable<K>, V> LRUMap<K, V> createSafeMap() {
     return new LRUMap<>(new TreeMap<>());
   }
 
   /**
-   * Create a LRUMap that is safe to use with keys that can be controlled by an attacker. Meaning
-   * one based on a TreeMap, not a HashMap (think hash collision DoS's).
+   * Creates a variant that is safer for attacker-controlled keys using a custom comparator.
+   *
+   * <p>Backed by a {@link TreeMap} with the supplied {@link Comparator}.
+   *
+   * @param comparator comparator for ordering keys; must impose a total order
+   * @param <K> key type
+   * @param <V> value type
+   * @return a new map using {@link TreeMap} as the backing map
    */
   public static <K, V> LRUMap<K, V> createSafeMap(Comparator<K> comparator) {
     return new LRUMap<>(new TreeMap<>(comparator));
   }
 
   /**
-   * push()ing an object that is already in the queue moves that object to the most recently used
-   * position, but doesn't add a duplicate entry in the queue.
+   * Inserts or updates a mapping and promotes it to most-recently-used (MRU).
+   *
+   * <p>If the key already exists, its value is replaced and the entry is moved to the MRU position.
+   * No duplicate entry is inserted.
+   *
+   * @param key non-null key
+   * @param value value (may be null)
+   * @return the previous value associated with {@code key}, or {@code null} if none
+   * @throws NullPointerException if {@code key} is {@code null}
+   * @implNote Runs in {@code O(1)} time.
    */
   public final synchronized V push(K key, V value) {
     if (key == null) throw new NullPointerException();
@@ -68,58 +118,115 @@ public class LRUMap<K, V> {
       insert = new QItem<>(key, value);
       hash.put(key, insert);
     } else {
-      old = insert.value;
-      insert.value = value;
+      old = insert.getValue();
+      insert.setValue(value);
       list.remove(insert);
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Pushed " + insert + " ( " + key + ' ' + value + " )");
+    LOG.debug("Pushed {} ( {} {} )", insert, key, value);
 
     list.unshift(insert);
     return old;
   }
 
   /**
-   * @return Least recently pushed key.
+   * Removes and returns the least-recently-used key.
+   *
+   * <p>Also removes the corresponding mapping.
+   *
+   * @return the LRU key, or {@code null} if empty
+   * @implNote Runs in {@code O(1)} time.
    */
   public final synchronized K popKey() {
     if (!list.isEmpty()) {
-      return hash.remove(list.pop().obj).obj;
+      QItem<K, V> popped = list.pop();
+      if (popped == null) return null; // defensive: static analysis may not infer non-null here
+      K k = Objects.requireNonNull(popped.getObj(), NULL_KEY_IN_QITEM);
+      QItem<K, V> removed =
+          Objects.requireNonNull(
+              hash.remove(k), "LRUMap invariant violated: hash missing popped key");
+      return removed.getObj();
     } else {
       return null;
     }
   }
 
   /**
-   * @return Least recently pushed value.
+   * Removes and returns the least-recently-used value.
+   *
+   * <p>Also removes the corresponding mapping.
+   *
+   * @return the LRU value, or {@code null} if empty
+   * @implNote Runs in {@code O(1)} time.
    */
   public final synchronized V popValue() {
     if (!list.isEmpty()) {
-      return hash.remove(list.pop().obj).value;
+      QItem<K, V> popped = list.pop();
+      if (popped == null) return null; // defensive: static analysis may not infer non-null here
+      K k = Objects.requireNonNull(popped.getObj(), NULL_KEY_IN_QITEM);
+      QItem<K, V> removed =
+          Objects.requireNonNull(
+              hash.remove(k), "LRUMap invariant violated: hash missing popped key");
+      return removed.getValue();
     } else {
       return null;
     }
   }
 
+  /**
+   * Returns the least-recently-used value without removing it.
+   *
+   * @return the LRU value, or {@code null} if empty
+   */
   public final synchronized V peekValue() {
     if (!list.isEmpty()) {
-      return hash.get(list.tail().obj).value;
+      QItem<K, V> tail = list.tail();
+      if (tail == null) return null; // defensive
+      K k = Objects.requireNonNull(tail.getObj(), NULL_KEY_IN_QITEM);
+      QItem<K, V> q =
+          Objects.requireNonNull(hash.get(k), "LRUMap invariant violated: hash missing tail key");
+      return q.getValue();
     } else {
       return null;
     }
   }
 
+  /**
+   * Returns the least-recently-used key without removing it.
+   *
+   * @return the LRU key, or {@code null} if empty
+   */
   public final synchronized K peekKey() {
     if (!list.isEmpty()) {
-      return hash.get(list.tail().obj).obj;
+      QItem<K, V> tail = list.tail();
+      if (tail == null) return null; // defensive
+      K k = Objects.requireNonNull(tail.getObj(), NULL_KEY_IN_QITEM);
+      QItem<K, V> q =
+          Objects.requireNonNull(hash.get(k), "LRUMap invariant violated: hash missing tail key");
+      return q.getObj();
     } else {
       return null;
     }
   }
 
+  /**
+   * Returns the number of mappings currently stored.
+   *
+   * <p>Not synchronized; may reflect a slightly stale value under concurrent access.
+   *
+   * @return current entry count (never negative)
+   */
   public final int size() {
     return list.size();
   }
 
+  /**
+   * Removes a mapping by key.
+   *
+   * @param key non-null key
+   * @return {@code true} if a mapping was removed; {@code false} if the key was absent
+   * @throws NullPointerException if {@code key} is {@code null}
+   * @implNote Runs in {@code O(1)} time.
+   */
   public final synchronized boolean removeKey(K key) {
     if (key == null) throw new NullPointerException();
     QItem<K, V> i = (hash.remove(key));
@@ -132,10 +239,11 @@ public class LRUMap<K, V> {
   }
 
   /**
-   * Check if this queue contains obj
+   * Returns whether a mapping for the key exists.
    *
-   * @param obj Object to match
-   * @return true if this queue contains obj.
+   * @param key non-null key
+   * @return {@code true} if present; {@code false} otherwise
+   * @throws NullPointerException if {@code key} is {@code null}
    */
   public final synchronized boolean containsKey(K key) {
     if (key == null) throw new NullPointerException();
@@ -143,67 +251,100 @@ public class LRUMap<K, V> {
   }
 
   /**
-   * Note that this does not automatically promote the key. You have to do that by hand with
-   * push(key, value).
+   * Returns the value for the key without promotion.
+   *
+   * <p>This does not change LRU order. To promote, call {@link #push(Object, Object)} with the same
+   * key and value.
+   *
+   * @param key non-null key
+   * @return the value, or {@code null} if absent
+   * @throws NullPointerException if {@code key} is {@code null}
    */
   public final synchronized V get(K key) {
     if (key == null) throw new NullPointerException();
     QItem<K, V> q = hash.get(key);
     if (q == null) return null;
-    return q.value;
+    return q.getValue();
   }
 
+  /**
+   * Returns a snapshot {@link Enumeration} of keys in LRU→MRU order.
+   *
+   * <p>The snapshot is built under synchronization and is not affected by subsequent changes.
+   *
+   * @return enumeration of keys from least- to most-recently-used
+   */
   public Enumeration<K> keys() {
-    return new ItemEnumeration();
+    synchronized (this) {
+      ArrayList<K> out = new ArrayList<>(list.size());
+      Enumeration<QItem<K, V>> e = list.reverseElements();
+      while (e.hasMoreElements()) {
+        out.add(e.nextElement().getObj());
+      }
+      return Collections.enumeration(out);
+    }
   }
 
+  /**
+   * Returns a snapshot {@link Enumeration} of values in LRU→MRU order.
+   *
+   * <p>The snapshot is built under synchronization and is not affected by subsequent changes.
+   *
+   * @return enumeration of values from least- to most-recently-used
+   */
   public Enumeration<V> values() {
-    return new ValuesEnumeration();
-  }
-
-  private class ItemEnumeration implements Enumeration<K> {
-    private final Enumeration<QItem<K, V>> source = list.reverseElements();
-
-    @Override
-    public boolean hasMoreElements() {
-      synchronized (LRUMap.this) {
-        return source.hasMoreElements();
+    synchronized (this) {
+      ArrayList<V> out = new ArrayList<>(list.size());
+      Enumeration<QItem<K, V>> e = list.reverseElements();
+      while (e.hasMoreElements()) {
+        out.add(e.nextElement().getValue());
       }
-    }
-
-    @Override
-    public K nextElement() {
-      synchronized (LRUMap.this) {
-        return source.nextElement().obj;
-      }
+      return Collections.enumeration(out);
     }
   }
 
-  private class ValuesEnumeration implements Enumeration<V> {
-    private final Enumeration<QItem<K, V>> source = list.reverseElements();
-
-    @Override
-    public boolean hasMoreElements() {
-      synchronized (LRUMap.this) {
-        return source.hasMoreElements();
-      }
-    }
-
-    @Override
-    public V nextElement() {
-      synchronized (LRUMap.this) {
-        return source.nextElement().value;
-      }
-    }
-  }
-
+  /**
+   * Node stored in the intrusive list.
+   *
+   * <p>Public for historical reasons; intended for internal use. Holds a key/value pair and the
+   * neighbor links required by {@link DoublyLinkedListImpl}.
+   *
+   * @param <K> key type
+   * @param <V> value type
+   */
   public static class QItem<K, V> extends DoublyLinkedListImpl.Item<QItem<K, V>> {
-    public K obj;
-    public V value;
+    private K obj;
+    private V value;
 
+    /**
+     * Creates a node.
+     *
+     * @param key key (may be null only for internal/defensive states)
+     * @param val value (may be null)
+     */
     public QItem(K key, V val) {
       this.obj = key;
       this.value = val;
+    }
+
+    /** Returns the key. */
+    public K getObj() {
+      return obj;
+    }
+
+    /** Sets the key. */
+    public void setObj(K obj) {
+      this.obj = obj;
+    }
+
+    /** Returns the value. */
+    public V getValue() {
+      return value;
+    }
+
+    /** Sets the value. */
+    public void setValue(V value) {
+      this.value = value;
     }
 
     @Override
@@ -212,16 +353,24 @@ public class LRUMap<K, V> {
     }
   }
 
+  /**
+   * Returns whether the map is empty.
+   *
+   * <p>Not synchronized; may reflect a slightly stale value under concurrent access.
+   *
+   * @return {@code true} if size is 0, otherwise {@code false}
+   */
   public boolean isEmpty() {
     return list.isEmpty();
   }
 
   /**
-   * Note that unlike the java.util versions, this will not reallocate (hence it doesn't return), so
-   * pass in an appropriately big array, and make sure you hold the lock!
+   * Copies values into the provided array in LRU→MRU order.
    *
-   * @param entries
-   * @return
+   * <p>Unlike many {@code java.util} methods, this method never reallocates and therefore does not
+   * return the filled array. Ensure {@code entries.length >= size()} before calling.
+   *
+   * @param entries destination array in which values are written from index 0 upward
    */
   public synchronized void valuesToArray(V[] entries) {
     Enumeration<V> values = values();
@@ -229,6 +378,11 @@ public class LRUMap<K, V> {
     while (values.hasMoreElements()) entries[i++] = values.nextElement();
   }
 
+  /**
+   * Removes all entries.
+   *
+   * <p>Clears both the intrusive list and the backing map.
+   */
   public synchronized void clear() {
     list.clear();
     hash.clear();

--- a/src/main/java/network/crypta/support/LRUQueue.java
+++ b/src/main/java/network/crypta/support/LRUQueue.java
@@ -1,31 +1,63 @@
 package network.crypta.support;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
- * LRU Queue
+ * A hash-indexed least-recently-used (LRU) queue with {@code O(1)} updates.
  *
- * <p>push()'ing an existing object move it to tail, no duplicated object are ever added.
+ * <p>This queue stores each element at most once. Calling {@link #push(Object)} with an element
+ * that is already present moves it to the most recently used position (the head) rather than
+ * inserting a duplicate. {@link #pushLeast(Object)} inserts or moves an element to the least
+ * recently used position (the tail). {@link #pop()} removes and returns the least recently used
+ * element.
+ *
+ * <p>Implementation notes: the queue maintains order in an intrusive {@link DoublyLinkedListImpl}
+ * and a {@link java.util.HashMap} from element to list node to avoid duplicates and to provide
+ * constant-time membership checks and removals.
+ *
+ * <p>Concurrency: Most operations synchronize on {@code this}. Mutations and the majority of read
+ * operations (e.g., {@link #contains(Object)}, {@link #toArray()}, {@link #toArrayOrdered()},
+ * {@link #clear()}, {@link #get(Object)}) are synchronized. The {@link #size()} and {@link
+ * #elements()} methods are not synchronized and may observe transient states if other threads
+ * mutate the queue concurrently. For a consistent snapshot, prefer the synchronized array-producing
+ * methods.
+ *
+ * <p>Nullability: {@link #push(Object)}, {@link #pushLeast(Object)}, and {@link #remove(Object)}
+ * reject {@code null} and throw {@link NullPointerException}. Other lookups using {@code null}
+ * simply return {@code null} or {@code false}.
+ *
+ * <p>Complexity: {@code push}, {@code pushLeast}, {@code pop}, {@code remove}, and {@code contains}
+ * are {@code O(1)}; array conversions and enumerations are {@code O(n)}.
+ *
+ * @param <T> element type stored in the queue; must provide stable {@link Object#equals(Object)}
+ *     and {@link Object#hashCode()} while enqueued
  */
 public class LRUQueue<T> {
 
   /*
-   * I've just converted this to using the DLList and Hashtable
-   * this makes it Hashtable time instead of O(N) for push and
-   * remove, and Hashtable time instead of O(1) for pop.  Since
-   * push is by far the most done operation, this should be an
-   * overall improvement.
+   * Data structure overview:
+   * - 'list' preserves LRU order: head = most recently used; tail = least recently used.
+   * - 'hash' maps each element to its intrusive list node for O(1) lookup/removal.
+   * Invariants: every node in 'list' is referenced by exactly one entry in 'hash' and vice versa.
    */
   private final DoublyLinkedListImpl<QItem<T>> list = new DoublyLinkedListImpl<>();
   private final Map<T, QItem<T>> hash = new HashMap<>();
 
-  public LRUQueue() {}
+  // Default constructor intentionally implicit; no additional initialization required.
 
   /**
-   * push()ing an object that is already in the queue moves that object to the most recently used
-   * position, but doesn't add a duplicate entry in the queue.
+   * Inserts an element at the most recently used position (head).
+   *
+   * <p>If the element is already present, it is moved to the head and the queue does not contain a
+   * duplicate.
+   *
+   * @param obj element to record as most recently used; must not be {@code null}
+   * @throws NullPointerException if {@code obj} is {@code null}
    */
   public final synchronized void push(T obj) {
     if (obj == null) throw new NullPointerException();
@@ -41,7 +73,15 @@ public class LRUQueue<T> {
     list.unshift(insert);
   }
 
-  /** push to bottom (least recently used position) */
+  /**
+   * Inserts an element at the least recently used position (tail).
+   *
+   * <p>If the element is already present, it is moved to the tail and the queue does not contain a
+   * duplicate.
+   *
+   * @param obj element to record as least recently used; must not be {@code null}
+   * @throws NullPointerException if {@code obj} is {@code null}
+   */
   public synchronized void pushLeast(T obj) {
     if (obj == null) throw new NullPointerException();
 
@@ -57,20 +97,35 @@ public class LRUQueue<T> {
   }
 
   /**
-   * @return Least recently pushed Object.
+   * Removes and returns the least recently used element.
+   *
+   * @return the LRU element, or {@code null} if the queue is empty
    */
   public final synchronized T pop() {
     if (!list.isEmpty()) {
-      return hash.remove(list.pop().obj).obj;
+      QItem<T> popped = list.pop();
+      QItem<T> notNull =
+          Objects.requireNonNull(popped, "List.pop() returned null despite non-empty");
+      return hash.remove(notNull.obj).obj;
     } else {
       return null;
     }
   }
 
+  /**
+   * Returns the current number of elements.
+   *
+   * <p>Concurrency: This method is not synchronized and may return a stale value if other threads
+   * mutate the queue concurrently. For a consistent view in multithreaded code, call it while
+   * holding the same lock used by the synchronized methods on this class.
+   *
+   * @return element count (non-negative)
+   */
   public final int size() {
     return list.size();
   }
 
+  @SuppressWarnings("SuspiciousMethodCalls")
   public final synchronized boolean remove(Object obj) {
     if (obj == null) throw new NullPointerException();
 
@@ -84,61 +139,72 @@ public class LRUQueue<T> {
   }
 
   /**
-   * Check if this queue contains obj
+   * Returns whether the queue currently contains an element equal to {@code obj}.
    *
-   * @param obj Object to match
-   * @return true if this queue contains obj.
+   * @param obj element to test; may be any type
+   * @return {@code true} if present; {@code false} otherwise
    */
+  @SuppressWarnings("SuspiciousMethodCalls")
   public final synchronized boolean contains(Object obj) {
     return hash.containsKey(obj);
   }
 
+  /**
+   * Returns an {@link Enumeration} over the elements from least recently used to most recently
+   * used.
+   *
+   * <p>The enumeration is backed by a snapshot constructed at the time of the call. It does not
+   * reflect later mutations and is not fail-fast.
+   *
+   * @return enumeration from LRU to MRU
+   */
   public Enumeration<T> elements() {
-    return new ItemEnumeration();
-  }
-
-  private class ItemEnumeration implements Enumeration<T> {
-
-    private final Enumeration<QItem<T>> source = list.reverseElements();
-
-    @Override
-    public boolean hasMoreElements() {
-      return source.hasMoreElements();
+    // Provide an Enumeration view without implementing Enumeration ourselves (Sonar S1150).
+    ArrayList<T> snapshot = new ArrayList<>(list.size());
+    for (Enumeration<QItem<T>> e = list.reverseElements(); e.hasMoreElements(); ) {
+      snapshot.add(e.nextElement().obj);
     }
-
-    @Override
-    public T nextElement() {
-      return source.nextElement().obj;
-    }
+    return Collections.enumeration(snapshot);
   }
 
   private static class QItem<T> extends DoublyLinkedListImpl.Item<QItem<T>> {
-    public T obj;
+    public final T obj;
 
     public QItem(T obj) {
       this.obj = obj;
     }
   }
 
-  /** Return the objects in the queue as an array in an arbitrary and meaningless order. */
+  /**
+   * Returns the elements as an array in an unspecified order.
+   *
+   * <p>The order is the internal hash iteration order and has no relation to recency.
+   *
+   * @return new array containing all elements in arbitrary order
+   */
   public synchronized Object[] toArray() {
     return hash.keySet().toArray();
   }
 
   /**
-   * Return the objects in the queue as an array in an arbitrary and meaningless order.
+   * Returns the elements as a typed array in an unspecified order.
    *
-   * @param array The array to fill in. If it is too small a new array of the same type will be
-   *     allocated.
+   * <p>The order is the internal hash iteration order and has no relation to recency.
+   *
+   * @param <E> array component type
+   * @param array destination array; if too small, a new array of the same runtime type is returned
+   * @return the provided array if large enough, otherwise a new array of the same type
    */
   public synchronized <E> E[] toArray(E[] array) {
     return hash.keySet().toArray(array);
   }
 
   /**
-   * Return the objects in the queue as an array. The <strong>least</strong> recently used object is
-   * in <tt>[0]</tt>, the <strong>most</strong> recently used object is in
-   * <tt>[array.length-1]</tt>.
+   * Returns the elements ordered from least to most recently used.
+   *
+   * <p>The element at index {@code 0} is the LRU; the last element is the MRU.
+   *
+   * @return new array ordered from LRU to MRU
    */
   public synchronized Object[] toArrayOrdered() {
     Object[] array = new Object[list.size()];
@@ -150,12 +216,16 @@ public class LRUQueue<T> {
   }
 
   /**
-   * Return the objects in the queue as an array. The <strong>least</strong> recently used object is
-   * in <tt>[0]</tt>, the <strong>most</strong> recently used object is in
-   * <tt>[array.length-1]</tt>.
+   * Returns the elements ordered from least to most recently used, into a typed array.
    *
-   * @param array The array to fill in. If it is too small a new array of the same type will be
-   *     allocated.
+   * <p>The element at index {@code 0} is the LRU; the last element is the MRU.
+   *
+   * @param <E> array component type
+   * @param array destination array; if too small, a new array of the same runtime type is returned
+   * @return the provided array if large enough, otherwise a new array of the same type, filled from
+   *     LRU to MRU
+   * @throws IllegalStateException if an internal size invariant is violated while materializing the
+   *     snapshot (should not occur under normal use)
    */
   public synchronized <E> E[] toArrayOrdered(E[] array) {
     array = toArray(array);
@@ -184,15 +254,30 @@ public class LRUQueue<T> {
     return cast;
   }
 
+  /**
+   * Returns whether the queue contains no elements.
+   *
+   * @return {@code true} if empty; {@code false} otherwise
+   */
   public synchronized boolean isEmpty() {
     return hash.isEmpty();
   }
 
+  /** Removes all elements and resets recency order. */
   public synchronized void clear() {
     list.clear();
     hash.clear();
   }
 
+  /**
+   * Returns the stored instance equal to {@code obj} without changing recency.
+   *
+   * <p>When elements with custom equality semantics are used as keys, this method can return the
+   * canonical instance maintained by the queue.
+   *
+   * @param obj lookup key; may be {@code null}
+   * @return the equal element stored in the queue, or {@code null} if none
+   */
   public synchronized T get(T obj) {
     QItem<T> val = hash.get(obj);
     if (val == null) return null;

--- a/src/main/java/network/crypta/support/LRUQueue.java
+++ b/src/main/java/network/crypta/support/LRUQueue.java
@@ -22,10 +22,10 @@ import java.util.Objects;
  *
  * <p>Concurrency: Most operations synchronize on {@code this}. Mutations and the majority of read
  * operations (e.g., {@link #contains(Object)}, {@link #toArray()}, {@link #toArrayOrdered()},
- * {@link #clear()}, {@link #get(Object)}) are synchronized. The {@link #size()} and {@link
- * #elements()} methods are not synchronized and may observe transient states if other threads
- * mutate the queue concurrently. For a consistent snapshot, prefer the synchronized array-producing
- * methods.
+ * {@link #clear()}, {@link #get(Object)}, and {@link #elements()}) are synchronized. The {@link
+ * #size()} method is not synchronized and may observe transient states if other threads mutate the
+ * queue concurrently. The enumeration returned by {@link #elements()} is built from a snapshot
+ * captured while holding the monitor; it does not reflect later mutations.
  *
  * <p>Nullability: {@link #push(Object)}, {@link #pushLeast(Object)}, and {@link #remove(Object)}
  * reject {@code null} and throw {@link NullPointerException}. Other lookups using {@code null}
@@ -158,8 +158,8 @@ public class LRUQueue<T> {
    *
    * @return enumeration from LRU to MRU
    */
-  public Enumeration<T> elements() {
-    // Provide an Enumeration view without implementing Enumeration ourselves (Sonar S1150).
+  public synchronized Enumeration<T> elements() {
+    // Build snapshot under lock because DoublyLinkedListImpl is not thread-safe.
     ArrayList<T> snapshot = new ArrayList<>(list.size());
     for (Enumeration<QItem<T>> e = list.reverseElements(); e.hasMoreElements(); ) {
       snapshot.add(e.nextElement().obj);

--- a/src/test/java/network/crypta/support/LRUCacheTest.java
+++ b/src/test/java/network/crypta/support/LRUCacheTest.java
@@ -1,0 +1,130 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LRUCache}. Focus on public behavior: LRU eviction, promotion on get(),
+ * expiration handling, null key exceptions, and clear(). Uses simple String keys (Comparable) and
+ * Integer values.
+ */
+@SuppressWarnings("java:S100") // Allow method names with underscores
+class LRUCacheTest {
+
+  @Test
+  @DisplayName("put/get without expiration returns value and get() promotes key")
+  void get_whenNotExpired_promotesAndReturnsValue() {
+    // Arrange
+    LRUCache<String, Integer> cache = new LRUCache<>(2); // No expiration (Long.MAX_VALUE)
+    cache.put("a", 1);
+    cache.put("b", 2);
+
+    // Act: promote "a" to most-recently-used
+    Integer a1 = cache.get("a");
+    cache.put("c", 3); // should evict least recently used: "b"
+
+    // Assert
+    assertEquals(1, a1);
+    assertNull(cache.get("b"), "Expect LRU entry 'b' to be evicted after promoting 'a'.");
+    assertEquals(1, cache.get("a"));
+    assertEquals(3, cache.get("c"));
+  }
+
+  @Test
+  @DisplayName("put beyond size evicts least-recently-used")
+  void put_whenExceedsSize_evictsLeastRecentlyUsed() {
+    // Arrange
+    LRUCache<String, Integer> cache = new LRUCache<>(2);
+
+    // Act
+    cache.put("a", 1);
+    cache.put("b", 2);
+    cache.put("c", 3); // should evict "a"
+
+    // Assert
+    assertNull(cache.get("a"));
+    assertEquals(2, cache.get("b"));
+    assertEquals(3, cache.get("c"));
+  }
+
+  @Test
+  @DisplayName("re-putting same key updates value and moves to MRU")
+  void put_whenKeyExists_updatesValueAndPromotes() {
+    // Arrange
+    LRUCache<String, Integer> cache = new LRUCache<>(2);
+    cache.put("a", 1);
+    cache.put("b", 2);
+
+    // Act: update existing key and thus promote it
+    cache.put("a", 10);
+    cache.put("c", 3); // should evict "b" (now the LRU)
+
+    // Assert
+    assertNull(cache.get("b"));
+    assertEquals(10, cache.get("a"));
+    assertEquals(3, cache.get("c"));
+  }
+
+  @Test
+  @DisplayName("get on expired entry returns null and does not throw")
+  void get_whenExpired_returnsNullAndDropsEntry() {
+    // Arrange: negative delay guarantees immediate expiration
+    LRUCache<String, Integer> cache = new LRUCache<>(2, -1L);
+    cache.put("x", 42);
+
+    // Act & Assert
+    assertNull(cache.get("x"), "Expired entries must be treated as missing and removed.");
+
+    // Also confirm cache remains usable after removing an expired entry
+    cache.put("y", 7);
+    // Immediate expiration still applies for this cache; get() returns null as well
+    assertNull(cache.get("y"));
+  }
+
+  @Test
+  @DisplayName("clear removes all entries")
+  void clear_whenCalled_cacheIsEmpty() {
+    // Arrange
+    LRUCache<String, Integer> cache = new LRUCache<>(2);
+    cache.put("a", 1);
+    cache.put("b", 2);
+
+    // Act
+    cache.clear();
+
+    // Assert
+    assertNull(cache.get("a"));
+    assertNull(cache.get("b"));
+  }
+
+  @Test
+  @DisplayName("null key on put/get throws NullPointerException (delegated from LRUMap)")
+  void methods_whenNullKey_throwNullPointerException() {
+    // Arrange
+    LRUCache<String, Integer> cache = new LRUCache<>(1);
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> cache.put(null, 1));
+    assertThrows(NullPointerException.class, () -> cache.get(null));
+  }
+
+  @Test
+  @DisplayName("size limit zero keeps cache always empty")
+  void put_whenSizeLimitZero_neverStoresEntries() {
+    // Arrange
+    LRUCache<String, Integer> cache = new LRUCache<>(0);
+
+    // Act
+    cache.put("a", 1);
+    cache.put("b", 2);
+
+    // Assert: nothing can be stored
+    assertNull(cache.get("a"));
+    assertNull(cache.get("b"));
+  }
+}
+

--- a/src/test/java/network/crypta/support/LRUCacheTest.java
+++ b/src/test/java/network/crypta/support/LRUCacheTest.java
@@ -127,4 +127,3 @@ class LRUCacheTest {
     assertNull(cache.get("b"));
   }
 }
-

--- a/src/test/java/network/crypta/support/LRUMapTest.java
+++ b/src/test/java/network/crypta/support/LRUMapTest.java
@@ -1,347 +1,289 @@
 package network.crypta.support;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.Comparator;
 import java.util.Enumeration;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link LRUMap} class.
- *
- * @author Alberto Bacchelli &lt;sback@freenetproject.org&gt;
+ * Unit tests for {@link LRUMap}. Covers push/get/remove, LRU ordering, peeking/popping,
+ * enumerations, array export, clearing, and safe-map factory methods.
  */
-public class LRUMapTest {
+@SuppressWarnings("java:S100") // Allow method names with underscores for readability
+class LRUMapTest {
 
-  private static final int sampleElemsNumber = 100;
+  private static final int SAMPLE_ELEMS = 5;
 
-  /**
-   * Creates a double array of objects with a specified size where Object[i][0] is the key, and is
-   * an Integer, and Object[i][1] is the value
-   *
-   * @param size the array size
-   * @return the objects double array
-   */
   private Object[][] createSampleKeyVal(int size) {
-    Object[][] sampleObjects = new Object[size][2];
-    for (int i = 0; i < sampleObjects.length; i++) {
-      // key
-      sampleObjects[i][0] = i;
-      // value
-      sampleObjects[i][1] = new Object();
+    Object[][] arr = new Object[size][2];
+    for (int i = 0; i < size; i++) {
+      arr[i][0] = i; // key
+      arr[i][1] = "V" + i; // value for easier assertions
     }
-    return sampleObjects;
+    return arr;
   }
 
-  /**
-   * Creates a LRUMap filled with the specified objects number
-   *
-   * @param size HashTable size
-   * @return the created LRUMap
-   */
-  private LRUMap<Object, Object> createSampleHashTable(int size) {
-    LRUMap<Object, Object> methodLRUht = new LRUMap<>();
-    Object[][] sampleObjects = createSampleKeyVal(size);
-    for (int i = 0; i < sampleObjects.length; i++)
-      methodLRUht.push(sampleObjects[i][0], sampleObjects[i][1]);
-    return methodLRUht;
+  private LRUMap<Object, Object> createSampleMap(int size) {
+    LRUMap<Object, Object> map = new LRUMap<>();
+    Object[][] kv = createSampleKeyVal(size);
+    for (Object[] objects : kv) map.push(objects[0], objects[1]);
+    return map;
   }
 
-  /**
-   * It verifies if a key-value pair is present in a LRUMap
-   *
-   * @param aLRUht a LRUMap to check in
-   * @param aKey a key to find
-   * @param aValue the correspondent value
-   * @return true if the key is present and returned value is the same as in the argument
-   */
-  private boolean verifyKeyValPresence(LRUMap<Object, Object> aLRUht, Object aKey, Object aValue) {
-    if (aLRUht.containsKey(aKey)) return aLRUht.get(aKey).equals(aValue);
-    return false;
-  }
-
-  /**
-   * Tests push(Object,Object) method providing null object as arguments (after setting up a sample
-   * HashTable) and verifying if the correct exception is raised
-   */
   @Test
-  public void testPushNull() {
-    LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
-    try {
-      // a null value is admitted
-      methodLRUht.push(new Object(), null);
-    } catch (NullPointerException anException) {
-      fail("Not expected exception thrown : " + anException.getMessage());
+  @DisplayName("push with null key throws NPE; null value allowed")
+  void push_whenNullKey_throwsAndNullValueAllowed() {
+    // Arrange
+    LRUMap<String, String> map = new LRUMap<>();
+
+    // Act & Assert: null value is allowed
+    map.push("k", null);
+    assertTrue(map.containsKey("k"));
+    assertNull(map.get("k"));
+
+    // Act & Assert: null key not allowed
+    assertThrows(NullPointerException.class, () -> map.push(null, "x"));
+    assertThrows(NullPointerException.class, () -> map.push(null, null));
+  }
+
+  @Test
+  @DisplayName("push same key returns old value and promotes to MRU")
+  void push_whenKeyExists_returnsOldValueAndPromotes() {
+    // Arrange
+    LRUMap<String, String> map = new LRUMap<>();
+    map.push("a", "A"); // LRU: a
+    map.push("b", "B"); // LRU: a, b
+    map.push("c", "C"); // LRU: a, b, c
+
+    // Act
+    String old = map.push("b", "B2"); // new order LRU: a, c, b (b is MRU)
+
+    // Assert
+    assertEquals("B", old, "push must return the previous value for the key");
+    assertEquals("a", map.popKey());
+    assertEquals("c", map.popKey());
+    assertEquals("b", map.popKey());
+    assertNull(map.popKey());
+  }
+
+  @Test
+  @DisplayName("get returns value without promotion")
+  void get_whenCalled_doesNotPromoteKey() {
+    // Arrange
+    LRUMap<String, String> map = new LRUMap<>();
+    map.push("x", "X"); // LRU: x
+    map.push("y", "Y"); // LRU: x, y
+
+    // Act
+    assertEquals("X", map.get("x")); // does not promote
+
+    // Assert: x is still the least-recently-pushed
+    assertEquals("x", map.peekKey());
+    assertEquals("x", map.popKey());
+    assertEquals("y", map.popKey());
+  }
+
+  @Test
+  @DisplayName("popKey/popValue on empty return null")
+  void pop_whenEmpty_returnsNull() {
+    // Arrange
+    LRUMap<Integer, Integer> map = new LRUMap<>();
+
+    // Act & Assert
+    assertNull(map.popKey());
+    assertNull(map.popValue());
+  }
+
+  @Test
+  @DisplayName("popKey removes and returns least-recently-pushed key")
+  void popKey_whenCalled_returnsLRUKeyAndRemoves() {
+    // Arrange
+    LRUMap<Object, Object> map = createSampleMap(SAMPLE_ELEMS);
+
+    // Act & Assert (order: 0 .. SAMPLE_ELEMS-1)
+    for (int i = 0; i < SAMPLE_ELEMS; i++) {
+      assertEquals(i, map.popKey());
     }
-    try {
-      methodLRUht.push(null, null);
-      fail("Expected Exception Error Not Thrown!");
-    } catch (NullPointerException anException) {
-      assertNotNull(anException);
+    assertNull(map.popKey());
+  }
+
+  @Test
+  @DisplayName("popValue removes and returns least-recently-pushed value")
+  void popValue_whenCalled_returnsLRUValueAndRemoves() {
+    // Arrange
+    LRUMap<Object, Object> map = createSampleMap(SAMPLE_ELEMS);
+
+    // Act & Assert (values V0..Vn in LRU->MRU order)
+    for (int i = 0; i < SAMPLE_ELEMS; i++) {
+      assertEquals("V" + i, map.popValue());
     }
-    try {
-      methodLRUht.push(null, new Object());
-      fail("Expected Exception Error Not Thrown!");
-    } catch (NullPointerException anException) {
-      assertNotNull(anException);
+    assertNull(map.popValue());
+  }
+
+  @Test
+  @DisplayName("peekKey/peekValue return LRU without removing")
+  void peek_whenCalled_returnsLRUWithoutRemoving() {
+    // Arrange
+    LRUMap<Integer, String> map = new LRUMap<>();
+    map.push(1, "one");
+    map.push(2, "two");
+
+    // Act & Assert
+    assertEquals(1, map.peekKey());
+    assertEquals("one", map.peekValue());
+    assertEquals(2, map.size());
+    assertEquals(1, map.popKey()); // still the LRU
+  }
+
+  @Test
+  @DisplayName("containsKey/get/remove throw NPE on null key")
+  void methods_whenNullKey_throwNullPointerException() {
+    // Arrange
+    LRUMap<String, Integer> map = new LRUMap<>();
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> map.containsKey(null));
+    assertThrows(NullPointerException.class, () -> map.get(null));
+    assertThrows(NullPointerException.class, () -> map.removeKey(null));
+  }
+
+  @Test
+  @DisplayName("get on missing key returns null")
+  void get_whenMissingKey_returnsNull() {
+    // Arrange
+    LRUMap<String, Integer> map = new LRUMap<>();
+    map.push("a", 1);
+
+    // Act & Assert
+    assertNull(map.get("b"));
+  }
+
+  @Test
+  @DisplayName("keys() enumerates from LRU to MRU")
+  void keys_whenEnumerated_returnsFromLRUToMRU() {
+    // Arrange
+    LRUMap<Object, Object> map = createSampleMap(SAMPLE_ELEMS);
+
+    // Act
+    Enumeration<Object> keys = map.keys();
+
+    // Assert
+    int expected = 0;
+    while (keys.hasMoreElements()) {
+      assertEquals(expected++, keys.nextElement());
     }
+    assertEquals(SAMPLE_ELEMS, expected);
   }
 
-  /**
-   * Tests push(Object,Object) method and verifies the behaviour when pushing the same object more
-   * than one time.
-   */
   @Test
-  public void testPushSameObjTwice() {
-    LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
-    Object[][] sampleObj = {
-      {sampleElemsNumber, new Object()},
-      {sampleElemsNumber + 1, new Object()}
-    };
+  @DisplayName("values() enumerates from LRU to MRU")
+  void values_whenEnumerated_returnsFromLRUToMRU() {
+    // Arrange
+    LRUMap<Object, Object> map = createSampleMap(3); // values: V0, V1, V2
 
-    methodLRUht.push(sampleObj[0][0], sampleObj[0][1]);
-    methodLRUht.push(sampleObj[1][0], sampleObj[1][1]);
+    // Act
+    Enumeration<Object> vals = map.values();
 
-    // check presence
-    assertTrue(verifyKeyValPresence(methodLRUht, sampleObj[0][0], sampleObj[0][1]));
-    assertTrue(verifyKeyValPresence(methodLRUht, sampleObj[1][0], sampleObj[1][1]));
-    // check size
-    assertEquals(sampleElemsNumber + 2, methodLRUht.size());
-
-    // push the same object another time
-    methodLRUht.push(sampleObj[0][0], sampleObj[0][1]);
-    assertTrue(verifyKeyValPresence(methodLRUht, sampleObj[0][0], sampleObj[0][1]));
-    assertTrue(verifyKeyValPresence(methodLRUht, sampleObj[1][0], sampleObj[1][1]));
-    assertEquals(sampleElemsNumber + 2, methodLRUht.size());
+    // Assert
+    assertTrue(vals.hasMoreElements());
+    assertEquals("V0", vals.nextElement());
+    assertEquals("V1", vals.nextElement());
+    assertEquals("V2", vals.nextElement());
+    assertFalse(vals.hasMoreElements());
   }
 
-  /**
-   * Tests push(Object,Object) method and verifies the behaviour when pushing the same key with two
-   * different values.
-   */
   @Test
-  public void testPushSameKey() {
-    LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
-    Object[][] sampleObj = {
-      {sampleElemsNumber, new Object()},
-      {sampleElemsNumber + 1, new Object()}
-    };
+  @DisplayName("valuesToArray fills prefix in LRU->MRU order and leaves remaining null")
+  void valuesToArray_whenArrayLarger_fillsPrefixAndLeavesNulls() {
+    // Arrange
+    LRUMap<Integer, String> map = new LRUMap<>();
+    map.push(1, "A");
+    map.push(2, "B");
+    map.push(3, "C");
+    String[] out = new String[5];
 
-    methodLRUht.push(sampleObj[0][0], sampleObj[0][1]);
-    methodLRUht.push(sampleObj[1][0], sampleObj[1][1]);
+    // Act
+    map.valuesToArray(out);
 
-    // check presence
-    assertTrue(verifyKeyValPresence(methodLRUht, sampleObj[0][0], sampleObj[0][1]));
-    assertTrue(verifyKeyValPresence(methodLRUht, sampleObj[1][0], sampleObj[1][1]));
-    // check size
-    assertEquals(sampleElemsNumber + 2, methodLRUht.size());
-
-    // creating and pushing a different value
-    sampleObj[0][1] = new Object();
-    methodLRUht.push(sampleObj[0][0], sampleObj[0][1]);
-    assertTrue(verifyKeyValPresence(methodLRUht, sampleObj[0][0], sampleObj[0][1]));
-    assertTrue(verifyKeyValPresence(methodLRUht, sampleObj[1][0], sampleObj[1][1]));
-    assertEquals(sampleElemsNumber + 2, methodLRUht.size());
+    // Assert
+    assertArrayEquals(new String[] {"A", "B", "C", null, null}, out);
   }
 
-  /**
-   * Tests popKey() method pushing and popping objects and verifying if their keys are correctly (in
-   * a FIFO manner) fetched and the HashTable entry deleted
-   */
   @Test
-  public void testPopKey() {
-    LRUMap<Object, Object> methodLRUht = new LRUMap<>();
-    Object[][] sampleObjects = createSampleKeyVal(sampleElemsNumber);
-    // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++)
-      methodLRUht.push(sampleObjects[i][0], sampleObjects[i][1]);
-    // getting keys
-    for (int i = 0; i < sampleObjects.length; i++)
-      assertEquals(sampleObjects[i][0], methodLRUht.popKey());
-    // the HashTable must be empty
-    assertNull(methodLRUht.popKey());
+  @DisplayName("clear empties map and resets size")
+  void clear_whenCalled_mapBecomesEmpty() {
+    // Arrange
+    LRUMap<Integer, Integer> map = new LRUMap<>();
+    map.push(1, 10);
+    map.push(2, 20);
+
+    // Act
+    map.clear();
+
+    // Assert
+    assertTrue(map.isEmpty());
+    assertEquals(0, map.size());
+    assertNull(map.popKey());
   }
 
-  /**
-   * Tests popValue() method pushing and popping objects and verifying if their values are correctly
-   * (in a FIFO manner) fetched and the HashTable entry deleted
-   */
   @Test
-  public void testPopValue() {
-    LRUMap<Object, Object> methodLRUht = new LRUMap<>();
-    Object[][] sampleObjects = createSampleKeyVal(sampleElemsNumber);
-    // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++)
-      methodLRUht.push(sampleObjects[i][0], sampleObjects[i][1]);
-    // getting values
-    for (int i = 0; i < sampleObjects.length; i++)
-      assertEquals(sampleObjects[i][1], methodLRUht.popValue());
-    // the HashTable must be empty
-    assertNull(methodLRUht.popKey());
+  @DisplayName("createSafeMap() with Comparable keys behaves correctly")
+  void createSafeMap_whenComparableKey_works() {
+    // Arrange
+    LRUMap<Integer, String> map = LRUMap.createSafeMap();
+    map.push(1, "A");
+    map.push(2, "B");
+
+    // Act & Assert
+    assertEquals(1, map.popKey());
+    assertEquals(2, map.popKey());
+    assertNull(map.popKey());
   }
 
-  /** Tests popValue() method popping a value from an empty LRUMap. */
-  @Test
-  public void testPopValueFromEmpty() {
-    LRUMap<?, ?> methodLRUht = new LRUMap<>();
-    assertNull(methodLRUht.popValue());
+  private record NCKey(int id) { // Non-Comparable key for comparator-based safe map
   }
 
-  /**
-   * Tests peekValue() method pushing and popping objects and verifying if their peekValue is
-   * correct
-   */
   @Test
-  public void testPeekValue() {
-    LRUMap<Object, Object> methodLRUht = new LRUMap<>();
-    Object[][] sampleObjects = createSampleKeyVal(sampleElemsNumber);
-    // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++)
-      methodLRUht.push(sampleObjects[i][0], sampleObjects[i][1]);
-    // getting values
-    for (int i = 0; i < sampleObjects.length; i++) {
-      assertEquals(sampleObjects[i][1], methodLRUht.peekValue());
-      methodLRUht.popKey();
-    }
-    // the HashTable must be empty
-    assertNull(methodLRUht.peekValue());
-    // insert and fetch a null value
-    methodLRUht.push(new Object(), null);
-    assertNull(methodLRUht.peekValue());
+  @DisplayName("createSafeMap(Comparator) accepts non-comparable keys")
+  void createSafeMap_withComparator_acceptsNonComparableKey() {
+    // Arrange
+    LRUMap<NCKey, String> map = LRUMap.createSafeMap(Comparator.comparingInt(k -> k.id));
+    NCKey k1 = new NCKey(1);
+    NCKey k2 = new NCKey(2);
+    map.push(k1, "one");
+    map.push(k2, "two");
+
+    // Act & Assert
+    assertEquals("one", map.get(k1));
+    assertEquals("two", map.get(k2));
+    assertEquals(k1, map.popKey());
+    assertEquals(k2, map.popKey());
   }
 
-  /** Tests size() method pushing and popping elements into the LRUMap */
   @Test
-  public void testSize() {
-    LRUMap<Object, Object> methodLRUht = new LRUMap<>();
-    Object[][] sampleObjects = createSampleKeyVal(sampleElemsNumber);
-    assertTrue(methodLRUht.isEmpty());
-    // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++) {
-      methodLRUht.push(sampleObjects[i][0], sampleObjects[i][1]);
-      assertEquals(methodLRUht.size(), i + 1);
-    }
-    // popping keys
-    for (int i = sampleObjects.length - 1; i >= 0; i--) {
-      methodLRUht.popKey();
-      assertEquals(methodLRUht.size(), i);
-    }
-  }
+  @DisplayName("size reflects pushes and pops; isEmpty tracks emptiness")
+  void size_and_isEmpty_reflectState() {
+    // Arrange
+    LRUMap<Integer, String> map = new LRUMap<>();
+    assertTrue(map.isEmpty());
 
-  /**
-   * Tests removeKey(Object) method verifies if all elements are correctly removed checking the
-   * method return value, if the element is still contained and the HashTable size.
-   */
-  @Test
-  public void testRemoveKey() {
-    LRUMap<Object, Object> methodLRUht = new LRUMap<>();
-    Object[][] sampleObjects = createSampleKeyVal(sampleElemsNumber);
-    // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++)
-      methodLRUht.push(sampleObjects[i][0], sampleObjects[i][1]);
-    // popping keys
-    for (int i = sampleObjects.length - 1; i >= 0; i--) {
-      assertTrue(methodLRUht.removeKey(sampleObjects[i][0]));
-      assertFalse(methodLRUht.containsKey(sampleObjects[i][0]));
-      assertEquals(methodLRUht.size(), i);
-    }
-  }
-
-  /**
-   * Tests removeKey(Object) providing a null key and trying to remove it after setting up a sample
-   * queue.
-   */
-  @Test
-  public void testRemoveNullKey() {
-    LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
-    try {
-      methodLRUht.removeKey(null);
-      fail("Expected Exception Error Not Thrown!");
-    } catch (NullPointerException anException) {
-      assertNotNull(anException);
-    }
-  }
-
-  /**
-   * Tests removeKey(Object) method trying to remove a not present key after setting up a sample
-   * LRUMap.
-   */
-  @Test
-  public void testRemoveNotPresent() {
-    LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
-    assertFalse(methodLRUht.removeKey(new Object()));
-  }
-
-  /**
-   * Tests containsKey(Object) method trying to find a not present key after setting up a sample
-   * queue. Then it search for a present one.
-   */
-  @Test
-  public void testContainsKey() {
-    LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
-    assertFalse(methodLRUht.containsKey(new Object()));
-    Object methodSampleObj = new Object();
-    methodLRUht.push(methodSampleObj, null);
-    assertTrue(methodLRUht.containsKey(methodSampleObj));
-  }
-
-  /**
-   * Tests get(Object) method trying to find a not present key after setting up a sample HashTable,
-   * then it search a present key.
-   */
-  @Test
-  public void testGet() {
-    LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
-    assertNull(methodLRUht.get(new Object()));
-    Object methodSampleKey = new Object();
-    Object methodSampleValue = new Object();
-    methodLRUht.push(methodSampleKey, methodSampleValue);
-    assertEquals(methodLRUht.get(methodSampleKey), methodSampleValue);
-  }
-
-  /** Tests get(Object) trying to fetch a null key. */
-  @Test
-  public void testGetNullKey() {
-    LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
-    try {
-      methodLRUht.get(null);
-      fail("Expected Exception Error Not Thrown!");
-    } catch (NullPointerException anException) {
-      assertNotNull(anException);
-    }
-  }
-
-  /** Tests keys() method verifying if the Enumeration provided is correct */
-  @Test
-  public void testKeys() {
-    LRUMap<Object, Object> methodLRUht = new LRUMap<>();
-    Object[][] sampleObjects = createSampleKeyVal(sampleElemsNumber);
-    // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++)
-      methodLRUht.push(sampleObjects[i][0], sampleObjects[i][1]);
-    Enumeration<Object> methodEnumeration = methodLRUht.keys();
-    int j = 0;
-    while (methodEnumeration.hasMoreElements()) {
-      assertEquals(methodEnumeration.nextElement(), sampleObjects[j][0]);
-      j++;
-    }
-  }
-
-  /**
-   * Tests isEmpty() method trying it with a new generated HashTable and after popping out all keys
-   * in a sample LRUMap
-   */
-  @Test
-  public void testIsEmpty() {
-    LRUMap<Object, Object> methodLRUht = new LRUMap<>();
-    assertTrue(methodLRUht.isEmpty());
-    methodLRUht = createSampleHashTable(sampleElemsNumber);
-    // popping keys
-    for (int i = 0; i < sampleElemsNumber; i++) methodLRUht.popKey();
-    assertTrue(methodLRUht.isEmpty());
+    // Act & Assert
+    map.push(1, "A");
+    assertEquals(1, map.size());
+    map.push(2, "B");
+    assertEquals(2, map.size());
+    assertFalse(map.isEmpty());
+    map.popKey();
+    assertEquals(1, map.size());
+    map.popKey();
+    assertEquals(0, map.size());
+    assertTrue(map.isEmpty());
   }
 }

--- a/src/test/java/network/crypta/support/LRUQueueTest.java
+++ b/src/test/java/network/crypta/support/LRUQueueTest.java
@@ -1,6 +1,13 @@
 package network.crypta.support;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Enumeration;
 import org.junit.jupiter.api.Test;
@@ -10,9 +17,10 @@ import org.junit.jupiter.api.Test;
  *
  * @author Alberto Bacchelli &lt;sback@freenetproject.org&gt;
  */
-public class LRUQueueTest {
+@SuppressWarnings("java:S100") // test naming uses method_whenCondition_expectOutcome
+class LRUQueueTest {
 
-  private static final int sampleElemsNumber = 100;
+  private static final int SAMPLE_ELEMS_NUMBER = 100;
 
   /**
    * Creates an array of objects with a specified size
@@ -35,7 +43,7 @@ public class LRUQueueTest {
   private LRUQueue<Object> createSampleQueue(int size) {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
     Object[] sampleObjects = createSampleObjects(size);
-    for (int i = 0; i < sampleObjects.length; i++) methodLRUQueue.push(sampleObjects[i]);
+    for (Object sampleObject : sampleObjects) methodLRUQueue.push(sampleObject);
     return methodLRUQueue;
   }
 
@@ -47,7 +55,7 @@ public class LRUQueueTest {
    * @return true if there is at least one reference to the object
    */
   private boolean isPresent(Object[] anArray, Object aElementToSearch) {
-    for (int i = 0; i < anArray.length; i++) if (anArray[i].equals(aElementToSearch)) return true;
+    for (Object o : anArray) if (o.equals(aElementToSearch)) return true;
     return false;
   }
 
@@ -80,21 +88,14 @@ public class LRUQueueTest {
    * up a sample queue) and verifying if the correct exception is raised
    */
   @Test
-  public void testPushNull() {
-    LRUQueue<Object> methodLRUQueue = this.createSampleQueue(sampleElemsNumber);
-    try {
-      methodLRUQueue.push(null);
-      fail("Expected Exception Error Not Thrown!");
-    } catch (NullPointerException anException) {
-      assertNotNull(anException);
-    }
-
-    try {
-      methodLRUQueue.pushLeast(null);
-      fail("Expected Exception Error Not Thrown!");
-    } catch (NullPointerException anException) {
-      assertNotNull(anException);
-    }
+  void push_whenNull_expectNullPointerException() {
+    // Arrange
+    LRUQueue<Object> q = this.createSampleQueue(SAMPLE_ELEMS_NUMBER);
+    // Act + Assert
+    NullPointerException ex1 = assertThrows(NullPointerException.class, () -> q.push(null));
+    assertNotNull(ex1);
+    NullPointerException ex2 = assertThrows(NullPointerException.class, () -> q.pushLeast(null));
+    assertNotNull(ex2);
   }
 
   /**
@@ -102,28 +103,28 @@ public class LRUQueueTest {
    * object more than one time.
    */
   @Test
-  public void testPushSameObjTwice() {
-    LRUQueue<Object> methodLRUQueue = this.createSampleQueue(sampleElemsNumber);
+  void push_whenSameObjectTwice_movesToMostRecentWithoutDuplication() {
+    LRUQueue<Object> methodLRUQueue = this.createSampleQueue(SAMPLE_ELEMS_NUMBER);
     Object[] sampleObj = {new Object(), new Object()};
 
     methodLRUQueue.push(sampleObj[0]);
     methodLRUQueue.push(sampleObj[1]);
 
     // check size
-    assertEquals(sampleElemsNumber + 2, methodLRUQueue.size());
+    assertEquals(SAMPLE_ELEMS_NUMBER + 2, methodLRUQueue.size());
     // check order
     assertTrue(verifyLastElemsOrder(methodLRUQueue, sampleObj[0], sampleObj[1]));
 
     methodLRUQueue.push(sampleObj[0]);
     // check size
-    assertEquals(sampleElemsNumber + 2, methodLRUQueue.size());
+    assertEquals(SAMPLE_ELEMS_NUMBER + 2, methodLRUQueue.size());
     // check order
     assertTrue(verifyLastElemsOrder(methodLRUQueue, sampleObj[1], sampleObj[0]));
   }
 
   /** Tests {@link LRUQueue#pushLeast(Object)} method */
   @Test
-  public void testPushLeast() {
+  void pushLeast_whenCalled_placesAtLeastRecent_andMovesExistingToTail() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
     Object[] sampleObj = {new Object(), new Object()};
 
@@ -145,14 +146,13 @@ public class LRUQueueTest {
    * correctly (in a FIFO manner) fetched and deleted
    */
   @Test
-  public void testPop() {
+  void pop_whenFilled_returnsLeastRecentThenNull() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
-    Object[] sampleObjects = createSampleObjects(sampleElemsNumber);
+    Object[] sampleObjects = createSampleObjects(SAMPLE_ELEMS_NUMBER);
     // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++) methodLRUQueue.push(sampleObjects[i]);
+    for (Object object : sampleObjects) methodLRUQueue.push(object);
     // getting objects
-    for (int i = 0; i < sampleObjects.length; i++)
-      assertEquals(sampleObjects[i], methodLRUQueue.pop());
+    for (Object sampleObject : sampleObjects) assertEquals(sampleObject, methodLRUQueue.pop());
     // the queue must be empty
     assertNull(methodLRUQueue.pop());
   }
@@ -162,8 +162,8 @@ public class LRUQueueTest {
    * when popping each object.
    */
   @Test
-  public void testSize() {
-    Object[] sampleObjects = createSampleObjects(sampleElemsNumber);
+  void size_whenPushingAndPopping_tracksCount() {
+    Object[] sampleObjects = createSampleObjects(SAMPLE_ELEMS_NUMBER);
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
     assertEquals(0, methodLRUQueue.size());
     // pushing objects
@@ -184,10 +184,10 @@ public class LRUQueueTest {
    * checking the method return value, if the object is still contained and the queue size.
    */
   @Test
-  public void testRemove() {
+  void remove_whenPresent_removesAndReturnsTrue() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
-    Object[] sampleObjects = createSampleObjects(sampleElemsNumber);
-    for (int i = 0; i < sampleObjects.length; i++) methodLRUQueue.push(sampleObjects[i]);
+    Object[] sampleObjects = createSampleObjects(SAMPLE_ELEMS_NUMBER);
+    for (Object sampleObject : sampleObjects) methodLRUQueue.push(sampleObject);
     // removing all objects in the opposite way used by pop() method
     for (int i = sampleObjects.length - 1; i >= 0; i--) {
       assertTrue(methodLRUQueue.remove(sampleObjects[i]));
@@ -201,14 +201,10 @@ public class LRUQueueTest {
    * setting up a sample queue.
    */
   @Test
-  public void testRemoveNull() {
-    LRUQueue<Object> methodLRUQueue = createSampleQueue(sampleElemsNumber);
-    try {
-      methodLRUQueue.remove(null);
-      fail("Expected Exception Error Not Thrown!");
-    } catch (NullPointerException anException) {
-      assertNotNull(anException);
-    }
+  void remove_whenNull_expectNullPointerException() {
+    LRUQueue<Object> q = createSampleQueue(SAMPLE_ELEMS_NUMBER);
+    NullPointerException ex = assertThrows(NullPointerException.class, () -> q.remove(null));
+    assertNotNull(ex);
   }
 
   /**
@@ -216,8 +212,8 @@ public class LRUQueueTest {
    * setting up a sample queue.
    */
   @Test
-  public void testRemoveNotPresent() {
-    LRUQueue<Object> methodLRUQueue = createSampleQueue(sampleElemsNumber);
+  void remove_whenNotPresent_returnsFalse() {
+    LRUQueue<Object> methodLRUQueue = createSampleQueue(SAMPLE_ELEMS_NUMBER);
     assertFalse(methodLRUQueue.remove(new Object()));
   }
 
@@ -226,8 +222,8 @@ public class LRUQueueTest {
    * setting up a sample queue. Then it search a present object.
    */
   @Test
-  public void testContains() {
-    LRUQueue<Object> methodLRUQueue = createSampleQueue(sampleElemsNumber);
+  void contains_whenPresentAndNotPresent_behavesAsExpected() {
+    LRUQueue<Object> methodLRUQueue = createSampleQueue(SAMPLE_ELEMS_NUMBER);
     assertFalse(methodLRUQueue.contains(new Object()));
     Object methodSampleObj = new Object();
     methodLRUQueue.push(methodSampleObj);
@@ -236,11 +232,11 @@ public class LRUQueueTest {
 
   /** Tests {@link LRUQueue#elements()} method verifying if the Enumeration provided is correct */
   @Test
-  public void testElements() {
-    Object[] sampleObjects = createSampleObjects(sampleElemsNumber);
+  void elements_whenFilled_yieldsLeastToMostRecentOrder() {
+    Object[] sampleObjects = createSampleObjects(SAMPLE_ELEMS_NUMBER);
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
     // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++) methodLRUQueue.push(sampleObjects[i]);
+    for (Object sampleObject : sampleObjects) methodLRUQueue.push(sampleObject);
     Enumeration<Object> methodEnumeration = methodLRUQueue.elements();
     int j = 0;
     while (methodEnumeration.hasMoreElements()) {
@@ -254,45 +250,43 @@ public class LRUQueueTest {
    * that are put into the created LRUQueue
    */
   @Test
-  public void testToArray() {
+  void toArray_whenFilled_containsAllElementsInUnspecifiedOrder() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
-    Object[] sampleObjects = createSampleObjects(sampleElemsNumber);
+    Object[] sampleObjects = createSampleObjects(SAMPLE_ELEMS_NUMBER);
 
     // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++) methodLRUQueue.push(sampleObjects[i]);
+    for (Object object : sampleObjects) methodLRUQueue.push(object);
 
     Object[] resultingArray = methodLRUQueue.toArray();
 
     assertEquals(sampleObjects.length, resultingArray.length);
-    for (int i = 0; i < sampleObjects.length; i++)
-      assertTrue(isPresent(resultingArray, sampleObjects[i]));
+    for (Object sampleObject : sampleObjects) assertTrue(isPresent(resultingArray, sampleObject));
   }
 
   /** Tests {@link LRUQueue#toArray(Object[])} method */
   @Test
-  public void testToArray2() {
+  void toArray_withProvidedArrayExactSize_fillsArray() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
-    Object[] sampleObjects = createSampleObjects(sampleElemsNumber);
+    Object[] sampleObjects = createSampleObjects(SAMPLE_ELEMS_NUMBER);
 
     // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++) methodLRUQueue.push(sampleObjects[i]);
+    for (Object object : sampleObjects) methodLRUQueue.push(object);
 
     Object[] resultingArray = new Object[sampleObjects.length];
     methodLRUQueue.toArray(resultingArray);
 
     assertEquals(sampleObjects.length, resultingArray.length);
-    for (int i = 0; i < sampleObjects.length; i++)
-      assertTrue(isPresent(resultingArray, sampleObjects[i]));
+    for (Object sampleObject : sampleObjects) assertTrue(isPresent(resultingArray, sampleObject));
   }
 
   /** Tests {@link LRUQueue#toArrayOrdered()} method */
   @Test
-  public void testToArrayOrdered() {
+  void toArrayOrdered_whenFilled_returnsLeastToMostRecent() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
-    Object[] sampleObjects = createSampleObjects(sampleElemsNumber);
+    Object[] sampleObjects = createSampleObjects(SAMPLE_ELEMS_NUMBER);
 
     // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++) methodLRUQueue.push(sampleObjects[i]);
+    for (Object sampleObject : sampleObjects) methodLRUQueue.push(sampleObject);
 
     Object[] resultingArray = methodLRUQueue.toArrayOrdered();
 
@@ -303,12 +297,12 @@ public class LRUQueueTest {
 
   /** Tests <code>toArrayOrdered(Object[])</code> method */
   @Test
-  public void testToArrayOrdered2() {
+  void toArrayOrdered_withProvidedArrayExactSize_fillsInOrder() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
-    Object[] sampleObjects = createSampleObjects(sampleElemsNumber);
+    Object[] sampleObjects = createSampleObjects(SAMPLE_ELEMS_NUMBER);
 
     // pushing objects
-    for (int i = 0; i < sampleObjects.length; i++) methodLRUQueue.push(sampleObjects[i]);
+    for (Object sampleObject : sampleObjects) methodLRUQueue.push(sampleObject);
 
     Object[] resultingArray = new Object[sampleObjects.length];
     methodLRUQueue.toArrayOrdered(resultingArray);
@@ -320,20 +314,105 @@ public class LRUQueueTest {
 
   /** Tests toArray() method when the queue is empty */
   @Test
-  public void testToArrayEmptyQueue() {
+  void toArray_whenEmpty_returnsEmptyArray() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
     assertEquals(0, methodLRUQueue.toArray().length);
   }
 
   /** Tests isEmpty() method trying it with an empty queue and then with a sample queue. */
   @Test
-  public void testIsEmpty() {
+  void isEmpty_whenEmptyFilledEmptied_behavesAsExpected() {
     LRUQueue<Object> methodLRUQueue = new LRUQueue<>();
     assertTrue(methodLRUQueue.isEmpty());
-    methodLRUQueue = createSampleQueue(sampleElemsNumber);
+    methodLRUQueue = createSampleQueue(SAMPLE_ELEMS_NUMBER);
     assertFalse(methodLRUQueue.isEmpty());
     // emptying the queue...
-    for (int i = 0; i < sampleElemsNumber; i++) methodLRUQueue.pop();
+    for (int i = 0; i < SAMPLE_ELEMS_NUMBER; i++) methodLRUQueue.pop();
     assertTrue(methodLRUQueue.isEmpty());
+  }
+
+  // === Additional edge-case and API coverage tests ===
+
+  @Test
+  void contains_whenNull_expectFalse() {
+    // Arrange
+    LRUQueue<Object> q = new LRUQueue<>();
+    // Act + Assert
+    assertFalse(q.contains(null));
+    q.push("x");
+    assertFalse(q.contains(null));
+  }
+
+  @Test
+  void clear_whenNotEmpty_expectEmptyAndSizeZero() {
+    // Arrange
+    LRUQueue<Object> q = createSampleQueue(3);
+    assertFalse(q.isEmpty());
+    assertEquals(3, q.size());
+    // Act
+    q.clear();
+    // Assert
+    assertTrue(q.isEmpty());
+    assertEquals(0, q.size());
+    assertNull(q.pop());
+  }
+
+  @Test
+  void get_whenEqualKeyDifferentInstance_returnsStoredReference() {
+    // Arrange
+    LRUQueue<String> q = new LRUQueue<>();
+    String stored = "key1";
+    q.push(stored);
+    // Act
+    String result = q.get("key1");
+    // Assert
+    assertNotNull(result);
+    assertSame(stored, result, "Expected the same reference stored in the queue");
+  }
+
+  @Test
+  void toArrayOrdered_whenArrayTooSmall_allocatesNewAndPreservesOrder() {
+    // Arrange
+    LRUQueue<String> q = new LRUQueue<>();
+    q.push("c");
+    q.push("b");
+    q.push("a"); // LRU order: c, b, a
+    String[] small = new String[0];
+    // Act
+    String[] out = q.toArrayOrdered(small);
+    // Assert
+    assertEquals(3, out.length);
+    assertArrayEquals(new String[] {"c", "b", "a"}, out);
+  }
+
+  @Test
+  void toArrayOrdered_whenArrayLargerThanSize_throwsIllegalStateException() {
+    // Arrange
+    LRUQueue<String> q = new LRUQueue<>();
+    q.push("y");
+    q.push("x"); // size = 2
+    String[] tooLarge = new String[3];
+    // Act + Assert
+    assertThrows(IllegalStateException.class, () -> q.toArrayOrdered(tooLarge));
+  }
+
+  @Test
+  void toArrayOrdered_whenWrongComponentType_throwsArrayStoreException() {
+    // Arrange
+    LRUQueue<String> q = new LRUQueue<>();
+    q.push("b");
+    q.push("a");
+    Integer[] wrongType = new Integer[2];
+    // Act + Assert
+    assertThrows(ArrayStoreException.class, () -> q.toArrayOrdered(wrongType));
+  }
+
+  @Test
+  void elements_whenEmpty_hasNoElements() {
+    // Arrange
+    LRUQueue<Object> q = new LRUQueue<>();
+    Enumeration<Object> e = q.elements();
+    // Assert
+    assertFalse(e.hasMoreElements());
   }
 }


### PR DESCRIPTION
Summary
- Improve and complete API docs for LRU data structures.
- Switch LRUMap key/value enumerations to snapshot views (LRU→MRU order) and add defensive null checks.
- Refactor and extend unit tests for coverage and clarity.

Why
- Clarify threading, nullability, ordering, and complexity guarantees for maintainers and plugin authors.
- Snapshot enumerations avoid iterator invalidation pitfalls and satisfy static analysis rules.
- Additional tests cover edge cases and protect intended behaviors.

Changes (since develop)
- LRUQueue (docs only):
  - Add detailed Javadoc for class and public API (push/pushLeast/pop/contains/toArray variants/etc.).
  - Document concurrency, nullability, MRU/LRU ordering, and complexity.
  - Replace legacy block comment with clear invariants for list/hash coordination.
- LRUMap (docs + minor impl):
  - Add comprehensive Javadoc across the API and internal QItem.
  - Replace inner Enumeration implementations with snapshot-based enumerations for keys() and values().
  - Add defensive null checks around list.pop()/tail() to make invariants explicit.
- LRUCache (docs):
  - Expand class/method docs, expiration semantics, and threading notes.
- Tests:
  - LRUQueueTest: modernize assertion style/naming; add coverage for contains(null), clear(), get(), toArrayOrdered variants, and type/size edge cases.
  - LRUMapTest: align names with API docs; increase coverage (ordered enumeration snapshots).
  - LRUCacheTest: add comprehensive tests for capacity and expiration behavior.

Notes on Behavior
- LRUQueue: no production logic changes.
- LRUMap: keys()/values() now return snapshots rather than live enumerations; order remains LRU→MRU. Callers relying on concurrent structural reflection should take the snapshot semantics into account.

Risk/Impact
- Low. Snapshot enumeration is the only behavior-affecting change and improves safety. No public API signatures changed.

Testing
- Updated and added unit tests as above. Please let CI validate on all platforms.

Commit Shortlog
- 26f959cbea test(support): refactor and extend LRUQueueTest
- 207932e1fb docs(support): improve Javadoc and inline comments for LRUQueue
- dea482286b docs(support): improve Javadoc and inline comments for LRUMap; snapshot keys/values enumerations and defensive null checks
- e5a2d2970e chore: reformat file
- cac8c0dad0 test(support): add comprehensive LRUCache tests

Checklist
- [x] Builds and Spotless formatting applied locally
- [x] No public API signature changes
- [x] Unit tests updated/added

Please review. Target branch: develop (not main).