### PR TITLE
support: WrapperKeepalive keepalive loop cleanup + tests + Javadoc

### DIFF
--- a/src/main/java/network/crypta/support/WrapperKeepalive.java
+++ b/src/main/java/network/crypta/support/WrapperKeepalive.java
@@ -4,23 +4,83 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.IOException;
+import java.util.concurrent.locks.LockSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tanukisoftware.wrapper.WrapperManager;
 
+/**
+ * Periodic keepalive thread for the Tanuki Java Service Wrapper.
+ *
+ * <p>Purpose: while a long-running, potentially blocking operation is in progress (for example,
+ * disk preallocation), this thread periodically notifies the Wrapper that the application is still
+ * starting by invoking {@link WrapperManager#signalStarting(int)} with a wait hint equal to the
+ * keepalive interval plus a small margin. This prevents the Wrapper from timing out startup during
+ * work that legitimately takes time.
+ *
+ * <p>Lifecycle: create an instance, call {@link #start()} before entering the blocking section, and
+ * finally call {@link #close()} when the operation completes. This type implements {@link
+ * AutoCloseable} so it can be used with try-with-resources; remember to call {@code start()} inside
+ * the block:
+ *
+ * <pre>{@code
+ * try (WrapperKeepalive wk = new WrapperKeepalive()) {
+ *   wk.start();
+ *   // perform long operation here
+ * }
+ * }</pre>
+ *
+ * <p>Threading: the instance owns its thread. {@link #close()} is thread-safe and may be invoked
+ * from any thread. Closing requests termination; the loop exits after the current sleep interval or
+ * sooner if the thread is interrupted by the caller. This class never interrupts itself.
+ *
+ * <p>Interrupts: if interrupted while sleeping, the thread logs at DEBUG level, clears the
+ * interrupted status via {@link Thread#interrupted()}, and continues looping until closed.
+ */
 public class WrapperKeepalive extends Thread implements AutoCloseable {
-  private volatile boolean shutdown = false;
+  private static final Logger LOG = LoggerFactory.getLogger(WrapperKeepalive.class);
+  private volatile boolean shutdown;
   private static final int INTERVAL = (int) MINUTES.toMillis(2);
 
+  /**
+   * Executes the keepalive loop.
+   *
+   * <p>Each iteration:
+   *
+   * <ol>
+   *   <li>Calls {@link WrapperManager#signalStarting(int)} with a wait hint slightly larger than
+   *       the sleep interval.
+   *   <li>Sleeps for one interval using {@link LockSupport#parkNanos(long)} (no {@link
+   *       InterruptedException}).
+   *   <li>If interrupted, logs at DEBUG, clears the interrupted flag via {@link
+   *       Thread#interrupted()}, and continues unless {@link #close()} has been called.
+   * </ol>
+   */
   @Override
   public void run() {
     while (!shutdown) {
-      try {
-        WrapperManager.signalStarting(INTERVAL + (int) SECONDS.toMillis(5));
-        Thread.sleep(INTERVAL);
-      } catch (InterruptedException e) {
+      WrapperManager.signalStarting(INTERVAL + (int) SECONDS.toMillis(5));
+      // Sleep without throwing InterruptedException; park returns early on interrupt.
+      // The call to Thread.interrupted() below clears the flag.
+      LockSupport.parkNanos(INTERVAL * 1_000_000L);
+      if (Thread.interrupted()) {
+        LOG.debug("Wrapper keepalive thread interrupted while sleeping; continuing until closed.");
+        if (shutdown) break;
       }
     }
   }
 
+  /**
+   * Requests shutdown of this keepalive thread.
+   *
+   * <p>Sets an internal flag that causes {@link #run()} to exit on its next loop iteration. This
+   * method does not interrupt the thread; callers may additionally invoke {@link #interrupt()} to
+   * terminate the sleep promptly.
+   *
+   * <p>This method is idempotent and thread-safe.
+   *
+   * @throws IOException never thrown; present to satisfy {@link AutoCloseable}
+   */
   @Override
   public void close() throws IOException {
     shutdown = true;

--- a/src/test/java/network/crypta/support/WrapperKeepaliveTest.java
+++ b/src/test/java/network/crypta/support/WrapperKeepaliveTest.java
@@ -1,0 +1,89 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+class WrapperKeepaliveTest {
+
+  private static final long AWAIT_TIMEOUT_MS = 2_000L;
+
+  // Helper that waits until the thread is sleeping (TIMED_WAITING) or times out.
+  private static boolean awaitTimedWaiting(Thread t) {
+    final long deadline = System.nanoTime() + AWAIT_TIMEOUT_MS * 1_000_000L;
+    while (System.nanoTime() < deadline) {
+      if (t.getState() == Thread.State.TIMED_WAITING) {
+        return true;
+      }
+      Thread.onSpinWait();
+    }
+    return t.getState() == Thread.State.TIMED_WAITING;
+  }
+
+  @Test
+  @SuppressWarnings("java:S100") // test naming convention: method_whenCondition_expectOutcome
+  void run_whenClosedBeforeStart_exitsImmediately() throws Exception {
+    // Arrange
+    WrapperKeepalive keepalive = new WrapperKeepalive();
+    // Act: closing before start should make the loop skip entirely
+    keepalive.close();
+    keepalive.start();
+
+    // Assert: thread terminates promptly without needing an interrupt
+    keepalive.join(500);
+    assertFalse(keepalive.isAlive(), "Keepalive thread should exit immediately when pre-closed");
+  }
+
+  @Test
+  @SuppressWarnings("java:S100") // test naming convention: method_whenCondition_expectOutcome
+  void run_whenSleepingThenClosedAndInterrupted_exitsPromptly() throws Exception {
+    // Arrange
+    WrapperKeepalive keepalive = new WrapperKeepalive();
+    keepalive.start();
+
+    // Wait until the thread is in TIMED_WAITING (sleeping). This avoids any timing flakiness
+    // from racing the initial call to sleep.
+    boolean inSleep = awaitTimedWaiting(keepalive);
+    if (!inSleep) {
+      fail("Keepalive thread did not reach sleep state in time");
+    }
+
+    // Act: request shutdown and interrupt to break the sleep immediately
+    keepalive.close();
+    keepalive.interrupt();
+
+    // Assert: the thread should finish quickly after the interrupt because the loop condition
+    // is false on the next iteration.
+    keepalive.join(1_000);
+    assertFalse(keepalive.isAlive(), "Keepalive thread should exit promptly after close+interrupt");
+  }
+
+  @Test
+  @SuppressWarnings("java:S100") // test naming convention: method_whenCondition_expectOutcome
+  void run_whenInterruptedWithoutClose_continuesLoopUntilClosed() throws Exception {
+    // Arrange
+    WrapperKeepalive keepalive = new WrapperKeepalive();
+    keepalive.start();
+
+    // Ensure the thread is sleeping, then interrupt it to trigger the catch path.
+    boolean inSleep = awaitTimedWaiting(keepalive);
+    if (!inSleep) {
+      fail("Keepalive thread did not reach sleep state in time");
+    }
+
+    // Act: interrupt without closing; the loop should continue running.
+    keepalive.interrupt();
+
+    // Wait for it to return to sleeping again, proving the loop continued past the catch block.
+    boolean reenteredSleep = awaitTimedWaiting(keepalive);
+    assertTrue(reenteredSleep, "Keepalive thread should continue looping after an interrupt");
+
+    // Cleanup: now close and interrupt once more so the thread can exit immediately.
+    keepalive.close();
+    keepalive.interrupt();
+    keepalive.join(1_000);
+    assertFalse(keepalive.isAlive(), "Keepalive thread should terminate after final close");
+  }
+}


### PR DESCRIPTION
Summary
- Improve Wrapper keepalive behavior during long operations and document API.
- Add unit tests validating interrupt and shutdown semantics.

Changes
- Replace Thread.sleep with LockSupport.parkNanos to avoid InterruptedException and handle interrupts cleanly.
- Call WrapperManager.signalStarting(INTERVAL + 5s) each iteration; keep 2-minute interval.
- Log DEBUG when interrupted; continue until explicitly closed.
- Add comprehensive Javadoc and clarify inline comments.
- Add WrapperKeepaliveTest covering:
  - pre-closed start exits immediately,
  - interrupt without close continues sleeping,
  - close + interrupt exits promptly.

Files
- src/main/java/network/crypta/support/WrapperKeepalive.java
- src/test/java/network/crypta/support/WrapperKeepaliveTest.java

Notes
- Branch base may show unrelated diffs vs develop for WeakHashSet/WeakHashSetTest due to divergence. If preferred, I can rebase this branch onto origin/develop to narrow the PR to only WrapperKeepalive-related changes.

Testing
- Spotless applied; local tests compile. No functional regressions expected; behavior remains consistent with prior implementation while improving interrupt handling and observability.