### PR TITLE
refactor(crypt): modernize SHA-256 helpers; add tests

### DIFF
--- a/src/main/java/network/crypta/crypt/SHA256.java
+++ b/src/main/java/network/crypta/crypt/SHA256.java
@@ -6,17 +6,43 @@ import java.security.MessageDigest;
 import network.crypta.support.io.IOUtils;
 
 /**
+ * Utilities for computing SHA-256 message digests.
+ *
+ * <p>This class provides convenience helpers around the JCA {@link MessageDigest} implementation
+ * for the SHA-256 algorithm. All methods are static; the class is not instantiable.
+ *
+ * <p>Threading: {@link MessageDigest} instances are mutable and not thread-safe. Callers must use a
+ * separate instance per thread or task. {@link #getMessageDigest()} returns a new instance on each
+ * call.
+ *
+ * <p>Typical usage:
+ *
+ * <ul>
+ *   <li>{@link #hash(InputStream, MessageDigest)} reads a stream and updates a supplied digest.
+ *   <li>{@link #digest(byte[])} computes a one-shot digest of a byte array.
+ *   <li>{@link #getDigestLength()} returns the digest length in bytes.
+ * </ul>
+ *
  * @author Jeroen C. van Gelderen (gelderen@cryptix.org)
  */
 public class SHA256 {
 
+  private SHA256() {
+    throw new IllegalStateException("Utility class");
+  }
+
   /**
-   * It won't reset the Message Digest for you!
+   * Reads all bytes from the given input stream and updates the provided digest.
    *
-   * @param InputStream
-   * @param MessageDigest
-   * @return
-   * @throws IOException
+   * <p>The stream is consumed until end-of-file and is always closed on return (success or error).
+   * The supplied {@link MessageDigest} is updated incrementally and is not reset by this method. If
+   * an {@link IOException} occurs during reading, the digest state reflects the bytes processed
+   * before the exception was thrown.
+   *
+   * @param is input stream to read; must be readable and non-null. The stream is closed by this
+   *     method.
+   * @param md digest instance to update; must be non-null. The instance is modified but not reset.
+   * @throws IOException if an I/O error occurs while reading the stream
    */
   public static void hash(InputStream is, MessageDigest md) throws IOException {
     try {
@@ -31,23 +57,37 @@ public class SHA256 {
     }
   }
 
-  /** Create a new SHA-256 MessageDigest */
+  /**
+   * Returns a new {@link MessageDigest} instance for the SHA-256 algorithm.
+   *
+   * <p>The instance is created using the preferred provider configured by {@link HashType#SHA256}.
+   * The returned digest is mutable and not thread-safe.
+   *
+   * @return new SHA-256 {@link MessageDigest}
+   * @throws IllegalStateException if the algorithm or configured provider is unavailable
+   */
   public static MessageDigest getMessageDigest() {
     return HashType.SHA256.get();
   }
 
   /**
-   * No-op function retained for backwards compatibility.
+   * Computes the SHA-256 digest of the provided byte array.
    *
-   * @deprecated message digests are no longer pooled, there is no need to return them
+   * <p>This is equivalent to {@code getMessageDigest().digest(data)}.
+   *
+   * @param data input bytes; must be non-null
+   * @return 32-byte SHA-256 digest
+   * @throws NullPointerException if {@code data} is {@code null}
    */
-  @Deprecated
-  public static void returnMessageDigest(MessageDigest md256) {}
-
   public static byte[] digest(byte[] data) {
     return getMessageDigest().digest(data);
   }
 
+  /**
+   * Returns the SHA-256 digest length in bytes.
+   *
+   * @return 32
+   */
   public static int getDigestLength() {
     return HashType.SHA256.hashLength;
   }

--- a/src/test/java/network/crypta/crypt/SHA256Test.java
+++ b/src/test/java/network/crypta/crypt/SHA256Test.java
@@ -1,0 +1,232 @@
+package network.crypta.crypt;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import org.bouncycastle.util.encoders.Hex;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SHA256Test {
+
+  // ---- Test vectors ----
+  static java.util.stream.Stream<Arguments> knownVectors() {
+    return java.util.stream.Stream.of(
+        Arguments.of("", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+        Arguments.of("abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"),
+        Arguments.of(
+            "The quick brown fox jumps over the lazy dog",
+            "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"),
+        Arguments.of(
+            "The quick brown fox jumps over the lazy dog.",
+            "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"));
+  }
+
+  @ParameterizedTest(name = "digest(byte[]) matches vector for \"{0}\"")
+  @MethodSource("knownVectors")
+  void digest_whenKnownVectors_expectExpectedHex(String msg, String expectedHex) {
+    // Arrange
+    byte[] data = msg.getBytes(StandardCharsets.UTF_8);
+    byte[] expected = Hex.decode(expectedHex);
+    // Act
+    byte[] actual = SHA256.digest(data);
+    // Assert
+    assertArrayEquals(expected, actual);
+  }
+
+  @Test
+  void getMessageDigest_whenCalled_expectSha256AndNewInstances() {
+    // Act
+    MessageDigest md1 = SHA256.getMessageDigest();
+    MessageDigest md2 = SHA256.getMessageDigest();
+    // Assert
+    assertNotNull(md1);
+    assertNotNull(md2);
+    assertNotSame(md1, md2);
+    assertEquals("SHA-256", md1.getAlgorithm());
+    assertEquals(32, md1.getDigestLength());
+  }
+
+  @Test
+  void getDigestLength_whenCalled_expect32() {
+    assertEquals(32, SHA256.getDigestLength());
+  }
+
+  @Test
+  void hash_whenEmptyStream_expectEmptyDigestAndClosed() throws Exception {
+    // Arrange: mock InputStream to return -1 immediately
+    InputStream is = Mockito.mock(InputStream.class);
+    Mockito.when(is.read(ArgumentMatchers.any(byte[].class))).thenReturn(-1);
+    MessageDigest md = SHA256.getMessageDigest();
+    byte[] expectedEmpty = SHA256.digest(new byte[0]);
+
+    // Act
+    SHA256.hash(is, md);
+
+    // Assert
+    assertArrayEquals(expectedEmpty, md.digest());
+    Mockito.verify(is, Mockito.times(1)).close();
+    Mockito.verify(is, Mockito.atLeastOnce()).read(ArgumentMatchers.any(byte[].class));
+  }
+
+  @Test
+  void hash_whenRandomShortReads_expectSameAsSingleShotAndClosed() throws Exception {
+    // Arrange: deterministic data larger than the internal buffer (4096)
+    byte[] data = new byte[10000];
+    for (int i = 0; i < data.length; i++) data[i] = (byte) (i % 251);
+    byte[] expected = SHA256.digest(data);
+
+    CloseTrackingInputStream tracker = new CloseTrackingInputStream(new ByteArrayInputStream(data));
+    InputStream shortReads =
+        new DeterministicShortReadInputStream(tracker, new int[] {13, 4096, 7, 512, 3, 2048});
+    MessageDigest md = SHA256.getMessageDigest();
+
+    // Act
+    SHA256.hash(shortReads, md);
+
+    // Assert
+    assertArrayEquals(expected, md.digest());
+    assertTrue(tracker.wasClosed(), "input stream should be closed");
+  }
+
+  @Test
+  void hash_whenIOExceptionOnFirstRead_expectExceptionAndNoUpdateAndClosed() throws Exception {
+    // Arrange
+    InputStream is = Mockito.mock(InputStream.class);
+    Mockito.doThrow(new IOException("boom")).when(is).read(ArgumentMatchers.any(byte[].class));
+    MessageDigest md = SHA256.getMessageDigest();
+    byte[] expectedEmpty = SHA256.digest(new byte[0]);
+
+    // Act + Assert
+    assertThrows(IOException.class, () -> SHA256.hash(is, md));
+    Mockito.verify(is, Mockito.times(1)).close();
+    assertArrayEquals(expectedEmpty, md.digest());
+  }
+
+  @Test
+  void hash_whenIOExceptionAfterPartialRead_expectPartialUpdateAndClosed() throws Exception {
+    // Arrange: first chunk then fail
+    byte[] first = new byte[1024];
+    for (int i = 0; i < first.length; i++) first[i] = (byte) (i * 3 + 7);
+    MessageDigest md = SHA256.getMessageDigest();
+    byte[] expected = SHA256.digest(first);
+
+    try (FailingAfterFirstReadInputStream is = new FailingAfterFirstReadInputStream(first)) {
+      // Act + Assert
+      assertThrows(IOException.class, () -> SHA256.hash(is, md));
+      // Verify closure before try-with-resources would close it again
+      assertTrue(is.wasClosed, "input stream should be closed even on failure");
+      assertArrayEquals(expected, md.digest());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void hash_whenNullInputStream_expectNpe() {
+    MessageDigest md = SHA256.getMessageDigest();
+    assertThrows(NullPointerException.class, () -> SHA256.hash(null, md));
+  }
+
+  @Test
+  void hash_whenNullMessageDigest_expectNpeAndClosed() throws Exception {
+    // Arrange: ensure at least one successful read so md.update() is attempted
+    InputStream is = Mockito.mock(InputStream.class);
+    Mockito.when(is.read(ArgumentMatchers.any(byte[].class))).thenReturn(1, -1);
+
+    // Act + Assert
+    assertThrows(NullPointerException.class, () -> SHA256.hash(is, null));
+    Mockito.verify(is, Mockito.times(1)).close();
+  }
+
+  // The deprecated no-op SHA256.returnMessageDigest(...) was removed.
+
+  // ---- Helpers ----
+
+  /** Tracks whether {@link #close()} was called. */
+  private static final class CloseTrackingInputStream extends FilterInputStream {
+    private boolean closed;
+
+    CloseTrackingInputStream(InputStream in) {
+      super(in);
+    }
+
+    boolean wasClosed() {
+      return closed;
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed = true;
+      super.close();
+    }
+  }
+
+  /** Returns data once, then throws on the next read; tracks closure. */
+  private static final class FailingAfterFirstReadInputStream extends InputStream {
+    private final byte[] first;
+    private boolean served;
+    boolean wasClosed;
+
+    FailingAfterFirstReadInputStream(byte[] first) {
+      this.first = first.clone();
+    }
+
+    @Override
+    public int read() {
+      throw new UnsupportedOperationException("unused in tests");
+    }
+
+    @Override
+    public void close() throws IOException {
+      wasClosed = true;
+      super.close();
+    }
+
+    @Override
+    public int read(byte @NotNull [] b, int off, int len) throws IOException {
+      if (!served) {
+        System.arraycopy(first, 0, b, off, first.length);
+        served = true;
+        return first.length;
+      }
+      throw new IOException("fail on subsequent read");
+    }
+  }
+
+  /** Short-read wrapper with a deterministic chunk size pattern. */
+  private static final class DeterministicShortReadInputStream extends FilterInputStream {
+    private final int[] chunkSizes;
+    private int index;
+
+    DeterministicShortReadInputStream(InputStream in, int[] chunkSizes) {
+      super(in);
+      this.chunkSizes = chunkSizes.clone();
+    }
+
+    @Override
+    public int read(byte @NotNull [] b, int off, int len) throws IOException {
+      int n = Math.min(len, chunkSizes[index % chunkSizes.length]);
+      index++;
+      return in.read(b, off, n);
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Modernizes `network.crypta.crypt.SHA256` with clearer semantics and KDoc/Javadoc.
- Adds comprehensive `SHA256Test` (JUnit 6) covering happy path, short reads, early/late IOExceptions, null-argument behavior, and digest length.
- Removes deprecated no-op `SHA256.returnMessageDigest(...)` (source-only; no runtime behavior relied on it).

Changes
- src/main/java/network/crypta/crypt/SHA256.java
  - Improve class and method Javadoc (threading, close semantics, usage examples).
  - `hash(InputStream, MessageDigest)`: explicitly documents that it always closes the stream and does not reset the digest.
  - `getMessageDigest()`: documents provider and mutability.
  - `digest(byte[])`: new docs clarifying one-shot usage; unchanged behavior.
  - Remove `returnMessageDigest(...)` (deprecated no-op) and associated comment.
- src/test/java/network/crypta/crypt/SHA256Test.java (new)
  - Verifies empty/short-read behavior equals single-shot digests.
  - Verifies stream is closed on success and failure.
  - Verifies early and late IOException behavior (partial updates preserved when bytes were consumed).
  - Asserts `getDigestLength()` returns 32.

Diffstat
- 2 files changed, 283 insertions(+), 11 deletions(-)

Backward compatibility / Risk
- `SHA256.returnMessageDigest(...)` removed. It was a deprecated no-op; no production usages remain in this repo (search found none). External code calling it must delete those calls.

Notes
- Tests are written for JUnit 6 per project configuration.
- No behavior change intended for hashing routines besides clearer documentation and strictly enforced close semantics already present in try/finally.

Housekeeping
- Working tree is clean; no additional formatting commits were necessary.

