### PR TITLE
node: refactor Announce/Announcer flow; add tests; improve Javadoc

### DIFF
--- a/src/main/java/network/crypta/node/AnnounceSender.java
+++ b/src/main/java/network/crypta/node/AnnounceSender.java
@@ -6,6 +6,7 @@ import network.crypta.io.comm.DMT;
 import network.crypta.io.comm.DisconnectedException;
 import network.crypta.io.comm.Message;
 import network.crypta.io.comm.MessageFilter;
+import network.crypta.io.comm.MessageType;
 import network.crypta.io.comm.NotConnectedException;
 import network.crypta.io.comm.PeerParseException;
 import network.crypta.io.comm.ReferenceSignatureVerificationException;
@@ -15,16 +16,32 @@ import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Sends or forwards an Opennet announce request carrying a node reference ("noderef").
+ *
+ * <p>The sender chooses successive peers that are closer to a target location and relays replies
+ * back to the request source. It manages the initial handshake, HTL (hop-to-live) decrementing,
+ * acceptance/rejection handling, and final completion or route-not-found signaling. Byte accounting
+ * is reported via {@link ByteCounter}.
+ *
+ * <p>Threading: an instance is designed to be executed once on the node's executor. Incoming
+ * AnnouncementReply payloads are validated and relayed on background tasks; before emitting a
+ * terminal message (Completed or RouteNotFound) the instance waits for those background tasks to
+ * finish to avoid dropping late replies.
+ */
 public class AnnounceSender implements PrioRunnable, ByteCounter {
   private static final Logger LOG = LoggerFactory.getLogger(AnnounceSender.class);
+  private static final String LOG_REJECTING_NODEREF = "Rejecting noderef: {}";
+  private static final String LOG_FAILED_PARSE_REPLY = "Failed to parse reply: {}";
+  private static final String PARSE_FAILED_PREFIX = "parse failed: ";
 
-  // Constants
+  // Timeouts (milliseconds)
   static final int ACCEPTED_TIMEOUT = 10000;
   static final int ANNOUNCE_TIMEOUT =
-      120000; // longer than a regular request as have to transfer noderefs hop by hop etc
+      120000; // Longer than a regular request: noderefs transfer hop-by-hop.
   static final int END_TIMEOUT =
-      30000; // After received the completion message, wait 30 seconds for any late reordered
-  // replies
+      30000; // After receiving Completed, wait for late, possibly reordered replies.
+  // Replies may arrive slightly after completion due to reordering.
 
   private final PeerNode source;
   private final long uid;
@@ -40,6 +57,20 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
   private final PeerNode onlyNode;
   private int forwardedRefs;
 
+  /**
+   * Creates a sender used while forwarding an incoming announce from another peer.
+   *
+   * @param target Location key we route toward (unitless, implementation-specific).
+   * @param htl Starting hop-to-live. Decrements as the request is forwarded.
+   * @param uid Announce UID. Used to correlate protocol messages.
+   * @param source Upstream peer that originated the request we are forwarding.
+   * @param om Opennet manager for protocol helpers and crypto.
+   * @param node Local node services and executors.
+   * @param xferUID Transfer UID for the noderef blob sent by {@code source}.
+   * @param noderefLength Unpadded noderef length (bytes).
+   * @param paddedLength Padded noderef length (bytes).
+   * @param cb Optional callback for progress notifications; may be {@code null}.
+   */
   public AnnounceSender(
       double target,
       short htl,
@@ -64,6 +95,19 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
     this.cb = cb;
   }
 
+  /**
+   * Creates a sender for an origin announcement initiated by this node.
+   *
+   * <p>The noderef to broadcast is taken from our crypto state. When {@code onlyNode} is supplied,
+   * the announce is attempted only to that peer; otherwise the routing chooses successive closer
+   * peers.
+   *
+   * @param target Location key we route toward.
+   * @param om Opennet manager for protocol helpers and crypto.
+   * @param node Local node services and executors.
+   * @param cb Optional callback for progress notifications; may be {@code null}.
+   * @param onlyNode If non-null, restricts sending to this single peer.
+   */
   public AnnounceSender(
       double target, OpennetManager om, Node node, AnnouncementCallback cb, PeerNode onlyNode) {
     source = null;
@@ -82,13 +126,21 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
     this.noderefLength = 0;
   }
 
+  /**
+   * Executes the announce routing loop.
+   *
+   * <p>Always performs cleanup and stats reporting on exit, including notifying the tracker and
+   * completing the {@link AnnouncementCallback} when provided. All exceptions are caught and logged
+   * to avoid tearing down the executor thread.
+   */
   @Override
+  @SuppressWarnings("java:S1181")
   public void run() {
     try {
       realRun();
       node.getNodeStats().reportAnnounceForwarded(forwardedRefs, source);
     } catch (Throwable t) {
-      LOG.error("Caught {} announcing {} from {}", t.toString(), Long.valueOf(uid), source, t);
+      LOG.error("Caught {} announcing {} from {}", t, uid, source, t);
     } finally {
       if (source != null) {
         source.completedAnnounce(uid);
@@ -100,413 +152,472 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
   }
 
   private void realRun() {
-    boolean hasForwarded = false;
-    if (source != null) {
-      try {
-        source.sendAsync(DMT.createFNPAccepted(uid), null, this);
-      } catch (NotConnectedException e) {
-        return;
-      }
-      if (!transferNoderef()) return;
-    }
-
-    // Now route it.
+    if (!initialHandshakeAndMaybeTransfer()) return;
 
     HashSet<PeerNode> nodesRoutedTo = new HashSet<>();
-    PeerNode next = null;
+    PeerNode last = null;
+    boolean hasForwarded = false;
+
     while (true) {
-      if (LOG.isDebugEnabled()) LOG.debug("htl={}", Short.valueOf(htl));
-      /*
-       * If we haven't routed to any node yet, decrement according to the source.
-       * If we have, decrement according to the node which just failed.
-       * Because:
-       * 1) If we always decrement according to source then we can be at max or min HTL
-       * for a long time while we visit *every* peer node. This is BAD!
-       * 2) The node which just failed can be seen as the requestor for our purposes.
-       */
-      // Decrement at this point so we can DNF immediately on reaching HTL 0.
-      if (onlyNode == null) htl = node.decrementHTL(hasForwarded ? next : source, htl);
+      if (LOG.isDebugEnabled()) LOG.debug("htl={}", htl);
 
-      if (htl == 0) {
-        // No more nodes.
+      updateHtl(hasForwarded, last);
+
+      if (shouldCompleteNow()) {
         complete();
         return;
       }
 
-      if (!node.isOpennetEnabled()) {
-        complete();
-        return;
-      }
-
-      if (onlyNode == null) {
-        // Route it
-        next =
-            node.getPeers()
-                .closerPeer(
-                    source,
-                    nodesRoutedTo,
-                    target,
-                    true,
-                    node.isAdvancedModeEnabled(),
-                    -1,
-                    null,
-                    null,
-                    htl,
-                    0,
-                    source == null,
-                    false,
-                    false);
-      } else {
-        next = onlyNode;
-        if (nodesRoutedTo.contains(onlyNode)) {
-          rnf(onlyNode);
-          return;
-        }
-      }
-
+      PeerNode next = chooseNextNode(nodesRoutedTo);
       if (next == null) {
-        // Backtrack
-        rnf(next);
-        return;
-      }
-      if (LOG.isDebugEnabled()) LOG.debug("Routing request to {}", next);
-      if (onlyNode == null)
-        next.reportRoutedTo(target, source == null, false, source, nodesRoutedTo, htl);
-      nodesRoutedTo.add(next);
-
-      long xferUID = sendTo(next);
-      if (xferUID == -1) continue;
-
-      hasForwarded = true;
-
-      Message msg = null;
-
-      while (true) {
-
-        /**
-         * What are we waiting for? FNPAccepted - continue FNPRejectedLoop - go to another node
-         * FNPRejectedOverload - go to another node
-         */
-        MessageFilter mfAccepted =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ACCEPTED_TIMEOUT)
-                .setType(DMT.FNPAccepted);
-        MessageFilter mfRejectedLoop =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ACCEPTED_TIMEOUT)
-                .setType(DMT.FNPRejectedLoop);
-        MessageFilter mfRejectedOverload =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ACCEPTED_TIMEOUT)
-                .setType(DMT.FNPRejectedOverload);
-        MessageFilter mfOpennetDisabled =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ACCEPTED_TIMEOUT)
-                .setType(DMT.FNPOpennetDisabled);
-
-        // The order of these filters is performance critical. The last or-filter is checked first.
-        // So the last filter in the or-"chain" must be the filter which matches most frequently.
-        MessageFilter mf =
-            mfRejectedOverload.or(mfRejectedLoop.or(mfOpennetDisabled.or(mfAccepted)));
-
-        try {
-          msg = node.getUSM().waitFor(mf, this);
-          if (LOG.isDebugEnabled()) LOG.debug("first part got {}", msg);
-        } catch (DisconnectedException e) {
-          LOG.info(
-              "Disconnected from {} while waiting for Accepted on {}", next, Long.valueOf(uid));
-          break;
-        }
-
-        if (msg == null) {
-          if (LOG.isDebugEnabled()) LOG.debug("Timeout waiting for Accepted");
-          // Try next node
-          msg = null;
-          break;
-        }
-
-        if (msg.getSpec() == DMT.FNPRejectedLoop) {
-          if (LOG.isDebugEnabled()) LOG.debug("Rejected loop");
-          // Find another node to route to
-          msg = null;
-          break;
-        }
-
-        if (msg.getSpec() == DMT.FNPRejectedOverload) {
-          if (LOG.isDebugEnabled()) LOG.debug("Rejected: overload");
-          // Give up on this one, try another
-          msg = null;
-          break;
-        }
-
-        if (msg.getSpec() == DMT.FNPOpennetDisabled) {
-          if (LOG.isDebugEnabled()) LOG.debug("Opennet disabled");
-          msg = null;
-          break;
-        }
-
-        if (msg.getSpec() != DMT.FNPAccepted) {
-          LOG.error("Unrecognized message: {}", msg);
-          continue;
-        }
-
-        break;
+        if (onlyNode == null) rnf(null);
+        return; // rnf() may already have been sent when appropriate
       }
 
-      if ((msg == null) || (msg.getSpec() != DMT.FNPAccepted)) {
-        // Try another node
-        continue;
-      }
-
-      if (LOG.isDebugEnabled()) LOG.debug("Got Accepted");
-
-      if (cb != null) cb.acceptedSomewhere();
-
-      // Send the rest
-
-      try {
-        sendRest(next, xferUID);
-      } catch (NotConnectedException e1) {
-        if (LOG.isDebugEnabled()) LOG.debug("Not connected while sending noderef on {}", next);
-        continue;
-      }
-
-      // Otherwise, must be Accepted
-
-      // So wait...
-
-      while (true) {
-
-        MessageFilter mfAnnounceCompleted =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ANNOUNCE_TIMEOUT)
-                .setType(DMT.FNPOpennetAnnounceCompleted);
-        MessageFilter mfRouteNotFound =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ANNOUNCE_TIMEOUT)
-                .setType(DMT.FNPRouteNotFound);
-        MessageFilter mfRejectedOverload =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ANNOUNCE_TIMEOUT)
-                .setType(DMT.FNPRejectedOverload);
-        MessageFilter mfAnnounceReply =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ANNOUNCE_TIMEOUT)
-                .setType(DMT.FNPOpennetAnnounceReply);
-        MessageFilter mfOpennetDisabled =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ANNOUNCE_TIMEOUT)
-                .setType(DMT.FNPOpennetDisabled);
-        MessageFilter mfNotWanted =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ANNOUNCE_TIMEOUT)
-                .setType(DMT.FNPOpennetAnnounceNodeNotWanted);
-        MessageFilter mfOpennetNoderefRejected =
-            MessageFilter.create()
-                .setSource(next)
-                .setField(DMT.UID, uid)
-                .setTimeout(ANNOUNCE_TIMEOUT)
-                .setType(DMT.FNPOpennetNoderefRejected);
-        MessageFilter mf =
-            mfAnnounceCompleted.or(
-                mfRouteNotFound.or(
-                    mfRejectedOverload.or(
-                        mfAnnounceReply.or(
-                            mfOpennetDisabled.or(mfNotWanted.or(mfOpennetNoderefRejected))))));
-
-        try {
-          msg = node.getUSM().waitFor(mf, this);
-        } catch (DisconnectedException e) {
-          LOG.info("Disconnected from {} while waiting for announcement", next);
-          break;
-        }
-
-        if (LOG.isDebugEnabled()) LOG.debug("second part got {}", msg);
-
-        if (msg == null) {
-          // Fatal timeout, must be terminal (IS_LOCAL==true)
-          timedOut(next);
+      NodeProcessResult result = routeOnce(nodesRoutedTo, next);
+      switch (result) {
+        case TERMINATE:
           return;
-        }
-
-        if (msg.getSpec() == DMT.FNPOpennetNoderefRejected) {
-          int reason = msg.getInt(DMT.REJECT_CODE);
-          LOG.info("Announce rejected by {} : {}", next, DMT.getOpennetRejectedCode(reason));
-          msg = null;
+        case CONTINUE_FORWARDED:
+          hasForwarded = true;
+          last = next;
           break;
-        }
-
-        if (msg.getSpec() == DMT.FNPOpennetAnnounceCompleted) {
-          // Send the completion on immediately. We don't want to accumulate 30 seconds per hop!
-          complete();
-          mfAnnounceReply.setTimeout(END_TIMEOUT).setTimeoutRelativeToCreation(true);
-          mfNotWanted.setTimeout(END_TIMEOUT).setTimeoutRelativeToCreation(true);
-          mfAnnounceReply.clearOr();
-          mfNotWanted.clearOr();
-          mf = mfAnnounceReply.or(mfNotWanted);
-          while (true) {
-            try {
-              msg = node.getUSM().waitFor(mf, this);
-            } catch (DisconnectedException e) {
-              return;
-            }
-            if (msg == null) return;
-            if (msg.getSpec() == DMT.FNPOpennetAnnounceReply) {
-              validateForwardReply(msg, next);
-              continue;
-            }
-            if (msg.getSpec() == DMT.FNPOpennetAnnounceNodeNotWanted) {
-              if (cb != null) cb.nodeNotWanted();
-              if (source != null) {
-                try {
-                  sendNotWanted();
-                } catch (NotConnectedException e) {
-                  LOG.warn("Lost connection to source (announce completed)");
-                  return;
-                }
-              }
-            }
-          }
-        }
-
-        if (msg.getSpec() == DMT.FNPRouteNotFound) {
-          // Backtrack within available hops
-          short newHtl = msg.getShort(DMT.HTL);
-          if (newHtl < 0) newHtl = 0;
-          if (newHtl < htl) htl = newHtl;
+        case CONTINUE_NO_FORWARD:
+          // Track the attempted peer even if we failed to send/forward.
+          // This keeps HTL decrement attribution consistent with the peer we just tried.
+          last = next;
           break;
-        }
+      }
+      // else: no forward this iteration, keep previous 'last' and hasForwarded
+    }
+  }
 
