### PR TITLE
refactor(node): harden DNSRequester loop and logging; add tests

### DIFF
--- a/src/main/java/network/crypta/node/DNSRequester.java
+++ b/src/main/java/network/crypta/node/DNSRequester.java
@@ -9,8 +9,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Background worker that periodically resolves DNS for unconnected peers to refresh handshake
+ * endpoints.
+ *
+ * <p>The worker selects at most one unconnected peer per cycle and spreads queries using randomized
+ * delays to avoid bursts. Recently checked peers are tracked by their location and skipped until
+ * roughly 81% of the remaining unconnected set has been visited, which reduces duplicated lookups
+ * while still making progress across the pool.
+ *
+ * <p>Lifecycle: {@link #start()} schedules this instance on the node's executor; {@link #run()}
+ * loops until the thread is interrupted. Non-fatal throwables are logged and the loop continues.
+ * Call {@link #forceRun()} to wake the worker early.
+ *
  * @author amphibian
- *     <p>Thread that does DNS queries for unconnected peers
  */
 public class DNSRequester implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(DNSRequester.class);
@@ -19,11 +30,9 @@ public class DNSRequester implements Runnable {
   private long lastLogTime;
   private final Set<Double> recentNodeIdentitySet = new HashSet<>();
   private final Deque<Double> recentNodeIdentityQueue = new ArrayDeque<>();
-  // Only set when doing simulations.
-  static boolean DISABLE = false;
-
-  static {
-  }
+  // For simulations/tests only; may be set by external harnesses when supported.
+  static boolean disable = false;
+  private boolean wakeRequested;
 
   DNSRequester(Node node) {
     this.node = node;
@@ -31,37 +40,49 @@ public class DNSRequester implements Runnable {
 
   void start() {
     LOG.info("Starting DNSRequester");
-    System.out.println("Starting DNSRequester");
+    // Schedule the worker on the node's executor with a descriptive thread name.
     node.getExecutor().execute(this, "DNSRequester thread for " + node.getDarknetPortNumber());
   }
 
+  /**
+   * Executes the background loop and returns only when the worker thread is interrupted.
+   *
+   * <p>Fatal JVM conditions ({@link VirtualMachineError}) are rethrown to allow higher-level
+   * handlers to terminate the process. Other throwables are caught and logged so the worker can
+   * continue.
+   */
   @Override
+  @SuppressWarnings("java:S1181")
   public void run() {
-    while (true) {
+    while (!Thread.currentThread().isInterrupted()) {
       try {
         realRun();
+      } catch (VirtualMachineError fatal) {
+        // Propagate truly fatal JVM conditions; do not attempt to keep the worker alive. We avoid
+        // logging here to prevent duplicate stack traces when uncaught handlers also log.
+        throw fatal;
       } catch (Throwable t) {
-        LOG.error("Caught in DNSRequester: " + t, t);
+        // Keep the background worker alive on non-fatal throwables.
+        LOG.error("Caught in DNSRequester: {}", t, t);
       }
     }
   }
 
   private void realRun() {
-    // run DNS requests for not recently checked, unconnected
-    // nodes to avoid the coupon collector's problem
+    // Resolve DNS for unconnected peers that were not checked recently. This avoids repeatedly
+    // selecting the same locations (coupon collector effect) and spreads lookups over time.
     PeerNode[] nodesToCheck =
         Arrays.stream(node.getPeers().myPeers())
             .filter(peerNode -> !peerNode.isConnected())
-            // identify recent nodes by location, because the exact location cannot be used twice
-            // (that already triggers the simplest pitch black attack defenses)
-            // Double may not be comparable in general (floating point),
-            // but just checking for equality with itself is safe
+            // Identify recent peers by location rather than identity. Double equality is used only
+            // for exact-match deduplication; ordering/approximation is not required here.
             .filter(peerNode -> !recentNodeIdentitySet.contains(peerNode.getLocation()))
             .toArray(PeerNode[]::new);
 
     if (LOG.isDebugEnabled()) {
       long now = System.currentTimeMillis();
       if ((now - lastLogTime) > 100) {
+        // Rate-limit debug logs to at most once every ~100 ms.
         LOG.debug("Processing DNS Requests (log rate-limited)");
       }
       lastLogTime = now;
@@ -69,38 +90,54 @@ public class DNSRequester implements Runnable {
 
     int unconnectedNodesLength = nodesToCheck.length;
     if (unconnectedNodesLength > 0) {
-      // check a randomly chosen node that has not been checked
-      // recently to avoid sending bursts of DNS requests
+      // Check a randomly chosen unconnected peer that has not been visited recently to avoid
+      // bursts of DNS requests.
       PeerNode pn = nodesToCheck[node.getFastWeakRandom().nextInt(unconnectedNodesLength)];
       if (unconnectedNodesLength < 5) {
-        // no need for optimizations: just clear all state
+        // For tiny eligible sets, clear recent-selection state for simplicity.
         recentNodeIdentitySet.clear();
         recentNodeIdentityQueue.clear();
       } else {
-        // do not request this node again,
-        // until at least 81% of the other unconnected nodes have been checked
+        // Defer rechecking this location until ~81% of the other unconnected peers have been
+        // visited. This reduces duplicate lookups while maintaining coverage.
         recentNodeIdentitySet.add(pn.getLocation());
         recentNodeIdentityQueue.offerFirst(pn.getLocation());
         while (recentNodeIdentityQueue.size() > (0.81 * unconnectedNodesLength)) {
           recentNodeIdentitySet.remove(recentNodeIdentityQueue.removeLast());
         }
       }
-      // Try new DNS lookup
+      // Attempt a DNS refresh for the chosen peer.
       pn.maybeUpdateHandshakeIPs(false);
     }
 
     int nextMaxWaitTime = 1000 + node.getFastWeakRandom().nextInt(60000);
     try {
       synchronized (this) {
-        wait(nextMaxWaitTime); // sleep 1-61s ...
+        // Randomized sleep (1s..61s) to spread queries and avoid synchronized bursts across nodes.
+        long deadline = System.currentTimeMillis() + nextMaxWaitTime;
+        while (!wakeRequested) {
+          long remaining = deadline - System.currentTimeMillis();
+          if (remaining <= 0) break;
+          wait(remaining); // Sleep up to the remaining time or until notified.
+        }
+        // Consume any pending wake so subsequent waits block as expected.
+        wakeRequested = false;
       }
     } catch (InterruptedException e) {
-      // Ignore, just wake up. Just sleeping to not busy wait anyway
+      // Restore interrupt status so callers can act accordingly.
+      Thread.currentThread().interrupt();
     }
   }
 
+  /**
+   * Wakes the worker if it is currently waiting.
+   *
+   * <p>Signals the internal wait/notify gate so a pending sleep ends early and the next lookup
+   * cycle can begin sooner. Safe to call from any thread.
+   */
   public void forceRun() {
     synchronized (this) {
+      wakeRequested = true;
       notifyAll();
     }
   }

--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -175,7 +175,7 @@ public class NodeStarter implements WrapperListener {
       plug.start();
     }
 
-    DNSRequester.DISABLE = noDNS;
+    DNSRequester.disable = noDNS;
 
     return random;
   }

--- a/src/test/java/network/crypta/node/DNSRequesterTest.java
+++ b/src/test/java/network/crypta/node/DNSRequesterTest.java
@@ -1,0 +1,347 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import network.crypta.support.PriorityAwareExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class DNSRequesterTest {
+
+  @Mock private Node node;
+
+  // Track only threads started by this test instance.
+  private final java.util.List<Thread> startedThreads =
+      java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+
+  @AfterEach
+  void afterEach() throws InterruptedException {
+    // Interrupt and join only threads created by these tests.
+    synchronized (startedThreads) {
+      for (Thread t : startedThreads) {
+        if (t == null) continue;
+        if (t.isAlive()) t.interrupt();
+      }
+      for (Thread t : startedThreads) {
+        if (t == null) continue;
+        joinOrFail(t, Duration.ofSeconds(2));
+      }
+      startedThreads.clear();
+    }
+  }
+
+  @Test
+  @DisplayName("start() delegates to executor with descriptive thread name")
+  void start_whenCalled_executorExecuteWithName() {
+    // Arrange
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    when(node.getExecutor()).thenReturn(executor);
+    when(node.getDarknetPortNumber()).thenReturn(12345);
+
+    DNSRequester requester = new DNSRequester(node);
+
+    // Act
+    requester.start();
+
+    // Assert
+    verify(executor).execute(requester, "DNSRequester thread for 12345");
+  }
+
+  @Test
+  @DisplayName("forceRun() notifies waiting threads")
+  void forceRun_whenThreadWaiting_notified() throws Exception {
+    DNSRequester requester = new DNSRequester(node);
+    CountDownLatch waiting = new CountDownLatch(1);
+    CountDownLatch awakened = new CountDownLatch(1);
+
+    Thread waiter =
+        new Thread(
+            () -> {
+              synchronized (requester) {
+                waiting.countDown();
+                try {
+                  requester.wait(5000);
+                } catch (InterruptedException ignored) {
+                  Thread.currentThread().interrupt();
+                }
+              }
+              awakened.countDown();
+            },
+            "dnsrequester-test-waiter");
+
+    // Track and start the waiter owned by this test.
+    startedThreads.add(waiter);
+    waiter.start();
+    assertTrue(waiting.await(1, TimeUnit.SECONDS), "waiter did not enter wait state");
+
+    // Act
+    requester.forceRun();
+
+    // Assert
+    assertTrue(awakened.await(1, TimeUnit.SECONDS), "waiter was not awakened by notifyAll()");
+  }
+
+  @Test
+  @Timeout(5)
+  @DisplayName("realRun(): with no unconnected peers, does not attempt DNS update")
+  void realRun_whenNoUnconnectedPeers_doesNothing() {
+    // Arrange: peers all connected
+    PeerManager pm = mock(PeerManager.class);
+    PeerNode p1 = mock(PeerNode.class);
+    PeerNode p2 = mock(PeerNode.class);
+    when(p1.isConnected()).thenReturn(true);
+    when(p2.isConnected()).thenReturn(true);
+    when(pm.myPeers()).thenReturn(new PeerNode[] {p1, p2});
+    when(node.getPeers()).thenReturn(pm);
+    when(node.getFastWeakRandom()).thenReturn(new FixedSequenceRandom(0));
+
+    DNSRequester requester = new DNSRequester(node);
+
+    // Act: call private realRun() once in a worker and interrupt promptly to avoid sleeping
+    runRealRunOnceAndInterrupt(requester);
+
+    // Assert: no DNS update attempted
+    verify(p1, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+    verify(p2, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+  }
+
+  @Test
+  @Timeout(5)
+  @DisplayName("realRun(): selects an unconnected peer and triggers maybeUpdateHandshakeIPs(false)")
+  void realRun_whenEligiblePeers_selectsOne_callsMaybeUpdateHandshakeIPs() throws Exception {
+    // Arrange: three unconnected peers, choose index 1 deterministically
+    PeerManager pm = mock(PeerManager.class);
+    PeerNode p0 = mock(PeerNode.class);
+    PeerNode p1 = mock(PeerNode.class);
+    PeerNode p2 = mock(PeerNode.class);
+    when(p0.isConnected()).thenReturn(false);
+    when(p1.isConnected()).thenReturn(false);
+    when(p2.isConnected()).thenReturn(false);
+    when(p0.getLocation()).thenReturn(0.10);
+    when(p1.getLocation()).thenReturn(0.20);
+    when(p2.getLocation()).thenReturn(0.30);
+    when(pm.myPeers()).thenReturn(new PeerNode[] {p0, p1, p2});
+    when(node.getPeers()).thenReturn(pm);
+    // Sequence: select index=1, then minimal wait; run only once
+    when(node.getFastWeakRandom()).thenReturn(new FixedSequenceRandom(1, 0));
+
+    CountDownLatch called = new CountDownLatch(1);
+    doAnswer(
+            inv -> {
+              called.countDown();
+              return null;
+            })
+        .when(p1)
+        .maybeUpdateHandshakeIPs(false);
+
+    DNSRequester requester = new DNSRequester(node);
+
+    // Act
+    Thread t = startRealRunInThread(requester);
+    assertTrue(called.await(1, TimeUnit.SECONDS), "Selected peer did not receive DNS update call");
+    t.interrupt();
+    t.join(2000);
+
+    // Assert
+    verify(p1).maybeUpdateHandshakeIPs(false);
+    verify(p0, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+    verify(p2, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+  }
+
+  @Test
+  @Timeout(10)
+  @DisplayName(
+      "realRun(): with >=5 peers, cache works until filtered set <5 then clears; reselection"
+          + " follows")
+  void realRun_whenSixPeers_recentnessTrimsAndReallowsOldest() throws Exception {
+    // Arrange: six unconnected peers with stable order and distinct locations
+    PeerManager pm = mock(PeerManager.class);
+    PeerNode[] peers = new PeerNode[6];
+    for (int i = 0; i < peers.length; i++) {
+      peers[i] = mock(PeerNode.class);
+      when(peers[i].isConnected()).thenReturn(false);
+      when(peers[i].getLocation()).thenReturn(10.0 + i);
+    }
+    when(pm.myPeers()).thenReturn(peers);
+    when(node.getPeers()).thenReturn(pm);
+
+    // Random always selects index 0 of the current filtered list, then minimal wait.
+    // For 7 runs we need 14 numbers: [0,0] * 7
+    int[] seq = new int[14];
+    Arrays.fill(seq, 0);
+    when(node.getFastWeakRandom()).thenReturn(new FixedSequenceRandom(seq));
+
+    DNSRequester requester = new DNSRequester(node);
+
+    // Capture invocation order
+    java.util.List<Integer> order =
+        java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+    final CountDownLatch[] perRunLatch = {new CountDownLatch(1)};
+
+    for (int i = 0; i < peers.length; i++) {
+      final int idx = i;
+      if (idx < 3) {
+        doAnswer(
+                inv -> {
+                  order.add(idx);
+                  perRunLatch[0].countDown();
+                  return null;
+                })
+            .when(peers[idx])
+            .maybeUpdateHandshakeIPs(false);
+      }
+    }
+
+    // Expected selection given we always choose index 0 within the filtered array.
+    // After two selections, filtered size drops below 5 and the cache is cleared each run,
+    // cycling deterministically over the first three peers again.
+    int[] expected = new int[] {0, 1, 2, 0, 1, 2, 0};
+
+    for (int run = 0; run < expected.length; run++) {
+      perRunLatch[0] = new CountDownLatch(1);
+      Thread t = startRealRunInThread(requester);
+      assertTrue(
+          perRunLatch[0].await(1, TimeUnit.SECONDS),
+          "DNS update not called in time (run " + run + ")");
+      t.interrupt();
+      t.join(2000);
+    }
+
+    // Assert exact order and that peer[5] was never selected
+    org.junit.jupiter.api.Assertions.assertEquals(
+        expected.length, order.size(), "Unexpected call count");
+    for (int i = 0; i < expected.length; i++) {
+      org.junit.jupiter.api.Assertions.assertEquals(
+          expected[i], order.get(i), "Mismatch at run " + i + "; actual order=" + order);
+    }
+    // Peers 3,4,5 are never selected in this deterministic path
+    verify(peers[3], never()).maybeUpdateHandshakeIPs(false);
+    verify(peers[4], never()).maybeUpdateHandshakeIPs(false);
+    verify(peers[5], never()).maybeUpdateHandshakeIPs(false);
+  }
+
+  @Test
+  @Timeout(5)
+  @DisplayName("realRun(): connected peers are ignored")
+  void realRun_filtersOutConnectedPeers() throws Exception {
+    PeerManager pm = mock(PeerManager.class);
+    PeerNode connected = mock(PeerNode.class);
+    PeerNode unconnectedA = mock(PeerNode.class);
+    PeerNode unconnectedB = mock(PeerNode.class);
+
+    when(connected.isConnected()).thenReturn(true);
+    when(unconnectedA.isConnected()).thenReturn(false);
+    when(unconnectedB.isConnected()).thenReturn(false);
+    when(unconnectedA.getLocation()).thenReturn(1.1);
+    when(unconnectedB.getLocation()).thenReturn(2.2);
+
+    when(pm.myPeers()).thenReturn(new PeerNode[] {connected, unconnectedA, unconnectedB});
+    when(node.getPeers()).thenReturn(pm);
+    // Choose the first eligible (index 0 of filtered -> unconnectedA)
+    when(node.getFastWeakRandom()).thenReturn(new FixedSequenceRandom(0, 0));
+
+    CountDownLatch called = new CountDownLatch(1);
+    doAnswer(
+            inv -> {
+              called.countDown();
+              return null;
+            })
+        .when(unconnectedA)
+        .maybeUpdateHandshakeIPs(false);
+
+    DNSRequester requester = new DNSRequester(node);
+
+    Thread t = startRealRunInThread(requester);
+    assertTrue(called.await(1, TimeUnit.SECONDS), "Unconnected peer was not selected");
+    t.interrupt();
+    t.join(2000);
+
+    verify(unconnectedA).maybeUpdateHandshakeIPs(false);
+    verify(unconnectedB, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+    verify(connected, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+  }
+
+  // Helpers
+
+  private Thread startRealRunInThread(DNSRequester requester) {
+    Thread t =
+        new Thread(
+            () -> {
+              try {
+                invokeRealRun(requester);
+              } catch (Exception t1) {
+                // Fail fast in the worker to make the issue visible in reports
+                org.junit.jupiter.api.Assertions.fail(
+                    "Unexpected exception in DNSRequester worker thread", t1);
+              }
+            },
+            "DNSRequesterTest-worker");
+    startedThreads.add(t);
+    t.start();
+    return t;
+  }
+
+  private void runRealRunOnceAndInterrupt(DNSRequester requester) {
+    Thread t = startRealRunInThread(requester);
+    // Interrupt immediately to avoid the internal 1s wait
+    t.interrupt();
+    assertDoesNotThrow(() -> joinOrFail(t, Duration.ofSeconds(2)));
+  }
+
+  private static void joinOrFail(Thread t, Duration timeout) throws InterruptedException {
+    t.join(timeout.toMillis());
+    assertFalse(t.isAlive(), "Worker thread did not terminate in time");
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static void invokeRealRun(DNSRequester requester)
+      throws NoSuchMethodException,
+          IllegalAccessException,
+          java.lang.reflect.InvocationTargetException {
+    Method m = DNSRequester.class.getDeclaredMethod("realRun");
+    m.setAccessible(true);
+    m.invoke(requester);
+  }
+
+  /**
+   * Random with a fixed, repeating sequence of values used for deterministic selection and minimal
+   * waiting inside DNSRequester.realRun().
+   */
+  private static final class FixedSequenceRandom extends Random {
+    private final int[] seq;
+    private int idx;
+
+    private FixedSequenceRandom(int... seq) {
+      this.seq = (seq == null || seq.length == 0) ? new int[] {0} : seq.clone();
+    }
+
+    @Override
+    public int nextInt(int bound) {
+      int v = seq[idx++ % seq.length];
+      if (v < 0) v = -v;
+      if (bound <= 0) return 0;
+      return v % bound;
+    }
+  }
+}

--- a/src/test/java/network/crypta/node/DNSRequesterTest.java
+++ b/src/test/java/network/crypta/node/DNSRequesterTest.java
@@ -3,7 +3,7 @@ package network.crypta.node;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -122,8 +122,8 @@ class DNSRequesterTest {
     runRealRunOnceAndInterrupt(requester);
 
     // Assert: no DNS update attempted
-    verify(p1, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
-    verify(p2, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+    verify(p1, never()).maybeUpdateHandshakeIPs(anyBoolean());
+    verify(p2, never()).maybeUpdateHandshakeIPs(anyBoolean());
   }
 
   @Test
@@ -165,8 +165,8 @@ class DNSRequesterTest {
 
     // Assert
     verify(p1).maybeUpdateHandshakeIPs(false);
-    verify(p0, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
-    verify(p2, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+    verify(p0, never()).maybeUpdateHandshakeIPs(anyBoolean());
+    verify(p2, never()).maybeUpdateHandshakeIPs(anyBoolean());
   }
 
   @Test
@@ -278,8 +278,8 @@ class DNSRequesterTest {
     t.join(2000);
 
     verify(unconnectedA).maybeUpdateHandshakeIPs(false);
-    verify(unconnectedB, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
-    verify(connected, never()).maybeUpdateHandshakeIPs(any(Boolean.class));
+    verify(unconnectedB, never()).maybeUpdateHandshakeIPs(anyBoolean());
+    verify(connected, never()).maybeUpdateHandshakeIPs(anyBoolean());
   }
 
   // Helpers


### PR DESCRIPTION
Summary
- Harden the DNSRequester background worker: interruption-aware loop, safe wake/notify, and clearer SLF4J logging.
- Improve Javadoc and inline docs for lifecycle and selection heuristics.
- Add unit tests for executor delegation, notify behavior, and selection path with deterministic randomness.

Changes
- src/main/java/network/crypta/node/DNSRequester.java
  - Replace `while(true)` with interruption-aware loop; rethrow `VirtualMachineError`, continue on other throwables.
  - Rate-limit debug logging; switch to SLF4J placeholders.
  - Add `wakeRequested` gate and `forceRun()` semantics; restore interrupt status on InterruptedException.
  - Expand Javadoc on lifecycle and selection strategy.
- src/main/java/network/crypta/node/NodeStarter.java
  - Rename flag usage `DISABLE` -> `disable`.
- src/test/java/network/crypta/node/DNSRequesterTest.java
  - Tests: executor delegation naming, `forceRun()` notify, single-iteration selection/invocation, recentness cache behavior.

Rationale
- The worker previously ran an infinite loop and concatenated exceptions into messages. The refactor makes shutdown intent explicit, avoids duplicate fatal-VM logging, and reduces log churn while keeping the loop resilient to recoverable errors.

Testing
- New JUnit 6 tests cover behavior under deterministic conditions.
- Build formatting enforced via Spotless; no pending changes locally.

Compatibility & Risk
- Behavioral changes are internal to the background scheduler; no public API changes.

Notes
- Target base: develop.
- Branch: feature/fix-DNSRequester.
