### PR TITLE
API docs sweep + ManifestElement serialization tests

### DIFF
--- a/src/main/java/network/crypta/support/api/BooleanCallback.java
+++ b/src/main/java/network/crypta/support/api/BooleanCallback.java
@@ -1,28 +1,56 @@
 package network.crypta.support.api;
 
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import network.crypta.config.ConfigCallback;
 import network.crypta.config.ConfigConsumer;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
 
 /**
- * A callback to be called when a config value of integer type changes. Also reports the current
- * value.
+ * Callback for reading and writing a boolean configuration value.
+ *
+ * <p>This specialization of {@link ConfigCallback} is used by components that expose a boolean
+ * setting. Implementations provide the current effective value via {@link #get()} and accept a new
+ * value via {@link #set(Boolean)}.
+ *
+ * <p>Details:
+ *
+ * <ul>
+ *   <li><strong>Purpose:</strong> reflect and apply a boolean configuration flag.
+ *   <li><strong>Inputs/outputs:</strong> {@link #get()} returns the current value; {@link
+ *       #set(Boolean)} receives the requested new value.
+ *   <li><strong>Preconditions:</strong> provided values are expected to be non-{@code null}.
+ *   <li><strong>Postconditions:</strong> if {@link #set(Boolean)} returns normally, the value is
+ *       accepted; some implementations may defer activation until a restart.
+ *   <li><strong>Side effects:</strong> implementations may persist to disk and/or perform
+ *       validation.
+ *   <li><strong>Threading:</strong> no synchronization is defined by this type; thread-safety
+ *       depends on concrete implementations.
+ * </ul>
  */
 public abstract class BooleanCallback extends ConfigCallback<Boolean> {
 
   /**
-   * Create a config callback from lambdas.
+   * Creates a callback that delegates to the supplied functions.
    *
-   * @param set accepts the new value.
+   * <p>The returned instance delegates {@link #get()} to {@link BooleanSupplier#getAsBoolean()} and
+   * {@link #set(Boolean)} to {@link ConfigConsumer#accept(Object)}. No caching or additional
+   * validation occurs in this adapter.
+   *
+   * <p>Preconditions: {@code get} and {@code set} must be non-{@code null}. The {@code value}
+   * passed to {@link #set(Boolean)} is expected to be non-{@code null}.
+   *
+   * @param get supplies the current effective value.
+   * @param set accepts and applies a new value.
+   * @return a {@link BooleanCallback} that delegates to the provided functions.
    */
-  public static BooleanCallback from(Supplier<Boolean> get, ConfigConsumer<Boolean> set) {
+  public static BooleanCallback from(BooleanSupplier get, ConfigConsumer<Boolean> set) {
+    // Delegate directly to the provided supplier/consumer; this adapter adds no caching.
     return new BooleanCallback() {
 
       @Override
       public Boolean get() {
-        return get.get();
+        return get.getAsBoolean();
       }
 
       @Override

--- a/src/main/java/network/crypta/support/api/Bucket.java
+++ b/src/main/java/network/crypta/support/api/Bucket.java
@@ -8,67 +8,123 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.support.io.ResumeFailedException;
 
 /**
- * A bucket is any arbitrary object can temporarily store data. In other words, it is the equivalent
- * of a temporary file, but it could be in RAM, on disk, encrypted, part of a file on disk, composed
- * from a chain of other buckets etc.
+ * Abstraction of a temporary data container.
  *
- * <p>Not all buckets are Serializable.
+ * <p>A {@code Bucket} behaves like a temporary file but the underlying storage can vary: it may
+ * live in memory, on disk, be encrypted, occupy a slice of another file, or be composed from a
+ * chain of other buckets. Implementations are free to choose the storage strategy while exposing a
+ * simple stream-based read/write API.
+ *
+ * <p>Serialization is not required; not all bucket implementations are {@link java.io.Serializable
+ * Serializable}.
+ *
+ * <p>Thread-safety: unless otherwise documented by a specific implementation, instances are not
+ * guaranteed to be safe for concurrent use. Coordinate access externally.
  *
  * @author oskar
  */
 public interface Bucket extends AutoCloseable {
 
   /**
-   * Returns an OutputStream that is used to put data in this Bucket, from the beginning. It is not
-   * possible to append data to a Bucket! This simplifies the code significantly for some classes.
-   * If you need to append, just pass the OutputStream around. Will be buffered if appropriate (e.g.
-   * byte array backed buckets don't need to be buffered).
+   * Opens a stream for writing the bucket's content from the beginning.
+   *
+   * <p>Writing always starts at offset {@code 0}; appending is not supported. If the caller needs
+   * append-like behavior, it must retain and reuse the returned {@link OutputStream} while writing
+   * sequentially. Implementations may return a buffered stream where appropriate (for example,
+   * memory-backed buckets may not require additional buffering).
+   *
+   * <p>Callers must close the returned stream (preferably using try-with-resources) to ensure all
+   * data is flushed and resources are released.
+   *
+   * @return an {@link OutputStream} for writing, positioned at the start
+   * @throws IOException if the stream cannot be created or the bucket cannot be opened for write
    */
   OutputStream getOutputStream() throws IOException;
 
   /**
-   * Get an OutputStream which is not buffered. Should be called when we will buffer the stream at a
-   * higher level or when we will only be doing large writes (e.g. copying data from one Bucket to
-   * another). Does not make any more persistence guarantees than getOutputStream() does, this is
-   * just to save memory.
+   * Opens an unbuffered stream for writing from the beginning.
+   *
+   * <p>Prefer this when the caller provides its own buffering or performs large block writes (for
+   * example, when piping data from one bucket to another). This method does not provide stronger
+   * durability guarantees than {@link #getOutputStream()}—it exists primarily to avoid redundant
+   * buffering and reduce memory overhead.
+   *
+   * <p>Callers must close the returned stream to complete the writing.
+   *
+   * @return an unbuffered {@link OutputStream} for writing, positioned at the start
+   * @throws IOException if the stream cannot be created or the bucket cannot be opened for write
    */
   OutputStream getOutputStreamUnbuffered() throws IOException;
 
   /**
-   * Returns an InputStream that reads data from this Bucket. If there is no data in this bucket,
-   * null is returned.
+   * Opens a stream for reading the bucket's current content.
    *
-   * <p>You have to call IOUtils.closeQuietly(inputStream) on the obtained stream to prevent
-   * resource leakage.
+   * <p>If the bucket currently contains no data, this method returns {@code null}. Callers should
+   * use try-with-resources or explicitly close the returned {@link InputStream} to avoid resource
+   * leaks.
+   *
+   * @return an {@link InputStream} for reading, or {@code null} when the bucket is empty
+   * @throws IOException if the stream cannot be created or the content cannot be read
    */
   InputStream getInputStream() throws IOException;
 
+  /**
+   * Opens an unbuffered stream for reading the bucket's current content.
+   *
+   * <p>Semantics match {@link #getInputStream()} except that the returned stream is not wrapped in
+   * additional buffering layers. Use when the caller manages buffering explicitly.
+   *
+   * @return an unbuffered {@link InputStream} for reading, or {@code null} when the bucket is empty
+   * @throws IOException if the stream cannot be created or the content cannot be read
+   */
   InputStream getInputStreamUnbuffered() throws IOException;
 
   /**
-   * Returns a name for the bucket, may be used to identify them in certain in certain situations.
+   * Returns a human-readable identifier for the bucket.
+   *
+   * <p>The value is intended for diagnostics and logging only; callers must not rely on uniqueness
+   * or a specific format.
+   *
+   * @return a descriptive name suitable for logs and debug output
    */
   String getName();
 
-  /** Returns the amount of data currently in this bucket in bytes. */
+  /**
+   * Returns the number of bytes currently stored in the bucket.
+   *
+   * @return size in bytes; {@code 0} when empty
+   */
   long size();
 
-  /** Is the bucket read-only? */
+  /**
+   * Reports whether the bucket currently rejects further writes.
+   *
+   * @return {@code true} if the bucket is read-only; {@code false} otherwise
+   */
   boolean isReadOnly();
 
-  /** Make the bucket read-only. Irreversible. */
+  /**
+   * Permanently marks the bucket as read-only.
+   *
+   * <p>After this call, attempts to obtain a writable stream are expected to fail. The operation is
+   * irreversible for the lifetime of the instance.
+   */
   void setReadOnly();
 
   /**
-   * Free the bucket, if supported. Note that you must call free() even if you haven't used the
-   * Bucket (haven't called getOutputStream()) for some kinds of Bucket's, as they may have
-   * allocated space (e.g. created a temporary file).
+   * Releases the bucket and its underlying resources, if supported by the implementation.
+   *
+   * <p>Call this even if no streams were opened; some implementations may eagerly allocate
+   * resources (for example, creating a temporary file). After freeing, further operations on the
+   * instance may fail.
    */
   void free();
 
   /**
-   * AutoCloseable implementation that delegates to free(). This allows Bucket to be used with
-   * try-with-resources.
+   * Allows use with try-with-resources by delegating to {@link #free()}.
+   *
+   * <p>Calling close() is equivalent to calling {@link #free()} and should be considered a terminal
+   * operation for the bucket instance.
    */
   @Override
   default void close() {
@@ -76,28 +132,38 @@ public interface Bucket extends AutoCloseable {
   }
 
   /**
-   * Create a shallow read-only copy of this bucket, using different objects but using the same
-   * external storage. If this is not possible, return null. Note that if the underlying bucket is
-   * deleted, the copy will become invalid and probably throw an IOException on read, or possibly
-   * return too-short data etc. In some use cases e.g. on fproxy, this is acceptable.
+   * Creates a shallow, read-only view of this bucket that shares the same underlying storage.
+   *
+   * <p>The returned instance is logically independent but references the same external data. If the
+   * original bucket is deleted or freed, the shadow may become invalid and subsequent reads can
+   * throw {@link IOException} or yield truncated data. Some call sites tolerate this behavior (for
+   * example, HTTP proxying scenarios).
+   *
+   * @return a read-only shadow bucket, or {@code null} if shadowing is not supported
    */
   Bucket createShadow();
 
   /**
-   * Called after restarting. The Bucket should do any necessary housekeeping after resuming, e.g.
-   * registering itself with the appropriate persistent bucket tracker to avoid being
-   * garbage-collected. May be called twice, so the Bucket may need to track this internally.
+   * Notifies the bucket that the application has resumed after a restart.
    *
-   * @param context All the necessary runtime support will be on this object.
-   * @throws ResumeFailedException
+   * <p>Implementations should perform any required housekeeping (for example, re-registering with a
+   * persistent bucket tracker) to prevent premature garbage collection of external resources. The
+   * method may be invoked more than once; implementations should handle duplicate notifications.
+   *
+   * @param context runtime services and helpers required to reinitialize the bucket
+   * @throws ResumeFailedException if the bucket cannot reattach to its persisted state
    */
   void onResume(ClientContext context) throws ResumeFailedException;
 
   /**
-   * Write enough data to reconstruct the Bucket, or throw UnsupportedOperationException. Used for
-   * recovering in emergencies, should be versioned if necessary.
+   * Writes the metadata necessary to reconstruct the bucket to the given stream.
    *
-   * @throws IOException
+   * <p>Implementations that do not support persistence should throw {@link
+   * UnsupportedOperationException}. When supported, the written format should be treated as an
+   * internal contract and versioned as needed for forward compatibility.
+   *
+   * @param dos destination for serialization data
+   * @throws IOException on I/O failure while writing the metadata
    */
   void storeTo(DataOutputStream dos) throws IOException;
 }

--- a/src/main/java/network/crypta/support/api/BucketFactory.java
+++ b/src/main/java/network/crypta/support/api/BucketFactory.java
@@ -2,14 +2,34 @@ package network.crypta.support.api;
 
 import java.io.IOException;
 
+/**
+ * Factory for creating {@link RandomAccessBucket} instances.
+ *
+ * <p>Implementations may choose different storage backends (memory, disk, encrypted, etc.) and may
+ * apply limits, buffering, or other policies internally. Unless otherwise documented, this
+ * interface and the created buckets are not guaranteed to be thread-safe; coordinate access
+ * externally.
+ */
 public interface BucketFactory {
   /**
-   * Create a bucket.
+   * Creates a new, empty random-access bucket.
    *
-   * @param size The maximum size of the data, or -1 or Long.MAX_VALUE if we don't know. Some
-   *     buckets will throw IOException if you go over this length.
-   * @return
-   * @throws IOException
+   * <p>The returned {@link RandomAccessBucket} supports reading and writing by position. The {@code
+   * size} parameter acts as a hint or limit on the maximum number of bytes that may be written:
+   *
+   * <ul>
+   *   <li>{@code size >= 0}: Implementations may enforce this as a hard limit and throw an {@link
+   *       IOException} if writes would exceed it.
+   *   <li>{@code size == -1} or {@code size == Long.MAX_VALUE}: Size is unknown/unspecified; the
+   *       implementation may grow as needed within its own constraints.
+   * </ul>
+   *
+   * <p>Callers are responsible for releasing resources by invoking {@link Bucket#free()} or closing
+   * the bucket when finished.
+   *
+   * @param size maximum expected size in bytes, or {@code -1}/{@code Long.MAX_VALUE} if unknown
+   * @return a new {@link RandomAccessBucket}, never {@code null}
+   * @throws IOException if storage cannot be allocated, a limit is violated, or an I/O error occurs
    */
   RandomAccessBucket makeBucket(long size) throws IOException;
 }

--- a/src/main/java/network/crypta/support/api/HTTPRequest.java
+++ b/src/main/java/network/crypta/support/api/HTTPRequest.java
@@ -5,164 +5,321 @@ import java.util.NoSuchElementException;
 import javax.naming.SizeLimitExceededException;
 
 /**
- * A parsed HTTP request (GET or POST). Request parameters are parameters encoded into the URI, or
- * part of a POST form which is encoded as application/x-www-form-urlencoded. Parts are parameters
- * (including files) uploaded in a POST in multipart/form-data. Use of the former encoding for POSTs
- * is strongly discouraged as it has character set issues. We do support methods other than GET and
- * POST for e.g. WebDAV, but they are not common.
+ * Represents a parsed HTTP request.
+ *
+ * <p>This interface provides access to the request path, method, headers, parameters, and
+ * optionally submitted body data. Parameters originate either from the query string or from a POST
+ * body encoded as {@code application/x-www-form-urlencoded}. Parts refer to items submitted via
+ * {@code multipart/form-data} (including uploaded files) and are exposed as buckets.
+ *
+ * <p>Unless otherwise noted, methods prefer returning empty values (for example, an empty {@code
+ * String} or empty array) over {@code null}. Callers should explicitly check return values and use
+ * the "throwing" variants where they need strict failure signaling.
+ *
+ * <p>Resource management: implementations may spool multipart parts to disk. Call {@link
+ * #freeParts()} when finished to release any associated resources; after freeing, part accessors
+ * may throw {@link IllegalStateException}.
+ *
+ * <p>Thread-safety: implementations are not required to be thread-safe. Treat a given instance as
+ * request-local and confine it to a single thread.
  */
 public interface HTTPRequest {
 
   /**
-   * The path of this request, where the part of the path the specified the plugin has already been
-   * removed..
+   * Returns the request path.
+   *
+   * <p>The segment identifying the toadlet/plugin is already removed from this path.
+   *
+   * @return the normalized path component of the request URI
    */
   String getPath();
 
   /**
-   * @return false if the query string was totally empty
+   * Indicates whether any parameters are present.
+   *
+   * <p>The result reflects the presence of parameters parsed from the URI (and, depending on the
+   * implementation, potentially from {@code application/x-www-form-urlencoded} request bodies).
+   *
+   * @return {@code false} if no parameters were parsed, {@code true} otherwise
    */
   boolean hasParameters();
 
   /**
-   * Check if a parameter was set in the request at all, either with or without a value.
+   * Tests whether a parameter is present, regardless of its value.
    *
-   * @param name the name of the parameter to check
-   * @return true if the parameter was set in the request, not regarding if the value is empty
+   * @param name the parameter name
+   * @return {@code true} if the parameter exists (even if its value is empty)
    */
   boolean isParameterSet(String name);
 
   /**
-   * Get the value of a request parameter, using an empty string as default value if the parameter
-   * was not set. This method will never return null, so its safe to do things like
+   * Returns the value of a parameter or an empty string if absent.
+   *
+   * <p>This method never returns {@code null}. If multiple values exist, the first value is
+   * returned.
    *
    * <p><code>
    *   if (request.getParam(&quot;abc&quot;).equals(&quot;def&quot;))
    * </code>
    *
-   * @param name the name of the parameter to get
-   * @return the parameter value as String, or an empty String if the value was missing or empty
+   * @param name the parameter name
+   * @return the value or {@code ""} when missing or empty
    */
   String getParam(String name);
 
   /**
-   * Get the value of a request parameter, using the specified default value if the parameter was
-   * not set or has an empty value.
+   * Returns the value of a parameter or the provided default when absent or empty.
    *
-   * @param name the name of the parameter to get
-   * @param defaultValue the default value to be returned if the parameter is missing or empty
-   * @return either the parameter value as String, or the default value
+   * <p>If multiple values exist, the first value is returned.
+   *
+   * @param name the parameter name
+   * @param defaultValue the value to return when missing or empty
+   * @return the parameter value or {@code defaultValue}
    */
   String getParam(String name, String defaultValue);
 
   /**
-   * Get the value of a request parameter converted to an int, using 0 as default value. If there
-   * are multiple values for this parameter, the first value is used.
+   * Returns a parameter parsed as an {@code int}, defaulting to {@code 0} when absent or invalid.
    *
-   * @param name the name of the parameter to get
-   * @return either the parameter value as int, or 0 if the parameter is missing, empty or invalid
+   * <p>If multiple values exist, the first value is used.
+   *
+   * @param name the parameter name
+   * @return the parsed value or {@code 0} if missing, empty, or not an integer
    */
+  @SuppressWarnings("unused")
   int getIntParam(String name);
 
   /**
-   * Get the value of a request parameter converted to an <code>int</code>, using the specified
-   * default value. If there are multiple values for this parameter, the first value is used.
+   * Returns a parameter parsed as an {@code int}, defaulting to the provided value when absent or
+   * invalid.
    *
-   * @param name the name of the parameter to get
-   * @param defaultValue the default value to be returned if the parameter is missing, empty or
-   *     invalid
-   * @return either the parameter value as int, or the default value
+   * <p>If multiple values exist, the first value is used.
+   *
+   * @param name the parameter name
+   * @param defaultValue the value to return when missing, empty, or not an integer
+   * @return the parsed value or {@code defaultValue}
    */
   int getIntParam(String name, int defaultValue);
 
-  /** Get a part as an integer with a default value if it is not set. */
+  /**
+   * Returns a part parsed as an {@code int}, defaulting when absent or invalid.
+   *
+   * <p>The part is read as UTF-8 text and parsed as a decimal integer.
+   *
+   * @param name the part name
+   * @param defaultValue the value to return when missing or not an integer
+   * @return the parsed value or {@code defaultValue}
+   * @throws IllegalStateException if parts were freed via {@link #freeParts()}
+   */
   int getIntPart(String name, int defaultValue);
 
   /**
-   * Get all values of a request parameter as a string array. If the parameter was not set at all,
-   * an empty array is returned, so this method will never return <code>null</code>.
+   * Returns all values of a parameter.
    *
-   * @param name the name of the parameter to get
-   * @return an array of all parameter values that might include empty values
+   * <p>The returned array is never {@code null}. If the parameter is absent the array is empty.
+   *
+   * @param name the parameter name
+   * @return all values, which may include empty strings
    */
+  @SuppressWarnings("unused")
   String[] getMultipleParam(String name);
 
   /**
-   * Get all values of a request parameter as int array, ignoring all values that can not be parsed.
-   * If the parameter was not set at all, an empty array is returned, so this method will never
-   * return <code>null</code>.
+   * Returns all values of a parameter parsed as {@code int}s.
    *
-   * @param name the name of the parameter to get
-   * @return an int array of all parameter values that could be parsed as int
+   * <p>Any values that cannot be parsed are ignored. The returned array is never {@code null}; when
+   * no values are present the array is empty.
+   *
+   * @param name the parameter name
+   * @return all successfully parsed integer values
    */
+  @SuppressWarnings("unused")
   int[] getMultipleIntParam(String name);
 
-  /** Get a file uploaded in the HTTP request. */
+  /**
+   * Returns metadata for an uploaded file.
+   *
+   * <p>Only applicable to {@code multipart/form-data} requests. The returned object exposes the
+   * original filename, content type, and a {@link Bucket} containing the file data.
+   *
+   * @param name the form field name
+   * @return the uploaded file, or {@code null} if not present or no filename was supplied
+   */
   HTTPUploadedFile getUploadedFile(String name);
 
   /**
-   * Get a part as a Bucket. Parts can be very large, as they are POST data from multipart/form-data
-   * and can include uploaded files.
+   * Returns a multipart part as a {@link RandomAccessBucket}.
+   *
+   * <p>Parts may be large (for example, file uploads) and may be spooled to disk by the
+   * implementation.
+   *
+   * @param name the part name
+   * @return the part bucket, or {@code null} if not present
+   * @throws IllegalStateException if parts were freed via {@link #freeParts()}
    */
   RandomAccessBucket getPart(String name);
 
-  /** Is a part set with the given name? */
+  /**
+   * Tests whether a multipart part with the given name exists.
+   *
+   * @param name the part name
+   * @return {@code true} if present, otherwise {@code false}
+   * @throws IllegalStateException if parts were freed via {@link #freeParts()}
+   */
   boolean isPartSet(String name);
 
   /**
-   * Get a request part as a String. Parts are passed in through attached data in a POST in
-   * multipart/form-data encoding; parameters are passed in through the URI. Returns an empty String
-   * if the length limit is exceeded and therefore is deprecated.
+   * Returns a multipart part as a UTF-8 {@code String} with a maximum length.
+   *
+   * <p>If the part exceeds {@code maxlength} (characters), this method returns {@code ""} instead
+   * of throwing; prefer {@link #getPartAsStringThrowing(String, int)} for strict behavior.
+   *
+   * @param name the part name
+   * @param maxlength maximum number of characters to read
+   * @return the content as text, or {@code ""} on overflow or when missing
+   * @deprecated Prefer {@link #getPartAsStringThrowing(String, int)} or {@link
+   *     #getPartAsStringFailsafe(String, int)} depending on desired behavior.
    */
-  @Deprecated
+  @Deprecated(since = "1")
   String getPartAsString(String name, int maxlength);
 
+  /**
+   * Returns a multipart part as a UTF-8 {@code String} with a maximum length.
+   *
+   * <p>If the named part is missing a {@link NoSuchElementException} is thrown. If its size exceeds
+   * {@code maxlength} a {@link SizeLimitExceededException} is thrown. Implementations may throw
+   * {@link IllegalStateException} if parts were freed via {@link #freeParts()}.
+   *
+   * @param name the part name
+   * @param maxlength maximum number of characters to read
+   * @return the content as text (possibly truncated to {@code maxlength})
+   * @throws NoSuchElementException if the part is not present
+   * @throws SizeLimitExceededException if the part exceeds {@code maxlength}
+   * @throws IllegalStateException if parts were freed
+   */
   String getPartAsStringThrowing(String name, int maxlength)
       throws NoSuchElementException, SizeLimitExceededException;
 
   /**
-   * Gets up to maxLength characters from the part, ignores any characters after the limit. If no
-   * such part exists, an empty String is returned.
+   * Returns up to {@code maxlength} characters from a part without throwing.
+   *
+   * <p>Characters beyond the limit are ignored. If the part is missing, an empty string is
+   * returned.
+   *
+   * @param name the part name
+   * @param maxlength maximum number of characters to read
+   * @return the content as text, possibly truncated, or {@code ""} when missing
+   * @throws IllegalStateException if parts were freed via {@link #freeParts()}
    */
   String getPartAsStringFailsafe(String name, int maxlength);
 
   /**
-   * Get a request part as bytes. Returns an empty array if the length limit is exceeded and
-   * therefore is deprecated.
+   * Returns a multipart part as a {@code byte[]} with a maximum length.
+   *
+   * <p>If the part exceeds {@code maxlength} (bytes), this method returns a zero-length array
+   * instead of throwing; prefer {@link #getPartAsBytesThrowing(String, int)} for strict behavior.
+   *
+   * @param name the part name
+   * @param maxlength maximum number of bytes to read
+   * @return the content as bytes, or {@code new byte[0]} on overflow or when missing
+   * @deprecated Prefer {@link #getPartAsBytesThrowing(String, int)} or {@link
+   *     #getPartAsBytesFailsafe(String, int)} depending on desired behavior.
    */
-  @Deprecated
+  @Deprecated(since = "1")
   byte[] getPartAsBytes(String name, int maxlength);
 
+  /**
+   * Returns a multipart part as a {@code byte[]} with a maximum length.
+   *
+   * <p>If the named part is missing a {@link NoSuchElementException} is thrown. If its size exceeds
+   * {@code maxlength} a {@link SizeLimitExceededException} is thrown. Implementations may throw
+   * {@link IllegalStateException} if parts were freed via {@link #freeParts()}.
+   *
+   * @param name the part name
+   * @param maxlength maximum number of bytes to read
+   * @return the content as bytes (possibly truncated to {@code maxlength})
+   * @throws NoSuchElementException if the part is not present
+   * @throws SizeLimitExceededException if the part exceeds {@code maxlength}
+   * @throws IllegalStateException if parts were freed
+   */
+  @SuppressWarnings("unused")
   byte[] getPartAsBytesThrowing(String name, int maxlength)
       throws NoSuchElementException, SizeLimitExceededException;
 
   /**
-   * Gets up to maxLength bytes from the part, ignores any bytes after the limit. If no such part
-   * exists, a byte[] with size 0 is returned.
+   * Returns up to {@code maxlength} bytes from a part without throwing.
+   *
+   * <p>Bytes beyond the limit are ignored. If the part is missing, an empty array is returned.
+   *
+   * @param name the part name
+   * @param maxlength maximum number of bytes to read
+   * @return the content as bytes, possibly truncated, or an empty array when missing
+   * @throws IllegalStateException if parts were freed via {@link #freeParts()}
    */
+  @SuppressWarnings("unused")
   byte[] getPartAsBytesFailsafe(String name, int maxlength);
 
   /**
-   * Free all the parts. They may be stored on disk so it is important that this be called at some
-   * point.
+   * Releases resources associated with multipart parts.
+   *
+   * <p>Implementations may store parts on disk or in temporary buffers. After this call, methods
+   * that access parts may throw {@link IllegalStateException}.
    */
   void freeParts();
 
-  /** Get a part as a long, with a default value if it is not set. */
+  /**
+   * Returns a parameter parsed as a {@code long}, defaulting when absent or invalid.
+   *
+   * @param name the parameter name
+   * @param defaultValue the value to return when missing or unparsable
+   * @return the parsed value or {@code defaultValue}
+   */
   long getLongParam(String name, long defaultValue);
 
-  /** Get the HTTP method, typically GET or POST. */
+  /**
+   * Returns the HTTP method of the request (for example, {@code GET} or {@code POST}).
+   *
+   * @return the request method
+   */
   String getMethod();
 
-  /** Get the original uploaded raw data for a POST. */
+  /**
+   * Returns the original request body as a {@link Bucket}.
+   *
+   * <p>For methods without an entity body (for example, {@code GET}) this may be {@code null}.
+   *
+   * @return the raw body bucket, or {@code null} if none
+   */
   Bucket getRawData();
 
-  /** Get the value of a specific header on the request. */
+  /**
+   * Returns the value of a specific request header.
+   *
+   * <p>Callers should pass header names in lower case; some implementations enforce this and may
+   * reject mixed-case names.
+   *
+   * @param name the lower-case header name (for example, {@code "content-type"})
+   * @return the first header value, or {@code null} if not present
+   */
   String getHeader(String name);
 
-  /** Get the length of the original uploaded raw data for a POST. */
+  /**
+   * Returns the {@code Content-Length} of the request, if known.
+   *
+   * @return the content length in bytes, or {@code -1} if unknown or not provided
+   */
+  @SuppressWarnings("unused")
   int getContentLength();
 
+  /**
+   * Returns the names of all multipart parts included with the request.
+   *
+   * <p>The returned array is never {@code null}. After {@link #freeParts()}, calling this method
+   * may throw {@link IllegalStateException}.
+   *
+   * @return the part field names, possibly empty
+   * @throws IllegalStateException if parts were freed via {@link #freeParts()}
+   */
   String[] getParts();
 
   /**
@@ -173,11 +330,21 @@ public interface HTTPRequest {
   Collection<String> getParameterNames();
 
   /**
-   * Is the incognito=true boolean set? Sadly this does not prove that it is actually running
-   * incognito mode...
+   * Indicates whether {@code incognito=true} is present as a parameter.
+   *
+   * <p>This checks only the presence and boolean value of the parameter and does not validate any
+   * broader runtime mode.
+   *
+   * @return {@code true} if {@code incognito} is present and set to {@code true}
    */
   boolean isIncognito();
 
-  /** Is the browser Chrome according to User-Agent? */
+  /**
+   * Indicates whether the client appears to be Chrome based on the {@code User-Agent} header.
+   *
+   * <p>This is a best-effort heuristic.
+   *
+   * @return {@code true} if the {@code User-Agent} contains {@code "Chrome"}
+   */
   boolean isChrome();
 }

--- a/src/main/java/network/crypta/support/api/HTTPUploadedFile.java
+++ b/src/main/java/network/crypta/support/api/HTTPUploadedFile.java
@@ -1,25 +1,53 @@
 package network.crypta.support.api;
 
+/**
+ * View of a single file received via an HTTP upload.
+ *
+ * <p>This interface models one uploaded file (typically a part of a {@code multipart/form-data}
+ * request). It exposes the associated MIME type, the client-provided file name, and the file data
+ * as a {@link Bucket}. Implementations may back the data with memory, disk, or other storage and
+ * may stream content on demand.
+ *
+ * <p>Resource management: callers are responsible for releasing resources held by the returned
+ * {@link Bucket} (for example, via {@link Bucket#close()} or {@link Bucket#free()}) once the data
+ * is no longer needed.
+ *
+ * <p>Thread-safety: unless otherwise specified by the implementation, instances are not guaranteed
+ * to be safe for concurrent use.
+ */
 public interface HTTPUploadedFile {
 
   /**
-   * Returns the MIME type of the file.
+   * Returns the MIME type associated with the uploaded content.
    *
-   * @return The MIME type of the file
+   * <p>The value typically reflects the {@code Content-Type} declared for the uploaded part, but
+   * callers must not rely on it for trust or validation. If content-type correctness matters,
+   * validate independently (e.g., by sniffing or verifying against expected types).
+   *
+   * @return MIME type string (for example, {@code application/octet-stream}).
    */
   String getContentType();
 
   /**
-   * Returns the data of the file.
+   * Returns the file data as a {@link Bucket} for streaming access.
    *
-   * @return The data of the file
+   * <p>The returned bucket may hold substantial resources (temporary files, buffers, handles). The
+   * caller must close or free it after use. Access patterns are implementation-defined; prefer
+   * reading sequentially via {@link Bucket#getInputStream()} and obtain the size with {@link
+   * Bucket#size()} when needed.
+   *
+   * @return container that provides the uploaded bytes.
    */
   Bucket getData();
 
   /**
-   * Returns the name of the file.
+   * Returns the client-provided file name.
    *
-   * @return The name of the file
+   * <p>This is metadata supplied by the uploading client. Treat it as untrusted input: it may be
+   * missing, non-ASCII, or contain path separators. Do not use it directly as a filesystem path;
+   * sanitize or replace with a server-generated name as appropriate.
+   *
+   * @return original file name as provided by the client.
    */
   String getFilename();
 }

--- a/src/main/java/network/crypta/support/api/IntCallback.java
+++ b/src/main/java/network/crypta/support/api/IntCallback.java
@@ -3,7 +3,22 @@ package network.crypta.support.api;
 import network.crypta.config.ConfigCallback;
 
 /**
- * A callback to be called when a config value of integer type changes. Also reports the current
- * value.
+ * Callback for configuration options that use {@link Integer} values.
+ *
+ * <p>Implementations expose the current value via {@link #get()} and apply updates in {@link
+ * #set(Integer)}. Validation and units (e.g., bytes, seconds) are option-specific and should be
+ * enforced in {@code set}.
+ *
+ * <p>Contract notes:
+ *
+ * <ul>
+ *   <li>{@link #get()} returns the effective, non-null value currently in use.
+ *   <li>{@link #set(Integer)} may reject invalid values by throwing {@link
+ *       network.crypta.config.InvalidConfigValueException} and may request a restart by throwing
+ *       {@link network.crypta.config.NodeNeedRestartException}, as defined by the {@link
+ *       network.crypta.config.ConfigCallback} contract.
+ * </ul>
+ *
+ * @see network.crypta.config.ConfigCallback
  */
 public abstract class IntCallback extends ConfigCallback<Integer> {}

--- a/src/main/java/network/crypta/support/api/LockableRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/api/LockableRandomAccessBuffer.java
@@ -6,19 +6,38 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.support.io.ResumeFailedException;
 
 /**
- * A RandomAccessBuffer which allows you to lock it open for a brief period to indicate that you are
- * using it and it would be a bad idea to close the pooled fd. Locking the RAF open does not provide
- * any concurrency guarantees but the implementation must guarantee to do the right thing, either
- * using a mutex or supporting concurrent writes. Also has methods for persisting itself to a
- * DataOutputStream. Implementations must register with BucketTools.restoreRAFFrom().
+ * Random-access buffer with a lightweight "keep-open" lock and persistence support.
+ *
+ * <p>This API extends {@link RandomAccessBuffer} with the ability to temporarily mark the
+ * underlying resource (typically a pooled file descriptor) as in-use so that pooling layers do not
+ * close it while callers are actively working with it. The lock is cooperative and does not provide
+ * mutual exclusion: other readers/writers may still access the buffer concurrently. It is the
+ * responsibility of the implementation to behave correctly under concurrency, either by serializing
+ * access (e.g., via a mutex) or by providing a truly concurrent backing store.
+ *
+ * <p>Implementations may also persist enough information to later reconstruct an equivalent buffer
+ * via {@link #storeTo(DataOutputStream)} and restore it using {@code
+ * BucketTools.restoreRAFFrom(...)}.
+ *
+ * <p><strong>Concurrency and blocking:</strong> acquiring a lock with {@link #lockOpen()} may block
+ * until a slot becomes available. Misuse (for example, locking multiple buffers in different orders
+ * across threads) can cause deadlocks; callers should keep lock lifetimes short and release them
+ * promptly.
  *
  * @author toad
  */
 public interface LockableRandomAccessBuffer extends RandomAccessBuffer {
 
   /**
-   * Keep the RAF open. Does not prevent others from writing to it. Will block until a slot is
-   * available if necessary. Hence can deadlock.
+   * Acquire a cooperative lock to keep the underlying resource open while in use.
+   *
+   * <p>The lock does not provide mutual exclusion. Other callers may read or write concurrently,
+   * depending on the implementation. The call may block if no lock slots are currently available.
+   * Holding multiple locks in different orders can deadlock.
+   *
+   * @return a token that must be released exactly once via {@link RAFLock#unlock()} when work is
+   *     finished; callers should use a {@code try/finally} pattern to guarantee release
+   * @throws IOException if the lock cannot be obtained due to I/O or resource limits
    */
   RAFLock lockOpen() throws IOException;
 
@@ -26,10 +45,23 @@ public interface LockableRandomAccessBuffer extends RandomAccessBuffer {
 
     private boolean locked;
 
-    public RAFLock() {
+    /**
+     * Creates a new lock token in the locked state.
+     *
+     * <p>Subclasses are constructed by the {@link LockableRandomAccessBuffer} implementation when a
+     * lock is acquired. The initial state is locked; the framework guarantees that {@link
+     * #innerUnlock()} is invoked at most once per instance.
+     */
+    protected RAFLock() {
       locked = true;
     }
 
+    /**
+     * Releases the lock.
+     *
+     * <p>After this method returns, the associated buffer may be closed by pooling layers if
+     * otherwise eligible. Calling this method more than once throws {@link IllegalStateException}.
+     */
     public final void unlock() {
       synchronized (this) {
         if (!locked) throw new IllegalStateException("Already unlocked");
@@ -38,32 +70,57 @@ public interface LockableRandomAccessBuffer extends RandomAccessBuffer {
       innerUnlock();
     }
 
+    /**
+     * Implementation hook invoked exactly once when the lock transitions from locked to unlocked.
+     *
+     * <p>Subclasses should perform any resource-release or accounting needed by the owning buffer.
+     * The base class ensures this method is not called again after an unlock.
+     */
     protected abstract void innerUnlock();
   }
 
   /**
-   * Called on resuming, i.e. after serialization. Use to e.g. register with the list of temporary
-   * files.
+   * Callback invoked after the buffer is restored from persistent state.
+   *
+   * <p>Typical implementations use this to (re)register temporary files or renew memberships in
+   * process-local registries.
+   *
+   * @param context runtime context available during resume
+   * @throws ResumeFailedException if the buffer cannot be made ready for use after restoration
    */
   void onResume(ClientContext context) throws ResumeFailedException;
 
   /**
-   * Write enough data to reconstruct the Bucket, or throw UnsupportedOperationException. Used for
-   * recovering in emergencies, should be versioned if necessary. To make this work, write a fixed,
-   * unique integer magic value for the class, and add a clause to BucketTools.restoreRAFFrom().
+   * Writes enough information to reconstruct an equivalent buffer later.
    *
-   * @throws IOException
+   * <p>The record should be self-identifying and versioned if necessary. Implementations commonly
+   * write a fixed, unique integer "magic" followed by any parameters required for reconstruction,
+   * and add a corresponding clause to {@code BucketTools.restoreRAFFrom(...)}.
+   *
+   * @param dos destination stream
+   * @throws IOException on write errors
+   * @throws UnsupportedOperationException if this buffer type cannot persist itself
    */
   void storeTo(DataOutputStream dos) throws IOException;
 
   /**
-   * Must reimplement equals(). Sometimes we will need to compare two RAFs to see if they represent
-   * the same stored object, notably during resuming a splitfile insert.
+   * Compares this buffer to another for logical equality.
+   *
+   * <p>Implementations should define equality to reflect whether two instances refer to the same
+   * stored content or resource identity, as appropriate for the type. This is used, for example,
+   * when resuming a splitfile insert to detect identical underlying storage.
+   *
+   * @param o the object to compare with
+   * @return {@code true} if the objects are equal according to the implementation's definition
    */
   @Override
   boolean equals(Object o);
 
-  /** Must reimplement hashCode() if we change equals(). */
+  /**
+   * Returns a hash code consistent with the definition of {@link #equals(Object)}.
+   *
+   * @return a hash code value
+   */
   @Override
   int hashCode();
 }

--- a/src/main/java/network/crypta/support/api/LockableRandomAccessBufferFactory.java
+++ b/src/main/java/network/crypta/support/api/LockableRandomAccessBufferFactory.java
@@ -3,35 +3,57 @@ package network.crypta.support.api;
 import java.io.IOException;
 
 /**
- * Serves a similar function to BucketFactory. Different factories may serve different functions
- * e.g. temporary storage (not persistent across restarts) only.
+ * Factory for creating {@link LockableRandomAccessBuffer} instances.
+ *
+ * <p>Implementations may allocate memory-backed or file-backed storage, and may add behaviors such
+ * as encryption, padding, or disk-space checks. Some factories produce only temporary
+ * (non-persistent) buffers, while others can persist enough information for later restoration via
+ * the buffer API. See concrete implementations for details.
+ *
+ * <p><strong>Ownership:</strong> Callers are responsible for releasing resources held by returned
+ * buffers (for example, by calling {@link LockableRandomAccessBuffer#free()}) when finished.
+ *
+ * <p><strong>Thread-safety:</strong> Concurrency characteristics are implementation-defined;
+ * consult the concrete class documentation. Concurrency guarantees for the buffers themselves are
+ * documented on {@link LockableRandomAccessBuffer} and its implementations.
+ *
+ * <p><strong>Units:</strong> Sizes are in bytes.
  *
  * @author toad
  */
 public interface LockableRandomAccessBufferFactory {
 
   /**
-   * Create a bucket.
+   * Creates a zero-initialized random-access buffer of fixed size.
    *
-   * @param size The maximum size of the data. Most factories will pre-allocate this space, and it
-   *     may not be exceeded. However we do not guarantee that any I/O operation will complete; even
-   *     if we have pre-allocated the disk space, we may be unable to write to it because of e.g. a
-   *     hardware error.
-   * @return A LockableRandomAccessBuffer of the requested size.
-   * @throws IOException If an I/O error prevented the operation.
-   * @throws IllegalArgumentException If size < 0.
+   * <p>Implementations typically pre-allocate the requested capacity; callers should not assume the
+   * size can grow beyond {@code size}. Even when space is reserved up front, subsequent I/O may
+   * still fail due to hardware or operating-system errors.
+   *
+   * @param size logical length in bytes; must be {@code >= 0}
+   * @return a {@link LockableRandomAccessBuffer} of length {@code size}
+   * @throws IOException if creating the buffer fails due to an I/O error
+   * @throws IllegalArgumentException if {@code size < 0}
    */
   LockableRandomAccessBuffer makeRAF(long size) throws IOException;
 
   /**
-   * Create a bucket with specified initial contents.
+   * Creates a random-access buffer initialized from a segment of a byte array.
    *
-   * @param initialContents Byte array from which to copy data. Data will be copied even if the
-   *     underlying implementation is a byte array, for reasons of consistency.
-   * @param offset Offset within the array to start copying data from.
-   * @param size Number of bytes to copy i.e. length of the new RandomAccessBuffer.
-   * @return
-   * @throws IOException If an I/O error prevented the operation.
+   * <p>The new buffer's content equals {@code initialContents[offset .. offset + size)}. Data is
+   * copied into the buffer even when the underlying implementation is in-memory; callers should not
+   * rely on the factory retaining a reference to {@code initialContents}.
+   *
+   * @param initialContents source array that contains at least {@code offset + size} bytes
+   * @param offset starting index within {@code initialContents}
+   * @param size number of bytes to copy; also the logical length of the returned buffer; must be
+   *     {@code >= 0}
+   * @param readOnly whether the returned buffer should prohibit writes if supported by the
+   *     implementation
+   * @return a {@link LockableRandomAccessBuffer} whose first {@code size} bytes are initialized
+   *     from {@code initialContents}
+   * @throws IOException if allocation or initialization fails due to an I/O error
+   * @throws IllegalArgumentException if {@code size < 0}
    */
   LockableRandomAccessBuffer makeRAF(byte[] initialContents, int offset, int size, boolean readOnly)
       throws IOException;

--- a/src/main/java/network/crypta/support/api/LongCallback.java
+++ b/src/main/java/network/crypta/support/api/LongCallback.java
@@ -3,6 +3,27 @@ package network.crypta.support.api;
 import network.crypta.config.ConfigCallback;
 
 /**
- * A callback to be called when a config value of long type changes. Also reports the current value.
+ * Callback for configuration options that use {@link Long} values.
+ *
+ * <p>This specialization of {@link ConfigCallback} is intended for numeric settings whose domain
+ * fits in a 64-bit signed integer. Implementations expose the current effective value via {@link
+ * #get()} and apply updates in {@link #set(Long)}.
+ *
+ * <p>Details and contract notes:
+ *
+ * <ul>
+ *   <li><strong>Purpose:</strong> reflect and apply a long-valued configuration option (units are
+ *       option-specific, e.g., bytes, milliseconds, or counts).
+ *   <li><strong>Inputs/outputs:</strong> {@link #get()} returns the effective, non-{@code null}
+ *       value; {@link #set(Long)} receives the new requested value.
+ *   <li><strong>Validation:</strong> implementations may reject invalid values by throwing {@link
+ *       network.crypta.config.InvalidConfigValueException}; some changes may require a restart and
+ *       signal this via {@link network.crypta.config.NodeNeedRestartException}.
+ *   <li><strong>Threading:</strong> no synchronization guarantees are provided here; thread-safety
+ *       depends on the concrete implementation and calling context.
+ * </ul>
+ *
+ * @see network.crypta.config.ConfigCallback
+ * @see network.crypta.config.LongOption
  */
 public abstract class LongCallback extends ConfigCallback<Long> {}

--- a/src/main/java/network/crypta/support/api/ManifestElement.java
+++ b/src/main/java/network/crypta/support/api/ManifestElement.java
@@ -1,5 +1,10 @@
 package network.crypta.support.api;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamField;
+import java.io.OptionalDataException;
 import java.io.Serial;
 import java.io.Serializable;
 import network.crypta.client.DefaultMIMETypes;
@@ -8,32 +13,92 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.support.io.ResumeFailedException;
 
 /**
- * Represents an element in a manifest. Fed to *ManifestPutter. An element can be a file or a
- * redirect.
+ * A single entry in a directory manifest.
+ *
+ * <p>An element describes either:
+ *
+ * <ul>
+ *   <li>a file payload backed by a {@link RandomAccessBucket}, or
+ *   <li>a redirect to a {@link FreenetURI}.
+ * </ul>
+ *
+ * <p>Instances are mostly immutable once constructed. The {@code data} reference may become {@code
+ * null} after the payload is consumed and freed by higher layers.
+ *
+ * <p>Serialization: this class participates in Java serialization for checkpointing. The bucket
+ * field is {@code transient} at runtime but is included in {@link #serialPersistentFields} so
+ * {@link ObjectInputStream#defaultReadObject()} can restore it from legacy streams. The writer
+ * stores the bucket inside the default field block when it implements {@link java.io.Serializable};
+ * if it does not, a {@link java.io.NotSerializableException} is thrown and the checkpoint is not
+ * written. The reader also tolerates a trailing object carrying the bucket for compatibility with
+ * intermediary streams.
  */
 public class ManifestElement implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
 
-  /** Filename */
+  // Include 'data' in the persistent field list so defaultReadObject() can restore it from streams
+  // that carry it in the default field block. The writer below stores the actual bucket there when
+  // it implements java.io.Serializable; this keeps older readers working. No trailing object is
+  // required for the common case; readObject(ObjectInputStream) tolerates a trailing object for
+  // compatibility with streams that may include it.
+  @Serial
+  private static final ObjectStreamField[] serialPersistentFields = {
+    new ObjectStreamField("name", String.class),
+    new ObjectStreamField("fullName", String.class),
+    new ObjectStreamField("data", RandomAccessBucket.class),
+    new ObjectStreamField("mimeOverride", String.class),
+    new ObjectStreamField("dataSize", long.class),
+    new ObjectStreamField("targetURI", FreenetURI.class)
+  };
+
+  /** Name of the element within the manifest (file name or relative path). */
   final String name;
 
-  /** Full name in the container it is inserted as part of. */
+  /**
+   * Full path used within the container. When different from {@link #name}, it reflects a display
+   * or canonicalized form used by the caller.
+   */
   public final String fullName;
 
-  /** Data to be inserted. Can be null, if the insert has completed. */
-  final RandomAccessBucket data;
+  /**
+   * Data to be inserted for file entries.
+   *
+   * <p>May be {@code null} for redirects and after a file entry has completed and released its
+   * storage.
+   *
+   * <p>Serialization semantics: {@link RandomAccessBucket} implementations are not required to be
+   * {@link java.io.Serializable}. We therefore keep this field {@code transient} and serialize it
+   * explicitly via {@code writeObject}/{@code readObject}. If {@code data} is present but not
+   * {@link java.io.Serializable}, Java serialization fails with {@link
+   * java.io.NotSerializableException}. Failing the checkpoint is intentional and avoids persisting
+   * a corrupted manifest entry that would lose its data on resume.
+   */
+  transient RandomAccessBucket data;
 
-  /** MIME type override. null => use default for filename */
+  /** Optional MIME type override. When {@code null}, a type is guessed from {@link #name}. */
   public final String mimeOverride;
 
-  /** Original size of the bucket. Can be set explicitly even if data == null. */
+  /**
+   * Original payload size in bytes.
+   *
+   * <p>For redirects the value is {@code -1}. For files, this may be set even when {@link #data} is
+   * {@code null} (e.g., after freeing the bucket).
+   */
   final long dataSize;
 
-  /** Redirect target */
+  /** Redirect target for redirect entries; {@code null} for file entries. */
   public final FreenetURI targetURI;
 
-  /** Construct a ManifestElement for a file. */
+  /**
+   * Creates a file entry.
+   *
+   * @param name2 file name as it appears in the manifest
+   * @param fullName2 full path within the container
+   * @param data2 payload bucket; expected to be non-{@code null}
+   * @param mimeOverride2 optional MIME type override; when {@code null}, a type is guessed
+   * @param size original payload length in bytes; expected to be non-negative
+   */
   public ManifestElement(
       String name2, String fullName2, RandomAccessBucket data2, String mimeOverride2, long size) {
     this.name = name2;
@@ -45,6 +110,14 @@ public class ManifestElement implements Serializable {
     this.targetURI = null;
   }
 
+  /**
+   * Creates a file entry using the same value for {@code name} and {@code fullName}.
+   *
+   * @param name2 file name as it appears in the manifest
+   * @param data2 payload bucket; expected to be non-{@code null}
+   * @param mimeOverride2 optional MIME type override; when {@code null}, a type is guessed
+   * @param size2 original payload length in bytes; expected to be non-negative
+   */
   public ManifestElement(String name2, RandomAccessBucket data2, String mimeOverride2, long size2) {
     this.name = name2;
     this.fullName = name2;
@@ -54,7 +127,14 @@ public class ManifestElement implements Serializable {
     this.targetURI = null;
   }
 
-  /** Copy and change name */
+  /**
+   * Copy constructor that returns a new element with a different {@code name}.
+   *
+   * <p>All other attributes are copied from {@code me}.
+   *
+   * @param me source element to copy
+   * @param newName replacement name within the manifest
+   */
   public ManifestElement(ManifestElement me, String newName) {
     this.name = newName;
     this.fullName = me.fullName;
@@ -64,7 +144,15 @@ public class ManifestElement implements Serializable {
     this.targetURI = me.targetURI;
   }
 
-  /** Copy and change full name */
+  /**
+   * Copy constructor that returns a new element with different {@code name} and {@code fullName}.
+   *
+   * <p>All other attributes are copied from {@code me}.
+   *
+   * @param me source element to copy
+   * @param newName replacement name within the manifest
+   * @param newFullName replacement full path within the container
+   */
   public ManifestElement(ManifestElement me, String newName, String newFullName) {
     this.name = newName;
     this.fullName = newFullName;
@@ -75,7 +163,13 @@ public class ManifestElement implements Serializable {
     this.targetURI = me.targetURI;
   }
 
-  /** Construct a ManifestElement for a redirect */
+  /**
+   * Creates a redirect entry using the same value for {@code name} and {@code fullName}.
+   *
+   * @param name2 entry name within the manifest
+   * @param targetURI2 redirect target; must be non-{@code null}
+   * @param mimeOverride2 optional MIME type override for the redirect
+   */
   public ManifestElement(String name2, FreenetURI targetURI2, String mimeOverride2) {
     this.name = name2;
     this.fullName = name2;
@@ -86,6 +180,14 @@ public class ManifestElement implements Serializable {
     assert (targetURI != null);
   }
 
+  /**
+   * Creates a redirect entry with distinct {@code name} and {@code fullName} values.
+   *
+   * @param name2 entry name within the manifest
+   * @param fullName2 full path within the container
+   * @param mimeOverride2 optional MIME type override for the redirect
+   * @param targetURI2 redirect target; must be non-{@code null}
+   */
   public ManifestElement(
       String name2, String fullName2, String mimeOverride2, FreenetURI targetURI2) {
     this.name = name2;
@@ -110,21 +212,44 @@ public class ManifestElement implements Serializable {
     return false;
   }
 
+  /**
+   * Releases the payload bucket if present.
+   *
+   * <p>Calls {@link RandomAccessBucket#free()}. Safe to invoke multiple times; subsequent calls
+   * have no effect when the bucket is already {@code null} or freed by the implementation.
+   */
   public void freeData() {
     if (data != null) {
       data.free();
     }
   }
 
+  /**
+   * Returns the entry name as it appears in the manifest.
+   *
+   * @return file name or relative path; never {@code null}
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Returns the MIME type override.
+   *
+   * @return explicit type when provided; otherwise {@code null}
+   */
   public String getMimeTypeOverride() {
     return mimeOverride;
   }
 
-  /** A MIME type to feed into ClientMetadata. */
+  /**
+   * Returns a MIME type suitable for client metadata.
+   *
+   * <p>When {@link #mimeOverride} is non-{@code null}, it is returned as-is. Otherwise, a type is
+   * guessed from {@link #name} using {@link DefaultMIMETypes#guessMIMEType(String, boolean)}.
+   *
+   * @return resolved MIME type, or {@code null} when it cannot be determined
+   */
   public String getMimeType() {
     String mimeType = mimeOverride;
     if ((mimeOverride == null) && (name != null))
@@ -132,19 +257,87 @@ public class ManifestElement implements Serializable {
     return mimeType;
   }
 
+  /**
+   * Returns the payload bucket for file entries.
+   *
+   * @return the bucket, or {@code null} for redirects or after freeing
+   */
   public RandomAccessBucket getData() {
     return data;
   }
 
+  /**
+   * Returns the original payload length.
+   *
+   * @return size in bytes, or {@code -1} for redirects
+   */
   public long getSize() {
     return dataSize;
   }
 
+  /**
+   * Returns the redirect target for redirect entries.
+   *
+   * @return destination URI, or {@code null} for file entries
+   */
   public FreenetURI getTargetURI() {
     return targetURI;
   }
 
+  /**
+   * Reattaches runtime state after a restart.
+   *
+   * <p>Delegates to {@link RandomAccessBucket#onResume(ClientContext)} when a bucket is present.
+   *
+   * @param context runtime context used by nested bucket implementations
+   * @throws ResumeFailedException if the bucket cannot resume
+   */
   public void onResume(ClientContext context) throws ResumeFailedException {
     if (data != null) data.onResume(context);
+  }
+
+  /* ===== Java serialization support (explicit bucket handling) ===== */
+
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    // Preserve forward compatibility: when the bucket is Serializable, keep writing it inside the
+    // default field block so older releases (which only read default fields) restore it correctly.
+    // Only when the bucket is non-Serializable do we refuse to persist the checkpoint, matching the
+    // historical behavior of similar bucket wrappers.
+    ObjectOutputStream.PutField fields = out.putFields();
+    fields.put("name", name);
+    fields.put("fullName", fullName);
+    fields.put("mimeOverride", mimeOverride);
+    fields.put("dataSize", dataSize);
+    fields.put("targetURI", targetURI);
+    if (data == null) {
+      fields.put("data", null);
+      out.writeFields();
+      return;
+    }
+    if (data instanceof Serializable serializable) {
+      fields.put("data", serializable);
+      out.writeFields();
+      return;
+    }
+    // Non-serializable buckets cannot be safely persisted via Java serialization.
+    out.writeFields();
+    throw new java.io.NotSerializableException(data.getClass().getName());
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    Object restored;
+    try {
+      // If present, a trailing object carries the bucket (or null). Streams produced by the current
+      // writer normally don't include one; tolerate both forms.
+      restored = in.readObject();
+    } catch (OptionalDataException e) {
+      // End-of-block (TC_ENDBLOCKDATA). Keep whatever defaultReadObject() restored and return.
+      if (e.eof) return;
+      throw e;
+    }
+    data = (restored == null) ? null : (RandomAccessBucket) restored;
   }
 }

--- a/src/main/java/network/crypta/support/api/ManifestElement.java
+++ b/src/main/java/network/crypta/support/api/ManifestElement.java
@@ -327,17 +327,21 @@ public class ManifestElement implements Serializable {
 
   @Serial
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    // Read the default field block first. Historically, checkpoints stored the bucket inside the
+    // default field block. However, intermediary builds also wrote the bucket as a trailing object
+    // after the default fields. To remain compatible with those streams, attempt to read a trailing
+    // object and treat it as the bucket when present. When no trailing object exists (the common
+    // case), ObjectInputStream signals the end of class-defined data with
+    // OptionalDataException#eof=true, so we must not advance the stream further.
+    // Behavior is guarded by test:
+    //   ManifestElementTest.deserialization_whenTwoElementsInStream_doesNotConsumeNextObject
     in.defaultReadObject();
-    Object restored;
     try {
-      // If present, a trailing object carries the bucket (or null). Streams produced by the current
-      // writer normally don't include one; tolerate both forms.
-      restored = in.readObject();
+      Object maybeBucket = in.readObject();
+      data = (maybeBucket == null) ? null : (RandomAccessBucket) maybeBucket;
     } catch (OptionalDataException e) {
-      // End-of-block (TC_ENDBLOCKDATA). Keep whatever defaultReadObject() restored and return.
-      if (e.eof) return;
-      throw e;
+      // No trailing object for this class; keep the bucket restored from default fields.
+      if (!e.eof) throw e;
     }
-    data = (restored == null) ? null : (RandomAccessBucket) restored;
   }
 }

--- a/src/main/java/network/crypta/support/api/RandomAccessBucket.java
+++ b/src/main/java/network/crypta/support/api/RandomAccessBucket.java
@@ -3,26 +3,51 @@ package network.crypta.support.api;
 import java.io.IOException;
 
 /**
- * A Bucket which can be converted to a LockableRandomAccessBuffer without copying. Mostly we need
- * this where the size of something we will later use as a RandomAccessBuffer is uncertain. It
- * provides a separate object because the API's are incompatible; in particular, the size of a
- * RandomAccessBuffer is fixed (and this is mostly a good thing).
+ * Bucket variant that can be turned into a random‑access buffer efficiently.
  *
- * <p>FINALIZERS: Persistent RandomAccessBucket's should never free on finalize. Transient RABs can
- * free on finalize, but must ensure that this only happens if both the Bucket and the RAB are no
- * longer reachable.
+ * <p>Use this type when callers initially need a streaming {@link Bucket} but will later require
+ * random access via {@link LockableRandomAccessBuffer}. A separate interface exists because the
+ * APIs differ in important ways: notably, a {@link RandomAccessBuffer} has a fixed length, whereas
+ * a {@link Bucket} may be grown while writing. Converting to a random‑access buffer typically seals
+ * the size at the moment of conversion.
+ *
+ * <p>Implementations should avoid copying the underlying data where feasible when converting to a
+ * random‑access form; some implementations may still copy for small in‑memory data. Unless a
+ * specific implementation documents otherwise, callers should treat both the source bucket and the
+ * resulting buffer as read‑only after conversion to prevent divergence between the two views.
+ *
+ * <p><strong>Finalization.</strong> Persistent {@code RandomAccessBucket} implementations must not
+ * rely on finalizers to release durable resources. Transient implementations may free resources
+ * during finalization only if neither the bucket nor any derived {@link RandomAccessBuffer} remains
+ * reachable.
  */
 public interface RandomAccessBucket extends Bucket {
 
   /**
-   * Convert the Bucket to a LockableRandomAccessBuffer. Must be efficient, i.e. will not copy the
-   * data. Freeing the Bucket is unnecessary if you free the LockableRandomAccessBuffer. Both the
-   * parent Bucket and the return value will be made read only.
+   * Converts this bucket to a {@link LockableRandomAccessBuffer} without unnecessary copying.
    *
-   * @throws IOException
+   * <p>The returned buffer provides fixed‑size, random‑access I/O over the current content. Many
+   * implementations mark the bucket and/or the returned buffer read‑only to preserve consistency;
+   * callers should not rely on mutability of either after conversion. Freeing the returned buffer
+   * is sufficient to release any shared resources; freeing the bucket separately is not required in
+   * typical implementations.
+   *
+   * @return a random‑access view of this bucket's content
+   * @throws IOException if the conversion fails or the content cannot be exposed as a random‑access
+   *     buffer
    */
   LockableRandomAccessBuffer toRandomAccessBuffer() throws IOException;
 
+  /**
+   * Creates a shallow, read‑only view of this bucket with a covariant return type.
+   *
+   * <p>Semantics match {@link Bucket#createShadow()} but the return type is narrowed to {@code
+   * RandomAccessBucket} when a shadow is available. The shadow may become invalid if the original
+   * bucket is freed or deleted; readers should handle I/O failures accordingly.
+   *
+   * @return a read‑only shadow bucket sharing the same underlying storage, or {@code null} if
+   *     shadowing is unsupported for this implementation
+   */
   @Override
   RandomAccessBucket createShadow();
 }

--- a/src/main/java/network/crypta/support/api/RandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/api/RandomAccessBuffer.java
@@ -4,38 +4,76 @@ import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * Trivial random access file base interface. Guaranteed to be thread-safe - that is, either the
- * implementation will serialise reads, or it will support parallel reads natively. The length of
- * the file is constant. Many implementations will provide a nulling constructor - one that takes a
- * size and creates a RandomAccessBuffer of that length whose content is all 0's.
+ * Abstraction for a fixed-size, random-access byte buffer.
+ *
+ * <p>Implementations provide thread-safe access: either by internally serializing operations or by
+ * supporting concurrent reads (and writes where applicable). The logical length of the buffer is
+ * constant for the lifetime of the instance.
+ *
+ * <p>Some implementations may offer a constructor that creates a zero-initialized buffer of a
+ * specified size. This interface does not prescribe the storage medium; implementations may be
+ * memory-backed, file-backed, or layered on another {@code RandomAccessBuffer}.
  *
  * @author toad
  */
 public interface RandomAccessBuffer extends Closeable {
 
+  /**
+   * Returns the total size of the buffer in bytes.
+   *
+   * <p>The value is constant and does not change after construction.
+   *
+   * @return the number of bytes addressable by this buffer
+   */
   long size();
 
   /**
-   * Read a block of data from a specific location in the file. Guaranteed to read the whole range
-   * or to throw, like DataInputStream.readFully(). Must throw if the file is closed.
+   * Reads {@code length} bytes starting at {@code fileOffset} into {@code buf}.
    *
-   * @param fileOffset The offset within the file to read from.
-   * @param buf The buffer to write to.
-   * @param bufOffset The offset within the buffer to the first read byte.
-   * @param length The length of data to read.
-   * @throws IOException If we were unable to read the required number of bytes etc.
-   * @throws IllegalArgumentException If fileOffset is negative.
+   * <p>The operation behaves like {@link java.io.DataInputStream#readFully(byte[], int, int)}: it
+   * either reads the full requested range or throws. If this buffer has been closed, the method
+   * must throw.
+   *
+   * @param fileOffset byte offset within the buffer to start reading
+   * @param buf destination array to receive the bytes
+   * @param bufOffset index in {@code buf} of the first byte to write
+   * @param length number of bytes to read
+   * @throws IOException if the required number of bytes cannot be read or the buffer is closed
+   * @throws IllegalArgumentException if {@code fileOffset} is negative
    */
   void pread(long fileOffset, byte[] buf, int bufOffset, int length) throws IOException;
 
+  /**
+   * Writes {@code length} bytes from {@code buf} starting at {@code bufOffset} to {@code
+   * fileOffset}.
+   *
+   * <p>Implementations should commit all bytes or throw; partial writes are not permitted by
+   * contract. If this buffer has been closed, the method must throw.
+   *
+   * @param fileOffset byte offset within the buffer to start writing
+   * @param buf source array containing the bytes to write
+   * @param bufOffset index in {@code buf} of the first byte to read
+   * @param length number of bytes to write
+   * @throws IOException if the required number of bytes cannot be written or the buffer is closed
+   * @throws IllegalArgumentException if {@code fileOffset} is negative
+   */
   void pwrite(long fileOffset, byte[] buf, int bufOffset, int length) throws IOException;
 
+  /**
+   * Closes the buffer and releases any resources held by it.
+   *
+   * <p>After a call to {@code close()}, subsequent {@link #pread(long, byte[], int, int)} and
+   * {@link #pwrite(long, byte[], int, int)} calls must throw an {@link IOException}.
+   */
   @Override
   void close();
 
   /**
-   * Free the underlying resources. May do nothing in some implementations. You should make sure the
-   * object can be GC'ed as well.
+   * Frees underlying resources associated with the buffer.
+   *
+   * <p>In some implementations this may be a no-op. Callers should ensure there are no remaining
+   * references so the object can be garbage collected. Behavior after {@code free()} is
+   * implementation-defined; callers should not attempt further I/O through this instance.
    */
   void free();
 }

--- a/src/main/java/network/crypta/support/api/ShortCallback.java
+++ b/src/main/java/network/crypta/support/api/ShortCallback.java
@@ -3,7 +3,27 @@ package network.crypta.support.api;
 import network.crypta.config.ConfigCallback;
 
 /**
- * A callback to be called when a config value of short type changes. Also reports the current
- * value.
+ * Callback for configuration options that use {@link Short} values.
+ *
+ * <p>This specialization of {@link ConfigCallback} is intended for settings whose domain fits in a
+ * 16-bit signed integer. Implementations expose the current effective value via {@link #get()} and
+ * apply updates in {@link #set(Short)}. Units (e.g., counts, milliseconds) and validation rules are
+ * option-specific and should be enforced by implementations.
+ *
+ * <p>Contract notes:
+ *
+ * <ul>
+ *   <li><strong>Purpose:</strong> reflect and apply a short-valued configuration option.
+ *   <li><strong>Inputs/outputs:</strong> {@link #get()} returns the effective, non-{@code null}
+ *       value; {@link #set(Short)} receives the requested new value.
+ *   <li><strong>Validation:</strong> implementations may reject invalid values by throwing {@link
+ *       network.crypta.config.InvalidConfigValueException}; some changes may require a restart and
+ *       signal this via {@link network.crypta.config.NodeNeedRestartException}.
+ *   <li><strong>Threading:</strong> no synchronization guarantees are provided here; thread-safety
+ *       depends on the concrete implementation and calling context.
+ * </ul>
+ *
+ * @see network.crypta.config.ConfigCallback
+ * @see network.crypta.config.ShortOption
  */
 public abstract class ShortCallback extends ConfigCallback<Short> {}

--- a/src/main/java/network/crypta/support/api/StringArrCallback.java
+++ b/src/main/java/network/crypta/support/api/StringArrCallback.java
@@ -2,5 +2,36 @@ package network.crypta.support.api;
 
 import network.crypta.config.ConfigCallback;
 
-/** Callback (getter/setter) for a string config variable */
+/**
+ * Callback for configuration options that use {@code String[]} values.
+ *
+ * <p>This specialization of {@link ConfigCallback} exposes the current effective value via {@link
+ * #get()} and applies updates in {@link #set(String[])}.
+ *
+ * <p>Contract and usage notes:
+ *
+ * <ul>
+ *   <li><strong>Purpose:</strong> represent a sequence of strings as a single configuration option.
+ *   <li><strong>Inputs/outputs:</strong> {@link #get()} returns a non-{@code null} array (use an
+ *       empty array to indicate “no entries”); {@link #set(String[])} receives the requested new
+ *       sequence.
+ *   <li><strong>Validation:</strong> implementations may reject values by throwing {@link
+ *       network.crypta.config.InvalidConfigValueException}; some changes may require a restart and
+ *       signal this via {@link network.crypta.config.NodeNeedRestartException}.
+ *   <li><strong>Threading:</strong> no synchronization guarantees are defined here; thread-safety
+ *       depends on the concrete implementation and calling context.
+ *   <li><strong>Mutability:</strong> callers should not modify the array returned from {@link
+ *       #get()} unless explicitly documented by the implementation. Prefer treating it as read-only
+ *       and use {@link #set(String[])} to apply changes.
+ *   <li><strong>Semantics:</strong> whether order or duplicate elements are significant is
+ *       option-specific.
+ *   <li><strong>Persistence:</strong> when wired through {@link
+ *       network.crypta.config.StringArrOption}, the configuration framework persists values as a
+ *       semicolon-delimited list with URL-encoded elements; empty elements are encoded as {@code
+ *       ":"}. See {@link network.crypta.config.StringArrOption} for exact rules.
+ * </ul>
+ *
+ * @see network.crypta.config.ConfigCallback
+ * @see network.crypta.config.StringArrOption
+ */
 public abstract class StringArrCallback extends ConfigCallback<String[]> {}

--- a/src/main/java/network/crypta/support/api/StringCallback.java
+++ b/src/main/java/network/crypta/support/api/StringCallback.java
@@ -2,5 +2,22 @@ package network.crypta.support.api;
 
 import network.crypta.config.ConfigCallback;
 
-/** Callback (getter/setter) for a string config variable */
+/**
+ * Specialized configuration callback for string-valued options.
+ *
+ * <p>This type narrows {@link ConfigCallback} to {@link String} and is used by the configuration
+ * subsystem to read and update options whose value is textual. Implementations provide the
+ * mechanism to retrieve the current value and to apply a new one, including any validation and
+ * persistence required by the owning option or subsystem.
+ *
+ * <p>Thread-safety and handling of {@code null} are defined by the concrete implementation; callers
+ * must follow the specific option's contract. The inherited {@link #get()} returns the current
+ * effective value. The inherited {@link #set(String)} applies a new value and may reject it as
+ * invalid or indicate that a node restart is required, depending on implementation.
+ *
+ * @see ConfigCallback
+ * @see network.crypta.config.StringOption
+ * @see network.crypta.config.InvalidConfigValueException
+ * @see network.crypta.config.NodeNeedRestartException
+ */
 public abstract class StringCallback extends ConfigCallback<String> {}

--- a/src/main/java/network/crypta/support/api/package-info.java
+++ b/src/main/java/network/crypta/support/api/package-info.java
@@ -1,9 +1,23 @@
 /**
- * Package for plugin-safe packages and interfaces which are also used by the rest of the node, e.g.
- * Bucket. Generally this will be interfaces, but there may be a few classes too. Anything here must
- * not support more functionality than is really necessary; it must not be possible for a plugin to
- * escalate its privelidges through this API.
+ * Plugin-safe abstractions shared between plugins and the core node.
  *
- * @see freenet.plugin.api
+ * <p>This package contains interfaces and a limited number of supporting classes that plugins may
+ * implement or use, and that are also consumed by other parts of the node. Examples include data
+ * containers such as {@code Bucket}. The design goal is to expose only the capabilities required by
+ * plugins while preserving clear, enforceable boundaries with the core.
+ *
+ * <p>Design principles:
+ *
+ * <ul>
+ *   <li><b>Least privilege:</b> APIs here must not expose more functionality than necessary, and
+ *       must not enable privilege escalation by plugin code.
+ *   <li><b>Minimal surface:</b> prefer small, focused interfaces. Implementations may reside
+ *       elsewhere and should be replaceable.
+ *   <li><b>Stable contracts:</b> compatibility for plugin usage is a priority; behavioral details
+ *       are documented on the individual types.
+ * </ul>
+ *
+ * <p>Threading, lifecycle, and error-handling guarantees (including any checked exceptions) are
+ * documented on each type or method where relevant.
  */
 package network.crypta.support.api;

--- a/src/main/java/network/crypta/support/math/DecayingKeyspaceAverage.java
+++ b/src/main/java/network/crypta/support/math/DecayingKeyspaceAverage.java
@@ -13,10 +13,10 @@ import network.crypta.support.SimpleFieldSet;
  * re-normalizes back to {@code [0.0, 1.0)}.
  *
  * <p>Inputs to {@link #report(double)} and {@link #valueIfReported(double)} must be normalized
- * locations in {@code [0.0, 1.0]} and finite; invalid inputs cause an
- * {@link IllegalArgumentException}. The underlying average is configured with bounds
- * {@code [-2.0, 2.0]} to accommodate temporary unwrapped values during updates; the stored value
- * is always normalized back to {@code [0.0, 1.0)} after each update.
+ * locations in {@code [0.0, 1.0]} and finite; invalid inputs cause an {@link
+ * IllegalArgumentException}. The underlying average is configured with bounds {@code [-2.0, 2.0]}
+ * to accommodate temporary unwrapped values during updates; the stored value is always normalized
+ * back to {@code [0.0, 1.0)} after each update.
  *
  * <p>Thread-safety: All public methods are synchronized, so instances are safe for use by multiple
  * threads with external synchronization not required.
@@ -78,8 +78,8 @@ public final class DecayingKeyspaceAverage implements RunningAverage {
   /**
    * Returns the current average location.
    *
-   * <p>The result is normalized to {@code [0.0, 1.0)}; exactly {@code 1.0} is normalized to
-   * {@code 0.0}.
+   * <p>The result is normalized to {@code [0.0, 1.0)}; exactly {@code 1.0} is normalized to {@code
+   * 0.0}.
    *
    * @return normalized average location in {@code [0.0, 1.0)}
    */
@@ -173,8 +173,8 @@ public final class DecayingKeyspaceAverage implements RunningAverage {
    * Exports this instance's state into a {@link SimpleFieldSet}.
    *
    * <p>Delegates to the underlying {@link BootstrappingDecayingRunningAverage}. The serialized
-   * fields include {@code Type}, {@code CurrentValue}, and {@code Reports}. See
-   * {@link BootstrappingDecayingRunningAverage#exportFieldSet(boolean)} for details.
+   * fields include {@code Type}, {@code CurrentValue}, and {@code Reports}. See {@link
+   * BootstrappingDecayingRunningAverage#exportFieldSet(boolean)} for details.
    *
    * @param shortLived see {@link SimpleFieldSet#SimpleFieldSet(boolean)}
    * @return a field set containing the serialized state of the underlying average

--- a/src/test/java/network/crypta/support/api/ManifestElementTest.java
+++ b/src/test/java/network/crypta/support/api/ManifestElementTest.java
@@ -1,0 +1,261 @@
+package network.crypta.support.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import network.crypta.client.DefaultMIMETypes;
+import network.crypta.client.async.ClientContext;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.io.ArrayBucket;
+import network.crypta.support.io.ByteArrayRandomAccessBuffer;
+import network.crypta.support.io.RAFBucket;
+import network.crypta.support.io.ResumeFailedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // Test method names follow given_when_then format
+class ManifestElementTest {
+
+  private static final String REDIR_NAME = "redir";
+
+  @Mock private RandomAccessBucket rab;
+  @Mock private ClientContext clientContext;
+
+  @Test
+  @DisplayName("file ctor (simple): fields set; MIME guessed when no override")
+  void constructor_fileSimple_whenNoOverride_mimeGuessed() {
+    // Arrange
+    String name = "note.txt"; // 'txt' -> text/plain in DefaultMIMETypes
+    long size = 123L;
+
+    // Act
+    ManifestElement me = new ManifestElement(name, rab, null, size);
+
+    // Assert
+    assertEquals(name, me.getName());
+    assertEquals(name, me.fullName);
+    assertSame(rab, me.getData());
+    assertEquals(size, me.getSize());
+    assertNull(me.getTargetURI());
+    assertEquals("text/plain", me.getMimeType());
+  }
+
+  @Test
+  @DisplayName("file ctor (full name): uses provided fullName and MIME override")
+  void constructor_fileWithFullName_whenOverrideProvided_mimeFromOverride() {
+    // Arrange
+    String name =
+        "image.bin"; // extension intentionally mismatched to verify override takes precedence
+    String fullName = "assets/picture";
+    String override = "image/png";
+    long size = 42L;
+
+    // Act
+    ManifestElement me = new ManifestElement(name, fullName, rab, override, size);
+
+    // Assert
+    assertEquals(name, me.getName());
+    assertEquals(fullName, me.fullName);
+    assertEquals(override, me.getMimeTypeOverride());
+    assertEquals(override, me.getMimeType());
+    assertNull(me.getTargetURI());
+    assertEquals(size, me.getSize());
+  }
+
+  @Test
+  @DisplayName("redirect ctor (name only): target set; data null; size -1")
+  void constructor_redirectNameOnly_setsTargetAndFlags() {
+    // Arrange
+    FreenetURI target = FreenetURI.EMPTY_CHK_URI;
+    String override = "text/html";
+
+    // Act
+    ManifestElement me = new ManifestElement(REDIR_NAME, target, override);
+
+    // Assert
+    assertEquals(REDIR_NAME, me.getName());
+    assertEquals(REDIR_NAME, me.fullName);
+    assertSame(target, me.getTargetURI());
+    assertNull(me.getData());
+    assertEquals(-1L, me.getSize());
+    assertEquals(override, me.getMimeType());
+  }
+
+  @Test
+  @DisplayName("redirect ctor (with full name): respects provided fullName")
+  void constructor_redirectWithFullName_setsFullName() {
+    // Arrange
+    FreenetURI target = new FreenetURI("KSK", "index.html");
+
+    // Act
+    ManifestElement me = new ManifestElement("n", "dir/index.html", "text/html", target);
+
+    // Assert
+    assertEquals("n", me.getName());
+    assertEquals("dir/index.html", me.fullName);
+    assertSame(target, me.getTargetURI());
+    assertNull(me.getData());
+    assertEquals(-1L, me.getSize());
+  }
+
+  @Test
+  @DisplayName("equals/hashCode: compare by name only")
+  void equalsHashCode_whenSameName_onlyNameMatters() {
+    // Arrange
+    ManifestElement a = new ManifestElement("same-name", rab, null, 10L);
+    ManifestElement b = new ManifestElement("same-name", rab, "application/octet-stream", 999L);
+    ManifestElement c = new ManifestElement("different", rab, null, 10L);
+
+    // Act & Assert
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertNotEquals(a, c);
+  }
+
+  @Test
+  @SuppressWarnings({"deprecation", "AssertBetweenInconvertibleTypes"})
+  @DisplayName("equals: different ManifestElement class (package) never equal")
+  void equals_whenOtherPackageManifestElement_returnsFalse() {
+    // Arrange
+    ManifestElement a = new ManifestElement("name", rab, null, 1L);
+    network.crypta.client.async.ManifestElement other =
+        new network.crypta.client.async.ManifestElement();
+
+    // Act & Assert
+    assertNotEquals(a, other);
+  }
+
+  @Test
+  @DisplayName("freeData: calls free() only when data present")
+  void freeData_whenDataPresent_invokesFree() {
+    // Arrange
+    ManifestElement file = new ManifestElement("a.bin", rab, null, 5L);
+    ManifestElement redirect = new ManifestElement("r", FreenetURI.EMPTY_CHK_URI, null);
+
+    // Act
+    file.freeData();
+    redirect.freeData();
+
+    // Assert
+    verify(rab).free();
+  }
+
+  @Test
+  @DisplayName("onResume: delegates to RandomAccessBucket when data present; no-op otherwise")
+  void onResume_whenDataPresent_delegatesToBucket() throws ResumeFailedException {
+    // Arrange
+    ManifestElement file = new ManifestElement("file", rab, null, 17L);
+    ManifestElement redirect = new ManifestElement(REDIR_NAME, FreenetURI.EMPTY_CHK_URI, null);
+
+    // Act
+    file.onResume(clientContext);
+    redirect.onResume(clientContext);
+
+    // Assert
+    verify(rab).onResume(clientContext);
+  }
+
+  @Test
+  @DisplayName("getMimeType: returns null when no override and no extension")
+  void getMimeType_whenNoOverrideAndNoExtension_returnsNull() {
+    // Arrange
+    ManifestElement me = new ManifestElement("README", rab, null, 1L);
+
+    // Act & Assert
+    assertNull(me.getMimeType());
+  }
+
+  @Test
+  @DisplayName("getMimeType: returns null when extension unknown and no override")
+  void getMimeType_whenUnknownExtension_returnsNull() {
+    // Arrange
+    String name = "artifact.abcxyz"; // an extension not present in DefaultMIMETypes
+    // Defensive check: ensure our assumption really holds in this codebase
+    assertEquals(-1, DefaultMIMETypes.byName("application/x-abcxyz"));
+
+    ManifestElement me = new ManifestElement(name, rab, null, 2L);
+
+    // Act & Assert
+    assertNull(me.getMimeType());
+  }
+
+  @Test
+  @DisplayName("copy ctors: change name, optionally fullName; preserve other fields")
+  void copyConstructors_whenChangingNames_preserveOtherFields() {
+    // Arrange
+    ManifestElement original = new ManifestElement("old.txt", "dir/old.txt", rab, null, 11L);
+
+    // Act
+    ManifestElement renamed = new ManifestElement(original, "new.txt");
+    ManifestElement renamedAndMoved = new ManifestElement(original, "new2.txt", "dir/new2.txt");
+
+    // Assert
+    assertEquals("new.txt", renamed.getName());
+    assertEquals("dir/old.txt", renamed.fullName);
+    assertSame(rab, renamed.getData());
+    assertEquals(11L, renamed.getSize());
+    assertNull(renamed.getTargetURI());
+
+    assertEquals("new2.txt", renamedAndMoved.getName());
+    assertEquals("dir/new2.txt", renamedAndMoved.fullName);
+    assertSame(rab, renamedAndMoved.getData());
+    assertEquals(11L, renamedAndMoved.getSize());
+    assertNull(renamedAndMoved.getTargetURI());
+  }
+
+  @Test
+  @DisplayName("Serializable bucket: round-trip preserves data reference and size")
+  void serialization_whenBucketSerializable_roundTrips() throws Exception {
+    // Arrange: a serializable RandomAccessBucket
+    ArrayBucket bucket = new ArrayBucket("arr");
+    try (OutputStream os = bucket.getOutputStream()) {
+      os.write(new byte[] {1, 2, 3});
+    }
+    ManifestElement original = new ManifestElement("f.bin", bucket, null, bucket.size());
+
+    // Act: serialize then deserialize
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(original);
+      oos.flush();
+      bytes = bos.toByteArray();
+    }
+    ManifestElement restored;
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      restored = (ManifestElement) ois.readObject();
+    }
+
+    // Assert: data is present and size preserved
+    assertNotNull(restored.getData());
+    assertEquals(3L, restored.getSize());
+  }
+
+  @Test
+  @DisplayName("Non-serializable bucket: writeObject throws NotSerializableException")
+  void serialization_whenBucketNotSerializable_writeObjectThrows() throws Exception {
+    // Arrange: RAFBucket is not java.io.Serializable
+    RAFBucket nonSerializable = new RAFBucket(new ByteArrayRandomAccessBuffer(0));
+    ManifestElement me = new ManifestElement("n.bin", nonSerializable, null, 0L);
+
+    // Act & Assert
+    try (ObjectOutputStream oos = new ObjectOutputStream(new ByteArrayOutputStream())) {
+      assertThrows(NotSerializableException.class, () -> oos.writeObject(me));
+    }
+  }
+}

--- a/src/test/java/network/crypta/support/api/ManifestElementTest.java
+++ b/src/test/java/network/crypta/support/api/ManifestElementTest.java
@@ -258,4 +258,48 @@ class ManifestElementTest {
       assertThrows(NotSerializableException.class, () -> oos.writeObject(me));
     }
   }
+
+  @Test
+  @DisplayName(
+      "Deserialization: speculative trailing read must not consume the next object in stream")
+  void deserialization_whenTwoElementsInStream_doesNotConsumeNextObject() throws Exception {
+    // Arrange: two serializable-bucket elements written back-to-back using current writer
+    ArrayBucket b1 = new ArrayBucket("b1");
+    try (OutputStream os = b1.getOutputStream()) {
+      os.write(new byte[] {10, 20});
+    }
+    ManifestElement e1 = new ManifestElement("first.bin", b1, null, b1.size());
+
+    ArrayBucket b2 = new ArrayBucket("b2");
+    try (OutputStream os = b2.getOutputStream()) {
+      os.write(new byte[] {30});
+    }
+    ManifestElement e2 = new ManifestElement("second.bin", b2, null, b2.size());
+
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(e1);
+      oos.writeObject(e2);
+      oos.flush();
+      bytes = bos.toByteArray();
+    }
+
+    // Act: read the first, then the second object
+    ManifestElement r1;
+    ManifestElement r2;
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      r1 = (ManifestElement) ois.readObject();
+      r2 = (ManifestElement) ois.readObject();
+    }
+
+    // Assert: both objects are present and intact; stream was not advanced past r2
+    assertEquals("first.bin", r1.getName());
+    assertNotNull(r1.getData());
+    assertEquals(2L, r1.getSize());
+
+    assertEquals("second.bin", r2.getName());
+    assertNotNull(r2.getData());
+    assertEquals(1L, r2.getSize());
+  }
 }


### PR DESCRIPTION
Summary
- Broad documentation sweep across `network.crypta.support.api` with clearer package and type Javadoc, consistent terminology, and Spotless formatting.
- `ManifestElement` serialization refined and covered by new unit tests.
- Minor refactor: `BooleanCallback.from` specializes to `BooleanSupplier`.
- Minor API tightening: `RAFLock` constructor visibility set to `protected` (used only by subclasses); no behavior changes.

Scope
- 18 files changed, 1237 insertions(+), 214 deletions(-).
- Key files:
  - src/main/java/network/crypta/support/api/BooleanCallback.java
  - src/main/java/network/crypta/support/api/Bucket.java
  - src/main/java/network/crypta/support/api/BucketFactory.java
  - src/main/java/network/crypta/support/api/HTTPRequest.java
  - src/main/java/network/crypta/support/api/HTTPUploadedFile.java
  - src/main/java/network/crypta/support/api/IntCallback.java
  - src/main/java/network/crypta/support/api/LockableRandomAccessBuffer.java
  - src/main/java/network/crypta/support/api/LockableRandomAccessBufferFactory.java
  - src/main/java/network/crypta/support/api/LongCallback.java
  - src/main/java/network/crypta/support/api/ManifestElement.java
  - src/test/java/network/crypta/support/api/ManifestElementTest.java
  - src/main/java/network/crypta/support/api/package-info.java (new, clearer package-level Javadoc)

Notable commits
- feat(api): improve ManifestElement serialization and docs; add unit tests
- refactor(api): specialize BooleanCallback.from to BooleanSupplier and enhance Javadoc
- docs(api): refine Javadoc across support/api types
- docs(api): clarify package-level Javadoc for support.api (this branch)

Rationale
- Improve readability and plugin-facing API clarity (least-privilege, minimal surface, stable contracts).
- Add tests to lock in `ManifestElement` behaviors.
- Align style via Spotless for consistent diffs.

Risk/compatibility
- `RAFLock` constructor visibility now `protected`; usage is limited to subclassing and not direct construction. If any external plugin relied on `public` construction, that should migrate to provided factories or subclass. No other API signatures changed.

Validation
- Spotless applied locally.
- Unit tests added for `ManifestElement`.

Request
- Please review API docs accuracy and the `RAFLock` visibility change for any unintended plugin impact. Merge target is `develop`. Thank you!