### PR TITLE
Improve config option parsing and add comprehensive tests

### DIFF
--- a/src/main/java/network/crypta/config/BandwidthOption.java
+++ b/src/main/java/network/crypta/config/BandwidthOption.java
@@ -4,12 +4,39 @@ import network.crypta.support.Fields;
 import network.crypta.support.api.IntCallback;
 
 /**
- * Integer option for bandwidth. Allows "/s" and similar "per second" qualifiers.
+ * Configuration option representing a bandwidth limit as an integer rate.
+ *
+ * <p>This class specializes {@link IntOption} for bandwidth values. It accepts human‑friendly size
+ * forms (see {@link Fields#parseInt(String)}), and tolerates optional “per second” qualifiers such
+ * as {@code "/s"}, {@code "/sec"}, and {@code "/second"}. Any per‑second qualifier is removed
+ * before parsing so inputs like {@code "10MiB/s"} and {@code "8192b/s"} are interpreted correctly.
+ * By default, values are treated as bytes; a trailing {@code 'b'} denotes bits and is converted to
+ * bytes during parsing.
+ *
+ * <p>Display formatting follows {@link Dimension#SIZE} via {@link Fields#intToString(int,
+ * Dimension)}, which prefers compact unit suffixes when evenly divisible. No global state is
+ * modified; instances are safe for use by configuration UIs and loaders.
  *
  * @see Fields#trimPerSecond(String)
+ * @see Fields#parseInt(String)
  */
 public class BandwidthOption extends IntOption {
-
+  /**
+   * Creates a bandwidth option whose default value is provided as text.
+   *
+   * <p>The textual default may include size suffixes and an optional per‑second qualifier; the
+   * latter is ignored during parsing.
+   *
+   * @param conf owning sub‑configuration.
+   * @param optionName stable key used to persist and retrieve the option.
+   * @param defaultValueString textual default; interpreted as a size and converted to bytes.
+   * @param sortOrder relative ordering hint for UIs.
+   * @param expert whether the option targets advanced users.
+   * @param forceWrite whether to always write the option, even when equal to the default.
+   * @param shortDesc single‑line description suitable for lists.
+   * @param longDesc extended help text; may contain localization tokens.
+   * @param cb callback invoked on value change; may be {@code null} when no side effect is needed.
+   */
   public BandwidthOption(
       SubConfig conf,
       String optionName,
@@ -32,6 +59,19 @@ public class BandwidthOption extends IntOption {
         cb);
   }
 
+  /**
+   * Creates a bandwidth option with a typed default value.
+   *
+   * @param conf owning sub‑configuration.
+   * @param optionName stable key used to persist and retrieve the option.
+   * @param defaultValue default value in bytes per second.
+   * @param sortOrder relative ordering hint for UIs.
+   * @param expert whether the option targets advanced users.
+   * @param forceWrite whether to always write the option, even when equal to the default.
+   * @param shortDesc single‑line description suitable for lists.
+   * @param longDesc extended help text; may contain localization tokens.
+   * @param cb callback invoked on value change; may be {@code null} when no side effect is needed.
+   */
   public BandwidthOption(
       SubConfig conf,
       String optionName,
@@ -55,8 +95,20 @@ public class BandwidthOption extends IntOption {
         Dimension.SIZE);
   }
 
+  /**
+   * Parses user input after removing an optional per‑second qualifier.
+   *
+   * <p>Examples accepted by this option include {@code "2048"}, {@code "2MiB/s"}, and {@code
+   * "8192b/s"}. The {@code /s} (or localized equivalent) is stripped via {@link
+   * Fields#trimPerSecond(String)} before delegating to dimension‑aware parsing in the base class.
+   *
+   * @param val input string from configuration.
+   * @return the parsed value in bytes per second.
+   * @throws InvalidConfigValueException if the string cannot be parsed.
+   */
   @Override
   protected Integer parseString(String val) throws InvalidConfigValueException {
+    // Strip optional per‑second suffix, then parse using Dimension.SIZE rules.
     return super.parseString(Fields.trimPerSecond(val));
   }
 }

--- a/src/main/java/network/crypta/config/BooleanOption.java
+++ b/src/main/java/network/crypta/config/BooleanOption.java
@@ -3,7 +3,33 @@ package network.crypta.config;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.api.BooleanCallback;
 
