### PR TITLE
docs(support): improve package-level Javadoc; fix NullPointerException link

### DIFF
--- a/src/main/java/network/crypta/support/package-info.java
+++ b/src/main/java/network/crypta/support/package-info.java
@@ -1,7 +1,56 @@
 /**
- * Package for general utility code which is not Freenet-specific: Stuff that could conceivably be
- * reused by other projects.
+ * General-purpose utilities shared across the project.
  *
- * <p>E.g. helpers for disk I/O, generic data structures, encryption, logging, etc.
+ * <p>This package collects reusable building blocks that do not depend on Crypta's networking
+ * protocols. It focuses on data structures, small algorithms, encoding/decoding, lightweight
+ * executors and timing helpers, and assorted support code that can be reused by other projects.
+ *
+ * <p>Highlights include:
+ *
+ * <ul>
+ *   <li>Data structures and primitives: {@link network.crypta.support.LRUMap}, {@link
+ *       network.crypta.support.LRUCache}, {@link network.crypta.support.BloomFilter}, {@link
+ *       network.crypta.support.CountingBloomFilter}, {@link network.crypta.support.BitArray},
+ *       {@link network.crypta.support.IdentityHashSet}.
+ *   <li>Concurrency and scheduling helpers: {@link network.crypta.support.PooledExecutor}, {@link
+ *       network.crypta.support.PriorityAwareExecutor}, {@link
+ *       network.crypta.support.PrioritizedSerialExecutor}, {@link network.crypta.support.Ticker}
+ *       and related tickers.
+ *   <li>Encoding and text utilities: {@link network.crypta.support.Base64}, {@link
+ *       network.crypta.support.HTMLEncoder}, {@link network.crypta.support.HTMLDecoder}, {@link
+ *       network.crypta.support.URLEncoder}, {@link network.crypta.support.URIPreEncoder}.
+ *   <li>Containers and measurement helpers: {@link network.crypta.support.ContainerSizeEstimator},
+ *       {@link network.crypta.support.SizeUtil}.
+ *   <li>Streams and wrappers: {@link network.crypta.support.ByteBufferInputStream} and related
+ *       small utilities.
+ * </ul>
+ *
+ * <p>Related subpackages:
+ *
+ * <ul>
+ *   <li>{@link network.crypta.support.io} — file and buffer abstractions, disk-space checking, and
+ *       random-access utilities.
+ *   <li>{@link network.crypta.support.compress} — compression/decompression APIs and
+ *       implementations (e.g., GZIP, BZip2, LZMA).
+ *   <li>{@link network.crypta.support.transport.ip} — host/IP parsing and utilities.
+ * </ul>
+ *
+ * <h2>Usage notes</h2>
+ *
+ * <ul>
+ *   <li><strong>Thread-safety:</strong> Threading guarantees are documented per type. Do not assume
+ *       concurrent use is safe unless stated; prefer external synchronization or concurrent
+ *       collections where appropriate.
+ *   <li><strong>Nullability:</strong> Unless an API explicitly documents support for {@code null},
+ *       inputs are expected to be non-null and may raise {@link java.lang.NullPointerException}
+ *       when violated.
+ *   <li><strong>Units and limits:</strong> Byte sizes are in bytes unless a method states
+ *       otherwise. Algorithmic complexity and bounds are described on the individual classes when
+ *       notable.
+ *   <li><strong>Independence:</strong> The code here avoids dependencies on node-specific logic to
+ *       keep it broadly reusable.
+ * </ul>
+ *
+ * @since 2
  */
 package network.crypta.support;


### PR DESCRIPTION
Summary
- Rewrite package-level Javadoc for `network.crypta.support` to document scope, key utilities, and subpackages.
- Add usage notes (thread-safety expectations, nullability assumptions, units/limits, and intent to keep code independent of node-specific logic).
- Fix unresolved Javadoc link by fully qualifying `java.lang.NullPointerException`.

Motivation
- Make support package purpose and contents discoverable from IDE / Javadoc.
- Reduce ambiguity around concurrency and nullability expectations for shared utilities.

Changes
- File: `src/main/java/network/crypta/support/package-info.java`
  - 52 insertions, 3 deletions (comments only).
  - No code or API behavior changes.

Formatting
- Ran `./gradlew spotlessApply` prior to commit.

Risk / Compatibility
- Docs-only change; no runtime impact.

How to review
- View the rendered Javadoc for the package to verify links and formatting.
- Confirm the `NullPointerException` link resolves and that subpackage links navigate correctly.

Branch
- Source: `doc/support-package-info`
- Target: `develop`

