### PR TITLE
test(config): fix PersistentConfigTest to match Option Meta constructor

### DIFF
--- a/src/test/java/network/crypta/config/PersistentConfigTest.java
+++ b/src/test/java/network/crypta/config/PersistentConfigTest.java
@@ -120,11 +120,7 @@ class PersistentConfigTest {
                             // No-op for test stub (intentionally empty)
                           }
                         },
-                        0,
-                        false,
-                        false,
-                        null,
-                        null,
+                        /* meta= */ null,
                         Option.DataType.STRING)
                     .defaultAnswer(org.mockito.Mockito.RETURNS_DEFAULTS));
 


### PR DESCRIPTION
Summary
- Fixes Mockito InstantiationException on Ubuntu CI in PersistentConfigTest.onRegister_whenMatchingSFSValue_setsTrimmedInitialValue.
- Root cause: Option was refactored to use a Meta record; the test still tried to call the old constructor with individual parameters. Mockito’s partial mock could not find a matching constructor and failed to instantiate the class.

User-visible changes
- None; test-only change.

Technical details
- Updated the Mockito partial mock to call Option(SubConfig, String, ConfigCallback, Meta, DataType) and pass null for Meta (handled by Option with sensible defaults) and DataType.STRING.
- File: src/test/java/network/crypta/config/PersistentConfigTest.java

Why this is safe
- Only affects tests. The behavior under test (trimming value before setInitialValue) remains the same.

Reproduction
- Before: ./gradlew test --tests *PersistentConfigTest.onRegister_whenMatchingSFSValue_setsTrimmedInitialValue would throw a Mockito InstantiationException.
- After: test passes locally.

Validation
- Ran targeted test and entire PersistentConfigTest class locally. Also ran full test task locally.

Related code
- Option constructor at src/main/java/network/crypta/config/Option.java:86

Commits in this PR
- 2535c78cb6 test(config): fix PersistentConfigTest for Option Meta constructor

Notes
- Ran ./gradlew spotlessApply before committing to satisfy formatting.