+/**
+ * Configuration option representing a boolean value.
+ *
+ * <p>This type provides parsing and formatting for {@code true}/{@code false} values and accepts
+ * common synonyms when parsing ("yes"/"no", case-insensitive). Error messages are localized via
+ * {@link NodeL10n}. All life-cycle, threading, and initialization semantics follow those of the
+ * base {@link Option} class.
+ */
 public class BooleanOption extends Option<Boolean> {
+
+  /**
+   * Creates a boolean option with the given metadata and callback.
+   *
+   * <p>The option's declared data type is {@link Option.DataType#BOOLEAN}. Upon construction the
+   * {@code defaultValue} is stored as both the default and the initial current value; no callback
+   * invocation occurs here.
+   *
+   * @param conf owning {@link SubConfig}; typically non-null for registered options
+   * @param optionName canonical name used in config files and APIs
+   * @param defaultValue default and initial value
+   * @param sortOrder relative ordering within the parent {@link SubConfig}
+   * @param expert whether this option targets advanced users
+   * @param forceWrite whether to persist even when equal to the default
+   * @param shortDesc localization key for a brief label
+   * @param longDesc localization key for a detailed description
+   * @param cb callback used to read/apply values
+   */
   public BooleanOption(
       SubConfig conf,
       String optionName,
@@ -24,6 +50,17 @@ public class BooleanOption extends Option<Boolean> {
     this.currentValue = defaultValue;
   }
 
+  /**
+   * Parses a textual boolean.
+   *
+   * <p>Accepted values are {@code "true"} and {@code "false"}, as well as the synonyms {@code
+   * "yes"} and {@code "no"}. Matching is case-insensitive.
+   *
+   * @param val text to parse; must be non-null
+   * @return {@code true} or {@code false} according to {@code val}
+   * @throws OptionFormatException if {@code val} is not a recognized boolean token; the message is
+   *     localized through {@link NodeL10n}
+   */
   @Override
   public Boolean parseString(String val) throws InvalidConfigValueException {
     if (val.equalsIgnoreCase("true") || val.equalsIgnoreCase("yes")) {
@@ -35,6 +72,12 @@ public class BooleanOption extends Option<Boolean> {
           NodeL10n.getBase().getString("BooleanOption.parseError", "val", val));
   }
 
+  /**
+   * Formats a boolean as its canonical lowercase string.
+   *
+   * @param val value to format; typically non-null
+   * @return {@code "true"} or {@code "false"}
+   */
   @Override
   protected String toString(Boolean val) {
     return val.toString();

--- a/src/main/java/network/crypta/config/BooleanOption.java
+++ b/src/main/java/network/crypta/config/BooleanOption.java
@@ -18,11 +18,7 @@ public class BooleanOption extends Option<Boolean> {
         conf,
         optionName,
         cb,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
+        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
         Option.DataType.BOOLEAN);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;

--- a/src/main/java/network/crypta/config/IntOption.java
+++ b/src/main/java/network/crypta/config/IntOption.java
@@ -76,11 +76,7 @@ public class IntOption extends Option<Integer> {
         conf,
         optionName,
         cb,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
+        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
         Option.DataType.NUMBER);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;

--- a/src/main/java/network/crypta/config/IntOption.java
+++ b/src/main/java/network/crypta/config/IntOption.java
@@ -4,10 +4,41 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.support.Fields;
 import network.crypta.support.api.IntCallback;
 
-/** Integer config variable */
+/**
+ * Integer-backed configuration option with optional unit/duration semantics.
+ *
+ * <p>This option stores an {@link Integer} and can interpret and format values according to a
+ * {@link Dimension}:
+ *
+ * <ul>
+ *   <li>{@link Dimension#NOT}: treat the value as a plain number.
+ *   <li>{@link Dimension#SIZE}: allow human-friendly size suffixes when parsing and prefer compact
+ *       IEC/SI forms when formatting (see {@link Fields#intToString(int, Dimension)}).
+ *   <li>{@link Dimension#DURATION}: parse durations (via {@code TimeUtil}) and format as a
+ *       human-readable time span.
+ * </ul>
+ *
+ * <p>Parsing is locale-agnostic and tolerant: when a dimension-aware parse fails, the code falls
+ * back to parsing a plain integer to preserve historical behavior and interoperability with
+ * existing configuration files.
+ */
 public class IntOption extends Option<Integer> {
   private final Dimension dimension;
 
+  /**
+   * Creates an integer option whose default value is provided as text.
+   *
+   * @param conf owning sub-configuration.
+   * @param optionName stable key used to persist and retrieve the option.
+   * @param defaultValueString textual default; interpreted using {@code dimension}.
+   * @param sortOrder relative ordering hint for UIs.
+   * @param expert whether the option targets advanced users.
+   * @param forceWrite whether to always write the option, even when equal to the default.
+   * @param shortDesc single-line description suitable for lists.
+   * @param longDesc extended help text; may contain localization tokens.
+   * @param cb callback invoked on value change; may be {@code null} when no side effect is needed.
+   * @param dimension interpretation of numeric text and preferred display format.
+   */
   public IntOption(
       SubConfig conf,
       String optionName,
@@ -33,34 +64,19 @@ public class IntOption extends Option<Integer> {
   }
 
   /**
-   * @deprecated Replaced by {@link #IntOption(SubConfig, String, String, int, boolean, boolean,
-   *     String, String, IntCallback, Dimension)}
+   * Creates an integer option with a typed default value.
+   *
+   * @param conf owning sub-configuration.
+   * @param optionName stable key used to persist and retrieve the option.
+   * @param defaultValue default value stored as an {@link Integer}.
+   * @param sortOrder relative ordering hint for UIs.
+   * @param expert whether the option targets advanced users.
+   * @param forceWrite whether to always write the option, even when equal to the default.
+   * @param shortDesc single-line description suitable for lists.
+   * @param longDesc extended help text; may contain localization tokens.
+   * @param cb callback invoked on value change; may be {@code null} when no side effect is needed.
+   * @param dimension interpretation of numeric text and preferred display format.
    */
-  @Deprecated
-  public IntOption(
-      SubConfig conf,
-      String optionName,
-      String defaultValueString,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      IntCallback cb,
-      boolean isSize) {
-    this(
-        conf,
-        optionName,
-        defaultValueString,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
-        cb,
-        isSize ? Dimension.SIZE : Dimension.NOT);
-  }
-
   public IntOption(
       SubConfig conf,
       String optionName,
@@ -84,44 +100,27 @@ public class IntOption extends Option<Integer> {
   }
 
   /**
-   * @deprecated Replaced by {@link #IntOption(SubConfig, String, Integer, int, boolean, boolean,
-   *     String, String, IntCallback, Dimension)}
+   * Parses textual input into an {@link Integer} using the configured {@link Dimension}.
+   *
+   * <p>On failure, the method falls back to a plain integer parse (equivalent to {@link
+   * Dimension#NOT}). If parsing still fails, a localized error message is returned via {@link
+   * InvalidConfigValueException}.
+   *
+   * @param val input string from configuration.
+   * @return the parsed value.
+   * @throws InvalidConfigValueException if the string cannot be parsed.
    */
-  @Deprecated
-  public IntOption(
-      SubConfig conf,
-      String optionName,
-      Integer defaultValue,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      IntCallback cb,
-      boolean isSize) {
-    this(
-        conf,
-        optionName,
-        defaultValue,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
-        cb,
-        isSize ? Dimension.SIZE : Dimension.NOT);
-  }
-
   @Override
   protected Integer parseString(String val) throws InvalidConfigValueException {
     try {
       return parseString(val, dimension);
     } catch (NumberFormatException e) {
-      throw new InvalidConfigValueException(l10n("parseError", "val", val));
+      throw new InvalidConfigValueException(l10nParseError(val));
     }
   }
 
-  // can be two string representations: #toDisplayString(Integer) and #toString(Integer)
+  // Parse either a dimension-aware or a plain integer form. If the dimension-aware parse fails,
+  // fall back to {@code Dimension.NOT} to maintain compatibility with existing config files.
   private static Integer parseString(String val, Dimension dimension) throws NumberFormatException {
     try {
       return Fields.parseInt(val, dimension);
@@ -130,15 +129,37 @@ public class IntOption extends Option<Integer> {
     }
   }
 
-  private String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("IntOption." + key, pattern, value);
+  private static final String PARSE_ERROR_KEY = "IntOption.parseError";
+  private static final String VAL_PATTERN = "val";
+
+  /** Returns a localized parse error string for display in UIs and logs. */
+  private String l10nParseError(String value) {
+    return NodeL10n.getBase().getString(PARSE_ERROR_KEY, VAL_PATTERN, value);
   }
 
+  /**
+   * Converts a value to user-facing text using the configured {@link Dimension}.
+   *
+   * <p>For example, durations are formatted as time spans and sizes may use compact unit suffixes
+   * when evenly divisible.
+   *
+   * @param val value to format; never {@code null}.
+   * @return formatted string for UI display.
+   */
   @Override
   protected String toDisplayString(Integer val) {
     return Fields.intToString(val, dimension);
   }
 
+  /**
+   * Converts a value to a stable, non-localized string suitable for persistence.
+   *
+   * <p>This representation always uses {@link Dimension#NOT} to avoid introducing unit suffixes or
+   * localized forms into configuration files.
+   *
+   * @param val value to encode; never {@code null}.
+   * @return plain numeric string.
+   */
   @Override
   protected String toString(Integer val) {
     return Fields.intToString(val, Dimension.NOT);

--- a/src/main/java/network/crypta/config/LongOption.java
+++ b/src/main/java/network/crypta/config/LongOption.java
@@ -4,10 +4,48 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.support.Fields;
 import network.crypta.support.api.LongCallback;
 
-/** Long config variable */
+/**
+ * Option representing a {@link Long} configuration value.
+ *
+ * <p>This option parses textual input using {@link Fields#parseLong(String)}, which accepts plain
+ * numbers as well as quantities with SI/IEC suffixes (e.g., {@code 10k}, {@code 4M}, {@code 2GiB}).
+ * Invalid inputs are reported as {@link InvalidConfigValueException}s with a localized message.
+ *
+ * <p>Formatting distinguishes between persistence and display:
+ *
+ * <ul>
+ *   <li>{@link #toString(Long)} returns a canonical form suitable for config files and APIs. It
+ *       uses plain numbers or SI multiples of 1000 when an even division exists (e.g., {@code 2000
+ *       -> "2k"}).
+ *   <li>{@link #toDisplayString(Long)} uses {@code isSize} to decide whether IEC units may be shown
+ *       for human‑readable output (e.g., {@code 2048 -> "2KiB"} when {@code isSize} is {@code
+ *       true}).
+ * </ul>
+ */
 public class LongOption extends Option<Long> {
+  /**
+   * When {@code true}, display formatting may use IEC size suffixes (e.g., {@code KiB}, {@code
+   * MiB}). When {@code false}, only SI multiples of 1000 are considered for compact forms.
+   */
   protected final boolean isSize;
 
+  /**
+   * Constructs a long option with a string default.
+   *
+   * <p>The {@code defaultValueString} is parsed via {@link Fields#parseLong(String)}. See that
+   * method for the accepted syntax and units.
+   *
+   * @param conf Owning {@link SubConfig}.
+   * @param optionName Canonical option name within {@code conf}.
+   * @param defaultValueString Default value in text form.
+   * @param sortOrder Relative order among sibling options in UIs/exports.
+   * @param expert Whether the option targets advanced users.
+   * @param forceWrite Whether to persist even when equal to the default.
+   * @param shortDesc Message key for a short label.
+   * @param longDesc Message key for a detailed description.
+   * @param cb Callback used to read/apply values.
+   * @param isSize Enables IEC size formatting for display when {@code true}.
+   */
   public LongOption(
       SubConfig conf,
       String optionName,
@@ -32,6 +70,20 @@ public class LongOption extends Option<Long> {
         isSize);
   }
 
+  /**
+   * Constructs a long option with a typed default.
+   *
+   * @param conf Owning {@link SubConfig}.
+   * @param optionName Canonical option name within {@code conf}.
+   * @param defaultValue Default numeric value.
+   * @param sortOrder Relative order among sibling options in UIs/exports.
+   * @param expert Whether the option targets advanced users.
+   * @param forceWrite Whether to persist even when equal to the default.
+   * @param shortDesc Message key for a short label.
+   * @param longDesc Message key for a detailed description.
+   * @param cb Callback used to read/apply values.
+   * @param isSize Enables IEC size formatting for display when {@code true}.
+   */
   public LongOption(
       SubConfig conf,
       String optionName,
@@ -54,28 +106,55 @@ public class LongOption extends Option<Long> {
     this.isSize = isSize;
   }
 
+  /**
+   * Parses a long value from text.
+   *
+   * <p>Delegates to {@link Fields#parseLong(String)} and converts any parse failure into an {@link
+   * InvalidConfigValueException} with a localized message.
+   *
+   * @param val Textual representation (supports SI/IEC suffixes).
+   * @return Parsed {@link Long} value.
+   * @throws InvalidConfigValueException if the input cannot be parsed.
+   */
   @Override
   protected Long parseString(String val) throws InvalidConfigValueException {
-    Long x;
+    // Delegate to Fields to keep parsing consistent across the codebase (supports SI/IEC suffixes
+    // and decimal multipliers). Convert any format errors into a localized config exception.
+    long x;
     try {
       x = Fields.parseLong(val);
     } catch (NumberFormatException e) {
-      throw new InvalidConfigValueException(l10n("parseError", "val", val));
+      throw new InvalidConfigValueException(parseErrorMessage(val));
     }
     return x;
   }
 
-  private String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("LongOption." + key, pattern, value);
+  /** Returns a localized parse error message for the given invalid value. */
+  private String parseErrorMessage(String value) {
+    return NodeL10n.getBase().getString("LongOption.parseError", "val", value);
   }
 
+  /**
+   * Formats a value for end‑user display.
+   *
+   * @param val Value to format.
+   * @return Human‑readable string; may include IEC units when {@code isSize} is {@code true}.
+   */
   @Override
   protected String toDisplayString(Long val) {
+    // Human‑readable form; may use IEC units when isSize is true.
     return Fields.longToString(val, isSize);
   }
 
+  /**
+   * Formats a value for persistence and APIs.
+   *
+   * @param val Value to format.
+   * @return Canonical form using plain numbers or SI multiples.
+   */
   @Override
   protected String toString(Long val) {
+    // Canonical/persistence form; restricts to plain numbers or SI multiples.
     return Fields.longToString(val, false);
   }
 }

--- a/src/main/java/network/crypta/config/LongOption.java
+++ b/src/main/java/network/crypta/config/LongOption.java
@@ -47,11 +47,7 @@ public class LongOption extends Option<Long> {
         conf,
         optionName,
         cb,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
+        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
         Option.DataType.NUMBER);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;

--- a/src/main/java/network/crypta/config/Option.java
+++ b/src/main/java/network/crypta/config/Option.java
@@ -5,69 +5,106 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.pluginmanager.FredPluginConfigurable;
 import network.crypta.support.HTMLNode;
 
-/** A config option. */
+/**
+ * Base type for a single configuration option.
+ *
+ * <p>An {@code Option<T>} represents one typed setting belonging to a {@link SubConfig}. It
+ * encapsulates:
+ *
+ * <ul>
+ *   <li>Parsing from and formatting to strings for persistence and UI
+ *   <li>Tracking of a default value versus the current value
+ *   <li>Descriptive metadata (short/long description, ordering, expert flag)
+ *   <li>Application of changes via a {@link ConfigCallback} supplied by the owner
+ * </ul>
+ *
+ * <p>Unless stated otherwise by a subclass, no internal synchronization is performed. Typical
+ * access occurs through the configuration subsystem (e.g., {@link SubConfig}), which coordinates
+ * registration and lookups.
+ */
 public abstract class Option<T> {
-  /** The parent SubConfig object */
+  private static final String DEFAULT_L10N_KEY = "default";
+
+  /**
+   * Metadata for an option that groups descriptive and ordering properties.
+   *
+   * <p>Using a record keeps constructor parameter lists compact without changing behavior.
+   *
+   * @param sortOrder Relative ordering among sibling options in UI and exports.
+   * @param expert Whether this option targets advanced users. UIs may hide it by default.
+   * @param forceWrite Whether to write the value even when it equals the default.
+   * @param shortDesc Message key (not the translated text) for a brief label.
+   * @param longDesc Message key (not the translated text) for a longer description.
+   */
+  public record Meta(
+      int sortOrder, boolean expert, boolean forceWrite, String shortDesc, String longDesc) {}
+
+  /** Parent {@link SubConfig} that owns this option. */
   protected final SubConfig config;
 
-  /** The option name */
+  /** Canonical option name as used in config files and APIs. */
   protected final String name;
 
-  /** The sort order */
+  /** Relative ordering among options in the same {@link SubConfig}. */
   protected final int sortOrder;
 
-  /** Is this config variable expert-only? */
+  /** Whether this option is intended for expert users. */
   protected final boolean expert;
 
-  /** Is this config variable to be written out even if it uses the default value? */
+  /** Whether to persist the value even when it equals the default. */
   protected final boolean forceWrite;
 
-  /** Short description of value e.g. "FCP port" */
+  /** Message key for a brief label (e.g., {@code "FCP port"}). */
   protected final String shortDesc;
 
-  /** Long description of value e.g. "The TCP port to listen for FCP connections on" */
+  /**
+   * Message key for a detailed description (e.g., {@code "The TCP port to listen for FCP
+   * connections on"}).
+   */
   protected final String longDesc;
 
-  /** The configCallback associated to the Option */
+  /** Callback used to read/apply the effective value. */
   protected final ConfigCallback<T> cb;
 
   protected T defaultValue;
   protected T currentValue;
 
   public enum DataType {
+    /** Arbitrary text value. */
     STRING,
+    /** Numeric value (integral or fixed-format as defined by the subclass). */
     NUMBER,
+    /** {@code true}/{@code false}. */
     BOOLEAN,
+    /** Ordered list of text values. */
     STRING_ARRAY
   }
 
-  /** Data type : used to make it possible to make user inputs more friendly in FCP apps */
+  /** Declared data type used by external UIs (FCP/HTTP) to render appropriate editors. */
   final DataType dataType;
 
-  Option(
-      SubConfig config,
-      String name,
-      ConfigCallback<T> cb,
-      int sortOrder,
-      boolean expert,
-      boolean forceWrite,
-      String shortDesc,
-      String longDesc,
-      DataType dataType) {
+  Option(SubConfig config, String name, ConfigCallback<T> cb, Meta meta, DataType dataType) {
     this.config = config;
     this.name = name;
     this.cb = cb;
-    this.sortOrder = sortOrder;
-    this.expert = expert;
-    this.shortDesc = shortDesc;
-    this.longDesc = longDesc;
-    this.forceWrite = forceWrite;
+    this.sortOrder = meta != null ? meta.sortOrder() : 0;
+    this.expert = meta != null && meta.expert();
+    this.shortDesc = (meta != null) ? meta.shortDesc() : null;
+    this.longDesc = (meta != null) ? meta.longDesc() : null;
+    this.forceWrite = meta != null && meta.forceWrite();
     this.dataType = dataType;
   }
 
   /**
-   * Set this option's current value to a string. Will call the callback. Does not care whether the
-   * value of the option has changed.
+   * Parses the provided string and applies it as the current value.
+   *
+   * <p>This method always delegates to the {@link ConfigCallback} regardless of whether the new
+   * value equals the current one.
+   *
+   * @param val String representation of the value (format defined by the subclass).
+   * @throws InvalidConfigValueException If {@link #parseString(String)} rejects {@code val}, or if
+   *     the callback refuses the value.
+   * @throws NodeNeedRestartException If applying the value succeeds but a restart is required.
    */
   public final void setValue(String val)
       throws InvalidConfigValueException, NodeNeedRestartException {
@@ -75,14 +112,46 @@ public abstract class Option<T> {
     set(x);
   }
 
+  /**
+   * Converts a textual representation into a typed value.
+   *
+   * @param val Text to parse. Never {@code null}.
+   * @return Parsed value used by this option and its callback. May be {@code null} if the subtype
+   *     permits {@code null} as a valid state.
+   * @throws InvalidConfigValueException If the text cannot be parsed or violates constraints.
+   */
   protected abstract T parseString(String val) throws InvalidConfigValueException;
 
+  /**
+   * Formats a value for persistence and programmatic APIs.
+   *
+   * <p>Subclasses must ensure the result can be consumed by {@link #parseString(String)}.
+   *
+   * @param val Value to format.
+   * @return Canonical string form.
+   */
   protected abstract String toString(T val);
 
+  /**
+   * Formats a value for end‑user display. Defaults to {@link #toString(Object)}.
+   *
+   * @param val Value to display.
+   * @return Human‑readable form suitable for UI.
+   */
   protected String toDisplayString(T val) {
     return toString(val);
   }
 
+  /**
+   * Applies a typed value via the callback and records it as current.
+   *
+   * <p>If the callback throws {@link NodeNeedRestartException}, the {@code currentValue} is still
+   * updated and the exception is rethrown so callers can surface the restart requirement.
+   *
+   * @param val New typed value.
+   * @throws InvalidConfigValueException If the callback rejects the value.
+   * @throws NodeNeedRestartException If a restart is required after applying the value.
+   */
   protected final void set(T val) throws InvalidConfigValueException, NodeNeedRestartException {
     try {
       cb.set(val);
@@ -93,65 +162,115 @@ public abstract class Option<T> {
     }
   }
 
-  /** Get the current value of the option as a string. */
+  /**
+   * Returns the current value formatted for persistence and APIs.
+   *
+   * @return Canonical string form of the current value.
+   */
   public final String getValueString() {
     return toString(currentValue);
   }
 
-  /** Get the current value of the option as a string suited to end-user display. */
+  /**
+   * Returns the current value in a form suitable for end‑user display.
+   *
+   * @return Human‑readable string form of the current value.
+   */
   public final String getValueDisplayString() {
     return toDisplayString(currentValue);
   }
 
   /**
-   * Set to a value from the config file; this is not passed on to the callback, as we expect the
-   * client-side initialization to check the value. The callback is not valid until the client calls
-   * finishedInitialization().
+   * Sets the initial value loaded from a configuration source.
    *
-   * @throws InvalidConfigValueException
+   * <p>This does not call the {@link ConfigCallback}. It allows the owning component to finish its
+   * initialization first and then explicitly apply values. The callback is considered valid only
+   * after the client calls {@code finishedInitialization()} on the owning {@link SubConfig}.
+   *
+   * @param val Text to parse from the configuration.
+   * @throws InvalidConfigValueException If parsing fails.
    */
   public final void setInitialValue(String val) throws InvalidConfigValueException {
     currentValue = parseString(val);
   }
 
-  /** Call the callback with the current value of the option. */
+  /**
+   * Re-applies the current value through the callback.
+   *
+   * @throws InvalidConfigValueException If the callback rejects the value.
+   * @throws NodeNeedRestartException If the new value requires a restart.
+   */
   public void forceUpdate() throws InvalidConfigValueException, NodeNeedRestartException {
     setValue(getValueString());
   }
 
+  /**
+   * Returns the canonical name of this option.
+   *
+   * @return Non-null option name.
+   */
   public String getName() {
     return name;
   }
 
   /**
-   * Used in alt="" to label a box with the option name used in the config file. FIXME get rid of
-   * said alt=""? Not much use for most users. See caller.
+   * Returns the short description message key used for labels.
+   *
+   * <p>Callers may use this in UI elements (e.g., an {@code alt} attribute) after localizing it via
+   * {@link #getLocalisedShortDesc()}.
    */
   public String getShortDesc() {
     return shortDesc;
   }
 
-  /** Not used outside the class. */
+  /** Returns the long description message key. */
   private String getLongDesc() {
     return longDesc;
   }
 
+  /**
+   * Indicates whether this option is intended for expert users.
+   *
+   * @return {@code true} if expert‑only; otherwise {@code false}.
+   */
   public boolean isExpert() {
     return expert;
   }
 
+  /**
+   * Indicates whether the value should be written even when it equals the default.
+   *
+   * @return {@code true} if the option is force‑written; otherwise {@code false}.
+   */
   public boolean isForcedWrite() {
     return forceWrite;
   }
 
+  /**
+   * Returns the sort order within the parent {@link SubConfig}.
+   *
+   * @return Relative ordering value; lower values sort first.
+   */
   public int getSortOrder() {
     return sortOrder;
   }
 
+  /**
+   * Returns the declared data type, which guides external UI rendering.
+   *
+   * @return Data type enum value.
+   */
   public DataType getDataType() {
     return dataType;
   }
 
+  /**
+   * Returns the data type as a stable lower‑camel string.
+   *
+   * <p>Intended for FCP/HTTP clients that do not directly depend on the enum.
+   *
+   * @return One of {@code "string"}, {@code "number"}, {@code "boolean"}, or {@code "stringArray"}.
+   */
   public String getDataTypeStr() {
     return switch (dataType) {
       case STRING -> "string";
@@ -162,76 +281,127 @@ public abstract class Option<T> {
   }
 
   /**
-   * Get the current value. This is the value in use if we have finished initialization, otherwise
-   * it is the value set at startup (possibly the default).
+   * Returns the effective typed value.
+   *
+   * <p>If the owning {@link SubConfig} has finished initialization, the value is refreshed from the
+   * {@link ConfigCallback}. Otherwise, the last parsed value is returned (possibly the default).
+   *
+   * @return Current typed value; may be {@code null} if the subtype permits it.
    */
   public final T getValue() {
-    if (config.hasFinishedInitialization()) return currentValue = cb.get();
-    else return currentValue;
+    if (config.hasFinishedInitialization()) {
+      currentValue = cb.get();
+    }
+    return currentValue;
   }
 
-  /** Is this option set to the default? */
+  /**
+   * Returns whether the current value equals the default value.
+   *
+   * @return {@code true} if current equals default; otherwise {@code false}.
+   */
   public boolean isDefault() {
     getValue();
     return (currentValue != null && currentValue.equals(defaultValue));
   }
 
   /**
-   * Set to the default. Don't use after completed initialization, as this does not call the
-   * callback.
+   * Sets the current value to the default without invoking the callback.
+   *
+   * <p>Do not use after completed initialization when side effects are required.
    */
   public final void setDefault() {
     currentValue = defaultValue;
   }
 
+  /**
+   * Returns the default value formatted for persistence and APIs.
+   *
+   * @return Canonical string form of the default value.
+   */
   public final String getDefault() {
     return toString(defaultValue);
   }
 
+  /**
+   * Returns the callback used to read/apply values for this option.
+   *
+   * @return Non-null callback instance.
+   */
   public final ConfigCallback<T> getCallback() {
     return cb;
   }
 
-  /** Useful for plugins as can pass own BaseL10n in */
+  /**
+   * Resolves the localized short description using the provided localization bundle.
+   *
+   * @param l10n Localization source.
+   * @return Localized short description; falls back to {@code getDefault()} when needed.
+   */
   public String getLocalisedShortDesc(BaseL10n l10n) {
-    return l10n.getString(getShortDesc(), "default", getDefault());
+    return l10n.getString(getShortDesc(), DEFAULT_L10N_KEY, getDefault());
   }
 
-  /** Get the localised short description */
+  /** Returns the localized short description using the node's default bundle. */
   public String getLocalisedShortDesc() {
     return getLocalisedShortDesc(NodeL10n.getBase());
   }
 
-  /** Useful for plugins as can pass own BaseL10n in */
+  /**
+   * Resolves the localized long description using the provided localization bundle.
+   *
+   * @param l10n Localization source.
+   * @return Localized long description; falls back to {@code getDefault()} when needed.
+   */
   public String getLocalisedLongDesc(BaseL10n l10n) {
-    return l10n.getString(getLongDesc(), "default", getDefault());
+    return l10n.getString(getLongDesc(), DEFAULT_L10N_KEY, getDefault());
   }
 
-  /** Get the localised long description */
+  /** Returns the localized long description using the node's default bundle. */
   public String getLocalisedLongDesc() {
     return getLocalisedLongDesc(NodeL10n.getBase());
   }
 
-  /** Get the localised short description as an HTMLNode, possibly with translation link */
+  /**
+   * Returns the localized short description as an {@link HTMLNode}.
+   *
+   * <p>When {@code plugin} is {@code null}, the text is produced via {@link NodeL10n} and may
+   * include translation metadata. When {@code plugin} is non-null, the string is obtained from the
+   * plugin and wrapped in a simple anchor node.
+   *
+   * @param plugin Optional plugin to resolve translations from.
+   * @return HTML node containing the translated short description.
+   */
   public HTMLNode getShortDescNode(FredPluginConfigurable plugin) {
     return (plugin == null)
         ? NodeL10n.getBase()
-            .getHTMLNode(getShortDesc(), new String[] {"default"}, new String[] {getDefault()})
+            .getHTMLNode(
+                getShortDesc(), new String[] {DEFAULT_L10N_KEY}, new String[] {getDefault()})
         : new HTMLNode("#", plugin.getString(getShortDesc()));
   }
 
+  /** Convenience overload of {@link #getShortDescNode(FredPluginConfigurable)} without a plugin. */
   public HTMLNode getShortDescNode() {
     return getShortDescNode(null);
   }
 
-  /** Get the localised long description as an HTMLNode, possibly with translation link */
+  /**
+   * Returns the localized long description as an {@link HTMLNode}.
+   *
+   * <p>See {@link #getShortDescNode(FredPluginConfigurable)} for resolution rules.
+   *
+   * @param plugin Optional plugin to resolve translations from.
+   * @return HTML node containing the translated long description.
+   */
   public HTMLNode getLongDescNode(FredPluginConfigurable plugin) {
     return (plugin == null)
         ? NodeL10n.getBase()
-            .getHTMLNode(getLongDesc(), new String[] {"default"}, new String[] {getDefault()})
+            .getHTMLNode(
+                getLongDesc(), new String[] {DEFAULT_L10N_KEY}, new String[] {getDefault()})
         : new HTMLNode("#", plugin.getString(getLongDesc()));
   }
 
+  /** Convenience overload of {@link #getLongDescNode(FredPluginConfigurable)} without a plugin. */
   public HTMLNode getLongDescNode() {
     return getLongDescNode(null);
   }

--- a/src/main/java/network/crypta/config/OptionFormatException.java
+++ b/src/main/java/network/crypta/config/OptionFormatException.java
@@ -3,11 +3,25 @@ package network.crypta.config;
 import java.io.Serial;
 
 /**
- * Thrown when a format error occurs, and we cannot parse the string set into the appropriate type.
+ * Signals that a configuration value cannot be parsed into the required type.
+ *
+ * <p>This exception is typically thrown while reading or validating options when a textual
+ * representation cannot be converted to a target type such as a number, boolean, enum, or a
+ * structured value. Catchers can use it to surface a clear error to the user and request a
+ * corrected value.
+ *
+ * <p>See also {@link InvalidConfigValueException} for other value-related failures.
  */
 public class OptionFormatException extends InvalidConfigValueException {
+  // Serialization ID for binary compatibility across versions of this exception type.
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates a new instance with a human-readable detail message.
+   *
+   * @param msg detail message describing the option and the value that failed to parse; forwarded
+   *     to the superclass
+   */
   public OptionFormatException(String msg) {
     super(msg);
   }

--- a/src/main/java/network/crypta/config/ShortOption.java
+++ b/src/main/java/network/crypta/config/ShortOption.java
@@ -4,9 +4,42 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.support.Fields;
 import network.crypta.support.api.ShortCallback;
 
+/**
+ * Configuration option that stores a {@link Short} value.
+ *
+ * <p>This implementation parses textual input into a 16-bit signed integer and provides two string
+ * representations:
+ *
+ * <ul>
+ *   <li>{@link #toDisplayString(Short)} — human‑readable, optionally formatted as a size (e.g.,
+ *       using units) when {@code isSize} is enabled.
+ *   <li>{@link #toString(Short)} — canonical form intended for serialization and config files,
+ *       without size formatting.
+ * </ul>
+ *
+ * <p>Error messages for invalid input are localized via {@link NodeL10n}.
+ */
 public class ShortOption extends Option<Short> {
+  /**
+   * When {@code true}, display formatting treats the value as a byte size for {@link
+   * #toDisplayString(Short)}; parsing and canonical {@link #toString(Short)} are unaffected.
+   */
   protected final boolean isSize;
 
+  /**
+   * Creates a short-valued configuration option.
+   *
+   * @param conf owning configuration section
+   * @param optionName unique key within {@code conf}
+   * @param defaultValue value used when no explicit value is set
+   * @param sortOrder display order hint for UIs
+   * @param expert whether the option is intended for advanced users
+   * @param forceWrite whether the option should be written even when set to the default
+   * @param shortDesc concise description (single line, localized key or text)
+   * @param longDesc detailed description (may span multiple sentences)
+   * @param cb optional callback invoked when the value changes
+   * @param isSize whether display formatting should treat values as sizes
+   */
   public ShortOption(
       SubConfig conf,
       String optionName,
@@ -29,26 +62,54 @@ public class ShortOption extends Option<Short> {
     this.isSize = isSize;
   }
 
-  private String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("ShortOption." + key, pattern, value);
+  /** Builds a localized error message for an unparseable short value. */
+  private String unrecognisedShortMessage(String value) {
+    return NodeL10n.getBase().getString("ShortOption.unrecognisedShort", "val", value);
   }
 
+  /**
+   * Parses a textual value to a {@link Short}.
+   *
+   * <p>On failure, a localized message is provided.
+   *
+   * @param val source text
+   * @return parsed short value
+   * @throws InvalidConfigValueException if the text cannot be parsed as a short
+   */
   @Override
   protected Short parseString(String val) throws InvalidConfigValueException {
     short x;
     try {
       x = Fields.parseShort(val);
     } catch (NumberFormatException e) {
-      throw new InvalidConfigValueException(l10n("unrecognisedShort", "val", val));
+      throw new InvalidConfigValueException(unrecognisedShortMessage(val));
     }
     return x;
   }
 
+  /**
+   * Returns a human‑readable representation for UI display.
+   *
+   * <p>When {@code isSize} is {@code true}, the value is formatted as a size (units may be applied
+   * by {@link Fields#shortToString(short, boolean)}). This method must not be used for persistence.
+   *
+   * @param val value to render; may be {@code null} if allowed by the caller
+   * @return display string
+   */
   @Override
   protected String toDisplayString(Short val) {
     return Fields.shortToString(val, isSize);
   }
 
+  /**
+   * Returns the canonical string form for persistence and configuration files.
+   *
+   * <p>Formatting as a size is disabled to avoid unit annotations; callers that need a UI-friendly
+   * form should use {@link #toDisplayString(Short)} instead.
+   *
+   * @param val value to render; may be {@code null} if allowed by the caller
+   * @return canonical string without size formatting
+   */
   @Override
   protected String toString(Short val) {
     return Fields.shortToString(val, false);

--- a/src/main/java/network/crypta/config/ShortOption.java
+++ b/src/main/java/network/crypta/config/ShortOption.java
@@ -22,11 +22,7 @@ public class ShortOption extends Option<Short> {
         conf,
         optionName,
         cb,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
+        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
         Option.DataType.NUMBER);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;

--- a/src/main/java/network/crypta/config/StringArrOption.java
+++ b/src/main/java/network/crypta/config/StringArrOption.java
@@ -7,9 +7,47 @@ import network.crypta.support.URLEncodedFormatException;
 import network.crypta.support.URLEncoder;
 import network.crypta.support.api.StringArrCallback;
 
+/**
+ * Configuration option whose value is a sequence of strings.
+ *
+ * <p>Values are persisted and exchanged as a single semicolon-delimited list where each element is
+ * URL-encoded. The delimiter is {@link #VALUE_DELIMITER} ({@code ;}). Within an element, unsafe
+ * characters (including the delimiter itself) are percent-encoded via {@link URLEncoder}; Unicode
+ * characters may pass through unescaped. Empty elements are represented by the single-character
+ * token {@code ":"}.
+ *
+ * <p>Parsing accepts the format produced by {@link #toString(String[])} and tolerates certain
+ * malformed escapes only until the first successful decode (see {@link URLDecoder}). Truncated or
+ * otherwise invalid encodings result in {@link InvalidConfigValueException}.
+ *
+ * <p>Unless coordinated by the surrounding configuration subsystem, this class performs no internal
+ * synchronization. Arrays returned to or received from the callback are treated as mutable by
+ * convention of the concrete implementation.
+ */
 public class StringArrOption extends Option<String[]> {
-  public static final String delimiter = ";";
+  /**
+   * Delimiter used to persist and parse string arrays.
+   *
+   * <p>Values themselves never contain this delimiter in clear form because {@link URLEncoder}
+   * percent-encodes it inside elements. External callers should prefer {@link #toString(String[])}
+   * and {@link #parseString(String)} rather than constructing formats manually.
+   */
+  public static final String VALUE_DELIMITER = ";";
 
+  /**
+   * Creates an option backed by a {@link StringArrCallback}.
+   *
+   * @param conf parent configuration container
+   * @param optionName canonical option name used in config and APIs
+   * @param defaultValue default sequence when unspecified; {@code null} is treated as an empty
+   *     array
+   * @param sortOrder relative ordering among sibling options
+   * @param expert whether the option targets advanced users
+   * @param forceWrite whether to persist even when equal to the default
+   * @param shortDesc localization key for a short label
+   * @param longDesc localization key for a detailed description
+   * @param cb callback that provides and accepts the effective value
+   */
   public StringArrOption(
       SubConfig conf,
       String optionName,
@@ -30,43 +68,93 @@ public class StringArrOption extends Option<String[]> {
     this.currentValue = (defaultValue == null) ? new String[0] : defaultValue;
   }
 
+  /**
+   * Parses a semicolon-delimited, URL-encoded list into an array of strings.
+   *
+   * <p>Rules:
+   *
+   * <ul>
+   *   <li>An empty input yields an empty array.
+   *   <li>Each element is separated by {@link #VALUE_DELIMITER}.
+   *   <li>A token equal to {@code ":"} maps to the empty string.
+   *   <li>All other tokens are URL-decoded (tolerant mode; see {@link URLDecoder}).
+   * </ul>
+   *
+   * @param val non-{@code null} string to parse
+   * @return newly allocated array containing decoded elements
+   * @throws InvalidConfigValueException if decoding fails or the input violates the expected format
+   */
   @Override
   public String[] parseString(String val) throws InvalidConfigValueException {
     if (val.isEmpty()) return new String[0];
-    String[] out = val.split(delimiter);
+    String[] out = val.split(VALUE_DELIMITER);
 
     try {
       for (int i = 0; i < out.length; i++) {
+        // Map sentinel token to an empty element; otherwise decode percent-encoding.
         if (out[i].equals(":")) out[i] = "";
-        else out[i] = URLDecoder.decode(out[i], true /* FIXME false */);
+        else out[i] = URLDecoder.decode(out[i], true /* tolerant mode */);
       }
     } catch (URLEncodedFormatException e) {
-      throw new InvalidConfigValueException(l10n("parseError", "error", e.getLocalizedMessage()));
+      throw new InvalidConfigValueException(l10nParseError(e.getLocalizedMessage()));
     }
     return out;
   }
 
-  public void setInitialValue(String[] val) throws InvalidConfigValueException {
+  /**
+   * Sets the in-memory value without invoking the callback or performing parsing.
+   *
+   * <p>Intended for initialization flows that provide a typed value directly.
+   *
+   * @param val sequence to record as current
+   */
+  public void setInitialValue(String[] val) {
     this.currentValue = val;
   }
 
-  private String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("StringArrOption." + key, pattern, value);
+  private String l10nParseError(String value) {
+    return NodeL10n.getBase().getString("StringArrOption.parseError", "error", value);
   }
 
+  /**
+   * Formats an array as a semicolon-delimited, URL-encoded list.
+   *
+   * <p>Rules:
+   *
+   * <ul>
+   *   <li>{@code null} returns {@code null}.
+   *   <li>Each element is URL-encoded via {@link URLEncoder#encode(String, boolean)} with {@code
+   *       ascii=false} and followed by {@link #VALUE_DELIMITER}.
+   *   <li>Empty strings are encoded as the token {@code ":"} to distinguish them from missing
+   *       elements.
+   *   <li>The trailing delimiter is removed from the final result.
+   * </ul>
+   *
+   * @param arr array to format; may be {@code null}
+   * @return canonical string form or {@code null}
+   */
   @Override
   public String toString(String[] arr) {
     if (arr == null) return null;
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < arr.length; i++) {
-      String val = arr[i];
-      if (val.isEmpty()) sb.append(":").append(delimiter);
-      else sb.append(URLEncoder.encode(arr[i], false)).append(delimiter);
+    for (String val : arr) {
+      if (val.isEmpty()) sb.append(":").append(VALUE_DELIMITER);
+      else sb.append(URLEncoder.encode(val, false)).append(VALUE_DELIMITER);
     }
-    if (!sb.isEmpty()) sb.setLength(sb.length() - 1); // drop surplus delimiter
+    // Drop the surplus delimiter appended after the last element, if any.
+    if (!sb.isEmpty()) sb.setLength(sb.length() - 1);
     return sb.toString();
   }
 
+  /**
+   * Decodes a single URL-encoded token using strict rules.
+   *
+   * <p>This is a convenience for callers that need to interpret an element outside the context of a
+   * full list.
+   *
+   * @param s token to decode
+   * @return decoded string, or {@code null} when the input is malformed
+   */
   public static String decode(String s) {
     try {
       return URLDecoder.decode(s, false);
@@ -75,6 +163,15 @@ public class StringArrOption extends Option<String[]> {
     }
   }
 
+  /**
+   * Returns whether the current sequence equals the default sequence.
+   *
+   * <p>Equality is determined via {@link Arrays#equals(Object[], Object[])}. When the configuration
+   * subsystem has finished initialization, {@link Option#getValue()} refreshes the current value
+   * from the callback before comparison.
+   *
+   * @return {@code true} if equal to the default; otherwise {@code false}
+   */
   @Override
   public boolean isDefault() {
     getValue();

--- a/src/main/java/network/crypta/config/StringArrOption.java
+++ b/src/main/java/network/crypta/config/StringArrOption.java
@@ -24,11 +24,7 @@ public class StringArrOption extends Option<String[]> {
         conf,
         optionName,
         cb,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
+        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
         Option.DataType.STRING_ARRAY);
     this.defaultValue = (defaultValue == null) ? new String[0] : defaultValue;
     this.currentValue = (defaultValue == null) ? new String[0] : defaultValue;

--- a/src/main/java/network/crypta/config/StringOption.java
+++ b/src/main/java/network/crypta/config/StringOption.java
@@ -17,11 +17,7 @@ public class StringOption extends Option<String> {
         conf,
         optionName,
         cb,
-        sortOrder,
-        expert,
-        forceWrite,
-        shortDesc,
-        longDesc,
+        new Option.Meta(sortOrder, expert, forceWrite, shortDesc, longDesc),
         Option.DataType.STRING);
     this.defaultValue = defaultValue;
     this.currentValue = defaultValue;

--- a/src/main/java/network/crypta/config/StringOption.java
+++ b/src/main/java/network/crypta/config/StringOption.java
@@ -2,7 +2,32 @@ package network.crypta.config;
 
 import network.crypta.support.api.StringCallback;
 
+/**
+ * String-valued configuration option.
+ *
+ * <p>This specialization of {@link Option} stores and exposes textual values. Parsing and
+ * formatting are identity operations: the input string is returned as-is by {@link
+ * #parseString(String)} and {@link #toString(String)}. The declared data type reported to external
+ * UIs is {@link Option.DataType#STRING}.
+ *
+ * <p>The constructor records the provided default value as both the initial default and current
+ * value. Subsequent reads after {@link SubConfig#finishedInitialization()} reflect the value
+ * supplied by the associated {@link StringCallback}.
+ */
 public class StringOption extends Option<String> {
+  /**
+   * Creates a string option and registers its descriptive metadata.
+   *
+   * @param conf Owning {@link SubConfig} that manages registration and lookups.
+   * @param optionName Canonical name used in configuration files and APIs.
+   * @param defaultValue Initial value used before callbacks become authoritative.
+   * @param sortOrder Relative ordering among sibling options in UI and exports.
+   * @param expert Whether intended for advanced users (UIs may hide by default).
+   * @param forceWrite Whether to persist even when equal to the default value.
+   * @param shortDesc Message key for a short label (not the translated text).
+   * @param longDesc Message key for a longer description (not translated text).
+   * @param cb Callback used to read/apply values for this option.
+   */
   public StringOption(
       SubConfig conf,
       String optionName,
@@ -23,11 +48,29 @@ public class StringOption extends Option<String> {
     this.currentValue = defaultValue;
   }
 
+  /**
+   * Parses a textual value.
+   *
+   * <p>For string options, parsing is an identity conversion and returns the provided text
+   * unchanged.
+   *
+   * @param val Text to parse; not {@code null}.
+   * @return The same string instance or an equivalent value.
+   * @throws InvalidConfigValueException Never thrown by this implementation.
+   */
   @Override
   protected String parseString(String val) throws InvalidConfigValueException {
     return val;
   }
 
+  /**
+   * Formats a value for persistence and programmatic APIs.
+   *
+   * <p>For string options, formatting is an identity operation and returns the provided value.
+   *
+   * @param val Value to format; may be {@code null} only if the owning subsystem permits it.
+   * @return The same string instance or an equivalent value.
+   */
   @Override
   protected String toString(String val) {
     return val;

--- a/src/main/java/network/crypta/config/SubConfig.java
+++ b/src/main/java/network/crypta/config/SubConfig.java
@@ -622,11 +622,7 @@ public class SubConfig implements Comparable<SubConfig> {
             @Override
             public void set(Void value) {}
           },
-          -1,
-          false,
-          false,
-          null,
-          null,
+          new Option.Meta(-1, false, false, null, null),
           null);
     }
 

--- a/src/test/java/network/crypta/config/BandwidthOptionTest.java
+++ b/src/test/java/network/crypta/config/BandwidthOptionTest.java
@@ -1,0 +1,169 @@
+package network.crypta.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import network.crypta.support.api.IntCallback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // Allow method names like method_whenCondition_expectOutcome
+@ExtendWith(MockitoExtension.class)
+class BandwidthOptionTest {
+
+  private SubConfig subConfig;
+  private static final String TWO_KIB_PER_S = "2KiB/s";
+
+  @Mock private IntCallback callback;
+
+  @BeforeEach
+  void setUp() {
+    // Real Config/SubConfig so Option logic (initialization gating, etc.) runs as in production
+    Config config = new Config();
+    subConfig = config.createSubConfig("test");
+    // No stubbing: tests verify only set() side-effects; get() is unused before initialization
+  }
+
+  private BandwidthOption newOptionWithDefault(int defaultValue) {
+    return new BandwidthOption(
+        subConfig, "bandwidth", defaultValue, 10, false, false, "short", "long", callback);
+  }
+
+  // no helper for String default to avoid Sonar warning about always-constant parameter values
+
+  @ParameterizedTest(name = "{0} -> {1} bytes")
+  @CsvSource({
+    // plain numbers
+    "1000,1000",
+    // SI unit
+    "2k,2000",
+    // IEC unit
+    "2K,2048",
+    "2KiB,2048",
+    // bits (lowercase 'b' means bits)
+    "16kb,2000",
+    // with per-second variants
+    "1000/s,1000",
+    "2KiB/s,2048",
+    "16kb/s,2000",
+    "16kbps,2000",
+    // case-insensitive suffix
+    "1000/S,1000",
+    // surrounding whitespace
+    "  2000/s  ,2000",
+    // zero boundary
+    "0/s,0"
+  })
+  @DisplayName("setInitialValue trims per-second and parses units deterministically")
+  void setInitialValue_whenVariousInputs_expectParsedBytes(String input, int expectedBytes)
+      throws Exception {
+    BandwidthOption opt = newOptionWithDefault(0);
+
+    // Act: parse without invoking callback
+    opt.setInitialValue(input);
+
+    // Assert: current value and string forms
+    assertEquals(expectedBytes, opt.getValue(), "parsed numeric value");
+    String expectedPersist =
+        network.crypta.support.Fields.intToString(expectedBytes, Dimension.NOT);
+    assertEquals(expectedPersist, opt.getValueString(), "persistence string");
+  }
+
+  @Test
+  void setValue_whenValidBandwidth_callsCallbackWithParsedValue() throws Exception {
+    BandwidthOption opt = newOptionWithDefault(0);
+
+    opt.setValue(TWO_KIB_PER_S);
+
+    verify(callback, times(1)).set(2048);
+    assertEquals(2048, opt.getValue());
+    // UI display uses Dimension.SIZE (may compact when evenly divisible)
+    assertEquals("2KiB", opt.getValueDisplayString());
+    // Persistence always uses plain number
+    assertEquals("2048", opt.getValueString());
+  }
+
+  @Test
+  void setValue_whenInvalidString_throwsInvalidConfigValueException_andKeepsOldValue() {
+    BandwidthOption opt = newOptionWithDefault(1000);
+
+    assertThrows(InvalidConfigValueException.class, () -> opt.setValue("bogus/s"));
+
+    // Value unchanged after failed set
+    assertEquals(1000, opt.getValue());
+    assertEquals("1000", opt.getValueString());
+  }
+
+  @Test
+  void setValue_whenCallbackRequestsRestart_updatesCurrentValueAndRethrows() throws Exception {
+    BandwidthOption opt = newOptionWithDefault(0);
+
+    doThrow(new NodeNeedRestartException("restart please")).when(callback).set(2048);
+
+    assertThrows(NodeNeedRestartException.class, () -> opt.setValue(TWO_KIB_PER_S));
+
+    // Even though a restart is required, Option updates currentValue before rethrowing
+    assertEquals(2048, opt.getValue());
+    verify(callback, times(1)).set(2048);
+  }
+
+  @Test
+  void setValue_whenCallbackRejects_keepsPreviousValue() throws Exception {
+    BandwidthOption opt = newOptionWithDefault(2000); // default: 2000 bytes
+
+    doThrow(new InvalidConfigValueException("nope")).when(callback).set(2048);
+
+    assertThrows(InvalidConfigValueException.class, () -> opt.setValue(TWO_KIB_PER_S));
+
+    // Current value should remain the default (unchanged)
+    assertEquals(2000, opt.getValue());
+    String expectedPersist = network.crypta.support.Fields.intToString(2000, Dimension.NOT);
+    assertEquals(expectedPersist, opt.getValueString());
+    verify(callback, times(1)).set(2048);
+  }
+
+  @Test
+  void constructor_withStringDefault_parsesSizeUnits() {
+    BandwidthOption opt =
+        new BandwidthOption(
+            subConfig,
+            "bandwidth",
+            "2MiB",
+            10,
+            false,
+            false,
+            "short",
+            "long",
+            callback); // 2 * 1<<20 = 2097152 bytes
+
+    // Default (and initial current) value
+    assertEquals(2 * 1024 * 1024, opt.getValue());
+    // UI: Dimension.SIZE compacts to IEC when evenly divisible
+    assertEquals("2MiB", opt.getValueDisplayString());
+    // Persistence: plain number
+    assertEquals("2097152", opt.getDefault());
+  }
+
+  @Test
+  void setValue_whenOnlySuffixOrEmpty_throwsInvalidConfigValueException() {
+    BandwidthOption opt = newOptionWithDefault(0);
+    assertThrows(InvalidConfigValueException.class, () -> opt.setValue("/s"));
+    assertThrows(InvalidConfigValueException.class, () -> opt.setValue("   "));
+  }
+
+  @Test
+  void getDataTypeStr_whenQueried_isNumber() {
+    BandwidthOption opt = newOptionWithDefault(0);
+    assertEquals(Option.DataType.NUMBER, opt.getDataType());
+    assertEquals("number", opt.getDataTypeStr());
+  }
+}

--- a/src/test/java/network/crypta/config/BooleanOptionTest.java
+++ b/src/test/java/network/crypta/config/BooleanOptionTest.java
@@ -1,0 +1,164 @@
+package network.crypta.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.support.api.BooleanCallback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // method_whenCondition_expectOutcome naming
+class BooleanOptionTest {
+
+  private SubConfig subConfig;
+
+  @Mock private BooleanCallback callback;
+
+  // Do not override NodeL10n base: rely on default main translations for stability.
+
+  @BeforeEach
+  void setUp() {
+    Config config = new Config();
+    subConfig = config.createSubConfig("test");
+  }
+
+  private BooleanOption newOption(boolean defaultValue) {
+    return new BooleanOption(
+        subConfig, "flag", defaultValue, 1, false, false, "short", "long", callback);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"true", "TRUE", "TrUe", "yes", "YeS"})
+  @DisplayName("parseString accepts yes/true case-insensitively")
+  void parseString_whenTrueSynonyms_expectTrue(String input) throws Exception {
+    BooleanOption opt = newOption(false);
+    assertTrue(opt.parseString(input));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"false", "FALSE", "FaLsE", "no", "NO"})
+  @DisplayName("parseString accepts no/false case-insensitively")
+  void parseString_whenFalseSynonyms_expectFalse(String input) throws Exception {
+    BooleanOption opt = newOption(true);
+    assertFalse(opt.parseString(input));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "y", "n", "maybe", "1", "0", "on", "off", "truthy", "falsa"})
+  @DisplayName("parseString rejects unknown values")
+  void parseString_whenInvalid_throwsOptionFormatException(String input) {
+    BooleanOption opt = newOption(false);
+    assertThrows(OptionFormatException.class, () -> opt.parseString(input));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true,true", "false,false"})
+  @DisplayName("toString(Boolean) returns lowercase canonical form")
+  void toString_whenGivenValue_returnsCanonical(boolean value, String expected) {
+    BooleanOption opt = newOption(!value);
+    assertEquals(expected, opt.toString(value));
+  }
+
+  @Test
+  void constructor_setsDefaultAndCurrent_andDataTypeIsBoolean() {
+    BooleanOption opt = newOption(true);
+    assertTrue(opt.isDefault());
+    assertEquals("true", opt.getDefault());
+    assertEquals("true", opt.getValueString());
+    assertEquals(Option.DataType.BOOLEAN, opt.getDataType());
+    assertEquals("boolean", opt.getDataTypeStr());
+  }
+
+  @Test
+  void setInitialValue_whenValid_updatesCurrentWithoutCallback() throws Exception {
+    BooleanOption opt = newOption(false);
+
+    opt.setInitialValue("YeS");
+
+    assertTrue(opt.getValue());
+    assertEquals("true", opt.getValueString());
+    verifyNoInteractions(callback);
+  }
+
+  @Test
+  void setValue_whenValid_invokesCallbackAndUpdatesCurrent() throws Exception {
+    BooleanOption opt = newOption(false);
+
+    opt.setValue("true");
+
+    verify(callback, times(1)).set(Boolean.TRUE);
+    assertTrue(opt.getValue());
+    assertEquals("true", opt.getValueString());
+  }
+
+  @Test
+  void setValue_whenCallbackRejects_keepsPreviousValue() throws Exception {
+    BooleanOption opt = newOption(false); // default false
+    doThrow(new InvalidConfigValueException("bad")).when(callback).set(Boolean.TRUE);
+
+    assertThrows(InvalidConfigValueException.class, () -> opt.setValue("true"));
+
+    // Value should remain unchanged (default)
+    assertFalse(opt.getValue());
+    verify(callback, times(1)).set(Boolean.TRUE);
+  }
+
+  @Test
+  void setValue_whenCallbackRequestsRestart_updatesCurrentAndPropagates() throws Exception {
+    BooleanOption opt = newOption(false);
+    doThrow(new NodeNeedRestartException("restart")).when(callback).set(Boolean.TRUE);
+
+    NodeNeedRestartException ex =
+        assertThrows(NodeNeedRestartException.class, () -> opt.setValue("true"));
+    assertEquals("restart", ex.getMessage());
+    // Even on restart‑required, currentValue must be updated
+    assertTrue(opt.getValue());
+    verify(callback, times(1)).set(Boolean.TRUE);
+  }
+
+  @Test
+  void getValue_whenFinishedInitialization_readsFromCallback() {
+    BooleanOption opt = newOption(false);
+    when(callback.get()).thenReturn(Boolean.TRUE);
+
+    subConfig.finishedInitialization();
+    boolean value = opt.getValue();
+
+    assertTrue(value);
+    // getValue() should have consulted the callback exactly once
+    verify(callback, times(1)).get();
+  }
+
+  @Test
+  void getValue_whenNotFinishedInitialization_usesCachedValue() {
+    BooleanOption opt = newOption(true);
+
+    boolean value = opt.getValue();
+
+    assertTrue(value);
+    verify(callback, never()).get();
+  }
+
+  @Test
+  void isDefault_afterChange_returnsFalse_withoutInitialization() throws Exception {
+    BooleanOption opt = newOption(false);
+    opt.setValue("true");
+    assertFalse(opt.isDefault());
+  }
+}

--- a/src/test/java/network/crypta/config/IntOptionTest.java
+++ b/src/test/java/network/crypta/config/IntOptionTest.java
@@ -1,52 +1,229 @@
 package network.crypta.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import network.crypta.support.api.IntCallback;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class IntOptionTest {
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class IntOptionTest {
+
+  private SubConfig subConfig;
+
+  @BeforeEach
+  void setUp() {
+    Config config = new Config();
+    subConfig = new SubConfig("test", config);
+  }
 
   @Test
-  public void twoStringRepresentationsTest() {
-    IntOption intOption =
+  void constructor_withDisplayOrCanonicalString_parsesToSameValue() {
+    // Arrange
+    IntOption optDurationFromDisplay =
         new IntOption(
             null,
-            "test",
+            "duration",
             "5m",
             0,
             false,
             false,
-            "test",
-            "test",
+            "short",
+            "long",
             new NullIntCallback(),
             Dimension.DURATION);
 
-    IntOption sameIntOption =
+    // Act: Build from canonical string produced by toString (falls back via Dimension.NOT)
+    IntOption optFromCanonical =
         new IntOption(
             null,
-            "test",
-            intOption.toString(intOption.currentValue),
+            "duration",
+            optDurationFromDisplay.toString(optDurationFromDisplay.currentValue),
             0,
             false,
             false,
-            "test",
-            "test",
+            "short",
+            "long",
             new NullIntCallback(),
             Dimension.DURATION);
-    assertEquals(intOption.currentValue, sameIntOption.currentValue);
 
-    sameIntOption =
+    // Assert
+    assertEquals(optDurationFromDisplay.currentValue, optFromCanonical.currentValue);
+
+    // Act: Build from display string produced by toDisplayString (e.g., "5m")
+    IntOption optFromDisplay =
         new IntOption(
             null,
-            "test",
-            intOption.toDisplayString(intOption.currentValue),
+            "duration",
+            optDurationFromDisplay.toDisplayString(optDurationFromDisplay.currentValue),
             0,
             false,
             false,
-            "test",
-            "test",
+            "short",
+            "long",
             new NullIntCallback(),
             Dimension.DURATION);
-    assertEquals(intOption.currentValue, sameIntOption.currentValue);
+
+    // Assert
+    assertEquals(optDurationFromDisplay.currentValue, optFromDisplay.currentValue);
+  }
+
+  @Test
+  void setValue_whenValid_updatesCurrentAndInvokesCallback() throws Exception {
+    // Arrange
+    int defaultValue = 0;
+
+    // Use a new instance with a mocked callback to verify interactions
+    IntOption optionWithMockCb =
+        new IntOption(
+            subConfig,
+            "size",
+            defaultValue,
+            1,
+            false,
+            false,
+            "short",
+            "long",
+            mockCb,
+            Dimension.SIZE);
+
+    // Act
+    optionWithMockCb.setValue("1KiB"); // 1024 bytes
+
+    // Assert
+    assertEquals(1024, optionWithMockCb.currentValue);
+    assertEquals("1024", optionWithMockCb.getValueString()); // canonical string (Dimension.NOT)
+    verify(mockCb, times(1)).set(1024);
+  }
+
+  @Mock private IntCallback mockCb;
+
+  @Test
+  void setValue_whenInvalidString_throwsInvalidConfigValueException() {
+    // Arrange
+    IntOption option =
+        new IntOption(
+            subConfig, "num", 10, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+
+    // Act + Assert
+    assertThrows(InvalidConfigValueException.class, () -> option.setValue("not_a_number"));
+    // Callback isn't called on parse failure
+    verifyNoInteractions(mockCb);
+    // Current value remains unchanged (default)
+    assertEquals(10, option.currentValue);
+  }
+
+  @Test
+  void setInitialValue_whenInvalid_throwsInvalidConfigValueException_withoutCallback() {
+    // Arrange
+    IntOption option =
+        new IntOption(subConfig, "num", 7, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+
+    // Act + Assert
+    assertThrows(InvalidConfigValueException.class, () -> option.setInitialValue("garbage"));
+    verifyNoInteractions(mockCb);
+    assertEquals(7, option.currentValue);
+  }
+
+  @Test
+  void setValue_whenCallbackRejects_doesNotUpdateCurrentValue() throws Exception {
+    // Arrange
+    IntOption option =
+        new IntOption(
+            subConfig, "num", 123, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+    // Callback throws validation error
+    org.mockito.Mockito.doThrow(new InvalidConfigValueException("bad")).when(mockCb).set(anyInt());
+
+    // Act + Assert
+    assertThrows(InvalidConfigValueException.class, () -> option.setValue("1024"));
+    // Value should not change on InvalidConfigValueException
+    assertEquals(123, option.currentValue);
+  }
+
+  @Test
+  void setValue_whenCallbackRequestsRestart_updatesCurrentAndPropagates() throws Exception {
+    // Arrange
+    IntOption option =
+        new IntOption(
+            subConfig, "num", 0, 1, false, false, "short", "long", mockCb, Dimension.SIZE);
+    org.mockito.Mockito.doThrow(new NodeNeedRestartException("restart")).when(mockCb).set(1024);
+
+    // Act + Assert
+    NodeNeedRestartException ex =
+        assertThrows(NodeNeedRestartException.class, () -> option.setValue("1KiB"));
+    assertEquals("restart", ex.getMessage());
+    // Even on restart-required, currentValue must be updated
+    assertEquals(1024, option.currentValue);
+    verify(mockCb, times(1)).set(1024);
+  }
+
+  @Test
+  void getValue_whenFinishedInitialization_readsFromCallback() {
+    // Arrange
+    IntOption option =
+        new IntOption(
+            subConfig, "num", 10, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+    when(mockCb.get()).thenReturn(42);
+    subConfig.finishedInitialization();
+
+    // Act
+    int value = option.getValue();
+
+    // Assert
+    assertEquals(42, value);
+    assertEquals(42, option.currentValue);
+    verify(mockCb, times(1)).get();
+  }
+
+  @Test
+  void getValue_whenNotFinishedInitialization_usesCachedValue() {
+    // Arrange
+    IntOption option =
+        new IntOption(
+            subConfig, "num", 77, 1, false, false, "short", "long", mockCb, Dimension.NOT);
+
+    // Act
+    int value = option.getValue();
+
+    // Assert
+    assertEquals(77, value);
+    verify(mockCb, never()).get();
+  }
+
+  @Test
+  void formatting_whenSizeDimension_differsBetweenDisplayAndCanonical() {
+    // Arrange
+    IntOption sizeOption =
+        new IntOption(
+            subConfig,
+            "size",
+            1024,
+            1,
+            false,
+            false,
+            "short",
+            "long",
+            new NullIntCallback(),
+            Dimension.SIZE);
+
+    // Act + Assert
+    // For 2048, display uses IEC units while canonical remains plain
+    assertEquals("2048", sizeOption.toString(2048));
+    assertEquals("2KiB", sizeOption.toDisplayString(2048));
+
+    // Also sanity-check a SI multiple representation
+    assertEquals("2k", sizeOption.toString(2000));
+    assertEquals("2k", sizeOption.toDisplayString(2000));
   }
 }

--- a/src/test/java/network/crypta/config/LongOptionTest.java
+++ b/src/test/java/network/crypta/config/LongOptionTest.java
@@ -1,0 +1,152 @@
+package network.crypta.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.support.api.LongCallback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LongOptionTest {
+
+  private SubConfig subConfig;
+
+  @Mock private LongCallback cb;
+
+  @BeforeEach
+  void setup() {
+    Config config = new Config();
+    subConfig = new SubConfig("test", config);
+  }
+
+  private LongOption newOption(
+      String name, long defaultValue, boolean isSize, LongCallback callback) {
+    return new LongOption(
+        subConfig,
+        name,
+        defaultValue,
+        /* sortOrder */ 10,
+        /* expert */ false,
+        /* forceWrite */ false,
+        /* shortDesc */ "short.key",
+        /* longDesc */ "long.key",
+        callback,
+        isSize);
+  }
+
+  @Test
+  @DisplayName("constructor(String) parses default and sets current")
+  void constructorStringDefault_whenValid_expectDefaultAndCurrentSet() {
+    // Arrange
+    // "3M" uses IEC upper-case M => 3 * 2^20
+    LongOption opt =
+        new LongOption(
+            subConfig,
+            "alpha",
+            "3M",
+            /* sortOrder */ 10,
+            /* expert */ false,
+            /* forceWrite */ false,
+            /* shortDesc */ "short.key",
+            /* longDesc */ "long.key",
+            cb,
+            /* isSize */ false);
+
+    // Act & Assert
+    assertEquals(Option.DataType.NUMBER, opt.getDataType());
+    // Not finished initialization -> currentValue equals parsed default
+    assertEquals("3145728", opt.getValueString());
+    assertEquals("3145728", opt.getValueDisplayString());
+  }
+
+  @Test
+  @DisplayName("display formatting honors isSize (IEC units)")
+  void displayFormatting_whenIsSizeTrue_usesIecSuffix() throws Exception {
+    // Arrange
+    LongOption opt = newOption("beta", 0L, /* isSize= */ true, cb);
+
+    // Act: parse a human-size value and set as initial without invoking callback
+    opt.setInitialValue("2048");
+
+    // Assert: display string uses IEC (KiB) while value string stays raw
+    assertEquals("2048", opt.getValueString());
+    assertEquals("2KiB", opt.getValueDisplayString());
+  }
+
+  @Test
+  @DisplayName("parse invalid value -> InvalidConfigValueException with l10n message")
+  void parseString_whenInvalid_throwsInvalidConfigValueExceptionWithMessage() {
+    // Arrange
+    LongOption opt = newOption("gamma", 0L, /* isSize= */ false, cb);
+
+    // Act
+    InvalidConfigValueException ex =
+        assertThrows(InvalidConfigValueException.class, () -> opt.setInitialValue("not a number"));
+
+    // Assert: message comes from l10n and contains the offending value
+    String msg = ex.getMessage();
+    assertNotNull(msg);
+    assertTrue(msg.contains("64-bit integer"), msg);
+    assertTrue(msg.contains("not a number"), msg);
+  }
+
+  @Test
+  @DisplayName("setValue propagates NodeNeedRestartException but updates current value")
+  void setValue_whenCallbackThrowsNodeNeedRestart_updatesValueAndRethrows() throws Exception {
+    // Arrange
+    LongOption opt = newOption("delta", 100L, /* isSize= */ false, cb);
+    doThrow(new NodeNeedRestartException("restart")).when(cb).set(2048L);
+
+    // Act
+    NodeNeedRestartException ex =
+        assertThrows(NodeNeedRestartException.class, () -> opt.setValue("2048"));
+
+    // Assert: value applied to currentValue even though restart is required
+    assertEquals("2048", opt.getValueString());
+    verify(cb).set(2048L);
+    assertEquals("restart", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("setValue keeps old value on InvalidConfigValueException from callback")
+  void setValue_whenCallbackThrowsInvalid_keepsOldValue() throws Exception {
+    // Arrange
+    LongOption opt = newOption("epsilon", 1000L, /* isSize= */ false, cb);
+    // Make callback reject the new value
+    doThrow(new InvalidConfigValueException("bad")).when(cb).set(2000L);
+
+    // Act
+    assertThrows(InvalidConfigValueException.class, () -> opt.setValue("2000"));
+
+    // Assert: current value unchanged (1000)
+    assertEquals("1000", opt.getValueString());
+    verify(cb).set(2000L);
+  }
+
+  @Test
+  @DisplayName("getValue reflects callback after finishedInitialization()")
+  void getValue_whenFinishedInitialization_readsFromCallback() {
+    // Arrange
+    LongOption opt = newOption("zeta", 7L, /* isSize= */ false, cb);
+    subConfig.finishedInitialization();
+    when(cb.get()).thenReturn(12345L);
+
+    // Act
+    long val = opt.getValue();
+
+    // Assert
+    assertEquals(12345L, val);
+    assertEquals("12345", opt.getValueString());
+  }
+}

--- a/src/test/java/network/crypta/config/ShortOptionTest.java
+++ b/src/test/java/network/crypta/config/ShortOptionTest.java
@@ -1,0 +1,183 @@
+package network.crypta.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.api.ShortCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ShortOptionTest {
+
+  private static ShortOption newOption(
+      SubConfig sc, ShortCallback cb, boolean isSize, short defaultValue) {
+    return new ShortOption(
+        sc,
+        "test.short",
+        defaultValue,
+        42,
+        true,
+        false,
+        "ShortOption.unrecognisedShort", // any key; not used in happy paths
+        "ShortOption.unrecognisedShort",
+        cb,
+        isSize);
+  }
+
+  @Test
+  void setValue_whenValidNumber_expectCallbackSetAndValueUpdated(@Mock ShortCallback cb)
+      throws Exception {
+    // Arrange
+    Config config = new Config();
+    SubConfig sc = config.createSubConfig("core");
+    ShortOption opt = newOption(sc, cb, false, (short) 5);
+
+    // Act
+    opt.setValue("123");
+
+    // Assert
+    verify(cb).set((short) 123);
+    assertEquals((short) 123, opt.getValue());
+    assertEquals("123", opt.getValueString()); // toString() does not use size units
+  }
+
+  @Test
+  void setInitialValue_whenCalled_expectNoCallbackAndValueParsed(@Mock ShortCallback cb)
+      throws Exception {
+    // Arrange
+    Config config = new Config();
+    SubConfig sc = config.createSubConfig("core");
+    ShortOption opt = newOption(sc, cb, false, (short) 7);
+
+    // Act
+    opt.setInitialValue("2000");
+
+    // Assert
+    verify(cb, never()).set((short) 2000);
+    assertEquals((short) 2000, opt.getValue());
+    assertEquals("2k", opt.getValueString()); // 2000 -> 2k for persistence/API form
+  }
+
+  @Test
+  void setValue_whenInvalidNumber_expectInvalidConfigValueExceptionWithL10n(
+      @Mock ShortCallback cb) {
+    // Arrange
+    // Reset global translations to production bundle. Other tests may install
+    // a test-only bundle via BaseL10nTest.useTestTranslation(), which would
+    // make this localized message assertion nondeterministic.
+    //noinspection InstantiationOfUtilityClass
+    new NodeL10n();
+    Config config = new Config();
+    SubConfig sc = config.createSubConfig("core");
+    ShortOption opt = newOption(sc, cb, false, (short) 0);
+
+    // Act + Assert
+    InvalidConfigValueException ex =
+        assertThrows(InvalidConfigValueException.class, () -> opt.setValue("garbage"));
+    assertTrue(
+        ex.getMessage()
+            .contains("The value specified can't be parsed as a 16-bit integer: garbage"));
+  }
+
+  @Test
+  void getValueDisplayString_whenIsSizeTrue_expectIECUnits(@Mock ShortCallback cb)
+      throws Exception {
+    // Arrange: value chosen to format as IEC (KiB) when isSize=true
+    Config config = new Config();
+    SubConfig sc = config.createSubConfig("core");
+    ShortOption opt = newOption(sc, cb, true, (short) 0);
+
+    // Act
+    opt.setInitialValue("2048");
+
+    // Assert: display uses IEC units, persistence uses plain
+    assertEquals("2KiB", opt.getValueDisplayString());
+    assertEquals("2048", opt.getValueString());
+  }
+
+  @Test
+  void setValue_whenCallbackThrowsNodeNeedRestartException_expectPropagateAndValueRecorded(
+      @Mock ShortCallback cb) throws Exception {
+    // Arrange
+    Config config = new Config();
+    SubConfig sc = config.createSubConfig("core");
+    ShortOption opt = newOption(sc, cb, false, (short) 1);
+    doThrow(new NodeNeedRestartException("need restart")).when(cb).set((short) 1500);
+
+    // Act + Assert
+    NodeNeedRestartException ex =
+        assertThrows(NodeNeedRestartException.class, () -> opt.setValue("1500"));
+    assertEquals("need restart", ex.getMessage());
+    assertEquals(
+        (short) 1500, opt.getValue()); // currentValue is still updated on restart requirement
+    assertEquals("1500", opt.getValueString());
+  }
+
+  @Test
+  void setValue_whenCallbackThrowsInvalidConfigValueException_expectPropagateAndValueUnchanged(
+      @Mock ShortCallback cb) throws Exception {
+    // Arrange
+    Config config = new Config();
+    SubConfig sc = config.createSubConfig("core");
+    ShortOption opt = newOption(sc, cb, false, (short) 7);
+    doThrow(new InvalidConfigValueException("bad"))
+        .when(cb)
+        .set((short) 100); // parse succeeds, callback rejects
+
+    // Act + Assert
+    assertThrows(InvalidConfigValueException.class, () -> opt.setValue("100"));
+    assertEquals((short) 7, opt.getValue()); // remains default
+  }
+
+  @Test
+  void getValue_whenFinishedInitialization_expectDelegatesToCallbackGet(@Mock ShortCallback cb)
+      throws Exception {
+    // Arrange
+    Config config = new Config();
+    SubConfig sc = config.createSubConfig("core");
+    ShortOption opt = newOption(sc, cb, false, (short) 11);
+    doAnswer(
+            invocation -> {
+              // simulate successful apply; underlying state would become 1234
+              return null;
+            })
+        .when(cb)
+        .set((short) 1234);
+    when(cb.get()).thenReturn((short) 3210);
+
+    // Act: apply value before initialization completes, then complete init and read back
+    opt.setValue("1234");
+    sc.finishedInitialization();
+    short effective = opt.getValue();
+
+    // Assert: get() path used after initialization
+    assertEquals((short) 3210, effective);
+  }
+
+  @Test
+  void ctor_and_accessors_expectMetadataAndDataTypeSet(@Mock ShortCallback cb) {
+    // Arrange
+    Config config = new Config();
+    SubConfig sc = config.createSubConfig("core");
+    ShortOption opt = newOption(sc, cb, false, (short) 9);
+
+    // Assert
+    assertEquals("test.short", opt.getName());
+    assertEquals(42, opt.getSortOrder());
+    assertTrue(opt.isExpert());
+    assertFalse(opt.isForcedWrite());
+    assertEquals(Option.DataType.NUMBER, opt.getDataType());
+  }
+}

--- a/src/test/java/network/crypta/config/StringArrOptionTest.java
+++ b/src/test/java/network/crypta/config/StringArrOptionTest.java
@@ -1,0 +1,166 @@
+package network.crypta.config;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.support.api.StringArrCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class StringArrOptionTest {
+
+  @Mock private SubConfig subConfig;
+  @Mock private StringArrCallback callback;
+
+  private StringArrOption newOption(String[] deflt) {
+    // Common constructor wiring for tests
+    return new StringArrOption(
+        subConfig,
+        "test.string.array",
+        deflt,
+        10,
+        false,
+        false,
+        "short.desc.key",
+        "long.desc.key",
+        callback);
+  }
+
+  @Test
+  void parseString_whenEmptyInput_returnsEmptyArray() throws Exception {
+    StringArrOption opt = newOption(new String[] {"a"});
+    String[] out = opt.parseString("");
+    assertEquals(0, out.length);
+  }
+
+  @Test
+  void parseString_whenHasEncodedValuesAndColonTokens_decodesAndMapsEmpty() throws Exception {
+    StringArrOption opt = newOption(new String[] {});
+    // "hello%20world" => "hello world"
+    // ":" => empty string
+    // "%E2%9C%93" => ✓ (check mark)
+    // "%3b" => ';' within a value
+    // "%25" => '%'
+    // "%F0%9F%98%80" => 😀
+    String val =
+        "hello%20world"
+            + StringArrOption.VALUE_DELIMITER
+            + ":"
+            + StringArrOption.VALUE_DELIMITER
+            + "%E2%9C%93"
+            + StringArrOption.VALUE_DELIMITER
+            + "%3b"
+            + StringArrOption.VALUE_DELIMITER
+            + "%25"
+            + StringArrOption.VALUE_DELIMITER
+            + "%F0%9F%98%80";
+
+    String[] out = opt.parseString(val);
+    assertArrayEquals(new String[] {"hello world", "", "✓", ";", "%", "😀"}, out);
+  }
+
+  @Test
+  void parseString_whenMalformedAfterSuccessfulDecode_throwsInvalidConfigValue() {
+    StringArrOption opt = newOption(new String[] {});
+    // First escape decodes (":"), second is malformed — tolerant mode now throws
+    String malformed = "%3a%zz";
+    assertThrows(InvalidConfigValueException.class, () -> opt.parseString(malformed));
+  }
+
+  @Test
+  void parseString_whenTruncatedPercentAtEnd_throwsInvalidConfigValue() {
+    StringArrOption opt = newOption(new String[] {});
+    assertThrows(InvalidConfigValueException.class, () -> opt.parseString("abc%"));
+  }
+
+  @Test
+  void toString_whenNull_returnsNull() {
+    StringArrOption opt = newOption(new String[] {});
+    assertNull(opt.toString(null));
+  }
+
+  @Test
+  void toString_whenContainsEmptyAndSpecials_encodesAsSpecified() {
+    StringArrOption opt = newOption(new String[] {});
+    String[] in = new String[] {"", "a b", "✓", ";", ":", "%"};
+    String str = opt.toString(in);
+    // Empty string => ":"; space => %20; ';' => %3b; ':' => %3a; '%' => %25; Unicode ✓ passes
+    // through
+    String expected =
+        ":"
+            + StringArrOption.VALUE_DELIMITER
+            + "a%20b"
+            + StringArrOption.VALUE_DELIMITER
+            + "✓"
+            + StringArrOption.VALUE_DELIMITER
+            + "%3b"
+            + StringArrOption.VALUE_DELIMITER
+            + "%3a"
+            + StringArrOption.VALUE_DELIMITER
+            + "%25";
+    assertEquals(expected, str);
+  }
+
+  @Test
+  void roundTrip_whenVariousValues_preservesValues() throws Exception {
+    StringArrOption opt = newOption(new String[] {});
+    String[] in = new String[] {"", ":", " semi;colon", "white space", "✓"};
+    String s = opt.toString(in);
+    String[] out = opt.parseString(s);
+    assertArrayEquals(in, out);
+  }
+
+  @Test
+  void decode_whenMalformed_returnsNull() {
+    assertNull(StringArrOption.decode("abc%"));
+  }
+
+  @Test
+  void decode_whenValid_returnsDecodedString() {
+    assertEquals(":", StringArrOption.decode("%3a"));
+    assertEquals("✓", StringArrOption.decode("%E2%9C%93"));
+  }
+
+  @Test
+  void isDefault_whenNotInitialized_usesCurrentValue() throws Exception {
+    when(subConfig.hasFinishedInitialization()).thenReturn(false);
+    String[] deflt = new String[] {"x", "y"};
+    StringArrOption opt = newOption(deflt);
+
+    assertTrue(opt.isDefault());
+
+    String[] other = new String[] {"z"};
+    // Use typed overload to avoid invoking the callback
+    opt.setInitialValue(other);
+    assertFalse(opt.isDefault());
+    // Callback shouldn't be touched for setInitialValue(T)
+    verify(callback, never()).set(other);
+  }
+
+  @Test
+  void isDefault_whenInitialized_usesCallbackValue() {
+    when(subConfig.hasFinishedInitialization()).thenReturn(true);
+    String[] deflt = new String[] {"a"};
+    StringArrOption opt = newOption(deflt);
+
+    when(callback.get()).thenReturn(deflt);
+    assertTrue(opt.isDefault());
+
+    when(callback.get()).thenReturn(new String[] {"different"});
+    assertFalse(opt.isDefault());
+    // get() must be consulted each time when initialized
+    verify(callback, times(2)).get();
+  }
+}

--- a/src/test/java/network/crypta/config/StringOptionTest.java
+++ b/src/test/java/network/crypta/config/StringOptionTest.java
@@ -1,0 +1,183 @@
+package network.crypta.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.l10n.BaseL10n;
+import network.crypta.pluginmanager.FredPluginConfigurable;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.api.StringCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class StringOptionTest {
+  private static final String SHORT_KEY = "short.desc.key";
+  private static final String LONG_KEY = "long.desc.key";
+  private static final String NEW_VALUE = "newValue";
+  private static final String RESTART_VALUE = "needsRestart";
+  private static final String FROM_CB = "fromCb";
+  private static final String BAD_VALUE = "badValue";
+  private static final String DEFAULT_VAL = "def";
+
+  private static StringOption newOption(SubConfig subConfig, StringCallback cb) {
+    return new StringOption(
+        subConfig, "test.option", DEFAULT_VAL, 42, true, true, SHORT_KEY, LONG_KEY, cb);
+  }
+
+  @Test
+  void constructor_setsDefaultAndMeta_expectInitialState() {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+
+    StringOption opt = newOption(sc, cb);
+
+    assertEquals("test.option", opt.getName());
+    assertEquals(DEFAULT_VAL, opt.getDefault());
+    assertEquals(DEFAULT_VAL, opt.getValueString());
+    assertTrue(opt.isExpert());
+    assertTrue(opt.isForcedWrite());
+    assertEquals(42, opt.getSortOrder());
+    assertEquals(Option.DataType.STRING, opt.getDataType());
+    assertEquals("string", opt.getDataTypeStr());
+
+    BaseL10n l10n = Mockito.mock(BaseL10n.class);
+    Mockito.when(l10n.getString(SHORT_KEY, "default", DEFAULT_VAL)).thenReturn("SHORT(def)");
+    Mockito.when(l10n.getString(LONG_KEY, "default", DEFAULT_VAL)).thenReturn("LONG(def)");
+    assertEquals("SHORT(def)", opt.getLocalisedShortDesc(l10n));
+    assertEquals("LONG(def)", opt.getLocalisedLongDesc(l10n));
+
+    // getCallback() should return the same instance we injected
+    assertEquals(cb, opt.getCallback());
+  }
+
+  @Test
+  void setValue_whenCallbackAccepts_expectCurrentUpdatedAndCallbackCalled() throws Exception {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+
+    StringOption opt = newOption(sc, cb);
+
+    opt.setValue("");
+    assertEquals("", opt.getValueString());
+
+    opt.setValue(NEW_VALUE);
+    assertEquals(NEW_VALUE, opt.getValueString());
+
+    Mockito.verify(cb, Mockito.times(1)).set("");
+    Mockito.verify(cb, Mockito.times(1)).set(NEW_VALUE);
+  }
+
+  @Test
+  void setValue_whenCallbackThrowsInvalid_expectExceptionAndCurrentNotChanged() throws Exception {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+    Mockito.doThrow(new InvalidConfigValueException("bad")).when(cb).set(BAD_VALUE);
+
+    StringOption opt = newOption(sc, cb);
+
+    InvalidConfigValueException ex =
+        assertThrows(InvalidConfigValueException.class, () -> opt.setValue(BAD_VALUE));
+    assertEquals("bad", ex.getMessage());
+    // current value must remain the default because set() failed before updating
+    assertEquals("def", opt.getValueString());
+    Mockito.verify(cb).set(BAD_VALUE);
+  }
+
+  @Test
+  void setValue_whenCallbackThrowsRestart_expectExceptionButCurrentUpdated() throws Exception {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+    Mockito.doThrow(new NodeNeedRestartException("restart")).when(cb).set(RESTART_VALUE);
+
+    StringOption opt = newOption(sc, cb);
+
+    NodeNeedRestartException ex =
+        assertThrows(NodeNeedRestartException.class, () -> opt.setValue(RESTART_VALUE));
+    assertEquals("restart", ex.getMessage());
+    // For restart, currentValue is still updated
+    assertEquals(RESTART_VALUE, opt.getValueString());
+    Mockito.verify(cb).set(RESTART_VALUE);
+  }
+
+  @Test
+  void setInitialValue_beforeInitialization_expectCurrentUpdatedAndNoCallback() throws Exception {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+    StringOption opt = newOption(sc, cb);
+
+    opt.setInitialValue("init");
+    assertEquals("init", opt.getValueString());
+    Mockito.verify(cb, Mockito.never()).set(Mockito.any());
+  }
+
+  @Test
+  void getValue_whenNotInitialized_expectNoCallbackGetAndCurrentReturned() {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+    StringOption opt = newOption(sc, cb);
+
+    // simulate value parsed from config file without calling callback
+    opt.setDefault();
+    assertEquals("def", opt.getValue());
+    Mockito.verify(cb, Mockito.never()).get();
+  }
+
+  @Test
+  void getValue_whenInitialized_expectRefreshFromCallback() {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+    Mockito.when(cb.get()).thenReturn(FROM_CB);
+
+    StringOption opt = newOption(sc, cb);
+    sc.finishedInitialization();
+
+    assertEquals(FROM_CB, opt.getValue());
+    assertEquals(FROM_CB, opt.getValueString());
+    Mockito.verify(cb, Mockito.times(1)).get();
+  }
+
+  @Test
+  void isDefault_and_setDefault_expectTransitions() throws Exception {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+    StringOption opt = newOption(sc, cb);
+
+    assertTrue(opt.isDefault());
+    opt.setValue("notDefault");
+    assertFalse(opt.isDefault());
+    opt.setDefault();
+    assertTrue(opt.isDefault());
+  }
+
+  @Test
+  void getShortAndLongDescNode_withPlugin_expectPluginStrings() {
+    Config cfg = new Config();
+    SubConfig sc = cfg.createSubConfig("test");
+    StringCallback cb = Mockito.mock(StringCallback.class);
+    StringOption opt = newOption(sc, cb);
+
+    FredPluginConfigurable plugin = Mockito.mock(FredPluginConfigurable.class);
+    Mockito.when(plugin.getString(SHORT_KEY)).thenReturn("SHORT from plugin");
+    Mockito.when(plugin.getString(LONG_KEY)).thenReturn("LONG from plugin");
+
+    HTMLNode shortNode = opt.getShortDescNode(plugin);
+    HTMLNode longNode = opt.getLongDescNode(plugin);
+
+    assertEquals("SHORT from plugin", shortNode.generate());
+    assertEquals("LONG from plugin", longNode.generate());
+  }
+}


### PR DESCRIPTION
Summary
- Improve parsing and error reporting across config options: IntOption, LongOption, ShortOption, StringOption, StringArrOption, BooleanOption, BandwidthOption, and the Option base type.
- Clarify display semantics (toString vs toDisplayString), use IEC units when appropriate, and avoid unnecessary boxing for primitive types.
- Enrich Javadoc across the config package and refine OptionFormatException docs/messages.
- Add comprehensive unit tests for options (parsing, formatting, callback/restart behavior, and persistence/display strings).

Commits since develop (most recent first)
- a21a606f62 test(config): add StringOption unit tests; improve Javadoc for StringOption
- c9cff45edf fix(config): improve StringArrOption parse/format and add tests
- 3225081df0 refactor(config): clarify ShortOption docs and error handling
- 4e8908dd5d docs(config): clarify OptionFormatException Javadoc and inline comments
- cf7958963b fix(config): improve LongOption parsing, error messages, and display
- 37b279dc07 test(config): add BooleanOption tests and Javadoc
- dfe1a85b97 test(config): add BandwidthOption parsing tests
- f1f50069dd refactor(config): IntOption parsing/docs cleanup; tests expanded
- 295ba2e6b4 chore(config): format sources with Spotless

Files changed (highlights)
- src/main/java/network/crypta/config/{BandwidthOption,BooleanOption,IntOption,LongOption,ShortOption,StringArrOption,StringOption,Option,OptionFormatException,SubConfig}.java
- src/test/java/network/crypta/config/{BandwidthOptionTest,BooleanOptionTest,IntOptionTest,LongOptionTest,ShortOptionTest,StringArrOptionTest,StringOptionTest}.java

Notes
- Working tree was clean locally; no pending files required commit.
- Spotless was previously applied in commits; no additional formatting changes needed.
- Base branch: develop; Head branch: feature/fix-config-options.

Validation
- Local inspection of diffs and unit test additions.
- Please run the full Gradle test suite in CI to validate and collect coverage.

Checklist
- [ ] CI: gradlew test (JUnit 6) and jacocoTestReport should pass
- [ ] Review Javadoc updates for clarity and accuracy
- [ ] Confirm no public API breaks in network.crypta.config