### PR TITLE
crypt: MultiHash digester/streams modernization; expand tests and docs

### DIFF
--- a/src/main/java/network/crypta/crypt/MultiHashDigester.java
+++ b/src/main/java/network/crypta/crypt/MultiHashDigester.java
@@ -4,8 +4,17 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
+/**
+ * Computes several cryptographic hashes over the same byte stream in one pass.
+ *
+ * <p>This utility owns one {@link MessageDigest} per {@link HashType} selected via a bit mask. Feed
+ * data through {@link #update(byte[], int, int)} and obtain all results via {@link #getResults()}.
+ * The order of results follows {@link HashType#values()}.
+ *
+ * <p>Thread-safety: not thread-safe. Create a new instance per computation and use it from a single
+ * thread.
+ */
 final class MultiHashDigester {
 
   private final Collection<Digester> digesters;
@@ -14,17 +23,44 @@ final class MultiHashDigester {
     this.digesters = digesters;
   }
 
+  /**
+   * Feeds a slice of the input array to every configured digest.
+   *
+   * @param input source bytes (must not be {@code null})
+   * @param offset start index within {@code input}
+   * @param len number of bytes to read
+   * @throws NullPointerException if {@code input} is {@code null}
+   * @throws IndexOutOfBoundsException if the range {@code [offset, offset+len)} is out of bounds
+   * @throws IllegalArgumentException if {@code offset < 0} or {@code len < 0}
+   */
   void update(byte[] input, int offset, int len) {
     digesters.forEach(digester -> digester.update(input, offset, len));
   }
 
+  /**
+   * Finalizes all digests and returns their values.
+   *
+   * <p>Each call completes the underlying {@link MessageDigest} instances (they are reset after
+   * completion). Subsequent calls to {@link #update(byte[], int, int)} start a new computation.
+   *
+   * <p>The returned list is unmodifiable and ordered according to {@link HashType#values()}.
+   *
+   * @return unmodifiable list of results; may be empty when no hash types were selected
+   */
   List<HashResult> getResults() {
-    return digesters.stream().map(Digester::getResult).collect(Collectors.toList());
+    // Use Stream.toList() so callers cannot mutate the returned list.
+    return digesters.stream().map(Digester::getResult).toList();
   }
 
   /**
-   * Create a digester for the hash types indicated by the bitmask.
+   * Creates a digester configured for the hash types indicated by {@code bitmask}.
    *
+   * <p>For each {@link HashType} whose {@link HashType#bitmask} bit is set in {@code bitmask}, a
+   * corresponding digester is included. Result ordering produced by {@link #getResults()} matches
+   * the declaration order of {@link HashType#values()}.
+   *
+   * @param bitmask bit set of desired hash types
+   * @return a new digester for the selected types
    * @see HashType#bitmask
    */
   static MultiHashDigester fromBitmask(long bitmask) {
@@ -32,7 +68,8 @@ final class MultiHashDigester {
         Arrays.stream(HashType.values())
             .filter(hashType -> (bitmask & hashType.bitmask) == hashType.bitmask)
             .map(Digester::new)
-            .collect(Collectors.toList());
+            // Stream.toList() returns an unmodifiable list; we never mutate it.
+            .toList();
 
     return new MultiHashDigester(digesters);
   }
@@ -47,10 +84,12 @@ final class MultiHashDigester {
     }
 
     HashResult getResult() {
+      // Complete and reset this MessageDigest; safe because each instance is owned here.
       return new HashResult(hashType, digest.digest());
     }
 
     void update(byte[] input, int offset, int len) {
+      // Delegate bounds validation to JCA; exceptions propagate unchanged.
       digest.update(input, offset, len);
     }
   }

--- a/src/main/java/network/crypta/crypt/MultiHashInputStream.java
+++ b/src/main/java/network/crypta/crypt/MultiHashInputStream.java
@@ -46,7 +46,11 @@ public class MultiHashInputStream extends SkipShieldingInputStream {
   }
 
   @Override
-  public void mark(int readlimit) {}
+  public void mark(int readlimit) {
+    // Intentionally a no-op: mark/reset are not supported because this stream
+    // updates multiple digests incrementally and cannot rewind that state.
+    // See: markSupported() returns false and reset() throws IOException.
+  }
 
   public HashResult[] getResults() {
     return digester.getResults().toArray(new HashResult[0]);

--- a/src/main/java/network/crypta/crypt/MultiHashOutputStream.java
+++ b/src/main/java/network/crypta/crypt/MultiHashOutputStream.java
@@ -3,28 +3,80 @@ package network.crypta.crypt;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * An {@link OutputStream} that forwards all writes to a wrapped stream while computing multiple
+ * hash digests in parallel.
+ *
+ * <p>Each call to {@code write(...)} is passed through to the underlying {@link OutputStream} and
+ * the same bytes are fed into a {@link MultiHashDigester}. Use {@link #getResults()} to obtain the
+ * current digest values for all configured algorithms.
+ *
+ * <p>Thread safety: instances are not thread-safe. External synchronization is required when
+ * accessed concurrently.
+ *
+ * <p>Flush/close semantics follow {@link FilterOutputStream}: {@code flush()} and {@code close()}
+ * are delegated to the wrapped stream.
+ */
 public class MultiHashOutputStream extends FilterOutputStream {
 
   private final MultiHashDigester digester;
 
+  /**
+   * Creates a new stream that computes a set of digests selected by a bit mask while writing to the
+   * given {@code proxy} stream.
+   *
+   * <p>The {@code generateHashes} mask is interpreted by {@link
+   * MultiHashDigester#fromBitmask(long)} to choose the hash algorithms to compute.
+   *
+   * @param proxy the destination stream to which all bytes are written
+   * @param generateHashes bit mask selecting which hashes to compute
+   */
   public MultiHashOutputStream(OutputStream proxy, long generateHashes) {
     super(proxy);
     this.digester = MultiHashDigester.fromBitmask(generateHashes);
   }
 
+  /**
+   * Writes one byte to the underlying stream and updates all active hash digests with the same
+   * value.
+   *
+   * @param b the byte value to write; only the low-order eight bits are used
+   * @throws IOException if the underlying stream throws an I/O error
+   */
   @Override
   public void write(int b) throws IOException {
     out.write(b);
     digester.update(new byte[] {(byte) b}, 0, 1);
   }
 
+  /**
+   * Writes {@code len} bytes starting at {@code off} from {@code buf} to the underlying stream and
+   * updates all active hash digests with the same range.
+   *
+   * <p>Preconditions mirror {@link OutputStream#write(byte[], int, int)}: {@code buf} must not be
+   * {@code null}; {@code off} and {@code len} must specify a valid subrange of {@code buf}.
+   *
+   * @param buf the source buffer (non-null)
+   * @param off the start offset within the buffer
+   * @param len the number of bytes to write
+   * @throws IOException if the underlying stream throws an I/O error
+   */
   @Override
-  public void write(byte[] buf, int off, int len) throws IOException {
+  public void write(byte @NotNull [] buf, int off, int len) throws IOException {
     out.write(buf, off, len);
     digester.update(buf, off, len);
   }
 
+  /**
+   * Returns the current digest results for all configured algorithms.
+   *
+   * <p>The returned array is a snapshot and modifications to it do not affect this stream. The
+   * order and contents of the results are defined by the associated {@link MultiHashDigester}.
+   *
+   * @return an array of computed {@link HashResult} values
+   */
   public HashResult[] getResults() {
     return digester.getResults().toArray(new HashResult[0]);
   }

--- a/src/test/java/network/crypta/crypt/MultiHashDigesterTest.java
+++ b/src/test/java/network/crypta/crypt/MultiHashDigesterTest.java
@@ -1,71 +1,178 @@
 package network.crypta.crypt;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class MultiHashDigesterTest {
+@SuppressWarnings({"java:S100", "java:S4790"})
+@ExtendWith(MockitoExtension.class)
+class MultiHashDigesterTest {
 
   @Test
-  public void createFromBitmask() {
+  void fromBitmask_whenSingleType_returnsOnlyThatType() {
     for (HashType hashType : HashType.values()) {
       MultiHashDigester digester = MultiHashDigester.fromBitmask(hashType.bitmask);
+
       List<HashResult> results = digester.getResults();
 
       assertEquals(1, results.size());
-      assertEquals(hashType, results.get(0).type);
+      assertEquals(hashType, results.getFirst().type);
     }
   }
 
   @Test
-  public void noHash() {
+  void fromBitmask_whenZero_returnsEmptyResults() {
     MultiHashDigester digester = MultiHashDigester.fromBitmask(0);
+
     List<HashResult> results = digester.getResults();
 
-    assertEquals(0, results.size());
+    assertTrue(results.isEmpty());
   }
 
   @Test
-  public void multiHash() {
+  void fromBitmask_whenMultipleBits_resultsOrderedByEnum() {
     MultiHashDigester digester =
         MultiHashDigester.fromBitmask(
-            HashType.SHA1.bitmask | HashType.MD5.bitmask | HashType.SHA256.bitmask);
+            HashType.MD5.bitmask | HashType.SHA512.bitmask | HashType.SHA1.bitmask);
+
     List<HashResult> results = digester.getResults();
 
     assertEquals(3, results.size());
+    // Order must follow HashType.values(): SHA1, MD5, SHA256, SHA384, SHA512, ED2K, TTH
     assertEquals(HashType.SHA1, results.get(0).type);
     assertEquals(HashType.MD5, results.get(1).type);
-    assertEquals(HashType.SHA256, results.get(2).type);
+    assertEquals(HashType.SHA512, results.get(2).type);
   }
 
   @Test
-  public void digestEmpty() {
+  void getResults_whenNoUpdate_hashesEmptyInput_matchKnownHex() {
     MultiHashDigester digester =
         MultiHashDigester.fromBitmask(
             HashType.SHA1.bitmask | HashType.MD5.bitmask | HashType.SHA256.bitmask);
 
     List<HashResult> results = digester.getResults();
-    assertEquals(results.get(0).hashAsHex(), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
-    assertEquals(results.get(1).hashAsHex(), "d41d8cd98f00b204e9800998ecf8427e");
+
+    assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", results.get(0).hashAsHex());
+    assertEquals("d41d8cd98f00b204e9800998ecf8427e", results.get(1).hashAsHex());
     assertEquals(
-        results.get(2).hashAsHex(),
-        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        results.get(2).hashAsHex());
   }
 
   @Test
-  public void updateAndDigest() {
+  void update_whenSingleByte_producesExpectedJcaDigests() throws NoSuchAlgorithmException {
     MultiHashDigester digester =
         MultiHashDigester.fromBitmask(
             HashType.SHA1.bitmask | HashType.MD5.bitmask | HashType.SHA256.bitmask);
-    digester.update("$".getBytes(StandardCharsets.UTF_8), 0, 1);
+
+    byte[] input = "$".getBytes(StandardCharsets.UTF_8);
+    digester.update(input, 0, 1);
 
     List<HashResult> results = digester.getResults();
-    assertEquals(results.get(0).hashAsHex(), "3cdf2936da2fc556bfa533ab1eb59ce710ac80e5");
-    assertEquals(results.get(1).hashAsHex(), "c3e97dd6e97fb5125688c97f36720cbe");
+
+    assertEquals(hex(MessageDigest.getInstance("SHA1").digest(input)), results.get(0).hashAsHex());
+    assertEquals(hex(MessageDigest.getInstance("MD5").digest(input)), results.get(1).hashAsHex());
     assertEquals(
-        results.get(2).hashAsHex(),
-        "09fc96082d34c2dfc1295d92073b5ea1dc8ef8da95f14dfded011ffb96d3e54b");
+        hex(MessageDigest.getInstance("SHA-256").digest(input)), results.get(2).hashAsHex());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = HashType.class,
+      names = {"SHA1", "MD5", "SHA256", "SHA384", "SHA512"})
+  void update_whenJcaType_matchesIndependentJca(HashType type) throws NoSuchAlgorithmException {
+    MultiHashDigester digester = MultiHashDigester.fromBitmask(type.bitmask);
+
+    byte[] input = "Hello, Crypta!".getBytes(StandardCharsets.UTF_8);
+    digester.update(input, 0, input.length);
+
+    byte[] expected = MessageDigest.getInstance(type.javaName).digest(input);
+
+    List<HashResult> results = digester.getResults();
+
+    assertEquals(1, results.size());
+    assertEquals(type, results.getFirst().type);
+    assertArrayEquals(expected, HashResult.get(results.toArray(new HashResult[0]), type));
+  }
+
+  @Test
+  void update_whenOffsetAndLength_hashesSubrangeOnly() throws NoSuchAlgorithmException {
+    MultiHashDigester digester = MultiHashDigester.fromBitmask(HashType.MD5.bitmask);
+
+    byte[] input = "abcXYZdef".getBytes(StandardCharsets.UTF_8); // hash should be for "XYZ"
+    digester.update(input, 3, 3);
+
+    byte[] expected =
+        MessageDigest.getInstance("MD5").digest("XYZ".getBytes(StandardCharsets.UTF_8));
+
+    List<HashResult> results = digester.getResults();
+    assertEquals(1, results.size());
+    assertArrayEquals(expected, HashResult.get(results.toArray(new HashResult[0]), HashType.MD5));
+  }
+
+  @Test
+  void update_whenZeroLength_isNoOpAndEqualsEmptyDigest() throws NoSuchAlgorithmException {
+    MultiHashDigester digester = MultiHashDigester.fromBitmask(HashType.SHA1.bitmask);
+
+    byte[] input = "ignored".getBytes(StandardCharsets.UTF_8);
+    digester.update(input, 0, 0);
+
+    byte[] expectedEmpty = MessageDigest.getInstance("SHA1").digest(new byte[0]);
+
+    List<HashResult> results = digester.getResults();
+    assertEquals(1, results.size());
+    assertArrayEquals(
+        expectedEmpty, HashResult.get(results.toArray(new HashResult[0]), HashType.SHA1));
+  }
+
+  @Test
+  void update_whenInvalidBounds_throwsRuntimeBoundsException() {
+    MultiHashDigester digester = MultiHashDigester.fromBitmask(HashType.SHA256.bitmask);
+    byte[] input = new byte[] {1, 2, 3};
+
+    RuntimeException ex1 =
+        assertThrows(RuntimeException.class, () -> digester.update(input, -1, 1));
+    assertTrue(
+        ex1 instanceof IndexOutOfBoundsException || ex1 instanceof IllegalArgumentException,
+        "expected IndexOutOfBoundsException or IllegalArgumentException");
+
+    RuntimeException ex2 = assertThrows(RuntimeException.class, () -> digester.update(input, 1, 5));
+    assertTrue(
+        ex2 instanceof IndexOutOfBoundsException || ex2 instanceof IllegalArgumentException,
+        "expected IndexOutOfBoundsException or IllegalArgumentException");
+  }
+
+  @Test
+  void ed2kAndTth_whenSelected_produceResultsWithDeclaredLengths() {
+    long mask = HashType.ED2K.bitmask | HashType.TTH.bitmask;
+    MultiHashDigester digester = MultiHashDigester.fromBitmask(mask);
+
+    List<HashResult> results = digester.getResults();
+
+    assertEquals(2, results.size());
+    assertEquals(HashType.ED2K, results.get(0).type);
+    assertEquals(HashType.TTH, results.get(1).type);
+    assertEquals(HashType.ED2K.hashLength, results.get(0).hashAsHex().length() / 2);
+    assertEquals(HashType.TTH.hashLength, results.get(1).hashAsHex().length() / 2);
+  }
+
+  // ----- helpers -----
+  private static String hex(byte[] bytes) {
+    StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
   }
 }

--- a/src/test/java/network/crypta/crypt/MultiHashInputStreamTest.java
+++ b/src/test/java/network/crypta/crypt/MultiHashInputStreamTest.java
@@ -7,34 +7,258 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class MultiHashInputStreamTest {
+@SuppressWarnings("java:S100") // Allow method names like method_whenCondition_expectOutcome
+class MultiHashInputStreamTest {
   private static final byte[] MESSAGE = "Hello, World!".getBytes(StandardCharsets.UTF_8);
   private static final String MESSAGE_MD5 = "65a8e27d8879283831b664bd8b7f0ad4";
 
-  private final ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
-  private final MultiHashInputStream hash = new MultiHashInputStream(input, HashType.MD5.bitmask);
+  private static MultiHashInputStream newHasher(InputStream in, long bitmask) {
+    return new MultiHashInputStream(in, bitmask);
+  }
 
   @Test
-  public void read() throws IOException {
+  void read_whenMixingSingleAndBulk_expectAllBytesCountedAndHashed() throws IOException {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, HashType.MD5.bitmask);
+
     byte[] buf = new byte[MESSAGE.length];
     buf[0] = (byte) hash.read();
     assertEquals(buf.length - 1, hash.read(buf, 1, buf.length - 1));
     assertEquals(-1, hash.read());
     assertEquals(MESSAGE.length, hash.getReadBytes());
-    assertArrayEquals(buf, MESSAGE);
+    assertArrayEquals(MESSAGE, buf);
 
     HashResult[] results = hash.getResults();
     assertEquals(1, results.length);
     assertEquals(HashType.MD5, results[0].type);
-    assertEquals(results[0].hashAsHex(), MESSAGE_MD5);
+    assertEquals(MESSAGE_MD5, results[0].hashAsHex());
   }
 
   @Test
-  public void markResetNotSupported() {
+  void markResetNotSupported() {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, HashType.MD5.bitmask);
+
     assertFalse(hash.markSupported());
     assertThrows(IOException.class, hash::reset);
+    // mark() is a no-op and must not throw
+    hash.mark(1);
+  }
+
+  @Test
+  void read_withZeroLength_doesNotAdvanceOrHash() throws IOException {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, HashType.MD5.bitmask);
+
+    byte[] buf = new byte[0];
+    assertEquals(0, hash.read(buf, 0, 0));
+    assertEquals(0, hash.getReadBytes());
+
+    // MD5 of empty string
+    MessageDigest md5 = HashType.MD5.get();
+    byte[] emptyDigest = md5.digest();
+    HashResult[] results = hash.getResults();
+    assertEquals(1, results.length);
+    assertEquals(HashType.MD5, results[0].type);
+    assertArrayEquals(emptyDigest, HashResult.get(results, HashType.MD5));
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void read_withNullBuffer_throwsNPE() {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, HashType.MD5.bitmask);
+
+    assertThrows(NullPointerException.class, () -> hash.read(null, 0, 1));
+  }
+
+  @Test
+  void read_withInvalidBounds_throwsIndexOutOfBounds() {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, HashType.MD5.bitmask);
+
+    byte[] buf = new byte[4];
+    assertThrows(IndexOutOfBoundsException.class, () -> hash.read(buf, -1, 1));
+    assertThrows(IndexOutOfBoundsException.class, () -> hash.read(buf, 0, -1));
+    assertThrows(IndexOutOfBoundsException.class, () -> hash.read(buf, 3, 2));
+  }
+
+  @Test
+  void getResults_whenNoAlgorithmsSelected_returnsEmptyArray() throws IOException {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, 0);
+
+    // Read everything to exercise the stream despite no digests being active
+    byte[] buf = new byte[16];
+    int total = 0;
+    int read;
+    while ((read = hash.read(buf, 0, buf.length)) > 0) {
+      total += read; // accumulate to avoid an empty loop body warning
+    }
+    assertEquals(MESSAGE.length, total);
+
+    assertEquals(MESSAGE.length, hash.getReadBytes());
+    assertEquals(0, hash.getResults().length);
+  }
+
+  @Test
+  void skip_whenPositive_countsAsReadAndAffectsDigest() throws IOException {
+    byte[] data = new byte[10_000];
+    // Deterministic content: repeated pattern of 0..255
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) (i & 0xFF);
+    }
+
+    ByteArrayInputStream input = new ByteArrayInputStream(data);
+    MultiHashInputStream hash = newHasher(input, HashType.SHA256.bitmask);
+
+    // Read first 123 bytes
+    byte[] first = new byte[123];
+    assertEquals(123, hash.read(first, 0, first.length));
+
+    // Skip the rest in a loop using the shielding skip() (which internally calls read(...))
+    long totalSkipped = 0;
+    long skipped;
+    do {
+      skipped = hash.skip(Integer.MAX_VALUE);
+      totalSkipped += skipped;
+    } while (skipped > 0);
+
+    assertEquals(data.length, hash.getReadBytes());
+    assertEquals(data.length - first.length, totalSkipped);
+
+    // Expected SHA-256 over the entire data
+    MessageDigest sha256 = HashType.SHA256.get();
+    byte[] expected = sha256.digest(data);
+    assertArrayEquals(expected, HashResult.get(hash.getResults(), HashType.SHA256));
+  }
+
+  @Test
+  void skip_whenNegative_returnsZeroAndDoesNotAffectDigestOrCount() throws IOException {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, HashType.MD5.bitmask);
+
+    assertEquals(0, hash.skip(-1));
+    assertEquals(0, hash.getReadBytes());
+
+    // MD5 over empty input
+    MessageDigest md5 = HashType.MD5.get();
+    byte[] expected = md5.digest();
+    assertArrayEquals(expected, HashResult.get(hash.getResults(), HashType.MD5));
+  }
+
+  @Test
+  void getResults_whenCalledMidStream_startsNewComputationAfterReset() throws IOException {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, HashType.SHA1.bitmask);
+
+    // Read first half and capture digest
+    int half = MESSAGE.length / 2;
+    byte[] buf = new byte[half];
+    assertEquals(half, hash.read(buf, 0, buf.length));
+    HashResult[] firstHalf = hash.getResults();
+
+    // Compute expected SHA-1 over the first half
+    MessageDigest sha1 = HashType.SHA1.get();
+    byte[] expectedFirst = sha1.digest(Arrays.copyOfRange(MESSAGE, 0, half));
+    assertArrayEquals(expectedFirst, HashResult.get(firstHalf, HashType.SHA1));
+
+    // Read remaining bytes; the internal digests were reset by getResults()
+    byte[] rest = new byte[MESSAGE.length - half];
+    assertEquals(rest.length, hash.read(rest, 0, rest.length));
+    HashResult[] secondHalf = hash.getResults();
+
+    // Expected digest is only over the second segment
+    MessageDigest sha1Again = HashType.SHA1.get();
+    byte[] expectedSecond = sha1Again.digest(Arrays.copyOfRange(MESSAGE, half, MESSAGE.length));
+    assertArrayEquals(expectedSecond, HashResult.get(secondHalf, HashType.SHA1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitmasksForMultiAlgorithm")
+  void getResults_withMultipleAlgorithms_returnsOrderedAndCorrectValues(long bitmask)
+      throws IOException {
+    ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    MultiHashInputStream hash = newHasher(input, bitmask);
+
+    // Read all at once
+    byte[] buf = new byte[MESSAGE.length];
+    assertEquals(buf.length, hash.read(buf, 0, buf.length));
+
+    HashResult[] results = hash.getResults();
+
+    // Build expected results in HashType.values() order filtered by bitmask
+    List<HashResult> expected = new ArrayList<>();
+    for (HashType t : HashType.values()) {
+      if ((bitmask & t.bitmask) == t.bitmask) {
+        MessageDigest d = t.get();
+        expected.add(new HashResult(t, d.digest(MESSAGE)));
+      }
+    }
+
+    assertEquals(expected.size(), results.length);
+    for (int i = 0; i < expected.size(); i++) {
+      HashType type = expected.get(i).type;
+      assertEquals(type, results[i].type, "hash type order");
+      byte[] expectedBytes = HashResult.get(new HashResult[] {expected.get(i)}, type);
+      byte[] actualBytes = HashResult.get(results, type);
+      assertArrayEquals(expectedBytes, actualBytes);
+    }
+  }
+
+  private static LongStream bitmasksForMultiAlgorithm() {
+    long md5Sha1 = HashType.MD5.bitmask | HashType.SHA1.bitmask;
+    long sha256Sha512 = HashType.SHA256.bitmask | HashType.SHA512.bitmask;
+    long all = 0;
+    for (HashType t : HashType.values()) all |= t.bitmask;
+    return LongStream.of(md5Sha1, sha256Sha512, all);
+  }
+
+  @Test
+  void read_whenUnderlyingReturnsZero_doesNotHashOrCountUntilDataArrives() throws IOException {
+    // Underlying stream returns 0 on the first read(byte[],off,len), then delegates normally
+    class FirstZeroInputStream extends InputStream {
+      private final ByteArrayInputStream delegate = new ByteArrayInputStream(MESSAGE);
+      private boolean first = true;
+
+      @Override
+      public int read(byte @NotNull [] b, int off, int len) {
+        if (first) {
+          first = false;
+          return 0; // Simulate non-blocking stream that returns 0
+        }
+        return delegate.read(b, off, len);
+      }
+
+      @Override
+      public int read() {
+        return delegate.read();
+      }
+    }
+
+    MultiHashInputStream hash = newHasher(new FirstZeroInputStream(), HashType.MD5.bitmask);
+    byte[] buf = new byte[MESSAGE.length];
+
+    assertEquals(0, hash.read(buf, 0, buf.length));
+    assertEquals(0, hash.getReadBytes());
+
+    assertEquals(MESSAGE.length, hash.read(buf, 0, buf.length));
+    assertEquals(MESSAGE.length, hash.getReadBytes());
+
+    MessageDigest md5 = HashType.MD5.get();
+    byte[] expected = md5.digest(MESSAGE);
+    assertArrayEquals(expected, HashResult.get(hash.getResults(), HashType.MD5));
   }
 }

--- a/src/test/java/network/crypta/crypt/MultiHashOutputStreamTest.java
+++ b/src/test/java/network/crypta/crypt/MultiHashOutputStreamTest.java
@@ -2,29 +2,193 @@ package network.crypta.crypt;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class MultiHashOutputStreamTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class MultiHashOutputStreamTest {
   private static final byte[] MESSAGE = "Hello, World!".getBytes(StandardCharsets.UTF_8);
   private static final String MESSAGE_MD5 = "65a8e27d8879283831b664bd8b7f0ad4";
 
-  private final ByteArrayOutputStream output = new ByteArrayOutputStream();
-  private final MultiHashOutputStream hash =
-      new MultiHashOutputStream(output, HashType.MD5.bitmask);
+  private static String digestHex(HashType type, byte[] data) {
+    MessageDigest d = type.get();
+    d.update(data, 0, data.length);
+    return network.crypta.support.HexUtil.bytesToHex(d.digest());
+  }
 
   @Test
-  public void write() throws IOException {
+  void write_whenIntThenArray_expectForwardingAndMd5Match() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    MultiHashOutputStream hash = new MultiHashOutputStream(output, HashType.MD5.bitmask);
+
     hash.write(MESSAGE[0]);
     hash.write(MESSAGE, 1, MESSAGE.length - 1);
-    assertArrayEquals(output.toByteArray(), MESSAGE);
+
+    assertArrayEquals(MESSAGE, output.toByteArray());
 
     HashResult[] results = hash.getResults();
     assertEquals(1, results.length);
     assertEquals(HashType.MD5, results[0].type);
-    assertEquals(results[0].hashAsHex(), MESSAGE_MD5);
+    assertEquals(MESSAGE_MD5, results[0].hashAsHex());
+  }
+
+  @Test
+  void write_whenZeroLength_expectNoChangeAndEmptyDigest() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    MultiHashOutputStream hash = new MultiHashOutputStream(output, HashType.SHA1.bitmask);
+
+    byte[] buf = "ignored".getBytes(StandardCharsets.UTF_8);
+    hash.write(buf, 0, 0); // zero-length write
+
+    assertEquals(0, output.size());
+
+    HashResult[] results = hash.getResults();
+    assertEquals(1, results.length);
+    assertEquals(HashType.SHA1, results[0].type);
+
+    String emptySha1 = digestHex(HashType.SHA1, new byte[0]);
+    assertEquals(emptySha1, results[0].hashAsHex());
+  }
+
+  @Test
+  void getResults_whenNoHashSelected_returnsEmptyArray() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    MultiHashOutputStream hash = new MultiHashOutputStream(output, 0L);
+
+    hash.write(MESSAGE);
+    assertArrayEquals(MESSAGE, output.toByteArray());
+
+    HashResult[] results = hash.getResults();
+    assertEquals(0, results.length);
+  }
+
+  @Test
+  void write_whenOffsetAndLengthUsed_onlySliceIsProcessed() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    MultiHashOutputStream hash = new MultiHashOutputStream(output, HashType.SHA256.bitmask);
+
+    byte[] data = "abcde".getBytes(StandardCharsets.UTF_8);
+    hash.write(data, 1, 3); // "bcd"
+
+    assertArrayEquals("bcd".getBytes(StandardCharsets.UTF_8), output.toByteArray());
+
+    HashResult[] results = hash.getResults();
+    assertEquals(1, results.length);
+    assertEquals(HashType.SHA256, results[0].type);
+
+    String expected = digestHex(HashType.SHA256, "bcd".getBytes(StandardCharsets.UTF_8));
+    assertEquals(expected, results[0].hashAsHex());
+  }
+
+  @Test
+  void write_whenUnderlyingThrows_noDigestUpdateAndExceptionPropagates() {
+    OutputStream failing =
+        new OutputStream() {
+          @Override
+          public void write(int b) throws IOException {
+            throw new IOException("boom");
+          }
+
+          @Override
+          public void write(byte @NotNull [] b, int off, int len) throws IOException {
+            throw new IOException("boom");
+          }
+        };
+
+    MultiHashOutputStream hash = new MultiHashOutputStream(failing, HashType.MD5.bitmask);
+    byte[] data = "data".getBytes(StandardCharsets.UTF_8);
+
+    IOException ex = assertThrows(IOException.class, () -> hash.write(data, 0, data.length));
+    assertTrue(ex.getMessage().contains("boom"));
+
+    // Since underlying write failed before digester.update(), the digest should be for empty input.
+    HashResult[] results = hash.getResults();
+    assertEquals(1, results.length);
+    assertEquals(HashType.MD5, results[0].type);
+    assertEquals(digestHex(HashType.MD5, new byte[0]), results[0].hashAsHex());
+  }
+
+  @Test
+  void getResults_whenCalledTwice_resetsDigests() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    MultiHashOutputStream hash = new MultiHashOutputStream(output, HashType.SHA384.bitmask);
+
+    hash.write(MESSAGE);
+    String first = hash.getResults()[0].hashAsHex();
+
+    // Second call without updates returns digest of empty input (due to reset on digest()).
+    String second = hash.getResults()[0].hashAsHex();
+    assertEquals(digestHex(HashType.SHA384, new byte[0]), second);
+
+    // Writing the same message again should reproduce the first digest value.
+    hash.write(MESSAGE);
+    String third = hash.getResults()[0].hashAsHex();
+    assertEquals(first, third);
+  }
+
+  @Test
+  void writeInt_whenNegativeByte_expectCorrectHash() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    MultiHashOutputStream hash = new MultiHashOutputStream(output, HashType.SHA512.bitmask);
+
+    hash.write(0xFF); // -1 as signed byte
+    assertArrayEquals(new byte[] {(byte) 0xFF}, output.toByteArray());
+
+    HashResult[] results = hash.getResults();
+    assertEquals(1, results.length);
+    assertEquals(HashType.SHA512, results[0].type);
+
+    String expected = digestHex(HashType.SHA512, new byte[] {(byte) 0xFF});
+    assertEquals(expected, results[0].hashAsHex());
+  }
+
+  @Test
+  void multipleHashes_whenSelected_expectOrderedResults() throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    long mask = HashType.MD5.bitmask | HashType.SHA1.bitmask | HashType.SHA256.bitmask;
+    MultiHashOutputStream hash = new MultiHashOutputStream(output, mask);
+
+    hash.write(MESSAGE);
+    HashResult[] results = hash.getResults();
+
+    // Order must follow HashType.values(): SHA1, MD5, SHA256, ...
+    assertEquals(3, results.length);
+    assertEquals(HashType.SHA1, results[0].type);
+    assertEquals(HashType.MD5, results[1].type);
+    assertEquals(HashType.SHA256, results[2].type);
+
+    assertEquals(digestHex(HashType.SHA1, MESSAGE), results[0].hashAsHex());
+    assertEquals(digestHex(HashType.MD5, MESSAGE), results[1].hashAsHex());
+    assertEquals(digestHex(HashType.SHA256, MESSAGE), results[2].hashAsHex());
+  }
+
+  @Test
+  void write_withMockitoSpy_verifiesUnderlyingWriteParameters() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ByteArrayOutputStream spyOut = spy(baos);
+    MultiHashOutputStream hash = new MultiHashOutputStream(spyOut, HashType.MD5.bitmask);
+
+    byte[] buf = "0123456789".getBytes(StandardCharsets.UTF_8);
+    hash.write(buf, 2, 5);
+
+    // Verify underlying stream was called once with the exact offset/length.
+    verify(spyOut, times(1)).write(buf, 2, 5);
+
+    // And the content forwarded matches the slice
+    assertArrayEquals("23456".getBytes(StandardCharsets.UTF_8), spyOut.toByteArray());
   }
 }


