### PR TITLE
docs(crypt): improve Javadoc for exceptions and package docs

### DIFF
--- a/src/main/java/network/crypta/crypt/CryptFormatException.java
+++ b/src/main/java/network/crypta/crypt/CryptFormatException.java
@@ -3,16 +3,42 @@ package network.crypta.crypt;
 import java.io.IOException;
 import java.io.Serial;
 
+/**
+ * Signals that cryptographic input does not conform to the expected Crypta serialization or wire
+ * format.
+ *
+ * <p>Typical causes include truncated data, invalid headers, unsupported versions, or other
+ * inconsistencies detected while parsing or verifying cryptographic material. This is a checked
+ * exception so callers handle format errors explicitly. When constructed from an {@link
+ * IOException}, the original exception becomes the cause.
+ *
+ * @see IOException
+ */
 public class CryptFormatException extends Exception {
 
   @Serial private static final long serialVersionUID = -796276279268900609L;
 
+  /**
+   * Creates an exception with a descriptive message about the detected format problem.
+   *
+   * @param message detail message describing the format error.
+   */
   public CryptFormatException(String message) {
     super(message);
   }
 
+  /**
+   * Creates an exception that wraps an {@link IOException} encountered while reading or parsing
+   * cryptographic data.
+   *
+   * <p>The message from the provided exception is used as this exception's detail message, and the
+   * cause is initialized to the provided exception to preserve its stack trace.
+   *
+   * @param e the underlying I/O error that led to detecting the format problem.
+   */
   public CryptFormatException(IOException e) {
     super(e.getMessage());
+    // Preserve the original IOException as the cause to retain its stack trace.
     initCause(e);
   }
 }

--- a/src/main/java/network/crypta/crypt/UnsupportedCipherException.java
+++ b/src/main/java/network/crypta/crypt/UnsupportedCipherException.java
@@ -2,11 +2,28 @@ package network.crypta.crypt;
 
 import java.io.Serial;
 
