### PR TITLE
refactor(location): improve docs, expand tests, apply Spotless

### DIFF
--- a/src/main/java/network/crypta/node/Location.java
+++ b/src/main/java/network/crypta/node/Location.java
@@ -4,20 +4,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Utility for working with node positions in a circular keyspace of length {@code 1.0}.
+ *
+ * <p>The valid range for a location is {@code [0.0, 1.0]} (both endpoints are treated as valid
+ * values). Distances are computed on the unit circle and represent the minimal arc length between
+ * two points. Methods in this class are stateless and thread-safe.
+ *
  * @author amphibian
- *     <p>Location of a node in the circular keyspace. ~= specialization. Any number between 0.0 and
- *     1.0 (inclusive) is considered a valid location.
  */
 public class Location {
   private static final Logger LOG = LoggerFactory.getLogger(Location.class);
 
   public static final double LOCATION_INVALID = -1.0;
 
+  private Location() {
+    throw new IllegalStateException("Utility class");
+  }
+
   /**
-   * Parses a location.
+   * Parse a location from text.
    *
-   * @param init a location string
-   * @return the location, or LOCATION_INVALID for all invalid locations and on parse errors.
+   * <p>Accepts any decimal representation of a {@code double}. Values must lie within {@code [0.0,
+   * 1.0]} to be considered valid.
+   *
+   * @param init the textual representation of a location; {@code null} is treated as invalid
+   * @return the parsed value when valid; otherwise {@link #LOCATION_INVALID}
    */
   public static double getLocation(String init) {
     try {
@@ -35,26 +46,29 @@ public class Location {
   }
 
   /**
-   * Distance between a peer and a location.
+   * Compute the absolute circular distance between a peer and a location.
    *
    * @param p a peer with a valid location
    * @param loc a valid location
-   * @return the absolute distance between the peer and the location in the circular location space.
+   * @return the minimal arc length in {@code [0.0, 0.5]} between the peer and {@code loc}
+   * @throws IllegalArgumentException if either input location is invalid
    */
   public static double distance(PeerNode p, double loc) {
     return distance(p.getLocation(), loc);
   }
 
   /**
-   * Distance between two valid locations.
+   * Compute the absolute circular distance between two locations.
    *
    * @param a a valid location
    * @param b a valid location
-   * @return the absolute distance between the locations in the circular location space.
+   * @return the minimal arc length in {@code [0.0, 0.5]}
+   * @throws IllegalArgumentException if either {@code a} or {@code b} is invalid
    */
   public static double distance(double a, double b) {
     if (!isValid(a) || !isValid(b)) {
-      String errMsg = "Invalid Location ! a = " + a + " b = " + b + " Please report this bug!";
+      String errMsg =
+          "Invalid location values: a=" + a + " b=" + b + " (expected within [0.0, 1.0]).";
       LOG.error(errMsg);
       throw new IllegalArgumentException(errMsg);
     }
@@ -62,16 +76,18 @@ public class Location {
   }
 
   /**
-   * Distance between two potentially invalid locations.
+   * Compute the absolute circular distance, tolerating invalid inputs.
    *
-   * @param a a valid location
-   * @param b a valid location
-   * @return the absolute distance between the locations in the circular location space. Invalid
-   *     locations are considered to be at 2.0, and the result is returned accordingly.
+   * <p>Invalid locations are treated as being at {@code 2.0}. When both inputs are invalid, the
+   * distance is {@code 0.0}.
+   *
+   * @param a any location
+   * @param b any location
+   * @return the minimal arc length, or a value derived from the invalid-input rule above
    */
   public static double distanceAllowInvalid(double a, double b) {
     if (!isValid(a) && !isValid(b)) {
-      return 0.0; // Both are out of range so both are equal.
+      return 0.0; // Both invalid: treat as equal.
     }
     if (!isValid(a)) {
       return 2.0 - b;
@@ -79,31 +95,33 @@ public class Location {
     if (!isValid(b)) {
       return 2.0 - a;
     }
-    // Both values are valid.
+    // Both values are valid; compute minimal arc length.
     return simpleDistance(a, b);
   }
 
   /**
-   * Distance between two valid locations without bounds check. The behaviour is undefined for
-   * invalid locations.
+   * Compute absolute distance without validating inputs.
+   *
+   * <p>Behavior is undefined for invalid locations.
    *
    * @param a a valid location
    * @param b a valid location
-   * @return the absolute distance between the two locations in the circular location space.
+   * @return the minimal arc length in {@code [0.0, 0.5]}
    */
   private static double simpleDistance(double a, double b) {
     return Math.abs(change(a, b));
   }
 
   /**
-   * Distance between two locations, including direction of the change (positive/negative). When
-   * given two values on opposite ends of the keyspace, it will return +0.5. The behaviour is
-   * undefined for invalid locations.
+   * Compute the signed circular delta from {@code from} to {@code to}.
+   *
+   * <p>The result lies in {@code (-0.5, 0.5]} after accounting for wrap-around. For points exactly
+   * opposite on the unit circle, the method returns {@code +0.5}. Behavior is undefined for invalid
+   * locations.
    *
    * @param from a valid starting location
    * @param to a valid end location
-   * @return the signed distance from the first to the second location in the circular location
-   *     space
+   * @return the signed delta on the unit circle
    */
   public static double change(double from, double to) {
     double change = to - from;
@@ -117,14 +135,16 @@ public class Location {
   }
 
   /**
-   * Normalize a location to within the valid range. Given an arbitrary double (not bound to [0.0,
-   * 1.0)) return the normalized double [0.0, 1.0) which would result in simple
-   * wrapping/overflowing. e.g. normalize(0.3+1.0)==0.3, normalize(0.3-1.0)==0.3, normalize(x)==x
-   * with x in [0.0, 1.0)
+   * Normalize an arbitrary value into the canonical range.
    *
-   * @bug: if given double has wrapped too many times, the return value may be not be precise.
+   * <p>Maps any {@code double} to {@code [0.0, 1.0)} using modulo arithmetic, preserving the value
+   * modulo {@code 1.0}. For example, {@code normalize(0.3 + 1.0) == 0.3} and {@code normalize(0.3 -
+   * 1.0) == 0.3}.
+   *
+   * <p>Note: very large magnitudes may lose precision due to IEEE&nbsp;754 rounding.
+   *
    * @param rough any location
-   * @return the normalized location
+   * @return the normalized location in {@code [0.0, 1.0)}
    */
   public static double normalize(double rough) {
     double normal = rough % 1.0;
@@ -135,22 +155,24 @@ public class Location {
   }
 
   /**
-   * Tests for equality of two locations. Locations are considered equal if their distance is
-   * (almost) zero, e.g. equals(0.0, 1.0) is true, or if both locations are invalid.
+   * Test whether two locations are effectively equal.
+   *
+   * <p>Returns {@code true} when the circular distance is below a tiny tolerance ({@code 2 *
+   * Double.MIN_VALUE})—for example, {@code equals(0.0, 1.0)}—or when both locations are invalid.
    *
    * @param a any location
    * @param b any location
-   * @return whether the two locations are considered equal
+   * @return {@code true} if considered equal; otherwise {@code false}
    */
   public static boolean equals(double a, double b) {
     return distanceAllowInvalid(a, b) < Double.MIN_VALUE * 2;
   }
 
   /**
-   * Tests whether a location is valid, e.g. within [0.0, 1.0]
+   * Test whether a location lies within {@code [0.0, 1.0]}.
    *
    * @param loc any location
-   * @return whether the location is valid
+   * @return {@code true} if valid; otherwise {@code false}
    */
   public static boolean isValid(double loc) {
     return loc >= 0.0 && loc <= 1.0;

--- a/src/test/java/network/crypta/node/LocationTest.java
+++ b/src/test/java/network/crypta/node/LocationTest.java
@@ -1,10 +1,20 @@
 package network.crypta.node;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class LocationTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class LocationTest {
 
   // Maximal acceptable difference to consider two doubles equal.
   private static final double EPSILON = 1e-12;
@@ -23,7 +33,7 @@ public class LocationTest {
   private static final double INVALID_2 = 1.1;
 
   @Test
-  public void testIsValid() {
+  void isValid_whenWithinAndAtBounds_expectTrueOtherwiseFalse() {
     // Simple cases.
     assertTrue(Location.isValid(VALID_1));
     assertTrue(Location.isValid(VALID_2));
@@ -36,7 +46,7 @@ public class LocationTest {
   }
 
   @Test
-  public void testEquals() {
+  void equals_whenVariousValidAndInvalidCombinations_expectExpectedTruthValues() {
     // Simple cases.
     assertTrue(Location.equals(VALID_1, VALID_1));
     assertTrue(Location.equals(VALID_2, VALID_2));
@@ -61,7 +71,7 @@ public class LocationTest {
   }
 
   @Test
-  public void testDistance() {
+  void distance_whenValidLocations_expectShortestCircularDistance() {
     // Simple cases.
     assertEquals(DIST_12, Location.distance(VALID_1, VALID_2), EPSILON);
     assertEquals(DIST_12, Location.distance(VALID_2, VALID_1), EPSILON);
@@ -78,7 +88,7 @@ public class LocationTest {
   }
 
   @Test
-  public void testChange() {
+  void change_whenValidLocations_expectSignedShortestChange() {
     // Simple cases.
     assertEquals(CHANGE_12, Location.change(VALID_1, VALID_2), EPSILON);
     assertEquals(CHANGE_21, Location.change(VALID_2, VALID_1), EPSILON);
@@ -95,7 +105,7 @@ public class LocationTest {
   }
 
   @Test
-  public void testNormalize() {
+  void normalize_whenOffsetsApplied_expectValueWrappedIntoRange() {
     // Simple cases.
     for (int i = 0; i < 5; i++) {
       assertEquals(VALID_1, Location.normalize(VALID_1 + i), EPSILON);
@@ -109,7 +119,7 @@ public class LocationTest {
   }
 
   @Test
-  public void testDistanceAllowInvalid() {
+  void distanceAllowInvalid_whenAnyInvalid_expectSpecifiedSemantics() {
     // Simple cases.
     assertEquals(DIST_12, Location.distanceAllowInvalid(VALID_1, VALID_2), EPSILON);
     assertEquals(DIST_12, Location.distanceAllowInvalid(VALID_2, VALID_1), EPSILON);
@@ -143,5 +153,76 @@ public class LocationTest {
     assertEquals(0.0, Location.distanceAllowInvalid(INVALID_1, INVALID_2), EPSILON);
     assertEquals(0.0, Location.distanceAllowInvalid(INVALID_2, INVALID_1), EPSILON);
     assertEquals(0.0, Location.distanceAllowInvalid(INVALID_2, INVALID_2), EPSILON);
+  }
+
+  // --- Additional tests for untested public methods ---
+
+  @ParameterizedTest
+  @CsvSource({
+    // valid inputs
+    "0, 0.0",
+    "0.0, 0.0",
+    "1.0, 1.0",
+    "0.25, 0.25",
+    // whitespace tolerated by Double.parseDouble
+    " 0.5 , 0.5"
+  })
+  void getLocation_whenParsableAndInRange_expectSameValue(String input, double expected) {
+    // Act
+    double result = Location.getLocation(input);
+    // Assert
+    assertEquals(expected, result, EPSILON);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    // parse errors
+    "abc",
+    "\"\"",
+    // numbers out of range
+    "-0.1",
+    "1.0000000001",
+    // non-finite values
+    "NaN",
+    "Infinity",
+    "-Infinity"
+  })
+  void getLocation_whenUnparsableOrOutOfRange_expectLocationInvalid(String input) {
+    // Act
+    double result = Location.getLocation(input);
+    // Assert
+    assertEquals(Location.LOCATION_INVALID, result, EPSILON);
+  }
+
+  @Test
+  void getLocation_whenNullInput_expectLocationInvalid() {
+    // Act
+    double result = Location.getLocation(null);
+    // Assert
+    assertEquals(Location.LOCATION_INVALID, result, EPSILON);
+  }
+
+  @Test
+  void distance_withPeerNode_whenPeerAndTargetValid_expectSameAsDoubleDistance() {
+    // Arrange
+    PeerNode peer = Mockito.mock(PeerNode.class);
+    Mockito.when(peer.getLocation()).thenReturn(VALID_1);
+    double expected = Location.distance(VALID_1, VALID_2);
+
+    // Act
+    double result = Location.distance(peer, VALID_2);
+
+    // Assert
+    assertEquals(expected, result, EPSILON);
+  }
+
+  @Test
+  void distance_withPeerNode_whenPeerLocationInvalid_expectIllegalArgumentException() {
+    // Arrange
+    PeerNode peer = Mockito.mock(PeerNode.class);
+    Mockito.when(peer.getLocation()).thenReturn(INVALID_1);
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> Location.distance(peer, VALID_1));
   }
 }


### PR DESCRIPTION
Summary
- Improve Javadoc for `network.crypta.node.Location` and clarify semantics (valid range, circular distance, error messages).
- Make `Location` a non-instantiable utility class (private constructor guard).
- Expand and modernize tests in `LocationTest` (JUnit 6):
  - Parameterized coverage for `getLocation` including null/unparsable/out-of-range inputs.
  - Additional tests for `distance(PeerNode, double)` including invalid peer location.
  - Rename tests to descriptive, behavior-driven names.
- Apply Spotless formatting (google-java-format) to touched files.

Motivation
- Clarify API contracts for location parsing and distance calculations and strengthen test coverage for edge cases.
- Utility-class guard enforces intended static use and prevents accidental instantiation.

Scope of Changes
- Files changed (2):
  - src/main/java/network/crypta/node/Location.java
  - src/test/java/network/crypta/node/LocationTest.java
- Net: 147 insertions, 44 deletions.

Behavior/Risk
- No functional behavior change intended beyond preventing instantiation of `Location`. All methods are static; if any external code attempted `new Location()`, it will now fail at runtime with an IllegalStateException. No such usage was found in this repo during local review.

Testing
- Tests updated and expanded. If CI runs full suite, coverage for `Location` should improve. No other modules impacted.

Notes
- Formatting performed via `./gradlew spotlessApply`.
- Target base: `develop`. Please squash or rebase as desired.
