### PR TITLE
MessageFragment: clarify encoded length calculation and add basic tests

### DIFF
--- a/src/main/java/network/crypta/node/MessageFragment.java
+++ b/src/main/java/network/crypta/node/MessageFragment.java
@@ -1,5 +1,21 @@
 package network.crypta.node;
 
+/**
+ * Immutable descriptor for a single message fragment in the node's packet format.
+ *
+ * <p>A fragment contains a slice of payload and minimal metadata required for reassembly on the
+ * receiver. Its encoded size on the wire is the sum of:
+ *
+ * <ul>
+ *   <li>2 bytes: message id and flags
+ *   <li>1 or 2 bytes: fragment length (1 byte when {@code shortMessage} is {@code true})
+ *   <li>optional 1 or 2 bytes: present only when {@code isFragmented} is {@code true} (size again
+ *       follows {@code shortMessage})
+ *   <li>N bytes: payload ({@code fragmentData.length})
+ * </ul>
+ *
+ * <p>All fields are {@code final}; instances are thread-safe and may be shared across threads.
+ */
 class MessageFragment {
   final boolean shortMessage;
   final boolean isFragmented;
@@ -11,6 +27,19 @@ class MessageFragment {
   final byte[] fragmentData;
   final MessageWrapper wrapper;
 
+  /**
+   * Creates a new immutable fragment description.
+   *
+   * @param shortMessage {@code true} when the message uses single-byte size fields
+   * @param isFragmented {@code true} when the message is split across multiple fragments
+   * @param firstFragment {@code true} when this is the first fragment of the message
+   * @param messageID identifier of the logical message this fragment belongs to
+   * @param fragmentLength declared fragment length (may differ from {@code fragmentData.length})
+   * @param messageLength total message length for first fragments; otherwise ignored
+   * @param fragmentOffset byte offset of this fragment within the full message (0-based)
+   * @param fragmentData payload bytes of this fragment; used for size and transmission
+   * @param wrapper originating wrapper when sending; {@code null} when created by a receiver
+   */
   public MessageFragment(
       boolean shortMessage,
       boolean isFragmented,
@@ -32,13 +61,38 @@ class MessageFragment {
     this.wrapper = wrapper;
   }
 
+  /**
+   * Returns the number of bytes this fragment occupies in a packet.
+   *
+   * <p>The calculation includes the fixed header (message id and flags), the fragment length field,
+   * the optional extra field present for fragmented messages, and the payload size ({@code
+   * fragmentData.length}). The return value is independent of {@code fragmentLength}.
+   *
+   * @return encoded length in bytes
+   */
   public int length() {
-    return 2 // Message id + flags
-        + (shortMessage ? 1 : 2) // Fragment length
-        + (isFragmented ? (shortMessage ? 1 : 2) : 0) // Fragment offset or message length
+    // Compute header sizes explicitly to avoid nested ternaries for readability.
+    int messageIdAndFlagsBytes = 2; // 2 bytes for message id and flags
+    int fragmentLengthBytes = shortMessage ? 1 : 2; // size of the fragment-length field
+
+    // Size of the additional header field present only when the message is fragmented.
+    // The field carries either the total message length (first fragment) or the fragment offset.
+    int offsetOrMessageLengthBytes = 0;
+    if (isFragmented) {
+      // Use 1 byte for short messages; otherwise 2 bytes.
+      offsetOrMessageLengthBytes = shortMessage ? 1 : 2;
+    }
+
+    return messageIdAndFlagsBytes
+        + fragmentLengthBytes
+        + offsetOrMessageLengthBytes
         + fragmentData.length;
   }
 
+  /**
+   * Returns a concise, single-line summary containing the message id, byte offset, and payload
+   * length. The format is stable and consumed by tests.
+   */
   @Override
   public String toString() {
     return "Fragment from message "

--- a/src/test/java/network/crypta/node/MessageFragmentTest.java
+++ b/src/test/java/network/crypta/node/MessageFragmentTest.java
@@ -1,0 +1,106 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class MessageFragmentTest {
+
+  @ParameterizedTest(name = "length short={0}, fragmented={1}, dataLen={2} -> expected={3}")
+  @CsvSource({
+    // shortMessage, isFragmented, dataLen, expected
+    "true,  true,   10, 14", // 2 + 1 + 1 + 10 = 14
+    "true,  false,  10, 13", // 2 + 1 + 0 + 10 = 13
+    "false, true,   10, 16", // 2 + 2 + 2 + 10 = 16
+    "false, false,  10, 14", // 2 + 2 + 0 + 10 = 14
+    "true,  true,    0,  4", // 2 + 1 + 1 + 0  = 4 (empty payload)
+  })
+  @DisplayName("length() computes header + payload size for all flag combinations")
+  void length_whenFlagsVary_expectCalculatedSize(
+      boolean shortMessage, boolean isFragmented, int dataLen, int expected) {
+    // Arrange
+    byte[] data = new byte[dataLen];
+    MessageWrapper wrapper = mock(MessageWrapper.class);
+    MessageFragment fragment =
+        new MessageFragment(
+            shortMessage,
+            isFragmented,
+            /* firstFragment= */ true,
+            /* messageID= */ 123,
+            /* fragmentLength= */ dataLen,
+            /* messageLength= */ dataLen,
+            /* fragmentOffset= */ 0,
+            data,
+            wrapper);
+
+    // Act
+    int actual = fragment.length();
+
+    // Assert
+    assertEquals(expected, actual);
+    verifyNoInteractions(wrapper);
+  }
+
+  @Test
+  @DisplayName("toString() includes message id, offset and payload length")
+  void toString_whenCalled_expectFormattedSummary() {
+    // Arrange
+    byte[] data = new byte[7];
+    MessageWrapper wrapper = mock(MessageWrapper.class);
+    MessageFragment fragment =
+        new MessageFragment(
+            /* shortMessage= */ true,
+            /* isFragmented= */ true,
+            /* firstFragment= */ false,
+            /* messageID= */ 42,
+            /* fragmentLength= */ 999,
+            /* messageLength= */ 12345,
+            /* fragmentOffset= */ 1234,
+            data,
+            wrapper);
+
+    // Act
+    String s = fragment.toString();
+
+    // Assert
+    assertEquals("Fragment from message 42: offset 1234, data length 7", s);
+    verifyNoInteractions(wrapper);
+  }
+
+  @Test
+  @DisplayName("length() uses fragmentData length, not fragmentLength field")
+  void length_whenFragmentLengthDiffersFromData_expectDataLengthUsed() {
+    // Arrange
+    // Mismatch: fragmentLength=100, actual payload length=3
+    byte[] data = new byte[] {1, 2, 3};
+    MessageWrapper wrapper = mock(MessageWrapper.class);
+    MessageFragment fragment =
+        new MessageFragment(
+            /* shortMessage= */ false,
+            /* isFragmented= */ false,
+            /* firstFragment= */ true,
+            /* messageID= */ 77,
+            /* fragmentLength= */ 100,
+            /* messageLength= */ 1000,
+            /* fragmentOffset= */ 0,
+            data,
+            wrapper);
+
+    // Act
+    int actual = fragment.length();
+
+    // Assert
+    // For non-short, non-fragmented: 2 (id+flags) + 2 (frag length) + 0 + payload(3) = 7
+    assertEquals(7, actual);
+    verifyNoInteractions(wrapper);
+  }
+}


### PR DESCRIPTION
Summary
- Clarifies the encoded length calculation in `MessageFragment.length()` by replacing nested ternaries with explicit variables and comments to improve readability.
- Adds a focused JUnit 6 test `MessageFragmentTest` covering basic size/summary scenarios (short/normal size fields; fragmented vs single-fragment; stable `toString()` format).
- Adds comprehensive Javadoc to `MessageFragment` and key methods/constructor parameters.

Motivation
- The previous `length()` implementation used nested ternary expressions which were easy to misread. The new form is equivalent but more maintainable.
- Test coverage ensures length math and the single-line summary remain stable across refactors.

Change Details
- src/main/java/network/crypta/node/MessageFragment.java
  - Javadoc for class, constructor, and `length()`/`toString()`.
  - `length()` rewritten with explicit local variables (`messageIdAndFlagsBytes`, `fragmentLengthBytes`, `offsetOrMessageLengthBytes`) to make the rules obvious.
- src/test/java/network/crypta/node/MessageFragmentTest.java
  - New JUnit 6 tests for short/long size fields and fragmented vs non-fragmented messages.

Diff Stat
- 2 files changed, 163 insertions(+), 3 deletions(-).

Notes
- Non-functional refactor; no runtime behavior change intended beyond clearer code.
- Spotless was run prior to committing as per project guidelines.

Meta
- Base: develop
- Branch: feature/auto-pr-20251030-162805