### PR TITLE
refactor(support): URI encode/decode cleanup, docs, and tests

### DIFF
--- a/src/main/java/network/crypta/support/URIPreEncoder.java
+++ b/src/main/java/network/crypta/support/URIPreEncoder.java
@@ -5,30 +5,51 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Replace any invalid characters in a string (to be converted to a URI) with encoded chars using
- * UTF-8.
+ * Pre-encodes characters that are illegal in a URI by applying percent-encoding with UTF-8.
  *
- * <p>This does NOT do the same thing as either java.net.URLEncoder or freenet.support.URLEncoder!
+ * <p>This utility accepts "dirty" inputs (for example, strings containing spaces) and converts them
+ * into a form suitable for {@link URI#URI(String)} without altering characters that are already
+ * allowed in a URI or are already percent-encoded.
  *
- * <p>Its purpose is simply to allow us to accept "dirty" URIs - URIs which may contain e.g. spaces
- * - by preprocessing them before they reach the URI(String) constructor.
+ * <p>It is <em>not</em> equivalent to {@link java.net.URLEncoder}. That class implements the HTML
+ * form encoding scheme ({@code application/x-www-form-urlencoded}) and is inappropriate for general
+ * URI encoding.
  *
- * <p>I _think_ this may be what URLEncoder is for - but it seems to have become rather confused.
- * Somebody needs to check all the calls to URLEncoder...
+ * <p>Thread-safety: All methods are stateless and thread-safe.
  */
 public class URIPreEncoder {
 
-  // We deliberately include '%' because we don't want to interfere with stuff which is already
-  // encoded.
-  // add "#" here too, this allow anchors
-  public static final String allowedChars =
+  // Utility class: prevent instantiation.
+  private URIPreEncoder() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  /**
+   * Characters that pass through {@link #encode(String)} unchanged.
+   *
+   * <p>The set includes {@code '%'} to avoid double-encoding existing percent-escape sequences and
+   * {@code '#'} to preserve fragment anchors. The remainder corresponds to commonly accepted
+   * unreserved and sub-delims characters for URIs.
+   */
+  public static final String ALLOWED_CHARS =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-!.~'()*,;:$&+=?/@%#";
 
+  /**
+   * Returns a copy of the input where every character not present in {@link #ALLOWED_CHARS} is
+   * replaced with its percent-encoded UTF-8 byte sequence.
+   *
+   * <p>Existing percent-encoded sequences are left untouched because {@code '%'} is in the allowed
+   * set. No normalization of path segments or query parameters is performed.
+   *
+   * @param s input to encode; must not be {@code null}
+   * @return the encoded string, suitable for use in {@link URI#URI(String)}
+   * @throws NullPointerException if {@code s} is {@code null}
+   */
   public static String encode(String s) {
     StringBuilder output = new StringBuilder(s.length() * 2);
     for (int i = 0; i < s.length(); i++) {
       char c = s.charAt(i);
-      if (allowedChars.indexOf(c) >= 0) {
+      if (ALLOWED_CHARS.indexOf(c) >= 0) {
         output.append(c);
       } else {
         String tmp = String.valueOf(c);
@@ -44,9 +65,16 @@ public class URIPreEncoder {
   }
 
   /**
-   * Create a new URI from a string, which may contain characters which should have been encoded.
+   * Creates a {@link URI} from a possibly "dirty" string by first applying {@link #encode(String)}.
    *
-   * @throws URISyntaxException If the string does not represent a valid URI, even after encoding.
+   * <p>This method does not validate or normalize beyond what {@link URI} performs. Inputs that are
+   * invalid even after encoding will result in an exception.
+   *
+   * @param s input string that may contain characters requiring percent-encoding; must not be
+   *     {@code null}
+   * @return a URI constructed from the encoded representation of {@code s}
+   * @throws URISyntaxException if {@code s} does not represent a valid URI after encoding
+   * @throws NullPointerException if {@code s} is {@code null}
    */
   public static URI encodeURI(String s) throws URISyntaxException {
     return new URI(encode(s));

--- a/src/main/java/network/crypta/support/URLDecoder.java
+++ b/src/main/java/network/crypta/support/URLDecoder.java
@@ -1,71 +1,125 @@
 package network.crypta.support;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Decode encoded URLs (or parts of URLs). @see URLEncoder. This class does NOT decode
- * application/x-www-form-urlencoded strings, unlike @see java.net.URLDecoder. What it does is
- * decode bits of URIs, in UTF-8. This simply means that it converts encoded characters (assuming a
- * charset of UTF-8). java.net.URI does similar things internally.
+ * Decodes percent-encoded URL/URI segments using UTF-8.
+ *
+ * <p>This utility intentionally differs from {@link java.net.URLDecoder}:
+ *
+ * <ul>
+ *   <li>It deals with raw percent-encoding and does <em>not</em> implement the {@code
+ *       application/x-www-form-urlencoded} rules (for example, {@code '+'} is <b>not</b> treated as
+ *       a space).
+ *   <li>It always interprets bytes as UTF-8 when forming the resulting {@link String}.
+ *   <li>It rejects malformed escapes (e.g., truncated sequences, non-hex digits) and the NUL byte
+ *       escape {@code %00} by throwing {@link URLEncodedFormatException}.
+ * </ul>
+ *
+ * <p>Typical usage is to decode individual URI components (path segments, query parameter names or
+ * values) where percent-encoding represents UTF-8 bytes. Example: {@code
+ * URLDecoder.decode("%E2%9C%93", false)} yields the check mark character (✓).
+ *
+ * <p>Thread-safety: This class is stateless and its methods are thread-safe.
+ *
+ * <p>See also {@link URLEncoder} for the paired encoder.
  *
  * @author <a href="http://www.doc.ic.ac.uk/~twh1/">Theodore Hong</a> Originally!
  */
 public class URLDecoder {
+  private URLDecoder() {
+    throw new IllegalStateException("Utility class");
+  }
+
   /**
-   * Decodes a URLEncoder format string.
+   * Decodes percent-encoded sequences in {@code s} and returns the UTF-8 result.
    *
-   * @param s String to be translated.
-   * @param tolerant If true, be tolerant of bogus escapes; bogus escapes are treated as just plain
-   *     characters. Not recommended; a hack to allow users to paste in URLs containing %'s.
-   * @return the translated String.
+   * <p>The input is treated as a raw URI component where percent-encoding encodes individual bytes.
+   * Non-{@code '%'} characters are copied as their UTF-8 bytes; {@code "%XX"} sequences are
+   * converted to the corresponding byte, and the accumulated bytes are decoded as UTF-8 at the end.
+   * This method does not treat {@code '+'} as a space and does not implement the {@code
+   * application/x-www-form-urlencoded} rules.
+   *
+   * <p>Tolerance behavior: When {@code tolerant} is {@code true}, a malformed escape right where it
+   * appears (two non-hex digits following {@code '%'}) is passed through literally <em>until the
+   * first successful percent-decoding occurs</em>. After the first successful decode, subsequent
+   * malformed escapes cause {@link URLEncodedFormatException}. When {@code tolerant} is {@code
+   * false}, any malformed escape causes an exception. In all modes, {@code %00} is rejected.
+   *
+   * <p>Preconditions: {@code s} must be non-{@code null}.
+   *
+   * <p>Complexity: O(n) time and O(n) additional memory in the length of {@code s}.
+   *
+   * @param s string to decode; must not be {@code null}
+   * @param tolerant whether to pass through malformed escapes until the first successful decode
+   * @return decoded string, interpreted as UTF-8
+   * @throws URLEncodedFormatException if an escape is truncated, contains non-hex digits after
+   *     {@code '%'}, or encodes a NUL byte ({@code %00})
+   * @throws NullPointerException if {@code s} is {@code null}
    */
   public static String decode(String s, boolean tolerant) throws URLEncodedFormatException {
+    // Empty input short‑circuit to avoid allocating buffers.
     if (s.isEmpty()) return "";
-    int len = s.length();
-    ByteArrayOutputStream decodedBytes = new ByteArrayOutputStream();
+    final int len = s.length();
+    // Collect raw bytes (decoded and verbatim) and interpret them as UTF‑8 once at the end. This
+    // ensures percent‑encoded multi‑byte characters are reconstructed correctly.
+    final ByteArrayOutputStream decodedBytes = new ByteArrayOutputStream();
     boolean hasDecodedSomething = false;
 
-    for (int i = 0; i < len; i++) {
+    int i = 0;
+    while (i < len) {
       char c = s.charAt(i);
-      if (c == '%') {
-        if (i >= len - 2) {
-          throw new URLEncodedFormatException(s);
-        }
-        char[] hexChars = new char[2];
-
-        hexChars[0] = s.charAt(++i);
-        hexChars[1] = s.charAt(++i);
-
-        String hexval = new String(hexChars);
-        try {
-          long read = Fields.hexToLong(hexval);
-          if (read == 0) throw new URLEncodedFormatException("Can't encode" + " 00");
-          decodedBytes.write((int) read);
-          hasDecodedSomething = true;
-        } catch (NumberFormatException nfe) {
-          // Not encoded?
-          if (tolerant && !hasDecodedSomething) {
-            byte[] buf = ('%' + hexval).getBytes(StandardCharsets.UTF_8);
-            decodedBytes.write(buf, 0, buf.length);
-            continue;
-          }
-
-          throw new URLEncodedFormatException(
-              "Not a two character hex % escape: " + hexval + " in " + s);
-        }
-      } else {
+      if (c != '%') {
+        // Write the UTF‑8 bytes of the literal character.
         byte[] encoded = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
         decodedBytes.write(encoded, 0, encoded.length);
+        i++;
+      } else {
+        Result r = handlePercent(s, i, decodedBytes, tolerant, hasDecodedSomething);
+        hasDecodedSomething = hasDecodedSomething || r.decoded;
+        i = r.nextIndex;
       }
     }
-    try {
-      decodedBytes.close();
-      return decodedBytes.toString(StandardCharsets.UTF_8);
-    } catch (IOException ioe1) {
-      /* if this throws something's wrong */
-    }
-    throw new URLEncodedFormatException(s);
+
+    return decodedBytes.toString(StandardCharsets.UTF_8);
   }
+
+  private static Result handlePercent(
+      String s,
+      int i,
+      ByteArrayOutputStream decodedBytes,
+      boolean tolerant,
+      boolean hasDecodedSomething)
+      throws URLEncodedFormatException {
+    int len = s.length();
+    // Not enough characters remain for "%XX" — treat as malformed.
+    if (i >= len - 2) {
+      throw new URLEncodedFormatException(s);
+    }
+
+    String hexval = s.substring(i + 1, i + 3);
+    try {
+      long read = Fields.hexToLong(hexval);
+      // Reject NUL byte to avoid embedding 0x00 in results.
+      if (read == 0) {
+        throw new URLEncodedFormatException("Can't encode 00");
+      }
+      decodedBytes.write((int) read);
+      return new Result(i + 3, true);
+    } catch (NumberFormatException nfe) {
+      // Tolerate an apparent escape only until the first successful decode, to avoid silently
+      // "fixing" mixed or partially encoded input.
+      if (tolerant && !hasDecodedSomething) {
+        byte[] buf = ('%' + hexval).getBytes(StandardCharsets.UTF_8);
+        decodedBytes.write(buf, 0, buf.length);
+        return new Result(i + 3, false);
+      }
+      throw new URLEncodedFormatException(
+          "Not a two character hex % escape: " + hexval + " in " + s);
+    }
+  }
+
+  // Result of handling a single "%.." sequence: where to continue and whether a byte was decoded.
+  private record Result(int nextIndex, boolean decoded) {}
 }

--- a/src/main/java/network/crypta/support/URLEncodedFormatException.java
+++ b/src/main/java/network/crypta/support/URLEncodedFormatException.java
@@ -28,6 +28,7 @@ public class URLEncodedFormatException extends Exception {
    *
    * <p>Intended for use when the caller does not have additional error context.
    */
+  @SuppressWarnings("unused")
   URLEncodedFormatException() {}
 
   /**

--- a/src/main/java/network/crypta/support/URLEncoder.java
+++ b/src/main/java/network/crypta/support/URLEncoder.java
@@ -10,21 +10,30 @@ import java.nio.charset.StandardCharsets;
  */
 public class URLEncoder {
   // Moved here from FProxy by amphibian
-  static final String safeURLCharacters =
+  /**
+   * Uppercase-named constant for safe URL characters to satisfy constant naming conventions.
+   *
+   * <p>Keep {@code safeURLCharacters} as a non-final alias for backward source/binary compatibility
+   * across the codebase.
+   */
+  static final String SAFE_URL_CHARACTERS =
       "*-_./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
+
+  // Backward-compatibility alias used widely across the codebase and tests.
+  static String safeURLCharacters = SAFE_URL_CHARACTERS;
 
   public static String getSafeURLCharacters() {
     return safeURLCharacters;
   }
 
-  public static String encode(String URL, String force, boolean ascii) {
-    return encode(URL, force, ascii, "");
+  public static String encode(String url, String force, boolean ascii) {
+    return encode(url, force, ascii, "");
   }
 
   /**
    * Encode a string for inclusion in a URI.
    *
-   * @param URL String to encode
+   * @param url String to encode
    * @param force List of characters (in the form of a string) which must be encoded as well as the
    *     built-in.
    * @param ascii If true, encode all foreign letters, if false, leave them as is. Set to true if
@@ -32,42 +41,54 @@ public class URLEncoder {
    *     using in an HTML page.
    * @return Encoded version of string
    */
-  public static String encode(String URL, String force, boolean ascii, String extraSafeChars) {
-    StringBuilder enc = new StringBuilder(URL.length());
-    for (int i = 0; i < URL.length(); ++i) {
-      char c = URL.charAt(i);
-      if ((safeURLCharacters.indexOf(c) >= 0
-              || (!ascii
-                  && c >= 128
-                  && Character.isDefined(c)
-                  && !Character.isISOControl(c)
-                  && !Character.isSpaceChar(c))
-              || extraSafeChars.indexOf(c) >= 0)
-          && (force == null || force.indexOf(c) < 0)) {
+  public static String encode(String url, String force, boolean ascii, String extraSafeChars) {
+    StringBuilder enc = new StringBuilder(url.length());
+    for (int i = 0; i < url.length(); ++i) {
+      char c = url.charAt(i);
+      if (isPassThrough(c, force, ascii, extraSafeChars)) {
         enc.append(c);
-
       } else {
-        for (byte b : String.valueOf(c).getBytes(StandardCharsets.UTF_8)) {
-          int x = b & 0xFF;
-          if (x < 16) enc.append("%0");
-          else enc.append('%');
-          enc.append(Integer.toHexString(x));
-        }
+        appendUtf8PercentEncoded(enc, c);
       }
     }
     return enc.toString();
   }
 
+  private static boolean isPassThrough(char c, String force, boolean ascii, String extraSafeChars) {
+    boolean inSafeSet = safeURLCharacters.indexOf(c) >= 0 || extraSafeChars.indexOf(c) >= 0;
+    boolean unicodeAllowed =
+        !ascii
+            && c >= 128
+            && Character.isDefined(c)
+            && !Character.isISOControl(c)
+            && !Character.isSpaceChar(c);
+    boolean notForced = (force == null || force.indexOf(c) < 0);
+    return (inSafeSet || unicodeAllowed) && notForced;
+  }
+
+  private static void appendUtf8PercentEncoded(StringBuilder enc, char c) {
+    for (byte b : String.valueOf(c).getBytes(StandardCharsets.UTF_8)) {
+      int x = b & 0xFF;
+      if (x < 16) enc.append("%0");
+      else enc.append('%');
+      enc.append(Integer.toHexString(x));
+    }
+  }
+
   /**
    * Encode a string for inclusion in a URI.
    *
-   * @param URL String to encode
+   * @param url String to encode
    * @param ascii If true, encode all foreign letters, if false, leave them as is. Set to true if
    *     you are passing to something that needs ASCII (e.g. HTTP headers), set to false if you are
    *     using in an HTML page.
    * @return Encoded version of string
    */
-  public static String encode(String s, boolean ascii) {
-    return encode(s, null, ascii);
+  public static String encode(String url, boolean ascii) {
+    return encode(url, null, ascii);
+  }
+
+  private URLEncoder() {
+    throw new IllegalStateException("Utility class");
   }
 }

--- a/src/test/java/network/crypta/support/URIPreEncoderTest.java
+++ b/src/test/java/network/crypta/support/URIPreEncoderTest.java
@@ -1,54 +1,131 @@
 package network.crypta.support;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import network.crypta.test.UTFUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Test case for {@link URIPreEncoder} class
+ * Tests for {@link URIPreEncoder}.
  *
- * @author Alberto Bacchelli &lt;sback@freenetproject.org&gt;
+ * <p>Covers: happy-path encoding, preservation of allowed characters, multibyte UTF-8, anchors,
+ * already-encoded sequences, zero-padding, null handling, and URI construction success/error paths.
  */
-public class URIPreEncoderTest {
+@SuppressWarnings("java:S100")
+class URIPreEncoderTest {
 
-  public static final String allChars = new String(UTFUtil.ALL_CHARACTERS);
+  private static final String ALL_CHARS = new String(UTFUtil.ALL_CHARACTERS);
+  private final String printableAscii = new String(UTFUtil.PRINTABLE_ASCII);
+  private final String stressedUtfChars = new String(UTFUtil.STRESSED_UTF);
 
-  /** Tests encode(String) method to verify if it converts all not safe chars into safe chars. */
   @Test
-  public void testEncode() {
-    String toEncode = prtblAscii + stressedUTF_8Chars;
+  void encode_whenMixedAsciiAndUtf8_expectOnlyAllowedChars() {
+    // Arrange
+    String toEncode = printableAscii + stressedUtfChars;
+
+    // Act
     String encoded = URIPreEncoder.encode(toEncode);
+
+    // Assert
     assertTrue(containsOnlyValidChars(encoded));
 
-    encoded = URIPreEncoder.encode(allChars);
-    assertTrue(containsOnlyValidChars(encoded));
+    // Act/Assert again with a very wide range of characters
+    String encodedAll = URIPreEncoder.encode(ALL_CHARS);
+    assertTrue(containsOnlyValidChars(encodedAll));
   }
 
-  /** Tests encodeURI(String) method to verify if it converts all not safe chars into safe chars. */
+  @ParameterizedTest
+  @CsvSource({
+    // spaces and simple ASCII
+    "http://example.com/a b, http://example.com/a%20b",
+    // unicode é (C3 A9)
+    "http://example.com/café, http://example.com/caf%c3%a9",
+    // CJK example: 漢 (E6 BC A2)
+    "http://example.com/漢, http://example.com/%e6%bc%a2",
+    // plus should NOT be converted to space; remains '+'
+    "http://example.com/a+b c, http://example.com/a+b%20c",
+    // anchor preserved, its contents encoded
+    "http://example.com/page#sec tion, http://example.com/page#sec%20tion"
+  })
+  void encode_whenVariousInputs_expectExpectedPercentEncoding(String input, String expected) {
+    // Act
+    String actual = URIPreEncoder.encode(input);
+
+    // Assert
+    assertEquals(expected, actual);
+  }
+
   @Test
-  public void testEncodeURI() {
-    // String toEncode = prtblAscii+stressedUTF_8Chars;
-    // URI encoded;
-    // try {
-    //	encoded = URIPreEncoder.encodeURI(toEncode);		this method will throw a not expected
-    //	exception because '%' is included as a valid char
-    //	assertTrue(containsOnlyValidChars(encoded.toString()));
-    // } catch (URISyntaxException anException) {
-    //	fail("Not expected exception thrown : " + anException.getMessage()); }
+  void encode_whenContainsNewline_expectPercentEncodedZeroPadded() {
+    // Arrange
+    String input = "http://example.com/line\nfeed";
+    String expected = "http://example.com/line%0afeed";
+
+    // Act
+    String actual = URIPreEncoder.encode(input);
+
+    // Assert
+    assertEquals(expected, actual);
   }
 
-  private boolean containsOnlyValidChars(String aString) {
-    char eachChar;
-    for (int i = 0; i < aString.length(); i++) {
-      eachChar = aString.charAt(i);
-      if (URIPreEncoder.allowedChars.indexOf(eachChar) < 0) {
+  @Test
+  void encode_whenContainsAlreadyEncodedSequence_expectNotDoubleEncoded() {
+    // Arrange
+    String input = "http://example.com/a%20b";
+
+    // Act
+    String actual = URIPreEncoder.encode(input);
+
+    // Assert
+    assertEquals(input, actual);
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void encode_whenNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> URIPreEncoder.encode(null));
+  }
+
+  @Test
+  void encodeURI_whenSpacesAndUnicodePresent_expectValidURI() throws URISyntaxException {
+    // Arrange
+    String input = "http://example.com/café au lait?q=汉 字#frag ment";
+    String expected =
+        "http://example.com/caf%c3%a9%20au%20lait?q=%e6%b1%89%20%e5%ad%97#frag%20ment";
+
+    // Act
+    URI uri = URIPreEncoder.encodeURI(input);
+
+    // Assert
+    assertEquals(expected, uri.toString());
+  }
+
+  @Test
+  void encodeURI_whenInvalidPercentSequence_expectURISyntaxException() {
+    // Arrange: invalid percent-escape in path
+    String input = "http://example.com/a%2Zb";
+
+    // Act + Assert
+    assertThrows(URISyntaxException.class, () -> URIPreEncoder.encodeURI(input));
+  }
+
+  @Test
+  void encodeURI_whenNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> URIPreEncoder.encodeURI(null));
+  }
+
+  private static boolean containsOnlyValidChars(String s) {
+    for (int i = 0; i < s.length(); i++) {
+      if (URIPreEncoder.ALLOWED_CHARS.indexOf(s.charAt(i)) < 0) {
         return false;
       }
     }
     return true;
   }
-
-  private final String prtblAscii = new String(UTFUtil.PRINTABLE_ASCII);
-  private final String stressedUTF_8Chars = new String(UTFUtil.STRESSED_UTF);
 }

--- a/src/test/java/network/crypta/support/URLDecoderTest.java
+++ b/src/test/java/network/crypta/support/URLDecoderTest.java
@@ -1,0 +1,158 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@SuppressWarnings("java:S100") // Allow underscore style for test method names
+class URLDecoderTest {
+
+  @Test
+  @DisplayName("decode: empty string returns empty string")
+  void decode_whenEmptyString_returnsEmpty() throws URLEncodedFormatException {
+    // Arrange
+    String input = "";
+
+    // Act
+    String result = URLDecoder.decode(input, false);
+
+    // Assert
+    assertEquals("", result);
+  }
+
+  @Test
+  void decode_whenNoPercents_returnsOriginal() throws URLEncodedFormatException {
+    // Arrange
+    String input = "Hello_äöü"; // keep '+' unhandled by design; non-ASCII stays intact
+
+    // Act
+    String result = URLDecoder.decode(input, false);
+
+    // Assert
+    assertEquals(input, result);
+  }
+
+  @Test
+  void decode_whenPlusSign_present_keptLiteral() throws URLEncodedFormatException {
+    // Arrange
+    String input = "a+b+c"; // not application/x-www-form-urlencoded
+
+    // Act
+    String result = URLDecoder.decode(input, false);
+
+    // Assert
+    assertEquals("a+b+c", result);
+  }
+
+  @ParameterizedTest(name = "{index} -> decode('{0}') = '{1}'")
+  @CsvSource({
+    "%41,A",
+    "Hello%20World,Hello World",
+    "%2F,/",
+    "%7B%7D,{}",
+    "path%2Fto%2Ffile,path/to/file",
+    // lowercase hex should work
+    "%2f,/",
+    // UTF-8 multibyte sequences
+    "%C3%A9,é",
+    "%E2%82%AC,€"
+  })
+  void decode_whenValidEscapes_decodesUtf8(String input, String expected)
+      throws URLEncodedFormatException {
+    // Act
+    String result = URLDecoder.decode(input, false);
+
+    // Assert
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void decode_whenSingleByte0x7F_decodesControlChar() throws URLEncodedFormatException {
+    // Arrange
+    String input = "%7F";
+    String expected = new String(new byte[] {(byte) 0x7F}, StandardCharsets.UTF_8);
+
+    // Act
+    String result = URLDecoder.decode(input, false);
+
+    // Assert
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void decode_whenEncodedNullByte_throwsFormatException() {
+    // Arrange
+    String input = "%00";
+
+    // Act + Assert
+    URLEncodedFormatException ex =
+        assertThrows(URLEncodedFormatException.class, () -> URLDecoder.decode(input, false));
+    assertEquals("Can't encode 00", ex.getMessage());
+  }
+
+  @Test
+  void decode_whenInvalidHex_tolerantFalse_throws() {
+    // Arrange
+    String input = "%G1";
+
+    // Act + Assert
+    URLEncodedFormatException ex =
+        assertThrows(URLEncodedFormatException.class, () -> URLDecoder.decode(input, false));
+    // Message includes the offending two characters and the full input
+    // e.g., "Not a two character hex % escape: G1 in %G1"
+    // Keep assertion stable by checking significant fragment
+    String msg = ex.getMessage();
+    // Use exact prefix to ensure we hit the intended branch
+    // (avoid brittle full-string matches across potential future tweaks)
+    Assertions.assertTrue(
+        msg != null && msg.startsWith("Not a two character hex % escape: G1 in "));
+  }
+
+  @Test
+  void decode_whenInvalidHex_tolerantTrueBeforeAnyValid_passesThrough() throws Exception {
+    // Arrange
+    String input = "%GG%41";
+
+    // Act
+    String result = URLDecoder.decode(input, true);
+
+    // Assert: first bogus kept literally, then %41 -> 'A'
+    assertEquals("%GGA", result);
+  }
+
+  @Test
+  void decode_whenInvalidHex_afterValidEvenWithTolerant_throws() {
+    // Arrange
+    String input = "%41%GG"; // first decode sets hasDecodedSomething=true
+
+    // Act + Assert
+    assertThrows(URLEncodedFormatException.class, () -> URLDecoder.decode(input, true));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"abc%", "abc%A"})
+  void decode_whenIncompleteEscape_throwsOriginalInputAsMessage(String input) {
+    // Act + Assert
+    URLEncodedFormatException ex =
+        assertThrows(URLEncodedFormatException.class, () -> URLDecoder.decode(input, false));
+    assertEquals(input, ex.getMessage());
+  }
+
+  @Test
+  void decode_whenOnlyBogusAndTolerantTrue_passesThroughAll() throws Exception {
+    // Arrange
+    String input = "%GG%HH%II";
+
+    // Act
+    String result = URLDecoder.decode(input, true);
+
+    // Assert: stays unchanged because no successful decode ever occurred
+    assertEquals(input, result);
+  }
+}

--- a/src/test/java/network/crypta/support/URLEncoderTest.java
+++ b/src/test/java/network/crypta/support/URLEncoderTest.java
@@ -1,0 +1,90 @@
+package network.crypta.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link URLEncoder}. */
+@SuppressWarnings("java:S100") // test naming uses method_whenCondition_expectOutcome
+class URLEncoderTest {
+
+  @Test
+  void getSafeURLCharacters_containsExpected_withoutSpace() {
+    String safe = URLEncoder.getSafeURLCharacters();
+    assertTrue(safe.indexOf('/') >= 0);
+    assertTrue(safe.indexOf('_') >= 0);
+    assertTrue(safe.indexOf('-') >= 0);
+    assertTrue(safe.indexOf('.') >= 0);
+    assertTrue(safe.indexOf('A') >= 0 && safe.indexOf('z') >= 0);
+    assertTrue(safe.indexOf('0') >= 0 && safe.indexOf('9') >= 0);
+    assertTrue(safe.indexOf(' ') < 0); // spaces must not be safe by default
+  }
+
+  @Test
+  void encode_whenAsciiFalse_allowsUnicodeAndEncodesSpaces() {
+    String input = "café 123"; // contains non-ASCII 'é' and a space
+    String encoded = URLEncoder.encode(input, false);
+    assertEquals("café%20123", encoded);
+  }
+
+  @Test
+  void encode_whenAsciiTrue_encodesNonAsciiAndUnsafePunctuation() {
+    String input = "café ~!@\n"; // é, space, tilde, !, @, newline
+    String encoded = URLEncoder.encode(input, true);
+    // é -> c3 a9, space -> 20, ~ -> 7e, ! -> 21, @ -> 40, \n -> 0a (zero-padded)
+    assertEquals("caf%c3%a9%20%7e%21%40%0a", encoded);
+  }
+
+  @Test
+  void encode_withForce_encodesEvenSafeAndUnicode() {
+    String input = "A/é";
+    String force = "A/é"; // force all three characters
+    String encoded = URLEncoder.encode(input, force, false);
+    assertEquals("%41%2f%c3%a9", encoded);
+  }
+
+  @Test
+  void encode_withExtraSafeChars_allowsAdditionalCharactersToPassThrough() {
+    String input = "@?* ";
+    String extraSafe = "@?* ";
+    String encoded = URLEncoder.encode(input, null, true, extraSafe);
+    assertEquals(input, encoded);
+  }
+
+  @Test
+  void encode_withExtraSafeChars_andForce_overridesExtraSafe() {
+    String input = "a* b"; // '*' and space are extra-safe; only '*' is forced
+    String extraSafe = "* ";
+    String force = "*";
+    String encoded = URLEncoder.encode(input, force, true, extraSafe);
+    assertEquals("a%2a b", encoded);
+  }
+
+  @Test
+  void encode_overloadConsistency_encodeBooleanEqualsEncodeWithNullForce() {
+    String s = "abcXYZ";
+    assertEquals(URLEncoder.encode(s, true), URLEncoder.encode(s, null, true));
+    assertEquals(URLEncoder.encode(s, false), URLEncoder.encode(s, null, false));
+  }
+
+  @Test
+  void encode_emptyString_returnsEmptyString() {
+    assertEquals("", URLEncoder.encode("", true));
+    assertEquals("", URLEncoder.encode("", false));
+  }
+
+  @Test
+  void encode_nullInputs_throwNullPointerException() {
+    assertThrows(NullPointerException.class, () -> URLEncoder.encode(null, true));
+    assertThrows(NullPointerException.class, () -> URLEncoder.encode(null, null, true));
+  }
+
+  @Test
+  void encode_whenAsciiFalse_preservesNonBmpEmoji() {
+    String input = "hi\uD83D\uDE00"; // "hi😀" (U+1F600)
+    String encoded = URLEncoder.encode(input, false);
+    assertEquals(input, encoded);
+  }
+}


### PR DESCRIPTION
Summary
- Refactors URI encode/decode utilities under `network.crypta.support` for clarity and consistency, and adds comprehensive tests and documentation.
- Preserves public method signatures and behavior where possible; introduces small internal helpers and constant naming cleanup.

Key Changes
- `URLEncoder`:
  - Extract small helpers (`isPassThrough`, `appendUtf8PercentEncoded`) and add a private constructor (utility class pattern).
  - Introduce `SAFE_URL_CHARACTERS` constant (keeps `safeURLCharacters` as a non-final alias for source/binary compatibility).
  - Parameter names normalized (`url` instead of `URL`), Javadoc tightened; UTF-8 handling unchanged.
- `URLDecoder`:
  - Clear UTF-8 semantics and explicit differences from `java.net.URLDecoder` in Javadoc (does not treat `+` as space).
  - Tolerance rules clarified and enforced: malformed escapes are passed through only until the first successful decode; afterwards they raise `URLEncodedFormatException`. `%00` remains rejected.
  - Adds a private constructor and doc updates.
- `URIPreEncoder`:
  - Rename `allowedChars` → `ALLOWED_CHARS`, add private constructor, and expand Javadoc. Behavior unchanged (percent-encodes non-allowed chars using UTF‑8 and leaves `%`/`#` intact).
- `URLEncodedFormatException`:
  - Minor cleanup: suppress unused default ctor warning to satisfy static analysis.

Tests
- Add `URLDecoderTest` for tolerant/strict behavior, `%00` rejection, incomplete/invalid escapes.
- Add `URLEncoderTest` covering ASCII vs Unicode behavior, force/extra safe characters, and overload consistency.
- Update `URIPreEncoderTest` accordingly.

Scope
- Files changed:
  - `src/main/java/network/crypta/support/URIPreEncoder.java`
  - `src/main/java/network/crypta/support/URLDecoder.java`
  - `src/main/java/network/crypta/support/URLEncodedFormatException.java`
  - `src/main/java/network/crypta/support/URLEncoder.java`
  - `src/test/java/network/crypta/support/URIPreEncoderTest.java`
  - `src/test/java/network/crypta/support/URLDecoderTest.java` (new)
  - `src/test/java/network/crypta/support/URLEncoderTest.java` (new)

Stats
- 7 files changed, 543 insertions(+), 114 deletions(-).

Compatibility & Risk
- No breaking API changes expected; `safeURLCharacters` kept as alias for compatibility.
- Behavior clarification in `URLDecoder` tolerant mode is covered by new tests; callers depending on historically passing through malformed escapes after a successful decode should review.

How To Verify
- Run: `./gradlew --parallel test`.
- Spot-check encoding/decoding of mixed ASCII/Unicode strings and ensure `%00` triggers an exception in the decoder.

Commits
- a88728103d refactor(support): tidy URLEncoder API and constants; add encode tests (2025-10-17)
- 1538e3b0a2 style(java): apply Spotless formatting (2025-10-17)
- e214d76245 test(support): add URLDecoderTest covering tolerant mode, %00, UTF-8, and edge cases (2025-10-17)
- 95802ee36f docs(support): improve Javadoc and inline comments for URLDecoder (2025-10-17)
- b65181b8b9 refactor(support): URIPreEncoder docs and tests; apply Spotless (2025-10-17)

Notes
- This PR targets `develop`. Let me know if you prefer a different base.