+/**
+ * Thrown when a cipher algorithm, mode, or configuration is not supported by the current build or
+ * available cryptographic providers.
+ *
+ * <p>This exception may be raised when parsing stored data that references a cipher the runtime
+ * does not recognize, or when a caller requests an algorithm that is not enabled or compiled into
+ * the node. Callers can inspect the message (when provided) for additional context.
+ *
+ * @see java.security.NoSuchAlgorithmException
+ * @see javax.crypto.NoSuchPaddingException
+ */
 public class UnsupportedCipherException extends Exception {
   @Serial private static final long serialVersionUID = -1;
 
+  /** Creates an exception with no detail message. */
   public UnsupportedCipherException() {}
 
+  /**
+   * Creates an exception with the provided detail message.
+   *
+   * @param s human-readable description of the unsupported cipher condition.
+   */
   public UnsupportedCipherException(String s) {
     super(s);
   }

--- a/src/main/java/network/crypta/crypt/UnsupportedTypeException.java
+++ b/src/main/java/network/crypta/crypt/UnsupportedTypeException.java
@@ -3,20 +3,34 @@ package network.crypta.crypt;
 import java.io.Serial;
 
 /**
- * The UnsupportedTypeException is a subclass of IllegalArgumentException.
+ * Indicates that an unsupported enum constant was provided to a cryptographic API.
  *
- * <p>Thrown to indicate that a method has been passed an Enum value from one of the various Type
- * enums in freenet.crypt that is not supported by that method.
+ * <p>This exception is a specialized {@link IllegalArgumentException}. It is thrown when a caller
+ * supplies an {@link Enum} value (e.g., an algorithm, mode, or type selector) that the receiving
+ * method does not support. The exception message includes the enum's declaring class and constant
+ * name to aid diagnosis.
  *
  * @author unixninja92
  */
 public class UnsupportedTypeException extends IllegalArgumentException {
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception describing the unsupported enum value.
+   *
+   * @param type the unsupported enum constant; its declaring class and name are reported in the
+   *     message.
+   * @param s additional context appended to the message (may be empty).
+   */
   public UnsupportedTypeException(Enum<?> type, String s) {
     super("Unsupported " + type.getDeclaringClass().getName() + " " + type.name() + " used. " + s);
   }
 
+  /**
+   * Creates an exception describing the unsupported enum value with no additional context.
+   *
+   * @param type the unsupported enum constant.
+   */
   public UnsupportedTypeException(Enum<?> type) {
     this(type, "");
   }

--- a/src/main/java/network/crypta/crypt/package-info.java
+++ b/src/main/java/network/crypta/crypt/package-info.java
@@ -1,8 +1,40 @@
 /**
- * Freenet encryption support code. Some of this will be replaced with JCA code, but JCA has export
- * restrictions issues (which are a massive configuration/maintenance problem for end users even if
- * they are US citizens). Some of it wraps JCA code to provide convenient APIs, boost performance by
- * e.g. precomputing stuff, or support higher level functionality not provided by JCA (e.g. JFK
- * connection setup). Much of it is a bit too low level.
+ * Cryptographic primitives and helpers used by the Crypta node.
+ *
+ * <p>This package provides implementations and thin wrappers around the Java Cryptography
+ * Architecture (JCA) and BouncyCastle to expose stable, provider-agnostic APIs and higher-level
+ * utilities. It includes authenticated encryption streams, hashing and MAC helpers, key generation
+ * and agreement utilities, and random sources.
+ *
+ * <p>Highlights:
+ *
+ * <ul>
+ *   <li>Streaming AEAD using AES-GCM via {@link network.crypta.crypt.AEADInputStream} and {@link
+ *       network.crypta.crypt.AEADOutputStream}. On-disk format uses a 16-byte written prefix where
+ *       the first 12 bytes form the GCM nonce and the remaining 4 bytes are reserved, plus a
+ *       16-byte authentication tag (total overhead: 32 bytes).
+ *   <li>Digest/MAC utilities: {@link network.crypta.crypt.Hash}, {@link network.crypta.crypt.HMAC},
+ *       and multi-hash streams ({@link network.crypta.crypt.MultiHashInputStream}, {@link
+ *       network.crypta.crypt.MultiHashOutputStream}).
+ *   <li>Asymmetric primitives and helpers: {@link network.crypta.crypt.ECDSA}, {@link
+ *       network.crypta.crypt.ECDH}, and key utilities ({@link network.crypta.crypt.KeyGenUtils},
+ *       {@link network.crypta.crypt.KeyType}).
+ *   <li>Block cipher helpers: {@link network.crypta.crypt.BlockCipher} abstractions and {@link
+ *       network.crypta.crypt.BlockCiphers} factory methods.
+ *   <li>Errors surfaced as checked exceptions where appropriate: {@link
+ *       network.crypta.crypt.CryptFormatException}, {@link
+ *       network.crypta.crypt.UnsupportedCipherException}, and {@link
+ *       network.crypta.crypt.UnsupportedTypeException}.
+ * </ul>
+ *
+ * <p>Threading and usage notes:
+ *
+ * <ul>
+ *   <li>Unless noted otherwise, types are not thread-safe. Create a fresh instance per use.
+ *   <li>For AEAD streams, integrity is verified at end-of-stream. Always fully consume or close the
+ *       stream and check for {@code IOException} to detect authentication failures.
+ *   <li>Do not reuse nonces/IVs outside the provided stream formats; {@link
+ *       network.crypta.crypt.AEADOutputStream} manages them for the on-disk format.
+ * </ul>
  */
 package network.crypta.crypt;


### PR DESCRIPTION
Summary
- Enhance JavaDoc across `network.crypta.crypt` exceptions and package docs.
- Clarify AEAD (AES‑GCM) on‑disk format in `package-info.java` and link to key classes.
- No functional changes; formatting applied via Spotless.

Scope
- `src/main/java/network/crypta/crypt/CryptFormatException.java`
  - Add class and constructor JavaDoc.
  - Note checked nature and cause preservation for `IOException` constructor.
- `src/main/java/network/crypta/crypt/UnsupportedCipherException.java`
  - Add class summary, references to JCA exceptions, and constructor docs.
- `src/main/java/network/crypta/crypt/UnsupportedTypeException.java`
  - Reframe description to enum‑centric usage; add constructor docs.
- `src/main/java/network/crypta/crypt/package-info.java`
  - Rewrite package docs to reflect current AES‑GCM streams and utilities.
  - Include usage/threads notes and list of notable types.

Notes
- Build/test unaffected; only comments and formatting changed.
- No public API signature changes.

Change origin
- 1 commit on `doc/crypt` since `develop`:
  - docs(crypt): improve Javadoc for exceptions and package docs; apply Spotless formatting

Checklist
- [x] Spotless formatting applied
- [x] No behavioral change
- [x] Compiles on Java 21+

Request
- Please review wording/clarity; technical correctness has been validated against current AES‑GCM stream behavior and recent AEAD notes in the repo docs.