### PR TITLE
fix(store): tighten LockManager semantics; add concurrency tests

### DIFF
--- a/src/main/java/network/crypta/store/saltedhash/LockManager.java
+++ b/src/main/java/network/crypta/store/saltedhash/LockManager.java
@@ -10,25 +10,50 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Lock Manager
+ * Coordinates exclusive access to long-indexed entries.
  *
- * <p>Handle locking/unlocking of individual offsets.
+ * <p>This manager serializes access to entries addressed by a {@code long} offset. At any given
+ * time, at most one thread holds the lock for a specific offset. Successful acquisition returns a
+ * {@link Condition} that represents the ownership token; the caller must pass that same instance to
+ * {@link #unlockEntry(long, Condition)} to release the lock and signal the next waiter.
+ *
+ * <p>Locks are not reentrant and ownership is not tracked per thread. Do not attempt to acquire
+ * more than one offset lock at a time (doing so may deadlock), except for the special Cleaner
+ * thread referenced by the original design. Acquisition uses a timed wait to periodically re-check
+ * the shutdown flag and to tolerate spurious wakeups.
+ *
+ * <p>After {@link #shutdown()} is called, no new locks are granted and the method blocks until all
+ * outstanding locks are released.
+ *
+ * <p>Thread safety: all methods are thread-safe. Methods may block.
  *
  * @author sdiz
  */
 public class LockManager {
   private static final Logger LOG = LoggerFactory.getLogger(LockManager.class);
+  // Set to true to refuse new acquisitions and to allow waiters to exit promptly.
   private volatile boolean shutdown;
+  // Single lock guarding access to the map and backing all per-entry Conditions.
   private final Lock entryLock = new ReentrantLock();
+  // Presence of a key indicates that the corresponding offset is currently locked. The associated
+  // Condition is used to await/signal hand-off to the next waiter.
   private final Map<Long, Condition> lockMap = new HashMap<>();
 
   LockManager() {}
 
   /**
-   * Lock the entry
+   * Acquires exclusive access for the given offset.
    *
-   * <p>This lock is <strong>not</strong> re-entrance. No threads except Cleaner should hold more
-   * then one lock at a time (or deadlock may occur).
+   * <p>The returned {@link Condition} is the ownership token. Callers must eventually invoke {@link
+   * #unlockEntry(long, Condition)} with the same {@code Condition} instance to release the lock and
+   * wake one waiting thread, if any.
+   *
+   * <p>This lock is <strong>not</strong> reentrant. No threads except the Cleaner should hold more
+   * than one offset lock at a time because no global acquisition order is enforced.
+   *
+   * @param offset entry identifier to lock
+   * @return the {@code Condition} representing the acquired lock, or {@code null} if the manager is
+   *     shutting down or the thread is interrupted while waiting
    */
   Condition lockEntry(long offset) {
     if (LOG.isTraceEnabled()) LOG.trace("try locking {}", offset);
@@ -41,8 +66,14 @@ public class LockManager {
           if (shutdown) return null;
 
           Condition lockCond = lockMap.get(offset);
-          if (lockCond != null) lockCond.await(10, TimeUnit.SECONDS); // 10s for checking shutdown
-          else break;
+          if (lockCond != null) {
+            // Wait in bounded intervals so we periodically re-check the shutdown flag and tolerate
+            // spurious/missed signals (loop condition re-validates ownership availability).
+            boolean signaled = lockCond.await(10, TimeUnit.SECONDS);
+            if (!signaled && shutdown) {
+              return null;
+            }
+          } else break;
         } while (true);
         condition = entryLock.newCondition();
         lockMap.put(offset, condition);
@@ -51,6 +82,8 @@ public class LockManager {
       }
     } catch (InterruptedException e) {
       LOG.error("lock interrupted", e);
+      // Restore the interrupt status so higher layers can observe it.
+      Thread.currentThread().interrupt();
       return null;
     }
 
@@ -58,7 +91,16 @@ public class LockManager {
     return condition;
   }
 
-  /** Unlock the entry */
+  /**
+   * Releases the lock for {@code offset} and signals one waiting thread.
+   *
+   * <p>The {@code condition} argument must be the exact instance returned by the corresponding
+   * successful call to {@link #lockEntry(long)}; passing a different instance is a programming
+   * error and will trigger the assertion in debug builds.
+   *
+   * @param offset entry identifier to unlock
+   * @param condition the ownership token previously returned by {@code lockEntry}
+   */
   void unlockEntry(long offset, Condition condition) {
     if (LOG.isTraceEnabled()) LOG.trace("unlocking {}", offset);
 
@@ -66,19 +108,28 @@ public class LockManager {
     try {
       Condition cond = lockMap.remove(offset);
       assert cond == condition;
+      // Signal after removal so the next waiter can observe the map state as unlocked.
       cond.signal();
     } finally {
       entryLock.unlock();
     }
   }
 
-  /** Shutdown and wait for all entries unlocked */
+  /**
+   * Initiates shutdown and waits until all locks are released.
+   *
+   * <p>After this call sets the shutdown flag, new calls to {@link #lockEntry(long)} return {@code
+   * null}. The method then blocks until the {@linkplain #unlockEntry(long, Condition) owners} of
+   * all currently held locks release them. If a caller leaks a lock, this method may block
+   * indefinitely.
+   */
   void shutdown() {
     shutdown = true;
     entryLock.lock();
     try {
       while (!lockMap.isEmpty()) {
         Condition cond = lockMap.values().iterator().next();
+        // Wait for a holder to release and signal; uninterruptible to ensure progress to empty.
         cond.awaitUninterruptibly();
       }
     } finally {

--- a/src/test/java/network/crypta/store/saltedhash/LockManagerTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/LockManagerTest.java
@@ -1,0 +1,186 @@
+package network.crypta.store.saltedhash;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class LockManagerTest {
+
+  private final ExecutorService executor = Executors.newCachedThreadPool();
+
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+  }
+
+  @Test
+  void lockEntry_whenNotLocked_returnsNonNullCondition() {
+    // Arrange
+    LockManager manager = new LockManager();
+
+    // Act
+    Condition cond = manager.lockEntry(42L);
+
+    // Assert
+    assertNotNull(cond, "First lock acquire should return a condition");
+    manager.unlockEntry(42L, cond);
+  }
+
+  @Test
+  void lockEntry_concurrentOnSameOffset_blocksUntilUnlock() throws Exception {
+    // Arrange
+    LockManager manager = new LockManager();
+    Condition first = manager.lockEntry(1L);
+    assertNotNull(first);
+
+    // Act
+    Future<Condition> secondFuture = executor.submit(() -> manager.lockEntry(1L));
+
+    // Assert (does not complete before unlock)
+    assertThrows(
+        TimeoutException.class,
+        () -> {
+          try {
+            secondFuture.get(200, MILLISECONDS);
+          } catch (InterruptedException | ExecutionException e) {
+            throw new AssertionError(e);
+          }
+        });
+
+    // Act (now unlock and ensure the waiter proceeds)
+    manager.unlockEntry(1L, first);
+
+    Condition second = secondFuture.get(2, SECONDS);
+    assertNotNull(second, "Second acquire should succeed after unlock");
+
+    // Cleanup
+    manager.unlockEntry(1L, second);
+  }
+
+  @Test
+  void lockEntry_afterShutdown_returnsNull() {
+    // Arrange
+    LockManager manager = new LockManager();
+
+    // Act
+    manager.shutdown();
+    Condition cond = manager.lockEntry(100L);
+
+    // Assert
+    assertNull(cond, "Lock acquire after shutdown must return null");
+  }
+
+  @Test
+  void lockEntry_whenInterrupted_returnsNull() throws Exception {
+    // Arrange
+    LockManager manager = new LockManager();
+    Condition held = manager.lockEntry(5L);
+    assertNotNull(held);
+
+    AtomicReference<Condition> resultRef = new AtomicReference<>();
+    CountDownLatch started = new CountDownLatch(1);
+    Thread t =
+        new Thread(
+            () -> {
+              started.countDown();
+              resultRef.set(manager.lockEntry(5L));
+            },
+            "lock-waiter");
+
+    // Act
+    t.start();
+    // Ensure the waiter has started attempting to lock before we interrupt
+    assertTrue(
+        started.await(2, SECONDS), "Waiter thread did not begin lock attempt within timeout");
+    t.interrupt();
+    t.join(2000);
+
+    // Assert
+    assertNull(resultRef.get(), "Interrupted waiter should observe null from lockEntry");
+
+    // Cleanup
+    manager.unlockEntry(5L, held);
+  }
+
+  @Test
+  void shutdown_waitsUntilAllEntriesUnlocked() throws Exception {
+    // Arrange
+    LockManager manager = new LockManager();
+    Condition c1 = manager.lockEntry(11L);
+    Condition c2 = manager.lockEntry(22L);
+    assertNotNull(c1);
+    assertNotNull(c2);
+
+    CountDownLatch shutdownDone = new CountDownLatch(1);
+    Thread shutdownThread =
+        new Thread(
+            () -> {
+              manager.shutdown();
+              shutdownDone.countDown();
+            },
+            "shutdown-thread");
+
+    // Act: start shutdown in parallel
+    shutdownThread.start();
+
+    // Assert: should not finish until both locks are released
+    assertFalse(
+        shutdownDone.await(200, MILLISECONDS), "Shutdown should be waiting for locks to release");
+
+    manager.unlockEntry(11L, c1);
+    assertFalse(
+        shutdownDone.await(200, MILLISECONDS), "Shutdown should still wait for remaining locks");
+
+    manager.unlockEntry(22L, c2);
+    assertTrue(shutdownDone.await(3, SECONDS), "Shutdown should complete after all unlocks");
+
+    // After shutdown, further lock attempts must return null
+    assertNull(manager.lockEntry(33L));
+  }
+
+  @Test
+  void unlockEntry_whenOffsetNotLocked_throwsAssertionOrNpe() {
+    // Arrange
+    LockManager manager = new LockManager();
+    Condition bogus = new ReentrantLock().newCondition();
+
+    // Act + Assert: either AssertionError (asserts enabled) or NPE (asserts disabled)
+    Callable<Void> call =
+        () -> {
+          manager.unlockEntry(123L, bogus);
+          return null; // unreachable when an exception is thrown
+        };
+
+    if (assertionsEnabled()) {
+      assertThrows(AssertionError.class, call::call);
+    } else {
+      assertThrows(NullPointerException.class, call::call);
+    }
+  }
+
+  // Helper: detect whether JVM assertions are enabled for this class
+  @SuppressWarnings({"AssertWithSideEffects", "ConstantValue"})
+  private static boolean assertionsEnabled() {
+    boolean enabled = false;
+    assert enabled = true; // set to true when -ea is active
+    return enabled;
+  }
+}


### PR DESCRIPTION
Summary
- Clarify and harden LockManager semantics.
- Preserve interrupt status on InterruptedException.
- Use bounded await with periodic shutdown re-checks and toleration for spurious wakeups.
- Expand Javadoc to document ownership token, non-reentrancy, and shutdown behavior.
- Add JUnit 6 concurrency tests covering:
  - single-holder exclusivity and waiter handoff
  - shutdown waiting for outstanding locks and blocking new acquisitions
  - interrupted waiter path returning null
  - unlock with non-owned offset asserts

Diff (vs develop)
- Modified: `src/main/java/network/crypta/store/saltedhash/LockManager.java`
- Added: `src/test/java/network/crypta/store/saltedhash/LockManagerTest.java`

Rationale
- Existing code awaited on a condition without explicitly restoring the interrupt flag, which can hide interrupts from higher layers.
- Timed waits (10s) allow periodic shutdown checks and are resilient to spurious/missed signals.
- Clearer Javadoc reduces misuse (e.g., unlocking with a different Condition instance; attempting multiple offset locks without ordering).

Testing
- New tests pass locally; branch is ahead of `develop` by 1 commit.
- JUnit 6 (per project config) used for tests.

Formatting & Policy
- Ran `./gradlew spotlessApply` prior to commit; build reported BUILD SUCCESSFUL.
- Changes pushed on `feature/fix-LockManager` (no commits on `develop`/`main`).

Notes
- The repository prefers Kotlin for new files; this test is currently Java to keep close to the class under test. If desired, I can port the test to Kotlin in a follow-up.
