### PR TITLE
docs(io/comm): clarify AsyncMessage* callback semantics; adjust io Javadoc

### DIFF
--- a/src/main/java/network/crypta/io/comm/AsyncMessageCallback.java
+++ b/src/main/java/network/crypta/io/comm/AsyncMessageCallback.java
@@ -1,26 +1,38 @@
 package network.crypta.io.comm;
 
-/** Callback interface for async message sending. */
+/**
+ * Receives progress and completion notifications for an asynchronously sent packet/message.
+ *
+ * <p>The sender uses this callback to report when a packet has been handed off to the transport and
+ * when the transmission completes or fails. On a reliable (non-lossy) transport, the peer's
+ * acknowledgment may follow immediately after {@link #sent()}; on a lossy transport, only {@link
+ * #acknowledged()} confirms reception by the remote node.
+ *
+ * <p>Implementations should return quickly and avoid long blocking operations; callback methods may
+ * be invoked from internal networking or scheduler threads.
+ */
 public interface AsyncMessageCallback {
 
   /**
-   * Called when the packet actually leaves the node. This DOES NOT MEAN that it has been
-   * successfully received by the partner node (on a lossy transport).
+   * Invoked when the packet actually leaves the local node (i.e., handed to the transport or
+   * written to the socket/output queue). This does not imply the remote node has received it on a
+   * lossy transport.
    */
   void sent();
 
   /**
-   * Called when the packet is actually acknowledged by the other node. This is the end of the
-   * transaction. On a non-lossy transport this may be called immediately after sent().
+   * Invoked when the remote node acknowledges receipt of the packet. This marks the end of the
+   * transmission for this packet. On a reliable (non-lossy) transport this may be called
+   * immediately after {@link #sent()}.
    */
   void acknowledged();
 
   /**
-   * Called if the node is disconnected while the packet is queued, or after it has been sent.
+   * Invoked if the connection is lost while the packet is queued or after it has been sent.
    * Terminal.
    */
   void disconnected();
 
-  /** Called if the packet is lost due to an internal error. */
+  /** Invoked if the packet is lost due to an unrecoverable internal error. Terminal. */
   void fatalError();
 }

--- a/src/main/java/network/crypta/io/comm/AsyncMessageFilterCallback.java
+++ b/src/main/java/network/crypta/io/comm/AsyncMessageFilterCallback.java
@@ -1,44 +1,62 @@
 package network.crypta.io.comm;
 
 /**
- * Sometimes it really is simpler to do things asynchronously. And sometimes it's essential for
- * performance.
+ * Callback interface for asynchronous message filter events.
+ *
+ * <p>Implementations receive notifications when a message matches a filter, when a filter is
+ * expired, and when a peer connection is disconnected or restarted. Callbacks may be invoked from
+ * transport or maintenance threads; implementations should avoid long-running or blocking work and
+ * should offload heavy processing where appropriate.
+ *
+ * <p>Unless otherwise stated, callbacks are invoked after the corresponding filter has been removed
+ * and without holding filter-list locks. See individual method documentation for threading/locking
+ * constraints.
  *
  * @author toad
  */
 public interface AsyncMessageFilterCallback {
 
   /**
-   * Called when the filter is matched. It will have been removed before the callback is called, and
-   * no locks should be held.
+   * Notifies that a message matched the filter.
    *
-   * @param m The message which matched the filter.
+   * <p>The filter is removed before this callback is invoked, and no filter-list locks are held by
+   * the caller. Implementations should return promptly and perform only lightweight work in this
+   * method.
+   *
+   * @param m the {@link Message} that matched the filter; never modified by the caller.
    */
   void onMatched(Message m);
 
   /**
-   * Check whether the filter should be removed. Note that USM locks may be held by the caller when
-   * this is called: the implementation should not do anything that might cause USM-related locks to
-   * be taken or messages to be sent.
+   * Indicates whether the filter should be timed out immediately.
    *
-   * @return True if the filter should be immediately timed out.
+   * <p>This method may be called while USM locks are held by the caller. The implementation must
+   * not perform actions that acquire USM-related locks or that could trigger sending messages. Keep
+   * the check side effect free and fast.
+   *
+   * @return {@code true} to request immediate timeout/removal; {@code false} to keep the filter
+   *     active.
    */
   boolean shouldTimeout();
 
-  /** Called when the filter times out and is removed from the list of filters to match. */
+  /**
+   * Notifies that the filter has timed out and was removed from matching.
+   *
+   * <p>Use this to release resources associated with the filter or to update any related state.
+   */
   void onTimeout();
 
   /**
-   * Called when the filter is dropped because a connection is dropped.
+   * Notifies that the filter was dropped due to a peer connection being disconnected.
    *
-   * @param ctx
+   * @param ctx the {@link PeerContext} for the disconnected peer.
    */
   void onDisconnect(PeerContext ctx);
 
   /**
-   * Called when the filter is dropped because a connection is restarted.
+   * Notifies that the filter was dropped due to a peer connection restart.
    *
-   * @param ctx
+   * @param ctx the {@link PeerContext} for the restarted peer.
    */
   void onRestarted(PeerContext ctx);
 }

