### PR TITLE
docs(node): improve Javadoc for PeerTooOldException

### DIFF
--- a/src/main/java/network/crypta/node/PeerTooOldException.java
+++ b/src/main/java/network/crypta/node/PeerTooOldException.java
@@ -3,13 +3,38 @@ package network.crypta.node;
 import java.io.Serial;
 import java.util.Date;
 
-/** Thrown when a peer is dropped because it is too old. */
+/**
+ * Exception indicating that a remote peer was rejected because its software build is older than the
+ * minimum version supported by this node.
+ *
+ * <p>Instances include a human‑readable reason, the peer‑reported build number, and the
+ * peer‑reported build date to aid diagnostics and logging. The {@linkplain #getMessage() message}
+ * concatenates these details for convenience.
+ */
 public class PeerTooOldException extends Exception {
   @Serial private static final long serialVersionUID = 1L;
+
+  /**
+   * Human-readable explanation of why the peer is considered too old (e.g., below minimum build).
+   */
   public final String reason;
+
+  /** Peer-reported integer build number of the remote node. */
   public final int buildNumber;
+
+  /**
+   * Peer-reported build date. May be {@code null} when the date is unknown or not provided by the
+   * remote peer.
+   */
   public final Date buildDate;
 
+  /**
+   * Constructs a new exception with contextual details about the outdated remote peer.
+   *
+   * @param reason human-readable explanation of the incompatibility
+   * @param build peer-reported build number
+   * @param d peer-reported build date; may be {@code null} if unavailable
+   */
   public PeerTooOldException(final String reason, final int build, final Date d) {
     super("Peer too old: " + reason + " from " + build + " at " + d);
     this.buildDate = d;


### PR DESCRIPTION
Summary
- Clarifies purpose and usage of PeerTooOldException.
- Documents public fields (reason, buildNumber, buildDate) with meaning and nullability notes.
- Documents constructor parameters and message composition.
- No code, API, or behavioral changes.

Changes
- src/main/java/network/crypta/node/PeerTooOldException.java
  - Expanded class Javadoc: explains rejection criteria and diagnostic context.
  - Added Javadoc to fields: rationale for reason, units/type for buildNumber, nullability for buildDate.
  - Added Javadoc for constructor with @param tags.

Rationale
- Improves discoverability and correctness of public API docs in the node layer.
- Aligns with project guidance to enhance API documentation while keeping logic intact.

Formatting
- Ran `./gradlew spotlessApply` prior to commit.

Testing/Impact
- Pure documentation change; build and runtime behavior are unaffected.

Checklist
- [x] Spotless formatting applied
- [x] No functional changes
- [x] Target branch: develop