### PR TITLE
docs(config): complete API docs for ConfigCallback and Null* callbacks

### DIFF
--- a/src/main/java/network/crypta/config/ConfigCallback.java
+++ b/src/main/java/network/crypta/config/ConfigCallback.java
@@ -1,18 +1,54 @@
 package network.crypta.config;
 
+/**
+ * Base callback abstraction for reading and writing a configuration value.
+ *
+ * <p>Implementations encapsulate access and validation logic for a single setting. Callers use
+ * {@link #get()} to obtain the current effective value and {@link #set(Object)} to request a
+ * change. Concrete implementations may persist values, perform validation, and—where
+ * applicable—signal that a restart is required before the new value takes effect.
+ *
+ * <p>Threading: this type defines no synchronization; thread-safety depends on the implementation.
+ *
+ * <p>Nullability: whether {@link #get()} can return {@code null} and whether {@link #set(Object)}
+ * accepts {@code null} depends on the specific setting and implementation.
+ *
+ * @param <T> the value type of the configuration setting.
+ */
 public abstract class ConfigCallback<T> {
 
-  /** Get the current, used value of the config variable. */
+  /**
+   * Returns the current effective value of the setting.
+   *
+   * <p>The value may reflect defaults, persisted configuration, or computed state. It may be {@code
+   * null} if the setting is optional and unset, depending on the implementation.
+   *
+   * @return the current value; may be {@code null}.
+   */
   public abstract T get();
 
   /**
-   * Set the config variable to a new value.
+   * Applies a new value to the setting.
    *
-   * @param val The new value.
-   * @throws InvalidConfigOptionException If the new value is invalid for this particular option.
+   * <p>Implementations may validate and persist the value. Some settings become effective only
+   * after a restart; in such cases, implementations may throw {@link NodeNeedRestartException} to
+   * indicate that the value is accepted but not yet active.
+   *
+   * @param val the requested new value; may be {@code null} if allowed by the implementation.
+   * @throws InvalidConfigValueException if the value is rejected as invalid.
+   * @throws NodeNeedRestartException if the change is accepted but requires a node restart to take
+   *     effect.
    */
   public abstract void set(T val) throws InvalidConfigValueException, NodeNeedRestartException;
 
+  /**
+   * Indicates whether this callback permits writes.
+   *
+   * <p>The base implementation returns {@code false}. Implementations may override to return {@code
+   * true} for read-only settings.
+   *
+   * @return {@code true} if writes are not supported by this instance.
+   */
   public boolean isReadOnly() {
     return false;
   }

--- a/src/main/java/network/crypta/config/NullBooleanCallback.java
+++ b/src/main/java/network/crypta/config/NullBooleanCallback.java
@@ -2,15 +2,41 @@ package network.crypta.config;
 
 import network.crypta.support.api.BooleanCallback;
 
+/**
+ * No-op {@link BooleanCallback} following the null-object pattern.
+ *
+ * <p>This implementation provides a safe, do-nothing callback for boolean configuration values.
+ * {@link #get()} always returns {@code false}. Calls to {@link #set(Boolean)} are accepted and
+ * ignored, producing no state changes or side effects. Using this class allows callers to avoid
+ * {@code null} checks when a setting is optional or intentionally read-only.
+ *
+ * <p>Threading: instances are stateless and safe to share across threads.
+ *
+ * <p>Side effects: none.
+ */
 public class NullBooleanCallback extends BooleanCallback {
 
+  /**
+   * Returns a constant {@code false} value.
+   *
+   * @return {@code false} in all cases.
+   */
   @Override
   public Boolean get() {
     return false;
   }
 
+  /**
+   * Ignores the requested value; no state changes occur.
+   *
+   * <p>This implementation never throws but declares {@link InvalidConfigValueException} to satisfy
+   * the callback contract.
+   *
+   * @param val the requested new value; ignored. May be {@code null}.
+   * @throws InvalidConfigValueException never thrown by this implementation.
+   */
   @Override
   public void set(Boolean val) throws InvalidConfigValueException {
-    // Ignore
+    // No-op setter: writes are intentionally ignored.
   }
 }

--- a/src/main/java/network/crypta/config/NullIntCallback.java
+++ b/src/main/java/network/crypta/config/NullIntCallback.java
@@ -2,15 +2,41 @@ package network.crypta.config;
 
 import network.crypta.support.api.IntCallback;
 
+/**
+ * No-op {@link IntCallback} following the null-object pattern.
+ *
+ * <p>This implementation provides a safe, do-nothing callback for integer configuration values.
+ * {@link #get()} always returns {@code 0}. Calls to {@link #set(Integer)} are accepted and ignored,
+ * producing no state changes or side effects. Use this when a setting is optional or intentionally
+ * read-only to avoid {@code null} checks.
+ *
+ * <p>Threading: instances are stateless and safe to share across threads.
+ *
+ * <p>Side effects: none.
+ */
 public class NullIntCallback extends IntCallback {
 
+  /**
+   * Returns a constant {@code 0} value.
+   *
+   * @return {@code 0} in all cases.
+   */
   @Override
   public Integer get() {
     return 0;
   }
 
+  /**
+   * Ignores the requested value; no state changes occur.
+   *
+   * <p>This implementation never throws but declares {@link InvalidConfigValueException} to satisfy
+   * the callback contract.
+   *
+   * @param val the requested new value; ignored. May be {@code null}.
+   * @throws InvalidConfigValueException never thrown by this implementation.
+   */
   @Override
   public void set(Integer val) throws InvalidConfigValueException {
-    // Ignore
+    // No-op setter: writes are intentionally ignored.
   }
 }

--- a/src/main/java/network/crypta/config/NullLongCallback.java
+++ b/src/main/java/network/crypta/config/NullLongCallback.java
@@ -2,15 +2,41 @@ package network.crypta.config;
 
 import network.crypta.support.api.LongCallback;
 
+/**
+ * No-op {@link LongCallback} that implements the null-object pattern.
+ *
+ * <p>This implementation provides a safe, do-nothing callback for long-valued configuration
+ * settings. {@link #get()} always returns {@code 0L}. Calls to {@link #set(Long)} are accepted and
+ * ignored, producing no state changes or side effects. Use when a setting is optional or
+ * intentionally read-only to avoid {@code null} checks and special cases.
+ *
+ * <p>Threading: instances are stateless and safe to share across threads.
+ *
+ * <p>Side effects: none.
+ */
 public class NullLongCallback extends LongCallback {
 
+  /**
+   * Returns a constant {@code 0L} value.
+   *
+   * @return {@code 0L} in all cases.
+   */
   @Override
   public Long get() {
     return 0L;
   }
 
+  /**
+   * Ignores the requested value; no state changes occur.
+   *
+   * <p>This implementation never throws but declares {@link InvalidConfigValueException} to satisfy
+   * the callback contract.
+   *
+   * @param val the requested new value; ignored. May be {@code null}.
+   * @throws InvalidConfigValueException never thrown by this implementation.
+   */
   @Override
   public void set(Long val) throws InvalidConfigValueException {
-    // Ignore
+    // No-op setter: writes are intentionally ignored.
   }
 }

--- a/src/main/java/network/crypta/config/NullShortCallback.java
+++ b/src/main/java/network/crypta/config/NullShortCallback.java
@@ -2,15 +2,41 @@ package network.crypta.config;
 
 import network.crypta.support.api.ShortCallback;
 
+/**
+ * No-op {@link ShortCallback} implementing the null-object pattern.
+ *
+ * <p>This implementation provides a safe, do-nothing callback for short-valued configuration
+ * settings. {@link #get()} always returns {@code 0}. Calls to {@link #set(Short)} are accepted and
+ * ignored, producing no state changes or side effects. Use when a setting is optional or
+ * intentionally read-only to avoid {@code null} checks and special-case handling.
+ *
+ * <p>Threading: instances are stateless and safe to share across threads.
+ *
+ * <p>Side effects: none.
+ */
 public class NullShortCallback extends ShortCallback {
 
+  /**
+   * Returns a constant {@code 0} value.
+   *
+   * @return {@code 0} in all cases.
+   */
   @Override
   public Short get() {
     return 0;
   }
 
+  /**
+   * Ignores the requested value; no state changes occur.
+   *
+   * <p>This implementation never throws but declares {@link InvalidConfigValueException} to satisfy
+   * the callback contract.
+   *
+   * @param val the requested new value; ignored. May be {@code null}.
+   * @throws InvalidConfigValueException never thrown by this implementation.
+   */
   @Override
   public void set(Short val) throws InvalidConfigValueException {
-    // Ignore
+    // No-op setter: writes are intentionally ignored.
   }
 }

--- a/src/main/java/network/crypta/config/NullStringCallback.java
+++ b/src/main/java/network/crypta/config/NullStringCallback.java
@@ -2,15 +2,42 @@ package network.crypta.config;
 
 import network.crypta.support.api.StringCallback;
 
+/**
+ * No-op {@link StringCallback} implementing the null-object pattern.
+ *
+ * <p>This implementation provides a safe, do-nothing callback for string-valued configuration
+ * settings. {@link #get()} always returns the empty string ({@code ""}). Calls to {@link
+ * #set(String)} are accepted and ignored, producing no state changes or side effects. Use this when
+ * a setting is optional or intentionally read-only to avoid {@code null} checks and special-case
+ * handling.
+ *
+ * <p>Threading: instances are stateless and safe to share across threads.
+ *
+ * <p>Side effects: none.
+ */
 public class NullStringCallback extends StringCallback {
 
+  /**
+   * Returns a constant empty string.
+   *
+   * @return {@code ""} in all cases.
+   */
   @Override
   public String get() {
     return "";
   }
 
+  /**
+   * Ignores the requested value; no state changes occur.
+   *
+   * <p>This implementation never throws but declares {@link InvalidConfigValueException} to satisfy
+   * the callback contract.
+   *
+   * @param val the requested new value; ignored. May be {@code null}.
+   * @throws InvalidConfigValueException never thrown by this implementation.
+   */
   @Override
   public void set(String val) throws InvalidConfigValueException {
-    // Ignore
+    // No-op setter: writes are intentionally ignored.
   }
 }


### PR DESCRIPTION
Summary
- Improve and complete API documentation and inline comments across config callbacks.
- Comments only; no logic, signatures, or visibility changed.

Files Touched
- src/main/java/network/crypta/config/ConfigCallback.java
- src/main/java/network/crypta/config/NullBooleanCallback.java
- src/main/java/network/crypta/config/NullIntCallback.java
- src/main/java/network/crypta/config/NullLongCallback.java
- src/main/java/network/crypta/config/NullShortCallback.java
- src/main/java/network/crypta/config/NullStringCallback.java

Key Changes
- Add class-level Javadoc describing purpose, threading, nullability, and side effects.
- Add method-level Javadoc for getters/setters including @param/@return/@throws with accurate contract details.
- Clarify null-object behavior for all Null* callbacks (constant return + no-op setters), with rationale.
- Fix previously misnamed exception in ConfigCallback docs and detail NodeNeedRestartException semantics.

Why
- Makes the configuration callback API self-explanatory, reduces ambiguity for integrations and reviewers, and aligns with the project’s documentation standards.

Validation
- Ran `./gradlew spotlessApply` to ensure formatting; build tooling completed successfully.
- No functional changes; tests and runtime behavior unaffected.

Notes
- Branch: feature/fix-callbacks (does not target main or develop directly).
- Please advise on labels (e.g., docs, config) and reviewers you'd like assigned.