### PR DESCRIPTION
Summary
- Modernize MultiHash utilities, improve documentation, and significantly expand test coverage.
- No functional changes expected except: MultiHashDigester#getResults() now returns an unmodifiable List via Stream.toList().

Key Changes
- MultiHashDigester
  - Add API/KDoc with bounds and threading notes.
  - Return results via Stream.toList() (unmodifiable) instead of Collectors.toList().
- MultiHashInputStream
  - Clarify mark/reset semantics: mark() is a no-op; markSupported() remains false; reset() continues to throw.
- MultiHashOutputStream
  - Add detailed Javadoc and annotate non-null parameters.
- MessageAuthCode / MasterSecret
  - Javadoc and test maintenance; Spotless formatting applied.

Test Coverage
- Expand unit tests across MultiHashDigester/InputStream/OutputStream: JCA parity, subrange/zero-length/bounds, ED2K/TTH lengths, clearer names and assertions.

Risk/Compatibility
- getResults() now returns an unmodifiable List. Callers that attempted to mutate the returned list will now fail fast; typical callers unaffected.

Files Changed (src/**)
- src/main/java/network/crypta/crypt/MasterSecret.java
- src/main/java/network/crypta/crypt/MessageAuthCode.java
- src/main/java/network/crypta/crypt/MultiHashDigester.java
- src/main/java/network/crypta/crypt/MultiHashInputStream.java
- src/main/java/network/crypta/crypt/MultiHashOutputStream.java
- src/test/java/network/crypta/crypt/MasterSecretTest.java
- src/test/java/network/crypta/crypt/MessageAuthCodeTest.java
- src/test/java/network/crypta/crypt/MultiHashDigesterTest.java
- src/test/java/network/crypta/crypt/MultiHashInputStreamTest.java
- src/test/java/network/crypta/crypt/MultiHashOutputStreamTest.java

Diffstat
  .../java/network/crypta/crypt/MasterSecret.java    |  64 +--
  .../java/network/crypta/crypt/MessageAuthCode.java | 253 ++++-----
  .../network/crypta/crypt/MultiHashDigester.java    |  47 +-
  .../network/crypta/crypt/MultiHashInputStream.java |   6 +-
  .../crypta/crypt/MultiHashOutputStream.java        |  54 +-
  .../network/crypta/crypt/MasterSecretTest.java     | 152 ++----
  .../network/crypta/crypt/MessageAuthCodeTest.java  | 563 ++++++++++++---------
  .../crypta/crypt/MultiHashDigesterTest.java        | 145 +++++-
  .../crypta/crypt/MultiHashInputStreamTest.java     | 238 ++++++++-
  .../crypta/crypt/MultiHashOutputStreamTest.java    | 178 ++++++-
  10 files changed, 1115 insertions(+), 585 deletions(-)

Commits
- 6ea705e20f docs(crypt): improve Javadoc for MultiHashOutputStream; apply Spotless; expand tests
- 78eb32c40e test: expand MultiHashInputStream coverage and clarify mark/reset contract
- 36a89ca76c refactor(crypt): document MultiHashDigester and modernize to Stream.toList()

Notes
- Working tree was clean; no local commits were required. Spotless was not needed.
- Base: origin/develop at creation time.