### PR TITLE
l10n: add PluginL10n tests and improve package-level Javadoc

### DIFF
--- a/src/main/java/network/crypta/l10n/PluginL10n.java
+++ b/src/main/java/network/crypta/l10n/PluginL10n.java
@@ -4,12 +4,22 @@ import network.crypta.l10n.BaseL10n.LANGUAGE;
 import network.crypta.pluginmanager.FredPluginBaseL10n;
 
 /**
- * That class basically do the same thing as NodeL10n, except that it's for plugins. Each plugin has
- * to implement FredPluginBaseL10n because each plugin can store its resource files in different
- * locations. The important thing here is that the node can easily access this data to automate
- * translation.
+ * Localization bridge for plugins.
  *
- * <p>Why is this class NOT static ? Because each plugin has is own instance of PluginL10n.
+ * <p>This class is a thin wrapper that configures a {@link BaseL10n} instance from information
+ * provided by a plugin via {@link network.crypta.pluginmanager.FredPluginBaseL10n}. It enables the
+ * node to look up translated strings for a plugin without knowing where the plugin stores its l10n
+ * resources or which class loader should be used to find them.
+ *
+ * <p>Why not a static utility? Each plugin may use different resource base paths, filename masks,
+ * override locations, and class loaders. A per-plugin instance keeps these concerns isolated and
+ * avoids coupling between plugins.
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>{@code PluginL10n} itself is immutable after construction. Thread-safety of lookups and state
+ * changes (for example, language selection or overrides) is governed by the underlying {@link
+ * BaseL10n}; see its documentation for details.
  *
  * @author Artefact2
  */
