### PR TITLE
FailureTableEntry cleanup: safer timeouts, API polish, and tests

### DIFF
--- a/src/main/java/network/crypta/node/FailureTable.java
+++ b/src/main/java/network/crypta/node/FailureTable.java
@@ -537,7 +537,7 @@ public class FailureTable {
   }
 
   private void removeEntryIfEmpty(FailureTableEntry entry, Key key, long now) {
-    if (entry.isEmpty(now)) {
+    if (entry.isEmpty()) {
       synchronized (this) {
         entriesByKey.removeKey(key);
       }
@@ -896,7 +896,7 @@ public class FailureTable {
       entry = entriesByKey.get(key);
       if (entry == null) return false; // Nobody cares
     }
-    return entry.othersWant(apartFrom);
+    return entry.othersWant();
   }
 
   /**

--- a/src/main/java/network/crypta/node/FailureTableEntry.java
+++ b/src/main/java/network/crypta/node/FailureTableEntry.java
@@ -5,64 +5,69 @@ import static java.util.concurrent.TimeUnit.HOURS;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import network.crypta.keys.Key;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tracks recent requests for a specific key. If we have recently routed to a specific node, and
- * failed, we should not route to it again, unless it is at a higher HTL. Different failures cause
- * different timeouts. Similarly we track the nodes that have requested the key, because for both
- * sets of nodes, when we find the data we offer them it; this greatly improves latency and
- * efficiency for polling-based tools. For nodes we have routed to, we keep up to HTL separate
- * entries; for nodes we have received requests from, we keep only one entry.
+ * Tracks recent activity for a single {@link Key} and decides when a peer should be avoided or
+ * offered the result.
  *
- * <p>SECURITY: All this could be a security risk if not regularly cleared - which it is, of course:
- * We forget about either kind of node after a fixed period, in cleanupRequested(), which the
- * FailureTable calls regularly. Against a near-omnipotent attacker able to compromise nodes at will
- * of course it is still a security risk to track anything but we have bigger problems at that
- * level.
+ * <p>This entry maintains two weakly referenced peer sets for the tracked key:
  *
- * @author toad
+ * <ul>
+ *   <li>Requestors — peers that asked us for the key. When the data becomes available we offer it
+ *       to them to reduce latency for polling clients.
+ *   <li>Requested-from — peers we routed a request to. Failures on this path set timeouts so we do
+ *       not retry the same peer too soon. Timeouts are tracked per-HTL (hops-to-live).
+ * </ul>
+ *
+ * <p>Routing policy: if a request to a peer recently failed, we avoid routing to that peer again at
+ * the same HTL. We may retry at a higher HTL. Different failure modes contribute different timeout
+ * durations; the caller computes these and passes them in.
+ *
+ * <p>Security and privacy: to limit state retention, entries automatically forget requestors and
+ * requested-from peers after a fixed interval (see {@link #MAX_TIME_BETWEEN_REQUEST_AND_OFFER}).
+ * Cleanup runs regularly via {@link #cleanup()} from {@link FailureTable}. As with any state, an
+ * omnipotent attacker could abuse it, but bounded retention mitigates the risk.
  */
 class FailureTableEntry implements TimedOutNodesList {
   private static final Logger LOG = LoggerFactory.getLogger(FailureTableEntry.class);
 
-  /** The key */
-  final Key key; // FIXME should this be stored compressed somehow e.g. just the routing key?
+  /** The content key being tracked. */
+  final Key key;
 
-  /** Time of creation of this entry */
+  /** Creation time (milliseconds since epoch). */
   long creationTime;
 
-  /** Time we last received a request for the key */
+  /** Time of the most recent incoming request for this key (ms since epoch). */
   long receivedTime;
 
-  /** Time we last received a DNF after sending a request for a key */
+  /** Time of the most recent negative outcome after we routed a request (ms since epoch). */
   long sentTime;
 
-  /** WeakReference's to PeerNodeUnlocked's who have requested the key */
+  /** Weak references to peers that have requested this key. */
   WeakReference<? extends PeerNodeUnlocked>[] requestorNodes;
 
-  /** Times at which they requested it */
+  /** Request times for {@link #requestorNodes} (ms since epoch). */
   long[] requestorTimes;
 
   /**
-   * Boot ID when they requested it. We don't send it to restarted nodes, as a (weak, but useful if
-   * combined with other measures) protection against seizure.
+   * Boot ID captured when the request was made. Offers are suppressed to peers that have since
+   * restarted (boot ID changed) to avoid misdelivery and as a weak anti-seizure measure.
    */
   long[] requestorBootIDs;
 
   short[] requestorHTLs;
 
-  // FIXME Note that just because a node is in this list doesn't mean it DNFed or RFed.
-  // We include *ALL* nodes we routed to here!
-  /** WeakReference's to PeerNodeUnlocked's we have requested it from */
+  // Membership does not imply DNF/RecentlyFailed; it includes all peers we routed to for this key.
+  /** Weak references to peers we routed a request to. */
   WeakReference<? extends PeerNodeUnlocked>[] requestedNodes;
 
   /**
-   * Their locations when we requested it. This may be needed in the future to determine whether to
-   * let a request through that we would otherwise have failed with RecentlyFailed, because the node
-   * we would route it to is closer to the target than any we've routed to in the past.
+   * Peer locations when the request was sent. Retained for potential routing heuristics (e.g.,
+   * allowing a request through if it targets a node closer than prior attempts).
    */
   double[] requestedLocs;
 
@@ -70,26 +75,22 @@ class FailureTableEntry implements TimedOutNodesList {
   long[] requestedTimes;
 
   /**
-   * Timeouts for each node for purposes of RecentlyFailed. We accept what they say, subject to an
-   * upper limit, because we MUST NOT suppress too many requests, as that could lead to a
-   * self-sustaining key blocking.
+   * Per-peer timeouts for the RecentlyFailed mechanism (absolute times in ms since epoch). Caller
+   * provided; bounded elsewhere to avoid over-suppressing requests.
    */
   long[] requestedTimeoutsRF;
 
   /**
-   * Timeouts for each node for purposes of per-node failure tables. We use our own estimates, based
-   * on time elapsed, for most failure modes; a fixed period for DNF and RecentlyFailed.
+   * Per-peer timeouts for per-node failure tables (absolute times in ms since epoch). Computed
+   * locally based on elapsed time, with fixed periods for DNF and RecentlyFailed.
    */
   long[] requestedTimeoutsFT;
 
   short[] requestedTimeoutHTLs;
 
-  static {
-  }
-
   /**
-   * We remember that a node has asked us for a key for up to an hour; after that, we won't offer
-   * the key, and if we receive an offer from that node, we will reject it
+   * Maximum interval to honor a prior request when deciding to issue an offer. After this window we
+   * neither offer to that peer nor accept their offer as related (milliseconds).
    */
   static final long MAX_TIME_BETWEEN_REQUEST_AND_OFFER = HOURS.toMillis(1);
 
@@ -97,13 +98,13 @@ class FailureTableEntry implements TimedOutNodesList {
   public static final short[] EMPTY_SHORT_ARRAY = new short[0];
   public static final double[] EMPTY_DOUBLE_ARRAY = new double[0];
 
-  public static final WeakReference<? extends PeerNodeUnlocked>[] EMPTY_WEAK_REFERENCE =
+  protected static final WeakReference<? extends PeerNodeUnlocked>[] EMPTY_WEAK_REFERENCE =
       weakArrayOfSize(0);
 
   @SuppressWarnings("unchecked")
   private static WeakReference<? extends PeerNodeUnlocked>[] weakArrayOfSize(int size) {
-    // All arrays store WeakReference to PeerNodeUnlocked (or subclasses). This localized cast is
-    // safe and centralizes the unchecked conversion.
+    // Arrays store WeakReference<PeerNodeUnlocked> (or subclasses). This localized cast centralizes
+    // the unchecked conversion and is safe because all assignments respect the element type.
     return (WeakReference<? extends PeerNodeUnlocked>[]) new WeakReference<?>[size];
   }
 
@@ -126,25 +127,28 @@ class FailureTableEntry implements TimedOutNodesList {
   }
 
   /**
-   * A request failed to a specific peer.
+   * Records a failed request to a peer and updates timeouts.
    *
-   * @param routedTo The peer we routed to.
-   * @param rfTimeout The time until we can route to the node again, for purposes of RecentlyFailed.
-   * @param ftTimeout The time until we can route to the node again, for purposes of per-node
-   *     failure tables.
-   * @param now The current time.
-   * @param htl The HTL of the request. Note that timeouts only apply to the same HTL.
+   * <p>Timeouts are tracked per HTL. A timeout recorded at HTL {@code h} does not block attempts at
+   * higher HTLs. Both timeout parameters are durations (milliseconds) and are converted into
+   * absolute times using {@code now}.
+   *
+   * @param routedTo peer the request was routed to.
+   * @param rfTimeout duration in milliseconds for the RecentlyFailed timeout; {@code <= 0} means no
+   *     update.
+   * @param ftTimeout duration in milliseconds for the per-node failure-table timeout; {@code <= 0}
+   *     means no update.
+   * @param now current time in milliseconds since epoch.
+   * @param htl HTL used when the failure occurred; determines applicability of the timeout.
    */
   public synchronized void failedTo(
       PeerNodeUnlocked routedTo, long rfTimeout, long ftTimeout, long now, short htl) {
     if (LOG.isDebugEnabled()) {
       LOG.debug(
-          "Failed sending request to "
-              + routedTo.shortToString()
-              + " : timeout "
-              + rfTimeout
-              + " / "
-              + ftTimeout);
+          "Failed sending request to {} : timeout {} / {}",
+          routedTo.shortToString(),
+          rfTimeout,
+          ftTimeout);
     }
     int idx = addRequestedFrom(routedTo, htl, now);
     if (rfTimeout > 0) {
@@ -165,69 +169,55 @@ class FailureTableEntry implements TimedOutNodesList {
     }
   }
 
-  // These are rather low level, in an attempt to absolutely minimize memory usage...
-  // The two methods have almost identical code/logic.
-  // Dunno if there's a more elegant way of dealing with this which doesn't significantly increase
-  // per entry byte cost.
-  // Note also this will generate some churn...
+  // Low-level array management to minimize per-entry memory usage. The requestor and requested
+  // paths intentionally share near-identical code to avoid additional object overhead. Arrays are
+  // compacted when needed; this may cause churn but keeps steady-state memory small.
 
+  @SuppressWarnings("UnusedReturnValue")
   synchronized int addRequestor(PeerNodeUnlocked requestor, long now, short origHTL) {
-    if (LOG.isDebugEnabled()) LOG.debug("Adding requestors: " + requestor + " at " + now);
+    if (LOG.isDebugEnabled()) LOG.debug("Adding requestors: {} at {}", requestor, now);
     receivedTime = now;
-    boolean includedAlready = false;
-    int nulls = 0;
-    int ret = -1;
-    for (int i = 0; i < requestorNodes.length; i++) {
-      PeerNodeUnlocked got = requestorNodes[i] == null ? null : requestorNodes[i].get();
-      // No longer subscribed if they have rebooted, or expired
-      if (got == requestor) {
-        // Update existing entry
-        includedAlready = true;
-        requestorTimes[i] = now;
-        requestorBootIDs[i] = requestor.getBootID();
-        requestorHTLs[i] = origHTL;
-        ret = i;
-        break;
-      } else if (got != null
-          && (got.getBootID() != requestorBootIDs[i]
-              || now - requestorTimes[i] > MAX_TIME_BETWEEN_REQUEST_AND_OFFER)) {
-        requestorNodes[i] = null;
-        got = null;
-      }
-      if (got == null) nulls++;
-    }
-    if (nulls == 0 && includedAlready) return ret;
-    int notIncluded = includedAlready ? 0 : 1;
-    // Because weak, these can become null; doesn't matter, but we want to minimise memory usage
-    if (nulls == 1 && !includedAlready) {
-      // Nice special case
-      for (int i = 0; i < requestorNodes.length; i++) {
-        if (requestorNodes[i] == null || requestorNodes[i].get() == null) {
-          requestorNodes[i] = requestor.getWeakRef();
-          requestorTimes[i] = now;
-          requestorBootIDs[i] = requestor.getBootID();
-          requestorHTLs[i] = origHTL;
-          return i;
-        }
-      }
-    }
+
+    ScanRequestorResult scan = scanAndCleanupRequestors(requestor, now, origHTL);
+    if (scan.nulls == 0 && scan.includedAlready) return scan.ret;
+
+    int notIncluded = scan.includedAlready ? 0 : 1;
+
+    int special =
+        tryFillSingleNullRequestor(requestor, now, origHTL, scan.includedAlready, scan.nulls);
+    if (special >= 0) return special;
+
+    return rebuildRequestorArraysAndReturnIndex(
+        requestor, now, origHTL, scan.includedAlready, notIncluded, scan.nulls, scan.ret);
+  }
+
+  private int rebuildRequestorArraysAndReturnIndex(
+      PeerNodeUnlocked requestor,
+      long now,
+      short origHTL,
+      boolean includedAlready,
+      int notIncluded,
+      int nulls,
+      int existingIndex) {
     WeakReference<? extends PeerNodeUnlocked>[] newRequestorNodes =
         weakArrayOfSize(requestorNodes.length + notIncluded - nulls);
     long[] newRequestorTimes = new long[requestorNodes.length + notIncluded - nulls];
     long[] newRequestorBootIDs = new long[requestorNodes.length + notIncluded - nulls];
     short[] newRequestorHTLs = new short[requestorNodes.length + notIncluded - nulls];
-    int toIndex = 0;
 
+    int toIndex = 0;
+    int ret = existingIndex;
     for (int i = 0; i < requestorNodes.length; i++) {
       WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
       PeerNodeUnlocked pn = ref == null ? null : ref.get();
-      if (pn == null) continue;
-      if (pn == requestor) ret = toIndex;
-      newRequestorNodes[toIndex] = requestorNodes[i];
-      newRequestorTimes[toIndex] = requestorTimes[i];
-      newRequestorBootIDs[toIndex] = requestorBootIDs[i];
-      newRequestorHTLs[toIndex] = requestorHTLs[i];
-      toIndex++;
+      if (pn != null) {
+        if (pn == requestor) ret = toIndex;
+        newRequestorNodes[toIndex] = requestorNodes[i];
+        newRequestorTimes[toIndex] = requestorTimes[i];
+        newRequestorBootIDs[toIndex] = requestorBootIDs[i];
+        newRequestorHTLs[toIndex] = requestorHTLs[i];
+        toIndex++;
+      }
     }
 
     if (!includedAlready) {
@@ -250,62 +240,84 @@ class FailureTableEntry implements TimedOutNodesList {
     requestorTimes = newRequestorTimes;
     requestorBootIDs = newRequestorBootIDs;
     requestorHTLs = newRequestorHTLs;
-
     return ret;
   }
 
-  /**
-   * Add a requested from entry to the node. If there already is one reuse it but only if the HTL
-   * matches. Return the index so we can update timeouts etc.
-   *
-   * @param requestedFrom The node we have routed the request to.
-   * @param htl The HTL at which the request was sent.
-   * @param now The current time.
-   * @return The index of the new or old entry.
-   */
-  private synchronized int addRequestedFrom(PeerNodeUnlocked requestedFrom, short htl, long now) {
-    if (LOG.isDebugEnabled()) LOG.debug("Adding requested from: " + requestedFrom + " at " + now);
-    sentTime = now;
-    boolean includedAlready = false;
-    int nulls = 0;
-    int ret = -1;
-    for (int i = 0; i < requestedNodes.length; i++) {
-      PeerNodeUnlocked got = requestedNodes[i] == null ? null : requestedNodes[i].get();
-      if (got == requestedFrom
-          && (requestedTimeoutsRF[i] == -1
-              || requestedTimeoutsFT[i] == -1
-              || requestedTimeoutHTLs[i] == htl)) {
-        includedAlready = true;
-        requestedLocs[i] = requestedFrom.getLocation();
-        requestedBootIDs[i] = requestedFrom.getBootID();
-        requestedTimes[i] = now;
-        ret = i;
-      } else if (got != null
-          && (got.getBootID() != requestedBootIDs[i]
-              || now - requestedTimes[i] > MAX_TIME_BETWEEN_REQUEST_AND_OFFER)) {
-        requestedNodes[i] = null;
-        got = null;
-      }
-      if (got == null) nulls++;
-    }
-    if (includedAlready && nulls == 0) return ret;
-    int notIncluded = includedAlready ? 0 : 1;
-    // Because weak, these can become null; doesn't matter, but we want to minimise memory usage
+  private int tryFillSingleNullRequestor(
+      PeerNodeUnlocked requestor, long now, short origHTL, boolean includedAlready, int nulls) {
     if (nulls == 1 && !includedAlready) {
-      // Nice special case
-      for (int i = 0; i < requestedNodes.length; i++) {
-        if (requestedNodes[i] == null || requestedNodes[i].get() == null) {
-          requestedNodes[i] = requestedFrom.getWeakRef();
-          requestedLocs[i] = requestedFrom.getLocation();
-          requestedBootIDs[i] = requestedFrom.getBootID();
-          requestedTimes[i] = now;
-          requestedTimeoutsRF[i] = -1;
-          requestedTimeoutsFT[i] = -1;
-          requestedTimeoutHTLs[i] = (short) -1;
+      for (int i = 0; i < requestorNodes.length; i++) {
+        if (requestorNodes[i] == null || requestorNodes[i].get() == null) {
+          requestorNodes[i] = requestor.getWeakRef();
+          requestorTimes[i] = now;
+          requestorBootIDs[i] = requestor.getBootID();
+          requestorHTLs[i] = origHTL;
           return i;
         }
       }
     }
+    return -1;
+  }
+
+  private ScanRequestorResult scanAndCleanupRequestors(
+      PeerNodeUnlocked requestor, long now, short origHTL) {
+    boolean includedAlready = false;
+    int nulls = 0;
+    int ret = -1;
+    for (int i = 0; i < requestorNodes.length; i++) {
+      PeerNodeUnlocked got = requestorNodes[i] == null ? null : requestorNodes[i].get();
+      if (got == requestor) {
+        includedAlready = true;
+        requestorTimes[i] = now;
+        requestorBootIDs[i] = requestor.getBootID();
+        requestorHTLs[i] = origHTL;
+        ret = i;
+        break;
+      } else if (got != null
+          && (got.getBootID() != requestorBootIDs[i]
+              || now - requestorTimes[i] > MAX_TIME_BETWEEN_REQUEST_AND_OFFER)) {
+        requestorNodes[i] = null;
+        got = null;
+      }
+      if (got == null) nulls++;
+    }
+    return new ScanRequestorResult(includedAlready, nulls, ret);
+  }
+
+  private record ScanRequestorResult(boolean includedAlready, int nulls, int ret) {}
+
+  /**
+   * Adds or updates a "requested-from" entry. If a matching peer is present and either timeout slot
+   * is unset or the stored HTL is compatible, the existing slot is reused.
+   *
+   * @param requestedFrom peer we routed the request to.
+   * @param htl HTL for the outgoing request.
+   * @param now current time in milliseconds since epoch.
+   * @return index of the reused or newly added entry.
+   */
+  private synchronized int addRequestedFrom(PeerNodeUnlocked requestedFrom, short htl, long now) {
+    if (LOG.isDebugEnabled()) LOG.debug("Adding requested from: {} at {}", requestedFrom, now);
+    sentTime = now;
+
+    ScanRequestedFromResult scan = scanAndCleanupRequestedFrom(requestedFrom, htl, now);
+    if (scan.includedAlready && scan.nulls == 0) return scan.ret;
+
+    int notIncluded = scan.includedAlready ? 0 : 1;
+    int special =
+        tryFillSingleNullRequestedFrom(requestedFrom, now, scan.includedAlready, scan.nulls);
+    if (special >= 0) return special;
+
+    return rebuildRequestedArraysAndReturnIndex(
+        requestedFrom, now, scan.includedAlready, notIncluded, scan.nulls, scan.ret);
+  }
+
+  private int rebuildRequestedArraysAndReturnIndex(
+      PeerNodeUnlocked requestedFrom,
+      long now,
+      boolean includedAlready,
+      int notIncluded,
+      int nulls,
+      int existingIndex) {
     WeakReference<? extends PeerNodeUnlocked>[] newRequestedNodes =
         weakArrayOfSize(requestedNodes.length + notIncluded - nulls);
     double[] newRequestedLocs = new double[requestedNodes.length + notIncluded - nulls];
@@ -316,23 +328,24 @@ class FailureTableEntry implements TimedOutNodesList {
     short[] newRequestedTimeoutHTLs = new short[requestedNodes.length + notIncluded - nulls];
 
     int toIndex = 0;
+    int ret = existingIndex;
     for (int i = 0; i < requestedNodes.length; i++) {
       WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
       PeerNodeUnlocked pn = ref == null ? null : ref.get();
-      if (pn == null) continue;
-      if (pn == requestedFrom) ret = toIndex;
-      newRequestedNodes[toIndex] = requestedNodes[i];
-      newRequestedTimes[toIndex] = requestedTimes[i];
-      newRequestedBootIDs[toIndex] = requestedBootIDs[i];
-      newRequestedLocs[toIndex] = requestedLocs[i];
-      newRequestedTimeoutsFT[toIndex] = requestedTimeoutsFT[i];
-      newRequestedTimeoutsRF[toIndex] = requestedTimeoutsRF[i];
-      newRequestedTimeoutHTLs[toIndex] = requestedTimeoutHTLs[i];
-      toIndex++;
+      if (pn != null) {
+        if (pn == requestedFrom) ret = toIndex;
+        newRequestedNodes[toIndex] = requestedNodes[i];
+        newRequestedTimes[toIndex] = requestedTimes[i];
+        newRequestedBootIDs[toIndex] = requestedBootIDs[i];
+        newRequestedLocs[toIndex] = requestedLocs[i];
+        newRequestedTimeoutsFT[toIndex] = requestedTimeoutsFT[i];
+        newRequestedTimeoutsRF[toIndex] = requestedTimeoutsRF[i];
+        newRequestedTimeoutHTLs[toIndex] = requestedTimeoutHTLs[i];
+        toIndex++;
+      }
     }
 
     if (!includedAlready) {
-      ret = toIndex;
       newRequestedNodes[toIndex] = requestedFrom.getWeakRef();
       newRequestedTimes[toIndex] = now;
       newRequestedBootIDs[toIndex] = requestedFrom.getBootID();
@@ -361,74 +374,131 @@ class FailureTableEntry implements TimedOutNodesList {
     requestedTimeoutsRF = newRequestedTimeoutsRF;
     requestedTimeoutsFT = newRequestedTimeoutsFT;
     requestedTimeoutHTLs = newRequestedTimeoutHTLs;
-
     return ret;
   }
 
+  private int tryFillSingleNullRequestedFrom(
+      PeerNodeUnlocked requestedFrom, long now, boolean includedAlready, int nulls) {
+    if (nulls == 1 && !includedAlready) {
+      for (int i = 0; i < requestedNodes.length; i++) {
+        if (requestedNodes[i] == null || requestedNodes[i].get() == null) {
+          requestedNodes[i] = requestedFrom.getWeakRef();
+          requestedLocs[i] = requestedFrom.getLocation();
+          requestedBootIDs[i] = requestedFrom.getBootID();
+          requestedTimes[i] = now;
+          requestedTimeoutsRF[i] = -1;
+          requestedTimeoutsFT[i] = -1;
+          requestedTimeoutHTLs[i] = (short) -1;
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  private ScanRequestedFromResult scanAndCleanupRequestedFrom(
+      PeerNodeUnlocked requestedFrom, short htl, long now) {
+    Objects.requireNonNull(requestedFrom, "requestedFrom");
+    boolean includedAlready = false;
+    int nulls = 0;
+    int ret = -1;
+    for (int i = 0; i < requestedNodes.length; i++) {
+      PeerNodeUnlocked got = requestedNodes[i] == null ? null : requestedNodes[i].get();
+      if (got == requestedFrom
+          && (requestedTimeoutsRF[i] == -1
+              || requestedTimeoutsFT[i] == -1
+              || requestedTimeoutHTLs[i] == htl)) {
+        includedAlready = true;
+        requestedLocs[i] = requestedFrom.getLocation();
+        requestedBootIDs[i] = requestedFrom.getBootID();
+        requestedTimes[i] = now;
+        ret = i;
+      } else if (got != null
+          && (got.getBootID() != requestedBootIDs[i]
+              || now - requestedTimes[i] > MAX_TIME_BETWEEN_REQUEST_AND_OFFER)) {
+        requestedNodes[i] = null;
+        got = null;
+      }
+      if (got == null) nulls++;
+    }
+    return new ScanRequestedFromResult(includedAlready, nulls, ret);
+  }
+
+  private record ScanRequestedFromResult(boolean includedAlready, int nulls, int ret) {}
+
   /**
-   * Offer this key to all the nodes that have requested it, and all the nodes it has been requested
-   * from. Called after a) the data has been stored, and b) this entry has been removed from the FT
+   * Offers the key to peers that previously asked for it and to peers we previously queried.
+   *
+   * <p>Intended to be called after the data is stored and this entry is removed from the failure
+   * table. Offers are deduplicated across both lists and sent outside this entry's monitor.
    */
   public void offer() {
     HashSet<PeerNodeUnlocked> set = new HashSet<>();
-    final boolean logMINOR = LOG.isDebugEnabled();
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Sending offers to nodes which requested the key from us: ("
-              + requestorNodes.length
-              + ") for "
-              + key);
+          "Sending offers to nodes which requested the key from us: ({}) for {}",
+          requestorNodes.length,
+          key);
     synchronized (this) {
-      for (int i = 0; i < requestorNodes.length; i++) {
-        WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-        if (ref == null) continue;
-        PeerNodeUnlocked pn = ref.get();
-        if (pn == null) continue;
-        if (pn.getBootID() != requestorBootIDs[i]) continue;
-        if (!set.add(pn)) {
-          LOG.error("Node is in requestorNodes twice: " + pn);
-        }
-      }
+      collectRequestorOfferTargets(set);
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Sending offers to nodes which we sent the key to: ("
-                + requestedNodes.length
-                + ") for "
-                + key);
-      for (int i = 0; i < requestedNodes.length; i++) {
-        WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
-        if (ref == null) continue;
-        PeerNodeUnlocked pn = ref.get();
-        if (pn == null) continue;
-        if (pn.getBootID() != requestedBootIDs[i]) continue;
-        set.add(pn);
-      }
+            "Sending offers to nodes which we sent the key to: ({}) for {}",
+            requestedNodes.length,
+            key);
+      collectRequestedOfferTargets(set);
     }
     // Do the offers outside the lock.
     // We do not need to hold it, offer() doesn't do anything that affects us.
     for (PeerNodeUnlocked pn : set) {
-      if (LOG.isDebugEnabled()) LOG.debug("Offering to " + pn);
+      if (LOG.isDebugEnabled()) LOG.debug("Offering to {}", pn);
       pn.offer(key);
     }
   }
 
-  /** Has any node asked for this key? */
-  public synchronized boolean othersWant(PeerNodeUnlocked peer) {
+  private void collectRequestorOfferTargets(HashSet<PeerNodeUnlocked> set) {
+    for (int i = 0; i < requestorNodes.length; i++) {
+      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      boolean valid = pn != null && pn.getBootID() == requestorBootIDs[i];
+      if (valid && !set.add(pn)) {
+        LOG.error("Node is in requestorNodes twice: {}", pn);
+      }
+    }
+  }
+
+  private void collectRequestedOfferTargets(HashSet<PeerNodeUnlocked> set) {
+    for (int i = 0; i < requestedNodes.length; i++) {
+      WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      boolean valid = pn != null && pn.getBootID() == requestedBootIDs[i];
+      if (valid) {
+        set.add(pn);
+      }
+    }
+  }
+
+  /**
+   * Returns whether any valid requestor remains.
+   *
+   * <p>A requestor is valid if its weak reference still resolves, the boot ID matches, and the
+   * request fell within {@link #MAX_TIME_BETWEEN_REQUEST_AND_OFFER}. Stale entries are dropped and
+   * backing arrays may be cleared as a side effect.
+   *
+   * @return {@code true} if at least one requestor is still valid; {@code false} otherwise.
+   */
+  public synchronized boolean othersWant() {
     boolean anyValid = false;
     for (int i = 0; i < requestorNodes.length; i++) {
       WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      if (ref == null) continue;
-      PeerNodeUnlocked pn = ref.get();
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
       if (pn == null) {
         requestorNodes[i] = null;
-        continue;
-      }
-      long bootID = pn.getBootID();
-      if (bootID != requestorBootIDs[i]) {
+      } else if (pn.getBootID() != requestorBootIDs[i]) {
         requestorNodes[i] = null;
-        continue;
+      } else {
+        anyValid = true;
       }
-      anyValid = true;
     }
     if (!anyValid) {
       requestorNodes = EMPTY_WEAK_REFERENCE;
@@ -438,24 +508,27 @@ class FailureTableEntry implements TimedOutNodesList {
     return anyValid;
   }
 
-  /** Has this peer asked us for the key? */
+  /**
+   * Returns whether the given peer asked us for this key within the offer window.
+   *
+   * <p>Also prunes stale requestors. The {@code now} parameter is used to compare against stored
+   * request times; units are milliseconds since epoch.
+   *
+   * @param peer peer to check.
+   * @param now current time in milliseconds since epoch.
+   * @return {@code true} if the peer asked within the window; {@code false} otherwise.
+   */
   public synchronized boolean askedByPeer(PeerNodeUnlocked peer, long now) {
     boolean anyValid = false;
     boolean ret = false;
     for (int i = 0; i < requestorNodes.length; i++) {
       WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      if (ref == null) continue;
-      PeerNodeUnlocked pn = ref.get();
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
       if (pn == null) {
         requestorNodes[i] = null;
-        continue;
-      }
-      long bootID = pn.getBootID();
-      if (bootID != requestorBootIDs[i]) {
+      } else if (pn.getBootID() != requestorBootIDs[i]) {
         requestorNodes[i] = null;
-        continue;
-      }
-      if (now - requestorTimes[i] < MAX_TIME_BETWEEN_REQUEST_AND_OFFER) {
+      } else if (now - requestorTimes[i] < MAX_TIME_BETWEEN_REQUEST_AND_OFFER) {
         if (pn == peer) ret = true;
         anyValid = true;
       }
@@ -468,27 +541,28 @@ class FailureTableEntry implements TimedOutNodesList {
     return ret;
   }
 
-  /** Have we asked this peer for the key? */
+  /**
+   * Returns whether we asked the given peer for the key within the offer window.
+   *
+   * <p>Also prunes stale "requested-from" entries.
+   *
+   * @param peer peer to check.
+   * @param now current time in milliseconds since epoch.
+   * @return {@code true} if we asked this peer recently; {@code false} otherwise.
+   */
   public synchronized boolean askedFromPeer(PeerNodeUnlocked peer, long now) {
     boolean anyValid = false;
     boolean ret = false;
     for (int i = 0; i < requestedNodes.length; i++) {
       WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
-      if (ref == null) continue;
-      PeerNodeUnlocked pn = ref.get();
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
       if (pn == null) {
         requestedNodes[i] = null;
-        continue;
-      }
-      long bootID = pn.getBootID();
-      if (bootID != requestedBootIDs[i]) {
+      } else if (pn.getBootID() != requestedBootIDs[i]) {
         requestedNodes[i] = null;
-        continue;
-      }
-      anyValid = true;
-      if (now - requestedTimes[i] < MAX_TIME_BETWEEN_REQUEST_AND_OFFER) {
-        if (pn == peer) ret = true;
+      } else {
         anyValid = true;
+        if (now - requestedTimes[i] < MAX_TIME_BETWEEN_REQUEST_AND_OFFER && pn == peer) ret = true;
       }
     }
     if (!anyValid) {
@@ -500,32 +574,55 @@ class FailureTableEntry implements TimedOutNodesList {
     return ret;
   }
 
-  public synchronized boolean isEmpty(long now) {
+  private synchronized boolean isEmptyInternal() {
     if (requestedNodes.length > 0) return false;
-    return requestorNodes.length <= 0;
+    return requestorNodes.length == 0;
   }
 
   /**
-   * Get the timeout time for the given peer, taking HTL into account. If there was a timeout at HTL
-   * 1, and we are now sending a request at HTL 2, we ignore the timeout.
+   * Returns the timeout time for the given peer, taking HTL into account.
+   *
+   * <p>If a timeout was recorded at HTL {@code 1} and we now send at HTL {@code 2}, the timeout is
+   * ignored. The result is an absolute time in milliseconds since epoch, or {@code -1} if there is
+   * no applicable timeout.
+   *
+   * @param peer peer to query.
+   * @param htl HTL for the pending request.
+   * @param now current time in milliseconds since epoch; used to filter expired timeouts.
+   * @param forPerNodeFailureTables when {@code true}, consult per-node failure-table timeouts,
+   *     otherwise consult RecentlyFailed timeouts.
+   * @return absolute timeout in milliseconds since epoch, or {@code -1} if none.
    */
   @Override
   public synchronized long getTimeoutTime(
       PeerNode peer, short htl, long now, boolean forPerNodeFailureTables) {
     long timeout = -1;
     for (int i = 0; i < requestedNodes.length; i++) {
-      WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
-      if (ref != null && ref.get() == peer) {
-        if (requestedTimeoutHTLs[i] >= htl) {
-          long thisTimeout =
-              forPerNodeFailureTables ? requestedTimeoutsFT[i] : requestedTimeoutsRF[i];
-          if (thisTimeout > timeout && thisTimeout > now) timeout = thisTimeout;
-        }
+      if (matchesPeerAndHtl(i, peer, htl)) {
+        long thisTimeout = computeTimeout(i, forPerNodeFailureTables);
+        if (thisTimeout > now && thisTimeout > timeout) timeout = thisTimeout;
       }
     }
     return timeout;
   }
 
+  private boolean matchesPeerAndHtl(int index, PeerNode peer, short htl) {
+    WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[index];
+    return ref != null && ref.get() == peer && requestedTimeoutHTLs[index] >= htl;
+  }
+
+  private long computeTimeout(int index, boolean forPerNodeFailureTables) {
+    return forPerNodeFailureTables ? requestedTimeoutsFT[index] : requestedTimeoutsRF[index];
+  }
+
+  /**
+   * Compacts both peer lists, removing disconnected, restarted, or expired entries.
+   *
+   * <p>The method captures the current time internally because a pass over the entire failure table
+   * may take a while.
+   *
+   * @return {@code true} if the entry becomes empty after cleanup; {@code false} otherwise.
+   */
   public synchronized boolean cleanup() {
     long now =
         System
@@ -542,19 +639,20 @@ class FailureTableEntry implements TimedOutNodesList {
     int x = 0;
     for (int i = 0; i < requestorNodes.length; i++) {
       WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      if (ref == null) continue;
-      PeerNodeUnlocked pn = ref.get();
-      if (pn == null) continue;
-      long bootID = pn.getBootID();
-      if (bootID != requestorBootIDs[i]) continue;
-      if (!pn.isConnected()) continue;
-      if (now - requestorTimes[i] > MAX_TIME_BETWEEN_REQUEST_AND_OFFER) continue;
-      empty = false;
-      requestorNodes[x] = requestorNodes[i];
-      requestorTimes[x] = requestorTimes[i];
-      requestorBootIDs[x] = requestorBootIDs[i];
-      requestorHTLs[x] = requestorHTLs[i];
-      x++;
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      boolean valid =
+          pn != null
+              && pn.getBootID() == requestorBootIDs[i]
+              && pn.isConnected()
+              && (now - requestorTimes[i] <= MAX_TIME_BETWEEN_REQUEST_AND_OFFER);
+      if (valid) {
+        empty = false;
+        requestorNodes[x] = requestorNodes[i];
+        requestorTimes[x] = requestorTimes[i];
+        requestorBootIDs[x] = requestorBootIDs[i];
+        requestorHTLs[x] = requestorHTLs[i];
+        x++;
+      }
     }
     if (x < requestorNodes.length) {
       requestorNodes = Arrays.copyOf(requestorNodes, x);
@@ -571,28 +669,31 @@ class FailureTableEntry implements TimedOutNodesList {
     int x = 0;
     for (int i = 0; i < requestedNodes.length; i++) {
       WeakReference<? extends PeerNodeUnlocked> ref = requestedNodes[i];
-      if (ref == null) continue;
-      PeerNodeUnlocked pn = ref.get();
-      if (pn == null) continue;
-      long bootID = pn.getBootID();
-      if (bootID != requestedBootIDs[i]) continue;
-      if (!pn.isConnected()) continue;
-      if (now - requestedTimes[i] > MAX_TIME_BETWEEN_REQUEST_AND_OFFER) continue;
-      empty = false;
-      requestedNodes[x] = requestedNodes[i];
-      requestedTimes[x] = requestedTimes[i];
-      requestedBootIDs[x] = requestedBootIDs[i];
-      requestedLocs[x] = requestedLocs[i];
-      if (now < requestedTimeoutsRF[x] || now < requestedTimeoutsFT[x]) {
-        requestedTimeoutsRF[x] = requestedTimeoutsRF[i];
-        requestedTimeoutsFT[x] = requestedTimeoutsFT[i];
-        requestedTimeoutHTLs[x] = requestedTimeoutHTLs[i];
-      } else {
-        requestedTimeoutsRF[x] = -1;
-        requestedTimeoutsFT[x] = -1;
-        requestedTimeoutHTLs[x] = (short) -1;
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      boolean valid =
+          pn != null
+              && pn.getBootID() == requestedBootIDs[i]
+              && pn.isConnected()
+              && (now - requestedTimes[i] <= MAX_TIME_BETWEEN_REQUEST_AND_OFFER);
+      if (valid) {
+        empty = false;
+        requestedNodes[x] = requestedNodes[i];
+        requestedTimes[x] = requestedTimes[i];
+        requestedBootIDs[x] = requestedBootIDs[i];
+        requestedLocs[x] = requestedLocs[i];
+        // Preserve timeouts based on the source slot 'i'. When compacting (x < i), reading from
+        // 'x' could observe stale values and drop live per-peer timeouts.
+        if (now < requestedTimeoutsRF[i] || now < requestedTimeoutsFT[i]) {
+          requestedTimeoutsRF[x] = requestedTimeoutsRF[i];
+          requestedTimeoutsFT[x] = requestedTimeoutsFT[i];
+          requestedTimeoutHTLs[x] = requestedTimeoutHTLs[i];
+        } else {
+          requestedTimeoutsRF[x] = -1;
+          requestedTimeoutsFT[x] = -1;
+          requestedTimeoutHTLs[x] = (short) -1;
+        }
+        x++;
       }
-      x++;
     }
     if (x < requestedNodes.length) {
       requestedNodes = Arrays.copyOf(requestedNodes, x);
@@ -606,30 +707,35 @@ class FailureTableEntry implements TimedOutNodesList {
     return empty;
   }
 
+  /** Returns whether both requestor and requested-from lists are empty. */
   public boolean isEmpty() {
-    return isEmpty(System.currentTimeMillis());
+    return isEmptyInternal();
   }
 
+  /**
+   * Returns the minimum HTL seen among valid requestors, clamped to the provided {@code htl}.
+   *
+   * <p>Only requestors within {@link #MAX_TIME_BETWEEN_REQUEST_AND_OFFER} are considered. Stale
+   * entries are pruned as a side effect.
+   *
+   * @param htl upper bound to clamp the minimum against.
+   * @return the smallest requestor HTL no greater than {@code htl}; if none, returns {@code htl}.
+   */
   public synchronized short minRequestorHTL(short htl) {
     long now = System.currentTimeMillis();
     boolean anyValid = false;
     for (int i = 0; i < requestorNodes.length; i++) {
       WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
-      if (ref == null) continue;
-      PeerNodeUnlocked pn = ref.get();
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
       if (pn == null) {
         requestorNodes[i] = null;
-        continue;
-      }
-      long bootID = pn.getBootID();
-      if (bootID != requestorBootIDs[i]) {
+      } else if (pn.getBootID() != requestorBootIDs[i]) {
         requestorNodes[i] = null;
-        continue;
+      } else {
+        if ((now - requestorTimes[i] < MAX_TIME_BETWEEN_REQUEST_AND_OFFER)
+            && requestorHTLs[i] < htl) htl = requestorHTLs[i];
+        anyValid = true;
       }
-      if (now - requestorTimes[i] < MAX_TIME_BETWEEN_REQUEST_AND_OFFER) {
-        if (requestorHTLs[i] < htl) htl = requestorHTLs[i];
-      }
-      anyValid = true;
     }
     if (!anyValid) {
       requestorNodes = EMPTY_WEAK_REFERENCE;

--- a/src/main/java/network/crypta/node/TimedOutNodesList.java
+++ b/src/main/java/network/crypta/node/TimedOutNodesList.java
@@ -1,23 +1,38 @@
 package network.crypta.node;
 
 /**
- * Interface which returns the time at which the failure table timeout on any given node will expire
- * for a specific key.
+ * Provides timeout information for peers that have recently failed requests.
+ *
+ * <p>Implementations answer when a failure-table based timeout for a peer ends so routing and
+ * request-quenching code can decide whether it is acceptable to route to that peer. The concrete
+ * key or request context is supplied by the caller's surrounding logic.
  *
  * @author toad
  */
 public interface TimedOutNodesList {
 
   /**
-   * When does the timeout for this node end?
+   * Returns the wall-clock time at which the timeout for the given peer ends under the supplied
+   * thresholds and mode.
    *
-   * @param peer The peer we are proposing to route to.
-   * @param htl Timeouts with lower HTL than this will be ignored.
-   * @param now The current time from System.currentTimeMillis().
-   * @param forPerNodeFailureTables If true, return the timeout for purposes of per-node failure
-   *     tables i.e. which to route to (paranoid high); if false, return the timeout for purposes of
-   *     RecentlyFailed request quenching (trusting low).
-   * @return The time at which the timeout ends for the node in question. -1 if there is no timeout.
+   * <p>Mode selection:
+   *
+   * <ul>
+   *   <li>{@code forPerNodeFailureTables == true}: compute the timeout used by per-node failure
+   *       tables (conservative routing decision).
+   *   <li>{@code forPerNodeFailureTables == false}: compute the timeout used by {@code
+   *       RecentlyFailed} request quenching (more permissive).
+   * </ul>
+   *
+   * @param peer the non-null peer that may be routed to
+   * @param htl the Hops-To-Live (HTL) threshold; timeouts recorded with an HTL lower than this
+   *     value are ignored
+   * @param now current time in milliseconds since the epoch, typically from {@link
+   *     System#currentTimeMillis()}
+   * @param forPerNodeFailureTables when {@code true}, use per-node failure-table semantics; when
+   *     {@code false}, use {@code RecentlyFailed} quenching semantics
+   * @return a millisecond timestamp (epoch) at which the timeout ends; {@code -1} if no timeout
+   *     applies under the provided parameters
    */
   long getTimeoutTime(PeerNode peer, short htl, long now, boolean forPerNodeFailureTables);
 }

--- a/src/test/java/network/crypta/node/FailureTableEntryTest.java
+++ b/src/test/java/network/crypta/node/FailureTableEntryTest.java
@@ -1,0 +1,239 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.ref.WeakReference;
+import network.crypta.keys.Key;
+import network.crypta.keys.NodeCHK;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class FailureTableEntryTest {
+
+  private static final short HTL_3 = 3;
+  private static final short HTL_5 = 5;
+
+  private Key key;
+  private FailureTableEntry entry;
+
+  @Mock private PeerNode peer1;
+  @Mock private PeerNode peer2;
+
+  @BeforeEach
+  void setUp() {
+    byte[] rk = new byte[NodeCHK.KEY_LENGTH];
+    for (int i = 0; i < rk.length; i++) rk[i] = (byte) (i + 1);
+    key = new NodeCHK(rk, Key.ALGO_AES_PCFB_256_SHA256);
+    entry = new FailureTableEntry(key);
+
+    // Default stubs for peers
+    setPeerDefaults(peer1, 1L, 0.42);
+    setPeerDefaults(peer2, 2L, 0.99);
+  }
+
+  private static void setPeerDefaults(PeerNode peer, long bootId, double loc) {
+    when(peer.getBootID()).thenReturn(bootId);
+    when(peer.getLocation()).thenReturn(loc);
+    when(peer.isConnected()).thenReturn(true);
+    when(peer.shortToString()).thenReturn("peer-" + bootId);
+    when(peer.getWeakRef()).thenAnswer(inv -> new WeakReference<>(peer));
+  }
+
+  @Test
+  @DisplayName("constructor_initialState_expectEmptyAndNoTimeouts")
+  void constructor_initialState_expectEmptyAndNoTimeouts() {
+    long now = System.currentTimeMillis();
+
+    assertTrue(entry.isEmpty());
+    assertTrue(entry.isEmpty());
+
+    assertFalse(entry.askedByPeer(peer1, now));
+    assertFalse(entry.askedFromPeer(peer1, now));
+
+    assertEquals(-1, entry.getTimeoutTime(peer1, HTL_3, now, false));
+    assertEquals(-1, entry.getTimeoutTime(peer1, HTL_3, now, true));
+  }
+
+  @Test
+  @DisplayName("failedTo_setsTimeoutsAndGetTimeoutTimeHonorsHtl")
+  void failedTo_setsTimeoutsAndGetTimeoutTimeHonorsHtl() {
+    long base = 10_000L;
+    long rf = 5_000L;
+    long ft = 10_000L;
+
+    entry.failedTo(peer1, rf, ft, base, HTL_5);
+
+    assertTrue(entry.askedFromPeer(peer1, base + 1));
+
+    assertEquals(base + rf, entry.getTimeoutTime(peer1, HTL_5, base + 1, false));
+    assertEquals(base + ft, entry.getTimeoutTime(peer1, HTL_5, base + 1, true));
+
+    // Higher HTL should ignore the timeout stored at a lower HTL
+    assertEquals(-1, entry.getTimeoutTime(peer1, (short) (HTL_5 + 1), base + 1, false));
+  }
+
+  @Test
+  @DisplayName("failedTo_secondCallDoesNotDecreaseTimeouts")
+  void failedTo_secondCallDoesNotDecreaseTimeouts() {
+    long base = 50_000L;
+    entry.failedTo(peer1, 5_000L, 10_000L, base, HTL_3);
+    // Attempt to lower the timeouts: should not shorten
+    entry.failedTo(peer1, 100L, 100L, base + 1, HTL_3);
+
+    assertEquals(base + 5_000L, entry.getTimeoutTime(peer1, HTL_3, base + 2, false));
+    assertEquals(base + 10_000L, entry.getTimeoutTime(peer1, HTL_3, base + 2, true));
+  }
+
+  @Test
+  @DisplayName("failedTo_samePeerDifferentHtl_keepsSeparateTimeoutsAndSelection")
+  void failedTo_samePeerDifferentHtl_keepsSeparateTimeoutsAndSelection() {
+    long base = 100_000L;
+    entry.failedTo(peer1, 100L, 0L, base, HTL_3); // RF=base+100 @ HTL_3
+    entry.failedTo(peer1, 500L, 0L, base, HTL_5); // RF=base+500 @ HTL_5
+
+    // At HTL 5: should see the entry with HTL 5
+    assertEquals(base + 500L, entry.getTimeoutTime(peer1, HTL_5, base + 1, false));
+    // At HTL 3: both entries are eligible; max wins
+    assertEquals(base + 500L, entry.getTimeoutTime(peer1, HTL_3, base + 1, false));
+  }
+
+  @Test
+  @DisplayName("othersWantAndAskedByPeer_withinAndAfterExpiry")
+  void othersWantAndAskedByPeer_withinAndAfterExpiry() {
+    long now = 200_000L;
+    short reqHtl = 7;
+
+    // Populate requestor list directly via package-private helper
+    entry.addRequestor(peer1, now, reqHtl);
+
+    assertTrue(entry.othersWant());
+    assertTrue(entry.askedByPeer(peer1, now + 1));
+    assertFalse(entry.askedByPeer(peer2, now + 1));
+
+    long afterExpiry = now + FailureTableEntry.MAX_TIME_BETWEEN_REQUEST_AND_OFFER + 1;
+    assertFalse(entry.askedByPeer(peer1, afterExpiry));
+    // askedByPeer() clears empty/expired requestors eagerly
+    assertFalse(entry.othersWant());
+  }
+
+  @Test
+  @DisplayName("offer_sendsToBothRequestedAndRequestor_onceEachAndSkipsDuplicates")
+  void offer_sendsToBothRequestedAndRequestor_onceEachAndSkipsDuplicates() {
+    long now = 300_000L;
+    short reqHtl = 9;
+
+    // Add one as requestor and the same also as requested-from to ensure uniqueness
+    entry.addRequestor(peer1, now, reqHtl);
+    entry.failedTo(peer1, 1000L, 1000L, now, HTL_3);
+    // And add another peer through the requested-from path
+    entry.failedTo(peer2, 1000L, 1000L, now, HTL_3);
+
+    entry.offer();
+
+    // Each peer gets exactly one offer with the entry's key
+    verify(peer1, times(1)).offer(entry.key);
+    verify(peer2, times(1)).offer(entry.key);
+  }
+
+  @Test
+  @DisplayName("askedFromPeer_expiredEntries_returnFalseUntilCleanup")
+  void askedFromPeer_expiredEntries_returnFalseUntilCleanup() {
+    long now = 400_000L;
+    entry.failedTo(peer1, 1000L, 1000L, now, HTL_3);
+
+    long max = FailureTableEntry.MAX_TIME_BETWEEN_REQUEST_AND_OFFER;
+    long afterExpiry = now + max + 1;
+    // Sanity: verify our computed timestamp is beyond expiry window relative to stored value
+    // (package-private array access used for determinism only)
+    assertTrue(afterExpiry - entry.requestedTimes[0] > max);
+    assertFalse(entry.askedFromPeer(peer1, afterExpiry));
+
+    // Not yet cleaned from arrays
+    assertFalse(entry.isEmpty());
+
+    // cleanup() uses wall clock. Use entries that are already far in the past to be pruned now.
+    FailureTableEntry e2 = new FailureTableEntry(key);
+    e2.failedTo(peer1, 0L, 0L, 1L, HTL_3);
+    assertTrue(e2.cleanup()); // everything pruned, empty
+    assertTrue(e2.isEmpty());
+  }
+
+  @Test
+  @DisplayName("minRequestorHTL_returnsMinimumAmongRecent_andKeepsInitialWhenAllExpired")
+  void minRequestorHTL_returnsMinimumAmongRecent_andKeepsInitialWhenAllExpired() {
+    long nowWall = System.currentTimeMillis();
+    entry.addRequestor(peer1, nowWall, (short) 8);
+    entry.addRequestor(peer2, nowWall, (short) 3);
+
+    assertEquals(3, entry.minRequestorHTL((short) 10));
+
+    // Expire both and verify initial HTL is returned
+    long past =
+        System.currentTimeMillis() - (FailureTableEntry.MAX_TIME_BETWEEN_REQUEST_AND_OFFER + 10);
+    FailureTableEntry e2 = new FailureTableEntry(key);
+    e2.addRequestor(peer1, past, (short) 8);
+    e2.addRequestor(peer2, past, (short) 3);
+    assertEquals(10, e2.minRequestorHTL((short) 10));
+  }
+
+  @Test
+  @DisplayName("cleanup_prunesDisconnectedOrExpired_andReportsEmptyState")
+  void cleanup_prunesDisconnectedOrExpired_andReportsEmptyState() {
+    long nowWall = System.currentTimeMillis();
+    entry.addRequestor(peer1, nowWall, (short) 6);
+    entry.failedTo(peer2, 1000L, 1000L, nowWall, HTL_3);
+
+    // First cleanup with everything connected and recent -> not empty
+    boolean emptyAfterFirst = entry.cleanup();
+    assertFalse(emptyAfterFirst);
+
+    // Mark peers disconnected; cleanup should now prune everything
+    when(peer1.isConnected()).thenReturn(false);
+    when(peer2.isConnected()).thenReturn(false);
+
+    // Simulate time after expiry window to ensure pruning
+    // With peers disconnected, cleanup should prune regardless of timing.
+    boolean emptyAfterSecond = entry.cleanup();
+    assertTrue(emptyAfterSecond);
+    assertTrue(entry.isEmpty());
+  }
+
+  @Test
+  @DisplayName("cleanupRequested_compaction_preservesLiveTimeouts")
+  void cleanupRequested_compaction_preservesLiveTimeouts() {
+    long wall = System.currentTimeMillis();
+    long base = wall - 1_000L; // ensure within validity window
+
+    // Index 0: will be pruned due to disconnection
+    entry.failedTo(peer1, 100_000L, 200_000L, base, HTL_3);
+    // Index 1: stays valid and should be compacted to index 0 with timeouts preserved
+    entry.failedTo(peer2, 120_000L, 250_000L, base, HTL_3);
+
+    // Make the first peer invalid so cleanup compacts the arrays
+    when(peer1.isConnected()).thenReturn(false);
+
+    // Trigger compaction; method computes 'now' internally
+    entry.cleanup();
+
+    // Peer2 must still be considered recently asked-from
+    assertTrue(entry.askedFromPeer(peer2, wall + 10));
+
+    // RF and FT timeouts must be preserved after compaction
+    assertEquals(base + 120_000L, entry.getTimeoutTime(peer2, HTL_3, wall + 20, false));
+    assertEquals(base + 250_000L, entry.getTimeoutTime(peer2, HTL_3, wall + 20, true));
+  }
+}


### PR DESCRIPTION
Summary
- Tightens FailureTableEntry invariants and simplifies API: replace `isEmpty(long now)` with `isEmpty()` and `othersWant(PeerNodeUnlocked apartFrom)` with `othersWant()`; callers updated in FailureTable.
- Makes cleanup safer and deterministic: preserves per-peer RF/FT timeouts when compacting arrays; prunes stale entries while minimizing memory overhead.
- Improves logs and Javadoc/KDoc for clarity; reduces null-handling edge cases and repeated patterns by refactoring internals into small helpers.
- Adds comprehensive unit tests for FailureTableEntry (JUnit 6 + Mockito).

Why
- Recent routing regressions around RecentlyFailed state and offer deduplication suggested the need for clearer invariants and better tested behavior. This PR reduces ambiguity and ensures compaction never drops live timeouts.

Changes
- network/crypta/node/FailureTableEntry.java
  - Refactor requestor/requested-from tracking; explicit scan/cleanup + rebuild helpers.
  - Ensure timeouts are preserved on compaction (read from source index not compacted index).
  - Improve logging with parameterized messages; add field/method Javadoc.
  - Replace `isEmpty(now)` → `isEmpty()`; `othersWant(apartFrom)` → `othersWant()`.
- network/crypta/node/FailureTable.java
  - Update call sites to new signatures.
- network/crypta/node/TimedOutNodesList.java
  - Javadoc wording improvements.
- src/test/java/network/crypta/node/FailureTableEntryTest.java
  - New tests covering: constructor state, timeout setting by HTL, non-decreasing timeouts on subsequent failures, HTL selection rules, requestor validity window and eager pruning, offer() de-duplication across both sets, cleanup behavior with disconnection and expiry, and compaction preserving timeouts.

Stats
- 4 files changed, ~650 insertions, ~290 deletions.

Commits in branch since merge-base with develop
- ab1318d277 fix(node): tighten FailureTableEntry invariants and API; add tests
- d866dba589 docs(node): improve Javadoc for TimedOutNodesList

Base/Head
- base: develop
- head: feature/fix-FailureTableEntry

Notes
- No Gradle task or CI behavior changes; ran `./gradlew spotlessApply` before committing.
- JUnit 6 + Mockito tests added; CI should pick them up under the existing JUnit Platform configuration.
