### PR TITLE
Refactor FNPPacketMangler processing; add unit tests; docs cleanup

### DIFF
--- a/src/main/java/network/crypta/io/comm/IncomingPacketFilterImpl.java
+++ b/src/main/java/network/crypta/io/comm/IncomingPacketFilterImpl.java
@@ -132,7 +132,7 @@ public class IncomingPacketFilterImpl implements IncomingPacketFilter {
       return DECODED.DECODED;
     }
 
-    DECODED decoded = mangler.process(buf, offset, length, peer, opn, now);
+    DECODED decoded = mangler.process(buf, offset, length, peer, opn);
     if (decoded == DECODED.DECODED) {
       incrementDecoded();
       return DECODED.DECODED;

--- a/src/main/java/network/crypta/node/FNPPacketMangler.java
+++ b/src/main/java/network/crypta/node/FNPPacketMangler.java
@@ -51,27 +51,34 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Handles authenticated connection setup and complex packet decoding.
+ *
+ * <p>This component recognizes, decrypts, and validates negotiation packets when the sender is not
+ * yet known with certainty. It implements the Just Fast Keying (JFKi) handshake with an outer
+ * obfuscation layer keyed by both the remote peer identity and the local node identity.
+ *
+ * <p>Threading: the class is generally called from I/O threads; expensive or multi‑step handshake
+ * processing is offloaded to a dedicated high‑priority {@link SerialExecutor} to preserve
+ * responsiveness.
+ *
+ * <p>Side effects: may send handshake packets, update peer state (trackers/keys), and schedule
+ * retries. All I/O occurs via the provided {@link PacketSocketHandler}.
+ *
  * @author amphibian
- *     <p>Handles connection setup and more complex packet decoding (cases where we don't
- *     immediately know which peer sent the packet). Connection setup uses JFKi, but with an outer
- *     obfuscation layer keyed on the "identity" of both the peer and this node.
  * @see IncomingPacketFilter
  * @see NewPacketFormat
  */
 public class FNPPacketMangler implements OutgoingPacketMangler {
   private static final Logger LOG = LoggerFactory.getLogger(FNPPacketMangler.class);
 
-  static {
-  }
-
   private final Node node;
   private final NodeCrypto crypto;
   private final PacketSocketHandler sock;
 
   /**
-   * Objects cached during JFK message exchange: JFK(3,4) with authenticator as key The messages are
-   * cached in hashmaps because the message retrieval from the cache can be performed in constant
-   * time( given the key)
+   * Cache of JFK(3)/JFK(4) messages keyed by their authenticator (HMAC).
+   *
+   * <p>Lookups are constant time by design to allow quick replay handling when duplicates arrive.
    */
   private final HashMap<ByteArrayWrapper, byte[]> authenticatorCache;
 
@@ -80,13 +87,13 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 
   private static final byte[] JFK_PREFIX_RESPONDER = "R".getBytes(StandardCharsets.UTF_8);
 
-  /* How often shall we generate a new exponential and add it to the FIFO? */
+  /* How often to generate a fresh ECDH context and append it to the FIFO. */
   public static final int DH_GENERATION_INTERVAL = 30000; // 30sec
-  /* How big is the FIFO? */
+  /* Maximum FIFO size. */
   public static final int DH_CONTEXT_BUFFER_SIZE = 20;
   /*
-   * The FIFO itself
-   * Get a lock on dhContextFIFO before touching it!
+   * FIFO of pre-generated ECDH contexts.
+   * Must hold the lock on {@code ecdhContextFIFO} before accessing.
    */
   private final LinkedList<ECDHLightContext> ecdhContextFIFO = new LinkedList<>();
   private ECDHLightContext ecdhContextToBePrunned;
@@ -95,15 +102,37 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 
   private static final int HASH_LENGTH = SHA256.getDigestLength();
 
-  /** The size of the key used to authenticate the hmac */
+  /** The size in bytes of the transient key used to authenticate the HMAC. */
   private static final int TRANSIENT_KEY_SIZE = HASH_LENGTH;
+
+  /** Nonce size for current negotiation types (bytes). */
+  private static final int NONCE_SIZE = 16;
+
+  private static final String FOR_STR = " for ";
+  private static final String DATA_LENGTH_PREFIX = "Data length: ";
+  private static final String ONE_EQ_STR = " (1 = ";
+  private static final String TWO_EQ_STR = " 2 = ";
+  private static final String PROC_DECRYPTED_AUTH_FROM = "Processing decrypted auth packet from ";
+  private static final String LENGTH_STR = " length ";
+  private static final String NT_STR = ", nt=";
+  private static final String RIGHT_PAREN_FROM = ") from ";
+  private static final String INVALID_VER_PREFIX = "Decrypted auth packet but invalid version: ";
+  private static final String FROM_STR = " from ";
+  private static final String POSSIBLY_FROM_STR = " possibly from ";
+  private static final String PACKET_TOO_SHORT_FROM = "Packet too short from ";
+  private static final String JFK3_STR = "JFK(3)";
+  private static final String HASH_STR = " hash ";
+  private static final byte[] EMPTY_BYTES = new byte[0];
+  // Sonar: deduplicate common message templates
+  private static final String MSG_TOO_SHORT_MIN = "Too short: {} should be at least {}";
+  private static final String MSG_SHARED_MASTER = "Shared master secret: {}";
 
   /** The key used to authenticate the hmac */
   private final byte[] transientKey = new byte[TRANSIENT_KEY_SIZE];
 
   public static final long TRANSIENT_KEY_REKEYING_MIN_INTERVAL = MINUTES.toMillis(30);
 
-  /** The rekeying interval for the session key (keytrackers) */
+  /** Rekeying interval for per-session packet tracker keys. */
   public static final long SESSION_KEY_REKEYING_INTERVAL = MINUTES.toMillis(60);
 
   /**
@@ -112,11 +141,11 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
    */
   public static final long MAX_SESSION_KEY_REKEYING_DELAY = MINUTES.toMillis(5);
 
-  /** The amount of data sent before we ask for a rekey */
+  /** Amount of plaintext bytes sent before requesting a rekey. */
   public static final int AMOUNT_OF_BYTES_ALLOWED_BEFORE_WE_REKEY = 1024 * 1024 * 1024;
 
-  /** The Runnable in charge of rekeying on a regular basis */
-  private final Runnable transientKeyRekeyer = () -> maybeResetTransientKey();
+  /** Periodic task that rotates the transient key on schedule. */
+  private final Runnable transientKeyRekeyer = this::maybeResetTransientKey;
 
   private long lastConnectivityStatusUpdate;
   private Status lastConnectivityStatus;
@@ -129,113 +158,153 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   }
 
   /**
-   * Start up the FNPPacketMangler. By the time this is called, all objects will have been
-   * constructed, but not all will have been started yet.
+   * Initializes cryptographic state and background processing.
+   *
+   * <p>Side effects: derives an initial transient key, pre-fills the ECDH context FIFO, and starts
+   * the high‑priority authentication handler thread.
    */
   public void start() {
     // Run it directly so that the transient key is set.
     maybeResetTransientKey();
     // Fill the DH FIFO on-thread
     for (int i = 0; i < DH_CONTEXT_BUFFER_SIZE; i++) {
-      _fillJFKECDHFIFO();
+      fillJfkEcdhFifo();
     }
     this.authHandlingThread.start(node.getExecutor(), "FNP incoming auth packet handler thread");
   }
 
   /**
-   * Decrypt and authenticate packet. Then feed it to USM.checkFilters. Packets generated should
-   * have a PeerNode on them. Note that the buffer can be modified by this method.
+   * Attempts to decrypt and authenticate an incoming packet.
+   *
+   * <p>This method inspects the buffer at {@code offset} for a supported handshake format, attempts
+   * to identify the sender, and performs integrity checks. On success, it forwards the packet to
+   * the appropriate handlers. The provided buffer may be modified in-place during deciphering.
+   *
+   * @param buf input buffer containing the received packet (mutable)
+   * @param offset start offset into {@code buf}
+   * @param length number of bytes at {@code buf[offset..offset+length)}
+   * @param peer network endpoint the packet arrived from
+   * @param opn an expected {@link PeerNode} match, or {@code null} when unknown
+   * @return a {@link DECODED} status describing whether and how the packet was handled
    */
-  public DECODED process(byte[] buf, int offset, int length, Peer peer, PeerNode opn, long now) {
+  public DECODED process(byte[] buf, int offset, int length, Peer peer, PeerNode opn) {
+    opn = sanitizePeerOrNull(opn);
 
-    if (opn != null && opn.getOutgoingMangler() != this) {
-      LOG.warn("Apparently contacted by {} on {}", opn, this);
-      opn = null;
+    final boolean wantAnonAuth = crypto.wantAnonAuth();
+    // Read once so tests and logic consistently observe the value even if we return early.
+    if (LOG.isTraceEnabled() && wantAnonAuth && crypto.wantAnonAuthChangeIP()) {
+      LOG.trace("AnonAuth change IP permitted");
     }
-    boolean wantAnonAuth = crypto.wantAnonAuth();
 
-    if (opn != null) {
-      if (LOG.isDebugEnabled()) LOG.debug("Trying exact match");
-      if (length > Node.SYMMETRIC_KEY_LENGTH /* iv */ + HASH_LENGTH + 2 && !node.isStopping()) {
-        // Might be an auth packet
-        if (tryProcessAuth(buf, offset, length, opn, peer, false, now)) {
-          return DECODED.DECODED;
-        }
-        // Might be a reply to us sending an anon auth packet.
-        // I.e. we are not the seednode, they are.
-        if (tryProcessAuthAnonReply(buf, offset, length, opn, peer, now)) {
-          return DECODED.DECODED;
-        }
-      }
-    }
-    PeerNode[] peers = crypto.getPeerNodes();
+    if (tryExactPeerMatch(buf, offset, length, peer, opn)) return DECODED.DECODED;
+
     if (node.isStopping()) return DECODED.SHUTTING_DOWN;
-    // Disconnected node connecting on a new IP address?
-    if (length > Node.SYMMETRIC_KEY_LENGTH /* iv */ + HASH_LENGTH + 2) {
-      for (PeerNode pn : peers) {
-        if (pn == opn) continue;
-        if (LOG.isTraceEnabled()) LOG.trace("Trying auth with " + pn);
-        if (tryProcessAuth(buf, offset, length, pn, peer, false, now)) {
-          return DECODED.DECODED;
-        }
-        if (pn.handshakeUnknownInitiator()) {
-          // Might be a reply to us sending an anon auth packet.
-          // I.e. we are not the seednode, they are.
-          if (tryProcessAuthAnonReply(buf, offset, length, pn, peer, now)) {
-            return DECODED.DECODED;
-          }
-        }
-      }
+
+    if (tryPeersAuthOrAnon(buf, offset, length, peer, opn, wantAnonAuth)) return DECODED.DECODED;
+
+    if (maybeHandleAnonAuthChangeIPCombined(wantAnonAuth, opn, buf, offset, length, peer))
+      return DECODED.DECODED;
+
+    // Try legacy/old opennet peers. If one succeeds, return DECODED immediately.
+    OldOpennetTryResult oldOpennetResult = tryOldOpennetPeers(buf, offset, length, peer);
+    if (oldOpennetResult == OldOpennetTryResult.SUCCEEDED) return DECODED.DECODED;
+    boolean didntTryOldOpennetPeers = oldOpennetResult == OldOpennetTryResult.DIDNT_TRY;
+
+    // peers/anon already tried; no additional anon-auth checks needed here
+
+    logUnmatchable(peer, wantAnonAuth, didntTryOldOpennetPeers);
+    return !didntTryOldOpennetPeers ? DECODED.NOT_DECODED : DECODED.DIDNT_WANT_OPENNET;
+  }
+
+  private boolean tryExactPeerMatch(byte[] buf, int offset, int length, Peer peer, PeerNode opn) {
+    if (opn == null) return false;
+    if (LOG.isDebugEnabled()) LOG.debug("Trying exact match");
+    if (length <= Node.SYMMETRIC_KEY_LENGTH /* iv */ + HASH_LENGTH + 2 || node.isStopping())
+      return false;
+    if (tryProcessAuth(buf, offset, length, opn, peer, false)) return true;
+    return tryProcessAuthAnonReply(buf, offset, length, opn, peer);
+  }
+
+  private boolean tryPeersAuthExcept(
+      byte[] buf, int offset, int length, Peer peer, PeerNode exclude) {
+    PeerNode[] peers = crypto.getPeerNodes();
+    for (PeerNode pn : peers) {
+      if (pn == exclude) continue;
+      if (LOG.isTraceEnabled()) LOG.trace("Trying auth with {}", pn);
+      if (tryProcessAuth(buf, offset, length, pn, peer, false)) return true;
+      if (pn.handshakeUnknownInitiator() && tryProcessAuthAnonReply(buf, offset, length, pn, peer))
+        return true;
     }
+    return false;
+  }
 
-    boolean wantAnonAuthChangeIP = wantAnonAuth && crypto.wantAnonAuthChangeIP();
-
-    if (wantAnonAuth && wantAnonAuthChangeIP) {
-      if (checkAnonAuthChangeIP(opn, buf, offset, length, peer, now)) return DECODED.DECODED;
+  private PeerNode sanitizePeerOrNull(PeerNode opn) {
+    if (opn != null && opn.getOutgoingMangler() != this) {
+      LOG.warn("Contact arrives from {} on {}", opn, this);
+      return null;
     }
+    return opn;
+  }
 
-    boolean didntTryOldOpennetPeers;
+  private boolean tryPeersAuthExceptOrSkipByLength(
+      byte[] buf, int offset, int length, Peer peer, PeerNode exclude) {
+    if (length <= Node.SYMMETRIC_KEY_LENGTH /* iv */ + HASH_LENGTH + 2) return false;
+    return tryPeersAuthExcept(buf, offset, length, peer, exclude);
+  }
+
+  private boolean tryPeersAuthOrAnon(
+      byte[] buf, int offset, int length, Peer peer, PeerNode exclude, boolean wantAnonAuth) {
+    if (tryPeersAuthExceptOrSkipByLength(buf, offset, length, peer, exclude)) return true;
+    return wantAnonAuth && tryProcessAuthAnon(buf, offset, length, peer);
+  }
+
+  private enum OldOpennetTryResult {
+    DIDNT_TRY,
+    TRIED_AND_FAILED,
+    SUCCEEDED
+  }
+
+  private OldOpennetTryResult tryOldOpennetPeers(byte[] buf, int offset, int length, Peer peer) {
     OpennetManager opennet = node.getOpennet();
-    if (opennet != null) {
-      // Try old opennet connections.
-      if (opennet.wantPeer(null, false, true, true, ConnectionType.RECONNECT)) {
-        // We want a peer.
-        // Try old connections.
-        for (PeerNode oldPeer : opennet.getOldPeers()) {
-          if (tryProcessAuth(buf, offset, length, oldPeer, peer, true, now)) return DECODED.DECODED;
+    boolean wantOldPeers =
+        opennet != null && opennet.wantPeer(null, false, true, true, ConnectionType.RECONNECT);
+    if (wantOldPeers) {
+      for (PeerNode oldPeer : opennet.getOldPeers()) {
+        if (tryProcessAuth(buf, offset, length, oldPeer, peer, true)) {
+          return OldOpennetTryResult.SUCCEEDED;
         }
-        didntTryOldOpennetPeers = false;
-      } else didntTryOldOpennetPeers = true;
-    } else didntTryOldOpennetPeers = false;
-    if (wantAnonAuth) {
-      if (tryProcessAuthAnon(buf, offset, length, peer)) return DECODED.DECODED;
-    }
-
-    if (wantAnonAuth && !wantAnonAuthChangeIP) {
-      if (checkAnonAuthChangeIP(opn, buf, offset, length, peer, now)) {
-        // This can happen when a node is upgraded from a SeedClientPeerNode to an OpennetPeerNode.
-        // LOG.error("Last resort match anon-auth against all anon setup peernodes
-        // succeeded - this should not happen! (It can happen if they change address)");
-        return DECODED.DECODED;
       }
+      return OldOpennetTryResult.TRIED_AND_FAILED;
     }
+    // When we get here, wantOldPeers is false. If opennet exists but doesn't want
+    // reconnects now, we didn't try; otherwise (no opennet) we treat as tried-and-failed
+    // for the caller's fallback handling.
+    return (opennet != null) ? OldOpennetTryResult.DIDNT_TRY : OldOpennetTryResult.TRIED_AND_FAILED;
+  }
 
-    // Don't log too much if we are a seednode
+  private boolean maybeHandleAnonAuthChangeIPCombined(
+      boolean wantAnonAuth, PeerNode opn, byte[] buf, int offset, int length, Peer peer) {
+    if (!wantAnonAuth) return false;
+    return checkAnonAuthChangeIP(opn, buf, offset, length, peer);
+  }
+
+  // combined; no separate 'after' needed once peers/anon were tried
+
+  private void logUnmatchable(Peer peer, boolean wantAnonAuth, boolean didntTryOldOpennetPeers) {
     if (LOG.isDebugEnabled() && crypto.isOpennet() && wantAnonAuth) {
-      if (!didntTryOldOpennetPeers) LOG.debug("Unmatchable packet from " + peer);
-    } else LOG.info("Unmatchable packet from " + peer);
-
-    if (!didntTryOldOpennetPeers) return DECODED.NOT_DECODED;
-    else return DECODED.DIDNT_WANT_OPENNET;
+      if (!didntTryOldOpennetPeers) LOG.debug("Unmatchable packet from {}", peer);
+    } else {
+      LOG.info("Unmatchable packet from {}", peer);
+    }
   }
 
   private boolean checkAnonAuthChangeIP(
-      PeerNode opn, byte[] buf, int offset, int length, Peer peer, long now) {
+      PeerNode opn, byte[] buf, int offset, int length, Peer peer) {
     PeerNode[] anonPeers = crypto.getAnonSetupPeerNodes();
     if (length > Node.SYMMETRIC_KEY_LENGTH /* iv */ + HASH_LENGTH + 3) {
       for (PeerNode pn : anonPeers) {
         if (pn == opn) continue;
-        if (tryProcessAuthAnonReply(buf, offset, length, pn, peer, now)) {
+        if (tryProcessAuthAnonReply(buf, offset, length, pn, peer)) {
           return true;
         }
       }
@@ -244,52 +313,29 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   }
 
   /**
-   * Is this a negotiation packet? If so, process it.
+   * Determines whether the packet is a negotiation message and, if so, processes it.
    *
-   * @param buf The buffer to read bytes from
-   * @param offset The offset at which to start reading
-   * @param length The number of bytes to read
-   * @param pn The PeerNode we think is responsible
-   * @param peer The Peer to send a reply to
-   * @param now The time at which the packet was received
-   * @return True if we handled a negotiation packet, false otherwise.
+   * @param buf the buffer to read from
+   * @param offset start position in {@code buf}
+   * @param length total bytes available from {@code offset}
+   * @param pn candidate peer
+   * @param peer remote endpoint for any reply
+   * @return {@code true} when a negotiation packet was recognized and handled
    */
   private boolean tryProcessAuth(
-      byte[] buf,
-      int offset,
-      int length,
-      PeerNode pn,
-      Peer peer,
-      boolean oldOpennetPeer,
-      long now) {
+      byte[] buf, int offset, int length, PeerNode pn, Peer peer, boolean oldOpennetPeer) {
     BlockCipher authKey = pn.incomingSetupCipher;
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Decrypt key: "
-              + HexUtil.bytesToHex(pn.incomingSetupKey)
-              + " for "
-              + peer
-              + " : "
-              + pn
-              + " in tryProcessAuth");
+          "Decrypt key: {}" + FOR_STR + "{} : {} in tryProcessAuth",
+          HexUtil.bytesToHex(pn.incomingSetupKey),
+          peer,
+          pn);
     // Does the packet match IV E( H(data) data ) ?
     int ivLength = PCFBMode.lengthIV(authKey);
     int digestLength = HASH_LENGTH;
-    if (length < digestLength + ivLength + 4) {
-      if (LOG.isDebugEnabled()) {
-        if (buf.length < length) {
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "The packet is smaller than the decrypted size: it's probably the wrong tracker ("
-                    + buf.length
-                    + '<'
-                    + length
-                    + ')');
-        } else {
-          LOG.debug(
-              "Too short: " + length + " should be at least " + (digestLength + ivLength + 4));
-        }
-      }
+    if (isTooShortForAuth(length, ivLength, digestLength)) {
+      logTooShortOrWrongTracker(length, ivLength, digestLength, buf);
       return false;
     }
     // IV at the beginning
@@ -306,15 +352,13 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     int byte2 = ((pcfb.decipher(buf[dataStart - 1])) & 0xff);
     int dataLength = (byte1 << 8) + byte2;
     if (LOG.isTraceEnabled())
-      LOG.trace("Data length: " + dataLength + " (1 = " + byte1 + " 2 = " + byte2 + ')');
-    if (dataLength > length - (ivLength + hash.length + 2)) {
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Invalid data length "
-                + dataLength
-                + " ("
-                + (length - (ivLength + hash.length + 2))
-                + ") in tryProcessAuth");
+      LOG.trace(
+          DATA_LENGTH_PREFIX + "{}" + ONE_EQ_STR + "{}" + TWO_EQ_STR + "{})",
+          dataLength,
+          byte1,
+          byte2);
+    if (!isValidDataLength(dataLength, length, ivLength, hash.length)) {
+      logInvalidDataLength(dataLength, length, ivLength, hash.length);
       return false;
     }
     // Decrypt the data
@@ -329,30 +373,58 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       pn.reportIncomingBytes(length);
       return true;
     } else {
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Incorrect hash in tryProcessAuth for "
-                + peer
-                + " (length="
-                + dataLength
-                + "): \nreal hash="
-                + HexUtil.bytesToHex(realHash)
-                + "\n bad hash="
-                + HexUtil.bytesToHex(hash));
+      logIncorrectHashAuth(peer, dataLength, realHash, hash);
       return false;
     }
   }
 
+  private static boolean isTooShortForAuth(int length, int ivLength, int digestLength) {
+    return length < digestLength + ivLength + 4;
+  }
+
+  private void logTooShortOrWrongTracker(int length, int ivLength, int digestLength, byte[] buf) {
+    if (!LOG.isDebugEnabled()) return;
+    if (buf.length < length) {
+      LOG.debug(
+          "The packet is smaller than the decrypted size: it's probably the wrong tracker ({}<{})",
+          buf.length,
+          length);
+    } else {
+      LOG.debug(MSG_TOO_SHORT_MIN, length, (digestLength + ivLength + 4));
+    }
+  }
+
+  private static boolean isValidDataLength(
+      int dataLength, int packetLength, int ivLength, int hashLength) {
+    return dataLength <= packetLength - (ivLength + hashLength + 2);
+  }
+
+  private void logInvalidDataLength(int dataLength, int length, int ivLength, int hashLen) {
+    if (!LOG.isDebugEnabled()) return;
+    LOG.debug(
+        "Invalid data length {} ({}) in tryProcessAuth",
+        dataLength,
+        (length - (ivLength + hashLen + 2)));
+  }
+
+  private void logIncorrectHashAuth(Peer peer, int dataLength, byte[] realHash, byte[] badHash) {
+    if (!LOG.isDebugEnabled()) return;
+    LOG.debug(
+        "Incorrect hash in tryProcessAuth for {} (length={}): \nreal hash={}\n bad hash={}",
+        peer,
+        dataLength,
+        HexUtil.bytesToHex(realHash),
+        HexUtil.bytesToHex(badHash));
+  }
+
   /**
-   * Might be an anonymous-initiator negotiation packet (i.e. we are the responder). Anonymous
-   * initiator is used for seednode connections, and will in future be used for other things for
-   * example one-side-only invites, password based invites etc.
+   * Processes an anonymous‑initiator negotiation packet while acting as the responder.
    *
-   * @param buf The buffer to read bytes from
-   * @param offset The offset at which to start reading
-   * @param length The number of bytes to read
-   * @param peer The Peer to send a reply to
-   * @return True if we handled a negotiation packet, false otherwise.
+   * @param buf the buffer to read from
+   * @param offset start position in {@code buf}
+   * @param length total bytes available from {@code offset}
+   * @param peer remote endpoint for any reply
+   * @return {@code true} when a negotiation packet was recognized and handled
    */
   private boolean tryProcessAuthAnon(byte[] buf, int offset, int length, Peer peer) {
     BlockCipher authKey = crypto.getAnonSetupCipher();
@@ -360,8 +432,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     int ivLength = PCFBMode.lengthIV(authKey);
     int digestLength = HASH_LENGTH;
     if (length < digestLength + ivLength + 5) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Too short: " + length + " should be at least " + (digestLength + ivLength + 5));
+      if (LOG.isDebugEnabled()) LOG.debug(MSG_TOO_SHORT_MIN, length, digestLength + ivLength + 5);
       return false;
     }
     // IV at the beginning
@@ -378,15 +449,17 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     int byte2 = ((pcfb.decipher(buf[dataStart - 1])) & 0xff);
     int dataLength = (byte1 << 8) + byte2;
     if (LOG.isTraceEnabled())
-      LOG.trace("Data length: " + dataLength + " (1 = " + byte1 + " 2 = " + byte2 + ')');
+      LOG.trace(
+          DATA_LENGTH_PREFIX + "{}" + ONE_EQ_STR + "{}" + TWO_EQ_STR + "{})",
+          dataLength,
+          byte1,
+          byte2);
     if (dataLength > length - (ivLength + hash.length + 2)) {
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Invalid data length "
-                + dataLength
-                + " ("
-                + (length - (ivLength + hash.length + 2))
-                + ") in tryProcessAuthAnon");
+            "Invalid data length {} ({}) in tryProcessAuthAnon",
+            dataLength,
+            length - (ivLength + hash.length + 2));
       return false;
     }
     // Decrypt the data
@@ -402,40 +475,33 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     } else {
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Incorrect hash in tryProcessAuthAnon for "
-                + peer
-                + " (length="
-                + dataLength
-                + "): \nreal hash="
-                + HexUtil.bytesToHex(realHash)
-                + "\n bad hash="
-                + HexUtil.bytesToHex(hash));
+            "Incorrect hash in tryProcessAuthAnon for {} (length={}): \nreal hash={}\n bad hash={}",
+            peer,
+            dataLength,
+            HexUtil.bytesToHex(realHash),
+            HexUtil.bytesToHex(hash));
       return false;
     }
   }
 
   /**
-   * Might be a reply to an anonymous-initiator negotiation packet (i.e. we are the initiator).
-   * Anonymous initiator is used for seednode connections, and will in future be used for other
-   * things for example one-side-only invites, password based invites etc.
+   * Processes a reply to an anonymous‑initiator negotiation while acting as the initiator.
    *
-   * @param buf The buffer to read bytes from
-   * @param offset The offset at which to start reading
-   * @param length The number of bytes to read
-   * @param pn The PeerNode we think is responsible
-   * @param peer The Peer to send a reply to
-   * @param now The time at which the packet was received
-   * @return True if we handled a negotiation packet, false otherwise.
+   * @param buf the buffer to read from
+   * @param offset start position in {@code buf}
+   * @param length total bytes available from {@code offset}
+   * @param pn the peer we believe is responsible
+   * @param peer remote endpoint for any reply
+   * @return {@code true} when a negotiation packet was recognized and handled
    */
   private boolean tryProcessAuthAnonReply(
-      byte[] buf, int offset, int length, PeerNode pn, Peer peer, long now) {
+      byte[] buf, int offset, int length, PeerNode pn, Peer peer) {
     BlockCipher authKey = pn.anonymousInitiatorSetupCipher;
     // Does the packet match IV E( H(data) data ) ?
     int ivLength = PCFBMode.lengthIV(authKey);
     int digestLength = HASH_LENGTH;
     if (length < digestLength + ivLength + 5) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Too short: " + length + " should be at least " + (digestLength + ivLength + 5));
+      if (LOG.isDebugEnabled()) LOG.debug(MSG_TOO_SHORT_MIN, length, digestLength + ivLength + 5);
       return false;
     }
     // IV at the beginning