@@ -18,21 +28,35 @@ public class PluginL10n {
   private final BaseL10n b;
 
   /**
-   * Create a new PluginL10n object using the node's selected language.
+   * Create a new instance using the node's currently selected language.
    *
-   * @param plugin Plugin to use.
+   * <p>The selected language is obtained from {@link NodeL10n#getBase()} and used to initialize the
+   * internal {@link BaseL10n}. Resource resolution uses the plugin's class loader and the base path
+   * and filename masks provided by the plugin.
+   *
+   * @param plugin plugin that supplies resource paths, filename masks (containing {@code ${lang}}),
+   *     an override-file mask (containing {@code ${lang}}), and the class loader to use; must not
+   *     be {@code null}
+   * @throws NullPointerException if {@code plugin} is {@code null}
    */
   public PluginL10n(FredPluginBaseL10n plugin) {
     this(plugin, NodeL10n.getBase().getSelectedLanguage());
   }
 
   /**
-   * Create a new PluginL10n object.
+   * Create a new instance with an explicit language.
    *
-   * <p>Note : you should call this once in your main plugin class, then store it somewhere static.
+   * <p>Call this once during plugin initialization and cache the resulting object to reuse its
+   * {@link BaseL10n}. The plugin provides the resource base path, masks (where {@code ${lang}} is
+   * replaced by {@link BaseL10n.LANGUAGE#shortCode}), an override-file mask, and a class loader for
+   * resource lookup.
    *
-   * @param plugin Plugin to use.
-   * @param lang Language to use.
+   * @param plugin plugin that supplies resource configuration and class loader; must not be {@code
+   *     null}
+   * @param lang language to use for the initial selection; must not be {@code null}
+   * @throws NullPointerException if {@code plugin} is {@code null}
+   * @throws java.util.MissingResourceException if {@code lang} is {@code null} (thrown by {@link
+   *     BaseL10n#setLanguage(BaseL10n.LANGUAGE)})
    */
   public PluginL10n(FredPluginBaseL10n plugin, final LANGUAGE lang) {
     this.b =
@@ -45,9 +69,12 @@ public class PluginL10n {
   }
 
   /**
-   * Get the BaseL10n object used by this Plugin.
+   * Return the {@link BaseL10n} configured for this plugin.
    *
-   * @return BaseL10n
+   * <p>The returned instance is the same object for the lifetime of this {@code PluginL10n} and may
+   * be cached by callers.
+   *
+   * @return the non-{@code null} localization helper
    */
   public BaseL10n getBase() {
     return this.b;

--- a/src/main/java/network/crypta/l10n/package-info.java
+++ b/src/main/java/network/crypta/l10n/package-info.java
@@ -1,2 +1,82 @@
-/** Freenet localisation code, including the actual translations. */
+/**
+ * Localization (l10n) utilities and translation resources for the Crypta node and its plugins.
+ *
+ * <p>This package provides the components that load, resolve, and format localized strings used by
+ * the application and by plugins.
+ *
+ * <p>Core types:
+ *
+ * <ul>
+ *   <li>{@link network.crypta.l10n.BaseL10n} — Core resolver. Loads language files, applies
+ *       variable substitution, exposes string and HTML helpers, and supports on-disk overrides.
+ *   <li>{@link network.crypta.l10n.NodeL10n} — Application-wide façade that exposes a single shared
+ *       {@code BaseL10n}. Lazily initialized on first access or re-initialized via its
+ *       constructors.
+ *   <li>{@link network.crypta.l10n.PluginL10n} — Per-plugin bridge that wires a {@code BaseL10n}
+ *       using paths, masks, and class loader provided by the plugin.
+ *   <li>{@link network.crypta.l10n.ISO639_3} — Typed access to the ISO 639‑3 language code table
+ *       for UIs and tooling.
+ * </ul>
+ *
+ * <h2>Resource format and lookup</h2>
+ *
+ * <ul>
+ *   <li>Language files live under a base path (default {@code "network/crypta/l10n/"}) and follow a
+ *       mask (default {@code "crypta.l10n.${lang}.properties"}), where {@code ${lang}} is the
+ *       {@link network.crypta.l10n.BaseL10n.LANGUAGE#shortCode short code} of the selected
+ *       language.
+ *   <li>Files use the {@link network.crypta.support.SimpleFieldSet} text format (key/value pairs
+ *       with dot‑separated keys). UTF‑8 is used when reading bundled resources.
+ *   <li>Lookup order is: override file for the selected language → selected language resource →
+ *       fallback language ({@link network.crypta.l10n.BaseL10n.LANGUAGE#getDefault()}) → the key
+ *       itself (as a last resort). Missing entries are logged.
+ *   <li>On-disk overrides use the same language mask; the default {@link
+ *       network.crypta.l10n.NodeL10n} configuration resolves {@code
+ *       crypta.l10n.${lang}.override.properties} in the working directory.
+ * </ul>
+ *
+ * <h2>Substitution and HTML helpers</h2>
+ *
+ * <ul>
+ *   <li>String substitution replaces {@code ${name}} tokens with caller-provided values (see {@link
+ *       network.crypta.l10n.BaseL10n#getString(String, String[], String[])}). Replacement values
+ *       are safely escaped for use with {@link java.lang.String#replaceAll(String, String)}.
+ *   <li>HTML helpers ({@link network.crypta.l10n.BaseL10n#getHTMLNode(String)} and {@link
+ *       network.crypta.l10n.BaseL10n#addL10nSubstitution(network.crypta.support.HTMLNode, String,
+ *       String[], network.crypta.support.HTMLNode[])}) treat {@code ${name}...${/name}} as a range
+ *       to wrap with a provided {@link network.crypta.support.HTMLNode} while preserving nested
+ *       substitutions.
+ * </ul>
+ *
+ * <h2>Threading and state</h2>
+ *
+ * <ul>
+ *   <li>{@code BaseL10n} instances are stateful (selected language and overrides). Only fallback
+ *       loading is synchronized; coordinate externally if sharing an instance across threads.
+ *   <li>{@code NodeL10n} holds a lazily created, shared {@code BaseL10n}. Concurrent
+ *       re-initialization is last‑writer‑wins.
+ * </ul>
+ *
+ * <h2>Examples</h2>
+ *
+ * <pre>{@code
+ * // Application code
+ * BaseL10n l10n = NodeL10n.getBase();
+ * String title = l10n.getString("wizard.title");
+ *
+ * // With HTML substitution: wizard.link=See ${link}help${/link}
+ * HTMLNode container = new HTMLNode("div");
+ * l10n.addL10nSubstitution(
+ *     container,
+ *     "wizard.link",
+ *     new String[]{"link"},
+ *     new HTMLNode[]{HTMLNode.link("/help")});
+ * }</pre>
+ *
+ * @see network.crypta.l10n.BaseL10n
+ * @see network.crypta.l10n.NodeL10n
+ * @see network.crypta.l10n.PluginL10n
+ * @see network.crypta.l10n.ISO639_3
+ * @see network.crypta.support.HTMLNode
+ */
 package network.crypta.l10n;

--- a/src/test/java/network/crypta/l10n/PluginL10nTest.java
+++ b/src/test/java/network/crypta/l10n/PluginL10nTest.java
@@ -1,0 +1,179 @@
+package network.crypta.l10n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import network.crypta.l10n.BaseL10n.LANGUAGE;
+import network.crypta.pluginmanager.FredPluginBaseL10n;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PluginL10nTest {
+
+  @Mock private FredPluginBaseL10n plugin;
+
+  @TempDir Path tempDir;
+
+  private BaseL10n nodeBaseBefore;
+
+  @BeforeEach
+  void captureNodeL10n() {
+    // Capture current NodeL10n Base to restore after tests that change it.
+    nodeBaseBefore = NodeL10n.getBase();
+  }
+
+  @AfterEach
+  void restoreNodeL10n() {
+    // Restore static NodeL10n Base to avoid cross-test interference.
+    NodeL10n.setBase(nodeBaseBefore);
+  }
+
+  @Test
+  void constructor_withExplicitLanguage_initializesBaseWithPluginParameters() {
+    // Arrange
+    String basePathNoSlash = "com/acme/plugin/l10n"; // deliberately no trailing '/'
+    String mask = "messages_${lang}.l10n";
+    String overrideMask = tempDir.resolve("plugin-${lang}.override").toString();
+
+    RecordingClassLoader rcl = new RecordingClassLoader(PluginL10nTest.class.getClassLoader());
+
+    org.mockito.Mockito.when(plugin.getL10nFilesBasePath()).thenReturn(basePathNoSlash);
+    org.mockito.Mockito.when(plugin.getL10nFilesMask()).thenReturn(mask);
+    org.mockito.Mockito.when(plugin.getL10nOverrideFilesMask()).thenReturn(overrideMask);
+    org.mockito.Mockito.when(plugin.getPluginClassLoader()).thenReturn(rcl);
+
+    LANGUAGE lang = LANGUAGE.FRENCH;
+    String expectedResource =
+        normalizedPath(basePathNoSlash) + mask.replace("${lang}", lang.shortCode);
+
+    // Provide minimal valid SimpleFieldSet content for the expected resource path.
+    rcl.addResource(expectedResource, "hello=world\nEnd\n");
+
+    // Act
+    PluginL10n underTest = new PluginL10n(plugin, lang);
+    BaseL10n base = underTest.getBase();
+
+    // Assert
+    assertNotNull(base, "BaseL10n must be created");
+    assertEquals(
+        lang, base.getSelectedLanguage(), "Selected language should match the constructor");
+    assertEquals(
+        expectedResource, base.getL10nFileName(lang), "Resource path must reflect plugin masks");
+    assertEquals(
+        overrideMask.replace("${lang}", lang.shortCode),
+        base.getL10nOverrideFileName(lang),
+        "Override mask must reflect plugin mask");
+    assertEquals(
+        expectedResource,
+        rcl.getLastRequested(),
+        "ClassLoader should be asked for the expected resource");
+  }
+
+  @Test
+  void constructor_withNodeSelectedLanguage_usesNodeLanguage() {
+    // Arrange: set NodeL10n to a non-default language to verify the 1-arg constructor picks it up.
+    LANGUAGE nodeLang = LANGUAGE.SPANISH;
+    new NodeL10n(nodeLang, tempDir.toFile());
+
+    String basePath = "com/acme/plugin/l10n/"; // already normalized
+    String mask = "messages_${lang}.l10n";
+    String overrideMask = tempDir.resolve("plugin-${lang}.override").toString();
+
+    RecordingClassLoader rcl = new RecordingClassLoader(PluginL10nTest.class.getClassLoader());
+    org.mockito.Mockito.when(plugin.getL10nFilesBasePath()).thenReturn(basePath);
+    org.mockito.Mockito.when(plugin.getL10nFilesMask()).thenReturn(mask);
+    org.mockito.Mockito.when(plugin.getL10nOverrideFilesMask()).thenReturn(overrideMask);
+    org.mockito.Mockito.when(plugin.getPluginClassLoader()).thenReturn(rcl);
+
+    String expectedResource = basePath + mask.replace("${lang}", nodeLang.shortCode);
+    rcl.addResource(expectedResource, "k=v\nEnd\n");
+
+    // Act
+    PluginL10n underTest = new PluginL10n(plugin);
+    BaseL10n base = underTest.getBase();
+
+    // Assert
+    assertEquals(
+        nodeLang, base.getSelectedLanguage(), "Constructor must use NodeL10n's selected language");
+    assertEquals(
+        expectedResource,
+        rcl.getLastRequested(),
+        "ClassLoader should be asked for resource in Node language");
+  }
+
+  @Test
+  void constructor_withNullPlugin_expectNullPointerException() {
+    // Arrange/Act/Assert
+    assertThrows(NullPointerException.class, () -> new PluginL10n(null));
+    //noinspection DataFlowIssue
+    assertThrows(NullPointerException.class, () -> new PluginL10n(null, LANGUAGE.ENGLISH));
+  }
+
+  @Test
+  void getBase_whenCalledTwice_returnsSameInstance() {
+    // Arrange
+    org.mockito.Mockito.when(plugin.getL10nFilesBasePath()).thenReturn("com/acme/plugin/l10n");
+    org.mockito.Mockito.when(plugin.getL10nFilesMask()).thenReturn("messages_${lang}.l10n");
+    org.mockito.Mockito.when(plugin.getL10nOverrideFilesMask())
+        .thenReturn(tempDir.resolve("plugin-${lang}.override").toString());
+    org.mockito.Mockito.when(plugin.getPluginClassLoader())
+        .thenReturn(new RecordingClassLoader(PluginL10nTest.class.getClassLoader()));
+
+    PluginL10n underTest = new PluginL10n(plugin, LANGUAGE.GERMAN);
+
+    // Act
+    BaseL10n first = underTest.getBase();
+    BaseL10n second = underTest.getBase();
+
+    // Assert
+    assertSame(first, second, "getBase() should consistently return the same instance");
+  }
+
+  // --- helpers ---
+
+  private static String normalizedPath(String basePath) {
+    return basePath.endsWith("/") ? basePath : (basePath + "/");
+  }
+
+  /** ClassLoader that records the last requested resource name and can serve predefined content. */
+  private static final class RecordingClassLoader extends ClassLoader {
+    private volatile String lastRequested;
+    private String resourceName;
+    private byte[] payload;
+
+    RecordingClassLoader(ClassLoader parent) {
+      super(parent);
+    }
+
+    void addResource(String name, String content) {
+      this.resourceName = name;
+      this.payload = content.getBytes(StandardCharsets.UTF_8);
+    }
+
+    String getLastRequested() {
+      return lastRequested;
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String name) {
+      lastRequested = name;
+      if (resourceName != null && resourceName.equals(name)) {
+        return new ByteArrayInputStream(payload);
+      }
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Add deterministic unit tests for PluginL10n covering constructors, NodeL10n language usage, resource path resolution, and getBase() stability.
- Improve package-level Javadoc for localization APIs: resource format and lookup order, substitution semantics, threading/state guidance, and usage examples.
- No production logic changes; only tests and documentation.

Branch comparison
- Source branch: feature/pluginl10n-tests-docs
- Target branch: develop
- Commits ahead of develop: 2
  - 7cefcce30e docs(l10n): improve package-level Javadoc for localization APIs (comments-only)
  - 536c537a80 test(l10n): add PluginL10nTest and improve PluginL10n Javadoc (production changes are comments-only)

Files touched (high level)
- src/main/java/network/crypta/l10n/package-info.java — expanded Javadoc with core types, resource format/masks, lookup order, substitution/HTML helpers, threading/state, and examples.
- src/test/java/network/crypta/l10n/PluginL10nTest.java — new tests using a RecordingClassLoader and @TempDir to validate path normalization, Node-selected language behavior, override masks, null handling, and base instance stability.

Notes
- Spotless has already been applied in prior commits; working tree is clean and there are no uncommitted changes.
- JUnit 6 (Platform/Jupiter) is used consistently.

Rationale
This PR strengthens localization quality by documenting the expected behavior for consumers and adds focused unit tests around the plugin-facing API without altering runtime behavior.
