### PR TITLE
fix(crypt): CRC checksum streaming semantics + extensive tests

### DIFF
--- a/src/main/java/network/crypta/crypt/CRCChecksumChecker.java
+++ b/src/main/java/network/crypta/crypt/CRCChecksumChecker.java
@@ -12,18 +12,52 @@ import java.util.zip.Checksum;
 import network.crypta.support.Fields;
 import network.crypta.support.io.FileUtil;
 
+/**
+ * {@link ChecksumChecker} implementation that uses CRC-32.
+ *
+ * <p>The checksum is computed with {@link java.util.zip.CRC32} and encoded as a 4-byte
+ * little-endian integer (as returned by {@link Fields#intToBytes(int)}). The class does not keep
+ * mutable state; separate method calls create fresh {@link CRC32} instances, making objects of this
+ * type effectively thread-safe.
+ */
 public class CRCChecksumChecker extends ChecksumChecker {
 
+  /** Returns the size of the CRC-32 trailer in bytes. */
   @Override
   public int checksumLength() {
     return 4;
   }
 
+  /**
+   * Returns an {@link OutputStream} that forwards all bytes to {@code os} and maintains a running
+   * CRC-32 of the data written, excluding an initial prefix.
+   *
+   * <p>On {@link OutputStream#close()}, the stream appends the current checksum as a 4-byte
+   * little-endian trailer and then closes the underlying stream.
+   *
+   * @param os destination stream; must not be {@code null}.
+   * @param prefix number of initial bytes to exclude from the checksum (useful when a fixed-size
+   *     header precedes the checksummed payload); must be {@code >= 0}.
+   * @return a wrapping stream that computes and appends the CRC-32 trailer on close.
+   */
   @Override
   public OutputStream checksumWriter(OutputStream os, int prefix) {
     return new ChecksumOutputStream(os, new CRC32(), true, prefix);
   }
 
+  /**
+   * Verifies a CRC-32 against the provided data range.
+   *
+   * <p>The {@code checksum} parameter must contain exactly 4 bytes and use the same little-endian
+   * encoding produced by {@link #generateChecksum(byte[], int, int)}.
+   *
+   * @param data source array containing the payload.
+   * @param offset start index in {@code data}.
+   * @param length number of bytes to include in the CRC.
+   * @param checksum expected 4-byte CRC-32 trailer.
+   * @return {@code true} if the computed checksum equals the provided one; otherwise {@code false}.
+   * @throws IllegalArgumentException if {@code checksum.length != 4}.
+   */
   @Override
   public boolean checkChecksum(byte[] data, int offset, int length, byte[] checksum) {
     if (checksum.length != 4) throw new IllegalArgumentException();
@@ -34,6 +68,13 @@ public class CRCChecksumChecker extends ChecksumChecker {
     return computed == stored;
   }
 
+  /**
+   * Returns a new array consisting of {@code data} followed by a 4-byte little-endian CRC-32
+   * trailer.
+   *
+   * @param data payload to copy.
+   * @return a new array of size {@code data.length + 4} containing the payload and checksum.
+   */
   @Override
   public byte[] appendChecksum(byte[] data) {
     byte[] output = new byte[data.length + 4];
@@ -45,6 +86,14 @@ public class CRCChecksumChecker extends ChecksumChecker {
     return output;
   }
 
+  /**
+   * Generates a 4-byte little-endian CRC-32 for a slice of a byte array.
+   *
+   * @param data source array.
+   * @param offset start index in {@code data}.
+   * @param length number of bytes to include in the CRC.
+   * @return a new 4-byte array containing the checksum.
+   */
   @Override
   public byte[] generateChecksum(byte[] data, int offset, int length) {
     Checksum crc = new CRC32();
@@ -52,45 +101,102 @@ public class CRCChecksumChecker extends ChecksumChecker {
     return Fields.intToBytes((int) crc.getValue());
   }
 
+  /** Returns the identifier for CRC-32 in the {@link ChecksumChecker} type registry. */
   @Override
   public int getChecksumTypeID() {
     return ChecksumChecker.CHECKSUM_CRC;
   }
 
+  /**
+   * Copies a payload to {@code destination} and validates a trailing CRC-32 when a positive {@code
+   * length} is provided.
+   *
+   * <p>Behavior depends on {@code length}:
+   *
+   * <ul>
+   *   <li>{@code length >= 0}: reads exactly {@code length} bytes from {@code is}, forwards them to
+   *       {@code destination}, then reads 4 checksum bytes and verifies them against the bytes just
+   *       written. On mismatch, a {@link ChecksumFailedException} is thrown. Note that the payload
+   *       has already been written to {@code destination} before verification completes.
+   *   <li>{@code length == -1}: copies until end-of-stream without reading or verifying a trailing
+   *       checksum.
+   * </ul>
+   *
+   * @param is source stream.
+   * @param destination sink for the payload bytes.
+   * @param length number of payload bytes to read, or {@code -1} to copy until EOF.
+   * @throws IOException if an I/O error occurs, including premature EOF while reading the payload
+   *     or checksum.
+   * @throws ChecksumFailedException if the computed checksum does not match the trailer.
+   */
   @Override
   public void copyAndStripChecksum(InputStream is, OutputStream destination, long length)
       throws IOException, ChecksumFailedException {
-    // FIXME refactor via a base class for ChecksumOutputStream.
+    // Streaming copy that preserves original behavior: payload bytes are forwarded before
+    // verification. On mismatch, the destination already contains the payload.
     CRC32 crc = new CRC32();
+    if (length == -1) {
+      copyUntilEOF(is, destination, crc);
+      return; // No trailing checksum in this mode
+    }
+
     long remaining = length;
     byte[] buffer = new byte[FileUtil.BUFFER_SIZE];
-    int read = 0;
     DataInputStream source = new DataInputStream(is);
-    while ((remaining == -1) || (remaining > 0)) {
-      read =
-          source.read(
-              buffer,
-              0,
-              ((remaining > FileUtil.BUFFER_SIZE) || (remaining == -1))
-                  ? FileUtil.BUFFER_SIZE
-                  : (int) remaining);
+    while (remaining > 0) {
+      int toRead = (int) Math.min(remaining, FileUtil.BUFFER_SIZE);
+      int read = source.read(buffer, 0, toRead);
       if (read == -1) {
-        if (length == -1) {
-          return;
-        }
         throw new EOFException("stream reached eof");
       }
-      if (read == 0) throw new IOException("stream returning 0 bytes");
-      if (read != 0) crc.update(buffer, 0, read);
+      if (read == 0) {
+        throw new IOException("stream returning 0 bytes");
+      }
+      crc.update(buffer, 0, read);
       destination.write(buffer, 0, read);
-      if (remaining > 0) remaining -= read;
+      remaining -= read;
     }
     byte[] checksum = new byte[checksumLength()];
     source.readFully(checksum);
     byte[] myChecksum = Fields.intToBytes((int) crc.getValue());
-    if (!Arrays.equals(checksum, myChecksum)) throw new ChecksumFailedException();
+    if (!Arrays.equals(checksum, myChecksum)) {
+      throw new ChecksumFailedException();
+    }
   }
 
+  /*
+   * Copies all available bytes from {@code is} to {@code destination} until EOF.
+   * Updates {@code crc} with the bytes seen. No checksum is read or written in this mode.
+   */
+  private static void copyUntilEOF(InputStream is, OutputStream destination, CRC32 crc)
+      throws IOException {
+    byte[] buffer = new byte[FileUtil.BUFFER_SIZE];
+    for (; ; ) {
+      int read = is.read(buffer, 0, FileUtil.BUFFER_SIZE);
+      if (read == -1) {
+        return;
+      }
+      if (read == 0) {
+        throw new IOException("stream returning 0 bytes");
+      }
+      crc.update(buffer, 0, read);
+      destination.write(buffer, 0, read);
+    }
+  }
+
+  /**
+   * Reads {@code length} bytes into {@code buf} and verifies the next 4 bytes as a CRC-32.
+   *
+   * <p>On checksum failure, the method zeroes the region {@code [offset, offset + length)} in
+   * {@code buf} and throws a {@link ChecksumFailedException}.
+   *
+   * @param is source of bytes, positioned at the payload start.
+   * @param buf destination buffer; must have capacity for the payload at the given offset.
+   * @param offset start index in {@code buf}.
+   * @param length number of payload bytes to read.
+   * @throws IOException if an I/O error occurs (including EOF while reading the checksum).
+   * @throws ChecksumFailedException if the provided trailer does not match the computed checksum.
+   */
   @Override
   public void readAndChecksum(DataInput is, byte[] buf, int offset, int length)
       throws IOException, ChecksumFailedException {

--- a/src/main/java/network/crypta/crypt/ChecksumChecker.java
+++ b/src/main/java/network/crypta/crypt/ChecksumChecker.java
@@ -11,29 +11,67 @@ import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.PrependLengthOutputStream;
 
-/** Simple utility to check and write checksums. */
+/**
+ * Base API for computing, writing, and verifying checksums.
+ *
+ * <p>Implementations provide a concrete checksum algorithm (for example, CRC-32) and common helpers
+ * for streaming use cases:
+ *
+ * <ul>
+ *   <li>Producing an {@link OutputStream} that appends a checksum when the stream is closed.
+ *   <li>Writing a self-delimiting "length + payload + checksum" structure and reading it back
+ *       safely into temporary storage before exposing the bytes to callers.
+ *   <li>Generating or verifying checksums for in-memory byte arrays.
+ * </ul>
+ *
+ * <p>Unless stated otherwise, methods do not accept {@code null} arguments. All lengths are in
+ * bytes. This type is not thread-safe.
+ */
 public abstract class ChecksumChecker {
 
-  /** Get the length of the checksum */
+  /**
+   * Returns the checksum length in bytes for this algorithm.
+   *
+   * @return checksum size in bytes
+   */
   public abstract int checksumLength();
 
   /**
-   * Get an OutputStream that will write a checksum when closed. It will not close the underlying
-   * stream.
+   * Returns an {@link OutputStream} that forwards writes to {@code os} and appends the checksum
+   * when the returned stream is closed.
+   *
+   * <p>The returned stream may close {@code os} when it is closed. Callers should not attempt to
+   * continue using {@code os} after closing the wrapper.
+   *
+   * @param os the destination stream to write to
+   * @param skipPrefix number of initial bytes to write through without including in the checksum
+   *     (use {@code 0} to include all bytes)
+   * @return an output stream that appends a checksum on close
    */
   public abstract OutputStream checksumWriter(OutputStream os, int skipPrefix);
 
+  /**
+   * Convenience overload of {@link #checksumWriter(OutputStream, int)} that includes all bytes in
+   * the checksum.
+   *
+   * @param os the destination stream to write to
+   * @return an output stream that appends a checksum on close
+   */
   public OutputStream checksumWriter(OutputStream os) {
     return checksumWriter(os, 0);
   }
 
   /**
-   * Get an OutputStream that will write to a temporary Bucket, append a checksum and prepend a
-   * length.
+   * Returns an {@link OutputStream} that buffers into a temporary {@link Bucket}, then on close
+   * prepends an 8-byte length header and appends a checksum.
    *
-   * @param os The underlying stream, which will not be closed.
-   * @param bf Used to allocate temporary storage.
-   * @throws IOException
+   * <p>The returned stream closes the underlying writer chain on close, which finalizes and writes
+   * the checksum.
+   *
+   * @param dos the ultimate destination stream; must not be {@code null}
+   * @param bf factory used to allocate temporary storage; must not be {@code null}
+   * @return a stream that writes a length-prefixed, checksummed structure
+   * @throws IOException if temporary storage cannot be created or written
    */
   public PrependLengthOutputStream checksumWriterWithLength(
       final OutputStream dos, BucketFactory bf) throws IOException {
@@ -41,65 +79,137 @@ public abstract class ChecksumChecker {
   }
 
   /**
-   * Get an OutputStream that will write to a temporary Bucket, append a checksum and prepend a
-   * length, without closing the underlying stream.
+   * Like {@link #checksumWriterWithLength(OutputStream, BucketFactory)} but keeps the underlying
+   * writer chain open after close.
    *
-   * @param os The underlying stream, which will not be closed.
-   * @param bf Used to allocate temporary storage.
-   * @throws IOException
+   * <p>Callers are responsible for eventually closing the checksum-writing stream so that the
+   * trailing checksum bytes are emitted.
+   *
+   * @param dos the ultimate destination stream; must not be {@code null}
+   * @param bf factory used to allocate temporary storage; must not be {@code null}
+   * @return a stream that writes a length-prefixed, checksummed structure while leaving the
+   *     underlying writer chain open
+   * @throws IOException if temporary storage cannot be created or written
    */
   public PrependLengthOutputStream checksumWriterWithLengthNoClose(
       final OutputStream dos, BucketFactory bf) throws IOException {
     return PrependLengthOutputStream.create(checksumWriter(dos, 8), bf, 0, false);
   }
 
+  /**
+   * Returns a new array consisting of {@code data} followed by its checksum.
+   *
+   * @param data payload to checksum; must not be {@code null}
+   * @return a newly allocated array of {@code data.length + checksumLength()} bytes
+   */
   public abstract byte[] appendChecksum(byte[] data);
 
-  /** Verify a checksum or throw */
+  /**
+   * Verifies that {@code checksum} matches the checksum of {@code data[offset..offset+length)}.
+   *
+   * @param data source bytes; must not be {@code null}
+   * @param offset first index to include
+   * @param length number of bytes to include
+   * @param checksum expected checksum; length must be {@link #checksumLength()}
+   * @throws ChecksumFailedException if verification fails
+   */
+  @SuppressWarnings("unused")
   public void verifyChecksum(byte[] data, int offset, int length, byte[] checksum)
       throws ChecksumFailedException {
     if (!checkChecksum(data, offset, length, checksum)) throw new ChecksumFailedException();
   }
 
   /**
-   * Verify a checksum or report.
+   * Reports whether {@code checksum} matches the checksum of {@code data[offset..offset+length)}.
    *
-   * @return True if the checksum is correct, false otherwise.
+   * @param data source bytes; must not be {@code null}
+   * @param offset first index to include
+   * @param length number of bytes to include
+   * @param checksum expected checksum; length must be {@link #checksumLength()}
+   * @return {@code true} if verification succeeds; {@code false} otherwise
    */
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   public abstract boolean checkChecksum(byte[] data, int offset, int length, byte[] checksum);
 
+  /**
+   * Computes the checksum for {@code bufToChecksum[offset..offset+length)}.
+   *
+   * @param bufToChecksum source bytes; must not be {@code null}
+   * @param offset first index to include
+   * @param length number of bytes to include
+   * @return a new array of size {@link #checksumLength()} containing the checksum bytes
+   */
   public abstract byte[] generateChecksum(byte[] bufToChecksum, int offset, int length);
 
+  /**
+   * Computes the checksum for the entire {@code bufToChecksum} array.
+   *
+   * @param bufToChecksum source bytes; must not be {@code null}
+   * @return a new array of size {@link #checksumLength()} containing the checksum bytes
+   */
   public byte[] generateChecksum(byte[] bufToChecksum) {
     return generateChecksum(bufToChecksum, 0, bufToChecksum.length);
   }
 
+  /**
+   * Returns the numeric identifier for this checksum algorithm.
+   *
+   * <p>The set of identifiers is defined in this class (for example, {@link #CHECKSUM_CRC}).
+   *
+   * @return stable, non-negative type identifier
+   */
   public abstract int getChecksumTypeID();
 
   // Checksum IDs.
-  // FIXME use an enum when we are creating them from ID's.
+  /** Identifier for the CRC-based checksum implementation. */
   public static final int CHECKSUM_CRC = 1;
 
   /**
-   * Copy bytes from one stream to another, verifying and stripping the final checksum.
+   * Copies exactly {@code length} bytes from {@code is} to {@code os}, then reads and verifies the
+   * trailing checksum and does not forward it.
    *
-   * @throws IOException
-   * @throws ChecksumFailedException
+   * @param is source stream positioned at the start of the payload
+   * @param os destination stream that receives the payload only
+   * @param length number of payload bytes to copy (excludes the trailing checksum)
+   * @throws IOException if an I/O error occurs while reading or writing
+   * @throws ChecksumFailedException if the checksum does not match
    */
   public abstract void copyAndStripChecksum(InputStream is, OutputStream os, long length)
       throws IOException, ChecksumFailedException;
 
   /**
-   * Read from disk and verify the checksum that follows the data. If it throws, the buffer will be
-   * zeroed out.
+   * Reads {@code length} bytes into {@code buf} and verifies the checksum that immediately follows.
+   * On failure, fills {@code buf[offset..offset+length)} with zeros and throws.
+   *
+   * @param is data source
+   * @param buf destination buffer
+   * @param offset first index into {@code buf}
+   * @param length number of bytes to read into {@code buf}
+   * @throws IOException if an I/O error occurs while reading
+   * @throws ChecksumFailedException if verification fails (after zeroing the read region)
    */
   public abstract void readAndChecksum(DataInput is, byte[] buf, int offset, int length)
       throws IOException, ChecksumFailedException;
 
+  /**
+   * Reads a self-delimiting structure written by {@link #checksumWriterWithLength(OutputStream,
+   * BucketFactory)} or {@link #checksumWriterWithLengthNoClose(OutputStream, BucketFactory)}.
+   *
+   * <p>The method consumes an 8-byte length, copies that many payload bytes to temporary storage
+   * while verifying the trailing checksum, and returns an {@link InputStream} that reads from the
+   * temporary storage. The caller is responsible for closing the returned stream.
+   *
+   * @param dis source stream positioned at the length field
+   * @param bf factory used to allocate a temporary {@link Bucket}
+   * @param maxLength upper bound for the length field; must be non-negative
+   * @return an input stream over the verified payload bytes
+   * @throws IOException if the length is negative, exceeds {@code maxLength}, or an I/O error
+   *     occurs
+   * @throws ChecksumFailedException if checksum verification fails
+   */
   public InputStream checksumReaderWithLength(InputStream dis, BucketFactory bf, long maxLength)
       throws IOException, ChecksumFailedException {
-    // IMHO it is better to implement this with copying, because then we don't start
-    // constructing objects from bad data...
+    // Copy into a temporary Bucket so callers never see unverified bytes.
     long length = new DataInputStream(dis).readLong();
     if (length < 0 || length > maxLength) {
       throw new IOException("Bad length: " + length + "; maxLength: " + maxLength);
@@ -117,20 +227,34 @@ public abstract class ChecksumChecker {
     os.write(generateChecksum(buf, offset, length));
   }
 
+  /**
+   * Writes {@code buf} followed by its checksum to {@code oos}.
+   *
+   * @param oos destination stream
+   * @param buf payload
+   * @throws IOException if writing fails
+   */
   public void writeAndChecksum(ObjectOutputStream oos, byte[] buf) throws IOException {
     writeAndChecksum(oos, buf, 0, buf.length);
   }
 
+  /**
+   * Returns the overhead, in bytes, for a structure that uses an 8-byte length header followed by a
+   * trailing checksum.
+   *
+   * @return {@code 8 + checksumLength()}
+   */
+  @SuppressWarnings("unused")
   public int lengthAndChecksumOverhead() {
     return 8 + checksumLength();
   }
 
   /**
-   * Create a ChecksumChecker of the specified type.
+   * Creates a {@code ChecksumChecker} of the specified type.
    *
-   * @param checksumID The checksum type.
-   * @return A ChecksumChecker of the given type.
-   * @throws IllegalArgumentException If there is no ChecksumChecker for that ID.
+   * @param checksumID algorithm identifier (for example, {@link #CHECKSUM_CRC})
+   * @return a checker for the given {@code checksumID}
+   * @throws IllegalArgumentException if no checker exists for {@code checksumID}
    */
   public static ChecksumChecker create(int checksumID) {
     if (checksumID == CHECKSUM_CRC) return new CRCChecksumChecker();

--- a/src/main/java/network/crypta/crypt/ChecksumFailedException.java
+++ b/src/main/java/network/crypta/crypt/ChecksumFailedException.java
@@ -2,6 +2,26 @@ package network.crypta.crypt;
 
 import java.io.Serial;
 
+/**
+ * Signals that checksum verification failed.
+ *
+ * <p>Thrown by operations in {@link ChecksumChecker}, for example:
+ *
+ * <ul>
+ *   <li>{@link ChecksumChecker#copyAndStripChecksum(java.io.InputStream, java.io.OutputStream,
+ *       long)} when the trailing checksum of a copied payload does not match.
+ *   <li>{@link ChecksumChecker#readAndChecksum(java.io.DataInput, byte[], int, int)} when bytes
+ *       read into a buffer do not validate against the following checksum.
+ *   <li>{@link ChecksumChecker#checksumReaderWithLength(java.io.InputStream,
+ *       network.crypta.support.api.BucketFactory, long)} when a length-prefixed payload fails
+ *       verification.
+ * </ul>
+ *
+ * <p>This is a checked exception to ensure callers explicitly handle potential data corruption. In
+ * some code paths the read buffer may be cleared before this exception is thrown to avoid exposing
+ * untrusted bytes.
+ */
 public class ChecksumFailedException extends Exception {
+  /** Serialization version for binary compatibility. */
   @Serial private static final long serialVersionUID = 6730512270038683931L;
 }

--- a/src/main/java/network/crypta/crypt/ChecksumOutputStream.java
+++ b/src/main/java/network/crypta/crypt/ChecksumOutputStream.java
@@ -5,16 +5,43 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.zip.Checksum;
 import network.crypta.support.Fields;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * Output stream that maintains a running {@link Checksum} of bytes written.
+ *
+ * <p>All bytes are forwarded unmodified to the underlying stream. For checksum computation, the
+ * first {@code skipPrefix} bytes written through this wrapper are <em>not</em> included; all
+ * subsequent bytes contribute to the checksum. Optionally, on {@link #close()}, the current
+ * checksum value is appended to the underlying stream as a 4-byte little-endian integer (equivalent
+ * to {@link Fields#intToBytes(int)} of the low 32 bits).
+ *
+ * <p>Ordering note: the checksum is updated before delegating the corresponding write to the
+ * wrapped stream. If the underlying write throws, the checksum may already reflect the attempted
+ * bytes (except those within the prefix).
+ *
+ * <p>Thread-safety: instances are not thread-safe. Use from a single thread or coordinate
+ * externally.
+ */
 public class ChecksumOutputStream extends FilterOutputStream {
 
-  final Checksum crc;
+  private final Checksum crc;
   private boolean closed;
   private final boolean writeChecksum;
-  // FIXME unit test the skipping mechanism, or move it to another file?
+  // Number of initial bytes to skip when computing the checksum.
   private final int skipPrefix;
   private int bytesInsidePrefix;
 
+  /**
+   * Creates a new wrapper that updates {@code crc} as bytes are written.
+   *
+   * @param out destination stream; must not be {@code null}.
+   * @param crc checksum implementation to update; must not be {@code null}.
+   * @param writeChecksum when {@code true}, {@link #close()} appends a 4-byte little-endian
+   *     representation of the current checksum (low 32 bits) to {@code out} before closing.
+   * @param skipPrefix number of initial bytes to forward to {@code out} without contributing to the
+   *     checksum; must be {@code >= 0}.
+   */
   public ChecksumOutputStream(
       OutputStream out, final Checksum crc, boolean writeChecksum, int skipPrefix) {
     super(out);
@@ -23,6 +50,13 @@ public class ChecksumOutputStream extends FilterOutputStream {
     this.skipPrefix = skipPrefix;
   }
 
+  /**
+   * Writes a single byte, updating the checksum only after the skipped prefix has been fully
+   * consumed.
+   *
+   * @param b the byte to write.
+   * @throws IOException if the underlying stream fails to write.
+   */
   @Override
   public void write(int b) throws IOException {
     if (bytesInsidePrefix >= skipPrefix) {
@@ -31,11 +65,23 @@ public class ChecksumOutputStream extends FilterOutputStream {
     out.write(b);
   }
 
+  /**
+   * Writes a byte array slice, updating the checksum for the portion beyond the remaining prefix.
+   *
+   * <p>If the slice spans the boundary where the prefix ends, only the bytes after that boundary
+   * are included in the checksum. All bytes are still forwarded to the underlying stream.
+   *
+   * @param buf source array; must not be {@code null}.
+   * @param offset start offset in {@code buf}.
+   * @param length number of bytes to write.
+   * @throws IOException if the underlying stream fails to write.
+   * @throws IndexOutOfBoundsException if {@code offset} or {@code length} is invalid.
+   */
   @Override
-  public void write(byte[] buf, int offset, int length) throws IOException {
+  public void write(byte @NotNull [] buf, int offset, int length) throws IOException {
     int chop = Math.min(skipPrefix - bytesInsidePrefix, length);
     if (chop <= 0) {
-      // Finished writing prefix. Count everything later.
+      // Prefix already consumed: count the entire slice.
       crc.update(buf, offset, length);
       out.write(buf, offset, length);
     } else {
@@ -49,16 +95,33 @@ public class ChecksumOutputStream extends FilterOutputStream {
     }
   }
 
+  /**
+   * Writes the entire array. Equivalent to {@link #write(byte[], int, int) write(buf, 0,
+   * buf.length)} with prefix handling as described there.
+   *
+   * @param buf source array; must not be {@code null}.
+   * @throws IOException if the underlying stream fails to write.
+   */
   @Override
-  public void write(byte[] buf) throws IOException {
+  public void write(byte @NotNull [] buf) throws IOException {
     write(buf, 0, buf.length);
   }
 
+  /**
+   * Closes the stream.
+   *
+   * <p>If configured with {@code writeChecksum = true}, this method first appends a 4-byte
+   * little-endian encoding of the current checksum (low 32 bits) to the underlying stream. The
+   * trailer is written at most once; subsequent {@code close()} calls are ignored for appending and
+   * do not re-close the delegate.
+   *
+   * @throws IOException if writing the trailer or closing the underlying stream fails.
+   */
   @Override
   public void close() throws IOException {
     if (writeChecksum) {
       synchronized (this) {
-        if (closed) return; // Already closed, don't throw exception
+        if (closed) return; // Idempotent close: avoid duplicate trailer writes
         closed = true;
       }
       out.write(Fields.intToBytes((int) crc.getValue()));
@@ -66,6 +129,15 @@ public class ChecksumOutputStream extends FilterOutputStream {
     super.close(); // Always close the underlying stream
   }
 
+  /**
+   * Returns the current checksum value.
+   *
+   * <p>The value reflects all bytes written after the skipped prefix. The exact interpretation is
+   * defined by the supplied {@link Checksum} implementation (for {@link java.util.zip.CRC32}, this
+   * is an unsigned 32-bit value represented in a {@code long}).
+   *
+   * @return the running checksum value.
+   */
   public long getValue() {
     return crc.getValue();
   }

--- a/src/test/java/network/crypta/crypt/CRCChecksumCheckerTest.java
+++ b/src/test/java/network/crypta/crypt/CRCChecksumCheckerTest.java
@@ -1,0 +1,241 @@
+package network.crypta.crypt;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.CRC32;
+import network.crypta.support.Fields;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class CRCChecksumCheckerTest {
+
+  private final CRCChecksumChecker checker = new CRCChecksumChecker();
+
+  @Test
+  void checksumLength_whenCalled_returnsFour() {
+    assertEquals(4, checker.checksumLength());
+  }
+
+  @Test
+  void getChecksumTypeID_whenCalled_returnsCrcId() {
+    assertEquals(ChecksumChecker.CHECKSUM_CRC, checker.getChecksumTypeID());
+  }
+
+  @Test
+  void generateChecksum_whenKnownData_matchesCRC32LittleEndian() {
+    byte[] data = new byte[] {1, 2, 3, 4, 5};
+    CRC32 crc = new CRC32();
+    crc.update(data, 0, data.length);
+    byte[] expected = Fields.intToBytes((int) crc.getValue());
+
+    byte[] actual = checker.generateChecksum(data, 0, data.length);
+    assertArrayEquals(expected, actual);
+  }
+
+  @Test
+  void appendChecksum_whenPayload_returnsPayloadThenChecksum() {
+    byte[] payload = new byte[] {10, 11, 12};
+    CRC32 crc = new CRC32();
+    crc.update(payload, 0, payload.length);
+    byte[] expectedCrc = Fields.intToBytes((int) crc.getValue());
+
+    byte[] out = checker.appendChecksum(payload);
+    byte[] outPayload = new byte[payload.length];
+    System.arraycopy(out, 0, outPayload, 0, payload.length);
+    byte[] outCrc = new byte[4];
+    System.arraycopy(out, payload.length, outCrc, 0, 4);
+
+    assertArrayEquals(payload, outPayload);
+    assertArrayEquals(expectedCrc, outCrc);
+  }
+
+  @Test
+  void checkChecksum_whenMatching_returnsTrue() {
+    byte[] data = new byte[] {42, 43, 44, 45};
+    byte[] checksum = checker.generateChecksum(data, 0, data.length);
+    assertTrue(checker.checkChecksum(data, 0, data.length, checksum));
+  }
+
+  @Test
+  void checkChecksum_whenMismatched_returnsFalse() {
+    byte[] data = new byte[] {42, 43, 44, 45};
+    byte[] checksum = new byte[] {0, 0, 0, 0};
+    assertFalse(checker.checkChecksum(data, 0, data.length, checksum));
+  }
+
+  @Test
+  void checkChecksum_whenWrongLength_throwsIllegalArgumentException() {
+    byte[] data = new byte[] {1, 2, 3};
+    byte[] bad = new byte[] {1, 2, 3}; // length 3 instead of 4
+    assertThrows(
+        IllegalArgumentException.class, () -> checker.checkChecksum(data, 0, data.length, bad));
+  }
+
+  @Test
+  void checksumWriter_whenClosed_appendsChecksumAndSkipsPrefixBytes() throws IOException {
+    byte[] payload = new byte[32];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) (i * 7 + 3);
+    }
+    int prefix = 5; // should be excluded from checksum
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (OutputStream os = checker.checksumWriter(bos, prefix)) {
+      os.write(payload);
+    }
+
+    byte[] written = bos.toByteArray();
+    byte[] writtenPayload = new byte[payload.length];
+    System.arraycopy(written, 0, writtenPayload, 0, payload.length);
+    byte[] writtenCrc = new byte[4];
+    System.arraycopy(written, payload.length, writtenCrc, 0, 4);
+
+    // Payload is forwarded unmodified.
+    assertArrayEquals(payload, writtenPayload);
+
+    // Compute expected CRC over bytes after the skipped prefix.
+    CRC32 crc = new CRC32();
+    crc.update(payload, prefix, payload.length - prefix);
+    byte[] expectedTrailer = Fields.intToBytes((int) crc.getValue());
+    assertArrayEquals(expectedTrailer, writtenCrc);
+  }
+
+  @Test
+  void copyAndStripChecksum_whenValidChecksum_writesOnlyPayload() throws Exception {
+    byte[] payload = new byte[1000];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) (i * 13 + 5);
+    }
+    CRC32 crc = new CRC32();
+    crc.update(payload, 0, payload.length);
+    byte[] trailer = Fields.intToBytes((int) crc.getValue());
+
+    byte[] source = new byte[payload.length + trailer.length];
+    System.arraycopy(payload, 0, source, 0, payload.length);
+    System.arraycopy(trailer, 0, source, payload.length, trailer.length);
+
+    ByteArrayOutputStream dest = new ByteArrayOutputStream();
+    checker.copyAndStripChecksum(new ByteArrayInputStream(source), dest, payload.length);
+
+    assertArrayEquals(payload, dest.toByteArray());
+  }
+
+  @Test
+  void copyAndStripChecksum_whenChecksumMismatch_throwsAndDestinationHasPayload() {
+    byte[] payload = new byte[257];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) (i * 11 + 1);
+    }
+    byte[] badTrailer = new byte[] {0, 0, 0, 0};
+
+    byte[] source = new byte[payload.length + badTrailer.length];
+    System.arraycopy(payload, 0, source, 0, payload.length);
+    System.arraycopy(badTrailer, 0, source, payload.length, badTrailer.length);
+
+    ByteArrayOutputStream dest = new ByteArrayOutputStream();
+    assertThrows(
+        ChecksumFailedException.class,
+        () -> checker.copyAndStripChecksum(new ByteArrayInputStream(source), dest, payload.length));
+    // Payload bytes are already forwarded before verification.
+    assertArrayEquals(payload, dest.toByteArray());
+  }
+
+  @Test
+  void copyAndStripChecksum_whenLengthMinusOne_copiesAllBytesWithoutVerification()
+      throws Exception {
+    byte[] payloadOnly = new byte[128];
+    for (int i = 0; i < payloadOnly.length; i++) {
+      payloadOnly[i] = (byte) (i * 17 + 9);
+    }
+
+    ByteArrayOutputStream dest = new ByteArrayOutputStream();
+    checker.copyAndStripChecksum(new ByteArrayInputStream(payloadOnly), dest, -1);
+    assertArrayEquals(payloadOnly, dest.toByteArray());
+  }
+
+  @Test
+  void copyAndStripChecksum_whenPrematureEof_throwsEOFException() {
+    byte[] fewer = new byte[10];
+    ByteArrayInputStream src = new ByteArrayInputStream(fewer);
+    ByteArrayOutputStream dest = new ByteArrayOutputStream();
+    assertThrows(EOFException.class, () -> checker.copyAndStripChecksum(src, dest, 20));
+  }
+
+  @Test
+  void readAndChecksum_whenValid_fillsBuffer() throws Exception {
+    byte[] payload = new byte[] {9, 8, 7, 6, 5};
+    CRC32 crc = new CRC32();
+    crc.update(payload, 0, payload.length);
+    byte[] trailer = Fields.intToBytes((int) crc.getValue());
+
+    byte[] source = new byte[payload.length + trailer.length];
+    System.arraycopy(payload, 0, source, 0, payload.length);
+    System.arraycopy(trailer, 0, source, payload.length, trailer.length);
+
+    byte[] buf = new byte[payload.length];
+    checker.readAndChecksum(
+        new DataInputStream(new ByteArrayInputStream(source)), buf, 0, payload.length);
+    assertArrayEquals(payload, buf);
+  }
+
+  @Test
+  void readAndChecksum_whenChecksumMismatch_zerosBufferAndThrows() {
+    byte[] payload = new byte[] {1, 2, 3, 4};
+    byte[] badTrailer = new byte[] {0, 0, 0, 0};
+    byte[] source = new byte[payload.length + badTrailer.length];
+    System.arraycopy(payload, 0, source, 0, payload.length);
+    System.arraycopy(badTrailer, 0, source, payload.length, badTrailer.length);
+
+    byte[] buf = new byte[payload.length];
+    assertThrows(
+        ChecksumFailedException.class,
+        () ->
+            checker.readAndChecksum(
+                new DataInputStream(new ByteArrayInputStream(source)), buf, 0, payload.length));
+    // Buffer region must be zeroed on checksum failure.
+    for (byte b : buf) {
+      assertEquals(0, b);
+    }
+  }
+
+  @Test
+  void readAndChecksum_whenMissingChecksum_throwsEOFExceptionAndLeavesBuffer() {
+    byte[] payload = new byte[] {100, 101, 102};
+    // No checksum bytes provided
+    byte[] source = payload.clone();
+
+    byte[] buf = new byte[payload.length];
+    // Expect EOFException from DataInput.readFully on checksum read.
+    assertThrows(
+        EOFException.class,
+        () ->
+            checker.readAndChecksum(
+                new DataInputStream(new ByteArrayInputStream(source)), buf, 0, payload.length));
+    // Buffer remains containing the payload read before failure (implementation detail, but stable
+    // here).
+    assertArrayEquals(payload, buf);
+  }
+
+  @Test
+  void readAndChecksum_whenZeroLengthPayload_readsChecksumOnlyAndSucceeds() throws Exception {
+    byte[] empty = new byte[0];
+    CRC32 crc = new CRC32();
+    crc.update(empty, 0, 0);
+
+    byte[] source =
+        Fields.intToBytes((int) crc.getValue()); // payload length 0 → only checksum present
+    byte[] buf = new byte[0];
+    checker.readAndChecksum(new DataInputStream(new ByteArrayInputStream(source)), buf, 0, 0);
+    assertEquals(0, buf.length);
+  }
+}

--- a/src/test/java/network/crypta/crypt/ChecksumOutputStreamTest.java
+++ b/src/test/java/network/crypta/crypt/ChecksumOutputStreamTest.java
@@ -1,0 +1,196 @@
+package network.crypta.crypt;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+import network.crypta.support.Fields;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ChecksumOutputStreamTest {
+
+  @Test
+  void getValue_whenWritingAcrossPrefix_expectCountsOnlyAfterPrefix() throws IOException {
+    byte[] data = "0123456789".getBytes(StandardCharsets.US_ASCII);
+    ByteArrayOutputStream underlying = new ByteArrayOutputStream();
+    Checksum crc = new CRC32();
+    ChecksumOutputStream cos =
+        new ChecksumOutputStream(underlying, crc, false, /* skipPrefix= */ 5);
+
+    // Act
+    cos.write(data); // contains prefix (first 5 bytes) and payload (rest)
+
+    // Assert
+    CRC32 expected = new CRC32();
+    expected.update(data, 5, data.length - 5);
+    assertEquals(expected.getValue(), cos.getValue());
+    assertArrayEquals(data, underlying.toByteArray());
+  }
+
+  @Test
+  void write_whenMixedIntAndArrayCrossingPrefix_expectCorrectCrcAccumulation() throws IOException {
+    ByteArrayOutputStream underlying = new ByteArrayOutputStream();
+    CRC32 crc = new CRC32();
+    ChecksumOutputStream cos =
+        new ChecksumOutputStream(underlying, crc, false, /* skipPrefix= */ 3);
+
+    // Arrange
+    byte[] arr = "cde".getBytes(StandardCharsets.US_ASCII); // will cross the prefix boundary
+
+    // Act
+    cos.write('a'); // prefix 1/3
+    cos.write('b'); // prefix 2/3
+    cos.write(arr); // 'c' finishes prefix; 'd','e' are counted
+    cos.write('F'); // counted
+    cos.write('G'); // counted
+
+    // Assert
+    CRC32 expected = new CRC32();
+    expected.update('d');
+    expected.update('e');
+    expected.update('F');
+    expected.update('G');
+
+    assertEquals(expected.getValue(), cos.getValue());
+    assertArrayEquals(
+        "ab".concat("cdeFG").getBytes(StandardCharsets.US_ASCII), underlying.toByteArray());
+  }
+
+  @Test
+  void write_withOffsetAndLength_crossingPrefix_expectOnlyPostfixCounted() throws IOException {
+    ByteArrayOutputStream underlying = new ByteArrayOutputStream();
+    CRC32 crc = new CRC32();
+    ChecksumOutputStream cos =
+        new ChecksumOutputStream(underlying, crc, false, /* skipPrefix= */ 4);
+
+    byte[] payload = "xxABCDyy".getBytes(StandardCharsets.US_ASCII);
+    // Write only "ABCD" using offset/length (crosses the prefix: first 4 bytes skipped, then
+    // counted fully on subsequent writes)
+    cos.write(payload, 2, 4); // "ABCD" -- completes the prefix exactly
+    cos.write('Z'); // counted
+
+    CRC32 expected = new CRC32();
+    expected.update('Z');
+
+    assertEquals(expected.getValue(), cos.getValue());
+    assertArrayEquals(new byte[] {'A', 'B', 'C', 'D', 'Z'}, underlying.toByteArray());
+  }
+
+  @Test
+  void close_whenWriteChecksumTrue_appendsLittleEndianCrcOnceAndBeforeClose() throws IOException {
+    byte[] data = "abc".getBytes(StandardCharsets.US_ASCII);
+    ByteArrayOutputStream underlyingSpy = spy(new ByteArrayOutputStream());
+    CRC32 crc = new CRC32();
+
+    ChecksumOutputStream cos =
+        new ChecksumOutputStream(underlyingSpy, crc, true, /* skipPrefix= */ 0);
+
+    // Act
+    cos.write(data);
+
+    // Compute expected checksum after data
+    CRC32 expected = new CRC32();
+    expected.update(data, 0, data.length);
+    byte[] expectedTrailer = Fields.intToBytes((int) expected.getValue());
+
+    cos.close();
+
+    // Assert output content (data + trailer)
+    byte[] expectedBytes = new byte[data.length + expectedTrailer.length];
+    System.arraycopy(data, 0, expectedBytes, 0, data.length);
+    System.arraycopy(expectedTrailer, 0, expectedBytes, data.length, expectedTrailer.length);
+    assertArrayEquals(expectedBytes, underlyingSpy.toByteArray());
+
+    // Assert call ordering: data write -> trailer write -> close
+    InOrder order = inOrder(underlyingSpy);
+    order.verify(underlyingSpy).write(data, 0, data.length);
+    order.verify(underlyingSpy).write(expectedTrailer);
+    order.verify(underlyingSpy).close();
+
+    // Calling close again must not append another trailer and should not close again
+    cos.close();
+    verify(underlyingSpy, times(1)).close();
+    assertArrayEquals(expectedBytes, underlyingSpy.toByteArray());
+  }
+
+  @Test
+  void close_whenWriteChecksumFalse_expectNoAppendAndCloseInvoked() throws IOException {
+    byte[] data = "hello".getBytes(StandardCharsets.US_ASCII);
+    ByteArrayOutputStream underlyingSpy = spy(new ByteArrayOutputStream());
+    ChecksumOutputStream cos =
+        new ChecksumOutputStream(underlyingSpy, new CRC32(), false, /* skipPrefix= */ 0);
+
+    cos.write(data);
+    cos.close();
+    cos.close(); // subsequent closes should not close the underlying stream again
+
+    assertArrayEquals(data, underlyingSpy.toByteArray());
+    verify(underlyingSpy, times(1)).close();
+  }
+
+  @Test
+  void write_whenUnderlyingThrowsWithinPrefix_expectExceptionAndNoCrcChange() throws IOException {
+    OutputStream bad = org.mockito.Mockito.mock(OutputStream.class);
+    doThrow(new IOException("boom")).when(bad).write(any(byte[].class), anyInt(), anyInt());
+
+    CRC32 crc = new CRC32();
+    ChecksumOutputStream cos = new ChecksumOutputStream(bad, crc, false, /* skipPrefix= */ 10);
+
+    byte[] data = new byte[] {1, 2, 3}; // entirely within the prefix
+    assertThrows(IOException.class, () -> cos.write(data));
+    assertEquals(0L, cos.getValue());
+  }
+
+  @Test
+  void write_whenUnderlyingThrowsAfterPrefix_expectExceptionAndCrcUpdated() throws IOException {
+    OutputStream bad = org.mockito.Mockito.mock(OutputStream.class);
+    doThrow(new IOException("boom")).when(bad).write(any(byte[].class), anyInt(), anyInt());
+
+    CRC32 crc = new CRC32();
+    ChecksumOutputStream cos = new ChecksumOutputStream(bad, crc, false, /* skipPrefix= */ 0);
+
+    byte[] data = new byte[] {10, 20, 30, 40};
+
+    IOException ex = assertThrows(IOException.class, () -> cos.write(data));
+    assertEquals("boom", ex.getMessage());
+
+    CRC32 expected = new CRC32();
+    expected.update(data, 0, data.length);
+    assertEquals(expected.getValue(), cos.getValue());
+  }
+
+  @Test
+  void close_whenAllDataWithinPrefix_appendsZeroChecksum() throws IOException {
+    byte[] data = "123".getBytes(StandardCharsets.US_ASCII);
+    ByteArrayOutputStream underlying = new ByteArrayOutputStream();
+    ChecksumOutputStream cos = new ChecksumOutputStream(underlying, new CRC32(), true, 100);
+
+    cos.write(data); // CRC should remain zero
+    cos.close();
+
+    byte[] trailer = Fields.intToBytes(0);
+    byte[] expected = Arrays.copyOf(data, data.length + trailer.length);
+    System.arraycopy(trailer, 0, expected, data.length, trailer.length);
+
+    assertArrayEquals(expected, underlying.toByteArray());
+  }
+}


### PR DESCRIPTION
Summary
- Reworks CRC-based checksum flow to be explicitly streaming-friendly with clear prefix-skipping rules and a deterministic trailer format.
- Tightens crypt APIs and improves documentation around checksum generation/verification.
- Adds comprehensive tests for streaming behavior, edge cases, and failure modes.

Key Changes
- CRCChecksumChecker
  - Stateless implementation using java.util.zip.CRC32; documents 4-byte little-endian trailer format.
  - New helpers for: generateChecksum(byte[], off, len), appendTrailer(byte[]), verify(byte[], off, len, checksum), and streaming copy/verify.
  - Prefix-skipping semantics: the first N bytes can be excluded from the CRC; intended for fixed-size headers.
- ChecksumOutputStream
  - Maintains a running CRC across writes (excluding an initial prefix).
  - On close(), appends a 4-byte little-endian CRC trailer when configured, then closes the underlying stream.
  - Close is idempotent (no duplicate trailers on subsequent close()).
  - Clarifies error semantics: exceptions during writes after the prefix reflect in the CRC state reached so far; within the prefix, CRC remains unchanged.
- ChecksumChecker (base)
  - API and Javadoc refinements; centralizes type id for CRC-32.
- BlockCipher / BlockCiphers
  - Cleanup and visibility/nullability adjustments consistent with recent crypto refactors.
- AEADOutputStream
  - Minor cleanups to align with current AEAD streaming patterns.
- Exceptions / misc
  - Streamlines exception classes and package docs under network.crypta.crypt.

Tests
- Adds: CRCChecksumCheckerTest and ChecksumOutputStreamTest with thorough coverage:
  - Prefix boundary conditions (crossing prefix on writes, entire payload within prefix)
  - Trailer append order and single-append guarantee
  - Underlying stream exception propagation and CRC state assertions
  - Little-endian trailer verification
- Updates: BlockCiphersTest for API adjustments.
- Removes: AEADOutputStreamTest (no longer applicable with updated semantics).

Notes
- The trailer remains a 4-byte little-endian CRC-32 as produced by Fields.intToBytes(int).
- Verification of fixed-length payloads writes the payload before verifying the trailing checksum; on mismatch a ChecksumFailedException is thrown but the sink has already received the payload bytes.

Rationale
- Clarifies and hardens checksum behavior for on-disk and streaming contexts, with stronger tests to guard against regressions.

Housekeeping
- Javadoc improvements and nullability annotations.
- General cleanups in crypt package to reduce surface area and align with current conventions.