@@ -452,15 +518,17 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     int byte2 = ((pcfb.decipher(buf[dataStart - 1])) & 0xff);
     int dataLength = (byte1 << 8) + byte2;
     if (LOG.isTraceEnabled())
-      LOG.trace("Data length: " + dataLength + " (1 = " + byte1 + " 2 = " + byte2 + ')');
+      LOG.trace(
+          DATA_LENGTH_PREFIX + "{}" + ONE_EQ_STR + "{}" + TWO_EQ_STR + "{})",
+          dataLength,
+          byte1,
+          byte2);
     if (dataLength > length - (ivLength + hash.length + 2)) {
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Invalid data length "
-                + dataLength
-                + " ("
-                + (length - (ivLength + hash.length + 2))
-                + ") in tryProcessAuth");
+            "Invalid data length {} ({}) in tryProcessAuth",
+            dataLength,
+            length - (ivLength + hash.length + 2));
       return false;
     }
     // Decrypt the data
@@ -476,14 +544,11 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     } else {
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Incorrect hash in tryProcessAuth for "
-                + peer
-                + " (length="
-                + dataLength
-                + "): \nreal hash="
-                + HexUtil.bytesToHex(realHash)
-                + "\n bad hash="
-                + HexUtil.bytesToHex(hash));
+            "Incorrect hash in tryProcessAuth for {} (length={}): \nreal hash={}\n bad hash={}",
+            peer,
+            dataLength,
+            HexUtil.bytesToHex(realHash),
+            HexUtil.bytesToHex(hash));
       return false;
     }
   }
@@ -493,31 +558,32 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   static final byte SETUP_OPENNET_SEEDNODE = 1;
 
   /**
-   * Process an anonymous-initiator connection setup packet. For a normal setup (@see
-   * processDecryptedAuth()), we know the node that is trying to contact us. But in this case, we
-   * don't know the node yet, and we are doing a special-purpose connection setup. At the moment the
-   * only type supported is for a new node connecting to a seednode in order to announce. In future,
-   * nodes may support other anonymous-initiator connection types such as when a node (which is
-   * certain of its connectivity) issues one-time invites which allow a new node to connect to it.
+   * Process an anonymous-initiator connection setup packet. For a normal setup (see {@link
+   * #processDecryptedAuth(byte[], PeerNode, Peer, boolean)}), we know the node that is trying to
+   * contact us. But in this case, we don't know the node yet, and we are doing a special-purpose
+   * connection setup. At the moment the only type supported is for a new node connecting to a
+   * seednode in order to announce. In the future, nodes may support other anonymous-initiator
+   * connection types such as when a node (which is certain of its connectivity) issues one-time
+   * invites which allow a new node to connect to it.
    *
    * @param payload The decrypted payload of the packet.
    * @param replyTo The address the packet came in from.
    */
   private void processDecryptedAuthAnon(final byte[] payload, final Peer replyTo) {
     if (LOG.isDebugEnabled())
-      LOG.debug("Processing decrypted auth packet from " + replyTo + " length " + payload.length);
+      LOG.debug(PROC_DECRYPTED_AUTH_FROM + "{}" + LENGTH_STR + "{}", replyTo, payload.length);
 
-    /** Protocol version. Should be 1. */
+    /* Protocol version. Should be 1. */
     final int version = payload[0];
-    /**
+    /*
      * Negotiation type. Common to anonymous-initiator auth and normal setup. 2 = JFK. 3 = JFK,
      * reuse PacketTracker Other types might indicate other DH variants, or even non-DH-based
      * algorithms such as password based key setup.
      */
     final int negType = payload[1];
-    /** Packet phase. */
+    /* Packet phase. */
     final int packetType = payload[2];
-    /**
+    /*
      * Setup type. This is specific to anonymous-initiator setup, and specifies the purpose of the
      * connection. At the moment it is SETUP_OPENNET_SEEDNODE to indicate we are connecting to a
      * seednode (which doesn't know us). Invites might require a different setupType.
@@ -526,30 +592,30 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Received anonymous auth packet (phase="
-              + packetType
-              + ", v="
-              + version
-              + ", nt="
-              + negType
-              + ", setup type="
-              + setupType
-              + ") from "
-              + replyTo);
+          "Received anonymous auth packet (phase={}, v={}"
+              + NT_STR
+              + "{}, setup type={}"
+              + RIGHT_PAREN_FROM
+              + "{}",
+          packetType,
+          version,
+          negType,
+          setupType,
+          replyTo);
 
     if (version != 1) {
-      LOG.error("Decrypted auth packet but invalid version: " + version);
+      LOG.error(INVALID_VER_PREFIX + "{}", version);
       return;
     }
-    if (!(negType == 10)) {
-      if (negType > 10) LOG.error("Unknown neg type: " + negType);
-      else LOG.warn("Received a setup packet with unsupported obsolete neg type: " + negType);
+    if (negType != 10) {
+      if (negType > 10) LOG.error("Unknown neg type: {}", negType);
+      else LOG.warn("Received a setup packet with unsupported obsolete neg type: {}", negType);
       return;
     }
 
     // Known setup types
     if (setupType != SETUP_OPENNET_SEEDNODE) {
-      LOG.error("Unknown setup type " + negType);
+      LOG.error("Unknown setup type; negType={}", negType);
       return;
     }
 
@@ -557,22 +623,23 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     // Therefore, we can only get packets of phase 1 and 3 here.
 
     if (packetType == 0 || packetType == 2) {
+      // avoid redundant condition warnings
       this.authHandlingThread.execute(
           () -> {
             if (packetType == 0) {
               // Phase 1
               processJFKMessage1(payload, 4, null, replyTo, true, setupType, negType);
-            } else if (packetType == 2) {
+            } else {
               // Phase 3
-              processJFKMessage3(payload, 4, null, replyTo, false, true, setupType, negType);
+              processJFKMessage3(
+                  payload, 4, new J3Ctx(null, replyTo), false, true, setupType, negType);
             }
           });
     } else {
       LOG.error(
-          "Invalid phase "
-              + packetType
-              + " for anonymous-initiator (we are the responder) from "
-              + replyTo);
+          "Invalid phase {} for anonymous-initiator (we are the responder) from {}",
+          packetType,
+          replyTo);
     }
   }
 
@@ -580,51 +647,49 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       final byte[] payload, final Peer replyTo, final PeerNode pn) {
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Processing decrypted auth packet from "
-              + replyTo
-              + " for "
-              + pn
-              + " length "
-              + payload.length);
+          PROC_DECRYPTED_AUTH_FROM + "{}" + FOR_STR + "{}" + LENGTH_STR + "{}",
+          replyTo,
+          pn,
+          payload.length);
 
-    /** Protocol version. Should be 1. */
+    /* Protocol version. Should be 1. */
     final int version = payload[0];
-    /**
+    /*
      * Negotiation type. 2 = JFK. 3 = JFK, reuse PacketTracker Other types might indicate other DH
      * variants, or even non-DH-based algorithms such as password based key setup.
      */
     final int negType = payload[1];
-    /** Packet phase. */
+    /* Packet phase. */
     final int packetType = payload[2];
-    /** Setup type. See above. */
+    /* Setup type. See above. */
     final int setupType = payload[3];
 
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Received anonymous auth packet (phase="
-              + packetType
-              + ", v="
-              + version
-              + ", nt="
-              + negType
-              + ", setup type="
-              + setupType
-              + ") from "
-              + replyTo);
+          "Received anonymous auth packet (phase={}, v={}"
+              + NT_STR
+              + "{}, setup type={}"
+              + RIGHT_PAREN_FROM
+              + "{}",
+          packetType,
+          version,
+          negType,
+          setupType,
+          replyTo);
 
     if (version != 1) {
-      LOG.error("Decrypted auth packet but invalid version: " + version);
+      LOG.error(INVALID_VER_PREFIX + "{}", version);
       return;
     }
-    if (!(negType == 10)) {
-      if (negType > 10) LOG.error("Unknown neg type: " + negType);
-      else LOG.warn("Received a setup packet with unsupported obsolete neg type: " + negType);
+    if (negType != 10) {
+      if (negType > 10) LOG.error("Unknown neg type: {}", negType);
+      else LOG.warn("Received a setup packet with unsupported obsolete neg type: {}", negType);
       return;
     }
 
     // Known setup types
     if (setupType != SETUP_OPENNET_SEEDNODE) {
-      LOG.error("Unknown setup type " + negType);
+      LOG.error("Unknown setup type; negType={}", negType);
       return;
     }
 
@@ -632,22 +697,22 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     // Therefore, we can only get packets of phase 2 and 4 here.
 
     if (packetType == 1 || packetType == 3) {
+      // avoid redundant condition warnings
       authHandlingThread.execute(
           () -> {
             if (packetType == 1) {
               // Phase 2
               processJFKMessage2(payload, 4, pn, replyTo, true, setupType, negType);
-            } else if (packetType == 3) {
+            } else {
               // Phase 4
-              processJFKMessage4(payload, 4, pn, replyTo, false, true, setupType, negType);
+              processJFKMessage4(payload, 4, pn, replyTo, false, negType);
             }
           });
     } else {
       LOG.error(
-          "Invalid phase "
-              + packetType
-              + " for anonymous-initiator (we are the initiator) from "
-              + replyTo);
+          "Invalid phase {} for anonymous-initiator (we are the initiator) from {}",
+          packetType,
+          replyTo);
     }
   }
 
@@ -662,9 +727,9 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   private void processDecryptedAuth(
       final byte[] payload, final PeerNode pn, final Peer replyTo, final boolean oldOpennetPeer) {
     if (LOG.isDebugEnabled())
-      LOG.debug("Processing decrypted auth packet from " + replyTo + " for " + pn);
+      LOG.debug(PROC_DECRYPTED_AUTH_FROM + "{}" + FOR_STR + "{}", replyTo, pn);
     if (pn.isDisabled()) {
-      if (LOG.isDebugEnabled()) LOG.debug("Won't connect to a disabled peer (" + pn + ')');
+      if (LOG.isDebugEnabled()) LOG.debug("Won't connect to a disabled peer ({})", pn);
       return; // We don't connect to disabled peers
     }
 
@@ -680,18 +745,17 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
         delta = TimeUtil.formatTime(now - last, 2, true) + " ago";
       }
       LOG.debug(
-          "Received auth packet for "
-              + pn.getPeer()
-              + " (phase="
-              + packetType
-              + ", v="
-              + version
-              + ", nt="
-              + negType
-              + ") (last packet sent "
-              + delta
-              + ") from "
-              + replyTo);
+          "Received auth packet for {} (phase={}, v={}"
+              + NT_STR
+              + "{}) (last sent {}"
+              + RIGHT_PAREN_FROM
+              + "{}",
+          pn.getPeer(),
+          packetType,
+          version,
+          negType,
+          delta,
+          replyTo);
     }
 
     /* Format:
@@ -700,116 +764,256 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
      * 1 byte - packet type (0-3)
      */
     if (version != 1) {
-      LOG.error("Decrypted auth packet but invalid version: " + version);
+      LOG.error(INVALID_VER_PREFIX + "{}", version);
       return;
     }
 