-        if (msg.getSpec() == DMT.FNPRejectedOverload) {
-          // Give up on this one, try another
+  private enum NodeProcessResult {
+    TERMINATE,
+    CONTINUE_NO_FORWARD,
+    CONTINUE_FORWARDED
+  }
+
+  private NodeProcessResult routeOnce(HashSet<PeerNode> nodesRoutedTo, PeerNode next) {
+    if (LOG.isDebugEnabled()) LOG.debug("Routing request to {}", next);
+    if (onlyNode == null)
+      next.reportRoutedTo(target, source == null, false, source, nodesRoutedTo, htl);
+    nodesRoutedTo.add(next);
+
+    long transferUID = sendTo(next);
+    if (transferUID == -1) {
+      return NodeProcessResult.CONTINUE_NO_FORWARD;
+    }
+
+    if (!waitForAccepted(next)) {
+      return NodeProcessResult.CONTINUE_FORWARDED;
+    }
+
+    if (LOG.isDebugEnabled()) LOG.debug("Got Accepted");
+    if (cb != null) cb.acceptedSomewhere();
+
+    if (!sendRestSafely(next, transferUID)) {
+      return NodeProcessResult.CONTINUE_FORWARDED;
+    }
+
+    if (waitForFinalResponses(next) == Flow.TERMINATE) {
+      return NodeProcessResult.TERMINATE;
+    }
+
+    return NodeProcessResult.CONTINUE_FORWARDED;
+  }
+
+  private boolean shouldCompleteNow() {
+    return (htl == 0) || !node.isOpennetEnabled();
+  }
+
+  private void updateHtl(boolean hasForwarded, PeerNode last) {
+    if (onlyNode == null) {
+      // Decrement at this point so HTL==0 is detected before routing the next hop.
+      htl = node.decrementHTL(hasForwarded ? last : source, htl);
+    }
+  }
+
+  private PeerNode chooseNextNode(HashSet<PeerNode> routed) {
+    if (onlyNode == null) {
+      return node.getPeers()
+          .closerPeer(
+              source,
+              routed,
+              target,
+              true,
+              node.isAdvancedModeEnabled(),
+              -1,
+              null,
+              null,
+              htl,
+              0,
+              source == null,
+              false,
+              false);
+    }
+    if (routed.contains(onlyNode)) {
+      rnf(onlyNode);
+      return null;
+    }
+    return onlyNode;
+  }
+
+  private boolean initialHandshakeAndMaybeTransfer() {
+    if (source == null) return true;
+    try {
+      source.sendAsync(DMT.createFNPAccepted(uid), null, this);
+    } catch (NotConnectedException e) {
+      return false;
+    }
+    return transferNoderef();
+  }
+
+  private enum Flow {
+    CONTINUE,
+    TERMINATE
+  }
+
+  private boolean waitForAccepted(PeerNode next) {
+    while (true) {
+      MessageFilter mf = buildAcceptedWaitFilter(next);
+      Message msg;
+      try {
+        msg = node.getUSM().waitFor(mf, this);
+        if (LOG.isDebugEnabled()) LOG.debug("first part got {}", msg);
+      } catch (DisconnectedException e) {
+        LOG.info("Disconnected from {} while waiting for Accepted on {}", next, uid);
+        return false;
+      }
+
+      AcceptWaitOutcome outcome = evaluateAcceptedMessage(msg);
+      if (outcome == AcceptWaitOutcome.ACCEPTED) return true;
+      if (outcome == AcceptWaitOutcome.TRY_ANOTHER) return false;
+      // KEEP_WAITING: loop again
+    }
+  }
+
+  private enum AcceptWaitOutcome {
+    ACCEPTED,
+    TRY_ANOTHER,
+    KEEP_WAITING
+  }
+
+  private MessageFilter buildAcceptedWaitFilter(PeerNode next) {
+    MessageFilter mfAccepted =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ACCEPTED_TIMEOUT)
+            .setType(DMT.FNPAccepted);
+    // Build alternative message filters in priority order; all constrain the same UID.
+    MessageFilter mfRejectedLoop =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ACCEPTED_TIMEOUT)
+            .setType(DMT.FNPRejectedLoop);
+    MessageFilter mfRejectedOverload =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ACCEPTED_TIMEOUT)
+            .setType(DMT.FNPRejectedOverload);
+    MessageFilter mfOpennetDisabled =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ACCEPTED_TIMEOUT)
+            .setType(DMT.FNPOpennetDisabled);
+    return mfRejectedOverload.or(mfRejectedLoop.or(mfOpennetDisabled.or(mfAccepted)));
+  }
+
+  private AcceptWaitOutcome evaluateAcceptedMessage(Message msg) {
+    if (msg == null) {
+      if (LOG.isDebugEnabled()) LOG.debug("Timeout waiting for Accepted");
+      return AcceptWaitOutcome.TRY_ANOTHER;
+    }
+    if (msg.getSpec() == DMT.FNPRejectedLoop) {
+      if (LOG.isDebugEnabled()) LOG.debug("Rejected loop");
+      return AcceptWaitOutcome.TRY_ANOTHER;
+    } else if (msg.getSpec() == DMT.FNPRejectedOverload) {
+      if (LOG.isDebugEnabled()) LOG.debug("Rejected: overload");
+      return AcceptWaitOutcome.TRY_ANOTHER;
+    } else if (msg.getSpec() == DMT.FNPOpennetDisabled) {
+      if (LOG.isDebugEnabled()) LOG.debug("Opennet disabled");
+      return AcceptWaitOutcome.TRY_ANOTHER;
+    } else if (msg.getSpec() == DMT.FNPAccepted) {
+      return AcceptWaitOutcome.ACCEPTED;
+    }
+    LOG.error("Unrecognized message: {}", msg);
+    return AcceptWaitOutcome.KEEP_WAITING;
+  }
+
+  private boolean sendRestSafely(PeerNode next, long xferUID) {
+    try {
+      sendRest(next, xferUID);
+      return true;
+    } catch (NotConnectedException e1) {
+      if (LOG.isDebugEnabled()) LOG.debug("Not connected while sending noderef on {}", next);
+      return false;
+    }
+  }
+
+  private Flow waitForFinalResponses(PeerNode next) {
+    while (true) {
+      Message msg;
+      MessageFilter mf = buildFinalWaitFilter(next);
+      try {
+        msg = node.getUSM().waitFor(mf, this);
+      } catch (DisconnectedException e) {
+        LOG.info("Disconnected from {} while waiting for announcement", next);
+        return Flow.CONTINUE;
+      }
+      if (LOG.isDebugEnabled()) LOG.debug("second part got {}", msg);
+
+      FinalOutcome outcome = evaluateFinalMessage(msg, next);
+      switch (outcome) {
+        case TERMINATE:
+          return Flow.TERMINATE;
+        case CONTINUE:
+          // Exit the final-response wait loop and try another peer.
+          return Flow.CONTINUE;
+        case COMPLETED:
+          handleCompletedSequence(next);
+          return Flow.TERMINATE;
+        case KEEP_WAITING:
+          // Keep waiting on this peer for more replies or completion.
           break;
-        }
-
-        if (msg.getSpec() == DMT.FNPOpennetDisabled) {
-          LOG.debug("Opennet disabled");
-          msg = null;
-          break;
-        }
-
-        if (msg.getSpec() == DMT.FNPOpennetAnnounceReply) {
-          validateForwardReply(msg, next);
-          continue; // There may be more
-        }
-
-        if (msg.getSpec() == DMT.FNPOpennetAnnounceNodeNotWanted) {
-          if (cb != null) cb.nodeNotWanted();
-          if (source != null) {
-            try {
-              sendNotWanted();
-            } catch (NotConnectedException e) {
-              LOG.warn("Lost connection to source (announce not wanted)");
-              return;
-            }
-          }
-          continue; // This message is propagated, they will send a Completed or RNF
-        }
-
-        LOG.error("Unexpected message: {}", msg);
       }
     }
   }
 
+  private enum FinalOutcome {
+    TERMINATE,
+    CONTINUE,
+    COMPLETED,
+    KEEP_WAITING
+  }
+
+  private MessageFilter buildFinalWaitFilter(PeerNode next) {
+    MessageFilter mfAnnounceCompleted =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ANNOUNCE_TIMEOUT)
+            .setType(DMT.FNPOpennetAnnounceCompleted);
+    MessageFilter mfRouteNotFound =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ANNOUNCE_TIMEOUT)
+            .setType(DMT.FNPRouteNotFound);
+    MessageFilter mfRejectedOverload =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ANNOUNCE_TIMEOUT)
+            .setType(DMT.FNPRejectedOverload);
+    MessageFilter mfAnnounceReply =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ANNOUNCE_TIMEOUT)
+            .setType(DMT.FNPOpennetAnnounceReply);
+    MessageFilter mfOpennetDisabled =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ANNOUNCE_TIMEOUT)
+            .setType(DMT.FNPOpennetDisabled);
+    MessageFilter mfNotWanted =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ANNOUNCE_TIMEOUT)
+            .setType(DMT.FNPOpennetAnnounceNodeNotWanted);
+    MessageFilter mfOpennetNoderefRejected =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(ANNOUNCE_TIMEOUT)
+            .setType(DMT.FNPOpennetNoderefRejected);
+    return mfAnnounceCompleted.or(
+        mfRouteNotFound.or(
+            mfRejectedOverload.or(
+                mfAnnounceReply.or(
+                    mfOpennetDisabled.or(mfNotWanted.or(mfOpennetNoderefRejected))))));
+  }
+
+  private FinalOutcome evaluateFinalMessage(Message msg, PeerNode next) {
+    if (msg == null) {
+      timedOut(next);
+      return FinalOutcome.TERMINATE;
+    }
+
+    MessageType spec = msg.getSpec();
+    java.util.function.BiFunction<Message, PeerNode, FinalOutcome> handler = handlerFor(spec);
+    if (handler != null) {
+      return handler.apply(msg, next);
+    }
+
+    LOG.error("Unexpected message: {}", msg);
+    return FinalOutcome.KEEP_WAITING;
+  }
+
+  private java.util.function.BiFunction<Message, PeerNode, FinalOutcome> handlerFor(
+      MessageType spec) {
+    if (spec == DMT.FNPOpennetNoderefRejected) return this::handleNoderefRejected;
+    if (spec == DMT.FNPOpennetAnnounceCompleted) return (m, n) -> FinalOutcome.COMPLETED;
+    if (spec == DMT.FNPRouteNotFound) return this::handleRouteNotFound;
+    if (spec == DMT.FNPRejectedOverload) return this::handleRejectedOverload;
+    if (spec == DMT.FNPOpennetDisabled) return this::handleOpennetDisabled;
+    if (spec == DMT.FNPOpennetAnnounceReply) return this::handleAnnounceReply;
+    if (spec == DMT.FNPOpennetAnnounceNodeNotWanted) return (m, n) -> handleNodeNotWanted();
+    return null;
+  }
+
+  private FinalOutcome handleNoderefRejected(Message msg, PeerNode next) {
+    int reason = msg.getInt(DMT.REJECT_CODE);
+    LOG.atInfo()
+        .addArgument(next)
+        .addArgument(() -> DMT.getOpennetRejectedCode(reason))
+        .log("Announce rejected by {} : {}");
+    return FinalOutcome.CONTINUE;
+  }
+
+  private FinalOutcome handleRouteNotFound(Message msg, PeerNode next) {
+    backtrackWithinHops(msg);
+    return FinalOutcome.CONTINUE;
+  }
+
+  private FinalOutcome handleRejectedOverload(Message msg, PeerNode next) {
+    if (onlyNode != null) {
+      rnf(next);
+      return FinalOutcome.TERMINATE;
+    }
+    return FinalOutcome.CONTINUE;
+  }
+
+  private FinalOutcome handleOpennetDisabled(Message msg, PeerNode next) {
+    LOG.debug("Opennet disabled");
+    return FinalOutcome.CONTINUE;
+  }
+
+  private FinalOutcome handleAnnounceReply(Message msg, PeerNode next) {
+    validateForwardReply(msg, next);
+    // Keep waiting on this peer for more replies or completion
+    return FinalOutcome.KEEP_WAITING;
+  }
+
+  private FinalOutcome handleNodeNotWanted() {
+    if (cb != null) cb.nodeNotWanted();
+    if (source != null) {
+      try {
+        sendNotWanted();
+      } catch (NotConnectedException e) {
+        LOG.warn("Lost connection to source (announce not wanted)");
+        return FinalOutcome.TERMINATE;
+      }
+    }
+    // Keep waiting for the downstream terminal message (Completed/RNF).
+    return FinalOutcome.KEEP_WAITING;
+  }
+
+  private void backtrackWithinHops(Message msg) {
+    short newHtl = msg.getShort(DMT.HTL);
+    if (newHtl < 0) newHtl = 0;
+    if (newHtl < htl) htl = newHtl;
+  }
+
+  private void handleCompletedSequence(PeerNode next) {
+    complete();
+    MessageFilter followup = buildCompletionFollowupFilter(next);
+    waitForCompletionFollowups(next, followup);
+  }
+
+  private MessageFilter buildCompletionFollowupFilter(PeerNode next) {
+    MessageFilter mfAnnounceReply =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(END_TIMEOUT)
+            .setTimeoutRelativeToCreation(true)
+            .setType(DMT.FNPOpennetAnnounceReply);
+    MessageFilter mfNotWanted =
+        MessageFilter.create()
+            .setSource(next)
+            .setField(DMT.UID, uid)
+            .setTimeout(END_TIMEOUT)
+            .setTimeoutRelativeToCreation(true)
+            .setType(DMT.FNPOpennetAnnounceNodeNotWanted);
+    mfAnnounceReply.clearOr();
+    mfNotWanted.clearOr();
+    return mfAnnounceReply.or(mfNotWanted);
+  }
+
+  private void waitForCompletionFollowups(PeerNode next, MessageFilter mf) {
+    while (true) {
+      Message msg;
+      try {
+        msg = node.getUSM().waitFor(mf, this);
+      } catch (DisconnectedException e) {
+        return;
+      }
+      if (!processCompletionFollowup(msg, next)) return;
+    }
+  }
+
+  private boolean processCompletionFollowup(Message msg, PeerNode next) {
+    if (msg == null) return false;
+    if (msg.getSpec() == DMT.FNPOpennetAnnounceReply) {
+      validateForwardReply(msg, next);
+      return true; // keep waiting; there may be more
+    }
+    if (msg.getSpec() == DMT.FNPOpennetAnnounceNodeNotWanted) {
+      if (cb != null) cb.nodeNotWanted();
+      if (source != null) {
+        try {
+          sendNotWanted();
+        } catch (NotConnectedException e) {
+          LOG.warn("Lost connection to source (announce completed)");
+          return false;
+        }
+      }
+      return true;
+    }
+    // Unexpected message; keep waiting.
+    return true;
+  }
+
   private int waitingForTransfers = 0;
 
