### PR TITLE
docs: improve DummyRandomSource Javadoc and add deterministic tests

### DIFF
--- a/src/main/java/network/crypta/crypt/DummyRandomSource.java
+++ b/src/main/java/network/crypta/crypt/DummyRandomSource.java
@@ -3,39 +3,109 @@ package network.crypta.crypt;
 import java.io.Serial;
 
 /**
+ * A simple, non-cryptographic pseudo-random source intended for tests and simulations.
+ *
+ * <p>This implementation extends {@link RandomSource} but deliberately ignores all external entropy
+ * inputs. Methods that accept entropy return {@code 0} to indicate that no entropy was
+ * incorporated. Randomness derives only from the internal deterministic state (seeded via the
+ * constructor or {@link #setSeed(long)} inherited from {@link RandomSource}).
+ *
+ * <p><strong>Security note:</strong> This class is not suitable for cryptographic purposes such as
+ * key generation, nonce creation, or any operation requiring unpredictability. Use a proper
+ * cryptographic RNG for security-sensitive tasks.
+ *
+ * <p>Thread-safety and other behavioral guarantees follow the contract of {@link RandomSource}.
+ *
  * @author amphibian
- *     <p>Not a real RNG at all, just a simple PRNG. Use it for e.g. simulations.
  */
 public class DummyRandomSource extends RandomSource {
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an unseeded instance. The actual initial state follows the semantics of the inherited
+   * random source.
+   */
   public DummyRandomSource() {}
 
+  /**
+   * Creates an instance seeded with the given value.
+   *
+   * @param seed initial seed used to set the internal deterministic state.
+   */
   public DummyRandomSource(long seed) {
     setSeed(seed);
   }
 
+  /**
+   * Accepts caller-provided entropy but discards it.
+   *
+   * <p>This dummy implementation does not mix in any external data and always reports that no
+   * entropy was used.
+   *
+   * @param source logical source of the entropy data.
+   * @param data entropy payload supplied by the caller.
+   * @param entropyGuess caller's estimate of the entropy carried by {@code data}.
+   * @return always {@code 0} to indicate that no entropy was incorporated.
+   */
   @Override
   public int acceptEntropy(EntropySource source, long data, int entropyGuess) {
     return 0;
   }
 
+  /**
+   * Accepts timer-derived entropy but discards it.
+   *
+   * @param timer logical timer source.
+   * @return always {@code 0} to indicate that no entropy was incorporated.
+   */
   @Override
   public int acceptTimerEntropy(EntropySource timer) {
     return 0;
   }
 
+  /**
+   * Accepts timer-derived entropy with a bias hint but discards it.
+   *
+   * <p>The {@code bias} parameter may be used by real implementations as a relative weighting hint.
+   * This dummy implementation ignores it.
+   *
+   * @param fnpTimingSource logical timer source.
+   * @param bias optional weighting hint for the provided timing data.
+   * @return always {@code 0} to indicate that no entropy was incorporated.
+   */
   @Override
   public int acceptTimerEntropy(EntropySource fnpTimingSource, double bias) {
     return 0;
   }
 
+  /**
+   * Accepts byte-based entropy but discards it.
+   *
+   * <p>The buffer region is defined by {@code offset} and {@code length}. A real implementation
+   * might read from {@code buf[offset..offset+length-1]}. This dummy implementation does not read
+   * or retain any data from the buffer and reports that no entropy was used.
+   *
+   * @param myPacketDataSource logical source of the byte data.
+   * @param buf input buffer that would contain entropy data.
+   * @param offset start position within {@code buf}.
+   * @param length number of bytes available from {@code buf} starting at {@code offset}.
+   * @param bias optional weighting hint for the provided data.
+   * @return always {@code 0} to indicate that no entropy was incorporated.
+   */
   @Override
   public int acceptEntropyBytes(
       EntropySource myPacketDataSource, byte[] buf, int offset, int length, double bias) {
     return 0;
   }
 
+  /**
+   * Closes this source.
+   *
+   * <p>This method is a no-op because the implementation holds only in-memory state and does not
+   * acquire external resources.
+   */
   @Override
-  public void close() {}
+  public void close() {
+    // No resources to release.
+  }
 }