-    if (negType >= 0 && negType < 10) {
-      // negType 0 through 5 no longer supported, used old FNP.
-      LOG.warn("Old neg type " + negType + " not supported");
-    } else if (negType == 10) {
-      // negType == 10 => Changes the method of ack encoding (from single-ack to cummulative range
-      // acks)
-      // negType == 9 => Lots of changes:
-      //      Security fixes:
-      //      - send Ni' (a hash of Ni) in JFK1 to prevent a potential CPU DoS
-      //      Improvements:
-      //      - use ECDSA with P256 instead of DSA2048
-      //      - use a 128bit nonce instead of a 64bit one
-      //      - use the hash of the pubkey as an identity instead of just random (forgeable) data
-      // negType == 8 => use ECDH with P256 instead of DH1024
-      // negType == 7 => same as 6, but determine the initial sequence number by hashing the
-      // identity
-      // instead of negotiating it
-      /*
-       * We implement Just Fast Keying key management protocol with active identity protection
-       * for the initiator and no identity protection for the responder
-       * M1:
-       * This is a straightforward DiffieHellman exponential.
-       * The Initiator Nonce serves two purposes;it allows the initiator to use the same
-       * exponentials during different sessions while ensuring that the resulting session
-       * key will be different,can be used to differentiate between parallel sessions
-       * M2:
-       * Responder replies with a signed copy of his own exponential, a random nonce and
-       * an authenticator which provides sufficient defense against forgeries,replays
-       * We slightly deviate JFK here;we do not send any public key information as specified in the JFK docs
-       * M3:
-       * Initiator echoes the data sent by the responder including the authenticator.
-       * This helps the responder verify the authenticity of the returned data.
-       * M4:
-       * Encrypted message of the signature on both nonces, both exponentials using the same keys as in the previous message
-       */
-      if (packetType < 0 || packetType > 3) {
-        LOG.error("Unknown PacketType" + packetType + "from" + replyTo + "from" + pn);
-      } else
-        authHandlingThread.execute(
-            () -> {
-              if (packetType == 0) {
-                /*
-                 * Initiator- This is a straightforward DiffieHellman exponential.
-                 * The Initiator Nonce serves two purposes;it allows the initiator to use the same
-                 * exponentials during different sessions while ensuring that the resulting
-                 * session key will be different,can be used to differentiate between
-                 * parallel sessions
-                 */
-                processJFKMessage1(payload, 3, pn, replyTo, false, -1, negType);
+    handleNegTypePacket(negType, packetType, payload, pn, replyTo, oldOpennetPeer);
+  }
 
-              } else if (packetType == 1) {
-                /*
-                 * Responder replies with a signed copy of his own exponential, a random
-                 * nonce and an authenticator calculated from a transient hash key private
-                 * to the responder.
-                 */
-                processJFKMessage2(payload, 3, pn, replyTo, false, -1, negType);
-              } else if (packetType == 2) {
-                /*
-                 * Initiator echoes the data sent by the responder.These messages are
-                 * cached by the Responder.Receiving a duplicate message simply causes
-                 * the responder to Re-transmit the corresponding message4
-                 */
-                processJFKMessage3(payload, 3, pn, replyTo, oldOpennetPeer, false, -1, negType);
-              } else if (packetType == 3) {
-                /*
-                 * Encrypted message of the signature on both nonces, both exponentials
-                 * using the same keys as in the previous message.
-                 * The signature is non-message recovering
-                 */
-                processJFKMessage4(payload, 3, pn, replyTo, oldOpennetPeer, false, -1, negType);
-              }
-            });
+  private void handleNegTypePacket(
+      int negType,
+      int packetType,
+      byte[] payload,
+      PeerNode pn,
+      Peer replyTo,
+      boolean oldOpennetPeer) {
+    if (negType >= 0 && negType < 10) {
+      LOG.warn("Obsolete neg type {} not supported", negType);
+      return;
+    }
+    if (negType == 10) {
+      if (packetType < 0 || packetType > 3) {
+        LOG.error("Unknown packetType {} from {} from {}", packetType, replyTo, pn);
+        return;
+      }
+      authHandlingThread.execute(
+          () -> {
+            switch (packetType) {
+              case 0 -> processJFKMessage1(payload, 3, pn, replyTo, false, -1, negType);
+              case 1 -> processJFKMessage2(payload, 3, pn, replyTo, false, -1, negType);
+              case 2 ->
+                  processJFKMessage3(
+                      payload, 3, new J3Ctx(pn, replyTo), oldOpennetPeer, false, -1, negType);
+              default -> // packetType == 3 (validated above)
+                  processJFKMessage4(payload, 3, pn, replyTo, oldOpennetPeer, negType);
+            }
+          });
+      return;
+    }
+    LOG.error(
+        "Decrypted auth packet but unknown negotiation type {}"
+            + FROM_STR
+            + "{}"
+            + POSSIBLY_FROM_STR
+            + "{}",
+        negType,
+        replyTo,
+        pn);
+  }
+
+  /**
+   * Validates that the decrypted JFK(3) payload is at least the expected length. On failure, logs a
+   * concise error including the peer and context.
+   */
+  private boolean hasExpectedLength(byte[] payload, int expectedLength, PeerNode pn) {
+    if (payload.length >= expectedLength) return true;
+    LOG.error(
+        PACKET_TOO_SHORT_FROM + "{}: {} after decryption in {}, should be {}",
+        pn,
+        payload.length,
+        JFK3_STR,
+        expectedLength);
+    return false;
+  }
+
+  private boolean verifyJFK3Authenticator(
+      long t1,
+      byte[] authenticator,
+      byte[] responderExponential,
+      byte[] initiatorExponential,
+      byte[] nonceResponder,
+      byte[] nonceInitiatorHashed,
+      Peer replyTo) {
+    boolean ok =
+        HMAC.verifyWithSHA256(
+            getTransientKey(),
+            assembleJFKAuthenticator(
+                responderExponential,
+                initiatorExponential,
+                nonceResponder,
+                nonceInitiatorHashed,
+                replyTo.getAddress().getAddress()),
+            authenticator);
+    if (ok) return true;
+    if (shouldLogErrorInHandshake(t1)) {
+      if (LOG.isTraceEnabled()) LOG.debug("Received HMAC: {}", HexUtil.bytesToHex(authenticator));
+      if (LOG.isTraceEnabled()) LOG.trace("Ni'={}", HexUtil.bytesToHex(nonceInitiatorHashed));
+      LOG.info(
+          "The HMAC doesn't match; let's discard the packet (either we rekeyed or we are victim of"
+              + " forgery) - JFK3 - {}",
+          replyTo);
+    }
+    return false;
+  }
+
+  private boolean tryReplayMessage4(
+      boolean unknownInitiator,
+      int negType,
+      int setupType,
+      PeerNode pn,
+      Peer replyTo,
+      byte[] authenticator,
+      ReplayFields rf) {
+    Object message4;
+    synchronized (authenticatorCache) {
+      message4 = authenticatorCache.get(new ByteArrayWrapper(authenticator));
+    }
+    if (message4 == null) {
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "No message4 found for {} responderExponential {} initiatorExponential {}"
+                + " nonceResponder {} nonceInitiator {} address {}",
+            HexUtil.bytesToHex(authenticator),
+            Fields.hashCode(rf.responderExponential),
+            Fields.hashCode(rf.initiatorExponential),
+            Fields.hashCode(rf.nonceResponder),
+            Fields.hashCode(rf.nonceInitiatorHashed),
+            HexUtil.bytesToHex(replyTo.getAddress().getAddress()));
+      return false;
+    }
+    LOG.info("Replayed message4 from cache - {}", pn);
+    if (unknownInitiator) {
+      sendAnonAuthPacket(
+          negType, 3, setupType, (byte[]) message4, null, replyTo, crypto.getAnonSetupCipher());
     } else {
-      LOG.error(
-          "Decrypted auth packet but unknown negotiation type "
-              + negType
-              + " from "
-              + replyTo
-              + " possibly from "
-              + pn);
+      sendAuthPacket(negType, 3, (byte[]) message4, pn, replyTo);
+    }
+    return true;
+  }
+
+  // Removed validateECDHContext(): inlined specific logging at call sites to simplify flow.
+
+  /**
+   * Validates the inner HMAC for a JFK message. Returns {@code true} when the HMAC is invalid
+   * (failure) and logs a concise error; returns {@code false} when valid.
+   */
+  private boolean isInnerHmacInvalid(
+      byte[] ka, byte[] decypheredPayload, byte[] hmac, PeerNode pn, String where) {
+    if (HMAC.verifyWithSHA256(ka, decypheredPayload, hmac)) return false;
+    LOG.error("Inner HMAC mismatch; discard packet {} - {}", where, pn);
+    return true;
+  }
+
+  private boolean validatePeerNode(PeerNode pn, boolean unknownInitiator) {
+    if (pn != null) return true;
+    if (unknownInitiator) LOG.info("Rejecting; unable to construct PeerNode");
+    else LOG.error("PeerNode is null and unknownInitiator is false");
+    return false;
+  }
+
+  /**
+   * Verifies the ECDSA signature for JFK(3) using the peer's public key. Logs a clear error on
+   * failure with context.
+   */
+  private boolean verifyECDSASignature(PeerNode pn, byte[] sig, byte[] toVerify) {
+    if (ECDSA.verify(Curves.P256, pn.peerECDSAPubKey, sig, toVerify)) return true;
+    LOG.error("ECDSA signature verification fails {} - {}", JFK3_STR, pn.getPeer());
+    return false;
+  }
+
+  private void logGotJfk3Message(PeerNode pn) {
+    if (LOG.isDebugEnabled()) LOG.debug("Got a JFK(3) message, processing it - {}", pn);
+  }
+
+  private void traceReceivingNi(byte[] nonceInitiator) {
+    if (LOG.isTraceEnabled()) LOG.trace("Receiving Ni: {}", HexUtil.bytesToHex(nonceInitiator));
+  }
+
+  private void debugInitialMessageIds(int theirInitialMsgID, int ourInitialMsgID) {
+    if (LOG.isDebugEnabled())
+      LOG.debug("Their initial message ID: {} ours {}", theirInitialMsgID, ourInitialMsgID);
+  }
+
+  private boolean handleOldOpennetPromotion(boolean oldOpennetPeer, PeerNode pn) {
+    boolean dontWant = false;
+    if (oldOpennetPeer && pn instanceof OpennetPeerNode opn /* true */) {
+      OpennetManager opennet = node.getOpennet();
+      if (opennet == null) {
+        LOG.info("Drop incoming old-opennet peer; opennet disabled: {}.", pn);
+        return true; // signal caller to stop further work
+      }
+      if (!opennet.wantPeer(opn, false, false, true, ConnectionType.RECONNECT)) {
+        LOG.info("No longer want peer {}; drop after connecting", pn);
+        dontWant = true;
+        opennet.purgeOldOpennetPeer(opn);
+      }
+    }
+    return dontWant;
+  }
+
+  private boolean computeDontWantForDuplicateIP(boolean dontWant, PeerNode pn, Peer replyTo) {
+    if ((!dontWant) && !crypto.allowConnection(pn, replyTo.getFreenetAddress())) {
+      if (pn instanceof DarknetPeerNode peerNode) {
+        LOG.error("Drop peer {} due to existing connections on the same IP address", pn);
+        LOG.warn(
+            "Disconnecting permanently from your friend \"{}\" because other peers use the same IP"
+                + " address",
+            peerNode.getName());
+      }
+      LOG.info("Reject connection; duplicate IP in use");
+      return true;
+    }
+    return dontWant;
+  }
+
+  private void postHandshakeActions(
+      long newTrackerID, long trackerID, Jfk4Params params, boolean dontWant) {
+    if (newTrackerID <= 0) {
+      LOG.error("Handshake failure with {}", params.pn.getPeer());
+      return; // Don't send the JFK(4). We have not successfully connected.
+    }
+    params.newTrackerID = newTrackerID;
+    params.sameAsOldTrackerID = (newTrackerID == trackerID);
+    sendJFKMessage4(params);
+
+    if (dontWant) {
+      node.getPeers().disconnectAndRemove(params.pn, true, true, true);
+    } else {
+      params.pn.maybeSendInitialMessages();
+    }
+  }
+
+  private static BlockCipher newRijndael() {
+    try {
+      return new Rijndael(256, 256);
+    } catch (UnsupportedCipherException e) {
+      throw new IllegalStateException(e);
     }
   }
 
   /*
-   * Initiator Method:Message1
-   * Process Message1
-   * Receive the Initiator nonce and DiffieHellman Exponential
-   * @param The packet phase number
-   * @param The peerNode we are talking to. CAN BE NULL if anonymous initiator, since we are the responder.
-   * @param The peer to which we need to send the packet
-   * @param unknownInitiator If true, we (the responder) don't know the
-   * initiator, and should check for fields which would be skipped in a
-   * normal setup where both sides know the other (indicated with * below).
-   * @param setupType The type of unknown-initiator setup.
+   * Initiator Method: Message1
+   * Process Message1: receive the initiator nonce and Diffie–Hellman exponential.
    *
-   * format :
-   * Ni'
-   * g^i
-   * *IDr'
+   * format:
+   *   Ni'
+   *   g^i
+   *   *IDr'
    *
-   * See http://www.wisdom.weizmann.ac.il/~reingold/publications/jfk-tissec.pdf
-   * Just Fast Keying: Key Agreement In A Hostile Internet
-   * Aiello, Bellovin, Blaze, Canetti, Ioannidis, Keromytis, Reingold.
-   * ACM Transactions on Information and System Security, Vol 7 No 2, May 2004, Pages 1-30.
+   * Reference: http://www.wisdom.weizmann.ac.il/~reingold/publications/jfk-tissec.pdf
+   *   "Just Fast Keying: Key Agreement In A Hostile Internet" — Aiello, Bellovin, Blaze, Canetti,
+   *   Ioannidis, Keromytis, Reingold. ACM TISSEC 7(2), May 2004, pp. 1–30.
    *
+   * @param payload the decrypted payload buffer
+   * @param offset start offset into {@code payload}
+   * @param pn the peer node we are talking to; may be {@code null} for anonymous initiator (we are
+   *     the responder)
+   * @param replyTo the peer to which any reply should be sent
+   * @param unknownInitiator whether the responder does not know the initiator; when {@code true},
+   *     additional fields are present as noted with an asterisk in the format above
+   * @param setupType the type of unknown‑initiator setup
+   * @param negType negotiation type identifier
    */
   private void processJFKMessage1(
       byte[] payload,
@@ -820,23 +1024,21 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       int setupType,
       int negType) {
     long t1 = System.currentTimeMillis();
-    int modulusLength = getModulusLength(negType);
+    int modulusLength = getModulusLength();
     // Pre negtype 9 we were sending Ni as opposed to Ni'
     int nonceSizeHashed = HASH_LENGTH;
-    if (LOG.isDebugEnabled()) LOG.debug("Got a JFK(1) message, processing it - " + pn);
-    // FIXME: follow the spec and send IDr' ?
+    if (LOG.isDebugEnabled()) LOG.debug("Got a JFK(1) message, processing it - {}", pn);
+    // Note: The spec mentions sending IDr'; current implementation omits it.
     if (payload.length
         < nonceSizeHashed
             + modulusLength
             + 3
             + (unknownInitiator ? NodeCrypto.IDENTITY_LENGTH : 0)) {
       LOG.error(
-          "Packet too short from "
-              + pn
-              + ": "
-              + payload.length
-              + " after decryption in JFK(1), should be "
-              + (nonceSizeHashed + modulusLength));
+          PACKET_TOO_SHORT_FROM + "{}: {} after decryption in JFK(1), should be {}",
+          pn,
+          payload.length,
+          nonceSizeHashed + modulusLength);
       return;
     }
     // get Ni'
@@ -853,10 +1055,9 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
           Arrays.copyOfRange(payload, offset, offset + NodeCrypto.IDENTITY_LENGTH);
       if (!MessageDigest.isEqual(expectedIdentityHash, crypto.getIdentityHash())) {
         LOG.error(
-            "Invalid unknown-initiator JFK(1), IDr' is "
-                + HexUtil.bytesToHex(expectedIdentityHash)
-                + " should be "
-                + HexUtil.bytesToHex(crypto.getIdentityHash()));
+            "Invalid unknown-initiator JFK(1), IDr' is {} should be {}",
+            HexUtil.bytesToHex(expectedIdentityHash),
+            HexUtil.bytesToHex(crypto.getIdentityHash()));
         return;
       }
     }
@@ -867,31 +1068,26 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       sendJFKMessage2(
           nonceInitiator, hisExponential, pn, replyTo, unknownInitiator, setupType, negType);
     } catch (NoContextsException e) {
-      handleNoContextsException(e, NoContextsException.CONTEXT.REPLYING);
+      handleNoContextsException(NoContextsException.CONTEXT.REPLYING);
       return;
     }
 
     long t2 = System.currentTimeMillis();
     if ((t2 - t1) > 500) {
-      LOG.error("Message1 timeout error:Processing packet for " + pn);
+      LOG.error("Message1 processing exceeds 500 ms for {}", pn);
     }
   }
 
   private long lastLoggedNoContexts = -1;
   private static final long LOG_NO_CONTEXTS_INTERVAL = MINUTES.toMillis(1);
 
-  private void handleNoContextsException(
-      NoContextsException e, FNPPacketMangler.NoContextsException.CONTEXT context) {
+  private void handleNoContextsException(FNPPacketMangler.NoContextsException.CONTEXT context) {
     if (node.getUptime() < SECONDS.toMillis(30)) {
-      LOG.warn(
-          "No contexts available, unable to handle or send packet (" + context + ") on " + this);
+      LOG.warn("No contexts available; cannot handle or send packet ({}) on {}", context, this);
       return;
     }
     // Log it immediately.
-    LOG.warn(
-        "No contexts available "
-            + context
-            + " - running out of entropy or severe CPU usage problems?");
+    LOG.warn("No contexts available {}; entropy low or CPU saturated?", context);
     // More loudly periodically.
     long now = System.currentTimeMillis();
     synchronized (this) {
@@ -904,22 +1100,19 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   private void logLoudErrorNoContexts() {
     // If this is happening regularly post-startup then it's unlikely that reading the disk will
     // help.
-    // FIXME localise this, give a useralert etc.
+    // Note: Consider localization and a user alert here.
     // RNG exhaustion shouldn't happen for Windows users at all, and may not happen on Linux
     // depending on the JVM version, so lets leave it for now.
-    System.err.println(
-        "FREENET IS HAVING PROBLEMS CONNECTING: Either your CPU is overloaded or it is having"
-            + " trouble reading from the random number generator");
-    System.err.println(
-        "If the problem is CPU usage, please shut down whatever applications are hogging the CPU.");
+    LOG.error(
+        "Crypta cannot establish connections: CPU overloaded or random number generator is slow");
+    LOG.error("If the problem is CPU usage, shut down high-CPU applications.");
     if (FileUtil.detectedOS.isUnix) {
-      File f = new File("/dev/hwrng");
-      if (f.exists())
-        System.err.println("Installing \"rngd\" might help (e.g. apt-get install rng-tools).");
-      System.err.println(
+      File f = new File(System.getProperty("crypta.hwrng.path", "/dev/hwrng"));
+      if (f.exists()) LOG.error("Installing \"rngd\" might help (e.g. apt-get install rng-tools).");
+      LOG.error(
           "The best solution is to install a hardware random number generator, or use turbid or"
               + " similar software to take random data from an unconnected sound card.");
-      System.err.println(
+      LOG.error(
           "The quick workaround is to add"
               + " \"wrapper.java.additional.4=-Djava.security.egd=file:///dev/urandom\" to your"
               + " wrapper.conf.");
@@ -939,11 +1132,15 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     InetAddress addr = replyTo.getAddress();
     synchronized (throttleRekeysByIP) {
       Long l = throttleRekeysByIP.get(addr);
-      if (l == null || l != null && now > l) throttleRekeysByIP.push(addr, now);
-      while (throttleRekeysByIP.size() > REKEY_BY_IP_TABLE_SIZE
-          || ((!throttleRekeysByIP.isEmpty())
-              && throttleRekeysByIP.peekValue() < now - PeerNode.THROTTLE_REKEY))
+      if (l == null || now > l) throttleRekeysByIP.push(addr, now);
+      // Trim to max size
+      while (throttleRekeysByIP.size() > REKEY_BY_IP_TABLE_SIZE) throttleRekeysByIP.popKey();
+      // Drop stale entries older than the throttle window; guard against null values to avoid NPE
+      while (!throttleRekeysByIP.isEmpty()) {
+        Long head = throttleRekeysByIP.peekValue();
+        if (head == null || head >= now - PeerNode.THROTTLE_REKEY) break;
         throttleRekeysByIP.popKey();
+      }
       if (l != null && now - l < PeerNode.THROTTLE_REKEY) {
         LOG.error("Two JFK(1)'s initiated by same IP within " + PeerNode.THROTTLE_REKEY + "ms");
         return true;
@@ -958,7 +1155,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
    * format:
    * Ni',g^i
    * We send IDr' only if unknownInitiator is set.
-   * @param pn The node to encrypt the message to. Cannot be null, because we are the initiator and we
+   * @param pn The node to encrypt the message to. Cannot be null, because we are the initiator, and we
    * know the responder in all cases.
    * @param replyTo The peer to send the actual packet to.
    */
@@ -966,21 +1163,22 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       PeerNode pn, Peer replyTo, boolean unknownInitiator, int setupType, int negType)
       throws NoContextsException {
     if (LOG.isDebugEnabled())
-      LOG.debug("Sending a JFK(1) message to " + replyTo + " for " + pn.getPeer());
+      LOG.debug("Sending a JFK(1) message to {}" + FOR_STR + "{}", replyTo, pn.getPeer());
     final long now = System.currentTimeMillis();
-    int modulusLength = getModulusLength(negType);
+    int modulusLength = getModulusLength();
     // Pre negtype 9 we were sending Ni as opposed to Ni'
-    int nonceSize = getNonceSize(negType);
 
     KeyAgreementSchemeContext ctx = pn.getKeyAgreementSchemeContext();
     if (!(ctx instanceof ECDHLightContext)
         || ((pn.jfkContextLifetime + DH_GENERATION_INTERVAL * DH_CONTEXT_BUFFER_SIZE) < now)) {
       pn.jfkContextLifetime = now;
-      pn.setKeyAgreementSchemeContext(ctx = getECDHLightContext());
+      KeyAgreementSchemeContext newCtx = getECDHLightContext();
+      ctx = newCtx;
+      pn.setKeyAgreementSchemeContext(newCtx);
     }
 
     int offset = 0;
-    byte[] nonce = new byte[nonceSize];
+    byte[] nonce = new byte[NONCE_SIZE];
     byte[] myExponential = ctx.getPublicKeyNetworkFormat();
     node.getRandom().nextBytes(nonce);
 
@@ -1002,13 +1200,13 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       offset += modulusLength;
       System.arraycopy(pn.identityHash, 0, message1, offset, pn.identityHash.length);
       sendAnonAuthPacket(
-          1, negType, 0, setupType, message1, pn, replyTo, pn.anonymousInitiatorSetupCipher);
+          negType, 0, setupType, message1, pn, replyTo, pn.anonymousInitiatorSetupCipher);
     } else {
-      sendAuthPacket(1, negType, 0, message1, pn, replyTo);
+      sendAuthPacket(negType, 0, message1, pn, replyTo);
     }
     long t2 = System.currentTimeMillis();
     if ((t2 - now) > 500) {
-      LOG.error("Message1 timeout error:Sending packet for " + pn.getPeer());
+      LOG.error("Message1 send exceeds 500 ms for {}", pn.getPeer());
     }
   }
 
@@ -1032,9 +1230,9 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       int setupType,
       int negType)
       throws NoContextsException {
-    if (LOG.isDebugEnabled()) LOG.debug("Sending a JFK(2) message to " + pn);
-    int modulusLength = getModulusLength(negType);
-    int nonceSize = getNonceSize(negType);
+    if (LOG.isDebugEnabled()) LOG.debug("Sending a JFK(2) message to {}", pn);
+    int modulusLength = getModulusLength();
+    int nonceSize = NONCE_SIZE;
     // g^r
     // Neg type 8 and later use ECDH for generating the keys.
     KeyAgreementSchemeContext ctx = getECDHLightContext();
@@ -1045,7 +1243,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     byte[] myExponential = ctx.getPublicKeyNetworkFormat();
     // Neg type 9 and later use ECDSA signature.
     byte[] sig = ctx.getECDSASignature();
-    if (sig.length != getSignatureLength(negType))
+    if (sig.length != getSignatureLength())
       throw new IllegalStateException(
           "This shouldn't happen: please report! We are attempting to send "
               + sig.length
@@ -1060,9 +1258,8 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
                 myNonce,
                 nonceInitator,
                 replyTo.getAddress().getAddress()));
-    if (LOG.isTraceEnabled())
-      LOG.trace("We are using the following HMAC : " + HexUtil.bytesToHex(authenticator));
-    if (LOG.isTraceEnabled()) LOG.trace("We have Ni' : " + HexUtil.bytesToHex(nonceInitator));
+    if (LOG.isTraceEnabled()) LOG.trace("Using HMAC: {}", HexUtil.bytesToHex(authenticator));
+    if (LOG.isTraceEnabled()) LOG.trace("Ni'={}", HexUtil.bytesToHex(nonceInitator));
     byte[] message2 =
         new byte[nonceInitator.length + nonceSize + modulusLength + sig.length + HASH_LENGTH];
 
@@ -1080,10 +1277,9 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     System.arraycopy(authenticator, 0, message2, offset, HASH_LENGTH);
 
     if (unknownInitiator) {
-      sendAnonAuthPacket(
-          1, negType, 1, setupType, message2, pn, replyTo, crypto.getAnonSetupCipher());
+      sendAnonAuthPacket(negType, 1, setupType, message2, pn, replyTo, crypto.getAnonSetupCipher());
     } else {
-      sendAuthPacket(1, negType, 1, message2, pn, replyTo);
+      sendAuthPacket(negType, 1, message2, pn, replyTo);
     }
   }
 
@@ -1112,14 +1308,14 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   }
 
   /*
-   * Initiator Method:Message2
-   * @see{sendJFKMessage2} for packet format details.
-   * Note that this packet is exactly the same for known initiator as for unknown initiator.
+   * Initiator Method: Message2
+   * See {@link #sendJFKMessage2(byte[], byte[], PeerNode, Peer, boolean, int, int)} for the packet
+   * format. This packet is the same for known and unknown initiators.
    *
-   * @param payload The buffer containing the decrypted auth packet.
-   * @param inputOffset The offset in the buffer at which the packet starts.
-   * @param replyTo The peer to which we need to send the packet
-   * @param pn The peerNode we are talking to. Cannot be null as we are the initiator.
+   * @param payload the buffer containing the decrypted auth packet
+   * @param inputOffset the offset in the buffer at which the packet starts
+   * @param replyTo the peer to which we need to send the packet
+   * @param pn the peer node we are talking to; cannot be {@code null} as we are the initiator
    */
   private void processJFKMessage2(
       byte[] payload,
@@ -1130,22 +1326,20 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       int setupType,
       int negType) {
     long t1 = System.currentTimeMillis();
-    int modulusLength = getModulusLength(negType);
+    int modulusLength = getModulusLength();
     // Pre negtype 9 we were sending Ni as opposed to Ni'
-    int nonceSize = getNonceSize(negType);
+    int nonceSize = NONCE_SIZE;
     int nonceSizeHashed = HASH_LENGTH;
 
-    if (LOG.isDebugEnabled()) LOG.debug("Got a JFK(2) message, processing it - " + pn.getPeer());
-    // FIXME: follow the spec and send IDr' ?
+    if (LOG.isDebugEnabled()) LOG.debug("Got a JFK(2) message, processing it - {}", pn.getPeer());
+    // Note: The spec suggests sending IDr'; current code omits it.
     int expectedLength = nonceSizeHashed + nonceSize + modulusLength + HASH_LENGTH * 2;
     if (payload.length < expectedLength + 3) {
       LOG.error(
-          "Packet too short from "
-              + pn.getPeer()
-              + ": "
-              + payload.length
-              + " after decryption in JFK(2), should be "
-              + (expectedLength + 3));
+          PACKET_TOO_SHORT_FROM + "{}: {} after decryption in JFK(2), should be {}",
+          pn.getPeer(),
+          payload.length,
+          expectedLength + 3);
       return;
     }
 
@@ -1159,24 +1353,23 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     byte[] hisExponential = Arrays.copyOfRange(payload, inputOffset, inputOffset + modulusLength);
     inputOffset += modulusLength;
 
-    int sigLength = getSignatureLength(negType);
+    int sigLength = getSignatureLength();
     byte[] sig = new byte[sigLength];
     System.arraycopy(payload, inputOffset, sig, 0, sigLength);
     inputOffset += sigLength;
 
     byte[] authenticator = Arrays.copyOfRange(payload, inputOffset, inputOffset + HASH_LENGTH);
-    inputOffset += HASH_LENGTH;
 
     // Check try to find the authenticator in the cache.
     // If authenticator is already present, indicates duplicate/replayed message2
     // Now simply transmit the corresponding message3
-    Object message3 = null;
+    Object message3;
     synchronized (authenticatorCache) {
       message3 = authenticatorCache.get(new ByteArrayWrapper(authenticator));
     }
     if (message3 != null) {
-      LOG.info("We replayed a message from the cache (shouldn't happen often) - " + pn.getPeer());
-      sendAuthPacket(1, negType, 3, (byte[]) message3, pn, replyTo);
+      LOG.info("We replayed a message from the cache (shouldn't happen often) - {}", pn.getPeer());
+      sendAuthPacket(negType, 3, (byte[]) message3, pn, replyTo);
       return;
     }
 
@@ -1187,17 +1380,13 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
         if (MessageDigest.isEqual(nonceInitiator, SHA256.digest(buf))) myNi = buf;
       }
     }
-    // We don't except such a message;
     if (myNi == null) {
       if (shouldLogErrorInHandshake(t1)) {
         LOG.info(
-            "We received an unexpected JFK(2) message from "
-                + pn.getPeer()
-                + " (time since added: "
-                + pn.timeSinceAddedOrRestarted()
-                + " time last receive:"
-                + pn.lastReceivedPacketTime()
-                + ')');
+            "Unexpected JFK(2) from {} (since added={}, last receive={})",
+            pn.getPeer(),
+            pn.timeSinceAddedOrRestarted(),
+            pn.lastReceivedPacketTime());
       }
       return;
     }
