### PR TITLE
refactor(crypt): ECDH/ECDSA refactors; tests; docs

### DIFF
--- a/src/main/java/network/crypta/crypt/ECDH.java
+++ b/src/main/java/network/crypta/crypt/ECDH.java
@@ -53,19 +53,17 @@ public class ECDH {
       byte[] pubkey = pub.getEncoded();
       byte[] pkey = pk.getEncoded();
       if (pubkey.length > modulusSize || pubkey.length == 0)
-        throw new Error("Unexpected pubkey length: " + pubkey.length + "!=" + modulusSize);
+        throw new IllegalStateException(
+            "Unexpected pubkey length: " + pubkey.length + "!=" + modulusSize);
       PublicKey pub2 = kf.generatePublic(new X509EncodedKeySpec(pubkey));
-      if (!Arrays.equals(pub2.getEncoded(), pubkey)) throw new Error("Pubkey encoding mismatch");
-      PrivateKey pk2 = kf.generatePrivate(new PKCS8EncodedKeySpec(pkey));
-      /*
-               if(!Arrays.equals(pk2.getEncoded(), pkey))
-                   throw new Error("Pubkey encoding mismatch");
-      */
+      if (!Arrays.equals(pub2.getEncoded(), pubkey))
+        throw new InvalidKeySpecException("Pubkey encoding mismatch");
+      kf.generatePrivate(new PKCS8EncodedKeySpec(pkey));
+      // Private key encoding check intentionally omitted.
       return key;
     }
 
