### PR TITLE
UptimeContainer docs + tests; update call sites to accessors

### DIFF
--- a/src/main/java/network/crypta/client/async/PersistentStatsPutter.java
+++ b/src/main/java/network/crypta/client/async/PersistentStatsPutter.java
@@ -44,8 +44,9 @@ public class PersistentStatsPutter implements Serializable {
     this.latestNodeBytesIn = nodeBW[1];
 
     final long uptime = n.getUptime();
-    this.latestUptime.totalUptime += uptime - this.latestUptimeVal;
-    this.latestUptime.creationTime = System.currentTimeMillis();
+    this.latestUptime.setTotalUptime(
+        this.latestUptime.getTotalUptime() + uptime - this.latestUptimeVal);
+    this.latestUptime.setCreationTime(System.currentTimeMillis());
     this.latestUptimeVal = uptime;
   }
 

--- a/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
@@ -304,7 +304,7 @@ public class StatisticsToadlet extends Toadlet {
           drawOverviewBox(
               overviewInfobox,
               nodeUptimeSeconds,
-              node.getClientCore().getBandwidthStatsPutter().getLatestUptimeData().totalUptime,
+              node.getClientCore().getBandwidthStatsPutter().getLatestUptimeData().getTotalUptime(),
               now,
               swaps,
               noSwaps);
@@ -847,7 +847,7 @@ public class StatisticsToadlet extends Toadlet {
         // FIXME this is not necessarily the same as the datastore's uptime if we've switched.
         // Ideally we'd track uptime there too.
         totalUptimeSeconds =
-            node.getClientCore().getBandwidthStatsPutter().getLatestUptimeData().totalUptime;
+            node.getClientCore().getBandwidthStatsPutter().getLatestUptimeData().getTotalUptime();
       } catch (StatsNotAvailableException e) {
         totalAccess = null;
       }

--- a/src/main/java/network/crypta/support/UptimeContainer.java
+++ b/src/main/java/network/crypta/support/UptimeContainer.java
@@ -4,15 +4,40 @@ import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * Contains uptime statistics.
+ * Container for basic uptime statistics.
+ *
+ * <p>This mutable value object carries two pieces of information, both expressed in milliseconds:
+ *
+ * <ul>
+ *   <li><b>Capture time</b> ({@link #getCreationTime()}): the wall-clock time, in milliseconds
+ *       since the Unix epoch (UTC), when the latest uptime sample was observed.
+ *   <li><b>Total uptime</b> ({@link #getTotalUptime()}): an accumulated uptime value intended to
+ *       represent the sum of per-interval uptimes.
+ * </ul>
+ *
+ * <p>Instances are not thread-safe. If multiple threads access the same instance, callers must
+ * provide external synchronization.
+ *
+ * <p>Equality and hash code are defined in terms of both fields.
  *
  * @author Artefact2
  */
 public class UptimeContainer implements Serializable {
   @Serial private static final long serialVersionUID = 1L;
-  public long creationTime = 0;
-  public long totalUptime = 0;
+  // Milliseconds since Unix epoch (UTC) of the most recent captured sample.
+  private long creationTime = 0;
+  // Accumulated uptime in milliseconds; expected non-negative (not enforced by this class).
+  private long totalUptime = 0;
 
+  /**
+   * Compares this container to the specified object for equality.
+   *
+   * <p>Two containers are equal when both their capture time and accumulated uptime are identical.
+   *
+   * @param o the object to compare against
+   * @return {@code true} if {@code o} is an {@code UptimeContainer} with the same values; otherwise
+   *     {@code false}
+   */
   @Override
   public boolean equals(Object o) {
     if (o == null) return false;
@@ -22,16 +47,78 @@ public class UptimeContainer implements Serializable {
     } else return false;
   }
 
+  /**
+   * Returns a hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>The hash is derived from both the capture time and the accumulated uptime.
+   *
+   * @return a hash code value for this container
+   */
   @Override
   public int hashCode() {
     int hash = 7;
-    hash = 29 * hash + (int) (this.creationTime ^ (this.creationTime >>> 32));
-    hash = 29 * hash + (int) (this.totalUptime ^ (this.totalUptime >>> 32));
+    hash = 29 * hash + Long.hashCode(this.creationTime);
+    hash = 29 * hash + Long.hashCode(this.totalUptime);
     return hash;
   }
 
+  /**
+   * Aggregates values from the provided container into this instance.
+   *
+   * <p>This method replaces this instance's capture time with the source container's capture time
+   * and adds the source's accumulated uptime to this instance's accumulated uptime. It mutates this
+   * instance and does not modify the argument.
+   *
+   * <p>Expected usage is to merge a later sample into an ongoing total; no ordering checks are
+   * performed.
+   *
+   * <p>Thread-safety: this method is not synchronized.
+   *
+   * @param latestUptime the source container to merge from; expected to represent a later sample
+   * @throws NullPointerException if {@code latestUptime} is {@code null}
+   */
   public void addFrom(UptimeContainer latestUptime) {
     this.creationTime = latestUptime.creationTime;
     this.totalUptime += latestUptime.totalUptime;
+  }
+
+  /**
+   * Returns the capture time of the latest sample.
+   *
+   * @return milliseconds since the Unix epoch (UTC)
+   */
+  public long getCreationTime() {
+    return creationTime;
+  }
+
+  /**
+   * Sets the capture time of the latest sample.
+   *
+   * <p>No validation is performed.
+   *
+   * @param creationTime milliseconds since the Unix epoch (UTC)
+   */
+  public void setCreationTime(long creationTime) {
+    this.creationTime = creationTime;
+  }
+
+  /**
+   * Returns the accumulated uptime.
+   *
+   * @return accumulated uptime in milliseconds
+   */
+  public long getTotalUptime() {
+    return totalUptime;
+  }
+
+  /**
+   * Sets the accumulated uptime.
+   *
+   * <p>No validation is performed; callers may enforce non-negativity as needed.
+   *
+   * @param totalUptime accumulated uptime in milliseconds
+   */
+  public void setTotalUptime(long totalUptime) {
+    this.totalUptime = totalUptime;
   }
 }

--- a/src/test/java/network/crypta/support/UptimeContainerTest.java
+++ b/src/test/java/network/crypta/support/UptimeContainerTest.java
@@ -1,0 +1,251 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // allow method names with underscores
+class UptimeContainerTest {
+
+  @Test
+  void defaults_whenConstructed_expectZeroFields() {
+    // Arrange & Act
+    UptimeContainer uc = new UptimeContainer();
+
+    // Assert
+    assertEquals(0L, uc.getCreationTime(), "Default creationTime should be 0");
+    assertEquals(0L, uc.getTotalUptime(), "Default totalUptime should be 0");
+  }
+
+  @Test
+  @SuppressWarnings("EqualsWithItself")
+  void equals_whenSameReference_expectTrue() {
+    // Arrange
+    UptimeContainer uc = new UptimeContainer();
+    uc.setCreationTime(123L);
+    uc.setTotalUptime(456L);
+
+    // Act & Assert
+    assertEquals(uc, uc);
+  }
+
+  @Test
+  void equals_whenEqualFields_expectSymmetricAndTransitive() {
+    // Arrange
+    UptimeContainer a = new UptimeContainer();
+    a.setCreationTime(10L);
+    a.setTotalUptime(20L);
+
+    UptimeContainer b = new UptimeContainer();
+    b.setCreationTime(10L);
+    b.setTotalUptime(20L);
+
+    UptimeContainer c = new UptimeContainer();
+    c.setCreationTime(10L);
+    c.setTotalUptime(20L);
+
+    // Act & Assert (symmetry)
+    assertEquals(a, b);
+    assertEquals(b, a);
+
+    // Act & Assert (transitivity)
+    assertTrue(a.equals(b) && b.equals(c) && a.equals(c));
+
+    // Hash code contract for equal objects
+    assertEquals(a.hashCode(), b.hashCode());
+    assertEquals(b.hashCode(), c.hashCode());
+  }
+
+  @Test
+  void equals_whenNull_expectFalse() {
+    // Arrange
+    UptimeContainer uc = new UptimeContainer();
+    uc.setCreationTime(1L);
+    uc.setTotalUptime(2L);
+
+    // Act & Assert
+    assertNotEquals(null, uc);
+  }
+
+  @Test
+  @SuppressWarnings("AssertBetweenInconvertibleTypes")
+  void equals_whenDifferentClass_expectFalse() {
+    // Arrange
+    UptimeContainer uc = new UptimeContainer();
+    uc.setCreationTime(1L);
+    uc.setTotalUptime(2L);
+
+    // Act & Assert
+    assertNotEquals("not-a-container", uc);
+  }
+
+  static class UptimeContainerSubclass extends UptimeContainer {}
+
+  @Test
+  void equals_whenSubclassWithSameFields_expectAsymmetricBehavior() {
+    // Arrange
+    UptimeContainer base = new UptimeContainer();
+    base.setCreationTime(7L);
+    base.setTotalUptime(9L);
+
+    UptimeContainerSubclass sub = new UptimeContainerSubclass();
+    sub.setCreationTime(7L);
+    sub.setTotalUptime(9L);
+
+    // Act & Assert — current implementation compares 'o.getClass()' only,
+    // leading to asymmetry: base.equals(sub) is false, sub.equals(base) is true.
+    assertNotEquals(base, sub);
+    assertEquals(sub, base);
+  }
+
+  @Test
+  void equals_whenFieldsDiffer_expectFalse() {
+    // Arrange
+    UptimeContainer a = new UptimeContainer();
+    a.setCreationTime(1L);
+    a.setTotalUptime(2L);
+
+    UptimeContainer b = new UptimeContainer();
+    b.setCreationTime(1L);
+    b.setTotalUptime(3L); // differs
+
+    // Act & Assert
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void equals_whenMutatedAfterEquality_expectNowFalse() {
+    // Arrange
+    UptimeContainer a = new UptimeContainer();
+    a.setCreationTime(42L);
+    a.setTotalUptime(100L);
+    UptimeContainer b = new UptimeContainer();
+    b.setCreationTime(42L);
+    b.setTotalUptime(100L);
+    assertEquals(a, b);
+
+    // Act
+    a.setTotalUptime(101L); // mutate
+
+    // Assert
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void addFrom_whenValidInput_expectCreationFromLatestAndSumTotal() {
+    // Arrange
+    UptimeContainer base = new UptimeContainer();
+    base.setCreationTime(1000L);
+    base.setTotalUptime(500L);
+
+    UptimeContainer latest = new UptimeContainer();
+    latest.setCreationTime(2000L);
+    latest.setTotalUptime(300L);
+
+    // Act
+    base.addFrom(latest);
+
+    // Assert
+    assertEquals(2000L, base.getCreationTime());
+    assertEquals(800L, base.getTotalUptime());
+    // Ensure source unchanged
+    assertEquals(2000L, latest.getCreationTime());
+    assertEquals(300L, latest.getTotalUptime());
+  }
+
+  @Test
+  void addFrom_whenMultipleAdds_expectAccumulatedTotalAndLatestCreation() {
+    // Arrange
+    UptimeContainer base = new UptimeContainer();
+    base.setCreationTime(10L);
+    base.setTotalUptime(1L);
+
+    UptimeContainer l1 = new UptimeContainer();
+    l1.setCreationTime(20L);
+    l1.setTotalUptime(2L);
+
+    UptimeContainer l2 = new UptimeContainer();
+    l2.setCreationTime(30L);
+    l2.setTotalUptime(3L);
+
+    // Act
+    base.addFrom(l1);
+    base.addFrom(l2);
+
+    // Assert
+    assertEquals(30L, base.getCreationTime());
+    assertEquals(1L + 2L + 3L, base.getTotalUptime());
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void addFrom_whenNullLatest_expectNullPointerException() {
+    // Arrange
+    UptimeContainer base = new UptimeContainer();
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> base.addFrom(null));
+  }
+
+  @Test
+  void addFrom_whenOverflowOccurs_expectJavaLongWraparound() {
+    // Arrange
+    UptimeContainer base = new UptimeContainer();
+    base.setCreationTime(1L);
+    base.setTotalUptime(Long.MAX_VALUE);
+
+    UptimeContainer latest = new UptimeContainer();
+    latest.setCreationTime(2L);
+    latest.setTotalUptime(1L);
+
+    long expected = base.getTotalUptime() + latest.getTotalUptime(); // wraparound to Long.MIN_VALUE
+
+    // Act
+    base.addFrom(latest);
+
+    // Assert
+    assertEquals(2L, base.getCreationTime());
+    assertEquals(expected, base.getTotalUptime());
+  }
+
+  @Test
+  void serialization_whenRoundTrip_expectEqualAndIndependentInstance()
+      throws IOException, ClassNotFoundException {
+    // Arrange
+    UptimeContainer original = new UptimeContainer();
+    original.setCreationTime(123456789L);
+    original.setTotalUptime(987654321L);
+
+    // Act — serialize then deserialize
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(original);
+      oos.flush();
+      bytes = bos.toByteArray();
+    }
+
+    UptimeContainer restored;
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      Object obj = ois.readObject();
+      restored = (UptimeContainer) obj;
+    }
+
+    // Assert — equal by value and not the same reference
+    assertEquals(original, restored);
+    assertEquals(original.hashCode(), restored.hashCode());
+    assertNotSame(original, restored);
+  }
+}


### PR DESCRIPTION
Summary
- Improve and complete API documentation for UptimeContainer.
- Add focused unit tests for UptimeContainer.
- Replace direct field access with getters/setters at call sites to align with encapsulation.

Commits
- 966345ffe2 — docs(support): expand Javadoc for UptimeContainer and apply Spotless formatting
- 78be247e88 — test(support): add UptimeContainerTest

Changes
- src/main/java/network/crypta/support/UptimeContainer.java
  - Expanded Javadoc: purpose, units (ms since Unix epoch for capture time; ms for accumulated uptime), equality/hash semantics, thread-safety, and method tags (@param/@return/@throws where relevant).
  - No behavioral changes; comments-only.
- src/main/java/network/crypta/client/async/PersistentStatsPutter.java
  - Replace direct access to UptimeContainer fields with getTotalUptime()/setTotalUptime() and setCreationTime().
  - Non-functional.
- src/main/java/network/crypta/clients/http/StatisticsToadlet.java
  - Replace direct access to UptimeContainer fields with getTotalUptime().
  - Non-functional.
- src/test/java/network/crypta/support/UptimeContainerTest.java (new)
  - Tests equality, hashCode contract, getters/setters, addFrom aggregation, and basic serialization roundtrip.

Diffstat (relative to develop)
- 4 files changed, 348 insertions(+), 9 deletions(-)

Notes
- Spotless formatting was run prior to commit; no logic changes from formatting.
- Requesting merge into develop. CI should validate tests and style.