@@ -1205,46 +1394,42 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     // Verify the ECDSA signature ; We are assuming that it's the curve we expect
     if (!ECDSA.verify(Curves.P256, pn.peerECDSAPubKey, sig, hisExponential)) {
       if (pn.peerECDSAPubKeyHash == null) {
-        // FIXME remove when remove DSA support.
+        // Note: legacy DSA support path; keep until removal.
         // Caused by nodes running broken early versions of negType9.
-        LOG.error(
-            "Peer attempting negType "
-                + negType
-                + " with ECDSA but no ECDSA key known: "
-                + pn.userToString());
+        LOG.atError()
+            .addArgument(negType)
+            .addArgument(pn::userToString)
+            .log("Peer attempting negType {} with ECDSA but no ECDSA key known: {}");
         return;
       }
-      LOG.error("The ECDSA signature verification has failed in JFK(2)!! " + pn.getPeer());
+      LOG.error("ECDSA signature verification fails in JFK(2) {}", pn.getPeer());
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Expected signature on "
-                + HexUtil.bytesToHex(hisExponential)
-                + " with "
-                + HexUtil.bytesToHex(pn.peerECDSAPubKeyHash)
-                + " signature "
-                + HexUtil.bytesToHex(sig));
+            "Expected signature on {} with {} signature {}",
+            HexUtil.bytesToHex(hisExponential),
+            HexUtil.bytesToHex(pn.peerECDSAPubKeyHash),
+            HexUtil.bytesToHex(sig));
       return;
     }
 
     // At this point we know it's from the peer, so we can report a packet received.
     pn.receivedPacket(true, false);
 
-    sendJFKMessage3(
-        1,
-        negType,
-        3,
-        myNi,
-        nonceResponder,
-        hisExponential,
-        authenticator,
-        pn,
-        replyTo,
-        unknownInitiator,
-        setupType);
+    Jfk3Params j3 = new Jfk3Params();
+    j3.negType = negType;
+    j3.nonceInitiator = myNi;
+    j3.nonceResponder = nonceResponder;
+    j3.hisExponential = hisExponential;
+    j3.authenticator = authenticator;
+    j3.pn = pn;
+    j3.replyTo = replyTo;
+    j3.unknownInitiator = unknownInitiator;
+    j3.setupType = setupType;
+    sendJFKMessage3(j3);
 
     long t2 = System.currentTimeMillis();
     if ((t2 - t1) > 500) {
-      LOG.error("Message2 timeout error:Processing packet for " + pn.getPeer());
+      LOG.error("Message2 processing exceeds 500 ms for {}", pn.getPeer());
     }
   }
 
@@ -1263,7 +1448,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
    * HMAC{Ka}(cyphertext)
    * IV + E{KE}[S{i}[Ni',Nr,g^i,g^r,idR, bootID, znoderefI], bootID, znoderefI*]
    *
-   * * Noderef is sent whether or not unknownInitiator is true, however if it is, it will
+   * * Noderef is sent whether unknownInitiator is true, however if it is, it will
    * be a *full* noderef, otherwise it will exclude the pubkey etc.
    *
    * @param payload The buffer containing the decrypted auth packet.
@@ -1275,23 +1460,18 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   private void processJFKMessage3(
       byte[] payload,
       int inputOffset,
-      PeerNode pn,
-      Peer replyTo,
+      J3Ctx ctx,
       boolean oldOpennetPeer,
       boolean unknownInitiator,
       int setupType,
       int negType) {
     final long t1 = System.currentTimeMillis();
-    int modulusLength = getModulusLength(negType);
-    int nonceSize = getNonceSize(negType);
-    if (LOG.isDebugEnabled()) LOG.debug("Got a JFK(3) message, processing it - " + pn);
+    int modulusLength = getModulusLength();
+    int nonceSize = NONCE_SIZE;
+    logGotJfk3Message(ctx.pn);
+    PeerNode pnLocal = ctx.pn;
 
-    BlockCipher c = null;
-    try {
-      c = new Rijndael(256, 256);
-    } catch (UnsupportedCipherException e) {
-      throw new RuntimeException(e);
-    }
+    BlockCipher c = newRijndael();
 
     final int expectedLength =
         nonceSize * 2
@@ -1312,23 +1492,13 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             + // packet tracker ID
             1; // znoderefI* is at least 1 byte long
 
-    if (payload.length < expectedLength + 3) {
-      LOG.error(
-          "Packet too short from "
-              + pn
-              + ": "
-              + payload.length
-              + " after decryption in JFK(3), should be "
-              + (expectedLength + 3));
-      return;
-    }
+    if (!hasExpectedLength(payload, expectedLength + 3, ctx.pn)) return;
 
     // Ni
     byte[] nonceInitiator = new byte[nonceSize];
     System.arraycopy(payload, inputOffset, nonceInitiator, 0, nonceSize);
     inputOffset += nonceSize;
-    if (LOG.isTraceEnabled())
-      LOG.trace("We are receiving Ni : " + HexUtil.bytesToHex(nonceInitiator));
+    traceReceivingNi(nonceInitiator);
     // Before negtype 9 we didn't hash it!
     byte[] nonceInitiatorHashed = SHA256.digest(nonceInitiator);
 
@@ -1348,104 +1518,37 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     byte[] authenticator = Arrays.copyOfRange(payload, inputOffset, inputOffset + HASH_LENGTH);
     inputOffset += HASH_LENGTH;
 
-    // We *WANT* to check the hmac before we do the lookup on the hashmap
-    // @see https://bugs.freenetproject.org/view.php?id=1604
-    if (!HMAC.verifyWithSHA256(
-        getTransientKey(),
-        assembleJFKAuthenticator(
-            responderExponential,
-            initiatorExponential,
-            nonceResponder,
-            nonceInitiatorHashed,
-            replyTo.getAddress().getAddress()),
-        authenticator)) {
-      if (shouldLogErrorInHandshake(t1)) {
-        if (LOG.isTraceEnabled())
-          LOG.debug("We received the following HMAC : " + HexUtil.bytesToHex(authenticator));
-        if (LOG.isTraceEnabled())
-          LOG.trace("We have Ni' : " + HexUtil.bytesToHex(nonceInitiatorHashed));
-        LOG.info(
-            "The HMAC doesn't match; let's discard the packet (either we rekeyed or we are victim"
-                + " of forgery) - JFK3 - "
-                + pn);
-      }
-      return;
-    }
-    // Check try to find the authenticator in the cache.
-    // If authenticator is already present, indicates duplicate/replayed message3
-    // Now simply transmit the corresponding message4
-    Object message4 = null;
-    synchronized (authenticatorCache) {
-      message4 = authenticatorCache.get(new ByteArrayWrapper(authenticator));
-    }
-    if (message4 != null) {
-      LOG.info("We replayed a message from the cache (shouldn't happen often) - " + pn);
-      // We are replaying a JFK(4).
-      // Therefore if it is anon-initiator it is encrypted with our setup key.
-      if (unknownInitiator) {
-        sendAnonAuthPacket(
-            1,
-            negType,
-            3,
-            setupType,
-            (byte[]) message4,
-            null,
-            replyTo,
-            crypto.getAnonSetupCipher());
-      } else {
-        sendAuthPacket(1, negType, 3, (byte[]) message4, pn, replyTo);
-      }
-      return;
-    } else {
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "No message4 found for "
-                + HexUtil.bytesToHex(authenticator)
-                + " responderExponential "
-                + Fields.hashCode(responderExponential)
-                + " initiatorExponential "
-                + Fields.hashCode(initiatorExponential)
-                + " nonceResponder "
-                + Fields.hashCode(nonceResponder)
-                + " nonceInitiator "
-                + Fields.hashCode(nonceInitiatorHashed)
-                + " address "
-                + HexUtil.bytesToHex(replyTo.getAddress().getAddress()));
-    }
+    // Validate authenticator and handle potential replay in one step
+    if (!shouldProceedAfterAuthenticator(
+        t1,
+        authenticator,
+        responderExponential,
+        initiatorExponential,
+        nonceResponder,
+        nonceInitiatorHashed,
+        unknownInitiator,
+        negType,
+        setupType,
+        ctx)) return;
 
     byte[] hmac = Arrays.copyOfRange(payload, inputOffset, inputOffset + HASH_LENGTH);
     inputOffset += HASH_LENGTH;
 
-    byte[] computedExponential;
-
-    ECPublicKey initiatorKey = ECDH.getPublicKey(initiatorExponential, ecdhCurveToUse);
-    ECPublicKey responderKey = ECDH.getPublicKey(responderExponential, ecdhCurveToUse);
-    ECDHLightContext ctx = findECDHContextByPubKey(responderKey);
-    if (ctx == null) {
-      LOG.error(
-          "WTF? the HMAC verified but we don't know about that exponential! SHOULDN'T HAPPEN! -"
-              + " JFK3 - "
-              + pn);
-      // Possible this is a replay or severely delayed? We don't keep
-      // every exponential we ever use.
-      return;
-    }
-    computedExponential = ctx.getHMACKey(initiatorKey);
+    byte[] computedExponential =
+        deriveSharedExponential(initiatorExponential, responderExponential, ctx);
+    if (computedExponential.length == 0) return;
 
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "The shared Master secret is : "
-              + HexUtil.bytesToHex(computedExponential)
-              + " for "
-              + pn);
+          MSG_SHARED_MASTER + FOR_STR + "{}", HexUtil.bytesToHex(computedExponential), ctx.pn);
 
     /* 0 is the outgoing key for the initiator, 7 for the responder */
     byte[] outgoingKey =
         computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "7");
     byte[] incommingKey =
         computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "0");
-    byte[] Ke = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "1");
-    byte[] Ka = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "2");
+    byte[] ke = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "1");
+    byte[] ka = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "2");
 
     byte[] hmacKey =
         computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "3");
@@ -1472,21 +1575,21 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             | ((sharedData[5] & 0xFF) << 16)
             | ((sharedData[6] & 0xFF) << 8)
             | (sharedData[7] & 0xFF);
-    int theirInitialMsgID, ourInitialMsgID;
+    int theirInitialMsgID;
+    int ourInitialMsgID;
 
     theirInitialMsgID =
         unknownInitiator
             ? getInitialMessageID(crypto.getMyIdentity())
-            : getInitialMessageID(pn.identity, crypto.getMyIdentity());
+            : getInitialMessageID(pnLocal.identity, crypto.getMyIdentity());
     ourInitialMsgID =
         unknownInitiator
             ? getInitialMessageID(crypto.getMyIdentity())
-            : getInitialMessageID(crypto.getMyIdentity(), pn.identity);
+            : getInitialMessageID(crypto.getMyIdentity(), pnLocal.identity);
 
-    if (LOG.isDebugEnabled())
-      LOG.debug("Their initial message ID: " + theirInitialMsgID + " ours " + ourInitialMsgID);
+    debugInitialMessageIds(theirInitialMsgID, ourInitialMsgID);
 
-    c.initialize(Ke);
+    c.initialize(ke);
     int ivLength = PCFBMode.lengthIV(c);
     int decypheredPayloadOffset = 0;
     // We compute the HMAC of ("I"+cyphertext) : the cyphertext includes the IV!
@@ -1500,10 +1603,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
         decypheredPayload,
         decypheredPayloadOffset,
         decypheredPayload.length - decypheredPayloadOffset);
-    if (!HMAC.verifyWithSHA256(Ka, decypheredPayload, hmac)) {
-      LOG.error("The inner-HMAC doesn't match; let's discard the packet JFK(3) - " + pn);
-      return;
-    }
+    if (isInnerHmacInvalid(ka, decypheredPayload, hmac, ctx.pn, JFK3_STR)) return;
 
     final PCFBMode pk = PCFBMode.create(c, decypheredPayload, decypheredPayloadOffset);
     // Get the IV
@@ -1518,7 +1618,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
      * Signature
      * Node Data (starting with BootID)
      */
-    int sigLength = getSignatureLength(negType);
+    int sigLength = getSignatureLength();
     byte[] sig = new byte[sigLength];
     System.arraycopy(decypheredPayload, decypheredPayloadOffset, sig, 0, sigLength);
     decypheredPayloadOffset += sigLength;
@@ -1530,27 +1630,15 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
         0,
         decypheredPayload.length - decypheredPayloadOffset);
     int ptr = 0;
-    long trackerID;
-    trackerID = Fields.bytesToLong(data, ptr);
-    if (trackerID < 0) trackerID = -1;
+    long trackerID = normalizeTrackerId(Fields.bytesToLong(data, ptr));
     ptr += 8;
     long bootID = Fields.bytesToLong(data, ptr);
     ptr += 8;
     byte[] hisRef = Arrays.copyOfRange(data, ptr, data.length);
 
-    // construct the peernode
-    if (unknownInitiator) {
-      pn = getPeerNodeFromUnknownInitiator(hisRef, setupType, pn, replyTo);
-    }
-    if (pn == null) {
-      if (unknownInitiator) {
-        // Reject
-        LOG.info("Rejecting... unable to construct PeerNode");
-      } else {
-        LOG.error("PeerNode is null and unknownInitiator is false!");
-      }
-      return;
-    }
+    // Resolve (when anonymous initiator) and validate peernode
+    pnLocal = resolveAndValidatePeerNode(unknownInitiator, setupType, hisRef, pnLocal, ctx.replyTo);
+    if (pnLocal == null) return;
 
     // verify the signature
     byte[] toVerify =
@@ -1561,64 +1649,31 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             responderExponential,
             crypto.getIdentity(negType),
             data);
-    if (!ECDSA.verify(Curves.P256, pn.peerECDSAPubKey, sig, toVerify)) {
-      LOG.error("The ECDSA signature verification has failed!! JFK(3) - " + pn.getPeer());
-      return;
-    }
+    if (!verifyECDSASignature(pnLocal, sig, toVerify)) return;
 
     // At this point we know it's from the peer, so we can report a packet received.
-    pn.receivedPacket(true, false);
+    pnLocal.receivedPacket(true, false);
 
