### PR TITLE
support: Add RemoveRangeArrayList tests and improve Javadoc

### DIFF
--- a/src/main/java/network/crypta/support/RemoveRangeArrayList.java
+++ b/src/main/java/network/crypta/support/RemoveRangeArrayList.java
@@ -3,14 +3,52 @@ package network.crypta.support;
 import java.io.Serial;
 import java.util.ArrayList;
 
+/**
+ * An {@link ArrayList} variant that exposes {@code removeRange(int, int)} as a public API.
+ *
+ * <p>This class behaves exactly like {@link ArrayList} with the only difference being that the
+ * normally {@code protected} {@code removeRange} method is made {@code public}. This is useful in
+ * code paths that need to efficiently delete a contiguous slice of elements without constructing a
+ * {@link java.util.List#subList(int, int) subList} or performing multiple single-element removes.
+ *
+ * <p>Null elements are permitted; iteration order and all other semantics are identical to {@link
+ * ArrayList}. This type is not thread-safe.
+ *
+ * @param <T> the element type stored in the list
+ */
 public class RemoveRangeArrayList<T> extends ArrayList<T> {
 
+  // Serial version for interoperability of serialized forms across compatible versions.
   @Serial private static final long serialVersionUID = -1L;
 
+  /**
+   * Creates a list with the specified initial capacity.
+   *
+   * <p>The list grows as needed; the capacity argument is only a performance hint for internal
+   * array sizing.
+   *
+   * @param capacity the initial capacity of the list (non-negative)
+   * @throws IllegalArgumentException if {@code capacity} is negative
+   */
   public RemoveRangeArrayList(int capacity) {
     super(capacity);
   }
 
+  /**
+   * Removes elements in the half-open interval {@code [fromIndex, toIndex)} from this list.
+   *
+   * <p>All elements with indices {@code fromIndex} through {@code toIndex - 1} are deleted. Any
+   * subsequent elements are shifted left to fill the gap, and the size decreases by {@code (toIndex
+   * - fromIndex)}. This is a structural modification and invalidates any active iterators.
+   *
+   * <p>Time complexity is linear in the number of elements moved (proportional to the remainder of
+   * the list after {@code toIndex}).
+   *
+   * @param fromIndex the start index, inclusive
+   * @param toIndex the end index, exclusive
+   * @throws IndexOutOfBoundsException if an index is out of range ({@code fromIndex < 0}, {@code
+   *     toIndex > size()}, or {@code fromIndex > toIndex})
+   */
   @Override
   public void removeRange(int fromIndex, int toIndex) {
     super.removeRange(fromIndex, toIndex);

--- a/src/test/java/network/crypta/support/RemoveRangeArrayListTest.java
+++ b/src/test/java/network/crypta/support/RemoveRangeArrayListTest.java
@@ -1,0 +1,84 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100") // test method names use given_when_then convention with underscores
+class RemoveRangeArrayListTest {
+
+  @Test
+  void removeRange_whenValidMiddleRange_removesExpectedElements() {
+    // Arrange
+    RemoveRangeArrayList<Integer> list = new RemoveRangeArrayList<>(10);
+    list.addAll(Arrays.asList(0, 1, 2, 3, 4));
+
+    // Act
+    list.removeRange(1, 3); // remove indices [1,3) => removes 1 and 2
+
+    // Assert
+    assertEquals(List.of(0, 3, 4), list);
+  }
+
+  @Test
+  void removeRange_whenFromEqualsToIndex_doesNothing() {
+    // Arrange
+    RemoveRangeArrayList<Integer> list = new RemoveRangeArrayList<>(5);
+    list.addAll(Arrays.asList(0, 1, 2, 3, 4));
+
+    // Act
+    list.removeRange(2, 2);
+
+    // Assert
+    assertEquals(List.of(0, 1, 2, 3, 4), list);
+  }
+
+  @Test
+  void removeRange_whenRemoveAll_clearsList() {
+    // Arrange
+    RemoveRangeArrayList<Integer> list = new RemoveRangeArrayList<>(5);
+    list.addAll(Arrays.asList(0, 1, 2, 3, 4));
+
+    // Act
+    list.removeRange(0, list.size());
+
+    // Assert
+    assertEquals(List.of(), list);
+  }
+
+  @Test
+  @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+  void removeRange_whenFromIndexNegative_throwsIndexOutOfBounds() {
+    // Arrange
+    RemoveRangeArrayList<Integer> list = new RemoveRangeArrayList<>(3);
+    list.addAll(Arrays.asList(0, 1, 2));
+
+    // Act + Assert
+    assertThrows(IndexOutOfBoundsException.class, () -> list.removeRange(-1, 2));
+  }
+
+  @Test
+  @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+  void removeRange_whenToIndexExceedsSize_throwsIndexOutOfBounds() {
+    // Arrange
+    RemoveRangeArrayList<Integer> list = new RemoveRangeArrayList<>(3);
+    list.addAll(Arrays.asList(0, 1, 2));
+
+    // Act + Assert
+    assertThrows(IndexOutOfBoundsException.class, () -> list.removeRange(1, 4));
+  }
+
+  @Test
+  @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+  void removeRange_whenFromIndexGreaterThanToIndex_throwsIndexOutOfBounds() {
+    // Arrange
+    RemoveRangeArrayList<Integer> list = new RemoveRangeArrayList<>(5);
+    list.addAll(Arrays.asList(0, 1, 2, 3, 4));
+
+    // Act + Assert
+    assertThrows(IndexOutOfBoundsException.class, () -> list.removeRange(4, 3));
+  }
+}


### PR DESCRIPTION
Summary
- Adds comprehensive JUnit 6 tests for RemoveRangeArrayList.
- Improves Javadoc for class, constructor, and removeRange method.

Details
- Tests cover: middle-range removal, no-op range (from==to), remove-all, and three invalid range cases (negative from, to>size, from>to). Deterministic and isolated.
- Javadoc clarifies [from, to) semantics, element shifting, iterator invalidation, complexity, and exceptions. Notes thread-safety and null handling.

Rationale
- Make protected removeRange usable via a small derived type and ensure behavior is verified by tests.
- Clarifies API contract for maintainers and callers.

Scope of changes
- src/main/java/network/crypta/support/RemoveRangeArrayList.java
- src/test/java/network/crypta/support/RemoveRangeArrayListTest.java

Validation
- Spotless applied successfully.
- Targeted test run for RemoveRangeArrayListTest passed.
- Full test suite also executed locally without failures.

Notes
- No production logic changed; documentation only in main source file.
- Branch: feature/fix-RemoveRangeArrayList; base: develop.