### PR TITLE
fix(failure-table): remove unused param and honor apartFrom in peersWantKey

### DIFF
--- a/src/main/java/network/crypta/node/FailureTable.java
+++ b/src/main/java/network/crypta/node/FailureTable.java
@@ -479,10 +479,10 @@ public class FailureTable {
       if (LOG.isDebugEnabled())
         //noinspection ConstantValue
         LOG.debug("Not propagating key: weAsked={} heAsked={}", weAsked, heAsked);
-      removeEntryIfEmpty(entry, key, now);
+      removeEntryIfEmpty(entry, key);
       return;
     }
-    removeEntryIfEmpty(entry, key, now);
+    removeEntryIfEmpty(entry, key);
 
     // Valid offer.
 
@@ -536,7 +536,7 @@ public class FailureTable {
     return a || b;
   }
 
-  private void removeEntryIfEmpty(FailureTableEntry entry, Key key, long now) {
+  private void removeEntryIfEmpty(FailureTableEntry entry, Key key) {
     if (entry.isEmpty()) {
       synchronized (this) {
         entriesByKey.removeKey(key);
@@ -896,7 +896,11 @@ public class FailureTable {
       entry = entriesByKey.get(key);
       if (entry == null) return false; // Nobody cares
     }
-    return entry.othersWant();
+    if (apartFrom == null) {
+      return entry.othersWant();
+    }
+    long now = System.currentTimeMillis();
+    return entry.othersWantExcept(apartFrom, now);
   }
 
   /**

--- a/src/main/java/network/crypta/node/FailureTableEntry.java
+++ b/src/main/java/network/crypta/node/FailureTableEntry.java
@@ -509,6 +509,40 @@ class FailureTableEntry implements TimedOutNodesList {
   }
 
   /**
+   * Returns whether any valid requestor other than {@code apartFrom} remains within the offer
+   * window.
+   *
+   * <p>Also prunes stale requestors. The {@code now} parameter is used to compare against stored
+   * request times.
+   *
+   * @param apartFrom peer to exclude from consideration; may be {@code null}.
+   * @param now current time in milliseconds since epoch.
+   * @return {@code true} if at least one other peer wants the key; {@code false} otherwise.
+   */
+  public synchronized boolean othersWantExcept(PeerNodeUnlocked apartFrom, long now) {
+    boolean anyValid = false;
+    boolean anyOther = false;
+    for (int i = 0; i < requestorNodes.length; i++) {
+      WeakReference<? extends PeerNodeUnlocked> ref = requestorNodes[i];
+      PeerNodeUnlocked pn = (ref == null) ? null : ref.get();
+      if (pn == null) {
+        requestorNodes[i] = null;
+      } else if (pn.getBootID() != requestorBootIDs[i]) {
+        requestorNodes[i] = null;
+      } else if (now - requestorTimes[i] < MAX_TIME_BETWEEN_REQUEST_AND_OFFER) {
+        anyValid = true;
+        if (pn != apartFrom) anyOther = true;
+      }
+    }
+    if (!anyValid) {
+      requestorNodes = EMPTY_WEAK_REFERENCE;
+      requestorTimes = requestorBootIDs = EMPTY_LONG_ARRAY;
+      requestorHTLs = EMPTY_SHORT_ARRAY;
+    }
+    return anyOther;
+  }
+
+  /**
    * Returns whether the given peer asked us for this key within the offer window.
    *
    * <p>Also prunes stale requestors. The {@code now} parameter is used to compare against stored


### PR DESCRIPTION
Summary
- Remove unused `now` parameter from private helper in `FailureTable` and update the two call sites.
- Implement `othersWantExcept(...)` in `FailureTableEntry` to support excluding a specific peer.
- Make `FailureTable#peersWantKey(key, apartFrom)` honor the `apartFrom` parameter as documented.

Rationale
- Resolves static analysis warnings for unused parameters.
- Aligns runtime behavior with Javadoc for `peersWantKey(...)` (exclusion parameter was previously ignored).
- Keeps locking and pruning semantics identical to existing helpers (`othersWant()`, `askedByPeer(...)`).

Risk/Compatibility
- Only private helper signature changed inside `FailureTable` (internal use only).
- New method added in `FailureTableEntry`; referenced only by updated `FailureTable` method.
- No behavior change unless callers rely on the old bug (ignoring `apartFrom`).

Validation
- Local compile succeeded with `./gradlew compileJava`.
- `spotlessApply` run locally; formatting is consistent.

Files
- src/main/java/network/crypta/node/FailureTable.java
- src/main/java/network/crypta/node/FailureTableEntry.java

Request
- Please review for correctness and concurrency/locking assumptions.
- Target base: `develop`.