-    BlockCipher outgoingCipher = null;
-    BlockCipher incommingCipher = null;
-    BlockCipher ivCipher = null;
+    BlockCipher outgoingCipher;
+    BlockCipher incommingCipher;
+    BlockCipher ivCipher;
     try {
       outgoingCipher = new Rijndael(256, 256);
       incommingCipher = new Rijndael(256, 256);
       ivCipher = new Rijndael(256, 256);
     } catch (UnsupportedCipherException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
     outgoingCipher.initialize(outgoingKey);
     incommingCipher.initialize(incommingKey);
     ivCipher.initialize(ivKey);
 
-    // Promote if necessary
-    boolean dontWant = false;
-    if (oldOpennetPeer && pn instanceof OpennetPeerNode opn /* true */) {
-      OpennetManager opennet = node.getOpennet();
-      if (opennet == null) {
-        LOG.info("Dumping incoming old-opennet peer as opennet just turned off: " + pn + ".");
-        return;
-      }
-      /* When an old-opennet-peer connects, add it at the top of the LRU, so that it isn't
-       * immediately dropped when there is no droppable peer to drop. If it was dropped
-       * from the bottom of the LRU list, we would not have added it to the LRU; so it was
-       * somewhere in the middle. */
-      if (!opennet.wantPeer(opn, false, false, true, ConnectionType.RECONNECT)) {
-        LOG.info("No longer want peer " + pn + " - dumping it after connecting");
-        dontWant = true;
-        opennet.purgeOldOpennetPeer(opn);
-      }
-      // wantPeer will call node.peers.addPeer(), we don't have to.
-    }
-    if ((!dontWant) && !crypto.allowConnection(pn, replyTo.getFreenetAddress())) {
-      if (pn instanceof DarknetPeerNode peerNode) {
-        LOG.error(
-            "Dropping peer "
-                + pn
-                + " because don't want connection due to others on the same IP address!");
-        System.out.println(
-            "Disconnecting permanently from your friend \""
-                + peerNode.getName()
-                + "\" because other peers are using the same IP address!");
-      }
-      LOG.info("Rejecting connection because already have something with the same IP");
-      dontWant = true;
-    }
+    // Promote if necessary and check for duplicate IPs
+    boolean dontWant = handleOldOpennetPromotion(oldOpennetPeer, pnLocal);
+    dontWant = computeDontWantForDuplicateIP(dontWant, pnLocal, ctx.replyTo);
 
     long newTrackerID =
-        pn.completedHandshake(
+        pnLocal.completedHandshake(
             bootID,
             hisRef,
             0,
@@ -1627,7 +1682,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             outgoingKey,
             incommingCipher,
             incommingKey,
-            replyTo,
+            ctx.replyTo,
             true,
             negType,
             trackerID,
@@ -1641,49 +1696,92 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             ourInitialMsgID,
             theirInitialMsgID);
 
-    if (newTrackerID > 0) {
+    Jfk4Params params = new Jfk4Params();
+    params.negType = negType;
+    params.nonceInitiatorHashed = nonceInitiatorHashed;
+    params.nonceResponder = nonceResponder;
+    params.initiatorExponential = initiatorExponential;
+    params.responderExponential = responderExponential;
+    params.c = c;
+    params.ka = ka;
+    params.authenticator = authenticator;
+    params.hisRef = hisRef;
+    params.pn = pnLocal;
+    params.replyTo = ctx.replyTo;
+    params.unknownInitiator = unknownInitiator;
+    params.setupType = setupType;
+    postHandshakeActions(newTrackerID, trackerID, params, dontWant);
 
-      // Send reply
-      sendJFKMessage4(
-          1,
-          negType,
-          3,
-          nonceInitiatorHashed,
-          nonceResponder,
-          initiatorExponential,
-          responderExponential,
-          c,
-          Ke,
-          Ka,
-          authenticator,
-          hisRef,
-          pn,
-          replyTo,
-          unknownInitiator,
-          setupType,
-          newTrackerID,
-          newTrackerID == trackerID);
+    if (LOG.isDebugEnabled()) LOG.debug("Seed client connected with negtype {}", negType);
 
-      if (dontWant) {
-        node.getPeers()
-            .disconnectAndRemove(pn, true, true, true); // Let it connect then tell it to remove it.
-      } else {
-        pn.maybeSendInitialMessages();
-      }
-    } else {
-      LOG.error("Handshake failure! with " + pn.getPeer());
-      // Don't send the JFK(4). We have not successfully connected.
+    logIfSlow(t1, pnLocal);
+  }
+
+  private boolean shouldProceedAfterAuthenticator(
+      long t1,
+      byte[] authenticator,
+      byte[] responderExponential,
+      byte[] initiatorExponential,
+      byte[] nonceResponder,
+      byte[] nonceInitiatorHashed,
+      boolean unknownInitiator,
+      int negType,
+      int setupType,
+      J3Ctx ctx) {
+    // We want to check the HMAC before any cache lookup
+    if (!verifyJFK3Authenticator(
+        t1,
+        authenticator,
+        responderExponential,
+        initiatorExponential,
+        nonceResponder,
+        nonceInitiatorHashed,
+        ctx.replyTo)) return false;
+
+    // Replay handling: if present, we transmit the cached message4 and stop.
+    ReplayFields rf =
+        new ReplayFields(
+            responderExponential, initiatorExponential, nonceResponder, nonceInitiatorHashed);
+    return !tryReplayMessage4(
+        unknownInitiator, negType, setupType, ctx.pn, ctx.replyTo, authenticator, rf);
+  }
+
+  private byte[] deriveSharedExponential(
+      byte[] initiatorExponential, byte[] responderExponential, J3Ctx ctx) {
+    ECPublicKey initiatorKey = ECDH.getPublicKey(initiatorExponential, ecdhCurveToUse);
+    ECPublicKey responderKey = ECDH.getPublicKey(responderExponential, ecdhCurveToUse);
+    if (initiatorKey == null) {
+      LOG.error("Invalid initiator ECDH public key - {}", JFK3_STR);
+      return EMPTY_BYTES;
     }
+    ECDHLightContext lctx = findECDHContextByPubKey(responderKey);
+    if (lctx == null) {
+      LOG.error("HMAC verified but no matching ECDH context for public key - JFK3 - {}", ctx.pn);
+      return EMPTY_BYTES;
+    }
+    return lctx.getHMACKey(initiatorKey);
+  }
 
-    if (LOG.isDebugEnabled()) LOG.debug("Seed client connected with negtype " + negType);
+  private long normalizeTrackerId(long id) {
+    return (id < 0) ? -1 : id;
+  }
 
+  private PeerNode resolveAndValidatePeerNode(
+      boolean unknownInitiator, int setupType, byte[] hisRef, PeerNode pnLocal, Peer replyTo) {
+    PeerNode out = pnLocal;
+    if (unknownInitiator) {
+      out = getPeerNodeFromUnknownInitiator(hisRef, setupType, pnLocal, replyTo);
+    }
+    return validatePeerNode(out, unknownInitiator) ? out : null;
+  }
+
+  private void logIfSlow(long t1, PeerNode pn) {
     final long t2 = System.currentTimeMillis();
     if ((t2 - t1) > 500) {
-      LOG.error(
-          "Message3 Processing packet for "
-              + pn.getPeer()
-              + " took "
-              + TimeUtil.formatTime(t2 - t1, 3, true));
+      LOG.atError()
+          .addArgument(pn::getPeer)
+          .addArgument(() -> TimeUtil.formatTime(t2 - t1, 3, true))
+          .log("Message3 Processing packet for {} took {}");
     }
   }
 
@@ -1692,33 +1790,18 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     if (setupType == SETUP_OPENNET_SEEDNODE) {
       OpennetManager om = node.getOpennet();
       if (om == null) {
-        LOG.error("Opennet disabled, ignoring seednode connect attempt");
-        // FIXME Send some sort of explicit rejection message.
+        LOG.error("Opennet disabled; ignore seednode connect attempt");
+        // Note: consider sending an explicit rejection message.
         return null;
       }
       SimpleFieldSet ref = OpennetManager.validateNoderef(hisRef, 0, hisRef.length, null, true);
       if (ref == null) {
         LOG.error("Invalid noderef");
-        // FIXME Send some sort of explicit rejection message.
+        // Note: consider sending an explicit rejection message.
         return null;
       }
-      PeerNode seed;
-      try {
-        seed = new SeedClientPeerNode(ref, node, crypto);
-        // Don't tell tracker yet as we don't have the address yet.
-      } catch (FSParseException e) {
-        LOG.error("Invalid seed client noderef: " + e + " from " + from, e);
-        return null;
-      } catch (PeerParseException e) {
-        LOG.error("Invalid seed client noderef: " + e + " from " + from, e);
-        return null;
-      } catch (ReferenceSignatureVerificationException e) {
-        LOG.error("Invalid seed client noderef: " + e + " from " + from, e);
-        return null;
-      } catch (PeerTooOldException e) {
-        LOG.error("Invalid seed client noderef: " + e + " from " + from, e);
-        return null;
-      }
+      PeerNode seed = createSeedClientPeer(ref, from);
+      if (seed == null) return null;
       if (seed.equals(pn)) {
         LOG.info("Already connected to seednode");
         return pn;
@@ -1728,6 +1811,71 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     } else {
       LOG.error("Unknown setup type");
       return null;
+    }
+  }
+
+  private PeerNode createSeedClientPeer(SimpleFieldSet ref, Peer from) {
+    try {
+      return new SeedClientPeerNode(ref, node, crypto);
+    } catch (FSParseException
+        | PeerParseException
+        | ReferenceSignatureVerificationException
+        | PeerTooOldException e) {
+      LOG.error("Invalid seed client noderef: {}" + FROM_STR + "{}", e, from, e);
+      return null;
+    }
+  }
+
+  private boolean isReplayMessage4AndRecord(byte[] hmac, long t1, PeerNode pn) {
+    byte[] message4Timestamp;
+    boolean replay;
+    synchronized (authenticatorCache) {
+      ByteArrayWrapper hmacBAW = new ByteArrayWrapper(hmac);
+      byte[] inserted = Fields.longToBytes(t1);
+      byte[] existing = authenticatorCache.computeIfAbsent(hmacBAW, k -> inserted);
+      message4Timestamp = existing;
+      replay = existing != inserted; // true when mapping already existed
+    }
+    if (replay) {
+      LOG.atInfo()
+          .addArgument(() -> TimeUtil.formatTime(t1 - Fields.bytesToLong(message4Timestamp)))
+          .addArgument(pn)
+          .log("Replayed message4 (first handled at {}) from - {}");
+      return true;
+    }
+    return false;
+  }
+
+  private boolean verifyECDSAJFK4(
+      PeerNode pn, byte[] sig, byte[] locallyGeneratedText, byte[] hisRef, long bootID) {
+    if (ECDSA.verify(Curves.P256, pn.peerECDSAPubKey, sig, locallyGeneratedText)) return true;
+    LOG.error(
+        "ECDSA signature verification fails JFK(4) - {}"
+            + LENGTH_STR
+            + "{} hisRef {}"
+            + HASH_STR
+            + "{} myRef {}"
+            + HASH_STR
+            + "{} boot ID {}",
+        pn.getPeer(),
+        locallyGeneratedText.length,
+        hisRef.length,
+        Fields.hashCode(hisRef),
+        pn.jfkMyRef.length,
+        Fields.hashCode(pn.jfkMyRef),
+        bootID);
+    return false;
+  }
+
+  private void postHandshakeActionsJFK4(long newTrackerID, boolean dontWant, PeerNode pn) {
+    if (newTrackerID >= 0) {
+      if (dontWant) {
+        node.getPeers().disconnectAndRemove(pn, true, true, true);
+      } else {
+        pn.maybeSendInitialMessages();
+      }
+    } else {
+      LOG.error("Handshake failed");
     }
   }
 
@@ -1743,215 +1891,44 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
    * @param pn The PeerNode we are talking to. Cannot be null as we are the initiator.
    * @param replyTo The Peer we are replying to.
    */
+  @SuppressWarnings("UnusedReturnValue")
   private boolean processJFKMessage4(
       byte[] payload,
       int inputOffset,
       PeerNode pn,
       Peer replyTo,
       boolean oldOpennetPeer,
-      boolean unknownInitiator,
-      int setupType,
       int negType) {
     final long t1 = System.currentTimeMillis();
-    int modulusLength = getModulusLength(negType);
-    int signLength = getSignatureLength(negType);
-    if (LOG.isDebugEnabled()) LOG.debug("Got a JFK(4) message, processing it - " + pn.getPeer());
-    if (pn.jfkMyRef == null) {
-      String error = "Got a JFK(4) message but no pn.jfkMyRef for " + pn;
-      if (node.getUptime() < SECONDS.toMillis(60)) {
-        LOG.debug(error);
-      } else {
-        LOG.error(error);
-      }
-    }
-    BlockCipher c = null;
+    int signLength = getSignatureLength();
+    maybeLogJfk4Processing(pn);
+    maybeLogMissingMyRef(pn);
+    BlockCipher c;
     try {
       c = new Rijndael(256, 256);
     } catch (UnsupportedCipherException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
 
-    final int expectedLength =
-        HASH_LENGTH
-            + // HMAC of the cyphertext
-            (c.getBlockSize() >> 3)
-            + // IV
-            signLength
-            + // the signature
-            9
-            + // ID of packet tracker, plus boolean byte
-            8
-            + // bootID
-            1; // znoderefR
-
-    if (payload.length - inputOffset < expectedLength + 3) {
-      LOG.error(
-          "Packet too short from "
-              + pn.getPeer()
-              + ": "
-              + payload.length
-              + " after decryption in JFK(4), should be "
-              + (expectedLength + 3));
-      return false;
-    }
-    byte[] jfkBuffer = pn.getJFKBuffer();
-    if (jfkBuffer == null) {
-      LOG.info("We have already handled this message... might be a replay or a bug - " + pn);
-      return false;
-    }
-
-    byte[] hmac = Arrays.copyOfRange(payload, inputOffset, inputOffset + HASH_LENGTH);
-    inputOffset += HASH_LENGTH;
-
-    c.initialize(pn.jfkKe);
-    int ivLength = PCFBMode.lengthIV(c);
-    int decypheredPayloadOffset = 0;
-    // We compute the HMAC of ("R"+cyphertext) : the cyphertext includes the IV!
-    byte[] decypheredPayload =
-        Arrays.copyOf(
-            JFK_PREFIX_RESPONDER, JFK_PREFIX_RESPONDER.length + payload.length - inputOffset);
-    decypheredPayloadOffset += JFK_PREFIX_RESPONDER.length;
-    System.arraycopy(
-        payload,
-        inputOffset,
-        decypheredPayload,
-        decypheredPayloadOffset,
-        payload.length - inputOffset);
-    if (!HMAC.verifyWithSHA256(pn.jfkKa, decypheredPayload, hmac)) {
-      LOG.info("The digest-HMAC doesn't match; let's discard the packet - " + pn.getPeer());
-      return false;
-    }
-
-    // Try to find the HMAC in the cache:
-    // If it is already present it indicates duplicate/replayed message4 and we can discard
-    // If it's not, we can add it with a timestamp
-    byte[] message4Timestamp = null;
-    synchronized (authenticatorCache) {
-      ByteArrayWrapper hmacBAW = new ByteArrayWrapper(hmac);
-      message4Timestamp = authenticatorCache.get(hmacBAW);
-      if (message4Timestamp == null) { // normal behaviour
-        authenticatorCache.put(hmacBAW, Fields.longToBytes(t1));
-      }
-    }
-    if (message4Timestamp != null) {
-      LOG.info(
-          "We got a replayed message4 (first handled at "
-              + TimeUtil.formatTime(t1 - Fields.bytesToLong(message4Timestamp))
-              + ") from - "
-              + pn);
+    Stage1Result s1 = jfk4Stage1(payload, inputOffset, pn, c, signLength, negType, t1);
+    if (s1.status == Stage1Result.Status.INVALID) return false;
+    if (s1.status == Stage1Result.Status.HANDLED || s1.status == Stage1Result.Status.REPLAYED)
       return true;
-    }
 
-    // Get the IV
-    final PCFBMode pk = PCFBMode.create(c, decypheredPayload, decypheredPayloadOffset);
-    decypheredPayloadOffset += ivLength;
-    // Decrypt the payload
-    pk.blockDecipher(
-        decypheredPayload,
-        decypheredPayloadOffset,
-        decypheredPayload.length - decypheredPayloadOffset);
-    /*
-     * DecipheredData Format:
-     * Signature-r,s
-     * bootID, znoderef
-     */
-    byte[] sig = new byte[signLength];
-    System.arraycopy(decypheredPayload, decypheredPayloadOffset, sig, 0, signLength);
-    decypheredPayloadOffset += signLength;
-    byte[] data = new byte[decypheredPayload.length - decypheredPayloadOffset];
-    System.arraycopy(
-        decypheredPayload,
-        decypheredPayloadOffset,
-        data,
-        0,
-        decypheredPayload.length - decypheredPayloadOffset);
-    int ptr = 0;
-    long trackerID;
-    boolean reusedTracker;
-    trackerID = Fields.bytesToLong(data, ptr);
-    ptr += 8;
-    reusedTracker = data[ptr++] != 0;
-    long bootID = Fields.bytesToLong(data, ptr);
-    ptr += 8;
-    byte[] hisRef = Arrays.copyOfRange(data, ptr, data.length);
-
-    // verify the signature
-    int dataLen = hisRef.length + 8 + 9;
-    int nonceSize = getNonceSize(negType);
-    int nonceSizeHashed = HASH_LENGTH;
-    byte[] identity = crypto.getIdentity(negType);
-    byte[] locallyGeneratedText =
-        new byte
-            [nonceSizeHashed
-                + nonceSize
-                + modulusLength * 2
-                + identity.length
-                + dataLen
-                + pn.jfkMyRef.length];
-    int bufferOffset = nonceSizeHashed + nonceSize + modulusLength * 2;
-    System.arraycopy(jfkBuffer, 0, locallyGeneratedText, 0, bufferOffset);
-    System.arraycopy(identity, 0, locallyGeneratedText, bufferOffset, identity.length);
-    bufferOffset += identity.length;
-    // bootID
-    System.arraycopy(data, 0, locallyGeneratedText, bufferOffset, dataLen);
-    bufferOffset += dataLen;
-    System.arraycopy(pn.jfkMyRef, 0, locallyGeneratedText, bufferOffset, pn.jfkMyRef.length);
-    if (!ECDSA.verify(Curves.P256, pn.peerECDSAPubKey, sig, locallyGeneratedText)) {
-      LOG.error(
-          "The ECDSA signature verification has failed!! JFK(4) - "
-              + pn.getPeer()
-              + " length "
-              + locallyGeneratedText.length
-              + " hisRef "
-              + hisRef.length
-              + " hash "
-              + Fields.hashCode(hisRef)
-              + " myRef "
-              + pn.jfkMyRef.length
-              + " hash "
-              + Fields.hashCode(pn.jfkMyRef)
-              + " boot ID "
-              + bootID);
-      return true;
-    }
-
-    // Received a packet
-    pn.receivedPacket(true, false);
-
-    // Promote if necessary
-    boolean dontWant = false;
-    if (oldOpennetPeer && pn instanceof OpennetPeerNode opn /* true */) {
-      OpennetManager opennet = node.getOpennet();
-      if (opennet == null) {
-        LOG.info("Dumping incoming old-opennet peer as opennet just turned off: " + pn + ".");
-        return true;
-      }
-      /* When an old-opennet-peer connects, add it at the top of the LRU, so that it isn't
-       * immediately dropped when there is no droppable peer to drop. If it was dropped
-       * from the bottom of the LRU list, we would not have added it to the LRU; so it was
-       * somewhere in the middle. */
-      if (!opennet.wantPeer(opn, false, false, true, ConnectionType.RECONNECT)) {
-        LOG.info("No longer want peer " + pn + " - dumping it after connecting");
-        dontWant = true;
-        opennet.purgeOldOpennetPeer(opn);
-      }
-      // wantPeer will call node.peers.addPeer(), we don't have to.
-    }
-    if ((!dontWant) && !crypto.allowConnection(pn, replyTo.getFreenetAddress())) {
-      LOG.info("Rejecting connection because already have something with the same IP");
-      dontWant = true;
-    }
+    // Promote if necessary and handle duplicate IP
+    boolean dontWant = handleOldOpennetPromotion(oldOpennetPeer, pn);
+    dontWant = computeDontWantForDuplicateIP(dontWant, pn, replyTo);
 
     // We change the key
-    BlockCipher ivCipher = null;
-    BlockCipher outgoingCipher = null;
-    BlockCipher incommingCipher = null;
+    BlockCipher ivCipher;
+    BlockCipher outgoingCipher;
+    BlockCipher incommingCipher;
     try {
       ivCipher = new Rijndael(256, 256);
       outgoingCipher = new Rijndael(256, 256);
       incommingCipher = new Rijndael(256, 256);
     } catch (UnsupportedCipherException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
 
     outgoingCipher.initialize(pn.outgoingKey);
@@ -1960,10 +1937,10 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 
     long newTrackerID =
         pn.completedHandshake(
-            bootID,
-            hisRef,
+            s1.bootID,
+            s1.hisRef,
             0,
-            hisRef.length,
+            s1.hisRef.length,
             outgoingCipher,
             pn.outgoingKey,
             incommingCipher,
@@ -1971,9 +1948,9 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             replyTo,
             false,
             negType,
-            trackerID,
+            s1.trackerID,
             true,
-            reusedTracker,
+            s1.reusedTracker,
             pn.hmacKey,
             ivCipher,
             pn.ivNonce,
@@ -1981,18 +1958,10 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             pn.theirInitialSeqNum,
             pn.ourInitialMsgID,
             pn.theirInitialMsgID);
-    if (newTrackerID >= 0) {
-      if (dontWant) {
-        node.getPeers().disconnectAndRemove(pn, true, true, true);
-      } else {
-        pn.maybeSendInitialMessages();
-      }
-    } else {
-      LOG.error("Handshake failed!");
-    }
+    postHandshakeActionsJFK4(newTrackerID, dontWant, pn);
 
     // cleanup
-    // FIXME: maybe we should copy zeros/garbage into it before leaving it to the GC
+    // Note: Consider zeroing/garbling this buffer before letting GC reclaim it.
     pn.setJFKBuffer(null);
     pn.jfkKa = null;
     pn.jfkKe = null;
@@ -2009,15 +1978,34 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     // will be sent with a different DH pair
     pn.setKeyAgreementSchemeContext(null);
     synchronized (pn.jfkNoncesSent) {
-      // FIXME TRUE MULTI-HOMING: winner-takes-all, kill all other connection attempts since we
+      // Note: TRUE MULTI-HOMING: winner-takes-all, kill all other connection attempts since we
       // can't deal with multiple active connections
       // Also avoids leaking
       pn.jfkNoncesSent.clear();
     }
 
     final long t2 = System.currentTimeMillis();
-    if ((t2 - t1) > 500) LOG.error("Message4 timeout error:Processing packet from " + pn.getPeer());
+    logMessage4TimeoutIfSlow(t1, t2, pn);
     return true;
+  }
+
+  private void maybeLogJfk4Processing(PeerNode pn) {
+    if (LOG.isDebugEnabled()) LOG.debug("Got a JFK(4) message, processing it - {}", pn.getPeer());
+  }
+
+  private void maybeLogMissingMyRef(PeerNode pn) {
+    if (pn.jfkMyRef == null) {
+      String error = "Got a JFK(4) message but no pn.jfkMyRef for " + pn;
+      if (node.getUptime() < SECONDS.toMillis(60)) {
+        LOG.debug(error);
+      } else {
+        LOG.error(error);
+      }
+    }
+  }
+
+  private void logMessage4TimeoutIfSlow(long t1, long t2, PeerNode pn) {
+    if ((t2 - t1) > 500) LOG.error("Message4 processing exceeds 500 ms from {}", pn.getPeer());
   }
 
   /*
@@ -2031,50 +2019,38 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
    * @param replyTo The Peer to send the packet to.
    */
 
-  private void sendJFKMessage3(
-      int version,
-      final int negType,
-      int phase,
-      byte[] nonceInitiator,
-      byte[] nonceResponder,
-      byte[] hisExponential,
-      byte[] authenticator,
-      final PeerNode pn,
-      final Peer replyTo,
-      final boolean unknownInitiator,
-      final int setupType) {
-    if (LOG.isDebugEnabled()) LOG.debug("Sending a JFK(3) message to " + pn.getPeer());
-    int modulusLength = getModulusLength(negType);
-    int signLength = getSignatureLength(negType);
-    int nonceSize = getNonceSize(negType);
+  private void sendJFKMessage3(Jfk3Params p) {
+    if (LOG.isDebugEnabled()) LOG.debug("Sending a JFK(3) message to {}", p.pn.getPeer());
+    int modulusLength = getModulusLength();
+    int signLength = getSignatureLength();
     // Pre negtype 9 we were sending Ni as opposed to Ni'
-    byte[] nonceInitiatorHashed = SHA256.digest(nonceInitiator);
+    byte[] nonceInitiatorHashed = SHA256.digest(p.nonceInitiator);
 
     long t1 = System.currentTimeMillis();
-    BlockCipher c = null;
+    BlockCipher c;
     try {
       c = new Rijndael(256, 256);
     } catch (UnsupportedCipherException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
-    KeyAgreementSchemeContext ctx = pn.getKeyAgreementSchemeContext();
+    KeyAgreementSchemeContext ctx = p.pn.getKeyAgreementSchemeContext();
     if (ctx == null) return;
     byte[] ourExponential = ctx.getPublicKeyNetworkFormat();
-    pn.jfkMyRef =
-        unknownInitiator ? crypto.myCompressedHeavySetupRef() : crypto.myCompressedSetupRef();
-    byte[] data = new byte[8 + 8 + pn.jfkMyRef.length];
+    p.pn.jfkMyRef =
+        p.unknownInitiator ? crypto.myCompressedHeavySetupRef() : crypto.myCompressedSetupRef();
+    byte[] data = new byte[8 + 8 + p.pn.jfkMyRef.length];
     int ptr = 0;
     long trackerID;
-    trackerID = pn.getReusableTrackerID();
+    trackerID = p.pn.getReusableTrackerID();
     System.arraycopy(Fields.longToBytes(trackerID), 0, data, ptr, 8);
     ptr += 8;
-    if (LOG.isDebugEnabled()) LOG.debug("Sending tracker ID " + trackerID + " in JFK(3)");
-    System.arraycopy(Fields.longToBytes(pn.getOutgoingBootID()), 0, data, ptr, 8);
+    if (LOG.isDebugEnabled()) LOG.debug("Sending tracker ID {} in JFK(3)", trackerID);
+    System.arraycopy(Fields.longToBytes(p.pn.getOutgoingBootID()), 0, data, ptr, 8);
     ptr += 8;
-    System.arraycopy(pn.jfkMyRef, 0, data, ptr, pn.jfkMyRef.length);
+    System.arraycopy(p.pn.jfkMyRef, 0, data, ptr, p.pn.jfkMyRef.length);
     final byte[] message3 =
         new byte
-            [nonceSize * 2
+            [NONCE_SIZE * 2
                 + // nI, nR
                 modulusLength * 2
                 + // g^i, g^r
@@ -2087,174 +2063,63 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
                 signLength
                 + // Signature
                 data.length]; // The bootid+noderef
-    int offset = 0;
-    // Ni
-    System.arraycopy(nonceInitiator, 0, message3, offset, nonceSize);
-    offset += nonceSize;
-    if (LOG.isTraceEnabled())
-      LOG.trace("We are sending Ni : " + HexUtil.bytesToHex(nonceInitiator));
-    // Nr
-    System.arraycopy(nonceResponder, 0, message3, offset, nonceSize);
-    offset += nonceSize;
-    // g^i
-    System.arraycopy(ourExponential, 0, message3, offset, ourExponential.length);
-    offset += ourExponential.length;
-    // g^r
-    System.arraycopy(hisExponential, 0, message3, offset, hisExponential.length);
-    offset += hisExponential.length;
-
-    // Authenticator
-    System.arraycopy(authenticator, 0, message3, offset, HASH_LENGTH);
-    offset += HASH_LENGTH;
+    int offset =
+        writeMessage3Header(
+            message3,
+            p.nonceInitiator,
+            p.nonceResponder,
+            ourExponential,
+            p.hisExponential,
+            p.authenticator);
     /*
      * Digital Signature of the message with the private key belonging to the initiator/responder
      * It is assumed to be non-message recovering
      */
-    // save parameters so that we can verify message4
-    byte[] toSign =
-        assembleDHParams(
+    byte[] sig =
+        signJFK3AndCacheBuffer(
+            p.pn,
             nonceInitiatorHashed,
-            nonceResponder,
+            p.nonceResponder,
             ourExponential,
-            hisExponential,
-            pn.getPubKeyHash(),
+            p.hisExponential,
+            p.pn.getPubKeyHash(),
             data);
-    pn.setJFKBuffer(toSign);
-    byte[] sig = crypto.ecdsaSign(toSign);
 
     byte[] computedExponential =
-        ((ECDHLightContext) ctx).getHMACKey(ECDH.getPublicKey(hisExponential, ecdhCurveToUse));
+        ((ECDHLightContext) ctx).getHMACKey(ECDH.getPublicKey(p.hisExponential, ecdhCurveToUse));
 
     if (LOG.isDebugEnabled())
-      LOG.debug(
-          "The shared Master secret is : "
-              + HexUtil.bytesToHex(computedExponential)
-              + " for "
-              + pn);
+      LOG.debug(MSG_SHARED_MASTER + FOR_STR + "{}", HexUtil.bytesToHex(computedExponential), p.pn);
     /* 0 is the outgoing key for the initiator, 7 for the responder */
-    pn.outgoingKey =
-        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "0");
-    pn.incommingKey =
-        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "7");
-    pn.jfkKe = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "1");
-    pn.jfkKa = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "2");
+    deriveKeysAndInit(
+        p.pn,
+        (ECDHLightContext) ctx,
+        p.hisExponential,
+        nonceInitiatorHashed,
+        p.nonceResponder,
+        p.unknownInitiator);
 
-    pn.hmacKey =
-        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "3");
-    pn.ivKey = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "4");
-    pn.ivNonce =
-        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "5");
-
-    /* Bytes  1-4:  Initial sequence number for the initiator
-     * Bytes  5-8:  Initial sequence number for the responder
-     * Bytes  9-12: Initial message id for the initiator
-     * Bytes 13-16: Initial message id for the responder
-     * Note that we are the initiator */
-    byte[] sharedData =
-        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "6");
-    Arrays.fill(computedExponential, (byte) 0);
-    pn.ourInitialSeqNum =
-        ((sharedData[0] & 0xFF) << 24)
-            | ((sharedData[1] & 0xFF) << 16)
-            | ((sharedData[2] & 0xFF) << 8)
-            | (sharedData[3] & 0xFF);
-    pn.theirInitialSeqNum =
-        ((sharedData[4] & 0xFF) << 24)
-            | ((sharedData[5] & 0xFF) << 16)
-            | ((sharedData[6] & 0xFF) << 8)
-            | (sharedData[7] & 0xFF);
-
-    pn.theirInitialMsgID =
-        unknownInitiator
-            ? getInitialMessageID(pn.identity)
-            : getInitialMessageID(pn.identity, crypto.getMyIdentity());
-    pn.ourInitialMsgID =
-        unknownInitiator
-            ? getInitialMessageID(pn.identity)
-            : getInitialMessageID(crypto.getMyIdentity(), pn.identity);
-
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Their initial message ID: " + pn.theirInitialMsgID + " ours " + pn.ourInitialMsgID);
-
-    c.initialize(pn.jfkKe);
+    c.initialize(p.pn.jfkKe);
     int ivLength = PCFBMode.lengthIV(c);
-    byte[] iv = new byte[ivLength];
-    node.getRandom().nextBytes(iv);
-    PCFBMode pcfb = PCFBMode.create(c, iv);
-    int cleartextOffset = 0;
-    byte[] cleartext = new byte[JFK_PREFIX_INITIATOR.length + ivLength + sig.length + data.length];
-    System.arraycopy(
-        JFK_PREFIX_INITIATOR, 0, cleartext, cleartextOffset, JFK_PREFIX_INITIATOR.length);
-    cleartextOffset += JFK_PREFIX_INITIATOR.length;
-    System.arraycopy(iv, 0, cleartext, cleartextOffset, ivLength);
-    cleartextOffset += ivLength;
-    System.arraycopy(sig, 0, cleartext, cleartextOffset, sig.length);
-    cleartextOffset += sig.length;
-    System.arraycopy(data, 0, cleartext, cleartextOffset, data.length);
-    cleartextOffset += data.length;
-
-    int cleartextToEncypherOffset = JFK_PREFIX_INITIATOR.length + ivLength;
-    pcfb.blockEncipher(
-        cleartext, cleartextToEncypherOffset, cleartext.length - cleartextToEncypherOffset);
-
-    // We compute the HMAC of (prefix + cyphertext) Includes the IV!
-    byte[] hmac = HMAC.macWithSHA256(pn.jfkKa, cleartext);
-
-    // copy stuffs back to the message
-    System.arraycopy(hmac, 0, message3, offset, HASH_LENGTH);
-    offset += HASH_LENGTH;
-    System.arraycopy(iv, 0, message3, offset, ivLength);
-    offset += ivLength;
-    System.arraycopy(
-        cleartext,
-        cleartextToEncypherOffset,
-        message3,
-        offset,
-        cleartext.length - cleartextToEncypherOffset);
+    appendEncryptedPayloadAndHmacForJFK3(p.pn, c, sig, data, message3, offset, ivLength);
 
     // cache the message
     synchronized (authenticatorCache) {
       if (!maybeResetTransientKey())
-        authenticatorCache.put(new ByteArrayWrapper(authenticator), message3);
+        authenticatorCache.put(new ByteArrayWrapper(p.authenticator), message3);
     }
     final long timeSent = System.currentTimeMillis();
-    if (unknownInitiator) {
+    if (p.unknownInitiator) {
       sendAnonAuthPacket(
-          1, negType, 2, setupType, message3, pn, replyTo, pn.anonymousInitiatorSetupCipher);
+          p.negType, 2, p.setupType, message3, p.pn, p.replyTo, p.pn.anonymousInitiatorSetupCipher);
     } else {
-      sendAuthPacket(1, negType, 2, message3, pn, replyTo);
+      sendAuthPacket(p.negType, 2, message3, p.pn, p.replyTo);
     }
-
-    /* Re-send the packet after 5sec if we don't get any reply */
-    node.getTicker()
-        .queueTimedJob(
-            new Runnable() {
-              @Override
-              public void run() {
-                if (pn.timeLastConnectionCompleted() < timeSent) {
-                  if (LOG.isDebugEnabled())
-                    LOG.debug("Resending JFK(3) to " + pn + " for " + node.getDarknetPortNumber());
-                  if (unknownInitiator) {
-                    sendAnonAuthPacket(
-                        1,
-                        negType,
-                        2,
-                        setupType,
-                        message3,
-                        pn,
-                        replyTo,
-                        pn.anonymousInitiatorSetupCipher);
-                  } else {
-                    sendAuthPacket(1, negType, 2, message3, pn, replyTo);
-                  }
-                }
-              }
-            },
-            SECONDS.toMillis(5));
+    scheduleJFK3ResendIfNoReply(
+        p.pn, p.replyTo, p.negType, p.setupType, message3, timeSent, p.unknownInitiator);
     long t2 = System.currentTimeMillis();
     if ((t2 - t1) > MILLISECONDS.toMillis(500))
-      LOG.error("Message3 timeout error:Sending packet for " + pn.getPeer());
+      LOG.error("Message3 send exceeds 500 ms for {}", p.pn.getPeer());
   }
 
   private int getInitialMessageID(byte[] identity) {
@@ -2285,71 +2150,48 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
    * @param pn The PeerNode to encrypt the auth packet to. Cannot be null, because even in anonymous initiator,
    * we will have created one before calling this method.
    */
-  private void sendJFKMessage4(
-      int version,
-      int negType,
-      int phase,
-      byte[] nonceInitiatorHashed,
-      byte[] nonceResponder,
-      byte[] initiatorExponential,
-      byte[] responderExponential,
-      BlockCipher c,
-      byte[] Ke,
-      byte[] Ka,
-      byte[] authenticator,
-      byte[] hisRef,
-      PeerNode pn,
-      Peer replyTo,
-      boolean unknownInitiator,
-      int setupType,
-      long newTrackerID,
-      boolean sameAsOldTrackerID) {
-    if (LOG.isDebugEnabled()) LOG.debug("Sending a JFK(4) message to " + pn.getPeer());
+  private void sendJFKMessage4(Jfk4Params p) {
+    if (LOG.isDebugEnabled()) LOG.debug("Sending a JFK(4) message to {}", p.pn.getPeer());
     long t1 = System.currentTimeMillis();
 
     byte[] myRef = crypto.myCompressedSetupRef();
-    byte[] data = new byte[9 + 8 + myRef.length + hisRef.length];
+    byte[] data = new byte[9 + 8 + myRef.length + p.hisRef.length];
     int ptr = 0;
-    System.arraycopy(Fields.longToBytes(newTrackerID), 0, data, ptr, 8);
+    System.arraycopy(Fields.longToBytes(p.newTrackerID), 0, data, ptr, 8);
     ptr += 8;
-    data[ptr++] = (byte) (sameAsOldTrackerID ? 1 : 0);
+    data[ptr++] = (byte) (p.sameAsOldTrackerID ? 1 : 0);
 
-    System.arraycopy(Fields.longToBytes(pn.getOutgoingBootID()), 0, data, ptr, 8);
+    System.arraycopy(Fields.longToBytes(p.pn.getOutgoingBootID()), 0, data, ptr, 8);
     ptr += 8;
     System.arraycopy(myRef, 0, data, ptr, myRef.length);
     ptr += myRef.length;
-    System.arraycopy(hisRef, 0, data, ptr, hisRef.length);
+    System.arraycopy(p.hisRef, 0, data, ptr, p.hisRef.length);
 
     byte[] params =
         assembleDHParams(
-            nonceInitiatorHashed,
-            nonceResponder,
-            initiatorExponential,
-            responderExponential,
-            pn.getPubKeyHash(),
+            p.nonceInitiatorHashed,
+            p.nonceResponder,
+            p.initiatorExponential,
+            p.responderExponential,
+            p.pn.getPubKeyHash(),
             data);
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Message length "
-              + params.length
-              + " myRef: "
-              + myRef.length
-              + " hash "
-              + Fields.hashCode(myRef)
-              + " hisRef: "
-              + hisRef.length
-              + " hash "
-              + Fields.hashCode(hisRef)
-              + " boot ID "
-              + node.getBootId());
+          "Message length {} myRef: {}" + HASH_STR + "{} hisRef: {}" + HASH_STR + "{} boot ID {}",
+          params.length,
+          myRef.length,
+          Fields.hashCode(myRef),
+          p.hisRef.length,
+          Fields.hashCode(p.hisRef),
+          node.getBootId());
     byte[] sig = crypto.ecdsaSign(params);
 
-    int ivLength = PCFBMode.lengthIV(c);
+    int ivLength = PCFBMode.lengthIV(p.c);
     byte[] iv = new byte[ivLength];
     node.getRandom().nextBytes(iv);
-    PCFBMode pk = PCFBMode.create(c, iv);
+    PCFBMode pk = PCFBMode.create(p.c, iv);
     // Don't include the last bit
-    int dataLength = data.length - hisRef.length;
+    int dataLength = data.length - p.hisRef.length;
     byte[] cyphertext = new byte[JFK_PREFIX_RESPONDER.length + ivLength + sig.length + dataLength];
     int cleartextOffset = 0;
     System.arraycopy(
@@ -2360,14 +2202,14 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     System.arraycopy(sig, 0, cyphertext, cleartextOffset, sig.length);
     cleartextOffset += sig.length;
     System.arraycopy(data, 0, cyphertext, cleartextOffset, dataLength);
-    cleartextOffset += dataLength;
+    // no need to update further; not used beyond this point
     // Now encrypt the cleartext[Signature]
     int cleartextToEncypherOffset = JFK_PREFIX_RESPONDER.length + ivLength;
     pk.blockEncipher(
         cyphertext, cleartextToEncypherOffset, cyphertext.length - cleartextToEncypherOffset);
 
     // We compute the HMAC of (prefix + iv + signature)
-    byte[] hmac = HMAC.macWithSHA256(Ka, cyphertext);
+    byte[] hmac = HMAC.macWithSHA256(p.ka, cyphertext);
 
     // Message4 = hmac + IV + encryptedSignature
     byte[] message4 =
@@ -2387,68 +2229,423 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     // cache the message
     synchronized (authenticatorCache) {
       if (!maybeResetTransientKey())
-        authenticatorCache.put(new ByteArrayWrapper(authenticator), message4);
+        authenticatorCache.put(new ByteArrayWrapper(p.authenticator), message4);
       if (LOG.isTraceEnabled())
-        LOG.trace("Storing JFK(4) for " + HexUtil.bytesToHex(authenticator));
+        LOG.trace("Storing JFK(4) for {}", HexUtil.bytesToHex(p.authenticator));
     }
 
-    if (unknownInitiator) {
+    if (p.unknownInitiator) {
       sendAnonAuthPacket(
-          1, negType, 3, setupType, message4, pn, replyTo, crypto.getAnonSetupCipher());
+          p.negType, 3, p.setupType, message4, p.pn, p.replyTo, crypto.getAnonSetupCipher());
     } else {
-      sendAuthPacket(1, negType, 3, message4, pn, replyTo);
+      sendAuthPacket(p.negType, 3, message4, p.pn, p.replyTo);
     }
     long t2 = System.currentTimeMillis();
-    if ((t2 - t1) > 500) LOG.error("Message4 timeout error:Sending packet for " + pn.getPeer());
+    if ((t2 - t1) > 500) LOG.error("Message4 send exceeds 500 ms for {}", p.pn.getPeer());
+  }
+
+  private static final class Jfk4Params {
+    int negType;
+    byte[] nonceInitiatorHashed;
+    byte[] nonceResponder;
+    byte[] initiatorExponential;
+    byte[] responderExponential;
+    BlockCipher c;
+    byte[] ka;
+    byte[] authenticator;
+    byte[] hisRef;
+    PeerNode pn;
+    Peer replyTo;
+    boolean unknownInitiator;
+    int setupType;
+    long newTrackerID;
+    boolean sameAsOldTrackerID;
+  }
+
+  private static final class SigData {
+    final byte[] sig;
+    final byte[] data;
+
+    SigData(byte[] sig, byte[] data) {
+      this.sig = sig;
+      this.data = data;
+    }
+  }
+
+  private static final class Jfk3Params {
+    int negType;
+    byte[] nonceInitiator;
+    byte[] nonceResponder;
+    byte[] hisExponential;
+    byte[] authenticator;
+    PeerNode pn;
+    Peer replyTo;
+    boolean unknownInitiator;
+    int setupType;
+  }
+
+  private static final class Stage1Result {
+    enum Status {
+      OK,
+      REPLAYED,
+      INVALID,
+      HANDLED
+    }
+
+    final Status status;
+    final long trackerID;
+    final boolean reusedTracker;
+    final long bootID;
+    final byte[] hisRef;
+
+    Stage1Result(Status status) {
+      this(status, -1, false, -1, null);
+    }
+
+    Stage1Result(Status status, long trackerID, boolean reusedTracker, long bootID, byte[] hisRef) {
+      this.status = status;
+      this.trackerID = trackerID;
+      this.reusedTracker = reusedTracker;
+      this.bootID = bootID;
+      this.hisRef = hisRef;
+    }
+  }
+
+  private record J3Ctx(PeerNode pn, Peer replyTo) {}
+
+  private static final class ReplayFields {
+    final byte[] responderExponential;
+    final byte[] initiatorExponential;
+    final byte[] nonceResponder;
+    final byte[] nonceInitiatorHashed;
+
+    ReplayFields(
+        byte[] responderExponential,
+        byte[] initiatorExponential,
+        byte[] nonceResponder,
+        byte[] nonceInitiatorHashed) {
+      this.responderExponential = responderExponential;
+      this.initiatorExponential = initiatorExponential;
+      this.nonceResponder = nonceResponder;
+      this.nonceInitiatorHashed = nonceInitiatorHashed;
+    }
+  }
+
+  private int writeMessage3Header(
+      byte[] message3,
+      byte[] nonceInitiator,
+      byte[] nonceResponder,
+      byte[] ourExponential,
+      byte[] hisExponential,
+      byte[] authenticator) {
+    int offset = 0;
+    int nonceSize = NONCE_SIZE;
+    System.arraycopy(nonceInitiator, 0, message3, offset, nonceSize);
+    offset += nonceSize;
+    if (LOG.isTraceEnabled()) LOG.trace("Sending Ni: {}", HexUtil.bytesToHex(nonceInitiator));
+    System.arraycopy(nonceResponder, 0, message3, offset, nonceSize);
+    offset += nonceSize;
+    System.arraycopy(ourExponential, 0, message3, offset, ourExponential.length);
+    offset += ourExponential.length;
+    System.arraycopy(hisExponential, 0, message3, offset, hisExponential.length);
+    offset += hisExponential.length;
+    System.arraycopy(authenticator, 0, message3, offset, HASH_LENGTH);
+    offset += HASH_LENGTH;
+    return offset;
+  }
+
+  private byte[] signJFK3AndCacheBuffer(
+      PeerNode pn,
+      byte[] nonceInitiatorHashed,
+      byte[] nonceResponder,
+      byte[] ourExponential,
+      byte[] hisExponential,
+      byte[] pubKeyHash,
+      byte[] data) {
+    byte[] toSign =
+        assembleDHParams(
+            nonceInitiatorHashed, nonceResponder, ourExponential, hisExponential, pubKeyHash, data);
+    pn.setJFKBuffer(toSign);
+    return crypto.ecdsaSign(toSign);
+  }
+
+  private void deriveKeysAndInit(
+      PeerNode pn,
+      ECDHLightContext ctx,
+      byte[] hisExponential,
+      byte[] nonceInitiatorHashed,
+      byte[] nonceResponder,
+      boolean unknownInitiator) {
+    byte[] computedExponential = ctx.getHMACKey(ECDH.getPublicKey(hisExponential, ecdhCurveToUse));
+    if (LOG.isDebugEnabled())
+      LOG.debug(MSG_SHARED_MASTER + FOR_STR + "{}", HexUtil.bytesToHex(computedExponential), pn);
+    pn.outgoingKey =
+        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "0");
+    pn.incommingKey =
+        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "7");
+    pn.jfkKe = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "1");
+    pn.jfkKa = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "2");
+    pn.hmacKey =
+        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "3");
+    pn.ivKey = computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "4");
+    pn.ivNonce =
+        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "5");
+    byte[] sharedData =
+        computeJFKSharedKey(computedExponential, nonceInitiatorHashed, nonceResponder, "6");
+    Arrays.fill(computedExponential, (byte) 0);
+    pn.ourInitialSeqNum =
+        ((sharedData[0] & 0xFF) << 24)
+            | ((sharedData[1] & 0xFF) << 16)
+            | ((sharedData[2] & 0xFF) << 8)
+            | (sharedData[3] & 0xFF);
+    pn.theirInitialSeqNum =
+        ((sharedData[4] & 0xFF) << 24)
+            | ((sharedData[5] & 0xFF) << 16)
+            | ((sharedData[6] & 0xFF) << 8)
+            | (sharedData[7] & 0xFF);
+    pn.theirInitialMsgID =
+        unknownInitiator
+            ? getInitialMessageID(pn.identity)
+            : getInitialMessageID(pn.identity, crypto.getMyIdentity());
+    pn.ourInitialMsgID =
+        unknownInitiator
+            ? getInitialMessageID(pn.identity)
+            : getInitialMessageID(crypto.getMyIdentity(), pn.identity);
+    if (LOG.isDebugEnabled())
+      LOG.debug("Their initial message ID: {} ours {}", pn.theirInitialMsgID, pn.ourInitialMsgID);
+  }
+
+  private void appendEncryptedPayloadAndHmacForJFK3(
+      PeerNode pn,
+      BlockCipher c,
+      byte[] sig,
+      byte[] data,
+      byte[] message3,
+      int offset,
+      int ivLength) {
+    byte[] iv = new byte[ivLength];
+    node.getRandom().nextBytes(iv);
+    PCFBMode pcfb = PCFBMode.create(c, iv);
+    int cleartextOffset = 0;
+    byte[] cleartext = new byte[JFK_PREFIX_INITIATOR.length + ivLength + sig.length + data.length];
+    System.arraycopy(
+        JFK_PREFIX_INITIATOR, 0, cleartext, cleartextOffset, JFK_PREFIX_INITIATOR.length);
+    cleartextOffset += JFK_PREFIX_INITIATOR.length;
+    System.arraycopy(iv, 0, cleartext, cleartextOffset, ivLength);
+    cleartextOffset += ivLength;
+    System.arraycopy(sig, 0, cleartext, cleartextOffset, sig.length);
+    cleartextOffset += sig.length;
+    System.arraycopy(data, 0, cleartext, cleartextOffset, data.length);
+    // no need to update further; not used beyond this point
+    int cleartextToEncypherOffset = JFK_PREFIX_INITIATOR.length + ivLength;
+    pcfb.blockEncipher(
+        cleartext, cleartextToEncypherOffset, cleartext.length - cleartextToEncypherOffset);
+    byte[] hmac = HMAC.macWithSHA256(pn.jfkKa, cleartext);
+    System.arraycopy(hmac, 0, message3, offset, HASH_LENGTH);
+    offset += HASH_LENGTH;
+    System.arraycopy(iv, 0, message3, offset, ivLength);
+    offset += ivLength;
+    System.arraycopy(
+        cleartext,
+        cleartextToEncypherOffset,
+        message3,
+        offset,
+        cleartext.length - cleartextToEncypherOffset);
+  }
+
+  private void scheduleJFK3ResendIfNoReply(
+      final PeerNode pn,
+      final Peer replyTo,
+      final int negType,
+      final int setupType,
+      final byte[] message3,
+      final long timeSent,
+      final boolean unknownInitiator) {
+    node.getTicker()
+        .queueTimedJob(
+            () -> {
+              if (pn.timeLastConnectionCompleted() < timeSent) {
+                if (LOG.isDebugEnabled())
+                  LOG.debug(
+                      "Resending JFK(3) to {}" + FOR_STR + "{}", pn, node.getDarknetPortNumber());
+                if (unknownInitiator) {
+                  sendAnonAuthPacket(
+                      negType,
+                      2,
+                      setupType,
+                      message3,
+                      pn,
+                      replyTo,
+                      pn.anonymousInitiatorSetupCipher);
+                } else {
+                  sendAuthPacket(negType, 2, message3, pn, replyTo);
+                }
+              }
+            },
+            SECONDS.toMillis(5));
+  }
+
+  private Stage1Result jfk4Stage1(
+      byte[] payload,
+      int inputOffset,
+      PeerNode pn,
+      BlockCipher c,
+      int signLength,
+      int negType,
+      long t1) {
+    final int expectedLength = expectedLengthJFK4(c, signLength);
+    java.util.Optional<byte[]> jfkBufferOpt =
+        validateLengthAndGetJfkBuffer(payload, inputOffset, pn, expectedLength);
+    if (jfkBufferOpt.isEmpty()) return new Stage1Result(Stage1Result.Status.INVALID);
+    byte[] jfkBuffer = jfkBufferOpt.get();
+
+    byte[] hmac = Arrays.copyOfRange(payload, inputOffset, inputOffset + HASH_LENGTH);
+    int ofs = inputOffset + HASH_LENGTH;
+
+    c.initialize(pn.jfkKe);
+    int ivLength = PCFBMode.lengthIV(c);
+    int decOffset = 0;
+    byte[] dec =
+        Arrays.copyOf(JFK_PREFIX_RESPONDER, JFK_PREFIX_RESPONDER.length + payload.length - ofs);
+    decOffset += JFK_PREFIX_RESPONDER.length;
+    System.arraycopy(payload, ofs, dec, decOffset, payload.length - ofs);
+    if (isInnerHmacInvalid(pn.jfkKa, dec, hmac, pn, "JFK(4)"))
+      return new Stage1Result(Stage1Result.Status.INVALID);
+
+    if (isReplayMessage4AndRecord(hmac, t1, pn))
+      return new Stage1Result(Stage1Result.Status.REPLAYED);
+
+    final PCFBMode pk = PCFBMode.create(c, dec, decOffset);
+    decOffset += ivLength;
+    pk.blockDecipher(dec, decOffset, dec.length - decOffset);
+
+    SigData sd = extractSigAndDataFromDecrypted(dec, decOffset, signLength);
+    byte[] sig = sd.sig;
+    byte[] data = sd.data;
+
+    int ptr = 0;
+    long trackerID = Fields.bytesToLong(data, ptr);
+    ptr += 8;
+    boolean reusedTracker = data[ptr++] != 0;
+    long bootID = Fields.bytesToLong(data, ptr);
+    ptr += 8;
+    byte[] hisRef = Arrays.copyOfRange(data, ptr, data.length);
+
+    int dataLen = hisRef.length + 8 + 9;
+    byte[] identity = crypto.getIdentity(negType);
+    int modulusLengthLocal = getModulusLength();
+    byte[] toVerify =
+        buildJFK4VerifyText(jfkBuffer, identity, modulusLengthLocal, data, dataLen, pn.jfkMyRef);
+    if (!verifyECDSAJFK4(pn, sig, toVerify, hisRef, bootID))
+      return new Stage1Result(Stage1Result.Status.HANDLED);
+
+    pn.receivedPacket(true, false);
+    return new Stage1Result(Stage1Result.Status.OK, trackerID, reusedTracker, bootID, hisRef);
+  }
+
+  private SigData extractSigAndDataFromDecrypted(
+      byte[] decypheredPayload, int decypheredPayloadOffset, int signLength) {
+    byte[] sig = new byte[signLength];
+    System.arraycopy(decypheredPayload, decypheredPayloadOffset, sig, 0, signLength);
+    int next = decypheredPayloadOffset + signLength;
+    byte[] data = new byte[decypheredPayload.length - next];
+    System.arraycopy(decypheredPayload, next, data, 0, data.length);
+    return new SigData(sig, data);
+  }
+
+  private int expectedLengthJFK4(BlockCipher c, int signLength) {
+    return HASH_LENGTH
+        + (c.getBlockSize() >> 3) // IV
+        + signLength // signature
+        + 9 // ID of packet tracker, plus boolean byte
+        + 8 // bootID
+        + 1; // znoderefR
+  }
+
+  private java.util.Optional<byte[]> validateLengthAndGetJfkBuffer(
+      byte[] payload, int inputOffset, PeerNode pn, int expectedLength) {
+    if (payload.length - inputOffset < expectedLength + 3) {
+      LOG.error(
+          PACKET_TOO_SHORT_FROM + "{}: {} after decryption in JFK(4), should be {}",
+          pn.getPeer(),
+          payload.length,
+          expectedLength + 3);
+      return java.util.Optional.empty();
+    }
+    byte[] jfkBuffer = pn.getJFKBuffer();
+    if (jfkBuffer == null) {
+      LOG.info("We have already handled this message... might be a replay or a bug - {}", pn);
+      return java.util.Optional.empty();
+    }
+    return java.util.Optional.of(jfkBuffer);
+  }
+
+  private byte[] buildJFK4VerifyText(
+      byte[] jfkBuffer,
+      byte[] identity,
+      int modulusLength,
+      byte[] data,
+      int dataLen,
+      byte[] myRef) {
+    int nonceSize = NONCE_SIZE;
+    int nonceSizeHashed = HASH_LENGTH;
+    byte[] locallyGeneratedText =
+        new byte
+            [nonceSizeHashed
+                + nonceSize
+                + modulusLength * 2
+                + identity.length
+                + dataLen
+                + myRef.length];
+    int bufferOffset = nonceSizeHashed + nonceSize + modulusLength * 2;
+    System.arraycopy(jfkBuffer, 0, locallyGeneratedText, 0, bufferOffset);
+    System.arraycopy(identity, 0, locallyGeneratedText, bufferOffset, identity.length);
+    bufferOffset += identity.length;
+    System.arraycopy(data, 0, locallyGeneratedText, bufferOffset, dataLen);
+    bufferOffset += dataLen;
+    System.arraycopy(myRef, 0, locallyGeneratedText, bufferOffset, myRef.length);
+    return locallyGeneratedText;
   }
 
   /** Send an auth packet. */
