### PR TITLE
Refactor WrapperConfig to meet SonarLint; add focused tests

### DIFF
--- a/src/main/java/network/crypta/config/WrapperConfig.java
+++ b/src/main/java/network/crypta/config/WrapperConfig.java
@@ -24,6 +24,10 @@ import org.tanukisoftware.wrapper.WrapperManager;
 public class WrapperConfig {
   private static final Logger LOG = LoggerFactory.getLogger(WrapperConfig.class);
 
+  private WrapperConfig() {
+    throw new IllegalStateException("Utility class");
+  }
+
   private static final HashMap<String, String> overrides = new HashMap<>();
 
   public static String getWrapperProperty(String name) {
@@ -81,6 +85,33 @@ public class WrapperConfig {
       newConfig = new File("wrapper.conf.new");
       wrapperDir = ".";
     }
+
+    try {
+      writeUpdatedConfig(oldConfig, newConfig, name, value);
+    } catch (IOException e) {
+      if (oldConfig.exists()) {
+        try {
+          java.nio.file.Files.deleteIfExists(newConfig.toPath());
+        } catch (IOException ioe) {
+          LOG.warn(
+              "Failed to delete temporary wrapper config: {} ({}).", newConfig, ioe.toString());
+        }
+      }
+      LOG.error("Unable to update wrapper property '{}': {}", name, e, e);
+      return false;
+    }
+
+    if (!replaceOldConfigWithNew(oldConfig, newConfig, wrapperDir, name)) {
+      return false;
+    }
+
+    // Wrapper properties are read-only, so don't setProperty().
+    overrides.put(name, value);
+    return true;
+  }
+
+  private static void writeUpdatedConfig(File oldConfig, File newConfig, String name, String value)
+      throws IOException {
     try (FileInputStream fis = new FileInputStream(oldConfig);
         BufferedInputStream bis = new BufferedInputStream(fis);
         InputStreamReader isr = new InputStreamReader(bis);
@@ -90,12 +121,10 @@ public class WrapperConfig {
         BufferedWriter bw = new BufferedWriter(osw)) {
 
       String line;
-
       boolean written = false;
       boolean writtenReload = false;
 
       while ((line = br.readLine()) != null) {
-
         if (line.startsWith(name + "=")) {
           bw.write(name + '=' + value + '\n');
           written = true;
@@ -109,17 +138,24 @@ public class WrapperConfig {
 
       if (!written) bw.write(name + '=' + value + '\n');
       if (!writtenReload) bw.write("wrapper.restart.reload_configuration=TRUE\n");
+    }
+  }
 
-    } catch (IOException e) {
-      if (oldConfig.exists()) newConfig.delete();
-      LOG.error("Cannot update wrapper property " + "name: " + e, e);
-      System.err.println("Unable to update wrapper property " + name + " : " + e);
-      return false;
+  private static boolean replaceOldConfigWithNew(
+      File oldConfig, File newConfig, String wrapperDir, String name) {
+    if (newConfig.renameTo(oldConfig)) {
+      return true;
     }
 
-    if (!newConfig.renameTo(oldConfig)) {
-      File oldOldConfig = new File(wrapperDir + "/wrapper.conf.old");
-      if (oldOldConfig.exists() && !oldOldConfig.delete())
+    File oldOldConfig = new File(wrapperDir + "/wrapper.conf.old");
+    if (oldOldConfig.exists()) {
+      boolean deletionFailed = false;
+      try {
+        java.nio.file.Files.deleteIfExists(oldOldConfig.toPath());
+      } catch (IOException e) {
+        deletionFailed = true;
+      }
+      if (deletionFailed) {
         try {
           oldOldConfig =
               File.createTempFile(wrapperDir + "/wrapper.conf", ".old.tmp", new File("."));
@@ -128,47 +164,44 @@ public class WrapperConfig {
               "Unable to create temporary file and unable to copy wrapper.conf to wrapper.conf.old."
                   + " Could not update wrapper.conf trying to set property "
                   + name;
-          LOG.error(error);
-          System.err.println(error);
+          LOG.error(error, e);
           return false;
-        }
-      if (!oldConfig.renameTo(oldOldConfig)) {
-        String error =
-            "Unable to change property "
-                + name
-                + ": Could not move old config file "
-                + oldConfig
-                + ", so could not rename new config file "
-                + newConfig
-                + " over it (already tried without deleting.";
-        LOG.error(error);
-        System.err.println(error);
-        return false;
-      }
-      if (!newConfig.renameTo(oldConfig)) {
-        String error =
-            "Unable to rename "
-                + newConfig
-                + " to "
-                + oldConfig
-                + " even after moving the old config file out of the way! Trying to restore"
-                + " previous config file so the node will start up...";
-        LOG.error(error);
-        System.err.println(error);
-        if (!oldOldConfig.renameTo(oldConfig)) {
-          System.err.println(
-              "CATASTROPHIC UPDATE ERROR: Unable to rename backup copy of config file over the"
-                  + " current config file, after failing to update config file! The node will not"
-                  + " boot until you get a new wrapper.conf!\n"
-                  + "The old config file is saved in "
-                  + oldOldConfig
-                  + " and it should be renamed to wrapper.conf");
-          System.exit(NodeInitException.EXIT_BROKE_WRAPPER_CONF);
         }
       }
     }
-    // Wrapper properties are read-only, so don't setProperty().
-    overrides.put(name, value);
+
+    if (!oldConfig.renameTo(oldOldConfig)) {
+      String error =
+          "Unable to change property "
+              + name
+              + ": Could not move old config file "
+              + oldConfig
+              + ", so could not rename new config file "
+              + newConfig
+              + " over it (already tried without deleting.";
+      LOG.error(error);
+      return false;
+    }
+
+    if (!newConfig.renameTo(oldConfig)) {
+      String error =
+          "Unable to rename "
+              + newConfig
+              + " to "
+              + oldConfig
+              + " even after moving the old config file out of the way! Trying to restore"
+              + " previous config file so the node will start up...";
+      LOG.error(error);
+      if (!oldOldConfig.renameTo(oldConfig)) {
+        LOG.error(
+            "CATASTROPHIC UPDATE ERROR: Unable to rename backup copy of config file over the"
+                + " current config file, after failing to update config file! The node will not"
+                + " boot until you get a new wrapper.conf!\n"
+                + "The old config file is saved in {} and it should be renamed to wrapper.conf",
+            oldOldConfig);
+        System.exit(NodeInitException.EXIT_BROKE_WRAPPER_CONF);
+      }
+    }
     return true;
   }
 }

--- a/src/test/java/network/crypta/config/WrapperConfigTest.java
+++ b/src/test/java/network/crypta/config/WrapperConfigTest.java
@@ -1,0 +1,254 @@
+package network.crypta.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tanukisoftware.wrapper.WrapperManager;
+
+@SuppressWarnings({"java:S100", "java:S3011"})
+@ExtendWith(MockitoExtension.class)
+class WrapperConfigTest {
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // Clear static overrides map to avoid cross-test pollution
+    Field f = WrapperConfig.class.getDeclaredField("overrides");
+    f.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, String> map = (Map<String, String>) f.get(null);
+    map.clear();
+
+    // Ensure repository-root wrapper artifacts are absent before each test
+    cleanupRootWrapperFiles();
+  }
+
+  @AfterEach
+  void tearDown() {
+    cleanupRootWrapperFiles();
+  }
+
+  private static Path repoRoot() {
+    return Path.of(System.getProperty("user.dir")).toAbsolutePath();
+  }
+
+  @SuppressWarnings(
+      "java:S1166") // best-effort cleanup in tests; ignoring deletion failures is OK here
+  private static void cleanupRootWrapperFiles() {
+    try {
+      Path root = repoRoot();
+      Path wrapperDir = root.resolve("wrapper");
+      // Top-level variants
+      Files.deleteIfExists(root.resolve("wrapper.conf"));
+      Files.deleteIfExists(root.resolve("wrapper.conf.new"));
+      Files.deleteIfExists(root.resolve("wrapper.conf.old"));
+      // Nested variants under wrapper/
+      Files.deleteIfExists(wrapperDir.resolve("wrapper.conf"));
+      Files.deleteIfExists(wrapperDir.resolve("wrapper.conf.new"));
+      Files.deleteIfExists(wrapperDir.resolve("wrapper.conf.old"));
+    } catch (IOException ignore) {
+      // ignore cleanup errors
+    }
+  }
+
+  @Test
+  void getWrapperProperty_whenOverridePresent_returnsOverride() throws Exception {
+    // Arrange
+    Field f = WrapperConfig.class.getDeclaredField("overrides");
+    f.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, String> map = (Map<String, String>) f.get(null);
+    map.put("my.prop", "override");
+
+    // Also mock WrapperManager to prove override takes precedence
+    try (MockedStatic<WrapperManager> mocked = Mockito.mockStatic(WrapperManager.class)) {
+      Properties props = new Properties();
+      props.setProperty("my.prop", "fromWrapper");
+      mocked.when(WrapperManager::getProperties).thenReturn(props);
+
+      // Act
+      String value = WrapperConfig.getWrapperProperty("my.prop");
+
+      // Assert
+      assertEquals("override", value);
+    }
+  }
+
+  @Test
+  void getWrapperProperty_whenNoOverride_readsFromWrapperManager() {
+    // Arrange
+    try (MockedStatic<WrapperManager> mocked = Mockito.mockStatic(WrapperManager.class)) {
+      Properties props = new Properties();
+      props.setProperty("foo", "bar");
+      mocked.when(WrapperManager::getProperties).thenReturn(props);
+
+      // Act
+      String value = WrapperConfig.getWrapperProperty("foo");
+
+      // Assert
+      assertEquals("bar", value);
+    }
+  }
+
+  @Test
+  void getWrapperProperty_whenAbsent_returnsNull() {
+    // Arrange
+    try (MockedStatic<WrapperManager> mocked = Mockito.mockStatic(WrapperManager.class)) {
+      Properties props = new Properties();
+      mocked.when(WrapperManager::getProperties).thenReturn(props);
+
+      // Act
+      String value = WrapperConfig.getWrapperProperty("does.not.exist");
+
+      // Assert
+      assertNull(value);
+    }
+  }
+
+  @Test
+  void canChangeProperties_whenNotUnderWrapper_returnsFalse() {
+    // Arrange
+    try (MockedStatic<WrapperManager> mocked = Mockito.mockStatic(WrapperManager.class)) {
+      mocked.when(WrapperManager::isControlledByNativeWrapper).thenReturn(false);
+
+      // Act / Assert
+      assertFalse(WrapperConfig.canChangeProperties());
+    }
+  }
+
+  @Test
+  void canChangeProperties_whenWrapperConfMissing_returnsFalse() {
+    // Arrange
+    try (MockedStatic<WrapperManager> mocked = Mockito.mockStatic(WrapperManager.class)) {
+      mocked.when(WrapperManager::isControlledByNativeWrapper).thenReturn(true);
+
+      // No wrapper.conf anywhere under tempDir
+      // Act / Assert
+      assertFalse(WrapperConfig.canChangeProperties());
+    }
+  }
+
+  @Test
+  void canChangeProperties_whenReadableWritable_parentWritable_returnsTrue() throws IOException {
+    // Arrange
+    try (MockedStatic<WrapperManager> mocked = Mockito.mockStatic(WrapperManager.class)) {
+      mocked.when(WrapperManager::isControlledByNativeWrapper).thenReturn(true);
+
+      Path wrapper = repoRoot().resolve("wrapper");
+      Files.createDirectories(wrapper);
+      Path conf = wrapper.resolve("wrapper.conf");
+      Files.writeString(conf, "# test conf\n");
+
+      // Act / Assert
+      assertTrue(WrapperConfig.canChangeProperties());
+    }
+  }
+
+  @Test
+  @Tag("io")
+  void setWrapperProperty_whenPropertyExists_updatesValueAndKeepsReload() throws Exception {
+    // Arrange: wrapper/wrapper.conf exists with the target property and reload flag present
+    Path wrapper = repoRoot().resolve("wrapper");
+    Files.createDirectories(wrapper);
+    Path conf = wrapper.resolve("wrapper.conf");
+    String initial =
+        String.join(
+            "\n",
+            "foo=bar",
+            "my.key=old",
+            "wrapper.restart.reload_configuration=TRUE",
+            "other=val");
+    Files.writeString(conf, initial + "\n");
+
+    // Act
+    boolean ok = WrapperConfig.setWrapperProperty("my.key", "new");
+
+    // Assert
+    assertTrue(ok);
+    String content = Files.readString(conf, StandardCharsets.UTF_8);
+    // Ensure updated exactly once and reload flag preserved exactly once
+    assertTrue(content.contains("my.key=new"));
+    assertFalse(content.contains("my.key=old"));
+
+    long reloadCount =
+        content
+            .lines()
+            .filter(l -> l.equalsIgnoreCase("wrapper.restart.reload_configuration=TRUE"))
+            .count();
+    assertEquals(1L, reloadCount);
+
+    // And getWrapperProperty should reflect the override set by setWrapperProperty
+    try (MockedStatic<WrapperManager> mocked = Mockito.mockStatic(WrapperManager.class)) {
+      Properties props = new Properties();
+      mocked.when(WrapperManager::getProperties).thenReturn(props);
+      assertEquals("new", WrapperConfig.getWrapperProperty("my.key"));
+    }
+  }
+
+  @Test
+  @Tag("io")
+  void setWrapperProperty_whenMissingProperty_appendsPropertyAndReload() throws Exception {
+    // Arrange: wrapper.conf without the target property and without reload flag
+    Path wrapper = repoRoot().resolve("wrapper");
+    Files.createDirectories(wrapper);
+    Path conf = wrapper.resolve("wrapper.conf");
+    Files.writeString(conf, "foo=bar\n");
+
+    // Act
+    boolean ok = WrapperConfig.setWrapperProperty("added.key", "value");
+
+    // Assert
+    assertTrue(ok);
+    String content = Files.readString(conf, StandardCharsets.UTF_8);
+    assertTrue(content.contains("added.key=value"));
+    assertTrue(content.toLowerCase().contains("wrapper.restart.reload_configuration=true"));
+  }
+
+  @Test
+  @Tag("io")
+  void setWrapperProperty_whenNoWrapperConf_returnsFalse() {
+    // Arrange: no wrapper/ and no top-level wrapper.conf
+    // Act
+    boolean ok = WrapperConfig.setWrapperProperty("k", "v");
+
+    // Assert
+    assertFalse(ok);
+    // Ensure no config files were created implicitly
+    Path root = repoRoot();
+    assertFalse(Files.exists(root.resolve("wrapper.conf")));
+    assertFalse(Files.exists(root.resolve("wrapper.conf.new")));
+  }
+
+  @Test
+  @Tag("io")
+  void setWrapperProperty_whenTopLevelConf_updatesUsingFallbackLocation() throws Exception {
+    // Arrange: Only top-level wrapper.conf exists (no wrapper/ directory)
+    Path conf = repoRoot().resolve("wrapper.conf");
+    Files.writeString(conf, "foo=bar\n");
+
+    // Act
+    boolean ok = WrapperConfig.setWrapperProperty("top.level", "ok");
+
+    // Assert
+    assertTrue(ok);
+    String content = Files.readString(conf, StandardCharsets.UTF_8);
+    assertTrue(content.contains("top.level=ok"));
+    assertTrue(content.toLowerCase().contains("wrapper.restart.reload_configuration=true"));
+  }
+}


### PR DESCRIPTION
Summary
- Refactors `WrapperConfig` to reduce cognitive complexity by extracting helper methods:
  - `writeUpdatedConfig(...)` handles read/modify/write of wrapper.conf
  - `replaceOldConfigWithNew(...)` encapsulates rename/backup/restore flow
- Replaces System.err usage with SLF4J logging
- Uses NIO `Files.deleteIfExists` for clearer error handling on temp/backup deletion
- Adds `WrapperConfigTest` covering overrides, property reads, permission checks, and update paths

Why
- SonarLint flagged high cognitive complexity (S3776), direct System.err usage (S106), and ignoring return values of `File.delete` (S899/S4042). This change addresses all three without altering behavior.

Behavior
- No feature changes. The code continues to:
  - Update or append the target property
  - Ensure `wrapper.restart.reload_configuration=TRUE` is present exactly once
  - Attempt atomic-ish replacement with `.old` backup and restoration on failure

Testing
- New tests: `src/test/java/network/crypta/config/WrapperConfigTest.java`
- Local runs:
  - `./gradlew test --tests "*WrapperConfigTest"` → PASS
  - `./gradlew sonarlintFile -Psonarlint.file=src/main/java/network/crypta/config/WrapperConfig.java` → No issues
  - `./gradlew test` full suite → PASS

Notes
- Formatting via Spotless is clean.
- Branch: `feature/fix-WrapperConfig` targeting `develop`.
