### PR TITLE
docs(config): improve Javadoc across config package; run Spotless

### DIFF
--- a/src/main/java/network/crypta/config/ConfigConsumer.java
+++ b/src/main/java/network/crypta/config/ConfigConsumer.java
@@ -1,5 +1,35 @@
 package network.crypta.config;
 
+/**
+ * Functional contract for applying a configuration value with validation.
+ *
+ * <p>This interface is analogous to {@code java.util.function.Consumer} but tailored for the
+ * configuration domain where setters may reject values or accept them while requiring a restart.
+ * Implementations typically persist the new value and/or update in-memory state.
+ *
+ * <p>Threading: no synchronization is defined by this type; thread-safety depends on the
+ * implementation.
+ *
+ * <p>Nullability: whether {@link #accept(Object)} permits {@code null} depends on the specific
+ * setting and implementation.
+ *
+ * @param <T> the type of the configuration value to apply.
+ */
 public interface ConfigConsumer<T> {
+
+  /**
+   * Applies the provided configuration value.
+   *
+   * <p>Implementations may validate and persist the value. If the change cannot be accepted, they
+   * throw {@link InvalidConfigValueException}. If the value is accepted but will only take effect
+   * after a node restart, they throw {@link NodeNeedRestartException}. Callers should treat a
+   * normal return as immediate acceptance.
+   *
+   * @param value the requested new value; may be {@code null} if allowed by the implementation.
+   * @throws InvalidConfigValueException if the value is rejected as invalid (e.g., malformed or out
+   *     of range relative to constraints for the setting).
+   * @throws NodeNeedRestartException if the value is accepted but requires a node restart before it
+   *     becomes effective; implementors should ensure persistence in this case.
+   */
   void accept(T value) throws InvalidConfigValueException, NodeNeedRestartException;
 }

--- a/src/main/java/network/crypta/config/ConfigException.java
+++ b/src/main/java/network/crypta/config/ConfigException.java
@@ -2,14 +2,30 @@ package network.crypta.config;
 
 import java.io.Serial;
 