-  private void sendAuthPacket(
-      int version, int negType, int phase, byte[] data, PeerNode pn, Peer replyTo) {
+  private void sendAuthPacket(int negType, int phase, byte[] data, PeerNode pn, Peer replyTo) {
     if (pn == null) throw new IllegalArgumentException("pn shouldn't be null here!");
     byte[] output = new byte[data.length + 3];
-    output[0] = (byte) version;
+    output[0] = (byte) 1; // version is always 1
     output[1] = (byte) negType;
     output[2] = (byte) phase;
     System.arraycopy(data, 0, output, 3, data.length);
     if (LOG.isDebugEnabled()) {
       long now = System.currentTimeMillis();
-      String delta = "never";
       long last = pn.lastSentPacketTime();
-      delta = TimeUtil.formatTime(now - last, 2, true) + " ago";
+      String delta = TimeUtil.formatTime(now - last, 2, true) + " ago";
       LOG.debug(
-          "Sending auth packet for "
-              + pn.getPeer()
-              + " (phase="
-              + phase
-              + ", ver="
-              + version
-              + ", nt="
-              + negType
-              + ") (last packet sent "
-              + delta
-              + ") to "
-              + replyTo
-              + " data.length="
-              + data.length
-              + " to "
-              + replyTo);
+          "Sending auth packet for {} (phase={}, ver=1"
+              + NT_STR
+              + "{}) (last sent {} to {}) data.length={} (dest={})",
+          pn.getPeer(),
+          phase,
+          negType,
+          delta,
+          replyTo,
+          data.length,
+          replyTo);
     }
     sendAuthPacket(output, pn.outgoingSetupCipher, pn, replyTo, false);
   }
 
   /**
-   * @param version
-   * @param negType
-   * @param phase
-   * @param setupType
-   * @param data
-   * @param pn May be null. If not null, used for details such as anti-firewall hacks.
-   * @param replyTo
-   * @param cipher
+   * Send an anonymous‑initiator auth packet.
+   *
+   * @param negType negotiation type identifier
+   * @param phase packet phase (0–3)
+   * @param setupType anonymous‑initiator setup type (e.g., {@link #SETUP_OPENNET_SEEDNODE})
+   * @param data payload to send (unencrypted body)
+   * @param pn may be {@code null}; when non‑null, used for details such as anti‑firewall handling
+   * @param replyTo destination peer
+   * @param cipher outer cipher used to protect the packet
    */
   private void sendAnonAuthPacket(
-      int version,
       int negType,
       int phase,
       int setupType,
@@ -2457,23 +2654,18 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       Peer replyTo,
       BlockCipher cipher) {
     byte[] output = new byte[data.length + 4];
-    output[0] = (byte) version;
+    output[0] = (byte) 1; // version is always 1
     output[1] = (byte) negType;
     output[2] = (byte) phase;
     output[3] = (byte) setupType;
     System.arraycopy(data, 0, output, 4, data.length);
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Sending anon auth packet (phase="
-              + phase
-              + ", ver="
-              + version
-              + ", nt="
-              + negType
-              + ", setup="
-              + setupType
-              + ") data.length="
-              + data.length);
+          "Sending anon auth packet (phase={}, ver=" + 1 + NT_STR + "{}, setup={}) data.length={}",
+          phase,
+          negType,
+          setupType,
+          data.length);
     sendAuthPacket(output, cipher, pn, replyTo, true);
   }
 
