### PR TITLE
xfer: Add BulkReceiver tests and improve Javadoc; comment-only receiver docs

### DIFF
--- a/src/main/java/network/crypta/io/xfer/BulkReceiver.java
+++ b/src/main/java/network/crypta/io/xfer/BulkReceiver.java
@@ -13,31 +13,72 @@ import network.crypta.io.comm.RetrievalException;
 import network.crypta.support.ShortBuffer;
 
 /**
- * Bulk (not block) data transfer - receiver class. Bulk transfer is designed for largish files,
- * much larger than blocks, where we have the whole file at the outset.
+ * Receives a segmented bulk transfer from a single peer and writes packets into a {@link
+ * PartiallyReceivedBulk}.
+ *
+ * <p>This helper drives the receive side of the bulk protocol used for large files. It waits for
+ * {@link network.crypta.io.comm.DMT#FNPBulkPacketSend} messages from the configured {@link
+ * network.crypta.io.comm.PeerContext}, commits data to the supplied {@link PartiallyReceivedBulk},
+ * and acknowledges completion via {@link network.crypta.io.comm.DMT#FNPBulkReceivedAll} when all
+ * blocks have been received. It also reacts to sender aborts, timeouts, disconnects, and peer
+ * restarts by aborting the {@code PartiallyReceivedBulk} with an appropriate {@link
+ * network.crypta.io.comm.RetrievalException} reason.
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <ul>
+ *   <li>Construction records the peer's boot id and sets {@code prb.recv = this} for callbacks.
+ *   <li>{@link #receive()} blocks in a loop until the transfer completes (returns {@code true}) or
+ *       fails (returns {@code false}).
+ *   <li>{@link #onAborted()} may be invoked to inform the peer that the receiver cancelled; it is
+ *       idempotent and safe to call more than once.
+ * </ul>
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>Instances are not thread‑safe. Callers must serialize use, typically by invoking {@link
+ * #receive()} from a single worker thread. {@link #onAborted()} uses a small synchronized guard so
+ * duplicate notifications are suppressed.
+ *
+ * <h2>Timeouts</h2>
+ *
+ * <p>Each {@code waitFor(...)} iteration uses a per‑iteration timeout of {@link #TIMEOUT}. The
+ * overall wall‑clock time to complete can exceed this value because the method loops until a
+ * terminal condition is reached.
  *
  * @author toad
  */
 public class BulkReceiver {
 
+  /** Per-iteration wait timeout (milliseconds) used while receiving packets. */
   static final long TIMEOUT = SECONDS.toMillis(60);
 
-  /** Tracks the data we have received */
+  /** Tracks receive progress and persists packet data. */
   final PartiallyReceivedBulk prb;
 
-  /** Peer we are receiving from */
+  /** Peer we expect to receive messages from for this transfer. */
   final PeerContext peer;
 
-  /** Transfer UID for messages */
+  /** Transfer identifier used to filter and send protocol messages. */
   final long uid;
 
   private boolean sentCancel;
 
-  /** Not persistent over reboots */
+  /** Peer boot id captured at construction; used to detect remote restarts. */
   final long peerBootID;
 
   private final ByteCounter ctr;
 
+  /**
+   * Creates a receiver bound to a target {@link PartiallyReceivedBulk} and peer.
+   *
+   * @param prb destination that records blocks and abort state; its {@code size} must match the
+   *     file being transferred, and its backing buffer must be at least that size.
+   * @param peer source peer for all matching messages; its current boot id is recorded to detect
+   *     restarts during the transfer.
+   * @param uid protocol identifier shared by all transfer messages.
+   * @param ctr optional byte counter for accounting; may be {@code null}.
+   */
   public BulkReceiver(PartiallyReceivedBulk prb, PeerContext peer, long uid, ByteCounter ctr) {
     this.prb = prb;
     this.peer = peer;
@@ -48,6 +89,12 @@ public class BulkReceiver {
     prb.recv = this;
   }
 
+  /**
+   * Sends a single {@link network.crypta.io.comm.DMT#FNPBulkReceiveAborted} to the peer.
+   *
+   * <p>Multiple calls are safe; only the first results in a message being sent. A missing
+   * connection is ignored because the sender cannot be notified in that state.
+   */
   public void onAborted() {
     synchronized (this) {
       if (sentCancel) return;
@@ -56,17 +103,41 @@ public class BulkReceiver {
     try {
       peer.sendAsync(DMT.createFNPBulkReceiveAborted(uid), null, ctr);
     } catch (NotConnectedException e) {
-      // Cool
+      // Peer is already disconnected; there is nothing to notify.
     }
   }
 
   /**
-   * Receive the file.
+   * Drives the blocking receive loop for this transfer.
    *
-   * @return True if the whole file was received, false otherwise.
+   * <p>On each iteration the method waits for either a data packet ({@link
+   * network.crypta.io.comm.DMT#FNPBulkPacketSend}) or a sender abort ({@link
+   * network.crypta.io.comm.DMT#FNPBulkSendAborted}) from the configured peer with the matching
+   * {@link #uid}. Received packet payloads are written to the {@link PartiallyReceivedBulk}. When
+   * {@link PartiallyReceivedBulk#hasWholeFile()} becomes {@code true}, the method acknowledges
+   * completion by sending {@link network.crypta.io.comm.DMT#FNPBulkReceivedAll} and returns.
+   *
+   * <p>Failure conditions abort the {@code PartiallyReceivedBulk} and cause the method to return
+   * {@code false}. The abort reason is one of:
+   *
+   * <ul>
+   *   <li>{@link network.crypta.io.comm.RetrievalException#SENDER_DISCONNECTED} when waiting fails
+   *       due to a disconnect.
+   *   <li>{@link network.crypta.io.comm.RetrievalException#SENDER_DIED} when the sender restarts or
+   *       cancels the send.
+   *   <li>{@link network.crypta.io.comm.RetrievalException#TIMED_OUT} when no relevant message
+   *       arrives within {@link #TIMEOUT}.
+   * </ul>
+   *
+   * <p>Blocking: May block repeatedly for up to {@link #TIMEOUT} per iteration until a terminal
+   * condition is reached.
+   *
+   * @return {@code true} if the entire file was received and acknowledged; {@code false} if the
+   *     transfer aborted or timed out.
    */
   public boolean receive() {
     while (true) {
+      // Build per-iteration filters for either a sender abort or a data packet from this peer.
       MessageFilter mfSendKilled =
           MessageFilter.create()
               .setSource(peer)
@@ -81,34 +152,40 @@ public class BulkReceiver {
               .setTimeout(TIMEOUT);
       if (prb.hasWholeFile()) {
         try {
+          // Fast-path: data may have arrived concurrently; acknowledge completion immediately.
           peer.sendAsync(DMT.createFNPBulkReceivedAll(uid), null, ctr);
         } catch (NotConnectedException e) {
-          // Ignore, we have the data.
+          // Acknowledge best-effort only. We already have the data locally.
         }
         return true;
       }
       Message m;
       try {
+        // Wait for either filter to match; returns null on timeout.
         m = prb.usm.waitFor(mfSendKilled.or(mfPacket), ctr);
       } catch (DisconnectedException e) {
         prb.abort(RetrievalException.SENDER_DISCONNECTED, "Sender disconnected");
         return false;
       }
       if (peer.getBootID() != peerBootID) {
+        // Remote peer restarted during the transfer; treat as sender death.
         prb.abort(RetrievalException.SENDER_DIED, "Sender restarted");
         return false;
       }
       if (m == null) {
+        // Neither packet nor abort arrived within TIMEOUT.
         prb.abort(RetrievalException.TIMED_OUT, "Sender timeout");
         return false;
       }
       if (m.getSpec() == DMT.FNPBulkSendAborted) {
+        // Sender explicitly cancelled this transfer.
         prb.abort(RetrievalException.SENDER_DIED, "Sender cancelled send");
         return false;
       }
       if (m.getSpec() == DMT.FNPBulkPacketSend) {
         int packetNo = m.getInt(DMT.PACKET_NO);
         byte[] data = ((ShortBuffer) m.getObject(DMT.DATA)).getData();
+        // Commit the packet payload to storage. Length is validated by PartiallyReceivedBulk.
         prb.received(packetNo, data, 0, data.length);
       }
     }

--- a/src/test/java/network/crypta/io/xfer/BulkReceiverTest.java
+++ b/src/test/java/network/crypta/io/xfer/BulkReceiverTest.java
@@ -1,0 +1,249 @@
+package network.crypta.io.xfer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.io.comm.ByteCounter;
+import network.crypta.io.comm.DMT;
+import network.crypta.io.comm.DisconnectedException;
+import network.crypta.io.comm.Message;
+import network.crypta.io.comm.MessageCore;
+import network.crypta.io.comm.MessageFilter;
+import network.crypta.io.comm.NotConnectedException;
+import network.crypta.io.comm.PeerContext;
+import network.crypta.io.comm.RetrievalException;
+import network.crypta.support.ShortBuffer;
+import network.crypta.support.io.ByteArrayRandomAccessBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BulkReceiverTest {
+
+  @Mock PeerContext peer;
+
+  @Mock MessageCore usm;
+
+  @Mock ByteCounter ctr;
+
+  private static PartiallyReceivedBulk newPrb(
+      MessageCore usm, long size, int blockSize, boolean initialState) {
+    // Backing RAF must be at least "size" bytes.
+    return new PartiallyReceivedBulk(
+        usm, size, blockSize, new ByteArrayRandomAccessBuffer((int) size), initialState);
+  }
+
+  @BeforeEach
+  void setupPeerBootId() {
+    when(peer.getBootID()).thenReturn(42L); // Default unless a test overrides with a sequence
+  }
+
+  @Test
+  @DisplayName("receive_whenHasWholeFileInitially_sendsAllReceivedAckAndReturnsTrue")
+  @SuppressWarnings("java:S100") // Intentional test naming style
+  void receive_whenHasWholeFileInitially_sendsAllReceivedAckAndReturnsTrue() throws Exception {
+    PartiallyReceivedBulk prb = newPrb(usm, 0, 4, true); // whole-file already present
+    long uid = 12345L;
+    BulkReceiver recv = new BulkReceiver(prb, peer, uid, ctr);
+
+    // Act
+    boolean result = recv.receive();
+
+    // Assert
+    assertTrue(result, "Expected receive() to return true when we already have the file");
+    ArgumentCaptor<Message> msgCap = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(msgCap.capture(), eq(null), eq(ctr));
+    Message sent = msgCap.getValue();
+    assertEquals(DMT.FNPBulkReceivedAll, sent.getSpec());
+    assertEquals(uid, sent.getLong(DMT.UID));
+    // When whole-file is present, we must not block on the message core.
+    verify(usm, never()).waitFor(any(MessageFilter.class), any());
+  }
+
+  @Test
+  @DisplayName("receive_whenPacketsArrive_writesBlocksAndAcksAll")
+  @SuppressWarnings("java:S100")
+  void receive_whenPacketsArrive_writesBlocksAndAcksAll() throws Exception {
+    // Arrange: two blocks (4 bytes + 3 bytes)
+    int blockSize = 4;
+    long size = 7; // -> blocks = 2
+    PartiallyReceivedBulk prb = newPrb(usm, size, blockSize, false);
+    long uid = 999L;
+    BulkReceiver recv = new BulkReceiver(prb, peer, uid, ctr);
+
+    byte[] p0 = new byte[] {1, 2, 3, 4};
+    byte[] p1 = new byte[] {5, 6, 7};
+    Message m0 = DMT.createFNPBulkPacketSend(uid, 0, new ShortBuffer(p0));
+    Message m1 = DMT.createFNPBulkPacketSend(uid, 1, new ShortBuffer(p1));
+
+    // First wait returns packet 0, second returns packet 1.
+    when(usm.waitFor(any(MessageFilter.class), eq(ctr))).thenReturn(m0, m1);
+
+    // Act
+    boolean result = recv.receive();
+
+    // Assert
+    assertTrue(result, "Expected receive() to complete after both packets");
+
+    // Stored bytes match inputs
+    assertArrayEquals(p0, prb.getBlockData(0));
+    assertArrayEquals(p1, prb.getBlockData(1));
+
+    // Acknowledgment that all packets were received
+    ArgumentCaptor<Message> sent = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(sent.capture(), eq(null), eq(ctr));
+    assertEquals(DMT.FNPBulkReceivedAll, sent.getValue().getSpec());
+    assertEquals(uid, sent.getValue().getLong(DMT.UID));
+  }
+
+  @Test
+  @DisplayName(
+      "receive_whenDisconnectedDuringWait_abortsWithSenderDisconnectedAndSendsReceiveAborted")
+  @SuppressWarnings("java:S100")
+  void receive_whenDisconnectedDuringWait_abortsWithSenderDisconnectedAndSendsReceiveAborted()
+      throws Exception {
+    // Arrange
+    PartiallyReceivedBulk prb = newPrb(usm, 8, 4, false);
+    long uid = 777L;
+    BulkReceiver recv = new BulkReceiver(prb, peer, uid, ctr);
+    when(usm.waitFor(any(MessageFilter.class), eq(ctr))).thenThrow(new DisconnectedException());
+
+    // Act
+    boolean result = recv.receive();
+
+    // Assert
+    assertFalse(result, "Expected receive() to fail on disconnection");
+    assertTrue(prb.isAborted(), "PRB should be aborted");
+    assertEquals(RetrievalException.SENDER_DISCONNECTED, prb.getAbortReason());
+    ArgumentCaptor<Message> msgCap = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(msgCap.capture(), eq(null), eq(ctr));
+    assertEquals(DMT.FNPBulkReceiveAborted, msgCap.getValue().getSpec());
+    assertEquals(uid, msgCap.getValue().getLong(DMT.UID));
+  }
+
+  @Test
+  @DisplayName("receive_whenPeerBootIdChanges_abortsWithSenderDiedAndDoesNotWrite")
+  @SuppressWarnings("java:S100")
+  void receive_whenPeerBootIdChanges_abortsWithSenderDiedAndDoesNotWrite() throws Exception {
+    // Arrange
+    int blockSize = 4;
+    long size = 4;
+    PartiallyReceivedBulk prb = org.mockito.Mockito.spy(newPrb(usm, size, blockSize, false));
+    long uid = 314L;
+    // Record initial boot id at construction, then simulate a restart.
+    when(peer.getBootID()).thenReturn(1L, 2L);
+    BulkReceiver recv = new BulkReceiver(prb, peer, uid, ctr);
+
+    Message m0 = DMT.createFNPBulkPacketSend(uid, 0, new ShortBuffer(new byte[] {9, 9, 9, 9}));
+    when(usm.waitFor(any(MessageFilter.class), eq(ctr))).thenReturn(m0);
+
+    // Act
+    boolean result = recv.receive();
+
+    // Assert
+    assertFalse(result, "Expected receive() to abort when peer boot ID changed");
+    assertTrue(prb.isAborted());
+    assertEquals(RetrievalException.SENDER_DIED, prb.getAbortReason());
+    // Ensure we never attempted to store the received packet because we detected restart first
+    verify(prb, never())
+        .received(any(Integer.class), any(byte[].class), any(Integer.class), any(Integer.class));
+    // Receiver notifies peer about abort
+    ArgumentCaptor<Message> msgCap = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(msgCap.capture(), eq(null), eq(ctr));
+    assertEquals(DMT.FNPBulkReceiveAborted, msgCap.getValue().getSpec());
+  }
+
+  @Test
+  @DisplayName("receive_whenTimeout_abortsWithTimedOut")
+  @SuppressWarnings("java:S100")
+  void receive_whenTimeout_abortsWithTimedOut() throws Exception {
+    // Arrange
+    PartiallyReceivedBulk prb = newPrb(usm, 8, 4, false);
+    long uid = 2024L;
+    BulkReceiver recv = new BulkReceiver(prb, peer, uid, ctr);
+    when(usm.waitFor(any(MessageFilter.class), eq(ctr))).thenReturn(null);
+
+    // Act
+    boolean result = recv.receive();
+
+    // Assert
+    assertFalse(result);
+    assertTrue(prb.isAborted());
+    assertEquals(RetrievalException.TIMED_OUT, prb.getAbortReason());
+    ArgumentCaptor<Message> msgCap = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(msgCap.capture(), eq(null), eq(ctr));
+    assertEquals(DMT.FNPBulkReceiveAborted, msgCap.getValue().getSpec());
+  }
+
+  @Test
+  @DisplayName("receive_whenSenderCancelled_abortsWithSenderDied")
+  @SuppressWarnings("java:S100")
+  void receive_whenSenderCancelled_abortsWithSenderDied() throws Exception {
+    // Arrange
+    PartiallyReceivedBulk prb = newPrb(usm, 8, 4, false);
+    long uid = 55L;
+    BulkReceiver recv = new BulkReceiver(prb, peer, uid, ctr);
+    Message aborted = DMT.createFNPBulkSendAborted(uid);
+    when(usm.waitFor(any(MessageFilter.class), eq(ctr))).thenReturn(aborted);
+
+    // Act
+    boolean result = recv.receive();
+
+    // Assert
+    assertFalse(result);
+    assertTrue(prb.isAborted());
+    assertEquals(RetrievalException.SENDER_DIED, prb.getAbortReason());
+    ArgumentCaptor<Message> msgCap = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(msgCap.capture(), eq(null), eq(ctr));
+    assertEquals(DMT.FNPBulkReceiveAborted, msgCap.getValue().getSpec());
+  }
+
+  @Test
+  @DisplayName("onAborted_whenCalledTwice_sendsAbortedMessageOnlyOnce")
+  @SuppressWarnings("java:S100")
+  void onAborted_whenCalledTwice_sendsAbortedMessageOnlyOnce() throws Exception {
+    // Arrange
+    PartiallyReceivedBulk prb = newPrb(usm, 8, 4, false);
+    long uid = 888L;
+    BulkReceiver recv = new BulkReceiver(prb, peer, uid, ctr);
+
+    // Act: call twice; the second call should be ignored by the guard.
+    recv.onAborted();
+    recv.onAborted();
+
+    // Assert
+    ArgumentCaptor<Message> msgCap = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(msgCap.capture(), eq(null), eq(ctr));
+    assertEquals(DMT.FNPBulkReceiveAborted, msgCap.getValue().getSpec());
+    assertEquals(uid, msgCap.getValue().getLong(DMT.UID));
+  }
+
+  @Test
+  @DisplayName("onAborted_whenPeerNotConnected_swallowsException")
+  @SuppressWarnings("java:S100")
+  void onAborted_whenPeerNotConnected_swallowsException() throws Exception {
+    // Arrange
+    PartiallyReceivedBulk prb = newPrb(usm, 8, 4, false);
+    long uid = 321L;
+    BulkReceiver recv = new BulkReceiver(prb, peer, uid, ctr);
+    when(peer.sendAsync(any(Message.class), eq(null), eq(ctr)))
+        .thenThrow(new NotConnectedException());
+
+    // Act & Assert: no exception should escape
+    recv.onAborted();
+    verify(peer, times(1)).sendAsync(any(Message.class), eq(null), eq(ctr));
+  }
+}


### PR DESCRIPTION
Summary
- Adds deterministic JUnit 6 + Mockito tests for BulkReceiver covering both success and error paths.
- Improves BulkReceiver Javadoc and inline intent comments (no logic changes).
- Ran Spotless to keep formatting consistent.

Changes
- src/main/java/network/crypta/io/xfer/BulkReceiver.java
  - Comment-only update: expanded class/constructor/method Javadoc.
  - Clarified non-obvious behavior (filter construction, ack fast-path, timeout/restart handling).
- src/test/java/network/crypta/io/xfer/BulkReceiverTest.java (new)
  - receive_whenHasWholeFileInitially_sendsAllReceivedAckAndReturnsTrue
  - receive_whenPacketsArrive_writesBlocksAndAcksAll
  - receive_whenDisconnectedDuringWait_abortsWithSenderDisconnectedAndSendsReceiveAborted
  - receive_whenPeerBootIdChanges_abortsWithSenderDiedAndDoesNotWrite
  - receive_whenTimeout_abortsWithTimedOut
  - receive_whenSenderCancelled_abortsWithSenderDied
  - onAborted_whenCalledTwice_sendsAbortedMessageOnlyOnce
  - onAborted_whenPeerNotConnected_swallowsException

Commit(s)
- test(xfer): add BulkReceiverTest covering success + error paths

Diffstat
- 2 files changed, 336 insertions(+), 10 deletions(-)

Notes
- Tests are deterministic and do not perform network or file I/O beyond in-memory buffers.
- On abort paths, tests assert PRB abort reason and peer notification; where RAF is closed, tests avoid post-abort reads.
- No production logic was modified.

How to run locally
- Single class: `./gradlew test --tests 'network.crypta.io.xfer.BulkReceiverTest'`
- Full suite: `./gradlew test`

CI expectations
- Should pass formatting (Spotless), compile, and tests on Java 21.

Request
- Please review the Javadoc changes for clarity and any additional context you’d like captured.
