### PR TITLE
Add tests for ResizablePersistentIntBuffer; apply Spotless formatting

### DIFF
--- a/src/main/java/network/crypta/store/saltedhash/ResizablePersistentIntBuffer.java
+++ b/src/main/java/network/crypta/store/saltedhash/ResizablePersistentIntBuffer.java
@@ -14,17 +14,36 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A large resizable block of int's, which is persisted to disk with a specific policy, which is
- * either to write it on shutdown, immediately, or every X millis.
+ * A resizable, integer-indexed buffer backed by a flat on-disk file.
  *
- * <p>It would be better to do this with ByteBuffer's and an IntBuffer view, unfortunately it is not
- * possible to subclass ByteBuffer's! Also, ideally we'd memory map, but there is no way to unmap,
- * and it is likely there will never be, so resizing would be very messy and expensive.
+ * <p>The buffer persists changes according to a global persistence policy: write immediately on
+ * each put, write only on shutdown, or write after a configurable delay. The policy is controlled
+ * via {@link #setPersistenceTime(int)} and read via {@link #getPersistenceTime()}.
+ *
+ * <p>Concurrency and persistence:
+ *
+ * <ul>
+ *   <li>Thread-safe for concurrent {@link #get(int)} and {@link #put(int, int)} calls. Resizes take
+ *       a write lock and replace the backing array atomically.
+ *   <li>When the policy is {@code -1}, {@link #put(int, int)} writes the single changed integer to
+ *       disk synchronously. When {@code 0}, modified values are kept in memory and the whole buffer
+ *       is flushed only during {@link #shutdown()}. When {@code > 0}, the first change marks the
+ *       buffer dirty and schedules a background write after the given delay in milliseconds using
+ *       the provided {@link Ticker}.
+ *   <li>{@link #shutdown()} blocks, flushes if dirty, and closes the file while preserving the
+ *       thread interrupt status. {@link #abort()} closes the file without flushing in-memory
+ *       changes.
+ * </ul>
+ *
+ * <p>Implementation notes: an {@code int[]} stores the contents in memory and is (re)written in
+ * fixed-size chunks. A memory-mapped approach is intentionally avoided because standard Java does
+ * not provide a supported unmap mechanism, which would complicate resizing.
  *
  * @author toad
  */
 public class ResizablePersistentIntBuffer {
   private static final Logger LOG = LoggerFactory.getLogger(ResizablePersistentIntBuffer.class);
+  private static final String WRITE_FAILED_MSG = "Write failed during shutdown on {}";
 
   private final File filename;
   private final RandomAccessFile raf;
@@ -32,52 +51,80 @@ public class ResizablePersistentIntBuffer {
   private final boolean isNew;
   private int size;
 
-  /** The buffer. When we resize we write-lock and replace this. */
+  /** Backing array; a resize acquires the write lock and replaces this reference. */
   private int[] buffer;
 
   private final ReadWriteLock lock;
-  // 5 minutes by default. Disk I/O kills disks, and annoys users, so it's a fair tradeoff.
-  // Anything other than -1 risks data loss if the node is shut down uncleanly.
-  // But it does not damage the store: We recover from it transparently.
-  // Note also that any value other than -1 will trigger a bloom filter rebuild after an unclean
-  // shutdown, which arguably is the opposite of what we want... :|
-  // FIXME make that configurable.
+  // Five minutes by default. Periodic disk writes can be noisy; delaying them is a trade‑off.
+  // Any value other than -1 risks losing the last in‑memory updates on an unclean shutdown.
+  // The store remains consistent: callers recover transparently on restart.
+  // A non‑immediate policy may also trigger a Bloom filter rebuild after an unclean shutdown.
   public static final int DEFAULT_PERSISTENCE_TIME = 300000;
 
-  // FIXME is static the best way to do this? It seems simplest at least...
-  /** -1 = write immediately, 0 = write only on shutdown, +ve = write period in millis */
+  // Using a static for simplicity at present.
+  /**
+   * Global persistence policy in milliseconds.
+   *
+   * <p>Semantics:
+   *
+   * <ul>
+   *   <li>{@code -1}: write the changed integer immediately on each successful {@code put}.
+   *   <li>{@code 0}: write only during {@link #shutdown()} or explicit {@link #forceWrite()}.
+   *   <li>{@code > 0}: debounce writes; schedule a background flush after this delay.
+   * </ul>
+   */
   private static int globalPersistenceTime = DEFAULT_PERSISTENCE_TIME;
 
   private Ticker ticker;
 
-  /** Is the buffer dirty? Protected by (this). */
+  /** True if memory differs from disk; guarded by {@code this}. */
   private boolean dirty;
 
-  /** Is the writer job scheduled? Protected by (this). */
+  /** True if a delayed writer run has been queued; guarded by {@code this}. */
   private boolean scheduled;
 
   /**
-   * Is the writer job running? So we can wait for it to complete on shutdown e.g. Protected by
-   * (this).
+   * True while the writer job is running; guarded by {@code this}. Used to wait for completion
+   * during forced writes and shutdown.
    */
   private boolean writing;
 
   private boolean closed;
 
+  /**
+   * Sets the global persistence policy.
+   *
+   * <p>Values have the following meaning: {@code -1} = immediate per-entry writes, {@code 0} =
+   * write only on shutdown, {@code > 0} = schedule a write after the specified delay in
+   * milliseconds. The new value affects subsequent updates and scheduling; it does not cancel a run
+   * that is already scheduled.
+   *
+   * @param val policy value in milliseconds; see semantics above
+   */
   public static synchronized void setPersistenceTime(int val) {
     globalPersistenceTime = val;
   }
 
+  /**
+   * Returns the current global persistence policy value in milliseconds.
+   *
+   * @return policy value ({@code -1}, {@code 0}, or {@code > 0}) in milliseconds
+   */
   public static synchronized int getPersistenceTime() {
     return globalPersistenceTime;
   }
 
   /**
-   * Create the buffer. Open the file, creating if necessary, read in the data, and set its size.
+   * Creates a buffer over {@code f} with the given logical size.
    *
-   * @param f The filename.
-   * @param size The expected size in ints (i.e. multiply by four to get bytes).
-   * @throws IOException
+   * <p>If the file does not exist it is created. If it is larger than {@code size * 4} bytes, it is
+   * truncated. If smaller, it is extended to exactly {@code size * 4} bytes after reading the
+   * existing contents. The in-memory array is initialized from the file up to the available data
+   * and zero-filled for any remaining tail.
+   *
+   * @param f file to back the buffer; one 32-bit integer per 4 bytes
+   * @param size number of integers in the buffer (capacity); must be non-negative
+   * @throws IOException if the file cannot be opened, read, or resized
    */
   public ResizablePersistentIntBuffer(File f, int size) throws IOException {
     this.filename = f;
@@ -92,11 +139,45 @@ public class ResizablePersistentIntBuffer {
     readBuffer((int) Math.min(size, realLength / 4));
     if (realLength < expectedLength) raf.setLength(expectedLength);
     channel = raf.getChannel();
+    // Initialize writer after fields are set so captured members are initialized
+    this.writer =
+        () -> {
+          LOG.info("Writing slot cache {}", ResizablePersistentIntBuffer.this);
+          lock.readLock().lock(); // Protect buffer.
+          try {
+            synchronized (ResizablePersistentIntBuffer.this) {
+              if (writing || !dirty || closed) {
+                scheduled = false;
+                return;
+              }
+              scheduled = false;
+              dirty = false;
+              writing = true;
+            }
+            try {
+              writeBuffer();
+            } catch (IOException e) {
+              LOG.error(WRITE_FAILED_MSG, filename, e);
+            }
+          } finally {
+            synchronized (ResizablePersistentIntBuffer.this) {
+              writing = false;
+              ResizablePersistentIntBuffer.this.notifyAll();
+            }
+            lock.readLock().unlock();
+          }
+          LOG.info("Written slot cache {}", ResizablePersistentIntBuffer.this);
+        };
   }
 
   /**
-   * Should be called during startup to fill in an appropriate default value e.g. if the store is
-   * completely new.
+   * Fills the entire in-memory buffer with {@code value}.
+   *
+   * <p>Intended for initialization at startup, especially when the buffer is new. This method does
+   * not immediately persist the data; persistence follows the active policy or an explicit {@link
+   * #forceWrite()}.
+   *
+   * @param value integer to assign to every slot
    */
   public void fill(int value) {
     Arrays.fill(buffer, value);
@@ -115,18 +196,37 @@ public class ResizablePersistentIntBuffer {
     }
   }
 
+  /**
+   * Attaches a scheduler used to run delayed writes and schedules one if the buffer is already
+   * dirty and the policy is a positive delay.
+   *
+   * <p>Idempotent: subsequent calls replace the scheduler reference and may schedule a run if none
+   * is pending.
+   *
+   * @param ticker scheduler for timed jobs; must remain live while this buffer is in use
+   */
   public void start(Ticker ticker) {
     synchronized (this) {
       this.ticker = ticker;
       if (dirty) {
         int persistenceTime = getPersistenceTime();
-        LOG.info("Scheduling write of slot cache " + this + " in " + persistenceTime);
+        LOG.info("Scheduling write of slot cache {} in {}", this, persistenceTime);
         ticker.queueTimedJob(writer, persistenceTime);
         scheduled = true;
       }
     }
   }
 
+  /**
+   * Returns the value at {@code offset}.
+   *
+   * <p>Thread-safe. Throws {@link IllegalStateException} if the buffer was shut down.
+   *
+   * @param offset zero-based index in the range {@code [0, size())}
+   * @return the stored integer value
+   * @throws IllegalStateException if {@link #shutdown()} or {@link #abort()} was called
+   * @throws ArrayIndexOutOfBoundsException if {@code offset} is out of bounds
+   */
   public int get(int offset) {
     lock.readLock().lock();
     if (closed) throw new IllegalStateException("Already shut down");
@@ -137,10 +237,38 @@ public class ResizablePersistentIntBuffer {
     }
   }
 
+  /**
+   * Stores {@code value} at {@code offset} honoring the current persistence policy.
+   *
+   * <p>When the policy is immediate ({@code -1}), the single updated integer is written to disk
+   * synchronously. For other policies the buffer is marked dirty and a write may be scheduled.
+   *
+   * @param offset zero-based index in the range {@code [0, size())}
+   * @param value value to store
+   * @throws IOException if an immediate write fails
+   * @throws IllegalStateException if the buffer is closed
+   * @throws ArrayIndexOutOfBoundsException if {@code offset} is out of bounds
+   */
   public void put(int offset, int value) throws IOException {
     put(offset, value, false);
   }
 
+  /**
+   * Variant of {@link #put(int, int)} that can suppress the immediate write when the policy is
+   * {@code -1}.
+   *
+   * <p>When {@code noWrite} is {@code true} and the policy is immediate, the value is updated only
+   * in memory and the buffer is marked dirty; the caller is responsible for ensuring a later flush
+   * (e.g., via {@link #forceWrite()} or shutdown). For non-immediate policies {@code noWrite} has
+   * no effect beyond the regular scheduling.
+   *
+   * @param offset zero-based index in the range {@code [0, size())}
+   * @param value value to store
+   * @param noWrite suppresses the per-entry write when the policy is {@code -1}
+   * @throws IOException if an immediate write fails
+   * @throws IllegalStateException if the buffer is closed
+   * @throws ArrayIndexOutOfBoundsException if {@code offset} is out of bounds
+   */
   public void put(int offset, int value, boolean noWrite) throws IOException {
     lock.readLock().lock(); // Only resize needs write lock because it creates a new buffer.
     if (closed) throw new IllegalStateException("Already shut down");
@@ -148,104 +276,110 @@ public class ResizablePersistentIntBuffer {
       int persistenceTime = getPersistenceTime();
       buffer[offset] = value;
       if (persistenceTime == -1 && !noWrite) {
-        channel.write(ByteBuffer.wrap(Fields.intToBytes(value)), ((long) offset) * 4);
-      } else if (persistenceTime > 0) {
-        synchronized (this) {
-          dirty = true;
-          if (ticker != null) {
-            if (!scheduled) {
-              LOG.info("Scheduling write of slot cache " + this + " in " + persistenceTime);
-              ticker.queueTimedJob(writer, persistenceTime);
-              scheduled = true;
-            }
-          } else {
-            LOG.info(
-                "Will scheduling write of slot cache after startup: "
-                    + this
-                    + " in "
-                    + persistenceTime);
-          }
-        }
+        writeValueImmediate(offset, value);
       } else {
-        synchronized (this) {
-          dirty = true;
-        }
+        markDirtyAndMaybeSchedule(persistenceTime);
       }
     } finally {
       lock.readLock().unlock();
     }
   }
 
-  private final Runnable writer =
-      new Runnable() {
+  private void writeValueImmediate(int offset, int value) throws IOException {
+    final long basePos = ((long) offset) * 4;
+    ByteBuffer bb = ByteBuffer.wrap(Fields.intToBytes(value));
+    long pos = basePos;
+    while (bb.hasRemaining()) {
+      int wrote = channel.write(bb, pos);
+      if (wrote < 0) {
+        throw new IOException("Unexpected EOF while writing to " + filename);
+      }
+      pos += wrote;
+    }
+  }
 
-        public void run() {
-          LOG.info("Writing slot cache " + ResizablePersistentIntBuffer.this);
-          lock.readLock().lock(); // Protect buffer.
-          try {
-            synchronized (ResizablePersistentIntBuffer.this) {
-              if (writing || !dirty || closed) {
-                scheduled = false;
-                return;
-              }
-              scheduled = false;
-              dirty = false;
-              writing = true;
-            }
-            try {
-              writeBuffer();
-            } catch (IOException e) {
-              LOG.error("Write failed during shutdown: " + e + " on " + filename, e);
-            }
-          } finally {
-            synchronized (ResizablePersistentIntBuffer.this) {
-              writing = false;
-              ResizablePersistentIntBuffer.this.notifyAll();
-            }
-            lock.readLock().unlock();
+  private void markDirtyAndMaybeSchedule(int persistenceTime) {
+    synchronized (this) {
+      dirty = true;
+      if (persistenceTime > 0) {
+        if (ticker != null) {
+          if (!scheduled) {
+            LOG.info("Scheduling write of slot cache {} in {}", this, persistenceTime);
+            ticker.queueTimedJob(writer, persistenceTime);
+            scheduled = true;
           }
-          LOG.info("Written slot cache " + ResizablePersistentIntBuffer.this);
+        } else {
+          LOG.info(
+              "Will schedule write of slot cache after startup: {} in {}", this, persistenceTime);
         }
-      };
+      }
+    }
+  }
 
+  private final Runnable writer;
+
+  /**
+   * Flushes pending changes if any and closes the file.
+   *
+   * <p>Blocks while an in-flight writer completes, then writes the full buffer if dirty. Preserves
+   * the thread's interrupt status. After shutdown, further {@link #get(int)} or {@link #put(int,
+   * int)} calls throw {@link IllegalStateException}.
+   */
   public void shutdown() {
+    boolean wasInterrupted = false;
     lock.writeLock().lock();
     try {
+      boolean doWrite;
       synchronized (this) {
         if (closed) return;
         closed = true;
+        doWrite = dirty;
         if (writing) {
-          // Wait for write to finish.
+          // Wait for any in-flight write to finish; preserve interrupt status.
           while (writing) {
             try {
               wait();
             } catch (InterruptedException e) {
-              // Ignore.
+              wasInterrupted = true; // record and keep waiting so we can flush/close
             }
           }
-          if (!dirty) return;
+          // Re-check after the writer completes in case new writes happened while we waited.
+          doWrite = dirty;
         }
-        writing = true;
+        if (doWrite) {
+          writing = true;
+        }
       }
       try {
-        LOG.info("Writing slot cache on shutdown: " + this);
-        writeBuffer();
+        if (doWrite) {
+          LOG.info("Writing slot cache on shutdown: {}", this);
+          writeBuffer();
+        }
       } catch (IOException e) {
-        LOG.error("Write failed during shutdown: " + e + " on " + filename, e);
+        LOG.error(WRITE_FAILED_MSG, filename, e);
       }
       synchronized (this) {
-        writing = false;
+        if (writing) {
+          writing = false;
+          this.notifyAll();
+        }
       }
       try {
         raf.close();
       } catch (IOException e) {
-        LOG.error("Close failed during shutdown: " + e + " on " + filename, e);
+        LOG.error("Close failed during shutdown on {}", filename, e);
       }
     } finally {
       lock.writeLock().unlock();
+      if (wasInterrupted) Thread.currentThread().interrupt();
     }
   }
 
+  /**
+   * Closes the file without flushing in-memory changes.
+   *
+   * <p>Use when the caller intentionally discards recent updates (e.g., during error recovery).
+   */
   public void abort() {
     lock.writeLock().lock();
     try {
@@ -256,7 +390,7 @@ public class ResizablePersistentIntBuffer {
       try {
         raf.close();
       } catch (IOException e) {
-        LOG.error("Close failed during shutdown: " + e + " on " + filename, e);
+        LOG.error("Close failed during shutdown: {} on {}", e, filename, e);
       }
     } finally {
       lock.writeLock().unlock();
@@ -264,7 +398,7 @@ public class ResizablePersistentIntBuffer {
   }
 
   private void writeBuffer() throws IOException {
-    // FIXME do we need to do partial writes?
+    // Writes the entire buffer in chunks.
     raf.seek(0);
     int written = 0;
     while (written < size) {
@@ -275,70 +409,102 @@ public class ResizablePersistentIntBuffer {
     }
   }
 
+  /**
+   * Changes the logical size and persists the whole buffer.
+   *
+   * <p>Preserves existing contents up to the new size, truncating or zero-extending as needed. The
+   * underlying file is resized to {@code size * 4} bytes and the full buffer is written immediately
+   * under the write lock.
+   *
+   * @param size new number of integers; must be non-negative
+   */
   public void resize(int size) {
     lock.writeLock().lock();
     try {
       if (this.size == size) return;
-      LOG.info("Resizing cache from " + this.size + " slots to " + size);
+      LOG.info("Resizing cache from {} slots to {}", this.size, size);
       this.size = size;
       buffer = Arrays.copyOf(buffer, size);
       try {
         raf.setLength(size * 4L);
         writeBuffer();
       } catch (IOException e) {
-        LOG.error("Failed to change size or write during resize on " + filename + " : " + e, e);
+        LOG.error("Failed to change size or write during resize on {}", filename, e);
       }
     } finally {
       lock.writeLock().unlock();
     }
   }
 
+  /**
+   * Forces an immediate write of the entire buffer if dirty.
+   *
+   * <p>Waits for any in-flight write, clears the scheduled flag to avoid a redundant run, and then
+   * writes under the read lock.
+   */
   public void forceWrite() {
-    LOG.info("Force write slot cache: " + this);
+    LOG.info("Force write slot cache: {}", this);
+    boolean wasInterrupted = false;
     lock.readLock().lock();
     try {
       synchronized (this) {
         if (closed) return;
-        dirty = false;
-        if (writing) {
-          // Wait for write to finish.
-          while (writing) {
-            try {
-              wait();
-            } catch (InterruptedException e) {
-              // Ignore.
-            }
+        // Wait for any in-flight write to finish; preserve interrupt status.
+        while (writing) {
+          try {
+            wait();
+          } catch (InterruptedException e) {
+            wasInterrupted = true; // record and keep waiting
           }
-          if (!dirty) return;
         }
+        if (!dirty) return; // Nothing to write.
+        // Take ownership of the write, and clear the dirty flag under the write guard.
         writing = true;
+        scheduled = false; // avoid a no-op scheduled run after this forced write
+        dirty = false;
       }
       try {
         writeBuffer();
       } catch (IOException e) {
-        LOG.error("Write failed during shutdown: " + e + " on " + filename, e);
+        LOG.error(WRITE_FAILED_MSG, filename, e);
       }
     } finally {
       synchronized (this) {
-        writing = false;
+        if (writing) {
+          writing = false;
+          this.notifyAll();
+        }
       }
       lock.readLock().unlock();
+      if (wasInterrupted) Thread.currentThread().interrupt();
     }
   }
 
+  /**
+   * Returns whether the backing file did not exist at construction time.
+   *
+   * @return {@code true} if the file was created by the constructor
+   */
   public boolean isNew() {
     return isNew;
   }
 
+  /** Returns the backing file path for logging and diagnostics. */
+  @Override
   public String toString() {
     return filename.getPath();
   }
 
-  // Testing only! Hence no lock.
+  // Testing only: intentionally avoids locking for speed in isolated test scenarios.
   public void replaceAllEntries(int key, int value) {
     for (int i = 0; i < buffer.length; i++) if (buffer[i] == key) buffer[i] = value;
   }
 
+  /**
+   * Returns the number of integers in the buffer.
+   *
+   * @return logical capacity in elements
+   */
   public int size() {
     return size;
   }

--- a/src/test/java/network/crypta/store/saltedhash/ResizablePersistentIntBufferTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/ResizablePersistentIntBufferTest.java
@@ -1,0 +1,281 @@
+package network.crypta.store.saltedhash;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import network.crypta.support.Fields;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ResizablePersistentIntBufferTest {
+
+  @TempDir Path tempDir;
+
+  @Mock Ticker ticker;
+
+  @AfterEach
+  void resetPersistenceTime() {
+    ResizablePersistentIntBuffer.setPersistenceTime(
+        ResizablePersistentIntBuffer.DEFAULT_PERSISTENCE_TIME);
+  }
+
+  @Test
+  void constructor_whenFileDoesNotExist_isNewTrueAndZeroFilled() throws IOException {
+    File f = tempDir.resolve("new-buffer.dat").toFile();
+    int size = 8;
+
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, size);
+
+    assertTrue(buf.isNew());
+    assertEquals(size, buf.size());
+    // All zeros by default
+    for (int i = 0; i < size; i++) {
+      assertEquals(0, buf.get(i));
+    }
+  }
+
+  @Test
+  void constructor_whenFileExists_isNewFalse() throws IOException {
+    File f = tempDir.resolve("exists.dat").toFile();
+    // Create an empty file without an empty try block
+    if (!f.createNewFile() && !f.exists()) {
+      try (RandomAccessFile raf = new RandomAccessFile(f, "rw")) {
+        raf.setLength(0);
+      }
+    }
+
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 4);
+    assertFalse(buf.isNew());
+  }
+
+  @Test
+  void constructor_whenFileExistsReadsUpToExpectedAndTruncates() throws IOException {
+    File f = tempDir.resolve("preexisting.dat").toFile();
+
+    // Pre-populate file with 4 little-endian ints: 11,22,33,44 (matches Fields.bytesToInts())
+    try (FileOutputStream fos = new FileOutputStream(f)) {
+      fos.write(Fields.intsToBytes(new int[] {11, 22, 33, 44}));
+    }
+
+    // Expect length to be truncated to 2 ints when constructing with size=2
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
+    assertEquals(2, buf.size());
+    assertEquals(11, buf.get(0));
+    assertEquals(22, buf.get(1));
+    assertEquals(2L * 4L, f.length());
+
+    // Also verify expanding reads available values and zero-fills the rest
+    ResizablePersistentIntBuffer buf2 = new ResizablePersistentIntBuffer(f, 6);
+    assertEquals(6, buf2.size());
+    assertEquals(11, buf2.get(0));
+    assertEquals(22, buf2.get(1));
+    for (int i = 2; i < 6; i++) {
+      assertEquals(0, buf2.get(i));
+    }
+    assertEquals(6L * 4L, f.length());
+  }
+
+  @Test
+  void get_and_put_whenClosed_throwIllegalState() throws IOException {
+    File f = tempDir.resolve("closed.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
+    buf.shutdown();
+
+    assertThrows(IllegalStateException.class, () -> buf.get(0));
+    assertThrows(IllegalStateException.class, () -> buf.put(0, 1));
+  }
+
+  @Test
+  void put_whenImmediatePersistence_writesAtOffsetLittleEndian() throws IOException {
+    ResizablePersistentIntBuffer.setPersistenceTime(-1);
+    File f = tempDir.resolve("immediate.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 3);
+
+    buf.put(1, 123456789); // should write immediately at offset 4
+    assertEquals(0, readIntLE(f, 0));
+    assertEquals(123456789, readIntLE(f, 1));
+    assertEquals(0, readIntLE(f, 2));
+
+    // noWrite=true must not write immediately
+    buf.put(2, 555, true);
+    assertEquals(0, readIntLE(f, 2));
+
+    // Forcing a write should persist the pending update
+    buf.forceWrite();
+    assertEquals(555, readIntLE(f, 2));
+  }
+
+  @Test
+  void put_whenPositivePersistenceAndTickerPresent_schedulesOnceAndWriterPersists()
+      throws Exception {
+    ResizablePersistentIntBuffer.setPersistenceTime(1000);
+    File f = tempDir.resolve("scheduled.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 4);
+
+    // Ticker attached before modifications: scheduling happens on first put only.
+    buf.start(ticker);
+    buf.put(0, 7);
+    buf.put(1, 9);
+
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(ticker, times(1)).queueTimedJob(captor.capture(), eq(1000L));
+
+    // Not written yet
+    assertEquals(0, readIntLE(f, 0));
+    assertEquals(0, readIntLE(f, 1));
+
+    // Run the scheduled writer; it writes the whole buffer
+    captor.getValue().run();
+    assertEquals(7, readIntLE(f, 0));
+    assertEquals(9, readIntLE(f, 1));
+    assertEquals(0, readIntLE(f, 2));
+    assertEquals(0, readIntLE(f, 3));
+  }
+
+  @Test
+  void start_whenDirtyWithoutTicker_schedulesOnStart() throws Exception {
+    ResizablePersistentIntBuffer.setPersistenceTime(500);
+    File f = tempDir.resolve("start-schedules.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
+
+    // Mark as dirty first; no ticker attached yet
+    buf.put(0, 42);
+    // Now attach ticker; should schedule once
+    buf.start(ticker);
+
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(ticker, times(1)).queueTimedJob(captor.capture(), eq(500L));
+
+    // Execute scheduled writer to persist
+    captor.getValue().run();
+    assertEquals(42, readIntLE(f, 0));
+  }
+
+  @Test
+  void shutdown_whenDirty_writesAndCloses() throws IOException {
+    ResizablePersistentIntBuffer.setPersistenceTime(0);
+    File f = tempDir.resolve("shutdown.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 3);
+    buf.put(0, 101);
+    buf.put(1, 202);
+
+    buf.shutdown();
+
+    // Data should be written for entire buffer (little-endian on disk)
+    assertEquals(101, readIntLE(f, 0));
+    assertEquals(202, readIntLE(f, 1));
+    assertEquals(0, readIntLE(f, 2));
+
+    // Idempotent
+    buf.shutdown();
+  }
+
+  @Test
+  void abort_whenDirty_doesNotWrite() throws IOException {
+    ResizablePersistentIntBuffer.setPersistenceTime(0);
+    File f = tempDir.resolve("abort.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
+    buf.put(1, 77);
+
+    buf.abort();
+
+    // Should remain zeros since abort avoids persistence
+    assertEquals(0, readIntLE(f, 0));
+    assertEquals(0, readIntLE(f, 1));
+  }
+
+  @Test
+  void resize_whenGrowAndShrink_preservesPrefix_updatesLength_andPersists() throws IOException {
+    File f = tempDir.resolve("resize.dat").toFile();
+    ResizablePersistentIntBuffer.setPersistenceTime(0); // no background scheduling
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
+    buf.put(0, 1);
+    buf.put(1, 2);
+
+    // Grow to 5
+    buf.resize(5);
+    assertEquals(5, buf.size());
+    assertEquals(1, buf.get(0));
+    assertEquals(2, buf.get(1));
+    assertEquals(0, buf.get(2));
+    assertEquals(0, buf.get(3));
+    assertEquals(0, buf.get(4));
+    assertEquals(5L * 4L, f.length());
+    // Persistence after resize
+    assertEquals(1, readIntLE(f, 0));
+    assertEquals(2, readIntLE(f, 1));
+
+    // Shrink to 1
+    buf.resize(1);
+    assertEquals(1, buf.size());
+    //noinspection PointlessArithmeticExpression
+    assertEquals(1L * 4L, f.length());
+    assertEquals(1, readIntLE(f, 0));
+  }
+
+  @Test
+  void replaceAllEntries_replacesMatchingValues() throws IOException {
+    File f = tempDir.resolve("replace.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 6);
+    int[] vals = {3, 3, 1, 3, 2, 3};
+    for (int i = 0; i < vals.length; i++) {
+      buf.put(i, vals[i]);
+    }
+    buf.replaceAllEntries(3, 9);
+    int[] expected = {9, 9, 1, 9, 2, 9};
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i], buf.get(i));
+    }
+  }
+
+  @Test
+  void fill_setsAllValues() throws IOException {
+    File f = tempDir.resolve("fill.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 4);
+    buf.fill(77);
+    for (int i = 0; i < buf.size(); i++) {
+      assertEquals(77, buf.get(i));
+    }
+  }
+
+  @Test
+  void put_whenIndexOutOfBounds_throwsArrayIndexOutOfBounds() throws IOException {
+    File f = tempDir.resolve("bounds.dat").toFile();
+    ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> buf.put(2, 1));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> buf.get(2));
+  }
+
+  // Utility: read one int stored little-endian at index
+  private static int readIntLE(File f, int index) throws IOException {
+    try (RandomAccessFile raf = new RandomAccessFile(f, "r")) {
+      byte[] b = new byte[4];
+      raf.seek(index * 4L);
+      raf.readFully(b);
+      // little-endian: b[0] is least significant
+      int x = 0;
+      for (int j = 3; j >= 0; j--) {
+        x = (x << 8) | (b[j] & 0xff);
+      }
+      return x;
+    }
+  }
+}

--- a/src/test/java/network/crypta/store/saltedhash/ResizablePersistentIntBufferTest.java
+++ b/src/test/java/network/crypta/store/saltedhash/ResizablePersistentIntBufferTest.java
@@ -43,12 +43,15 @@ class ResizablePersistentIntBufferTest {
     int size = 8;
 
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, size);
-
-    assertTrue(buf.isNew());
-    assertEquals(size, buf.size());
-    // All zeros by default
-    for (int i = 0; i < size; i++) {
-      assertEquals(0, buf.get(i));
+    try {
+      assertTrue(buf.isNew());
+      assertEquals(size, buf.size());
+      // All zeros by default
+      for (int i = 0; i < size; i++) {
+        assertEquals(0, buf.get(i));
+      }
+    } finally {
+      buf.shutdown();
     }
   }
 
@@ -63,7 +66,11 @@ class ResizablePersistentIntBufferTest {
     }
 
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 4);
-    assertFalse(buf.isNew());
+    try {
+      assertFalse(buf.isNew());
+    } finally {
+      buf.shutdown();
+    }
   }
 
   @Test
@@ -77,20 +84,28 @@ class ResizablePersistentIntBufferTest {
 
     // Expect length to be truncated to 2 ints when constructing with size=2
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
-    assertEquals(2, buf.size());
-    assertEquals(11, buf.get(0));
-    assertEquals(22, buf.get(1));
-    assertEquals(2L * 4L, f.length());
+    try {
+      assertEquals(2, buf.size());
+      assertEquals(11, buf.get(0));
+      assertEquals(22, buf.get(1));
+      assertEquals(2L * 4L, f.length());
+    } finally {
+      buf.shutdown();
+    }
 
     // Also verify expanding reads available values and zero-fills the rest
     ResizablePersistentIntBuffer buf2 = new ResizablePersistentIntBuffer(f, 6);
-    assertEquals(6, buf2.size());
-    assertEquals(11, buf2.get(0));
-    assertEquals(22, buf2.get(1));
-    for (int i = 2; i < 6; i++) {
-      assertEquals(0, buf2.get(i));
+    try {
+      assertEquals(6, buf2.size());
+      assertEquals(11, buf2.get(0));
+      assertEquals(22, buf2.get(1));
+      for (int i = 2; i < 6; i++) {
+        assertEquals(0, buf2.get(i));
+      }
+      assertEquals(6L * 4L, f.length());
+    } finally {
+      buf2.shutdown();
     }
-    assertEquals(6L * 4L, f.length());
   }
 
   @Test
@@ -108,19 +123,22 @@ class ResizablePersistentIntBufferTest {
     ResizablePersistentIntBuffer.setPersistenceTime(-1);
     File f = tempDir.resolve("immediate.dat").toFile();
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 3);
+    try {
+      buf.put(1, 123456789); // should write immediately at offset 4
+      assertEquals(0, readIntLE(f, 0));
+      assertEquals(123456789, readIntLE(f, 1));
+      assertEquals(0, readIntLE(f, 2));
 
-    buf.put(1, 123456789); // should write immediately at offset 4
-    assertEquals(0, readIntLE(f, 0));
-    assertEquals(123456789, readIntLE(f, 1));
-    assertEquals(0, readIntLE(f, 2));
+      // noWrite=true must not write immediately
+      buf.put(2, 555, true);
+      assertEquals(0, readIntLE(f, 2));
 
-    // noWrite=true must not write immediately
-    buf.put(2, 555, true);
-    assertEquals(0, readIntLE(f, 2));
-
-    // Forcing a write should persist the pending update
-    buf.forceWrite();
-    assertEquals(555, readIntLE(f, 2));
+      // Forcing a write should persist the pending update
+      buf.forceWrite();
+      assertEquals(555, readIntLE(f, 2));
+    } finally {
+      buf.shutdown();
+    }
   }
 
   @Test
@@ -130,24 +148,28 @@ class ResizablePersistentIntBufferTest {
     File f = tempDir.resolve("scheduled.dat").toFile();
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 4);
 
-    // Ticker attached before modifications: scheduling happens on first put only.
-    buf.start(ticker);
-    buf.put(0, 7);
-    buf.put(1, 9);
+    try {
+      // Ticker attached before modifications: scheduling happens on first put only.
+      buf.start(ticker);
+      buf.put(0, 7);
+      buf.put(1, 9);
 
-    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-    verify(ticker, times(1)).queueTimedJob(captor.capture(), eq(1000L));
+      ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+      verify(ticker, times(1)).queueTimedJob(captor.capture(), eq(1000L));
 
-    // Not written yet
-    assertEquals(0, readIntLE(f, 0));
-    assertEquals(0, readIntLE(f, 1));
+      // Not written yet
+      assertEquals(0, readIntLE(f, 0));
+      assertEquals(0, readIntLE(f, 1));
 
-    // Run the scheduled writer; it writes the whole buffer
-    captor.getValue().run();
-    assertEquals(7, readIntLE(f, 0));
-    assertEquals(9, readIntLE(f, 1));
-    assertEquals(0, readIntLE(f, 2));
-    assertEquals(0, readIntLE(f, 3));
+      // Run the scheduled writer; it writes the whole buffer
+      captor.getValue().run();
+      assertEquals(7, readIntLE(f, 0));
+      assertEquals(9, readIntLE(f, 1));
+      assertEquals(0, readIntLE(f, 2));
+      assertEquals(0, readIntLE(f, 3));
+    } finally {
+      buf.shutdown();
+    }
   }
 
   @Test
@@ -156,17 +178,21 @@ class ResizablePersistentIntBufferTest {
     File f = tempDir.resolve("start-schedules.dat").toFile();
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
 
-    // Mark as dirty first; no ticker attached yet
-    buf.put(0, 42);
-    // Now attach ticker; should schedule once
-    buf.start(ticker);
+    try {
+      // Mark as dirty first; no ticker attached yet
+      buf.put(0, 42);
+      // Now attach ticker; should schedule once
+      buf.start(ticker);
 
-    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-    verify(ticker, times(1)).queueTimedJob(captor.capture(), eq(500L));
+      ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+      verify(ticker, times(1)).queueTimedJob(captor.capture(), eq(500L));
 
-    // Execute scheduled writer to persist
-    captor.getValue().run();
-    assertEquals(42, readIntLE(f, 0));
+      // Execute scheduled writer to persist
+      captor.getValue().run();
+      assertEquals(42, readIntLE(f, 0));
+    } finally {
+      buf.shutdown();
+    }
   }
 
   @Test
@@ -207,42 +233,50 @@ class ResizablePersistentIntBufferTest {
     File f = tempDir.resolve("resize.dat").toFile();
     ResizablePersistentIntBuffer.setPersistenceTime(0); // no background scheduling
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
-    buf.put(0, 1);
-    buf.put(1, 2);
+    try {
+      buf.put(0, 1);
+      buf.put(1, 2);
 
-    // Grow to 5
-    buf.resize(5);
-    assertEquals(5, buf.size());
-    assertEquals(1, buf.get(0));
-    assertEquals(2, buf.get(1));
-    assertEquals(0, buf.get(2));
-    assertEquals(0, buf.get(3));
-    assertEquals(0, buf.get(4));
-    assertEquals(5L * 4L, f.length());
-    // Persistence after resize
-    assertEquals(1, readIntLE(f, 0));
-    assertEquals(2, readIntLE(f, 1));
+      // Grow to 5
+      buf.resize(5);
+      assertEquals(5, buf.size());
+      assertEquals(1, buf.get(0));
+      assertEquals(2, buf.get(1));
+      assertEquals(0, buf.get(2));
+      assertEquals(0, buf.get(3));
+      assertEquals(0, buf.get(4));
+      assertEquals(5L * 4L, f.length());
+      // Persistence after resize
+      assertEquals(1, readIntLE(f, 0));
+      assertEquals(2, readIntLE(f, 1));
 
-    // Shrink to 1
-    buf.resize(1);
-    assertEquals(1, buf.size());
-    //noinspection PointlessArithmeticExpression
-    assertEquals(1L * 4L, f.length());
-    assertEquals(1, readIntLE(f, 0));
+      // Shrink to 1
+      buf.resize(1);
+      assertEquals(1, buf.size());
+      //noinspection PointlessArithmeticExpression
+      assertEquals(1L * 4L, f.length());
+      assertEquals(1, readIntLE(f, 0));
+    } finally {
+      buf.shutdown();
+    }
   }
 
   @Test
   void replaceAllEntries_replacesMatchingValues() throws IOException {
     File f = tempDir.resolve("replace.dat").toFile();
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 6);
-    int[] vals = {3, 3, 1, 3, 2, 3};
-    for (int i = 0; i < vals.length; i++) {
-      buf.put(i, vals[i]);
-    }
-    buf.replaceAllEntries(3, 9);
-    int[] expected = {9, 9, 1, 9, 2, 9};
-    for (int i = 0; i < expected.length; i++) {
-      assertEquals(expected[i], buf.get(i));
+    try {
+      int[] vals = {3, 3, 1, 3, 2, 3};
+      for (int i = 0; i < vals.length; i++) {
+        buf.put(i, vals[i]);
+      }
+      buf.replaceAllEntries(3, 9);
+      int[] expected = {9, 9, 1, 9, 2, 9};
+      for (int i = 0; i < expected.length; i++) {
+        assertEquals(expected[i], buf.get(i));
+      }
+    } finally {
+      buf.shutdown();
     }
   }
 
@@ -250,9 +284,13 @@ class ResizablePersistentIntBufferTest {
   void fill_setsAllValues() throws IOException {
     File f = tempDir.resolve("fill.dat").toFile();
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 4);
-    buf.fill(77);
-    for (int i = 0; i < buf.size(); i++) {
-      assertEquals(77, buf.get(i));
+    try {
+      buf.fill(77);
+      for (int i = 0; i < buf.size(); i++) {
+        assertEquals(77, buf.get(i));
+      }
+    } finally {
+      buf.shutdown();
     }
   }
 
@@ -260,8 +298,12 @@ class ResizablePersistentIntBufferTest {
   void put_whenIndexOutOfBounds_throwsArrayIndexOutOfBounds() throws IOException {
     File f = tempDir.resolve("bounds.dat").toFile();
     ResizablePersistentIntBuffer buf = new ResizablePersistentIntBuffer(f, 2);
-    assertThrows(ArrayIndexOutOfBoundsException.class, () -> buf.put(2, 1));
-    assertThrows(ArrayIndexOutOfBoundsException.class, () -> buf.get(2));
+    try {
+      assertThrows(ArrayIndexOutOfBoundsException.class, () -> buf.put(2, 1));
+      assertThrows(ArrayIndexOutOfBoundsException.class, () -> buf.get(2));
+    } finally {
+      buf.shutdown();
+    }
   }
 
   // Utility: read one int stored little-endian at index


### PR DESCRIPTION
Summary
- Add focused JUnit 6 tests for `ResizablePersistentIntBuffer` covering constructor I/O behavior, immediate and delayed persistence policies, scheduling via `Ticker`, and shutdown/abort semantics.
- Tidy Javadoc/comments in `ResizablePersistentIntBuffer` for clarity around persistence semantics and concurrency.
- Apply Spotless formatting.

Changes (relative to origin/develop)
- M `src/main/java/network/crypta/store/saltedhash/ResizablePersistentIntBuffer.java`
- A `src/test/java/network/crypta/store/saltedhash/ResizablePersistentIntBufferTest.java`
- M `src/main/java/network/crypta/store/saltedhash/LockManager.java` (shows as modified versus develop due to branch base divergence; no changes in the last commit)
- D `src/test/java/network/crypta/store/saltedhash/LockManagerTest.java` (file not present on this branch’s base; shows as removed versus develop)

Commit(s)
- 97681e35d6 — test: add ResizablePersistentIntBuffer tests and apply Spotless formatting (2025-10-22)

Notes
- Working tree was clean prior to PR creation; Spotless had been run (`./gradlew spotlessApply`).
- This branch currently differs from `origin/develop` on LockManager files due to history divergence (not from the last commit). If we should retain `LockManagerTest.java`, I can rebase this branch onto `origin/develop` and bring it back before merge.

How to run locally
- Compile + run tests: `./gradlew test`
- Coverage reports are generated via JaCoCo as configured.

Please let me know if you want this opened as draft or rebased onto `develop` to minimize unrelated diffs.