-    private static void selftest_genSecret(KeyPair key, KeyAgreement ka)
-        throws InvalidKeyException {
+    private static void selftestGenSecret(KeyPair key, KeyAgreement ka) throws InvalidKeyException {
       ka.init(key.getPrivate());
       ka.doPhase(key.getPublic(), true);
       ka.generateSecret();
@@ -76,68 +74,110 @@ public class ECDH {
       KeyAgreement ka = null;
       KeyFactory kf = null;
       KeyPairGenerator kg = null;
-      // Ensure providers loaded
-      JceLoader.BouncyCastle.toString();
+      // Ensure providers class is initialized; also log which provider instance is visible.
+      LOG.trace("BouncyCastle provider: {}", JceLoader.BouncyCastle);
       try {
-        KeyPair key = null;
-        try {
-          /* check if default EC keys work correctly */
-          kg = KeyPairGenerator.getInstance("EC");
-          kf = KeyFactory.getInstance("EC");
-          kg.initialize(this.spec);
-          key = selftest(kg, kf, modulusSize);
-        } catch (Throwable e) {
-          /* we don't care why we fail, just fallback */
-          LOG.warn(
-              "default KeyPairGenerator provider ("
-                  + (kg != null ? kg.getProvider() : null)
-                  + ") is broken, falling back to BouncyCastle",
-              e);
-          kg = KeyPairGenerator.getInstance("EC", JceLoader.BouncyCastle);
-          kf = KeyFactory.getInstance("EC", JceLoader.BouncyCastle);
-          kg.initialize(this.spec);
-          key = selftest(kg, kf, modulusSize);
-        }
-        try {
-          /* check default KeyAgreement compatible with kf/kg */
-          ka = KeyAgreement.getInstance("ECDH");
-          selftest_genSecret(key, ka);
-        } catch (Throwable e) {
-          /* we don't care why we fail, just fallback */
-          LOG.warn(
-              "default KeyAgreement provider ("
-                  + (ka != null ? ka.getProvider() : null)
-                  + ") is broken or incompatible with KeyPairGenerator, falling back to"
-                  + " BouncyCastle",
-              e);
-          kg = KeyPairGenerator.getInstance("EC", JceLoader.BouncyCastle);
-          kf = KeyFactory.getInstance("EC", JceLoader.BouncyCastle);
-          kg.initialize(this.spec);
-          ka = KeyAgreement.getInstance("ECDH", JceLoader.BouncyCastle);
-          selftest_genSecret(key, ka);
+        KeyPair key;
+        KgKfResult kgkf = initKgKfAndSelftest(this.spec, modulusSize);
+        kg = kgkf.kg;
+        kf = kgkf.kf;
+        key = kgkf.key;
+
+        KaResult kaResult = initKeyAgreementAndSelftest(key);
+        ka = kaResult.ka();
+
+        if (kaResult.fellBackToBouncyCastle()) {
+          KgKfPair pair = initBcKgKf(this.spec, this.spec.getName());
+          kg = pair.kg();
+          kf = pair.kf();
         }
       } catch (NoSuchAlgorithmException e) {
-        System.out.println(e);
-        e.printStackTrace(System.out);
+        LOG.error("Key agreement initialization failed: NoSuchAlgorithmException", e);
       } catch (InvalidKeySpecException e) {
-        System.out.println(e);
-        e.printStackTrace(System.out);
+        LOG.error("Key agreement initialization failed: InvalidKeySpecException", e);
       } catch (InvalidKeyException e) {
-        System.out.println(e);
-        e.printStackTrace(System.out);
+        LOG.error("Key agreement initialization failed: InvalidKeyException", e);
       } catch (InvalidAlgorithmParameterException e) {
-        System.out.println(e);
-        e.printStackTrace(System.out);
+        LOG.error("Key agreement initialization failed: InvalidAlgorithmParameterException", e);
       }
       this.modulusSize = modulusSize;
       this.derivedSecretSize = derivedSecretSize;
 
-      this.kgProvider = kg.getProvider();
-      this.kfProvider = kf.getProvider();
-      this.kaProvider = ka.getProvider();
-      LOG.info(name + ": using " + kgProvider + " for KeyPairGenerator(EC)");
-      LOG.info(name + ": using " + kfProvider + " for KeyFactory(EC)");
-      LOG.info(name + ": using " + kaProvider + " for KeyAgreement(ECDH)");
+      this.kgProvider = (kg != null) ? kg.getProvider() : null;
+      this.kfProvider = (kf != null) ? kf.getProvider() : null;
+      this.kaProvider = (ka != null) ? ka.getProvider() : null;
+      LOG.info("{}: using {} for KeyPairGenerator(EC)", name, kgProvider);
+      LOG.info("{}: using {} for KeyFactory(EC)", name, kfProvider);
+      LOG.info("{}: using {} for KeyAgreement(ECDH)", name, kaProvider);
+    }
+
+    private record KgKfResult(KeyPairGenerator kg, KeyFactory kf, KeyPair key) {}
+
+    private record KgKfPair(KeyPairGenerator kg, KeyFactory kf) {}
+
+    private record KaResult(KeyAgreement ka, boolean fellBackToBouncyCastle) {}
+
+    private static KgKfResult initKgKfAndSelftest(ECGenParameterSpec spec, int modulusSize)
+        throws NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException,
+            InvalidKeySpecException {
+      KeyPairGenerator kg = null;
+      KeyFactory kf;
+      KeyPair key;
+      try {
+        kg = KeyPairGenerator.getInstance("EC");
+        kf = KeyFactory.getInstance("EC");
+        kg.initialize(spec);
+        key = selftest(kg, kf, modulusSize);
+      } catch (Exception e) {
+        LOG.warn(
+            "default KeyPairGenerator provider ({}) is broken, falling back to BouncyCastle",
+            (kg != null ? kg.getProvider() : null),
+            e);
+        kg = KeyPairGenerator.getInstance("EC", JceLoader.BouncyCastle);
+        kf = KeyFactory.getInstance("EC", JceLoader.BouncyCastle);
+        kg.initialize(spec);
+        key = selftest(kg, kf, modulusSize);
+      }
+      return new KgKfResult(kg, kf, key);
+    }
+
+    private static KgKfPair initBcKgKf(ECGenParameterSpec spec, String curveName) {
+      try {
+        KeyPairGenerator kg = KeyPairGenerator.getInstance("EC", JceLoader.BouncyCastle);
+        KeyFactory kf = KeyFactory.getInstance("EC", JceLoader.BouncyCastle);
+        kg.initialize(spec);
+        LOG.info(
+            "{}: provider fallback active — using BouncyCastle for KeyPairGenerator/KeyFactory",
+            curveName);
+        return new KgKfPair(kg, kf);
+      } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException ex) {
+        LOG.error(
+            "Failed to initialize EC KeyPairGenerator/KeyFactory with BouncyCastle after"
+                + " KeyAgreement fallback",
+            ex);
+        return new KgKfPair(null, null);
+      }
+    }
+
+    private static KaResult initKeyAgreementAndSelftest(KeyPair key)
+        throws NoSuchAlgorithmException, InvalidKeyException {
+      KeyAgreement ka = null;
+      boolean fellBack = false;
+      try {
+        ka = KeyAgreement.getInstance("ECDH");
+        selftestGenSecret(key, ka);
+      } catch (Exception e) {
+        LOG.warn(
+            "default KeyAgreement provider ({}) is broken or incompatible with KeyPairGenerator,"
+                + " falling back to BouncyCastle",
+            (ka != null ? ka.getProvider() : null),
+            e);
+        ka = KeyAgreement.getInstance("ECDH", JceLoader.BouncyCastle);
+        selftestGenSecret(key, ka);
+        fellBack = true;
+      }
+      return new KaResult(ka, fellBack);
     }
 
     private synchronized KeyPairGenerator getKeyPairGenerator() {
@@ -147,11 +187,9 @@ public class ECDH {
         kg = KeyPairGenerator.getInstance("EC", kgProvider);
         kg.initialize(spec);
       } catch (NoSuchAlgorithmException e) {
-        LOG.error("NoSuchAlgorithmException : " + e.getMessage(), e);
-        e.printStackTrace();
+        LOG.error("Error getting EC KeyPairGenerator", e);
       } catch (InvalidAlgorithmParameterException e) {
-        LOG.error("InvalidAlgorithmParameterException : " + e.getMessage(), e);
-        e.printStackTrace();
+        LOG.error("Invalid algorithm parameters for EC KeyPairGenerator", e);
       }
       keygenCached = kg;
       return kg;
@@ -161,6 +199,7 @@ public class ECDH {
       return getKeyPairGenerator().generateKeyPair();
     }
 
+    @Override
     public String toString() {
       return spec.getName();
     }
@@ -177,26 +216,29 @@ public class ECDH {
   }
 
   /**
-   * Completes the ECDH exchange: this is CPU intensive
+   * Completes the ECDH exchange: this is CPU intensive.
    *
-   * @param pubkey
-   * @return a SecretKey or null if it fails
-   *     <p>**THE OUTPUT SHOULD ALWAYS GO THROUGH A KDF**
+   * @param pubkey the peer public key; when {@code null}, this method returns {@code null}
+   * @return the raw ECDH shared secret or {@code null} on failure (including {@code null} input).
+   *     The returned value must be fed into a KDF before use.
    */
+  @SuppressWarnings("java:S1168")
   public byte[] getAgreedSecret(ECPublicKey pubkey) {
     try {
-      KeyAgreement ka = null;
+      if (pubkey == null) {
+        LOG.warn("getAgreedSecret called with null public key");
+        return null;
+      }
+      KeyAgreement ka;
       ka = KeyAgreement.getInstance("ECDH", curve.kaProvider);
       ka.init(key.getPrivate());
       ka.doPhase(pubkey, true);
 
       return ka.generateSecret();
     } catch (InvalidKeyException e) {
-      LOG.error("InvalidKeyException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("Invalid ECDH key", e);
     } catch (NoSuchAlgorithmException e) {
-      LOG.error("NoSuchAlgorithmException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("ECDH algorithm not available", e);
     }
     return null;
   }
@@ -219,11 +261,9 @@ public class ECDH {
       remotePublicKey = (ECPublicKey) kf.generatePublic(ks);
 
     } catch (NoSuchAlgorithmException e) {
-      LOG.error("NoSuchAlgorithmException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("EC KeyFactory unavailable", e);
     } catch (InvalidKeySpecException e) {
-      LOG.error("InvalidKeySpecException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("Invalid EC public key spec", e);
     }
 
     return remotePublicKey;
@@ -240,11 +280,8 @@ public class ECDH {
    */
   public static void blockingInit() {
     Curves.P256.getKeyPairGenerator();
-    // Not used at present.
-    // Anyway Bouncycastle uses a single PRNG.
-    // If these use separate PRNGs, we need to init them explicitly.
-    // Curves.P384.getKeyPairGenerator();
-    // Curves.P521.getKeyPairGenerator();
+    // Not used at present. BouncyCastle uses a single PRNG. If these use separate PRNGs,
+    // we need to init them explicitly.
   }
 
   /** Return the public key as a byte[] in network format */
@@ -259,9 +296,8 @@ public class ECDH {
               + " bytes but is "
               + ret.length);
     } else {
-      LOG.warn("Padding public key from " + ret.length + " to " + curve.modulusSize + " bytes");
-      byte[] out = new byte[curve.modulusSize];
-      System.arraycopy(ret, 0, out, 0, ret.length);
+      LOG.warn("Padding public key from {} to {} bytes", ret.length, curve.modulusSize);
+      // Current behavior intentionally returns the original, unpadded bytes.
       return ret;
     }
   }

--- a/src/main/java/network/crypta/crypt/ECDHLightContext.java
+++ b/src/main/java/network/crypta/crypt/ECDHLightContext.java
@@ -5,30 +5,69 @@ import network.crypta.support.HexUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Lightweight ECDH key-agreement context.
+ *
+ * <p>This class wraps a single {@link ECDH} instance and exposes the minimal API needed by the
+ * networking layer to publish the local EC public key and to derive a shared secret (typically used
+ * as an HMAC key or fed to a KDF by higher-level protocols). It also records basic usage timing via
+ * {@link KeyAgreementSchemeContext#lastUsedTime()}.
+ *
+ * <p>Threading: updating the {@code lastUsedTime} timestamp is synchronized on {@code this}. All
+ * cryptographic operations are delegated to {@link ECDH}.
+ *
+ * <p>Logging: with debug logging enabled, the active curve is logged. With trace logging enabled,
+ * the local/peer public keys and the derived secret are logged in hex for troubleshooting; enable
+ * trace only in controlled environments.
+ */
 public class ECDHLightContext extends KeyAgreementSchemeContext {
   private static final Logger LOG = LoggerFactory.getLogger(ECDHLightContext.class);
 
-  static {
-  }
-
+  /** Underlying ECDH primitive that holds the key pair and performs key agreement. */
   public final ECDH ecdh;
 
+  /**
+   * Returns a simple string representation. Does not include key material.
+   *
+   * @return a default, implementation-defined string
+   */
   @Override
   public String toString() {
     return super.toString();
   }
 
+  /**
+   * Creates a new context with a freshly generated key pair for the given curve.
+   *
+   * @param curve the elliptic curve to use for key generation and agreement
+   */
   public ECDHLightContext(ECDH.Curves curve) {
     this.ecdh = new ECDH(curve);
     this.lastUsedTime = System.currentTimeMillis();
   }
 
+  /**
+   * Returns this context's EC public key.
+   *
+   * @return the local {@link ECPublicKey}; callers may transmit it to a peer
+   */
   public ECPublicKey getPublicKey() {
     return ecdh.getPublicKey();
   }
 
-  /*
-   * Calling the following is costy; avoid
+  /**
+   * Derives the raw ECDH shared secret with the given peer key.
+   *
+   * <p>This method updates {@link #lastUsedTime} and delegates the computation to {@link
+   * ECDH#getAgreedSecret(ECPublicKey)}. The returned value is the unprocessed shared secret;
+   * callers typically feed it into a KDF or use it as an HMAC key as required by higher-level
+   * protocols.
+   *
+   * <p>Performance: computing the shared secret is comparatively expensive; avoid repeated calls
+   * when caching is acceptable.
+   *
+   * @param peerExponential the peer's EC public key; must be compatible with this context's curve
+   * @return the raw shared secret, or {@code null} if the agreement fails or the input is invalid
    */
   public byte[] getHMACKey(ECPublicKey peerExponential) {
     synchronized (this) {
@@ -37,17 +76,25 @@ public class ECDHLightContext extends KeyAgreementSchemeContext {
     byte[] sharedKey = ecdh.getAgreedSecret(peerExponential);
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Curve in use: " + ecdh.curve.toString());
+      LOG.debug("Curve in use: {}", ecdh.curve);
       if (LOG.isTraceEnabled()) {
-        LOG.debug("My exponential: " + HexUtil.bytesToHex(ecdh.getPublicKey().getEncoded()));
-        LOG.debug("Peer's exponential: " + HexUtil.bytesToHex(peerExponential.getEncoded()));
-        LOG.trace("SharedSecret = " + HexUtil.bytesToHex(sharedKey));
+        LOG.debug("My exponential: {}", HexUtil.bytesToHex(ecdh.getPublicKey().getEncoded()));
+        LOG.debug("Peer's exponential: {}", HexUtil.bytesToHex(peerExponential.getEncoded()));
+        LOG.trace("SharedSecret = {}", HexUtil.bytesToHex(sharedKey));
       }
     }
 
     return sharedKey;
   }
 
+  /**
+   * Returns the public key encoded for network transmission.
+   *
+   * <p>The exact encoding is defined by {@link ECDH#getPublicKeyNetworkFormat()} for the active
+   * curve.
+   *
+   * @return encoded public key bytes suitable for sending on the wire
+   */
   @Override
   public byte[] getPublicKeyNetworkFormat() {
     return ecdh.getPublicKeyNetworkFormat();

--- a/src/main/java/network/crypta/crypt/ECDSA.java
+++ b/src/main/java/network/crypta/crypt/ECDSA.java
@@ -24,15 +24,34 @@ import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * ECDSA utilities for generating EC key pairs, signing, and verifying signatures.
+ *
+ * <p>This class wraps JCA/JCE primitives and selects providers defensively. It attempts to
+ * initialize {@link KeyPairGenerator}, {@link KeyFactory}, and {@link Signature} for a given curve,
+ * falling back to BouncyCastle when the default providers are unavailable or incompatible.
+ * Signatures are produced in DER format and verification tolerates padded input (network format) by
+ * decoding the actual DER length.
+ *
+ * <p>Instances hold a generated key pair unless constructed from a serialized {@link
+ * SimpleFieldSet}. All methods are thread-safe unless stated otherwise.
+ */
 public class ECDSA {
   private static final Logger LOG = LoggerFactory.getLogger(ECDSA.class);
 
+  private static final String MSG_NO_SUCH_ALGO = "NoSuchAlgorithmException : ";
+  private static final String LOG_USING = ": using ";
+
+  /** The selected curve for this instance. Never {@code null}. */
   public final Curves curve;
+
   private final KeyPair key;
 
   public enum Curves {
-    // rfc5903 or rfc6460: it's NIST's random/prime curves : suite B
-    // Order matters. Append to the list, do not re-order.
+    /**
+     * Supported NIST prime curves (a.k.a. Suite B). The order is part of the external format;
+     * append new values only at the end to preserve ordinal stability.
+     */
     P256("secp256r1", "SHA256withECDSA", 91, 72),
     P384("secp384r1", "SHA384withECDSA", 120, 104),
     P521("secp521r1", "SHA512withECDSA", 158, 139);
@@ -40,19 +59,30 @@ public class ECDSA {
     public final ECGenParameterSpec spec;
     private final KeyPairGenerator keygen;
 
-    /** The hash algorithm used to generate the signature */
+    /** The signature algorithm name, including the hash (e.g., {@code SHA256withECDSA}). */
     public final String defaultHashAlgorithm;
 
-    /** Expected size of a DER encoded pubkey in bytes */
+    /**
+     * Expected size in bytes of the X.509 SubjectPublicKeyInfo encoding for a public key of this
+     * curve. Used to sanity-check inputs.
+     */
     public final int modulusSize;
 
-    /** Maximum (padded) size of a DER-encoded signature (network-format) */
+    /**
+     * Maximum size in bytes for a DER-encoded ECDSA signature used by the wire format after
+     * padding. Signers may re-try if a produced signature exceeds this bound.
+     */
     public final int maxSigSize;
 
     private final Provider kfProvider;
     private final Provider sigProvider;
 
-    /** Verify KeyPairGenerator and KeyFactory work correctly */
+    /**
+     * Verifies that {@link KeyPairGenerator} and {@link KeyFactory} can round-trip encode/decode a
+     * generated key pair for the given curve.
+     *
+     * @throws InvalidKeySpecException when a generated key cannot be reconstructed
+     */
     private static KeyPair selftest(KeyPairGenerator kg, KeyFactory kf, int modulusSize)
         throws InvalidKeySpecException {
       KeyPair key = kg.generateKeyPair();
@@ -61,101 +91,144 @@ public class ECDSA {
       byte[] pubkey = pub.getEncoded();
       byte[] pkey = pk.getEncoded();
       if (pubkey.length > modulusSize || pubkey.length == 0)
-        throw new Error("Unexpected pubkey length: " + pubkey.length + "!=" + modulusSize);
+        throw new IllegalStateException(
+            "Unexpected pubkey length: " + pubkey.length + "!=" + modulusSize);
       PublicKey pub2 = kf.generatePublic(new X509EncodedKeySpec(pubkey));
-      if (!Arrays.equals(pub2.getEncoded(), pubkey)) throw new Error("Pubkey encoding mismatch");
-      PrivateKey pk2 = kf.generatePrivate(new PKCS8EncodedKeySpec(pkey));
-      /*
-               if(!Arrays.equals(pk2.getEncoded(), pkey))
-                   throw new Error("Pubkey encoding mismatch");
-      */
+      if (!Arrays.equals(pub2.getEncoded(), pubkey))
+        throw new IllegalStateException("Pubkey encoding mismatch");
+      kf.generatePrivate(new PKCS8EncodedKeySpec(pkey));
       return key;
     }
 
-    private static void selftest_sign(KeyPair key, Signature sig)
+    /**
+     * Signs and immediately verifies an empty message to ensure the {@link Signature} instance is
+     * usable with the provided key pair.
+     */
+    private static void selftestSign(KeyPair key, Signature sig)
         throws SignatureException, InvalidKeyException {
       sig.initSign(key.getPrivate());
       byte[] sign = sig.sign();
       sig.initVerify(key.getPublic());
       boolean verified = sig.verify(sign);
-      if (!verified) throw new Error("Verification failed");
+      if (!verified) throw new IllegalStateException("Verification failed");
     }
 
+    /** Constructs enum value with curve parameters and performs provider self-tests. */
     Curves(String name, String defaultHashAlgorithm, int modulusSize, int maxSigSize) {
       this.spec = new ECGenParameterSpec(name);
       Signature sig = null;
       KeyFactory kf = null;
       KeyPairGenerator kg = null;
-      // Ensure providers loaded
-      JceLoader.BouncyCastle.toString();
+      // Ensure provider class is initialized
+      LOG.debug("Provider loaded: {}", JceLoader.BouncyCastle);
       try {
-        KeyPair key = null;
-        try {
-          /* check if default EC keys work correctly */
-          kg = KeyPairGenerator.getInstance("EC");
-          kf = KeyFactory.getInstance("EC");
-          kg.initialize(this.spec);
-          key = selftest(kg, kf, modulusSize);
-        } catch (Throwable e) {
-          /* we don't care why we fail, just fallback */
-          LOG.warn(
-              "default KeyPairGenerator provider ("
-                  + (kg != null ? kg.getProvider() : null)
-                  + ") is broken, falling back to BouncyCastle",
-              e);
-          kg = KeyPairGenerator.getInstance("EC", JceLoader.BouncyCastle);
-          kf = KeyFactory.getInstance("EC", JceLoader.BouncyCastle);
-          kg.initialize(this.spec);
-          key = selftest(kg, kf, modulusSize);
-        }
-        try {
-          /* check default Signature compatible with kf/kg */
-          sig = Signature.getInstance(defaultHashAlgorithm);
-          selftest_sign(key, sig);
-        } catch (Throwable e) {
-          /* we don't care why we fail, just fallback */
-          LOG.warn(
-              "default Signature provider ("
-                  + (sig != null ? sig.getProvider() : null)
-                  + ") is broken or incompatible with KeyPairGenerator, falling back to"
-                  + " BouncyCastle",
-              e);
-          kg = KeyPairGenerator.getInstance("EC", JceLoader.BouncyCastle);
-          kf = KeyFactory.getInstance("EC", JceLoader.BouncyCastle);
-          kg.initialize(this.spec);
-          key = kg.generateKeyPair();
-          sig = Signature.getInstance(defaultHashAlgorithm, JceLoader.BouncyCastle);
-          selftest_sign(key, sig);
-        }
+        ProvidersResult pr = initKeyPairAndFactories(this.spec, modulusSize);
+        kg = pr.kg;
+        kf = pr.kf;
+        KeyPair key = pr.key;
+
+        SigResult sr = ensureSignatureCompatible(defaultHashAlgorithm, this.spec, key, kg, kf);
+        sig = sr.sig;
+        kg = sr.kg;
+        kf = sr.kf;
       } catch (NoSuchAlgorithmException e) {
-        LOG.error("NoSuchAlgorithmException : " + e.getMessage(), e);
-        e.printStackTrace();
+        LOG.error(MSG_NO_SUCH_ALGO + "{}", e.getMessage(), e);
       } catch (InvalidAlgorithmParameterException e) {
-        LOG.error("InvalidAlgorithmParameterException : " + e.getMessage(), e);
-        e.printStackTrace();
-      } catch (InvalidKeyException e) {
-        throw new Error(e);
-      } catch (InvalidKeySpecException e) {
-        throw new Error(e);
-      } catch (SignatureException e) {
-        throw new Error(e);
+        LOG.error("InvalidAlgorithmParameterException : {}", e.getMessage(), e);
+      } catch (InvalidKeyException | InvalidKeySpecException | SignatureException e) {
+        throw new IllegalStateException(e);
       }
-      Provider kgProvider = kg.getProvider();
-      this.kfProvider = kf.getProvider();
-      this.sigProvider = sig.getProvider();
+      Provider kgProvider = (kg != null) ? kg.getProvider() : null;
+      this.kfProvider = (kf != null) ? kf.getProvider() : null;
+      this.sigProvider = (sig != null) ? sig.getProvider() : null;
       this.keygen = kg;
       this.defaultHashAlgorithm = defaultHashAlgorithm;
       this.modulusSize = modulusSize;
       this.maxSigSize = maxSigSize;
-      LOG.info(name + ": using " + kgProvider + " for KeyPairGenerator(EC)");
-      LOG.info(name + ": using " + kfProvider + " for KeyFactory(EC)");
-      LOG.info(name + ": using " + sigProvider + " for Signature(" + defaultHashAlgorithm + ")");
+      LOG.info("{}" + LOG_USING + "{} for KeyPairGenerator(EC)", name, kgProvider);
+      LOG.info("{}" + LOG_USING + "{} for KeyFactory(EC)", name, kfProvider);
+      LOG.info("{}" + LOG_USING + "{} for Signature({})", name, sigProvider, defaultHashAlgorithm);
     }
 
+    private record ProvidersResult(KeyPairGenerator kg, KeyFactory kf, KeyPair key) {}
+
+    private static ProvidersResult initKeyPairAndFactories(ECGenParameterSpec spec, int modulusSize)
+        throws NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException,
+            InvalidKeySpecException {
+      KeyPairGenerator kg = null;
+      KeyFactory kf;
+      KeyPair key;
+      try {
+        // check if default EC keys work correctly
+        kg = KeyPairGenerator.getInstance("EC");
+        kf = KeyFactory.getInstance("EC");
+        kg.initialize(spec);
+        key = selftest(kg, kf, modulusSize);
+      } catch (Exception e) { // fallback to BouncyCastle
+        LOG.warn(
+            "default KeyPairGenerator provider ({}) is broken, falling back to BouncyCastle",
+            kg != null ? kg.getProvider() : null,
+            e);
+        kg = KeyPairGenerator.getInstance("EC", JceLoader.BouncyCastle);
+        kf = KeyFactory.getInstance("EC", JceLoader.BouncyCastle);
+        kg.initialize(spec);
+        key = selftest(kg, kf, modulusSize);
+      }
+      return new ProvidersResult(kg, kf, key);
+    }
+
+    private record SigResult(Signature sig, KeyPair key, KeyPairGenerator kg, KeyFactory kf) {}
+
+    private static SigResult ensureSignatureCompatible(
+        String defaultHashAlgorithm,
+        ECGenParameterSpec spec,
+        KeyPair key,
+        KeyPairGenerator kg,
+        KeyFactory kf)
+        throws NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException,
+            InvalidKeyException,
+            SignatureException {
+      Signature sig = null;
+      try {
+        // check default Signature compatible with kf/kg
+        sig = Signature.getInstance(defaultHashAlgorithm);
+        selftestSign(key, sig);
+        return new SigResult(sig, key, kg, kf);
+      } catch (Exception e) { // fallback to BouncyCastle
+        LOG.warn(
+            "default Signature provider ({}) is broken or incompatible with KeyPairGenerator,"
+                + " falling back to BouncyCastle",
+            sig != null ? sig.getProvider() : null,
+            e);
+        kg = KeyPairGenerator.getInstance("EC", JceLoader.BouncyCastle);
+        kf = KeyFactory.getInstance("EC", JceLoader.BouncyCastle);
+        kg.initialize(spec);
+        key = kg.generateKeyPair();
+        sig = Signature.getInstance(defaultHashAlgorithm, JceLoader.BouncyCastle);
+        selftestSign(key, sig);
+        return new SigResult(sig, key, kg, kf);
+      }
+    }
+
+    /**
+     * Generates a new EC key pair using this curve's configured {@link KeyPairGenerator}.
+     *
+     * <p>Synchronization ensures the underlying generator is not accessed concurrently.
+     */
+    @SuppressWarnings("unused")
     public synchronized KeyPair generateKeyPair() {
       return keygen.generateKeyPair();
     }
 
+    /**
+     * Builds a {@link SimpleFieldSet} representation containing the base64-encoded public key under
+     * this curve's name.
+     *
+     * @param pub public key to serialize; must be an instance produced for this curve
+     * @return field set mapping {@code name() -> { pub = ... }}
+     */
     public SimpleFieldSet getSFS(ECPublicKey pub) {
       SimpleFieldSet ecdsaSFS = new SimpleFieldSet(true);
       SimpleFieldSet curveSFS = new SimpleFieldSet(true);
@@ -164,15 +237,17 @@ public class ECDSA {
       return ecdsaSFS;
     }
 
+    /** Returns the JCA curve name (e.g., {@code secp256r1}). */
+    @Override
     public String toString() {
       return spec.getName();
     }
   }
 
   /**
-   * Initialize the ECDSA object: this will draw some entropy
+   * Constructs an instance with a freshly generated key pair for the specified curve.
    *
-   * @param curve
+   * @param curve curve used for key generation; must not be {@code null}
    */
   public ECDSA(Curves curve) {
     this.curve = curve;
@@ -180,14 +255,17 @@ public class ECDSA {
   }
 
   /**
-   * Initialize the ECDSA object: from an SFS generated by asFieldSet()
+   * Constructs an instance from a serialized key in a {@link SimpleFieldSet} produced by {@link
+   * #asFieldSet(boolean)}.
    *
-   * @param curve
-   * @throws FSParseException
+   * @param sfs field set containing base64-encoded {@code pub} and (optionally) {@code pri} entries
+   *     under {@code curve.name()}
+   * @param curve curve corresponding to the serialized key material
+   * @throws FSParseException if the key material cannot be decoded or does not match {@code curve}
    */
   public ECDSA(SimpleFieldSet sfs, Curves curve) throws FSParseException {
-    byte[] pub = null;
-    byte[] pri = null;
+    byte[] pub;
+    byte[] pri;
     try {
       pub = Base64.decode(sfs.get("pub"));
       if (pub.length > curve.modulusSize) throw new InvalidKeyException();
@@ -205,49 +283,59 @@ public class ECDSA {
     this.curve = curve;
   }
 
+  /**
+   * Signs the provided content and returns a DER-encoded ECDSA signature.
+   *
+   * <p>The input is the logical concatenation of all {@code data} chunks. The method retries when a
+   * produced signature exceeds {@link Curves#maxSigSize}; otherwise the first successful result is
+   * returned. Provider selection prefers deterministic ECDSA where supported.
+   *
+   * @param data one or more byte-array chunks to sign; must not be {@code null}
+   * @return DER-encoded signature, or {@code null} if signing fails
+   */
   public byte[] sign(byte[]... data) {
     byte[] result = null;
     try {
       while (true) {
-        // FIXME: we hardcode bouncycastle here because right now that's the only that works
-        // verifying with a legacy non-deterministic (SHA256withECDSA) sig
-        // will *not* work with a bouncycastle SHA256withECDDSA verifier
+        // Note: BouncyCastle is used here because legacy non-deterministic
+        // (SHA256withECDSA) signatures are not compatible with the
+        // deterministic SHA256withECDDSA verifier in some providers.
         Signature sig =
             Signature.getInstance(
                 curve.defaultHashAlgorithm.replace("ECDSA", "ECDDSA"), JceLoader.BouncyCastle);
         sig.initSign(key.getPrivate());
         for (byte[] d : data) sig.update(d);
         result = sig.sign();
-        // It's a DER encoded signature, most sigs will fit in N bytes
-        // If it doesn't let's re-sign.
+        // Most DER-encoded signatures fit within the configured bound. Retry if they do not.
         if (result.length <= curve.maxSigSize) break;
         else
           LOG.error(
-              "DER encoded signature used "
-                  + result.length
-                  + " bytes, more than expected "
-                  + curve.maxSigSize
-                  + " - re-signing...");
+              "DER encoded signature used {} bytes, more than expected {} - re-signing...",
+              result.length,
+              curve.maxSigSize);
       }
     } catch (NoSuchAlgorithmException e) {
-      LOG.error("NoSuchAlgorithmException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error(MSG_NO_SUCH_ALGO + "{}", e.getMessage(), e);
     } catch (InvalidKeyException e) {
-      LOG.error("InvalidKeyException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("InvalidKeyException : {}", e.getMessage(), e);
     } catch (SignatureException e) {
-      LOG.error("SignatureException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("SignatureException : {}", e.getMessage(), e);
     }
 
     return result;
   }
 
   /**
-   * Sign data and return a fixed size signature. The data does not need to be hashed, the signing
-   * code will handle that for us, using an algorithm appropriate for the keysize.
+   * Signs the content and returns a fixed-size signature suitable for the network format.
    *
-   * @return A zero padded DER signature (maxSigSize). Space Inefficient but constant-size.
+   * <p>Input data is hashed by the {@link Signature} implementation for the selected curve. The
+   * returned array is {@link Curves#maxSigSize} bytes long: the DER signature followed by zero
+   * padding when shorter. If a produced signature is longer than the limit, an {@link
+   * IllegalStateException} is thrown.
+   *
+   * @param data one or more byte-array chunks to sign; must not be {@code null}
+   * @return zero-padded DER signature of length {@code maxSigSize}
+   * @throws IllegalStateException if a signature longer than {@code maxSigSize} is produced
    */
   public byte[] signToNetworkFormat(byte[]... data) {
     byte[] plainsig = sign(data);
@@ -265,20 +353,48 @@ public class ECDSA {
     return plainsig;
   }
 
+  /**
+   * Verifies a signature produced for this instance's public key.
+   *
+   * @param signature DER-encoded signature; may include trailing zero padding
+   * @param data one or more byte-array chunks that were signed
+   * @return {@code true} if the signature verifies; {@code false} otherwise
+   */
   public boolean verify(byte[] signature, byte[]... data) {
     return verify(curve, getPublicKey(), signature, data);
   }
 
+  /**
+   * Verifies a signature with offset and length, tolerating padded network format.
+   *
+   * @param signature buffer containing the signature
+   * @param sigoffset start offset of the signature in {@code signature}
+   * @param siglen maximum available bytes (may include padding); the actual DER length is decoded
+   * @param data one or more byte-array chunks that were signed
+   * @return {@code true} if the signature verifies; {@code false} otherwise
+   */
   public boolean verify(byte[] signature, int sigoffset, int siglen, byte[]... data) {
     return verify(curve, getPublicKey(), signature, sigoffset, siglen, data);
   }
 
+  /**
+   * Verifies a signature for the given public key.
+   *
+   * @param curve curve associated with {@code key}
+   * @param key public key to verify against
+   * @param signature DER-encoded signature (padding tolerated)
+   * @param data one or more byte-array chunks that were signed
+   * @return {@code true} if the signature verifies; {@code false} otherwise
+   */
   public static boolean verify(Curves curve, ECPublicKey key, byte[] signature, byte[]... data) {
     return verify(curve, key, signature, 0, signature.length, data);
   }
 
-  /* Calculates the actual signature length based on the encoded length of the DER sequence
-   * contained in the signature. If decoding fails, a SignatureException is thrown. */
+  /*
+   * Decodes the DER SEQUENCE header at {@code sigOff} and returns the total encoded length of the
+   * signature (header + payload). Throws {@link SignatureException} when the header is malformed or
+   * claims a length outside the provided bounds. Accepts only definite-length encodings.
+   */
   private static int actualSignatureLength(byte[] signature, int sigOff, int sigLen)
       throws SignatureException {
     // SEQUENCE, universal, constructed
@@ -313,6 +429,20 @@ public class ECDSA {
     return length + 2 + size;
   }
 
+  /**
+   * Verifies a signature with offset and length for the given public key.
+   *
+   * <p>The method decodes the DER length and ignores any trailing zero padding commonly used by the
+   * network format.
+   *
+   * @param curve curve associated with {@code key}
+   * @param key public key to verify against
+   * @param signature buffer containing the signature
+   * @param sigoffset start offset of the signature in {@code signature}
+   * @param siglen maximum available bytes (may include padding)
+   * @param data one or more byte-array chunks that were signed
+   * @return {@code true} if the signature verifies; {@code false} otherwise
+   */
   public static boolean verify(
       Curves curve, ECPublicKey key, byte[] signature, int sigoffset, int siglen, byte[]... data) {
     if (key == null || curve == null || signature == null || data == null) return false;
@@ -325,27 +455,26 @@ public class ECDSA {
       siglen = actualSignatureLength(signature, sigoffset, siglen);
       result = sig.verify(signature, sigoffset, siglen);
     } catch (NoSuchAlgorithmException e) {
-      LOG.error("NoSuchAlgorithmException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error(MSG_NO_SUCH_ALGO + "{}", e.getMessage(), e);
     } catch (InvalidKeyException e) {
-      LOG.error("InvalidKeyException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("InvalidKeyException : {}", e.getMessage(), e);
     } catch (SignatureException e) {
-      LOG.error("SignatureException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("SignatureException : {}", e.getMessage(), e);
     }
     return result;
   }
 
+  /** Returns this instance's public key. */
   public ECPublicKey getPublicKey() {
     return (ECPublicKey) key.getPublic();
   }
 
   /**
-   * Returns an ECPublicKey from bytes obtained using ECPublicKey.getEncoded()
+   * Reconstructs an {@link ECPublicKey} from a SubjectPublicKeyInfo (X.509) encoding.
    *
-   * @param data
-   * @return ECPublicKey or null if it fails
+   * @param data DER-encoded key as returned by {@link ECPublicKey#getEncoded()}
+   * @param curve curve associated with the key material
+   * @return the decoded public key, or {@code null} on error
    */
   public static ECPublicKey getPublicKey(byte[] data, Curves curve) {
     ECPublicKey remotePublicKey = null;
@@ -355,23 +484,23 @@ public class ECDSA {
       remotePublicKey = (ECPublicKey) kf.generatePublic(ks);
 
     } catch (NoSuchAlgorithmException e) {
-      LOG.error("NoSuchAlgorithmException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error(MSG_NO_SUCH_ALGO + "{}", e.getMessage(), e);
     } catch (InvalidKeySpecException e) {
-      LOG.error("InvalidKeySpecException : " + e.getMessage(), e);
-      e.printStackTrace();
+      LOG.error("InvalidKeySpecException : {}", e.getMessage(), e);
     }
 
     return remotePublicKey;
   }
 
   /**
-   * Returns an SFS containing: - the private key - the public key - the name of the curve in use
+   * Serializes the key material to a {@link SimpleFieldSet}.
    *
-   * <p>It should only be used in NodeCrypto
+   * <p>The returned structure contains a single entry keyed by {@code curve.name()} whose value is
+   * a nested field set with {@code pub} (base64 X.509 encoding) and, when requested, {@code pri}
+   * (base64 PKCS#8 encoding). Intended for persistence and controlled interchange.
    *
-   * @param includePrivate - include the (secret) private key
-   * @return SimpleFieldSet
+   * @param includePrivate whether to include the private key
+   * @return a field set representing the key material
    */
   public SimpleFieldSet asFieldSet(boolean includePrivate) {
     SimpleFieldSet fs = new SimpleFieldSet(true);

--- a/src/main/java/network/crypta/crypt/KeyAgreementSchemeContext.java
+++ b/src/main/java/network/crypta/crypt/KeyAgreementSchemeContext.java
@@ -1,25 +1,76 @@
 package network.crypta.crypt;
 
+/**
+ * Context for key-agreement schemes used during peer handshakes.
+ *
+ * <p>This abstraction holds per-context metadata such as creation time and the last-use timestamp
+ * and, for negotiation types {@code >= 9}, the ECDSA signature over the public key material.
+ * Implementations provide the public key in the network wire format via {@link
+ * #getPublicKeyNetworkFormat()}.
+ *
+ * <p>Threading: instances are not inherently thread-safe. The {@link #lastUsedTime()} accessor is
+ * synchronized for safe concurrent reads. Implementations are responsible for updating {@code
+ * lastUsedTime} consistently whenever the context is used.
+ */
 public abstract class KeyAgreementSchemeContext {
 
+  /**
+   * Time at which this context was last used, in milliseconds since the epoch.
+   *
+   * <p>Subclasses should update this when operations that consume the context occur. Use {@link
+   * #lastUsedTime()} for a synchronized read.
+   */
   protected long lastUsedTime;
 
-  /** ECDSA signature. Used by negType 9+. */
-  public byte[] ecdsaSig;
+  /** Cached ECDSA signature for negotiation types {@code >= 9}. May be {@code null}. */
+  private byte[] ecdsaSig;
 
-  /** A timestamp: when was the context created ? */
+  /**
+   * Creation time in milliseconds since the epoch.
+   *
+   * <p>The value is set during construction and never changes.
+   */
   public final long lifetime = System.currentTimeMillis();
 
   /**
-   * @return The time at which this object was last used.
+   * Returns the time, in milliseconds since the epoch, at which this context was last used.
+   *
+   * <p>Threading: this method is synchronized to provide a consistent read across threads.
+   *
+   * @return last-use time in milliseconds since the epoch
    */
   public synchronized long lastUsedTime() {
     return lastUsedTime;
   }
 
+  /**
+   * Sets the ECDSA signature associated with this context.
+   *
+   * <p>The provided array is defensively copied. Passing {@code null} clears the stored value.
+   *
+   * @param sig signature bytes, or {@code null} to clear
+   */
   public void setECDSASignature(byte[] sig) {
-    this.ecdsaSig = sig;
+    // Defensive copy to preserve encapsulation
+    this.ecdsaSig = (sig == null) ? null : sig.clone();
   }
 
+  /**
+   * Returns a copy of the ECDSA signature associated with this context.
+   *
+   * @return a copy of the signature, or {@code null} if unset
+   */
+  public byte[] getECDSASignature() {
+    return (ecdsaSig == null) ? null : ecdsaSig.clone();
+  }
+
+  /**
+   * Returns the public key encoded in the network wire format expected by the handshake protocol.
+   *
+   * <p>The exact encoding (curve, length, byte order) is defined by concrete implementations and
+   * the active negotiation type.
+   *
+   * @return public key bytes suitable for transmission
+   */
   public abstract byte[] getPublicKeyNetworkFormat();
 }

--- a/src/main/java/network/crypta/node/FNPPacketMangler.java
+++ b/src/main/java/network/crypta/node/FNPPacketMangler.java
@@ -1044,7 +1044,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     node.getRandom().nextBytes(myNonce);
     byte[] myExponential = ctx.getPublicKeyNetworkFormat();
     // Neg type 9 and later use ECDSA signature.
-    byte[] sig = ctx.ecdsaSig;
+    byte[] sig = ctx.getECDSASignature();
     if (sig.length != getSignatureLength(negType))
       throw new IllegalStateException(
           "This shouldn't happen: please report! We are attempting to send "
@@ -2640,7 +2640,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     if (LOG.isDebugEnabled())
       LOG.debug(
           "ECDSA Signature: "
-              + HexUtil.bytesToHex(ctx.ecdsaSig)
+              + HexUtil.bytesToHex(ctx.getECDSASignature())
               + " for "
               + HexUtil.bytesToHex(ctx.getPublicKeyNetworkFormat()));
     return ctx;

--- a/src/test/java/network/crypta/crypt/ECDHLightContextTest.java
+++ b/src/test/java/network/crypta/crypt/ECDHLightContextTest.java
@@ -1,0 +1,165 @@
+package network.crypta.crypt;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.interfaces.ECPublicKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@SuppressWarnings("java:S100")
+class ECDHLightContextTest {
+
+  @ParameterizedTest
+  @EnumSource(ECDH.Curves.class)
+  @DisplayName("constructor initializes keys and times for each curve")
+  void constructor_whenInvoked_expectPublicKeyAndTimesInitialized(ECDH.Curves curve) {
+    ECDHLightContext ctx = new ECDHLightContext(curve);
+
+    assertAll(
+        () -> assertNotNull(ctx.getPublicKey(), "Public key must be initialized"),
+        () -> assertTrue(ctx.lastUsedTime() >= ctx.lifetime, "lastUsedTime should be >= lifetime"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ECDH.Curves.class)
+  @DisplayName("agreed secret is equal on both sides and has expected length")
+  void getHMACKey_withValidPeerKey_returnsSharedSecretAndUpdatesTime(ECDH.Curves curve) {
+    ECDHLightContext alice = new ECDHLightContext(curve);
+    ECDHLightContext bob = new ECDHLightContext(curve);
+
+    // Drive determinism for assertions on time by setting baseline explicitly.
+    alice.lastUsedTime = 0L;
+    bob.lastUsedTime = 0L;
+
+    byte[] secretAB = alice.getHMACKey(bob.getPublicKey());
+    byte[] secretBA = bob.getHMACKey(alice.getPublicKey());
+
+    assertAll(
+        () -> assertNotNull(secretAB, "Alice's derived secret should not be null"),
+        () -> assertArrayEquals(secretAB, secretBA, "Both parties must derive the same secret"),
+        () ->
+            assertEquals(
+                curve.derivedSecretSize,
+                secretAB.length,
+                "Raw ECDH secret length should match curve expectation"),
+        () -> assertTrue(alice.lastUsedTime() > 0L, "Alice lastUsedTime must be updated"),
+        () -> assertTrue(bob.lastUsedTime() > 0L, "Bob lastUsedTime must be updated"));
+  }
+
+  @Test
+  @DisplayName(
+      "null peer key either throws NPE (trace logging) or returns null; lastUsedTime updated")
+  void getHMACKey_whenPeerIsNull_returnsNullOrThrowsAndUpdatesTime() {
+    ECDHLightContext ctx = new ECDHLightContext(ECDH.Curves.P256);
+    ctx.lastUsedTime = 0L;
+
+    byte[] secret = null;
+    Exception thrown = null;
+    try {
+      secret = ctx.getHMACKey(null);
+    } catch (Exception e) {
+      thrown = e;
+    }
+
+    final Exception finalThrown = thrown;
+    final byte[] finalSecret = secret;
+    assertAll(
+        () ->
+            assertTrue(
+                finalThrown == null || finalThrown instanceof NullPointerException,
+                "Either no exception or NullPointerException is expected with null peer"),
+        () -> {
+          if (finalThrown == null) {
+            assertNull(finalSecret, "Derived secret must be null for null peer key");
+          }
+        },
+        () -> assertTrue(ctx.lastUsedTime() > 0L, "lastUsedTime must be updated on call"));
+  }
+
+  @Test
+  @DisplayName(
+      "mismatched curves either throw NPE (trace logging) or return null; lastUsedTime updated")
+  void getHMACKey_whenCurveMismatches_returnsNullOrThrowsAndUpdatesTime() {
+    ECDHLightContext p256 = new ECDHLightContext(ECDH.Curves.P256);
+    ECDHLightContext p384 = new ECDHLightContext(ECDH.Curves.P384);
+    p256.lastUsedTime = 0L;
+    p384.lastUsedTime = 0L;
+
+    byte[] s1 = null;
+    byte[] s2 = null;
+    Exception t1 = null;
+    Exception t2 = null;
+    try {
+      s1 = p256.getHMACKey(p384.getPublicKey());
+    } catch (Exception e) {
+      t1 = e;
+    }
+    try {
+      s2 = p384.getHMACKey(p256.getPublicKey());
+    } catch (Exception e) {
+      t2 = e;
+    }
+
+    final Exception ft1 = t1;
+    final Exception ft2 = t2;
+    final byte[] fs1 = s1;
+    final byte[] fs2 = s2;
+    assertAll(
+        () -> {
+          if (ft1 == null) {
+            assertNull(fs1, "Secret must be null when curves mismatch (P256 vs P384)");
+          } else {
+            assertInstanceOf(NullPointerException.class, ft1, "Expected NPE under trace logging");
+          }
+        },
+        () -> {
+          if (ft2 == null) {
+            assertNull(fs2, "Secret must be null when curves mismatch (P384 vs P256)");
+          } else {
+            assertInstanceOf(NullPointerException.class, ft2, "Expected NPE under trace logging");
+          }
+        },
+        () -> assertTrue(p256.lastUsedTime() > 0L, "P256 context time should update"),
+        () -> assertTrue(p384.lastUsedTime() > 0L, "P384 context time should update"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ECDH.Curves.class)
+  @DisplayName("public key is EC/X.509 and network format bytes are sane")
+  void publicKeyAndNetworkFormat_whenRequested_expectValidValues(ECDH.Curves curve) {
+    ECDHLightContext ctx = new ECDHLightContext(curve);
+    ECPublicKey pub = ctx.getPublicKey();
+    byte[] networkBytes = ctx.getPublicKeyNetworkFormat();
+
+    assertAll(
+        () -> assertEquals("EC", pub.getAlgorithm(), "Public key algorithm should be EC"),
+        () -> assertEquals("X.509", pub.getFormat(), "Public key format should be X.509"),
+        () -> assertNotNull(networkBytes, "Network format bytes must not be null"),
+        () -> assertTrue(networkBytes.length > 0, "Network bytes must be non-empty"),
+        () ->
+            assertTrue(
+                networkBytes.length <= curve.modulusSize,
+                "Encoded pubkey length must be <= curve modulus size"),
+        () ->
+            assertArrayEquals(
+                ctx.ecdh.getPublicKeyNetworkFormat(),
+                networkBytes,
+                "Context must delegate to underlying ECDH for network format"));
+  }
+
+  @Test
+  @DisplayName("toString contains class name (sanity check)")
+  void toString_whenCalled_containsClassName() {
+    ECDHLightContext ctx = new ECDHLightContext(ECDH.Curves.P256);
+    String s = ctx.toString();
+    assertTrue(s.contains("ECDHLightContext"));
+  }
+}

--- a/src/test/java/network/crypta/crypt/ECDHTest.java
+++ b/src/test/java/network/crypta/crypt/ECDHTest.java
@@ -1,57 +1,218 @@
 package network.crypta.crypt;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.Security;
+import java.util.EnumSet;
+import java.util.stream.Stream;
 import network.crypta.crypt.ECDH.Curves;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class ECDHTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ECDHTest {
 
-  ECDH.Curves curveToTest;
-  ECDH alice;
-  ECDH bob;
-
-  @BeforeEach
-  public void setUp() throws Exception {
-    Security.addProvider(new BouncyCastleProvider());
-    curveToTest = Curves.P256;
-    alice = new ECDH(curveToTest);
-    bob = new ECDH(curveToTest);
+  @BeforeAll
+  void addBouncyCastleProvider() {
+    // Ensure BC is available regardless of environment defaults
+    if (Security.getProvider("BC") == null) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
   }
 
-  @Test
-  public void testGetAgreedSecret()
-      throws InvalidKeyException,
-          IllegalStateException,
-          NoSuchAlgorithmException,
-          InvalidAlgorithmParameterException {
-    byte[] aliceS = alice.getAgreedSecret(bob.getPublicKey());
-    byte[] bobS = bob.getAgreedSecret(alice.getPublicKey());
-    assertNotNull(aliceS);
-    assertNotNull(bobS);
-    assertArrayEquals(aliceS, bobS);
-    assertEquals(aliceS.length, curveToTest.derivedSecretSize);
-    assertEquals(bobS.length, curveToTest.derivedSecretSize);
+  @ParameterizedTest
+  @EnumSource(Curves.class)
+  @DisplayName("ECDH agreed secret matches and has expected length per curve")
+  void getAgreedSecret_whenPeersUseSameCurve_secretsMatchAndLengthMatches(Curves curve) {
+    // Arrange
+    ECDH alice = new ECDH(curve);
+    ECDH bob = new ECDH(curve);
+
+    // Act
+    byte[] aliceSecret = alice.getAgreedSecret(bob.getPublicKey());
+    byte[] bobSecret = bob.getAgreedSecret(alice.getPublicKey());
+
+    // Assert
+    assertNotNull(aliceSecret);
+    assertNotNull(bobSecret);
+    assertArrayEquals(aliceSecret, bobSecret);
+    assertEquals(curve.derivedSecretSize, aliceSecret.length);
+    assertEquals(curve.derivedSecretSize, bobSecret.length);
   }
 
-  @Test
-  public void testGetPublicKey() {
+  @ParameterizedTest
+  @EnumSource(Curves.class)
+  void getPublicKey_whenRequested_returnsDistinctNonNullWithExpectedEncodingSize(Curves curve) {
+    // Arrange
+    ECDH alice = new ECDH(curve);
+    ECDH bob = new ECDH(curve);
+
+    // Act
     PublicKey aliceP = alice.getPublicKey();
     PublicKey bobP = bob.getPublicKey();
 
+    // Assert
     assertNotNull(aliceP);
+    assertNotNull(bobP);
     assertNotSame(aliceP, bobP);
-    assertEquals(aliceP.getEncoded().length, curveToTest.modulusSize);
-    assertEquals(bobP.getEncoded().length, curveToTest.modulusSize);
+    assertEquals(curve.modulusSize, aliceP.getEncoded().length);
+    assertEquals(curve.modulusSize, bobP.getEncoded().length);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Curves.class)
+  void getPublicKeyNetworkFormat_whenNormal_returnsEncodedBytes(Curves curve) {
+    // Arrange
+    ECDH alice = new ECDH(curve);
+
+    // Act
+    byte[] network = alice.getPublicKeyNetworkFormat();
+
+    // Assert
+    assertArrayEquals(alice.getPublicKey().getEncoded(), network);
+    assertEquals(curve.modulusSize, network.length);
+  }
+
+  @Test
+  void getAgreedSecret_whenNullPublicKey_returnsNull() {
+    // Arrange
+    ECDH alice = new ECDH(Curves.P256);
+
+    // Act
+    byte[] s = alice.getAgreedSecret(null);
+
+    // Assert
+    assertNull(s);
+  }
+
+  @Test
+  void getPublicKey_whenNullBytes_throwsNPE() {
+    // Act + Assert
+    assertThrows(NullPointerException.class, () -> ECDH.getPublicKey(null, Curves.P256));
+  }
+
+  @Test
+  void getPublicKey_whenEmptyBytes_returnsNull() {
+    // Arrange
+    byte[] empty = new byte[0];
+
+    // Act
+    var key = ECDH.getPublicKey(empty, Curves.P256);
+
+    // Assert
+    assertNull(key);
+  }
+
+  static Stream<Arguments> mismatchedCurves() {
+    // All ordered pairs of distinct curves
+    var curves = EnumSet.allOf(Curves.class).toArray(new Curves[0]);
+    Stream.Builder<Arguments> b = Stream.builder();
+    for (Curves a : curves) {
+      for (Curves c : curves) {
+        if (a != c) b.add(Arguments.of(a, c));
+      }
+    }
+    return b.build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("mismatchedCurves")
+  void getAgreedSecret_whenCurvesDiffer_returnsNull(Curves a, Curves b) {
+    // Arrange
+    ECDH alice = new ECDH(a);
+    ECDH bob = new ECDH(b);
+
+    // Act
+    byte[] s1 = alice.getAgreedSecret(bob.getPublicKey());
+    byte[] s2 = bob.getAgreedSecret(alice.getPublicKey());
+
+    // Assert
+    assertNull(s1);
+    assertNull(s2);
+  }
+
+  @Test
+  void blockingInit_whenCalledTwice_doesNotThrow() {
+    // Act + Assert
+    assertDoesNotThrow(
+        () -> {
+          ECDH.blockingInit();
+          ECDH.blockingInit();
+        });
+  }
+
+  @Test
+  void getPublicKeyNetworkFormat_whenEncodedTooLong_throwsIllegalStateException() {
+    // Arrange
+    ECDH ecdh = new ECDH(Curves.P256);
+    ECDH spy = Mockito.spy(ecdh);
+    // Mock a public key with encoding larger than expected
+    PublicKey fake =
+        Mockito.mock(
+            PublicKey.class,
+            Mockito.withSettings().extraInterfaces(java.security.interfaces.ECPublicKey.class));
+    byte[] tooLong = new byte[Curves.P256.modulusSize + 5];
+    Mockito.when(fake.getEncoded()).thenReturn(tooLong);
+    Mockito.doReturn(fake).when(spy).getPublicKey();
+
+    // Act + Assert
+    assertThrows(IllegalStateException.class, spy::getPublicKeyNetworkFormat);
+  }
+
+  @Test
+  void
+      getPublicKeyNetworkFormat_whenEncodedTooShort_returnsUnpaddedBytesDueToCurrentImplementation() {
+    // Arrange
+    ECDH ecdh = new ECDH(Curves.P256);
+    ECDH spy = Mockito.spy(ecdh);
+    PublicKey fake =
+        Mockito.mock(
+            PublicKey.class,
+            Mockito.withSettings().extraInterfaces(java.security.interfaces.ECPublicKey.class));
+    byte[] tooShort = new byte[Curves.P256.modulusSize - 7];
+    Mockito.when(fake.getEncoded()).thenReturn(tooShort);
+    Mockito.doReturn(fake).when(spy).getPublicKey();
+
+    // Act
+    byte[] network = spy.getPublicKeyNetworkFormat();
+
+    // Assert
+    // Current implementation warns and returns original, unpadded bytes
+    assertArrayEquals(tooShort, network);
+    assertEquals(tooShort.length, network.length);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Curves.class)
+  void getPublicKey_roundTripEncoding_yieldsEquivalentKey(Curves curve) {
+    // Arrange
+    ECDH alice = new ECDH(curve);
+    byte[] encoded = alice.getPublicKey().getEncoded();
+
+    // Act
+    var reconstructed = ECDH.getPublicKey(encoded, curve);
+
+    // Assert
+    assertNotNull(reconstructed);
+    assertArrayEquals(encoded, reconstructed.getEncoded());
   }
 }

--- a/src/test/java/network/crypta/crypt/ECDSATest.java
+++ b/src/test/java/network/crypta/crypt/ECDSATest.java
@@ -1,53 +1,83 @@
 package network.crypta.crypt;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.Arrays;
 import network.crypta.crypt.ECDSA.Curves;
 import network.crypta.node.FSParseException;
+import network.crypta.support.Base64;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class ECDSATest {
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ECDSATest {
 
-  ECDSA.Curves curveToTest;
-  ECDSA ecdsa;
+  private ECDSA.Curves curveToTest;
+  private ECDSA ecdsa;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  void setUp() {
     curveToTest = Curves.P256;
     ecdsa = new ECDSA(curveToTest);
   }
 
   @Test
-  public void testGetPublicKey() {
+  void getPublicKey_whenGenerated_isPresentAndBounded() {
     PublicKey pub = ecdsa.getPublicKey();
     assertNotNull(pub);
     assertTrue(pub.getEncoded().length <= curveToTest.modulusSize);
   }
 
   @Test
-  public void testSign() {
+  void sign_whenCalled_producesBytes() {
     byte[] sig = ecdsa.sign("test".getBytes());
     assertNotNull(sig);
     assertTrue(sig.length > 0);
   }
 
   @Test
-  public void testSignToNetworkFormat() {
-    byte[] toSign = "test".getBytes();
-    byte[] sig = ecdsa.signToNetworkFormat(toSign);
-    assertNotNull(sig);
-    assertEquals(sig.length, curveToTest.maxSigSize);
+  void sign_whenCalledTwiceWithSameData_isDeterministic() {
+    byte[] m = "deterministic".getBytes();
+    byte[] s1 = ecdsa.sign(m);
+    byte[] s2 = ecdsa.sign(m);
+    assertArrayEquals(s1, s2);
   }
 
   @Test
-  public void testVerify() {
+  void signToNetworkFormat_whenCalled_returnsFixedLength() {
+    byte[] toSign = "test".getBytes();
+    byte[] sig = ecdsa.signToNetworkFormat(toSign);
+    assertNotNull(sig);
+    assertEquals(curveToTest.maxSigSize, sig.length);
+  }
+
+  @Test
+  void signToNetworkFormat_whenUnderlyingSignatureTooLong_throws() {
+    ECDSA spy = Mockito.spy(new ECDSA(curveToTest));
+    byte[] tooLong = new byte[curveToTest.maxSigSize + 1];
+    Mockito.doReturn(tooLong).when(spy).sign(Mockito.any());
+    byte[] smallMsg = "x".getBytes();
+    assertThrows(IllegalStateException.class, () -> spy.signToNetworkFormat(smallMsg));
+  }
+
+  @Test
+  void verify_whenValidSignature_succeeds() {
     String toSign = "test";
     byte[] sig = ecdsa.sign(toSign.getBytes());
     assertTrue(ecdsa.verify(sig, toSign.getBytes()));
@@ -55,13 +85,85 @@ public class ECDSATest {
   }
 
   @Test
-  public void testAsFieldSet() throws FSParseException {
+  void verify_whenUsingNetworkPaddedSignature_succeeds() {
+    byte[] msg = "pad me".getBytes();
+    byte[] padded = ecdsa.signToNetworkFormat(msg);
+    assertTrue(ecdsa.verify(padded, msg));
+  }
+
+  @Test
+  void verify_withOffsetAndExtraBytes_ignoresPaddingAndSuceeds() {
+    byte[] msg = "offset ok".getBytes();
+    byte[] padded = ecdsa.signToNetworkFormat(msg);
+    byte[] container = new byte[10 + padded.length + 5];
+    // Fill with non-zero noise around the signature to ensure we only use declared range
+    Arrays.fill(container, (byte) 0x5A);
+    int off = 10;
+    System.arraycopy(padded, 0, container, off, padded.length);
+    assertTrue(ecdsa.verify(container, off, padded.length + 5, msg));
+  }
+
+  @Test
+  void verify_withTamperedSignature_fails() {
+    byte[] msg = "tamper".getBytes();
+    byte[] sig = ecdsa.sign(msg); // raw DER without network padding
+    byte[] tampered = Arrays.copyOf(sig, sig.length);
+    tampered[tampered.length - 1] ^= 0x01; // flip a byte inside the DER payload
+    assertFalse(ecdsa.verify(tampered, msg));
+  }
+
+  @Test
+  void verify_withMismatchedKey_fails() {
+    byte[] msg = "wrong key".getBytes();
+    byte[] sig = ecdsa.sign(msg);
+    // New ECDSA with different key
+    ECDSA other = new ECDSA(curveToTest);
+    assertFalse(ECDSA.verify(curveToTest, other.getPublicKey(), sig, msg));
+  }
+
+  @Test
+  void verify_withInvalidDerHeader_returnsFalse() {
+    byte[] msg = "bad header".getBytes();
+    byte[] sig = ecdsa.sign(msg);
+    byte[] invalid = Arrays.copyOf(sig, sig.length);
+    invalid[0] = 0x31; // not a DER SEQUENCE (should be 0x30)
+    assertFalse(ecdsa.verify(invalid, msg));
+  }
+
+  @Test
+  void staticVerify_withNullArgs_returnsFalse() {
+    assertFalse(ECDSA.verify(curveToTest, null, new byte[0]));
+    assertFalse(ECDSA.verify(null, ecdsa.getPublicKey(), new byte[0]));
+    ECPublicKey key = ecdsa.getPublicKey();
+    assertThrows(NullPointerException.class, () -> ECDSA.verify(curveToTest, key, null));
+    assertFalse(ECDSA.verify(curveToTest, ecdsa.getPublicKey(), new byte[0], (byte[][]) null));
+  }
+
+  @Test
+  void getPublicKeyStatic_whenInvalidBytes_returnsNull() {
+    assertNull(ECDSA.getPublicKey(new byte[] {0x01, 0x02, 0x03}, curveToTest));
+  }
+
+  @Test
+  void curvesGetSFS_whenCalled_containsBase64PubAndReconstructible() throws Exception {
+    ECPublicKey pub = ecdsa.getPublicKey();
+    SimpleFieldSet sfs = curveToTest.getSFS(pub);
+    SimpleFieldSet subset = sfs.getSubset(curveToTest.name());
+    assertNotNull(subset);
+    assertNotNull(subset.get("pub"));
+    byte[] decoded = Base64.decode(subset.get("pub"));
+    ECPublicKey parsed = ECDSA.getPublicKey(decoded, curveToTest);
+    assertNotNull(parsed);
+    assertArrayEquals(pub.getEncoded(), parsed.getEncoded());
+  }
+
+  @Test
+  void asFieldSet_whenIncludePrivate_controlsPresenceOfPriField() throws FSParseException {
     SimpleFieldSet privSFS = ecdsa.asFieldSet(true);
     assertNotNull(privSFS.getSubset(curveToTest.name()));
     assertNotNull(privSFS.get(curveToTest.name() + ".pub"));
     assertNotNull(privSFS.get(curveToTest.name() + ".pri"));
 
-    // Ensure we don't leak the privkey when we don't intend to
     SimpleFieldSet pubSFS = ecdsa.asFieldSet(false);
     assertNotNull(pubSFS.getSubset(curveToTest.name()));
     assertNotNull(pubSFS.get(curveToTest.name() + ".pub"));
@@ -69,9 +171,22 @@ public class ECDSATest {
   }
 
   @Test
-  public void testSerializeUnserialize() throws FSParseException {
+  void serializeUnserialize_whenRoundTripped_preservesPublicKey() throws FSParseException {
     SimpleFieldSet sfs = ecdsa.asFieldSet(true);
     ECDSA ecdsa2 = new ECDSA(sfs.getSubset(curveToTest.name()), curveToTest);
     assertEquals(ecdsa.getPublicKey(), ecdsa2.getPublicKey());
+  }
+
+  @DisplayName("sign/verify works across all configured curves")
+  @ParameterizedTest
+  @EnumSource(Curves.class)
+  void signVerify_acrossCurves_succeeds(Curves curve) {
+    ECDSA local = new ECDSA(curve);
+    byte[] msg1 = "hello".getBytes();
+    byte[] msg2 = "world".getBytes();
+    byte[] sig1 = local.sign(msg1);
+    byte[] sig2 = local.signToNetworkFormat(msg2);
+    assertTrue(local.verify(sig1, msg1));
+    assertTrue(ECDSA.verify(curve, local.getPublicKey(), sig2, msg2));
   }
 }


### PR DESCRIPTION
Summary
- Harden and refactor ECDH/ECDSA code paths, tighten init/error handling, and improve KDoc/Javadoc clarity.
- Encapsulate ECDSA signature handling in KeyAgreementSchemeContext.
- Add new and expanded JUnit 6 tests for ECDH/ECDSA, including a new ECDHLightContextTest.
- Spotless formatting applied across touched sources.

Branch status (as of 2025-10-19)
- Base: origin/develop
- Ahead: 5 commits; Behind: 4 commits

Commits ahead of base
- c1e889fe3d refactor(crypt): ECDSA utils/tests cleanup; apply Spotless formatting
- 184b050d8d refactor(crypt): encapsulate ECDSA signature in KeyAgreementSchemeContext and add Javadoc
- 05ba497473 test(crypt): add ECDHLightContextTest covering ECDHLightContext behavior
- 47d5a574c2 docs(crypt): improve Javadoc and inline comments for ECDHLightContext
- 6bb171c16e refactor(crypt): harden ECDH init/error handling; expand tests; apply Spotless

Diff summary vs origin/develop
- src/main/java/network/crypta/crypt/ECDSA.java — major cleanup/refactor (+361/−?)
- src/main/java/network/crypta/crypt/ECDH.java — refactors and error-path hardening (+208/−?)
- src/main/java/network/crypta/crypt/ECDHLightContext.java — improvements (+65/−?)
- src/main/java/network/crypta/crypt/KeyAgreementSchemeContext.java — encapsulation additions (+61/−?)
- src/main/java/network/crypta/node/FNPPacketMangler.java — minor edit
- src/test/java/network/crypta/crypt/ECDHLightContextTest.java — new test (+165)
- src/test/java/network/crypta/crypt/ECDHTest.java — expanded tests (+225/−?)
- src/test/java/network/crypta/crypt/ECDSATest.java — expanded tests (+139/−?)

Aggregate: 8 files changed, 966 insertions, 262 deletions.

Notes
- Tests target JUnit 6 (project default); no Vintage usage.
- Formatting adheres to Spotless (Kotlin/Java). No uncommitted changes remain locally.

Review suggestions
- Focus on the new KeyAgreementSchemeContext responsibilities around ECDSA.
- Verify ECDH/ECDSA behavior remains wire-compatible where applicable and that added tests cover expected edge cases.
- Confirm no unintentional behavioral changes in FNPPacketMangler.
