### PR TITLE
Refactor DMT message utilities + builder; update transmitters/updater; Spotless formatting

### DIFF
--- a/src/main/java/network/crypta/io/comm/DMT.java
+++ b/src/main/java/network/crypta/io/comm/DMT.java
@@ -12,13 +12,36 @@ import network.crypta.support.Fields;
 import network.crypta.support.ShortBuffer;
 
 /**
- * @author ian
- *     <p>To change the template for this generated type comment go to Window - Preferences - Java -
- *     Code Generation - Code and Comments
+ * Registry of data message types (DMT) and field keys used by the Crypta node-to-node communication
+ * layer.
+ *
+ * <p>This utility exposes:
+ *
+ * <ul>
+ *   <li>String constants for field names used when declaring {@link MessageType} schemas.
+ *   <li>Static {@link MessageType} instances describing request and response payloads.
+ *   <li>Factory helpers that create correctly typed {@link Message} instances.
+ * </ul>
+ *
+ * <p>All members are static; the class is non-instantiable. Priorities indicate relative scheduling
+ * on the link; lower numeric values are more urgent. See the {@code PRIORITY_*} constants for
+ * semantics.
+ *
+ * <p>Thread-safety: message type definitions are initialized once and then immutable. Factory
+ * methods allocate new {@link Message} objects and are thread-safe.
  */
