### PR TITLE
docs(io): expand package Javadoc and clarify WritableToDataOutputStream contract

### DIFF
--- a/src/main/java/network/crypta/io/WritableToDataOutputStream.java
+++ b/src/main/java/network/crypta/io/WritableToDataOutputStream.java
@@ -4,13 +4,29 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
- * @author ian
- *     <p>To change the template for this generated type comment go to Window - Preferences - Java -
- *     Code Generation - Code and Comments
+ * Contract for types that can write their serialized form to a {@link DataOutputStream}.
+ *
+ * <p>Implementations write their binary representation to the provided stream. This interface does
+ * not prescribe a specific on-wire format; consult the implementing class for details about layout,
+ * versioning, and compatibility. Unless otherwise documented by an implementation, instances are
+ * not assumed to be thread-safe.
  */
 public interface WritableToDataOutputStream {
 
+  /**
+   * Legacy source-control revision identifier retained for diagnostics and historical context. The
+   * value is not normative and may not reflect the current project versioning scheme.
+   */
   String VERSION = "$Id: WritableToDataOutputStream.java,v 1.1 2005/01/29 19:12:10 amphibian Exp $";
 
+  /**
+   * Writes this object's serialized representation to the given {@link DataOutputStream}.
+   *
+   * <p>Implementations write zero or more bytes to the stream. Unless explicitly documented
+   * otherwise by the implementation, this method does not close the provided stream.
+   *
+   * @param stream destination that receives the binary representation; must be non-null and open
+   * @throws IOException if an I/O error occurs while writing to the stream
+   */
   void writeToDataOutputStream(DataOutputStream stream) throws IOException;
 }

--- a/src/main/java/network/crypta/io/package-info.java
+++ b/src/main/java/network/crypta/io/package-info.java
@@ -1,2 +1,44 @@
-/** Some utilities for IP addresses, running TCP servers on ports etc. */
+/**
+ * Networking utilities for working with IP addresses and inbound server endpoints.
+ *
+ * <p>This package provides building blocks used by higher-level components to listen for and accept
+ * incoming connections, and to decide which clients may connect. Core areas include:
+ *
+ * <ul>
+ *   <li><b>Address allow/deny checks</b> — a small, literal-only matching DSL parsed by {@link
+ *       network.crypta.io.AllowedHosts}. It supports IPv4/IPv6 literals, dotted or CIDR masks (for
+ *       example, {@code 192.168.1.0/24} or {@code 2001:db8::/64}), and a wildcard token ({@code
+ *       *}). Hostnames are not resolved.
+ *   <li><b>Address matchers</b> — family-specific implementations such as {@link
+ *       network.crypta.io.Inet4AddressMatcher}, {@link network.crypta.io.Inet6AddressMatcher}, and
+ *       {@link network.crypta.io.EverythingMatcher} that evaluate a client {@link
+ *       java.net.InetAddress} against the configured rules.
+ *   <li><b>Server endpoint abstraction</b> — {@link network.crypta.io.NetworkInterface} wraps one
+ *       or more {@link java.net.ServerSocket} instances to bind on multiple addresses, filter
+ *       connections using {@link network.crypta.io.AllowedHosts}, and expose a single {@code
+ *       accept()} queue. {@link network.crypta.io.SSLNetworkInterface} adds TLS via {@link
+ *       javax.net.ssl.SSLServerSocket}.
+ *   <li><b>Auxiliary helpers</b> — utilities for tracking/identifying addresses and writing to
+ *       streams (for example, {@link network.crypta.io.AddressIdentifier}, {@link
+ *       network.crypta.io.AddressTracker}, and {@link
+ *       network.crypta.io.WritableToDataOutputStream}).
+ * </ul>
+ *
+ * <p>Defaults and behavior:
+ *
+ * <ul>
+ *   <li>When no explicit bind or allow list is provided, the code defaults to loopback-only binding
+ *       as indicated by {@link network.crypta.io.NetworkInterface#DEFAULT_BIND_TO}.
+ *   <li>Tokens in allow lists must be numeric address literals; DNS names are ignored.
+ *   <li>Concurrency characteristics are documented on each type. The implementation favors explicit
+ *       locking for accept queues and atomic replacement for rule updates.
+ * </ul>
+ *
+ * <p>Related packages:
+ *
+ * <ul>
+ *   <li>{@link network.crypta.io.comm} — peer communication, socket handlers, and message framing.
+ *   <li>{@link network.crypta.io.xfer} — block/bulk transfer primitives and throttling.
+ * </ul>
+ */
 package network.crypta.io;


### PR DESCRIPTION
Summary
- Improve and expand Javadoc for the I/O package (`network.crypta.io`) and the `WritableToDataOutputStream` interface.
- No functional changes; documentation-only with Spotless formatting.

Changes
- src/main/java/network/crypta/io/package-info.java
  - Replace single-line comment with full package-level Javadoc describing:
    - Address allow/deny DSL and matchers (IPv4/IPv6, CIDR, wildcard `*`)
    - Server endpoint abstraction (`NetworkInterface`, `SSLNetworkInterface`)
    - Related helpers and linked packages (`io.comm`, `io.xfer`)
    - Defaults (loopback-only bind, literal-only tokens, concurrency notes)
- src/main/java/network/crypta/io/WritableToDataOutputStream.java
  - Clarify contract: writing to a provided `DataOutputStream` without closing it.
  - Add method-level Javadoc with parameters and error semantics.
  - Keep legacy `VERSION` field for diagnostics with clarified context.

Commit History (this branch)
- 047e9db8a1 docs(io): improve Javadoc for WritableToDataOutputStream; run Spotless
- fdbcd6a4a5 docs(io): expand package-level Javadoc for network.crypta.io

Rationale
- Brings the IO package up to our commenting standards; improves discoverability for contributors and reviewers.
- Aligns with guideline to improve Javadoc/KDoc when touching Java/Kotlin files.

Risk
- Low. Docs-only changes; no production logic modified.

Testing
- Built locally; no tests affected.

Notes
- If preferred, I can split package and interface docs into separate PRs, but the scope is small.
