### PR TITLE
Fix PeerStatusTracker handling and add tests

### DIFF
--- a/src/main/java/network/crypta/node/PeerStatusTracker.java
+++ b/src/main/java/network/crypta/node/PeerStatusTracker.java
@@ -6,15 +6,24 @@ import network.crypta.support.WeakHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Track a collection of PeerNode's for each status. */
-class PeerStatusTracker<K extends Object> {
+/**
+ * Maintains the set of {@link PeerNode} instances for each status key.
+ *
+ * <p>The map values are weak sets; a peer may be removed automatically when it becomes only weakly
+ * reachable. All methods are synchronized on the instance. While holding this monitor, the
+ * implementation does not call back into {@link PeerNode} to avoid lock-order inversions. Acquire
+ * this lock last when composing with other locks.
+ *
+ * @param <K> application-defined status key used to group peers
+ */
+class PeerStatusTracker<K> {
   private static final Logger LOG = LoggerFactory.getLogger(PeerStatusTracker.class);
 
-  static {
-  }
-
   /**
-   * PeerNode statuses, by status. WARNING: LOCK THIS LAST. Must NOT call PeerNode inside this lock.
+   * Map from status key to the weak set of peers that currently have that status.
+   *
+   * <p>Guarded by {@code this}. Do not invoke {@link PeerNode} methods while holding this lock; see
+   * the class-level locking note above.
    */
   private final HashMap<K, WeakHashSet<PeerNode>> statuses;
 
@@ -22,74 +31,123 @@ class PeerStatusTracker<K extends Object> {
     statuses = new HashMap<>();
   }
 
+  /**
+   * Adds the given peer to the set for the provided status.
+   *
+   * <p>If the set already contains the peer, the operation is a no-op. When {@code noLog} is {@code
+   * false}, a duplicate membership triggers an {@code ERROR}-level log (with a short debug stack
+   * trace).
+   *
+   * <p>Thread safety: synchronized; does not call into {@link PeerNode}.
+   *
+   * @param peerNodeStatus status key that the peer should be associated with
+   * @param peerNode peer to add
+   * @param noLog when {@code true}, suppresses the duplicate-membership error log
+   */
   public synchronized void addStatus(K peerNodeStatus, PeerNode peerNode, boolean noLog) {
     WeakHashSet<PeerNode> statusSet = statuses.get(peerNodeStatus);
     if (statusSet != null) {
       if (statusSet.contains(peerNode)) {
         if (!noLog)
           LOG.error(
-              "addPeerNodeStatus(): node already in peerNodeStatuses: "
-                  + peerNode
-                  + " status "
-                  + peerNodeStatus,
+              "addPeerNodeStatus(): node already in peerNodeStatuses: {} status {}",
+              peerNode,
+              peerNodeStatus,
               new Exception("debug"));
         return;
       }
+      // Reinsert the entry after mutation. Functionally equivalent for HashMap, but keeps the
+      // write path consistent and ensures the map records the latest set reference.
       statuses.remove(peerNodeStatus);
     } else statusSet = new WeakHashSet<>();
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "addPeerNodeStatus(): adding PeerNode for '"
-              + peerNode.getIdentityString()
-              + "' with status '"
-              + peerNodeStatus
-              + "'");
+          "addPeerNodeStatus(): adding PeerNode for '{}' with status '{}'",
+          peerNode.getIdentityString(),
+          peerNodeStatus);
     statusSet.add(peerNode);
     statuses.put(peerNodeStatus, statusSet);
   }
 
+  /**
+   * Returns the number of peers currently recorded with the given status.
+   *
+   * <p>Returns {@code 0} if the status key is not present. Because the underlying set is weak,
+   * entries may disappear when peers are only weakly reachable.
+   *
+   * @param pnStatus status key
+   * @return number of peers associated with the status
+   */
   public synchronized int statusSize(K pnStatus) {
     WeakHashSet<PeerNode> statusSet = statuses.get(pnStatus);
     if (statusSet != null) return statusSet.size();
     else return 0;
   }
 
