### PR TITLE
refactor(keys): clarify KeyBlock verification; add CHK/SSK tests and docs

### DIFF
--- a/src/main/java/network/crypta/keys/CHKBlock.java
+++ b/src/main/java/network/crypta/keys/CHKBlock.java
@@ -6,55 +6,152 @@ import network.crypta.crypt.SHA256;
 import network.crypta.support.Fields;
 
 /**
+ * Content Hash Key (CHK) block holding raw headers and data.
+ *
+ * <p>A CHK block pairs an immutable header section with a fixed-size data section. The routing key
+ * used by the network is the SHA-256 digest of {@code headers || data}. Constructors either compute
+ * the routing key from the provided bytes or verify it against a supplied {@link NodeCHK}. The
+ * header format is implementation-defined; only the first two bytes are interpreted here to carry a
+ * hash identifier. At present, only SHA-256 is accepted.
+ *
+ * <p>Instances are logically immutable; however, accessors return the backing byte arrays without
+ * copying for performance. Callers must treat the returned arrays as read-only and never modify
+ * them. Mutating the arrays will break equality, hashing, and integrity verification assumptions.
+ *
  * @author amphibian
- *     <p>CHK plus data. When fed a ClientCHK, can decode into the original data for a client.
  */
 public class CHKBlock implements KeyBlock {
 
+  // Backing arrays; returned by accessors without defensive copies. Treat as read-only.
   final byte[] data;
   final byte[] headers;
+
+  // Parsed from the first two header bytes. Only HASH_SHA256 is considered valid.
   final short hashIdentifier;
+
+  // Computed or verified content key derived from SHA-256(headers || data).
   final NodeCHK chk;
+
+  // Precomputed structural hash for this object (not to be confused with the routing key).
   final int hashCode;
+
+  /**
+   * Upper bound for the uncompressed content length prior to any optional compression stage. Units:
+   * bytes.
+   */
   public static final int MAX_LENGTH_BEFORE_COMPRESSION = Integer.MAX_VALUE;
+
+  /** Total header size in bytes expected by this implementation. */
   public static final int TOTAL_HEADERS_LENGTH = 36;
+
+  /** Fixed payload size in bytes for the data section. */
   public static final int DATA_LENGTH = 32768;
-  /* Maximum length of compressed payload */
+
+  /**
+   * Maximum number of bytes available to a compressed payload within {@link #DATA_LENGTH}.
+   *
+   * <p>Leaves 4 bytes for per-block framing/metadata used by readers and writers.
+   */
   public static final int MAX_COMPRESSED_DATA_LENGTH = DATA_LENGTH - 4;
 
+  /**
+   * Returns a diagnostic string containing the object identity and the derived key.
+   *
+   * @return a concise representation including {@code chk}.
+   */
   @Override
   public String toString() {
     return super.toString() + ": chk=" + chk;
   }
 
   /**
-   * @return The header for this key. DO NOT MODIFY THIS DATA!
+   * Returns the raw header bytes.
+   *
+   * <p>The returned array is the internal backing storage; callers must treat it as read-only.
+   *
+   * @return header bytes of length {@link #TOTAL_HEADERS_LENGTH}.
    */
   public byte[] getHeaders() {
     return headers;
   }
 
   /**
-   * @return The actual data for this key. DO NOT MODIFY THIS DATA!
+   * Returns the raw data bytes.
+   *
+   * <p>The returned array is the internal backing storage; callers must treat it as read-only.
+   *
+   * @return data bytes of length {@link #DATA_LENGTH}.
    */
   public byte[] getData() {
     return data;
   }
 
+  /**
+   * Builds a {@code CHKBlock} from raw components and computes/validates the routing key.
+   *
+   * <p>This convenience method behaves like {@link #CHKBlock(byte[], byte[], NodeCHK, boolean,
+   * byte)} with {@code key == null} and {@code verify == true}.
+   *
+   * @param data payload bytes of length {@link #DATA_LENGTH}.
+   * @param header header bytes of length {@link #TOTAL_HEADERS_LENGTH}.
+   * @param cryptoAlgorithm crypto algorithm identifier associated with the resulting {@link
+   *     NodeCHK}.
+   * @return a verified block whose routing key is {@code SHA-256(header || data)}.
+   * @throws CHKVerifyException if the header hash identifier is unsupported or verification fails.
+   */
   public static CHKBlock construct(byte[] data, byte[] header, byte cryptoAlgorithm)
       throws CHKVerifyException {
     return new CHKBlock(data, header, null, true, cryptoAlgorithm);
   }
 
+  /**
+   * Creates a block and verifies the content against the supplied key.
+   *
+   * <p>Verification recomputes the SHA-256 digest of {@code headers || data} and compares it with
+   * {@code key.getRoutingKey()}.
+   *
+   * @param data2 payload bytes of length {@link #DATA_LENGTH}.
+   * @param header2 header bytes of length {@link #TOTAL_HEADERS_LENGTH}.
+   * @param key expected content key; must not be {@code null}.
+   * @throws CHKVerifyException if the header hash identifier is unsupported or the digest
+   *     mismatches the supplied key.
+   */
   public CHKBlock(byte[] data2, byte[] header2, NodeCHK key) throws CHKVerifyException {
     this(data2, header2, key, key.cryptoAlgorithm);
   }
 
+  /**
+   * Creates a block and verifies content using the given key and algorithm.
+   *
+   * @param data2 payload bytes of length {@link #DATA_LENGTH}.
+   * @param header2 header bytes of length {@link #TOTAL_HEADERS_LENGTH}.
+   * @param key expected content key; must not be {@code null}.
+   * @param cryptoAlgorithm crypto algorithm identifier to associate with the block.
+   * @throws CHKVerifyException if the header hash identifier is unsupported or the digest
+   *     mismatches the supplied key.
+   */
   public CHKBlock(byte[] data2, byte[] header2, NodeCHK key, byte cryptoAlgorithm)
       throws CHKVerifyException {
     this(data2, header2, key, true, cryptoAlgorithm);
   }
 
+  /**
+   * Creates a block, optionally skipping digest verification when a key is provided.
+   *
+   * <p>When {@code key == null}, the constructor computes the routing key from the bytes and stores
+   * it in the resulting {@link NodeCHK}. When {@code key != null} and {@code verify == true}, the
+   * constructor recomputes the digest and compares it to {@code key}. When {@code key != null} and
+   * {@code verify == false}, no digest is computed and the supplied key is trusted as-is.
+   *
+   * @param data2 payload bytes of length {@link #DATA_LENGTH}.
+   * @param header2 header bytes of length {@link #TOTAL_HEADERS_LENGTH}.
+   * @param key optional content key; may be {@code null}.
+   * @param verify whether to recompute and validate the digest when {@code key != null}.
+   * @param cryptoAlgorithm crypto algorithm identifier to associate with the block.
+   * @throws CHKVerifyException if verification is requested and fails, or if the header indicates
+   *     an unsupported hash.
+   * @throws IllegalArgumentException if {@code header2.length != TOTAL_HEADERS_LENGTH}.
+   */
   public CHKBlock(byte[] data2, byte[] header2, NodeCHK key, boolean verify, byte cryptoAlgorithm)
       throws CHKVerifyException {
     data = data2;
@@ -63,8 +160,7 @@ public class CHKBlock implements KeyBlock {
       throw new IllegalArgumentException(
           "Wrong length: " + headers.length + " should be " + TOTAL_HEADERS_LENGTH);
     hashIdentifier = (short) (((headers[0] & 0xff) << 8) + (headers[1] & 0xff));
-    //        Logger.debug(CHKBlock.class, "Data length: "+data.length+", header length:
-    // "+header.length);
+    // Header ID parsed above; minimal verification and hashing follow.
     if ((key != null) && !verify) {
       this.chk = key;
       hashCode =
@@ -72,8 +168,7 @@ public class CHKBlock implements KeyBlock {
       return;
     }
 
-    // Minimal verification
-    // Check the hash
+    // Minimal verification: accept only SHA-256 and verify digest when required.
     if (hashIdentifier != HASH_SHA256) throw new CHKVerifyException("Hash not SHA-256");
     MessageDigest md = SHA256.getMessageDigest();
 
@@ -88,46 +183,86 @@ public class CHKBlock implements KeyBlock {
       if (!Arrays.equals(hash, check)) {
         throw new CHKVerifyException("Hash does not verify");
       }
-      // Otherwise it checks out
+      // Otherwise the content verifies against the supplied key.
     }
     hashCode = chk.hashCode() ^ Fields.hashCode(data) ^ Fields.hashCode(headers) ^ cryptoAlgorithm;
   }
 
+  /**
+   * Returns the derived content key for this block.
+   *
+   * @return non-null {@link NodeCHK} representing the routing key and algorithm.
+   */
   @Override
   public NodeCHK getKey() {
     return chk;
   }
 
+  /**
+   * Returns the header bytes as stored, without defensive copying.
+   *
+   * @return the backing header array; treat as read-only.
+   */
   @Override
   public byte[] getRawHeaders() {
     return headers;
   }
 
+  /**
+   * Returns the data bytes as stored, without defensive copying.
+   *
+   * @return the backing data array; treat as read-only.
+   */
   @Override
   public byte[] getRawData() {
     return data;
   }
 
+  /**
+   * Returns public-key material if present.
+   *
+   * <p>CHK blocks do not contain public keys; this method always returns {@code null}.
+   *
+   * @return {@code null} for CHK blocks.
+   */
   @Override
+  @SuppressWarnings("java:S1168")
   public byte[] getPubkeyBytes() {
     return null;
   }
 
+  /**
+   * Returns the serialized full key as defined by {@link NodeCHK}.
+   *
+   * @return byte array containing the algorithm identifier and routing key.
+   */
   @Override
   public byte[] getFullKey() {
     return getKey().getFullKey();
   }
 
+  /**
+   * Returns the routing key used for lookup and storage.
+   *
+   * @return SHA-256 digest of {@code headers || data}.
+   */
   @Override
   public byte[] getRoutingKey() {
     return getKey().getRoutingKey();
   }
 
+  /** Returns a hash code consistent with {@link #equals(Object)}. */
   @Override
   public int hashCode() {
     return hashCode;
   }
 
+  /**
+   * Compares this block with another for structural equality.
+   *
+   * <p>Two blocks are equal when their derived keys, header bytes, data bytes, and parsed hash
+   * identifiers are all equal.
+   */
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof CHKBlock block)) return false;

--- a/src/main/java/network/crypta/keys/KeyBlock.java
+++ b/src/main/java/network/crypta/keys/KeyBlock.java
@@ -3,18 +3,59 @@ package network.crypta.keys;
 import network.crypta.store.StorableBlock;
 
 /**
- * Interface for fetched blocks. Can be decoded by using a ClientKey to construct a ClientKeyBlock,
- * which can then be decoded to a Bucket.
+ * Represents a fetched, storable key block.
+ *
+ * <p>A {@code KeyBlock} is the raw result of retrieving a block identified by a {@link Key} (e.g.,
+ * CHK/SSK). Client code typically uses a {@link ClientKey} to construct a {@link ClientKeyBlock}
+ * from this interface and then decodes the payload into a {@link
+ * network.crypta.support.api.Bucket}. Implementations expose the unprocessed bytes that were
+ * received from the network or read from disk so higher layers can verify and decode them.
+ *
+ * <p>This interface only defines accessors; it does not prescribe mutability or thread-safety.
  */
 public interface KeyBlock extends StorableBlock {
 
+  /**
+   * Constant identifier for the SHA‑256 hash algorithm.
+   *
+   * <p>The exact usage depends on the concrete block type and associated header format.
+   */
   int HASH_SHA256 = 1;
 
+  /**
+   * Returns the locating key for this block.
+   *
+   * @return the {@link Key} that identifies the block instance.
+   */
   Key getKey();
 
+  /**
+   * Returns the raw header bytes associated with the block, if any.
+   *
+   * <p>The format and presence of headers are defined by the concrete key type. The bytes are
+   * provided as obtained from storage or the wire without interpretation.
+   *
+   * @return the header bytes in their original encoding.
+   */
   byte[] getRawHeaders();
 
+  /**
+   * Returns the raw payload bytes of the block.
+   *
+   * <p>These bytes are the undecoded content to be verified and decrypted/decoded by key‑specific
+   * logic (e.g., via {@link ClientKey} → {@link ClientKeyBlock}).
+   *
+   * @return the block payload bytes as stored or received.
+   */
   byte[] getRawData();
 
+  /**
+   * Returns the public key bytes associated with this block.
+   *
+   * <p>The presence and format of the public key depend on the block type (for example, SSK may
+   * include a key, while CHK may not). The bytes are returned in the block’s native encoding.
+   *
+   * @return the public key bytes for verification or decoding.
+   */
   byte[] getPubkeyBytes();
 }

--- a/src/main/java/network/crypta/keys/SSKBlock.java
+++ b/src/main/java/network/crypta/keys/SSKBlock.java
@@ -14,43 +14,53 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * SSKBlock. Contains a full fetched key. Can do a node-level verification. Can decode original data
- * when fed a ClientSSK.
+ * Represents a Signed Subspace Key (SSK) block fetched from the network.
+ *
+ * <p>An instance encapsulates the fixed-size payload ({@link #DATA_LENGTH}) and its headers and can
+ * perform node-level signature verification using the public key contained in the provided {@link
+ * NodeSSK}. The actual payload decryption is handled elsewhere (e.g., by client-level code) using
+ * the data-decrypt key that is stored in the encrypted portion of the headers.
+ *
+ * <p>Equality intentionally ignores the trailing signature bytes in the header (see {@link
+ * #HEADER_COMPARE_TO}) because legacy blocks may be signed over different digests (truncated vs.
+ * full) while remaining semantically equivalent.
  */
 public class SSKBlock implements KeyBlock {
   private static final Logger LOG = LoggerFactory.getLogger(SSKBlock.class);
 
-  static {
-  }
-
-  // how much of the headers we compare in order to consider two
-  // SSKBlocks equal - necessary because the last 64 bytes need not
-  // be the same for the same data and the same key (see comments below)
+  // Number of initial header bytes compared for equality.
+  // The final 64 bytes hold the DSA (r,s) signature and may legitimately differ for
+  // semantically identical blocks; see class Javadoc and the verification logic below.
   private static final int HEADER_COMPARE_TO = 71;
   final byte[] data;
   final byte[] headers;
 
-  /** The index of the first byte of encrypted fields in the headers, after E(H(docname)) */
+  /**
+   * Index of the first byte of the encrypted header segment, immediately after {@code
+   * E(H(docname))}.
+   */
   final int headersOffset;
 
-  /* HEADERS FORMAT:
-   * 2 bytes - hash ID
-   * 2 bytes - symmetric cipher ID
-   * 32 bytes - E(H(docname))
-   * ENCRYPTED WITH E(H(docname)) AS IV:
-   *  32 bytes - H(decrypted data), = data decryption key
-   *  2 bytes - data length + metadata flag
-   *  2 bytes - data compression algorithm or -1
-   * IMPLICIT - hash of data
-   * IMPLICIT - hash of remaining fields, including the implicit hash of data
+  /*
+   * Header layout (big-endian where applicable):
    *
-   * SIGNATURE ON THE ABOVE HASH:
-   *  32 bytes - signature: R (unsigned bytes)
-   *  32 bytes - signature: S (unsigned bytes)
+   *  - 2 bytes  : hash identifier
+   *  - 2 bytes  : symmetric cipher identifier
+   *  - 32 bytes : E(H(docname)) — encrypted hash of the document name
+   *  - 36 bytes : encrypted header segment, using E(H(docname)) as IV
+   *               (32) H(decrypted data) — also used as the data-decrypt key
+   *               ( 2) data length with an embedded metadata flag
+   *               ( 2) compression algorithm id or -1
+   *  - implicit : SHA-256 of the {@code data} (not stored directly in the header array)
+   *  - implicit : overall header hash that also includes the implicit data hash
+   *  - 32 bytes : DSA signature component R (unsigned)
+   *  - 32 bytes : DSA signature component S (unsigned)
    *
-   * PLUS THE PUBKEY:
-   *  Pubkey
-   *  Group
+   * Notes:
+   *  - The header byte array validated by this class does not contain the public key. The public
+   *    key is supplied out-of-band via {@link NodeSSK}.
+   *  - The DSA signature may have been generated over either the truncated overall hash or the
+   *    full hash for historical reasons; verification accepts both forms.
    */
   final NodeSSK nodeKey;
   final DSAPublicKey pubKey;
@@ -58,8 +68,13 @@ public class SSKBlock implements KeyBlock {
   final short symCipherIdentifier;
   final int hashCode;
 
+  /** Size in bytes of the fixed payload area carried by an SSK block. */
   public static final short DATA_LENGTH = 1024;
-  /* Maximum length of compressed payload */
+
+  /**
+   * Maximum number of bytes available for the compressed payload. Two bytes are reserved in the
+   * encrypted header segment for the payload length and a metadata flag.
+   */
   public static final int MAX_COMPRESSED_DATA_LENGTH = DATA_LENGTH - 2;
 
   static final short SIG_R_LENGTH = 32;
@@ -86,11 +101,10 @@ public class SSKBlock implements KeyBlock {
     if (block.headersOffset != headersOffset) return false;
     if (block.hashIdentifier != hashIdentifier) return false;
     if (block.symCipherIdentifier != symCipherIdentifier) return false;
-    // only compare some of the headers (see top)
+    // Compare only the leading portion of the header to ignore the signature bytes.
     for (int i = 0; i < HEADER_COMPARE_TO; i++) {
       if (block.headers[i] != headers[i]) return false;
     }
-    // if(!Arrays.equals(block.headers, headers)) return false;
     return Arrays.equals(block.data, data);
   }
 
@@ -100,7 +114,25 @@ public class SSKBlock implements KeyBlock {
   }
 
   /**
-   * Initialize, and verify data, headers against key. Provided key must have a pubkey, or we throw.
+   * Creates a block and optionally verifies its signature and header bindings.
+   *
+   * <p>Preconditions: - {@code headers.length == TOTAL_HEADERS_LENGTH} - {@code data.length ==
+   * DATA_LENGTH} - {@code nodeKey} provides a non-null public key
+   *
+   * <p>Verification computes the legacy overall hash (data hash plus selected header bytes) and
+   * checks the DSA signature against the public key from {@code nodeKey}. For compatibility, the
+   * signature is validated against both the truncated and full digest forms. It also verifies that
+   * the {@code E(H(docname))} field in the header matches the corresponding value in {@code
+   * nodeKey}.
+   *
+   * @param data the fixed-size payload; treated as opaque by this class
+   * @param headers the block headers in the format described above
+   * @param nodeKey the node-level SSK that supplies the public key and {@code E(H(docname))}
+   * @param dontVerify when {@code true}, skips signature verification (still performs basic
+   *     structural checks); validation always runs when debug logging is enabled
+   * @throws IllegalArgumentException if {@code headers.length != TOTAL_HEADERS_LENGTH}
+   * @throws SSKVerifyException if the payload length is wrong, the public key is missing, the
+   *     signature does not verify, or the header is not bound to {@code nodeKey}
    */
   public SSKBlock(byte[] data, byte[] headers, NodeSSK nodeKey, boolean dontVerify)
       throws SSKVerifyException {
@@ -121,40 +153,30 @@ public class SSKBlock implements KeyBlock {
     int x = 2;
     symCipherIdentifier = (short) (((headers[x] & 0xff) << 8) + (headers[x + 1] & 0xff));
     x += 2;
-    // Then E(H(docname))
+    // Read E(H(docname)) and determine the start of the encrypted header segment.
     byte[] ehDocname = new byte[E_H_DOCNAME_LENGTH];
     System.arraycopy(headers, x, ehDocname, 0, ehDocname.length);
     x += E_H_DOCNAME_LENGTH;
-    headersOffset = x; // is index to start of encrypted headers
+    headersOffset = x; // index of the first byte of the encrypted header segment
     x += ENCRYPTED_HEADERS_LENGTH;
-    // Extract the signature
-    if (x + SIG_R_LENGTH + SIG_S_LENGTH > headers.length)
-      throw new SSKVerifyException(
-          "Headers too short: "
-              + headers.length
-              + " should be at least "
-              + x
-              + SIG_R_LENGTH
-              + SIG_S_LENGTH);
-    // Compute the hash on the data
+    // Extract the signature (safe due to TOTAL_HEADERS_LENGTH pre-check) and compute the legacy
+    // overall hash used by the signature.
     if (!dontVerify || LOG.isDebugEnabled()) { // force verify on debug
       byte[] bufR = new byte[SIG_R_LENGTH];
       byte[] bufS = new byte[SIG_S_LENGTH];
 
       System.arraycopy(headers, x, bufR, 0, SIG_R_LENGTH);
-      x += SIG_R_LENGTH;
-      System.arraycopy(headers, x, bufS, 0, SIG_S_LENGTH);
-      x += SIG_S_LENGTH;
+      System.arraycopy(headers, x + SIG_R_LENGTH, bufS, 0, SIG_S_LENGTH);
 
       byte[] overallHash;
       MessageDigest md = SHA256.getMessageDigest();
       md.update(data);
       byte[] dataHash = md.digest();
-      // All headers up to and not including the signature
+      // Include all header bytes up to (but not including) the signature.
       md.update(headers, 0, headersOffset + ENCRYPTED_HEADERS_LENGTH);
-      // Then the implicit data hash
+      // Then incorporate the implicit data hash.
       md.update(dataHash);
-      // Makes the implicit overall hash
+      // Finalize the overall hash.
       overallHash = md.digest();
 
       // Now verify it
@@ -164,15 +186,15 @@ public class SSKBlock implements KeyBlock {
       dsa.init(
           false, new DSAPublicKeyParameters(pubKey.getY(), Global.getDSAgroupBigAParameters()));
 
-      // We probably don't need to try both here...
-      // but that's what the legacy code was doing...
-      // @see comments in Global before touching it
+      // Legacy blocks may be signed over the truncated digest; accept both truncated and full
+      // forms for backward compatibility. See Global.truncateHash(...).
       if (!(dsa.verifySignature(Global.truncateHash(overallHash), r, s)
           || dsa.verifySignature(overallHash, r, s))) {
         if (dontVerify) LOG.error("DSA verification failed with dontVerify!!!!");
         throw new SSKVerifyException("Signature verification failed for node-level SSK");
       }
-    } // x isn't verified otherwise so no need to += SIG_R_LENGTH + SIG_S_LENGTH
+    } // No further parsing beyond the signature is required here.
+    // Ensure the header is bound to the supplied nodeKey by comparing E(H(docname)).
     if (!Arrays.equals(ehDocname, nodeKey.encryptedHashedDocname))
       throw new SSKVerifyException(
           "E(H(docname)) wrong - wrong key?? \nfrom headers: "
@@ -187,35 +209,72 @@ public class SSKBlock implements KeyBlock {
             ^ hashIdentifier;
   }
 
+  /**
+   * Returns the node-level SSK used for verification and routing. Never {@code null}.
+   *
+   * @return the associated {@link NodeSSK}
+   */
   @Override
   public NodeSSK getKey() {
     return nodeKey;
   }
 
+  /**
+   * Exposes the raw header bytes as stored in this instance. The returned array is the backing
+   * storage; callers must treat it as immutable.
+   *
+   * @return the header byte array of length {@link #TOTAL_HEADERS_LENGTH}
+   */
   @Override
   public byte[] getRawHeaders() {
     return headers;
   }
 
+  /**
+   * Exposes the raw payload bytes. The returned array is the backing storage; callers must not
+   * modify it.
+   *
+   * @return the payload byte array of length {@link #DATA_LENGTH}
+   */
   @Override
   public byte[] getRawData() {
     return data;
   }
 
+  /**
+   * Returns the DSA public key extracted from {@link #getKey()}.
+   *
+   * @return the public key used to verify the block signature
+   */
   public DSAPublicKey getPubKey() {
     return pubKey;
   }
 
+  /**
+   * Returns the encoded form of the DSA public key.
+   *
+   * @return public key bytes in the format produced by {@link DSAPublicKey#asBytes()}
+   */
   @Override
   public byte[] getPubkeyBytes() {
     return pubKey.asBytes();
   }
 
+  /**
+   * Returns the full routing key bytes for this block as defined by {@link NodeSSK}.
+   *
+   * @return the full routing key
+   */
   @Override
   public byte[] getFullKey() {
     return getKey().getFullKey();
   }
 
+  /**
+   * Returns the routing key used for DHT placement.
+   *
+   * @return the routing key
+   */
   @Override
   public byte[] getRoutingKey() {
     return getKey().getRoutingKey();

--- a/src/test/java/network/crypta/keys/CHKBlockTest.java
+++ b/src/test/java/network/crypta/keys/CHKBlockTest.java
@@ -1,0 +1,184 @@
+package network.crypta.keys;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import network.crypta.crypt.SHA256;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100") // Test method-naming: method_whenCondition_expectOutcome
+class CHKBlockTest {
+
+  private static byte[] sha256(byte[] headers, byte[] data) {
+    MessageDigest md = SHA256.getMessageDigest();
+    md.update(headers);
+    md.update(data);
+    return md.digest();
+  }
+
+  private static byte[] makeHeaders(short hashIdentifier) {
+    byte[] h = new byte[CHKBlock.TOTAL_HEADERS_LENGTH];
+    // Big-endian short
+    h[0] = (byte) ((hashIdentifier >> 8) & 0xFF);
+    h[1] = (byte) (hashIdentifier & 0xFF);
+    // The rest can be zero for these tests.
+    return h;
+  }
+
+  private static Stream<Byte> cryptoAlgos() {
+    return Stream.of(Key.ALGO_AES_PCFB_256_SHA256, Key.ALGO_AES_CTR_256_SHA256);
+  }
+
+  @ParameterizedTest
+  @MethodSource("cryptoAlgos")
+  @DisplayName("construct(null key) builds NodeCHK from SHA-256(headers||data)")
+  void construct_whenKeyNull_buildsNodeCHKFromHash(byte cryptoAlgorithm) throws Exception {
+    // Arrange
+    byte[] data = new byte[] {1, 2, 3, 4, 5};
+    byte[] headers = makeHeaders((short) KeyBlock.HASH_SHA256);
+    byte[] expectedRoutingKey = sha256(headers, data);
+
+    // Act
+    CHKBlock block = CHKBlock.construct(data, headers, cryptoAlgorithm);
+
+    // Assert
+    assertArrayEquals(expectedRoutingKey, block.getRoutingKey(), "routingKey must match digest");
+    assertEquals(cryptoAlgorithm, NodeCHK.cryptoAlgorithmFromFullKey(block.getFullKey()));
+    assertArrayEquals(
+        expectedRoutingKey,
+        NodeCHK.routingKeyFromFullKey(block.getFullKey()),
+        "fullKey must embed routingKey");
+    assertSame(headers, block.getHeaders(), "headers must be exposed as the same array reference");
+    assertSame(data, block.getData(), "data must be exposed as the same array reference");
+    assertNull(block.getPubkeyBytes(), "CHK blocks do not carry pubkey bytes");
+  }
+
+  @Test
+  void constructor_withExplicitKey_matchingHash_verifiesAndUsesProvidedKey() throws Exception {
+    // Arrange
+    byte[] data = new byte[] {10, 20, 30};
+    byte[] headers = makeHeaders((short) KeyBlock.HASH_SHA256);
+    byte[] digest = sha256(headers, data);
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+    NodeCHK key = new NodeCHK(digest, algo);
+
+    // Act
+    CHKBlock block = new CHKBlock(data, headers, key);
+
+    // Assert
+    assertNotNull(block.getKey());
+    assertEquals(key, block.getKey(), "Block must keep the provided NodeCHK");
+    assertArrayEquals(digest, block.getRoutingKey());
+    assertEquals(key.getType(), block.getKey().getType());
+  }
+
+  @Test
+  void constructor_withExplicitKey_mismatchedHash_throwsCHKVerifyException() {
+    // Arrange
+    byte[] data = new byte[] {42};
+    byte[] headers = makeHeaders((short) KeyBlock.HASH_SHA256);
+    byte[] wrongDigest = new byte[NodeCHK.KEY_LENGTH]; // all zeros -> guaranteed mismatch
+    NodeCHK wrongKey = new NodeCHK(wrongDigest, Key.ALGO_AES_CTR_256_SHA256);
+
+    // Act + Assert
+    assertThrows(CHKVerifyException.class, () -> new CHKBlock(data, headers, wrongKey));
+  }
+
+  @Test
+  void constructor_withNonSHA256Header_throwsCHKVerifyException() {
+    // Arrange
+    byte[] data = new byte[] {1, 2};
+    byte[] badHeaders = makeHeaders((short) 0x0002); // not HASH_SHA256
+
+    // Act + Assert
+    assertThrows(
+        CHKVerifyException.class,
+        () -> CHKBlock.construct(data, badHeaders, Key.ALGO_AES_CTR_256_SHA256));
+  }
+
+  @Test
+  void constructor_withInvalidHeaderLength_throwsIllegalArgumentException() {
+    // Arrange
+    byte[] data = new byte[] {9, 9, 9};
+    byte[] wrongLenHeaders = new byte[CHKBlock.TOTAL_HEADERS_LENGTH - 1];
+
+    // Act + Assert
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CHKBlock.construct(data, wrongLenHeaders, Key.ALGO_AES_PCFB_256_SHA256));
+  }
+
+  @Test
+  void constructor_verifyFalse_allowsNonSHA256HeaderAndSkipsHashCheck() throws Exception {
+    // Arrange: invalid header ID but verify=false should bypass checks
+    byte[] data = new byte[] {7, 7, 7};
+    byte[] badHeaders = makeHeaders((short) 0x1234);
+    byte[] arbitraryRoutingKey = new byte[NodeCHK.KEY_LENGTH];
+    Arrays.fill(arbitraryRoutingKey, (byte) 0xA5);
+    NodeCHK providedKey = new NodeCHK(arbitraryRoutingKey, Key.ALGO_AES_CTR_256_SHA256);
+
+    // Act
+    CHKBlock block =
+        new CHKBlock(data, badHeaders, providedKey, false, providedKey.cryptoAlgorithm);
+
+    // Assert: constructed and kept the provided key; no exceptions
+    assertSame(providedKey, block.getKey(), "verify=false must accept the provided key verbatim");
+    assertSame(badHeaders, block.getHeaders());
+    assertSame(data, block.getData());
+  }
+
+  @Test
+  void equals_and_hashCode_whenAllFieldsMatch_areEqual() throws Exception {
+    // Arrange
+    byte[] data1 = new byte[] {1, 3, 3, 7};
+    byte[] headers1 = makeHeaders((short) KeyBlock.HASH_SHA256);
+    byte[] data2 = Arrays.copyOf(data1, data1.length);
+    byte[] headers2 = Arrays.copyOf(headers1, headers1.length);
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+
+    CHKBlock a = CHKBlock.construct(data1, headers1, algo);
+    CHKBlock b = CHKBlock.construct(data2, headers2, algo);
+
+    // Act + Assert
+    assertEquals(a, b, "Blocks with identical content must be equal");
+    assertEquals(a.hashCode(), b.hashCode(), "Equal blocks must share hashCode");
+  }
+
+  @Test
+  void equals_whenHeadersOrDataDiffer_notEqualEvenIfKeySameWithBypass() throws Exception {
+    // Arrange: build a baseline block
+    byte[] data = new byte[] {5, 6, 7};
+    byte[] headers = makeHeaders((short) KeyBlock.HASH_SHA256);
+    CHKBlock original = CHKBlock.construct(data, headers, Key.ALGO_AES_CTR_256_SHA256);
+
+    // Now construct a block with the same key but a different header and data via verify=false
+    byte[] differentHeaders = makeHeaders((short) KeyBlock.HASH_SHA256);
+    differentHeaders[5] = 1; // mutate some header byte
+    byte[] differentData = new byte[] {9, 9};
+    CHKBlock different =
+        new CHKBlock(
+            differentData,
+            differentHeaders,
+            original.getKey(),
+            false,
+            NodeCHK.cryptoAlgorithmFromFullKey(original.getFullKey()));
+
+    // Act + Assert
+    assertNotEquals(original, different);
+    assertNotEquals(
+        original.hashCode(),
+        different.hashCode(),
+        "Likely different hashCodes when content differs (not strictly required)");
+  }
+}

--- a/src/test/java/network/crypta/keys/SSKBlockTest.java
+++ b/src/test/java/network/crypta/keys/SSKBlockTest.java
@@ -1,0 +1,350 @@
+package network.crypta.keys;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import network.crypta.crypt.DSAPrivateKey;
+import network.crypta.crypt.DSAPublicKey;
+import network.crypta.crypt.Global;
+import network.crypta.crypt.SHA256;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.params.DSAPrivateKeyParameters;
+import org.bouncycastle.crypto.params.ParametersWithRandom;
+import org.bouncycastle.crypto.signers.DSASigner;
+import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class SSKBlockTest {
+
+  private static final byte CRYPTO_ALGO = Key.ALGO_AES_PCFB_256_SHA256;
+
+  private static NodeSSK newNodeSSK(DSAPublicKey pub, byte[] ehDocname) throws SSKVerifyException {
+    byte[] pkHash = SHA256.digest(pub.asBytes());
+    return new NodeSSK(pkHash, ehDocname, pub, CRYPTO_ALGO);
+  }
+
+  private static byte[] newData() {
+    // Deterministic 1024 bytes.
+    byte[] data = new byte[SSKBlock.DATA_LENGTH];
+    for (int i = 0; i < data.length; i++) data[i] = (byte) (i & 0xFF);
+    return data;
+  }
+
+  private static byte[] headersUnsignedPrefix(byte[] ehDocname) {
+    return headersUnsignedPrefix(ehDocname, CRYPTO_ALGO);
+  }
+
+  private static byte[] headersUnsignedPrefix(byte[] ehDocname, short symCipher) {
+    byte[] headers = new byte[SSKBlock.TOTAL_HEADERS_LENGTH];
+    int x = 0;
+    headers[x++] = 0; // HASH_SHA256 high byte
+    headers[x++] = (byte) KeyBlock.HASH_SHA256; // low byte
+    headers[x++] = (byte) (symCipher >> 8);
+    headers[x++] = (byte) symCipher;
+    System.arraycopy(ehDocname, 0, headers, x, SSKBlock.E_H_DOCNAME_LENGTH);
+    x += SSKBlock.E_H_DOCNAME_LENGTH;
+    for (int i = 0; i < SSKBlock.ENCRYPTED_HEADERS_LENGTH; i++) headers[x++] = (byte) (0xA0 + i);
+    // Leave signature area zeroed for signing
+    assertEquals(SSKBlock.TOTAL_HEADERS_LENGTH - 64, x);
+    return headers;
+  }
+
+  private static void signHeaders(
+      byte[] headers, byte[] data, DSAPrivateKey priv, boolean deterministic, byte[] randomSeed) {
+    // Compute overallHash as SSKBlock does
+    byte[] dataHash = SHA256.digest(data);
+    int signedPrefixLen = 2 + 2 + SSKBlock.E_H_DOCNAME_LENGTH + SSKBlock.ENCRYPTED_HEADERS_LENGTH;
+    // overallHash = SHA256(headers[0..prefix) || dataHash)
+    byte[] tmp = new byte[signedPrefixLen + dataHash.length];
+    System.arraycopy(headers, 0, tmp, 0, signedPrefixLen);
+    System.arraycopy(dataHash, 0, tmp, signedPrefixLen, dataHash.length);
+    byte[] overallHash = SHA256.digest(tmp);
+
+    DSASigner dsa =
+        deterministic ? new DSASigner(new HMacDSAKCalculator(new SHA256Digest())) : new DSASigner();
+    DSAPrivateKeyParameters params =
+        new DSAPrivateKeyParameters(priv.getX(), Global.getDSAgroupBigAParameters());
+    if (deterministic) {
+      dsa.init(true, params);
+    } else {
+      SecureRandom sr = new SecureRandom(randomSeed);
+      dsa.init(true, new ParametersWithRandom(params, sr));
+    }
+    var sig = dsa.generateSignature(Global.truncateHash(overallHash));
+    byte[] r = toFixed(sig[0].toByteArray(), SSKBlock.SIG_R_LENGTH);
+    byte[] s = toFixed(sig[1].toByteArray(), SSKBlock.SIG_S_LENGTH);
+    int x = signedPrefixLen;
+    System.arraycopy(r, 0, headers, x, r.length);
+    x += r.length;
+    System.arraycopy(s, 0, headers, x, s.length);
+  }
+
+  private static byte[] toFixed(byte[] in, int len) {
+    if (in.length == len) return in;
+    if (in.length > len) {
+      for (int i = 0; i < in.length - len; i++)
+        if (in[i] != 0) throw new IllegalArgumentException("cannot truncate");
+      return Arrays.copyOfRange(in, in.length - len, in.length);
+    }
+    byte[] out = new byte[len];
+    System.arraycopy(in, 0, out, len - in.length, in.length);
+    return out;
+  }
+
+  private static byte[] signedHeaders(
+      byte[] ehDocname,
+      short symCipher,
+      byte[] data,
+      DSAPrivateKey priv,
+      boolean deterministic,
+      byte[] seed) {
+    byte[] headers = headersUnsignedPrefix(ehDocname, symCipher);
+    signHeaders(headers, data, priv, deterministic, seed);
+    return headers;
+  }
+
+  @Test
+  @DisplayName("constructor_whenValidAndDontVerifyTrue_buildsBlock")
+  void constructor_whenValidAndDontVerifyTrue_buildsBlock() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {9, 8, 7, 6}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x7B);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    byte[] headers = signedHeaders(ehDocname, CRYPTO_ALGO, data, priv, true, null);
+
+    SSKBlock block = new SSKBlock(data, headers, nodeKey, /* dontVerify= */ true);
+
+    assertNotNull(block);
+    assertArrayEquals(data, block.getRawData());
+    assertArrayEquals(headers, block.getRawHeaders());
+    assertArrayEquals(pub.asBytes(), block.getPubkeyBytes());
+    assertArrayEquals(nodeKey.getFullKey(), block.getFullKey());
+    assertArrayEquals(nodeKey.getRoutingKey(), block.getRoutingKey());
+    assertEquals(nodeKey, block.getKey());
+    assertEquals(pub, block.getPubKey());
+  }
+
+  @Test
+  @DisplayName("constructor_whenHashIdentifierNotSHA256_throwsVerifyException")
+  void constructor_whenHashIdentifierNotSHA256_throwsVerifyException() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {1, 1, 1, 1}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x11);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    byte[] headers = headersUnsignedPrefix(ehDocname);
+    // Corrupt hash identifier (bytes 0..1)
+    headers[0] = 0;
+    headers[1] = 2; // not HASH_SHA256
+
+    assertThrows(SSKVerifyException.class, () -> new SSKBlock(data, headers, nodeKey, true));
+  }
+
+  @Test
+  @DisplayName("constructor_whenEHDocnameMismatch_throwsVerifyException")
+  void constructor_whenEHDocnameMismatch_throwsVerifyException() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {2, 2, 2, 2}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x22);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    byte[] ehDocnameDifferent = ehDocname.clone();
+    ehDocnameDifferent[0] ^= 0x01; // mismatch
+    byte[] headers = signedHeaders(ehDocnameDifferent, CRYPTO_ALGO, data, priv, true, null);
+
+    assertThrows(SSKVerifyException.class, () -> new SSKBlock(data, headers, nodeKey, false));
+  }
+
+  @Test
+  @DisplayName("constructor_whenDataLengthWrong_throwsVerifyException")
+  void constructor_whenDataLengthWrong_throwsVerifyException() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {3, 3, 3, 3}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x33);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] shortData = new byte[SSKBlock.DATA_LENGTH - 1];
+    byte[] headers = signedHeaders(ehDocname, CRYPTO_ALGO, newData(), priv, true, null);
+
+    assertThrows(SSKVerifyException.class, () -> new SSKBlock(shortData, headers, nodeKey, true));
+  }
+
+  @Test
+  @DisplayName("constructor_whenHeadersLengthWrong_throwsIllegalArgument")
+  void constructor_whenHeadersLengthWrong_throwsIllegalArgument() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {4, 4, 4, 4}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x44);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    byte[] badHeaders =
+        Arrays.copyOf(
+            signedHeaders(ehDocname, CRYPTO_ALGO, data, priv, true, null),
+            SSKBlock.TOTAL_HEADERS_LENGTH - 1);
+
+    assertThrows(
+        IllegalArgumentException.class, () -> new SSKBlock(data, badHeaders, nodeKey, true));
+  }
+
+  @Test
+  @DisplayName("constructor_whenNodeKeyMissingPubkey_throwsVerifyException")
+  void constructor_whenNodeKeyMissingPubkey_throwsVerifyException() {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {5, 5, 5, 5}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x55);
+    // Create NodeSSK without a pubkey
+    byte[] pkHash = SHA256.digest(pub.asBytes());
+    NodeSSK nodeKey = new NodeSSK(pkHash, ehDocname, CRYPTO_ALGO);
+
+    byte[] data = newData();
+    byte[] headers = signedHeaders(ehDocname, CRYPTO_ALGO, data, priv, true, null);
+
+    assertThrows(SSKVerifyException.class, () -> new SSKBlock(data, headers, nodeKey, true));
+  }
+
+  @Test
+  @DisplayName("constructor_whenSignatureInvalidAndVerifyEnabled_throwsVerifyException")
+  void constructor_whenSignatureInvalidAndVerifyEnabled_throwsVerifyException() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {6, 6, 6, 6}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x66);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    byte[] headers = headersUnsignedPrefix(ehDocname);
+    // With dontVerify=false, bogus R/S must fail verification.
+    assertThrows(SSKVerifyException.class, () -> new SSKBlock(data, headers, nodeKey, false));
+  }
+
+  @Test
+  @DisplayName("equals_whenHeadersDifferOnlyAfterCompareWindow_returnsTrue")
+  void equals_whenHeadersDifferOnlyAfterCompareWindow_returnsTrue() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {7, 7, 7, 7}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x77);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    // Same header prefix, different valid signatures (deterministic vs seeded random)
+    byte[] headersA = signedHeaders(ehDocname, CRYPTO_ALGO, data, priv, true, null);
+    byte[] headersB =
+        signedHeaders(ehDocname, CRYPTO_ALGO, data, priv, false, new byte[] {9, 9, 9, 9});
+
+    SSKBlock a = new SSKBlock(data, headersA, nodeKey, false);
+    SSKBlock b = new SSKBlock(data, headersB, nodeKey, false);
+
+    assertEquals(a, b);
+  }
+
+  @Test
+  @DisplayName("hashCode_whenBlocksIdentical_returnsSameValue")
+  void hashCode_whenBlocksIdentical_returnsSameValue() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {7, 7, 7, 7}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x77);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    byte[] headers = signedHeaders(ehDocname, CRYPTO_ALGO, data, priv, true, null);
+
+    SSKBlock a = new SSKBlock(data, headers, nodeKey, false);
+    SSKBlock b = new SSKBlock(data, headers.clone(), nodeKey, false);
+
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  @DisplayName("equals_whenHeadersDifferInsideCompareWindow_returnsFalse")
+  void equals_whenHeadersDifferInsideCompareWindow_returnsFalse() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {8, 8, 8, 8}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x78);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    byte[] headersA = signedHeaders(ehDocname, CRYPTO_ALGO, data, priv, true, null);
+    // Change one byte within 0..70, then re-sign so constructor passes
+    byte[] headersB = headersUnsignedPrefix(ehDocname);
+    headersB[70] ^= 0x01;
+    signHeaders(headersB, data, priv, true, null);
+
+    SSKBlock a = new SSKBlock(data, headersA, nodeKey, false);
+    SSKBlock b = new SSKBlock(data, headersB, nodeKey, false);
+
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  @DisplayName("equals_whenDataDiffers_returnsFalse")
+  void equals_whenDataDiffers_returnsFalse() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {10, 10, 10, 10}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x79);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] dataA = newData();
+    byte[] dataB = newData();
+    dataB[0] ^= 0x7F; // mutate one byte
+    byte[] headersA = signedHeaders(ehDocname, CRYPTO_ALGO, dataA, priv, true, null);
+    byte[] headersB = signedHeaders(ehDocname, CRYPTO_ALGO, dataB, priv, true, null);
+
+    SSKBlock a = new SSKBlock(dataA, headersA, nodeKey, false);
+    SSKBlock b = new SSKBlock(dataB, headersB, nodeKey, false);
+
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  @DisplayName("equals_whenSymCipherIdentifierDiffers_returnsFalse")
+  void equals_whenSymCipherIdentifierDiffers_returnsFalse() throws Exception {
+    DSAPrivateKey priv =
+        new DSAPrivateKey(Global.DSAgroupBigA, new SecureRandom(new byte[] {11, 11, 11, 11}));
+    DSAPublicKey pub = new DSAPublicKey(Global.DSAgroupBigA, priv);
+    byte[] ehDocname = new byte[NodeSSK.E_H_DOCNAME_SIZE];
+    Arrays.fill(ehDocname, (byte) 0x7A);
+    NodeSSK nodeKey = newNodeSSK(pub, ehDocname);
+
+    byte[] data = newData();
+    byte[] headersA = signedHeaders(ehDocname, CRYPTO_ALGO, data, priv, true, null);
+    byte[] headersB = signedHeaders(ehDocname, (short) (CRYPTO_ALGO + 1), data, priv, true, null);
+
+    SSKBlock a = new SSKBlock(data, headersA, nodeKey, false);
+    SSKBlock b = new SSKBlock(data, headersB, nodeKey, false);
+
+    assertNotEquals(a, b);
+  }
+}


