### PR TITLE
test: add HourlyStatsTest and clarify HourlyStats Javadoc

### DIFF
--- a/src/main/java/network/crypta/node/HourlyStats.java
+++ b/src/main/java/network/crypta/node/HourlyStats.java
@@ -5,18 +5,42 @@ import java.util.Date;
 import java.util.TimeZone;
 import network.crypta.support.HTMLNode;
 
-/** Statistics tracking for performance analysis. */
+/**
+ * Collects per-hour and aggregate statistics for accepted remote requests.
+ *
+ * <p>This tracker maintains three rolling records: the current UTC hour, the previous UTC hour
+ * (finalized), and a cumulative total since the instance was created. On a UTC hour change, the
+ * current record is finalized, logged, and moved to {@code prevRecord}; a fresh current record is
+ * started.
+ *
+ * <p>All mutating operations are synchronized, so instances are safe for concurrent use from
+ * multiple threads.
+ *
+ * @see HourlyStatsRecord
+ */
 public class HourlyStats {
+  // Finalized snapshot for the previous UTC hour.
   private HourlyStatsRecord prevRecord;
+  // Mutable stats for the current UTC hour.
   private HourlyStatsRecord currentRecord;
+  // Cumulative stats since this tracker was created.
   private final HourlyStatsRecord totalRecord;
 
+  // UTC clocks used exclusively to detect hour boundaries (DST-safe).
   private final Calendar lastHourlyTime;
   private final Calendar currentTime;
 
   private final Node node;
 
-  /** Public constructor. */
+  /**
+   * Creates a new hourly statistics tracker tied to the provided node.
+   *
+   * <p>Timestamps are evaluated in UTC. The initial current record begins immediately and may
+   * represent a partial hour if construction occurs after the top of the hour.
+   *
+   * @param node the local node whose configuration (e.g., max HTL and location) is used by
+   *     underlying records
+   */
   public HourlyStats(Node node) {
     this.node = node;
     prevRecord = null;
@@ -27,20 +51,30 @@ public class HourlyStats {
   }
 
   /**
-   * Report an incoming accepted remote request.
+   * Records a single incoming, accepted remote request.
    *
-   * @param ssk Whether the request was an ssk
-   * @param success Whether the request succeeded
-   * @param local If the request succeeded, whether it succeeded locally
-   * @param htl The htl counter the request had when it arrived
-   * @param location The routing location of the request
+   * <p>If a UTC hour change is detected at call time, the current record is finalized and logged,
+   * then a new current record is started before the sample is recorded. The cumulative total is
+   * always updated.
+   *
+   * <p>Thread-safety: this method is synchronized.
+   *
+   * @param ssk whether the request targeted an SSK key
+   * @param success whether the request succeeded
+   * @param local when {@code success} is true, whether it was satisfied locally
+   * @param htl hop-to-live (HTL) value observed on arrival; values above the node's maximum are
+   *     clamped
+   * @param location routing location in the closed interval {@code [0, 1]}
+   * @throws IllegalArgumentException if {@code htl < 0} or {@code location} lies outside {@code [0,
+   *     1]}
    */
   public synchronized void remoteRequest(
       boolean ssk, boolean success, boolean local, int htl, double location) {
     Date now = new Date();
     currentTime.setTime(now);
     if (lastHourlyTime.get(Calendar.HOUR_OF_DAY) != currentTime.get(Calendar.HOUR_OF_DAY)) {
-      // new hour, cycle things.
+      // Hour boundary crossed (UTC): finalize and log the previous hour,
+      // then start a fresh current record.
       lastHourlyTime.setTime(now);
       prevRecord = currentRecord;
       currentRecord = new HourlyStatsRecord(node, true);
@@ -52,6 +86,15 @@ public class HourlyStats {
     totalRecord.remoteRequest(ssk, success, local, htl, location);
   }
 
+  /**
+   * Appends an HTML table summarizing remote-request outcomes by HTL.
+   *
+   * <p>The table contains one row per HTL (descending) and a final total row. For CHK and SSK
+   * separately, it shows the success rate and the counts used to compute it. Values are derived
+   * from the cumulative record maintained by this tracker (not only the current hour).
+   *
+   * @param html parent node to which the table is appended; must not be null
+   */
   public void fillRemoteRequestHTLsBox(HTMLNode html) {
     totalRecord.fillRemoteRequestHTLsBox(html);
   }

--- a/src/test/java/network/crypta/node/HourlyStatsTest.java
+++ b/src/test/java/network/crypta/node/HourlyStatsTest.java
@@ -1,0 +1,148 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class HourlyStatsTest {
+
+  @Mock private Node node;
+
+  @BeforeEach
+  void setUp() {
+    when(node.maxHTL()).thenReturn((short) 10);
+  }
+
+  @Test
+  void remoteRequest_withinSameHour_doesNotRotateAndForwards() throws Exception {
+    // Arrange
+    HourlyStats stats = new HourlyStats(node);
+    when(node.getLocation()).thenReturn(0.5);
+    HourlyStatsRecord initialCurrent = getField(stats, "currentRecord", HourlyStatsRecord.class);
+
+    // Act
+    stats.remoteRequest(false, true, true, 3, 0.75);
+
+    // Assert
+    HourlyStatsRecord afterCurrent = getField(stats, "currentRecord", HourlyStatsRecord.class);
+    HourlyStatsRecord prev = getField(stats, "prevRecord", HourlyStatsRecord.class);
+    assertSame(
+        initialCurrent, afterCurrent, "currentRecord should not be replaced within same hour");
+    assertNull(prev, "prevRecord must stay null without an hour rollover");
+  }
+
+  @Test
+  void remoteRequest_whenHourChanges_rotatesAndMarksPreviousFinal() throws Exception {
+    // Arrange
+    HourlyStats stats = new HourlyStats(node);
+    HourlyStatsRecord beforeCurrent = getField(stats, "currentRecord", HourlyStatsRecord.class);
+
+    // Force lastHourlyTime to a different UTC hour than 'now' to trigger rollover
+    // deterministically.
+    Calendar lastHourly = getField(stats, "lastHourlyTime", Calendar.class);
+    Calendar nowUtc = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    nowUtc.setTime(new Date());
+    nowUtc.add(Calendar.HOUR_OF_DAY, -1);
+    lastHourly.setTime(nowUtc.getTime());
+
+    // Act: first request in the new hour triggers rotation
+    when(node.getLocation()).thenReturn(0.5);
+    stats.remoteRequest(true, false, false, 2, 0.80);
+
+    // Assert
+    HourlyStatsRecord prev = getField(stats, "prevRecord", HourlyStatsRecord.class);
+    HourlyStatsRecord current = getField(stats, "currentRecord", HourlyStatsRecord.class);
+    assertNotNull(prev, "prevRecord should be set after hour rollover");
+    assertTrue(getBooleanField(prev, "finishedReporting"), "previous record must be marked final");
+
+    // The record that became previous is the old current, which was constructed with
+    // completeHour=false
+    assertFalse(
+        getBooleanField(prev, "completeHour"),
+        "previous record should not represent a complete hour");
+
+    // A fresh current record should be created for the new hour with completeHour=true
+    assertNotNull(current, "current record must exist after rotation");
+    assertTrue(
+        getBooleanField(current, "completeHour"), "new current must represent a complete hour");
+
+    // And it must be a different instance than the old current.
+    // (prev was the old current; current must be new)
+    assertTrue(
+        beforeCurrent == prev && current != beforeCurrent,
+        "rotation must move old current to prev");
+  }
+
+  @Test
+  void remoteRequest_withNegativeHtl_throwsIllegalArgument() {
+    // Arrange
+    HourlyStats stats = new HourlyStats(node);
+
+    // Act + Assert
+    assertThrows(
+        IllegalArgumentException.class, () -> stats.remoteRequest(false, true, true, -1, 0.5));
+  }
+
+  @Test
+  void remoteRequest_withInvalidLocation_throwsIllegalArgument() {
+    // Arrange
+    HourlyStats stats = new HourlyStats(node);
+
+    // Act + Assert: below 0 range
+    assertThrows(
+        IllegalArgumentException.class, () -> stats.remoteRequest(false, false, false, 1, -0.01));
+
+    // Act + Assert: above 1 range
+    assertThrows(
+        IllegalArgumentException.class, () -> stats.remoteRequest(true, false, false, 1, 1.01));
+  }
+
+  @Test
+  void fillRemoteRequestHTLsBox_buildsTableStructure() {
+    // Arrange
+    HourlyStats stats = new HourlyStats(node);
+    HTMLNode root = new HTMLNode("div");
+
+    // Act
+    stats.fillRemoteRequestHTLsBox(root);
+
+    // Assert: ensure table and expected headers are present in generated HTML
+    String html = root.generate();
+    assertTrue(html.contains("<table>"), "should contain a table");
+    assertTrue(html.contains("<th>HTL</th>"), "should include HTL header");
+    assertTrue(html.contains("<th>CHKs</th>"), "should include CHKs header");
+    assertTrue(html.contains("<th>SSKs</th>"), "should include SSKs header");
+    assertTrue(html.contains("Total"), "should include a Total row");
+  }
+
+  // --- Reflection helpers ---
+
+  private static <T> T getField(Object target, String name, Class<T> type) throws Exception {
+    Field f = target.getClass().getDeclaredField(name);
+    f.setAccessible(true);
+    return type.cast(f.get(target));
+  }
+
+  private static boolean getBooleanField(Object target, String name) throws Exception {
+    Field f = target.getClass().getDeclaredField(name);
+    f.setAccessible(true);
+    return f.getBoolean(target);
+  }
+}


### PR DESCRIPTION
Summary
- Add JUnit 6 tests for HourlyStats rollover, input validation, and HTML table generation.
- Clarify HourlyStats Javadoc: UTC hour rotation, thread-safety, and parameter semantics.

Why
- Ensures the hourly rotation logic triggers at UTC hour boundaries and that the previous record is finalized correctly.
- Adds guardrail tests for invalid HTL/location inputs.
- Verifies HTML summary is emitted with expected headers.

Scope
- No production logic changes beyond Javadoc/comment improvements.
- Formatting applied via Spotless.

Changes
- src/test/java/network/crypta/node/HourlyStatsTest.java:1 — New JUnit 6 test class using Mockito.
- src/main/java/network/crypta/node/HourlyStats.java:1 — Expanded class/method Javadoc and clarifying comments.

Implementation Notes
- Tests use Mockito JUnit 6 extension and minimal reflection helpers to observe internal rotation state (no public accessors exist).
- Rollover is forced deterministically by adjusting lastHourlyTime to a different UTC hour prior to invoking remoteRequest.

How To Validate
- Run: `./gradlew test`
- Optional coverage report: `./gradlew jacocoTestReport` (see build/reports/jacoco/test/jacocoTestReport.xml and HTML).

Commit(s)
- 2ded6ea519: test: add HourlyStatsTest and improve HourlyStats Javadoc

Notes
- JUnit 6 is already configured via project build-logic. No Gradle or dependency changes were needed.
