### PR TITLE
store: BlockMetadata tests and documentation improvements

### DIFF
--- a/src/main/java/network/crypta/store/BlockMetadata.java
+++ b/src/main/java/network/crypta/store/BlockMetadata.java
@@ -1,28 +1,50 @@
 package network.crypta.store;
 
-/** Metadata returned from the datastore along with a block */
+/**
+ * Mutable metadata describing properties of a datastore block.
+ *
+ * <p>Instances accompany blocks read from the store and influence higher-level caching and
+ * advertising decisions. This type is a simple value holder and performs no validation or
+ * synchronization; callers are responsible for any required thread-safety when sharing instances
+ * across threads.
+ */
 public final class BlockMetadata {
 
   /**
-   * If true, the block is old, that is, it was added to the store prior to 1224, or it was added
-   * since but only because low physical seclevel caused everything to be cached. In other words, if
-   * this is true, we cannot be sure that the block *should* be cached, so others should only know
-   * about it if we are actually transmitting the data.
+   * Flag indicating that the block originates from legacy or opportunistic caching.
+   *
+   * <p>When {@code true}, the block was either persisted before build 1224 or cached because a low
+   * physical security level caused all traffic to be written to the datastore. In such cases we
+   * cannot assert that it should be cached or advertised to peers; other nodes should learn about
+   * it only when we actively transmit the data.
    */
   private boolean oldBlock;
 
+  /**
+   * Clear all metadata and restore default values.
+   *
+   * <p>Postcondition: {@link #isOldBlock()} returns {@code false}.
+   */
   public void reset() {
     oldBlock = false;
   }
 
   /**
-   * If true, the block should not be cached i.e. it was either added before 1224, or it was only
-   * cached because of writing everything to the datastore including local and nearby requests.
+   * Report whether the block should be treated as "old" and therefore not proactively cached or
+   * advertised.
+   *
+   * @return {@code true} if the block predates build 1224 or was cached only due to global
+   *     write-to-store settings (e.g., low physical security level); {@code false} otherwise.
    */
   public boolean isOldBlock() {
     return oldBlock;
   }
 
+  /**
+   * Mark the block as originating from legacy or opportunistic caching.
+   *
+   * <p>Postcondition: {@link #isOldBlock()} returns {@code true}.
+   */
   public void setOldBlock() {
     oldBlock = true;
   }

--- a/src/test/java/network/crypta/store/BlockMetadataTest.java
+++ b/src/test/java/network/crypta/store/BlockMetadataTest.java
@@ -1,0 +1,94 @@
+package network.crypta.store;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@SuppressWarnings("java:S100")
+class BlockMetadataTest {
+
+  @Test
+  @DisplayName("isOldBlock is false for a new instance")
+  void isOldBlock_whenNewInstance_expectFalse() {
+    // Arrange
+    BlockMetadata metadata = new BlockMetadata();
+
+    // Act
+    boolean result = metadata.isOldBlock();
+
+    // Assert
+    assertFalse(result, "New BlockMetadata should default to not old");
+  }
+
+  @Test
+  @DisplayName("setOldBlock sets the flag to true")
+  void setOldBlock_whenCalled_expectTrue() {
+    // Arrange
+    BlockMetadata metadata = new BlockMetadata();
+
+    // Act
+    metadata.setOldBlock();
+
+    // Assert
+    assertTrue(metadata.isOldBlock(), "setOldBlock should mark block as old");
+  }
+
+  @Test
+  @DisplayName("reset clears the old flag after being set")
+  void reset_whenAfterSetOldBlock_expectFalse() {
+    // Arrange
+    BlockMetadata metadata = new BlockMetadata();
+    metadata.setOldBlock();
+
+    // Act
+    metadata.reset();
+
+    // Assert
+    assertFalse(metadata.isOldBlock(), "reset should clear the old flag");
+  }
+
+  @ParameterizedTest(name = "ops={0} -> isOldBlock={1}")
+  @CsvSource({
+    "'', false",
+    "S, true",
+    "R, false",
+    "SS, true",
+    "RR, false",
+    "SR, false",
+    "RS, true",
+    "SRS, true",
+    "RSR, false"
+  })
+  @DisplayName("Final state after operation sequence matches expectation")
+  void finalState_afterOperationSequence_expectExpectedValue(String ops, boolean expected) {
+    // Arrange
+    BlockMetadata metadata = new BlockMetadata();
+
+    // Act
+    applyOps(metadata, ops == null ? "" : ops);
+
+    // Assert
+    if (expected) {
+      assertTrue(metadata.isOldBlock(), "Expected old=true after ops: " + ops);
+    } else {
+      assertFalse(metadata.isOldBlock(), "Expected old=false after ops: " + ops);
+    }
+  }
+
+  private static void applyOps(BlockMetadata metadata, String ops) {
+    for (int i = 0; i < ops.length(); i++) {
+      char c = ops.charAt(i);
+      if (c == 'S') {
+        metadata.setOldBlock();
+      } else if (c == 'R') {
+        metadata.reset();
+      } else {
+        throw new IllegalArgumentException("Unknown op '" + c + "' in sequence: " + ops);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Add comprehensive JUnit 6 tests for BlockMetadata covering default state, set/reset transitions, and a parameterized sequence table.
- Improve Javadoc for BlockMetadata: clarify purpose, semantics of the legacy/opportunistic caching flag, and postconditions for reset() and setOldBlock().

Details
- Tests: src/test/java/network/crypta/store/BlockMetadataTest.java
  - Parameterized sequences: "", S, R, SS, RR, SR, RS, SRS, RSR
  - Deterministic, Mockito not required (no collaborators)
- Docs: src/main/java/network/crypta/store/BlockMetadata.java (comments only; no code changes)

Validation
- Ran: ./gradlew test --tests 'network.crypta.store.BlockMetadataTest' → PASS
- Ran full suite once: ./gradlew test → PASS
- Ran: ./gradlew spotlessApply prior to commit

Notes
- No functional changes in production code; comments only.
- Conventional commit messages used.