### PR DESCRIPTION
Summary
- Clarifies SSKBlock verification flow and tightens KeyBlock API contracts.
- Improves CHKBlock and SSKBlock KDoc/Javadoc; aligns naming and invariants.
- Adds unit tests for CHKBlock and SSKBlock; expands DSA tests.
- Refactors legacy Util helpers around key handling to reduce surface area.

Change Details
- Commits (new since origin/develop):
  - 74d2922db7 — refactor(keys): clarify SSKBlock verification and docs; add tests
  - 0db5c05a88 — refactor(keys): improve CHKBlock API docs and add unit tests
  - e6e1838781 — docs(keys): improve Javadoc for KeyBlock and clarify API contracts

- Files changed (13):
  - src/main/java/network/crypta/crypt/CryptoKey.java (minor)
  - src/main/java/network/crypta/crypt/DSAGroup.java (minor)
  - src/main/java/network/crypta/crypt/DSAPrivateKey.java (minor)
  - src/main/java/network/crypta/crypt/DSAPublicKey.java (minor)
  - src/main/java/network/crypta/crypt/Util.java (refactor; simplify/trim helpers)
  - src/main/java/network/crypta/keys/CHKBlock.java (docs + API cleanups)
  - src/main/java/network/crypta/keys/KeyBlock.java (docs + contracts)
  - src/main/java/network/crypta/keys/SSKBlock.java (verification clarifications)
  - src/test/java/network/crypta/crypt/DSAGroupTest.java (expanded)
  - src/test/java/network/crypta/crypt/DSAPrivateKeyTest.java (expanded)
  - src/test/java/network/crypta/crypt/UtilTest.java (removed legacy coverage)
  - src/test/java/network/crypta/keys/CHKBlockTest.java (added)
  - src/test/java/network/crypta/keys/SSKBlockTest.java (added)

- Diff stat: 13 files changed, 914 insertions(+), 760 deletions(-).

Rationale
- KeyBlock-related docs and tests were light; this tightens contracts and increases confidence.
- Util reductions remove dead/unnecessary helpers now covered elsewhere.

Testing
- New tests: CHKBlockTest, SSKBlockTest.
- Updated tests pass locally on Java 21.

Notes
- Formatting: tree was clean; no additional formatting commits required.
- No behavior changes expected for runtime crypto flows; refactors are docs/tests-focused with minimal code touch in Util.

Request
- Please review the CHK/SSK test cases and KeyBlock contract clarifications.
- If any of the Util removals should remain for downstream compatibility, I can restore behind internal helpers.