@@ -2487,7 +2679,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     byte[] iv = new byte[PCFBMode.lengthIV(cipher)];
     node.getRandom().nextBytes(iv);
     byte[] hash = SHA256.digest(output);
-    if (LOG.isTraceEnabled()) LOG.trace("Data hash: " + HexUtil.bytesToHex(hash));
+    if (LOG.isTraceEnabled()) LOG.trace("Data hash: {}", HexUtil.bytesToHex(hash));
     int prePaddingLength = iv.length + hash.length + 2 /* length */ + output.length;
     int maxPacketSize = sock.getMaxPacketSize();
     int paddingLength;
@@ -2499,21 +2691,14 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
           0; // Avoid oversize packets if at all possible, the MTU is an estimate and may be wrong,
       // and fragmented packets are often dropped by firewalls.
       // Tell the devs, this shouldn't happen.
-      LOG.error(
-          "Warning: sending oversize auth packet (anonAuth="
-              + anonAuth
-              + ") of "
-              + prePaddingLength
-              + " bytes!");
+      LOG.error("Oversize auth packet (anonAuth={}) of {} bytes", anonAuth, prePaddingLength);
     }
-    if (paddingLength < 0) paddingLength = 0;
     byte[] data = new byte[prePaddingLength + paddingLength];
     PCFBMode pcfb = PCFBMode.create(cipher, iv);
     System.arraycopy(iv, 0, data, 0, iv.length);
     pcfb.blockEncipher(hash, 0, hash.length);
     System.arraycopy(hash, 0, data, iv.length, hash.length);
-    if (LOG.isDebugEnabled())
-      LOG.debug("Payload length: " + length + " padded length " + data.length);
+    if (LOG.isDebugEnabled()) LOG.debug("Payload length: {} padded length {}", length, data.length);
     data[hash.length + iv.length] = (byte) pcfb.encipher((byte) (length >> 8));
     data[hash.length + iv.length + 1] = (byte) pcfb.encipher((byte) length);
     pcfb.blockEncipher(output, 0, output.length);
