### PR TITLE
fix(io/xfer): improve BulkTransmitter reliability and add tests

### DIFF
--- a/src/main/java/network/crypta/io/xfer/BulkTransmitter.java
+++ b/src/main/java/network/crypta/io/xfer/BulkTransmitter.java
@@ -19,68 +19,92 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Bulk data transfer (not block). Bulk transfer is designed for files which may be much bigger than
- * a key block, and where we have the whole file at the outset. Do not persist across node restarts.
+ * Sends large, file-like payloads to a single peer using the bulk transfer protocol. The
+ * transmitter assumes the data is locally available and is not persisted across node restarts.
  *
- * <p>Used by update over mandatory, sending a file to our peers attached to an N2NTM etc.
+ * <p>It streams block-sized packets, tracks in-flight packets, and—unless {@code noWait} is
+ * true—waits for the final {@code FNPBulkReceivedAll} acknowledgement before reporting success.
+ * Local aborts or remote cancellations unblock the send loop promptly.
+ *
+ * <p>Threading: state transitions synchronize on {@code this}. Instances are notified by {@link
+ * PartiallyReceivedBulk} (new blocks or abort) and by asynchronous message filters registered on
+ * {@link network.crypta.io.comm.MessageCore}. Public methods may block until progress, completion,
+ * cancellation, or timeout.
  *
  * @author toad
  */
 public class BulkTransmitter {
   private static final Logger LOG = LoggerFactory.getLogger(BulkTransmitter.class);
 
+  /**
+   * Callback invoked when all packets have been queued and their send callbacks have fired.
+   *
+   * <p>The callback is invoked at most once, asynchronously on the message executor.
+   */
   public interface AllSentCallback {
 
+    /**
+     * Notifies that all packets were queued and observed as {@code sent}.
+     *
+     * @param bulkTransmitter the transmitter reporting completion of queuing
+     * @param anyFailed {@code true} if any packet failed to send; {@code false} otherwise
+     */
     void allSent(BulkTransmitter bulkTransmitter, boolean anyFailed);
   }
 
-  /**
-   * If no packets sent in this period, and no completion acknowledgement / cancellation, assume
-   * failure.
-   */
+  /** Maximum time without progress before the transfer is considered failed. Unit: milliseconds. */
   static final long TIMEOUT = MINUTES.toMillis(5);
 
-  /** Time to hang around listening for the last FNPBulkReceivedAll message */
+  /**
+   * Grace period to keep listening for the final {@code FNPBulkReceivedAll} after finishing. Unit:
+   * milliseconds.
+   */
   static final long FINAL_ACK_TIMEOUT = SECONDS.toMillis(10);
 
   final AllSentCallback allSentCallback;
 
-  /** Available blocks */
+  /** Available blocks. Provided by the associated {@link PartiallyReceivedBulk}. */
   final PartiallyReceivedBulk prb;
 
-  /** Peer who we are sending the data to */
+  /** Peer receiving the data. */
   final PeerContext peer;
 
-  /** Transfer UID for messages */
+  /** Transfer UID used in all protocol messages. */
   final long uid;
 
   /**
-   * Blocks we have but haven't sent yet. 0 = block sent or not present, 1 = block present but not
-   * sent
+   * Tracks blocks present but not yet sent. Bit semantics: 0 = sent or not present; 1 = present and
+   * pending.
    */
   final BitArray blocksNotSentButPresent;
 
   private boolean cancelled;
 
-  /** Not persistent over reboots */
+  /** Peer boot identifier observed when the transfer started; used to detect restarts. */
   final long peerBootID;
 
   private boolean sentCancel;
   private boolean finished;
 
-  /** Not expecting a response? */
+  /** When {@code true}, do not wait for the final acknowledgement after sending. */
   final boolean noWait;
 
   private long finishTime = -1;
   private String cancelReason;
   private final ByteCounter ctr;
-  private final boolean realTime;
+
+  // 'realTime' parameter is accepted in the constructor for API compatibility, but no field is
+  // needed here.
+  /**
+   * Whether an {@link InterruptedException} was observed inside internal waits. Interrupt status is
+   * restored when {@link #send()} returns to allow callers to observe it (see java:S2142).
+   */
+  private volatile boolean interruptedDuringWait = false;
 
   private static long transfersCompleted;
   private static long transfersSucceeded;
 
-  static {
-  }
+  // No static initialization required.
 
   public BulkTransmitter(
       PartiallyReceivedBulk prb,
@@ -94,15 +118,20 @@ public class BulkTransmitter {
   }
 
   /**
-   * Create a bulk data transmitter.
+   * Creates a bulk transmitter.
    *
-   * @param prb The PartiallyReceivedBulk containing the file we want to send, or the part of it
-   *     that we have so far.
-   * @param peer The peer we want to send it to.
-   * @param uid The unique identifier for this data transfer
-   * @param noWait If true, don't wait for an FNPBulkReceivedAll, return as soon as we've sent
-   *     everything.
-   * @throws DisconnectedException If the peer we are trying to send to becomes disconnected.
+   * <p>The constructor registers asynchronous filters for abort and final-ack messages on the
+   * underlying message core and associates the transmitter with the supplied {@link
+   * PartiallyReceivedBulk}.
+   *
+   * @param prb the data source that exposes available blocks and notifies of new blocks/aborts
+   * @param peer the destination peer
+   * @param uid a unique transfer identifier used in protocol messages
+   * @param noWait when {@code true}, return after sending all available data without waiting for
+   *     {@code FNPBulkReceivedAll}
+   * @param ctr byte counter to record payload accounting; must not be {@code null}
+   * @param realTime accepted for API compatibility; does not alter scheduling semantics here
+   * @throws DisconnectedException if the peer disconnects while registering filters
    */
   public BulkTransmitter(
       PartiallyReceivedBulk prb,
@@ -118,15 +147,16 @@ public class BulkTransmitter {
     this.uid = uid;
     this.noWait = noWait;
     this.ctr = ctr;
-    this.realTime = realTime;
+    // Touch the flag to make the intent explicit without changing behavior.
+    if (realTime && LOG.isTraceEnabled()) {
+      LOG.trace("Real-time flag set for {}", this);
+    }
     this.allSentCallback = cb;
     if (ctr == null) throw new NullPointerException();
     peerBootID = peer.getBootID();
-    // Need to sync on prb while doing both operations, to avoid race condition.
-    // Specifically, we must not get calls to blockReceived() until blocksNotSentButPresent
-    // has been set, AND it must be accurate, so there must not be an unlocked period
-    // between cloning and adding.
-    synchronized (prb) {
+    // Synchronize on PRB while cloning and registering to avoid seeing block updates before the
+    // bitmap snapshot is initialized.
+    synchronized (this.prb) {
       // We can just clone it.
       blocksNotSentButPresent = prb.cloneBlocksReceived();
       prb.add(this);
@@ -154,17 +184,17 @@ public class BulkTransmitter {
 
             @Override
             public void onTimeout() {
-              // Ignore
+              // No-op: the filter is removed by cancellation/completion.
             }
 
             @Override
             public void onDisconnect(PeerContext ctx) {
-              // Ignore
+              // No-op: cancellation paths handle disconnects.
             }
 
             @Override
             public void onRestarted(PeerContext ctx) {
-              // Ignore
+              // No-op: peer restarts are detected via boot ID in the send loop.
             }
           },
           ctr);
@@ -193,17 +223,17 @@ public class BulkTransmitter {
 
             @Override
             public void onTimeout() {
-              // Ignore
+              // No-op: the filter is removed by cancellation/completion.
             }
 
             @Override
             public void onDisconnect(PeerContext ctx) {
-              // Ignore
+              // No-op: cancellation paths handle disconnects.
             }
 
             @Override
             public void onRestarted(PeerContext ctx) {
-              // Ignore
+              // No-op: peer restarts are detected via boot ID in the send loop.
             }
           },
           ctr);
@@ -224,7 +254,12 @@ public class BulkTransmitter {
     notifyAll();
   }
 
-  /** Called when the PRB is aborted. */
+  /**
+   * Notifies the transmitter that the associated {@link PartiallyReceivedBulk} aborted.
+   *
+   * <p>Sends a best-effort {@code FNPBulkSendAborted} to the peer and wakes any waiting threads.
+   * Idempotent.
+   */
   public void onAborted() {
     sendAbortedMessage();
     synchronized (this) {
@@ -232,6 +267,7 @@ public class BulkTransmitter {
     }
   }
 
+  /** Sends {@code FNPBulkSendAborted} once. Subsequent calls are no-ops. */
   private void sendAbortedMessage() {
     synchronized (this) {
       if (sentCancel) return;
@@ -240,12 +276,12 @@ public class BulkTransmitter {
     try {
       peer.sendAsync(DMT.createFNPBulkSendAborted(uid), null, ctr);
     } catch (NotConnectedException e) {
-      // Cool
+      // Best-effort notification only; ignore if not connected.
     }
   }
 
   public void cancel(String reason) {
-    if (LOG.isDebugEnabled()) LOG.debug("Cancelling " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Cancelling {}", this);
     sendAbortedMessage();
     synchronized (this) {
       if (cancelled || finished) return;
@@ -258,12 +294,15 @@ public class BulkTransmitter {
       transfersCompleted++;
     }
     // Call AllSentCallback if necessary.
-    // If there are packets still waiting, it will be called after they are sent or failed.
+    // If packets are still in flight, the callback is invoked after they complete or fail.
     setAllQueued();
   }
 
   /**
-   * Like cancel(), but without the negative overtones: The client says it's got everything, we
+   * Marks the transfer successful, updates counters, and notifies waiting threads and the optional
+   * callback.
+   *
+   * <p>Like cancel(), but without the negative overtones: The client says it's got everything, we
    * believe them (even if we haven't sent everything; maybe they had a partial).
    */
   public void completed() {
@@ -278,121 +317,256 @@ public class BulkTransmitter {
       transfersCompleted++;
       transfersSucceeded++;
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Completed transfer successfully " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Completed transfer successfully {}", this);
   }
 
   /**
-   * Send the file.
+   * Runs the send loop until success, failure, or cancellation.
    *
-   * @return True if the file was successfully sent. False otherwise.
-   * @throws DisconnectedException
+   * <p>When {@code noWait} is {@code true} and the full file is already present locally, this
+   * method completes after enqueueing all packets without waiting for the final acknowledgement.
+   *
+   * @return {@code true} if the peer acknowledged receipt (or {@code noWait} short-circuited after
+   *     enqueueing); {@code false} if cancelled, aborted, or timed out
+   * @throws DisconnectedException if the peer disconnects or restarts during the transfer
    */
   public boolean send() throws DisconnectedException {
-    long lastSentPacket = System.currentTimeMillis();
-    outer:
-    while (true) {
-      int max = Math.min(Integer.MAX_VALUE, prb.blocks);
-      max = Math.min(max, peer.getThrottleWindowSize());
-      // FIXME Need to introduce the global limiter of [code]max[/code] for memory management
-      // instead of hard-code for each, no?
-      max = Math.min(max, 100);
-      if (max < 1) max = 1;
+    try {
+      long lastSentPacket = System.currentTimeMillis();
+      while (true) {
+        IterationResult r = doOneSendIteration(lastSentPacket);
+        if (r.outcome == Outcome.SUCCEEDED) return true;
+        if (r.outcome == Outcome.FAILED) return false;
+        lastSentPacket = r.lastSentPacket;
+      }
+    } finally {
+      // Restore interrupt status if we swallowed any InterruptedException during internal waits.
+      if (interruptedDuringWait) Thread.currentThread().interrupt();
+    }
+  }
 
-      if (prb.isAborted()) {
-        if (LOG.isDebugEnabled()) LOG.debug("Aborted " + this);
-        return false;
-      }
-      int blockNo;
-      if (peer.getBootID() != peerBootID) {
-        synchronized (this) {
-          cancelled = true;
-          notifyAll();
-        }
-        prb.remove(BulkTransmitter.this);
-        if (LOG.isDebugEnabled()) LOG.debug("Failed to send " + uid + ": peer restarted: " + peer);
-        throw new DisconnectedException();
-      }
+  private record IterationResult(Outcome outcome, long lastSentPacket) {
+
+    static IterationResult cont(long ts) {
+      return new IterationResult(Outcome.CONTINUE, ts);
+    }
+
+    static IterationResult success(long ts) {
+      return new IterationResult(Outcome.SUCCEEDED, ts);
+    }
+
+    static IterationResult fail(long ts) {
+      return new IterationResult(Outcome.FAILED, ts);
+    }
+  }
+
+  private IterationResult doOneSendIteration(long lastSentPacket) throws DisconnectedException {
+    int max = computeMaxInFlight();
+
+    if (prb.isAborted()) {
+      if (LOG.isDebugEnabled()) LOG.debug("Aborted {}", this);
+      return IterationResult.fail(lastSentPacket);
+    }
+
+    ensurePeerNotRestarted();
+
+    int blockNo = nextBlockOrStatus();
+    if (blockNo == FINISHED_SENTINEL) return IterationResult.success(lastSentPacket);
+    if (blockNo == CANCELLED_SENTINEL) return IterationResult.fail(lastSentPacket);
+
+    if (blockNo < 0) {
+      Outcome outcome = handleNoBlockAvailable(lastSentPacket);
+      if (outcome == Outcome.SUCCEEDED) return IterationResult.success(lastSentPacket);
+      if (outcome == Outcome.FAILED) return IterationResult.fail(lastSentPacket);
+      return IterationResult.cont(lastSentPacket);
+    }
+
+    long ts = sendPacket(blockNo, max);
+    if (ts < 0) return IterationResult.fail(lastSentPacket); // Already cancelled, quit
+    return IterationResult.cont(ts);
+  }
+
+  private int computeMaxInFlight() {
+    int max = prb.blocks;
+    max = Math.min(max, peer.getThrottleWindowSize());
+    // Note: A global limiter of [code]max[/code] for memory management may be desirable
+    // instead of hard-coding per use.
+    max = Math.min(max, 100);
+    if (max < 1) max = 1;
+    return max;
+  }
+
+  private void ensurePeerNotRestarted() throws DisconnectedException {
+    if (peer.getBootID() != peerBootID) {
       synchronized (this) {
-        if (finished) return true;
-        if (cancelled) return false;
-        blockNo = blocksNotSentButPresent.firstOne();
+        cancelled = true;
+        notifyAll();
       }
-      if (blockNo < 0) {
-        setAllQueued();
-        if (noWait && prb.hasWholeFile()) {
-          completed();
-          return true;
-        }
-        synchronized (this) {
-          // Wait for all packets to complete
-          while (true) {
-            if (failedPacket) {
-              cancel("Packet send failed");
-              return false;
-            }
-            if (LOG.isDebugEnabled())
-              LOG.debug("Waiting for packets: remaining: " + inFlightPackets);
-            if (inFlightPackets == 0) break;
-            try {
-              wait();
-              if (failedPacket) {
-                cancel("Packet send failed");
-                return false;
-              }
-              if (inFlightPackets == 0) break;
-              continue outer; // Might be a packet...
-            } catch (InterruptedException e) {
-              // Ignore
-            }
-          }
+      prb.remove(BulkTransmitter.this);
+      if (LOG.isDebugEnabled()) LOG.debug("Failed to send {}: peer restarted: {}", uid, peer);
+      throw new DisconnectedException();
+    }
+  }
 
-          // Wait for a packet to come in, BulkReceivedAll or BulkReceiveAborted
-          try {
-            wait(SECONDS.toMillis(60));
-          } catch (InterruptedException e) {
-            // No problem
-            continue;
-          }
-        }
-        long end = System.currentTimeMillis();
-        if (end - lastSentPacket > TIMEOUT) {
-          LOG.error("Send timed out on " + this);
-          cancel("Timeout awaiting BulkReceivedAll");
-          return false;
-        }
-        continue;
+  private static final int FINISHED_SENTINEL = Integer.MIN_VALUE;
+  private static final int CANCELLED_SENTINEL = Integer.MAX_VALUE;
+
+  private int nextBlockOrStatus() {
+    synchronized (this) {
+      if (finished) return FINISHED_SENTINEL;
+      if (cancelled) return CANCELLED_SENTINEL;
+      return blocksNotSentButPresent.firstOne();
+    }
+  }
+
+  private enum Outcome {
+    CONTINUE,
+    SUCCEEDED,
+    FAILED
+  }
+
+  private Outcome handleNoBlockAvailable(long lastSentPacket) {
+    setAllQueued();
+    Outcome early = fastCompleteIfNoWait();
+    if (early != null) return early;
+    Outcome drained = waitForInFlightToDrainOrContinue();
+    if (drained != null) return drained;
+    return waitForAckOrAbort(lastSentPacket);
+  }
+
+  private Outcome fastCompleteIfNoWait() {
+    if (noWait && prb.hasWholeFile()) {
+      completed();
+      return Outcome.SUCCEEDED;
+    }
+    return null;
+  }
+
+  /**
+   * Wait while there are packets in flight, but wake opportunistically.
+   *
+   * <p>When the transmitter temporarily runs out of locally available blocks, we do not want to
+   * stall until every outstanding packet completes. New blocks may arrive (via {@link
+   * #blockReceived(int)}) while there are still packets in flight; in that case, we should return
+   * to the outer send loop as soon as we are woken so the new block can be queued the moment the
+   * congestion window permits.
+   *
+   * <p>Return semantics: - {@code Outcome.FAILED}: a packet failed while waiting. - {@code
+   * Outcome.CONTINUE}: woke before fully draining; re-check availability and possibly send. -
+   * {@code null}: in-flight packets fully drained; caller may proceed to ACK/abort wait path.
+   */
+  @SuppressWarnings("java:S2142")
+  private Outcome waitForInFlightToDrainOrContinue() {
+    synchronized (this) {
+      if (failedPacket) {
+        cancel("Packet send failed");
+        return Outcome.FAILED;
       }
-      // Send a packet
-      byte[] buf = prb.getBlockData(blockNo);
-      if (buf == null) {
-        if (LOG.isDebugEnabled())
-          LOG.debug("Block " + blockNo + " is null, presumably the send is cancelled: " + this);
-        // Already cancelled, quit
-        return false;
+      if (inFlightPackets == 0) return null; // Already drained; fall through to ACK wait.
+
+      if (LOG.isDebugEnabled())
+        LOG.debug("Waiting for packets (opportunistic wake): remaining: {}", inFlightPackets);
+
+      // Guard against spurious wakeup; wake early only when a new block is available or when
+      // in-flight packets drain to zero.
+      while (!failedPacket && inFlightPackets != 0 && blocksNotSentButPresent.firstOne() < 0) {
+        try {
+          wait();
+        } catch (InterruptedException e) {
+          // Ignore and continue waiting; do not reassert the interrupt flag (see java:S2142).
+          // We must not exit early here, or subsequent waits will spin and bypass throttling.
+          interruptedDuringWait = true; // restored by send() finally block
+        }
       }
 
-      // Congestion control and bandwidth limiting
-      try {
-        if (LOG.isDebugEnabled()) LOG.debug("Sending packet " + blockNo);
-        Message msg = DMT.createFNPBulkPacketSend(uid, blockNo, buf);
-        UnsentPacketTag tag = new UnsentPacketTag();
-        peer.sendAsync(msg, tag, ctr);
-        synchronized (this) {
-          while (inFlightPackets >= max && !failedPacket)
-            try {
-              wait(1000);
-            } catch (InterruptedException e) {
-              // Ignore
-            }
+      if (failedPacket) {
+        cancel("Packet send failed");
+        return Outcome.FAILED;
+      }
+      if (inFlightPackets == 0) return null; // Fully drained, proceed to ACK wait path.
+      // A new block is now available; give control back to the outer loop to enqueue it
+      // (congestion control still enforced in waitWhileCongested()).
+      return Outcome.CONTINUE;
+    }
+  }
+
+  @SuppressWarnings("java:S2142")
+  private Outcome waitForAckOrAbort(long lastSentPacket) {
+    // When there are no packets in flight, we may be waiting for the final
+    // FNPBulkReceivedAll. However, new blocks can become available at any time
+    // (blockReceived()), so we must also wake and return to the outer loop
+    // immediately to queue them instead of stalling for up to 60 seconds.
+    synchronized (this) {
+      long deadline = System.currentTimeMillis() + SECONDS.toMillis(60);
+      while (!failedPacket
+          && !finished
+          && !cancelled
+          && !prb.isAborted()
+          && inFlightPackets == 0
+          && blocksNotSentButPresent.firstOne() < 0) { // break early when a new block appears
+        long remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0) break;
+        try {
+          wait(remaining);
+        } catch (InterruptedException e) {
+          // Ignore and loop; we restore the interrupt in send() finally.
+          interruptedDuringWait = true;
         }
-        synchronized (this) {
-          blocksNotSentButPresent.setBit(blockNo, false);
+      }
+      // If we observed completion/cancellation while waiting, return immediately so the outer
+      // loop can see FINISHED/CANCELLED without stalling for the full deadline.
+      // Also return promptly if the local PRB aborted while we were waiting; the outer loop
+      // checks prb.isAborted() at the start of the iteration and will fail fast.
+      if (finished || cancelled || prb.isAborted()) return Outcome.CONTINUE;
+    }
+    long end = System.currentTimeMillis();
+    if (end - lastSentPacket > TIMEOUT) {
+      LOG.error("Send timed out on {}", this);
+      cancel("Timeout awaiting BulkReceivedAll");
+      return Outcome.FAILED;
+    }
+    return Outcome.CONTINUE;
+  }
+
+  private long sendPacket(int blockNo, int max) throws DisconnectedException {
+    // Send a packet
+    byte[] buf = prb.getBlockData(blockNo);
+    if (buf == null) {
+      if (LOG.isDebugEnabled())
+        LOG.debug("Block {} is null, presumably the send is cancelled: {}", blockNo, this);
+      // Already cancelled, quit
+      return -1L;
+    }
+
+    // Congestion control and bandwidth limiting
+    try {
+      if (LOG.isDebugEnabled()) LOG.debug("Sending packet {}", blockNo);
+      Message msg = DMT.createFNPBulkPacketSend(uid, blockNo, buf);
+      UnsentPacketTag tag = new UnsentPacketTag();
+      peer.sendAsync(msg, tag, ctr);
+      waitWhileCongested(max);
+      synchronized (this) {
+        blocksNotSentButPresent.setBit(blockNo, false);
+      }
+      return System.currentTimeMillis();
+    } catch (NotConnectedException e) {
+      cancel("Disconnected");
+      if (LOG.isDebugEnabled()) LOG.debug("Cancelled: not connected {}", this);
+      throw new DisconnectedException();
+    }
+  }
+
+  @SuppressWarnings("java:S2142")
+  private void waitWhileCongested(int max) {
+    synchronized (this) {
+      while (inFlightPackets >= max && !failedPacket) {
+        try {
+          wait(1000);
+        } catch (InterruptedException e) {
+          // Ignore and continue waiting; keep honoring congestion/throttle semantics.
+          // We restore the interrupt when send() returns to avoid spinning here.
+          interruptedDuringWait = true;
         }
-        lastSentPacket = System.currentTimeMillis();
-      } catch (NotConnectedException e) {
-        cancel("Disconnected");
-        if (LOG.isDebugEnabled()) LOG.debug("Cancelled: not connected " + this);
-        throw new DisconnectedException();
       }
     }
   }
@@ -404,12 +578,12 @@ public class BulkTransmitter {
       synchronized (this) {
         allQueued = true;
         if (unsentPackets == 0 && !calledAllSent) {
-          if (LOG.isDebugEnabled()) LOG.debug("Calling all sent callback on " + this);
+          if (LOG.isDebugEnabled()) LOG.debug("Calling all sent callback on {}", this);
           callAllSent = true;
           calledAllSent = true;
           anyFailed = failedPacket;
-        } else if (!calledAllSent) {
-          if (LOG.isDebugEnabled()) LOG.debug("Still waiting for " + unsentPackets);
+        } else if (!calledAllSent && LOG.isDebugEnabled()) {
+          LOG.debug("Still waiting for {}", unsentPackets);
         }
       }
       if (callAllSent) {
@@ -470,13 +644,13 @@ public class BulkTransmitter {
         if (failed) {
           failedPacket = true;
           BulkTransmitter.this.notifyAll();
-          if (LOG.isDebugEnabled()) LOG.debug("Packet failed for " + BulkTransmitter.this);
+          if (LOG.isDebugEnabled()) LOG.debug("Packet failed for {}", BulkTransmitter.this);
         } else {
           inFlightPackets--;
           BulkTransmitter.this.notifyAll();
           if (LOG.isDebugEnabled())
             LOG.debug(
-                "Packet sent " + BulkTransmitter.this + " remaining in flight: " + inFlightPackets);
+                "Packet sent {} remaining in flight: {}", BulkTransmitter.this, inFlightPackets);
         }
       }
       sent(true);
@@ -514,20 +688,29 @@ public class BulkTransmitter {
         calledAllSent = true;
         anyFailed = failedPacket;
       }
-      if (LOG.isDebugEnabled()) LOG.debug("Calling all sent callback on " + this);
+      if (LOG.isDebugEnabled()) LOG.debug("Calling all sent callback on {}", this);
       callAllSentCallbackInner(anyFailed);
     }
   }
 
+  /** Returns a short, human-readable identifier containing the UID and peer. */
   @Override
   public String toString() {
     return "BulkTransmitter:" + uid + ":" + peer.shortToString();
   }
 
+  /** Returns the cancellation reason, or {@code null} if not cancelled. */
   public String getCancelReason() {
     return cancelReason;
   }
 
+  /**
+   * Returns aggregate counters for completed and successful transfers.
+   *
+   * <p>Index {@code 0} = total completed, index {@code 1} = total succeeded.
+   *
+   * @return a two-element array {@code [completed, succeeded]}
+   */
   public static synchronized long[] transferSuccess() {
     return new long[] {transfersCompleted, transfersSucceeded};
   }

--- a/src/test/java/network/crypta/io/xfer/BulkTransmitterTest.java
+++ b/src/test/java/network/crypta/io/xfer/BulkTransmitterTest.java
@@ -1,0 +1,402 @@
+package network.crypta.io.xfer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.io.comm.AsyncMessageCallback;
+import network.crypta.io.comm.ByteCounter;
+import network.crypta.io.comm.DMT;
+import network.crypta.io.comm.DisconnectedException;
+import network.crypta.io.comm.Message;
+import network.crypta.io.comm.MessageCore;
+import network.crypta.io.comm.NotConnectedException;
+import network.crypta.io.comm.PacketSocketHandler;
+import network.crypta.io.comm.PeerContext;
+import network.crypta.node.MessageItem;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.io.ByteArrayRandomAccessBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BulkTransmitterTest {
+
+  private static final int BLOCK_SIZE = 1024;
+  private static final int BLOCKS = 3;
+  private static final long UID = 123L;
+
+  @Mock ByteCounter ctr;
+
+  // Inline executor used by MessageCore (runs tasks on the calling thread deterministically).
+  private static final class InlineExecutor implements PriorityAwareExecutor {
+    @Override
+    public void execute(Runnable job) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName, boolean fromTicker) {
+      job.run();
+    }
+
+    @Override
+    public int[] waitingThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int[] runningThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int getWaitingThreadsCount() {
+      return 0;
+    }
+  }
+
+  private MessageCore usm;
+
+  @BeforeEach
+  void setUp() {
+    usm = new MessageCore(new InlineExecutor());
+  }
+
+  private PartiallyReceivedBulk newPrb() {
+    int size = BLOCKS * BLOCK_SIZE;
+    ByteArrayRandomAccessBuffer rab = new ByteArrayRandomAccessBuffer(size);
+    // Fill deterministic content; the transmitter does not inspect it but PRB reads it back.
+    byte[] pattern = new byte[BLOCK_SIZE];
+    for (int i = 0; i < BLOCK_SIZE; i++) pattern[i] = (byte) (i & 0xFF);
+    for (int b = 0; b < BLOCKS; b++) {
+      try {
+        rab.pwrite((long) b * BLOCK_SIZE, pattern, 0, BLOCK_SIZE);
+      } catch (Exception ignored) {
+        // ByteArrayRandomAccessBuffer bounds are correct for our input; no exception expected.
+      }
+    }
+    return new PartiallyReceivedBulk(usm, size, BLOCK_SIZE, rab, true);
+  }
+
+  @Test
+  void send_whenAllBlocksPresentAndNoWait_expectSuccessAndAllSentCallback() throws Exception {
+    PartiallyReceivedBulk prb = newPrb();
+
+    PeerContext peer = mock(PeerContext.class);
+    when(peer.getBootID()).thenReturn(42L);
+    when(peer.isConnected()).thenReturn(true);
+    when(peer.getThrottleWindowSize()).thenReturn(2);
+    when(peer.shortToString()).thenReturn("peerX");
+    // getWeakRef() is not used by BulkTransmitter; no need to stub.
+
+    // Ack every packet immediately and report payload via ByteCounter
+    doAnswer(
+            inv -> {
+              AsyncMessageCallback cb = inv.getArgument(1);
+              if (cb != null) {
+                cb.sent();
+                cb.acknowledged();
+              }
+              return mock(MessageItem.class);
+            })
+        .when(peer)
+        .sendAsync(any(Message.class), any(AsyncMessageCallback.class), eq(ctr));
+
+    // Capture baseline success counters
+    long[] before = BulkTransmitter.transferSuccess();
+
+    BulkTransmitter.AllSentCallback allSent = mock(BulkTransmitter.AllSentCallback.class);
+    BulkTransmitter bt = new BulkTransmitter(prb, peer, UID, true, ctr, false, allSent);
+
+    boolean ok = bt.send();
+    assertTrue(ok, "send() should return true on successful no-wait transfer");
+
+    // ByteCounter should be notified once per block with the configured block size
+    verify(ctr, times(BLOCKS)).sentPayload(BLOCK_SIZE);
+
+    // All-sent callback should be invoked exactly once with anyFailed=false
+    ArgumentCaptor<Boolean> anyFailed = ArgumentCaptor.forClass(Boolean.class);
+    verify(allSent, times(1)).allSent(eq(bt), anyFailed.capture());
+    assertEquals(Boolean.FALSE, anyFailed.getValue(), "allSent should report no failures");
+
+    long[] after = BulkTransmitter.transferSuccess();
+    assertEquals(before[0] + 1, after[0], "transfersCompleted should increase by 1");
+    assertEquals(before[1] + 1, after[1], "transfersSucceeded should increase by 1");
+  }
+
+  @Test
+  void send_whenPeerNotConnected_expectDisconnectedAndCancelReasonSet() throws Exception {
+    PartiallyReceivedBulk prb = newPrb();
+
+    PeerContext peer = mock(PeerContext.class);
+    when(peer.getBootID()).thenReturn(7L);
+    when(peer.isConnected()).thenReturn(true);
+    when(peer.getThrottleWindowSize()).thenReturn(1);
+    when(peer.shortToString()).thenReturn("peerY");
+    // getWeakRef() not needed here
+
+    // Throw on any sendAsync to simulate immediate disconnect.
+    doAnswer(
+            inv -> {
+              throw new NotConnectedException();
+            })
+        .when(peer)
+        .sendAsync(any(Message.class), any(AsyncMessageCallback.class), eq(ctr));
+
+    BulkTransmitter bt = new BulkTransmitter(prb, peer, UID, true, ctr, false, null);
+
+    assertThrows(DisconnectedException.class, bt::send, "send() should rethrow as Disconnected");
+    assertEquals("Disconnected", bt.getCancelReason());
+
+    // A best-effort aborted notification is attempted; it may also throw and is ignored.
+    verify(peer, times(1)).sendAsync(any(Message.class), any(AsyncMessageCallback.class), eq(ctr));
+  }
+
+  @Test
+  void onAborted_whenCalledTwice_expectSendAbortedOnlyOnce() throws Exception {
+    PartiallyReceivedBulk prb = newPrb();
+
+    PeerContext peer = mock(PeerContext.class);
+    when(peer.getBootID()).thenReturn(9L);
+    when(peer.isConnected()).thenReturn(true);
+
+    // For data packets (not used in this test) we would ack immediately. Here the callback is
+    // null for the aborted message, so just accept the call.
+    doAnswer(inv -> mock(MessageItem.class))
+        .when(peer)
+        .sendAsync(any(Message.class), isNull(), eq(ctr));
+
+    BulkTransmitter bt = new BulkTransmitter(prb, peer, UID, true, ctr, false, null);
+
+    bt.onAborted();
+    bt.onAborted();
+
+    ArgumentCaptor<Message> msgCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(msgCaptor.capture(), isNull(), eq(ctr));
+    assertEquals(DMT.FNPBulkSendAborted, msgCaptor.getValue().getSpec());
+    assertEquals(UID, msgCaptor.getValue().getLong(DMT.UID));
+    // Constructor interactions (e.g., getBootID) are expected; nothing else to assert here.
+  }
+
+  @Test
+  void filters_whenReceiveAbortedMessage_expectCancelAndAllSent() throws Exception {
+    PartiallyReceivedBulk prb = newPrb();
+
+    PeerContext peer = mock(PeerContext.class);
+    when(peer.getBootID()).thenReturn(111L);
+    when(peer.isConnected()).thenReturn(true);
+    // Only the null-callback variant is exercised by cancel()'s aborted notify in this test.
+    doAnswer(inv -> mock(MessageItem.class))
+        .when(peer)
+        .sendAsync(any(Message.class), isNull(), eq(ctr));
+
+    BulkTransmitter.AllSentCallback allSent = mock(BulkTransmitter.AllSentCallback.class);
+    BulkTransmitter bt = new BulkTransmitter(prb, peer, UID, true, ctr, false, allSent);
+
+    // Craft a mocked inbound message that matches the registered filter: type + source + UID.
+    Message aborted = mock(Message.class);
+    when(aborted.getSpec()).thenReturn(DMT.FNPBulkReceiveAborted);
+    when(aborted.getSource()).thenReturn(peer);
+    when(aborted.isSet(DMT.UID)).thenReturn(true);
+    when(aborted.getFromPayload(DMT.UID)).thenReturn(UID);
+
+    // Deliver to MessageCore; onMatched() cancels the transmitter.
+    prb.usm.checkFilters(aborted, mock(PacketSocketHandler.class));
+
+    assertEquals(
+        "Other side sent FNPBulkReceiveAborted", bt.getCancelReason(), "cancel reason should set");
+    verify(allSent, times(1)).allSent(bt, false);
+  }
+
+  @Test
+  void send_whenNewBlockArrivesWithPacketsInFlight_expectOpportunisticSecondSend()
+      throws Exception {
+    // Prepare a PRB with two blocks but no initial data available.
+    int blocks = 2;
+    int size = blocks * BLOCK_SIZE;
+    ByteArrayRandomAccessBuffer rab = new ByteArrayRandomAccessBuffer(size);
+    byte[] pattern = new byte[BLOCK_SIZE];
+    for (int i = 0; i < BLOCK_SIZE; i++) pattern[i] = (byte) (i & 0xFF);
+    for (int b = 0; b < blocks; b++) rab.pwrite((long) b * BLOCK_SIZE, pattern, 0, BLOCK_SIZE);
+    PartiallyReceivedBulk prb = new PartiallyReceivedBulk(usm, size, BLOCK_SIZE, rab, false);
+
+    PeerContext peer = mock(PeerContext.class);
+    when(peer.getBootID()).thenReturn(222L);
+    when(peer.isConnected()).thenReturn(true);
+    when(peer.getThrottleWindowSize()).thenReturn(2); // Window allows 2 in flight
+    when(peer.shortToString()).thenReturn("peerZ");
+
+    // Control acknowledgements to keep the first packet in flight while the second is queued.
+    CountDownLatch firstSent = new CountDownLatch(1);
+    CountDownLatch secondSent = new CountDownLatch(1);
+    AtomicReference<AsyncMessageCallback> cb0 = new AtomicReference<>();
+    AtomicInteger calls = new AtomicInteger();
+
+    doAnswer(
+            inv -> {
+              AsyncMessageCallback cb = inv.getArgument(1);
+              int idx = calls.getAndIncrement();
+              if (idx == 0) {
+                cb0.set(cb);
+                cb.sent(); // Mark as sent but deliberately do not ack yet
+                firstSent.countDown();
+              } else if (idx == 1) {
+                cb.sent();
+                // Ack the second immediately to let the send loop progress to completion.
+                cb.acknowledged();
+                secondSent.countDown();
+              }
+              return mock(MessageItem.class);
+            })
+        .when(peer)
+        .sendAsync(any(Message.class), any(AsyncMessageCallback.class), eq(ctr));
+
+    BulkTransmitter bt = new BulkTransmitter(prb, peer, UID, true, ctr, false, null);
+
+    // Start sending in the background; initially there are no blocks, so it will wait.
+    CompletableFuture<Boolean> result =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                return bt.send();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+
+    // Deliver the first block; the transmitter should send it and keep it in flight.
+    prb.received(0, pattern, 0, BLOCK_SIZE);
+    assertTrue(firstSent.await(5, TimeUnit.SECONDS), "first packet sent");
+
+    // While the first remains in-flight, deliver the second block. The new logic should wake and
+    // queue it immediately, without waiting for inFlight=0.
+    prb.received(1, pattern, 0, BLOCK_SIZE);
+    assertTrue(secondSent.await(5, TimeUnit.SECONDS), "second packet sent opportunistically");
+
+    // Now allow the first packet to complete so send() can finish.
+    cb0.get().acknowledged();
+
+    assertTrue(result.get(10, TimeUnit.SECONDS), "send() should succeed");
+    // Verify both payloads were accounted for.
+    verify(ctr, times(2)).sentPayload(BLOCK_SIZE);
+  }
+
+  @Test
+  void send_whenQueueEmpty_thenNewBlockArrives_expectWakeFromAckWait() throws Exception {
+    // Prepare a PRB with one block but initially no data available.
+    int blocks = 1;
+    int size = blocks * BLOCK_SIZE;
+    ByteArrayRandomAccessBuffer rab = new ByteArrayRandomAccessBuffer(size);
+    byte[] pattern = new byte[BLOCK_SIZE];
+    for (int i = 0; i < BLOCK_SIZE; i++) pattern[i] = (byte) (i & 0xFF);
+    PartiallyReceivedBulk prb = new PartiallyReceivedBulk(usm, size, BLOCK_SIZE, rab, false);
+
+    PeerContext peer = mock(PeerContext.class);
+    when(peer.getBootID()).thenReturn(333L);
+    when(peer.isConnected()).thenReturn(true);
+    when(peer.getThrottleWindowSize()).thenReturn(1);
+    when(peer.shortToString()).thenReturn("peerAckWait");
+
+    CountDownLatch sent = new CountDownLatch(1);
+    doAnswer(
+            inv -> {
+              AsyncMessageCallback cb = inv.getArgument(1);
+              cb.sent();
+              cb.acknowledged();
+              sent.countDown();
+              return mock(MessageItem.class);
+            })
+        .when(peer)
+        .sendAsync(any(Message.class), any(AsyncMessageCallback.class), eq(ctr));
+
+    BulkTransmitter bt = new BulkTransmitter(prb, peer, UID, true, ctr, false, null);
+
+    // Start sending in the background; with no blocks and no in-flight packets, the sender enters
+    // the ack-wait path. When a block arrives, it should wake immediately and send it.
+    CompletableFuture<Boolean> result =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                return bt.send();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+
+    // No fixed sleep: rely on the latch below to await the async send.
+    prb.received(0, pattern, 0, BLOCK_SIZE);
+
+    assertTrue(sent.await(5, TimeUnit.SECONDS), "packet sent after wake");
+    assertTrue(result.get(5, TimeUnit.SECONDS), "send() should succeed fast");
+    verify(ctr, times(1)).sentPayload(BLOCK_SIZE);
+  }
+
+  @Test
+  void send_whenAbortedDuringAckWait_expectImmediateReturn() throws Exception {
+    // PRB with no initial data so sender enters the ACK-wait path (no in-flight, nothing to send).
+    int blocks = 1;
+    int size = blocks * BLOCK_SIZE;
+    ByteArrayRandomAccessBuffer rab = new ByteArrayRandomAccessBuffer(size);
+    PartiallyReceivedBulk prb = new PartiallyReceivedBulk(usm, size, BLOCK_SIZE, rab, false);
+
+    PeerContext peer = mock(PeerContext.class);
+    when(peer.getBootID()).thenReturn(444L);
+    when(peer.isConnected()).thenReturn(true);
+    when(peer.getThrottleWindowSize()).thenReturn(1);
+    when(peer.shortToString()).thenReturn("peerAbortAckWait");
+
+    // For the aborted notification, BulkTransmitter sends FNPBulkSendAborted with a null callback.
+    doAnswer(inv -> mock(MessageItem.class))
+        .when(peer)
+        .sendAsync(any(Message.class), isNull(), eq(ctr));
+
+    BulkTransmitter bt = new BulkTransmitter(prb, peer, UID, true, ctr, false, null);
+
+    // Run send() in the background; with no blocks available, it will enter waitForAckOrAbort().
+    CompletableFuture<Boolean> result =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                return bt.send();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+
+    // Abort locally; the transmitter should break its wait loop immediately and return false.
+    prb.abort(42, "test-abort");
+
+    assertEquals(false, result.get(2, TimeUnit.SECONDS), "send() should fail promptly on abort");
+
+    // Verify the sender attempted to notify the peer once about the aborted send.
+    ArgumentCaptor<Message> msgCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(peer, times(1)).sendAsync(msgCaptor.capture(), isNull(), eq(ctr));
+    Message aborted = msgCaptor.getValue();
+    assertEquals(DMT.FNPBulkSendAborted, aborted.getSpec());
+    assertEquals(UID, aborted.getLong(DMT.UID));
+  }
+}


### PR DESCRIPTION
Summary
- Refines BulkTransmitter send/ack flow, clarifies threading and timeout behavior, and improves cancellation handling.
- Adds comprehensive JUnit 6 tests for success (noWait), disconnect/exception paths, and aborted semantics.
- Applies Spotless formatting across touched sources for consistent style.

Changes
- src/main/java/network/crypta/io/xfer/BulkTransmitter.java
  - Expand KDoc/JavaDoc: clarify protocol, TIMEOUT/FINAL_ACK semantics, and callback guarantees.
  - Tighten state transitions and cancellation path; ensure InterruptedException is handled and status restored.
  - Improve guard checks for peer connectivity and boot ID, align logging and ByteCounter usage.
- src/test/java/network/crypta/io/xfer/BulkTransmitterTest.java
  - New test suite targeting: all-sent callback when noWait=true, disconnect propagation (NotConnected → Disconnected), and idempotent abort behavior.

Diffstat (since origin/develop)
- 2 files changed, ~734 insertions, 149 deletions.

Rationale
- The transmitter previously mixed concerns of queuing, ack waiting, and finish detection. The refactor documents and streamlines these behaviors and adds tests to keep them stable.

Testing
- Local: `./gradlew test` (JUnit 6 platform). No new external dependencies.
- The new tests use lightweight mocks and in-memory buffers; they run quickly.

Compatibility
- API surface is unchanged; behavior tightened around cancellation/ack edge cases.
- No persistence or wire-format changes.

Notes
- Formatting applied via Spotless to adhere to project style.
- Let me know if you prefer splitting the test addition and transmitter changes into separate PRs.