### PR TITLE
test(ip): add comprehensive IPAddressDetector tests

### DIFF
--- a/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
+++ b/src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java
@@ -1,7 +1,16 @@
 package network.crypta.support.transport.ip;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
 import java.net.InetAddress;
@@ -13,8 +22,12 @@ import network.crypta.node.NodeIPDetector;
 import network.crypta.support.PriorityAwareExecutor;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /** Unit tests for {@link IPAddressDetector}. */
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // allow underscore-based test method names per project convention
 class IPAddressDetectorTest {
 
   @Test
@@ -51,7 +64,7 @@ class IPAddressDetectorTest {
   }
 
   @Test
-  void getAddress_triggers_detector_callback_when_changed() throws Exception {
+  void getAddress_triggers_detector_callback_when_changed() {
     NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
     // Override checkpoint to inject a deterministic change without touching real interfaces
     TestIPAddressDetector det = new TestIPAddressDetector(1, nodeIPDetector);
@@ -64,6 +77,62 @@ class IPAddressDetectorTest {
     assertEquals("8.8.8.8", out[0].getHostAddress());
     // Verify that change triggered detector.redetectAddress() via executor
     verify(nodeIPDetector, times(1)).redetectAddress();
+  }
+
+  @Test
+  void getAddress_whenNullExecutor_expectNullPointerException() {
+    NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
+    IPAddressDetector det = new IPAddressDetector(10, nodeIPDetector);
+    det.lastDetectedTime = System.currentTimeMillis();
+    det.lastAddressList = new InetAddress[0];
+
+    NullPointerException npe = assertThrows(NullPointerException.class, () -> det.getAddress(null));
+    assertEquals("executor", npe.getMessage());
+  }
+
+  @Test
+  void getAddress_whenStaleButUnchanged_expectNoCallback() {
+    NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
+    // checkpoint returns false (no change)
+    TestNoChangeDetector det = new TestNoChangeDetector(1, nodeIPDetector);
+    det.lastDetectedTime = -1; // force checkpoint
+
+    CapturingExecutor exec = new CapturingExecutor();
+    InetAddress[] out = det.getAddress(exec);
+    assertNotNull(out);
+    assertEquals(1, out.length);
+    assertEquals("8.8.4.4", out[0].getHostAddress());
+    // No runnable submitted, no callback invoked
+    assertEquals(0, exec.capturedCount());
+    verify(nodeIPDetector, times(0)).redetectAddress();
+  }
+
+  @Test
+  void getAddressNoCallback_whenNoSnapshotAndFresh_expectEmptyArray() {
+    NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
+    IPAddressDetector det = new IPAddressDetector(10, nodeIPDetector);
+    det.lastDetectedTime = System.currentTimeMillis(); // fresh -> no checkpoint
+    det.lastAddressList = null; // no snapshot yet
+
+    InetAddress[] out = assertDoesNotThrow(det::getAddressNoCallback);
+    assertNotNull(out);
+    assertEquals(0, out.length);
+  }
+
+  @Test
+  void getAddressNoCallback_whenStale_callsCheckpoint() throws Exception {
+    NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
+    CountingDetector det = new CountingDetector(1, nodeIPDetector);
+    det.lastDetectedTime = -1; // force checkpoint
+
+    InetAddress[] out = det.getAddressNoCallback();
+    assertEquals(1, det.checkpointCalls);
+    assertNotNull(out);
+    assertEquals(2, out.length);
+    // Result equals the list set by checkpoint()
+    assertArrayEquals(
+        new InetAddress[] {InetAddress.getByName("1.1.1.1"), InetAddress.getByName("9.9.9.9")},
+        out);
   }
 
   @Test
@@ -93,6 +162,43 @@ class IPAddressDetectorTest {
     assertTrue(changedDifferent, "Different content should be considered changed");
     assertTrue(changedFromNull, "Transition from null to non-null should be a change");
     assertFalse(changedSameRef, "Same reference should not be a change");
+  }
+
+  @Test
+  void onGetAddresses_whenEmpty_expectNullSnapshot() {
+    NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
+    IPAddressDetector det = new IPAddressDetector(10, nodeIPDetector);
+    det.onGetAddresses(new ArrayList<>());
+    assertNull(det.lastAddressList);
+  }
+
+  @Test
+  void onGetAddresses_skips_null_entries() throws Exception {
+    NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
+    IPAddressDetector det = new IPAddressDetector(10, nodeIPDetector);
+    List<InetAddress> input = new ArrayList<>();
+    input.add(null);
+    input.add(InetAddress.getByName("127.0.0.1"));
+    det.onGetAddresses(input);
+    assertNotNull(det.lastAddressList);
+    assertEquals(1, det.lastAddressList.length);
+    assertEquals("127.0.0.1", det.lastAddressList[0].getHostAddress());
+  }
+
+  @Test
+  @SuppressWarnings("java:S100") // method naming convention per project test style
+  void cleanGlobalIPv6_whenGlobalV6WithScope_removesScopeId() throws Exception {
+    NodeIPDetector nodeIPDetector = mock(NodeIPDetector.class);
+    IPAddressDetector det = new IPAddressDetector(10, nodeIPDetector);
+
+    InetAddress withScope = InetAddress.getByName("2001:db8::1%42");
+    Method m = IPAddressDetector.class.getDeclaredMethod("cleanGlobalIPv6", InetAddress.class);
+    m.setAccessible(true);
+    InetAddress cleaned = (InetAddress) m.invoke(det, withScope);
+
+    assertEquals("2001:db8:0:0:0:0:0:1", cleaned.getHostAddress());
+    // Ensure original still contains the scope id
+    assertTrue(withScope.getHostAddress().contains("%"));
   }
 
   /** Test subclass to provide a deterministic checkpoint without touching system interfaces. */
@@ -138,6 +244,88 @@ class IPAddressDetectorTest {
     @Override
     public int[] runningThreads() {
       return new int[] {1};
+    }
+
+    @Override
+    public int getWaitingThreadsCount() {
+      return 0;
+    }
+  }
+
+  /**
+   * Test subclass which sets a fixed list and reports no change, to verify that getAddress() does
+   * not dispatch callbacks when the snapshot is identical.
+   */
+  private static final class TestNoChangeDetector extends IPAddressDetector {
+    TestNoChangeDetector(long interval, NodeIPDetector detector) {
+      super(interval, detector);
+    }
+
+    @Override
+    protected synchronized boolean checkpoint() {
+      try {
+        this.lastAddressList = new InetAddress[] {InetAddress.getByName("8.8.4.4")};
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
+      this.lastDetectedTime = System.currentTimeMillis();
+      return false; // no change
+    }
+  }
+
+  /** Test subclass that counts checkpoint invocations and supplies a deterministic snapshot. */
+  private static final class CountingDetector extends IPAddressDetector {
+    int checkpointCalls = 0;
+
+    CountingDetector(long interval, NodeIPDetector detector) {
+      super(interval, detector);
+    }
+
+    @Override
+    protected synchronized boolean checkpoint() {
+      checkpointCalls++;
+      try {
+        this.lastAddressList =
+            new InetAddress[] {InetAddress.getByName("1.1.1.1"), InetAddress.getByName("9.9.9.9")};
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
+      this.lastDetectedTime = System.currentTimeMillis();
+      return true;
+    }
+  }
+
+  /** Executor that captures submitted runnables without executing them automatically. */
+  private static final class CapturingExecutor implements PriorityAwareExecutor {
+    private final List<Runnable> captured = new ArrayList<>();
+
+    int capturedCount() {
+      return captured.size();
+    }
+
+    @Override
+    public void execute(@NotNull Runnable job) {
+      captured.add(job);
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName) {
+      captured.add(job);
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName, boolean fromTicker) {
+      captured.add(job);
+    }
+
+    @Override
+    public int[] waitingThreads() {
+      return new int[] {0};
+    }
+
+    @Override
+    public int[] runningThreads() {
+      return new int[] {0};
     }
 
     @Override


### PR DESCRIPTION
Summary
- Add deterministic, comprehensive unit tests for IPAddressDetector using JUnit 6 and Mockito.
- Cover getAddress() callback behavior (changed vs unchanged), null executor exception contract, and getAddressNoCallback() refresh logic.
- Validate IPv6 scope-id stripping for global addresses via cleanGlobalIPv6 (reflection; pure function, no I/O).
- Exercise onGetAddresses filtering rules (exclude wildcard/multicast, include loopback/link-local/site-local/global as intended).
- Verify addressListChanged() order-insensitivity and null/identity cases (reflection).

Context
- Tests are fully isolated: no real network interfaces, no filesystem use, and no sleeps. Detection is simulated via tiny test-only subclasses overriding checkpoint().
- Follows project conventions: JUnit 6, Mockito Jupiter, explicit imports, Sonar-friendly naming with a class-level suppression for java:S100.

Changes
- src/test/java/network/crypta/support/transport/ip/IPAddressDetectorTest.java (+191 −3)

Commit(s)
- b578d9049e test(ip): add comprehensive IPAddressDetector tests

Diffstat
- 1 file changed, 191 insertions(+), 3 deletions(-)

Validation
- Ran the focused test class and the full test suite locally with Gradle; both succeeded.

Notes
- No production code modified.
- Ready for review; maintainers can edit this PR.
