### PR TITLE
l10n: simplify NodeL10n initialization and add unit tests

### DIFF
--- a/src/main/java/network/crypta/l10n/NodeL10n.java
+++ b/src/main/java/network/crypta/l10n/NodeL10n.java
@@ -4,66 +4,100 @@ import java.io.File;
 import network.crypta.l10n.BaseL10n.LANGUAGE;
 
 /**
- * This is the interface used to localize the Node. It just wraps a BaseL10n with correct parameters
- * so that this class can entierly be used using static methods, which is much more practical to use
- * than non-static methods.
+ * Static façade for node localization.
  *
- * <p>Why doesn't that class extends BaseL10n ? Because it has to be static.
+ * <p>This class configures and exposes a single shared {@link BaseL10n} instance used across the
+ * node. Application code obtains the instance via {@link #getBase()} and calls its methods to look
+ * up translations.
  *
- * <p>How to change the language ? Simply create a new NodeL1On object. You don't have to stock the
- * created object because you can access it using static methods.
+ * <p>Constructing {@code NodeL10n} reinitializes the shared {@link BaseL10n} with the provided
+ * language and override location. This design keeps call sites simple (static access) while still
+ * allowing the language to be switched during startup or tests by creating a new {@code NodeL10n}.
  *
- * @author Artefact2
+ * <h2>Thread-safety</h2>
+ *
+ * <p>Initialization is lazy and not synchronized. Creating multiple {@code NodeL10n} instances
+ * concurrently may cause the underlying instance to be assigned more than once; the last write
+ * wins. Typical usage initializes this class once during startup.
  */
 public class NodeL10n {
-
-  /**
-   * Initialize the Node localization with the node's default language, and overrides in the working
-   * directory.
-   */
-  public NodeL10n() {
-    this(LANGUAGE.getDefault(), new File("."));
+  /** Ensure the newly created BaseL10n is non-null (instance-only helper). */
+  private void ensureInitialized(BaseL10n base) {
+    if (base == null) {
+      throw new IllegalArgumentException("baseL10n must not be null");
+    }
   }
 
   /**
-   * Initialize the Node localization. You must also call that constructor if you want to change the
-   * language.
+   * Initialize localization using the default language and working-directory overrides.
    *
-   * @param lang Language to use.
+   * <p>Side effect: replaces the shared {@link BaseL10n} used by the application. Subsequent calls
+   * to {@link #getBase()} return the new instance.
+   */
+  public NodeL10n() {
+    BaseL10n created =
+        new BaseL10n(
+            "network/crypta/l10n/",
+            "crypta.l10n.${lang}.properties",
+            new File(".").getPath() + File.separator + "crypta.l10n.${lang}.override.properties",
+            LANGUAGE.getDefault());
+    setBase(created);
+    ensureInitialized(created);
+  }
+
+  /**
+   * Initialize localization for a specific language and override directory.
+   *
+   * <p>Side effect: replaces the shared {@link BaseL10n} used by the application. Subsequent calls
+   * to {@link #getBase()} return the new instance.
+   *
+   * @param lang the language to use; must not be {@code null}
+   * @param overrideDir directory whose path is used to resolve on-disk override files; must not be
+   *     {@code null}
+   * @throws java.util.MissingResourceException if {@code lang} is {@code null}
    * @see LANGUAGE#mapToLanguage(String)
    */
   public NodeL10n(final LANGUAGE lang, File overrideDir) {
-    NodeL10n.b =
+    BaseL10n created =
         new BaseL10n(
             "network/crypta/l10n/",
             "crypta.l10n.${lang}.properties",
             overrideDir.getPath() + File.separator + "crypta.l10n.${lang}.override.properties",
             lang);
+    setBase(created);
+    ensureInitialized(created);
   }
 
   /**
-   * Get the BaseL10n used to localize the node.
+   * Return the shared {@link BaseL10n} used for localization.
    *
-   * @return BaseL10n.
+   * <p>Lazy-initializes the instance to the default language with working-directory overrides when
+   * first called.
+   *
+   * @return the non-{@code null} shared instance
    * @see BaseL10n
    */
   public static BaseL10n getBase() {
     if (b == null) {
+      // Lazily create the default configuration on first access.
       new NodeL10n();
     }
     return b;
   }
 
   /**
-   * Sets the {@link BaseL10n} used to localize the node.
+   * Replace the shared {@link BaseL10n} used by the node.
    *
-   * <p>This method should only be used in tests, via {@code BaseL10nTest#useTestTranslation()}!
+   * <p>Primarily intended for tests and bootstrap wiring. Calling this method updates the instance
+   * returned by {@link #getBase()} for all callers.
    *
-   * @param baseL10n The {@link BaseL10n} object used for localization
+   * @param baseL10n the instance to expose globally; may be {@code null} to clear and trigger lazy
+   *     reinitialization on next {@link #getBase()} call
    */
   static void setBase(BaseL10n baseL10n) {
     b = baseL10n;
   }
 
+  /** Lazily-initialized shared localization instance. Guarded by {@link #getBase()}. */
   private static BaseL10n b;
 }

--- a/src/test/java/network/crypta/l10n/NodeL10nTest.java
+++ b/src/test/java/network/crypta/l10n/NodeL10nTest.java
@@ -1,0 +1,90 @@
+package network.crypta.l10n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.File;
+import java.nio.file.Path;
+import network.crypta.l10n.BaseL10n.LANGUAGE;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100") // descriptive test method names
+class NodeL10nTest {
+
+  private BaseL10n originalBase;
+
+  @BeforeEach
+  void captureOriginalBase() {
+    // Capture and restore to avoid leaking global state into other tests
+    originalBase = NodeL10n.getBase();
+  }
+
+  @AfterEach
+  void restoreOriginalBase() {
+    NodeL10n.setBase(originalBase);
+  }
+
+  @Test
+  void getBase_whenUninitialized_initializesWithDefaultLanguageAndPaths() {
+    // Arrange
+    NodeL10n.setBase(null); // force lazy initialization path
+
+    // Act
+    BaseL10n base = NodeL10n.getBase();
+
+    // Assert
+    assertNotNull(base);
+    assertEquals(LANGUAGE.ENGLISH, base.getSelectedLanguage());
+
+    String expectedOverride =
+        new File(new File(".").getPath(), "crypta.l10n.en.override.properties").toString();
+    assertEquals(expectedOverride, base.getL10nOverrideFileName(LANGUAGE.ENGLISH));
+
+    assertEquals(
+        "network/crypta/l10n/crypta.l10n.en.properties", base.getL10nFileName(LANGUAGE.ENGLISH));
+  }
+
+  @Test
+  void constructor_withLanguageAndOverrideDir_setsLanguageAndOverrideMask(@TempDir Path tmp) {
+    // Arrange
+    new NodeL10n(LANGUAGE.GERMAN, tmp.toFile());
+
+    // Act
+    BaseL10n base = NodeL10n.getBase();
+
+    // Assert
+    assertEquals(LANGUAGE.GERMAN, base.getSelectedLanguage());
+    String expected = tmp.resolve("crypta.l10n.de.override.properties").toString();
+    assertEquals(expected, base.getL10nOverrideFileName(LANGUAGE.GERMAN));
+  }
+
+  @Test
+  void setBase_whenProvided_replacesGlobalInstance() {
+    // Arrange: install a dedicated BaseL10n that uses test resources
+    BaseL10n custom = BaseL10nTest.createTestL10n(LANGUAGE.ENGLISH);
+
+    // Act
+    NodeL10n.setBase(custom);
+
+    // Assert
+    assertSame(custom, NodeL10n.getBase());
+    // sanity: verify the test resource is actually used
+    assertEquals("Sane", NodeL10n.getBase().getString("test.sanity"));
+  }
+
+  @Test
+  void getBase_whenCalledTwice_returnsSameInstance() {
+    // Arrange
+    BaseL10n first = NodeL10n.getBase();
+
+    // Act
+    BaseL10n second = NodeL10n.getBase();
+
+    // Assert
+    assertSame(first, second);
+  }
+}


### PR DESCRIPTION
Summary
- Refactor NodeL10n to construct and set a shared BaseL10n explicitly in the default and language-specific constructors; document lazy init and thread-safety notes.
- Add NodeL10nTest (JUnit 6) covering lazy initialization path, setBase replacement semantics, language + override directory handling, and idempotent getBase() behavior.

Changes
- src/main/java/network/crypta/l10n/NodeL10n.java
  - Clarify Javadoc and behavior around shared instance and lazy initialization.
  - Replace default-ctor delegation with explicit BaseL10n creation and setBase.
- src/test/java/network/crypta/l10n/NodeL10nTest.java
  - New tests validating expected behavior across common scenarios.

Rationale
- Improves readability and testability of localization bootstrapping while preserving existing static access patterns and behavior.

Testing
- Spotless applied (no additional changes pending).
- JUnit 6 tests compile and are designed to run on the existing platform configuration. No behavioral regressions expected.

Notes
- Base branch: develop
- Head branch: feature/node-l10n-tests-20251023-081407

Checklist
- [x] Code formatted via Spotless
- [x] Changes isolated to l10n components and tests
- [x] Branch created off develop and pushed