### PR TITLE
IPv6 scope compatibility, noderef normalization, peer parsing compat, and clearer UnknownHost logs

### DIFF
--- a/src/main/java/network/crypta/io/AddressIdentifier.java
+++ b/src/main/java/network/crypta/io/AddressIdentifier.java
@@ -40,16 +40,15 @@ public class AddressIdentifier {
   public static final Pattern ipv6Pattern;
 
   /**
-   * Like {@link #ipv6Pattern} but allows an optional numeric percent scope ID suffix (for example,
-   * {@code fe80::1%2}). The scope ID is limited to 1–3 ASCII digits; interface names are not
-   * matched by design. Intended for whole-input matching via {@link
+   * Like {@link #ipv6Pattern} but allows an optional percent scope ID suffix (for example, {@code
+   * fe80::1%2} or {@code fe80::1%eth0}). Intended for whole-input matching via {@link
    * java.util.regex.Matcher#matches()}.
    */
   public static final Pattern ipv6PatternWithPercentScopeID;
 
   /**
    * Precompiled, case-insensitive regex for detecting IPv6 ISATAP addresses as defined in
-   * RFC&nbsp;4214. The pattern permits an optional numeric percent scope ID. Use via {@link
+   * RFC&nbsp;4214. The pattern permits an optional percent scope ID. Use via {@link
    * java.util.regex.Matcher#matches()} and prefer the convenience method {@link
    * #isAnISATAPIPv6Address(String)} for boolean checks.
    */
@@ -76,7 +75,8 @@ public class AddressIdentifier {
     ipv4Pattern = Pattern.compile(ipv4AddressRegex);
 
     String wordRegex = "(?>[0-9a-f]{1,4})"; // single hex word; atomic to limit backtracking
-    String percentScopeIDRegex = "(?>%\\d{1,3})?"; // numeric zone index only, by design
+    // Accept numeric or interface-name zone indices: 1–32 of [0-9A-Za-z._-]
+    String percentScopeIDRegex = "(?>%[0-9A-Za-z._-]{1,32})?";
     /*
      * IPv6 recognition in compressed/expanded forms. The following alternatives cover the legal
      * positions of the double-colon run and remaining words (X = hex word):

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -1158,6 +1158,13 @@ public class Node implements TimeSkewDetectorCallback {
         Peer p;
         try {
           p = new Peer(udpAddr, false, true);
+        } catch (UnknownHostException e) {
+          LOG.info(
+              "Unknown host while parsing our darknet node reference: {} (likely host-local scope"
+                  + " or transient DNS)",
+              udpAddr);
+          System.err.println("Unknown host while parsing our darknet node reference: " + udpAddr);
+          continue;
         } catch (HostnameSyntaxException e) {
           LOG.error(
               "Invalid hostname or IP Address syntax error while parsing our darknet node"

--- a/src/main/java/network/crypta/node/NodeCrypto.java
+++ b/src/main/java/network/crypta/node/NodeCrypto.java
@@ -412,8 +412,14 @@ public class NodeCrypto {
       // IP addresses
       Peer[] ips = detector.detectPrimaryPeers();
       if (ips != null) {
-        for (Peer ip : ips)
-          fs.putAppend("physical.udp", ip.toString()); // Keep; important that node know all our IPs
+        for (Peer ip : ips) {
+          // Normalize IPv6 link-local zone to numeric index to keep read-side validator happy.
+          java.net.InetAddress a = ip.getFreenetAddress().getAddress();
+          String host = network.crypta.support.transport.ip.HostnameUtil.toNoderefHost(a);
+          String value =
+              (host != null ? host : ip.getFreenetAddress().toString()) + ':' + ip.getPort();
+          fs.putAppend("physical.udp", value); // important that node know all our IPs
+        }
       }
     } // Don't include IPs for anonymous initiator.
     // Negotiation types

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -796,8 +796,9 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
     String[] physical = fs.getAll(SFS_KEY_PHYSICAL_UDP);
     if (physical != null) {
       for (String phys : physical) {
-        Peer p = tryParsePeerForNominal(phys, fromLocal);
-        if (p != null && !nominalPeer.contains(p)) nominalPeer.add(p);
+        for (Peer p : parsePeerEntryCompat(phys, fromLocal)) {
+          if (p != null && !nominalPeer.contains(p)) nominalPeer.add(p);
+        }
       }
     }
     if (nominalPeer.isEmpty()) {
@@ -810,10 +811,59 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
     updateShortToString();
   }
 
-  private Peer tryParsePeerForNominal(String phys, boolean fromLocal) {
+  /**
+   * Parses a physical.udp entry. In addition to the standard "host:port" form, tolerates a
+   * comma-separated host list with a shared port suffix (e.g., "A,B:port") or multiple comma-
+   * separated full entries (e.g., "A:port,B:port"). Returns zero or more parsed peers.
+   */
+  private List<Peer> parsePeerEntryCompat(String phys, boolean fromLocal) {
+    ArrayList<Peer> out = new ArrayList<>(2);
     try {
-      return new Peer(phys, true, true);
+      out.add(new Peer(phys, true, true));
+      return out;
     } catch (HostnameSyntaxException | PeerParseException | UnknownHostException e) {
+      // Try compatibility forms only if a comma appears.
+      if (phys.indexOf(',') >= 0) {
+        // Pattern: A,B,C:port → apply trailing port to each host
+        int lastColon = phys.lastIndexOf(':');
+        if (lastColon > 0 && lastColon < phys.length() - 1) {
+          String portStr = phys.substring(lastColon + 1);
+          boolean portOk = true;
+          try {
+            int p = Integer.parseInt(portStr);
+            if (p < 0 || p > 65535) portOk = false;
+          } catch (NumberFormatException nfe) {
+            portOk = false;
+          }
+          if (portOk) {
+            String hostList = phys.substring(0, lastColon);
+            String[] hosts = hostList.split(",");
+            for (String h : hosts) {
+              String cand = h.trim() + ":" + portStr;
+              try {
+                out.add(new Peer(cand, true, true));
+              } catch (Exception ignored) {
+                // try next
+              }
+            }
+          }
+        }
+        // Additionally try: split by comma and parse each token as-is (covers A:port,B:port)
+        for (String token : phys.split(",")) {
+          String cand = token.trim();
+          if (cand.isEmpty()) continue;
+          try {
+            Peer parsed = new Peer(cand, true, true);
+            if (!out.contains(parsed)) out.add(parsed);
+          } catch (Exception ignored) {
+            // continue
+          }
+        }
+        if (!out.isEmpty()) {
+          LOG.info("Parsed {} into {} peer(s) via compatibility split", phys, out.size());
+          return out;
+        }
+      }
       if (fromLocal) {
         LOG.error(
             "Invalid hostname or IP Address syntax error while parsing peer reference in local"
@@ -823,7 +873,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
         LOG.warn(
             "Invalid hostname or IP Address syntax error while parsing peer reference: {}", phys);
       }
-      return null;
+      return out;
     }
   }
 
@@ -3198,7 +3248,16 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
   private Peer tryParsePeer(String phys) {
     try {
       return new Peer(phys, true, true);
-    } catch (HostnameSyntaxException | PeerParseException | UnknownHostException e) {
+    } catch (UnknownHostException e) {
+      // Host appears syntactically valid but cannot be resolved here (e.g., link‑local scope name
+      // not present on this host). Lower severity to INFO to avoid noisy logs.
+      LOG.info(
+          STR_INVALID_HOST_OR_IP_WHILE_PARSING
+              + "{} (unresolvable here; likely host-local scope or transient DNS)",
+          phys);
+      return null;
+    } catch (HostnameSyntaxException | PeerParseException e) {
+      // True syntax issues: keep ERROR to surface malformed noderefs.
       LOG.error(STR_INVALID_HOST_OR_IP_WHILE_PARSING + "{}", phys);
       return null;
     }

--- a/src/main/java/network/crypta/node/PeerNode.java
+++ b/src/main/java/network/crypta/node/PeerNode.java
@@ -3225,6 +3225,13 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
   private List<Peer> collectPeersFromPhysical(String[] physical) {
     List<Peer> list = new ArrayList<>(physical.length);
     for (String phys : physical) {
+      if (phys.indexOf(',') >= 0) {
+        // Apply the same compatibility splitting we use for local parsing.
+        for (Peer p : parsePeerEntryCompat(phys, /*fromLocal=*/ false)) {
+          if (p != null && !list.contains(p)) list.add(p);
+        }
+        continue;
+      }
       Peer p = tryParsePeer(phys);
       if (p != null && !list.contains(p)) list.add(p);
     }

--- a/src/main/java/network/crypta/support/transport/ip/HostnameUtil.java
+++ b/src/main/java/network/crypta/support/transport/ip/HostnameUtil.java
@@ -133,9 +133,43 @@ public class HostnameUtil {
     int pct = s.indexOf('%');
     if (pct < 0) return s;
     String scope = s.substring(pct + 1);
-    if (scope.isEmpty() || scope.length() > 3) return null; // conservative numeric scope length
-    for (int i = 0; i < scope.length(); i++) if (!Character.isDigit(scope.charAt(i))) return null;
+    // Accept numeric and common interface-name scopes (1–32 of [0-9A-Za-z._-])
+    if (scope.isEmpty() || scope.length() > 32) return null;
+    for (int i = 0; i < scope.length(); i++) {
+      char c = scope.charAt(i);
+      boolean ok =
+          (c >= '0' && c <= '9')
+              || (c >= 'A' && c <= 'Z')
+              || (c >= 'a' && c <= 'z')
+              || c == '.'
+              || c == '_'
+              || c == '-';
+      if (!ok) return null;
+    }
     return s.substring(0, pct);
+  }
+
+  /**
+   * Produces a noderef-friendly textual host for an {@link java.net.InetAddress}.
+   *
+   * <p>- For IPv4, returns the dotted-quad. - For IPv6, returns the literal; if a zone is present
+   * and the JVM exposes a numeric scope ID, replaces the interface-name zone with the numeric ID
+   * (e.g., "%eth0" -> "%3").
+   */
+  public static String toNoderefHost(java.net.InetAddress addr) {
+    if (addr == null) return null;
+    if (addr instanceof java.net.Inet6Address i6) {
+      String s = i6.getHostAddress();
+      int pct = s.indexOf('%');
+      if (pct >= 0) {
+        int scopeId = i6.getScopeId();
+        if (scopeId > 0) {
+          return s.substring(0, pct + 1) + scopeId;
+        }
+      }
+      return s;
+    }
+    return addr.getHostAddress();
   }
 
   private static boolean hasAtMostOneDoubleColon(String addr) {

--- a/src/test/java/network/crypta/node/DarknetPeerNodeTest.java
+++ b/src/test/java/network/crypta/node/DarknetPeerNodeTest.java
@@ -192,6 +192,36 @@ class DarknetPeerNodeTest {
     assertFalse(node.shouldSendHandshake());
   }
 
+  @Test
+  void parse_physicalUdp_comma_hosts_with_shared_port() throws Exception {
+    SimpleFieldSet sfs =
+        minimalDarknetNoderef("CompatA", new String[] {"198.51.100.10,2001:db8::1:4711"});
+    DarknetPeerNode pn =
+        new DarknetPeerNode(
+            sfs, mockNode, mockCrypto, true, FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.YES, mockPeers);
+
+    SimpleFieldSet out = pn.exportFieldSet();
+    java.util.Set<String> all =
+        new java.util.HashSet<>(java.util.Arrays.asList(out.getAll("physical.udp")));
+    assertTrue(all.contains("198.51.100.10:4711"), "actual=" + all);
+    assertTrue(all.contains("2001:db8:0:0:0:0:0:1:4711"), "actual=" + all);
+  }
+
+  @Test
+  void parse_physicalUdp_comma_separated_full_entries() throws Exception {
+    SimpleFieldSet sfs =
+        minimalDarknetNoderef("CompatB", new String[] {"198.51.100.11:14444,2001:db8::2:14444"});
+    DarknetPeerNode pn =
+        new DarknetPeerNode(
+            sfs, mockNode, mockCrypto, true, FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.YES, mockPeers);
+
+    SimpleFieldSet out = pn.exportFieldSet();
+    java.util.Set<String> all =
+        new java.util.HashSet<>(java.util.Arrays.asList(out.getAll("physical.udp")));
+    assertTrue(all.contains("198.51.100.11:14444"), "actual=" + all);
+    assertTrue(all.contains("2001:db8:0:0:0:0:0:2:14444"), "actual=" + all);
+  }
+
   // --- Helpers ---
 
   private DarknetPeerNode newPeer(String name, String[] addresses) throws Exception {

--- a/src/test/java/network/crypta/support/transport/ip/HostnameUtilTest.java
+++ b/src/test/java/network/crypta/support/transport/ip/HostnameUtilTest.java
@@ -1,9 +1,14 @@
 package network.crypta.support.transport.ip;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.Inet6Address;
+import network.crypta.io.AddressIdentifier;
+import network.crypta.io.AddressIdentifier.AddressType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -93,8 +98,10 @@ class HostnameUtilTest {
           "2001:db8::ffff:192.0.2.1",
           // IPv4-compatible (deprecated, but should still parse as a literal)
           "::192.0.2.1",
-          // With percent scope id (syntactic only)
-          "2001:db8::ffff:192.0.2.1%1"
+          // With percent scope id (syntactic only; accepts numeric and interface-name scopes)
+          "2001:db8::ffff:192.0.2.1%1",
+          "2001:db8::ffff:192.0.2.1%abc",
+          "2001:db8::ffff:192.0.2.1%1234"
         })
     void isValidHostname_whenIpsAllowed_ipv6EmbeddedIPv4_returnTrue(String ip) {
       assertTrue(HostnameUtil.isValidHostname(ip, true));
@@ -108,9 +115,7 @@ class HostnameUtilTest {
           // Invalid IPv4 tail
           "2001:db8::ffff:192.0.256.1",
           "2001:db8::ffff:192.0.2",
-          // Invalid percent scope id (non-numeric or too long or empty)
-          "2001:db8::ffff:192.0.2.1%abc",
-          "2001:db8::ffff:192.0.2.1%1234",
+          // Invalid percent scope id: empty only (non-empty names and longer numeric are allowed)
           "2001:db8::ffff:192.0.2.1%",
           // Bracketed forms are not recognized by this utility
           "[::ffff:192.0.2.1]"
@@ -167,5 +172,21 @@ class HostnameUtilTest {
     void isValidHostname_whenIpsAllowed_invalidHostnames_returnFalse(String domain) {
       assertFalse(HostnameUtil.isValidHostname(domain, true));
     }
+  }
+
+  @Test
+  void ipv6_with_interface_name_scope_is_classified_as_ipv6_and_valid() {
+    String s = "fe80::1%eth0";
+    AddressType t = AddressIdentifier.getAddressType(s, /* allowIPv6PercentScopeID= */ true);
+    assertSame(AddressType.IPV6, t, "expected IPV6 literal classification");
+    assertTrue(HostnameUtil.isValidHostname(s, /* allowIPAddress= */ true));
+  }
+
+  @Test
+  void toNoderefHost_prefers_numeric_scope_when_available() throws Exception {
+    byte[] bytes = new byte[] {(byte) 0xFE, (byte) 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    Inet6Address addr = Inet6Address.getByAddress(null, bytes, /* scope_id= */ 3);
+    String s = HostnameUtil.toNoderefHost(addr);
+    assertEquals("fe80:0:0:0:0:0:0:1%3", s, "got=" + s);
   }
 }


### PR DESCRIPTION
Summary

Fixes parsing and logging issues observed in logs like:
- Invalid hostname or IP Address syntax error while parsing new peer reference: fe80:...%eth0:5519
- Invalid hostname or IP Address syntax error while parsing peer reference: 198.50.223.20,2607:...

This PR:

- Parser: accept IPv6 interface-name scope IDs (e.g., %eth0, %bridge101) in addition to numeric scopes (%3) when classifying IPv6 literals.
- Writer: normalize link‑local IPv6 addresses in noderefs to a numeric scope ID when available, improving portability and re‑reads on the same host.
- Peer parsing robustness: tolerate comma-separated physical.udp entries:
  - A,B:port → parsed as A:port and B:port
  - A:port,B:port → parsed as two entries
- Logging: distinguish UnknownHost (unresolvable here, e.g., host‑local scope name) from true syntax errors and lower UnknownHost to INFO while keeping syntax errors at ERROR/WARN.
- Tests: merge and extend tests under Java suites; remove redundant Kotlin test files.

Details of Changes

- AddressIdentifier
  - Allow IPv6 literals with percent scope IDs containing [0-9A-Za-z._-] (1–32 chars) to support interface-name zones. Numeric scopes remain valid.

- HostnameUtil
  - Add `toNoderefHost(InetAddress)` which returns IPv4 dotted-quad or IPv6 literal, and prefers a numeric scope ID for IPv6 link‑local addresses when the JVM exposes it.

- NodeCrypto
  - When exporting `physical.udp`, use `toNoderefHost()` to produce noderef-friendly host strings.

- PeerNode
  - Add compatibility parsing of `physical.udp` values that contain commas, covering both the shared-port case (`A,B:port`) and the multi-entry case (`A:port,B:port`).
  - While parsing new peer references, log `UnknownHostException` at INFO with a clarifying message and keep true syntax errors at higher severity.

- Node
  - During our own noderef read, log `UnknownHostException` at INFO with context; treat `HostnameSyntaxException` as before.

- Tests (merged into existing Java suites)
  - HostnameUtilTest gains:
    - `ipv6_with_interface_name_scope_is_classified_as_ipv6_and_valid`
    - `toNoderefHost_prefers_numeric_scope_when_available`
    - Adjusted expectations for accepted scope ID variants (numeric and interface‑name); empty scope remains invalid.
  - DarknetPeerNodeTest gains:
    - `parse_physicalUdp_comma_hosts_with_shared_port`
    - `parse_physicalUdp_comma_separated_full_entries`
  - Removed redundant Kotlin tests: AddressIdentifierScopeIdTest, HostnameUtilToNoderefHostTest, and PeerNodeCommaCompatTest.

Why

- Interface-name scope IDs are valid per RFC 4007 and commonly emitted by platforms (e.g., %eth0). Treating them as syntax errors led to noisy logs and dropped addresses.
- Nodes may encounter remote noderefs with commas separating multiple addresses; previously, such entries were rejected wholesale. The compatibility parser recovers individual endpoints where possible.
- Logging at INFO for `UnknownHostException` better reflects the situation (unresolvable here) and reduces error noise, while still surfacing true syntax problems.

Compatibility / Risk

- Address validation is more permissive only for IPv6 percent scopes; hostname validation remains unchanged. The writer normalization prefers numeric scopes (safer for re-reads) without removing information.
- Lowering `UnknownHostException` to INFO does not affect behavior; it improves operator signal/noise.
- Compatibility parsing only adds acceptance for malformed-but-recoverable entries; it does not change well-formed behavior.

How I tested

- Ran targeted unit tests:
  - HostnameUtilTest and DarknetPeerNodeTest new/merged cases.
- Verified targeted Gradle invocation:
  - `./gradlew test --tests "network.crypta.support.transport.ip.HostnameUtilTest" --tests "network.crypta.node.DarknetPeerNodeTest"`
- Confirmed noderef export now writes numeric scope when available; reader accepts interface-name scopes.

Files touched (high level)
- src/main/java/network/crypta/io/AddressIdentifier.java
- src/main/java/network/crypta/support/transport/ip/HostnameUtil.java
- src/main/java/network/crypta/node/NodeCrypto.java
- src/main/java/network/crypta/node/PeerNode.java
- src/main/java/network/crypta/node/Node.java
- src/test/java/network/crypta/support/transport/ip/HostnameUtilTest.java
- src/test/java/network/crypta/node/DarknetPeerNodeTest.java

Request

- Please review the validation and writer changes for scope ID handling and the log-level adjustment for `UnknownHostException`.
- If desired, I can add an optional guard to skip link‑local-with-scope from remote noderefs entirely to avoid even INFO logs.
