### PR TITLE
docs(store): improve package-level docs and KeyCollisionException Javadoc

### DIFF
--- a/src/main/java/network/crypta/store/KeyCollisionException.java
+++ b/src/main/java/network/crypta/store/KeyCollisionException.java
@@ -5,14 +5,35 @@ import network.crypta.support.LightweightException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Signals that a store operation would insert a block under a routing key that already exists.
+ *
+ * <p>Store implementations throw this exception when an insert collides with an existing entry and
+ * overwriting is not allowed. It extends {@link LightweightException} because collisions are an
+ * expected control-flow outcome on hot paths; by default, no stack trace is captured to avoid the
+ * associated overhead.
+ *
+ * <p>Diagnostics: when debug logging is enabled for this class, stack traces are captured to aid
+ * troubleshooting. See {@link #shouldFillInStackTrace()}.
+ *
+ * @see FreenetStore#put(StorableBlock, byte[], byte[], boolean, boolean)
+ * @see LightweightException
+ */
 public class KeyCollisionException extends LightweightException {
-  private static final Logger LOG = LoggerFactory.getLogger(KeyCollisionException.class);
-
   @Serial private static final long serialVersionUID = -1;
 
-  static {
-  }
+  private static final Logger LOG = LoggerFactory.getLogger(KeyCollisionException.class);
 
+  /**
+   * Enables stack-trace capture only when debug logging is active.
+   *
+   * <p>Collisions are common in normal operation; omitting stack traces keeps them inexpensive to
+   * throw and catch. Turning on debug logging for this class opts into full traces for deeper
+   * diagnostics.
+   *
+   * @return {@code true} if {@link Logger#isDebugEnabled()} is {@code true}; {@code false}
+   *     otherwise.
+   */
   @Override
   protected boolean shouldFillInStackTrace() {
     return LOG.isDebugEnabled();

--- a/src/main/java/network/crypta/store/package-info.java
+++ b/src/main/java/network/crypta/store/package-info.java
@@ -1,7 +1,55 @@
 /**
- * Datastore implementations. These classes store key:block pairs, either on disk or in memory. This
- * package provides adapters to store different types of blocks (SSKs, CHKs, pubkeys), with each
- * actual store storing one key type, but the node itself will have multiple such stores, for
- * different purposes (e.g. short term caching vs long term storage).
+ * Storage layer for immutable blocks addressed by routing keys.
+ *
+ * <p>This package defines the {@link network.crypta.store.FreenetStore} SPI and concrete
+ * implementations that persist or cache key–block pairs. Stores operate on a single block type per
+ * instance (e.g., CHK, SSK, or pubkey) and are typically composed by the node to serve different
+ * roles such as short‑term caching and long‑term persistence.
+ *
+ * <h2>Concepts</h2>
+ *
+ * <ul>
+ *   <li><b>Routing key</b>: the primary lookup key used by stores (a byte array).
+ *   <li><b>Full key</b>: additional key material used by higher layers to validate or construct a
+ *       {@link network.crypta.store.StorableBlock}.
+ *   <li><b>Block metadata</b>: optional hints passed to {@code fetch} that do not change stored
+ *       content but may influence construction or selection strategies.
+ * </ul>
+ *
+ * <h2>Concurrency</h2>
+ *
+ * <p>Thread-safety is implementation-defined. Many implementations are designed to be used by
+ * multiple threads; consult the class documentation for guarantees and contention behavior.
+ *
+ * <h2>Error handling</h2>
+ *
+ * <ul>
+ *   <li>Persistent failures (e.g., disk access) surface as {@link java.io.IOException}.
+ *   <li>Attempting to insert an existing key without overwrite permission throws {@link
+ *       network.crypta.store.KeyCollisionException}. This exception is lightweight by default to
+ *       keep collisions inexpensive on hot paths.
+ * </ul>
+ *
+ * <h2>Typical usage</h2>
+ *
+ * <pre>{@code
+ * FreenetStore<StorableBlock> store = ...;
+ * // Fetch by routing key; returns null when not present
+ * StorableBlock block = store.fetch(routingKey, fullKey, false,
+ *     /* canReadClientCache *-/ true,
+ *     /* canReadSlashdotCache *-/ true,
+ *     /* ignoreOldBlocks *-/ false,
+ *     /* meta *-/ null);
+ *
+ * // Insert; may throw KeyCollisionException if overwrite=false and key exists
+ * store.put(block, data, header, /* overwrite *-/ false, /* oldBlock *-/ false);
+ * }</pre>
+ *
+ * @see network.crypta.store.FreenetStore
+ * @see network.crypta.store.StorableBlock
+ * @see network.crypta.store.BlockMetadata
+ * @see network.crypta.store.KeyCollisionException
+ * @see network.crypta.store.caching.CachingFreenetStore
+ * @see network.crypta.store.saltedhash.SaltedHashFreenetStore
  */
 package network.crypta.store;


### PR DESCRIPTION
Summary
- Clarify package purpose, concepts, concurrency guarantees, and error handling in `network.crypta.store` package-level Javadoc.
- Add usage example for `fetch`/`put` and relevant @see references in `package-info.java`.
- Document collision semantics and lightweight diagnostics for `KeyCollisionException` (stack traces enabled only when debug logging is active).

Scope
- Comments only; no functional changes.
- Files changed:
  - src/main/java/network/crypta/store/package-info.java
  - src/main/java/network/crypta/store/KeyCollisionException.java

Rationale
- Improves API discoverability and onboarding for storage layer.
- Aligns docs with current behavior (LightweightException semantics; collision handling on hot paths).

Formatting
- Ran `./gradlew spotlessApply`.

Branch diff
```
$ git log --oneline develop..HEAD
3ac1663c78 docs(store): improve package-level docs and KeyCollisionException Javadoc
```

Change summary
```
$ git show --stat -1 HEAD
2 files changed, 77 insertions(+), 8 deletions(-)
```

Testing
- Build not required for comment-only change.
- Verified Spotless passes locally.

Risk
- None; documentation-only.

Checklist
- [x] Conventional commit message
- [x] No public API signature changes
- [x] Spotless formatting applied
