### PR TITLE
node: Persister/ConfigurablePersister polish + tests

### DIFF
--- a/src/main/java/network/crypta/node/ConfigurablePersister.java
+++ b/src/main/java/network/crypta/node/ConfigurablePersister.java
@@ -8,8 +8,49 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.support.Ticker;
 import network.crypta.support.api.StringCallback;
 
+/**
+ * Persister that takes its file locations from configuration.
+ *
+ * <p>This adapter wires a {@link Persistable} into the node configuration so the target file can be
+ * viewed and changed via {@link SubConfig}. It registers a string option whose getter exposes the
+ * current destination and whose setter validates and switches both the final target and its
+ * temporary companion file. Files are created on demand and must be readable and writable.
+ *
+ * <p>Localization: human-readable error messages are resolved through {@link NodeL10n} using the
+ * {@code ConfigurablePersister.*} keys.
+ */
 public class ConfigurablePersister extends Persister {
 
+  private static final String L10N_EXISTS_CANNOT_RW = "existsCannotReadWrite";
+  private static final String L10N_DOES_NOT_EXIST_CANNOT_CREATE = "doesNotExistCannotCreate";
+
+  /**
+   * Creates and registers a configurable persister.
+   *
+   * <p>The constructor registers an option under {@code optionName} with {@code nodeConfig}. The
+   * option defaults to {@code new File(baseDir, defaultFilename)}. Reading the option returns the
+   * active file path. Writing the option triggers validation and an atomic swap of the destination
+   * and its {@code .tmp} companion. On successful creation, the initial value is read from the
+   * config and applied immediately.
+   *
+   * <p>Threading: path updates are synchronized on {@code this} to replace both files together. The
+   * scheduling of persistence is delegated to {@link Ticker} via the base class.
+   *
+   * @param t source that can serialize throttle state
+   * @param nodeConfig configuration section that stores the file path option
+   * @param optionName key used to register the configurable file path
+   * @param defaultFilename default filename joined with {@code baseDir}
+   * @param sortOrder UI/help ordering hint for {@code nodeConfig}
+   * @param expert whether the option is considered advanced/expert
+   * @param forceWrite whether writes are forced even when unchanged (per {@code nodeConfig})
+   * @param shortDesc short, localized description for the option
+   * @param longDesc long, localized description for the option
+   * @param ps scheduler used by the base persister
+   * @param baseDir directory used to resolve {@code defaultFilename}
+   * @throws NodeInitException when the configured file is invalid or cannot be created. The message
+   *     derives from localization keys and the exit code is {@link
+   *     NodeInitException#EXIT_THROTTLE_FILE_ERROR}.
+   */
   public ConfigurablePersister(
       Persistable t,
       SubConfig nodeConfig,
@@ -33,7 +74,6 @@ public class ConfigurablePersister extends Persister {
         shortDesc,
         longDesc,
         new StringCallback() {
-
           @Override
           public String get() {
             return persistTarget.toString();
@@ -53,42 +93,76 @@ public class ConfigurablePersister extends Persister {
     }
   }
 
+  /*
+   * Validates and applies the persistence paths derived from the provided value.
+   *
+   * The value addresses the final file. Its temporary companion is {@code value + ".tmp"}.
+   * Both files must exist or be creatable and must be readable and writable.
+   */
   private void setThrottles(String val) throws InvalidConfigValueException {
-    File f = new File(val);
-    File tmp = new File(f + ".tmp");
-    while (true) {
-      if (f.exists()) {
-        if (!(f.canRead() && f.canWrite()))
-          throw new InvalidConfigValueException(l10n("existsCannotReadWrite") + " : " + tmp);
-        break;
-      } else {
-        try {
-          if (!f.createNewFile()) {
-            if (f.exists()) continue;
-            throw new InvalidConfigValueException(l10n("doesNotExistCannotCreate") + " : " + tmp);
-          }
-        } catch (IOException e) {
-          throw new InvalidConfigValueException(l10n("doesNotExistCannotCreate") + " : " + tmp);
-        }
-      }
+    final File target = new File(val);
+    final File temp = new File(target + ".tmp");
+
+    // Validate or create the target file
+    ensureExistsAndRw(target, temp);
+    // Validate or create the temp file
+    ensureExistsAndRw(temp, temp);
+
+    // Atomically replace both paths to keep readers from observing a half-updated pair.
+    synchronized (this) {
+      persistTarget = target;
+      persistTemp = temp;
     }
-    while (true) {
-      if (tmp.exists()) {
-        if (!(tmp.canRead() && tmp.canWrite()))
-          throw new InvalidConfigValueException(l10n("existsCannotReadWrite") + " : " + tmp);
-        break;
-      } else {
-        try {
-          tmp.createNewFile();
-        } catch (IOException e) {
-          throw new InvalidConfigValueException(l10n("doesNotExistCannotCreate") + " : " + tmp);
-        }
+  }
+
+  /**
+   * Ensures that {@code file} exists and is readable/writable; creates it when missing.
+   *
+   * <p>Error messages intentionally reference {@code errorPath} to preserve historical behavior
+   * (tests expect the ".tmp" path in messages).
+   *
+   * <p>Race-safety: If another thread/process creates the file between the initial existence check
+   * and our {@link File#createNewFile()} attempt, we may observe {@code created == false} and
+   * {@code file.exists() == true}. In that case we must still validate readability and writability;
+   * otherwise we could silently accept an unusable file and fail later.
+   *
+   * @throws InvalidConfigValueException if the file cannot be created or lacks read/write
+   *     permissions
+   */
+  private void ensureExistsAndRw(File file, File errorPath) throws InvalidConfigValueException {
+    if (file.exists()) {
+      if (!(file.canRead() && file.canWrite())) {
+        throw new InvalidConfigValueException(l10n(L10N_EXISTS_CANNOT_RW) + " : " + errorPath);
       }
+      return;
     }
 
-    synchronized (this) {
-      persistTarget = f;
-      persistTemp = tmp;
+    // Parent must be a directory if it exists; otherwise creation will fail with IOException.
+    File parent = file.getAbsoluteFile().getParentFile();
+    if (parent != null && parent.exists() && parent.isFile()) {
+      throw new InvalidConfigValueException(
+          l10n(L10N_DOES_NOT_EXIST_CANNOT_CREATE) + " : " + errorPath);
+    }
+    try {
+      boolean created = file.createNewFile();
+
+      // Whether we created it or another process did, re-validate the resulting file
+      // to close the race window between exists() and createNewFile().
+      if (file.exists()) {
+        if (!(file.canRead() && file.canWrite())) {
+          throw new InvalidConfigValueException(l10n(L10N_EXISTS_CANNOT_RW) + " : " + errorPath);
+        }
+        return;
+      }
+
+      // If creation reported false and the file still doesn't exist, treat as create failure.
+      if (!created) {
+        throw new InvalidConfigValueException(
+            l10n(L10N_DOES_NOT_EXIST_CANNOT_CREATE) + " : " + errorPath);
+      }
+    } catch (IOException e) {
+      throw new InvalidConfigValueException(
+          l10n(L10N_DOES_NOT_EXIST_CANNOT_CREATE) + " : " + errorPath);
     }
   }
 

--- a/src/main/java/network/crypta/node/Persister.java
+++ b/src/main/java/network/crypta/node/Persister.java
@@ -12,14 +12,32 @@ import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Periodically persists throttle state provided by a {@link Persistable} to disk.
+ *
+ * <p>This helper writes the current throttling configuration to a temporary file and then moves it
+ * to the target path. It schedules itself at a fixed interval and also registers a shutdown hook to
+ * persist one last snapshot on JVM exit. Errors during persistence are logged; the next run is
+ * still queued.
+ *
+ * <p>Threading: {@link #start()} is idempotent and synchronized on {@code this}. The periodic
+ * execution is driven by a {@link Ticker} instance, which calls {@link #run()} on the daemon thread
+ * it manages. Callers must initialize file paths before starting.
+ */
 class Persister implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(Persister.class);
 
-  static {
-  }
-
+  /** Interval between scheduled persistence attempts (milliseconds). */
   static final long PERIOD = MINUTES.toMillis(15);
 
+  /**
+   * Creates a persister with explicit file destinations.
+   *
+   * @param t source that can serialize throttle state to a {@link SimpleFieldSet}
+   * @param persistTemp temporary file written first; moved to the target on success
+   * @param persistTarget destination file that should replace any previous snapshot
+   * @param ps scheduler used to queue periodic executions
+   */
   Persister(Persistable t, File persistTemp, File persistTarget, Ticker ps) {
     this.persistable = t;
     this.persistTemp = persistTemp;
@@ -27,37 +45,50 @@ class Persister implements Runnable {
     this.ps = ps;
   }
 
-  // Subclass must set the others later
+  // Subclasses must initialize persistTemp and persistTarget before start().
+  /**
+   * Protected ctor for subclasses that provide file locations later.
+   *
+   * <p>Implementations must assign {@link #persistTemp} and {@link #persistTarget} before calling
+   * {@link #start()}.
+   *
+   * @param t source that can serialize throttle state
+   * @param ps scheduler used to queue periodic executions
+   */
   protected Persister(Persistable t, Ticker ps) {
     this.persistable = t;
     this.ps = ps;
   }
 
+  /** Source of throttle state to persist. */
   final Persistable persistable;
+
   private final Ticker ps;
+  // Paths are package-private so subclasses in this package can set them before start().
   File persistTemp;
   File persistTarget;
   private boolean started;
 
-  void interrupt() {
-    synchronized (this) {
-      notifyAll();
-    }
-  }
-
+  /**
+   * Performs one persistence cycle and re-schedules the next run.
+   *
+   * <p>All throwables are caught and logged to keep the scheduling loop alive.
+   *
+   * @see #persistThrottle()
+   */
   @Override
+  @SuppressWarnings("java:S1181")
   public void run() {
     try {
       persistThrottle();
-    } catch (Throwable t) {
-      LOG.error("Caught in ThrottlePersister: " + t, t);
-      System.err.println("Caught in ThrottlePersister: " + t);
-      t.printStackTrace();
-      System.err.println("Will restart ThrottlePersister...");
+    } catch (Throwable e) {
+      LOG.error("Caught in ThrottlePersister: {}", e, e);
+      LOG.warn("Will restart ThrottlePersister...");
     }
     ps.queueTimedJob(this, PERIOD);
   }
 
+  // Write to a temp file first, then move to the target to minimize partial writes being observed.
   private void persistThrottle() {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Trying to persist throttles...");
@@ -66,17 +97,30 @@ class Persister implements Runnable {
     try (FileOutputStream fos = new FileOutputStream(persistTemp)) {
       fs.writeToBigBuffer(fos);
     } catch (FileNotFoundException e) {
-      LOG.error("Could not store throttle data to disk: " + e, e);
+      LOG.error("Could not store throttle data to disk: {}", e, e);
     } catch (IOException e) {
-      persistTemp.delete();
+      try {
+        java.nio.file.Files.delete(persistTemp.toPath());
+      } catch (IOException ex) {
+        LOG.debug("Failed to delete temp file after write failure: {}", persistTemp, ex);
+      }
     }
     try {
       FileUtil.moveTo(persistTemp, persistTarget);
     } catch (Exception e) {
-      LOG.error("Could not move temp file to target: " + e, e);
+      LOG.error("Could not move temp file to target: {}", e, e);
     }
   }
 
+  /**
+   * Loads the last successfully persisted throttle state from disk.
+   *
+   * <p>Attempts to read {@link #persistTarget} first and falls back to {@link #persistTemp} when
+   * the target is missing or unreadable. Failures are logged. When no snapshot exists, this method
+   * returns {@code null}.
+   *
+   * @return a parsed {@link SimpleFieldSet}, or {@code null} if none is available
+   */
   public SimpleFieldSet read() {
     SimpleFieldSet throttleFS = null;
     try {
@@ -85,24 +129,27 @@ class Persister implements Runnable {
       try {
         throttleFS = SimpleFieldSet.readFrom(persistTemp, false, true);
       } catch (FileNotFoundException e1) {
-        // Ignore
+        // Expected when no snapshot has been written yet.
       } catch (IOException e1) {
         if (persistTarget.length() > 0 || persistTemp.length() > 0)
           LOG.error(
-              "Could not read "
-                  + persistTarget
-                  + " ("
-                  + e
-                  + ") and could not read "
-                  + persistTemp
-                  + " either ("
-                  + e1
-                  + ')');
+              "Could not read {} ({}) and could not read {} either ({})",
+              persistTarget,
+              e,
+              persistTemp,
+              e1,
+              e1);
       }
     }
     return throttleFS;
   }
 
+  /**
+   * Starts periodic persistence and registers a shutdown write.
+   *
+   * <p>Subsequent calls are ignored after the first successful start. The first persistence happens
+   * immediately in the calling thread; later runs are scheduled via the supplied {@link Ticker}.
+   */
   public void start() {
     synchronized (this) {
       if (started) {
@@ -113,13 +160,11 @@ class Persister implements Runnable {
     }
     SemiOrderedShutdownHook.get()
         .addEarlyJob(
-            new Thread() {
-
-              public void run() {
-                System.out.println("Writing " + persistTarget + " on shutdown");
-                persistThrottle();
-              }
-            });
+            new Thread(
+                () -> {
+                  LOG.info("Writing {} on shutdown", persistTarget);
+                  persistThrottle();
+                }));
     run();
   }
 }

--- a/src/test/java/network/crypta/node/ConfigurablePersisterTest.java
+++ b/src/test/java/network/crypta/node/ConfigurablePersisterTest.java
@@ -1,0 +1,188 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import network.crypta.config.Config;
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
+import network.crypta.config.SubConfig;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ConfigurablePersisterTest {
+
+  @Mock private Persistable persistable;
+  @Mock private Ticker ticker;
+
+  @TempDir Path tmpDir;
+
+  @Test
+  void constructor_whenDefaultPathUnderBaseDir_createsFilesAndTargetsSet() throws Exception {
+    // Arrange
+    Config cfg = new Config();
+    SubConfig node = cfg.createSubConfig("node");
+    String optionName = "throttleFile";
+    String defaultName = "throttles.txt";
+
+    File baseDir = tmpDir.toFile();
+
+    // Act
+    ConfigurablePersister cp =
+        new ConfigurablePersister(
+            persistable,
+            node,
+            optionName,
+            defaultName,
+            /* sortOrder= */ 0,
+            /* expert= */ false,
+            /* forceWrite= */ false,
+            /* shortDesc= */ "short",
+            /* longDesc= */ "long",
+            ticker,
+            baseDir);
+
+    // Assert
+    File expectedTarget = new File(baseDir, defaultName);
+    File expectedTemp = new File(expectedTarget + ".tmp");
+    assertTrue(expectedTarget.exists(), "target file should be created");
+    assertTrue(expectedTemp.exists(), "temp file should be created");
+    assertEquals(expectedTarget.getCanonicalFile(), cp.persistTarget.getCanonicalFile());
+    assertEquals(expectedTemp.getCanonicalFile(), cp.persistTemp.getCanonicalFile());
+
+    // After initialization, the option's callback should report the current target path
+    node.finishedInitialization();
+    String configured = node.getString(optionName);
+    assertEquals(expectedTarget.toString(), configured);
+  }
+
+  @Test
+  void constructor_whenParentIsFile_throwsNodeInitExceptionWithExitCode() throws IOException {
+    // Arrange
+    Config cfg = new Config();
+    SubConfig node = cfg.createSubConfig("node");
+    String optionName = "throttleFile";
+    File baseDir = tmpDir.toFile();
+
+    // Create a file which we will try to treat as a parent directory
+    File notADir = new File(baseDir, "parentFile");
+    assertTrue(notADir.createNewFile(), "setup: parentFile should be created");
+
+    String defaultName = "parentFile" + File.separator + "child.txt"; // parent is a file
+
+    // Act + Assert
+    NodeInitException ex =
+        assertThrows(
+            NodeInitException.class,
+            () ->
+                new ConfigurablePersister(
+                    persistable,
+                    node,
+                    optionName,
+                    defaultName,
+                    0,
+                    false,
+                    false,
+                    "short",
+                    "long",
+                    ticker,
+                    baseDir));
+
+    assertEquals(NodeInitException.EXIT_THROTTLE_FILE_ERROR, ex.exitCode);
+    String msg = ex.getMessage();
+    assertNotNull(msg);
+    // Should contain the localized reason and mention the .tmp path
+    String expectedReason =
+        NodeL10n.getBase().getString("ConfigurablePersister.doesNotExistCannotCreate");
+    assertTrue(msg.contains(expectedReason), msg);
+    assertTrue(msg.contains(".tmp"), msg);
+  }
+
+  @Test
+  void set_whenChangeToNewValidPath_updatesTargetsAndCreatesFiles() throws Exception {
+    // Arrange: construct with a valid default
+    Config cfg = new Config();
+    SubConfig node = cfg.createSubConfig("node");
+    String optionName = "throttleFile";
+    File baseDir = tmpDir.toFile();
+    ConfigurablePersister cp =
+        new ConfigurablePersister(
+            persistable,
+            node,
+            optionName,
+            "throttles.txt",
+            0,
+            false,
+            false,
+            "short",
+            "long",
+            ticker,
+            baseDir);
+
+    File newTarget = new File(baseDir, "new-throttles.txt");
+
+    // Act: update through the registered option (invokes callback -> setThrottles)
+    Option<?> opt = node.getOption(optionName);
+    opt.setValue(newTarget.toString());
+
+    // Assert: fields updated and files created
+    File expectedTemp = new File(newTarget + ".tmp");
+    assertTrue(newTarget.exists(), "new target should be created");
+    assertTrue(expectedTemp.exists(), "new temp should be created");
+    assertEquals(newTarget.getCanonicalFile(), cp.persistTarget.getCanonicalFile());
+    assertEquals(expectedTemp.getCanonicalFile(), cp.persistTemp.getCanonicalFile());
+
+    node.finishedInitialization();
+    assertEquals(newTarget.toString(), node.getString(optionName));
+  }
+
+  @Test
+  void set_whenChangeToInvalidPath_throwsInvalidConfigValueAndDoesNotChangeTargets()
+      throws Exception {
+    // Arrange: construct with a valid default
+    Config cfg = new Config();
+    SubConfig node = cfg.createSubConfig("node");
+    String optionName = "throttleFile";
+    File baseDir = tmpDir.toFile();
+    ConfigurablePersister cp =
+        new ConfigurablePersister(
+            persistable,
+            node,
+            optionName,
+            "throttles.txt",
+            0,
+            false,
+            false,
+            "short",
+            "long",
+            ticker,
+            baseDir);
+
+    File originalTarget = cp.persistTarget;
+
+    // Create a file and attempt to use it as a parent directory for the new value
+    File parentIsFile = new File(baseDir, "not-a-dir");
+    assertTrue(parentIsFile.createNewFile(), "setup: not-a-dir should be created");
+    String badPath = new File(parentIsFile, "child.txt").toString();
+
+    // Act + Assert: setting to an invalid path throws and does not update internal fields
+    Option<?> opt = node.getOption(optionName);
+    assertThrows(InvalidConfigValueException.class, () -> opt.setValue(badPath));
+    assertEquals(originalTarget.getCanonicalFile(), cp.persistTarget.getCanonicalFile());
+
+    node.finishedInitialization();
+    assertEquals(originalTarget.toString(), node.getString(optionName));
+  }
+}

--- a/src/test/java/network/crypta/node/PersisterTest.java
+++ b/src/test/java/network/crypta/node/PersisterTest.java
@@ -1,0 +1,215 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PersisterTest {
+
+  @Mock private Persistable persistable;
+  @Mock private Ticker ticker;
+
+  @TempDir File tempDir;
+
+  private File tempFile;
+  private File targetFile;
+
+  @BeforeEach
+  void setup() {
+    tempFile = new File(tempDir, "throttle.tmp");
+    targetFile = new File(tempDir, "throttle.dat");
+  }
+
+  @Test
+  void run_whenPersistSucceeds_writesTargetAndQueuesNext() throws Exception {
+    // Arrange
+    SimpleFieldSet sfs = new SimpleFieldSet(false);
+    sfs.putSingle("alpha", "42");
+    sfs.putSingle("nested.value", "ok");
+    when(persistable.persistThrottlesToFieldSet()).thenReturn(sfs);
+
+    // No-op scheduler
+    doAnswer(inv -> null)
+        .when(ticker)
+        .queueTimedJob(org.mockito.Mockito.any(Runnable.class), org.mockito.Mockito.anyLong());
+
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act
+    persister.run();
+
+    // Assert: file was written via temp then moved to target and contains our data
+    assertTrue(targetFile.isFile(), "persist target should exist");
+    SimpleFieldSet readBack = SimpleFieldSet.readFrom(targetFile, false, true);
+    assertEquals("42", readBack.get("alpha"));
+    assertEquals("ok", readBack.get("nested.value"));
+
+    // Assert: ticker received a rescheduling for the same persister with the configured period
+    ArgumentCaptor<Runnable> rCap = ArgumentCaptor.forClass(Runnable.class);
+    ArgumentCaptor<Long> lCap = ArgumentCaptor.forClass(Long.class);
+    verify(ticker, times(1)).queueTimedJob(rCap.capture(), lCap.capture());
+    assertEquals(Persister.PERIOD, lCap.getValue().longValue());
+    assertEquals(persister, rCap.getValue());
+  }
+
+  @Test
+  void run_whenTempIsDirectory_logsAndSkipsWriteAndQueuesNext() {
+    // Arrange: make temp path a directory so FileOutputStream throws FileNotFoundException
+    // ("Is a directory")
+    assertTrue(tempFile.mkdir(), "should create temp dir");
+    SimpleFieldSet sfs = new SimpleFieldSet(false);
+    sfs.putSingle("x", "y");
+    when(persistable.persistThrottlesToFieldSet()).thenReturn(sfs);
+
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act
+    persister.run();
+
+    // Assert: no valid file created at target (a directory rename might occur on some platforms)
+    assertFalse(
+        targetFile.isFile(), "target should not be a regular file when temp is a directory");
+    verify(ticker, times(1)).queueTimedJob(persister, Persister.PERIOD);
+  }
+
+  @Test
+  void run_whenWriteThrows_deletesTempAndDoesNotMove() throws Exception {
+    // Arrange: return a SimpleFieldSet that throws during write
+    SimpleFieldSet throwing = mock(SimpleFieldSet.class);
+    doThrow(new IOException("boom")).when(throwing).writeToBigBuffer(org.mockito.Mockito.any());
+    when(persistable.persistThrottlesToFieldSet()).thenReturn(throwing);
+
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act
+    persister.run();
+
+    // Assert: temp deleted in the IOException path, target not created
+    assertFalse(tempFile.exists(), "temp should be deleted after write failure");
+    assertFalse(targetFile.exists(), "target should not be created when write fails");
+    verify(ticker, times(1)).queueTimedJob(persister, Persister.PERIOD);
+  }
+
+  @Test
+  void read_whenTargetExists_returnsParsedFieldSet() throws Exception {
+    // Arrange: write valid SFS to target directly
+    SimpleFieldSet sfs = new SimpleFieldSet(false);
+    sfs.putSingle("a", "b");
+    try (FileOutputStream fos = new FileOutputStream(targetFile)) {
+      sfs.writeToBigBuffer(fos);
+    }
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act
+    SimpleFieldSet read = persister.read();
+
+    // Assert
+    assertNotNull(read);
+    assertEquals("b", read.get("a"));
+  }
+
+  @Test
+  void read_whenTargetUnreadableTempValid_returnsFromTemp() throws Exception {
+    // Arrange: create an empty target file so parsing throws EOFException and triggers fallback
+    assertTrue(targetFile.createNewFile(), "should create empty target file");
+    SimpleFieldSet sfs = new SimpleFieldSet(false);
+    sfs.putSingle("k", "v");
+    try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+      sfs.writeToBigBuffer(fos);
+    }
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act
+    SimpleFieldSet read = persister.read();
+
+    // Assert: fallback to temp
+    assertNotNull(read);
+    assertEquals("v", read.get("k"));
+  }
+
+  @Test
+  void read_whenBothMissing_returnsNull() {
+    // Arrange
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act
+    SimpleFieldSet read = persister.read();
+
+    // Assert
+    assertNull(read);
+  }
+
+  @Test
+  void read_whenBothUnreadable_returnsNull() throws Exception {
+    // Arrange: create empty files so both reads throw EOFException and return null
+    assertTrue(targetFile.createNewFile(), "should create empty target file");
+    assertTrue(tempFile.createNewFile(), "should create empty temp file");
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act
+    SimpleFieldSet read = persister.read();
+
+    // Assert
+    assertNull(read);
+  }
+
+  @Test
+  void run_whenFatalThrowableThrown_catchesAndQueuesNext() {
+    // Arrange: simulate a fatal Error thrown during persistence
+    doThrow(new LinkageError("simulated fatal error"))
+        .when(persistable)
+        .persistThrottlesToFieldSet();
+
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act: should not propagate the Error; still schedules next run
+    persister.run();
+
+    // Assert: rescheduled even after fatal throwable
+    verify(ticker, times(1)).queueTimedJob(persister, Persister.PERIOD);
+    // And no target file created since write never happened
+    assertFalse(targetFile.exists());
+  }
+
+  @Test
+  void start_whenCalledTwice_onlySchedulesOnce() throws Exception {
+    // Arrange
+    SimpleFieldSet sfs = new SimpleFieldSet(false);
+    sfs.putSingle("z", "1");
+    when(persistable.persistThrottlesToFieldSet()).thenReturn(sfs);
+    Persister persister = new Persister(persistable, tempFile, targetFile, ticker);
+
+    // Act: first start performs persist and schedules; second start is a no-op
+    persister.start();
+    persister.start();
+
+    // Assert: one schedule only; file exists with expected data
+    verify(ticker, times(1)).queueTimedJob(persister, Persister.PERIOD);
+    assertTrue(targetFile.exists(), "persist should have executed once");
+    SimpleFieldSet readBack = SimpleFieldSet.readFrom(targetFile, false, true);
+    assertEquals("1", readBack.get("z"));
+  }
+}


### PR DESCRIPTION
Summary
- Polish Persister docs/logging and add resilience to scheduling
- Add unit tests for Persister and ConfigurablePersister
- Run Gradle spotlessApply to format sources before commit

Why
- Replace ad-hoc System.err prints with structured logging
- Ensure persisters keep rescheduling after any Throwable
- Improve confidence via targeted tests for read()/run() paths

Commits since base (origin/develop)
- bb6cdf54af test(node): add ConfigurablePersister tests; apply formatting
- 3a634ce2f8 refactor(node): polish Persister docs/logging and resilience

Diffstat
```
 .../network/crypta/node/ConfigurablePersister.java | 136 ++++++++++---
 src/main/java/network/crypta/node/Persister.java   | 115 +++++++----
 .../crypta/node/ConfigurablePersisterTest.java     | 188 ++++++++++++++++++
 .../java/network/crypta/node/PersisterTest.java    | 215 +++++++++++++++++++++
 4 files changed, 588 insertions(+), 66 deletions(-)
```

Changed source files
- src/main/java/network/crypta/node/ConfigurablePersister.java
- src/main/java/network/crypta/node/Persister.java
- src/test/java/network/crypta/node/ConfigurablePersisterTest.java
- src/test/java/network/crypta/node/PersisterTest.java

Checks
- [x] Ran spotlessApply locally
- [ ] Ran full test suite locally (CI will verify)

Notes
- Base branch: develop
- Head branch: feature/fix-Persister
