### PR TITLE
test: Fix ModuloTimeTriggeringPolicyTest boundary race

### DIFF
--- a/src/test/java/network/crypta/support/ModuloTimeTriggeringPolicyTest.java
+++ b/src/test/java/network/crypta/support/ModuloTimeTriggeringPolicyTest.java
@@ -125,8 +125,8 @@ class ModuloTimeTriggeringPolicyTest {
     assertFalse(policy.isTriggeringEvent(null, null));
     policy.setCurrentTimePublic(boundary);
 
-    ZonedDateTime zdtCall =
-        ZonedDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), zone);
+    // Compute expectation from the same instant the policy uses to avoid races.
+    ZonedDateTime zdtCall = ZonedDateTime.ofInstant(Instant.ofEpochMilli(boundary), zone);
     boolean expected = (zdtCall.getHour() % multiple) == 0 && zdtCall.getMinute() == 0;
     assertEquals(policy.isTriggeringEvent(null, null), expected);
   }
@@ -153,8 +153,8 @@ class ModuloTimeTriggeringPolicyTest {
     assertFalse(policy.isTriggeringEvent(null, null));
     policy.setCurrentTimePublic(boundary);
 
-    ZonedDateTime zdtCall =
-        ZonedDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), zone);
+    // Compute expectation from the same instant the policy uses to avoid races.
+    ZonedDateTime zdtCall = ZonedDateTime.ofInstant(Instant.ofEpochMilli(boundary), zone);
     long epochDay = zdtCall.toLocalDate().toEpochDay();
     boolean expected =
         (epochDay % multiple) == 0 && zdtCall.getHour() == 0 && zdtCall.getMinute() == 0;
@@ -183,8 +183,8 @@ class ModuloTimeTriggeringPolicyTest {
     assertFalse(policy.isTriggeringEvent(null, null));
     policy.setCurrentTimePublic(boundary);
 
-    ZonedDateTime zdtCall =
-        ZonedDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), zone);
+    // Compute expectation from the same instant the policy uses to avoid races.
+    ZonedDateTime zdtCall = ZonedDateTime.ofInstant(Instant.ofEpochMilli(boundary), zone);
     long epochDay = zdtCall.toLocalDate().toEpochDay();
     long isoWeekIndex = Math.floorDiv(epochDay + 3, 7);
     boolean expected =
@@ -217,8 +217,8 @@ class ModuloTimeTriggeringPolicyTest {
     assertFalse(policy.isTriggeringEvent(null, null));
     policy.setCurrentTimePublic(boundary);
 
-    ZonedDateTime zdtCall =
-        ZonedDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), zone);
+    // Compute expectation from the same instant the policy uses to avoid races.
+    ZonedDateTime zdtCall = ZonedDateTime.ofInstant(Instant.ofEpochMilli(boundary), zone);
     int monthIndex = zdtCall.getYear() * 12 + (zdtCall.getMonthValue() - 1);
     boolean expected =
         (monthIndex % multiple) == 0
@@ -250,8 +250,8 @@ class ModuloTimeTriggeringPolicyTest {
     assertFalse(policy.isTriggeringEvent(null, null));
     policy.setCurrentTimePublic(boundary);
 
-    ZonedDateTime zdtCall =
-        ZonedDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), zone);
+    // Compute expectation from the same instant the policy uses to avoid races.
+    ZonedDateTime zdtCall = ZonedDateTime.ofInstant(Instant.ofEpochMilli(boundary), zone);
     boolean expected =
         (zdtCall.getYear() % multiple) == 0
             && zdtCall.getDayOfYear() == 1


### PR DESCRIPTION
Summary
- Stabilizes ModuloTimeTriggeringPolicyTest by computing the expected predicate from the same boundary instant the policy evaluates, eliminating a race with System.currentTimeMillis under CI load.

Context
- CI failure observed: “HOUR unit: result matches (hour%N==0 && minute==0) at boundary” — expected was derived from now(), while the policy used a captured boundary instant.
- This could diverge when the minute/hour ticks between those reads.

Changes
- src/test/java/network/crypta/support/ModuloTimeTriggeringPolicyTest.java
  - For HOUR/DAY/WEEK/MONTH/YEAR boundary tests, compute expected using Instant.ofEpochMilli(boundary) instead of System.currentTimeMillis.
  - Keeps the existing assumption to avoid minute-edge races when priming state.

Why safe
- Test-only change. No production code altered.
- Preserves original intent: verify modulo alignment at the enforced boundary.

Local validation
- Ran targeted test: ./gradlew test --tests "*ModuloTimeTriggeringPolicyTest" → PASS.
- Ran full test suite: ./gradlew test → PASS.

Branch & Commit
- Branch: bugfix/modulo-time-policy-test-race
- Conventional commit: test: eliminate race in ModuloTimeTriggeringPolicyTest by deriving expected from boundary instant

Notes
- Formatting enforced via ./gradlew spotlessApply before commit.