--- a/src/main/java/network/crypta/io/comm/SlowAsyncMessageFilterCallback.java
+++ b/src/main/java/network/crypta/io/comm/SlowAsyncMessageFilterCallback.java
@@ -1,7 +1,37 @@
 package network.crypta.io.comm;
 
-/** AsyncMessageFilterCallback where the callbacks may do things that take significant time. */
+/**
+ * Callback variant for filter events whose handlers may block or take noticeable time to run.
+ *
+ * <p>Implementations indicate that their {@link AsyncMessageFilterCallback} methods can perform
+ * work that should not run inline on transport or maintenance threads. When a callback implements
+ * this interface, the filter machinery schedules the invocation on a background executor using the
+ * priority supplied by {@link #getPriority()} rather than calling it directly.
+ *
+ * <p>Scheduling details:
+ *
+ * <ul>
+ *   <li>Callbacks are dispatched via a {@link network.crypta.support.PriorityAwareExecutor} using a
+ *       {@code Runnable} that carries the returned priority.
+ *   <li>The exact priority scale is executor-specific. In the built-in pooled executor,
+ *       implementations typically return one of the values from {@link
+ *       network.crypta.support.io.NativeThread.PriorityLevel} (e.g., {@code NORM_PRIORITY.value}).
+ * </ul>
+ *
+ * <p>Thread-safety: Implementations may be called concurrently on different events; any shared
+ * state must be protected appropriately.
+ */
 public interface SlowAsyncMessageFilterCallback extends AsyncMessageFilterCallback {
 
+  /**
+   * Returns the scheduling priority to use when dispatching the callback on a worker thread.
+   *
+   * <p>The value is interpreted by the underlying executor. For the default pooled executor,
+   * recommended values are the {@link network.crypta.support.io.NativeThread.PriorityLevel#value
+   * priority} constants provided by {@code NativeThread.PriorityLevel} where larger numbers
+   * generally denote higher urgency.
+   *
+   * @return an integer priority understood by the executor
+   */
   int getPriority();
 }


### PR DESCRIPTION
Summary
- Clarifies Javadoc for io/comm async callback interfaces:
  - AsyncMessageCallback — documents lifecycle (sent/ack/disconnect/fatal), lossy vs. reliable semantics, and threading guidance.
  - AsyncMessageFilterCallback — clarifies event semantics, timeout contract, and locking/threading constraints.
  - SlowAsyncMessageFilterCallback — explains scheduling behavior and priority handling when callbacks may block.

Diff overview (origin/develop..HEAD)
- 5 files changed, 86 insertions(+), 84 deletions(-)
- Files:
  - M src/main/java/network/crypta/io/WritableToDataOutputStream.java
  - M src/main/java/network/crypta/io/comm/AsyncMessageCallback.java
  - M src/main/java/network/crypta/io/comm/AsyncMessageFilterCallback.java
  - M src/main/java/network/crypta/io/comm/SlowAsyncMessageFilterCallback.java
  - M src/main/java/network/crypta/io/package-info.java

Commits
- bea576e235 2025-10-18 docs(io/comm): clarify SlowAsyncMessageFilterCallback Javadoc
- 040a335dde 2025-10-18 docs(io-comm): clarify AsyncMessageFilterCallback Javadoc and threading/locking semantics
- 3aedcac651 2025-10-18 docs(io/comm): clarify AsyncMessageCallback lifecycle and threading

Reviewer notes
- WritableToDataOutputStream.java currently contains an older template-style comment and a legacy $Id tag, replacing a more detailed doc block. Please confirm whether this regression is intentional or if we should restore/improve the prior Javadoc to match current conventions (KDoc/JavaDoc per coding guidelines).
- package-info.java was reduced to a single-sentence summary. If intentional, we can follow up with a focused package doc that links to the key components; otherwise I can restore the more comprehensive overview.

Testing & checks
- No functional logic changes in the comm interfaces; changes are documentation-only.
- Did not run the Gradle test suite here to avoid long cycles; happy to trigger CI or run `./gradlew test` if desired.

Housekeeping
- Base: develop
- Head: feature/fix-AsyncMessage
- Maintainers are welcome to edit this PR.