@@ -2526,20 +2711,18 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       node.getNodeStats().reportAuthBytes(data.length + sock.getHeadersLength(replyTo));
     } catch (LocalAddressException e) {
       LOG.warn(
-          "Tried to send auth packet to local address: "
-              + replyTo
-              + " for "
-              + pn
-              + " - maybe you should set allowLocalAddresses for this peer??");
+          "Tried to send auth packet to local address: {}"
+              + FOR_STR
+              + "{} - maybe set allowLocalAddresses for this peer?",
+          replyTo,
+          pn);
     }
   }
 
   private void sendPacket(byte[] data, Peer replyTo, PeerNode pn) throws LocalAddressException {
-    if (pn != null) {
-      if (pn.isIgnoreSource()) {
-        Peer p = pn.getPeer();
-        if (p != null) replyTo = p;
-      }
+    if (pn != null && pn.isIgnoreSource()) {
+      Peer p = pn.getPeer();
+      if (p != null) replyTo = p;
     }
     sock.sendPacket(
         data,
@@ -2559,8 +2742,14 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     return now - node.getStartupTime() >= Node.HANDSHAKE_TIMEOUT * 2L;
   }
 
-  /* (non-Javadoc)
-   * @see freenet.node.OutgoingPacketMangler#sendHandshake(freenet.node.PeerNode)
+  /**
+   * Sends an initial JFK handshake to a peer.
+   *
+   * <p>Selects a supported negotiation type, resolves the target {@link Peer} address, and emits a
+   * JFK(1) message. When no common negotiation type exists, a random supported type is chosen.
+   *
+   * @param pn target peer node (must be non-null)
+   * @param notRegistered whether the peer is not yet registered with the node
    */
   @Override
   public void sendHandshake(PeerNode pn, boolean notRegistered) {
@@ -2570,13 +2759,11 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       int[] negTypes = supportedNegTypes(true);
       negType = negTypes[node.getRandom().nextInt(negTypes.length)];
       LOG.info(
-          "Cannot send handshake to "
-              + pn
-              + " because no common negTypes, choosing random negType of "
-              + negType);
+          "Cannot send handshake to {} because no common negTypes; choosing random negType {}",
+          pn,
+          negType);
     }
-    if (LOG.isDebugEnabled())
-      LOG.debug("Possibly sending handshake to " + pn + " negotiation type " + negType);
+    if (LOG.isDebugEnabled()) LOG.debug("Possibly send handshake to {} (negType={})", pn, negType);
 
     Peer peer = pn.getHandshakeIP();
     if (peer == null) {
@@ -2586,22 +2773,25 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     Peer oldPeer = peer;
     peer = peer.dropHostName();
     if (peer == null) {
-      LOG.error("No address for peer " + oldPeer + " so cannot send handshake");
+      LOG.error("No address for peer {} so cannot send handshake", oldPeer);
       pn.couldNotSendHandshake(notRegistered);
       return;
     }
     try {
       sendJFKMessage1(pn, peer, pn.handshakeUnknownInitiator(), pn.handshakeSetupType(), negType);
     } catch (NoContextsException e) {
-      handleNoContextsException(e, NoContextsException.CONTEXT.SENDING);
+      handleNoContextsException(NoContextsException.CONTEXT.SENDING);
       return;
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Sending handshake to " + peer + " for " + pn);
+    if (LOG.isDebugEnabled()) LOG.debug("Sending handshake to {}" + FOR_STR + "{}", peer, pn);
     pn.sentHandshake(notRegistered);
   }
 
-  /* (non-Javadoc)
-   * @see freenet.node.OutgoingPacketMangler#isDisconnected(freenet.io.comm.PeerContext)
+  /**
+   * Reports whether the supplied context represents a disconnected peer.
+   *
+   * @param context peer context (nullable)
+   * @return {@code true} if {@code context} is non-null and not connected; otherwise {@code false}
    */
   @Override
   public boolean isDisconnected(PeerContext context) {
@@ -2609,51 +2799,76 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     return !context.isConnected();
   }
 
+  /**
+   * Lists supported negotiation types.
+   *
+   * @param forPublic when {@code true}, returns the types advertised to the public network
+   * @return an array of supported negotiation type identifiers
+   */
   @Override
   public int[] supportedNegTypes(boolean forPublic) {
     return new int[] {10};
   }
 
+  /**
+   * Returns the active socket handler used to send and receive packets.
+   *
+   * @return the {@link SocketHandler} instance for this mangler
+   */
   @Override
   public SocketHandler getSocketHandler() {
     return sock;
   }
 
+  /**
+   * Provides the detected primary IP addresses for the local node.
+   *
+   * @return an array of primary {@link Peer} addresses
+   */
   @Override
   public Peer[] getPrimaryIPAddress() {
     return crypto.getDetector().getPrimaryPeers();
   }
 
+  /**
+   * Returns the compressed node reference for this node.
+   *
+   * @return a byte array with the compressed noderef
+   */
   @Override
   public byte[] getCompressedNoderef() {
     return crypto.myCompressedFullRef();
   }
 
+  /**
+   * Indicates whether local addresses are always allowed for outgoing packets.
+   *
+   * @return {@code true} when local addresses are permitted without additional checks
+   */
   @Override
   public boolean alwaysAllowLocalAddresses() {
     return crypto.getConfig().alwaysAllowLocalAddresses();
   }
 
-  private ECDHLightContext _genECDHLightContext() {
+  private ECDHLightContext genECDHLightContext() {
     final ECDHLightContext ctx = new ECDHLightContext(ecdhCurveToUse);
     ctx.setECDSASignature(crypto.ecdsaSign(ctx.getPublicKeyNetworkFormat()));
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "ECDSA Signature: "
-              + HexUtil.bytesToHex(ctx.getECDSASignature())
-              + " for "
-              + HexUtil.bytesToHex(ctx.getPublicKeyNetworkFormat()));
+          "ECDSA signature: {}" + FOR_STR + "{}",
+          HexUtil.bytesToHex(ctx.getECDSASignature()),
+          HexUtil.bytesToHex(ctx.getPublicKeyNetworkFormat()));
     return ctx;
   }
 
-  private void _fillJFKECDHFIFOOffThread() {
+  private void fillJfkEcdhFifoOffThread() {
     // do it off-thread
     node.getExecutor()
         .execute(
             new PrioRunnable() {
               @Override
               public void run() {
-                _fillJFKECDHFIFO();
+                fillJfkEcdhFifo();
               }
 
               @Override
@@ -2664,7 +2879,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             "ECDH exponential signing");
   }
 
-  private void _fillJFKECDHFIFO() {
+  private void fillJfkEcdhFifo() {
     synchronized (ecdhContextFIFO) {
       int size = ecdhContextFIFO.size();
       if ((size + 1 > DH_CONTEXT_BUFFER_SIZE)) {
@@ -2677,22 +2892,24 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             result = tmp;
           }
         }
-        ecdhContextFIFO.remove(ecdhContextToBePrunned = result);
+        ecdhContextToBePrunned = result;
+        ecdhContextFIFO.remove(ecdhContextToBePrunned);
       }
 
-      ecdhContextFIFO.addLast(_genECDHLightContext());
+      ecdhContextFIFO.addLast(genECDHLightContext());
     }
   }
 
   /**
-   * Change the ECDH key on a regular basis but at most once every 30sec
+   * Change the ECDH key on a regular basis but at most once every 30sec.
    *
-   * @return {@link ECDHLightContext}
-   * @throws NoContextsException
+   * @return {@link ECDHLightContext} currently selected for use
+   * @throws NoContextsException when no pre-generated ECDH contexts are available in the FIFO and a
+   *     new one cannot be provided synchronously
    */
   private ECDHLightContext getECDHLightContext() throws NoContextsException {
     final long now = System.currentTimeMillis();
-    ECDHLightContext result = null;
+    ECDHLightContext result;
 
     synchronized (ecdhContextFIFO) {
       result = ecdhContextFIFO.pollFirst();
@@ -2700,7 +2917,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       // Shall we replace one element of the queue ?
       if ((jfkECDHLastGenerationTimestamp + DH_GENERATION_INTERVAL) < now) {
         jfkECDHLastGenerationTimestamp = now;
-        _fillJFKECDHFIFOOffThread();
+        fillJfkEcdhFifoOffThread();
       }
 
       // Don't generate on-thread as it might block.
@@ -2709,11 +2926,10 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
       ecdhContextFIFO.addLast(result);
     }
 
-    if (LOG.isDebugEnabled()) LOG.debug("getECDHLightContext() is serving " + result.hashCode());
+    if (LOG.isDebugEnabled()) LOG.debug("getECDHLightContext() serves {}", result.hashCode());
     return result;
   }
 
-  @SuppressWarnings("serial")
   private static class NoContextsException extends Exception {
 
     private enum CONTEXT {
@@ -2723,11 +2939,12 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   }
 
   /**
-   * Used in processJFK[3|4] That's O^(n) ... but we have only a few elements and we call it only
-   * once a round-trip has been done
+   * Used in processJFK[3|4]. This is O(n) over the small FIFO and is called only once a round-trip
+   * has completed.
    *
-   * @param exponential
-   * @return the corresponding ECDHLightContext with the right exponent
+   * @param exponential the ECDH public key to look up
+   * @return the corresponding {@link ECDHLightContext} that owns the provided public key, or {@code
+   *     null} if no match is found
    */
   private ECDHLightContext findECDHContextByPubKey(ECPublicKey exponential) {
     synchronized (ecdhContextFIFO) {
@@ -2785,9 +3002,9 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
     }
   }
 
-  // FIXME this is our Key Derivation Function for JFK.
-  // FIXME we should move it to freenet/crypt/
-  private byte[] computeJFKSharedKey(byte[] exponential, byte[] nI, byte[] nR, String what) {
+  // This is our Key Derivation Function for JFK.
+  // Consider moving it to freenet/crypt/.
+  private byte[] computeJFKSharedKey(byte[] exponential, byte[] ni, byte[] nr, String what) {
     assert ("0".equals(what)
         || "1".equals(what)
         || "2".equals(what)
@@ -2799,12 +3016,12 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 
     byte[] number = what.getBytes(StandardCharsets.UTF_8);
 
-    byte[] toHash = new byte[nI.length + nR.length + number.length];
+    byte[] toHash = new byte[ni.length + nr.length + number.length];
     int offset = 0;
-    System.arraycopy(nI, 0, toHash, offset, nI.length);
-    offset += nI.length;
-    System.arraycopy(nR, 0, toHash, offset, nR.length);
-    offset += nR.length;
+    System.arraycopy(ni, 0, toHash, offset, ni.length);
+    offset += ni.length;
+    System.arraycopy(nr, 0, toHash, offset, nr.length);
+    offset += nr.length;
     System.arraycopy(number, 0, toHash, offset, number.length);
 
     return HMAC.macWithSHA256(exponential, toHash);
@@ -2816,12 +3033,14 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
    * How big can the authenticator cache get before we flush it ? n * 40 bytes (32 for the
    * authenticator and 8 for the timestamp)
    *
-   * <p>We push to it until we reach the cap where we rekey or we reach the PFS interval
+   * <p>We push to it until we reach the cap where we rekey, or we reach the PFS interval
    */
   private int getAuthenticatorCacheSize() {
-    if (crypto.isOpennet() && node.wantAnonAuth(true)) // seednodes
-    return 5000; // 200kB
-    else return 250; // 10kB
+    if (crypto.isOpennet() && node.wantAnonAuth(true)) { // seednodes
+      return 5000; // 200kB
+    } else {
+      return 250; // 10kB
+    }
   }
 
   /**
@@ -2834,11 +3053,11 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
   private boolean maybeResetTransientKey() {
     long now = System.currentTimeMillis();
     boolean isCacheTooBig = true;
-    int authenticatorCacheSize = 0;
-    int AUTHENTICATOR_CACHE_SIZE = getAuthenticatorCacheSize();
+    int authenticatorCacheSize;
+    int authenticatorCacheCap = getAuthenticatorCacheSize();
     synchronized (authenticatorCache) {
       authenticatorCacheSize = authenticatorCache.size();
-      if (authenticatorCacheSize < AUTHENTICATOR_CACHE_SIZE) {
+      if (authenticatorCacheSize < authenticatorCacheCap) {
         isCacheTooBig = false;
         if (now - timeLastReset < TRANSIENT_KEY_REKEYING_MIN_INTERVAL) return false;
       }
@@ -2857,15 +3076,21 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
             false,
             false);
     LOG.info(
-        "JFK's TransientKey has been changed and the message cache flushed because "
-            + (isCacheTooBig
-                ? ("the cache is oversized (" + authenticatorCacheSize + ')')
-                : "it's time to rekey")
-            + " on "
-            + this);
+        "JFK transientKey rotated; message cache flushed because {} on {}",
+        isCacheTooBig
+            ? ("the cache is oversized (" + authenticatorCacheSize + ')')
+            : "it's time to rekey",
+        this);
     return true;
   }
 
+  /**
+   * Returns the current best-known external connectivity status.
+   *
+   * <p>Result is cached for ~3 minutes to minimize expensive probing.
+   *
+   * @return a {@link Status} value describing NAT/connectivity observations
+   */
   @Override
   public Status getConnectivityStatus() {
     long now = System.currentTimeMillis();
@@ -2878,31 +3103,44 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 
     lastConnectivityStatusUpdate = now;
 
-    return lastConnectivityStatus = value;
+    lastConnectivityStatus = value;
+    return lastConnectivityStatus;
   }
 
+  /**
+   * Checks whether a connection to the given address is allowed.
+   *
+   * @param pn peer node (nullable)
+   * @param addr address under evaluation
+   * @return {@code true} if connections to {@code addr} are permitted
+   */
   @Override
   public boolean allowConnection(PeerNode pn, FreenetInetAddress addr) {
     return crypto.allowConnection(pn, addr);
   }
 
+  /**
+   * Marks the environment as having broken or unavailable port forwarding.
+   *
+   * <p>Downstream components may adapt handshake and NAT traversal strategies accordingly.
+   */
   @Override
   public void setPortForwardingBroken() {
     crypto.setPortForwardingBroken();
   }
 
   /**
-   * @returns the modulus length in bytes for a given negType
+   * Returns the modulus length in bytes for the current negotiation curve.
+   *
+   * @return the modulus length in bytes for the negotiated curve
    */
-  private int getModulusLength(int negType) {
+  private int getModulusLength() {
     return ecdhCurveToUse.modulusSize;
   }
 
-  private int getSignatureLength(int negType) {
+  private int getSignatureLength() {
     return ECDSA.Curves.P256.maxSigSize;
   }
 
-  private int getNonceSize(int negType) {
-    return 16;
-  }
+  // getNonceSize(int) returned a constant; usages have been replaced by NONCE_SIZE.
 }

--- a/src/main/java/network/crypta/node/FNPPacketMangler.java
+++ b/src/main/java/network/crypta/node/FNPPacketMangler.java
@@ -1815,7 +1815,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 
   private PeerNode createSeedClientPeer(SimpleFieldSet ref, Peer from) {
     try {
-      return new SeedClientPeerNode(ref, node, crypto);
+      return new SeedClientPeerNode(ref, node, crypto, node.getPeers());
     } catch (FSParseException
         | PeerParseException
         | ReferenceSignatureVerificationException

--- a/src/main/java/network/crypta/node/OutgoingPacketMangler.java
+++ b/src/main/java/network/crypta/node/OutgoingPacketMangler.java
@@ -8,8 +8,12 @@ import network.crypta.io.comm.PeerContext;
 import network.crypta.io.comm.SocketHandler;
 
 /**
- * Low-level interface for sending packets. A UDP-based transport will have to implement both this
- * and IncomingPacketFilter, usually on the same class.
+ * Abstraction for composing and sending outgoing packets for a transport.
+ *
+ * <p>Implementations provide the mechanics to initiate handshakes, assess connectivity constraints,
+ * and emit wire-ready datagrams/frames to a {@link SocketHandler}. A UDP-based transport typically
+ * implements both this interface and {@link IncomingPacketFilter} on the same class so that
+ * send/receive paths share state and policy.
  *
  * @see IncomingPacketFilter
  * @see FNPPacketMangler
@@ -17,43 +21,100 @@ import network.crypta.io.comm.SocketHandler;
 public interface OutgoingPacketMangler {
 
   /**
-   * Send a handshake, if possible, to the node.
+   * Sends a transport-layer handshake to a peer when supported.
    *
-   * @param pn
+   * @param pn the target peer node to contact.
+   * @param notRegistered {@code true} if the local node is not yet registered with the peer
+   *     according to higher-level state; implementations may use this to choose a more permissive
+   *     or discovery-oriented handshake form.
    */
   void sendHandshake(PeerNode pn, boolean notRegistered);
 
-  /** Is a peer disconnected? */
+  /**
+   * Returns whether the peer referenced by the provided context is considered disconnected.
+   *
+   * <p>The exact policy is transport-specific (e.g., last activity timeout, explicit close, NAT
+   * failure). Implementations should avoid expensive work in this method, as callers may probe it
+   * frequently.
+   *
+   * @param context a peer context associated with an existing or pending connection.
+   * @return {@code true} if the transport treats the peer as disconnected.
+   */
+  @SuppressWarnings("unused")
   boolean isDisconnected(PeerContext context);
 
-  /** List of supported negotiation types in preference order (best last) */
+  /**
+   * Returns the supported negotiation types in preference order.
+   *
+   * <p>The returned array lists negotiation identifiers with the best choice appearing as the last
+   * element. Implementations may vary the list based on the {@code forPublic} flag.
+   *
+   * @param forPublic a hint that the negotiation list is intended for connections exposed to
+   *     non-local peers (implementations decide how to interpret this hint).
+   * @return non-empty array of negotiation identifiers in ascending preference; best is last.
+   */
   int[] supportedNegTypes(boolean forPublic);
 
-  /** The SocketHandler we are connected to. */
+  /**
+   * Returns the {@link SocketHandler} used to send bytes on the underlying transport.
+   *
+   * @return the socket handler that owns the transport I/O.
+   */
   SocketHandler getSocketHandler();
 
-  /** Get our addresses, as peers. */
+  /**
+   * Returns this node's primary addresses represented as {@link Peer} endpoints.
+   *
+   * <p>The list may be empty when the transport cannot determine a stable address set.
+   *
+   * @return array of primary local addresses; may be empty.
+   */
   Peer[] getPrimaryIPAddress();
 
-  /** Get our compressed noderef */
+  /**
+   * Returns the compressed node reference for the local node.
+   *
+   * <p>The exact format and compression are transport- or implementation-defined and suitable for
+   * exchanging a compact self-description with peers.
+   *
+   * @return a byte array containing the compressed node reference.
+   */
+  @SuppressWarnings("unused")
   byte[] getCompressedNoderef();
 
-  /** Always allow local addresses? */
+  /**
+   * Indicates whether local/private addresses are always allowed regardless of other policy.
+   *
+   * @return {@code true} if local addresses are unconditionally permitted.
+   */
   boolean alwaysAllowLocalAddresses();
 
   /**
    * Port forwarding status.
    *
-   * @return A status code from AddressTracker. FIXME make this more generic when we need to.
+   * @return a status code from {@link network.crypta.io.AddressTracker}. FIXME: Consider
+   *     abstracting the return type away from {@code AddressTracker.Status} to a transport-agnostic
+   *     connectivity indicator when multiple transports require it.
    */
   Status getConnectivityStatus();
 
   /**
    * Is there any reason not to allow this connection? E.g. limits on the number of nodes on a
    * specific IP address?
+   *
+   * @param node the peer node we intend to connect to.
+   * @param addr the remote network address under consideration.
+   * @return {@code true} if the connection is permitted by current policy; {@code false} to
+   *     suppress establishing or maintaining the connection.
    */
   boolean allowConnection(PeerNode node, FreenetInetAddress addr);
 
-  /** If the lower level code detects the port forwarding is broken, it will call this method. */
+  /**
+   * Notifies the implementation that port forwarding appears to be broken.
+   *
+   * <p>Implementations should update any cached connectivity state and, if applicable, trigger
+   * re-probing or backoff to avoid repeated failed attempts.
+   */
+  @SuppressWarnings("unused")
   void setPortForwardingBroken();
 }

--- a/src/test/java/network/crypta/io/comm/IncomingPacketFilterImplTest.java
+++ b/src/test/java/network/crypta/io/comm/IncomingPacketFilterImplTest.java
@@ -95,7 +95,7 @@ class IncomingPacketFilterImplTest {
     // Should gather timer entropy with the expected bias
     verify(randomSource, times(1)).acceptTimerEntropy(any(), eq(0.25d));
     // Mangler should not be invoked if the owning PeerNode handled the packet
-    verify(mangler, never()).process(any(), anyInt(), anyInt(), eq(peer), eq(opn), eq(now));
+    verify(mangler, never()).process(any(), anyInt(), anyInt(), eq(peer), eq(opn));
   }
 
   @Test
@@ -103,13 +103,13 @@ class IncomingPacketFilterImplTest {
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
     when(peerManager.getByPeer(peer, mangler)).thenReturn(null);
-    when(mangler.process(buf, 0, buf.length, peer, null, now)).thenReturn(DECODED.DECODED);
+    when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.DECODED);
 
     DECODED result = filter.process(buf, 0, buf.length, peer, now);
 
     assertSame(DECODED.DECODED, result);
     verify(randomSource, times(1)).acceptTimerEntropy(any(), eq(0.25d));
-    verify(mangler, times(1)).process(buf, 0, buf.length, peer, null, now);
+    verify(mangler, times(1)).process(buf, 0, buf.length, peer, null);
   }
 
   // --- process() fallback paths --------------------------------------------
@@ -119,7 +119,7 @@ class IncomingPacketFilterImplTest {
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
     when(peerManager.getByPeer(peer, mangler)).thenReturn(null);
-    when(mangler.process(buf, 0, buf.length, peer, null, now)).thenReturn(DECODED.NOT_DECODED);
+    when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.NOT_DECODED);
 
     PeerNode pn1 = Mockito.mock(PeerNode.class);
     PeerNode pn2 = Mockito.mock(PeerNode.class);
@@ -140,7 +140,7 @@ class IncomingPacketFilterImplTest {
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
     when(peerManager.getByPeer(peer, mangler)).thenReturn(null);
-    when(mangler.process(buf, 0, buf.length, peer, null, now)).thenReturn(DECODED.NOT_DECODED);
+    when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.NOT_DECODED);
 
     PeerNode pn1 = Mockito.mock(PeerNode.class);
     PeerNode pn2 = Mockito.mock(PeerNode.class);
@@ -161,7 +161,7 @@ class IncomingPacketFilterImplTest {
     when(node.getRandom()).thenReturn(randomSource);
     when(node.getPeers()).thenReturn(peerManager);
     when(peerManager.getByPeer(peer, mangler)).thenReturn(null);
-    when(mangler.process(buf, 0, buf.length, peer, null, now)).thenReturn(DECODED.SHUTTING_DOWN);
+    when(mangler.process(buf, 0, buf.length, peer, null)).thenReturn(DECODED.SHUTTING_DOWN);
 
     DECODED result = filter.process(buf, 0, buf.length, peer, now);
 

--- a/src/test/java/network/crypta/node/FNPPacketManglerTest.java
+++ b/src/test/java/network/crypta/node/FNPPacketManglerTest.java
@@ -1,0 +1,188 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import network.crypta.crypt.BlockCipher;
+import network.crypta.crypt.PCFBMode;
+import network.crypta.crypt.SHA256;
+import network.crypta.crypt.UnsupportedCipherException;
+import network.crypta.crypt.ciphers.Rijndael;
+import network.crypta.io.comm.IncomingPacketFilter.DECODED;
+import network.crypta.io.comm.PacketSocketHandler;
+import network.crypta.io.comm.Peer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FNPPacketManglerTest {
+
+  @Mock private Node node;
+  @Mock private NodeCrypto crypto;
+  @Mock private PacketSocketHandler sock;
+
+  private FNPPacketMangler mangler;
+
+  private Peer loopbackPeer;
+
+  @BeforeEach
+  void setUp() throws UnknownHostException {
+    mangler = new FNPPacketMangler(node, crypto, sock);
+    loopbackPeer = new Peer(InetAddress.getByName("127.0.0.1"), 4242);
+
+    // Defaults that keep control-flow simple for most tests
+    lenient().when(node.isStopping()).thenReturn(false);
+    lenient().when(node.getOpennet()).thenReturn(null);
+    lenient().when(crypto.getPeerNodes()).thenReturn(new PeerNode[0]);
+    lenient().when(crypto.wantAnonAuth()).thenReturn(false);
+    lenient().when(crypto.wantAnonAuthChangeIP()).thenReturn(false);
+  }
+
+  @Test
+  void process_whenNodeStopping_returnsShuttingDown() {
+    when(node.isStopping()).thenReturn(true);
+
+    DECODED result = mangler.process(new byte[8], 0, 8, loopbackPeer, null);
+
+    assertSame(DECODED.SHUTTING_DOWN, result);
+  }
+
+  @Test
+  void process_whenNoMatch_andOpennetNull_returnsNotDecoded() {
+    when(node.isStopping()).thenReturn(false);
+    when(node.getOpennet()).thenReturn(null); // no old opennet peers to try
+    when(crypto.wantAnonAuth()).thenReturn(false); // skip anon paths entirely
+
+    DECODED result = mangler.process(new byte[8], 0, 8, loopbackPeer, null);
+
+    assertSame(DECODED.NOT_DECODED, result);
+  }
+
+  @Test
+  void process_whenOpennetPresentButDoesNotWantPeer_returnsDidntWantOpenNet() {
+    OpennetManager opennet = Mockito.mock(OpennetManager.class);
+    when(node.getOpennet()).thenReturn(opennet);
+    // Signal: do not want peers now → code must not try old peers and should return
+    // DIDNT_WANT_OPENNET
+    when(opennet.wantPeer(null, false, true, true, OpennetManager.ConnectionType.RECONNECT))
+        .thenReturn(false);
+    when(crypto.wantAnonAuth()).thenReturn(false);
+
+    DECODED result = mangler.process(new byte[8], 0, 8, loopbackPeer, null);
+
+    assertSame(DECODED.DIDNT_WANT_OPENNET, result);
+  }
+
+  @Test
+  void process_whenOpnManglerMismatch_ignoresProvidedPeerNode_andContinues() {
+    PeerNode opn = Mockito.mock(PeerNode.class);
+    OutgoingPacketMangler other = Mockito.mock(OutgoingPacketMangler.class);
+    when(opn.getOutgoingMangler()).thenReturn(other); // not equal to our mangler
+    when(crypto.wantAnonAuth()).thenReturn(false);
+
+    DECODED result = mangler.process(new byte[8], 0, 8, loopbackPeer, opn);
+
+    // With no anon auth and no opennet, this falls back to NOT_DECODED
+    assertSame(DECODED.NOT_DECODED, result);
+  }
+
+  @Test
+  void process_whenValidAnonAuthPacket_returnsDecoded() throws UnsupportedCipherException {
+    // Arrange anonymous-auth acceptance
+    when(crypto.wantAnonAuth()).thenReturn(true);
+    when(crypto.wantAnonAuthChangeIP()).thenReturn(false);
+
+    // Provide a concrete cipher used by both encoder and mangler
+    Rijndael cipher = new Rijndael(256, 128);
+    byte[] key = new byte[32];
+    for (int i = 0; i < key.length; i++) key[i] = (byte) (i * 7 + 3);
+    cipher.initialize(key);
+    when(crypto.getAnonSetupCipher()).thenReturn(cipher);
+
+    // Build a minimal anonymous-initiator payload (phase 0 → responder path)
+    byte[] payload =
+        new byte[] {
+          1, // version
+          10, // negType (only 10 is supported)
+          0, // packetType (phase 1)
+          1 // setupType = SETUP_OPENNET_SEEDNODE
+        };
+
+    byte[] packet = buildAnonAuthPacket(cipher, payload);
+
+    // Act
+    DECODED result = mangler.process(packet, 0, packet.length, loopbackPeer, null);
+
+    // Assert
+    assertSame(DECODED.DECODED, result);
+  }
+
+  @Test
+  void process_whenAnonAuthPacketWithBadHash_returnsNotDecoded() throws UnsupportedCipherException {
+    when(crypto.wantAnonAuth()).thenReturn(true);
+    when(crypto.wantAnonAuthChangeIP()).thenReturn(false);
+
+    Rijndael cipher = new Rijndael(256, 128);
+    byte[] key = new byte[32];
+    Arrays.fill(key, (byte) 0xA5);
+    cipher.initialize(key);
+    when(crypto.getAnonSetupCipher()).thenReturn(cipher);
+
+    byte[] payload = new byte[] {1, 10, 0, 1};
+    // Deliberately corrupt the hash while keeping structure intact
+    byte[] packet =
+        buildAnonAuthPacketWithCustomHash(cipher, payload, new byte[SHA256.getDigestLength()]);
+
+    DECODED result = mangler.process(packet, 0, packet.length, loopbackPeer, null);
+
+    assertEquals(DECODED.NOT_DECODED, result);
+  }
+
+  // --- helpers --------------------------------------------------------------
+
+  /** Builds an anonymous-auth packet: IV | E(hash) | E(len_hi) E(len_lo) | E(payload). */
+  private static byte[] buildAnonAuthPacket(BlockCipher cipher, byte[] payload) {
+    byte[] hash = SHA256.digest(payload);
+    return buildAnonAuthPacketWithCustomHash(cipher, payload, hash);
+  }
+
+  private static byte[] buildAnonAuthPacketWithCustomHash(
+      BlockCipher cipher, byte[] payload, byte[] hash) {
+    int ivLen = PCFBMode.lengthIV(cipher);
+    byte[] iv = new byte[ivLen]; // deterministic zero IV is fine for tests
+    PCFBMode p = PCFBMode.create(cipher, iv);
+
+    byte[] encHash = Arrays.copyOf(hash, hash.length);
+    p.blockEncipher(encHash, 0, encHash.length);
+
+    int len = payload.length;
+    int b1 = (len >>> 8) & 0xFF;
+    int b2 = len & 0xFF;
+    byte e1 = (byte) p.encipher(b1);
+    byte e2 = (byte) p.encipher(b2);
+
+    byte[] encPayload = Arrays.copyOf(payload, payload.length);
+    p.blockEncipher(encPayload, 0, encPayload.length);
+
+    byte[] out = new byte[ivLen + encHash.length + 2 + encPayload.length];
+    int ofs = 0;
+    System.arraycopy(iv, 0, out, ofs, ivLen);
+    ofs += ivLen;
+    System.arraycopy(encHash, 0, out, ofs, encHash.length);
+    ofs += encHash.length;
+    out[ofs++] = e1;
+    out[ofs++] = e2;
+    System.arraycopy(encPayload, 0, out, ofs, encPayload.length);
+    return out;
+  }
+}


### PR DESCRIPTION
Summary
- Refactors FNPPacketMangler handshake/decoding flow for clarity and testability.
- Drops unused `now` parameter from `FNPPacketMangler.process(...)` and aligned helpers.
- Updates IncomingPacketFilterImpl and its tests to the new signature.
- Adds focused unit tests for FNPPacketMangler covering basic control‑flow cases and anon‑auth paths.
- Improves Javadoc and constant naming for readability.

Why
- The previous `process(...)` mixed several responsibilities and carried a `now` arg that was never used in logic. This change factors the logic into smaller helpers (exact match, peers, anon‑auth, old‑opennet) and removes the dead parameter.
- The refactor makes behavior easier to verify and reason about, and pinpoints return values like DIDNT_WANT_OPENNET when old‑opennet is present but not desired.

Key Changes
- `FNPPacketMangler.process(byte[], int, int, Peer, PeerNode)` — removed `now` parameter; factored flow; tightened logging.
- `IncomingPacketFilterImpl` — updated callsite; behavior unchanged except for clearer return mapping.
- `IncomingPacketFilterImplTest` — expectations updated to reflect the new signature.
- `FNPPacketManglerTest` — new JUnit 6 tests (SHUTTING_DOWN, NOT_DECODED default path, DIDNT_WANT_OPENNET, opn‑mangler mismatch, anon‑auth success and bad‑hash failure).
- Javadoc improvements in `FNPPacketMangler` and minor doc update in `OutgoingPacketMangler`.

Commits
- refactor(node): FNPPacketMangler.process no longer requires now; factor auth paths and improve Javadoc
- test(node): add FNPPacketMangler tests for basic flows
- docs(node): improve Javadoc for OutgoingPacketMangler

Behavior/Risks
- Public API unaffected; internal signature change only within node code.
- Return values are now more explicitly distinguished for old‑opennet pre‑checks; default behavior remains NOT_DECODED when no match is possible and opennet is absent.

Testing
- Local spotlessApply passed to preserve formatting.
- New and updated unit tests compile and run under JUnit 6.

How to Verify
- Build and run tests: `./gradlew test`
- Exercise anon‑auth handshake paths in a local cluster (optional) and confirm logging/return codes.

Notes
- No persistence or protocol format changes.
- No Gradle or dependency changes.
