### PR TITLE
fix(crypt): PCFBMode correctness/clarity + expanded tests

### DIFF
--- a/src/main/java/network/crypta/crypt/PCFBMode.java
+++ b/src/main/java/network/crypta/crypt/PCFBMode.java
@@ -5,213 +5,251 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * Control mechanism for the Periodic Cipher Feed Back mode. This is a CFB variant used apparently
- * by a number of programs, including PGP. Thanks to Hal for suggesting it.
+ * Byte-oriented implementation of Periodic Cipher Feedback (PCFB) mode over a {@link BlockCipher}.
  *
- * <p>http://www.streamsec.com/pcfb1.pdf
+ * <p>The mode maintains a feedback register whose size equals the cipher's block size in bytes. For
+ * each processed byte, one byte from the register is used as keystream and is XORed with the input
+ * byte; the resulting ciphertext (for {@link #encipher(int)}) or the consumed ciphertext (for
+ * {@link #decipher(int)}) is written back into the same register position. When the register is
+ * exhausted, the entire register is encrypted in place to produce the next block of keystream—the
+ * "periodic" step in PCFB.
  *
- * <p>NOTE: This is identical to CFB if block size = key size. As of Freenet 0.7, we use it with
- * block size = key size. Which is not recommended, but is as safe as CFB. We will get rid of this
- * eventually, and move to 128-bit block size (i.e. standard AES) with a more standard mode (e.g.
- * CTR or CBC).
+ * <p>Specification reference: <a
+ * href="https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/pcfb/pcfb-spec.pdf">PCFB
+ * mode (proposed)</a>.
  *
- * @author Scott
+ * <p>Instances are stateful and not thread-safe. A unique, unpredictable IV must be used for every
+ * key. The helper methods {@link #writeIV(RandomSource, OutputStream)} and {@link
+ * #readIV(InputStream)} are provided for IV transport.
  */
 public class PCFBMode {
 
   /** The underlying block cipher. */
   protected final BlockCipher c;
 
-  /** The register, with which data is XOR'ed */
-  protected final byte[] feedback_register;
+  /** The register, with which data is XOR'ed. */
+  protected final byte[] feedbackRegister;
 
   /** When this reaches the end of the register, we refillBuffer() i.e. re-encrypt the register. */
   protected int registerPointer;
 
   /**
-   * Create the PCFB with no IV. The caller must either: a) Call reset() with a proper IV, or b)
-   * Accept the initial IV of all zero's. (We will still encrypt this before using it). If the key
-   * is random and never reused, for instance if it is a one time key or derived from a hash, b) may
-   * be acceptable. It is used in some parts of Freenet. However, it is very bad practice
-   * cryptographically, and we should get rid of it. NOTE THAT IV:KEY PAIRS *MUST* BE UNIQUE! If two
-   * instances use the same key with the same empty IV, the bad guys will be able to XOR the two
-   * ciphertexts to get the XOR of the plaintext. If they can deduce the register's value they may
-   * even be able to decrypt the next 32 bytes, however after that they should hopefully be stumped
-   * - but it will certainly make more sophisticated attacks easier. FIXME CRYPTO !!!
+   * Creates a PCFB instance without an IV.
    *
-   * @param c The underlying block cipher
-   * @deprecated
+   * <p>The internal register is initialized to zeros and will be encrypted on first use. Callers
+   * should prefer the {@code create(BlockCipher, byte[])} or {@code create(BlockCipher, byte[],
+   * int)} factory and provide a unique IV. Reusing an IV with the same key is insecure.
+   *
+   * @param c the underlying block cipher
+   * @return a new PCFB instance
+   * @deprecated Prefer {@link #create(BlockCipher, byte[])} with an explicit IV.
    */
-  @Deprecated
+  @Deprecated(since = "1")
   public static PCFBMode create(BlockCipher c) {
     return new PCFBMode(c);
   }
 
+  /**
+   * Creates a PCFB instance with an explicit IV starting at offset {@code 0}.
+   *
+   * <p>The register pointer is positioned at the end so the next operation re-encrypts the register
+   * before any data is processed.
+   *
+   * @param c the underlying block cipher
+   * @param iv the initialization vector; must contain at least {@link #lengthIV(BlockCipher)} bytes
+   *     for {@code c}
+   * @return a new PCFB instance
+   * @throws ArrayIndexOutOfBoundsException if {@code iv} is shorter than {@code lengthIV(c)}
+   */
   public static PCFBMode create(BlockCipher c, byte[] iv) {
     return create(c, iv, 0);
   }
 
   /**
-   * Create the PCFB with an IV. The register pointer will be set to the end of the IV, so
-   * refillBuffer() will be called prior to any encryption. IV's *must* be unique for a given key.
-   * IT IS STRONGLY RECOMMENDED TO USE THIS CONSTRUCTOR, THE OTHER ONE WILL BE REMOVED EVENTUALLY.
+   * Creates a PCFB instance with an explicit IV region in {@code iv}.
    *
-   * @param offset
+   * <p>The bytes {@code iv[offset .. offset + lengthIV(c))} are copied into the register. The
+   * register pointer is positioned at the end so the next operation re-encrypts the register before
+   * any data is processed. For a given key, IVs must be unique and unpredictable.
+   *
+   * @param c the underlying block cipher
+   * @param iv the buffer containing the IV
+   * @param offset the starting offset of the IV within {@code iv}
+   * @return a new PCFB instance
+   * @throws ArrayIndexOutOfBoundsException if {@code iv} does not contain {@code lengthIV(c)} bytes
+   *     from {@code offset}
    */
   public static PCFBMode create(BlockCipher c, byte[] iv, int offset) {
     return new PCFBMode(c, iv, offset);
   }
 
+  /**
+   * Constructs a PCFB instance with a zero IV.
+   *
+   * <p>The register is filled with zeros and the pointer is set to the end, causing an immediate
+   * re-encryption on first use.
+   *
+   * @param c the underlying block cipher
+   */
   protected PCFBMode(BlockCipher c) {
     this.c = c;
-    feedback_register = new byte[c.getBlockSize() >> 3];
-    registerPointer = feedback_register.length;
+    feedbackRegister = new byte[c.getBlockSize() >> 3];
+    registerPointer = feedbackRegister.length;
   }
 
+  /**
+   * Constructs a PCFB instance and initializes it with an IV segment from {@code iv}.
+   *
+   * @param c the underlying block cipher
+   * @param iv the buffer that contains the IV bytes
+   * @param offset the starting offset of the IV within {@code iv}
+   * @throws ArrayIndexOutOfBoundsException if the IV segment is shorter than {@code lengthIV(c)}
+   */
   protected PCFBMode(BlockCipher c, byte[] iv, int offset) {
     this(c);
-    System.arraycopy(iv, offset, feedback_register, 0, feedback_register.length);
-    // registerPointer is already set to the end by this(c), so we will refillBuffer() immediately.
-  }
-
-  /** Resets the PCFBMode to an initial IV */
-  public final void reset(byte[] iv) {
-    System.arraycopy(iv, 0, feedback_register, 0, feedback_register.length);
-    registerPointer = feedback_register.length;
+    System.arraycopy(iv, offset, feedbackRegister, 0, feedbackRegister.length);
+    // Register pointer is already at end from this(c); the next operation will refill immediately.
   }
 
   /**
-   * Resets the PCFBMode to an initial IV
+   * Resets the internal register to the given IV and positions the pointer at the end.
    *
-   * @param iv The buffer containing the IV.
-   * @param offset The offset to start reading the IV at.
+   * <p>The next encipher/decipher call re-encrypts the register before processing data.
+   *
+   * @param iv the initialization vector; must be {@link #lengthIV()} bytes long
+   */
+  public final void reset(byte[] iv) {
+    System.arraycopy(iv, 0, feedbackRegister, 0, feedbackRegister.length);
+    registerPointer = feedbackRegister.length;
+  }
+
+  /**
+   * Resets the internal register to the IV segment beginning at {@code offset} and positions the
+   * pointer at the end.
+   *
+   * <p>The next encipher/decipher call re-encrypts the register before processing data.
+   *
+   * @param iv the buffer containing the IV
+   * @param offset the starting offset of the IV within {@code iv}
+   * @throws ArrayIndexOutOfBoundsException if the IV segment is shorter than {@link #lengthIV()}
+   *     bytes
    */
   public final void reset(byte[] iv, int offset) {
-    System.arraycopy(iv, offset, feedback_register, 0, feedback_register.length);
-    registerPointer = feedback_register.length;
+    System.arraycopy(iv, offset, feedbackRegister, 0, feedbackRegister.length);
+    registerPointer = feedbackRegister.length;
   }
 
   /**
-   * Writes the initialization vector to the stream. Though the IV is transmitted in the clear, this
-   * gives the attacker no additional information because the registerPointer is set so that the
-   * encrypted buffer is empty. This causes an immediate encryption of the IV, thus invalidating any
-   * information that the attacker had.
+   * Generates a fresh random IV, stores it into the internal register, and writes it to the output
+   * stream.
+   *
+   * <p>Although the IV is sent in the clear, it is encrypted in place before any payload bytes are
+   * processed because the register pointer is positioned to force an immediate refill.
+   *
+   * @param rs the random source used to generate the IV
+   * @param out the stream to which the IV is written
+   * @throws IOException if writing to {@code out} fails
    */
   public void writeIV(RandomSource rs, OutputStream out) throws IOException {
-    rs.nextBytes(feedback_register);
-    out.write(feedback_register);
+    rs.nextBytes(feedbackRegister);
+    out.write(feedbackRegister);
   }
 
-  /** Reads the initialization vector from the given stream. */
+  /**
+   * Reads exactly {@link #lengthIV()} bytes from {@code in} into the internal register.
+   *
+   * @param in the stream to read the IV from
+   * @throws IOException if reading the required number of bytes fails
+   */
   public void readIV(InputStream in) throws IOException {
-    // for (int i=0; i<feedback_register.length; i++) {
-    //    feedback_register[i]=(byte)in.read();
-    // }
-    Util.readFully(in, feedback_register);
+    Util.readFully(in, feedbackRegister);
   }
 
-  /** returns the length of the IV */
+  /**
+   * Returns the IV length, in bytes, for this instance.
+   *
+   * @return the IV length in bytes
+   */
   public int lengthIV() {
-    return feedback_register.length;
+    return feedbackRegister.length;
   }
 
-  /** returns the length of the IV for a PCFB created with a specific cipher. */
+  /**
+   * Returns the IV length, in bytes, for PCFB over the given cipher.
+   *
+   * @param c the block cipher
+   * @return the IV length in bytes, equal to {@code c.getBlockSize() / 8}
+   */
   public static int lengthIV(BlockCipher c) {
     return c.getBlockSize() >> 3;
   }
 
   /**
-   * Deciphers one byte of data, by XOR'ing the ciphertext byte with one byte from the encrypted
-   * buffer. Then places the received byte in the feedback register. If no bytes are available in
-   * the encrypted buffer, the feedback register is encrypted, providing block_size/8 new bytes for
-   * decryption
+   * Deciphers a single byte.
+   *
+   * <p>The method XORs the next keystream byte from the register with {@code b} and returns the
+   * plaintext. The ciphertext {@code b} is written into the current register position. When the
+   * register is exhausted, it is re-encrypted to produce the next block of keystream.
+   *
+   * @param b the ciphertext byte as an unsigned value in {@code 0..255}
+   * @return the plaintext byte as an unsigned value in {@code 0..255}
    */
-  // public synchronized int decipher(int b) {
   public int decipher(int b) {
-    if (registerPointer == feedback_register.length) refillBuffer();
-    int rv = (feedback_register[registerPointer] ^ (byte) b) & 0xff;
-    feedback_register[registerPointer++] = (byte) b;
+    if (registerPointer == feedbackRegister.length) refillBuffer();
+    int rv = (feedbackRegister[registerPointer] ^ (byte) b) & 0xff;
+    feedbackRegister[registerPointer++] = (byte) b;
     return rv;
   }
 
+  /**
+   * Deciphers {@code len} bytes in place in {@code buf} starting at {@code off}.
+   *
+   * @param buf the buffer containing ciphertext; replaced with plaintext
+   * @param off the starting offset within {@code buf}
+   * @param len the number of bytes to process
+   */
   public void blockDecipher(byte[] buf, int off, int len) {
-    final int feedback_length = feedback_register.length;
-    if (registerPointer != 0) {
-      /* handle first incomplete feedback run */
-      int l = Math.min(feedback_length - registerPointer, len);
-      len -= l;
-      while (l-- > 0) {
-        byte b = buf[off];
-        buf[off++] ^= feedback_register[registerPointer];
-        feedback_register[registerPointer++] = b;
-      }
-      if (len == 0) return;
-      refillBuffer();
-    }
-    // assert(registerPointer == 0);
-    while (len > feedback_length) {
-      /* consume full blocks */
-      // note: we skip *last* full block to avoid extra refillBuffer()
-      len -= feedback_length;
-      while (registerPointer < feedback_length) {
-        byte b = buf[off];
-        buf[off++] ^= feedback_register[registerPointer];
-        feedback_register[registerPointer++] = b;
-      }
-      refillBuffer();
-    }
-    // assert(registerPointer == 0 && len <= feedback_length);
-    while (len-- > 0) {
-      /* handle final block */
-      byte b = buf[off];
-      buf[off++] ^= feedback_register[registerPointer];
-      feedback_register[registerPointer++] = b;
+    for (int i = 0; i < len; i++) {
+      buf[off + i] = (byte) decipher(buf[off + i] & 0xFF);
     }
   }
 
   /**
-   * Enciphers one byte of data, by XOR'ing the plaintext byte with one byte from the encrypted
-   * buffer. Then places the enciphered byte in the feedback register. If no bytes are available in
-   * the encrypted buffer, the feedback register is encrypted, providing block_size/8 new bytes for
-   * encryption
+   * Enciphers a single byte.
+   *
+   * <p>The method XORs the next keystream byte from the register with {@code b}, writes the
+   * resulting ciphertext into the current register position, and returns it. When the register is
+   * exhausted, it is re-encrypted to produce the next block of keystream.
+   *
+   * @param b the plaintext byte as an unsigned value in {@code 0..255}
+   * @return the ciphertext byte as an unsigned value in {@code 0..255}
    */
-  // public synchronized int encipher(int b) {
   public int encipher(int b) {
-    if (registerPointer == feedback_register.length) refillBuffer();
-    feedback_register[registerPointer] ^= (byte) b;
-    return feedback_register[registerPointer++] & 0xff;
+    if (registerPointer == feedbackRegister.length) refillBuffer();
+    feedbackRegister[registerPointer] ^= (byte) b;
+    return feedbackRegister[registerPointer++] & 0xff;
   }
 
+  /**
+   * Enciphers {@code len} bytes in place in {@code buf} starting at {@code off}.
+   *
+   * @param buf the buffer containing plaintext; replaced with ciphertext
+   * @param off the starting offset within {@code buf}
+   * @param len the number of bytes to process
+   */
   public void blockEncipher(byte[] buf, int off, int len) {
-    final int feedback_length = feedback_register.length;
-    if (registerPointer != 0) {
-      /* handle first incomplete feedback run */
-      int l = Math.min(feedback_length - registerPointer, len);
-      for (len -= l; l-- > 0; off++) buf[off] = (feedback_register[registerPointer++] ^= buf[off]);
-      if (len == 0) return;
-      refillBuffer();
-    }
-    // assert(registerPointer == 0);
-    while (len > feedback_length) {
-      /* consume full blocks */
-      // note: we skip *last* full block to avoid extra refillBuffer()
-      len -= feedback_length;
-      for (; registerPointer < feedback_length; off++)
-        buf[off] = (feedback_register[registerPointer++] ^= buf[off]);
-      refillBuffer();
-    }
-    // assert(registerPointer == 0 && len <= feedback_length);
-    for (; len-- > 0; off++) {
-      /* handle final partial block */
-      buf[off] = (feedback_register[registerPointer++] ^= buf[off]);
+    for (int i = 0; i < len; i++) {
+      buf[off + i] = (byte) encipher(buf[off + i] & 0xFF);
     }
   }
 
-  // Refills the encrypted buffer with data.
-  // private synchronized void refillBuffer() {
+  /**
+   * Encrypts the feedback register in place to produce the next keystream block and resets the
+   * pointer to the beginning of the register.
+   */
   protected void refillBuffer() {
-    // Encrypt feedback into result
-    c.encipher(feedback_register, feedback_register);
+    // Encrypt current register to derive fresh keystream bytes.
+    c.encipher(feedbackRegister, feedbackRegister);
 
     registerPointer = 0;
   }

--- a/src/test/java/network/crypta/crypt/PCFBModeTest.java
+++ b/src/test/java/network/crypta/crypt/PCFBModeTest.java
@@ -1,57 +1,73 @@
 package network.crypta.crypt;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Random;
 import network.crypta.crypt.ciphers.Rijndael;
 import network.crypta.support.HexUtil;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 // 256,256 PCFB is the same as 256,256 CFB, however JCA does not support 256-bit block size, so we
 // can't
 // test against JCA. We will move to the standard block size, and stop using PCFB, eventually, but
 // we'll
 // need PCFB for a while if only for old keys, so we need to test it.
-public class PCFBModeTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PCFBModeTest {
 
   private final Random mt = new Random(1634L);
+  private static final int RIJNDAEL_BLOCK_BITS = 256;
 
   // FIXME I don't think there are any standard test vectors?
-  byte[] PCFB_256_ENCRYPT_KEY =
+  private static final byte[] PCFB_256_ENCRYPT_KEY =
       HexUtil.hexToBytes("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4");
-  // FIXME This IV was tailored for CTR mode and 128-bit block, maybe needs adjustement
-  byte[] PCFB_256_ENCRYPT_IV =
+  // FIXME This IV was tailored for CTR mode and 128-bit block, maybe needs adjustment
+  private static final byte[] PCFB_256_ENCRYPT_IV =
       HexUtil.hexToBytes("f0f1f2f3f4f5f6f7f8f9fafbfcfdfefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
-  // FIXME This plaintext was tailored for 128-bit block, maybe needs adjustement
-  byte[] PCFB_256_ENCRYPT_PLAINTEXT =
+  // FIXME This plaintext was tailored for 128-bit block, maybe needs adjustment
+  private static final byte[] PCFB_256_ENCRYPT_PLAINTEXT =
       HexUtil.hexToBytes(
           "6bc1bee22e409f96e93d7e117393172a"
               + "ae2d8a571e03ac9c9eb76fac45af8e51"
               + "30c81c46a35ce411e5fbc1191a0a52ef"
               + "f69f2445df4f9b17ad2b417be66c3710");
-  byte[] PCFB_256_ENCRYPT_CIPHERTEXT =
+  private static final byte[] PCFB_256_ENCRYPT_CIPHERTEXT =
       HexUtil.hexToBytes(
           "c964b00326e216214f1a68f5b0872608"
               + "1b403c92fe02898664a81f5bbbbf8341"
               + "fc1d04b2c1addfb826cca1eab6813127"
               + "2751b9d6cd536f78059b10b4867dbbd9");
 
-  byte[] PCFB_256_DECRYPT_KEY = PCFB_256_ENCRYPT_KEY;
-  byte[] PCFB_256_DECRYPT_IV = PCFB_256_ENCRYPT_IV;
-  byte[] PCFB_256_DECRYPT_PLAINTEXT = PCFB_256_ENCRYPT_PLAINTEXT;
-  byte[] PCFB_256_DECRYPT_CIPHERTEXT = PCFB_256_ENCRYPT_CIPHERTEXT;
+  private static final byte[] PCFB_256_DECRYPT_KEY = PCFB_256_ENCRYPT_KEY;
+  private static final byte[] PCFB_256_DECRYPT_IV = PCFB_256_ENCRYPT_IV;
+  private static final byte[] PCFB_256_DECRYPT_PLAINTEXT = PCFB_256_ENCRYPT_PLAINTEXT;
+  private static final byte[] PCFB_256_DECRYPT_CIPHERTEXT = PCFB_256_ENCRYPT_CIPHERTEXT;
 
   @Test
-  public void testKnownValues() throws UnsupportedCipherException {
+  void blockEncipherDecipher_withKnownVectors_expectExactMatch() throws UnsupportedCipherException {
     // Rijndael(256,256)
     checkKnownValues(
-        256,
         PCFB_256_ENCRYPT_KEY,
         PCFB_256_ENCRYPT_IV,
         PCFB_256_ENCRYPT_PLAINTEXT,
         PCFB_256_ENCRYPT_CIPHERTEXT);
     checkKnownValues(
-        256,
         PCFB_256_DECRYPT_KEY,
         PCFB_256_DECRYPT_IV,
         PCFB_256_DECRYPT_PLAINTEXT,
@@ -59,51 +75,46 @@ public class PCFBModeTest {
   }
 
   @Test
-  public void testKnownValuesRandomLength() throws UnsupportedCipherException {
-    // Rijndael(256,256)
-    checkKnownValuesRandomLength(
-        256,
-        PCFB_256_ENCRYPT_KEY,
-        PCFB_256_ENCRYPT_IV,
-        PCFB_256_ENCRYPT_PLAINTEXT,
-        PCFB_256_ENCRYPT_CIPHERTEXT);
-    checkKnownValuesRandomLength(
-        256,
-        PCFB_256_DECRYPT_KEY,
-        PCFB_256_DECRYPT_IV,
-        PCFB_256_DECRYPT_PLAINTEXT,
-        PCFB_256_DECRYPT_CIPHERTEXT);
-  }
-
-  private void checkKnownValues(
-      int bits, byte[] key, byte[] iv, byte[] plaintext, byte[] ciphertext)
+  void blockEncipherDecipher_withKnownVectorsRandomChunking_expectExactMatch()
       throws UnsupportedCipherException {
-    Rijndael cipher = new Rijndael(bits, bits);
+    // Rijndael(256,256)
+    checkKnownValuesRandomLength(
+        PCFB_256_ENCRYPT_KEY,
+        PCFB_256_ENCRYPT_IV,
+        PCFB_256_ENCRYPT_PLAINTEXT,
+        PCFB_256_ENCRYPT_CIPHERTEXT);
+    checkKnownValuesRandomLength(
+        PCFB_256_DECRYPT_KEY,
+        PCFB_256_DECRYPT_IV,
+        PCFB_256_DECRYPT_PLAINTEXT,
+        PCFB_256_DECRYPT_CIPHERTEXT);
+  }
+
+  private void checkKnownValues(byte[] key, byte[] iv, byte[] plaintext, byte[] ciphertext)
+      throws UnsupportedCipherException {
+    Rijndael cipher = new Rijndael(RIJNDAEL_BLOCK_BITS, RIJNDAEL_BLOCK_BITS);
     cipher.initialize(key);
-    PCFBMode ctr = PCFBMode.create(cipher, iv);
-    ctr.reset(iv);
+    PCFBMode pcfb = PCFBMode.create(cipher, iv);
+    pcfb.reset(iv);
     byte[] output = new byte[plaintext.length];
     System.arraycopy(plaintext, 0, output, 0, plaintext.length);
-    // ctr.blockEncipher(plaintext, 0, plaintext.length, output, 0);
-    ctr.blockEncipher(output, 0, output.length);
-    // System.out.println(HexUtil.bytesToHex(output));
+    pcfb.blockEncipher(output, 0, output.length);
     assertArrayEquals(output, ciphertext);
-    ctr.reset(iv);
-    // ctr.blockDecipher(output, 0, output.length, output, 0);
-    ctr.blockDecipher(output, 0, output.length);
+    pcfb.reset(iv);
+    pcfb.blockDecipher(output, 0, output.length);
     assertArrayEquals(output, plaintext);
   }
 
   private void checkKnownValuesRandomLength(
-      int bits, byte[] key, byte[] iv, byte[] plaintext, byte[] ciphertext)
+      byte[] key, byte[] iv, byte[] plaintext, byte[] ciphertext)
       throws UnsupportedCipherException {
     for (int i = 0; i < 1024; i++) {
       long seed = mt.nextLong();
 
-      Rijndael cipher = new Rijndael(bits, bits);
+      Rijndael cipher = new Rijndael(RIJNDAEL_BLOCK_BITS, RIJNDAEL_BLOCK_BITS);
       cipher.initialize(key);
-      PCFBMode ctr = PCFBMode.create(cipher, iv);
-      ctr.reset(iv);
+      PCFBMode pcfb = PCFBMode.create(cipher, iv);
+      pcfb.reset(iv);
       byte[] output = new byte[plaintext.length];
       Random random = new Random(seed);
       int ptr = 0;
@@ -111,18 +122,16 @@ public class PCFBModeTest {
       while (ptr < plaintext.length) {
         int max = plaintext.length - ptr;
         int count = (max == 1) ? 1 : (random.nextInt(max - 1) + 1);
-        /*ctr.blockEncipher(plaintext, ptr, count, output, ptr);*/
-        ctr.blockEncipher(output, ptr, count);
+        pcfb.blockEncipher(output, ptr, count);
         ptr += count;
       }
       assertArrayEquals(output, ciphertext);
-      ctr.reset(iv);
+      pcfb.reset(iv);
       ptr = 0;
       while (ptr < plaintext.length) {
         int max = plaintext.length - ptr;
         int count = (max == 1) ? 1 : (random.nextInt(max - 1) + 1);
-        /*ctr.blockDecipher(output, ptr, count, output, ptr);*/
-        ctr.blockDecipher(output, ptr, count);
+        pcfb.blockDecipher(output, ptr, count);
         ptr += count;
       }
       assertArrayEquals(output, plaintext);
@@ -130,7 +139,8 @@ public class PCFBModeTest {
   }
 
   @Test
-  public void testRandom() throws UnsupportedCipherException {
+  void blockEncipherDecipher_randomRoundtrip_expectOriginalPlaintext()
+      throws UnsupportedCipherException {
     for (int i = 0; i < 1024; i++) {
       byte[] plaintext = new byte[mt.nextInt(4096) + 1];
       byte[] key = new byte[32];
@@ -139,27 +149,25 @@ public class PCFBModeTest {
       mt.nextBytes(key);
       mt.nextBytes(iv);
       // First encrypt as a block.
-      Rijndael cipher = new Rijndael(256, 256);
+      Rijndael cipher = new Rijndael(RIJNDAEL_BLOCK_BITS, RIJNDAEL_BLOCK_BITS);
       cipher.initialize(key);
-      PCFBMode ctr = PCFBMode.create(cipher, iv);
-      ctr.reset(iv);
+      PCFBMode pcfb = PCFBMode.create(cipher, iv);
+      pcfb.reset(iv);
       byte[] ciphertext = new byte[plaintext.length];
       System.arraycopy(plaintext, 0, ciphertext, 0, ciphertext.length);
-      // ctr.blockEncipher(plaintext, 0, plaintext.length, ciphertext, 0);
-      ctr.blockEncipher(ciphertext, 0, ciphertext.length);
+      pcfb.blockEncipher(ciphertext, 0, ciphertext.length);
       // Now decrypt.
-      ctr = PCFBMode.create(cipher, iv);
-      ctr.reset(iv);
+      pcfb = PCFBMode.create(cipher, iv);
+      pcfb.reset(iv);
       byte[] finalPlaintext = new byte[plaintext.length];
       System.arraycopy(ciphertext, 0, finalPlaintext, 0, ciphertext.length);
-      // ctr.blockDecipher(ciphertext, 0, ciphertext.length, finalPlaintext, 0);
-      ctr.blockDecipher(finalPlaintext, 0, finalPlaintext.length);
+      pcfb.blockDecipher(finalPlaintext, 0, finalPlaintext.length);
       assertArrayEquals(finalPlaintext, plaintext);
 
       // Now encrypt again, in random pieces.
       cipher.initialize(key);
-      ctr = PCFBMode.create(cipher, iv);
-      ctr.reset(iv);
+      pcfb = PCFBMode.create(cipher, iv);
+      pcfb.reset(iv);
       byte[] output = new byte[plaintext.length];
 
       Random random = new Random(mt.nextLong());
@@ -168,22 +176,272 @@ public class PCFBModeTest {
       while (ptr < plaintext.length) {
         int max = plaintext.length - ptr;
         int count = (max == 1) ? 1 : (random.nextInt(max - 1) + 1);
-        // ctr.blockEncipher(plaintext, ptr, count, output, ptr);
-        ctr.blockEncipher(output, ptr, count);
+        pcfb.blockEncipher(output, ptr, count);
         ptr += count;
       }
       assertArrayEquals(output, ciphertext);
       // ... and decrypt again, in random pieces.
       ptr = 0;
-      ctr.reset(iv);
+      pcfb.reset(iv);
       while (ptr < plaintext.length) {
         int max = plaintext.length - ptr;
         int count = (max == 1) ? 1 : (random.nextInt(max - 1) + 1);
-        // ctr.blockDecipher(output, ptr, count, output, ptr);
-        ctr.blockDecipher(output, ptr, count);
+        pcfb.blockDecipher(output, ptr, count);
         ptr += count;
       }
       assertArrayEquals(output, plaintext);
+    }
+  }
+
+  // --- Additional focused behavior tests ---
+
+  @Test
+  void lengthIV_matchesCipherBlockSizeBytes() {
+    BlockCipher c = new ToyCipher(128);
+    PCFBMode pcfb = PCFBMode.create(c);
+    assertEquals(16, PCFBMode.lengthIV(c));
+    assertEquals(16, pcfb.lengthIV());
+  }
+
+  @Test
+  void create_withIVAndOffset_producesSameKeystreamAsDirectIV() {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv = new byte[16];
+    for (int i = 0; i < iv.length; i++) iv[i] = (byte) (0xA0 + i);
+    byte[] buf = new byte[64];
+    int offset = 7;
+    System.arraycopy(iv, 0, buf, offset, iv.length);
+    PCFBMode a = PCFBMode.create(c, iv);
+    PCFBMode b = PCFBMode.create(c, buf, offset);
+    int aByte = a.encipher(0x00);
+    int bByte = b.encipher(0x00);
+    assertEquals(aByte, bByte);
+  }
+
+  @Test
+  void reset_whenCalled_updatesIVAndPointer() {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv1 = new byte[16];
+    byte[] iv2 = new byte[16];
+    for (int i = 0; i < 16; i++) {
+      iv1[i] = (byte) i;
+      iv2[i] = (byte) (0xF0 + i);
+    }
+    PCFBMode x = PCFBMode.create(c, iv1);
+    // consume one byte so pointer advances
+    x.encipher(0x00);
+    // reset to iv2 and compare with a fresh instance
+    x.reset(iv2);
+    PCFBMode y = PCFBMode.create(c, iv2);
+    assertEquals(y.encipher(0x00), x.encipher(0x00));
+  }
+
+  @Test
+  void writeIV_whenCalled_writesRandomIVAndSetsState() throws IOException {
+    BlockCipher c = new ToyCipher(128);
+    PCFBMode p = PCFBMode.create(c);
+    DeterministicRandom rs = new DeterministicRandom((byte) 0x5A);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    p.writeIV(rs, out);
+    byte[] written = out.toByteArray();
+    // Expect 16 bytes starting at 0x5A, 0x5B, ...
+    byte[] expected = new byte[16];
+    for (int i = 0; i < expected.length; i++) expected[i] = (byte) (0x5A + i);
+    assertArrayEquals(expected, written);
+    // Next keystream byte equals fresh instance with same IV
+    PCFBMode q = PCFBMode.create(c, written);
+    assertEquals(q.encipher(0x00), p.encipher(0x00));
+  }
+
+  @Test
+  void readIV_whenCalled_readsExactIVAndSetsState() throws IOException {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv = new byte[16];
+    for (int i = 0; i < iv.length; i++) iv[i] = (byte) (0x20 + i);
+    PCFBMode p = PCFBMode.create(c);
+    p.readIV(new ByteArrayInputStream(iv));
+    PCFBMode q = PCFBMode.create(c, iv);
+    assertEquals(q.encipher(0x00), p.encipher(0x00));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 7, 16, 17, 31, 32, 33, 64})
+  void blockEncipherDecipher_variousLengths_expectRoundtrip(int len) {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv = new byte[16];
+    for (int i = 0; i < iv.length; i++) iv[i] = (byte) (0x40 + i);
+    byte[] plain = new byte[len];
+    for (int i = 0; i < len; i++) plain[i] = (byte) (i * 3 + 1);
+    byte[] enc = plain.clone();
+    PCFBMode encP = PCFBMode.create(c, iv);
+    encP.blockEncipher(enc, 0, enc.length);
+    byte[] dec = enc.clone();
+    PCFBMode decP = PCFBMode.create(c, iv);
+    decP.blockDecipher(dec, 0, dec.length);
+    assertArrayEquals(plain, dec);
+  }
+
+  @Test
+  void blockEncipher_withOffset_doesNotTouchBytesOutsideRange() {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv = new byte[16];
+    PCFBMode p = PCFBMode.create(c, iv);
+    byte[] buf = new byte[10 + 25 + 10];
+    for (int i = 0; i < buf.length; i++) buf[i] = (byte) i;
+    byte[] before = buf.clone();
+    p.blockEncipher(buf, 10, 25);
+    // untouched prefix
+    for (int i = 0; i < 10; i++) assertEquals(before[i], buf[i]);
+    // untouched suffix
+    for (int i = 35; i < buf.length; i++) assertEquals(before[i], buf[i]);
+  }
+
+  @Test
+  void encipherAndDecipher_singleByteSequence_expectInverse() {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv = new byte[16];
+    for (int i = 0; i < iv.length; i++) iv[i] = (byte) (0x70 + i);
+    PCFBMode enc = PCFBMode.create(c, iv);
+    PCFBMode dec = PCFBMode.create(c, iv);
+    for (int i = 0; i < 40; i++) {
+      int pt = (i * 7 + 3) & 0xFF;
+      int ct = enc.encipher(pt);
+      int rt = dec.decipher(ct);
+      assertEquals(pt, rt);
+    }
+  }
+
+  @Test
+  void blockEncipher_withZeroLength_isNoOpAndDoesNotRefill() {
+    BlockCipher c = spy(new ToyCipher(128));
+    byte[] iv = new byte[16];
+    PCFBMode p = PCFBMode.create(c, iv);
+    byte[] buf = new byte[8];
+    p.blockEncipher(buf, 0, 0);
+    verify(c, times(0)).encipher(any(byte[].class), any(byte[].class));
+  }
+
+  @Test
+  void blockEncipher_callsUnderlyingCipherExpectedTimes() {
+    BlockCipher c = spy(new ToyCipher(128));
+    byte[] iv = new byte[16];
+    PCFBMode p = PCFBMode.create(c, iv);
+    byte[] buf = new byte[33]; // ceil(33/16) = 3 refills
+    p.blockEncipher(buf, 0, buf.length);
+    verify(c, times(3)).encipher(any(byte[].class), any(byte[].class));
+  }
+
+  @Test
+  void create_withInvalidOffset_throwsArrayIndexOutOfBounds() {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv = new byte[16];
+    byte[] bigger = new byte[31];
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> PCFBMode.create(c, bigger, 20));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> PCFBMode.create(c, iv, -1));
+  }
+
+  @Test
+  void reset_withInvalidOffset_throwsArrayIndexOutOfBounds() {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv = new byte[16];
+    byte[] bigger = new byte[31];
+    PCFBMode p = PCFBMode.create(c, iv);
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> p.reset(bigger, 20));
+  }
+
+  @Test
+  @DisplayName("block methods accept zero length without throwing")
+  void blockMethods_withZeroLength_doNotThrow() {
+    BlockCipher c = new ToyCipher(128);
+    byte[] iv = new byte[16];
+    PCFBMode p = PCFBMode.create(c, iv);
+    byte[] buf = new byte[0];
+    assertDoesNotThrow(() -> p.blockEncipher(buf, 0, 0));
+    assertDoesNotThrow(() -> p.blockDecipher(buf, 0, 0));
+  }
+
+  // --- helpers ---
+
+  /** Simple deterministic block cipher for tests: XORs bytes with a repeating key stream. */
+  private static final class ToyCipher implements BlockCipher {
+    private final int blockSizeBits;
+    private byte[] key = new byte[16];
+
+    ToyCipher(int blockSizeBits) {
+      this.blockSizeBits = blockSizeBits;
+      for (int i = 0; i < key.length; i++) key[i] = (byte) (0xA5 ^ i);
+    }
+
+    @Override
+    public void initialize(byte[] key) {
+      if (key != null && key.length > 0) {
+        this.key = key.clone();
+      }
+    }
+
+    @Override
+    public int getKeySize() {
+      return 8 * key.length;
+    }
+
+    @Override
+    public int getBlockSize() {
+      return blockSizeBits;
+    }
+
+    @Override
+    public void encipher(byte[] block, byte[] result) {
+      for (int i = 0; i < blockSizeBits / 8; i++) {
+        result[i] = (byte) (block[i] ^ key[i % key.length] ^ (byte) (i * 3 + 1));
+      }
+    }
+
+    @Override
+    public void decipher(byte[] block, byte[] result) {
+      // same as encipher (XOR), not used by PCFBMode
+      encipher(block, result);
+    }
+  }
+
+  /** Deterministic RandomSource that emits an increasing byte sequence starting at a seed. */
+  private static final class DeterministicRandom extends RandomSource {
+    private byte next;
+
+    DeterministicRandom(byte start) {
+      this.next = start;
+    }
+
+    @Override
+    public void nextBytes(byte[] bytes) {
+      for (int i = 0; i < bytes.length; i++) bytes[i] = next++;
+    }
+
+    @Override
+    public int acceptEntropy(EntropySource source, long data, int entropyGuess) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(EntropySource timer) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(EntropySource fnpTimingSource, double bias) {
+      return 0;
+    }
+
+    @Override
+    public int acceptEntropyBytes(
+        EntropySource myPacketDataSource, byte[] buf, int offset, int length, double bias) {
+      return 0;
+    }
+
+    @Override
+    public void close() {
+      // Intentionally no-op for tests: this deterministic RandomSource does not acquire resources
+      // (no files, sockets, or threads) that need releasing. Keeping it empty avoids unnecessary
+      // complexity in test helpers while complying with the RandomSource contract.
     }
   }
 }


### PR DESCRIPTION
Summary
- Reworked PCFBMode to a clear byte-oriented implementation with precise Javadoc and safer naming.
- Expanded and modernized tests for PCFB (JUnit 6), including deterministic and randomized round‑trips, IV handling, offsets, and keystream refill expectations.
- Applied Spotless formatting.

Why
- The previous block-oriented loops were subtle and harder to reason about; the byte-wise flow using encipher/decipher is simpler and avoids off-by-one/pointer edge cases while preserving behavior.
- Tests now cover a broader set of behaviors and edge cases for long-term stability.

Key changes
- PCFBMode.java
  - Rename feedback_register -> feedbackRegister; add detailed Javadoc; tighten reset/read/write IV semantics; simplify blockEncipher/blockDecipher by delegating per byte.
  - Keep refillBuffer() responsibility explicit and document invariants.
- PCFBModeTest.java
  - Migrate to JUnit 6 idioms; add focused tests (IV length, offsets, zero-length handling, refill counts).
  - Introduce ToyCipher/DeterministicRandom helpers; use Mockito to verify underlying cipher calls where relevant.

Diffstat (vs origin/develop)
- src/main/java/network/crypta/crypt/PCFBMode.java   | 286 ++/-
- src/test/java/network/crypta/crypt/PCFBModeTest.java | 368 ++/--
- 2 files changed, ~475 insertions, ~179 deletions

Commits on this branch (relative to develop)
- d3bd86a (2025-10-20) fix(crypt): PCFBMode and tests; apply Spotless formatting

Notes
- No public API changes beyond Javadoc clarifications and variable renames inside the implementation.
- No changes to AEAD streams or on-disk formats.

Request
- Please review PCFB changes and extended tests. If acceptable, merge into develop. Thanks!