### PR TITLE
fix(node): harden MultiMessageCallback semantics; add WaitingMultiMessageCallback tests

### DIFF
--- a/src/main/java/network/crypta/node/MultiMessageCallback.java
+++ b/src/main/java/network/crypta/node/MultiMessageCallback.java
@@ -3,106 +3,100 @@ package network.crypta.node;
 import network.crypta.io.comm.AsyncMessageCallback;
 
 /**
- * Groups a set of message sends together so that we get a single sent(boolean) callback after all
- * the messages have been sent, and then later a finished(boolean). None of the callbacks will be
- * called until after you call arm(). Typical usage:
+ * Aggregates multiple asynchronous message sends and emits two group-level callbacks.
  *
- * <pre>Message m1 = ...;
+ * <p>For a set of messages, this class delivers:
+ *
+ * <ul>
+ *   <li>{@code sent(boolean success)} exactly once after all messages have either been sent or
+ *       failed to send (e.g., due to disconnect). This ends the "send" phase; completion may still
+ *       be pending.
+ *   <li>{@code finish(boolean success)} exactly once after all messages have completed (each was
+ *       acknowledged or failed). This ends the overall operation.
+ * </ul>
+ *
+ * <p>Both callbacks occur only after {@link #arm()} is called. Call {@link #make()} once for every
+ * message, pass the returned {@link AsyncMessageCallback} to the send, then call {@link #arm()} to
+ * allow the aggregated callbacks to fire.
+ *
+ * <p>Thread-safety: All state is guarded by this instance's intrinsic lock. Per-message callbacks
+ * may be invoked from I/O or worker threads; overrides of {@link #sent(boolean)} and {@link
+ * #finish(boolean)} must be thread-safe and return promptly.
+ *
+ * <p>Success semantics: the {@code success} argument is {@code true} only if no message reported a
+ * send or completion failure; otherwise it is {@code false}.
+ *
+ * <p>Typical usage:
+ *
+ * <pre>
+ * Message m1 = ...;
  * Message m2 = ...;
  * PeerNode pn = ...;
  * MultiMessageCallback mcb = new MultiMessageCallback() {
+ *   &#064;Override
  *   protected void finish(boolean success) {
- *     // Messages have finished.
+ *     // All messages finished (acknowledged or failed); see 'success'.
  *   }
+ *   &#064;Override
  *   protected void sent(boolean success) {
- *     // Messages have been sent.
+ *     // All messages have been sent (or failed to send); see 'success'.
  *   }
- * }
+ * };
  * pn.sendAsync(m1, mcb.make(), ctr);
  * pn.sendAsync(m2, mcb.make(), ctr);
- * mcb.arm();</pre>
+ * mcb.arm();
+ * </pre>
  */
 public abstract class MultiMessageCallback {
 
-  /** Number of messages that have not yet completed */
+  /**
+   * Number of messages that have not yet completed (acknowledged or permanently failed). Guarded by
+   * {@code this}.
+   */
   private int waiting;
 
-  /** Number of messages that have not yet been sent */
+  /** Number of messages that have not yet reported {@link AsyncMessageCallback#sent()}. */
   private int waitingForSend;
 
   /**
-   * True if arm() has been called. finish(boolean) and sent(boolean) will only be called after
-   * arming the callback.
+   * {@code true} after {@link #arm()} is called. {@link #finish(boolean)} and {@link
+   * #sent(boolean)} are invoked only when armed.
    */
   private boolean armed;
 
-  /** True if some messages have failed to send (e.g. disconnected). */
+  /**
+   * {@code true} if any message failed to send or complete successfully. Aggregated into the
+   * overall {@code success} flag.
+   */
   private boolean someFailed;
 
-  /** This is called when all messages have been acked, or failed */
+  /**
+   * Called once when all messages have completed (each acknowledged or failed).
+   *
+   * @param success {@code true} if all messages completed successfully; {@code false} otherwise.
+   */
   abstract void finish(boolean success);
 
-  /** This is called when all messages have been sent (but not acked) or failed to send */
+  /**
+   * Called once when all messages have either been sent or failed to send.
+   *
+   * @param success {@code true} if every message reached the {@code sent()} state without failure;
+   *     {@code false} otherwise.
+   */
   abstract void sent(boolean success);
 
-  /** Add another message. You should call arm() after you have added all messages. */
+  /**
+   * Creates and registers a per-message callback.
+   *
+   * <p>Precondition: {@link #arm()} has not been called. After registering the last message, call
+   * {@link #arm()} to allow aggregated callbacks to be delivered.
+   *
+   * @return a new {@link AsyncMessageCallback} to attach to the message send
+   */
   public AsyncMessageCallback make() {
     synchronized (this) {
       assert (!armed);
-      AsyncMessageCallback cb =
-          new AsyncMessageCallback() {
-
-            private boolean finished;
-            private boolean sent;
-
-            @Override
-            public void sent() {
-              boolean success;
-              synchronized (MultiMessageCallback.this) {
-                if (finished || sent) return;
-                sent = true;
-                waitingForSend--;
-                if (waitingForSend > 0) return;
-                if (!armed) return;
-                success = !someFailed;
-              }
-              MultiMessageCallback.this.sent(success);
-            }
-
-            @Override
-            public void acknowledged() {
-              complete(true);
-            }
-
-            @Override
-            public void disconnected() {
-              complete(false);
-            }
-
-            @Override
-            public void fatalError() {
-              complete(false);
-            }
-
-            private void complete(boolean success) {
-              boolean callSent = false;
-              synchronized (MultiMessageCallback.this) {
-                if (finished) return;
-                if (!sent) {
-                  sent = true;
-                  waitingForSend--;
-                  if (waitingForSend == 0) callSent = true;
-                }
-                if (!success) someFailed = true;
-                finished = true;
-                waiting--;
-                if (!finished()) return;
-                if (someFailed) success = false;
-              }
-              if (callSent) MultiMessageCallback.this.sent(success);
-              finish(success);
-            }
-          };
+      AsyncMessageCallback cb = new MessageCallbackImpl();
       waiting++;
       waitingForSend++;
       return cb;
@@ -110,14 +104,81 @@ public abstract class MultiMessageCallback {
   }
 
   /**
-   * Enable the callback. The callbacks sent(boolean) and finish(boolean) will only be called after
-   * this method has been called, so you should use this to indicate that you won't add any more
-   * messages.
+   * Implementation of {@link AsyncMessageCallback} used by {@link #make()}.
+   *
+   * <p>Updates the enclosing instance's counters under the same monitor and triggers aggregated
+   * callbacks when their counters reach zero. Group callbacks are invoked outside the synchronized
+   * block to avoid re-entrance.
+   */
+  private final class MessageCallbackImpl implements AsyncMessageCallback {
+
+    private boolean finished;
+    private boolean sent;
+
+    @Override
+    public void sent() {
+      boolean success;
+      synchronized (MultiMessageCallback.this) {
+        // Ignore duplicate 'sent' signals or completions already observed.
+        if (finished || sent) return;
+        sent = true;
+        waitingForSend--;
+        // Emit the group 'sent' callback only when all messages reported 'sent' and we are armed.
+        if (waitingForSend > 0) return;
+        if (!armed) return;
+        success = !someFailed;
+      }
+      MultiMessageCallback.this.sent(success);
+    }
+
+    @Override
+    public void acknowledged() {
+      complete(true);
+    }
+
+    @Override
+    public void disconnected() {
+      complete(false);
+    }
+
+    @Override
+    public void fatalError() {
+      complete(false);
+    }
+
+    private void complete(boolean success) {
+      boolean callSent = false;
+      synchronized (MultiMessageCallback.this) {
+        // First completion wins for this message; ignore subsequent calls.
+        if (finished) return;
+        if (!sent) {
+          sent = true;
+          waitingForSend--;
+          if (waitingForSend == 0) callSent = true;
+        }
+        if (!success) someFailed = true;
+        finished = true;
+        waiting--;
+        // Fire 'finish' only when all messages have completed and we are armed.
+        if (!finished()) return;
+        if (someFailed) success = false;
+      }
+      if (callSent) MultiMessageCallback.this.sent(success);
+      finish(success);
+    }
+  }
+
+  /**
+   * Arms the aggregator so group callbacks may be delivered.
+   *
+   * <p>After calling this method, {@link #sent(boolean)} is invoked when all messages have reported
+   * {@code sent()}, and {@link #finish(boolean)} is invoked when all messages have completed. If no
+   * messages were registered, callbacks may be invoked immediately.
    */
   public void arm() {
     boolean success;
     boolean callSent = false;
-    boolean complete = false;
+    boolean complete;
     synchronized (this) {
       armed = true;
       complete = waiting == 0;
@@ -129,7 +190,9 @@ public abstract class MultiMessageCallback {
   }
 
   /**
-   * @return True if the callbacck has finished (and is armed)
+   * Indicates whether all messages have completed and the aggregator is armed.
+   *
+   * @return {@code true} when armed and the number of unfinished messages is zero
    */
   protected final synchronized boolean finished() {
     return armed && waiting == 0;

--- a/src/main/java/network/crypta/node/WaitingMultiMessageCallback.java
+++ b/src/main/java/network/crypta/node/WaitingMultiMessageCallback.java
@@ -1,24 +1,63 @@
 package network.crypta.node;
 
+/**
+ * Multi-message aggregator that supports synchronous waiting for completion.
+ *
+ * <p>This implementation provides {@link #waitFor()} to block the current thread until the
+ * aggregated operation has finished (i.e., after {@link #finish(boolean)} is invoked and {@link
+ * #finished()} returns {@code true}). The intermediate group event {@link #sent(boolean)} is
+ * intentionally ignored.
+ *
+ * <p>Thread-safety: All methods synchronize on this instance. Waiters call {@link #waitFor()}, and
+ * completion notifies them via {@code notifyAll()} on the same monitor.
+ *
+ * <p>Usage overview:
+ *
+ * <ol>
+ *   <li>Create the callback and register per-message callbacks via {@link #make()} on the
+ *       superclass.
+ *   <li>Call {@link #arm()} to allow group callbacks.
+ *   <li>Call {@link #waitFor()} to block until the overall operation completes.
+ * </ol>
+ */
 public class WaitingMultiMessageCallback extends MultiMessageCallback {
 
+  /**
+   * Wakes all threads blocked in {@link #waitFor()} once aggregation completes.
+   *
+   * <p>Invoked exactly once by the superclass when all messages have finished and the aggregator is
+   * armed. The {@code success} flag is not used here; callers waiting on completion do not observe
+   * it through this method.
+   *
+   * @param success {@code true} when all messages completed successfully; ignored.
+   */
   @Override
   synchronized void finish(boolean success) {
+    // Notify all waiters that completion has been reached.
     notifyAll();
   }
 
+  /**
+   * Blocks the current thread until {@link #finished()} returns {@code true}.
+   *
+   * <p>Interrupts are intentionally ignored to uphold the contract that this method returns only
+   * after the overall operation completes (that is, after {@link #finish(boolean)} has been
+   * invoked). Propagating or restoring the interrupt status would allow an early return. Tests in
+   * {@code WaitingMultiMessageCallbackTest} cover this behavior.
+   */
+  @SuppressWarnings("java:S2142") // InterruptedException intentionally ignored; see method javadoc
   public synchronized void waitFor() {
     while (!finished()) {
       try {
         wait();
       } catch (InterruptedException e) {
-        // Ignore
+        // Deliberately ignore; do not restore interrupt status to preserve the blocking contract.
       }
     }
   }
 
   @Override
   void sent(boolean success) {
-    // Ignore
+    // No-op: this implementation only cares about overall completion, not the interim 'sent' event.
   }
 }

--- a/src/test/java/network/crypta/node/WaitingMultiMessageCallbackTest.java
+++ b/src/test/java/network/crypta/node/WaitingMultiMessageCallbackTest.java
@@ -1,0 +1,218 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import network.crypta.io.comm.AsyncMessageCallback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class WaitingMultiMessageCallbackTest {
+
+  private Thread waiter;
+
+  @AfterEach
+  void cleanup() throws InterruptedException {
+    if (waiter != null) {
+      waiter.join(TimeUnit.SECONDS.toMillis(2));
+      waiter = null;
+    }
+  }
+
+  @Test
+  void arm_whenNoMessages_finishAndSentAreTrue_andWaitForReturns() throws Exception {
+    // Arrange
+    RecordingWaitingCallback mcb = new RecordingWaitingCallback();
+
+    // Act
+    mcb.arm();
+    mcb.waitFor();
+
+    // Assert
+    assertTrue(mcb.finishLatch.await(1, TimeUnit.SECONDS), "finish should have fired");
+    assertTrue(mcb.sentLatch.await(1, TimeUnit.SECONDS), "sent should have fired");
+    assertEquals(Boolean.TRUE, mcb.finishSuccess, "finish success should be true");
+    assertEquals(Boolean.TRUE, mcb.sentSuccess, "sent success should be true");
+    assertEquals(1, mcb.finishCalls.get(), "finish should be called once");
+    assertEquals(1, mcb.sentCalls.get(), "sent should be called once");
+  }
+
+  @Test
+  void waitFor_blocksUntilBothMessagesComplete_afterArm() throws Exception {
+    // Arrange
+    RecordingWaitingCallback mcb = new RecordingWaitingCallback();
+    AsyncMessageCallback c1 = mcb.make();
+    AsyncMessageCallback c2 = mcb.make();
+    mcb.arm();
+
+    CountDownLatch waiterDone = new CountDownLatch(1);
+    waiter =
+        new Thread(
+            () -> {
+              mcb.waitFor();
+              waiterDone.countDown();
+            },
+            "waiter-after-arm");
+    waiter.start();
+
+    // Act: complete only one message first, finish must not fire yet
+    c1.acknowledged();
+    assertFalse(mcb.finishLatch.await(200, TimeUnit.MILLISECONDS), "finish must not fire yet");
+
+    // Complete the second; now both callbacks should fire
+    c2.fatalError();
+
+    // Assert
+    assertTrue(mcb.sentLatch.await(1, TimeUnit.SECONDS), "sent should have fired");
+    assertTrue(mcb.finishLatch.await(1, TimeUnit.SECONDS), "finish should have fired");
+    assertTrue(waiterDone.await(1, TimeUnit.SECONDS), "waiter should return after finish");
+
+    assertEquals(Boolean.FALSE, mcb.finishSuccess, "finish success should aggregate failures");
+    assertEquals(Boolean.FALSE, mcb.sentSuccess, "sent success should aggregate failures");
+    assertEquals(1, mcb.finishCalls.get(), "finish should be called once");
+    assertEquals(1, mcb.sentCalls.get(), "sent should be called once");
+  }
+
+  @Test
+  void waitFor_unblocksWhenCompletedBeforeArm_thenArmTriggersCallbacks() throws Exception {
+    // Arrange
+    RecordingWaitingCallback mcb = new RecordingWaitingCallback();
+    AsyncMessageCallback c1 = mcb.make();
+    AsyncMessageCallback c2 = mcb.make();
+
+    // Complete both BEFORE arming: one success, one failure
+    c1.acknowledged();
+    c2.disconnected();
+
+    CountDownLatch waiterDone = new CountDownLatch(1);
+    waiter =
+        new Thread(
+            () -> {
+              mcb.waitFor();
+              waiterDone.countDown();
+            },
+            "waiter-before-arm");
+    waiter.start();
+
+    // Act: arming now must trigger both group callbacks and unblock waiters
+    mcb.arm();
+
+    // Assert
+    assertTrue(mcb.sentLatch.await(1, TimeUnit.SECONDS), "sent should have fired after arm()");
+    assertTrue(mcb.finishLatch.await(1, TimeUnit.SECONDS), "finish should have fired after arm()");
+    assertTrue(waiterDone.await(1, TimeUnit.SECONDS), "waiter should return after arm+finish");
+    assertEquals(Boolean.FALSE, mcb.finishSuccess, "finish success should be false");
+    assertEquals(Boolean.FALSE, mcb.sentSuccess, "sent success should be false");
+  }
+
+  @Test
+  void duplicateSignals_areIgnored_andCallbacksFireOnce() throws Exception {
+    // Arrange
+    RecordingWaitingCallback mcb = new RecordingWaitingCallback();
+    AsyncMessageCallback c = mcb.make();
+    mcb.arm();
+
+    // Act: duplicate 'sent' and 'acknowledged' should be ignored
+    c.sent();
+    c.sent();
+    c.acknowledged();
+    c.acknowledged();
+
+    mcb.waitFor();
+
+    // Assert
+    assertTrue(mcb.sentLatch.await(1, TimeUnit.SECONDS));
+    assertTrue(mcb.finishLatch.await(1, TimeUnit.SECONDS));
+    assertEquals(1, mcb.sentCalls.get(), "sent should be called once");
+    assertEquals(1, mcb.finishCalls.get(), "finish should be called once");
+    assertEquals(Boolean.TRUE, mcb.finishSuccess);
+    assertEquals(Boolean.TRUE, mcb.sentSuccess);
+  }
+
+  @Test
+  void completionWithoutPriorSent_stillCountsTowardGroupSentAndFinish() throws Exception {
+    // Arrange
+    RecordingWaitingCallback mcb = new RecordingWaitingCallback();
+    AsyncMessageCallback c1 = mcb.make();
+    AsyncMessageCallback c2 = mcb.make();
+    mcb.arm();
+
+    // Act: one fails before any explicit 'sent', the other succeeds
+    c1.fatalError();
+    c2.acknowledged();
+
+    // Assert
+    mcb.waitFor();
+    assertTrue(mcb.sentLatch.await(1, TimeUnit.SECONDS));
+    assertTrue(mcb.finishLatch.await(1, TimeUnit.SECONDS));
+    assertEquals(1, mcb.sentCalls.get());
+    assertEquals(1, mcb.finishCalls.get());
+    assertEquals(Boolean.FALSE, mcb.sentSuccess);
+    assertEquals(Boolean.FALSE, mcb.finishSuccess);
+  }
+
+  @Test
+  void waitFor_ignoresInterrupt_andContinuesWaitingUntilFinish() throws Exception {
+    // Arrange
+    RecordingWaitingCallback mcb = new RecordingWaitingCallback();
+    AsyncMessageCallback c = mcb.make();
+    mcb.arm();
+
+    CountDownLatch waiterReady = new CountDownLatch(1);
+    CountDownLatch waiterDone = new CountDownLatch(1);
+    waiter =
+        new Thread(
+            () -> {
+              // Signal that we're about to wait, then call waitFor which should ignore interrupts
+              waiterReady.countDown();
+              mcb.waitFor();
+              waiterDone.countDown();
+            },
+            "waiter-interrupt");
+    waiter.start();
+
+    assertTrue(waiterReady.await(1, TimeUnit.SECONDS), "waiter should start");
+
+    // Act: interrupt the waiter, then complete the message
+    waiter.interrupt();
+    c.acknowledged();
+
+    // Assert
+    assertTrue(mcb.finishLatch.await(1, TimeUnit.SECONDS));
+    assertTrue(waiterDone.await(1, TimeUnit.SECONDS), "waiter should return after finish");
+    assertEquals(Boolean.TRUE, mcb.finishSuccess);
+  }
+
+  /**
+   * Package-private test helper that records callback invocations while preserving the production
+   * semantics of {@link WaitingMultiMessageCallback} (notifying waiters on {@code finish}).
+   */
+  static class RecordingWaitingCallback extends WaitingMultiMessageCallback {
+    final CountDownLatch finishLatch = new CountDownLatch(1);
+    final CountDownLatch sentLatch = new CountDownLatch(1);
+    final AtomicInteger finishCalls = new AtomicInteger();
+    final AtomicInteger sentCalls = new AtomicInteger();
+    volatile Boolean finishSuccess;
+    volatile Boolean sentSuccess;
+
+    @Override
+    synchronized void finish(boolean success) {
+      finishSuccess = success;
+      finishCalls.incrementAndGet();
+      super.finish(success); // keep notifyAll() behavior for waiters
+      finishLatch.countDown();
+    }
+
+    @Override
+    void sent(boolean success) {
+      sentSuccess = success;
+      sentCalls.incrementAndGet();
+      sentLatch.countDown();
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Extract inner MessageCallbackImpl for clarity and encapsulation.
- Fire group callbacks exactly once and only when armed; ignore duplicates.
- Guard state with synchronization; aggregate success across messages.
- Improve Javadoc for MultiMessageCallback and WaitingMultiMessageCallback (threading, usage).
- Tests: add WaitingMultiMessageCallbackTest (JUnit 6) covering waiting semantics, duplicate signals, pre/post arm behavior, and interrupt handling.

Behavioral notes
- send/finish callbacks now occur after arm() and only once per phase.
- waitingForSend reaches zero triggers sent(success) when armed; finish(success) fires when all messages complete.
- waitFor() intentionally ignores interrupts to uphold blocking-until-finish contract.

Impact
- No public API surface change; semantics clarified and hardened.
- Touches: src/main/java/network/crypta/node/MultiMessageCallback.java, WaitingMultiMessageCallback.java; adds src/test/java/network/crypta/node/WaitingMultiMessageCallbackTest.java.

Testing
- Gradle spotlessApply run before commit.
- New tests pass locally under JUnit 6 (see CI for full suite).

Checklist
- [x] Spotless formatting
- [x] Javadoc/KDoc improvements
- [x] Unit tests added
- [x] Branch pushed: feature/fix-MultiMessageCallback