### PR TITLE
docs(node): clarify FastRunnable Javadoc and inline-execution contract

### DIFF
--- a/src/main/java/network/crypta/node/FastRunnable.java
+++ b/src/main/java/network/crypta/node/FastRunnable.java
@@ -1,4 +1,28 @@
 package network.crypta.node;
 
-/** Runnable which can be executed in-line on the PacketSender. */
+/**
+ * Marker interface for short, non‑blocking tasks that are safe to execute inline on
+ * latency‑sensitive threads.
+ *
+ * <p>Schedulers in this codebase (for example {@link PacketSender} as well as ticker
+ * implementations such as {@link network.crypta.support.PrioritizedTicker} and {@link
+ * network.crypta.support.TrivialTicker}) may check whether a task implements {@code FastRunnable}.
+ * When it does, they can invoke {@link #run()} directly on the calling thread to minimize
+ * scheduling overhead and wake‑up latency. Tasks that do not implement this interface are typically
+ * offloaded to an executor.
+ *
+ * <p>Contract for implementers: - Keep the body of {@link #run()} very short and avoid blocking
+ * operations (sleep, I/O, waiting on locks, long computations). A slow "fast" task can stall the
+ * networking/ticker thread and degrade throughput. - Assume execution occurs on a shared
+ * infrastructure thread; do not perform work that may rely on thread‑local context or
+ * thread‑affinity semantics. - Unchecked exceptions will be handled by the calling scheduler;
+ * implementations should avoid throwing when possible.
+ *
+ * <p>Memory visibility follows the usual {@link Runnable} semantics; there are no extra
+ * happens‑before guarantees beyond those established by the scheduler invoking {@link #run()}.
+ *
+ * @see PacketSender
+ * @see network.crypta.support.PrioritizedTicker
+ * @see network.crypta.support.TrivialTicker
+ */
 public interface FastRunnable extends Runnable {}


### PR DESCRIPTION
Summary
- Expand and clarify the Javadoc on FastRunnable to document purpose, inline-execution contract, threading expectations, and links to PacketSender, PrioritizedTicker, and TrivialTicker.

Rationale
- Several schedulers (PacketSender, PrioritizedTicker, TrivialTicker) treat FastRunnable specially by running it inline to minimize latency. The previous one-line comment did not explain when and why to implement this marker, nor its constraints.

What changed
- Comments only. No code, signatures, visibility, or logic were modified.
- File: src/main/java/network/crypta/node/FastRunnable.java
  - Added detailed Javadoc: purpose, guidelines for implementers (keep run() short, avoid blocking I/O/locks/long computations), threading considerations, exception handling expectations, and references to related components.

Behavioral impact
- None. Documentation-only change.

Testing/validation
- Ran `./gradlew spotlessApply` to satisfy formatting checks.

Diff summary
```
$ git log --oneline develop..HEAD
(a7b9544) docs(node): expand Javadoc for FastRunnable and inline-execution contract; add references to PacketSender and Tickers

$ git show --stat -1
 src/main/java/network/crypta/node/FastRunnable.java | 26 +++++++++++++++++++++- 
 1 file changed, 25 insertions(+), 1 deletion(-)
```

Risks
- None. Comments only.

Checklist
- [x] Spotless formatting applied
- [x] Conventional commit message used
- [x] No placeholders added (TODO/FIXME/etc.)