### PR TITLE
ShortBuffer: Javadoc improvements, naming cleanup, and comprehensive tests

### DIFF
--- a/src/main/java/network/crypta/support/ShortBuffer.java
+++ b/src/main/java/network/crypta/support/ShortBuffer.java
@@ -6,104 +6,174 @@ import java.io.IOException;
 import java.util.Arrays;
 import network.crypta.io.WritableToDataOutputStream;
 
-/** Byte array which is limited to 32KiB. */
+/**
+ * A lightweight view over a byte array whose logical size is limited to 32&nbsp;KiB.
+ *
+ * <p>The buffer stores a backing array together with a start offset and a {@code short}-sized
+ * length. Instances are immutable with respect to their offset and length (all fields are final),
+ * but they do not defensively copy the provided array. Mutating the backing array after passing it
+ * to the constructor will therefore be reflected by this buffer.
+ *
+ * <p>Serialization via {@link #writeToDataOutputStream(DataOutputStream)} writes the length as a
+ * two-byte signed big-endian value followed by the raw bytes. The constructor that accepts a {@link
+ * DataInput} performs the inverse operation and rejects negative lengths.
+ */
 public class ShortBuffer implements WritableToDataOutputStream {
 
+  /**
+   * Historical source control identifier retained for compatibility and debugging only.
+   *
+   * <p>Not intended for programmatic versioning.
+   */
   public static final String VERSION =
       "$Id: ShortBuffer.java,v 1.2 2005/08/25 17:28:19 amphibian Exp $";
 
-  private final byte[] _data;
-  private final int _start;
-  private final short _length;
+  private final byte[] data;
+  private final int start;
+  private final short length;
 
   /**
-   * Create a Buffer by reading a DataInputStream
+   * Constructs a buffer by reading from a {@link DataInput}.
    *
-   * @param dis to read bytes from
-   * @throws IllegalArgumentException If the length integer is negative.
-   * @throws IOException error reading from dis
+   * <p>This method consumes exactly two bytes for the length (signed big-endian {@code short})
+   * followed by that many payload bytes. Only non-negative lengths are accepted; the maximum length
+   * is {@link Short#MAX_VALUE} (32&nbsp;KiB minus one).
+   *
+   * @param dis the input to read from; not {@code null}.
+   * @throws IllegalArgumentException if the encoded length is negative.
+   * @throws IOException if an I/O error occurs or there are not enough bytes to satisfy the read.
    */
   public ShortBuffer(DataInput dis) throws IOException {
-    _length = dis.readShort();
-    if (_length < 0) throw new IllegalArgumentException("Negative Length: " + _length);
-    _data = new byte[_length];
-    _start = 0;
-    dis.readFully(_data);
+    length = dis.readShort();
+    if (length < 0) throw new IllegalArgumentException("Negative Length: " + length);
+    data = new byte[length];
+    start = 0;
+    dis.readFully(data);
   }
 
-  /** Create an empty Buffer */
+  /** Constructs an empty buffer with zero length. */
   public ShortBuffer() {
-    _data = new byte[0];
-    _start = 0;
-    _length = 0;
+    data = new byte[0];
+    start = 0;
+    length = 0;
   }
 
   /**
-   * Create a Buffer from a byte array
+   * Constructs a buffer over the entire provided array.
    *
-   * @param data
+   * <p>No defensive copy is made. Modifying {@code data} after construction will change the bytes
+   * exposed by this buffer.
+   *
+   * @param data the backing array; not {@code null}.
+   * @throws IllegalArgumentException if {@code data.length} exceeds {@link Short#MAX_VALUE}.
    */
   public ShortBuffer(byte[] data) {
     if (data.length > Short.MAX_VALUE)
       throw new IllegalArgumentException("Too big: " + data.length);
-    _start = 0;
-    _length = (short) data.length;
-    _data = data;
+    start = 0;
+    length = (short) data.length;
+    this.data = data;
   }
 
+  /**
+   * Constructs a buffer that exposes a contiguous window of the provided array.
+   *
+   * <p>No defensive copy is made. The window is defined by {@code start} and {@code length}. Both
+   * arguments are validated to ensure the window lies inside {@code data} and that {@code length <=
+   * Short.MAX_VALUE}.
+   *
+   * @param data the backing array; not {@code null}.
+   * @param start the starting offset in {@code data}, inclusive; must be {@code >= 0}.
+   * @param length the number of bytes in the window; must be {@code >= 0} and {@code <=} {@link
+   *     Short#MAX_VALUE}.
+   * @throws IllegalArgumentException if the window is invalid or exceeds {@link Short#MAX_VALUE}.
+   */
   public ShortBuffer(byte[] data, int start, int length) {
     if (length > Short.MAX_VALUE || length < 0 || start < 0 || start + length > data.length)
       throw new IllegalArgumentException("Invalid Length: start=" + start + ", length=" + length);
-    _start = start;
-    _data = data;
-    _length = (short) length;
+    this.start = start;
+    this.data = data;
+    this.length = (short) length;
   }
 
   /**
-   * Retrieve a byte array containing the data in this buffer. May be copied, so don't rely on it
-   * being the internal buffer.
+   * Returns the logical contents as a byte array.
    *
-   * @return The byte array
+   * <p>If this buffer already spans the entire backing array, the internal array reference is
+   * returned for efficiency; callers must not modify it unless they control all references. When
+   * the buffer represents a window into a larger array, a new array containing only the visible
+   * bytes is returned.
+   *
+   * @return a byte array representing the logical contents; either the internal array or a copy.
    */
   public byte[] getData() {
-    if ((_start == 0) && (_length == _data.length)) {
-      return _data;
+    if ((start == 0) && (length == data.length)) {
+      return data;
     } else {
-      return Arrays.copyOfRange(_data, _start, _start + _length);
+      return Arrays.copyOfRange(data, start, start + length);
     }
   }
 
   /**
-   * Copy the data to a byte array
+   * Copies the logical contents into the destination array at the specified offset.
    *
-   * @param array
-   * @param position
+   * <p>No bounds checks are performed beyond those of {@link System#arraycopy(Object, int, Object,
+   * int, int)}. If {@code array} is too small to hold the bytes starting at {@code position},
+   * {@link ArrayIndexOutOfBoundsException} will be thrown by the JVM.
+   *
+   * @param array the destination array; not {@code null}.
+   * @param position the starting index in {@code array} where bytes are written; must be valid.
    */
   public void copyTo(byte[] array, int position) {
-    System.arraycopy(_data, _start, array, position, _length);
+    System.arraycopy(data, start, array, position, length);
   }
 
+  /**
+   * Returns the byte at the given logical position.
+   *
+   * @param pos zero-based index into the logical contents; must be {@code 0 <= pos < length}.
+   * @return the byte value at {@code pos}.
+   * @throws ArrayIndexOutOfBoundsException if {@code pos} is outside the valid range.
+   */
   public byte byteAt(int pos) {
-    if (pos >= _length) {
+    if (pos >= length) {
       throw new ArrayIndexOutOfBoundsException();
     }
-    return _data[pos + _start];
+    return data[pos + start];
   }
 
+  /**
+   * Writes this buffer to a {@link DataOutputStream}.
+   *
+   * <p>The format is a two-byte signed big-endian length followed by {@code length} raw bytes. This
+   * is the inverse of the {@link #ShortBuffer(DataInput)} constructor.
+   *
+   * @param stream destination stream; not {@code null}.
+   * @throws IOException if the stream fails while writing.
+   */
   @Override
   public void writeToDataOutputStream(DataOutputStream stream) throws IOException {
-    stream.writeShort(_length);
-    stream.write(_data, _start, _length);
+    stream.writeShort(length);
+    stream.write(data, start, length);
   }
 
+  /**
+   * Returns a human-readable representation intended for debugging.
+   *
+   * <p>For buffers with {@code length > 50}, the result is {@code "Buffer {<length>}"}. Otherwise,
+   * the result starts with {@code "{"}, then the length and a colon, followed by the signed byte
+   * values separated by spaces, and ends with a trailing space (historical format).
+   *
+   * <p>Format stability is not guaranteed. Do not parse this output.
+   */
   @Override
   public String toString() {
-    if (this._length > 50) {
-      return "Buffer {" + this._length + '}';
+    if (this.length > 50) {
+      return "Buffer {" + this.length + '}';
     } else {
-      StringBuilder b = new StringBuilder(this._length * 3);
-      b.append('{').append(this._length).append(':');
-      for (int x = 0; x < this._length; x++) {
+      StringBuilder b = new StringBuilder(this.length * 3);
+      b.append('{').append(this.length).append(':');
+      for (int x = 0; x < this.length; x++) {
         b.append(byteAt(x));
         b.append(' ');
       }
@@ -111,6 +181,14 @@ public class ShortBuffer implements WritableToDataOutputStream {
     }
   }
 
+  /**
+   * Compares this buffer to another for equality.
+   *
+   * <p>Equality requires that the logical length and start offset match, and that the entire
+   * backing arrays are equal (not just the visible window). This means two buffers exposing the
+   * same window over different arrays may be considered unequal if the arrays differ in bytes
+   * outside the window.
+   */
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -120,21 +198,34 @@ public class ShortBuffer implements WritableToDataOutputStream {
       return false;
     }
 
-    if (_length != buffer._length) {
+    if (length != buffer.length) {
       return false;
     }
-    if (_start != buffer._start) {
+    if (start != buffer.start) {
       return false;
     }
-    return Arrays.equals(_data, buffer._data);
+    // Intentionally compare the entire arrays (not just the visible window).
+    return Arrays.equals(data, buffer.data);
   }
 
+  /**
+   * Computes a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The result mixes the hash of the full backing array with the start offset and length.
+   *
+   * @return the hash code.
+   */
   @Override
   public int hashCode() {
-    return Fields.hashCode(_data) ^ _start ^ (_length << 16);
+    return Fields.hashCode(data) ^ start ^ (length << 16);
   }
 
+  /**
+   * Returns the logical number of bytes in this buffer.
+   *
+   * @return the length as a non-negative {@code int} not exceeding {@link Short#MAX_VALUE}.
+   */
   public int getLength() {
-    return _length;
+    return length;
   }
 }

--- a/src/test/java/network/crypta/support/ShortBufferTest.java
+++ b/src/test/java/network/crypta/support/ShortBufferTest.java
@@ -1,190 +1,244 @@
 package network.crypta.support;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Test case for {@link ShortBuffer} class.
- *
- * @author stuart martin &lt;wavey@freenetproject.org&gt;
- * @author Daniel Cheng &lt;sdiz@freenetproject.org&gt;
- */
-public class ShortBufferTest {
+@SuppressWarnings("java:S100") // method_whenCondition_expectOutcome naming
+class ShortBufferTest {
 
-  private static final String DATA_STRING_1 =
+  private static final String DATA_STRING =
       "asldkjaskjdsakdhasdhaskjdhaskjhbkasbhdjkasbduiwbxgdoudgboewuydxbybuewyxbuewyuwe"
           + "dasdkljasndijwnodhnqweoidhnaouidhbnwoduihwnxodiuhnwuioxdhnwqiouhnxwqoiushdnxwqoiudhxnwqoiudhxni";
 
-  @Test
-  public void testByteArrayShortBuffer() {
+  // ---------- Constructors ----------
 
-    byte[] data = DATA_STRING_1.getBytes();
+  @Test
+  void constructor_withByteArray_returnsSameArrayAndLength() {
+    byte[] data = DATA_STRING.getBytes();
 
     ShortBuffer buffer = new ShortBuffer(data);
 
-    assertEquals(data, buffer.getData());
-
-    doTestShortBuffer(data, buffer);
-  }
-
-  @Test
-  public void testByteArrayIndexShortBuffer() {
-
-    // get content
-    byte[] data = DATA_STRING_1.getBytes();
-
-    byte[] dataSub = new byte[5];
-
-    // prepare 'substring'
-    System.arraycopy(data, 4, dataSub, 0, 5);
-
-    ShortBuffer buffer = new ShortBuffer(data, 4, 5);
-
-    assertNotEquals(dataSub, buffer.getData());
-
-    doTestShortBuffer(dataSub, buffer);
-  }
-
-  @Test
-  public void testBadLength() {
-    try {
-      new ShortBuffer(new byte[0], 0, -1);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expect this
-    }
-    try {
-      new ShortBuffer(new byte[0], 0, 1);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expect this
-    }
-    try {
-      new ShortBuffer(new byte[0], 1, 0);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expect this
-    }
-    try {
-      new ShortBuffer(new byte[32768], 0, 32768);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expect this
-    }
-    new Buffer(new byte[1], 1, 0);
-    new Buffer(new byte[1], 0, 1);
-  }
-
-  @Test
-  public void testDataInputStreamShortBuffer() {
-
-    byte[] data = DATA_STRING_1.getBytes(); // get some content
-
-    byte[] data2 = new byte[data.length + 2]; // make room for 4 byte length indicator
-
-    int length = DATA_STRING_1.getBytes().length;
-
-    // populate length as first 4 bytes
-    data2[0] = (byte) ((length & 0xff00) >> 8);
-    data2[1] = (byte) ((length & 0xff));
-
-    System.arraycopy(data, 0, data2, 2, data.length); // populate rest of content
-
-    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data2));
-    ShortBuffer buffer = null;
-
-    try {
-      buffer = new ShortBuffer(dis);
-    } catch (IOException e) {
-      fail("unexpected exception: " + e.getMessage());
-    }
-    // perform rest of test with the *original* array because ShortBuffer(DataInputStream) chomps
-    // first 4 bytes
-    doTestShortBuffer(data, buffer);
-  }
-
-  private void doTestShortBuffer(byte[] data, ShortBuffer buffer) {
+    assertSame(data, buffer.getData());
     assertEquals(data.length, buffer.getLength());
-
-    for (int i = 0; i < buffer.getLength(); i++) {
+    for (int i = 0; i < data.length; i++) {
       assertEquals(data[i], buffer.byteAt(i));
     }
+  }
 
-    try {
-      buffer.byteAt(data.length + 1); // expect exception
-      fail();
-    } catch (ArrayIndexOutOfBoundsException e) {
-      // expect this
+  @Test
+  void constructor_withByteArrayStartLength_returnsCopyAndExposesSlice() {
+    byte[] data = DATA_STRING.getBytes();
+    ShortBuffer buffer = new ShortBuffer(data, 4, 5);
+
+    byte[] expected = new byte[5];
+    System.arraycopy(data, 4, expected, 0, 5);
+
+    assertNotSame(data, buffer.getData());
+    assertArrayEquals(expected, buffer.getData());
+    assertEquals(5, buffer.getLength());
+    for (int i = 0; i < buffer.getLength(); i++) {
+      assertEquals(expected[i], buffer.byteAt(i));
     }
   }
 
   @Test
-  public void testShortBufferToString() {
-    String shortString = "feep";
-    ShortBuffer shortShortBuffer = new ShortBuffer(shortString.getBytes());
-
-    String outString = shortShortBuffer.toString();
-    assertEquals(outString, "{4:102 101 101 112 "); // FIXME: final brace?
+  void constructor_withEmpty_noThrowAndHasZeroLength() {
+    ShortBuffer buffer = new ShortBuffer();
+    assertEquals(0, buffer.getLength());
+    assertEquals(0, buffer.getData().length);
   }
 
   @Test
-  public void testEquals() {
-    ShortBuffer b1 = new ShortBuffer("ShortBuffer1".getBytes());
-    ShortBuffer b2 = new ShortBuffer("ShortBuffer2".getBytes());
-    ShortBuffer b3 = new ShortBuffer("ShortBuffer1".getBytes());
+  void constructor_withTooLargeArray_throwsIllegalArgument() {
+    byte[] big = new byte[Short.MAX_VALUE + 1];
+    assertThrows(IllegalArgumentException.class, () -> new ShortBuffer(big));
+  }
 
+  static Stream<Arguments> invalidStartLenCases() {
+    return Stream.of(
+        // length < 0
+        Arguments.of(0, -1, 0),
+        // start < 0
+        Arguments.of(-1, 0, 0),
+        // start + length > data.length
+        Arguments.of(0, 1, 0),
+        Arguments.of(1, 0, 0),
+        // length > Short.MAX_VALUE
+        Arguments.of(0, Short.MAX_VALUE + 1, Short.MAX_VALUE + 1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidStartLenCases")
+  void constructor_withInvalidStartOrLength_throwsIllegalArgument(
+      int start, int length, int dataLen) {
+    byte[] data = new byte[dataLen];
+    assertThrows(IllegalArgumentException.class, () -> new ShortBuffer(data, start, length));
+  }
+
+  @Test
+  void constructor_withMaxAllowedLength_succeeds() {
+    byte[] data = new byte[Short.MAX_VALUE];
+    ShortBuffer buffer = new ShortBuffer(data, 0, data.length);
+    assertEquals(Short.MAX_VALUE, buffer.getLength());
+  }
+
+  @Test
+  void constructor_withDataInput_readsLengthAndBytes() throws IOException {
+    byte[] data = DATA_STRING.getBytes();
+    int len = data.length;
+    byte[] in = new byte[len + 2];
+    in[0] = (byte) ((len >>> 8) & 0xFF);
+    in[1] = (byte) (len & 0xFF);
+    System.arraycopy(data, 0, in, 2, len);
+
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(in))) {
+      ShortBuffer buffer = new ShortBuffer(dis);
+      assertEquals(len, buffer.getLength());
+      for (int i = 0; i < len; i++) {
+        assertEquals(data[i], buffer.byteAt(i));
+      }
+    }
+  }
+
+  @Test
+  void constructor_withDataInputNegativeLength_throwsIllegalArgument() {
+    // length = -1 -> 0xFFFF
+    byte[] in = new byte[] {(byte) 0xFF, (byte) 0xFF};
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(in))) {
+      assertThrows(IllegalArgumentException.class, () -> new ShortBuffer(dis));
+    } catch (IOException e) {
+      throw new java.io.UncheckedIOException(e);
+    }
+  }
+
+  @Test
+  void constructor_withDataInputInsufficientBytes_throwsIOException() {
+    // declare length 5 but only provide 2 payload bytes
+    byte[] in = new byte[] {0, 5, 1, 2};
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(in))) {
+      assertThrows(EOFException.class, () -> new ShortBuffer(dis));
+    } catch (IOException e) {
+      throw new java.io.UncheckedIOException(e);
+    }
+  }
+
+  // ---------- Accessors ----------
+
+  @Test
+  void getData_whenFullRange_returnsInternalArray() {
+    byte[] data = {1, 2, 3};
+    ShortBuffer b = new ShortBuffer(data);
+    assertSame(data, b.getData());
+  }
+
+  @Test
+  void getData_whenSlice_returnsCopy() {
+    byte[] data = {10, 20, 30, 40};
+    ShortBuffer b = new ShortBuffer(data, 1, 2);
+    byte[] out = b.getData();
+    assertNotSame(data, out);
+    assertArrayEquals(new byte[] {20, 30}, out);
+  }
+
+  @Test
+  void byteAt_whenNegativeOrAtLength_throws() {
+    byte[] data = {9, 8, 7};
+    ShortBuffer b = new ShortBuffer(data);
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.byteAt(-1));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.byteAt(data.length));
+  }
+
+  // ---------- write/copy semantics ----------
+
+  @Test
+  void writeToDataOutputStream_roundTripsViaDataInputConstructor() throws IOException {
+    byte[] data = {1, 2, 3, 4, 5};
+    ShortBuffer original = new ShortBuffer(data);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(bos)) {
+      original.writeToDataOutputStream(dos);
+    }
+
+    byte[] payload = bos.toByteArray();
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload))) {
+      ShortBuffer restored = new ShortBuffer(dis);
+      assertEquals(original, restored);
+      assertEquals(original.hashCode(), restored.hashCode());
+    }
+  }
+
+  @Test
+  void copyTo_whenOffsetCopiesIntoDestination() {
+    byte[] data = {10, 20, 30};
+    ShortBuffer b = new ShortBuffer(data);
+
+    byte[] dest = new byte[6];
+    Arrays.fill(dest, (byte) 0x7F);
+
+    b.copyTo(dest, 2);
+
+    assertArrayEquals(new byte[] {(byte) 0x7F, (byte) 0x7F, 10, 20, 30, (byte) 0x7F}, dest);
+  }
+
+  @Test
+  void copyTo_whenDestinationTooSmall_throws() {
+    byte[] data = {1, 2, 3, 4};
+    ShortBuffer b = new ShortBuffer(data);
+    byte[] dest = new byte[5];
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> b.copyTo(dest, 2));
+  }
+
+  // ---------- equals / hashCode / toString ----------
+
+  @Test
+  void equalsAndHashCode_whenDifferentArraysSameContent_areEqual() {
+    byte[] a1 = "ShortBuffer1".getBytes();
+    byte[] a2 = "ShortBuffer1".getBytes();
+    ShortBuffer b1 = new ShortBuffer(a1);
+    ShortBuffer b2 = new ShortBuffer(a2);
+
+    assertEquals(b1, b2);
+    assertEquals(b1.hashCode(), b2.hashCode());
+  }
+
+  @Test
+  void equals_whenSameArrayDifferentStart_notEqual() {
+    byte[] arr = {1, 2, 3, 4};
+    ShortBuffer b1 = new ShortBuffer(arr, 0, 2);
+    ShortBuffer b2 = new ShortBuffer(arr, 1, 2);
     assertNotEquals(b1, b2);
-    assertEquals(b1, b3);
-    assertNotEquals(b2, b3);
-    assertEquals(b1, b1);
-    assertEquals(b2, b2);
-    assertEquals(b3, b1);
   }
 
   @Test
-  public void testHashcode() {
-
-    ShortBuffer b1 = new ShortBuffer("ShortBuffer1".getBytes());
-    ShortBuffer b2 = new ShortBuffer("ShortBuffer2".getBytes());
-    ShortBuffer b3 = new ShortBuffer("ShortBuffer1".getBytes());
-
-    Map<ShortBuffer, ShortBuffer> hashMap = new HashMap<>();
-
-    hashMap.put(b1, b1);
-    hashMap.put(b2, b2);
-    hashMap.put(b3, b3); // should clobber b1 due to content
-
-    // see if b3 survived
-    Object o = hashMap.get(b3);
-    assertNotSame(o, b1);
-    assertSame(o, b3);
-
-    // see if b1 survived
-    o = hashMap.get(b1);
-    assertNotSame(o, b1);
-    assertSame(o, b3);
+  @DisplayName("toString small: shows bytes and trailing space")
+  void toString_whenShort_returnsVerboseWithTrailingSpace() {
+    ShortBuffer b = new ShortBuffer("feep".getBytes());
+    assertEquals("{4:102 101 101 112 ", b.toString());
   }
 
   @Test
-  public void testCopy() {
-    byte[] oldBuf = DATA_STRING_1.getBytes();
-    ShortBuffer b = new ShortBuffer(oldBuf);
-
-    byte[] newBuf = new byte[b.getLength()];
-    b.copyTo(newBuf, 0);
-
-    for (int i = 0; i < oldBuf.length; i++) {
-      assertEquals(newBuf[i], oldBuf[i]);
-    }
+  void toString_whenLengthGreaterThan50_isSummaryOnly() {
+    byte[] longArr = new byte[51];
+    ShortBuffer b = new ShortBuffer(longArr);
+    assertEquals("Buffer {51}", b.toString());
   }
 }


### PR DESCRIPTION
Summary
- Improve and complete Javadoc for ShortBuffer: class overview, serialization contract, constructors, accessors, IO, equals/hashCode, and toString semantics.
- Clarify immutability of offset/length and that the backing array is not defensively copied.
- Document exception conditions and edge cases.
- Keep behavior unchanged.
- Run Spotless to ensure formatting is consistent with project style.

Implementation Notes
- Internal field names were cleaned up earlier in this branch (data/start/length) to satisfy SonarLint naming rules without changing behavior or public API.
- Tests for ShortBuffer were modernized to JUnit 6 style and expanded for edge conditions, serialization round-trip, equals/hashCode consistency, copy semantics, and toString formats (short vs. long buffers). Tests are deterministic and avoid mocks.

Verification
- Targeted tests: `./gradlew --parallel test --tests 'network.crypta.support.ShortBufferTest'` passed.
- Full test suite: `./gradlew --parallel test` passed locally.
- SonarLint for ShortBuffer.java (`sonarlintFile`) reports no issues.

Changes
- src/main/java/network/crypta/support/ShortBuffer.java (Javadoc and comments)
- src/test/java/network/crypta/support/ShortBufferTest.java (modernized + expanded coverage)

Risk & Compatibility
- No public API changes. Behavior preserved, including toString’s historical trailing space for short buffers.

Checklist
- [x] Tests updated and passing
- [x] No behavior changes
- [x] SonarLint clean on modified source file
- [x] Spotless applied

Please review. This targets `develop`. Thanks!