### PR TITLE
chore: remove unused HandlePortTuple class

### DIFF
--- a/src/main/java/network/crypta/node/HandlePortTuple.java
+++ b/src/main/java/network/crypta/node/HandlePortTuple.java
@@ -1,8 +1,0 @@
-package network.crypta.node;
-
-/** Used to associate a port with a node database handle */
-// WARNING: THIS CLASS IS STORED IN DB4O -- THINK TWICE BEFORE ADD/REMOVE/RENAME FIELDS
-class HandlePortTuple {
-  long handle;
-  int portNumber;
-}


### PR DESCRIPTION
Summary
- Remove unused `HandlePortTuple` class.

Rationale
- Searched the repository for references: only occurrence was the class itself; no usages found.
- This class carried a historical note about being stored in DB4O, but there are no remaining reads/writes or type references.

Changes
- Delete: `src/main/java/network/crypta/node/HandlePortTuple.java` (8 lines).

Build/Format
- Ran `./gradlew spotlessApply` to ensure formatting.
- Ran `./gradlew compileJava`; build succeeded with warnings only (no errors).

Verification
- Commit range vs develop: `origin/develop..feature/remove-unused-handle-port-tuple` contains one commit.
- Diff summary:
  - D\t`src/main/java/network/crypta/node/HandlePortTuple.java`

Notes
- No functional behavior change.
- If any downstream code or persisted data depends on the presence of this class purely for schema mapping, please flag and we can consider a no-op stub instead. Current tree shows no references.