-/** Usefull if you want to catch all exceptions the config framework can return; */
+/**
+ * Base class for exceptions thrown by the configuration subsystem.
+ *
+ * <p>This abstraction lets callers catch a single type to handle all configuration-related
+ * failures. Concrete subclasses include {@link InvalidConfigValueException} for invalid input and
+ * {@link NodeNeedRestartException} for changes that require a restart.
+ */
 public abstract class ConfigException extends Exception {
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates a new exception with the specified detail message.
+   *
+   * @param msg human-readable detail describing the configuration failure.
+   */
   public ConfigException(String msg) {
     super(msg);
   }
 
+  /**
+   * Creates a new exception that wraps the given cause.
+   *
+   * @param cause the underlying cause; may be {@code null}.
+   */
   public ConfigException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/network/crypta/config/Dimension.java
+++ b/src/main/java/network/crypta/config/Dimension.java
@@ -1,7 +1,20 @@
 package network.crypta.config;
 
+/**
+ * Describes the unit category (dimension) associated with a configuration value.
+ *
+ * <p>Some configuration options represent dimensionless values, while others denote a size (e.g., a
+ * data amount) or a time duration. This enum allows parsers, validators, and UIs to interpret,
+ * validate, and present values consistently. Concrete units and accepted suffixes, if any, are
+ * defined by the specific option and its parser.
+ */
 public enum Dimension {
+  /** A dimensionless value; no unit semantics are applied. */
   NOT,
+
+  /** A data-size quantity; unit handling is defined by the option/parser. */
   SIZE,
+
+  /** A time-based duration; unit handling is defined by the option/parser. */
   DURATION
 }

--- a/src/main/java/network/crypta/config/EnumerableOptionCallback.java
+++ b/src/main/java/network/crypta/config/EnumerableOptionCallback.java
@@ -1,8 +1,38 @@
 package network.crypta.config;
 
+/**
+ * Identifies a string-valued option that exposes a finite set of selectable values.
+ *
+ * <p>Implementations typically also implement {@code StringCallback} (or another {@link
+ * ConfigCallback}) to perform validation and persistence. The values returned by {@link
+ * #getPossibleValues()} should be acceptable inputs for the corresponding setter, and are used by
+ * UIs to render a dropdown or similar control. Ordering may be used for presentation; any
+ * case-sensitivity or alias handling is defined by the implementation.
+ */
 public interface EnumerableOptionCallback {
+
+  /**
+   * Returns the list of values that the option can accept.
+   *
+   * <p>The returned array must not be {@code null} and should not contain {@code null} elements.
+   * Implementations may return a new array on each call; callers must not modify the returned array
+   * if it is shared. The set should be stable for the lifetime of the option instance unless
+   * explicitly documented otherwise by the implementation.
+   *
+   * @return an array of acceptable values, in display order.
+   */
   String[] getPossibleValues();
 
-  /** Return the current value */
+  /**
+   * Returns the current effective value of the option.
+   *
+   * <p>Implementations are expected to return a value that appears in {@link #getPossibleValues()}
+   * (subject to any normalization rules they define). The value reflects the currently applied
+   * configuration and may come from defaults, persisted state, or runtime changes, depending on the
+   * owning option.
+   *
+   * @return the current value; never {@code null} unless explicitly documented by the
+   *     implementation.
+   */
   String get();
 }

--- a/src/main/java/network/crypta/config/InvalidConfigValueException.java
+++ b/src/main/java/network/crypta/config/InvalidConfigValueException.java
@@ -1,17 +1,29 @@
 package network.crypta.config;
 
 /**
- * Thrown when the node refuses to set a config variable to a particular value because it is
- * invalid. Just because this is not thrown does not necessarily mean that there are no problems
- * with the value defined, it merely means that there are no immediately detectable problems with
- * it.
+ * Indicates that a configuration value is rejected as invalid.
+ *
+ * <p>This exception is thrown by configuration setters such as {@link ConfigCallback#set(Object)}
+ * or {@link ConfigConsumer#accept(Object)} when a supplied value fails validation (for example,
+ * wrong format, out of range, or otherwise prohibited). The absence of this exception does not
+ * guarantee overall correctness; it only means no immediately detectable problem was found during
+ * validation.
  */
-@SuppressWarnings("serial")
 public class InvalidConfigValueException extends ConfigException {
+  /**
+   * Creates a new exception with the provided detail message.
+   *
+   * @param msg human-readable explanation of why the value is considered invalid.
+   */
   public InvalidConfigValueException(String msg) {
     super(msg);
   }
 
+  /**
+   * Creates a new exception wrapping the given cause.
+   *
+   * @param cause underlying cause; may be {@code null}.
+   */
   public InvalidConfigValueException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/network/crypta/config/NodeNeedRestartException.java
+++ b/src/main/java/network/crypta/config/NodeNeedRestartException.java
@@ -1,11 +1,20 @@
 package network.crypta.config;
 
 /**
- * Thrown when the node must be restarted for a config setting to be applied. The thrower must
- * ensure that the value reaches the config file, even though it cannot be immediately used.
+ * Signals that a configuration change is accepted but requires a node restart to take effect.
+ *
+ * <p>Configuration setters such as {@link ConfigCallback#set(Object)} or {@link
+ * ConfigConsumer#accept(Object)} throw this exception to indicate that the provided value has been
+ * validated and recorded, but will not become active until the process restarts. When throwing this
+ * exception, implementations should ensure the value is persisted so that it will be applied on the
+ * next startup.
  */
-@SuppressWarnings("serial")
 public class NodeNeedRestartException extends ConfigException {
+  /**
+   * Creates a new exception with a human-readable reason.
+   *
+   * @param msg detail describing why a restart is required.
+   */
   public NodeNeedRestartException(String msg) {
     super(msg);
   }

--- a/src/main/java/network/crypta/config/package-info.java
+++ b/src/main/java/network/crypta/config/package-info.java
@@ -1,8 +1,25 @@
 /**
- * Supporting classes: Configuration framework. Probably we could switch to some standard system one
- * day. Most options can be changed on the fly, some require a restart. Config is the global config,
- * divided up into SubConfig objects by subsystem. Option's are registered on the SubConfig object
- * with the appropriate ConfigCallback. WrapperConfig provides limited support for changing config
- * options that are kept in wrapper.conf (in collaboration with @link freenet.node.updater ).
+ * Configuration framework for Crypta's node and plugin settings.
+ *
+ * <p>The framework organizes settings under a root {@link network.crypta.config.Config}, which owns
+ * multiple {@link network.crypta.config.SubConfig} sections identified by a prefix (for example,
+ * {@code node.} or {@code plugins.}). Each section registers typed {@link
+ * network.crypta.config.Option} instances backed by a {@link network.crypta.config.ConfigCallback}.
+ * Specialized callbacks live under {@code network.crypta.support.api} (e.g., {@link
+ * network.crypta.support.api.StringCallback}) and may be accompanied by helper contracts such as
+ * {@link network.crypta.config.EnumerableOptionCallback} when a finite set of values is supported.
+ *
+ * <p>Many options apply immediately at runtime. If a change is accepted but cannot take effect
+ * until restart, implementations signal this with {@link
+ * network.crypta.config.NodeNeedRestartException}. Invalid values are rejected with {@link
+ * network.crypta.config.InvalidConfigValueException}. Where unit semantics are relevant, options
+ * may indicate a logical {@link network.crypta.config.Dimension} (for example, {@code SIZE} or
+ * {@code DURATION}).
+ *
+ * <p>Persistence is environment-specific. {@link network.crypta.config.PersistentConfig} consumes
+ * an initial {@link network.crypta.support.SimpleFieldSet} and exports the current state back to a
+ * field set for storage. {@link network.crypta.config.WrapperConfig} provides limited support for
+ * editing {@code wrapper.conf} when running under the Tanuki Wrapper, subject to filesystem and
+ * runtime constraints.
  */
 package network.crypta.config;


### PR DESCRIPTION
Summary
- Improve Javadoc across `network.crypta.config`:
  - `ConfigConsumer`, `ConfigException`, `Dimension`, `EnumerableOptionCallback`,
    `InvalidConfigValueException`, `NodeNeedRestartException`, and `package-info`.
- Clarify threading/nullability and exception contracts; add links to related APIs.
- Apply Spotless formatting (Java/Kotlin). No behavioral changes.

Scope
- Source-only doc changes; no logic or signatures altered.

Files Changed
- src/main/java/network/crypta/config/ConfigConsumer.java
- src/main/java/network/crypta/config/ConfigException.java
- src/main/java/network/crypta/config/Dimension.java
- src/main/java/network/crypta/config/EnumerableOptionCallback.java
- src/main/java/network/crypta/config/InvalidConfigValueException.java
- src/main/java/network/crypta/config/NodeNeedRestartException.java
- src/main/java/network/crypta/config/package-info.java

Validation
- Repository was clean; no uncommitted changes.
- Spotless was already applied in the commit; nothing to reformat locally.
- Branch tracks `origin/feature/config-doc`; pushed and up to date.

Notes
- Base: `develop`
- Head: `feature/config-doc`
- If you prefer a different title/wording, I can update the PR description.