### PR TITLE
feat(store): harden CipherManager and add unit tests

### DIFF
--- a/src/main/java/network/crypta/store/saltedhash/CipherManager.java
+++ b/src/main/java/network/crypta/store/saltedhash/CipherManager.java
@@ -4,6 +4,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import network.crypta.crypt.BlockCipher;
 import network.crypta.crypt.PCFBMode;
@@ -12,18 +13,18 @@ import network.crypta.crypt.UnsupportedCipherException;
 import network.crypta.crypt.ciphers.Rijndael;
 import network.crypta.node.MasterKeys;
 import network.crypta.support.ByteArrayWrapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Cipher Manager
+ * Manages key digestion and symmetric encryption for salted-hash stores.
  *
- * <p>Manage all kind of digestion and encryption in store
+ * <p>This class derives and caches SHA-256 digests of routing keys, and encrypts/decrypts {@link
+ * SaltedHashFreenetStore.Entry} payloads using AES (Rijndael-256) in {@link PCFBMode}. The
+ * per-store {@code salt} is combined with a per-entry IV to form a 256-bit IV used by the cipher.
  *
- * @author sdiz
+ * <p>Thread safety: the digest cache is synchronized. The {@code encrypt} and {@code decrypt}
+ * methods mutate the provided entry and must not be called concurrently for the same entry.
  */
 public class CipherManager {
-  private static final Logger LOG = LoggerFactory.getLogger(CipherManager.class);
 
   /** The actual salt. 16 bytes. */
   private final byte[] salt;
@@ -31,6 +32,16 @@ public class CipherManager {
   /** The original on-disk salt, may be encrypted. 16 bytes. */
   private final byte[] diskSalt;
 
+  /**
+   * Creates a new manager bound to a specific store salt.
+   *
+   * <p>The {@code salt} is used for digest computation and as part of the cipher IV. The {@code
+   * diskSalt} preserves the original 16-byte value as stored on disk (which may be encrypted) so it
+   * can be persisted or exposed as needed by callers within the package.
+   *
+   * @param salt 16-byte salt used for digests and IV derivation; not copied.
+   * @param diskSalt 16-byte salt as read from disk; not copied.
+   */
   CipherManager(byte[] salt, byte[] diskSalt) {
     assert salt.length == 0x10;
     this.salt = salt;
@@ -38,16 +49,23 @@ public class CipherManager {
   }
 
   /**
-   * Get salt
+   * Returns the on-disk salt value.
    *
-   * @return salt
+   * <p>The returned array is the internal reference and must be treated as read-only by callers in
+   * the same package.
+   *
+   * @return the 16-byte on-disk salt (may be encrypted).
    */
   byte[] getDiskSalt() {
     return diskSalt;
   }
 
-  /** Cache for digested keys */
-  @SuppressWarnings("serial")
+  /**
+   * LRU-like cache of digested routing keys.
+   *
+   * <p>Bounded to 128 entries by overriding {@code removeEldestEntry} on a {@code LinkedHashMap} to
+   * limit memory usage.
+   */
   private final Map<ByteArrayWrapper, byte[]> digestRoutingKeyCache =
       new LinkedHashMap<>() {
         @Override
@@ -57,10 +75,13 @@ public class CipherManager {
       };
 
   /**
-   * Get digested routing key
+   * Computes the salted SHA-256 digest of a routing key.
    *
-   * @param plainKey
-   * @return
+   * <p>The digest is {@code SHA-256(plainKey || salt)} and is cached for reuse. The returned array
+   * is a new 32-byte value owned by the cache; callers must not modify it.
+   *
+   * @param plainKey routing key in plaintext; not retained by this method
+   * @return 32-byte digest of the routing key
    */
   byte[] getDigestedKey(byte[] plainKey) {
     ByteArrayWrapper key = new ByteArrayWrapper(plainKey);
@@ -83,58 +104,100 @@ public class CipherManager {
     return hashedRoutingKey;
   }
 
-  /** Encrypt this entry */
+  /**
+   * Encrypts an entry's header and data in place.
+   *
+   * <p>Generates a new 16-byte per-entry IV, derives the cipher IV as {@code salt || entryIV}, and
+   * encrypts {@code header} and {@code data} using PCFB with AES-256 and the entry's plain routing
+   * key. Marks the entry as encrypted and computes its digested key for later lookups.
+   *
+   * @param entry entry to encrypt; mutated on success
+   * @param random source of randomness for IV generation
+   * @throws UnsupportedOperationException if the cipher cannot be initialized
+   */
   void encrypt(SaltedHashFreenetStore<?>.Entry entry, Random random) {
     if (entry.isEncrypted) return;
 
     entry.dataEncryptIV = new byte[16];
     random.nextBytes(entry.dataEncryptIV);
 
-    PCFBMode cipher = makeCipher(entry.dataEncryptIV, entry.plainRoutingKey);
-    cipher.blockEncipher(entry.header, 0, entry.header.length);
-    cipher.blockEncipher(entry.data, 0, entry.data.length);
+    encipher(makeCipher(entry.dataEncryptIV, entry.plainRoutingKey), entry.header, entry.data);
 
     entry.getDigestedRoutingKey();
     entry.isEncrypted = true;
   }
 
   /**
-   * Verify and decrypt this entry
+   * Verifies the routing key and decrypts an entry in place.
    *
-   * @param routingKey
-   * @return <code>true</code> if the <code>routeKey</code> match and the entry is decrypted.
+   * <p>If the entry is already decrypted, simply checks that the plain routing key matches the
+   * provided {@code routingKey}. Otherwise, it verifies the digested routing key (when the plain
+   * key is unknown) or the plain key itself, and decrypts the header and data using the derived
+   * PCFB/AES-256 cipher. On success, the entry is marked as decrypted.
+   *
+   * @param entry entry to verify and decrypt; mutated on success
+   * @param routingKey candidate plain routing key
+   * @return {@code true} if {@code routingKey} matches and decryption succeeds; {@code false}
+   *     otherwise
+   * @throws UnsupportedOperationException if the cipher cannot be initialized
    */
   boolean decrypt(SaltedHashFreenetStore<?>.Entry entry, byte[] routingKey) {
     assert entry.header != null;
     assert entry.data != null;
 
     if (!entry.isEncrypted) {
-      // Already decrypted
+      // Entry is already decrypted; verify caller-provided key matches the stored one.
       return Arrays.equals(entry.plainRoutingKey, routingKey);
     }
 
     if (entry.plainRoutingKey != null) {
-      // we knew the key
+      // Plain key is known; require exact match.
       if (!Arrays.equals(entry.plainRoutingKey, routingKey)) {
         return false;
       }
     } else {
-      // we do not know the plain key, let's check the digest
+      // Plain key unknown; verify by comparing digests.
       if (!Arrays.equals(entry.digestedRoutingKey, getDigestedKey(routingKey))) return false;
     }
 
     entry.plainRoutingKey = routingKey;
 
-    PCFBMode cipher = makeCipher(entry.dataEncryptIV, entry.plainRoutingKey);
-    cipher.blockDecipher(entry.header, 0, entry.header.length);
-    cipher.blockDecipher(entry.data, 0, entry.data.length);
+    decipher(makeCipher(entry.dataEncryptIV, entry.plainRoutingKey), entry.header, entry.data);
 
     entry.isEncrypted = false;
 
     return true;
   }
 
-  /** Create PCFBMode object for this key */
+  /*
+   * Encrypts header and data buffers using the supplied cipher instance.
+   * PCFB is stateful; the order of operations is preserved between encipher/decipher pairs.
+   */
+  private static void encipher(PCFBMode cipher, byte[] header, byte[] data) {
+    Objects.requireNonNull(cipher).blockEncipher(header, 0, header.length);
+    Objects.requireNonNull(cipher).blockEncipher(data, 0, data.length);
+  }
+
+  /*
+   * Decrypts header and data buffers using the supplied cipher instance.
+   * Mirrors {@link #encipher(PCFBMode, byte[], byte[])} in call order.
+   */
+  private static void decipher(PCFBMode cipher, byte[] header, byte[] data) {
+    Objects.requireNonNull(cipher).blockDecipher(header, 0, header.length);
+    Objects.requireNonNull(cipher).blockDecipher(data, 0, data.length);
+  }
+
+  /**
+   * Creates a PCFB cipher configured for the given key and IV.
+   *
+   * <p>The 256-bit IV is {@code salt || iv}. The cipher uses Rijndael with a 256-bit block size and
+   * a key as provided by the caller. The returned instance is ready for block operations.
+   *
+   * @param iv 16-byte per-entry IV
+   * @param key key bytes for {@link Rijndael#initialize(byte[])}; not validated here
+   * @return initialized {@link PCFBMode} instance
+   * @throws UnsupportedOperationException if the platform does not support the configured cipher
+   */
   PCFBMode makeCipher(byte[] iv, byte[] key) {
     byte[] iv2 = new byte[0x20]; // 256 bits
 
@@ -147,11 +210,22 @@ public class CipherManager {
 
       return PCFBMode.create(aes, iv2);
     } catch (UnsupportedCipherException e) {
-      LOG.error("Rijndael not supported!", e);
-      throw new Error("Rijndael not supported!", e);
+      // Rethrow with context; caller is responsible for handling/logging.
+      throw new UnsupportedOperationException(
+          "Failed to initialize PCFB/AES-256 cipher (Rijndael unsupported): keyLen="
+              + (key == null ? -1 : key.length)
+              + ", ivLen="
+              + iv2.length,
+          e);
     }
   }
 
+  /**
+   * Clears sensitive material held by this instance.
+   *
+   * <p>Overwrites the in-memory {@code salt} and {@code diskSalt} arrays via {@link
+   * MasterKeys#clear(byte[])}. After shutdown, this instance should not be used.
+   */
   public void shutdown() {
     MasterKeys.clear(salt);
     MasterKeys.clear(diskSalt);

--- a/src/test/java/network/crypta/store/saltedhash/CipherManagerTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/CipherManagerTest.java
@@ -1,0 +1,348 @@
+package network.crypta.store.saltedhash;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Random;
+import network.crypta.crypt.SHA256;
+import network.crypta.node.SemiOrderedShutdownHook;
+import network.crypta.store.BlockMetadata;
+import network.crypta.store.StorableBlock;
+import network.crypta.store.StoreCallback;
+import network.crypta.support.PooledExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.TrivialTicker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings({
+  "java:S100",
+  "java:S3011"
+}) // naming; reflection accessibility for test scaffolding
+class CipherManagerTest {
+
+  @TempDir File tmp;
+
+  private static final int RK_LEN = 32;
+  private static final int HDR_LEN = 16;
+  private static final int DATA_LEN = 32;
+
+  private static byte[] seq(int len, int start) {
+    byte[] b = new byte[len];
+    for (int i = 0; i < len; i++) b[i] = (byte) (start + i);
+    return b;
+  }
+
+  // ----- Basic helpers -----
+
+  private CipherManager newCipherManager() {
+    byte[] salt = seq(16, 0xA0);
+    byte[] diskSalt = Arrays.copyOf(salt, salt.length);
+    return new CipherManager(salt, diskSalt);
+  }
+
+  private SaltedHashFreenetStore<StubBlock> newStore(String name) throws Exception {
+    StoreCallback<StubBlock> cb = new StubCallback();
+    Random weak = new Random(1234);
+    Ticker ticker = new TrivialTicker(new PooledExecutor());
+    // Minimal store, not started; used only to instantiate Entry via reflection.
+    return SaltedHashFreenetStore.construct(
+        tmp, name, cb, weak, 2, false, SemiOrderedShutdownHook.get(), false, false, ticker, null);
+  }
+
+  private SaltedHashFreenetStore<StubBlock>.Entry newEntry(
+      SaltedHashFreenetStore<StubBlock> store, byte[] rk, byte[] header, byte[] data)
+      throws Exception {
+    @SuppressWarnings("rawtypes")
+    Class inner = Class.forName("network.crypta.store.saltedhash.SaltedHashFreenetStore$Entry");
+    @SuppressWarnings("unchecked")
+    Constructor<SaltedHashFreenetStore<StubBlock>.Entry> ctor =
+        inner.getDeclaredConstructor(
+            SaltedHashFreenetStore.class,
+            byte[].class,
+            byte[].class,
+            byte[].class,
+            boolean.class,
+            boolean.class);
+    ctor.setAccessible(true);
+    return ctor.newInstance(store, rk, header, data, false, false);
+  }
+
+  private void setStoreCipherManager(SaltedHashFreenetStore<?> store, CipherManager cm)
+      throws Exception {
+    Field f = SaltedHashFreenetStore.class.getDeclaredField("cipherManager");
+    f.setAccessible(true);
+    f.set(store, cm);
+  }
+
+  // ----- Tests: getDigestedKey -----
+
+  @Test
+  void getDigestedKey_deterministicAndCached() {
+    CipherManager cm = newCipherManager();
+    byte[] rk = seq(RK_LEN, 0x10);
+
+    byte[] d1 = cm.getDigestedKey(rk);
+    assertNotNull(d1);
+    assertEquals(32, d1.length);
+
+    // Same array → same cached instance
+    byte[] d2 = cm.getDigestedKey(rk);
+    assertSame(d1, d2, "should return cached array instance");
+
+    // Equal content on a different array → same cached instance
+    byte[] rkCopy = rk.clone();
+    byte[] d3 = cm.getDigestedKey(rkCopy);
+    assertSame(d1, d3, "cache should use value semantics for keys");
+
+    // Content check: SHA-256(plainKey || salt)
+    MessageDigest md = SHA256.getMessageDigest();
+    md.update(rk);
+    md.update(seq(16, 0xA0)); // salt used by newCipherManager()
+    byte[] expected = md.digest();
+    assertArrayEquals(expected, d1);
+  }
+
+  @Test
+  void getDigestedKey_whenNull_throwsNPE() {
+    CipherManager cm = newCipherManager();
+    assertThrows(NullPointerException.class, () -> cm.getDigestedKey(null));
+  }
+
+  @Test
+  void getDigestedKey_lruEvictsOldest() {
+    CipherManager cm = newCipherManager();
+    // Insert 128 distinct keys + 1 to trigger LRU eviction of the eldest
+    byte[] firstKey = new byte[RK_LEN];
+    firstKey[0] = 0;
+    byte[] firstDigest = cm.getDigestedKey(firstKey);
+
+    for (int i = 1; i <= 128; i++) {
+      byte[] k = new byte[RK_LEN];
+      k[0] = (byte) i;
+      cm.getDigestedKey(k);
+    }
+
+    byte[] again = cm.getDigestedKey(firstKey);
+    assertArrayEquals(firstDigest, again, "digest bytes remain the same");
+    assertNotSame(firstDigest, again, "evicted eldest should produce a new array instance");
+  }
+
+  // ----- Tests: makeCipher -----
+
+  @Test
+  void makeCipher_roundTrip_success() {
+    CipherManager cm = newCipherManager();
+    byte[] iv = seq(16, 0x40);
+    byte[] key = seq(RK_LEN, 0x20);
+    byte[] data = seq(64, 0x55);
+    byte[] enc = data.clone();
+
+    cm.makeCipher(iv, key).blockEncipher(enc, 0, enc.length);
+    assertFalse(Arrays.equals(data, enc), "ciphertext should differ from plaintext");
+
+    cm.makeCipher(iv, key).blockDecipher(enc, 0, enc.length);
+    assertArrayEquals(data, enc, "decipher should restore original bytes");
+  }
+
+  @Test
+  void makeCipher_differentIvOrSalt_changesCiphertext() {
+    byte[] key = seq(RK_LEN, 0x33);
+    byte[] data = seq(48, 0x66);
+
+    CipherManager cm1 = newCipherManager();
+    byte[] iv1 = seq(16, 0x01);
+    byte[] c1 = data.clone();
+    cm1.makeCipher(iv1, key).blockEncipher(c1, 0, c1.length);
+
+    // Different IV with same salt
+    byte[] iv2 = seq(16, 0x02);
+    byte[] c2 = data.clone();
+    cm1.makeCipher(iv2, key).blockEncipher(c2, 0, c2.length);
+    assertFalse(Arrays.equals(c1, c2), "different IV must change ciphertext");
+
+    // Different salt (new CipherManager)
+    CipherManager cm2 = new CipherManager(seq(16, 0xB0), seq(16, 0xB0));
+    byte[] c3 = data.clone();
+    cm2.makeCipher(iv1, key).blockEncipher(c3, 0, c3.length);
+    assertFalse(Arrays.equals(c1, c3), "different salt must change ciphertext");
+  }
+
+  // ----- Tests: encrypt / decrypt -----
+
+  @Test
+  void encrypt_thenDecrypt_withCorrectKey_roundTrips() throws Exception {
+    CipherManager cm = newCipherManager();
+    try (SaltedHashFreenetStore<StubBlock> store = newStore("cm-roundtrip")) {
+      setStoreCipherManager(store, cm); // ensure Entry.getDigestedRoutingKey() uses the same salt
+
+      byte[] rk = seq(RK_LEN, 0x10);
+      byte[] header = seq(HDR_LEN, 0x70);
+      byte[] data = seq(DATA_LEN, 0x80);
+      SaltedHashFreenetStore<StubBlock>.Entry entry = newEntry(store, rk, header, data);
+
+      byte[] headerOrig = entry.header.clone();
+      byte[] dataOrig = entry.data.clone();
+
+      Random rnd = new Random(1337);
+      cm.encrypt(entry, rnd);
+      assertTrue(entry.isEncrypted);
+      assertEquals(16, entry.dataEncryptIV.length);
+      assertFalse(Arrays.equals(headerOrig, entry.header));
+      assertFalse(Arrays.equals(dataOrig, entry.data));
+
+      assertTrue(cm.decrypt(entry, rk));
+      assertFalse(entry.isEncrypted);
+      assertArrayEquals(headerOrig, entry.header);
+      assertArrayEquals(dataOrig, entry.data);
+    }
+  }
+
+  @Test
+  void decrypt_whenWrongKey_returnsFalseAndDoesNotMutate() throws Exception {
+    CipherManager cm = newCipherManager();
+    try (SaltedHashFreenetStore<StubBlock> store = newStore("cm-wrongkey")) {
+      setStoreCipherManager(store, cm);
+      byte[] rk = seq(RK_LEN, 0x22);
+      byte[] wrong = rk.clone();
+      wrong[0] ^= 0x7F;
+      SaltedHashFreenetStore<StubBlock>.Entry entry =
+          newEntry(store, rk, seq(HDR_LEN, 0x11), seq(DATA_LEN, 0x22));
+
+      cm.encrypt(entry, new Random(7));
+      byte[] encHeader = entry.header.clone();
+      byte[] encData = entry.data.clone();
+
+      assertFalse(cm.decrypt(entry, wrong));
+      assertTrue(entry.isEncrypted, "entry must remain encrypted");
+      assertArrayEquals(encHeader, entry.header, "header must not change on failed decrypt");
+      assertArrayEquals(encData, entry.data, "data must not change on failed decrypt");
+    }
+  }
+
+  @Test
+  void decrypt_whenAlreadyDecrypted_returnsBooleanByKeyMatch() throws Exception {
+    CipherManager cm = newCipherManager();
+    try (SaltedHashFreenetStore<StubBlock> store = newStore("cm-notencrypted")) {
+      byte[] rk = seq(RK_LEN, 0x44);
+      SaltedHashFreenetStore<StubBlock>.Entry entry =
+          newEntry(store, rk, seq(HDR_LEN, 0x33), seq(DATA_LEN, 0x55));
+
+      // By constructor this entry is not encrypted.
+      assertFalse(entry.isEncrypted);
+      assertTrue(cm.decrypt(entry, rk));
+      assertFalse(cm.decrypt(entry, seq(RK_LEN, 0x45)));
+      assertFalse(entry.isEncrypted);
+    }
+  }
+
+  // ----- Tests: shutdown & disk salt -----
+
+  @Test
+  void shutdown_clearsSaltAndDiskSalt() {
+    byte[] salt = seq(16, 0x60);
+    byte[] diskSalt = seq(16, 0x61);
+    CipherManager cm = new CipherManager(salt, diskSalt);
+
+    cm.shutdown();
+    assertArrayEquals(new byte[16], salt, "salt must be zeroized");
+    assertArrayEquals(new byte[16], diskSalt, "diskSalt must be zeroized");
+  }
+
+  @Test
+  void getDiskSalt_returnsOriginalArray() {
+    byte[] salt = seq(16, 0x10);
+    byte[] diskSalt = seq(16, 0x11);
+    CipherManager cm = new CipherManager(salt, diskSalt);
+
+    byte[] got = cm.getDiskSalt();
+    assertSame(diskSalt, got);
+    assertArrayEquals(diskSalt, got);
+  }
+
+  // ----- Test scaffolding -----
+
+  private static final class StubBlock implements StorableBlock {
+    private final byte[] routingKey;
+    private final byte[] fullKey;
+
+    StubBlock(byte[] routingKey, byte[] fullKey) {
+      this.routingKey = routingKey;
+      this.fullKey = fullKey;
+    }
+
+    @Override
+    public byte[] getRoutingKey() {
+      return routingKey;
+    }
+
+    @Override
+    public byte[] getFullKey() {
+      return fullKey;
+    }
+  }
+
+  private static final class StubCallback extends StoreCallback<StubBlock> {
+    @Override
+    public int dataLength() {
+      return DATA_LEN;
+    }
+
+    @Override
+    public int headerLength() {
+      return HDR_LEN;
+    }
+
+    @Override
+    public int routingKeyLength() {
+      return RK_LEN;
+    }
+
+    @Override
+    public boolean storeFullKeys() {
+      return false;
+    }
+
+    @Override
+    public boolean constructNeedsKey() {
+      return false;
+    }
+
+    @Override
+    public int fullKeyLength() {
+      return 64;
+    }
+
+    @Override
+    public boolean collisionPossible() {
+      return false;
+    }
+
+    @Override
+    public StubBlock construct(
+        byte[] data,
+        byte[] headers,
+        byte[] routingKey,
+        byte[] fullKey,
+        boolean canReadClientCache,
+        boolean canReadSlashdotCache,
+        BlockMetadata meta,
+        network.crypta.crypt.DSAPublicKey knownPubKey) {
+      return new StubBlock(routingKey, fullKey);
+    }
+
+    @Override
+    public byte[] routingKeyFromFullKey(byte[] keyBuf) {
+      return Arrays.copyOf(keyBuf, RK_LEN);
+    }
+  }
+
+  // No per-test global setup/teardown needed; stores are closed in each test.
+}


### PR DESCRIPTION
This PR hardens the salted-hash `CipherManager` and adds a comprehensive unit test suite.

Summary
- Add detailed Javadoc and clarify responsibilities
- Replace `Error` with `UnsupportedOperationException` and improve messages
- Extract small encipher/decipher helpers; minor cleanup
- Preserve PCFB/AES-256 semantics; IV derived from `salt||entryIV`
- Add `CipherManagerTest` for digests, cipher round-trip, encrypt/decrypt, shutdown
- Apply Spotless formatting (no functional changes beyond the above)

Diff vs develop
```
 .../crypta/store/saltedhash/CipherManager.java     | 132 ++++++--
 .../crypta/store/saltedhash/CipherManagerTest.java | 348 +++++++++++++++++++++
 2 files changed, 451 insertions(+), 29 deletions(-)
```

Notes
- Targets Java 21+ as per project config.
- JUnit 6 tests included; coverage should improve for the salted-hash store.

Please review with focus on exception types/messages and the IV derivation path to ensure no behavior regressions for existing store data.
