### PR TITLE
Refactor MasterKeys: logging, structure, safer I/O; rewrite tests

### DIFF
--- a/src/main/java/network/crypta/node/MasterKeys.java
+++ b/src/main/java/network/crypta/node/MasterKeys.java
@@ -22,19 +22,53 @@ import network.crypta.crypt.UnsupportedCipherException;
 import network.crypta.crypt.ciphers.Rijndael;
 import network.crypta.support.Fields;
 import network.crypta.support.io.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/** Keys read from the master keys file */
+/**
+ * Holds the node's master secrets and manages persistence in {@code master.keys}.
+ *
+ * <p>The on-disk format (version 1) stores, in order:
+ *
+ * <ul>
+ *   <li>{@code flags} (8 bytes, reserved for future use)
+ *   <li>client cache key (32 bytes)
+ *   <li>database key (32 bytes)
+ *   <li>persistent tempfiles master secret (64 bytes)
+ * </ul>
+ *
+ * The payload is encrypted using a key derived from the supplied password, a per-file salt, and
+ * iterations of SHA-256. Integrity is verified with a truncated hash.
+ *
+ * <p>Instances are lightweight containers for decoded secrets. Backing arrays are mutable; callers
+ * must not modify them unless they fully understand the ramifications. Use {@link #clear(byte[])}
+ * to wipe arrays when no longer needed.
+ */
 public class MasterKeys {
 
-  // Currently we only encrypt the client cache
+  private static final Logger LOG = LoggerFactory.getLogger(MasterKeys.class);
+
+  // Currently only the client cache uses this key for its legacy persistence.
 
   final byte[] clientCacheMasterKey;
   private final byte[] databaseKey;
   private final byte[] tempfilesMasterSecret;
   final long flags;
 
-  static final long FLAG_ENCRYPT_DATABASE = 2;
+  // Reserved feature flags (none defined at present).
 
+  /**
+   * Constructs a new bundle of master secrets.
+   *
+   * <p>Inputs are stored by reference; they are not defensively copied here. Callers should clear
+   * or replace their arrays if further mutation is undesired.
+   *
+   * @param clientCacheKey 32-byte key for the client cache; must not be {@code null}.
+   * @param databaseKey 32-byte database key; must not be {@code null}.
+   * @param tempfilesMasterSecret 64-byte secret for persistent encrypted tempfiles; must not be
+   *     {@code null}.
+   * @param flags reserved value for future format extensions.
+   */
   public MasterKeys(
       byte[] clientCacheKey, byte[] databaseKey, byte[] tempfilesMasterSecret, long flags) {
     this.clientCacheMasterKey = clientCacheKey;
@@ -44,10 +78,11 @@ public class MasterKeys {
   }
 
   /**
-   * Create a MasterKeys with random keys.
+   * Creates a new instance with randomly generated secrets.
    *
-   * @param random A secure RNG. Not specifically a SecureRandom because we want to be able to use
-   *     this in tests.
+   * @param random randomness source; for production, supply a cryptographically strong RNG.
+   * @return a new {@code MasterKeys} with 32-byte client cache and database keys and a 64-byte
+   *     tempfiles master secret.
    */
   public static MasterKeys createRandom(Random random) {
     byte[] clientCacheKey = new byte[32];
@@ -59,30 +94,49 @@ public class MasterKeys {
     return new MasterKeys(clientCacheKey, databaseKey, tempfilesMasterSecret, 0);
   }
 
-  void clearClientCacheKeys() {
-    clear(clientCacheMasterKey);
-  }
-
   static final int OLD_HASH_LENGTH = 4;
   static final int HASH_LENGTH = 12;
 
   static final int VERSION = 1;
 
-  /** Sanity check */
+  /** Upper bound to prevent pathological iteration counts. */
   static final long MAX_ITERATIONS = 1L << 40;
 
-  /**
-   * Time in milliseconds to iterate for when encrypting a non-empty password. FIXME make this
-   * configurable. FIXME Have a look at real password to key functions.
-   */
-  static int ITERATE_TIME = 1000;
+  /** Time budget in milliseconds for password-key derivation when a password is non-empty. */
+  static int iterateTime = 1000;
 
+  /**
+   * Test-only hook to adjust the password derivation duration. Keeps unit tests fast and
+   * deterministic without affecting production defaults.
+   */
+  @SuppressWarnings("SameParameterValue")
+  static void setIterateTimeForTests(int millis) {
+    iterateTime = millis;
+  }
+
+  /**
+   * Reads or initializes the master keys from {@code master.keys}.
+   *
+   * <p>If a supported file exists, it is decrypted and parsed. If an old-format file is detected,
+   * it is migrated in place to the current format. If the file is missing, a new one is generated
+   * and written.
+   *
+   * @param masterKeysFile path to {@code master.keys}; must refer to a readable/writable file
+   *     location.
+   * @param hardRandom randomness source used for salts, IVs, and newly generated secrets.
+   * @param password UTF-8 password used to derive the encryption key; may be empty to disable key
+   *     stretching.
+   * @return decoded secrets contained in the file, or newly generated values when the file does not
+   *     exist.
+   * @throws MasterKeysWrongPasswordException when decryption or integrity verification fails with
+   *     the provided password.
+   * @throws MasterKeysFileSizeException when the file length is outside expected bounds.
+   * @throws IOException on I/O errors while reading or writing the file.
+   */
   public static MasterKeys read(File masterKeysFile, Random hardRandom, String password)
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
-    System.err.println("Trying to read master keys file...");
+    LOG.info("Reading master.keys file");
     if (masterKeysFile != null && masterKeysFile.exists()) {
-      // Try to read the keys
-      // FIXME move declarations of sensitive data out and clear() in finally {}
       long len = masterKeysFile.length();
       if (len > 1024) throw new MasterKeysFileSizeException(true);
       if (len < (32 + 32 + 8 + 32)) throw new MasterKeysFileSizeException(false);
@@ -91,100 +145,120 @@ public class MasterKeys {
           DataInputStream dis = new DataInputStream(fis)) {
         if (len == 140) {
           MasterKeys ret = readOldFormat(dis, length, hardRandom, password);
-          System.out.println(
-              "Read old-format master keys file. Writing new format master.keys ...");
+          LOG.info("Old-format master.keys detected; writing new format");
           ret.changePassword(masterKeysFile, password, hardRandom);
           return ret;
         }
-        if (dis.readInt() != VERSION) throw new IOException("Bad version for master.keys");
-        long iterations = dis.readLong();
-        if (iterations < 0 || iterations > MAX_ITERATIONS)
-          throw new IOException("Bad iterations " + iterations + " for master.keys");
-
-        byte[] salt = new byte[32];
-        dis.readFully(salt);
-        byte[] iv = new byte[32];
-        dis.readFully(iv);
-        byte[] dataAndHash = new byte[length - salt.length - iv.length - 4 - 8];
-        dis.readFully(dataAndHash);
-        //				System.err.println("Data and hash: "+HexUtil.bytesToHex(dataAndHash));
-        byte[] pwd = password.getBytes(StandardCharsets.UTF_8);
-        MessageDigest md = SHA256.getMessageDigest();
-        md.update(pwd);
-        md.update(salt);
-        byte[] outerKey = md.digest();
-        if (iterations > 0) {
-          System.out.println(
-              "Decrypting master keys using password with " + iterations + " iterations...");
-          for (long i = 0; i < iterations; i++) {
-            md.update(salt);
-            md.update(outerKey);
-            outerKey = md.digest();
-          }
-        }
-        BlockCipher cipher;
-        try {
-          cipher = new Rijndael(256, 256);
-        } catch (UnsupportedCipherException e) {
-          // Impossible
-          throw new Error(e);
-        }
-        //				System.err.println("Outer key: "+HexUtil.bytesToHex(outerKey));
-        cipher.initialize(outerKey);
-        PCFBMode pcfb = PCFBMode.create(cipher, iv);
-        pcfb.blockDecipher(dataAndHash, 0, dataAndHash.length);
-        //				System.err.println("Decrypted data and hash: "+HexUtil.bytesToHex(dataAndHash));
-        byte[] data = Arrays.copyOf(dataAndHash, dataAndHash.length - HASH_LENGTH);
-        byte[] hash = Arrays.copyOfRange(dataAndHash, data.length, dataAndHash.length);
-        //				System.err.println("Data: "+HexUtil.bytesToHex(data));
-        //				System.err.println("Hash: "+HexUtil.bytesToHex(hash));
-        clear(dataAndHash);
-        byte[] checkHash = md.digest(data);
-        //				System.err.println("Check hash: "+HexUtil.bytesToHex(checkHash));
-        if (!Fields.byteArrayEqual(checkHash, hash, 0, 0, HASH_LENGTH)) {
-          clear(data);
-          clear(hash);
-          throw new MasterKeysWrongPasswordException();
-        }
-
-        // It matches. Now decode it.
-        ByteArrayInputStream bais = new ByteArrayInputStream(data);
-        DataInputStream dataStream = new DataInputStream(bais);
-        long flags = dataStream.readLong();
-        // At the moment there are no interesting flags.
-        // In future the flags will tell us whether the database and the datastore are encrypted.
-        byte[] clientCacheKey = new byte[32];
-        dataStream.readFully(clientCacheKey);
-        byte[] databaseKey = null;
-        databaseKey = new byte[32];
-        dataStream.readFully(databaseKey);
-        byte[] tempfilesMasterSecret = new byte[64];
-        boolean mustWrite = false;
-        if (data.length >= 8 + 32 + 32 + 64) {
-          dataStream.readFully(tempfilesMasterSecret);
-        } else {
-          System.err.println("Created new master secret for encrypted tempfiles");
-          hardRandom.nextBytes(tempfilesMasterSecret);
-          mustWrite = true;
-        }
-        MasterKeys ret = new MasterKeys(clientCacheKey, databaseKey, tempfilesMasterSecret, flags);
-        clear(data);
-        clear(hash);
-        System.err.println("Read old master keys file");
-        if (mustWrite) {
-          ret.changePassword(masterKeysFile, password, hardRandom);
-        }
-        return ret;
+        return readNewFormat(dis, length, hardRandom, password, masterKeysFile);
       } catch (FileNotFoundException e) {
         // Ok, create a new one.
       } catch (EOFException e) {
         throw new MasterKeysFileSizeException(false);
       }
     }
-    System.err.println("Creating new master keys file");
+    LOG.info("Creating new master.keys file");
     MasterKeys ret = createRandom(hardRandom);
     ret.write(masterKeysFile, password, hardRandom);
     return ret;
+  }
+
+  private static MasterKeys readNewFormat(
+      DataInputStream dis, int length, Random hardRandom, String password, File masterKeysFile)
+      throws IOException, MasterKeysWrongPasswordException {
+    if (dis.readInt() != VERSION) throw new IOException("Bad version for master.keys");
+    long iterations = dis.readLong();
+    if (iterations < 0 || iterations > MAX_ITERATIONS)
+      throw new IOException("Bad iterations " + iterations + " for master.keys");
+
+    byte[] salt = new byte[32];
+    dis.readFully(salt);
+    byte[] iv = new byte[32];
+    dis.readFully(iv);
+    byte[] dataAndHash = new byte[length - salt.length - iv.length - 4 - 8];
+    dis.readFully(dataAndHash);
+
+    MessageDigest md = SHA256.getMessageDigest();
+    byte[] outerKey = deriveOuterKey(password, salt, iterations, md);
+
+    byte[] data = decryptAndVerify(dataAndHash, outerKey, iv, md);
+
+    Decoded decoded = decodeV1Data(data, hardRandom);
+    MasterKeys ret = decoded.keys();
+    if (decoded.mustWrite()) {
+      LOG.info("Create new master secret for encrypted tempfiles");
+      ret.changePassword(masterKeysFile, password, hardRandom);
+    }
+    return ret;
+  }
+
+  private static byte[] deriveOuterKey(
+      String password, byte[] salt, long iterations, MessageDigest md) {
+    byte[] pwd = password.getBytes(StandardCharsets.UTF_8);
+    md.update(pwd);
+    md.update(salt);
+    byte[] outerKey = md.digest();
+    if (iterations > 0) {
+      LOG.info("Deriving password key with {} iterations", iterations);
+      for (long i = 0; i < iterations; i++) {
+        md.update(salt);
+        md.update(outerKey);
+        outerKey = md.digest();
+      }
+    }
+    return outerKey;
+  }
+
+  private static byte[] decryptAndVerify(
+      byte[] dataAndHash, byte[] outerKey, byte[] iv, MessageDigest md)
+      throws MasterKeysWrongPasswordException {
+    BlockCipher cipher = newRijndael256();
+    cipher.initialize(outerKey);
+    PCFBMode pcfb = PCFBMode.create(cipher, iv);
+    pcfb.blockDecipher(dataAndHash, 0, dataAndHash.length);
+    byte[] data = Arrays.copyOf(dataAndHash, dataAndHash.length - HASH_LENGTH);
+    byte[] hash = Arrays.copyOfRange(dataAndHash, data.length, dataAndHash.length);
+    clear(dataAndHash);
+    byte[] checkHash = md.digest(data);
+    if (!Fields.byteArrayEqual(checkHash, hash, 0, 0, HASH_LENGTH)) {
+      clear(data);
+      clear(hash);
+      throw new MasterKeysWrongPasswordException();
+    }
+    clear(hash);
+    return data;
+  }
+
+  private static BlockCipher newRijndael256() {
+    try {
+      return new Rijndael(256, 256);
+    } catch (UnsupportedCipherException e) {
+      // Should never happen in supported environments; treat as unrecoverable configuration error.
+      throw new IllegalStateException("AES-256 Rijndael cipher not available", e);
+    }
+  }
+
+  private record Decoded(MasterKeys keys, boolean mustWrite) {}
+
+  private static Decoded decodeV1Data(byte[] data, Random hardRandom) throws IOException {
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        DataInputStream dataStream = new DataInputStream(bais)) {
+      long flags = dataStream.readLong();
+      byte[] clientCacheKey = new byte[32];
+      dataStream.readFully(clientCacheKey);
+      byte[] databaseKey = new byte[32];
+      dataStream.readFully(databaseKey);
+      byte[] tempfilesMasterSecret = new byte[64];
+      boolean mustWrite = false;
+      if (data.length >= 8 + 32 + 32 + 64) {
+        dataStream.readFully(tempfilesMasterSecret);
+      } else {
+        hardRandom.nextBytes(tempfilesMasterSecret);
+        mustWrite = true;
+      }
+      MasterKeys ret = new MasterKeys(clientCacheKey, databaseKey, tempfilesMasterSecret, flags);
+      clear(data);
+      return new Decoded(ret, mustWrite);
+    }
   }
 
   private static MasterKeys readOldFormat(
@@ -196,53 +270,38 @@ public class MasterKeys {
     dis.readFully(iv);
     byte[] dataAndHash = new byte[length - salt.length - iv.length];
     dis.readFully(dataAndHash);
-    //      System.err.println("Data and hash: "+HexUtil.bytesToHex(dataAndHash));
     byte[] pwd = password.getBytes(StandardCharsets.UTF_8);
     MessageDigest md = SHA256.getMessageDigest();
     md.update(pwd);
     md.update(salt);
     byte[] outerKey = md.digest();
-    BlockCipher cipher;
-    try {
-      cipher = new Rijndael(256, 256);
-    } catch (UnsupportedCipherException e) {
-      // Impossible
-      throw new Error(e);
-    }
-    //      System.err.println("Outer key: "+HexUtil.bytesToHex(outerKey));
+    BlockCipher cipher = newRijndael256();
     cipher.initialize(outerKey);
     PCFBMode pcfb = PCFBMode.create(cipher, iv);
     pcfb.blockDecipher(dataAndHash, 0, dataAndHash.length);
-    //      System.err.println("Decrypted data and hash: "+HexUtil.bytesToHex(dataAndHash));
     byte[] data = Arrays.copyOf(dataAndHash, dataAndHash.length - OLD_HASH_LENGTH);
     byte[] hash = Arrays.copyOfRange(dataAndHash, data.length, dataAndHash.length);
-    //      System.err.println("Data: "+HexUtil.bytesToHex(data));
-    //      System.err.println("Hash: "+HexUtil.bytesToHex(hash));
     clear(dataAndHash);
     byte[] checkHash = md.digest(data);
-    //      System.err.println("Check hash: "+HexUtil.bytesToHex(checkHash));
     if (!Fields.byteArrayEqual(checkHash, hash, 0, 0, OLD_HASH_LENGTH)) {
       clear(data);
       clear(hash);
       throw new MasterKeysWrongPasswordException();
     }
 
-    // It matches. Now decode it.
+    // Integrity check passed; decode the legacy payload.
     ByteArrayInputStream bais = new ByteArrayInputStream(data);
     dis = new DataInputStream(bais);
-    // FIXME Fields.longToBytes and dis.readLong may not be compatible, find out if they are.
     byte[] flagsBytes = new byte[8];
     dis.readFully(flagsBytes);
     long flags = Fields.bytesToLong(flagsBytes);
-    // At the moment there are no interesting flags.
-    // In future the flags will tell us whether the database and the datastore are encrypted.
+    // Flags are reserved. Future formats may indicate which subsystems are encrypted.
     byte[] clientCacheKey = new byte[32];
     dis.readFully(clientCacheKey);
-    byte[] databaseKey = null;
-    databaseKey = new byte[32];
+    byte[] databaseKey = new byte[32];
     dis.readFully(databaseKey);
     byte[] tempfilesMasterSecret = new byte[64];
-    System.err.println("Created new master secret for encrypted tempfiles");
+    LOG.info("Create new master secret for encrypted tempfiles");
     hardRandom.nextBytes(tempfilesMasterSecret);
     MasterKeys ret = new MasterKeys(clientCacheKey, databaseKey, tempfilesMasterSecret, flags);
     clear(data);
@@ -250,22 +309,37 @@ public class MasterKeys {
     return ret;
   }
 
+  /**
+   * Overwrites the provided byte array with zeros.
+   *
+   * @param buf target buffer; may be {@code null} for a no-op.
+   */
   public static void clear(byte[] buf) {
     if (buf == null) return; // Valid no-op, simplifies code
     Arrays.fill(buf, (byte) 0x00);
   }
 
+  /**
+   * Re-encrypts and writes {@code master.keys} with a new password.
+   *
+   * <p>Uses fresh salt and IV. The file is rewritten in place and synced.
+   *
+   * @param masterKeysFile destination file; must be writable.
+   * @param newPassword UTF-8 password; may be empty to store with minimal derivation.
+   * @param hardRandom randomness source for salt/IV.
+   * @throws IOException on I/O failures.
+   */
   public void changePassword(File masterKeysFile, String newPassword, Random hardRandom)
       throws IOException {
-    System.err.println("Writing new master.keys file");
+    LOG.info("Writing master.keys file");
     write(masterKeysFile, newPassword, hardRandom);
   }
 
   private void write(File masterKeysFile, String newPassword, Random hardRandom)
       throws IOException {
-    // Write it to a byte[], check size, then replace in-place atomically
+    // Assemble the encrypted blob in memory, then replace the file contents.
 
-    // New IV, new salt, same client cache key, same database key
+    // New IV and salt; payload carries existing keys and flags.
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -282,7 +356,7 @@ public class MasterKeys {
     long iterations = 0;
     if (!newPassword.isEmpty()) {
       long startTime = System.currentTimeMillis();
-      while (System.currentTimeMillis() < startTime + ITERATE_TIME
+      while (System.currentTimeMillis() < startTime + iterateTime
           && iterations < MAX_ITERATIONS - 20) {
         for (int i = 0; i < 10; i++) {
           iterations++;
@@ -291,7 +365,7 @@ public class MasterKeys {
           outerKey = md.digest();
         }
       }
-      System.out.println("Encrypted password with " + iterations + " iterations.");
+      LOG.info("Derived password key with {} iterations.", iterations);
     }
 
     DataOutputStream dos = new DataOutputStream(baos);
@@ -312,29 +386,22 @@ public class MasterKeys {
     baos.write(hash, 0, HASH_LENGTH);
     data = baos.toByteArray();
 
-    BlockCipher cipher;
-    try {
-      cipher = new Rijndael(256, 256);
-    } catch (UnsupportedCipherException e) {
-      // Impossible
-      throw new Error(e);
-    }
+    BlockCipher cipher = newRijndael256();
     cipher.initialize(outerKey);
     PCFBMode pcfb = PCFBMode.create(cipher, iv);
     pcfb.blockEncipher(data, hashedStart, data.length - hashedStart);
 
-    RandomAccessFile raf = new RandomAccessFile(masterKeysFile, "rw");
-
-    raf.seek(0);
-    raf.write(data);
-    long len = raf.length();
-    if (len > data.length) {
-      byte[] diff = new byte[(int) (len - data.length)];
-      raf.write(diff);
-      raf.setLength(data.length);
+    try (RandomAccessFile raf = new RandomAccessFile(masterKeysFile, "rw")) {
+      raf.seek(0);
+      raf.write(data);
+      long len = raf.length();
+      if (len > data.length) {
+        byte[] diff = new byte[(int) (len - data.length)];
+        raf.write(diff);
+        raf.setLength(data.length);
+      }
+      raf.getFD().sync();
     }
-    raf.getFD().sync();
-    raf.close();
   }
 
   public static void killMasterKeys(File masterKeysFile) throws IOException {
@@ -342,22 +409,25 @@ public class MasterKeys {
   }
 
   /**
-   * @param unused randomness source object. Note: this parameter is not used in this call, and
-   *     database key material is generated during or before construction of the {@link MasterKeys}
-   *     object.
-   * @return database key object
-   * @deprecated use other {@link #createDatabaseKey()} method without parameters
+   * Returns a database key wrapper for deriving component-specific keys.
+   *
+   * <p>The returned {@link DatabaseKey} defends against external mutation by copying the secret
+   * internally.
+   *
+   * @return a new {@link DatabaseKey} based on the stored database key.
    */
-  @Deprecated
-  public DatabaseKey createDatabaseKey(Random unused) {
-    return createDatabaseKey();
-  }
-
   public DatabaseKey createDatabaseKey() {
     return new DatabaseKey(databaseKey);
   }
 
-  /** Used for creating keys for persistent encrypted tempfiles */
+  /**
+   * Returns the master secret used to derive keys for persistent encrypted tempfiles.
+   *
+   * <p>The returned {@link MasterSecret} receives a clone of the underlying bytes so subsequent
+   * mutations by the caller do not affect this instance.
+   *
+   * @return a {@link MasterSecret} for tempfiles encryption.
+   */
   public MasterSecret getPersistentMasterSecret() {
     return new MasterSecret(tempfilesMasterSecret.clone());
   }

--- a/src/test/java/network/crypta/node/MasterKeysTest.java
+++ b/src/test/java/network/crypta/node/MasterKeysTest.java
@@ -1,52 +1,67 @@
 package network.crypta.node;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Random;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.MasterSecret;
-import network.crypta.support.io.FileUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class MasterKeysTest {
+@SuppressWarnings("java:S100") // test method naming style: method_whenCondition_expectOutcome
+class MasterKeysTest {
 
-  private final File base = new File("tmp.master-keys-test");
+  @TempDir File base;
+  private int prevIterateTime;
 
   @BeforeEach
-  public void setUp() {
-    FileUtil.removeAll(base);
-    base.mkdir();
-    MasterKeys.ITERATE_TIME = 100; // Speed up test.
+  void setUp() {
+    // Keep password hashing loop instantaneous for deterministic, fast tests.
+    // Remember the current value so we can restore it after each test run.
+    prevIterateTime = MasterKeys.iterateTime;
+    MasterKeys.setIterateTimeForTests(0);
   }
 
   @AfterEach
-  public void tearDown() {
-    FileUtil.removeAll(base);
+  void tearDown() {
+    // Restore production/default behavior for subsequent tests in the same JVM.
+    MasterKeys.setIterateTimeForTests(prevIterateTime);
   }
 
   @Test
-  public void testRestartNoPassword()
+  void read_whenNoPassword_persistsAndRestoresSameKeys()
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
-    testRestart("");
+    read_persistsAndRestoresSameKeys("");
   }
 
   @Test
-  public void testRestartWithPassword()
+  void read_whenWithPassword_persistsAndRestoresSameKeys()
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
-    testRestart("password");
+    read_persistsAndRestoresSameKeys("password");
   }
 
-  private void testRestart(String password)
+  private void read_persistsAndRestoresSameKeys(String password)
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
     File keysFile = new File(base, "test.master.keys");
     DummyRandomSource random = new DummyRandomSource(77391);
+
     MasterKeys original = MasterKeys.read(keysFile, random, password);
     byte[] clientCacheMasterKey = original.clientCacheMasterKey;
     DatabaseKey dkey = original.createDatabaseKey();
     MasterSecret tempfileMasterSecret = original.getPersistentMasterSecret();
+
     MasterKeys restored = MasterKeys.read(keysFile, random, password);
     assertArrayEquals(clientCacheMasterKey, restored.clientCacheMasterKey);
     assertEquals(dkey, restored.createDatabaseKey());
@@ -54,51 +69,143 @@ public class MasterKeysTest {
   }
 
   @Test
-  public void testChangePasswordEmptyToSomething()
+  void changePassword_whenEmptyToSomething_oldPasswordRejectedNewAccepted()
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
-    testChangePassword("", "password");
+    changePassword_preservesKeysAndEnforcesNewPassword("", "password");
   }
 
   @Test
-  public void testChangePasswordEmptyToEmpty()
+  void changePassword_whenEmptyToEmpty_oldPasswordStillAccepted()
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
-    testChangePassword("", "");
+    changePassword_preservesKeysAndEnforcesNewPassword("", "");
   }
 
   @Test
-  public void testChangePasswordSomethingToEmpty()
+  void changePassword_whenSomethingToEmpty_oldPasswordRejectedAndKeysStable()
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
-    testChangePassword("password", "");
+    changePassword_preservesKeysAndEnforcesNewPassword("password", "");
   }
 
   @Test
-  public void testChangePasswordSomethingToSomething()
+  void changePassword_whenSomethingToSomething_oldPasswordRejectedAndKeysStable()
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
-    testChangePassword("password", "new password");
+    changePassword_preservesKeysAndEnforcesNewPassword("password", "new password");
   }
 
-  private void testChangePassword(String oldPassword, String newPassword)
+  private void changePassword_preservesKeysAndEnforcesNewPassword(
+      String oldPassword, String newPassword)
       throws MasterKeysWrongPasswordException, MasterKeysFileSizeException, IOException {
     File keysFile = new File(base, "test.master.keys");
     DummyRandomSource random = new DummyRandomSource(77391);
+
     MasterKeys original = MasterKeys.read(keysFile, random, oldPassword);
     byte[] clientCacheMasterKey = original.clientCacheMasterKey;
     DatabaseKey dkey = original.createDatabaseKey();
     MasterSecret tempfileMasterSecret = original.getPersistentMasterSecret();
-    // Change password.
+
+    // Act: change password and reload
     original.changePassword(keysFile, newPassword, random);
-    // Now restore.
+
     if (!oldPassword.equals(newPassword)) {
-      try {
-        MasterKeys.read(keysFile, random, oldPassword);
-        fail("Old password should not work!");
-      } catch (MasterKeysWrongPasswordException e) {
-        // Ok.
-      }
+      assertThrows(
+          MasterKeysWrongPasswordException.class,
+          () -> MasterKeys.read(keysFile, random, oldPassword));
     }
+
     MasterKeys restored = MasterKeys.read(keysFile, random, newPassword);
     assertArrayEquals(clientCacheMasterKey, restored.clientCacheMasterKey);
     assertEquals(dkey, restored.createDatabaseKey());
     assertEquals(tempfileMasterSecret, restored.getPersistentMasterSecret());
+  }
+
+  @Test
+  void clear_whenNull_doesNothing() {
+    assertDoesNotThrow(() -> MasterKeys.clear(null));
+  }
+
+  @Test
+  void clear_whenNonNull_zerosArray() {
+    byte[] buf = new byte[] {1, 2, 3, (byte) 0xFF};
+    MasterKeys.clear(buf);
+    assertArrayEquals(new byte[] {0, 0, 0, 0}, buf);
+  }
+
+  @Test
+  void killMasterKeys_whenExistingFile_deletesFile() throws IOException {
+    File f = new File(base, "to-delete.master.keys");
+    try (FileOutputStream os = new FileOutputStream(f)) {
+      os.write(new byte[] {1, 2, 3, 4});
+    }
+    assertTrue(f.exists());
+    MasterKeys.killMasterKeys(f);
+    assertFalse(f.exists());
+  }
+
+  @Test
+  void read_whenFileTooSmall_throwsFileSizeExceptionTooSmall() throws IOException {
+    File f = new File(base, "too-small.master.keys");
+    try (FileOutputStream os = new FileOutputStream(f)) {
+      // Minimum acceptable is 32 + 32 + 8 + 32 = 104
+      os.write(new byte[100]);
+    }
+    MasterKeysFileSizeException ex =
+        assertThrows(MasterKeysFileSizeException.class, () -> MasterKeys.read(f, new Random(), ""));
+    assertFalse(ex.isTooBig());
+    assertEquals("small", ex.sizeToString());
+  }
+
+  @Test
+  void read_whenFileTooBig_throwsFileSizeExceptionTooBig() throws IOException {
+    File f = new File(base, "too-big.master.keys");
+    try (FileOutputStream os = new FileOutputStream(f)) {
+      os.write(new byte[1025]);
+    }
+    MasterKeysFileSizeException ex =
+        assertThrows(MasterKeysFileSizeException.class, () -> MasterKeys.read(f, new Random(), ""));
+    assertTrue(ex.isTooBig());
+    assertEquals("big", ex.sizeToString());
+  }
+
+  @Test
+  void read_whenOldFormatFileLengthButWrongPassword_throwsWrongPasswordException()
+      throws IOException {
+    // Old format path is triggered by len == 140; content is bogus so decryption fails → exception
+    File f = new File(base, "old-format.master.keys");
+    try (FileOutputStream os = new FileOutputStream(f)) {
+      os.write(new byte[140]);
+    }
+    assertThrows(
+        MasterKeysWrongPasswordException.class, () -> MasterKeys.read(f, new Random(), "p"));
+  }
+
+  @Test
+  void createRandom_whenSeededRandom_producesDeterministicKeysAndSizes() {
+    Random seeded = new Random(123456789L);
+    MasterKeys mk = MasterKeys.createRandom(seeded);
+
+    // Reconstruct expected bytes using the same sequence the implementation uses
+    Random verify = new Random(123456789L);
+    byte[] expectedClient = new byte[32];
+    verify.nextBytes(expectedClient);
+    byte[] expectedDb = new byte[32];
+    verify.nextBytes(expectedDb);
+    byte[] expectedTemp = new byte[64];
+    verify.nextBytes(expectedTemp);
+
+    assertArrayEquals(expectedClient, mk.clientCacheMasterKey);
+    assertEquals(new DatabaseKey(expectedDb), mk.createDatabaseKey());
+    assertEquals(new MasterSecret(expectedTemp), mk.getPersistentMasterSecret());
+  }
+
+  // Deprecated overload removed; modern createDatabaseKey() is covered by other tests
+
+  @Test
+  void getPersistentMasterSecret_whenCalledTwice_returnsEqualButNotSame() {
+    MasterKeys mk = MasterKeys.createRandom(new Random(7L));
+    MasterSecret a = mk.getPersistentMasterSecret();
+    MasterSecret b = mk.getPersistentMasterSecret();
+    assertNotNull(a);
+    assertEquals(a, b);
+    assertNotSame(a, b);
   }
 }


### PR DESCRIPTION
Summary
- Replace System.out/err with SLF4J logger in MasterKeys
- Extract password-key derivation, decrypt/verify, and decode routines into focused helpers
- Harden file writing: try-with-resources, in-place rewrite, and fsync on master.keys updates
- Clarify and expand Javadoc; document on-disk v1 format and flags
- Introduce test-only hook to adjust password derivation time; keeps tests fast/deterministic
- Remove dead/unused code paths and deprecated overload
- Rewrite tests to JUnit 6 with @TempDir and explicit assertions; add new coverage for clear(), file size bounds, deterministic createRandom()

Motivation
- Reduce stderr noise and align with project logging conventions
- Improve readability/maintainability of legacy MasterKeys logic without changing behavior
- Ensure durability when changing passwords by syncing file descriptor

Behavior and compatibility
- No change to the v1 on-disk format; old-format detection path remains and triggers in-place migration
- Introduces `MasterKeys.setIterateTimeForTests(int)` as a package-visible, test-only hook (no production impact)
- Removes deprecated `createDatabaseKey(Random)` overload; use `createDatabaseKey()` instead

Testing
- Updated and expanded `MasterKeysTest` for JUnit 6
- Tests cover:
  - Persist/restore with and without password
  - Wrong-password failures
  - File size bounds (too small / too big)
  - Determinism of `createRandom()` with seeded RNG
  - `clear(null)` no-op and zeroing behavior

Files changed (by this branch)
- src/main/java/network/crypta/node/MasterKeys.java
- src/test/java/network/crypta/node/MasterKeysTest.java

Notes
- This is a pure refactor + test rewrite; functional behavior is preserved aside from logging improvements and safer I/O.