+@SuppressWarnings("unused")
 public class DMT {
 
+  private DMT() {
+    throw new IllegalStateException("Utility class");
+  }
+
   public static final String UID = "uid";
+  /*
+   * Field name constants used by {@link MessageType#addField(String, Class)} and by callers when
+   * reading/writing {@link Message} values. Names are part of the on-wire schema; avoid renaming.
+   */
   public static final String SEND_TIME = "sendTime";
   public static final String EXTERNAL_ADDRESS = "externalAddress";
   public static final String BUILD = "build";
@@ -164,37 +187,35 @@ public class DMT {
 
   public static final String REAL_TIME_FLAG = "realTimeFlag";
 
-  /** Very urgent */
+  /** Very urgent control messages. */
   public static final short PRIORITY_NOW = 0;
 
-  /** Short timeout, or urgent for other reasons - Accepted, RejectedLoop etc. */
+  /** Short timeout or otherwise urgent (for example, accepts and loop rejections). */
   public static final short PRIORITY_HIGH = 1; //
 
-  /** Stuff that completes a request, and miscellaneous stuff. */
+  /** Routine control messages and completions. */
   public static final short PRIORITY_UNSPECIFIED = 2;
 
-  /** Stuff that starts a request. */
+  /** Request initiators; may tolerate longer timeouts. */
   public static final short PRIORITY_LOW = 3; // long timeout, or moderately urgent
 
   /**
-   * Bulk data transfer for realtime requests. Not strictly inferior to PRIORITY_BULK_DATA: we will
-   * not allow PRIORITY_REALTIME_DATA to starve PRIORITY_BULK_DATA.
+   * Bulk data for realtime requests. Not strictly inferior to {@link #PRIORITY_BULK_DATA};
+   * scheduling enforces fairness so realtime data does not starve bulk data.
    */
   public static final short PRIORITY_REALTIME_DATA = 4;
 
   /**
-   * Bulk data transfer, bottom of the heap, high level limiting must ensure there is time to send
-   * it by not accepting an infeasible number of requests; starvation will cause bwlimitDelayTime to
-   * go high and requests to be rejected. That's the ultimate limiter if even output bandwidth
-   * liability fails.
+   * Bulk data transfer (lowest priority). Higher-level admission control must ensure feasibility;
+   * persistent starvation raises {@code bwlimitDelayTime} and causes request rejection.
    */
   public static final short PRIORITY_BULK_DATA = 5;
 
   public static final short NUM_PRIORITIES = 6;
 
-  // Assimilation
+  // Segmented bulk transfer primitives
 
-  // New data transmission messages
+  /** Message carrying one data packet in a segmented bulk transfer. */
   public static final MessageType packetTransmit =
       new MessageType("packetTransmit", PRIORITY_BULK_DATA);
 
@@ -205,6 +226,16 @@ public class DMT {
     packetTransmit.addField(DATA, Buffer.class);
   }
 
+  /**
+   * Creates a {@code packetTransmit} for a segmented bulk transfer.
+   *
+   * @param uid Transfer identifier shared by the bulk session.
+   * @param packetNo Zero-based packet index.
+   * @param sent Bitset of packets known to be sent; helps coalesce ACK/resend state.
+   * @param data Payload for this packet.
+   * @param realTime When true, boosts priority to {@link #PRIORITY_REALTIME_DATA}.
+   * @return Initialized message.
+   */
   public static Message createPacketTransmit(
       long uid, int packetNo, BitArray sent, Buffer data, boolean realTime) {
     Message msg = new Message(packetTransmit);
@@ -218,32 +249,52 @@ public class DMT {
     return msg;
   }
 
-  public static int packetTransmitSize(int size, int _packets) {
+  /**
+   * Computes approximate on-wire size in bytes for a {@code packetTransmit} message.
+   *
+   * @param size Payload size in bytes.
+   * @param packets Number of packets in the transfer (for the {@link BitArray}).
+   * @return Payload size plus header/metadata overhead.
+   */
+  public static int packetTransmitSize(int size, int packets) {
     return size
         + 8 /* uid */
         + 4 /* packet# */
-        + BitArray.serializedLength(_packets)
+        + BitArray.serializedLength(packets)
         + 4 /* Message header */;
   }
 
+  /**
+   * Computes approximate on-wire size for a bulk packet message that does not carry a BitArray.
+   *
+   * @param size Payload size in bytes.
+   * @return Payload size plus header/metadata overhead.
+   */
   public static int bulkPacketTransmitSize(int size) {
     return size + 8 /* uid */ + 4 /* packet# */ + 4 /* Message header */;
   }
 
-  // This is of priority BULK_DATA to cut down on suprious resend requests, it will be queued after
-  // the packets it represents
+  // Use BULK_DATA to reduce spurious resend requests; queued after the packets it represents.
+  /** Signals that all packets in the current transfer have been enqueued by the sender. */
   public static final MessageType allSent = new MessageType("allSent", PRIORITY_BULK_DATA);
 
   static {
     allSent.addField(UID, Long.class);
   }
 
-  public static Message createAllSent(long uid, boolean realTime) {
+  /**
+   * Creates an {@code allSent} notification for the given transfer.
+   *
+   * @param uid Transfer identifier.
+   * @return Initialized message.
+   */
+  public static Message createAllSent(long uid) {
     Message msg = new Message(allSent);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Signals that all packets in the current transfer have been received. */
   public static final MessageType allReceived =
       new MessageType("allReceived", PRIORITY_UNSPECIFIED);
 
@@ -251,12 +302,19 @@ public class DMT {
     allReceived.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code allReceived} notification for the given transfer.
+   *
+   * @param uid Transfer identifier.
+   * @return Initialized message.
+   */
   public static Message createAllReceived(long uid) {
     Message msg = new Message(allReceived);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Indicates that a transfer was aborted and will not complete. */
   public static final MessageType sendAborted =
       new MessageType("sendAborted", PRIORITY_UNSPECIFIED);
 
@@ -266,6 +324,14 @@ public class DMT {
     sendAborted.addField(REASON, Integer.class);
   }
 
+  /**
+   * Creates a {@code sendAborted} message.
+   *
+   * @param uid Transfer identifier.
+   * @param reason Implementation-defined error code.
+   * @param description Human-readable reason.
+   * @return Initialized message.
+   */
   public static Message createSendAborted(long uid, int reason, String description) {
     Message msg = new Message(sendAborted);
     msg.set(UID, uid);
@@ -274,6 +340,10 @@ public class DMT {
     return msg;
   }
 
+  /**
+   * Bulk transfer packet using {@link ShortBuffer} for payload. Used by the bulk transmitter when
+   * BitArray acknowledgments are not included inline.
+   */
   public static final MessageType FNPBulkPacketSend =
       new MessageType("FNPBulkPacketSend", PRIORITY_BULK_DATA);
 
@@ -283,8 +353,15 @@ public class DMT {
     FNPBulkPacketSend.addField(DATA, ShortBuffer.class);
   }
 
-  public static Message createFNPBulkPacketSend(
-      long uid, int packetNo, ShortBuffer data, boolean realTime) {
+  /**
+   * Creates an {@code FNPBulkPacketSend} for a segmented bulk transfer.
+   *
+   * @param uid Transfer identifier.
+   * @param packetNo Zero-based packet index.
+   * @param data Packet payload as a {@link ShortBuffer}.
+   * @return Initialized message.
+   */
+  public static Message createFNPBulkPacketSend(long uid, int packetNo, ShortBuffer data) {
     Message msg = new Message(FNPBulkPacketSend);
     msg.set(UID, uid);
     msg.set(PACKET_NO, packetNo);
@@ -292,11 +369,12 @@ public class DMT {
     return msg;
   }
 
-  public static Message createFNPBulkPacketSend(
-      long uid, int packetNo, byte[] data, boolean realTime) {
-    return createFNPBulkPacketSend(uid, packetNo, new ShortBuffer(data), realTime);
+  /** Convenience overload that wraps a byte array into {@link ShortBuffer}. */
+  public static Message createFNPBulkPacketSend(long uid, int packetNo, byte[] data) {
+    return createFNPBulkPacketSend(uid, packetNo, new ShortBuffer(data));
   }
 
+  /** Sender aborted a bulk transfer; no further packets will be sent. */
   public static final MessageType FNPBulkSendAborted =
       new MessageType("FNPBulkSendAborted", PRIORITY_UNSPECIFIED);
 
@@ -304,12 +382,14 @@ public class DMT {
     FNPBulkSendAborted.addField(UID, Long.class);
   }
 
+  /** Creates an {@code FNPBulkSendAborted} for the given transfer. */
   public static Message createFNPBulkSendAborted(long uid) {
     Message msg = new Message(FNPBulkSendAborted);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Receiver aborted a bulk transfer; subsequent packets should be discarded. */
   public static final MessageType FNPBulkReceiveAborted =
       new MessageType("FNPBulkReceiveAborted", PRIORITY_UNSPECIFIED);
 
@@ -317,12 +397,14 @@ public class DMT {
     FNPBulkReceiveAborted.addField(UID, Long.class);
   }
 
+  /** Creates an {@code FNPBulkReceiveAborted} for the given transfer. */
   public static Message createFNPBulkReceiveAborted(long uid) {
     Message msg = new Message(FNPBulkReceiveAborted);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Receiver acknowledges that all expected packets were received. */
   public static final MessageType FNPBulkReceivedAll =
       new MessageType("FNPBulkReceivedAll", PRIORITY_UNSPECIFIED);
 
@@ -330,12 +412,14 @@ public class DMT {
     FNPBulkReceivedAll.addField(UID, Long.class);
   }
 
+  /** Creates an {@code FNPBulkReceivedAll} acknowledgment. */
   public static Message createFNPBulkReceivedAll(long uid) {
     Message msg = new Message(FNPBulkReceivedAll);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Test harness: request that the peer start a trivial transfer. */
   public static final MessageType testTransferSend =
       new MessageType("testTransferSend", PRIORITY_UNSPECIFIED);
 
@@ -343,12 +427,14 @@ public class DMT {
     testTransferSend.addField(UID, Long.class);
   }
 
+  /** Creates a {@code testTransferSend} request. */
   public static Message createTestTransferSend(long uid) {
     Message msg = new Message(testTransferSend);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Test harness: acknowledgment of {@code testTransferSend}. */
   public static final MessageType testTransferSendAck =
       new MessageType("testTransferSendAck", PRIORITY_UNSPECIFIED);
 
@@ -356,12 +442,14 @@ public class DMT {
     testTransferSendAck.addField(UID, Long.class);
   }
 
+  /** Creates a {@code testTransferSendAck}. */
   public static Message createTestTransferSendAck(long uid) {
     Message msg = new Message(testTransferSendAck);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Test harness: send a CHK URI and header for validation. */
   public static final MessageType testSendCHK =
       new MessageType("testSendCHK", PRIORITY_UNSPECIFIED);
 
@@ -371,6 +459,14 @@ public class DMT {
     testSendCHK.addField(CHK_HEADER, Buffer.class);
   }
 
+  /**
+   * Creates a {@code testSendCHK} with a URI string and header buffer.
+   *
+   * @param uid Test identifier.
+   * @param uri CHK URI as a string.
+   * @param header Serialized header.
+   * @return Initialized message.
+   */
   public static Message createTestSendCHK(long uid, String uri, Buffer header) {
     Message msg = new Message(testSendCHK);
     msg.set(UID, uid);
@@ -379,6 +475,7 @@ public class DMT {
     return msg;
   }
 
+  /** Test harness: request data by routing key with an explicit HTL. */
   public static final MessageType testRequest =
       new MessageType("testRequest", PRIORITY_UNSPECIFIED);
 
@@ -388,14 +485,23 @@ public class DMT {
     testRequest.addField(HTL, Integer.class);
   }
 
-  public static Message createTestRequest(Key Key, long id, int htl) {
+  /**
+   * Creates a {@code testRequest} for a routing key.
+   *
+   * @param key Routing key.
+   * @param id Test identifier.
+   * @param htl Hops-to-live.
+   * @return Initialized message.
+   */
+  public static Message createTestRequest(Key key, long id, int htl) {
     Message msg = new Message(testRequest);
     msg.set(UID, id);
-    msg.set(FREENET_ROUTING_KEY, Key);
+    msg.set(FREENET_ROUTING_KEY, key);
     msg.set(HTL, htl);
     return msg;
   }
 
+  /** Test harness: negative lookup result. */
   public static final MessageType testDataNotFound =
       new MessageType("testDataNotFound", PRIORITY_UNSPECIFIED);
 
@@ -403,12 +509,14 @@ public class DMT {
     testDataNotFound.addField(UID, Long.class);
   }
 
+  /** Creates a {@code testDataNotFound}. */
   public static Message createTestDataNotFound(long uid) {
     Message msg = new Message(testDataNotFound);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Test harness: successful reply carrying serialized headers. */
   public static final MessageType testDataReply =
       new MessageType("testDataReply", PRIORITY_UNSPECIFIED);
 
@@ -417,6 +525,13 @@ public class DMT {
     testDataReply.addField(TEST_CHK_HEADERS, Buffer.class);
   }
 
+  /**
+   * Creates a {@code testDataReply} with serialized headers.
+   *
+   * @param uid Test identifier.
+   * @param headers Serialized headers.
+   * @return Initialized message.
+   */
   public static Message createTestDataReply(long uid, byte[] headers) {
     Message msg = new Message(testDataReply);
     msg.set(UID, uid);
@@ -424,6 +539,7 @@ public class DMT {
     return msg;
   }
 
+  /** Test harness: acknowledgment to {@code testSendCHK}. */
   public static final MessageType testSendCHKAck =
       new MessageType("testSendCHKAck", PRIORITY_UNSPECIFIED);
 
@@ -432,6 +548,13 @@ public class DMT {
     testSendCHKAck.addField(FREENET_URI, String.class);
   }
 
+  /**
+   * Creates a {@code testSendCHKAck} echoing the provided key.
+   *
+   * @param uid Test identifier.
+   * @param key Echo of the CHK key string.
+   * @return Initialized message.
+   */
   public static Message createTestSendCHKAck(long uid, String key) {
     Message msg = new Message(testSendCHKAck);
     msg.set(UID, uid);
@@ -439,6 +562,7 @@ public class DMT {
     return msg;
   }
 
+  /** Test harness: acknowledgment of {@code testDataReply}. */
   public static final MessageType testDataReplyAck =
       new MessageType("testDataReplyAck", PRIORITY_UNSPECIFIED);
 
@@ -446,12 +570,14 @@ public class DMT {
     testDataReplyAck.addField(UID, Long.class);
   }
 
+  /** Creates a {@code testDataReplyAck}. */
   public static Message createTestDataReplyAck(long id) {
     Message msg = new Message(testDataReplyAck);
     msg.set(UID, id);
     return msg;
   }
 
+  /** Test harness: acknowledgment of {@code testDataNotFound}. */
   public static final MessageType testDataNotFoundAck =
       new MessageType("testDataNotFoundAck", PRIORITY_UNSPECIFIED);
 
@@ -459,6 +585,7 @@ public class DMT {
     testDataNotFoundAck.addField(UID, Long.class);
   }
 
+  /** Creates a {@code testDataNotFoundAck}. */
   public static Message createTestDataNotFoundAck(long id) {
     Message msg = new Message(testDataNotFoundAck);
     msg.set(UID, id);
@@ -467,6 +594,7 @@ public class DMT {
 
   // Internal only messages
 
+  /** Internal: indicates completion of a test receive, with success flag and reason. */
   public static final MessageType testReceiveCompleted =
       new MessageType("testReceiveCompleted", PRIORITY_UNSPECIFIED, true, false);
 
@@ -476,6 +604,14 @@ public class DMT {
     testReceiveCompleted.addField(REASON, String.class);
   }
 
+  /**
+   * Creates a {@code testReceiveCompleted}.
+   *
+   * @param id Test identifier.
+   * @param success Whether the reception completed successfully.
+   * @param reason Optional reason text.
+   * @return Initialized message.
+   */
   public static Message createTestReceiveCompleted(long id, boolean success, String reason) {
     Message msg = new Message(testReceiveCompleted);
     msg.set(UID, id);
@@ -484,6 +620,7 @@ public class DMT {
     return msg;
   }
 
+  /** Internal: indicates completion of a test send, with success flag and reason. */
   public static final MessageType testSendCompleted =
       new MessageType("testSendCompleted", PRIORITY_UNSPECIFIED, true, false);
 
@@ -493,6 +630,14 @@ public class DMT {
     testSendCompleted.addField(REASON, String.class);
   }
 
+  /**
+   * Creates a {@code testSendCompleted}.
+   *
+   * @param id Test identifier.
+   * @param success Whether the sending completed successfully.
+   * @param reason Optional reason text.
+   * @return Initialized message.
+   */
   public static Message createTestSendCompleted(long id, boolean success, String reason) {
     Message msg = new Message(testSendCompleted);
     msg.set(UID, id);
@@ -501,7 +646,7 @@ public class DMT {
     return msg;
   }
 
-  // Node-To-Node Message (generic)
+  /** Generic node-to-node message carrying a small typed payload. */
   public static final MessageType nodeToNodeMessage =
       new MessageType("nodeToNodeMessage", PRIORITY_LOW, false, false);
 
@@ -510,6 +655,13 @@ public class DMT {
     nodeToNodeMessage.addField(NODE_TO_NODE_MESSAGE_DATA, ShortBuffer.class);
   }
 
+  /**
+   * Creates a generic node-to-node message with a caller-defined {@code type} and opaque payload.
+   *
+   * @param type Application-specific subtype.
+   * @param data Opaque payload; interpreted by the receiver based on {@code type}.
+   * @return Initialized message.
+   */
   public static Message createNodeToNodeMessage(int type, byte[] data) {
     Message msg = new Message(nodeToNodeMessage);
     msg.set(NODE_TO_NODE_MESSAGE_TYPE, type);
@@ -518,6 +670,7 @@ public class DMT {
   }
 
   // FNP messages
+  /** Request for CHK data (content-hash key) routed by location. */
   public static final MessageType FNPCHKDataRequest =
       new MessageType("FNPCHKDataRequest", PRIORITY_LOW);
 
@@ -528,6 +681,14 @@ public class DMT {
     FNPCHKDataRequest.addField(FREENET_ROUTING_KEY, NodeCHK.class);
   }
 
+  /**
+   * Creates an {@code FNPCHKDataRequest}.
+   *
+   * @param id Request identifier.
+   * @param htl Hops-to-live.
+   * @param key Routing key (CHK).
+   * @return Initialized message.
+   */
   public static Message createFNPCHKDataRequest(long id, short htl, NodeCHK key) {
     Message msg = new Message(FNPCHKDataRequest);
     msg.set(UID, id);
@@ -537,6 +698,7 @@ public class DMT {
     return msg;
   }
 
+  /** Request for SSK data (signed-subspace key) routed by location. */
   public static final MessageType FNPSSKDataRequest =
       new MessageType("FNPSSKDataRequest", PRIORITY_LOW);
 
@@ -548,6 +710,15 @@ public class DMT {
     FNPSSKDataRequest.addField(NEED_PUB_KEY, Boolean.class);
   }
 
+  /**
+   * Creates an {@code FNPSSKDataRequest}.
+   *
+   * @param id Request identifier.
+   * @param htl Hops-to-live.
+   * @param key Routing key (SSK).
+   * @param needPubKey Whether the caller requires the public key to be returned.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKDataRequest(
       long id, short htl, NodeSSK key, boolean needPubKey) {
     Message msg = new Message(FNPSSKDataRequest);
@@ -559,21 +730,28 @@ public class DMT {
     return msg;
   }
 
-  // Hit our tail, try a different node.
+  // Loop detected: choose a different peer.
+  /** Rejection indicating a routing loop was encountered. */
   public static final MessageType FNPRejectedLoop = new MessageType("FNPRejectLoop", PRIORITY_HIGH);
 
   static {
     FNPRejectedLoop.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPRejectedLoop} for the given request.
+   *
+   * @param id Request identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPRejectedLoop(long id) {
     Message msg = new Message(FNPRejectedLoop);
     msg.set(UID, id);
     return msg;
   }
 
-  // Too many requests for present capacity. Fail, propagate back
-  // to source, and reduce send rate.
+  // Too many concurrent requests for current capacity.
+  /** Rejection due to overload; caller may reduce rate or choose another peer. */
   public static final MessageType FNPRejectedOverload =
       new MessageType("FNPRejectOverload", PRIORITY_HIGH);
 
@@ -583,14 +761,12 @@ public class DMT {
   }
 
   /**
-   * @deprecated last two NLM related arguments are ignored and can be omitted
+   * Creates an {@code FNPRejectedOverload}.
+   *
+   * @param id Request identifier.
+   * @param isLocal Whether the rejecting peer is the local node.
+   * @return Initialized message.
    */
-  @Deprecated
-  public static Message createFNPRejectedOverload(
-      long id, boolean isLocal, boolean needsLoad, boolean realTimeFlag) {
-    return createFNPRejectedOverload(id, isLocal);
-  }
-
   public static Message createFNPRejectedOverload(long id, boolean isLocal) {
     Message msg = new Message(FNPRejectedOverload);
     msg.set(UID, id);
@@ -598,18 +774,26 @@ public class DMT {
     return msg;
   }
 
+  /** Acknowledge that a request was accepted and will proceed. */
   public static final MessageType FNPAccepted = new MessageType("FNPAccepted", PRIORITY_HIGH);
 
   static {
     FNPAccepted.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPAccepted} acknowledgment.
+   *
+   * @param id Request identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPAccepted(long id) {
     Message msg = new Message(FNPAccepted);
     msg.set(UID, id);
     return msg;
   }
 
+  /** Negative result indicating the requested data was not found. */
   public static final MessageType FNPDataNotFound =
       new MessageType("FNPDataNotFound", PRIORITY_UNSPECIFIED);
 
@@ -617,12 +801,19 @@ public class DMT {
     FNPDataNotFound.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPDataNotFound} for the given request.
+   *
+   * @param id Request identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPDataNotFound(long id) {
     Message msg = new Message(FNPDataNotFound);
     msg.set(UID, id);
     return msg;
   }
 
+  /** Indicates a recent failure; used to guide backoff and avoid repeated attempts. */
   public static final MessageType FNPRecentlyFailed =
       new MessageType("FNPRecentlyFailed", PRIORITY_HIGH);
 
@@ -631,6 +822,13 @@ public class DMT {
     FNPRecentlyFailed.addField(TIME_LEFT, Integer.class);
   }
 
+  /**
+   * Creates an {@code FNPRecentlyFailed} with a remaining-wait hint.
+   *
+   * @param id Request identifier.
+   * @param timeLeft Remaining time to wait before retrying (unit implementation-defined).
+   * @return Initialized message.
+   */
   public static Message createFNPRecentlyFailed(long id, int timeLeft) {
     Message msg = new Message(FNPRecentlyFailed);
     msg.set(UID, id);
@@ -638,6 +836,7 @@ public class DMT {
     return msg;
   }
 
+  /** Positive result for CHK requests carrying block headers. */
   public static final MessageType FNPCHKDataFound =
       new MessageType("FNPCHKDataFound", PRIORITY_UNSPECIFIED);
 
@@ -646,6 +845,13 @@ public class DMT {
     FNPCHKDataFound.addField(BLOCK_HEADERS, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPCHKDataFound} with serialized block headers.
+   *
+   * @param id Request identifier.
+   * @param buf Serialized headers.
+   * @return Initialized message.
+   */
   public static Message createFNPCHKDataFound(long id, byte[] buf) {
     Message msg = new Message(FNPCHKDataFound);
     msg.set(UID, id);
@@ -653,6 +859,7 @@ public class DMT {
     return msg;
   }
 
+  /** No route found for the request; includes remaining HTL. */
   public static final MessageType FNPRouteNotFound =
       new MessageType("FNPRouteNotFound", PRIORITY_UNSPECIFIED);
 
@@ -661,6 +868,13 @@ public class DMT {
     FNPRouteNotFound.addField(HTL, Short.class);
   }
 
+  /**
+   * Creates an {@code FNPRouteNotFound}.
+   *
+   * @param id Request identifier.
+   * @param htl Remaining hops-to-live.
+   * @return Initialized message.
+   */
   public static Message createFNPRouteNotFound(long id, short htl) {
     Message msg = new Message(FNPRouteNotFound);
     msg.set(UID, id);
@@ -668,6 +882,7 @@ public class DMT {
     return msg;
   }
 
+  /** Insert request routed by location (CHK/SSK-agnostic key interface). */
   public static final MessageType FNPInsertRequest =
       new MessageType("FNPInsertRequest", PRIORITY_LOW);
 
@@ -678,6 +893,14 @@ public class DMT {
     FNPInsertRequest.addField(FREENET_ROUTING_KEY, Key.class);
   }
 
+  /**
+   * Creates an {@code FNPInsertRequest}.
+   *
+   * @param id Request identifier.
+   * @param htl Hops-to-live.
+   * @param key Routing key.
+   * @return Initialized message.
+   */
   public static Message createFNPInsertRequest(long id, short htl, Key key) {
     Message msg = new Message(FNPInsertRequest);
     msg.set(UID, id);
@@ -687,6 +910,7 @@ public class DMT {
     return msg;
   }
 
+  /** Acknowledgment that an insert request was accepted downstream. */
   public static final MessageType FNPInsertReply =
       new MessageType("FNPInsertReply", PRIORITY_UNSPECIFIED);
 
@@ -694,12 +918,19 @@ public class DMT {
     FNPInsertReply.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPInsertReply} acknowledgment.
+   *
+   * @param id Request identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPInsertReply(long id) {
     Message msg = new Message(FNPInsertReply);
     msg.set(UID, id);
     return msg;
   }
 
+  /** Carries serialized block headers for a data insert. */
   public static final MessageType FNPDataInsert = new MessageType("FNPDataInsert", PRIORITY_HIGH);
 
   static {
@@ -707,6 +938,13 @@ public class DMT {
     FNPDataInsert.addField(BLOCK_HEADERS, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPDataInsert} message with serialized block headers.
+   *
+   * @param uid Insert identifier.
+   * @param headers Serialized headers.
+   * @return Initialized message.
+   */
   public static Message createFNPDataInsert(long uid, byte[] headers) {
     Message msg = new Message(FNPDataInsert);
     msg.set(UID, uid);
@@ -714,6 +952,7 @@ public class DMT {
     return msg;
   }
 
+  /** Indicates that all transfer segments for an insert completed (possibly with timeouts). */
   public static final MessageType FNPInsertTransfersCompleted =
       new MessageType("FNPInsertTransfersCompleted", PRIORITY_UNSPECIFIED);
 
@@ -722,6 +961,13 @@ public class DMT {
     FNPInsertTransfersCompleted.addField(ANY_TIMED_OUT, Boolean.class);
   }
 
+  /**
+   * Creates an {@code FNPInsertTransfersCompleted}.
+   *
+   * @param uid Insert identifier.
+   * @param anyTimedOut Whether any segment timed out.
+   * @return Initialized message.
+   */
   public static Message createFNPInsertTransfersCompleted(long uid, boolean anyTimedOut) {
     Message msg = new Message(FNPInsertTransfersCompleted);
     msg.set(UID, uid);
@@ -731,11 +977,11 @@ public class DMT {
 
   // This is used by CHK inserts when the DataInsert isn't received.
   // SSK inserts just use DataInsertRejected with a timeout reason.
-  // FIXME we probably should just use one message for both. One complication is that
+  // Consider using a single message for both. One complication is that
   // CHKs have a single DataInsert (followed by a transfer), whereas SSKs have 2-3 messages,
-  // any of which can timeout independantly. Arguably that's bad design and we should
-  // just send one message now that we have new packet format, see the discussion on
-  // FNPSSKInsertRequestNew vs the old version.
+  // any of which can time out independently. We could send one message now that we have the new
+  // packet format; see the discussion on FNPSSKInsertRequestNew vs the old version.
+  /** Timeout for CHK inserts when {@code FNPDataInsert} was not received in time. */
   public static final MessageType FNPRejectedTimeout =
       new MessageType("FNPTooSlow", PRIORITY_UNSPECIFIED);
 
@@ -743,12 +989,21 @@ public class DMT {
     FNPRejectedTimeout.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPRejectedTimeout} notification.
+   *
+   * @param uid Insert identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPRejectedTimeout(long uid) {
     Message msg = new Message(FNPRejectedTimeout);
     msg.set(UID, uid);
     return msg;
   }
 
+  /**
+   * Insert rejected with a reason code (see constants and {@link #getDataInsertRejectedReason}).
+   */
   public static final MessageType FNPDataInsertRejected =
       new MessageType("FNPDataInsertRejected", PRIORITY_UNSPECIFIED);
 
@@ -757,6 +1012,13 @@ public class DMT {
     FNPDataInsertRejected.addField(DATA_INSERT_REJECTED_REASON, Short.class);
   }
 
+  /**
+   * Creates an {@code FNPDataInsertRejected} with a reason code.
+   *
+   * @param uid Insert identifier.
+   * @param reason Reason code constant.
+   * @return Initialized message.
+   */
   public static Message createFNPDataInsertRejected(long uid, short reason) {
     Message msg = new Message(FNPDataInsertRejected);
     msg.set(UID, uid);
@@ -769,6 +1031,7 @@ public class DMT {
   public static final short DATA_INSERT_REJECTED_SSK_ERROR = 3;
   public static final short DATA_INSERT_REJECTED_TIMEOUT_WAITING_FOR_ACCEPTED = 4;
 
+  /** Returns a human-readable description for an insert rejection {@code reason} code. */
   public static String getDataInsertRejectedReason(short reason) {
     if (reason == DATA_INSERT_REJECTED_VERIFY_FAILED) {
       return "Verify failed";
@@ -782,11 +1045,12 @@ public class DMT {
     return "Unknown reason code: " + reason;
   }
 
-  // FIXME consider using this again now we have new packet format which can handle big messages on
-  // any connection.
-  // FIXME be careful if we do - make sure boost priority if realtime, and note timeout issues
-  // associated with sending a request at BULK.
+  // Consider using this again now we have a packet format that can handle big messages on any
+  // connection.
+  // If re-enabled, ensure priority handling for realtime and be mindful of timeouts associated
+  // with sending a request at BULK.
 
+  /** Legacy SSK insert request carrying headers, data, and pubkey hash in one message. */
   public static final MessageType FNPSSKInsertRequest =
       new MessageType("FNPSSKInsertRequest", PRIORITY_BULK_DATA);
 
@@ -800,6 +1064,18 @@ public class DMT {
     FNPSSKInsertRequest.addField(DATA, ShortBuffer.class);
   }
 
+  /**
+   * Creates a legacy {@code FNPSSKInsertRequest} bundling metadata and data.
+   *
+   * @param uid Insert identifier.
+   * @param htl Hops-to-live.
+   * @param myKey Routing key (SSK).
+   * @param headers Serialized block headers.
+   * @param data Serialized content.
+   * @param pubKeyHash Hash of the public key.
+   * @param realTime Boost to realtime if {@code true}.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKInsertRequest(
       long uid,
       short htl,
@@ -822,6 +1098,7 @@ public class DMT {
     return msg;
   }
 
+  /** Modern SSK insert request; headers and data are sent in follow-up bulk messages. */
   public static final MessageType FNPSSKInsertRequestNew =
       new MessageType("FNPSSKInsertRequestNew", PRIORITY_LOW);
 
@@ -831,6 +1108,14 @@ public class DMT {
     FNPSSKInsertRequestNew.addField(FREENET_ROUTING_KEY, NodeSSK.class);
   }
 
+  /**
+   * Creates the initial {@code FNPSSKInsertRequestNew} handshake.
+   *
+   * @param uid Insert identifier.
+   * @param htl Hops-to-live.
+   * @param myKey Routing key (SSK).
+   * @return Initialized message.
+   */
   public static Message createFNPSSKInsertRequestNew(long uid, short htl, NodeSSK myKey) {
     Message msg = new Message(FNPSSKInsertRequestNew);
     msg.set(UID, uid);
@@ -841,6 +1126,7 @@ public class DMT {
 
   // SSK inserts data and headers. These are BULK_DATA or REALTIME.
 
+  /** Follow-up message carrying SSK insert block headers. */
   public static final MessageType FNPSSKInsertRequestHeaders =
       new MessageType("FNPSSKInsertRequestHeaders", PRIORITY_BULK_DATA);
 
@@ -849,6 +1135,14 @@ public class DMT {
     FNPSSKInsertRequestHeaders.addField(BLOCK_HEADERS, ShortBuffer.class);
   }
 
+  /**
+   * Creates {@code FNPSSKInsertRequestHeaders} with serialized block headers.
+   *
+   * @param uid Insert identifier.
+   * @param headers Serialized headers.
+   * @param realTime Boost to realtime if {@code true}.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKInsertRequestHeaders(
       long uid, byte[] headers, boolean realTime) {
     Message msg = new Message(FNPSSKInsertRequestHeaders);
@@ -860,6 +1154,7 @@ public class DMT {
     return msg;
   }
 
+  /** Follow-up message carrying SSK insert payload data. */
   public static final MessageType FNPSSKInsertRequestData =
       new MessageType("FNPSSKInsertRequestData", PRIORITY_BULK_DATA);
 
@@ -868,6 +1163,14 @@ public class DMT {
     FNPSSKInsertRequestData.addField(DATA, ShortBuffer.class);
   }
 
+  /**
+   * Creates {@code FNPSSKInsertRequestData} with serialized payload.
+   *
+   * @param uid Insert identifier.
+   * @param data Serialized content bytes.
+   * @param realTime Boost to realtime if {@code true}.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKInsertRequestData(long uid, byte[] data, boolean realTime) {
     Message msg = new Message(FNPSSKInsertRequestData);
     msg.set(UID, uid);
@@ -882,6 +1185,7 @@ public class DMT {
   // Requests wait for them all equally, so there is no reason for them to be different,
   // plus everything is throttled now.
 
+  /** SSK positive result containing block headers. */
   public static final MessageType FNPSSKDataFoundHeaders =
       new MessageType("FNPSSKDataFoundHeaders", PRIORITY_BULK_DATA);
 
@@ -890,6 +1194,14 @@ public class DMT {
     FNPSSKDataFoundHeaders.addField(BLOCK_HEADERS, ShortBuffer.class);
   }
 
+  /**
+   * Creates {@code FNPSSKDataFoundHeaders}.
+   *
+   * @param uid Request identifier.
+   * @param headers Serialized headers.
+   * @param realTime Boost to realtime if {@code true}.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKDataFoundHeaders(long uid, byte[] headers, boolean realTime) {
     Message msg = new Message(FNPSSKDataFoundHeaders);
     msg.set(UID, uid);
@@ -900,6 +1212,7 @@ public class DMT {
     return msg;
   }
 
+  /** SSK positive result containing payload data. */
   public static final MessageType FNPSSKDataFoundData =
       new MessageType("FNPSSKDataFoundData", PRIORITY_BULK_DATA);
 
@@ -908,6 +1221,14 @@ public class DMT {
     FNPSSKDataFoundData.addField(DATA, ShortBuffer.class);
   }
 
+  /**
+   * Creates {@code FNPSSKDataFoundData}.
+   *
+   * @param uid Request identifier.
+   * @param data Serialized content bytes.
+   * @param realTime Boost to realtime if {@code true}.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKDataFoundData(long uid, byte[] data, boolean realTime) {
     Message msg = new Message(FNPSSKDataFoundData);
     msg.set(UID, uid);
@@ -918,6 +1239,7 @@ public class DMT {
     return msg;
   }
 
+  /** Acknowledges an SSK request and indicates whether a public key is needed. */
   public static final MessageType FNPSSKAccepted = new MessageType("FNPSSKAccepted", PRIORITY_HIGH);
 
   static {
@@ -925,6 +1247,13 @@ public class DMT {
     FNPSSKAccepted.addField(NEED_PUB_KEY, Boolean.class);
   }
 
+  /**
+   * Creates an {@code FNPSSKAccepted}.
+   *
+   * @param uid Request identifier.
+   * @param needPubKey Whether the receiver requires the public key.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKAccepted(long uid, boolean needPubKey) {
     Message msg = new Message(FNPSSKAccepted);
     msg.set(UID, uid);
@@ -932,6 +1261,7 @@ public class DMT {
     return msg;
   }
 
+  /** SSK public key payload. */
   public static final MessageType FNPSSKPubKey =
       new MessageType("FNPSSKPubKey", PRIORITY_BULK_DATA);
 
@@ -940,6 +1270,14 @@ public class DMT {
     FNPSSKPubKey.addField(PUBKEY_AS_BYTES, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPSSKPubKey} containing a padded public key.
+   *
+   * @param uid Request identifier.
+   * @param pubkey Public key to send.
+   * @param realTime Boost to realtime if {@code true}.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKPubKey(long uid, DSAPublicKey pubkey, boolean realTime) {
     Message msg = new Message(FNPSSKPubKey);
     msg.set(UID, uid);
@@ -950,6 +1288,7 @@ public class DMT {
     return msg;
   }
 
+  /** Acknowledges receipt of an SSK public key. */
   public static final MessageType FNPSSKPubKeyAccepted =
       new MessageType("FNPSSKPubKeyAccepted", PRIORITY_HIGH);
 
@@ -957,6 +1296,12 @@ public class DMT {
     FNPSSKPubKeyAccepted.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPSSKPubKeyAccepted} acknowledgment.
+   *
+   * @param uid Request identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPSSKPubKeyAccepted(long uid) {
     Message msg = new Message(FNPSSKPubKeyAccepted);
     msg.set(UID, uid);
@@ -966,8 +1311,8 @@ public class DMT {
   // Opennet completions (not sent to darknet nodes)
 
   /**
-   * Sent when a request to an opennet node is completed, but the data source does not want to path
-   * fold. Sent even on pure darknet. A better name might be FNPRequestCompletedAck.
+   * Sent when a request to an opennet node completes and the data source does not path-fold. Also
+   * used on darknet.
    */
   public static final MessageType FNPOpennetCompletedAck =
       new MessageType("FNPOpennetCompletedAck", PRIORITY_HIGH);
@@ -976,13 +1321,19 @@ public class DMT {
     FNPOpennetCompletedAck.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPOpennetCompletedAck} for the given request.
+   *
+   * @param uid Original request identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPOpennetCompletedAck(long uid) {
     Message msg = new Message(FNPOpennetCompletedAck);
     msg.set(UID, uid);
     return msg;
   }
 
-  /** Sent when we wait for an FNP transfer or a completion from upstream and it never comes. */
+  /** Sent when we wait for an FNP transfer or a completion from upstream, and it never comes. */
   public static final MessageType FNPOpennetCompletedTimeout =
       new MessageType("FNPOpennetCompletedTimeout", PRIORITY_HIGH);
 
@@ -990,6 +1341,13 @@ public class DMT {
     FNPOpennetCompletedTimeout.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPOpennetCompletedTimeout} when the expected transfer or completion never
+   * arrived.
+   *
+   * @param uid Original request identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPOpennetCompletedTimeout(long uid) {
     Message msg = new Message(FNPOpennetCompletedTimeout);
     msg.set(UID, uid);
@@ -1011,6 +1369,16 @@ public class DMT {
         PADDED_LENGTH, Integer.class); // Size of actual transfer i.e. padded length
   }
 
+  /**
+   * Creates an {@code FNPOpennetConnectDestinationNew} to initiate path folding with a noderef
+   * transfer.
+   *
+   * @param uid Original request identifier.
+   * @param transferUID Transfer identifier for the noderef payload.
+   * @param noderefLength Unpadded noderef length in bytes.
+   * @param paddedLength Padded transfer length in bytes.
+   * @return Initialized message.
+   */
   public static Message createFNPOpennetConnectDestinationNew(
       long uid, long transferUID, int noderefLength, int paddedLength) {
     Message msg = new Message(FNPOpennetConnectDestinationNew);
@@ -1036,6 +1404,15 @@ public class DMT {
         PADDED_LENGTH, Integer.class); // Size of actual transfer i.e. padded length
   }
 
+  /**
+   * Creates an {@code FNPOpennetConnectReplyNew} to accept path folding and start the transfer.
+   *
+   * @param uid Original request identifier.
+   * @param transferUID Transfer identifier for the noderef payload.
+   * @param noderefLength Unpadded noderef length in bytes.
+   * @param paddedLength Padded transfer length in bytes.
+   * @return Initialized message.
+   */
   public static Message createFNPOpennetConnectReplyNew(
       long uid, long transferUID, int noderefLength, int paddedLength) {
     Message msg = new Message(FNPOpennetConnectReplyNew);
@@ -1064,6 +1441,17 @@ public class DMT {
     FNPOpennetAnnounceRequest.addField(TARGET_LOCATION, Double.class);
   }
 
+  /**
+   * Creates an {@code FNPOpennetAnnounceRequest} with a padded noderef to be transferred first.
+   *
+   * @param uid Original request identifier.
+   * @param transferUID Transfer identifier for the noderef payload.
+   * @param noderefLength Unpadded noderef length in bytes.
+   * @param paddedLength Padded transfer length in bytes.
+   * @param target Target location.
+   * @param htl Hops-to-live.
+   * @return Initialized message.
+   */
   public static Message createFNPOpennetAnnounceRequest(
       long uid, long transferUID, int noderefLength, int paddedLength, double target, short htl) {
     Message msg = new Message(FNPOpennetAnnounceRequest);
@@ -1078,10 +1466,9 @@ public class DMT {
   }
 
   /**
-   * Announcement reply. Noderef is attached, will be transferred, both nodes add the other. A
-   * single request will result in many reply's. When the announcement is done, we return a
-   * DataNotFound; if we run into a dead-end, we return a RejectedLoop; if we can't accept it,
-   * RejectedOverload.
+   * Announcement reply. Noderef is attached and transferred; both nodes add the other. A single
+   * request may result in many replies. When the announcement is done, we return a DataNotFound; if
+   * we run into a dead-end, we return a RejectedLoop; if we can't accept it, RejectedOverload.
    */
   public static final MessageType FNPOpennetAnnounceReply =
       new MessageType("FNPOpennetAnnounceReply", PRIORITY_UNSPECIFIED);
@@ -1093,6 +1480,15 @@ public class DMT {
     FNPOpennetAnnounceReply.addField(PADDED_LENGTH, Integer.class);
   }
 
+  /**
+   * Creates an {@code FNPOpennetAnnounceReply} referencing an attached noderef transfer.
+   *
+   * @param uid Original request identifier.
+   * @param transferUID Transfer identifier for the noderef payload.
+   * @param noderefLength Unpadded noderef length in bytes.
+   * @param paddedLength Padded transfer length in bytes.
+   * @return Initialized message.
+   */
   public static Message createFNPOpennetAnnounceReply(
       long uid, long transferUID, int noderefLength, int paddedLength) {
     Message msg = new Message(FNPOpennetAnnounceReply);
@@ -1110,12 +1506,14 @@ public class DMT {
     FNPOpennetAnnounceCompleted.addField(UID, Long.class);
   }
 
+  /** Creates an {@code FNPOpennetAnnounceCompleted} notification. */
   public static Message createFNPOpennetAnnounceCompleted(long uid) {
     Message msg = new Message(FNPOpennetAnnounceCompleted);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Indicates that opennet functionality is disabled on the peer. */
   public static final MessageType FNPOpennetDisabled =
       new MessageType("FNPOpennetDisabled", PRIORITY_HIGH);
 
@@ -1123,12 +1521,14 @@ public class DMT {
     FNPOpennetDisabled.addField(UID, Long.class);
   }
 
+  /** Creates an {@code FNPOpennetDisabled} notification. */
   public static Message createFNPOpennetDisabled(long uid) {
     Message msg = new Message(FNPOpennetDisabled);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Noderef was rejected during path folding; includes a rejection code. */
   public static final MessageType FNPOpennetNoderefRejected =
       new MessageType("FNPOpennetNoderefRejected", PRIORITY_HIGH);
 
@@ -1137,6 +1537,13 @@ public class DMT {
     FNPOpennetNoderefRejected.addField(REJECT_CODE, Integer.class);
   }
 
+  /**
+   * Creates an {@code FNPOpennetNoderefRejected} with a reason code.
+   *
+   * @param uid Original request identifier.
+   * @param rejectCode One of the {@code NODEREF_REJECTED_*} constants.
+   * @return Initialized message.
+   */
   public static Message createFNPOpennetNoderefRejected(long uid, int rejectCode) {
     Message msg = new Message(FNPOpennetNoderefRejected);
     msg.set(UID, uid);
@@ -1144,6 +1551,7 @@ public class DMT {
     return msg;
   }
 
+  /** Returns a human-readable description for an opennet noderef rejection code. */
   public static String getOpennetRejectedCode(int x) {
     return switch (x) {
       case NODEREF_REJECTED_TOO_BIG -> "Too big";
@@ -1159,8 +1567,9 @@ public class DMT {
   public static final int NODEREF_REJECTED_TRANSFER_FAILED = 3;
   public static final int NODEREF_REJECTED_INVALID = 4;
 
-  // FIXME get rid???
+  // Legacy message retained; evaluate removal in a future cleanup.
 
+  /** Announcement declined: peer is not accepting new opennet links. */
   public static final MessageType FNPOpennetAnnounceNodeNotWanted =
       new MessageType("FNPOpennetAnnounceNodeNotWanted", PRIORITY_LOW);
 
@@ -1176,6 +1585,7 @@ public class DMT {
 
   // Key offers (ULPRs)
 
+  /** Offer a key (ULPR) out-of-band prior to a get. */
   public static final MessageType FNPOfferKey = new MessageType("FNPOfferKey", PRIORITY_LOW);
 
   static {
@@ -1183,6 +1593,13 @@ public class DMT {
     FNPOfferKey.addField(OFFER_AUTHENTICATOR, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPOfferKey} with a keyed authenticator.
+   *
+   * @param key Offered key.
+   * @param authenticator Authenticator bytes.
+   * @return Initialized message.
+   */
   public static Message createFNPOfferKey(Key key, byte[] authenticator) {
     Message msg = new Message(FNPOfferKey);
     msg.set(KEY, key);
@@ -1190,7 +1607,7 @@ public class DMT {
     return msg;
   }
 
-  // Short timeout so PRIORITY_HIGH
+  // Short timeout; priority choice is explicit below.
   public static final MessageType FNPGetOfferedKey =
       new MessageType("FNPGetOfferedKey", PRIORITY_LOW);
 
@@ -1201,6 +1618,15 @@ public class DMT {
     FNPGetOfferedKey.addField(UID, Long.class);
   }
 
+  /**
+   * Requests data for a previously offered key.
+   *
+   * @param key Key to fetch.
+   * @param authenticator Authenticator matching the offer.
+   * @param needPubkey Whether a public key should be returned when applicable.
+   * @param uid Request identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPGetOfferedKey(
       Key key, byte[] authenticator, boolean needPubkey, long uid) {
     Message msg = new Message(FNPGetOfferedKey);
@@ -1211,7 +1637,7 @@ public class DMT {
     return msg;
   }
 
-  // Permanently rejected. RejectedOverload means temporarily rejected.
+  // Permanently rejected. {@code FNPRejectedOverload} is temporary.
   public static final MessageType FNPGetOfferedKeyInvalid =
       new MessageType("FNPGetOfferedKeyInvalid", PRIORITY_HIGH);
 
@@ -1220,6 +1646,13 @@ public class DMT {
     FNPGetOfferedKeyInvalid.addField(REASON, Short.class);
   }
 
+  /**
+   * Creates an {@code FNPGetOfferedKeyInvalid} with a reason code.
+   *
+   * @param uid Request identifier.
+   * @param reason One of the {@code GET_OFFERED_KEY_REJECTED_*} constants.
+   * @return Initialized message.
+   */
   public static Message createFNPGetOfferedKeyInvalid(long uid, short reason) {
     Message msg = new Message(FNPGetOfferedKeyInvalid);
     msg.set(UID, uid);
@@ -1230,30 +1663,45 @@ public class DMT {
   public static final short GET_OFFERED_KEY_REJECTED_BAD_AUTHENTICATOR = 1;
   public static final short GET_OFFERED_KEY_REJECTED_NO_KEY = 2;
 
+  /** Link-level ping for reachability/latency checks. */
   public static final MessageType FNPPing = new MessageType("FNPPing", PRIORITY_HIGH);
 
   static {
     FNPPing.addField(PING_SEQNO, Integer.class);
   }
 
+  /**
+   * Creates a ping with a sequence number echoed by {@code FNPPong}.
+   *
+   * @param seqNo Sequence number.
+   * @return Initialized message.
+   */
   public static Message createFNPPing(int seqNo) {
     Message msg = new Message(FNPPing);
     msg.set(PING_SEQNO, seqNo);
     return msg;
   }
 
+  /** Ping response echoing the sequence number. */
   public static final MessageType FNPPong = new MessageType("FNPPong", PRIORITY_HIGH);
 
   static {
     FNPPong.addField(PING_SEQNO, Integer.class);
   }
 
+  /**
+   * Creates a pong echoing the sequence number from a ping.
+   *
+   * @param seqNo Sequence number.
+   * @return Initialized message.
+   */
   public static Message createFNPPong(int seqNo) {
     Message msg = new Message(FNPPong);
     msg.set(PING_SEQNO, seqNo);
     return msg;
   }
 
+  /** Reply containing routing-hints metrics gathered during a probe. */
   public static final MessageType FNPRHProbeReply =
       new MessageType("FNPRHProbeReply", PRIORITY_UNSPECIFIED);
 
@@ -1266,6 +1714,17 @@ public class DMT {
     FNPRHProbeReply.addField(LINEAR_COUNTER, Short.class);
   }
 
+  /**
+   * Creates an {@code FNPRHProbeReply}.
+   *
+   * @param uid Probe identifier.
+   * @param nearest Nearest known location.
+   * @param best Best known location.
+   * @param counter General counter value.
+   * @param uniqueCounter Distinct path count (semantics implementation-defined).
+   * @param linearCounter Linearized counter (semantics implementation-defined).
+   * @return Initialized message.
+   */
   public static Message createFNPRHProbeReply(
       long uid,
       double nearest,
@@ -1292,7 +1751,7 @@ public class DMT {
   }
 
   /**
-   * Constructs a a probe request.
+   * Constructs a probe request.
    *
    * @param htl hopsToLive: hops until result is requested.
    * @param uid Probe identifier: should be unique.
@@ -1535,12 +1994,27 @@ public class DMT {
         CAPACITY_USAGE, Float.class); // Noisy capacity usage.
   }
 
+  /**
+   * Coarsens a bandwidth limit to a small ordinal class for probes.
+   *
+   * @param bandwidthLimit Output bandwidth limit in bytes per second.
+   * @return A class in the range [{@link #CAPACITY_USAGE_MIN}, {@link #CAPACITY_USAGE_MAX}].
+   */
   public static byte bandwidthClassForCapacityUsage(int bandwidthLimit) {
     bandwidthLimit /= CAPACITY_USAGE_MULTIPLIER;
     bandwidthLimit = Math.min(bandwidthLimit, CAPACITY_USAGE_MAX);
     return (byte) Math.max(bandwidthLimit, CAPACITY_USAGE_MIN);
   }
 
+  /**
+   * Creates a probe message with an approximate output bandwidth class and a noisy capacity usage
+   * estimate.
+   *
+   * @param uid Probe identifier.
+   * @param outputBandwidthClass Ordinal class from {@link #bandwidthClassForCapacityUsage(int)}.
+   * @param capacityUsage Noisy capacity usage (unit-less fraction).
+   * @return Initialized message.
+   */
   public static Message createProbeOverallBulkOutputCapacityUsage(
       long uid, byte outputBandwidthClass, float capacityUsage) {
     Message msg = new Message(ProbeOverallBulkOutputCapacityUsage);
@@ -1550,6 +2024,7 @@ public class DMT {
     return msg;
   }
 
+  /** Start of a four-phase location swap handshake. */
   public static final MessageType FNPSwapRequest = new MessageType("FNPSwapRequest", PRIORITY_HIGH);
 
   static {
@@ -1558,6 +2033,14 @@ public class DMT {
     FNPSwapRequest.addField(HTL, Integer.class);
   }
 
+  /**
+   * Creates an {@code FNPSwapRequest}.
+   *
+   * @param uid Swap identifier.
+   * @param buf Hash or token bytes.
+   * @param htl Hops-to-live.
+   * @return Initialized message.
+   */
   public static Message createFNPSwapRequest(long uid, byte[] buf, int htl) {
     Message msg = new Message(FNPSwapRequest);
     msg.set(UID, uid);
@@ -1566,6 +2049,7 @@ public class DMT {
     return msg;
   }
 
+  /** Swap rejected; aborts the handshake. */
   public static final MessageType FNPSwapRejected =
       new MessageType("FNPSwapRejected", PRIORITY_HIGH);
 
@@ -1573,12 +2057,19 @@ public class DMT {
     FNPSwapRejected.addField(UID, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPSwapRejected}.
+   *
+   * @param uid Swap identifier.
+   * @return Initialized message.
+   */
   public static Message createFNPSwapRejected(long uid) {
     Message msg = new Message(FNPSwapRejected);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Swap reply carrying a hash/token. */
   public static final MessageType FNPSwapReply = new MessageType("FNPSwapReply", PRIORITY_HIGH);
 
   static {
@@ -1586,6 +2077,13 @@ public class DMT {
     FNPSwapReply.addField(HASH, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPSwapReply}.
+   *
+   * @param uid Swap identifier.
+   * @param buf Hash or token bytes.
+   * @return Initialized message.
+   */
   public static Message createFNPSwapReply(long uid, byte[] buf) {
     Message msg = new Message(FNPSwapReply);
     msg.set(UID, uid);
@@ -1593,6 +2091,7 @@ public class DMT {
     return msg;
   }
 
+  /** Commit step of the swap handshake, carrying final parameters. */
   public static final MessageType FNPSwapCommit = new MessageType("FNPSwapCommit", PRIORITY_HIGH);
 
   static {
@@ -1600,6 +2099,13 @@ public class DMT {
     FNPSwapCommit.addField(DATA, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPSwapCommit}.
+   *
+   * @param uid Swap identifier.
+   * @param buf Commit data bytes.
+   * @return Initialized message.
+   */
   public static Message createFNPSwapCommit(long uid, byte[] buf) {
     Message msg = new Message(FNPSwapCommit);
     msg.set(UID, uid);
@@ -1607,6 +2113,7 @@ public class DMT {
     return msg;
   }
 
+  /** Final state of the swap; both sides complete. */
   public static final MessageType FNPSwapComplete =
       new MessageType("FNPSwapComplete", PRIORITY_HIGH);
 
@@ -1615,6 +2122,13 @@ public class DMT {
     FNPSwapComplete.addField(DATA, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPSwapComplete}.
+   *
+   * @param uid Swap identifier.
+   * @param buf Completion data bytes.
+   * @return Initialized message.
+   */
   public static Message createFNPSwapComplete(long uid, byte[] buf) {
     Message msg = new Message(FNPSwapComplete);
     msg.set(UID, uid);
@@ -1622,6 +2136,7 @@ public class DMT {
     return msg;
   }
 
+  /** Notifies peers of a location change and provides peer location hints. */
   public static final MessageType FNPLocChangeNotificationNew =
       new MessageType("FNPLocationChangeNotification2", PRIORITY_LOW);
 
@@ -1630,6 +2145,13 @@ public class DMT {
     FNPLocChangeNotificationNew.addField(PEER_LOCATIONS, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPLocChangeNotificationNew}.
+   *
+   * @param myLocation This node's new location.
+   * @param locations Neighbor location hints.
+   * @return Initialized message.
+   */
   public static Message createFNPLocChangeNotificationNew(double myLocation, double[] locations) {
     Message msg = new Message(FNPLocChangeNotificationNew);
     ShortBuffer dst = new ShortBuffer(Fields.doublesToBytes(locations));
@@ -1639,6 +2161,7 @@ public class DMT {
     return msg;
   }
 
+  /** Routed ping targeting a location (used beyond direct neighbors). */
   public static final MessageType FNPRoutedPing = new MessageType("FNPRoutedPing", PRIORITY_LOW);
 
   static {
@@ -1646,6 +2169,16 @@ public class DMT {
     FNPRoutedPing.addField(COUNTER, Integer.class);
   }
 
+  /**
+   * Creates an {@code FNPRoutedPing} targeting a location.
+   *
+   * @param uid Request identifier.
+   * @param targetLocation Target location in keyspace.
+   * @param htl Hops-to-live.
+   * @param counter Counter for correlation by caller.
+   * @param nodeIdentity Identity bytes of the destination node.
+   * @return Initialized message.
+   */
   public static Message createFNPRoutedPing(
       long uid, double targetLocation, short htl, int counter, byte[] nodeIdentity) {
     Message msg = new Message(FNPRoutedPing);
@@ -1654,6 +2187,7 @@ public class DMT {
     return msg;
   }
 
+  /** Reply to a routed ping. */
   public static final MessageType FNPRoutedPong = new MessageType("FNPRoutedPong", PRIORITY_LOW);
 
   static {
@@ -1661,6 +2195,13 @@ public class DMT {
     FNPRoutedPong.addField(COUNTER, Integer.class);
   }
 
+  /**
+   * Creates an {@code FNPRoutedPong} reply.
+   *
+   * @param uid Request identifier.
+   * @param counter Counter echoed from the routed ping.
+   * @return Initialized message.
+   */
   public static Message createFNPRoutedPong(long uid, int counter) {
     Message msg = new Message(FNPRoutedPong);
     msg.set(UID, uid);
@@ -1668,6 +2209,7 @@ public class DMT {
     return msg;
   }
 
+  /** Routed request was rejected; includes remaining HTL. */
   public static final MessageType FNPRoutedRejected =
       new MessageType("FNPRoutedRejected", PRIORITY_UNSPECIFIED);
 
@@ -1676,6 +2218,13 @@ public class DMT {
     FNPRoutedRejected.addField(HTL, Short.class);
   }
 
+  /**
+   * Creates an {@code FNPRoutedRejected}.
+   *
+   * @param uid Request identifier.
+   * @param htl Remaining hops-to-live.
+   * @return Initialized message.
+   */
   public static Message createFNPRoutedRejected(long uid, short htl) {
     Message msg = new Message(FNPRoutedRejected);
     msg.set(UID, uid);
@@ -1683,6 +2232,7 @@ public class DMT {
     return msg;
   }
 
+  /** Announces a detected external address for the remote peer. */
   public static final MessageType FNPDetectedIPAddress =
       new MessageType("FNPDetectedIPAddress", PRIORITY_HIGH);
 
@@ -1690,49 +2240,76 @@ public class DMT {
     FNPDetectedIPAddress.addField(EXTERNAL_ADDRESS, Peer.class);
   }
 
+  /**
+   * Creates an {@code FNPDetectedIPAddress} containing a detected external address.
+   *
+   * @param peer Peering information with external address.
+   * @return Initialized message.
+   */
   public static Message createFNPDetectedIPAddress(Peer peer) {
     Message msg = new Message(FNPDetectedIPAddress);
     msg.set(EXTERNAL_ADDRESS, peer);
     return msg;
   }
 
+  /** Wall-clock time synchronization hint. */
   public static final MessageType FNPTime = new MessageType("FNPTime", PRIORITY_HIGH);
 
   static {
     FNPTime.addField(TIME, Long.class);
   }
 
+  /**
+   * Creates an {@code FNPTime} message.
+   *
+   * @param time Time in milliseconds since epoch.
+   * @return Initialized message.
+   */
   public static Message createFNPTime(long time) {
     Message msg = new Message(FNPTime);
     msg.set(TIME, time);
     return msg;
   }
 
+  /** Uptime percentage over a short window for visibility sharing. */
   public static final MessageType FNPUptime = new MessageType("FNPUptime", PRIORITY_LOW);
 
   static {
     FNPUptime.addField(UPTIME_PERCENT_48H, Byte.class);
   }
 
+  /**
+   * Creates an {@code FNPUptime} message.
+   *
+   * @param uptimePercent Percent uptime over the recent window.
+   * @return Initialized message.
+   */
   public static Message createFNPUptime(byte uptimePercent) {
     Message msg = new Message(FNPUptime);
     msg.set(UPTIME_PERCENT_48H, uptimePercent);
     return msg;
   }
 
+  /** Visibility setting toward friends (link-level trust/visibility). */
   public static final MessageType FNPVisibility = new MessageType("FNPVisibility", PRIORITY_HIGH);
 
   static {
     FNPVisibility.addField(FRIEND_VISIBILITY, Short.class);
   }
 
+  /**
+   * Creates an {@code FNPVisibility} message.
+   *
+   * @param visibility Visibility code (implementation-defined).
+   * @return Initialized message.
+   */
   public static Message createFNPVisibility(short visibility) {
     Message msg = new Message(FNPVisibility);
     msg.set(FRIEND_VISIBILITY, visibility);
     return msg;
   }
 
-  // FIXME remove this message.
+  // Legacy message retained for compatibility.
   public static final MessageType FNPSentPackets = new MessageType("FNPSentPackets", PRIORITY_HIGH);
 
   static {
@@ -1741,20 +2318,22 @@ public class DMT {
     FNPSentPackets.addField(TIME, Long.class);
   }
 
+  /** Empty no-op message used as a keepalive or placeholder. */
   public static final MessageType FNPVoid = new MessageType("FNPVoid", PRIORITY_LOW, false, true);
 
   public static Message createFNPVoid() {
     return new Message(FNPVoid);
   }
 
+  /** Informs peer about disconnect intent and optional cleanup behavior. */
   public static final MessageType FNPDisconnect = new MessageType("FNPDisconnect", PRIORITY_HIGH);
 
   static {
     // If true, remove from active routing table, likely to be down for a while.
-    // Otherwise just dump all current connection state and keep trying to connect.
+    // Otherwise, just dump all current connection state and keep trying to connect.
     FNPDisconnect.addField(REMOVE, Boolean.class);
     // If true, purge all references to this node. Otherwise, we can keep the node
-    // around in secondary tables etc in order to more easily reconnect later.
+    // around in secondary tables etc. in order to more easily reconnect later.
     // (Mostly used on opennet)
     FNPDisconnect.addField(PURGE, Boolean.class);
     // Parting message, may be empty. A SimpleFieldSet in exactly the same format
@@ -1763,6 +2342,15 @@ public class DMT {
     FNPDisconnect.addField(NODE_TO_NODE_MESSAGE_DATA, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPDisconnect} message with optional purge instructions and a parting note.
+   *
+   * @param remove Remove from active routing table if {@code true}.
+   * @param purge Purge references to the node if {@code true}.
+   * @param messageType Parting note type (node-to-node message type).
+   * @param messageData Parting note payload; may be empty.
+   * @return Initialized message.
+   */
   public static Message createFNPDisconnect(
       boolean remove, boolean purge, int messageType, ShortBuffer messageData) {
     Message msg = new Message(FNPDisconnect);
@@ -1777,6 +2365,10 @@ public class DMT {
   // level, and will be sent, and parsed, even if the node is out of date. Should be stable
   // long-term.
 
+  /**
+   * Announces core update metadata (keys, versions, and recent revocation fetch state) at link
+   * level.
+   */
   public static final MessageType CryptadUOMAnnouncement =
       new MessageType("CryptadUOMAnnouncement", PRIORITY_LOW);
 
@@ -1796,33 +2388,86 @@ public class DMT {
     CryptadUOMAnnouncement.addField(BWLIMIT_DELAY_TIME, Integer.class);
   }
 
-  public static Message createUOMAnnouncement(
-      String mainKey,
-      String revocationKey,
-      boolean haveRevocation,
-      int mainJarVersion,
-      long timeLastTriedRevocationFetch,
-      int revocationDNFCount,
-      long revocationKeyLength,
-      long mainJarLength,
-      int pingTime,
-      int bwlimitDelayTime) {
-    Message msg = new Message(CryptadUOMAnnouncement);
+  /** Fluent builder for {@link #CryptadUOMAnnouncement} messages. */
+  public static final class UOMAnnouncementBuilder {
+    private String mainKey;
+    private String revocationKey;
+    private boolean haveRevocation;
+    private int mainJarVersion;
+    private long timeLastTriedRevocationFetch;
+    private int revocationDNFCount;
+    private long revocationKeyLength;
+    private long mainJarLength;
+    private int pingTime;
+    private int bwlimitDelayTime;
 
-    msg.set(MAIN_JAR_KEY, mainKey);
-    msg.set(REVOCATION_KEY, revocationKey);
-    msg.set(HAVE_REVOCATION_KEY, haveRevocation);
-    msg.set(MAIN_JAR_VERSION, mainJarVersion);
-    msg.set(REVOCATION_KEY_TIME_LAST_TRIED, timeLastTriedRevocationFetch);
-    msg.set(REVOCATION_KEY_DNF_COUNT, revocationDNFCount);
-    msg.set(REVOCATION_KEY_FILE_LENGTH, revocationKeyLength);
-    msg.set(MAIN_JAR_FILE_LENGTH, mainJarLength);
-    msg.set(PING_TIME, pingTime);
-    msg.set(BWLIMIT_DELAY_TIME, bwlimitDelayTime);
+    public UOMAnnouncementBuilder mainKey(String v) {
+      this.mainKey = v;
+      return this;
+    }
 
-    return msg;
+    public UOMAnnouncementBuilder revocationKey(String v) {
+      this.revocationKey = v;
+      return this;
+    }
+
+    public UOMAnnouncementBuilder haveRevocation(boolean v) {
+      this.haveRevocation = v;
+      return this;
+    }
+
+    public UOMAnnouncementBuilder mainJarVersion(int v) {
+      this.mainJarVersion = v;
+      return this;
+    }
+
+    public UOMAnnouncementBuilder timeLastTriedRevocationFetch(long v) {
+      this.timeLastTriedRevocationFetch = v;
+      return this;
+    }
+
+    public UOMAnnouncementBuilder revocationDNFCount(int v) {
+      this.revocationDNFCount = v;
+      return this;
+    }
+
+    public UOMAnnouncementBuilder revocationKeyLength(long v) {
+      this.revocationKeyLength = v;
+      return this;
+    }
+
+    public UOMAnnouncementBuilder mainJarLength(long v) {
+      this.mainJarLength = v;
+      return this;
+    }
+
+    public UOMAnnouncementBuilder pingTime(int v) {
+      this.pingTime = v;
+      return this;
+    }
+
+    public UOMAnnouncementBuilder bwlimitDelayTime(int v) {
+      this.bwlimitDelayTime = v;
+      return this;
+    }
+
+    public Message build() {
+      Message msg = new Message(CryptadUOMAnnouncement);
+      msg.set(MAIN_JAR_KEY, mainKey);
+      msg.set(REVOCATION_KEY, revocationKey);
+      msg.set(HAVE_REVOCATION_KEY, haveRevocation);
+      msg.set(MAIN_JAR_VERSION, mainJarVersion);
+      msg.set(REVOCATION_KEY_TIME_LAST_TRIED, timeLastTriedRevocationFetch);
+      msg.set(REVOCATION_KEY_DNF_COUNT, revocationDNFCount);
+      msg.set(REVOCATION_KEY_FILE_LENGTH, revocationKeyLength);
+      msg.set(MAIN_JAR_FILE_LENGTH, mainJarLength);
+      msg.set(PING_TIME, pingTime);
+      msg.set(BWLIMIT_DELAY_TIME, bwlimitDelayTime);
+      return msg;
+    }
   }
 
+  /** Requests the revocation file referenced in the announcement. */
   public static final MessageType CryptadUOMRequestRevocation =
       new MessageType("CryptadUOMRequestRevocation", PRIORITY_HIGH);
 
@@ -1830,6 +2475,12 @@ public class DMT {
     CryptadUOMRequestRevocation.addField(UID, Long.class);
   }
 
+  /**
+   * Creates a {@code CryptadUOMRequestRevocation} using {@code uid} as the transfer identifier.
+   *
+   * @param uid Transfer identifier.
+   * @return Initialized message.
+   */
   public static Message createUOMRequestRevocation(long uid) {
     Message msg = new Message(CryptadUOMRequestRevocation);
     msg.set(UID, uid);
@@ -1837,6 +2488,7 @@ public class DMT {
   }
 
   // Used by new UOM.
+  /** Requests the main JAR referenced in the announcement. */
   public static final MessageType CryptadUOMRequestMainJar =
       new MessageType("CryptadUOMRequestMainJar", PRIORITY_LOW);
 
@@ -1844,12 +2496,19 @@ public class DMT {
     CryptadUOMRequestMainJar.addField(UID, Long.class);
   }
 
+  /**
+   * Creates a {@code CryptadUOMRequestMainJar} using {@code uid} as the transfer identifier.
+   *
+   * @param uid Transfer identifier.
+   * @return Initialized message.
+   */
   public static Message createUOMRequestMainJar(long uid) {
     Message msg = new Message(CryptadUOMRequestMainJar);
     msg.set(UID, uid);
     return msg;
   }
 
+  /** Announces that a revocation file will be sent, with length and key. */
   public static final MessageType CryptadUOMSendingRevocation =
       new MessageType("CryptadUOMSendingRevocation", PRIORITY_HIGH);
 
@@ -1861,6 +2520,14 @@ public class DMT {
     CryptadUOMSendingRevocation.addField(REVOCATION_KEY, String.class);
   }
 
+  /**
+   * Creates a {@code CryptadUOMSendingRevocation}.
+   *
+   * @param uid Transfer identifier.
+   * @param length File length in bytes.
+   * @param key Revocation key (URI string).
+   * @return Initialized message.
+   */
   public static Message createUOMSendingRevocation(long uid, long length, String key) {
     Message msg = new Message(CryptadUOMSendingRevocation);
     msg.set(UID, uid);
@@ -1870,6 +2537,7 @@ public class DMT {
   }
 
   // Used by new UOM. We need to distinguish them in NodeDispatcher.
+  /** Announces that the main JAR will be sent, with length, key, and version. */
   public static final MessageType CryptadUOMSendingMainJar =
       new MessageType("CryptadUOMSendingMainJar", PRIORITY_LOW);
 
@@ -1880,6 +2548,15 @@ public class DMT {
     CryptadUOMSendingMainJar.addField(MAIN_JAR_VERSION, Integer.class);
   }
 
+  /**
+   * Creates a {@code CryptadUOMSendingMainJar}.
+   *
+   * @param uid Transfer identifier.
+   * @param length File length in bytes.
+   * @param key Key (URI string) for the main JAR.
+   * @param version Build version.
+   * @return Initialized message.
+   */
   public static Message createUOMSendingMainJar(long uid, long length, String key, int version) {
     Message msg = new Message(CryptadUOMSendingMainJar);
     msg.set(UID, uid);
@@ -1903,6 +2580,14 @@ public class DMT {
     CryptadUOMFetchDependency.addField(FILE_LENGTH, Long.class); // Length is known by both sides.
   }
 
+  /**
+   * Creates a {@code CryptadUOMFetchDependency} request.
+   *
+   * @param uid Transfer identifier.
+   * @param hash Expected content hash.
+   * @param length Expected file length in bytes.
+   * @return Initialized message.
+   */
   public static Message createUOMFetchDependency(long uid, byte[] hash, long length) {
     Message msg = new Message(CryptadUOMFetchDependency);
     msg.set(UID, uid);
@@ -1913,6 +2598,7 @@ public class DMT {
 
   // Secondary messages (debug messages attached to primary messages)
 
+  /** Secondary diagnostic message listing node UIDs relevant to a swap. */
   public static final MessageType FNPSwapNodeUIDs =
       new MessageType("FNPSwapNodeUIDs", PRIORITY_UNSPECIFIED);
 
@@ -1920,6 +2606,12 @@ public class DMT {
     FNPSwapNodeUIDs.addField(NODE_UIDS, ShortBuffer.class);
   }
 
+  /**
+   * Creates an {@code FNPSwapNodeUIDs} diagnostic message.
+   *
+   * @param uids Node UID list.
+   * @return Initialized message.
+   */
   public static Message createFNPSwapLocations(long[] uids) {
     Message msg = new Message(FNPSwapNodeUIDs);
     msg.set(NODE_UIDS, new ShortBuffer(Fields.longsToBytes(uids)));
@@ -1928,6 +2620,7 @@ public class DMT {
 
   // More permanent secondary messages (should perhaps be replaced by new main messages when stable)
 
+  /** Diagnostics: best alternative routes that were not selected. */
   public static final MessageType FNPBestRoutesNotTaken =
       new MessageType("FNPBestRoutesNotTaken", PRIORITY_UNSPECIFIED);
 
@@ -1937,16 +2630,24 @@ public class DMT {
     FNPBestRoutesNotTaken.addField(BEST_LOCATIONS_NOT_VISITED, ShortBuffer.class);
   }
 
+  /**
+   * Creates {@code FNPBestRoutesNotTaken} with serialized locations.
+   *
+   * @param locs Serialized double array.
+   * @return Initialized message.
+   */
   public static Message createFNPBestRoutesNotTaken(byte[] locs) {
     Message msg = new Message(FNPBestRoutesNotTaken);
     msg.set(BEST_LOCATIONS_NOT_VISITED, new ShortBuffer(locs));
     return msg;
   }
 
+  /** Convenience overload that serializes {@code double[]} to bytes. */
   public static Message createFNPBestRoutesNotTaken(double[] locs) {
     return createFNPBestRoutesNotTaken(Fields.doublesToBytes(locs));
   }
 
+  /** Convenience overload for {@code Double[]} collections. */
   public static Message createFNPBestRoutesNotTaken(Double[] doubles) {
     double[] locs = new double[doubles.length];
     for (int i = 0; i < locs.length; i++) {
@@ -1955,6 +2656,7 @@ public class DMT {
     return createFNPBestRoutesNotTaken(locs);
   }
 
+  /** Advertises whether routing of requests is currently enabled. */
   public static final MessageType FNPRoutingStatus =
       new MessageType("FNPRoutingStatus", PRIORITY_HIGH);
 
@@ -1962,6 +2664,12 @@ public class DMT {
     FNPRoutingStatus.addField(ROUTING_ENABLED, Boolean.class);
   }
 
+  /**
+   * Creates an {@code FNPRoutingStatus} message.
+   *
+   * @param routeRequests {@code true} to enable routing; {@code false} to disable.
+   * @return Initialized message.
+   */
   public static Message createRoutingStatus(boolean routeRequests) {
     Message msg = new Message(FNPRoutingStatus);
     msg.set(ROUTING_ENABLED, routeRequests);
@@ -1969,6 +2677,7 @@ public class DMT {
     return msg;
   }
 
+  /** Sub-insert hint: allow fork when cacheable (tunable control for insert behavior). */
   public static final MessageType FNPSubInsertForkControl =
       new MessageType("FNPSubInsertForkControl", PRIORITY_HIGH);
 
@@ -1976,12 +2685,19 @@ public class DMT {
     FNPSubInsertForkControl.addField(ENABLE_INSERT_FORK_WHEN_CACHEABLE, Boolean.class);
   }
 
+  /**
+   * Creates a {@code FNPSubInsertForkControl} hint.
+   *
+   * @param enableInsertForkWhenCacheable Enable fork when cacheable.
+   * @return Initialized message.
+   */
   public static Message createFNPSubInsertForkControl(boolean enableInsertForkWhenCacheable) {
     Message msg = new Message(FNPSubInsertForkControl);
     msg.set(ENABLE_INSERT_FORK_WHEN_CACHEABLE, enableInsertForkWhenCacheable);
     return msg;
   }
 
+  /** Sub-insert hint: prefer insert over other options when possible. */
   public static final MessageType FNPSubInsertPreferInsert =
       new MessageType("FNPSubInsertPreferInsert", PRIORITY_HIGH);
 
@@ -1989,12 +2705,19 @@ public class DMT {
     FNPSubInsertPreferInsert.addField(PREFER_INSERT, Boolean.class);
   }
 
+  /**
+   * Creates a {@code FNPSubInsertPreferInsert} hint.
+   *
+   * @param preferInsert Prefer insert when {@code true}.
+   * @return Initialized message.
+   */
   public static Message createFNPSubInsertPreferInsert(boolean preferInsert) {
     Message msg = new Message(FNPSubInsertPreferInsert);
     msg.set(PREFER_INSERT, preferInsert);
     return msg;
   }
 
+  /** Sub-insert hint: ignore low backoff threshold. */
   public static final MessageType FNPSubInsertIgnoreLowBackoff =
       new MessageType("FNPSubInsertIgnoreLowBackoff", PRIORITY_HIGH);
 
@@ -2002,15 +2725,23 @@ public class DMT {
     FNPSubInsertIgnoreLowBackoff.addField(IGNORE_LOW_BACKOFF, Boolean.class);
   }
 
+  /**
+   * Creates a {@code FNPSubInsertIgnoreLowBackoff} hint.
+   *
+   * @param ignoreLowBackoff Ignore low backoff when {@code true}.
+   * @return Initialized message.
+   */
   public static Message createFNPSubInsertIgnoreLowBackoff(boolean ignoreLowBackoff) {
     Message msg = new Message(FNPSubInsertIgnoreLowBackoff);
     msg.set(IGNORE_LOW_BACKOFF, ignoreLowBackoff);
     return msg;
   }
 
+  /** Indicates that the preceding rejection is soft (retryable). */
   public static final MessageType FNPRejectIsSoft =
       new MessageType("FNPRejectIsSoft", PRIORITY_HIGH);
 
+  /** Creates an {@code FNPRejectIsSoft} marker message. */
   public static Message createFNPRejectIsSoft() {
     return new Message(FNPRejectIsSoft);
   }
@@ -2083,6 +2814,7 @@ public class DMT {
     FNPPeerLoadStatusInt.addField(REAL_TIME_FLAG, Boolean.class);
   }
 
+  /** Secondary message toggling realtime/bulk handling on a per-message basis. */
   public static final MessageType FNPRealTimeFlag =
       new MessageType("FNPRealTimeFlag", PRIORITY_HIGH);
 
@@ -2090,12 +2822,24 @@ public class DMT {
     FNPRealTimeFlag.addField(REAL_TIME_FLAG, Boolean.class);
   }
 
+  /**
+   * Creates a {@code FNPRealTimeFlag} submessage.
+   *
+   * @param isBulk Flag value; interpretation is implementation-defined.
+   * @return Initialized message.
+   */
   public static Message createFNPRealTimeFlag(boolean isBulk) {
     Message msg = new Message(FNPRealTimeFlag);
     msg.set(REAL_TIME_FLAG, isBulk);
     return msg;
   }
 
+  /**
+   * Extracts the flag value from an optional {@code FNPRealTimeFlag} submessage.
+   *
+   * @param m Message that may carry the submessage.
+   * @return Flag value when present; otherwise {@code false}.
+   */
   public static boolean getRealTimeFlag(Message m) {
     Message bulk = m.getSubMessage(FNPRealTimeFlag);
     if (bulk == null) {
@@ -2104,6 +2848,7 @@ public class DMT {
     return bulk.getBoolean(REAL_TIME_FLAG);
   }
 
+  /** Returns {@code true} if the message is one of the peer-load status variants. */
   public static boolean isPeerLoadStatusMessage(Message m) {
     MessageType spec = m.getSpec();
     return (spec == FNPPeerLoadStatusByte
@@ -2111,6 +2856,7 @@ public class DMT {
         || spec == FNPPeerLoadStatusInt);
   }
 
+  /** Returns {@code true} if the message is a request type subject to load limiting. */
   public static boolean isLoadLimitedRequest(Message m) {
     MessageType spec = m.getSpec();
     return (spec == FNPCHKDataRequest
@@ -2122,7 +2868,10 @@ public class DMT {
   }
 
   // Extended fatal timeout handling.
-
+  /**
+   * Queries whether a set of upstream request UIDs is still running. Reply is {@link
+   * #FNPIsStillRunning}.
+   */
   public static final MessageType FNPCheckStillRunning =
       new MessageType("FNPCheckStillRunning", PRIORITY_HIGH);
 
@@ -2131,6 +2880,7 @@ public class DMT {
     FNPCheckStillRunning.addField(LIST_OF_UIDS, ShortBuffer.class);
   }
 
+  /** Reply indicating which UIDs are still running using a bitset. */
   public static final MessageType FNPIsStillRunning =
       new MessageType("FNPIsStillRunning", PRIORITY_HIGH);
 
@@ -2141,13 +2891,16 @@ public class DMT {
 
   // Friend-of-a-friend (FOAF) related messages
 
+  /** FOAF: request the peer's full noderef. */
   public static final MessageType FNPGetYourFullNoderef =
       new MessageType("FNPGetYourFullNoderef", PRIORITY_LOW);
 
+  /** Creates an {@code FNPGetYourFullNoderef} request. */
   public static Message createFNPGetYourFullNoderef() {
     return new Message(FNPGetYourFullNoderef);
   }
 
+  /** FOAF: reply conveying the sender's full noderef length (payload transferred separately). */
   public static final MessageType FNPMyFullNoderef =
       new MessageType("FNPMyFullNoderef", PRIORITY_LOW);
 
@@ -2161,6 +2914,13 @@ public class DMT {
     FNPMyFullNoderef.addField(NODEREF_LENGTH, Integer.class);
   }
 
+  /**
+   * Creates an {@code FNPMyFullNoderef} reply.
+   *
+   * @param uid Request identifier associated with the original FOAF query.
+   * @param length Unpadded length in bytes of the noderef to follow.
+   * @return Initialized message.
+   */
   public static Message createFNPMyFullNoderef(long uid, int length) {
     Message m = new Message(FNPMyFullNoderef);
     m.set(UID, uid);

--- a/src/main/java/network/crypta/io/xfer/BlockTransmitter.java
+++ b/src/main/java/network/crypta/io/xfer/BlockTransmitter.java
@@ -470,7 +470,7 @@ public class BlockTransmitter {
 
   private void sendAllSentNotification() {
     try {
-      _usm.send(_destination, DMT.createAllSent(_uid, realTime), _ctr);
+      _usm.send(_destination, DMT.createAllSent(_uid), _ctr);
     } catch (NotConnectedException e) {
       LOG.info("disconnected for allSent()");
     }

--- a/src/main/java/network/crypta/io/xfer/BulkTransmitter.java
+++ b/src/main/java/network/crypta/io/xfer/BulkTransmitter.java
@@ -374,7 +374,7 @@ public class BulkTransmitter {
       // Congestion control and bandwidth limiting
       try {
         if (LOG.isDebugEnabled()) LOG.debug("Sending packet " + blockNo);
-        Message msg = DMT.createFNPBulkPacketSend(uid, blockNo, buf, realTime);
+        Message msg = DMT.createFNPBulkPacketSend(uid, blockNo, buf);
         UnsentPacketTag tag = new UnsentPacketTag();
         peer.sendAsync(msg, tag, ctr);
         synchronized (this) {

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -463,17 +463,18 @@ public class NodeUpdateManager {
     if (blobSize <= 0) {
       fetchedVersion = -1;
     }
-    return DMT.createUOMAnnouncement(
-        updateURI.toString(),
-        revocationURI.toString(),
-        revocationChecker.hasBlown(),
-        fetchedVersion,
-        revocationChecker.lastSucceededDelta(),
-        revocationChecker.getRevocationDNFCounter(),
-        revocationChecker.getBlobSize(),
-        blobSize,
-        (int) node.getNodeStats().getNodeAveragePingTime(),
-        (int) node.getNodeStats().getBwlimitDelayTime());
+    return new DMT.UOMAnnouncementBuilder()
+        .mainKey(updateURI.toString())
+        .revocationKey(revocationURI.toString())
+        .haveRevocation(revocationChecker.hasBlown())
+        .mainJarVersion(fetchedVersion)
+        .timeLastTriedRevocationFetch(revocationChecker.lastSucceededDelta())
+        .revocationDNFCount(revocationChecker.getRevocationDNFCounter())
+        .revocationKeyLength(revocationChecker.getBlobSize())
+        .mainJarLength(blobSize)
+        .pingTime((int) node.getNodeStats().getNodeAveragePingTime())
+        .bwlimitDelayTime((int) node.getNodeStats().getBwlimitDelayTime())
+        .build();
   }
 
   public void maybeSendUOMAnnounce(PeerNode peer) {


### PR DESCRIPTION
Summary
- Applies Spotless formatting across modified sources.
- Refactors DMT.java with comprehensive Javadoc, clearer priority docs, and factory helpers.
- Introduces UOMAnnouncementBuilder in DMT and updates NodeUpdateManager to use it.
- Adjusts xfer call sites to reflect DMT API changes:
  - BlockTransmitter: createAllSent(long) (removed realTime arg)
  - BulkTransmitter: createFNPBulkPacketSend(long,int,ShortBuffer) (removed realTime arg; keep convenience overload for byte[])

Details
- DMT.java
  - Adds class-level and method-level Javadoc for message types and factories.
  - Documents priority semantics and thread-safety of message type definitions.
  - Renames/clarifies parameters (e.g., packetTransmitSize(..., packets)).
  - Removes unused realTime parameter from allSent/FNPBulkPacketSend factories; realtime data still uses PRIORITY_REALTIME_DATA where applicable.
  - Adds convenience overloads for ShortBuffer/byte[] and size helpers.
  - Adds builder for UOM announcements to avoid long parameter lists.
- NodeUpdateManager.java
  - Switches from createUOMAnnouncement(...) to UOMAnnouncementBuilder for clarity and maintainability.
- BlockTransmitter.java / BulkTransmitter.java
  - Updates to new DMT factory signatures.

Compatibility
- Internal API changes within the module (DMT factory signatures). All in-repo call sites updated. External code calling these DMT factories (if any) must adapt to the removed realTime arg.

Testing
- Compiles on Java 21+. Please run CI to execute the full JUnit 6 test suite.

Context
- This branch contained the refactor edits; this commit includes those changes and formats them via Spotless.

Change scope
- Files (4):
  - src/main/java/network/crypta/io/comm/DMT.java
  - src/main/java/network/crypta/io/xfer/BlockTransmitter.java
  - src/main/java/network/crypta/io/xfer/BulkTransmitter.java
  - src/main/java/network/crypta/node/updater/NodeUpdateManager.java

Request
- Review API changes in DMT and builder usage.
- Confirm semantics around realtime/bulk priorities.
- If approved, merge into develop.