--- a/src/test/java/network/crypta/crypt/DummyRandomSourceTest.java
+++ b/src/test/java/network/crypta/crypt/DummyRandomSourceTest.java
@@ -1,0 +1,179 @@
+package network.crypta.crypt;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class DummyRandomSourceTest {
+
+  @Test
+  void seededConstructor_whenSameSeed_producesIdenticalSequences() {
+    // Arrange
+    long seed = 123456789L;
+    DummyRandomSource r1 = new DummyRandomSource(seed);
+    DummyRandomSource r2 = new DummyRandomSource(seed);
+
+    // Act
+    int[] ints1 = new int[5];
+    int[] ints2 = new int[5];
+    long[] longs1 = new long[3];
+    long[] longs2 = new long[3];
+    byte[] bytes1 = new byte[32];
+    byte[] bytes2 = new byte[32];
+
+    for (int i = 0; i < ints1.length; i++) {
+      ints1[i] = r1.nextInt();
+      ints2[i] = r2.nextInt();
+    }
+    for (int i = 0; i < longs1.length; i++) {
+      longs1[i] = r1.nextLong();
+      longs2[i] = r2.nextLong();
+    }
+    r1.nextBytes(bytes1);
+    r2.nextBytes(bytes2);
+
+    // Assert
+    assertArrayEquals(ints2, ints1, "nextInt() sequences must match for identical seeds");
+    assertArrayEquals(longs2, longs1, "nextLong() sequences must match for identical seeds");
+    assertArrayEquals(bytes2, bytes1, "nextBytes() output must match for identical seeds");
+  }
+
+  @Test
+  void setSeed_whenCalled_resetsSequenceToSeededStart() {
+    // Arrange
+    DummyRandomSource r = new DummyRandomSource(98765L);
+    // burn some values
+    int before = r.nextInt();
+    long beforeLong = r.nextLong();
+
+    // Act
+    r.setSeed(42L);
+    DummyRandomSource expected = new DummyRandomSource(42L);
+
+    int[] intsActual = new int[4];
+    int[] intsExpected = new int[4];
+    for (int i = 0; i < intsActual.length; i++) {
+      intsActual[i] = r.nextInt();
+      intsExpected[i] = expected.nextInt();
+    }
+
+    // Assert
+    assertNotEquals(0, before ^ (int) beforeLong, "pre-seed-change values should be consumed");
+    assertArrayEquals(
+        intsExpected, intsActual, "setSeed must reset sequence to deterministic start");
+  }
+
+  @Test
+  void defaultConstructor_thenSetSeed_matchesSeededConstructor() {
+    // Arrange
+    long seed = 24680L;
+    DummyRandomSource r1 = new DummyRandomSource();
+    DummyRandomSource r2 = new DummyRandomSource(seed);
+
+    // Act
+    r1.setSeed(seed);
+    int[] a = new int[6];
+    int[] b = new int[6];
+    for (int i = 0; i < a.length; i++) {
+      a[i] = r1.nextInt();
+      b[i] = r2.nextInt();
+    }
+
+    // Assert
+    assertArrayEquals(b, a, "Sequences must be identical when seeds are equal");
+  }
+
+  @Test
+  void nextFullFloat_whenComparedWithNextInt_hasSameRawBits() {
+    // Arrange
+    long seed = 13579L;
+    DummyRandomSource rFloat = new DummyRandomSource(seed);
+    DummyRandomSource rInt = new DummyRandomSource(seed);
+
+    // Act
+    float f = rFloat.nextFullFloat();
+    int i = rInt.nextInt();
+
+    // Assert
+    assertEquals(
+        i, Float.floatToRawIntBits(f), "nextFullFloat must be constructed from nextInt bits");
+  }
+
+  @Test
+  void nextFullDouble_whenComparedWithNextLong_hasSameRawBits() {
+    // Arrange
+    long seed = 86420L;
+    DummyRandomSource rDouble = new DummyRandomSource(seed);
+    DummyRandomSource rLong = new DummyRandomSource(seed);
+
+    // Act
+    double d = rDouble.nextFullDouble();
+    long l = rLong.nextLong();
+
+    // Assert
+    assertEquals(
+        l, Double.doubleToRawLongBits(d), "nextFullDouble must be constructed from nextLong bits");
+  }
+
+  @Test
+  void acceptMethods_whenCalled_returnZeroAndPreserveSequence() {
+    // Arrange
+    long seed = 111L;
+    DummyRandomSource rAffected = new DummyRandomSource(seed);
+    DummyRandomSource rBaseline = new DummyRandomSource(seed);
+    EntropySource source = new EntropySource();
+
+    // Act
+    int ret1 = rAffected.acceptEntropy(source, 123L, 7);
+    int ret2 = rAffected.acceptTimerEntropy(source);
+    int ret3 = rAffected.acceptTimerEntropy(source, 1.25); // out-of-range bias should still be ok
+    int ret4 = rAffected.acceptEntropyBytes(source, null, 0, 0, -0.5); // null buffer allowed here
+
+    // Assert
+    assertEquals(0, ret1, "acceptEntropy must return 0");
+    assertEquals(0, ret2, "acceptTimerEntropy(timer) must return 0");
+    assertEquals(0, ret3, "acceptTimerEntropy(timer,bias) must return 0");
+    assertEquals(0, ret4, "acceptEntropyBytes must return 0");
+
+    // And PRNG stream must be unaffected by the above no-op methods
+    for (int i = 0; i < 10; i++) {
+      assertEquals(
+          rBaseline.nextInt(),
+          rAffected.nextInt(),
+          "Entropy-accepting methods must not disturb the PRNG sequence");
+    }
+  }
+
+  @Test
+  void acceptEntropyBytes_whenNormalBuffer_returnsZeroAndDoesNotThrow() {
+    // Arrange
+    DummyRandomSource r = new DummyRandomSource(999L);
+    EntropySource src = new EntropySource();
+    byte[] buf = new byte[8];
+
+    // Act & Assert
+    assertEquals(
+        0,
+        r.acceptEntropyBytes(src, buf, 2, 4, 1.0),
+        "Expected 0 from DummyRandomSource.acceptEntropyBytes");
+  }
+
+  @Test
+  void close_whenCalled_doesNotThrow_andPRNGStillWorks() {
+    // Arrange
+    DummyRandomSource r1 = new DummyRandomSource(77L);
+    DummyRandomSource r2 = new DummyRandomSource(77L);
+
+    // Act
+    assertDoesNotThrow(r1::close, "close() should be a no-op");
+
+    // Assert
+    for (int i = 0; i < 6; i++) {
+      assertEquals(r2.nextInt(), r1.nextInt(), "close() must not alter the PRNG sequence");
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Improve Javadoc for DummyRandomSource to clarify non-cryptographic intent, deterministic seeding, and no-op entropy acceptance.
- Add focused tests (DummyRandomSourceTest) for seeded determinism, setSeed behavior, nextFullFloat/nextFullDouble raw-bit parity, and that entropy-accept methods return 0 and do not affect the PRNG sequence.
- close() explicitly documented as a no-op; test ensures it does not alter sequence.

Notes
- No production logic changes; comments and tests only.
- Applied Gradle Spotless before committing.
- Merged origin/develop into the feature branch to ensure a clean, minimal diff.

Files
- src/main/java/network/crypta/crypt/DummyRandomSource.java
- src/test/java/network/crypta/crypt/DummyRandomSourceTest.java

Risk
- Low. Tests only exercise existing deterministic behavior; runtime code paths unchanged.