### PR TITLE
fix(node): tighten PeerNodeStatus snapshot; identity-based equals; add tests/Javadoc

### DIFF
--- a/src/main/java/network/crypta/node/DarknetPeerNodeStatus.java
+++ b/src/main/java/network/crypta/node/DarknetPeerNodeStatus.java
@@ -3,6 +3,16 @@ package network.crypta.node;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
 
+/**
+ * Immutable snapshot of darknet‑specific peer state.
+ *
+ * <p>Extends {@link PeerNodeStatus} with values that apply only to darknet friends: display name,
+ * connection policy flags (burst/listen/disabled), a private note, friend trust, and visibility
+ * preferences. Values are copied from a live {@link DarknetPeerNode} during construction so UI and
+ * diagnostics do not read mutable node state directly.
+ *
+ * <p>Threading: instances are read‑only after construction and therefore thread‑safe.
+ */
 public class DarknetPeerNodeStatus extends PeerNodeStatus {
 
   private final String name;
@@ -21,6 +31,15 @@ public class DarknetPeerNodeStatus extends PeerNodeStatus {
   private final FRIEND_VISIBILITY theirVisibility;
   private final FRIEND_VISIBILITY overallVisibility;
 
+  /**
+   * Builds a snapshot from a live darknet peer.
+   *
+   * <p>Heavy statistics (message counters, load summaries) are handled by the {@link
+   * PeerNodeStatus} constructor; this subclass only reads darknet‑specific values.
+   *
+   * @param peerNode source peer (must be a {@link DarknetPeerNode})
+   * @param noHeavy forwarded to the parent constructor to optionally omit heavy statistics
+   */
   public DarknetPeerNodeStatus(DarknetPeerNode peerNode, boolean noHeavy) {
     super(peerNode, noHeavy);
     this.name = peerNode.getName();
@@ -31,66 +50,125 @@ public class DarknetPeerNodeStatus extends PeerNodeStatus {
     this.trustLevel = peerNode.getTrustLevel();
     this.ourVisibility = peerNode.getOurVisibility();
     this.theirVisibility = peerNode.getTheirVisibility();
+    // Effective visibility is the stricter of ours and theirs. If theirs is null, the helper
+    // treats it as less strict, so ourVisibility becomes the effective value.
     if (ourVisibility.isStricterThan(theirVisibility)) this.overallVisibility = ourVisibility;
     else this.overallVisibility = theirVisibility;
   }
 
   /**
-   * @return The peer's trust level.
+   * Returns the configured friend trust.
+   *
+   * @return trust level used by friend‑related heuristics
    */
   public FRIEND_TRUST getTrustLevel() {
     return trustLevel;
   }
 
   /**
-   * @return the name
+   * Returns the peer's display name.
+   *
+   * @return non‑null user‑provided name
    */
   public String getName() {
     return name;
   }
 
   /**
-   * @return the burstOnly
+   * Indicates that handshake attempts are sent only in infrequent bursts.
+   *
+   * @return {@code true} when burst‑only is enabled
    */
   public boolean isBurstOnly() {
     return burstOnly;
   }
 
   /**
-   * @return the disabled
+   * Indicates that the friend is locally disabled.
+   *
+   * @return {@code true} when disabled and not considered for new connections
    */
   public boolean isDisabled() {
     return disabled;
   }
 
   /**
-   * @return the listening
+   * Indicates that we accept inbound handshakes but do not initiate them.
+   *
+   * @return {@code true} when in listen‑only mode
    */
   public boolean isListening() {
     return listening;
   }
 
   /**
-   * @return the privateDarknetCommentNote
+   * Returns the private note shown on the friends page.
+   *
+   * @return note text; may be empty
    */
   public String getPrivateDarknetCommentNote() {
     return privateDarknetCommentNote;
   }
 
+  /**
+   * Returns a concise, human‑readable description including the name and {@link PeerNodeStatus}
+   * summary.
+   */
   @Override
   public String toString() {
     return name + ' ' + super.toString();
   }
 
+  /**
+   * Equality is identical to {@link PeerNodeStatus#equals(Object)}.
+   *
+   * <p>This subclass does not add identity beyond the underlying peer. We therefore delegate to the
+   * parent implementation to preserve symmetry and transitivity with {@code PeerNodeStatus}
+   * instances.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    return super.equals(obj);
+  }
+
+  /**
+   * Hash code consistent with {@link #equals(Object)}.
+   *
+   * <p>Delegates to the parent implementation so that instances of this subclass remain
+   * interchangeable with {@link PeerNodeStatus} for hashing based on the same peer identity.
+   */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /**
+   * Returns our visibility preference for this friend.
+   *
+   * @return enum describing what other friends may learn about this link
+   */
   public FRIEND_VISIBILITY getOurVisibility() {
     return ourVisibility;
   }
 
+  /**
+   * Returns the peer‑reported visibility preference.
+   *
+   * <p>If the peer has not sent a preference yet, returns {@link FRIEND_VISIBILITY#NO} to avoid
+   * null checks in callers.
+   *
+   * @return their preference, or {@code NO} when unknown
+   */
   public FRIEND_VISIBILITY getTheirVisibility() {
     if (theirVisibility == null) return FRIEND_VISIBILITY.NO;
     return theirVisibility;
   }
 
+  /**
+   * Returns the effective visibility, defined as the stricter of ours and theirs.
+   *
+   * @return stricter of {@link #getOurVisibility()} and {@link #getTheirVisibility()}
+   */
   public FRIEND_VISIBILITY getOverallVisibility() {
     return overallVisibility;
   }

--- a/src/main/java/network/crypta/node/OpennetPeerNodeStatus.java
+++ b/src/main/java/network/crypta/node/OpennetPeerNodeStatus.java
@@ -5,7 +5,7 @@ package network.crypta.node;
  *
  * <p>This type augments {@link PeerNodeStatus} with the timestamp of the last successful
  * interaction as reported by the associated {@link OpennetPeerNode}. Instances represent a snapshot
- * taken at construction time and do not update afterwards.
+ * taken at construction time and do not update afterward.
  *
  * <p>Immutability note: the fields declared in this class are {@code final}. The overall snapshot
  * semantics and identity behavior are inherited from {@link PeerNodeStatus}.

--- a/src/main/java/network/crypta/node/OpennetPeerNodeStatus.java
+++ b/src/main/java/network/crypta/node/OpennetPeerNodeStatus.java
@@ -1,11 +1,61 @@
 package network.crypta.node;
 
+/**
+ * Opennet-specific peer status snapshot.
+ *
+ * <p>This type augments {@link PeerNodeStatus} with the timestamp of the last successful
+ * interaction as reported by the associated {@link OpennetPeerNode}. Instances represent a snapshot
+ * taken at construction time and do not update afterwards.
+ *
+ * <p>Immutability note: the fields declared in this class are {@code final}. The overall snapshot
+ * semantics and identity behavior are inherited from {@link PeerNodeStatus}.
+ */
 public class OpennetPeerNodeStatus extends PeerNodeStatus {
 
+  /**
+   * Creates a new snapshot for an opennet peer.
+   *
+   * <p>The {@code peerNode} must be an instance of {@link OpennetPeerNode}. The {@code noHeavy}
+   * flag is forwarded to the superclass; see {@link PeerNodeStatus#PeerNodeStatus(PeerNode,
+   * boolean)} for details about how it affects snapshot contents.
+   *
+   * @param peerNode the peer whose status is captured; must be an {@link OpennetPeerNode}
+   * @param noHeavy forwarded to the superclass; consult {@link PeerNodeStatus}
+   * @throws ClassCastException if {@code peerNode} is not an {@link OpennetPeerNode}
+   */
   OpennetPeerNodeStatus(PeerNode peerNode, boolean noHeavy) {
     super(peerNode, noHeavy);
     timeLastSuccess = ((OpennetPeerNode) peerNode).timeLastSuccess();
   }
 
+  /**
+   * Timestamp of the most recent successful interaction with this opennet peer, as returned by
+   * {@link OpennetPeerNode#timeLastSuccess()} when this snapshot was created.
+   *
+   * <p>Units and clock source are defined by the provider method; this field is an immutable
+   * capture of that value.
+   */
   public final long timeLastSuccess;
+
+  /**
+   * Compares by peer identity as defined in {@link PeerNodeStatus}.
+   *
+   * <p>Two snapshots are equal if they refer to the same peer identity. This method intentionally
+   * does not include {@link #timeLastSuccess} in the comparison to maintain the equality contract
+   * across the class hierarchy (e.g., when comparing with a {@link PeerNodeStatus}).
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof PeerNodeStatus)) return false;
+    return super.equals(obj);
+  }
+
+  /**
+   * Returns a hash code consistent with {@link #equals(Object)} by delegating to the base class.
+   */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
 }

--- a/src/main/java/network/crypta/node/PeerNodeStatus.java
+++ b/src/main/java/network/crypta/node/PeerNodeStatus.java
@@ -1,6 +1,7 @@
 package network.crypta.node;
 
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.Map;
 import network.crypta.clients.http.DarknetConnectionsToadlet;
 import network.crypta.io.comm.FreenetInetAddress;
@@ -9,21 +10,30 @@ import network.crypta.io.xfer.PacketThrottle;
 import network.crypta.node.PeerNode.IncomingLoadSummaryStats;
 
 /**
- * Contains various status information for a {@link PeerNode}. Used e.g. in {@link
- * DarknetConnectionsToadlet} to reduce race-conditions while creating the page.
+ * Immutable snapshot of a {@link PeerNode}'s observable state.
+ *
+ * <p>Instances are constructed from a live {@link PeerNode} and copy the values required by
+ * presentation and diagnostics (for example {@link DarknetConnectionsToadlet}). Copying avoids
+ * reading mutable state from the node while rendering and therefore reduces race conditions.
+ *
+ * <p>Threading: this object is read-only and thread-safe after construction. No synchronization is
+ * required by callers.
+ *
+ * <p>Nullability: some address fields may be {@code null} when the peer is not known yet or the
+ * address cannot be resolved.
  *
  * @author David 'Bombe' Roden &lt;bombe@freenetproject.org&gt;
  * @version $Id$
  */
 public class PeerNodeStatus {
 
-  /** This is the preferred string form of the address. */
+  /** Preferred string form of the peer address (may be hostname or numeric). */
   private final String peerAddress;
 
-  /** This one is always an IP address or null. */
+  /** Numeric IP address string, or {@code null} if unresolved. */
   private final String peerAddressNumerical;
 
-  /** This one is always an IP address or null. */
+  /** Raw IP address bytes (length 4 for IPv4 or 16 for IPv6), or {@code null}. */
   private final byte[] peerAddressBytes;
 
   private final int peerPort;
@@ -80,6 +90,9 @@ public class PeerNodeStatus {
 
   private final int hashCode;
 
+  /** Stable identity for equality: SHA‑256 of the peer's ECDSA public key. */
+  private final byte[] peerPubKeyHash;
+
   private final double pReject;
 
   private final long totalBytesIn;
@@ -113,12 +126,31 @@ public class PeerNodeStatus {
   private final long messageQueueLengthBytes;
 
   private final long messageQueueLengthTime;
+
   // int's because that's what they are transferred as
 
+  /**
+   * Aggregate "real‑time" inbound load view for this peer.
+   *
+   * <p>Fields expose capacity and usage counters in bytes. Intended for UI and diagnostics and may
+   * be {@code null} when the constructor was invoked with {@code noHeavy=true} on the source node.
+   */
   public final IncomingLoadSummaryStats incomingLoadStatsRealTime;
 
+  /**
+   * Aggregate "bulk" inbound load view for this peer.
+   *
+   * <p>Fields expose capacity and usage counters in bytes. Intended for UI and diagnostics and may
+   * be {@code null} when the constructor was invoked with {@code noHeavy=true} on the source node.
+   */
   public final IncomingLoadSummaryStats incomingLoadStatsBulk;
 
+  /**
+   * Whether the local node holds the full node reference for this peer.
+   *
+   * <p>When {@code false}, only a partial/volatile reference is available (e.g., for opennet peers)
+   * and certain metadata will be missing.
+   */
   public final boolean hasFullNoderef;
 
   PeerNodeStatus(PeerNode peerNode, boolean noHeavy) {
@@ -176,6 +208,10 @@ public class PeerNodeStatus {
       this.localMessagesSent = null;
     }
     this.hashCode = peerNode.hashCode;
+    // Use the actual 32-byte public key hash for equality to avoid collisions on the 32-bit
+    // hashCode value. Copy defensively to keep this snapshot immutable.
+    byte[] pkh = peerNode.getPubKeyHash();
+    this.peerPubKeyHash = (pkh == null ? null : pkh.clone());
     this.pReject = peerNode.getPRejected();
     this.totalBytesIn = peerNode.getTotalInputBytes();
     this.totalBytesOut = peerNode.getTotalOutputBytes();
@@ -197,41 +233,64 @@ public class PeerNodeStatus {
     hasFullNoderef = peerNode.hasFullNoderef();
   }
 
+  /**
+   * Returns the approximate size of the outbound message queue for this peer.
+   *
+   * @return number of bytes currently queued for send; monotonically decreases as data is sent and
+   *     increases as messages are enqueued
+   */
   public long getMessageQueueLengthBytes() {
     return messageQueueLengthBytes;
   }
 
+  /**
+   * Returns a rough estimate of how long it will take to drain the outbound queue.
+   *
+   * @return estimated time to empty the send queue in milliseconds
+   */
   public long getMessageQueueLengthTime() {
     return messageQueueLengthTime;
   }
 
   /**
-   * @return the localMessagesReceived
+   * Returns per-message-type counters received locally from this peer.
+   *
+   * <p>Available only when the snapshot was built with {@code noHeavy=false}; otherwise returns
+   * {@code null}.
+   *
+   * @return a map of message type to count, or {@code null}
    */
   public Map<String, Long> getLocalMessagesReceived() {
     return localMessagesReceived;
   }
 
   /**
-   * @return the localMessagesSent
+   * Returns per-message-type counters sent locally to this peer.
+   *
+   * <p>Available only when the snapshot was built with {@code noHeavy=false}; otherwise returns
+   * {@code null}.
+   *
+   * @return a map of message type to count, or {@code null}
    */
   public Map<String, Long> getLocalMessagesSent() {
     return localMessagesSent;
   }
 
   /**
-   * @return the peerAddedTime
+   * Returns when this peer was first added to the peer manager.
+   *
+   * @return timestamp in milliseconds since the epoch, or {@code 0} if unknown/not persisted
    */
   public long getPeerAddedTime() {
     return peerAddedTime;
   }
 
   /**
-   * Counts the peers in <code>peerNodes</code> that have the specified status.
+   * Counts the peers in {@code peerNodeStatuses} that report the given status value.
    *
-   * @param peerNodeStatuses The peer nodes' statuses
-   * @param status The status to count
-   * @return The number of peers that have the specified status.
+   * @param peerNodeStatuses the snapshot array to inspect
+   * @param status the numeric status code to count
+   * @return number of entries whose {@link #getStatusValue()} equals {@code status}
    */
   public static int getPeerStatusCount(PeerNodeStatus[] peerNodeStatuses, int status) {
     int count = 0;
@@ -244,109 +303,152 @@ public class PeerNodeStatus {
   }
 
   /**
-   * @return the timeLastConnectionCompleted
+   * Returns when a connection last reached the "connected" state.
+   *
+   * @return timestamp in milliseconds since the epoch, or {@code 0} if never connected
    */
   public long getTimeLastConnectionCompleted() {
     return timeLastConnectionCompleted;
   }
 
   /**
-   * @return the backedOffPercent
+   * Returns the fraction of recent time during which this peer was in routing backoff.
+   *
+   * @param realTime {@code true} for real‑time traffic; {@code false} for bulk traffic
+   * @return fraction in {@code [0.0, 1.0]}
    */
   public double getBackedOffPercent(boolean realTime) {
     return realTime ? backedOffPercentRT : backedOffPercentBulk;
   }
 
   /**
-   * @return the lastBackoffReason
+   * Returns the most recent textual reason for entering routing backoff.
+   *
+   * @param realTime {@code true} for real‑time traffic; {@code false} for bulk traffic
+   * @return a short, human‑readable reason string (never {@code null})
    */
   public String getLastBackoffReason(boolean realTime) {
     return realTime ? lastBackoffReasonRT : lastBackoffReasonBulk;
   }
 
   /**
-   * @return the timeLastRoutable
+   * Returns when this peer was last routable.
+   *
+   * @return timestamp in milliseconds since the epoch, or {@code 0} if never routable
    */
   public long getTimeLastRoutable() {
     return timeLastRoutable;
   }
 
   /**
-   * @return the publicInvalidVersion
+   * Indicates whether our version is considered invalid by the peer according to public exchange.
+   *
+   * @return {@code true} if the peer reported our version as invalid
    */
   public boolean isPublicInvalidVersion() {
     return publicInvalidVersion;
   }
 
   /**
-   * @return the publicReverseInvalidVersion
+   * Indicates whether this peer's version is considered invalid according to our checks.
+   *
+   * @return {@code true} if we reported the peer's version as invalid
    */
   public boolean isPublicReverseInvalidVersion() {
     return publicReverseInvalidVersion;
   }
 
   /**
-   * @return the averagePingTime
+   * Returns the running average round‑trip time (RTT) to this peer.
+   *
+   * @return RTT in milliseconds
    */
   public double getAveragePingTime() {
     return averagePingTime;
   }
 
   /**
-   * @return The ping time for purposes of retransmissions.
+   * Returns the retransmission timeout (RTO) derived from RTT variance.
+   *
+   * <p>Calculated per RFC&nbsp;2988 and used for scheduling retransmissions.
+   *
+   * @return RTO in milliseconds
    */
   public double getAveragePingTimeCorrected() {
     return averagePingTimeCorrected;
   }
 
   /**
-   * @return the getRoutingBackedOffUntil
+   * Returns the deadline until which routing remains backed off.
+   *
+   * @param realTime {@code true} for real‑time traffic; {@code false} for bulk traffic
+   * @return timestamp in milliseconds since the epoch; values in the past indicate no active
+   *     backoff
    */
   public long getRoutingBackedOffUntil(boolean realTime) {
     return realTime ? routingBackedOffUntilRT : routingBackedOffUntilBulk;
   }
 
   /**
-   * @return the location
+   * Returns the peer's location on the routing ring.
+   *
+   * @return a double in {@code [0.0, 1.0)}
    */
   public double getLocation() {
     return location;
   }
 
+  /**
+   * Returns sampled locations of this peer's neighbors.
+   *
+   * @return an array of ring locations, or {@code null} if not available
+   */
   public double[] getPeersLocation() {
     return peersLocation;
   }
 
   /**
-   * @return the peerAddress, in its preferred string format.
+   * Returns the address in its preferred string form.
+   *
+   * @return hostname or numeric address; may be {@code null}
    */
   public String getPeerAddress() {
     return peerAddress;
   }
 
   /**
-   * @return the peer address, in numerical form, or null if not known.
+   * Returns the numeric IP address if known.
+   *
+   * @return numeric IP string, or {@code null} if unresolved
    */
   public String getPeerAddressNumerical() {
     return peerAddressNumerical;
   }
 
   /**
-   * @return the peer address, as raw bytes, or null if not known.
+   * Returns the raw IP address bytes if known.
+   *
+   * @return a 4‑byte (IPv4) or 16‑byte (IPv6) array, or {@code null}
    */
   public byte[] getPeerAddressBytes() {
     return peerAddressBytes;
   }
 
   /**
-   * @return the peerPort
+   * Returns the UDP port used by this peer.
+   *
+   * @return port number in {@code [0, 65535]}, or {@code -1} when unknown
    */
   public int getPeerPort() {
     return peerPort;
   }
 
   /**
-   * @return the string representation of peerAddress and peerPort
+   * Returns {@link #getPeerAddress()} combined with {@link #getPeerPort()}.
+   *
+   * <p>IPv6 addresses are wrapped in {@code []}, e.g., {@code [2001:db8::1]:12345}.
+   *
+   * @return address and port formatted for display
    */
   public String getPeerAddressAndPort() {
     if (peerAddressBytes != null && peerAddressBytes.length == 16) { // IPv6 address have [] around
@@ -357,70 +459,91 @@ public class PeerNodeStatus {
   }
 
   /**
-   * @return the routingBackoffLength
+   * Returns the configured routing backoff duration.
+   *
+   * @param realTime {@code true} for real‑time traffic; {@code false} for bulk traffic
+   * @return duration in milliseconds
    */
   public long getRoutingBackoffLength(boolean realTime) {
     return realTime ? routingBackoffLengthRT : routingBackoffLengthBulk;
   }
 
   /**
-   * @return the statusCSSName
+   * Returns the CSS class name that represents the current status in UI components.
+   *
+   * @return a stable, lowercase CSS class identifier
    */
   public String getStatusCSSName() {
     return statusCSSName;
   }
 
   /**
-   * @return the statusName
+   * Returns the human‑readable status string.
+   *
+   * @return a localized or fixed string describing the connection state
    */
   public String getStatusName() {
     return statusName;
   }
 
   /**
-   * @return the statusValue
+   * Returns the numeric status code defined by {@link PeerManager}.
+   *
+   * @return an integer constant representing the connection state
    */
   public int getStatusValue() {
     return statusValue;
   }
 
   /**
-   * @return the version
+   * Returns the peer's advertised software version string.
+   *
+   * @return a version identifier, never {@code null}
    */
   public String getVersion() {
     return version;
   }
 
   /**
-   * @return the connected
+   * Indicates whether a transport connection is currently established.
+   *
+   * @return {@code true} if connected
    */
   public boolean isConnected() {
     return connected;
   }
 
   /**
-   * @return the routable
+   * Indicates whether the peer is currently usable for routing.
+   *
+   * @return {@code true} if the node considers this peer routable
    */
   public boolean isRoutable() {
     return routable;
   }
 
   /**
-   * @return the isFetchingARK
+   * Indicates whether the peer is actively fetching its ARK.
+   *
+   * @return {@code true} if ARK retrieval is in progress
    */
   public boolean isFetchingARK() {
     return isFetchingARK;
   }
 
   /**
-   * @return the isOpennet
+   * Indicates whether the connection belongs to the opennet (not darknet).
+   *
+   * @return {@code true} for opennet peers
    */
   public boolean isOpennet() {
     return isOpennet;
   }
 
   /**
-   * @return the simpleVersion
+   * Returns a simplified, comparable version number derived from {@link #getVersion()}.
+   *
+   * @return an integer for coarse version comparisons
    */
   public int getSimpleVersion() {
     return simpleVersion;
@@ -451,62 +574,158 @@ public class PeerNodeStatus {
     return hashCode;
   }
 
+  /**
+   * Equality is based on the underlying peer's public key hash.
+   *
+   * <p>This object is a moment‑in‑time snapshot for a specific {@link PeerNode}. Two snapshots are
+   * considered equal if and only if they refer to the same peer identity. We compare on the 32‑byte
+   * SHA‑256 of the peer's ECDSA public key rather than the cached 32‑bit {@code hashCode} value to
+   * avoid false equality on integer hash collisions.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof PeerNodeStatus other)) return false;
+    if (this.peerPubKeyHash != null && other.peerPubKeyHash != null)
+      return Arrays.equals(this.peerPubKeyHash, other.peerPubKeyHash);
+    // Fallback for tests or degenerate cases where the pubkey hash is not available:
+    // compare on the cached identity-based integer hash. This preserves previous behavior while
+    // avoiding NPEs when mocks do not provide key material.
+    return this.hashCode == other.hashCode;
+  }
+
+  /**
+   * Returns the probability that requests to this peer are locally rejected or time out.
+   *
+   * @return fraction in {@code [0.0, 1.0]}
+   */
   public double getPReject() {
     return pReject;
   }
 
+  /**
+   * Returns the total number of bytes received from this peer.
+   *
+   * @return cumulative bytes (all time)
+   */
   public long getTotalInputBytes() {
     return totalBytesIn;
   }
 
+  /**
+   * Returns the total number of bytes sent to this peer.
+   *
+   * @return cumulative bytes (all time)
+   */
   public long getTotalOutputBytes() {
     return totalBytesOut;
   }
 
+  /**
+   * Returns the number of bytes received from this peer since the node started.
+   *
+   * @return cumulative bytes since current process start
+   */
   public long getTotalInputSinceStartup() {
     return totalBytesInSinceStartup;
   }
 
+  /**
+   * Returns the number of bytes sent to this peer since the node started.
+   *
+   * @return cumulative bytes since current process start
+   */
   public long getTotalOutputSinceStartup() {
     return totalBytesOutSinceStartup;
   }
 
+  /**
+   * Returns the fraction of recent time that a routable connection has existed.
+   *
+   * @return fraction in {@code [0.0, 1.0]}
+   */
   public double getPercentTimeRoutableConnection() {
     return percentTimeRoutableConnection;
   }
 
+  /**
+   * Returns the throttle associated with this peer, if any.
+   *
+   * @return the {@link PacketThrottle} used for rate limiting, or {@code null}
+   */
   public PacketThrottle getThrottle() {
     return throttle;
   }
 
+  /**
+   * Returns the estimated clock difference between this peer and the local node.
+   *
+   * @return time delta in milliseconds ({@code remoteTime - localTime})
+   */
   public long getClockDelta() {
     return clockDelta;
   }
 
+  /**
+   * Indicates whether status changes for this peer are recorded for statistics/logging.
+   *
+   * @return {@code true} if the node records this peer's status history
+   */
   public boolean recordStatus() {
     return recordStatus;
   }
 
+  /**
+   * Indicates that this peer is a seed server.
+   *
+   * @return {@code true} if this snapshot represents a seed server
+   */
   public boolean isSeedServer() {
     return isSeedServer;
   }
 
+  /**
+   * Indicates that this peer is a seed client.
+   *
+   * @return {@code true} if this snapshot represents a seed client
+   */
   public boolean isSeedClient() {
     return isSeedClient;
   }
 
+  /**
+   * Indicates whether the peer should appear in search and selection UIs.
+   *
+   * @return {@code true} if the connection is a real, searchable link
+   */
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   public boolean isSearchable() {
     return isSearchable;
   }
 
+  /**
+   * Returns the number of bytes sent that were retransmissions.
+   *
+   * @return cumulative bytes resent
+   */
   public long getResendBytesSent() {
     return resendBytesSent;
   }
 
+  /**
+   * Returns the uptime reported by the peer as a percentage.
+   *
+   * @return integer percentage in {@code [0, 100]}
+   */
   public int getReportedUptimePercentage() {
     return reportedUptimePercentage;
   }
 
+  /**
+   * Returns how often the peer has been selected since connecting.
+   *
+   * @return a rate expressed as selections per millisecond
+   */
   public double getSelectionRate() {
     return selectionRate;
   }

--- a/src/test/java/network/crypta/node/DarknetPeerNodeStatusTest.java
+++ b/src/test/java/network/crypta/node/DarknetPeerNodeStatusTest.java
@@ -1,0 +1,217 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.support.math.RunningAverage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class DarknetPeerNodeStatusTest {
+
+  // Creates a minimally‑stubbed peer suitable for constructing PeerNodeStatus deterministically.
+  private DarknetPeerNode basePeerMock() {
+    DarknetPeerNode peer = mock(DarknetPeerNode.class);
+
+    // Keep address and port null/-1 to make toString deterministic.
+    when(peer.getPeer()).thenReturn(null);
+
+    // Fields used by PeerNodeStatus#toString(); keep values stable.
+    when(peer.getPeerNodeStatusString()).thenReturn("CONNECTED");
+    when(peer.getLocation()).thenReturn(0.0);
+    when(peer.getVersion()).thenReturn("1");
+    when(peer.getRoutingBackoffLength(true)).thenReturn(0L);
+    when(peer.getRoutingBackoffLength(false)).thenReturn(0L);
+    when(peer.getRoutingBackedOffUntil(true)).thenReturn(0L);
+    when(peer.getRoutingBackedOffUntil(false)).thenReturn(0L);
+
+    // Avoid NPEs: PeerNodeStatus reads currentValue() from these averages.
+    RunningAverage avg = mock(RunningAverage.class);
+    when(avg.currentValue()).thenReturn(0.0);
+    when(peer.getBackedOffPercentRT()).thenReturn(avg);
+    when(peer.getBackedOffPercentBulk()).thenReturn(avg);
+
+    // Defaults for other primitive reads invoked by the constructor.
+    when(peer.isConnected()).thenReturn(false);
+    when(peer.isRoutable()).thenReturn(false);
+    when(peer.isFetchingARK()).thenReturn(false);
+    when(peer.isOpennet()).thenReturn(false);
+    when(peer.averagePingTime()).thenReturn(0.0);
+    when(peer.averagePingTimeCorrected()).thenReturn(0.0);
+    when(peer.publicInvalidVersion()).thenReturn(false);
+    when(peer.publicReverseInvalidVersion()).thenReturn(false);
+    when(peer.timeLastRoutable()).thenReturn(0L);
+    when(peer.timeLastConnectionCompleted()).thenReturn(0L);
+    when(peer.getPeerAddedTime()).thenReturn(0L);
+    when(peer.getPRejected()).thenReturn(0.0);
+    when(peer.getTotalInputBytes()).thenReturn(0L);
+    when(peer.getTotalOutputBytes()).thenReturn(0L);
+    when(peer.getTotalInputSinceStartup()).thenReturn(0L);
+    when(peer.getTotalOutputSinceStartup()).thenReturn(0L);
+    when(peer.getPercentTimeRoutableConnection()).thenReturn(0.0);
+    when(peer.getThrottle()).thenReturn(null);
+    when(peer.getClockDelta()).thenReturn(0L);
+    when(peer.recordStatus()).thenReturn(false);
+    when(peer.isRealConnection()).thenReturn(false);
+    when(peer.getResendBytesSent()).thenReturn(0L);
+    when(peer.getUptime()).thenReturn((short) 0);
+    when(peer.getMessageQueueLengthBytes()).thenReturn(0L);
+    when(peer.getProbableSendQueueTime()).thenReturn(0L);
+    when(peer.getIncomingLoadStats(true)).thenReturn(null);
+    when(peer.getIncomingLoadStats(false)).thenReturn(null);
+    when(peer.hasFullNoderef()).thenReturn(false);
+
+    return peer;
+  }
+
+  @Test
+  void constructor_copiesBasicFields_expectValues() {
+    DarknetPeerNode peer = basePeerMock();
+    when(peer.getName()).thenReturn("Alice");
+    when(peer.isBurstOnly()).thenReturn(true);
+    when(peer.isListenOnly()).thenReturn(true);
+    when(peer.isDisabled()).thenReturn(false);
+    when(peer.getPrivateDarknetCommentNote()).thenReturn("note-1");
+    when(peer.getTrustLevel()).thenReturn(FRIEND_TRUST.HIGH);
+    when(peer.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.NAME_ONLY);
+    when(peer.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+
+    DarknetPeerNodeStatus status = new DarknetPeerNodeStatus(peer, true);
+
+    assertEquals("Alice", status.getName());
+    assertTrue(status.isBurstOnly());
+    assertTrue(status.isListening());
+    assertFalse(status.isDisabled());
+    assertEquals("note-1", status.getPrivateDarknetCommentNote());
+    assertSame(FRIEND_TRUST.HIGH, status.getTrustLevel());
+    assertSame(FRIEND_VISIBILITY.NAME_ONLY, status.getOurVisibility());
+    assertSame(FRIEND_VISIBILITY.YES, status.getTheirVisibility());
+    // NAME_ONLY is stricter than YES → overall NAME_ONLY
+    assertSame(FRIEND_VISIBILITY.NAME_ONLY, status.getOverallVisibility());
+  }
+
+  @Test
+  void getOverallVisibility_whenTheirMoreStrict_expectTheir() {
+    DarknetPeerNode peer = basePeerMock();
+    when(peer.getName()).thenReturn("Carol");
+    when(peer.isBurstOnly()).thenReturn(false);
+    when(peer.isListenOnly()).thenReturn(false);
+    when(peer.isDisabled()).thenReturn(false);
+    when(peer.getPrivateDarknetCommentNote()).thenReturn("");
+    when(peer.getTrustLevel()).thenReturn(FRIEND_TRUST.NORMAL);
+    when(peer.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(peer.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.NO);
+
+    DarknetPeerNodeStatus status = new DarknetPeerNodeStatus(peer, true);
+
+    assertSame(FRIEND_VISIBILITY.NO, status.getOverallVisibility());
+    assertSame(FRIEND_VISIBILITY.NO, status.getTheirVisibility());
+    assertSame(FRIEND_VISIBILITY.YES, status.getOurVisibility());
+  }
+
+  @Test
+  void getTheirVisibility_whenNullStored_expectNOAndOverallFromOur() {
+    DarknetPeerNode peer = basePeerMock();
+    when(peer.getName()).thenReturn("Dave");
+    when(peer.isBurstOnly()).thenReturn(false);
+    when(peer.isListenOnly()).thenReturn(false);
+    when(peer.isDisabled()).thenReturn(true);
+    when(peer.getPrivateDarknetCommentNote()).thenReturn("pvt");
+    when(peer.getTrustLevel()).thenReturn(FRIEND_TRUST.LOW);
+    when(peer.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    // Simulate a legacy/mock path where their visibility is unknown (null)
+    when(peer.getTheirVisibility()).thenReturn(null);
+
+    DarknetPeerNodeStatus status = new DarknetPeerNodeStatus(peer, true);
+
+    // Getter maps null to NO.
+    assertSame(FRIEND_VISIBILITY.NO, status.getTheirVisibility());
+    // During construction, overall = stricter(our=YES, their=null) → our
+    assertSame(FRIEND_VISIBILITY.YES, status.getOverallVisibility());
+    assertTrue(status.isDisabled());
+  }
+
+  @Test
+  void toString_includesNameAndParentFields_deterministic() {
+    DarknetPeerNode peer = basePeerMock();
+    when(peer.getName()).thenReturn("Bob");
+    when(peer.isBurstOnly()).thenReturn(false);
+    when(peer.isListenOnly()).thenReturn(false);
+    when(peer.isDisabled()).thenReturn(false);
+    when(peer.getPrivateDarknetCommentNote()).thenReturn("");
+    when(peer.getTrustLevel()).thenReturn(FRIEND_TRUST.NORMAL);
+    when(peer.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(peer.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+
+    DarknetPeerNodeStatus status = new DarknetPeerNodeStatus(peer, true);
+
+    String expected = "Bob " + "CONNECTED null:-1 0.0 1 RT backoff: 0 (0 ) bulk backoff: 0 (0)";
+
+    String actual = status.toString();
+    assertNotNull(actual);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void equals_whenSamePubKeyHash_expectEqual() {
+    byte[] pkh = new byte[] {1, 2, 3};
+
+    DarknetPeerNode p1 = basePeerMock();
+    when(p1.getName()).thenReturn("P1");
+    when(p1.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(p1.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(p1.getTrustLevel()).thenReturn(FRIEND_TRUST.NORMAL);
+    when(p1.getPrivateDarknetCommentNote()).thenReturn("");
+    when(p1.getPubKeyHash()).thenReturn(pkh);
+
+    DarknetPeerNode p2 = basePeerMock();
+    when(p2.getName()).thenReturn("P2");
+    when(p2.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.NO);
+    when(p2.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.NO);
+    when(p2.getTrustLevel()).thenReturn(FRIEND_TRUST.HIGH);
+    when(p2.getPrivateDarknetCommentNote()).thenReturn("x");
+    when(p2.getPubKeyHash()).thenReturn(pkh.clone());
+
+    DarknetPeerNodeStatus s1 = new DarknetPeerNodeStatus(p1, true);
+    DarknetPeerNodeStatus s2 = new DarknetPeerNodeStatus(p2, true);
+
+    assertEquals(s1, s2);
+    assertEquals(s2, s1);
+  }
+
+  @Test
+  void equals_whenDifferentPubKeyHash_expectNotEqual() {
+    DarknetPeerNode p1 = basePeerMock();
+    when(p1.getName()).thenReturn("X");
+    when(p1.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(p1.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(p1.getTrustLevel()).thenReturn(FRIEND_TRUST.NORMAL);
+    when(p1.getPrivateDarknetCommentNote()).thenReturn("");
+    when(p1.getPubKeyHash()).thenReturn(new byte[] {9, 9, 9});
+
+    DarknetPeerNode p2 = basePeerMock();
+    when(p2.getName()).thenReturn("Y");
+    when(p2.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(p2.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(p2.getTrustLevel()).thenReturn(FRIEND_TRUST.NORMAL);
+    when(p2.getPrivateDarknetCommentNote()).thenReturn("");
+    when(p2.getPubKeyHash()).thenReturn(new byte[] {8, 8, 8});
+
+    DarknetPeerNodeStatus s1 = new DarknetPeerNodeStatus(p1, true);
+    DarknetPeerNodeStatus s2 = new DarknetPeerNodeStatus(p2, true);
+
+    assertNotEquals(s1, s2);
+    assertNotEquals(s2, s1);
+  }
+}

--- a/src/test/java/network/crypta/node/OpennetPeerNodeStatusTest.java
+++ b/src/test/java/network/crypta/node/OpennetPeerNodeStatusTest.java
@@ -1,0 +1,106 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Hashtable;
+import network.crypta.support.math.RunningAverage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class OpennetPeerNodeStatusTest {
+
+  private static OpennetPeerNode mockMinimalOpennetPeerNode(long timeLastSuccessValue) {
+    OpennetPeerNode node = mock(OpennetPeerNode.class);
+
+    // Keep address path in PeerNodeStatus constructor on the null branch.
+    when(node.getPeer()).thenReturn(null);
+
+    // Backoff percent access requires non-null RunningAverage instances.
+    RunningAverage rt = mock(RunningAverage.class);
+    when(rt.currentValue()).thenReturn(0.0);
+    RunningAverage bulk = mock(RunningAverage.class);
+    when(bulk.currentValue()).thenReturn(0.0);
+    when(node.getBackedOffPercentRT()).thenReturn(rt);
+    when(node.getBackedOffPercentBulk()).thenReturn(bulk);
+
+    // Specific to OpennetPeerNodeStatus.
+    when(node.timeLastSuccess()).thenReturn(timeLastSuccessValue);
+    return node;
+  }
+
+  @Test
+  @DisplayName("constructor_whenOpennetPeer_setsTimeLastSuccessFromNode")
+  void constructor_whenOpennetPeer_setsTimeLastSuccessFromNode() {
+    // Arrange
+    long expected = 123_456_789L;
+    OpennetPeerNode node = mockMinimalOpennetPeerNode(expected);
+
+    // Act
+    OpennetPeerNodeStatus status = new OpennetPeerNodeStatus(node, true);
+
+    // Assert
+    assertEquals(expected, status.timeLastSuccess);
+  }
+
+  @Test
+  @DisplayName("constructor_whenPeerIsNotOpennet_throwsClassCastException")
+  void constructor_whenPeerIsNotOpennet_throwsClassCastException() {
+    // Arrange: minimal PeerNode stub so super(...) path succeeds
+    PeerNode base = mock(PeerNode.class);
+    when(base.getPeer()).thenReturn(null);
+
+    RunningAverage rt = mock(RunningAverage.class);
+    when(rt.currentValue()).thenReturn(0.0);
+    RunningAverage bulk = mock(RunningAverage.class);
+    when(bulk.currentValue()).thenReturn(0.0);
+    // getBackedOffPercent* are package-private; the test lives in the same package
+    doReturn(rt).when(base).getBackedOffPercentRT();
+    doReturn(bulk).when(base).getBackedOffPercentBulk();
+
+    // Act + Assert
+    assertThrows(ClassCastException.class, () -> new OpennetPeerNodeStatus(base, true));
+  }
+
+  @Test
+  @DisplayName("constructor_whenNoHeavyTrue_heavyMapsAreNull")
+  void constructor_whenNoHeavyTrue_heavyMapsAreNull() {
+    // Arrange
+    OpennetPeerNode node = mockMinimalOpennetPeerNode(0L);
+
+    // Act
+    OpennetPeerNodeStatus status = new OpennetPeerNodeStatus(node, true);
+
+    // Assert
+    assertNull(status.getLocalMessagesReceived());
+    assertNull(status.getLocalMessagesSent());
+  }
+
+  @Test
+  @DisplayName("constructor_whenNoHeavyFalse_heavyMapsArePopulated")
+  void constructor_whenNoHeavyFalse_heavyMapsArePopulated() {
+    // Arrange
+    OpennetPeerNode node = mockMinimalOpennetPeerNode(42L);
+    Hashtable<String, Long> received = new Hashtable<>();
+    received.put("Hello", 3L);
+    Hashtable<String, Long> sent = new Hashtable<>();
+    sent.put("World", 4L);
+    when(node.getLocalNodeReceivedMessagesFromStatistic()).thenReturn(received);
+    when(node.getLocalNodeSentMessagesToStatistic()).thenReturn(sent);
+
+    // Act
+    OpennetPeerNodeStatus status = new OpennetPeerNodeStatus(node, false);
+
+    // Assert
+    assertEquals(received, status.getLocalMessagesReceived());
+    assertEquals(sent, status.getLocalMessagesSent());
+  }
+}

--- a/src/test/java/network/crypta/node/PeerNodeStatusTest.java
+++ b/src/test/java/network/crypta/node/PeerNodeStatusTest.java
@@ -1,0 +1,365 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.util.Hashtable;
+import network.crypta.io.comm.FreenetInetAddress;
+import network.crypta.io.comm.Peer;
+import network.crypta.io.xfer.PacketThrottle;
+import network.crypta.support.math.RunningAverage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PeerNodeStatusTest {
+
+  @Mock RunningAverage rtAvg;
+  @Mock RunningAverage bulkAvg;
+
+  private <T extends PeerNode> T basePeerNodeMock(Class<T> type) {
+    // Common, safe defaults to avoid NPEs in the PeerNodeStatus constructor
+    T pn = mock(type);
+
+    // Address chain default: no peer by default
+    when(pn.getPeer()).thenReturn(null);
+
+    // Status strings/values
+    when(pn.getPeerNodeStatus()).thenReturn(1);
+    when(pn.getPeerNodeStatusString()).thenReturn("CONNECTED");
+    when(pn.getPeerNodeStatusCSSClassName()).thenReturn("connected");
+
+    // Locations / versioning
+    when(pn.getLocation()).thenReturn(0.25);
+    when(pn.getPeersLocationArray()).thenReturn(new double[] {0.1, 0.2, 0.3});
+    when(pn.getVersion()).thenReturn("1.2.3");
+    when(pn.getSimpleVersion()).thenReturn(10203);
+
+    // Backoff lengths and deadlines
+    when(pn.getRoutingBackoffLength(true)).thenReturn(1000L);
+    when(pn.getRoutingBackoffLength(false)).thenReturn(2000L);
+    when(pn.getRoutingBackedOffUntil(true)).thenReturn(0L);
+    when(pn.getRoutingBackedOffUntil(false)).thenReturn(0L);
+
+    // Connectivity
+    when(pn.isConnected()).thenReturn(true);
+    when(pn.isRoutable()).thenReturn(true);
+    when(pn.isFetchingARK()).thenReturn(false);
+    when(pn.isOpennet()).thenReturn(false);
+    when(pn.isRealConnection()).thenReturn(true);
+
+    // Ping / versions
+    when(pn.averagePingTime()).thenReturn(123.0);
+    when(pn.averagePingTimeCorrected()).thenReturn(100.0);
+    when(pn.publicInvalidVersion()).thenReturn(false);
+    when(pn.publicReverseInvalidVersion()).thenReturn(false);
+
+    // Backoff percentages
+    when(pn.getBackedOffPercentRT()).thenReturn(rtAvg);
+    when(pn.getBackedOffPercentBulk()).thenReturn(bulkAvg);
+    lenient().when(rtAvg.currentValue()).thenReturn(0.1);
+    lenient().when(bulkAvg.currentValue()).thenReturn(0.2);
+
+    // Backoff reasons
+    when(pn.getLastBackoffReason(true)).thenReturn("reason-rt");
+    when(pn.getLastBackoffReason(false)).thenReturn("reason-bulk");
+
+    // Times
+    when(pn.timeLastRoutable()).thenReturn(111L);
+    when(pn.timeLastConnectionCompleted()).thenReturn(222L);
+    when(pn.getPeerAddedTime()).thenReturn(333L);
+
+    // Traffic / throttle / other
+    when(pn.getPRejected()).thenReturn(0.05);
+    when(pn.getTotalInputBytes()).thenReturn(11L);
+    when(pn.getTotalOutputBytes()).thenReturn(22L);
+    when(pn.getTotalInputSinceStartup()).thenReturn(33L);
+    when(pn.getTotalOutputSinceStartup()).thenReturn(44L);
+    when(pn.getPercentTimeRoutableConnection()).thenReturn(0.9);
+    when(pn.getThrottle()).thenReturn(mock(PacketThrottle.class));
+    when(pn.getClockDelta()).thenReturn(9L);
+    when(pn.recordStatus()).thenReturn(true);
+    when(pn.getResendBytesSent()).thenReturn(777L);
+    when(pn.getUptime()).thenReturn((short) 88);
+    when(pn.getMessageQueueLengthBytes()).thenReturn(999L);
+    when(pn.getProbableSendQueueTime()).thenReturn(555L);
+    when(pn.getIncomingLoadStats(true))
+        .thenReturn(new PeerNode.IncomingLoadSummaryStats(1, 2, 3, 4, 5, 6, 7, 8, 9));
+    when(pn.getIncomingLoadStats(false))
+        .thenReturn(new PeerNode.IncomingLoadSummaryStats(10, 20, 30, 40, 50, 60, 70, 80, 90));
+    when(pn.hasFullNoderef()).thenReturn(true);
+    when(pn.selectionRate()).thenReturn(0.123);
+
+    return pn;
+  }
+
+  @Test
+  @DisplayName("getPeerStatusCount counts only matching statuses")
+  void getPeerStatusCount_whenMixedStatuses_countsOnlyMatches() {
+    PeerNode a = basePeerNodeMock(SeedClientPeerNode.class);
+    PeerNode b = basePeerNodeMock(SeedServerPeerNode.class);
+    PeerNode c = basePeerNodeMock(SeedClientPeerNode.class);
+
+    when(a.getPeerNodeStatus()).thenReturn(1);
+    when(b.getPeerNodeStatus()).thenReturn(2);
+    when(c.getPeerNodeStatus()).thenReturn(1);
+
+    PeerNodeStatus s1 = new PeerNodeStatus(a, true);
+    PeerNodeStatus s2 = new PeerNodeStatus(b, true);
+    PeerNodeStatus s3 = new PeerNodeStatus(c, true);
+
+    int count = PeerNodeStatus.getPeerStatusCount(new PeerNodeStatus[] {s1, s2, s3}, 1);
+    assertEquals(2, count);
+  }
+
+  @Test
+  void getPeerAddressAndPort_whenIPv4_expectNoBrackets() throws Exception {
+    SeedServerPeerNode pn = basePeerNodeMock(SeedServerPeerNode.class);
+
+    // Mock underlying Peer and FreenetInetAddress for IPv4
+    Peer peer = mock(Peer.class);
+    FreenetInetAddress faddr = mock(FreenetInetAddress.class);
+    InetAddress inet = InetAddress.getByName("203.0.113.10");
+
+    when(pn.getPeer()).thenReturn(peer);
+    when(peer.getFreenetAddress()).thenReturn(faddr);
+    when(peer.getPort()).thenReturn(12345);
+    when(faddr.toString()).thenReturn("node.example");
+    when(faddr.getAddress(false)).thenReturn(inet);
+
+    PeerNodeStatus status = new PeerNodeStatus(pn, true);
+
+    assertEquals("node.example", status.getPeerAddress());
+    assertEquals("203.0.113.10", status.getPeerAddressNumerical());
+    assertArrayEquals(inet.getAddress(), status.getPeerAddressBytes());
+    assertEquals(12345, status.getPeerPort());
+    assertEquals("node.example:12345", status.getPeerAddressAndPort());
+  }
+
+  @Test
+  void getPeerAddressAndPort_whenIPv6_expectBrackets() throws Exception {
+    SeedClientPeerNode pn = basePeerNodeMock(SeedClientPeerNode.class);
+
+    // Mock underlying Peer and FreenetInetAddress for IPv6
+    Peer peer = mock(Peer.class);
+    FreenetInetAddress faddr = mock(FreenetInetAddress.class);
+    // Use a documentation prefix address (RFC 3849)
+    InetAddress inet6 = InetAddress.getByName("2001:db8::1");
+
+    when(pn.getPeer()).thenReturn(peer);
+    when(peer.getFreenetAddress()).thenReturn(faddr);
+    when(peer.getPort()).thenReturn(23456);
+    when(faddr.toString()).thenReturn("2001:db8::1");
+    when(faddr.getAddress(false)).thenReturn(inet6);
+
+    PeerNodeStatus status = new PeerNodeStatus(pn, true);
+
+    assertEquals("2001:db8::1", status.getPeerAddress());
+    // Numerical form is provided by JDK; format may be expanded or compressed
+    assertNotNull(status.getPeerAddressNumerical());
+    assertEquals(16, status.getPeerAddressBytes().length);
+    assertEquals(23456, status.getPeerPort());
+    assertEquals("[2001:db8::1]:23456", status.getPeerAddressAndPort());
+  }
+
+  @Test
+  void constructor_whenNoPeer_setsNullAddressAndMinusOnePort() {
+    SeedClientPeerNode pn = basePeerNodeMock(SeedClientPeerNode.class);
+    // Ensure getPeer() returns null (already default in base stub)
+    when(pn.getPeer()).thenReturn(null);
+
+    PeerNodeStatus status = new PeerNodeStatus(pn, true);
+
+    assertNull(status.getPeerAddress());
+    assertNull(status.getPeerAddressNumerical());
+    assertNull(status.getPeerAddressBytes());
+    assertEquals(-1, status.getPeerPort());
+    // getPeerAddressAndPort falls back to string concatenation with "null"
+    assertEquals("null:-1", status.getPeerAddressAndPort());
+  }
+
+  @Test
+  void constructor_whenNoHeavy_true_localMessageStatsAreNull() {
+    SeedServerPeerNode pn = basePeerNodeMock(SeedServerPeerNode.class);
+    PeerNodeStatus status = new PeerNodeStatus(pn, true);
+    assertNull(status.getLocalMessagesReceived());
+    assertNull(status.getLocalMessagesSent());
+  }
+
+  @Test
+  void constructor_whenNoHeavy_false_localMessageStatsCopied() {
+    SeedServerPeerNode pn = basePeerNodeMock(SeedServerPeerNode.class);
+    Hashtable<String, Long> recv = new Hashtable<>();
+    Hashtable<String, Long> sent = new Hashtable<>();
+    recv.put("Foo", 1L);
+    sent.put("Bar", 2L);
+    when(pn.getLocalNodeReceivedMessagesFromStatistic()).thenReturn(recv);
+    when(pn.getLocalNodeSentMessagesToStatistic()).thenReturn(sent);
+
+    PeerNodeStatus status = new PeerNodeStatus(pn, false);
+    assertEquals(recv, status.getLocalMessagesReceived());
+    assertEquals(sent, status.getLocalMessagesSent());
+  }
+
+  @Test
+  void toString_whenBackoffUntilZero_containsExpectedFieldsAndZeros() {
+    SeedClientPeerNode pn = basePeerNodeMock(SeedClientPeerNode.class);
+
+    // Provide a concrete peer so the address appears in toString
+    Peer peer = mock(Peer.class);
+    FreenetInetAddress faddr = mock(FreenetInetAddress.class);
+    when(pn.getPeer()).thenReturn(peer);
+    when(peer.getFreenetAddress()).thenReturn(faddr);
+    when(peer.getPort()).thenReturn(1010);
+    when(faddr.toString()).thenReturn("node");
+    when(faddr.getAddress(false)).thenReturn(null); // numerical unknown is fine
+
+    when(pn.getRoutingBackoffLength(true)).thenReturn(100L);
+    when(pn.getRoutingBackoffLength(false)).thenReturn(200L);
+    when(pn.getRoutingBackedOffUntil(true)).thenReturn(0L);
+    when(pn.getRoutingBackedOffUntil(false)).thenReturn(0L);
+
+    PeerNodeStatus status = new PeerNodeStatus(pn, true);
+    String s = status.toString();
+
+    assertTrue(s.contains("CONNECTED"));
+    assertTrue(s.contains("node:1010"));
+    assertTrue(s.contains(" RT backoff: 100 (0 ) bulk backoff: 200 (0)"));
+  }
+
+  @Test
+  void getters_locationVersionAndBackoff_reflectPeerNodeValues() {
+    SeedServerPeerNode pn = basePeerNodeMock(SeedServerPeerNode.class);
+    when(pn.getRoutingBackoffLength(true)).thenReturn(111L);
+    when(pn.getRoutingBackoffLength(false)).thenReturn(222L);
+    when(pn.getRoutingBackedOffUntil(true)).thenReturn(999_000L);
+    when(pn.getRoutingBackedOffUntil(false)).thenReturn(888_000L);
+
+    PeerNodeStatus status = new PeerNodeStatus(pn, true);
+
+    assertEquals(0.25, status.getLocation());
+    assertArrayEquals(new double[] {0.1, 0.2, 0.3}, status.getPeersLocation());
+    assertEquals("1.2.3", status.getVersion());
+    assertEquals(10203, status.getSimpleVersion());
+    assertEquals(111L, status.getRoutingBackoffLength(true));
+    assertEquals(222L, status.getRoutingBackoffLength(false));
+    assertEquals(999_000L, status.getRoutingBackedOffUntil(true));
+    assertEquals(888_000L, status.getRoutingBackedOffUntil(false));
+  }
+
+  @Test
+  void getters_pingBackoffReasonsAndTimes_reflectPeerNodeValues() {
+    SeedServerPeerNode pn = basePeerNodeMock(SeedServerPeerNode.class);
+    when(pn.getRoutingBackedOffUntil(true)).thenReturn(999_000L);
+    when(pn.getRoutingBackedOffUntil(false)).thenReturn(888_000L);
+
+    PeerNodeStatus status = new PeerNodeStatus(pn, true);
+
+    assertEquals(123.0, status.getAveragePingTime());
+    assertEquals(100.0, status.getAveragePingTimeCorrected());
+    assertEquals(0.1, status.getBackedOffPercent(true));
+    assertEquals(0.2, status.getBackedOffPercent(false));
+    assertEquals("reason-rt", status.getLastBackoffReason(true));
+    assertEquals("reason-bulk", status.getLastBackoffReason(false));
+    assertEquals(111L, status.getTimeLastRoutable());
+    assertEquals(222L, status.getTimeLastConnectionCompleted());
+    assertEquals(333L, status.getPeerAddedTime());
+  }
+
+  @Test
+  void getters_trafficConnectionQueuesAndRates_reflectPeerNodeValues() {
+    SeedServerPeerNode pn = basePeerNodeMock(SeedServerPeerNode.class);
+    PeerNodeStatus status = new PeerNodeStatus(pn, true);
+
+    assertEquals(0.05, status.getPReject());
+    assertEquals(11L, status.getTotalInputBytes());
+    assertEquals(22L, status.getTotalOutputBytes());
+    assertEquals(33L, status.getTotalInputSinceStartup());
+    assertEquals(44L, status.getTotalOutputSinceStartup());
+    assertEquals(0.9, status.getPercentTimeRoutableConnection());
+    assertNotNull(status.getThrottle());
+    assertEquals(9L, status.getClockDelta());
+    assertTrue(status.recordStatus());
+    assertTrue(status.isConnected());
+    assertTrue(status.isRoutable());
+    assertEquals(777L, status.getResendBytesSent());
+    assertEquals(88, status.getReportedUptimePercentage());
+    assertEquals(999L, status.getMessageQueueLengthBytes());
+    assertEquals(555L, status.getMessageQueueLengthTime());
+    assertEquals(0.123, status.getSelectionRate());
+  }
+
+  @Test
+  void seedFlags_whenSeedServer_detectTrueFalse() {
+    SeedServerPeerNode server = basePeerNodeMock(SeedServerPeerNode.class);
+
+    PeerNodeStatus status = new PeerNodeStatus(server, true);
+    assertTrue(status.isSeedServer());
+    assertFalse(status.isSeedClient());
+  }
+
+  @Test
+  void seedFlags_whenSeedClient_detectFalseTrue() {
+    SeedClientPeerNode client = basePeerNodeMock(SeedClientPeerNode.class);
+
+    PeerNodeStatus status = new PeerNodeStatus(client, true);
+    assertTrue(status.isSeedClient());
+    assertFalse(status.isSeedServer());
+  }
+
+  @Test
+  @DisplayName("equals(): different 32-byte pubkey hash but same 32-bit hashCode -> not equal")
+  void equals_whenSameIntHash_butDifferentPubKeyHash_notEqual() {
+    SeedServerPeerNode a = basePeerNodeMock(SeedServerPeerNode.class);
+    SeedServerPeerNode b = basePeerNodeMock(SeedServerPeerNode.class);
+
+    // Simulate two different peers with distinct public key hashes
+    byte[] hashA = new byte[32];
+    byte[] hashB = new byte[32];
+    for (int i = 0; i < 32; i++) hashA[i] = (byte) i;
+    for (int i = 0; i < 32; i++) hashB[i] = (byte) (255 - i);
+
+    // Both mocks will likely have the same cached 32-bit field (default 0) on the underlying
+    // PeerNode, but equals must ignore that and compare the full 32-byte hashes.
+    when(a.getPubKeyHash()).thenReturn(hashA);
+    when(b.getPubKeyHash()).thenReturn(hashB);
+
+    PeerNodeStatus sa = new PeerNodeStatus(a, true);
+    PeerNodeStatus sb = new PeerNodeStatus(b, true);
+
+    assertNotEquals(sa, sb, "Status objects with different pubkey hashes must not be equal");
+  }
+
+  @Test
+  @DisplayName("equals(): same 32-byte pubkey hash -> equal (hashCode contract holds)")
+  void equals_whenSamePubKeyHash_equalAndHashMatches() {
+    SeedClientPeerNode a = basePeerNodeMock(SeedClientPeerNode.class);
+    SeedClientPeerNode b = basePeerNodeMock(SeedClientPeerNode.class);
+
+    byte[] hash = new byte[32];
+    for (int i = 0; i < 32; i++) hash[i] = (byte) (i * 3 + 7);
+
+    when(a.getPubKeyHash()).thenReturn(hash);
+    when(b.getPubKeyHash()).thenReturn(hash);
+
+    PeerNodeStatus sa = new PeerNodeStatus(a, true);
+    PeerNodeStatus sb = new PeerNodeStatus(b, true);
+
+    assertEquals(sa, sb, "Status objects with same pubkey hash should be equal");
+    // If equal, their hashCode values should match (our implementation uses cached 32-bit field)
+    assertEquals(sa.hashCode(), sb.hashCode());
+  }
+}


### PR DESCRIPTION
Summary
- Make PeerNodeStatus an explicit immutable snapshot with clearer threading/nullability docs.
- Equality now compares the peer’s SHA‑256 public key hash (32 bytes) instead of relying solely on the cached 32‑bit hashCode; falls back to hashCode when key material is unavailable (e.g., tests/mocks).
- DarknetPeerNodeStatus/OpennetPeerNodeStatus: Javadoc overhaul, explicit snapshot semantics; equals/hashCode delegate to base to preserve identity semantics.
- Add focused JUnit 6 tests for PeerNodeStatus, DarknetPeerNodeStatus, and OpennetPeerNodeStatus.

Change Details
- src/main/java/network/crypta/node/PeerNodeStatus.java
  - Add field peerPubKeyHash and compare equality on key hash (defensive copy), retain hashCode cache.
  - Expand docs for getters: units, ranges, and edge cases (e.g., IPv6 address formatting and backoff timestamps).
- src/main/java/network/crypta/node/DarknetPeerNodeStatus.java
  - Clarify subclass‑specific fields (visibility/trust/burst/listen/disabled/private note) and summary.
  - equals/hashCode delegate to PeerNodeStatus for identity consistency.
- src/main/java/network/crypta/node/OpennetPeerNodeStatus.java
  - Add snapshot docs and constructor contract; expose timeLastSuccess field semantics.
  - equals/hashCode delegate to base.
- Tests (JUnit 6):
  - src/test/java/network/crypta/node/PeerNodeStatusTest.java
  - src/test/java/network/crypta/node/DarknetPeerNodeStatusTest.java
  - src/test/java/network/crypta/node/OpennetPeerNodeStatusTest.java

Rationale
- UI/diagnostics read status while the node is mutating; taking an immutable snapshot reduces race conditions.
- Equality by immutable peer identity avoids false equality on 32‑bit collisions and keeps collections/maps stable.

Diffstat
- 6 files changed, 1078 insertions(+), 43 deletions(-)
  - M src/main/java/network/crypta/node/DarknetPeerNodeStatus.java
  - M src/main/java/network/crypta/node/OpennetPeerNodeStatus.java
  - M src/main/java/network/crypta/node/PeerNodeStatus.java
  - A src/test/java/network/crypta/node/DarknetPeerNodeStatusTest.java
  - A src/test/java/network/crypta/node/OpennetPeerNodeStatusTest.java
  - A src/test/java/network/crypta/node/PeerNodeStatusTest.java

Notes
- No formatting-only changes were pending locally; Spotless not needed.
- Base: develop; Head: feature/fix-PeerNodeStatus.

Checklist
- [x] Compiles locally
- [x] Unit tests added/updated (JUnit 6)
- [ ] CI green