+  // Tracks the number of background reply-transfer tasks in flight. The sender blocks on this
+  // counter before emitting terminal messages so upstream peers do not miss late AnnouncementReply
+  // relays.
+
   /**
-   * Validate a reply, and relay it back to the source.
+   * Validates an incoming {@code AnnouncementReply} and relays it upstream or adds the node.
    *
-   * @param msg2 The AnnouncementReply message.
-   * @return True unless we lost the connection to our request source.
+   * <p>The reply body (noderef) is received asynchronously on a background task. While that task
+   * runs, {@code waitingForTransfers} is incremented to prevent premature completion.
    */
+  @SuppressWarnings("java:S1181")
   private void validateForwardReply(Message msg, final PeerNode next) {
-    final long xferUID = msg.getLong(DMT.TRANSFER_UID);
-    final int noderefLength = msg.getInt(DMT.NODEREF_LENGTH);
-    final int paddedLength = msg.getInt(DMT.PADDED_LENGTH);
+    final long replyTransferUID = msg.getLong(DMT.TRANSFER_UID);
+    final int replyNoderefLength = msg.getInt(DMT.NODEREF_LENGTH);
+    final int replyPaddedLength = msg.getInt(DMT.PADDED_LENGTH);
     synchronized (this) {
       waitingForTransfers++;
     }
     Runnable r =
-        new Runnable() {
-
-          @Override
-          public void run() {
-            try {
-              byte[] noderefBuf =
-                  OpennetManager.innerWaitForOpennetNoderef(
-                      xferUID,
-                      paddedLength,
-                      noderefLength,
-                      next,
-                      false,
-                      uid,
-                      true,
-                      AnnounceSender.this,
-                      node);
-              if (noderefBuf == null) {
-                return; // Don't relay
-              }
-              SimpleFieldSet fs =
-                  OpennetManager.validateNoderef(noderefBuf, 0, noderefLength, next, false);
-              if (fs == null) {
-                if (cb != null) cb.bogusNoderef("invalid noderef");
-                return; // Don't relay
-              }
-              if (source != null) {
-                // Now relay it
-                try {
-                  forwardedRefs++;
-                  om.sendAnnouncementReply(uid, source, noderefBuf, AnnounceSender.this);
-                  if (cb != null) {
-                    cb.relayedNoderef();
-                  }
-                } catch (NotConnectedException e) {
-                  // Hmmm...!
-                }
-              } else {
-                // Add it
-                try {
-                  OpennetPeerNode pn = node.addNewOpennetNode(fs, ConnectionType.ANNOUNCE);
-                  if (cb != null) {
-                    if (pn != null) cb.addedNode(pn);
-                    else cb.nodeNotAdded();
-                  }
-                } catch (FSParseException e) {
-                  LOG.info("Failed to parse reply: {}", e.toString(), e);
-                  if (cb != null) cb.bogusNoderef("parse failed: " + e);
-                } catch (PeerParseException e) {
-                  LOG.info("Failed to parse reply: {}", e.toString(), e);
-                  if (cb != null) cb.bogusNoderef("parse failed: " + e);
-                } catch (ReferenceSignatureVerificationException e) {
-                  LOG.info("Failed to parse reply: {}", e.toString(), e);
-                  if (cb != null) cb.bogusNoderef("parse failed: " + e);
-                }
-              }
-            } finally {
-              synchronized (AnnounceSender.this) {
-                waitingForTransfers--;
-                AnnounceSender.this.notifyAll();
-              }
+        () -> {
+          try {
+            processAnnouncementReply(replyTransferUID, replyPaddedLength, replyNoderefLength, next);
+          } finally {
+            synchronized (AnnounceSender.this) {
+              waitingForTransfers--;
+              AnnounceSender.this.notifyAll();
             }
           }
         };
@@ -519,11 +630,54 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
     }
   }
 
+  private void processAnnouncementReply(
+      long transferUID, int paddedLen, int length, PeerNode from) {
+    byte[] buf =
+        OpennetManager.innerWaitForOpennetNoderef(
+            transferUID, paddedLen, length, from, false, uid, true, this, node);
+    if (buf == null) {
+      return; // Don't relay
+    }
+    SimpleFieldSet fs = OpennetManager.validateNoderef(buf, 0, length, from, false);
+    if (fs == null) {
+      if (cb != null) cb.bogusNoderef("invalid noderef");
+      return; // Don't relay
+    }
+    if (source != null) {
+      relayToSource(buf);
+      return;
+    }
+    addNodeFromFs(fs);
+  }
+
+  private void relayToSource(byte[] buf) {
+    try {
+      forwardedRefs++;
+      om.sendAnnouncementReply(uid, source, buf, this);
+      if (cb != null) cb.relayedNoderef();
+    } catch (NotConnectedException e) {
+      // ignore
+    }
+  }
+
+  private void addNodeFromFs(SimpleFieldSet fs) {
+    try {
+      OpennetPeerNode pn = node.addNewOpennetNode(fs, ConnectionType.ANNOUNCE);
+      if (cb != null) {
+        if (pn != null) cb.addedNode(pn);
+        else cb.nodeNotAdded();
+      }
+    } catch (FSParseException | ReferenceSignatureVerificationException | PeerParseException e) {
+      LOG.info(LOG_FAILED_PARSE_REPLY, e, e);
+      if (cb != null) cb.bogusNoderef(PARSE_FAILED_PREFIX + e);
+    }
+  }
+
   /**
-   * Send an AnnouncementRequest.
+   * Sends the first part of an announcement request to {@code next}.
    *
-   * @param next The node to send the announcement to.
-   * @return True if the announcement was successfully sent.
+   * @param next Destination peer.
+   * @return Transfer UID used for the noderef payload, or {@code -1} if disconnected.
    */
   private long sendTo(PeerNode next) {
     try {
@@ -535,11 +689,11 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
   }
 
   /**
-   * Send an AnnouncementRequest.
+   * Sends the remaining announcement payload (the noderef) after an Accepted.
    *
-   * @param next The node to send the announcement to.
-   * @return True if the announcement was successfully sent.
-   * @throws NotConnectedException
+   * @param next Destination peer.
+   * @param xferUID Transfer UID obtained from {@link #sendTo(PeerNode)}.
+   * @throws NotConnectedException if {@code next} disconnects before the payload is sent.
    */
   private void sendRest(PeerNode next, long xferUID) throws NotConnectedException {
     om.finishSentAnnouncementRequest(next, noderefBuf, this, xferUID);
@@ -562,7 +716,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
       try {
         wait();
       } catch (InterruptedException e) {
-        // Ignore.
+        Thread.currentThread().interrupt();
       }
     }
   }
@@ -595,9 +749,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
     }
   }
 
-  /**
-   * @return True unless the noderef is bogus.
-   */
+  /** Returns {@code true} when the upstream noderef was received and validated. */
   private boolean transferNoderef() {
     noderefBuf =
         OpennetManager.innerWaitForOpennetNoderef(
@@ -620,16 +772,8 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
         sendNotWanted();
         // Okay, just route it.
       }
-    } catch (FSParseException e) {
-      LOG.warn("Rejecting noderef: {}", e.toString(), e);
-      OpennetManager.rejectRef(uid, source, DMT.NODEREF_REJECTED_INVALID, this);
-      return false;
-    } catch (PeerParseException e) {
-      LOG.warn("Rejecting noderef: {}", e.toString(), e);
-      OpennetManager.rejectRef(uid, source, DMT.NODEREF_REJECTED_INVALID, this);
-      return false;
-    } catch (ReferenceSignatureVerificationException e) {
-      LOG.warn("Rejecting noderef: {}", e.toString(), e);
+    } catch (FSParseException | ReferenceSignatureVerificationException | PeerParseException e) {
+      LOG.warn(LOG_REJECTING_NODEREF, e, e);
       OpennetManager.rejectRef(uid, source, DMT.NODEREF_REJECTED_INVALID, this);
       return false;
     } catch (NotConnectedException e) {
@@ -648,22 +792,30 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
     om.sendAnnouncementReply(uid, next, ref, this);
   }
 
+  /** Reports sent bytes to the announce byte counter. */
   @Override
   public void sentBytes(int x) {
     node.getNodeStats().announceByteCounter.sentBytes(x);
   }
 
+  /** Reports received bytes to the announce byte counter. */
   @Override
   public void receivedBytes(int x) {
     node.getNodeStats().announceByteCounter.receivedBytes(x);
   }
 
+  /** Reports payload bytes; not counted toward the total byte counter. */
   @Override
   public void sentPayload(int x) {
     node.getNodeStats().announceByteCounter.sentPayload(x);
     // Doesn't count.
   }
 