+  /**
+   * Removes the given peer from the set for the provided status, if present.
+   *
+   * <p>If the peer is not a member and {@code noLog} is {@code false}, the method logs an {@code
+   * ERROR}-level message (with a short debug stack trace). When the set becomes empty, the status
+   * key is removed from the map to keep the keys compact.
+   *
+   * @param peerNodeStatus status key from which the peer should be removed
+   * @param peerNode peer to remove
+   * @param noLog when {@code true}, suppresses the absent-membership error log
+   */
   public synchronized void removeStatus(K peerNodeStatus, PeerNode peerNode, boolean noLog) {
     WeakHashSet<PeerNode> statusSet = statuses.get(peerNodeStatus);
     if (statusSet != null) {
       if (!statusSet.remove(peerNode)) {
         if (!noLog)
           LOG.error(
-              "removePeerNodeStatus(): identity '"
-                  + peerNode.getIdentityString()
-                  + " for "
-                  + peerNode.shortToString()
-                  + "' not in peerNodeStatuses with status '"
-                  + peerNodeStatus
-                  + "'",
+              "removePeerNodeStatus(): identity '{} for {}' not in peerNodeStatuses with status"
+                  + " '{}'",
+              peerNode.getIdentityString(),
+              peerNode.shortToString(),
+              peerNodeStatus,
               new Exception("debug"));
         return;
       }
+      // Drop the key entirely when the associated set is empty to avoid stale status entries.
       if (statusSet.isEmpty()) statuses.remove(peerNodeStatus);
     }
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "removePeerNodeStatus(): removing PeerNode for '"
-              + peerNode.getIdentityString()
-              + "' with status '"
-              + peerNodeStatus
-              + "'");
+          "removePeerNodeStatus(): removing PeerNode for '{}' with status '{}'",
+          peerNode.getIdentityString(),
+          peerNodeStatus);
   }
 
+  /**
+   * Moves the peer from {@code oldPeerNodeStatus} to {@code peerNodeStatus} atomically with respect
+   * to this tracker.
+   *
+   * <p>The method performs a removal followed by an addition while holding the monitor, so callers
+   * observe a single, consistent transition. The {@code noLog} flag is forwarded to both operations
+   * to control duplicate/absent error logs.
+   *
+   * @param peerNode peer whose status changes
+   * @param oldPeerNodeStatus previous status key
+   * @param peerNodeStatus new status key
+   * @param noLog when {@code true}, suppresses duplicate/absent error logs
+   */
   public synchronized void changePeerNodeStatus(
       PeerNode peerNode, K oldPeerNodeStatus, K peerNodeStatus, boolean noLog) {
     if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Peer status change: " + oldPeerNodeStatus + " -> " + peerNodeStatus + " on " + peerNode);
+      LOG.debug("Peer status change: {} -> {} on {}", oldPeerNodeStatus, peerNodeStatus, peerNode);
     removeStatus(oldPeerNodeStatus, peerNode, noLog);
     addStatus(peerNodeStatus, peerNode, noLog);
   }
 
+  /**
+   * Appends the currently known status keys to the provided list.
+   *
+   * <p>The list is not cleared. The snapshot is taken under lock; keys may change after the call
+   * completes.
+   *
+   * @param list destination list that receives the keys
+   */
   public synchronized void addStatusList(List<K> list) {
     list.addAll(statuses.keySet());
   }

