### PR TITLE
docs(io-xfer): clarify and complete Javadoc for transfer exceptions and package docs

### DIFF
--- a/src/main/java/network/crypta/io/xfer/AbortedException.java
+++ b/src/main/java/network/crypta/io/xfer/AbortedException.java
@@ -3,12 +3,22 @@ package network.crypta.io.xfer;
 import java.io.Serial;
 
 /**
- * Thrown when a transfer is aborted, and caller tries to do something on PRB, in order to avoid
- * some races.
+ * Exception indicating that an I/O transfer was intentionally aborted.
+ *
+ * <p>Thrown by transfer components to signal that the current operation must cease immediately.
+ * Callers should not continue using the associated transfer or its resources after this exception
+ * is thrown, as doing so can cause races or inconsistent state. This exception represents a
+ * cooperative cancellation condition rather than a programming error.
  */
 public class AbortedException extends Exception {
+  // Explicit ID to keep serialization stable across versions.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Constructs a new {@code AbortedException} with the specified detail message.
+   *
+   * @param msg human‑readable reason describing why the transfer was aborted
+   */
   public AbortedException(String msg) {
     super(msg);
   }

--- a/src/main/java/network/crypta/io/xfer/WaitedTooLongException.java
+++ b/src/main/java/network/crypta/io/xfer/WaitedTooLongException.java
@@ -1,9 +1,13 @@
 package network.crypta.io.xfer;
 
 /**
- * Thrown when we wait too long to send a throttled packet.
+ * Exception indicating that sending a throttled packet exceeded the allowed wait time.
+ *
+ * <p>Used by throttling/rate‑limit code to signal that the caller has waited long enough for a
+ * permit or scheduling window and should stop the current send attempt. Callers typically abort,
+ * reschedule, or drop the packet according to higher‑level policy. This class carries no
+ * additional state.
  *
  * @author toad
  */
-@SuppressWarnings("serial")
 public class WaitedTooLongException extends Exception {}

--- a/src/main/java/network/crypta/io/xfer/WaitedTooLongException.java
+++ b/src/main/java/network/crypta/io/xfer/WaitedTooLongException.java
@@ -10,4 +10,5 @@ package network.crypta.io.xfer;
  *
  * @author toad
  */
+@SuppressWarnings("serial")
 public class WaitedTooLongException extends Exception {}

--- a/src/main/java/network/crypta/io/xfer/package-info.java
+++ b/src/main/java/network/crypta/io/xfer/package-info.java
@@ -1,8 +1,10 @@
 /**
- * Block transfers, bulk transfers and (part of) congestion control. A block is a CHK, 32KB divided
- * into 1kB packets. Bulk is anything else, e.g. opennet node references, friend-to-friend file
- * transfers. The block transfer code was originally from Dijjer but has been substantially
- * rewritten as the lower levels provide guaranteed delivery of @link freenet.io.comm.Message 's.
- * The other parts of congestion control are in freenet.node.
+ * Transfer layer for block and bulk data plus parts of congestion control.
+ *
+ * <p>A "block" is a CHK, typically 32 KiB split into 1 KiB packets. "Bulk" refers to other
+ * payloads such as opennet node references and friend-to-friend file transfers. The original
+ * block-transfer code was derived from Dijjer, but it has since been substantially rewritten as
+ * the lower layers provide guaranteed delivery of {@link network.crypta.io.comm.Message}
+ * instances. Additional congestion-control components live under {@link network.crypta.node}.
  */
 package network.crypta.io.xfer;


### PR DESCRIPTION
Summary
- Improve, clarify, and complete Javadoc across the xfer package for two exceptions and the package docs.
- No functional changes; comments only.

Details
- AbortedException: expand summary, explain cancellation semantics, add constructor @param, and add note on stable serialVersionUID.
- WaitedTooLongException: expand summary and typical handling (abort/reschedule/drop) while keeping the original author tag; Javadoc placed above annotations per rules.
- package-info: clarify roles of block vs bulk transfers, fix broken link, and reference the correct packages: {@link network.crypta.io.comm.Message} and {@link network.crypta.node}.

Files changed
- src/main/java/network/crypta/io/xfer/AbortedException.java
- src/main/java/network/crypta/io/xfer/WaitedTooLongException.java
- src/main/java/network/crypta/io/xfer/package-info.java

Commits
- 7a1aa0f chore(io-xfer): restore @SuppressWarnings("serial") on WaitedTooLongException to match develop
- c42092e docs(io-xfer): clarify and complete Javadoc for AbortedException, WaitedTooLongException, and package-level docs

Diffstat
- 3 files changed, 25 insertions(+), 8 deletions(-)

Notes
- Javadoc blocks are placed above annotations to avoid “Dangling Javadoc comment” warnings.
- Link in package docs now targets network.crypta.io.comm.Message (Crypta), not the legacy Freenet package.
