### PR TITLE
test(store): fix SimpleGetPubkeyTest to match new PubkeyStore.put signature

### DIFF
--- a/src/test/java/network/crypta/store/SimpleGetPubkeyTest.java
+++ b/src/test/java/network/crypta/store/SimpleGetPubkeyTest.java
@@ -112,7 +112,7 @@ class SimpleGetPubkeyTest {
         hash, key, deep, canWriteClientCache, canWriteDatastore, forULPR, writeLocalToDatastore);
 
     // Assert
-    verify(store).put(same(hash), same(key), eq(false));
+    verify(store).put(same(key), eq(false));
     verifyNoMoreInteractions(store);
   }
 
@@ -122,11 +122,11 @@ class SimpleGetPubkeyTest {
     // Arrange
     byte[] hash = new byte[] {0x11, 0x22};
     DSAPublicKey key = org.mockito.Mockito.mock(DSAPublicKey.class);
-    doThrow(new IOException("write failed")).when(store).put(hash, key, false);
+    doThrow(new IOException("write failed")).when(store).put(key, false);
 
     // Act & Assert (no throw)
     subject.cacheKey(hash, key, false, false, false, false, false);
-    verify(store).put(same(hash), same(key), eq(false));
+    verify(store).put(same(key), eq(false));
     verifyNoMoreInteractions(store);
   }
 }


### PR DESCRIPTION
This PR updates only `src/test/java/network/crypta/store/SimpleGetPubkeyTest.java` to align with the `PubkeyStore.put` signature change.

Changes
- Update verifications and exception stubbing to `store.put(key, false)`
- Keep `getKey` tests and assertions as-is

Scope
- No production code changes
- No other files modified

Build/CI
- JUnit 6 remains the test platform
- No Gradle flags changed

Please review. If desired, I can run the full Gradle test suite locally; otherwise CI should validate.