--- a/src/test/java/network/crypta/node/PeerStatusTrackerTest.java
+++ b/src/test/java/network/crypta/node/PeerStatusTrackerTest.java
@@ -1,0 +1,179 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Tests for {@link PeerStatusTracker}.
+ *
+ * <p>Note: {@code PeerStatusTracker} is package-private, so this test lives in the same package.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class PeerStatusTrackerTest {
+
+  private static PeerNode mockPeer(String id) {
+    PeerNode n = Mockito.mock(PeerNode.class, Mockito.withSettings().verboseLogging());
+    Mockito.when(n.getIdentityString()).thenReturn(id);
+    Mockito.when(n.shortToString()).thenReturn("peer-" + id);
+    return n;
+  }
+
+  @Test
+  void statusSize_whenUnknownStatus_returnsZero() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+
+    int size = tracker.statusSize("S-unknown");
+
+    assertEquals(0, size);
+  }
+
+  @Test
+  void addStatus_whenNewStatus_addsPeerAndKeyPresent() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+
+    tracker.addStatus("S1", a, true);
+
+    assertEquals(1, tracker.statusSize("S1"));
+    List<String> keys = new ArrayList<>();
+    tracker.addStatusList(keys);
+    assertTrue(keys.contains("S1"));
+  }
+
+  @Test
+  void addStatus_whenDuplicatePeerSameStatus_noChangeAndNoDuplicate() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+    tracker.addStatus("S1", a, true);
+
+    tracker.addStatus("S1", a, false); // duplicate; should be ignored
+
+    assertEquals(1, tracker.statusSize("S1"));
+    List<String> keys = new ArrayList<>();
+    tracker.addStatusList(keys);
+    assertIterableEquals(List.of("S1"), keys);
+  }
+
+  @Test
+  void addStatus_whenAddingDifferentPeerToExistingStatus_appendsToExistingSet() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+    PeerNode b = mockPeer("B");
+    tracker.addStatus("S1", a, true);
+
+    tracker.addStatus("S1", b, true); // implementation appends into the existing set
+
+    assertEquals(2, tracker.statusSize("S1"));
+    // Remove one peer; key should still exist with the other one
+    tracker.removeStatus("S1", b, true);
+    assertEquals(1, tracker.statusSize("S1"));
+  }
+
+  @Test
+  void removeStatus_whenPeerPresent_removesAndDeletesKeyWhenEmpty() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+    tracker.addStatus("S1", a, true);
+
+    tracker.removeStatus("S1", a, true);
+
+    assertEquals(0, tracker.statusSize("S1"));
+    List<String> keys = new ArrayList<>();
+    tracker.addStatusList(keys);
+    assertTrue(keys.isEmpty());
+  }
+
+  @Test
+  void removeStatus_whenPeerNotPresent_keepsSetUnchanged() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+    PeerNode b = mockPeer("B");
+    tracker.addStatus("S1", a, true);
+
+    tracker.removeStatus("S1", b, false); // not present; ignored
+
+    assertEquals(1, tracker.statusSize("S1"));
+    List<String> keys = new ArrayList<>();
+    tracker.addStatusList(keys);
+    assertIterableEquals(List.of("S1"), keys);
+  }
+
+  @Test
+  void changePeerNodeStatus_whenMovingSolePeer_movesFromOldToNew() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+    tracker.addStatus("OLD", a, true);
+
+    tracker.changePeerNodeStatus(a, "OLD", "NEW", true);
+
+    assertEquals(0, tracker.statusSize("OLD"));
+    assertEquals(1, tracker.statusSize("NEW"));
+    List<String> keys = new ArrayList<>();
+    tracker.addStatusList(keys);
+    assertIterableEquals(List.of("NEW"), keys);
+  }
+
+  @Test
+  void changePeerNodeStatus_whenNewStatusHasOtherPeers_preservesExistingPeers() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+    PeerNode x = mockPeer("X");
+    PeerNode y = mockPeer("Y");
+
+    tracker.addStatus("A", a, true);
+    tracker.addStatus("A", x, true);
+    tracker.addStatus("B", y, true);
+
+    tracker.changePeerNodeStatus(a, "A", "B", true);
+
+    // After change: A retains x; B contains both y and a
+    assertEquals(1, tracker.statusSize("A"));
+    assertEquals(2, tracker.statusSize("B"));
+
+    // Remove 'a' and ensure 'y' remains tracked under B
+    tracker.removeStatus("B", a, true);
+    assertEquals(1, tracker.statusSize("B"));
+  }
+
+  @Test
+  void addStatusList_whenExistingListHasElements_appendsKeys() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+    PeerNode b = mockPeer("B");
+    tracker.addStatus("S1", a, true);
+    tracker.addStatus("S2", b, true);
+
+    List<String> target = new ArrayList<>(List.of("seed"));
+    tracker.addStatusList(target);
+
+    assertTrue(target.containsAll(Arrays.asList("seed", "S1", "S2")));
+    assertEquals(3, target.size());
+  }
+
+  @Test
+  void addStatus_withNullStatusKey_allowedAndTracked() {
+    PeerStatusTracker<String> tracker = new PeerStatusTracker<>();
+    PeerNode a = mockPeer("A");
+
+    tracker.addStatus(null, a, true);
+
+    assertEquals(1, tracker.statusSize(null));
+    List<String> keys = new ArrayList<>();
+    tracker.addStatusList(keys);
+    // List will contain a null entry for the status key
+    assertTrue(keys.contains(null));
+  }
+}


### PR DESCRIPTION
Summary
- Parameterize slf4j logging in PeerStatusTracker and remove string concatenation
- Clarify locking semantics; add Javadoc and generics cleanup (<K> not <K extends Object>)
- Keep status map updates consistent on writes (reinsert after mutation)
- Add unit tests covering add/remove/status change flows

Why
- Reduce log noise and avoid redundant string building
- Document lock ordering to avoid inversions; make API and generics cleaner
- Ensure predictable behavior when moving peers between status sets
- Establish test coverage for core behaviors

Commits
- b4e798928a (2025-10-25) Leumor — fix(node): improve PeerStatusTracker logging and set handling

Diffstat (src/**)
- src/main/java/network/crypta/node/PeerStatusTracker.java — 116 ++/--
- src/test/java/network/crypta/node/PeerStatusTrackerTest.java — 179 +++
(2 files changed, 266 insertions, 29 deletions)

Notes
- No public API changes beyond internal type parameter simplification.
- Tests require JUnit Platform (already configured in the project).