### PR TITLE
docs(keys): Improve Javadoc for key exception classes

### DIFF
--- a/src/main/java/network/crypta/keys/CHKDecodeException.java
+++ b/src/main/java/network/crypta/keys/CHKDecodeException.java
@@ -3,24 +3,55 @@ package network.crypta.keys;
 import java.io.Serial;
 
 /**
+ * Signals a failure to decode a CHK (Content Hash Key) or CHK-encoded data.
+ *
+ * <p>This specialization of {@link KeyDecodeException} is used by code paths that parse or
+ * reconstruct CHK-related entities (e.g., URIs, keys, or blocks) when the input is malformed,
+ * truncated, uses an unsupported variant, or otherwise violates required invariants.
+ *
  * @author amphibian
- *     <p>Exception thrown when decode fails.
  */
 public class CHKDecodeException extends KeyDecodeException {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with no detail message.
+   *
+   * <p>The cause is not initialized and may be set later via {@link Throwable#initCause}.
+   */
+  @SuppressWarnings("unused")
   public CHKDecodeException() {
     super();
   }
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param message human-readable description of the decode failure
+   */
   public CHKDecodeException(String message) {
     super(message);
   }
 
+  /**
+   * Creates an exception with the specified detail message and cause.
+   *
+   * @param message human-readable description of the decode failure
+   * @param cause the underlying reason; may be {@code null}
+   */
   public CHKDecodeException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates an exception with the specified cause.
+   *
+   * <p>The detail message is set to {@code cause.toString()} if {@code cause} is not {@code null}.
+   *
+   * @param cause the underlying reason; may be {@code null}
+   */
+  @SuppressWarnings("unused")
   public CHKDecodeException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/network/crypta/keys/CHKEncodeException.java
+++ b/src/main/java/network/crypta/keys/CHKEncodeException.java
@@ -3,25 +3,54 @@ package network.crypta.keys;
 import java.io.Serial;
 
 /**
+ * Signals a failure to encode CHK (Content Hash Key) data.
+ *
+ * <p>This specialization of {@link KeyEncodeException} is thrown by code that constructs
+ * CHK-related entities (e.g., blocks or URIs) when an encoding precondition is not met. Typical
+ * causes include inputs that exceed supported size limits, invalid parameters, or unsupported
+ * variants.
+ *
  * @author amphibian
- *     <p>Exception thrown when a CHK encoding fails. Specifically, it is thrown when the data is
- *     too big to encode.
  */
 public class CHKEncodeException extends KeyEncodeException {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with no detail message.
+   *
+   * <p>The cause is not initialized and may be set later via {@link Throwable#initCause}.
+   */
   public CHKEncodeException() {
     super();
   }
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param message human-readable description of the encoding failure
+   */
   public CHKEncodeException(String message) {
     super(message);
   }
 
+  /**
+   * Creates an exception with the specified detail message and cause.
+   *
+   * @param message human-readable description of the encoding failure
+   * @param cause the underlying reason; may be {@code null}
+   */
   public CHKEncodeException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates an exception with the specified cause.
+   *
+   * <p>The detail message is set to {@code cause.toString()} if {@code cause} is not {@code null}.
+   *
+   * @param cause the underlying reason; may be {@code null}
+   */
   public CHKEncodeException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/network/crypta/keys/CHKVerifyException.java
+++ b/src/main/java/network/crypta/keys/CHKVerifyException.java
@@ -3,24 +3,53 @@ package network.crypta.keys;
 import java.io.Serial;
 
 /**
+ * Signals a failure to verify CHK (Content Hash Key) data.
+ *
+ * <p>This specialization of {@link KeyVerifyException} is thrown when decoded content or metadata
+ * does not match the expected CHK (for example, a hash mismatch or corrupted block). It indicates
+ * that decoding may have succeeded, but integrity checks failed.
+ *
  * @author amphibian
- *     <p>Exception thrown when a CHK doesn't verify.
  */
 public class CHKVerifyException extends KeyVerifyException {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with no detail message.
+   *
+   * <p>The cause is not initialized and may be set later via {@link Throwable#initCause}.
+   */
   public CHKVerifyException() {
     super();
   }
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param message human-readable description of the verification failure
+   */
   public CHKVerifyException(String message) {
     super(message);
   }
 
+  /**
+   * Creates an exception with the specified detail message and cause.
+   *
+   * @param message human-readable description of the verification failure
+   * @param cause the underlying reason; may be {@code null}
+   */
   public CHKVerifyException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates an exception with the specified cause.
+   *
+   * <p>The detail message is set to {@code cause.toString()} if {@code cause} is not {@code null}.
+   *
+   * @param cause the underlying reason; may be {@code null}
+   */
   public CHKVerifyException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/network/crypta/keys/KeyDecodeException.java
+++ b/src/main/java/network/crypta/keys/KeyDecodeException.java
@@ -2,22 +2,54 @@ package network.crypta.keys;
 
 import java.io.Serial;
 
-/** Base class for decode exceptions. */
+/**
+ * Base exception indicating a failure to decode key-derived data or structures.
+ *
+ * <p>Decoding failures typically arise from malformed inputs, unsupported formats/variants,
+ * truncated data, or violations of required invariants while reconstructing key-related entities
+ * (for example, CHK/SSK URIs, keys, or blocks). Concrete subclasses such as {@link
+ * CHKDecodeException} and {@link SSKDecodeException} provide additional context for specific key
+ * types.
+ */
 public class KeyDecodeException extends Exception {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param message human-readable description of the decode failure
+   */
   public KeyDecodeException(String message) {
     super(message);
   }
 
+  /**
+   * Creates an exception with no detail message.
+   *
+   * <p>The cause is not initialized and may be set later via {@link Throwable#initCause}.
+   */
   public KeyDecodeException() {
     super();
   }
 
+  /**
+   * Creates an exception with the specified detail message and cause.
+   *
+   * @param message human-readable description of the decode failure
+   * @param cause the underlying reason; may be {@code null}
+   */
   public KeyDecodeException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates an exception with the specified cause.
+   *
+   * <p>The detail message is set to {@code cause.toString()} if {@code cause} is not {@code null}.
+   *
+   * @param cause the underlying reason; may be {@code null}
+   */
   public KeyDecodeException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/network/crypta/keys/KeyEncodeException.java
+++ b/src/main/java/network/crypta/keys/KeyEncodeException.java
@@ -2,21 +2,53 @@ package network.crypta.keys;
 
 import java.io.Serial;
 
+/**
+ * Base exception indicating a failure to encode key-derived data or structures.
+ *
+ * <p>Encoding may fail due to inputs that exceed supported size limits, invalid parameters, or
+ * unsupported formats/variants when constructing key-related entities (for example, CHK/SSK blocks
+ * or URIs). Concrete subclasses such as {@link CHKEncodeException} and {@link SSKEncodeException}
+ * provide key-type specific context.
+ */
 public class KeyEncodeException extends Exception {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param string human-readable description of the encoding failure
+   */
   public KeyEncodeException(String string) {
     super(string);
   }
 
+  /**
+   * Creates an exception with no detail message.
+   *
+   * <p>The cause is not initialized and may be set later via {@link Throwable#initCause}.
+   */
   public KeyEncodeException() {
     super();
   }
 
+  /**
+   * Creates an exception with the specified detail message and cause.
+   *
+   * @param message human-readable description of the encoding failure
+   * @param cause the underlying reason; may be {@code null}
+   */
   public KeyEncodeException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates an exception with the specified cause.
+   *
+   * <p>The detail message is set to {@code cause.toString()} if {@code cause} is not {@code null}.
+   *
+   * @param cause the underlying reason; may be {@code null}
+   */
   public KeyEncodeException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/network/crypta/keys/KeyVerifyException.java
+++ b/src/main/java/network/crypta/keys/KeyVerifyException.java
@@ -2,21 +2,53 @@ package network.crypta.keys;
 
 import java.io.Serial;
 
+/**
+ * Base exception indicating a failure to verify key-derived content or metadata.
+ *
+ * <p>Verification refers to integrity checks such as comparing computed hashes with expected
+ * values, validating signatures, or confirming that decoded blocks match their associated keys.
+ * Concrete specializations (for example, {@link CHKVerifyException} or {@link SSKVerifyException})
+ * provide key-type specific context.
+ */
 public class KeyVerifyException extends Exception {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param message human-readable description of the verification failure
+   */
   public KeyVerifyException(String message) {
     super(message);
   }
 
+  /**
+   * Creates an exception with the specified detail message and cause.
+   *
+   * @param message human-readable description of the verification failure
+   * @param cause the underlying reason; may be {@code null}
+   */
   public KeyVerifyException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates an exception with no detail message.
+   *
+   * <p>The cause is not initialized and may be set later via {@link Throwable#initCause}.
+   */
   public KeyVerifyException() {
     super();
   }
 
+  /**
+   * Creates an exception with the specified cause.
+   *
+   * <p>The detail message is set to {@code cause.toString()} if {@code cause} is not {@code null}.
+   *
+   * @param cause the underlying reason; may be {@code null}
+   */
   public KeyVerifyException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/network/crypta/keys/PubkeyVerifyException.java
+++ b/src/main/java/network/crypta/keys/PubkeyVerifyException.java
@@ -3,14 +3,32 @@ package network.crypta.keys;
 import java.io.Serial;
 import network.crypta.crypt.CryptFormatException;
 
+/**
+ * Indicates a failure to verify public-key related content or metadata.
+ *
+ * <p>Typical scenarios include invalid signatures, mismatched key material, or inconsistent
+ * serialized formats discovered during verification. This is a specialization of {@link
+ * KeyVerifyException} for public-key operations.
+ */
 public class PubkeyVerifyException extends KeyVerifyException {
 
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = 1L;
 
+  /**
+   * Creates an exception wrapping a low-level cryptographic formatting error.
+   *
+   * @param e the underlying formatting exception; may be {@code null}
+   */
   public PubkeyVerifyException(CryptFormatException e) {
     super(e);
   }
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param msg human-readable description of the verification failure
+   */
   public PubkeyVerifyException(String msg) {
     super(msg);
   }

--- a/src/main/java/network/crypta/keys/SSKDecodeException.java
+++ b/src/main/java/network/crypta/keys/SSKDecodeException.java
@@ -2,9 +2,22 @@ package network.crypta.keys;
 
 import java.io.Serial;
 
+/**
+ * Signals a failure to decode an SSK (Signed Subspace Key) or SSK-encoded data.
+ *
+ * <p>This specialization of {@link KeyDecodeException} is used by code that parses or reconstructs
+ * SSK-related entities (for example, URIs, keys, or blocks) when the input is malformed, truncated,
+ * uses an unsupported variant, or violates required invariants.
+ */
 public class SSKDecodeException extends KeyDecodeException {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param string human-readable description of the decode failure
+   */
   public SSKDecodeException(String string) {
     super(string);
   }

--- a/src/main/java/network/crypta/keys/SSKEncodeException.java
+++ b/src/main/java/network/crypta/keys/SSKEncodeException.java
@@ -2,9 +2,23 @@ package network.crypta.keys;
 
 import java.io.Serial;
 
+/**
+ * Signals a failure to encode an SSK (Signed Subspace Key) or SSK-encoded data.
+ *
+ * <p>This specialization of {@link KeyEncodeException} is thrown when constructing SSK-related
+ * entities (for example, blocks or URIs) fails due to invalid parameters, size limits, or
+ * unsupported variants.
+ */
 public class SSKEncodeException extends KeyEncodeException {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with the specified detail message and cause.
+   *
+   * @param message human-readable description of the encoding failure
+   * @param e the underlying encoding exception that triggered this failure; may be {@code null}
+   */
   public SSKEncodeException(String message, KeyEncodeException e) {
     super(message, e);
   }

--- a/src/main/java/network/crypta/keys/SSKVerifyException.java
+++ b/src/main/java/network/crypta/keys/SSKVerifyException.java
@@ -2,10 +2,23 @@ package network.crypta.keys;
 
 import java.io.Serial;
 
-/** Thrown when an SSK fails to verify at the node level. */
+/**
+ * Signals a failure to verify an SSK (Signed Subspace Key) or SSK-derived content.
+ *
+ * <p>This specialization of {@link KeyVerifyException} is thrown when decoded content or associated
+ * metadata does not match the expected SSK, such as signature mismatches, corrupted blocks, or
+ * inconsistent key parameters. It indicates that decoding may have succeeded, but integrity checks
+ * failed.
+ */
 public class SSKVerifyException extends KeyVerifyException {
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param string human-readable description of the verification failure
+   */
   public SSKVerifyException(String string) {
     super(string);
   }

--- a/src/main/java/network/crypta/keys/TooBigException.java
+++ b/src/main/java/network/crypta/keys/TooBigException.java
@@ -3,11 +3,24 @@ package network.crypta.keys;
 import java.io.IOException;
 import java.io.Serial;
 
+/**
+ * Indicates that an input exceeds the maximum supported size for the requested operation.
+ *
+ * <p>This exception is used for I/O or encoding/decoding paths that enforce upper bounds on content
+ * or structure size. Callers may catch it to surface user-facing guidance (for example, asking to
+ * reduce payload size or split data into smaller parts) or to select an alternative processing
+ * strategy when available.
+ */
 public class TooBigException extends IOException {
 
-  /** */
+  // Serialization identifier for binary compatibility of this exception type.
   @Serial private static final long serialVersionUID = 1L;
 
+  /**
+   * Creates an exception with the specified detail message.
+   *
+   * @param msg human-readable description of the size limit violation
+   */
   public TooBigException(String msg) {
     super(msg);
   }

--- a/src/main/java/network/crypta/keys/package-info.java
+++ b/src/main/java/network/crypta/keys/package-info.java
@@ -1,7 +1,27 @@
 /**
- * Implementations of Freenet keys and blocks. Uses the encryption layer to implement signed and
- * hash-based block types, including code to verify them at the node level, and to encode and decode
- * them at the client level. Includes @link USK which is not really a key at all at the node level,
- * but implements a crude updating scheme at the client level. Also includes @link FreenetURI .
+ * Cryptographic key types and related blocks/URIs used by Crypta (Freenet‑compatible).
+ *
+ * <p>This package implements the core key families and their client/node utilities:
+ *
+ * <ul>
+ *   <li><b>CHK</b> (Content Hash Key) — content‑addressed; verification uses hash matching.
+ *   <li><b>SSK</b> (Signed Subspace Key) — keypair‑based; verification uses digital signatures.
+ *   <li><b>USK</b> (Updatable Subspace Key) — a client‑side alias and update scheme built on SSK;
+ *       not a distinct node‑level key type. See {@link network.crypta.keys.USK}.
+ * </ul>
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Node‑level verification of blocks (hash and signature checks).
+ *   <li>Client‑level encoding/decoding of keys, blocks, and {@link network.crypta.keys.FreenetURI}
+ *       forms.
+ * </ul>
+ *
+ * <p>Encode/decode/verify failures are reported via typed exceptions such as {@link
+ * network.crypta.keys.CHKDecodeException}, {@link network.crypta.keys.CHKEncodeException}, {@link
+ * network.crypta.keys.CHKVerifyException}, {@link network.crypta.keys.SSKDecodeException}, {@link
+ * network.crypta.keys.SSKEncodeException}, {@link network.crypta.keys.SSKVerifyException}, and
+ * {@link network.crypta.keys.PubkeyVerifyException}.
  */
 package network.crypta.keys;


### PR DESCRIPTION
Summary
- Enhances Javadoc for key-related exception classes under `network.crypta.keys`.
- Clarifies semantics, typical causes, and usage guidance for decode/encode/verify exception types.
- Adds constructor and parameter documentation; improves package-level docs; keeps binary compatibility notes (@Serial fields/comments remain intact).
- Applies Spotless formatting (no functional changes).

Changes
- src/main/java/network/crypta/keys/CHKDecodeException.java
- src/main/java/network/crypta/keys/CHKEncodeException.java
- src/main/java/network/crypta/keys/CHKVerifyException.java
- src/main/java/network/crypta/keys/KeyDecodeException.java
- src/main/java/network/crypta/keys/KeyEncodeException.java
- src/main/java/network/crypta/keys/KeyVerifyException.java
- src/main/java/network/crypta/keys/PubkeyVerifyException.java
- src/main/java/network/crypta/keys/SSKDecodeException.java
- src/main/java/network/crypta/keys/SSKEncodeException.java
- src/main/java/network/crypta/keys/SSKVerifyException.java
- src/main/java/network/crypta/keys/TooBigException.java
- src/main/java/network/crypta/keys/package-info.java

Motivation
- Make exception behavior clearer for callers and readers; provide consistent, discoverable API docs across CHK/SSK key paths.

Notes
- No behavior changes; only documentation and formatting updates.
- Builds/tests unaffected; no new dependencies.

Reference
- Ahead of base `develop` by 1 commit: `docs(keys): improve Javadoc for exception classes and package; apply Spotless formatting`.