+  /**
+   * Returns the thread priority used when scheduling this runnable.
+   *
+   * @return {@link NativeThread.PriorityLevel#HIGH_PRIORITY} numeric value.
+   */
   @Override
   public int getPriority() {
     return NativeThread.PriorityLevel.HIGH_PRIORITY.value;

--- a/src/main/java/network/crypta/node/AnnouncementCallback.java
+++ b/src/main/java/network/crypta/node/AnnouncementCallback.java
@@ -1,26 +1,58 @@
 package network.crypta.node;
 
-/** Callback for a local announcement. */
+/**
+ * Callbacks for the local node-announcement procedure.
+ *
+ * <p>Implementations receive progress and outcome notifications while attempting to announce a node
+ * reference ("noderef") to peers. Callbacks may be invoked multiple times during a single run
+ * depending on how many peers are contacted and how they respond. Avoid heavy or blocking work
+ * inside callbacks to keep the announcement pipeline responsive.
+ */
 public interface AnnouncementCallback {
 
+  /**
+   * Signals that the announcement attempt has finished. No further callbacks are expected for the
+   * current run.
+   */
   void completed();
 
+  /**
+   * Reports that a node reference was deemed invalid and rejected.
+   *
+   * @param reason diagnostic description of why the noderef was considered bogus
+   */
   void bogusNoderef(String reason);
 
+  /**
+   * Reports a failure while interacting with a specific peer during announcement.
+   *
+   * @param pn the peer involved in the failure
+   * @param reason diagnostic description of the failure
+   */
   void nodeFailed(PeerNode pn, String reason);
 
-  /* RNF */
+  /** Indicates there are no additional peers to consider for this announcement run. */
   void noMoreNodes();
 
+  /**
+   * Reports that a peer has been added as a result of the announcement.
+   *
+   * @param pn the peer that was added
+   */
   void addedNode(PeerNode pn);
 
+  /** Indicates that the noderef was declined by policy or otherwise not desired. */
   void nodeNotWanted();
 
-  /** Node valid but locally not added e.g. because we already have it */
+  /** Node reference was valid but not added locally (for example, because it already exists). */
   void nodeNotAdded();
 
+  /** Indicates that the announcement was accepted by at least one peer. */
   void acceptedSomewhere();
 
-  /** Relayed a valid noderef to the (downstream) node which started the announcement */
+  /**
+   * Reports that a valid noderef was relayed to the downstream node that initiated the announcement
+   * process.
+   */
   void relayedNoderef();
 }

--- a/src/main/java/network/crypta/node/Announcer.java
+++ b/src/main/java/network/crypta/node/Announcer.java
@@ -33,13 +33,32 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Decide whether to announce, and announce if necessary to a node in the routing table, or to a
- * seednode.
+ * Coordinates when and how this node announces itself to the network.
+ *
+ * <p>The announcer decides whether an announcement is needed based on the current peer count and
+ * then announces either to a node in the routing table or to seed nodes ("seednodes"). It manages
+ * backoff and deduplication so we do not repeatedly announce to the same identities or IP
+ * addresses, and so we avoid flooding the network.
+ *
+ * <p>Threading: calls may originate from different threads. Internal counters and the {@code
+ * announcedTo*} sets are guarded by synchronization on {@code this}. Long-running and
+ * network-facing operations are scheduled on the node's ticker/executor and are not performed on
+ * the caller's thread.
+ *
+ * <p>Side effects: reads seed nodes from disk, registers transient user alerts, and schedules
+ * background jobs.
  *
  * @author toad
  */
 public class Announcer {
   private static final Logger LOG = LoggerFactory.getLogger(Announcer.class);
+
+  // Reused logging fragments to avoid duplicated string literals (Sonar S1192)
+  private static final String TRYING_TO_SEND_ANNOUNCEMENTS = " trying to send announcements";
+  private static final String ANNOUNCE_DISABLED_TOO_OLD_KEY = "announceDisabledTooOld";
+  private static final String ANNOUNCEMENT_TO = "Announcement to ";
+  private static final String ANNOUNCEMENT_TO_NODE = "Announcement to node ";
+  private static final String L10N_PREFIX = "Announcer.";
 
   private final Node node;
   private final OpennetManager om;
@@ -94,44 +113,51 @@ public class Announcer {
     // Debug gating derives from LOG.isDebugEnabled() where needed
   }
 
+  /**
+   * Starts the announcer logic.
+   *
+   * <p>If opennet is enabled and the node has no peers at all (darknet, opennet, or old opennet),
+   * this immediately attempts to connect to seed nodes and announce. Otherwise, it waits for {@link
+   * #MIN_ADDED_SEEDS_INTERVAL} and reassesses. Work is scheduled on the node's ticker.
+   *
+   * <p>Preconditions: opennet must be enabled on the node; otherwise the call returns without
+   * scheduling anything. The method itself is non-blocking.
+   */
   protected void start() {
     if (!node.isOpennetEnabled()) return;
     int darkPeers = node.getPeers().getDarknetPeers().length;
     int openPeers = node.getPeers().getOpennetPeers().length;
     int oldOpenPeers = om.countOldOpennetPeers();
     if (darkPeers + openPeers + oldOpenPeers == 0) {
-      // We know opennet is enabled.
-      // We have no peers AT ALL.
-      // So lets connect to a few seednodes, and attempt an announcement.
-      System.err.println("Attempting announcement to seednodes...");
+      // Opennet is enabled and there are no peers. Connect to several seed nodes and announce.
+      LOG.info("Attempting announcement to seednodes...");
       synchronized (this) {
         registerEvent(STATUS_LOADING);
         started = true;
       }
       connectSomeSeednodes();
     } else {
-      System.out.println(
-          "Not attempting immediate announcement: dark peers="
-              + darkPeers
-              + " open peers="
-              + openPeers
-              + " old open peers="
-              + oldOpenPeers
-              + " - will wait 1 minute...");
+      LOG.info(
+          "Not attempting immediate announcement: dark peers={} open peers={} old open peers={} -"
+              + " will wait 1 minute...",
+          darkPeers,
+          openPeers,
+          oldOpenPeers);
       // Wait a minute, then check whether we need to seed.
       node.getTicker()
           .queueTimedJob(
-              new Runnable() {
-                @Override
-                public void run() {
-                  synchronized (Announcer.this) {
-                    started = true;
-                  }
-                  try {
-                    maybeSendAnnouncement();
-                  } catch (Throwable t) {
-                    LOG.error("Caught " + t + " trying to send announcements", t);
-                  }
+              () -> {
+                synchronized (Announcer.this) {
+                  started = true;
+                }
+                try {
+                  maybeSendAnnouncement();
+                } catch (Exception e) {
+                  LOG.atError()
+                      .setCause(e)
+                      .addArgument(e::toString)
+                      .addArgument(() -> TRYING_TO_SEND_ANNOUNCEMENTS)
+                      .log("{}{}");
                 }
               },
               MIN_ADDED_SEEDS_INTERVAL);
@@ -144,148 +170,190 @@ public class Announcer {
 
   private void connectSomeSeednodes() {
     if (!node.isOpennetEnabled()) return;
-    boolean announceNow = false;
+    boolean announceNow;
     if (LOG.isDebugEnabled()) LOG.debug("Connecting some seednodes...");
     List<SimpleFieldSet> seeds = Announcer.readSeednodes(NodeFile.Seednodes.getFile(node));
-    System.out.println("Trying to connect to " + seeds.size() + " seednodes...");
+    LOG.info("Trying to connect to {} seednodes...", seeds.size());
     long now = System.currentTimeMillis();
+    if (prepareSeedsAndRegister(seeds, now)) return;
+    // Connect to a subset of seed nodes. Once connected they report back and we can announce.
+
+    int count = connectSomeNodesInner(seeds);
+    boolean stillConnecting;
+    List<SeedServerPeerNode> tryingSeeds = node.getPeers().getSeedServerPeersVector();
+    stillConnecting = hasUnannouncedTryingSeeds(tryingSeeds);
+    debugCounts(count, stillConnecting);
+    announceNow = handleNoMorePeers(count, stillConnecting);
+    node.getDNSRequester().forceRun();
+    // If none connect in a minute, try some more.
+    scheduleMaybeSendAnnouncement(announceNow ? 0 : MIN_ADDED_SEEDS_INTERVAL);
+  }
+
+  /**
+   * Prepare seed handling by enforcing the minimum interval and registering the appropriate user
+   * event. Returns true when the caller should return early.
+   */
+  private boolean prepareSeedsAndRegister(List<SimpleFieldSet> seeds, long now) {
     synchronized (this) {
-      if (now - timeAddedSeeds < MIN_ADDED_SEEDS_INTERVAL) return;
+      if (now - timeAddedSeeds < MIN_ADDED_SEEDS_INTERVAL) return true;
       timeAddedSeeds = now;
       if (seeds.isEmpty()) {
         registerEvent(STATUS_NO_SEEDNODES);
-        /*
-         * Developers might run nodes in empty directories instead of one made by an installer.
-         * They can copy in the seed nodes file, so check for it periodically to support loading it
-         * without the need to restart the node.
-         *
-         * TODO: If the seed nodes file is found it does not unregister the STATUS_NO_SEEDNODES
-         * event.
-         */
+        // File may be added later; re-check periodically without requiring a restart.
         node.getTicker()
-            .queueTimedJob(() -> maybeSendAnnouncement(), Announcer.RETRY_MISSING_SEEDNODES_DELAY);
-        return;
-      } else {
-        registerEvent(STATUS_CONNECTING_SEEDNODES);
+            .queueTimedJob(this::maybeSendAnnouncement, Announcer.RETRY_MISSING_SEEDNODES_DELAY);
+        return true;
       }
+      registerEvent(STATUS_CONNECTING_SEEDNODES);
+      return false;
     }
-    // Try to connect to some seednodes.
-    // Once they are connected they will report back and we can attempt an announcement.
+  }
 
-    int count = connectSomeNodesInner(seeds);
-    boolean stillConnecting = false;
-    List<SeedServerPeerNode> tryingSeeds = node.getPeers().getSeedServerPeersVector();
+  /** Return true if any trying seed has not yet been announced to. */
+  private boolean hasUnannouncedTryingSeeds(List<SeedServerPeerNode> tryingSeeds) {
     synchronized (this) {
       for (SeedServerPeerNode seed : tryingSeeds) {
         if (!announcedToIdentities.contains(new ByteArrayWrapper(seed.peerECDSAPubKeyHash))) {
-          // Either:
-          // a) we are still trying to connect to this node,
-          // b) there is a race condition and we haven't sent the announcement yet despite
-          // connecting, or
-          // c) something is severely broken and we didn't send an announcement.
-          // In any of these cases, we want to delay for 1 minute before resetting the connection
-          // process and connecting to everyone.
-          stillConnecting = true;
-          break;
+          return true;
         }
       }
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "count = "
-                + count
-                + " announced = "
-                + announcedToIdentities.size()
-                + " running = "
-                + runningAnnouncements
-                + " still connecting "
-                + stillConnecting);
-      if (count == 0 && runningAnnouncements == 0) {
-        // No more peers to connect to, and no announcements running.
-        // Are there any peers which we are still trying to connect to?
-        if (stillConnecting) {
-          // Give them another minute.
-          if (LOG.isDebugEnabled()) LOG.debug("Will clear announced-to in 1 minute...");
-          node.getTicker()
-              .queueTimedJob(
-                  new Runnable() {
-                    @Override
-                    public void run() {
-                      if (LOG.isDebugEnabled()) LOG.debug("Clearing old announced-to list");
-                      synchronized (Announcer.this) {
-                        if (runningAnnouncements != 0) return;
-                        announcedToIdentities.clear();
-                        announcedToIPs.clear();
-                      }
-                      maybeSendAnnouncement();
-                    }
-                  },
-                  NOT_ALL_CONNECTED_DELAY);
-        } else {
-          // We connected to all the seeds.
-          // No point waiting!
-          announcedToIdentities.clear();
-          announcedToIPs.clear();
-          announceNow = true;
-        }
-      }
+      return false;
     }
-    node.getDNSRequester().forceRun();
-    // If none connect in a minute, try some more.
+  }
+
+  /** Log current counts when debug is enabled. */
+  private void debugCounts(int count, boolean stillConnecting) {
+    if (!LOG.isDebugEnabled()) return;
+    synchronized (this) {
+      LOG.debug(
+          "count = {} announced = {} running = {} still connecting {}",
+          count,
+          announcedToIdentities.size(),
+          runningAnnouncements,
+          stillConnecting);
+    }
+  }
+
+  /**
+   * Handle the case where there are no more peers to connect and no announcements running. Returns
+   * true when we should announce immediately.
+   */
+  private boolean handleNoMorePeers(int count, boolean stillConnecting) {
+    int runningNow;
+    synchronized (this) {
+      runningNow = runningAnnouncements;
+    }
+    if (count != 0 || runningNow != 0) return false;
+    if (stillConnecting) {
+      scheduleClearAnnouncedAndRetry();
+      return false;
+    }
+    synchronized (this) {
+      clearAnnouncedSets();
+    }
+    return true;
+  }
+
+  private void scheduleClearAnnouncedAndRetry() {
+    if (LOG.isDebugEnabled()) LOG.debug("Will clear announced-to in 1 minute...");
     node.getTicker()
         .queueTimedJob(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  maybeSendAnnouncement();
-                } catch (Throwable t) {
-                  LOG.error("Caught " + t + " trying to send announcements", t);
-                }
+            () -> {
+              if (LOG.isDebugEnabled()) LOG.debug("Clearing old announced-to list");
+              synchronized (Announcer.this) {
+                if (runningAnnouncements != 0) return;
+                clearAnnouncedSets();
+              }
+              maybeSendAnnouncement();
+            },
+            NOT_ALL_CONNECTED_DELAY);
+  }
+
+  private synchronized void clearAnnouncedSets() {
+    announcedToIdentities.clear();
+    announcedToIPs.clear();
+  }
+
+  /** Schedule maybeSendAnnouncement with a try/catch logging wrapper. */
+  private void scheduleMaybeSendAnnouncement(long delayMs) {
+    node.getTicker()
+        .queueTimedJob(
+            () -> {
+              try {
+                maybeSendAnnouncement();
+              } catch (Exception e) {
+                LOG.atError()
+                    .setCause(e)
+                    .addArgument(e::toString)
+                    .addArgument(() -> TRYING_TO_SEND_ANNOUNCEMENTS)
+                    .log("{}{}");
               }
             },
-            announceNow ? 0 : MIN_ADDED_SEEDS_INTERVAL);
+            delayMs);
   }
 
   // Synchronize to protect announcedToIdentities and prevent running in parallel.
   private synchronized int connectSomeNodesInner(List<SimpleFieldSet> seeds) {
-    if (LOG.isDebugEnabled()) LOG.debug("Connecting some seednodes from " + seeds.size());
+    if (LOG.isDebugEnabled()) LOG.debug("Connecting some seednodes from {}", seeds.size());
     int count = 0;
     while (count < CONNECT_AT_ONCE) {
       if (seeds.isEmpty()) break;
       SimpleFieldSet fs = ListUtils.removeRandomBySwapLastSimple(node.getRandom(), seeds);
-      try {
-        SeedServerPeerNode seed = new SeedServerPeerNode(fs, node, om.getCrypto(), false);
-        if (node.wantAnonAuth(true)
-            && Arrays.equals(node.getOpennetPubKeyHash(), seed.peerECDSAPubKeyHash)) {
-          if (LOG.isDebugEnabled()) LOG.debug(seed.userToString());
-          continue;
-        }
-        if (announcedToIdentities.contains(new ByteArrayWrapper(seed.peerECDSAPubKeyHash))) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("Not adding: already announced-to: " + seed.userToString());
-          continue;
-        }
-        if (LOG.isDebugEnabled()) LOG.debug("Trying to connect to seednode " + seed);
-        if (node.getPeers().addPeer(seed)) {
-          count++;
-          if (LOG.isDebugEnabled()) LOG.debug("Connecting to seednode " + seed);
-        } else {
-          if (LOG.isDebugEnabled()) LOG.debug("Not connecting to seednode " + seed);
-        }
-      } catch (FSParseException e) {
-        LOG.error("Invalid seed in file: " + e + " for\n" + fs, e);
-      } catch (PeerParseException e) {
-        LOG.error("Invalid seed in file: " + e + " for\n" + fs, e);
-      } catch (ReferenceSignatureVerificationException e) {
-        LOG.error("Invalid seed in file: " + e + " for\n" + fs, e);
-      } catch (PeerTooOldException e) {
-        LOG.error("Invalid seed in file: " + e + " for\n" + fs, e);
-      }
+      if (processSeedFromFieldSet(fs)) count++;
     }
-    if (LOG.isDebugEnabled()) LOG.debug("connectSomeNodesInner() returning " + count);
+    if (LOG.isDebugEnabled()) LOG.debug("connectSomeNodesInner() returning {}", count);
     return count;
   }
 
+  private boolean processSeedFromFieldSet(SimpleFieldSet fs) {
+    try {
+      SeedServerPeerNode seed = new SeedServerPeerNode(fs, node, om.getCrypto(), false);
+      if (shouldSkipSeed(seed)) return false;
+      if (LOG.isDebugEnabled()) LOG.debug("Trying to connect to seednode {}", seed);
+      boolean added = node.getPeers().addPeer(seed);
+      if (added) {
+        if (LOG.isDebugEnabled()) LOG.debug("Connecting to seednode {}", seed);
+      } else {
+        if (LOG.isDebugEnabled()) LOG.debug("Not connecting to seednode {}", seed);
+      }
+      return added;
+    } catch (FSParseException
+        | PeerTooOldException
+        | ReferenceSignatureVerificationException
+        | PeerParseException e) {
+      LOG.atError()
+          .setCause(e)
+          .addArgument(e::toString)
+          .addArgument(() -> fs)
+          .log("Invalid seed in file: {} for\n{}");
+    }
+    return false;
+  }
+
+  private boolean shouldSkipSeed(SeedServerPeerNode seed) {
+    if (node.wantAnonAuth(true)
+        && Arrays.equals(node.getOpennetPubKeyHash(), seed.peerECDSAPubKeyHash)) {
+      if (LOG.isDebugEnabled()) LOG.atDebug().log(seed::userToString);
+      return true;
+    }
+    if (announcedToIdentities.contains(new ByteArrayWrapper(seed.peerECDSAPubKeyHash))) {
+      if (LOG.isDebugEnabled())
+        LOG.atDebug().addArgument(seed::userToString).log("Not adding: already announced-to: {}");
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Reads {@link SimpleFieldSet} noderef blocks from a seed nodes file.
+   *
+   * <p>The parser continues after recoverable I/O errors and logs them; successfully parsed entries
+   * that follow are still returned. Resources are closed on exit.
+   *
+   * @param file path to the seed nodes file (for example, {@code NodeFile.Seednodes.getFile(node)})
+   * @return a list of parsed {@link SimpleFieldSet} objects; empty if the file is missing or could
+   *     not be read
+   */
   public static List<SimpleFieldSet> readSeednodes(File file) {
     List<SimpleFieldSet> list = new ArrayList<>();
     try (FileInputStream fis = new FileInputStream(file);
@@ -293,32 +361,65 @@ public class Announcer {
         InputStreamReader isr = new InputStreamReader(bis, StandardCharsets.UTF_8);
         BufferedReader br = new BufferedReader(isr)) {
       while (true) {
-        try {
-          SimpleFieldSet fs = new SimpleFieldSet(br, false, false, true, false);
-          if (!fs.isEmpty()) list.add(fs);
-        } catch (EOFException e) {
-          return list;
-        } catch (IOException e) {
-          LOG.error("Error while reading seednodes from " + file, e);
-          // Continue reading. If this entry failed, we still want the following noderefs.
-          // Read a line to advance the parsing position and avoid an endless loop.
-          br.readLine();
-        }
+        ReadStatus status = readNextSeed(br, file, list);
+        if (status == ReadStatus.EOF) return list;
+        // On IO_ERROR, continue the loop to try parsing the next block.
       }
     } catch (IOException e) {
-      LOG.error("Unexpected error while reading seednodes from " + file, e);
+      LOG.error("Unexpected error while reading seednodes from {}", file, e);
       return list;
     }
   }
 
+  private enum ReadStatus {
+    OK,
+    EOF,
+    IO_ERROR
+  }
+
+  private static ReadStatus readNextSeed(BufferedReader br, File file, List<SimpleFieldSet> out)
+      throws IOException {
+    try {
+      SimpleFieldSet fs = new SimpleFieldSet(br, false, false, true, false);
+      if (!fs.isEmpty()) out.add(fs);
+      return ReadStatus.OK;
+    } catch (EOFException e) {
+      return ReadStatus.EOF;
+    } catch (IOException e) {
+      LOG.error("Error while reading seednodes from {}", file, e);
+      // Continue reading to keep later noderefs. Advance one line to avoid an endless loop.
+      // If advancing fails, propagate the IOException; if EOF is reached, signal EOF.
+      String skipped = br.readLine();
+      if (skipped == null) {
+        return ReadStatus.EOF;
+      }
+      return ReadStatus.IO_ERROR;
+    }
+  }
+
+  /**
+   * Stops the announcer.
+   *
+   * <p>Currently a no-op placeholder kept for lifecycle symmetry with {@link #start()}. Future
+   * implementations may cancel scheduled tasks.
+   */
   protected void stop() {
-    // Do nothing at present
+    // Intentionally left blank
   }
 
   private long timeGotEnoughPeers = -1;
   private final Object timeGotEnoughPeersLock = new Object();
   private boolean killedAnnouncementTooOld;
 
+  /**
+   * Returns the minimum number of connected peers required before announcements are considered
+   * unnecessary.
+   *
+   * <p>The threshold is {@code min(MIN_OPENNET_CONNECTED_PEERS, target/2)}, where {@code target} is
+   * the desired number of connected peers (including darknet) reported by the opennet manager.
+   *
+   * @return a non-negative peer count threshold
+   */
   public int getAnnouncementThreshold() {
     // First, do we actually need to announce?
     return Math.min(
@@ -329,14 +430,14 @@ public class Announcer {
       new SimpleUserAlert(
           false,
           l10n("announceDisabledTooOldTitle"),
-          l10n("announceDisabledTooOld"),
+          l10n(ANNOUNCE_DISABLED_TOO_OLD_KEY),
           l10n("announceDisabledTooOldShort"),
           UserAlert.CRITICAL_ERROR) {
 
         @Override
         public HTMLNode getHTMLText() {
           HTMLNode div = new HTMLNode("div");
-          div.addChild("#", l10n("announceDisabledTooOld"));
+          div.addChild("#", l10n(ANNOUNCE_DISABLED_TOO_OLD_KEY));
           if (!node.getNodeUpdater().isEnabled()) {
             div.addChild("#", " ");
             NodeL10n.getBase()
@@ -353,7 +454,7 @@ public class Announcer {
         @Override
         public String getText() {
           StringBuilder sb = new StringBuilder();
-          sb.append(l10n("announceDisabledTooOld"));
+          sb.append(l10n(ANNOUNCE_DISABLED_TOO_OLD_KEY));
           sb.append(" ");
           if (!node.getNodeUpdater().isEnabled()) {
             sb.append(
@@ -376,7 +477,9 @@ public class Announcer {
       };
 
   /**
-   * @return True if we have enough peers that we don't need to announce.
+   * Returns whether the node currently has enough peers so no announcement is needed.
+   *
+   * @return true if announcements can be skipped
    */
   boolean enoughPeers() {
     if (om.stopping()) return true;
@@ -386,77 +489,76 @@ public class Announcer {
     if (opennetCount >= target) {
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "We have enough opennet peers: "
-                + opennetCount
-                + " > "
-                + target
-                + " since "
-                + (System.currentTimeMillis() - timeGotEnoughPeers)
-                + " ms");
+            "We have enough opennet peers: {} > {} since {} ms",
+            opennetCount,
+            target,
+            System.currentTimeMillis() - timeGotEnoughPeers);
       synchronized (timeGotEnoughPeersLock) {
         if (timeGotEnoughPeers <= 0) timeGotEnoughPeers = System.currentTimeMillis();
       }
       return true;
     }
-    boolean killAnnouncement = false;
+    if (checkAndMaybeKillForTooOld()) {
+      disconnectAllAsync();
+      return true;
+    }
+    clearKilledAndUnregisterAlert();
+    if (shouldPauseForUomAndTooNew()) return true;
+
+    synchronized (timeGotEnoughPeersLock) {
+      timeGotEnoughPeers = -1;
+    }
+    return false;
+  }
+
+  private boolean checkAndMaybeKillForTooOld() {
     if ((!node.getNodeUpdater().isEnabled())
         || (node.getNodeUpdater().canUpdateNow() && !node.getNodeUpdater().isArmed())) {
-      // If we also have 10 TOO_NEW peers, we should shut down the announcement,
-      // because we're obviously broken and would only be spamming the seednodes
       synchronized (this) {
-        // Once we have shut down announcement, this persists until the auto-updater
-        // is enabled.
         if (killedAnnouncementTooOld) return true;
       }
       if (node.getPeers().getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false) > 10) {
         synchronized (this) {
           if (killedAnnouncementTooOld) return true;
           killedAnnouncementTooOld = true;
-          killAnnouncement = true;
         }
         LOG.error(
             "Shutting down announcement as we are older than the current mandatory build and"
                 + " auto-update is disabled or waiting for user input.");
-        System.err.println(
-            "Shutting down announcement as we are older than the current mandatory build and"
-                + " auto-update is disabled or waiting for user input.");
         if (node.getClientCore() != null)
           node.getClientCore().getAlerts().register(announcementDisabledAlert);
-      }
-    }
-
-    if (killAnnouncement) {
-      node.getExecutor()
-          .execute(
-              () -> {
-                for (OpennetPeerNode pn : node.getPeers().getOpennetPeers()) {
-                  node.getPeers().disconnectAndRemove(pn, true, true, true);
-                }
-                for (SeedServerPeerNode pn : node.getPeers().getSeedServerPeersVector()) {
-                  node.getPeers().disconnectAndRemove(pn, true, true, true);
-                }
-              });
-      return true;
-    } else {
-      synchronized (this) {
-        killedAnnouncementTooOld = false;
-      }
-      if (node.getClientCore() != null)
-        node.getClientCore().getAlerts().unregister(announcementDisabledAlert);
-      if (node.getNodeUpdater().isEnabled()
-          && node.getNodeUpdater().isArmed()
-          && node.getNodeUpdater().getUpdateOverMandatory().fetchingFromTwo()
-          && node.getPeers().getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false)
-              > 5) {
-        // No point announcing at the moment, but we might need to if a transfer falls through.
         return true;
       }
     }
-
-    synchronized (timeGotEnoughPeersLock) {
-      timeGotEnoughPeers = -1;
-    }
     return false;
+  }
+
+  private void disconnectAllAsync() {
+    node.getExecutor()
+        .execute(
+            () -> {
+              for (OpennetPeerNode pn : node.getPeers().getOpennetPeers()) {
+                node.getPeers().disconnectAndRemove(pn, true, true, true);
+              }
+              for (SeedServerPeerNode pn : node.getPeers().getSeedServerPeersVector()) {
+                node.getPeers().disconnectAndRemove(pn, true, true, true);
+              }
+            });
+  }
+
+  private void clearKilledAndUnregisterAlert() {
+    synchronized (this) {
+      killedAnnouncementTooOld = false;
+    }
+    if (node.getClientCore() != null)
+      node.getClientCore().getAlerts().unregister(announcementDisabledAlert);
+  }
+
+  private boolean shouldPauseForUomAndTooNew() {
+    return node.getNodeUpdater().isEnabled()
+        && node.getNodeUpdater().isArmed()
+        && node.getNodeUpdater().getUpdateOverMandatory().fetchingFromTwo()
+        && node.getPeers().getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false) > 5;
   }
 
   /**
@@ -482,133 +584,146 @@ public class Announcer {
 
   private boolean started = false;
 
-  private final Runnable checker =
-      new Runnable() {
-
-        @Override
-        public void run() {
-          int running;
-          synchronized (Announcer.this) {
-            running = runningAnnouncements;
-          }
-          if (enoughPeers()) {
-            for (SeedServerPeerNode pn : node.getPeers().getConnectedSeedServerPeersVector(null)) {
-              node.getPeers().disconnectAndRemove(pn, true, true, false);
-            }
-            // Re-check every minute. Something bad might happen (e.g. cpu starvation), causing us
-            // to have to reseed.
-            node.getTicker()
-                .queueTimedJob(
-                    () -> maybeSendAnnouncement(),
-                    "Check whether we need to announce",
-                    RETRY_DELAY,
-                    false,
-                    true);
-          } else {
-            node.getTicker()
-                .queueTimedJob(
-                    () -> maybeSendAnnouncement(),
-                    "Check whether we need to announce",
-                    RETRY_DELAY,
-                    false,
-                    true);
-            if (running != 0) maybeSendAnnouncement();
-          }
-        }
-      };
-
-  public void maybeSendAnnouncementOffThread() {
-    if (enoughPeers()) return;
-    node.getTicker().queueTimedJob(() -> maybeSendAnnouncement(), 0);
-  }
-
-  protected void maybeSendAnnouncement() {
-    synchronized (this) {
-      if (!started) return;
-    }
-    // Debug gating derives from LOG.isDebugEnabled() where needed
-    if (LOG.isDebugEnabled()) LOG.debug("maybeSendAnnouncement()");
-    long now = System.currentTimeMillis();
-    if (!node.isOpennetEnabled()) return;
-    if (enoughPeers()) {
-      // Check again in 60 seconds.
-      node.getTicker().queueTimedJob(checker, "Announcement checker", FINAL_DELAY, false, true);
-      return;
-    }
-    synchronized (this) {
-      // Double check after taking the lock.
+  private Runnable checker() {
+    return () -> {
+      int running;
+      synchronized (Announcer.this) {
+        running = runningAnnouncements;
+      }
       if (enoughPeers()) {
-        // Check again in 60 seconds.
-        node.getTicker().queueTimedJob(checker, "Announcement checker", FINAL_DELAY, false, true);
-        return;
-      }
-      // Second, do we have many announcements running?
-      if (runningAnnouncements > WANT_ANNOUNCEMENTS) {
-        if (LOG.isDebugEnabled()) LOG.debug("Running announcements already");
-        return;
-      }
-      // In cooling-off period?
-      if (System.currentTimeMillis() < startTime) {
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "In cooling-off period for next "
-                  + TimeUtil.formatTime(startTime - System.currentTimeMillis()));
-        return;
-      }
-      if (sentAnnouncements >= WANT_ANNOUNCEMENTS) {
-        if (LOG.isDebugEnabled()) LOG.debug("Sent enough announcements");
-        return;
-      }
-      // Now find a node to announce to
-      List<SeedServerPeerNode> seeds =
-          node.getPeers().getConnectedSeedServerPeersVector(announcedToIdentities);
-      while (sentAnnouncements < WANT_ANNOUNCEMENTS) {
-        if (seeds.isEmpty()) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("No more seednodes, announcedTo = " + announcedToIdentities.size());
-          break;
+        for (SeedServerPeerNode pn : node.getPeers().getConnectedSeedServerPeersVector(null)) {
+          node.getPeers().disconnectAndRemove(pn, true, true, false);
         }
-        final SeedServerPeerNode seed =
-            ListUtils.removeRandomBySwapLastSimple(node.getRandom(), seeds);
-        InetAddress[] addrs = seed.getInetAddresses();
-        if (!newAnnouncedIPs(addrs)) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("Not announcing to " + seed + " because already used those IPs");
-          continue;
-        }
-        addAnnouncedIPs(addrs);
-        // If it throws, we do not want to increment, so call it first.
-        if (sendAnnouncement(seed)) {
-          sentAnnouncements++;
-          runningAnnouncements++;
-          announcedToIdentities.add(new ByteArrayWrapper(seed.peerECDSAPubKeyHash));
-        }
-      }
-      if (runningAnnouncements >= WANT_ANNOUNCEMENTS) {
-        if (LOG.isDebugEnabled()) LOG.debug("Running " + runningAnnouncements + " announcements");
-        return;
-      }
-      // Do we want to connect some more seednodes?
-      if (now - timeAddedSeeds < MIN_ADDED_SEEDS_INTERVAL) {
-        // Don't connect seednodes yet
-        LOG.debug("Waiting for MIN_ADDED_SEEDS_INTERVAL");
+        // Re-check every minute. Adverse conditions (e.g., CPU starvation) might require reseeding.
         node.getTicker()
             .queueTimedJob(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    try {
-                      maybeSendAnnouncement();
-                    } catch (Throwable t) {
-                      LOG.error("Caught " + t + " trying to send announcements", t);
-                    }
-                  }
-                },
-                (timeAddedSeeds + MIN_ADDED_SEEDS_INTERVAL) - now);
+                this::maybeSendAnnouncement,
+                "Check whether we need to announce",
+                RETRY_DELAY,
+                false,
+                true);
+      } else {
+        node.getTicker()
+            .queueTimedJob(
+                this::maybeSendAnnouncement,
+                "Check whether we need to announce",
+                RETRY_DELAY,
+                false,
+                true);
+        if (running != 0) maybeSendAnnouncement();
+      }
+    };
+  }
+
+  /**
+   * Asynchronously requests an immediate re-evaluation and announcement, if needed.
+   *
+   * <p>If {@link #enoughPeers()} is true, nothing is scheduled. Otherwise, this enqueues a job on
+   * the node's ticker to call {@link #maybeSendAnnouncement()}.
+   */
+  public void maybeSendAnnouncementOffThread() {
+    if (enoughPeers()) return;
+    node.getTicker().queueTimedJob(this::maybeSendAnnouncement, 0);
+  }
+
+  /**
+   * Entry point for the announcement decision flow.
+   *
+   * <p>Performs inexpensive pre-checks and, if announcements are needed, prefers announcing to
+   * already connected seed nodes first. If not enough announcements are running and the last batch
+   * of seeds was added too long ago, it schedules connecting to more seed nodes. Cooling-off and
+   * sent-announcement limits are enforced to avoid excessive traffic.
+   */
+  protected void maybeSendAnnouncement() {
+    if (preChecksAndScheduleIfNotNeeded()) return;
+    long now = System.currentTimeMillis();
+    synchronized (this) {
+      if (checksUnderLock()) return;
+      announceToAvailableSeeds();
+      if (runningAnnouncements >= WANT_ANNOUNCEMENTS) {
+        if (LOG.isDebugEnabled()) LOG.debug("Running {} announcements", runningAnnouncements);
         return;
       }
+      if (delayIfRecentlyAddedSeeds(now)) return;
     }
     connectSomeSeednodes();
+  }
+
+  private boolean preChecksAndScheduleIfNotNeeded() {
+    synchronized (this) {
+      if (!started) return true;
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("maybeSendAnnouncement()");
+    if (!node.isOpennetEnabled()) return true;
+    if (enoughPeers()) {
+      node.getTicker().queueTimedJob(checker(), "Announcement checker", FINAL_DELAY, false, true);
+      return true;
+    }
+    return false;
+  }
+
+  private boolean checksUnderLock() {
+    // Double check after taking the lock.
+    if (enoughPeers()) {
+      node.getTicker().queueTimedJob(checker(), "Announcement checker", FINAL_DELAY, false, true);
+      return true;
+    }
+    if (runningAnnouncements > WANT_ANNOUNCEMENTS) {
+      if (LOG.isDebugEnabled()) LOG.debug("Running announcements already");
+      return true;
+    }
+    if (System.currentTimeMillis() < startTime) {
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "In cooling-off period for next {}",
+            TimeUtil.formatTime(startTime - System.currentTimeMillis()));
+      return true;
+    }
+    if (sentAnnouncements >= WANT_ANNOUNCEMENTS) {
+      if (LOG.isDebugEnabled()) LOG.debug("Sent enough announcements");
+      return true;
+    }
+    return false;
+  }
+
+  private void announceToAvailableSeeds() {
+    List<SeedServerPeerNode> seeds =
+        node.getPeers().getConnectedSeedServerPeersVector(announcedToIdentities);
+    while (sentAnnouncements < WANT_ANNOUNCEMENTS && !seeds.isEmpty()) {
+      final SeedServerPeerNode seed =
+          ListUtils.removeRandomBySwapLastSimple(node.getRandom(), seeds);
+      if (seed == null) {
+        LOG.debug("Null seed encountered while selecting; skipping.");
+        continue; // Single allowed continue: keep nesting shallow and reduce complexity.
+      }
+      InetAddress[] addrs =
+          java.util.Objects.requireNonNullElseGet(
+              seed.getInetAddresses(), () -> new InetAddress[0]);
+      boolean skip = !newAnnouncedIPs(addrs);
+      if (skip) {
+        LOG.debug("Not announcing to {} because already used those IPs", seed);
+      } else {
+        addAnnouncedIPs(addrs);
+        recordAnnouncementIfSent(seed);
+      }
+    }
+  }
+
+  private void recordAnnouncementIfSent(final SeedServerPeerNode seed) {
+    if (sendAnnouncement(seed)) {
+      sentAnnouncements++;
+      runningAnnouncements++;
+      announcedToIdentities.add(new ByteArrayWrapper(seed.peerECDSAPubKeyHash));
+    }
+  }
+
+  private boolean delayIfRecentlyAddedSeeds(long now) {
+    if (now - timeAddedSeeds < MIN_ADDED_SEEDS_INTERVAL) {
+      LOG.debug("Waiting for MIN_ADDED_SEEDS_INTERVAL");
+      scheduleMaybeSendAnnouncement((timeAddedSeeds + MIN_ADDED_SEEDS_INTERVAL) - now);
+      return true;
+    }
+    return false;
   }
 
   private synchronized void addAnnouncedIPs(InetAddress[] addrs) {
@@ -616,12 +731,15 @@ public class Announcer {
   }
 
   /**
-   * Have we already announced to this node? Return true if the node has new non-local addresses we
-   * haven't announced to. Return false if the node has non-local addresses we have announced to.
-   * Return true if the node has no non-local addresses.
+   * Determines whether the provided addresses contain a new non-local IP that has not yet been
+   * announced to.
    *
-   * @param addrs
-   * @return
+   * <p>Returns {@code true} if at least one non-local address is new, or if the node has no
+   * non-local addresses at all. Returns {@code false} when all non-local addresses were already
+   * used for announcements.
+   *
+   * @param addrs node IP addresses to evaluate
+   * @return {@code true} if announcement via these addresses should proceed
    */
   private synchronized boolean newAnnouncedIPs(InetAddress[] addrs) {
     boolean hasNonLocalAddresses = false;
@@ -633,14 +751,25 @@ public class Announcer {
     return !hasNonLocalAddresses;
   }
 
+  /**
+   * Schedules an announcement to a connected seed node.
+   *
+   * <p>The work is executed asynchronously on the node's executor. Progress is reported via the
+   * {@link AnnouncementCallback}. When opennet is disabled, the method returns {@code false} and no
+   * work is scheduled.
+   *
+   * @param seed the seed to which the announcement should be sent; expected to be connected
+   * @return {@code true} if the announcement run was scheduled; {@code false} if opennet is
+   *     disabled
+   */
   protected boolean sendAnnouncement(final SeedServerPeerNode seed) {
     if (!node.isOpennetEnabled()) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Not announcing to " + seed + " because opennet is disabled");
+      if (LOG.isDebugEnabled()) LOG.debug("Not announcing to {} because opennet is disabled", seed);
       return false;
     }
-    System.out.println("Announcement to " + seed.userToString() + " starting...");
-    if (LOG.isDebugEnabled()) LOG.debug("Announcement to " + seed.userToString() + " starting...");
+    LOG.atInfo().addArgument(seed::userToString).log("Announcement to {} starting...");
+    if (LOG.isDebugEnabled())
+      LOG.atDebug().addArgument(seed::userToString).log(ANNOUNCEMENT_TO + "{} starting...");
     AnnounceSender sender =
         new AnnounceSender(
             node.getLocation(),
@@ -662,29 +791,27 @@ public class Announcer {
                   announcementAddedNodes++;
                   totalAdded++;
                 }
-                LOG.info(
-                    "Announcement to "
-                        + seed.userToString()
-                        + " added node "
-                        + pn
-                        + " for a total of "
-                        + announcementAddedNodes
-                        + " ("
-                        + totalAdded
-                        + " from this announcement)");
-                System.out.println(
-                    "Announcement to "
-                        + seed.userToString()
-                        + " added node "
-                        + pn.userToString()
-                        + '.');
+                LOG.atInfo()
+                    .addArgument(seed::userToString)
+                    .addArgument(pn::userToString)
+                    .addArgument(() -> announcementAddedNodes)
+                    .addArgument(() -> totalAdded)
+                    .log(
+                        ANNOUNCEMENT_TO
+                            + "{} added node {} for a total of {} ({} from this announcement)");
+                LOG.atInfo()
+                    .addArgument(seed::userToString)
+                    .addArgument(pn::userToString)
+                    .log("Announcement to {} added node {}.");
               }
 
               @Override
               public void bogusNoderef(String reason) {
-                LOG.info(
-                    "Announcement to " + seed.userToString() + " got bogus noderef: " + reason,
-                    new Exception("debug"));
+                LOG.atInfo()
+                    .setCause(new Exception("debug"))
+                    .addArgument(seed::userToString)
+                    .addArgument(() -> reason)
+                    .log(ANNOUNCEMENT_TO + "{} got bogus noderef: {}");
               }
 
               @Override
@@ -692,12 +819,10 @@ public class Announcer {
                 boolean announceNow = false;
                 synchronized (Announcer.this) {
                   runningAnnouncements--;
-                  LOG.info(
-                      "Announcement to "
-                          + seed.userToString()
-                          + " completed, now running "
-                          + runningAnnouncements
-                          + " announcements");
+                  LOG.atInfo()
+                      .addArgument(seed::userToString)
+                      .addArgument(() -> runningAnnouncements)
+                      .log(ANNOUNCEMENT_TO + "{} completed, now running {} announcements");
                   if (runningAnnouncements == 0 && announcementAddedNodes > 0) {
                     // No point waiting if no nodes have been added!
                     startTime = System.currentTimeMillis() + COOLING_OFF_PERIOD;
@@ -710,45 +835,39 @@ public class Announcer {
                     announceNow = true;
                   }
                 }
-                // If it takes more than COOLING_OFF_PERIOD to disconnect, we might not be able to
-                // reannounce to this
-                // node. However, we can't reannounce to it anyway until announcedTo is cleared,
-                // which probably will
-                // be more than that period in the future.
+                // If disconnect takes longer than COOLING_OFF_PERIOD we might not reannounce to
+                // this seed immediately. Regardless, we cannot reannounce until the announced-to
+                // set is cleared, which is typically later than that period.
                 node.getPeers().disconnectAndRemove(seed, true, false, false);
                 int shallow = node.maxHTL() - (totalAdded + totalNotWanted);
                 if (acceptedSomewhere)
-                  System.out.println(
-                      "Announcement to "
-                          + seed.userToString()
-                          + " completed ("
-                          + totalAdded
-                          + " added, "
-                          + totalNotWanted
-                          + " not wanted, "
-                          + shallow
-                          + " shallow)");
+                  LOG.atInfo()
+                      .addArgument(seed::userToString)
+                      .addArgument(() -> totalAdded)
+                      .addArgument(() -> totalNotWanted)
+                      .addArgument(() -> shallow)
+                      .log("Announcement to {} completed ({} added, {} not wanted, {} shallow)");
                 else
-                  System.out.println(
-                      "Announcement to "
-                          + seed.userToString()
-                          + " not accepted (version "
-                          + seed.getBuildNumber()
-                          + ") .");
+                  LOG.atInfo()
+                      .addArgument(seed::userToString)
+                      .addArgument(seed::getBuildNumber)
+                      .log("Announcement to {} not accepted (version {}).");
                 if (announceNow) maybeSendAnnouncement();
               }
 
               @Override
               public void nodeFailed(PeerNode pn, String reason) {
-                LOG.info("Announcement to node " + pn.userToString() + " failed: " + reason);
+                LOG.atInfo()
+                    .addArgument(pn::userToString)
+                    .addArgument(() -> reason)
+                    .log(ANNOUNCEMENT_TO_NODE + "{} failed: {}");
               }
 
               @Override
               public void noMoreNodes() {
-                LOG.info(
-                    "Announcement to "
-                        + seed.userToString()
-                        + " ran out of nodes (route not found)");
+                LOG.atInfo()
+                    .addArgument(seed::userToString)
+                    .log(ANNOUNCEMENT_TO + "{} ran out of nodes (route not found)");
               }
 
               @Override
@@ -757,28 +876,31 @@ public class Announcer {
                   announcementNotWantedNodes++;
                   totalNotWanted++;
                 }
-                LOG.info(
-                    "Announcement to "
-                        + seed.userToString()
-                        + " returned node not wanted for a total of "
-                        + announcementNotWantedNodes
-                        + " ("
-                        + totalNotWanted
-                        + " from this announcement)");
+                LOG.atInfo()
+                    .addArgument(seed::userToString)
+                    .addArgument(() -> announcementNotWantedNodes)
+                    .addArgument(() -> totalNotWanted)
+                    .log(
+                        ANNOUNCEMENT_TO
+                            + "{} returned node not wanted for a total of {} ({} from this"
+                            + " announcement)");
               }
 
               @Override
               public void nodeNotAdded() {
-                LOG.info(
-                    "Announcement to "
-                        + seed.userToString()
-                        + " : node not wanted (maybe already have it, opennet just turned off,"
-                        + " etc)");
+                LOG.atInfo()
+                    .addArgument(seed::userToString)
+                    .log(
+                        ANNOUNCEMENT_TO
+                            + "{} : node not wanted (maybe already have it, opennet just turned"
+                            + " off, etc)");
               }
 
               @Override
               public void relayedNoderef() {
-                LOG.error("Announcement to " + seed.userToString() + " : RELAYED ?!?!?!");
+                LOG.atError()
+                    .addArgument(seed::userToString)
+                    .log(ANNOUNCEMENT_TO + "{} : RELAYED ?!?!?!");
               }
             },
             seed);
@@ -825,7 +947,7 @@ public class Announcer {
         int addedNodes;
         int refusedNodes;
         int recentSentAnnouncements;
-        int runningAnnouncements;
+        int runningAnnouncementsLocal;
         int connectedSeednodes = 0;
         int disconnectedSeednodes = 0;
         long coolingOffSeconds = Math.max(0, startTime - System.currentTimeMillis()) / 1000;
@@ -833,7 +955,7 @@ public class Announcer {
           addedNodes = announcementAddedNodes;
           refusedNodes = announcementNotWantedNodes;
           recentSentAnnouncements = sentAnnouncements;
-          runningAnnouncements = Announcer.this.runningAnnouncements;
+          runningAnnouncementsLocal = Announcer.this.runningAnnouncements;
         }
         List<SeedServerPeerNode> nodes = node.getPeers().getSeedServerPeersVector();
         for (SeedServerPeerNode seed : nodes) {
@@ -841,8 +963,7 @@ public class Announcer {
           else disconnectedSeednodes++;
         }
         sb.append(
-            l10n(
-                "announceDetails",
+            l10nAnnounceDetails(
                 new String[] {
                   "addedNodes",
                   "refusedNodes",
@@ -855,13 +976,13 @@ public class Announcer {
                   Integer.toString(addedNodes),
                   Integer.toString(refusedNodes),
                   Integer.toString(recentSentAnnouncements),
-                  Integer.toString(runningAnnouncements),
+                  Integer.toString(runningAnnouncementsLocal),
                   Integer.toString(connectedSeednodes),
                   Integer.toString(disconnectedSeednodes)
                 }));
         if (coolingOffSeconds > 0) {
           sb.append(' ');
-          sb.append(l10n("coolingOff", "time", Long.toString(coolingOffSeconds)));
+          sb.append(l10nCoolingOffTime(Long.toString(coolingOffSeconds)));
         }
       }
       return sb.toString();
@@ -911,25 +1032,59 @@ public class Announcer {
     public UserEvent.Type getEventType() {
       return UserEvent.Type.Announcer;
     }
+
+    // Private helper specialized for the only usage here.
+    private String l10nCoolingOffTime(String seconds) {
+      return NodeL10n.getBase().getString(L10N_PREFIX + "coolingOff", "time", seconds);
+    }
+
+    // Delegate overloads to outer class for convenience within the inner class
+    private String l10n(String key) {
+      return Announcer.this.l10n(key);
+    }
+
+    private String l10nAnnounceDetails(String[] patterns, String[] values) {
+      return Announcer.this.l10n("announceDetails", patterns, values);
+    }
   }
 
   private String l10n(String key) {
-    return NodeL10n.getBase().getString("Announcer." + key);
+    return NodeL10n.getBase().getString(L10N_PREFIX + key);
   }
 
+  /**
+   * Localizes a key within the announcer bundle and applies simple substitutions.
+   *
+   * @param key key without the {@code Announcer.} prefix
+   * @param patterns placeholder names to replace
+   * @param values replacement values corresponding to {@code patterns}
+   * @return localized string with substitutions applied
+   */
   protected String l10n(String key, String[] patterns, String[] values) {
-    return NodeL10n.getBase().getString("Announcer." + key, patterns, values);
+    return NodeL10n.getBase().getString(L10N_PREFIX + key, patterns, values);
   }
 
-  private String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("Announcer." + key, pattern, value);
-  }
+  // Note: the inner class contains a narrowly scoped helper for its specific key to avoid a
+  // private outer helper used solely by an inner class (Sonar S3398).
 
+  /**
+   * Triggers a near-immediate re-evaluation and announcement attempt.
+   *
+   * <p>Equivalent to calling {@link #maybeSendAnnouncementOffThread()}.
+   */
   public void reannounce() {
-    System.out.println("Re-announcing...");
+    LOG.info("Re-announcing...");
     maybeSendAnnouncementOffThread();
   }
 
+  /**
+   * Indicates whether announcements are currently suppressed because the node is older than the
+   * mandatory build and the updater is disabled or awaiting user action.
+   *
+   * <p>Intended for UI and status surfaces.
+   *
+   * @return {@code true} if announcement has been killed due to an out-of-date build
+   */
   public boolean isWaitingForUpdater() {
     synchronized (this) {
       return killedAnnouncementTooOld;

--- a/src/main/java/network/crypta/node/PrioRunnable.java
+++ b/src/main/java/network/crypta/node/PrioRunnable.java
@@ -1,11 +1,25 @@
 package network.crypta.node;
 
 /**
- * A Runnable which specifies a priority.
+ * A {@link Runnable} that exposes a numeric priority.
+ *
+ * <p>Schedulers or queues that support priority-based execution can use this interface to obtain a
+ * task's priority and order execution accordingly. The meaning of the returned number (e.g.,
+ * whether higher or lower values denote "higher" priority) is defined by the scheduler using it.
+ * Implementations should avoid heavy computation inside {@link #getPriority()}.
  *
  * @author toad
  */
 public interface PrioRunnable extends Runnable {
 
+  /**
+   * Returns the priority associated with this task.
+   *
+   * <p>The value is an arbitrary integer consumed by the scheduling component. Callers commonly
+   * expect the priority to remain stable while a task is enqueued; if it is dynamic, document the
+   * behavior in the implementation.
+   *
+   * @return the priority value used by the scheduler
+   */
   int getPriority();
 }

--- a/src/test/java/network/crypta/node/AnnounceSenderTest.java
+++ b/src/test/java/network/crypta/node/AnnounceSenderTest.java
@@ -1,0 +1,266 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.crypt.RandomSource;
+import network.crypta.io.comm.DMT;
+import network.crypta.io.comm.Message;
+import network.crypta.io.comm.MessageCore;
+import network.crypta.io.comm.MessageFilter;
+import network.crypta.io.comm.NotConnectedException;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.io.NativeThread;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class AnnounceSenderTest {
+
+  @Mock private Node node;
+  @Mock private OpennetManager om;
+  @Mock private PeerNode onlyNode;
+  @Mock private AnnouncementCallback cb;
+  @Mock private RequestTracker tracker;
+  @Mock private MessageCore usm;
+  @Mock private NodeStats stats;
+  @Mock private NodeCrypto crypto;
+  @Mock private PriorityAwareExecutor executor;
+  @Mock private PeerManager peers;
+
+  private static final long FIXED_UID = 777L;
+
+  @BeforeEach
+  void setUpCommon() {
+    when(node.getTracker()).thenReturn(tracker);
+    when(node.getUSM()).thenReturn(usm);
+    when(node.getNodeStats()).thenReturn(stats);
+    when(node.getExecutor()).thenReturn(executor);
+    // Run runnables inline for determinism when used.
+    Mockito.doAnswer(
+            inv -> {
+              Runnable r = inv.getArgument(0);
+              r.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class));
+
+    when(om.getCrypto()).thenReturn(crypto);
+    when(crypto.myCompressedFullRef()).thenReturn(new byte[] {1, 2, 3});
+
+    // Local-origin announce defaults
+    when(node.maxHTL()).thenReturn((short) 3);
+    when(node.isOpennetEnabled()).thenReturn(true);
+    when(node.isAdvancedModeEnabled()).thenReturn(false);
+
+    // Deterministic UID
+    RandomSource rnd = Mockito.mock(RandomSource.class);
+    when(rnd.nextLong()).thenReturn(FIXED_UID);
+    when(node.getRandom()).thenReturn(rnd);
+  }
+
+  @Test
+  void run_whenAcceptedThenTimeout_expectNodeFailedTimedOut() throws Exception {
+    // Arrange
+    AnnounceSender sender = new AnnounceSender(0.5, om, node, cb, onlyNode);
+
+    // start -> returns transfer uid; finish -> no-op
+    when(om.startSendAnnouncementRequest(
+            anyLong(), any(PeerNode.class), any(), any(), anyDouble(), anyShort()))
+        .thenReturn(123L);
+    Mockito.doNothing()
+        .when(om)
+        .finishSentAnnouncementRequest(any(PeerNode.class), any(), any(), anyLong());
+
+    // First waitFor: Accepted; Second waitFor: timeout (null)
+    Message accepted = DMT.createFNPAccepted(FIXED_UID);
+    when(usm.waitFor(any(MessageFilter.class), any())).thenReturn(accepted).thenReturn(null);
+
+    // Act
+    sender.run();
+
+    // Assert
+    verify(cb, times(1)).acceptedSomewhere();
+    verify(cb, times(1)).nodeFailed(onlyNode, "timed out");
+    verify(cb, times(1)).completed();
+    verify(stats, atLeastOnce()).endAnnouncement(FIXED_UID);
+    // Originated locally: no source path or peer selection
+    verify(node, never()).getPeers();
+  }
+
+  @Test
+  void run_whenAcceptedThenRejectedOverload_expectRnfAndNodeFailedRouteNotFound() throws Exception {
+    // Arrange
+    AnnounceSender sender = new AnnounceSender(0.5, om, node, cb, onlyNode);
+
+    when(om.startSendAnnouncementRequest(
+            anyLong(), any(PeerNode.class), any(), any(), anyDouble(), anyShort()))
+        .thenReturn(9876L);
+    Mockito.doNothing()
+        .when(om)
+        .finishSentAnnouncementRequest(any(PeerNode.class), any(), any(), anyLong());
+
+    Message accepted = DMT.createFNPAccepted(FIXED_UID);
+    Message rejected = DMT.createFNPRejectedOverload(FIXED_UID, true);
+    when(usm.waitFor(any(MessageFilter.class), any())).thenReturn(accepted).thenReturn(rejected);
+
+    // Act
+    sender.run();
+
+    // Assert
+    verify(cb, times(1)).acceptedSomewhere();
+    verify(cb, times(1)).nodeFailed(onlyNode, "route not found");
+    verify(cb, times(1)).completed();
+    verify(stats, atLeastOnce()).endAnnouncement(FIXED_UID);
+  }
+
+  @Test
+  void run_whenNodeNotWantedThenCompleted_expectCompletedAndNoHang() throws Exception {
+    // Arrange
+    AnnounceSender sender = new AnnounceSender(0.5, om, node, cb, onlyNode);
+
+    when(om.startSendAnnouncementRequest(
+            anyLong(), any(PeerNode.class), any(), any(), anyDouble(), anyShort()))
+        .thenReturn(4242L);
+    Mockito.doNothing()
+        .when(om)
+        .finishSentAnnouncementRequest(any(PeerNode.class), any(), any(), anyLong());
+
+    Message accepted = DMT.createFNPAccepted(FIXED_UID);
+    Message notWanted = DMT.createFNPOpennetAnnounceNodeNotWanted(FIXED_UID);
+    Message completed = DMT.createFNPOpennetAnnounceCompleted(FIXED_UID);
+
+    when(usm.waitFor(any(MessageFilter.class), any()))
+        .thenReturn(accepted)
+        .thenReturn(notWanted)
+        .thenReturn(completed)
+        .thenReturn(null); // completion follow-up ends
+
+    // Act
+    sender.run();
+
+    // Assert
+    verify(cb, times(1)).acceptedSomewhere();
+    verify(cb, times(1)).nodeNotWanted();
+    verify(cb, times(1)).completed();
+    verify(stats, atLeastOnce()).endAnnouncement(FIXED_UID);
+  }
+
+  @Test
+  void run_whenNoOnlyNodeAndNoPeerChosen_expectNoMoreNodes() {
+    // Arrange: onlyNode == null, peers.closerPeer() returns null so we RNF with next == null
+    when(node.getPeers()).thenReturn(peers);
+    when(node.decrementHTL(isNull(), anyShort())).thenReturn((short) 1);
+    when(peers.closerPeer(
+            isNull(),
+            anySet(),
+            anyDouble(),
+            anyBoolean(),
+            anyBoolean(),
+            anyInt(),
+            isNull(),
+            isNull(),
+            anyShort(),
+            anyLong(),
+            anyBoolean(),
+            anyBoolean(),
+            anyBoolean()))
+        .thenReturn(null);
+
+    AnnounceSender sender = new AnnounceSender(0.25, om, node, cb, null);
+
+    // Act
+    sender.run();
+
+    // Assert
+    verify(cb, times(1)).noMoreNodes();
+    verify(cb, times(1)).completed();
+    Mockito.verifyNoInteractions(usm);
+    verify(stats, atLeastOnce()).endAnnouncement(FIXED_UID);
+  }
+
+  @Test
+  void getPriority_returnsHighPriorityValue() {
+    // Arrange
+    AnnounceSender sender = new AnnounceSender(0.1, om, node, cb, null);
+
+    // Act / Assert
+    assertEquals(NativeThread.PriorityLevel.HIGH_PRIORITY.value, sender.getPriority());
+  }
+
+  @Test
+  void updateHtl_usesLastPeerAfterSendFailure() throws Exception {
+    // Arrange: multi-peer routing (onlyNode == null)
+    when(node.getPeers()).thenReturn(peers);
+
+    PeerNode p1 = Mockito.mock(PeerNode.class);
+    PeerNode p2 = Mockito.mock(PeerNode.class);
+    when(peers.closerPeer(
+            isNull(),
+            anySet(),
+            anyDouble(),
+            anyBoolean(),
+            anyBoolean(),
+            anyInt(),
+            isNull(),
+            isNull(),
+            anyShort(),
+            anyLong(),
+            anyBoolean(),
+            anyBoolean(),
+            anyBoolean()))
+        .thenReturn(p1, p2, null);
+
+    // Decrement HTL returns a sequence to keep iterations going
+    when(node.decrementHTL(any(), anyShort())).thenReturn((short) 2, (short) 1, (short) 1);
+
+    // First peer p1: start OK, then we don't get Accepted (timeout), so routeOnce ->
+    // CONTINUE_FORWARDED
+    when(om.startSendAnnouncementRequest(
+            anyLong(), any(PeerNode.class), any(), any(), anyDouble(), anyShort()))
+        .thenReturn(111L)
+        // Second attempt on p2: fail to start transfer
+        .thenThrow(new NotConnectedException("send fail"));
+
+    // Accepted wait: first call returns null (timeout/try another), no further waits because p2
+    // send fails
+    when(usm.waitFor(any(MessageFilter.class), any())).thenReturn(null);
+
+    AnnounceSender sender = new AnnounceSender(0.2, om, node, cb, null);
+
+    // Act
+    sender.run();
+
+    // Assert: verify decrementHTL was called with p2 as the 'from' on the iteration after send
+    // failure
+    ArgumentCaptor<PeerNode> fromCaptor = ArgumentCaptor.forClass(PeerNode.class);
+    verify(node, atLeast(3)).decrementHTL(fromCaptor.capture(), anyShort());
+    // Calls expected: [null (initial), p1 (after first forward), p2 (after send failure)]
+    java.util.List<PeerNode> calls = fromCaptor.getAllValues();
+    // Ensure we have at least 3 calls and the third is p2
+    assertEquals(p2, calls.get(2));
+  }
+}

--- a/src/test/java/network/crypta/node/AnnouncerTest.java
+++ b/src/test/java/network/crypta/node/AnnouncerTest.java
@@ -1,0 +1,221 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.node.updater.UpdateOverMandatoryManager;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class AnnouncerTest {
+
+  @Mock private OpennetManager om;
+
+  @Mock private Node node;
+
+  @Mock private PeerManager peers;
+
+  @Mock private Ticker ticker;
+
+  @Mock private PriorityAwareExecutor executor;
+
+  @Mock private NodeUpdateManager updater;
+
+  @Mock private UpdateOverMandatoryManager uom;
+
+  @Mock private NodeClientCore clientCore;
+
+  @Mock private UserAlertManager alerts;
+
+  // (no helpers)
+
+  @Test
+  @DisplayName("readSeednodes when file has multiple blocks returns only non-empty SFS")
+  void readSeednodes_whenFileHasMultipleBlocks_returnsOnlyNonEmpty(@TempDir Path tmp)
+      throws IOException {
+    Path file = tmp.resolve("seednodes.txt");
+    String content =
+        """
+        foo=bar
+        End
+        End
+        # header
+        baz=qux
+        End
+        """;
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+
+    List<SimpleFieldSet> out = Announcer.readSeednodes(file.toFile());
+
+    assertEquals(2, out.size(), "Should parse 2 non-empty SimpleFieldSet blocks");
+    // Verify keys are present
+    boolean hasFoo = out.stream().anyMatch(sfs -> "bar".equals(sfs.get("foo")));
+    boolean hasBaz = out.stream().anyMatch(sfs -> "qux".equals(sfs.get("baz")));
+    assertTrue(hasFoo, "First block should contain foo=bar");
+    assertTrue(hasBaz, "Third block should contain baz=qux");
+  }
+
+  @ParameterizedTest(name = "aim={0} => threshold={1}")
+  @CsvSource({"0,0", "5,2", "8,4", "20,10", "30,10"})
+  @DisplayName("getAnnouncementThreshold applies min(10, aim/2)")
+  void getAnnouncementThreshold_variousTargets_expectedMin(int aim, int expected) {
+    when(om.getNode()).thenReturn(node);
+    when(om.getNumberOfConnectedPeersToAimIncludingDarknet()).thenReturn(aim);
+    Announcer announcer = new Announcer(om);
+
+    int threshold = announcer.getAnnouncementThreshold();
+
+    assertEquals(expected, threshold);
+  }
+
+  @Test
+  @DisplayName("maybeSendAnnouncementOffThread when enoughPeers true does not schedule")
+  void maybeSendAnnouncementOffThread_whenEnoughPeersTrue_doesNotSchedule() {
+    when(om.getNode()).thenReturn(node);
+    when(node.getTicker()).thenReturn(ticker);
+    Announcer announcer = Mockito.spy(new Announcer(om));
+    doReturn(true).when(announcer).enoughPeers();
+
+    announcer.maybeSendAnnouncementOffThread();
+
+    verify(ticker, never()).queueTimedJob(any(Runnable.class), any(Long.class));
+  }
+
+  @Test
+  @DisplayName("maybeSendAnnouncementOffThread when not enough peers schedules immediate job")
+  void maybeSendAnnouncementOffThread_whenNotEnoughPeers_schedulesImmediate() {
+    when(om.getNode()).thenReturn(node);
+    when(node.getTicker()).thenReturn(ticker);
+    Announcer announcer = Mockito.spy(new Announcer(om));
+    doReturn(false).when(announcer).enoughPeers();
+
+    announcer.maybeSendAnnouncementOffThread();
+
+    ArgumentCaptor<Runnable> r = ArgumentCaptor.forClass(Runnable.class);
+    ArgumentCaptor<Long> delay = ArgumentCaptor.forClass(Long.class);
+    verify(ticker, times(1)).queueTimedJob(r.capture(), delay.capture());
+    assertEquals(0L, delay.getValue(), "Should schedule immediately with 0 delay");
+    assertNotNull(r.getValue(), "Runnable should not be null");
+  }
+
+  @Test
+  @DisplayName("sendAnnouncement returns false when opennet disabled")
+  void sendAnnouncement_whenOpennetDisabled_returnsFalse() {
+    when(om.getNode()).thenReturn(node);
+    when(node.isOpennetEnabled()).thenReturn(false);
+    Announcer announcer = new Announcer(om);
+
+    SeedServerPeerNode seed = mock(SeedServerPeerNode.class);
+
+    boolean result = announcer.sendAnnouncement(seed);
+
+    assertFalse(result, "Should not announce when opennet is disabled");
+    // No executor interaction expected
+    verify(node, never()).getExecutor();
+  }
+
+  @Test
+  @DisplayName(
+      "isWaitingForUpdater reflects killAnnouncement flag when updater disabled and too-new peers >"
+          + " 10")
+  void isWaitingForUpdater_whenKillAnnouncementConditionMet_true() {
+    when(om.getNode()).thenReturn(node);
+    when(om.stopping()).thenReturn(false);
+    when(node.getPeers()).thenReturn(peers);
+    when(peers.countConnectedPeers()).thenReturn(0);
+    // ensure target > opennetCount(=0) so we do NOT early-return "enough"
+    when(om.getNumberOfConnectedPeersToAimIncludingDarknet()).thenReturn(2);
+
+    // Updater: disabled, and UOM not fetching from two
+    when(node.getNodeUpdater()).thenReturn(updater);
+    when(updater.isEnabled()).thenReturn(false);
+    when(updater.isArmed()).thenReturn(true);
+    when(updater.getUpdateOverMandatory()).thenReturn(uom);
+    when(uom.fetchingFromTwo()).thenReturn(false);
+
+    // Too-new peers > 10 triggers killAnnouncement path
+    when(peers.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false)).thenReturn(11);
+
+    // Executor present (no-op execution to avoid deep interactions)
+    when(node.getExecutor()).thenReturn(executor);
+    doAnswer(inv -> null).when(executor).execute(any(Runnable.class));
+
+    // Alerts mocked to avoid real notification logic
+    when(node.getClientCore()).thenReturn(clientCore);
+    when(clientCore.getAlerts()).thenReturn(alerts);
+
+    Announcer announcer = new Announcer(om);
+
+    // enoughPeers should return true (since we kill announcements) and set the flag
+    assertTrue(announcer.enoughPeers(), "Announcement should be killed and treated as enoughPeers");
+    assertTrue(announcer.isWaitingForUpdater(), "Waiting-for-updater flag should be set");
+
+    // Alert should be registered once
+    verify(alerts, times(1)).register(Mockito.<UserAlert>any());
+  }
+
+  @Test
+  @DisplayName("timeGotEnoughPeers tracks first time above threshold and resets below")
+  void enoughPeers_timeTracking_setsAndResets() {
+    when(om.getNode()).thenReturn(node);
+    when(om.stopping()).thenReturn(false);
+    when(node.getPeers()).thenReturn(peers);
+    when(node.getNodeUpdater()).thenReturn(updater);
+    when(updater.isEnabled()).thenReturn(true);
+    when(updater.isArmed()).thenReturn(true);
+    when(updater.getUpdateOverMandatory()).thenReturn(uom);
+    when(uom.fetchingFromTwo()).thenReturn(false);
+    when(peers.getPeerNodeStatusSize(PeerManager.PEER_NODE_STATUS_TOO_NEW, false)).thenReturn(0);
+
+    // Target = min(10, aim/2) => aim=8 -> target 4
+    when(om.getNumberOfConnectedPeersToAimIncludingDarknet()).thenReturn(8);
+
+    // First call: connected peers = 4 (>= target) => enoughPeers() true and time set
+    when(peers.countConnectedPeers()).thenReturn(4, 0); // second call returns 0
+
+    Announcer announcer = new Announcer(om);
+
+    assertTrue(announcer.enoughPeers(), "Should have enough peers at threshold");
+    assertTrue(
+        announcer.timeGotEnoughPeers() > 0,
+        "timeGotEnoughPeers should be set to a positive timestamp");
+
+    // Drop below threshold => enoughPeers false and time reset to -1
+    assertFalse(announcer.enoughPeers(), "Should no longer have enough peers");
+    assertEquals(-1L, announcer.timeGotEnoughPeers(), "timeGotEnoughPeers should reset to -1");
+  }
+}


### PR DESCRIPTION
Summary
- Refactors the AnnounceSender/Announcer flow to make routing decisions clearer and safer, splits the long loop into smaller helpers (e.g., initialHandshakeAndMaybeTransfer, updateHtl, shouldCompleteNow, chooseNextNode, routeOnce).
- Improves HTL handling: attribute decrements to the last attempted peer, terminate cleanly when HTL reaches 0 or opennet disabled, and avoid spurious backtracks.
- Strengthens logging with consistent messages and constants; minor MessageType import cleanup.
- Adds unit tests for AnnounceSender and Announcer to lock in expected behaviors.
- Polishes Javadoc for AnnouncementCallback and PrioRunnable; ran Spotless on touched files.

Changes
- src/main/java/network/crypta/node/AnnounceSender.java
- src/main/java/network/crypta/node/AnnouncementCallback.java
- src/main/java/network/crypta/node/Announcer.java
- src/main/java/network/crypta/node/PrioRunnable.java
- src/test/java/network/crypta/node/AnnounceSenderTest.java
- src/test/java/network/crypta/node/AnnouncerTest.java

Commit log
- b1af12008a docs(node): improve Javadoc for AnnouncementCallback and PrioRunnable; run Spotless
- a8dd6df04d test(node): add AnnounceSenderTest
- 8d9fa17af0 style(node): apply Spotless formatting to AnnounceSender
- 6f0f81028c refactor(node): rework Announcer logging/scheduling; add unit tests

Notes
- Working tree is clean; no additional Spotless changes were required.
- Targeting base branch develop as requested. Maintainers can edit the PR.
