### PR TITLE
docs(node): improve Javadoc and locking notes in KeysFetchingLocally

### DIFF
--- a/src/main/java/network/crypta/node/KeysFetchingLocally.java
+++ b/src/main/java/network/crypta/node/KeysFetchingLocally.java
@@ -2,28 +2,61 @@ package network.crypta.node;
 
 import network.crypta.keys.Key;
 
+/**
+ * Tracks locally running fetch/insert activity and provides routing helpers for scheduling.
+ *
+ * <p>Implementations expose a snapshot of keys currently in flight on this node and lightweight
+ * predicates to avoid duplicate work (for example, skipping a fetch when another request already
+ * handles the same key). Some methods may perform routing probes that are intentionally
+ * heavyweight; callers should avoid invoking them while holding unrelated locks.
+ *
+ * <p>Threading and locking: Implementations may synchronize on internal structures and, for routing
+ * probes, may lock {@code PeerNode} instances and other components. Acquire these locks last
+ * relative to other subsystem locks to prevent deadlocks.
+ */
 public interface KeysFetchingLocally {
 
   /**
-   * If we are fairly sure we'd like to send this request, we need to route it and determine whether
-   * it would be rejected with RecentlyFailed. Note that this method is fairly heavyweight and may
-   * involve locking PeerNode's and possibly other things.
+   * Performs a local routing probe to determine whether sending a request for {@code key} would be
+   * rejected due to a recent failure.
    *
-   * @param key The key to check.
-   * @return 0 if the request can be sent, otherwise the time at which it can be sent. The caller
-   *     must incorporate this into the relevant cooldown structures to avoid an expensive
-   *     recomputation.
+   * <p>This operation can be heavyweight and may lock {@code PeerNode} instances and other
+   * structures. Prefer calling it outside coarse-grained locks.
+   *
+   * @param key the key to evaluate
+   * @param realTime when {@code true}, apply real-time routing heuristics; otherwise use bulk
+   *     heuristics
+   * @return a non-positive value when the request can be sent immediately; otherwise the absolute
+   *     wakeup time (milliseconds since the epoch) when it may be retried. Callers should record
+   *     the returned wakeup in their cooldown tracking to avoid repeated probes.
    */
   long checkRecentlyFailed(Key key, boolean realTime);
 
   /**
-   * Is this key currently being fetched locally? LOCKING: This should be safe just about anywhere,
-   * the lock protecting it is always taken last.
+   * Returns whether {@code key} is currently being fetched by a locally originated request.
+   *
+   * <p>If the key is already in flight and {@code getterWaiting} is non-{@code null},
+   * implementations may register the provided getter to be woken when the in-flight request
+   * completes. Lock ordering must ensure the internal guard lock for this structure is acquired
+   * last.
+   *
+   * @param key the key to test
+   * @param getterWaiting optional requester to register for wakeup when the existing fetch
+   *     completes; may be {@code null}
+   * @return {@code true} if the key is currently fetching locally; otherwise {@code false}
    */
   boolean hasKey(Key key, BaseSendableGet getterWaiting);
 
   /**
-   * Is this request:token pair being executed? FIXME this should be tracked by the inserter itself.
+   * Returns whether the given request:token pair is currently executing.
+   *
+   * <p>Used to avoid duplicate inserts originating from the same scheduler context.
+   *
+   * <p>FIXME: Track the request:token association in the inserter implementation and retire this
+   * interface-level query.
+   *
+   * @param token identifier for the in-flight insert
+   * @return {@code true} if the token is executing locally; otherwise {@code false}
    */
   boolean hasInsert(SendableRequestItemKey token);
 }


### PR DESCRIPTION
Summary
- Improve and complete API documentation for KeysFetchingLocally.
- Clarify purpose, inputs/outputs, real-time vs bulk routing heuristics, and return contract.
- Document locking/threading expectations and side effects when registering waiting getters.
- Refine existing FIXME to be concise and actionable without changing scope.

Scope
- Comments and Javadoc only; no code, signatures, logic, or behavior changes.
- No logging calls were added or removed.

Details
- Type-level Javadoc added to describe role in scheduling and duplication avoidance.
- checkRecentlyFailed(Key, boolean): document heavy-weight probe, realTime semantics, and exact return values (<=0 send now, otherwise absolute wakeup time in ms).
- hasKey(Key, BaseSendableGet): document optional registration of waiting getter and lock ordering (guard lock taken last).
- hasInsert(SendableRequestItemKey): clarify purpose; keep single FIXME with precise forward action.

Rationale
- Aligns with project docs requirement to improve public API docs and inline comments, with emphasis on correct locking guidance and accurate return contracts.
- Aids maintainers and contributors by making scheduler interactions and cooldown handling explicit.

Verification
- Ran Spotless for Java only (spotlessJavaApply) due to an unrelated spotlessKotlinGradle issue on local workspace files. Java formatting succeeded.
- No functional changes; existing tests need not be re-run for this PR.

Change set
- src/main/java/network/crypta/node/KeysFetchingLocally.java (comments/Javadoc only).

CI/Formatting
- Java formatting applied via Spotless.

Risk
- None; documentation-only change.
