### PR TITLE
NewPacketFormat: tighten seqnum/ack logic, refactor processing, and add tests

### DIFF
--- a/src/main/java/network/crypta/node/NewPacketFormat.java
+++ b/src/main/java/network/crypta/node/NewPacketFormat.java
@@ -24,77 +24,92 @@ import network.crypta.support.SparseBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Packet format and transport for encrypted peer communication.
+ *
+ * <p>This implementation handles packet assembly and parsing including:
+ *
+ * <ul>
+ *   <li>Fragmenting and reassembling messages up to {@link #MAX_MESSAGE_SIZE} bytes.
+ *   <li>Per-session sequence numbers used in IV derivation and HMAC validation.
+ *   <li>Acknowledgments, retransmission heuristics, and keepalive scheduling.
+ *   <li>Send/receive windows and buffer accounting to avoid overruns.
+ * </ul>
+ *
+ * <p>Thread safety: this class uses fine‑grained locks. The send buffer and its counters are
+ * protected by {@code sendBufferLock}. The receive buffer usage counter is protected by {@code
+ * receiveBufferSizeLock}. Window pointers and some shared structures synchronize on {@code this} or
+ * their own monitors as documented. Callers may use an instance from multiple threads.
+ *
+ * <p>Time units are milliseconds unless stated otherwise.
+ */
 public class NewPacketFormat implements PacketFormat {
   private static final Logger LOG = LoggerFactory.getLogger(NewPacketFormat.class);
 
+  /** Number of bytes of the truncated HMAC stored in the packet header. */
   private static final int HMAC_LENGTH = 10;
-  // FIXME Use a more efficient structure - int[] or maybe just a big byte[].
-  // FIXME increase this significantly to let it ride over network interruptions.
+
+  // Watchlist of encrypted sequence-number probes used to match incoming packets.
+  // A larger list increases tolerance for bursts/latency at the cost of memory.
   private static final int NUM_SEQNUMS_TO_WATCH_FOR = 1024;
-  // FIXME This should be globally allocated according to available memory etc. For links with
-  // high bandwidth and high latency, and lots of memory, a much bigger buffer would be helpful.
+  // Upper bound for the summed size of all partially received message buffers.
+  // On high-bandwidth/latency links with ample memory, a larger value can reduce drops.
   private static final int MAX_RECEIVE_BUFFER_SIZE = 256 * 1024;
   private static final int MSG_WINDOW_SIZE = 65536;
   private static final int NUM_MESSAGE_IDS = 268435456;
   static final long NUM_SEQNUMS = 2147483648L;
   private static final long MAX_MSGID_BLOCK_TIME = MINUTES.toMillis(10);
   private static final int MAX_ACKS = 500;
-  static boolean DO_KEEPALIVES = true;
-
-  static {
-  }
+  static boolean doKeepalives = true;
 
   private final BasePeerNode pn;
 
   /**
-   * The actual buffer of outgoing messages that have not yet been acked. LOCKING: Protected by
-   * sendBufferLock.
+   * Outgoing messages in progress and not yet fully acknowledged. Guarded by {@code
+   * sendBufferLock}.
    */
   private final List<Map<Integer, MessageWrapper>> startedByPrio;
 
-  /** The next message ID for outgoing messages. LOCKING: Protected by (this). */
+  /** The next message ID for outgoing messages. Guarded by {@code this}. */
   private int nextMessageID;
 
-  /** The first message id that hasn't been acked by the receiver. LOCKING: Protected by (this). */
+  /** First message id not yet acked by the receiver. Guarded by {@code this}. */
   private int messageWindowPtrAcked;
 
   /**
-   * All messages that have been acked (we remove those which are out of window to limit space
-   * usage). LOCKING: Protected by (this).
+   * Messages that have been acked. Entries outside the window are periodically pruned. Guarded by
+   * {@code this}.
    */
   private final SparseBitmap ackedMessages = new SparseBitmap();
 
   private final HashMap<Integer, PartiallyReceivedBuffer> receiveBuffers = new HashMap<>();
   private final HashMap<Integer, SparseBitmap> receiveMaps = new HashMap<>();
 
-  /** The first message id that hasn't been fully received */
+  /** First message id that has not been fully received. */
   private int messageWindowPtrReceived;
 
   private final SparseBitmap receivedMessages = new SparseBitmap();
 
   /**
-   * How much of our receive buffer have we used? Equal to how much is used of the sender's send
-   * buffer. The receive buffer is actually implemented in receiveBuffers. LOCKING: Protected by
-   * receiveBufferSizeLock.
+   * Total bytes currently used by partially received buffers. This mirrors how much of the sender's
+   * send window we occupy. Guarded by {@code receiveBufferSizeLock}.
    */
   private int receiveBufferUsed = 0;
 
   /**
-   * How much of the other side's buffer have we used? Or alternatively, how much space have we used
-   * in our send buffer, namely startedByPrio? LOCKING: Protected by sendBufferLock
+   * Bytes we estimate to occupy in the peer's buffer (derived from our started messages). Guarded
+   * by {@code sendBufferLock}.
    */
   private int sendBufferUsed = 0;
 
   /**
-   * Lock protecting buffer usage counters, and the buffer itself (startedByPrio). MUST BE TAKEN
-   * LAST. Justification: The outgoing buffer and the buffer usage should be protected by the same
-   * lock, for consistency. The buffer usage and the connection status must be protected by the same
-   * lock, so we don't send packets when we are disconnected and get race conditions in
-   * onDisconnect(). The incoming buffer estimate could be separated in theory.
+   * Lock for the send-side state: both the in-flight map ({@code startedByPrio}) and the accounting
+   * counters. Acquire this lock last to avoid deadlocks with other locks protecting connection
+   * state. Using one lock ensures we do not enqueue or send while disconnecting.
    */
   private final Object sendBufferLock = new Object();
 
-  /** Lock protecting the size of the receive buffer. */
+  /** Lock protecting {@code receiveBufferUsed}. */
   private final Object receiveBufferSizeLock = new Object();
 
   private long timeLastSentPacket;
@@ -117,38 +132,38 @@ public class NewPacketFormat implements PacketFormat {
     messageWindowPtrReceived = theirInitialMsgID;
   }
 
+  /**
+   * Processes an incoming encrypted packet.
+   *
+   * <p>The method attempts decryption with available session keys, validates the truncated HMAC,
+   * processes acknowledgments, reassembles message fragments, and delivers completed messages to
+   * the peer for further handling. When appropriate, it schedules an acknowledgment for the
+   * received sequence number.
+   *
+   * @param buf the buffer containing the packet bytes.
+   * @param offset the start offset in {@code buf}.
+   * @param length the number of bytes in the packet.
+   * @param now current time in milliseconds; used for deadlines and scheduling.
+   * @param replyTo the peer to reply to; may be {@code null} for non-addressable transports.
+   * @return {@code true} if the packet was decrypted and processed; {@code false} if no session key
+   *     matched or validation failed.
+   */
   @Override
   public boolean handleReceivedPacket(byte[] buf, int offset, int length, long now, Peer replyTo) {
-    NPFPacket packet = null;
-    SessionKey s = null;
-    for (int i = 0; i < 3; i++) {
-      if (i == 0) {
-        s = pn.getCurrentKeyTracker();
-      } else if (i == 1) {
-        s = pn.getPreviousKeyTracker();
-      } else {
-        s = pn.getUnverifiedKeyTracker();
-      }
-      if (s == null) continue;
-      packet = tryDecipherPacket(buf, offset, length, s);
-      if (packet != null) {
-        if (LOG.isTraceEnabled()) LOG.trace("Decrypted packet with tracker " + i);
-        break;
-      }
-    }
-    if (packet == null) {
-      if (LOG.isDebugEnabled()) LOG.debug("Could not decrypt received packet");
+    DecryptionResult dec = tryDecryptOnAnyTracker(buf, offset, length);
+    if (dec.packet == null) {
+      if (LOG.isDebugEnabled()) LOG.debug("Skip packet: cannot decrypt with available keys");
       return false;
     }
 
     pn.receivedPacket(false, true);
-    pn.verified(s);
+    pn.verified(dec.sessionKey);
     pn.maybeRekey();
     pn.reportIncomingBytes(length);
 
-    List<byte[]> finished = handleDecryptedPacket(packet, s);
+    List<byte[]> finished = handleDecryptedPacket(dec.packet, dec.sessionKey);
     if (LOG.isDebugEnabled() && !finished.isEmpty())
-      LOG.debug("Decoded messages: " + finished.size());
+      LOG.debug("Decoded {} message(s)", finished.size());
     DecodingMessageGroup group = pn.startProcessingDecryptedMessages(finished.size());
     for (byte[] buffer : finished) {
       group.processDecryptedMessage(buffer, 0, buffer.length, 0);
@@ -158,224 +173,296 @@ public class NewPacketFormat implements PacketFormat {
     return true;
   }
 
+  private record DecryptionResult(NPFPacket packet, SessionKey sessionKey) {}
+
+  private DecryptionResult tryDecryptOnAnyTracker(byte[] buf, int offset, int length) {
+    for (int i = 0; i < 3; i++) {
+      SessionKey s =
+          switch (i) {
+            case 0 -> pn.getCurrentKeyTracker();
+            case 1 -> pn.getPreviousKeyTracker();
+            default -> pn.getUnverifiedKeyTracker();
+          };
+      if (s == null) continue;
+      NPFPacket packet = tryDecipherPacket(buf, offset, length, s);
+      if (packet != null) {
+        if (LOG.isTraceEnabled()) LOG.trace("Decrypted packet with tracker {}", i);
+        return new DecryptionResult(packet, s);
+      }
+    }
+    return new DecryptionResult(null, null);
+  }
+
   List<byte[]> handleDecryptedPacket(NPFPacket packet, SessionKey sessionKey) {
     List<byte[]> fullyReceived = new LinkedList<>();
 
     NewPacketFormatKeyContext keyContext = sessionKey.packetContext;
-    for (int ack : packet.getAcks()) {
-      keyContext.ack(ack, pn, sessionKey);
-    }
+    processAcks(packet, keyContext, sessionKey);
 
-    boolean dontAck = false;
-    boolean wakeUp = false;
-    if (packet.getError() || packet.getFragments().isEmpty()) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Not acking because " + (packet.getError() ? "error" : "no fragments"));
-      dontAck = true;
-    }
-    List<byte[]> l = packet.getLossyMessages();
-    if (l != null && !l.isEmpty()) {
-      ArrayList<Message> lossyMessages = new ArrayList<>(l.size());
-      for (byte[] buf : l) {
-        // FIXME factor out parsing once we are sure these are not bogus.
-        // For now we have to be careful.
-        Message msg = Message.decodeMessageLax(buf, pn, 0);
-        if (msg == null) {
-          lossyMessages.clear();
-          break;
-        }
-        if (!msg.getSpec().isLossyPacketMessage()) {
-          lossyMessages.clear();
-          break;
-        }
-        lossyMessages.add(msg);
-      }
-      // Handle them *before* the rest.
-      if (LOG.isDebugEnabled() && !lossyMessages.isEmpty())
-        LOG.debug("Successfully parsed " + lossyMessages.size() + " lossy packet messages");
-      for (Message msg : lossyMessages) pn.handleMessage(msg);
-    }
-    for (MessageFragment fragment : packet.getFragments()) {
-      if (messageWindowPtrReceived + MSG_WINDOW_SIZE > NUM_MESSAGE_IDS) {
-        int upperBound = (messageWindowPtrReceived + MSG_WINDOW_SIZE) % NUM_MESSAGE_IDS;
-        if ((fragment.messageID > upperBound) && (fragment.messageID < messageWindowPtrReceived)) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("Received message " + fragment.messageID + " outside window, acking");
-          continue;
-        }
-      } else {
-        int upperBound = messageWindowPtrReceived + MSG_WINDOW_SIZE;
-        if (!((fragment.messageID >= messageWindowPtrReceived)
-            && (fragment.messageID < upperBound))) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("Received message " + fragment.messageID + " outside window, acking");
-          continue;
-        }
-      }
-      synchronized (receivedMessages) {
-        if (receivedMessages.contains(fragment.messageID, fragment.messageID)) continue;
-      }
-
-      PartiallyReceivedBuffer recvBuffer = receiveBuffers.get(fragment.messageID);
-      SparseBitmap recvMap = receiveMaps.get(fragment.messageID);
-      if (recvBuffer == null) {
-        if (LOG.isTraceEnabled())
-          LOG.trace("Message id " + fragment.messageID + ": Creating buffer");
-
-        recvBuffer = new PartiallyReceivedBuffer(this);
-        if (fragment.firstFragment) {
-          if (!recvBuffer.setMessageLength(fragment.messageLength)) {
-            dontAck = true;
-            continue;
-          }
-        } else {
-          synchronized (receiveBufferSizeLock) {
-            if ((receiveBufferUsed + fragment.fragmentLength) > MAX_RECEIVE_BUFFER_SIZE) {
-              if (LOG.isDebugEnabled()) LOG.debug("Could not create buffer, would excede max size");
-              dontAck = true;
-              continue;
-            }
-          }
-        }
-
-        recvMap = new SparseBitmap();
-        receiveBuffers.put(fragment.messageID, recvBuffer);
-        receiveMaps.put(fragment.messageID, recvMap);
-      } else {
-        if (fragment.firstFragment) {
-          if (!recvBuffer.setMessageLength(fragment.messageLength)) {
-            dontAck = true;
-            continue;
-          }
-        }
-      }
-
-      if (!recvBuffer.add(fragment.fragmentData, fragment.fragmentOffset)) {
-        dontAck = true;
-        continue;
-      }
-      if (fragment.fragmentLength == 0) {
-        LOG.warn("Received fragment of length 0");
-        continue;
-      }
-      recvMap.add(fragment.fragmentOffset, fragment.fragmentOffset + fragment.fragmentLength - 1);
-      if ((recvBuffer.messageLength != -1) && recvMap.contains(0, recvBuffer.messageLength - 1)) {
-        receiveBuffers.remove(fragment.messageID);
-        receiveMaps.remove(fragment.messageID);
-
-        synchronized (receivedMessages) {
-          if (receivedMessages.contains(fragment.messageID, fragment.messageID)) continue;
-          receivedMessages.add(fragment.messageID, fragment.messageID);
-
-          int oldWindow = messageWindowPtrReceived;
-          while (receivedMessages.contains(messageWindowPtrReceived, messageWindowPtrReceived)) {
-            messageWindowPtrReceived++;
-            if (messageWindowPtrReceived == NUM_MESSAGE_IDS) messageWindowPtrReceived = 0;
-          }
-
-          if (messageWindowPtrReceived < oldWindow) {
-            receivedMessages.remove(oldWindow, NUM_MESSAGE_IDS - 1);
-            receivedMessages.remove(0, messageWindowPtrReceived);
-          } else {
-            receivedMessages.remove(oldWindow, messageWindowPtrReceived);
-          }
-        }
-
-        synchronized (receiveBufferSizeLock) {
-          receiveBufferUsed -= recvBuffer.messageLength;
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "Removed "
-                    + recvBuffer.messageLength
-                    + " from buffer. Total is now "
-                    + receiveBufferUsed);
-        }
-
-        fullyReceived.add(recvBuffer.buffer);
-
-        if (LOG.isTraceEnabled()) LOG.trace("Message id " + fragment.messageID + ": Completed");
-      } else {
-        if (LOG.isTraceEnabled()) LOG.trace("Message id " + fragment.messageID + ": " + recvMap);
-      }
-    }
-
-    if (!dontAck) {
-      int seqno = packet.getSequenceNumber();
-      int acksQueued = keyContext.queueAck(seqno);
-      boolean addedAck = acksQueued >= 0;
-      if (acksQueued > MAX_ACKS) wakeUp = true;
-      if (addedAck) {
-        if (!wakeUp) {
-          synchronized (receiveBufferSizeLock) {
-            if (receiveBufferUsed > MAX_RECEIVE_BUFFER_SIZE / 2) wakeUp = true;
-          }
-        }
-        if (wakeUp) pn.wakeUpSender();
-      }
-    }
+    boolean shouldAck = shouldAckPacket(packet);
+    handleLossyMessagesIfAny(packet);
+    boolean dontAckFromFragments = processFragments(packet, fullyReceived);
+    if (shouldAck && !dontAckFromFragments) maybeQueueAck(keyContext, packet);
 
     return fullyReceived;
   }
 
-  private NPFPacket tryDecipherPacket(byte[] buf, int offset, int length, SessionKey sessionKey) {
-    NewPacketFormatKeyContext keyContext = sessionKey.packetContext;
-    // Create the watchlist if the key has changed
-    if (keyContext.seqNumWatchList == null) {
+  private void processAcks(
+      NPFPacket packet, NewPacketFormatKeyContext keyContext, SessionKey sessionKey) {
+    for (int ack : packet.getAcks()) {
+      keyContext.ack(ack, pn, sessionKey);
+    }
+  }
+
+  private boolean shouldAckPacket(NPFPacket packet) {
+    if (packet.getError() || packet.getFragments().isEmpty()) {
       if (LOG.isDebugEnabled())
-        LOG.debug("Creating watchlist starting at " + keyContext.watchListOffset);
+        LOG.debug("Skip ack; reason={}", packet.getError() ? "error" : "no fragments");
+      return false;
+    }
+    return true;
+  }
 
-      keyContext.seqNumWatchList = new byte[NUM_SEQNUMS_TO_WATCH_FOR][4];
+  private void handleLossyMessagesIfAny(NPFPacket packet) {
+    List<byte[]> l = packet.getLossyMessages();
+    if (l == null || l.isEmpty()) return;
 
-      int seqNum = keyContext.watchListOffset;
-      for (int i = 0; i < keyContext.seqNumWatchList.length; i++) {
-        keyContext.seqNumWatchList[i] = NewPacketFormat.encryptSequenceNumber(seqNum++, sessionKey);
-        if (seqNum < 0) seqNum = 0;
+    ArrayList<Message> lossyMessages = new ArrayList<>(l.size());
+    for (byte[] buf : l) {
+      Message msg = Message.decodeMessageLax(buf, pn, 0);
+      if (msg == null || !msg.getSpec().isLossyPacketMessage()) {
+        lossyMessages.clear();
+        break;
+      }
+      lossyMessages.add(msg);
+    }
+    if (LOG.isDebugEnabled() && !lossyMessages.isEmpty())
+      LOG.debug("Parsed {} lossy packet messages", lossyMessages.size());
+    for (Message msg : lossyMessages) pn.handleMessage(msg);
+  }
+
+  private boolean processFragments(NPFPacket packet, List<byte[]> fullyReceived) {
+    boolean dontAck = false;
+    for (MessageFragment fragment : packet.getFragments()) {
+      boolean fragmentOk = processSingleFragment(fragment, fullyReceived);
+      if (!fragmentOk) dontAck = true;
+    }
+    return dontAck;
+  }
+
+  private boolean processSingleFragment(MessageFragment fragment, List<byte[]> fullyReceived) {
+    if (isOutsideReceiveWindow(fragment)) {
+      LOG.debug("Message {} outside receive window; sending ack", fragment.messageID);
+      return true; // Outside window does not suppress ack
+    }
+    synchronized (receivedMessages) {
+      if (receivedMessages.contains(fragment.messageID, fragment.messageID)) return true;
+    }
+
+    BufferMap bm = ensureBufferAndMap(fragment);
+    if (bm == null) {
+      return false; // Suppress ack on allocation failure
+    }
+
+    if (shouldSetMessageLength(fragment, bm)
+        && bm.buffer.cannotSetMessageLength(fragment.messageLength)) return false;
+
+    if (!bm.buffer.add(fragment.fragmentData, fragment.fragmentOffset)) {
+      return false;
+    }
+    if (fragment.fragmentLength == 0) {
+      LOG.warn("Ignore fragment with length 0");
+      return true;
+    }
+    bm.map.add(fragment.fragmentOffset, fragment.fragmentOffset + fragment.fragmentLength - 1);
+    if (isMessageComplete(bm)) {
+      onMessageFullyReceived(fragment, bm, fullyReceived);
+    } else {
+      if (LOG.isTraceEnabled()) LOG.trace("Message {} receive map {}", fragment.messageID, bm.map);
+    }
+    return true;
+  }
+
+  private boolean shouldSetMessageLength(MessageFragment fragment, BufferMap bm) {
+    return fragment.firstFragment && bm.buffer.messageLength == -1;
+  }
+
+  private boolean isMessageComplete(BufferMap bm) {
+    return bm.buffer.messageLength != -1 && bm.map.contains(0, bm.buffer.messageLength - 1);
+  }
+
+  private boolean isOutsideReceiveWindow(MessageFragment fragment) {
+    if (messageWindowPtrReceived + MSG_WINDOW_SIZE > NUM_MESSAGE_IDS) {
+      int upperBound = (messageWindowPtrReceived + MSG_WINDOW_SIZE) % NUM_MESSAGE_IDS;
+      return fragment.messageID > upperBound && fragment.messageID < messageWindowPtrReceived;
+    } else {
+      int upperBound = messageWindowPtrReceived + MSG_WINDOW_SIZE;
+      return !(fragment.messageID >= messageWindowPtrReceived && fragment.messageID < upperBound);
+    }
+  }
+
+  private record BufferMap(PartiallyReceivedBuffer buffer, SparseBitmap map) {}
+
+  private BufferMap ensureBufferAndMap(MessageFragment fragment) {
+    PartiallyReceivedBuffer recvBuffer = receiveBuffers.get(fragment.messageID);
+    SparseBitmap recvMap = receiveMaps.get(fragment.messageID);
+
+    if (recvBuffer == null) {
+      if (LOG.isTraceEnabled()) LOG.trace("Message {}: create receive buffer", fragment.messageID);
+      recvBuffer = new PartiallyReceivedBuffer(this);
+
+      if (cannotSetLengthIfFirstFragment(fragment, recvBuffer)) return null;
+
+      if (!fragment.firstFragment && exceedsReceiveBuffer(fragment.fragmentLength)) {
+        if (LOG.isDebugEnabled()) LOG.debug("Cannot create buffer; exceeds max size");
+        return null;
+      }
+
+      recvMap = new SparseBitmap();
+      receiveBuffers.put(fragment.messageID, recvBuffer);
+      receiveMaps.put(fragment.messageID, recvMap);
+    } else {
+      if (cannotSetLengthIfFirstFragment(fragment, recvBuffer)) return null;
+    }
+
+    return new BufferMap(recvBuffer, recvMap);
+  }
+
+  private boolean cannotSetLengthIfFirstFragment(
+      MessageFragment fragment, PartiallyReceivedBuffer recvBuffer) {
+    return fragment.firstFragment && recvBuffer.cannotSetMessageLength(fragment.messageLength);
+  }
+
+  private boolean exceedsReceiveBuffer(int additionalLength) {
+    synchronized (receiveBufferSizeLock) {
+      return receiveBufferUsed + additionalLength > MAX_RECEIVE_BUFFER_SIZE;
+    }
+  }
+
+  private void onMessageFullyReceived(
+      MessageFragment fragment, BufferMap bm, List<byte[]> fullyReceived) {
+    receiveBuffers.remove(fragment.messageID);
+    receiveMaps.remove(fragment.messageID);
+
+    synchronized (receivedMessages) {
+      if (receivedMessages.contains(fragment.messageID, fragment.messageID)) return;
+      receivedMessages.add(fragment.messageID, fragment.messageID);
+
+      int oldWindow = messageWindowPtrReceived;
+      while (receivedMessages.contains(messageWindowPtrReceived, messageWindowPtrReceived)) {
+        messageWindowPtrReceived++;
+        if (messageWindowPtrReceived == NUM_MESSAGE_IDS) messageWindowPtrReceived = 0;
+      }
+
+      if (messageWindowPtrReceived < oldWindow) {
+        receivedMessages.remove(oldWindow, NUM_MESSAGE_IDS - 1);
+        receivedMessages.remove(0, messageWindowPtrReceived);
+      } else {
+        receivedMessages.remove(oldWindow, messageWindowPtrReceived);
       }
     }
 
-    // Move the watchlist if needed
+    synchronized (receiveBufferSizeLock) {
+      receiveBufferUsed -= bm.buffer.messageLength;
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "Removed {} bytes from buffer; total={}", bm.buffer.messageLength, receiveBufferUsed);
+    }
+
+    fullyReceived.add(bm.buffer.buffer);
+
+    if (LOG.isTraceEnabled()) LOG.trace("Message {}: receive complete", fragment.messageID);
+  }
+
+  private void maybeQueueAck(NewPacketFormatKeyContext keyContext, NPFPacket packet) {
+    int seqno = packet.getSequenceNumber();
+    int acksQueued = keyContext.queueAck(seqno);
+    boolean addedAck = acksQueued >= 0;
+    boolean wakeUp = acksQueued > MAX_ACKS;
+    if (addedAck) {
+      if (!wakeUp) {
+        synchronized (receiveBufferSizeLock) {
+          if (receiveBufferUsed > MAX_RECEIVE_BUFFER_SIZE / 2) wakeUp = true;
+        }
+      }
+      if (wakeUp) pn.wakeUpSender();
+    }
+  }
+
+  private NPFPacket tryDecipherPacket(byte[] buf, int offset, int length, SessionKey sessionKey) {
+    NewPacketFormatKeyContext keyContext = sessionKey.packetContext;
+    initWatchlistIfNeeded(keyContext, sessionKey);
+
     int highestReceivedSeqNum;
     synchronized (this) {
       highestReceivedSeqNum = keyContext.highestReceivedSeqNum;
     }
-    // The entry for the highest received sequence number is kept in the middle of the list
+    moveWatchlistIfNeeded(keyContext, highestReceivedSeqNum, sessionKey);
+
+    return findMatchingPacket(keyContext, buf, offset, length, sessionKey);
+  }
+
+  private void initWatchlistIfNeeded(NewPacketFormatKeyContext keyContext, SessionKey sessionKey) {
+    if (keyContext.seqNumWatchList != null) return;
+    if (LOG.isDebugEnabled())
+      LOG.debug("Create watchlist at offset={}", keyContext.watchListOffset);
+    keyContext.seqNumWatchList = new byte[NUM_SEQNUMS_TO_WATCH_FOR][4];
+    int seqNum = keyContext.watchListOffset;
+    for (int i = 0; i < keyContext.seqNumWatchList.length; i++) {
+      keyContext.seqNumWatchList[i] = NewPacketFormat.encryptSequenceNumber(seqNum++, sessionKey);
+      if (seqNum < 0) seqNum = 0;
+    }
+  }
+
+  private void moveWatchlistIfNeeded(
+      NewPacketFormatKeyContext keyContext, int highestReceivedSeqNum, SessionKey sessionKey) {
     int oldHighestReceived =
         (int)
-            (((long) keyContext.watchListOffset + (keyContext.seqNumWatchList.length / 2))
+            (((long) keyContext.watchListOffset + keyContext.seqNumWatchList.length / 2)
                 % NUM_SEQNUMS);
-    if (seqNumGreaterThan(highestReceivedSeqNum, oldHighestReceived, 31)) {
-      int moveBy;
-      if (highestReceivedSeqNum > oldHighestReceived) {
-        moveBy = highestReceivedSeqNum - oldHighestReceived;
-      } else {
-        moveBy = ((int) (NUM_SEQNUMS - oldHighestReceived)) + highestReceivedSeqNum;
-      }
+    if (!seqNumGreaterThan(highestReceivedSeqNum, oldHighestReceived, 31)) return;
 
-      if (moveBy > keyContext.seqNumWatchList.length) {
-        LOG.warn("Moving watchlist pointer by " + moveBy);
-      } else if (moveBy < 0) {
-        LOG.warn("Tried moving watchlist pointer by " + moveBy);
-        moveBy = 0;
-      } else {
-        if (LOG.isTraceEnabled()) LOG.trace("Moving watchlist pointer by " + moveBy);
-      }
+    int moveBy = computeMoveBy(oldHighestReceived, highestReceivedSeqNum);
+    logMoveBy(moveBy, keyContext);
 
-      int seqNum =
-          (int)
-              (((long) keyContext.watchListOffset + keyContext.seqNumWatchList.length)
-                  % NUM_SEQNUMS);
-      for (int i = keyContext.watchListPointer; i < (keyContext.watchListPointer + moveBy); i++) {
-        keyContext.seqNumWatchList[i % keyContext.seqNumWatchList.length] =
-            encryptSequenceNumber(seqNum++, sessionKey);
-        if (seqNum < 0) seqNum = 0;
-      }
-
-      keyContext.watchListPointer =
-          (keyContext.watchListPointer + moveBy) % keyContext.seqNumWatchList.length;
-      keyContext.watchListOffset =
-          (int) (((long) keyContext.watchListOffset + moveBy) % NUM_SEQNUMS);
+    int seqNum =
+        (int)
+            (((long) keyContext.watchListOffset + keyContext.seqNumWatchList.length) % NUM_SEQNUMS);
+    for (int i = keyContext.watchListPointer; i < keyContext.watchListPointer + moveBy; i++) {
+      keyContext.seqNumWatchList[i % keyContext.seqNumWatchList.length] =
+          encryptSequenceNumber(seqNum++, sessionKey);
+      if (seqNum < 0) seqNum = 0;
     }
 
+    keyContext.watchListPointer =
+        (keyContext.watchListPointer + moveBy) % keyContext.seqNumWatchList.length;
+    keyContext.watchListOffset = (int) (((long) keyContext.watchListOffset + moveBy) % NUM_SEQNUMS);
+  }
+
+  private int computeMoveBy(int oldHighestReceived, int highestReceivedSeqNum) {
+    if (highestReceivedSeqNum > oldHighestReceived) {
+      return highestReceivedSeqNum - oldHighestReceived;
+    } else {
+      return (int) (NUM_SEQNUMS - oldHighestReceived) + highestReceivedSeqNum;
+    }
+  }
+
+  private void logMoveBy(int moveBy, NewPacketFormatKeyContext keyContext) {
+    if (moveBy > keyContext.seqNumWatchList.length) {
+      LOG.warn("Move watchlist pointer by {}", moveBy);
+    } else if (moveBy < 0) {
+      LOG.warn("Attempt to move watchlist pointer by {}", moveBy);
+    } else {
+      if (LOG.isTraceEnabled()) LOG.trace("Moving watchlist pointer by {}", moveBy);
+    }
+  }
+
+  private NPFPacket findMatchingPacket(
+      NewPacketFormatKeyContext keyContext,
+      byte[] buf,
+      int offset,
+      int length,
+      SessionKey sessionKey) {
     for (int i = 0; i < keyContext.seqNumWatchList.length; i++) {
       int index = (keyContext.watchListPointer + i) % keyContext.seqNumWatchList.length;
       if (!Fields.byteArrayEqual(
@@ -386,16 +473,14 @@ public class NewPacketFormat implements PacketFormat {
           keyContext.seqNumWatchList[index].length)) continue;
 
       int sequenceNumber = (int) (((long) keyContext.watchListOffset + i) % NUM_SEQNUMS);
-      if (LOG.isTraceEnabled())
-        LOG.trace("Received packet matches sequence number " + sequenceNumber);
+      if (LOG.isTraceEnabled()) LOG.trace("Packet matches sequenceNumber={}", sequenceNumber);
       NPFPacket p = decipherFromSeqnum(buf, offset, length, sessionKey, sequenceNumber);
       if (p != null) {
         if (LOG.isDebugEnabled())
-          LOG.debug("Received packet " + p.getSequenceNumber() + " on " + sessionKey);
+          LOG.debug("Decrypted packet seq={} tracker={}", p.getSequenceNumber(), sessionKey);
         return p;
       }
     }
-
     return null;
   }
 
@@ -404,27 +489,27 @@ public class NewPacketFormat implements PacketFormat {
       byte[] buf, int offset, int length, SessionKey sessionKey, int sequenceNumber) {
     BlockCipher ivCipher = sessionKey.ivCipher;
 
-    byte[] IV = new byte[ivCipher.getBlockSize() / 8];
-    System.arraycopy(sessionKey.ivNonce, 0, IV, 0, IV.length);
-    IV[IV.length - 4] = (byte) (sequenceNumber >>> 24);
-    IV[IV.length - 3] = (byte) (sequenceNumber >>> 16);
-    IV[IV.length - 2] = (byte) (sequenceNumber >>> 8);
-    IV[IV.length - 1] = (byte) (sequenceNumber);
+    byte[] iv = new byte[ivCipher.getBlockSize() / 8];
+    System.arraycopy(sessionKey.ivNonce, 0, iv, 0, iv.length);
+    iv[iv.length - 4] = (byte) (sequenceNumber >>> 24);
+    iv[iv.length - 3] = (byte) (sequenceNumber >>> 16);
+    iv[iv.length - 2] = (byte) (sequenceNumber >>> 8);
+    iv[iv.length - 1] = (byte) sequenceNumber;
 
-    ivCipher.encipher(IV, IV);
+    ivCipher.encipher(iv, iv);
 
     byte[] payload = Arrays.copyOfRange(buf, offset + HMAC_LENGTH, offset + length);
     byte[] hash = Arrays.copyOfRange(buf, offset, offset + HMAC_LENGTH);
     byte[] localHash = Arrays.copyOf(HMAC.macWithSHA256(sessionKey.hmacKey, payload), HMAC_LENGTH);
     if (!MessageDigest.isEqual(hash, localHash)) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Failed to validate the HMAC using TrackerID=" + sessionKey.trackerID);
+        LOG.debug("HMAC validation fails (trackerId={})", sessionKey.trackerID);
       }
 
       return null;
     }
 
-    PCFBMode payloadCipher = PCFBMode.create(sessionKey.incommingCipher, IV);
+    PCFBMode payloadCipher = PCFBMode.create(sessionKey.incommingCipher, iv);
     payloadCipher.blockDecipher(payload, 0, payload.length);
 
     NPFPacket p = NPFPacket.create(payload, pn);
@@ -443,8 +528,8 @@ public class NewPacketFormat implements PacketFormat {
     // halfValue is half the window of possible numbers, so this returns true if the distance from
     // i2->i1 is smaller than i1->i2. See RFC1982 for details and limitations.
 
-    long halfValue = (long) Math.pow(2, serialBits - 1);
-    return (((i1 < i2) && ((i2 - i1) > halfValue)) || ((i1 > i2) && (i1 - i2 < halfValue)));
+    long halfValue = 1L << (serialBits - 1);
+    return i1 < i2 && i2 - i1 > halfValue || i1 > i2 && i1 - i2 < halfValue;
   }
 
   static byte[] encryptSequenceNumber(int seqNum, SessionKey sessionKey) {
@@ -452,36 +537,43 @@ public class NewPacketFormat implements PacketFormat {
     seqNumBytes[0] = (byte) (seqNum >>> 24);
     seqNumBytes[1] = (byte) (seqNum >>> 16);
     seqNumBytes[2] = (byte) (seqNum >>> 8);
-    seqNumBytes[3] = (byte) (seqNum);
+    seqNumBytes[3] = (byte) seqNum;
 
     BlockCipher ivCipher = sessionKey.ivCipher;
 
-    byte[] IV = new byte[ivCipher.getBlockSize() / 8];
-    System.arraycopy(sessionKey.ivNonce, 0, IV, 0, IV.length);
-    System.arraycopy(seqNumBytes, 0, IV, IV.length - seqNumBytes.length, seqNumBytes.length);
-    ivCipher.encipher(IV, IV);
+    byte[] iv = new byte[ivCipher.getBlockSize() / 8];
+    System.arraycopy(sessionKey.ivNonce, 0, iv, 0, iv.length);
+    System.arraycopy(seqNumBytes, 0, iv, iv.length - seqNumBytes.length, seqNumBytes.length);
+    ivCipher.encipher(iv, iv);
 
-    PCFBMode cipher = PCFBMode.create(sessionKey.incommingCipher, IV);
+    PCFBMode cipher = PCFBMode.create(sessionKey.incommingCipher, iv);
     cipher.blockEncipher(seqNumBytes, 0, seqNumBytes.length);
 
     return seqNumBytes;
   }
 
+  /**
+   * Attempts to build and send a single packet.
+   *
+   * <p>When {@code ackOnly} is {@code true}, the packet contains only acks or keepalive payloads
+   * (no message fragments). When {@code false}, the method may coalesce queued message fragments
+   * according to priorities and deadlines.
+   *
+   * @param now current time in milliseconds.
+   * @param ackOnly whether to limit the packet to acks/keepalives.
+   * @return {@code true} if a packet was sent; {@code false} if nothing was sent.
+   * @throws BlockedTooLongException if message ID allocation is blocked beyond the configured
+   *     limit.
+   */
   @Override
   public boolean maybeSendPacket(long now, boolean ackOnly) throws BlockedTooLongException {
     SessionKey sessionKey = pn.getPreviousKeyTracker();
-    if (sessionKey != null) {
-      // Try to sent an ack-only packet.
-      if (maybeSendPacket(true, sessionKey)) return true;
-    }
+    if (sessionKey != null && maybeSendPacket(true, sessionKey)) return true;
     sessionKey = pn.getUnverifiedKeyTracker();
-    if (sessionKey != null) {
-      // Try to sent an ack-only packet.
-      if (maybeSendPacket(true, sessionKey)) return true;
-    }
+    if (sessionKey != null && maybeSendPacket(true, sessionKey)) return true;
     sessionKey = pn.getCurrentKeyTracker();
     if (sessionKey == null) {
-      LOG.warn("No key for encrypting hash");
+      LOG.warn("No session key available to secure packet");
       return false;
     }
     return maybeSendPacket(ackOnly, sessionKey);
@@ -494,102 +586,101 @@ public class NewPacketFormat implements PacketFormat {
     NPFPacket packet =
         createPacket(maxPacketSize - HMAC_LENGTH, pn.getMessageQueue(), sessionKey, ackOnly);
     if (packet == null) return false;
-
-    int paddedLen = packet.getLength() + HMAC_LENGTH;
-    if (pn.shouldPadDataPackets()) {
-      int packetLength = paddedLen;
-      if (LOG.isTraceEnabled()) LOG.trace("Pre-padding length: " + packetLength);
-
-      if (packetLength < 64) {
-        paddedLen = 64 + pn.paddingGen().nextInt(32);
-      } else {
-        paddedLen = ((packetLength + 63) / 64) * 64;
-        if (paddedLen < maxPacketSize) {
-          paddedLen += pn.paddingGen().nextInt(Math.min(64, maxPacketSize - paddedLen));
-        } else if ((packetLength <= maxPacketSize) && (paddedLen > maxPacketSize)) {
-          paddedLen = maxPacketSize;
-        }
-      }
-    }
+    int paddedLen = computePaddedLength(packet, maxPacketSize);
 
     byte[] data = new byte[paddedLen];
     packet.toBytes(data, HMAC_LENGTH, pn.paddingGen());
 
+    encryptPayloadAndAddHmac(sessionKey, paddedLen, data);
+
+    if (!sendPacketBytes(packet, data)) return false;
+
+    postSendUpdates(packet, data.length, keyContext);
+
+    return true;
+  }
+
+  private int computePaddedLength(NPFPacket packet, int maxPacketSize) {
+    int paddedLen = packet.getLength() + HMAC_LENGTH;
+    if (!pn.shouldPadDataPackets()) return paddedLen;
+    if (LOG.isTraceEnabled()) LOG.trace("Pre-padding length: {}", paddedLen);
+    if (paddedLen < 64) {
+      return 64 + pn.paddingGen().nextInt(32);
+    } else {
+      int result = (paddedLen + 63) / 64 * 64;
+      if (result < maxPacketSize) {
+        result += pn.paddingGen().nextInt(Math.min(64, maxPacketSize - result));
+      } else if (paddedLen <= maxPacketSize && result > maxPacketSize) {
+        result = maxPacketSize;
+      }
+      return result;
+    }
+  }
+
+  private void encryptPayloadAndAddHmac(SessionKey sessionKey, int paddedLen, byte[] data) {
     BlockCipher ivCipher = sessionKey.ivCipher;
-
-    byte[] IV = new byte[ivCipher.getBlockSize() / 8];
-    System.arraycopy(sessionKey.ivNonce, 0, IV, 0, IV.length);
-    System.arraycopy(data, HMAC_LENGTH, IV, IV.length - 4, 4);
-
-    ivCipher.encipher(IV, IV);
-
-    PCFBMode payloadCipher = PCFBMode.create(sessionKey.outgoingCipher, IV);
+    byte[] iv = new byte[ivCipher.getBlockSize() / 8];
+    System.arraycopy(sessionKey.ivNonce, 0, iv, 0, iv.length);
+    System.arraycopy(data, HMAC_LENGTH, iv, iv.length - 4, 4);
+    ivCipher.encipher(iv, iv);
+    PCFBMode payloadCipher = PCFBMode.create(sessionKey.outgoingCipher, iv);
     payloadCipher.blockEncipher(data, HMAC_LENGTH, paddedLen - HMAC_LENGTH);
-
-    // Add hash
     byte[] text = new byte[paddedLen - HMAC_LENGTH];
     System.arraycopy(data, HMAC_LENGTH, text, 0, text.length);
-
     byte[] hash = HMAC.macWithSHA256(sessionKey.hmacKey, text);
-
     System.arraycopy(hash, 0, data, 0, HMAC_LENGTH);
+  }
 
+  private boolean sendPacketBytes(NPFPacket packet, byte[] data) {
     try {
       if (LOG.isDebugEnabled()) {
-        String fragments = null;
-        for (MessageFragment frag : packet.getFragments()) {
-          if (fragments == null) fragments = String.valueOf(frag.messageID);
-          else fragments = fragments + ", " + frag.messageID;
-          fragments +=
-              " ("
-                  + frag.fragmentOffset
-                  + "->"
-                  + (frag.fragmentOffset + frag.fragmentLength - 1)
-                  + ")";
-        }
-
         LOG.debug(
-            "Sending packet "
-                + packet.getSequenceNumber()
-                + " ("
-                + data.length
-                + " bytes) with fragments "
-                + fragments
-                + " and "
-                + packet.getAcks().size()
-                + " acks on "
-                + this);
+            "Sending packet {} ({} bytes) with fragments {} and {} acks on {}",
+            packet.getSequenceNumber(),
+            data.length,
+            buildFragmentSummary(packet),
+            packet.getAcks().size(),
+            this);
       }
       pn.sendEncryptedPacket(data);
+      return true;
     } catch (LocalAddressException e) {
       LOG.error("Caught exception while sending packet", e);
       return false;
     }
+  }
 
-    packet.onSent(data.length, pn);
+  private String buildFragmentSummary(NPFPacket packet) {
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (MessageFragment frag : packet.getFragments()) {
+      if (!first) sb.append(", ");
+      first = false;
+      sb.append(frag.messageID)
+          .append(" (")
+          .append(frag.fragmentOffset)
+          .append("->")
+          .append(frag.fragmentOffset + frag.fragmentLength - 1)
+          .append(")");
+    }
+    return sb.isEmpty() ? null : sb.toString();
+  }
 
+  private void postSendUpdates(
+      NPFPacket packet, int bytesSent, NewPacketFormatKeyContext keyContext) {
+    packet.onSent(bytesSent, pn);
     if (!packet.getFragments().isEmpty()) {
       keyContext.sent(packet.getSequenceNumber(), packet.getLength());
     }
-
     long now = System.currentTimeMillis();
     pn.sentPacket();
-    pn.reportOutgoingBytes(data.length);
-    if (pn.shouldThrottle()) {
-      pn.sentThrottledBytes(data.length);
-    }
-    if (packet.getFragments().isEmpty()) {
-      pn.onNotificationOnlyPacketSent(data.length);
-    }
-
+    pn.reportOutgoingBytes(bytesSent);
+    if (pn.shouldThrottle()) pn.sentThrottledBytes(bytesSent);
+    if (packet.getFragments().isEmpty()) pn.onNotificationOnlyPacketSent(bytesSent);
     synchronized (this) {
       if (timeLastSentPacket < now) timeLastSentPacket = now;
-      if (!packet.getFragments().isEmpty()) {
-        if (timeLastSentPayload < now) timeLastSentPayload = now;
-      }
+      if (!packet.getFragments().isEmpty() && timeLastSentPayload < now) timeLastSentPayload = now;
     }
-
-    return true;
   }
 
   NPFPacket createPacket(
@@ -607,98 +698,24 @@ public class NewPacketFormat implements PacketFormat {
     NewPacketFormatKeyContext keyContext = sessionKey.packetContext;
 
     AddedAcks moved = keyContext.addAcks(packet, maxPacketSize, now);
-    if (moved != null && moved.anyUrgentAcks) {
-      if (LOG.isTraceEnabled()) LOG.trace("Must send because urgent acks");
-      mustSend = true;
-    }
+    mustSend |= updateMustSendForUrgentAcks(moved);
 
     int numAcks = packet.countAcks();
+    if (numAcks > MAX_ACKS) mustSend = true;
+    logAddedAcksIfAny(numAcks);
 
-    if (numAcks > MAX_ACKS) {
-      mustSend = true;
-    }
+    mustSend |= maybeFinishStartedMessages(ackOnly, packet, sentPacket, maxPacketSize);
 
-    if (numAcks > 0) {
-      if (LOG.isTraceEnabled()) LOG.trace("Added acks for " + this + " for " + pn.shortToString());
-    }
+    mustSend =
+        mustSend
+            || shouldSendDueToPacketSizeOrQueue(packet, maxPacketSize, now, messageQueue, ackOnly);
 
-    if (!ackOnly) {
+    mustSend = mustSend || shouldSendDueToRemoteBufferWithAcks(numAcks);
 
-      boolean addedFragments = false;
-
-      synchronized (sendBufferLock) {
-        // Always finish what we have started before considering sending more packets.
-        // Anything beyond this is beyond the scope of NPF and is PeerMessageQueue's job.
-        for (Map<Integer, MessageWrapper> started : startedByPrio) {
-          // Try to finish messages that have been started
-          Iterator<MessageWrapper> it = started.values().iterator();
-          while (it.hasNext() && packet.getLength() < maxPacketSize) {
-            MessageWrapper wrapper = it.next();
-            while (packet.getLength() < maxPacketSize) {
-              MessageFragment frag = wrapper.getMessageFragment(maxPacketSize - packet.getLength());
-              if (frag == null) break;
-              mustSend = true;
-              addedFragments = true;
-              packet.addMessageFragment(frag);
-              sentPacket.addFragment(frag);
-            }
-          }
-        }
-      }
-
-      if (addedFragments) {
-        if (LOG.isTraceEnabled()) LOG.trace("Added fragments for " + this + " (must send)");
-      }
-    }
-
-    if ((!mustSend) && packet.getLength() >= (maxPacketSize * 4 / 5)) {
-      if (LOG.isTraceEnabled()) LOG.trace("Must send because packet is big on acks alone");
-      // Lots of acks to send, send a packet.
-      mustSend = true;
-    }
-
-    if ((!ackOnly) && (!mustSend)) {
-      if (messageQueue.mustSendNow(now)
-          || messageQueue.mustSendSize(packet.getLength(), maxPacketSize)) {
-        if (LOG.isTraceEnabled()) LOG.trace("Must send because of message queue");
-        mustSend = true;
-      }
-    }
-
-    if ((!mustSend) && numAcks > 0) {
-      int maxSendBufferSize = maxSendBufferSize();
-      synchronized (sendBufferLock) {
-        if (sendBufferUsed > maxSendBufferSize / 2) {
-          if (LOG.isTraceEnabled())
-            LOG.trace("Must send because other side buffer size is " + sendBufferUsed);
-          mustSend = true;
-        }
-      }
-    }
-
-    boolean checkedCanSend = false;
-    boolean cantSend = false;
-
-    boolean mustSendKeepalive = false;
-
-    if (DO_KEEPALIVES) {
-      synchronized (this) {
-        if (!mustSend) {
-          if (now - timeLastSentPacket > Node.KEEPALIVE_INTERVAL) mustSend = true;
-        }
-        if ((!ackOnly)
-            && now - timeLastSentPayload > Node.KEEPALIVE_INTERVAL
-            && packet.getFragments().isEmpty()) mustSendKeepalive = true;
-      }
-    }
-
-    if (mustSendKeepalive) {
-      if (!checkedCanSend) cantSend = !canSend(sessionKey);
-      checkedCanSend = true;
-      if (!cantSend) {
-        mustSend = true;
-      }
-    }
+    // Keepalive decisions
+    mustSend |= shouldForceSendByKeepaliveTimer(now, mustSend);
+    boolean mustSendKeepalive = shouldScheduleKeepalivePayload(ackOnly, packet, now);
+    if (mustSendKeepalive && canSend(sessionKey)) mustSend = true;
 
     if (!mustSend) {
       if (moved != null) {
@@ -707,112 +724,223 @@ public class NewPacketFormat implements PacketFormat {
       return null;
     }
 
-    if (ackOnly && numAcks == 0) return null;
+    if (!canSendAckOnly(numAcks, ackOnly)) return null;
 
-    if ((!ackOnly) && (!cantSend)) {
+    if (!ackOnly) {
+      fillPacketWithFragments(
+          packet, sentPacket, maxPacketSize, messageQueue, sessionKey, mustSendKeepalive, now);
+    }
 
-      fragments:
-      for (int i = 0; i < startedByPrio.size(); i++) {
-        // Add messages from the message queue
-        while ((packet.getLength() + 10)
-            < maxPacketSize) { // Fragment header is max 9 bytes, allow min 1 byte data
+    if (!preparePacketForSend(packet, keyContext, ackOnly, sentPacket)) return null;
 
-          if (!checkedCanSend) {
-            // Check in advance to avoid reordering message items.
-            cantSend = !canSend(sessionKey);
-          }
-          checkedCanSend = false;
-          if (cantSend) break;
-          boolean wasGeneratedPing = false;
+    return packet;
+  }
 
-          MessageItem item = messageQueue.grabQueuedMessageItem(i);
-          if (item == null) {
-            if (mustSendKeepalive && packet.noFragments()) {
-              // Create a ping for keepalive purposes.
-              // It will be acked, this ensures both sides don't timeout.
-              Message msg;
-              synchronized (this) {
-                msg = DMT.createFNPPing(pingCounter++);
-              }
-              item = new MessageItem(msg, null, null);
-              item.setDeadline(now + PacketSender.MAX_COALESCING_DELAY);
-              wasGeneratedPing = true;
-              // Should we report this on the PeerNode's stats? We'd need to run a job off-thread,
-              // so probably not worth it.
-            } else {
-              break;
-            }
-          }
+  private void logAddedAcksIfAny(int numAcks) {
+    if (numAcks > 0 && LOG.isTraceEnabled())
+      LOG.trace("Added acks for {} for {}", this, pn.shortToString());
+  }
 
-          int messageID = getMessageID();
-          if (messageID == -1) {
-            // CONCURRENCY: This will fail sometimes if we send messages to the same peer from
-            // different threads.
-            // This doesn't happen at the moment because we use a single PacketSender for all ports
-            // and all peers.
-            // We might in future split it across multiple threads but it'd be best to keep the same
-            // peer on the same thread.
-            LOG.error(
-                "No availiable message ID, requeuing and sending packet (we already checked didn't"
-                    + " we???)");
-            if (!wasGeneratedPing) {
-              messageQueue.pushfrontPrioritizedMessageItem(item);
-              // No point adding to queue if it's just a ping:
-              //  We will try again next time.
-              //  But odds are the connection is broken and the other side isn't responding...
-            }
-            break fragments;
-          }
+  private boolean maybeFinishStartedMessages(
+      boolean ackOnly, NPFPacket packet, SentPacket sentPacket, int maxPacketSize) {
+    if (ackOnly) return false;
+    return finishStartedMessagesAndAddFragments(packet, sentPacket, maxPacketSize);
+  }
 
-          if (LOG.isTraceEnabled())
-            LOG.trace("Allocated " + messageID + " for " + item + " for " + this);
+  private boolean shouldSendDueToRemoteBufferWithAcks(int numAcks) {
+    return numAcks > 0 && shouldSendDueToRemoteBuffer();
+  }
 
-          MessageWrapper wrapper = new MessageWrapper(item, messageID);
-          MessageFragment frag = wrapper.getMessageFragment(maxPacketSize - packet.getLength());
-          if (frag == null) {
-            messageQueue.pushfrontPrioritizedMessageItem(item);
-            break;
-          }
-          packet.addMessageFragment(frag);
-          sentPacket.addFragment(frag);
+  private boolean canSendAckOnly(int numAcks, boolean ackOnly) {
+    return !(ackOnly && numAcks == 0);
+  }
 
-          // Priority of the one we grabbed might be higher than i
-          Map<Integer, MessageWrapper> queue = startedByPrio.get(item.getPriority());
-          synchronized (sendBufferLock) {
-            // CONCURRENCY: This could go over the limit if we allow createPacket() for the same
-            // node on two threads in parallel. That's probably a bad idea anyway.
-            sendBufferUsed += item.buf.length;
-            if (LOG.isDebugEnabled())
-              LOG.debug(
-                  "Added "
-                      + item.buf.length
-                      + " to remote buffer. Total is now "
-                      + sendBufferUsed
-                      + " for "
-                      + pn.shortToString());
-            queue.put(messageID, wrapper);
+  private boolean preparePacketForSend(
+      NPFPacket packet,
+      NewPacketFormatKeyContext keyContext,
+      boolean ackOnly,
+      SentPacket sentPacket) {
+    if (packet.getLength() == 5) return false;
+    int seqNum = keyContext.allocateSequenceNumber(pn);
+    if (seqNum == -1) return false;
+    packet.setSequenceNumber(seqNum);
+    if (LOG.isTraceEnabled()) {
+      if (ackOnly) {
+        LOG.trace("Send ack-only packet bytes={} for {}", packet.getLength(), this);
+      } else {
+        LOG.trace("Send packet bytes={} for {}", packet.getLength(), this);
+      }
+    }
+    if (!packet.getFragments().isEmpty()) {
+      keyContext.sent(sentPacket, seqNum, packet.getLength());
+    }
+    return true;
+  }
+
+  private boolean updateMustSendForUrgentAcks(AddedAcks moved) {
+    if (moved != null && moved.anyUrgentAcks) {
+      if (LOG.isTraceEnabled()) LOG.trace("Must send due to urgent acks");
+      return true;
+    }
+    return false;
+  }
+
+  private boolean finishStartedMessagesAndAddFragments(
+      NPFPacket packet, SentPacket sentPacket, int maxPacketSize) {
+    boolean addedFragments = false;
+    synchronized (sendBufferLock) {
+      for (Map<Integer, MessageWrapper> started : startedByPrio) {
+        Iterator<MessageWrapper> it = started.values().iterator();
+        while (it.hasNext() && packet.getLength() < maxPacketSize) {
+          MessageWrapper wrapper = it.next();
+          while (packet.getLength() < maxPacketSize) {
+            MessageFragment frag = wrapper.getMessageFragment(maxPacketSize - packet.getLength());
+            if (frag == null) break;
+            addedFragments = true;
+            packet.addMessageFragment(frag);
+            sentPacket.addFragment(frag);
           }
         }
       }
     }
+    if (addedFragments && LOG.isTraceEnabled())
+      LOG.trace("Added fragments for {}; must send", this);
+    return addedFragments;
+  }
 
-    if (packet.getLength() == 5) return null;
+  private boolean shouldSendDueToPacketSizeOrQueue(
+      NPFPacket packet,
+      int maxPacketSize,
+      long now,
+      PeerMessageQueue messageQueue,
+      boolean ackOnly) {
+    if (packet.getLength() >= maxPacketSize * 4 / 5) {
+      if (LOG.isTraceEnabled()) LOG.trace("Must send; ack-only packet size high");
+      return true;
+    }
+    if (!ackOnly
+        && (messageQueue.mustSendNow(now)
+            || messageQueue.mustSendSize(packet.getLength(), maxPacketSize))) {
+      if (LOG.isTraceEnabled()) LOG.trace("Must send due to message queue");
+      return true;
+    }
+    return false;
+  }
 
-    int seqNum = keyContext.allocateSequenceNumber(pn);
-    if (seqNum == -1) return null;
-    packet.setSequenceNumber(seqNum);
+  private boolean shouldSendDueToRemoteBuffer() {
+    int maxSendBufferSize = maxSendBufferSize();
+    synchronized (sendBufferLock) {
+      if (sendBufferUsed > maxSendBufferSize / 2) {
+        if (LOG.isTraceEnabled()) LOG.trace("Must send; remote buffer used={}", sendBufferUsed);
+        return true;
+      }
+    }
+    return false;
+  }
 
-    if (LOG.isTraceEnabled() && ackOnly) {
-      LOG.trace("Sending ack-only packet length " + packet.getLength() + " for " + this);
-    } else if (LOG.isTraceEnabled() && !ackOnly) {
-      LOG.trace("Sending packet length " + packet.getLength() + " for " + this);
+  private boolean shouldForceSendByKeepaliveTimer(long now, boolean alreadyMustSend) {
+    if (!doKeepalives) return false;
+    synchronized (this) {
+      return !alreadyMustSend && (now - timeLastSentPacket > Node.KEEPALIVE_INTERVAL);
+    }
+  }
+
+  private boolean shouldScheduleKeepalivePayload(boolean ackOnly, NPFPacket packet, long now) {
+    if (!doKeepalives) return false;
+    synchronized (this) {
+      return !ackOnly
+          && now - timeLastSentPayload > Node.KEEPALIVE_INTERVAL
+          && packet.getFragments().isEmpty();
+    }
+  }
+
+  private void fillPacketWithFragments(
+      NPFPacket packet,
+      SentPacket sentPacket,
+      int maxPacketSize,
+      PeerMessageQueue messageQueue,
+      SessionKey sessionKey,
+      boolean mustSendKeepalive,
+      long now)
+      throws BlockedTooLongException {
+
+    for (int i = 0; i < startedByPrio.size(); i++) {
+      while (packet.getLength() + 10 < maxPacketSize && canSend(sessionKey)) {
+        FillAction action =
+            appendNextFragmentForPriority(
+                i, packet, sentPacket, maxPacketSize, messageQueue, mustSendKeepalive, now);
+        if (action == FillAction.ABORT) return; // Abort filling entirely
+        if (action == FillAction.STOP) break; // Stop this priority level
+        // Otherwise CONTINUE
+      }
+    }
+  }
+
+  private enum FillAction {
+    CONTINUE,
+    STOP,
+    ABORT
+  }
+
+  private FillAction appendNextFragmentForPriority(
+      int priorityIndex,
+      NPFPacket packet,
+      SentPacket sentPacket,
+      int maxPacketSize,
+      PeerMessageQueue messageQueue,
+      boolean mustSendKeepalive,
+      long now)
+      throws BlockedTooLongException {
+    boolean wasGeneratedPing = false;
+    MessageItem item = messageQueue.grabQueuedMessageItem(priorityIndex);
+    if (item == null) {
+      if (mustSendKeepalive && packet.noFragments()) {
+        Message msg;
+        synchronized (this) {
+          msg = DMT.createFNPPing(pingCounter++);
+        }
+        item = new MessageItem(msg, null, null);
+        item.setDeadline(now + PacketSender.MAX_COALESCING_DELAY);
+        wasGeneratedPing = true;
+      } else {
+        return FillAction.STOP;
+      }
     }
 
-    if (!packet.getFragments().isEmpty()) {
-      keyContext.sent(sentPacket, seqNum, packet.getLength());
+    int messageID = getMessageID();
+    if (messageID == -1) {
+      LOG.error("No available message ID; requeue item and send packet");
+      if (!wasGeneratedPing) {
+        messageQueue.pushfrontPrioritizedMessageItem(item);
+      }
+      return FillAction.ABORT;
     }
 
-    return packet;
+    if (LOG.isTraceEnabled())
+      LOG.trace("Allocated messageId={} item={} peer={}", messageID, item, this);
+
+    MessageWrapper wrapper = new MessageWrapper(item, messageID);
+    MessageFragment frag = wrapper.getMessageFragment(maxPacketSize - packet.getLength());
+    if (frag == null) {
+      messageQueue.pushfrontPrioritizedMessageItem(item);
+      return FillAction.STOP;
+    } else {
+      packet.addMessageFragment(frag);
+      sentPacket.addFragment(frag);
+
+      Map<Integer, MessageWrapper> queue = startedByPrio.get(item.getPriority());
+      synchronized (sendBufferLock) {
+        sendBufferUsed += item.buf.length;
+        if (LOG.isDebugEnabled())
+          LOG.debug(
+              "Added {} bytes to remote buffer; total={} for {}",
+              item.buf.length,
+              sendBufferUsed,
+              pn.shortToString());
+        queue.put(messageID, wrapper);
+      }
+      return FillAction.CONTINUE;
+    }
   }
 
   private int pingCounter;
@@ -824,46 +952,64 @@ public class NewPacketFormat implements PacketFormat {
     return MAX_RECEIVE_BUFFER_SIZE;
   }
 
+  /**
+   * Computes the next time to run retransmission checks across all active session keys.
+   *
+   * @return an absolute timestamp (ms since epoch) when a loss check should next occur, or {@link
+   *     Long#MAX_VALUE} when there are no in-flight packets.
+   */
   @Override
   public long timeCheckForLostPackets() {
     long timeCheck = Long.MAX_VALUE;
     double averageRTT = averageRTT();
     SessionKey key = pn.getCurrentKeyTracker();
     if (key != null)
-      timeCheck = Math.min(timeCheck, ((key.packetContext)).timeCheckForLostPackets(averageRTT));
+      timeCheck = Math.min(timeCheck, key.packetContext.timeCheckForLostPackets(averageRTT));
     key = pn.getPreviousKeyTracker();
     if (key != null)
-      timeCheck = Math.min(timeCheck, ((key.packetContext)).timeCheckForLostPackets(averageRTT));
+      timeCheck = Math.min(timeCheck, key.packetContext.timeCheckForLostPackets(averageRTT));
     key = pn.getUnverifiedKeyTracker();
     if (key != null)
-      timeCheck = Math.min(timeCheck, ((key.packetContext)).timeCheckForLostPackets(averageRTT));
+      timeCheck = Math.min(timeCheck, key.packetContext.timeCheckForLostPackets(averageRTT));
     return timeCheck;
   }
 
   private long timeCheckForAcks() {
     long timeCheck = Long.MAX_VALUE;
     SessionKey key = pn.getCurrentKeyTracker();
-    if (key != null) timeCheck = Math.min(timeCheck, (key.packetContext).timeCheckForAcks());
+    if (key != null) timeCheck = Math.min(timeCheck, key.packetContext.timeCheckForAcks());
     key = pn.getPreviousKeyTracker();
-    if (key != null) timeCheck = Math.min(timeCheck, (key.packetContext).timeCheckForAcks());
+    if (key != null) timeCheck = Math.min(timeCheck, key.packetContext.timeCheckForAcks());
     key = pn.getUnverifiedKeyTracker();
-    if (key != null) timeCheck = Math.min(timeCheck, (key.packetContext).timeCheckForAcks());
+    if (key != null) timeCheck = Math.min(timeCheck, key.packetContext.timeCheckForAcks());
     return timeCheck;
   }
 
+  /**
+   * Scans in-flight packets and marks overdue ones as lost, updating throttling and backoff.
+   *
+   * <p>Side effects: may notify the {@link PacketThrottle} and peer backoff, and may wake the
+   * sender when new capacity becomes available.
+   */
   @Override
   public void checkForLostPackets() {
     if (pn == null) return;
     double averageRTT = averageRTT();
     long curTime = System.currentTimeMillis();
     SessionKey key = pn.getCurrentKeyTracker();
-    if (key != null) ((key.packetContext)).checkForLostPackets(averageRTT, curTime, pn);
+    if (key != null) key.packetContext.checkForLostPackets(averageRTT, curTime, pn);
     key = pn.getPreviousKeyTracker();
-    if (key != null) ((key.packetContext)).checkForLostPackets(averageRTT, curTime, pn);
+    if (key != null) key.packetContext.checkForLostPackets(averageRTT, curTime, pn);
     key = pn.getUnverifiedKeyTracker();
-    if (key != null) ((key.packetContext)).checkForLostPackets(averageRTT, curTime, pn);
+    if (key != null) key.packetContext.checkForLostPackets(averageRTT, curTime, pn);
   }
 
+  /**
+   * Clears send-side state on disconnect and returns message items to requeue upstream.
+   *
+   * @return a list of {@link MessageItem} instances that were partially sent and should be
+   *     re-enqueued by the caller.
+   */
   @Override
   public List<MessageItem> onDisconnect() {
     int messageSize = 0;
@@ -882,14 +1028,12 @@ public class NewPacketFormat implements PacketFormat {
       // This is just a check for logging/debugging purposes.
       if (sendBufferUsed != 0) {
         LOG.warn(
-            "Possible leak in transport code: Buffer size not empty after disconnecting on "
-                + this
-                + " for "
-                + pn
-                + " after removing "
-                + messageSize
-                + " total was "
-                + sendBufferUsed);
+            "Possible leak in transport code: Buffer size not empty after disconnecting on {} for"
+                + " {} after removing {} total was {}",
+            this,
+            pn,
+            messageSize,
+            sendBufferUsed);
         sendBufferUsed = 0;
       }
     }
@@ -897,152 +1041,148 @@ public class NewPacketFormat implements PacketFormat {
   }
 
   /**
-   * When do we need to send a packet?
+   * Computes the next time this peer would like to send any packet (acks, keepalive, or data).
    *
-   * @return 0 if there is anything already in flight. The time that the oldest ack was queued at
-   *     plus the lesser of half the RTT or 100ms if there are acks queued. Otherwise Long.MAX_VALUE
-   *     to indicate that we need to get messages from the queue.
+   * @param canSend whether {@link #canSend(SessionKey)} currently allows sending data.
+   * @param now current time in milliseconds.
+   * @return {@code 0} if something is already in flight; otherwise the earliest of the oldest ack
+   *     deadline, half the average RTT (capped at 100 ms), or the next keepalive time. Returns
+   *     {@link Long#MAX_VALUE} when nothing is pending.
    */
   @Override
   public long timeNextUrgent(boolean canSend, long now) {
     long ret = Long.MAX_VALUE;
-    if (canSend) {
-      // Is there anything in flight?
-      // Packets in flight limit applies even if there is stuff to resend.
-      synchronized (sendBufferLock) {
-        for (Map<Integer, MessageWrapper> started : startedByPrio) {
-          for (MessageWrapper wrapper : started.values()) {
-            if (wrapper.allSent()) continue;
-            // We do not reset the deadline when we resend.
-            // The RTO computation logic should ensure that we don't use horrible amounts of
-            // bandwidth for retransmission.
-            long d = wrapper.getItem().getDeadline();
-            if (d > 0) ret = Math.min(ret, d);
-            else
-              LOG.error("Started sending message " + wrapper.getItem() + " but deadline is " + d);
-          }
-        }
-      }
-    }
-    // Check for acks.
+    if (canSend) ret = Math.min(ret, earliestUnsentDeadline());
     ret = Math.min(ret, timeCheckForAcks());
-
     if (ret > now) {
-      // Always wake up after half an RTT, check whether stuff is lost or needs ack'ing.
-      ret = Math.min(ret, now + Math.min(100, (long) averageRTT() / 2));
-
-      if (canSend && DO_KEEPALIVES) {
-        synchronized (this) {
-          ret = Math.min(ret, timeLastSentPayload + Node.KEEPALIVE_INTERVAL);
-        }
-      }
+      ret = Math.min(ret, now + Math.min(100, (long) (averageRTT() / 2)));
+      if (canSend && doKeepalives) ret = Math.min(ret, nextKeepaliveTime());
     }
-
     return ret;
   }
 
+  private long earliestUnsentDeadline() {
+    long ret = Long.MAX_VALUE;
+    synchronized (sendBufferLock) {
+      for (Map<Integer, MessageWrapper> started : startedByPrio) {
+        for (MessageWrapper wrapper : started.values()) {
+          if (wrapper.allSent()) continue;
+          long d = wrapper.getItem().getDeadline();
+          if (d > 0) ret = Math.min(ret, d);
+          else LOG.error("Started sending {}; invalid deadline {}", wrapper.getItem(), d);
+        }
+      }
+    }
+    return ret;
+  }
+
+  private long nextKeepaliveTime() {
+    synchronized (this) {
+      return timeLastSentPayload + Node.KEEPALIVE_INTERVAL;
+    }
+  }
+
+  /**
+   * Returns the earliest deadline to flush queued acknowledgments.
+   *
+   * @return an absolute timestamp (ms since epoch), or {@link Long#MAX_VALUE} if no acks are
+   *     queued.
+   */
   @Override
   public long timeSendAcks() {
     return timeCheckForAcks();
   }
 
+  /**
+   * Returns whether a packet with data can be sent now under current constraints.
+   *
+   * <p>Checks include message ID availability, sequence-number allocation for the given key, remote
+   * buffer usage, and throttle window. When message ID allocation is not possible but there are
+   * partially started messages, a send may still be performed to finish them.
+   *
+   * @param tracker the session key whose sequence numbers will be used; may be {@code null} to
+   *     indicate that only throttling and buffering should be considered.
+   * @return {@code true} if data can be sent now; {@code false} otherwise.
+   */
   @Override
   public boolean canSend(SessionKey tracker) {
-
-    boolean canAllocateID;
-
-    synchronized (this) {
-      // Check whether we can allocate a message number.
-      canAllocateID =
-          !seqNumGreaterThan(
-              nextMessageID, (messageWindowPtrAcked + MSG_WINDOW_SIZE) % NUM_MESSAGE_IDS, 28);
-    }
-
+    boolean canAllocateID = canAllocateMessageId();
     if (canAllocateID) {
-      // Check whether we need to rekey.
-      if (tracker == null) return false;
-      NewPacketFormatKeyContext keyContext = tracker.packetContext;
-      if (!keyContext.canAllocateSeqNum()) {
-        // We can't allocate more sequence numbers because we haven't rekeyed yet
-        pn.startRekeying();
-        LOG.error("Can't send because we would block on " + this);
-        return false;
-      }
+      if (!rekeyCheck(tracker)) return false;
+      if (!withinRemoteBuffer()) return false;
     }
-
-    if (canAllocateID) {
-      int bufferUsage;
-      synchronized (sendBufferLock) {
-        bufferUsage = sendBufferUsed;
-      }
-      int maxSendBufferSize = maxSendBufferSize();
-      if ((bufferUsage + MAX_MESSAGE_SIZE) > maxSendBufferSize) {
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "Cannot send: Would exceed remote buffer size. Remote at "
-                  + bufferUsage
-                  + " max is "
-                  + maxSendBufferSize
-                  + " on "
-                  + this);
-        return false;
-      }
-    }
-
-    if (tracker != null && pn != null) {
-      PacketThrottle throttle = pn.getThrottle();
-      if (throttle == null) {
-        // Ignore
-      } else {
-        int maxPackets = (int) Math.min(Integer.MAX_VALUE, pn.getThrottle().getWindowSize());
-        // Impose a minimum so that we don't lose the ability to send anything.
-        if (maxPackets < 1) maxPackets = 1;
-        NewPacketFormatKeyContext packets = tracker.packetContext;
-        if (maxPackets <= packets.countSentPackets()) {
-          // FIXME some packets will be visible from the outside yet only contain acks.
-          // SECURITY/INVISIBILITY: They won't count here, this is bad.
-          // However, counting packets in flight, rather than bytes of messages, is the right
-          // solution:
-          // 1. It's closer to what TCP does.
-          // 2. It avoids needing to have an excessively high minimum window size.
-          // 3. It allows us to start work on any message even if it's big, while still having
-          // reasonably accurate congestion control.
-          // This prevents us from getting into a situation where we never use up the full window
-          // but can never send big messages either.
-          // 4. It's closer to what we used to do (only limit big packets), which seemed to work
-          // mostly.
-          // 5. It avoids some complicated headaches with PeerMessageQueue. E.g. we need to avoid
-          // requeueing.
-          // 6. In spite of the issue with acks, it's probably more "invisible" on the whole, in
-          // that the number of packets is visible,
-          // whereas messages are supposed to not be visible.
-          // Arguably we should count bytes rather than packets.
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "Cannot send because "
-                    + packets.countSentPackets()
-                    + " in flight of limit "
-                    + maxPackets
-                    + " on "
-                    + this);
-          return false;
-        }
-      }
-    }
-
+    if (!underThrottleLimit(tracker)) return false;
     if (!canAllocateID) {
-      synchronized (sendBufferLock) {
-        for (Map<Integer, MessageWrapper> started : startedByPrio) {
-          for (MessageWrapper wrapper : started.values()) {
-            if (!wrapper.allSent()) return true;
-          }
+      if (hasUnsentStartedMessages()) return true;
+      if (LOG.isTraceEnabled()) LOG.trace("Cannot send because cannot allocate ID on {}", this);
+    }
+    return canAllocateID;
+  }
+
+  private boolean canAllocateMessageId() {
+    synchronized (this) {
+      return !seqNumGreaterThan(
+          nextMessageID, (messageWindowPtrAcked + MSG_WINDOW_SIZE) % NUM_MESSAGE_IDS, 28);
+    }
+  }
+
+  private boolean rekeyCheck(SessionKey tracker) {
+    if (tracker == null) return false;
+    NewPacketFormatKeyContext keyContext = tracker.packetContext;
+    if (!keyContext.canAllocateSeqNum()) {
+      pn.startRekeying();
+      LOG.error("Can't send because we would block on {}", this);
+      return false;
+    }
+    return true;
+  }
+
+  private boolean withinRemoteBuffer() {
+    int bufferUsage;
+    synchronized (sendBufferLock) {
+      bufferUsage = sendBufferUsed;
+    }
+    int maxSendBufferSize = maxSendBufferSize();
+    if (bufferUsage + MAX_MESSAGE_SIZE > maxSendBufferSize) {
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "Cannot send; remote buffer used={} max={} on {}",
+            bufferUsage,
+            maxSendBufferSize,
+            this);
+      return false;
+    }
+    return true;
+  }
+
+  private boolean underThrottleLimit(SessionKey tracker) {
+    if (tracker == null || pn == null) return true;
+    PacketThrottle throttle = pn.getThrottle();
+    if (throttle == null) return true;
+    int maxPackets = (int) Math.min(Integer.MAX_VALUE, pn.getThrottle().getWindowSize());
+    if (maxPackets < 1) maxPackets = 1;
+    NewPacketFormatKeyContext packets = tracker.packetContext;
+    if (maxPackets <= packets.countSentPackets()) {
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "Cannot send; in-flight={} limit={} on {}",
+            packets.countSentPackets(),
+            maxPackets,
+            this);
+      return false;
+    }
+    return true;
+  }
+
+  private boolean hasUnsentStartedMessages() {
+    synchronized (sendBufferLock) {
+      for (Map<Integer, MessageWrapper> started : startedByPrio) {
+        for (MessageWrapper wrapper : started.values()) {
+          if (!wrapper.allSent()) return true;
         }
       }
     }
-
-    if (LOG.isTraceEnabled() && !canAllocateID)
-      LOG.trace("Cannot send because cannot allocate ID on " + this);
-    return canAllocateID;
+    return false;
   }
 
   private long blockedSince = -1;
@@ -1081,6 +1221,7 @@ public class NewPacketFormat implements PacketFormat {
 
     SentPacket(NewPacketFormat npf, SessionKey key) {
       this.npf = npf;
+      if (LOG.isTraceEnabled()) LOG.trace("Created SentPacket for {}", key);
     }
 
     void addFragment(MessageFragment frag) {
@@ -1091,69 +1232,64 @@ public class NewPacketFormat implements PacketFormat {
     public long acked(SessionKey key) {
       Iterator<MessageWrapper> msgIt = messages.iterator();
       Iterator<int[]> rangeIt = ranges.iterator();
-
       while (msgIt.hasNext()) {
         MessageWrapper wrapper = msgIt.next();
         int[] range = rangeIt.next();
+        processAckForWrapper(key, wrapper, range);
+      }
+      return System.currentTimeMillis() - sentTime;
+    }
 
+    private void processAckForWrapper(SessionKey key, MessageWrapper wrapper, int[] range) {
+      if (LOG.isDebugEnabled())
+        LOG.debug("Ack range {}-{} for messageId={}", range[0], range[1], wrapper.getMessageID());
+      if (!wrapper.ack(range[0], range[1], npf.pn)) return;
+      MessageWrapper removed = removeFromStartedAndUpdateBuffer(wrapper);
+      if (removed == null && LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Completed message {} not found in started map ({})", wrapper.getMessageID(), wrapper);
+      }
+      if (removed != null) {
         if (LOG.isDebugEnabled())
-          LOG.debug(
-              "Acknowledging " + range[0] + " to " + range[1] + " on " + wrapper.getMessageID());
-
-        if (wrapper.ack(range[0], range[1], npf.pn)) {
-          Map<Integer, MessageWrapper> started = npf.startedByPrio.get(wrapper.getPriority());
-          MessageWrapper removed = null;
-          synchronized (npf.sendBufferLock) {
-            removed = started.remove(wrapper.getMessageID());
-            if (removed != null) {
-              int size = wrapper.getLength();
-              npf.sendBufferUsed -= size;
-              if (LOG.isDebugEnabled())
-                LOG.debug(
-                    "Removed " + size + " from remote buffer. Total is now " + npf.sendBufferUsed);
-            }
-          }
-          if (removed == null && LOG.isDebugEnabled()) {
-            // ack() can return true more than once, it just only calls the callbacks once.
-            LOG.debug(
-                "Completed message "
-                    + wrapper.getMessageID()
-                    + " but it is not in the map from "
-                    + wrapper);
-          }
-
-          if (removed != null) {
-            if (LOG.isDebugEnabled())
-              LOG.debug("Completed message " + wrapper.getMessageID() + " from " + wrapper);
-
-            boolean couldSend = npf.canSend(key);
-            int id = wrapper.getMessageID();
-            synchronized (npf) {
-              npf.ackedMessages.add(id, id);
-
-              int oldWindow = npf.messageWindowPtrAcked;
-              while (npf.ackedMessages.contains(
-                  npf.messageWindowPtrAcked, npf.messageWindowPtrAcked)) {
-                npf.messageWindowPtrAcked++;
-                if (npf.messageWindowPtrAcked == NUM_MESSAGE_IDS) npf.messageWindowPtrAcked = 0;
-              }
-
-              if (npf.messageWindowPtrAcked < oldWindow) {
-                npf.ackedMessages.remove(oldWindow, NUM_MESSAGE_IDS - 1);
-                npf.ackedMessages.remove(0, npf.messageWindowPtrAcked);
-              } else {
-                npf.ackedMessages.remove(oldWindow, npf.messageWindowPtrAcked);
-              }
-            }
-            if (!couldSend && npf.canSend(key)) {
-              // We aren't blocked anymore, notify packet sender
-              npf.pn.wakeUpSender();
-            }
-          }
+          LOG.debug("Completed message {}; removed from {}", wrapper.getMessageID(), wrapper);
+        boolean couldSend = npf.canSend(key);
+        updateAckedWindow(wrapper.getMessageID());
+        if (!couldSend && npf.canSend(key)) {
+          npf.pn.wakeUpSender();
         }
       }
+    }
 
-      return System.currentTimeMillis() - sentTime;
+    private MessageWrapper removeFromStartedAndUpdateBuffer(MessageWrapper wrapper) {
+      Map<Integer, MessageWrapper> started = npf.startedByPrio.get(wrapper.getPriority());
+      MessageWrapper removed;
+      synchronized (npf.sendBufferLock) {
+        removed = started.remove(wrapper.getMessageID());
+        if (removed != null) {
+          int size = wrapper.getLength();
+          npf.sendBufferUsed -= size;
+          if (LOG.isDebugEnabled())
+            LOG.debug("Removed {} bytes from remote buffer; total={}", size, npf.sendBufferUsed);
+        }
+      }
+      return removed;
+    }
+
+    private void updateAckedWindow(int id) {
+      synchronized (npf) {
+        npf.ackedMessages.add(id, id);
+        int oldWindow = npf.messageWindowPtrAcked;
+        while (npf.ackedMessages.contains(npf.messageWindowPtrAcked, npf.messageWindowPtrAcked)) {
+          npf.messageWindowPtrAcked++;
+          if (npf.messageWindowPtrAcked == NUM_MESSAGE_IDS) npf.messageWindowPtrAcked = 0;
+        }
+        if (npf.messageWindowPtrAcked < oldWindow) {
+          npf.ackedMessages.remove(oldWindow, NUM_MESSAGE_IDS - 1);
+          npf.ackedMessages.remove(0, npf.messageWindowPtrAcked);
+        } else {
+          npf.ackedMessages.remove(oldWindow, npf.messageWindowPtrAcked);
+        }
+      }
     }
 
     public void lost() {
@@ -1169,6 +1305,7 @@ public class NewPacketFormat implements PacketFormat {
     }
 
     public void sent(int length) {
+      if (LOG.isTraceEnabled()) LOG.trace("Sent packet bytes {}", length);
       sentTime = System.currentTimeMillis();
     }
 
@@ -1189,9 +1326,8 @@ public class NewPacketFormat implements PacketFormat {
     }
 
     private boolean add(byte[] data, int dataOffset) {
-      if (buffer.length < (dataOffset + data.length)) {
-        if (!resize(dataOffset + data.length)) return false;
-      }
+      if (buffer.length < dataOffset + data.length && !resize(dataOffset + data.length))
+        return false;
 
       System.arraycopy(data, 0, buffer, dataOffset, data.length);
       return true;
@@ -1205,33 +1341,30 @@ public class NewPacketFormat implements PacketFormat {
       this.messageLength = messageLength;
 
       if (buffer.length > messageLength) {
-        LOG.warn(
-            "Buffer is larger than set message length! ("
-                + buffer.length
-                + ">"
-                + messageLength
-                + ")");
+        LOG.warn("Buffer larger than message length ({}>{})", buffer.length, messageLength);
       }
 
       return resize(messageLength);
     }
 
+    private boolean cannotSetMessageLength(int messageLength) {
+      return !setMessageLength(messageLength);
+    }
+
     private boolean resize(int length) {
-      if (LOG.isTraceEnabled()) LOG.trace("Resizing from " + buffer.length + " to " + length);
+      if (LOG.isTraceEnabled())
+        LOG.trace("Resize buffer from {} to {} bytes", buffer.length, length);
 
       synchronized (npf.receiveBufferSizeLock) {
-        if ((npf.receiveBufferUsed + (length - buffer.length)) > MAX_RECEIVE_BUFFER_SIZE) {
-          if (LOG.isDebugEnabled()) LOG.debug("Could not resize buffer, would excede max size");
+        if (npf.receiveBufferUsed + length - buffer.length > MAX_RECEIVE_BUFFER_SIZE) {
+          if (LOG.isDebugEnabled()) LOG.debug("Cannot resize buffer; exceeds max size");
           return false;
         }
 
-        npf.receiveBufferUsed += (length - buffer.length);
+        npf.receiveBufferUsed += length - buffer.length;
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "Added "
-                  + (length - buffer.length)
-                  + " to buffer. Total is now "
-                  + npf.receiveBufferUsed);
+              "Added {} bytes to buffer; total={}", length - buffer.length, npf.receiveBufferUsed);
       }
 
       buffer = Arrays.copyOf(buffer, length);
@@ -1246,9 +1379,15 @@ public class NewPacketFormat implements PacketFormat {
     else return super.toString();
   }
 
+  /**
+   * Returns whether enough data is queued to justify sending a packet immediately.
+   *
+   * @param maxPacketSize the maximum payload size available for this transport.
+   * @return {@code true} if queued data meets or exceeds the size threshold; {@code false}
+   *     otherwise.
+   */
   @Override
   public boolean fullPacketQueued(int maxPacketSize) {
-    return pn.getMessageQueue()
-        .mustSendSize(HMAC_LENGTH /* FIXME estimate headers */, maxPacketSize);
+    return pn.getMessageQueue().mustSendSize(HMAC_LENGTH /* header estimate */, maxPacketSize);
   }
 }

--- a/src/main/java/network/crypta/node/NewPacketFormatKeyContext.java
+++ b/src/main/java/network/crypta/node/NewPacketFormatKeyContext.java
@@ -11,33 +11,41 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * NewPacketFormat's context for each SessionKey. Specifically, packet numbers are unique to a
- * SessionKey, because the packet number is used in encrypting the packet. Hence this class has
- * everything to do with packet numbers - which to use next, which we've sent packets on and are
- * waiting for acks, which we've received and should ack etc.
+ * Context for sequence numbers and acknowledgments for a single session key.
+ *
+ * <p>Each {@code SessionKey} maintains its own sequence number space. Sequence numbers are used as
+ * part of packet encryption, so they must be unique per key. This class tracks which sequence
+ * number to allocate next, which outgoing packets are in flight and awaiting acknowledgment, and
+ * which incoming sequence numbers have been observed so that acks can be generated.
+ *
+ * <p>Thread safety: methods synchronize on internal locks for sequence number allocation and for
+ * the ack/sent-packet maps ({@code sequenceNumberLock}, {@code acks}, and {@code sentPackets}).
+ * Instances may be shared across threads as long as callers respect these synchronization points.
+ *
+ * <p>Time units are milliseconds unless stated otherwise.
  *
  * @author toad
  */
 public class NewPacketFormatKeyContext {
   private static final Logger LOG = LoggerFactory.getLogger(NewPacketFormatKeyContext.class);
 
-  public int firstSeqNumUsed = -1;
-  public int nextSeqNum;
-  public int highestReceivedSeqNum;
+  int firstSeqNumUsed = -1;
+  int nextSeqNum;
+  int highestReceivedSeqNum;
 
-  public byte[][] seqNumWatchList = null;
+  byte[][] seqNumWatchList = null;
 
-  /** Index of the packet with the lowest sequence number */
-  public int watchListPointer = 0;
+  /** Index of the packet with the lowest sequence number. */
+  int watchListPointer = 0;
 
-  public int watchListOffset = 0;
+  int watchListOffset;
 
   private final TreeMap<Integer, Long> acks = new TreeMap<>();
   private final HashMap<Integer, SentPacket> sentPackets = new HashMap<>();
 
   /**
-   * Keep this many sent times for lost packets, so we can compute an accurate round trip time if
-   * they are acked after we had decided they were lost.
+   * Capacity of the cache of sent-times for packets later deemed lost. Retaining recent sent-times
+   * allows computing an accurate RTT if an ack arrives after the packet was considered lost.
    */
   private static final int MAX_LOST_SENT_TIMES = 128;
 
@@ -48,7 +56,7 @@ public class NewPacketFormatKeyContext {
 
   private static final int REKEY_THRESHOLD = 100;
 
-  /** All acks must be sent within 200ms */
+  /** All acks must be sent within 200 ms. */
   static final int MAX_ACK_DELAY = 200;
 
   /**
@@ -58,9 +66,6 @@ public class NewPacketFormatKeyContext {
   private static final int MIN_RTT_FOR_RETRANSMIT = 250;
 
   private int maxSeenInFlight;
-
-  static {
-  }
 
   NewPacketFormatKeyContext(int ourFirstSeqNum, int theirFirstSeqNum) {
     ourFirstSeqNum &= 0x7FFFFFFF;
@@ -73,30 +78,44 @@ public class NewPacketFormatKeyContext {
     if (this.highestReceivedSeqNum == -1) this.highestReceivedSeqNum = Integer.MAX_VALUE;
   }
 
+  /**
+   * Returns whether a new sequence number can be allocated without rekeying.
+   *
+   * @return {@code true} if {@link #allocateSequenceNumber(BasePeerNode)} would return a valid
+   *     sequence number; {@code false} if allocation would wrap to the first used number and a
+   *     rekey is required.
+   */
   boolean canAllocateSeqNum() {
     synchronized (sequenceNumberLock) {
       return nextSeqNum != firstSeqNumUsed;
     }
   }
 
+  /**
+   * Allocates the next sequence number for an outgoing packet.
+   *
+   * <p>When the sequence number would wrap to {@code firstSeqNumUsed}, the method requests rekeying
+   * on the provided peer and returns {@code -1}.
+   *
+   * @param pn the peer used to trigger rekeying when needed; must not be {@code null} when rekeying
+   *     is possible.
+   * @return the allocated sequence number, or {@code -1} if allocation is blocked pending rekey.
+   */
   int allocateSequenceNumber(BasePeerNode pn) {
     synchronized (sequenceNumberLock) {
       if (firstSeqNumUsed == -1) {
         firstSeqNumUsed = nextSeqNum;
         if (LOG.isDebugEnabled())
-          LOG.debug("First seqnum used for " + this + " is " + firstSeqNumUsed);
+          LOG.debug("First sequence number for {} is {}", this, firstSeqNumUsed);
       } else {
         if (nextSeqNum == firstSeqNumUsed) {
-          LOG.error("Blocked because we haven't rekeyed yet");
+          LOG.error("Sequence number allocation blocked; rekey pending");
           pn.startRekeying();
           return -1;
         }
 
-        if (firstSeqNumUsed > nextSeqNum) {
-          if (firstSeqNumUsed - nextSeqNum < REKEY_THRESHOLD) pn.startRekeying();
-        } else {
-          if ((NewPacketFormat.NUM_SEQNUMS - nextSeqNum) + firstSeqNumUsed < REKEY_THRESHOLD)
-            pn.startRekeying();
+        if (shouldStartRekeying(firstSeqNumUsed, nextSeqNum)) {
+          pn.startRekeying();
         }
       }
       int seqNum = nextSeqNum++;
@@ -107,13 +126,31 @@ public class NewPacketFormatKeyContext {
     }
   }
 
-  /** One of our outgoing packets has been acknowledged. */
+  private static boolean shouldStartRekeying(int firstUsed, int next) {
+    if (firstUsed > next) {
+      return firstUsed - next < REKEY_THRESHOLD;
+    }
+    return (NewPacketFormat.NUM_SEQNUMS - next) + firstUsed < REKEY_THRESHOLD;
+  }
+
+  /**
+   * Processes an acknowledgment for one of our outgoing packets.
+   *
+   * <p>The method computes an RTT sample, updates the peer's throttle and ping statistics, and
+   * removes the corresponding in-flight entry. If the ack refers to a packet already marked as
+   * lost, a saved sent-time is used to compute RTT when available. Duplicate acks are ignored.
+   *
+   * @param ack the acknowledged sequence number.
+   * @param pn the peer associated with the packet; may be {@code null} when peer state is not
+   *     available.
+   * @param key the session key used to finalize the ack handling.
+   */
   public void ack(int ack, BasePeerNode pn, SessionKey key) {
     long rtt;
     int maxSize;
     boolean validAck = false;
     long ackReceived = System.currentTimeMillis();
-    if (LOG.isTraceEnabled()) LOG.trace("Acknowledging packet " + ack + " from " + pn);
+    if (LOG.isTraceEnabled()) LOG.trace("Ack received for packet {} from {}", ack, pn);
     SentPacket sent;
     synchronized (sentPackets) {
       sent = sentPackets.remove(ack);
@@ -123,10 +160,10 @@ public class NewPacketFormatKeyContext {
       rtt = sent.acked(key);
       validAck = true;
     } else {
-      if (LOG.isTraceEnabled()) LOG.trace("Already acked or lost " + ack);
+      if (LOG.isTraceEnabled()) LOG.trace("Packet {} already acknowledged or marked lost", ack);
       long packetSent = lostSentTimes.queryAndRemove(ack);
       if (packetSent < 0) {
-        if (LOG.isTraceEnabled()) LOG.trace("No time for " + ack + " - maybe acked twice?");
+        if (LOG.isTraceEnabled()) LOG.trace("Missing sent time for {}; duplicate ack likely", ack);
         return;
       }
       rtt = ackReceived - packetSent;
@@ -143,9 +180,10 @@ public class NewPacketFormatKeyContext {
   }
 
   /**
-   * Queue an ack.
+   * Queues an acknowledgment for transmission.
    *
-   * @return -1 If the ack was already queued, or the total number queued.
+   * @param seqno the sequence number to acknowledge.
+   * @return {@code -1} if the ack is already queued; otherwise the total count of queued acks.
    */
   public int queueAck(int seqno) {
     synchronized (acks) {
@@ -156,6 +194,12 @@ public class NewPacketFormatKeyContext {
     }
   }
 
+  /**
+   * Records that a packet with the given sequence number and length was sent.
+   *
+   * @param sequenceNumber the packet sequence number.
+   * @param length the number of bytes sent.
+   */
   public void sent(int sequenceNumber, int length) {
     synchronized (sentPackets) {
       SentPacket sentPacket = sentPackets.get(sequenceNumber);
@@ -167,9 +211,9 @@ public class NewPacketFormatKeyContext {
     /** Are there any urgent acks? */
     final boolean anyUrgentAcks;
 
-    private final HashMap<Integer, Long> moved;
+    private final Map<Integer, Long> moved;
 
-    public AddedAcks(boolean mustSend, HashMap<Integer, Long> moved) {
+    public AddedAcks(boolean mustSend, Map<Integer, Long> moved) {
       this.anyUrgentAcks = mustSend;
       this.moved = moved;
     }
@@ -182,30 +226,30 @@ public class NewPacketFormatKeyContext {
   }
 
   /**
-   * Add as many acks as possible to the packet.
+   * Adds as many queued acks as fit into the given packet.
    *
-   * @return True if there are any old acks i.e. acks that will force us to send a packet even if
-   *     there isn't anything else in it.
+   * @return a handle for restoring moved acks on abort, or {@code null} if none were added. The
+   *     handle indicates whether any acks are urgent and should force a send.
    */
-  public AddedAcks addAcks(NPFPacket packet, int maxPacketSize, long now) {
+  AddedAcks addAcks(NPFPacket packet, int maxPacketSize, long now) {
     boolean mustSend = false;
-    HashMap<Integer, Long> moved = null;
+    Map<Integer, Long> moved = null;
     int numAcks = 0;
     synchronized (acks) {
       Iterator<Map.Entry<Integer, Long>> it = acks.entrySet().iterator();
       while (it.hasNext() && packet.getLength() < maxPacketSize) {
         Map.Entry<Integer, Long> entry = it.next();
         int ack = entry.getKey();
-        // All acks must be sent within 200ms.
-        if (LOG.isTraceEnabled()) LOG.trace("Trying to ack " + ack);
+        // All acks must be sent within MAX_ACK_DELAY (200 ms).
+        if (LOG.isTraceEnabled()) LOG.trace("Attempting to add ack {} to packet", ack);
         if (!packet.addAck(ack, maxPacketSize)) {
-          if (LOG.isTraceEnabled()) LOG.trace("Can't add ack " + ack);
+          if (LOG.isTraceEnabled()) LOG.trace("Cannot add ack {} to packet", ack);
           break;
         }
         if (entry.getValue() + MAX_ACK_DELAY < now) mustSend = true;
         if (moved == null) {
-          // FIXME some more memory efficient representation, since this will normally be very
-          // small?
+          // Use a temporary map to stage moved acks so they can be restored on abort.
+          // Overhead is small because it only holds the acks added to this packet.
           moved = new HashMap<>();
         }
         moved.put(ack, entry.getValue());
@@ -223,7 +267,7 @@ public class NewPacketFormatKeyContext {
     }
   }
 
-  public void sent(SentPacket sentPacket, int seqNum, int length) {
+  void sent(SentPacket sentPacket, int seqNum, int length) {
     sentPacket.sent(length);
     synchronized (sentPackets) {
       sentPackets.put(seqNum, sentPacket);
@@ -231,16 +275,23 @@ public class NewPacketFormatKeyContext {
       if (inFlight > maxSeenInFlight) {
         maxSeenInFlight = inFlight;
         if (LOG.isTraceEnabled()) {
-          LOG.trace("Max seen in flight new record: " + maxSeenInFlight + " for " + this);
+          LOG.trace("Max in-flight packets updated to {} for {}", maxSeenInFlight, this);
         }
       }
     }
   }
 
+  /**
+   * Computes the next time to check for lost packets.
+   *
+   * @param averageRTT the peer's average RTT in milliseconds.
+   * @return an absolute timestamp (ms since epoch) when the next loss check should occur, or {@link
+   *     Long#MAX_VALUE} if there are no in-flight packets.
+   */
   public long timeCheckForLostPackets(double averageRTT) {
     long timeCheck = Long.MAX_VALUE;
-    // Because MIN_RTT_FOR_RETRANSMIT > MAX_ACK_DELAY, and because averageRTT() includes the
-    // actual ack delay, we don't need to add it on here.
+    // Because MIN_RTT_FOR_RETRANSMIT > MAX_ACK_DELAY and averageRTT includes the ack delay,
+    // there is no need to add the ack delay here.
     double avgRtt = Math.max(MIN_RTT_FOR_RETRANSMIT, averageRTT);
     long maxDelay = (long) (avgRtt + MAX_ACK_DELAY * 1.1);
     synchronized (sentPackets) {
@@ -254,13 +305,20 @@ public class NewPacketFormatKeyContext {
     return timeCheck;
   }
 
+  /**
+   * Marks overdue in-flight packets as lost and updates backoff.
+   *
+   * @param averageRTT the peer's average RTT in milliseconds.
+   * @param curTime the current time in milliseconds.
+   * @param pn the peer whose throttle/backoff should be updated; may be {@code null}.
+   */
   public void checkForLostPackets(double averageRTT, long curTime, BasePeerNode pn) {
-    // Mark packets as lost
+    // Mark overdue packets as lost.
     int bigLostCount = 0;
     int count = 0;
 
-    // Because MIN_RTT_FOR_RETRANSMIT > MAX_ACK_DELAY, and because averageRTT() includes the
-    // actual ack delay, we don't need to add it on here.
+    // Because MIN_RTT_FOR_RETRANSMIT > MAX_ACK_DELAY and averageRTT includes the ack delay,
+    // there is no need to add the ack delay here.
     double avgRtt = Math.max(MIN_RTT_FOR_RETRANSMIT, averageRTT);
     long maxDelay = (long) (avgRtt + MAX_ACK_DELAY * 1.1);
     long threshold = curTime - maxDelay;
@@ -271,25 +329,7 @@ public class NewPacketFormatKeyContext {
         Map.Entry<Integer, SentPacket> e = it.next();
         SentPacket s = e.getValue();
         if (s.getSentTime() < threshold) {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                "Assuming packet "
-                    + e.getKey()
-                    + " has been lost. "
-                    + "Delay "
-                    + (curTime - s.getSentTime())
-                    + "ms, "
-                    + "threshold "
-                    + threshold
-                    + "ms");
-          }
-          // Store the packet sentTime in our lost sent times cache, so we can calculate
-          // RTT if an ack may surface later on.
-          if (!s.messages.isEmpty()) {
-            lostSentTimes.report(e.getKey(), s.getSentTime());
-          }
-          // Mark the packet as lost and remove it from our active packets.
-          s.lost();
+          markPacketAsLost(e, s, curTime, threshold);
           it.remove();
           bigLostCount++;
         } else {
@@ -298,7 +338,7 @@ public class NewPacketFormatKeyContext {
       }
     }
     if (count > 0 && LOG.isDebugEnabled())
-      LOG.debug(count + " packets in flight with threshold " + maxDelay + "ms");
+      LOG.debug("In-flight packets={}, retransmit threshold={} ms", count, maxDelay);
     if (bigLostCount != 0 && pn != null) {
       PacketThrottle throttle = pn.getThrottle();
       if (throttle != null) {
@@ -308,6 +348,27 @@ public class NewPacketFormatKeyContext {
     }
   }
 
+  private void markPacketAsLost(
+      Map.Entry<Integer, SentPacket> entry, SentPacket packet, long curTime, long threshold) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "Mark packet {} as lost; delay {} ms, threshold {} ms",
+          entry.getKey(),
+          curTime - packet.getSentTime(),
+          threshold);
+    }
+    if (!packet.messages.isEmpty()) {
+      lostSentTimes.report(entry.getKey(), packet.getSentTime());
+    }
+    packet.lost();
+  }
+
+  /**
+   * Computes the next deadline to flush queued acks.
+   *
+   * @return an absolute timestamp (ms since epoch) for the earliest ack deadline, or {@link
+   *     Long#MAX_VALUE} if there are no queued acks.
+   */
   public long timeCheckForAcks() {
     long ret = Long.MAX_VALUE;
     synchronized (acks) {
@@ -319,6 +380,7 @@ public class NewPacketFormatKeyContext {
     return ret;
   }
 
+  /** Treats all in-flight packets as lost and clears state on disconnect. */
   public void disconnected() {
     synchronized (sentPackets) {
       for (SentPacket s : sentPackets.values()) {

--- a/src/test/java/network/crypta/node/NewPacketFormatKeyContextTest.java
+++ b/src/test/java/network/crypta/node/NewPacketFormatKeyContextTest.java
@@ -1,0 +1,371 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.TreeMap;
+import network.crypta.io.xfer.PacketThrottle;
+import network.crypta.node.NewPacketFormat.SentPacket;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // test method naming: method_whenCondition_expectOutcome
+class NewPacketFormatKeyContextTest {
+
+  @Mock private BasePeerNode pn;
+
+  @Mock private PacketThrottle throttle;
+
+  private static SessionKey dummyKey(NewPacketFormatKeyContext ctx) {
+    return new SessionKey(null, null, null, null, null, null, null, null, ctx, /*trackerId*/ 0L);
+  }
+
+  private static TreeMap<Integer, Long> acksOf(NewPacketFormatKeyContext ctx) throws Exception {
+    Field f = NewPacketFormatKeyContext.class.getDeclaredField("acks");
+    f.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    TreeMap<Integer, Long> m = (TreeMap<Integer, Long>) f.get(ctx);
+    return m;
+  }
+
+  private static HashMap<Integer, NewPacketFormat.SentPacket> sentPacketsOf(
+      NewPacketFormatKeyContext ctx) throws Exception {
+    Field f = NewPacketFormatKeyContext.class.getDeclaredField("sentPackets");
+    f.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    HashMap<Integer, NewPacketFormat.SentPacket> m =
+        (HashMap<Integer, NewPacketFormat.SentPacket>) f.get(ctx);
+    return m;
+  }
+
+  // Per-test stubbing is used to avoid Mockito's unnecessary stubbing failures.
+
+  // ---------- Constructor and basic state ----------
+
+  @Test
+  void constructor_whenTheirStartZero_setsHighestReceivedToMaxInt() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(123, 0);
+    assertEquals(123, ctx.nextSeqNum);
+    assertEquals(0, ctx.watchListOffset);
+    assertEquals(Integer.MAX_VALUE, ctx.highestReceivedSeqNum);
+    assertTrue(ctx.canAllocateSeqNum());
+  }
+
+  @Test
+  void constructor_masksNegativeInputs_into31bitRange() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(-1, -2);
+    assertEquals(Integer.MAX_VALUE, ctx.nextSeqNum);
+    // theirFirstSeqNum = 0x7ffffffe, so highestReceivedSeqNum = that - 1
+    assertEquals(Integer.MAX_VALUE - 2, ctx.highestReceivedSeqNum);
+  }
+
+  // ---------- Sequence number allocation ----------
+
+  @Test
+  void allocateSequenceNumber_firstCall_setsFirstSeqAndIncrements() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(10, 0);
+    int seq = ctx.allocateSequenceNumber(pn);
+    assertEquals(10, seq);
+    assertEquals(11, ctx.nextSeqNum);
+    // No rekeying expected on first allocation
+    verify(pn, never()).startRekeying();
+  }
+
+  @Test
+  void canAllocateSeqNum_whenNextEqualsFirstSeq_returnsFalse() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(5, 0);
+    // First allocation sets firstSeqNumUsed to 5
+    assertEquals(5, ctx.allocateSequenceNumber(pn));
+    // Force wrap back to first to simulate reuse condition
+    ctx.nextSeqNum = ctx.firstSeqNumUsed;
+    assertFalse(ctx.canAllocateSeqNum());
+  }
+
+  @Test
+  void allocateSequenceNumber_whenAtFirstSeq_triggersRekeyAndReturnsMinusOne() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(5, 0);
+    // Establish first used
+    assertEquals(5, ctx.allocateSequenceNumber(pn));
+    // Now next equals first => cannot allocate, rekey
+    ctx.nextSeqNum = ctx.firstSeqNumUsed;
+    int ret = ctx.allocateSequenceNumber(pn);
+    assertEquals(-1, ret);
+    verify(pn, times(1)).startRekeying();
+    // nextSeqNum should remain unchanged on failure
+    assertEquals(ctx.firstSeqNumUsed, ctx.nextSeqNum);
+  }
+
+  @Test
+  void allocateSequenceNumber_whenNearWrapWithinThreshold_triggersRekeyAndWrapsToZero() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(1, 0);
+    // Simulate many prior allocations so firstSeqNumUsed != -1
+    assertEquals(1, ctx.allocateSequenceNumber(pn));
+    ctx.firstSeqNumUsed = 10; // pretend we began at 10 on this key
+    ctx.nextSeqNum = Integer.MAX_VALUE; // 0x7fffffff
+
+    int ret = ctx.allocateSequenceNumber(pn);
+    assertEquals(Integer.MAX_VALUE, ret);
+    // After increment, it would overflow negative; implementation resets to 0
+    assertEquals(0, ctx.nextSeqNum);
+    verify(pn, times(1)).startRekeying();
+  }
+
+  // ---------- Ack queueing and emission ----------
+
+  @Test
+  void addAcks_whenEmpty_returnsNull() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    NPFPacket p = new NPFPacket();
+    NewPacketFormatKeyContext.AddedAcks res = ctx.addAcks(p, 1400, /*now*/ 0L);
+    assertNull(res);
+    assertEquals(0, p.getAcks().size());
+  }
+
+  @Test
+  void addAcks_whenWithinPacketSize_movesAcksAndFlagsUrgentBasedOnAge() throws Exception {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    TreeMap<Integer, Long> acks = acksOf(ctx);
+    acks.put(101, 1000L); // old
+    acks.put(202, 5000L); // newer
+
+    NPFPacket p = new NPFPacket();
+    long now = 1000L + NewPacketFormatKeyContext.MAX_ACK_DELAY + 1; // 1201 => 101 is urgent
+    NewPacketFormatKeyContext.AddedAcks added = ctx.addAcks(p, 1400, now);
+
+    assertNotNull(added);
+    assertTrue(added.anyUrgentAcks);
+    assertEquals(2, p.getAcks().size());
+    // All moved out of the internal map
+    assertTrue(acks.isEmpty());
+
+    // Abort should restore them
+    added.abort();
+    assertEquals(2, acks.size());
+    assertTrue(acks.containsKey(101));
+    assertTrue(acks.containsKey(202));
+  }
+
+  @Test
+  void addAcks_respectsMaxPacketSize_andStopsWhenFull() throws Exception {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    TreeMap<Integer, Long> acks = acksOf(ctx);
+    acks.put(10, 1000L);
+    acks.put(11, 1000L);
+
+    NPFPacket p = new NPFPacket();
+    // Allow exactly one ack to fit (initial length=5; one ack block adds 5 bytes)
+    int maxPacketSize = 10;
+    NewPacketFormatKeyContext.AddedAcks added = ctx.addAcks(p, maxPacketSize, /*now*/ 2000L);
+
+    assertNotNull(added);
+    assertEquals(1, p.getAcks().size());
+    // One ack remains queued because there was no space for it
+    assertEquals(1, acks.size());
+  }
+
+  @Test
+  void timeCheckForAcks_returnsEarliestTimeout() throws Exception {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    TreeMap<Integer, Long> acks = acksOf(ctx);
+    acks.put(1, 1000L);
+    acks.put(2, 1100L);
+    long expected = 1000L + NewPacketFormatKeyContext.MAX_ACK_DELAY; // 1200
+    assertEquals(expected, ctx.timeCheckForAcks());
+  }
+
+  // ---------- Sent tracking and ack processing ----------
+
+  private static class FixedRttSentPacket extends NewPacketFormat.SentPacket {
+    private final long fixedRtt;
+
+    FixedRttSentPacket(NewPacketFormat npf, SessionKey key, long fixedRtt) {
+      super(npf, key);
+      this.fixedRtt = fixedRtt;
+    }
+
+    @Override
+    public long acked(SessionKey key) {
+      return fixedRtt;
+    }
+  }
+
+  @Test
+  void sentAndAck_whenValidAck_updatesThrottleAndPeer_andUsesMaxSeenInFlight() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    // Minimal NPF instance; it won't be used because FixedRttSentPacket overrides acked()
+    NewPacketFormat npf = new NewPacketFormat(/*pn*/ null, 0, 0);
+    SessionKey key = dummyKey(ctx);
+
+    // Add two in-flight packets to establish maxSeenInFlight=2
+    NewPacketFormat.SentPacket sp1 = new FixedRttSentPacket(npf, key, /*rtt*/ 123);
+    NewPacketFormat.SentPacket sp2 = new FixedRttSentPacket(npf, key, /*rtt*/ 123);
+    ctx.sent(sp1, /*seq*/ 1, /*len*/ 100);
+    ctx.sent(sp2, /*seq*/ 2, /*len*/ 100);
+    assertEquals(2, ctx.countSentPackets());
+
+    when(pn.getThrottle()).thenReturn(throttle);
+
+    // Ack the first packet; should remove one and notify throttle with (2*2)+10=14
+    ctx.ack(1, pn, key);
+
+    verify(pn, times(1)).reportPing(123L);
+    verify(pn, times(1)).receivedAck(anyLong());
+    verify(throttle, times(1)).setRoundTripTime(123L);
+    verify(throttle, times(1)).notifyOfPacketAcknowledged(14);
+    assertEquals(1, ctx.countSentPackets());
+  }
+
+  @Test
+  void ack_whenNoSentAndNoLostRecord_performsNoPeerOrThrottleInteractions() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    SessionKey key = dummyKey(ctx);
+
+    ctx.ack(999, pn, key);
+
+    verify(pn, never()).reportPing(anyLong());
+    verify(pn, never()).receivedAck(anyLong());
+    verify(throttle, never()).setRoundTripTime(anyLong());
+    verify(throttle, never()).notifyOfPacketAcknowledged(anyDouble());
+  }
+
+  @Test
+  void checkForLostPackets_marksLost_notifiesThrottle_andStoresLostTime_enablingLateAck() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    NewPacketFormat npf = new NewPacketFormat(null, 0, 0);
+    SessionKey key = dummyKey(ctx);
+
+    // Build a SentPacket with at least one message so lostSentTimes is recorded on loss
+    SentPacket sp = getSentPacket(npf, key);
+
+    // Add to in-flight and force an old sent time so it qualifies as lost
+    ctx.sent(sp, /*seq*/ 42, /*len*/ 100);
+    // Compute threshold used by checkForLostPackets(avgRTT=0)
+    double avgRtt = 0.0; // will be clamped to MIN_RTT_FOR_RETRANSMIT (250)
+    long maxDelay = (long) (250 + NewPacketFormatKeyContext.MAX_ACK_DELAY * 1.1); // 470
+    long now = 10_000L;
+
+    // Override sent time to be older than threshold
+    sp.sentTime = now - maxDelay - 1; // package-private field; same package access
+
+    when(pn.getThrottle()).thenReturn(throttle);
+
+    ctx.checkForLostPackets(avgRtt, now, pn);
+
+    // Lost => one packet removed and throttle notified
+    verify(throttle, times(1)).notifyOfPacketsLost(1);
+    verify(pn, times(1)).backoffOnResend();
+    assertEquals(0, ctx.countSentPackets());
+
+    // A late ack for the lost packet should use the stored sent time:
+    ctx.ack(42, pn, key);
+    verify(pn, times(1)).reportPing(anyLong());
+    verify(throttle, times(1)).setRoundTripTime(anyLong());
+    // But not these, since it was not a valid (active) ack
+    verify(pn, never()).receivedAck(anyLong());
+    verify(throttle, never()).notifyOfPacketAcknowledged(anyDouble());
+  }
+
+  private static @NotNull NewPacketFormat.SentPacket getSentPacket(
+      NewPacketFormat npf, SessionKey key) {
+    SentPacket sp = new SentPacket(npf, key);
+    MessageItem mi = new MessageItem(new byte[] {1, 2, 3, 4}, null, false, null, (short) 0);
+    MessageWrapper mw = new MessageWrapper(mi, /*messageID*/ 7);
+    MessageFragment frag =
+        new MessageFragment(
+            /*shortMessage*/ true,
+            /*isFragmented*/ false,
+            /*firstFragment*/ true,
+            /*messageID*/ 7,
+            /*fragmentLength*/ 4,
+            /*messageLength*/ 4,
+            /*fragmentOffset*/ 0,
+            new byte[] {1, 2, 3, 4},
+            mw);
+    sp.addFragment(frag);
+    return sp;
+  }
+
+  @Test
+  void timeCheckForLostPackets_whenNoInFlight_returnsLongMax() {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    assertEquals(Long.MAX_VALUE, ctx.timeCheckForLostPackets(/*avgRTT*/ 10));
+  }
+
+  @Test
+  void disconnected_marksAllLost_andClearsInFlight() throws Exception {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    NewPacketFormat npf = new NewPacketFormat(null, 0, 0);
+    SessionKey key = dummyKey(ctx);
+
+    class FlagSentPacket extends NewPacketFormat.SentPacket {
+      boolean lostCalled;
+
+      FlagSentPacket(NewPacketFormat npf, SessionKey key) {
+        super(npf, key);
+      }
+
+      @Override
+      public void lost() {
+        lostCalled = true;
+        super.lost();
+      }
+    }
+
+    FlagSentPacket sp1 = new FlagSentPacket(npf, key);
+    FlagSentPacket sp2 = new FlagSentPacket(npf, key);
+    ctx.sent(sp1, 1, 100);
+    ctx.sent(sp2, 2, 100);
+    assertEquals(2, ctx.countSentPackets());
+
+    ctx.disconnected();
+
+    assertTrue(sp1.lostCalled);
+    assertTrue(sp2.lostCalled);
+    assertEquals(0, ctx.countSentPackets());
+    // Internal map should also be empty
+    assertTrue(sentPacketsOf(ctx).isEmpty());
+  }
+
+  @Test
+  void sent_withExistingSequence_invokesUnderlyingSent() throws Exception {
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    NewPacketFormat npf = new NewPacketFormat(null, 0, 0);
+    SessionKey key = dummyKey(ctx);
+
+    class ObservedSentPacket extends NewPacketFormat.SentPacket {
+      int seenLength;
+
+      ObservedSentPacket(NewPacketFormat npf, SessionKey key) {
+        super(npf, key);
+      }
+
+      @Override
+      public void sent(int length) {
+        seenLength = length;
+        super.sent(length);
+      }
+    }
+
+    ObservedSentPacket sp = new ObservedSentPacket(npf, key);
+    // Put directly into internal map so we can exercise sent(sequenceNumber, length)
+    sentPacketsOf(ctx).put(77, sp);
+
+    ctx.sent(77, 321);
+    assertEquals(321, sp.seenLength);
+  }
+}

--- a/src/test/java/network/crypta/node/NewPacketFormatTest.java
+++ b/src/test/java/network/crypta/node/NewPacketFormatTest.java
@@ -1,41 +1,61 @@
 package network.crypta.node;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 import network.crypta.crypt.BlockCipher;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.ciphers.Rijndael;
 import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.io.comm.Peer;
+import network.crypta.io.xfer.PacketThrottle;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class NewPacketFormatTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class NewPacketFormatTest {
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     // Because we don't call maybeSendPacket, the packet sent times are not updated,
     // so lets turn off the keepalives.
-    NewPacketFormat.DO_KEEPALIVES = false;
+    NewPacketFormat.doKeepalives = false;
   }
 
   @Test
-  public void testEmptyCreation() throws BlockedTooLongException {
+  void createPacket_whenQueueEmpty_returnsNull() throws BlockedTooLongException {
+    // Arrange
     NewPacketFormat npf = new NewPacketFormat(null, 0, 0);
     PeerMessageQueue pmq = new PeerMessageQueue(new DummyRandomSource(1234));
     SessionKey s =
         new SessionKey(
             null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
+    // Act
     NPFPacket p = npf.createPacket(1400, pmq, s, false);
+
+    // Assert
     if (p != null) fail("Created packet from nothing");
   }
 
   @Test
-  public void testAckOnlyCreation() throws BlockedTooLongException, InterruptedException {
+  void createPacket_whenAckQueued_addsAck() throws BlockedTooLongException {
+    // Arrange
     BasePeerNode pn = new NullBasePeerNode();
     NewPacketFormat npf = new NewPacketFormat(pn, 0, 0);
     PeerMessageQueue pmq = new PeerMessageQueue(new DummyRandomSource(1234));
@@ -43,11 +63,8 @@ public class NewPacketFormatTest {
         new SessionKey(
             null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
-    NPFPacket p = null;
-
-    // Packet that should be acked
-    p = new NPFPacket();
-    p.addMessageFragment(
+    NPFPacket generated = new NPFPacket();
+    generated.addMessageFragment(
         new MessageFragment(
             true,
             false,
@@ -67,15 +84,28 @@ public class NewPacketFormatTest {
               (byte) 0xEF
             },
             null));
-    assertEquals(1, npf.handleDecryptedPacket(p, s).size());
 
-    Thread.sleep(NewPacketFormatKeyContext.MAX_ACK_DELAY * 2);
-    p = npf.createPacket(1400, pmq, s, false);
-    assertEquals(1, p.getAcks().size());
+    // Act
+    assertEquals(1, npf.handleDecryptedPacket(generated, s).size());
+    boolean keepalivesOrig = NewPacketFormat.doKeepalives;
+    NewPacketFormat.doKeepalives = true; // force send without sleeping
+    NPFPacket ackOnly;
+    try {
+      ackOnly = npf.createPacket(1400, pmq, s, false);
+    } finally {
+      NewPacketFormat.doKeepalives = keepalivesOrig;
+    }
+
+    // Assert
+    assertNotNull(ackOnly);
+    assertEquals(1, ackOnly.getAcks().size());
   }
 
   @Test
-  public void testLostLastAck() throws BlockedTooLongException, InterruptedException {
+  void resend_whenAckLost_triggersAckOnlyLater() throws BlockedTooLongException {
+    // Arrange
+    boolean keepalivesOrig = NewPacketFormat.doKeepalives;
+    NewPacketFormat.doKeepalives = true; // avoid sleeps for ack scheduling
     NullBasePeerNode senderNode = new NullBasePeerNode();
     NewPacketFormat sender = new NewPacketFormat(senderNode, 0, 0);
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
@@ -93,6 +123,7 @@ public class NewPacketFormatTest {
     senderQueue.queueAndEstimateSize(
         new MessageItem(new byte[1024], null, false, null, (short) 0), 1024);
 
+    // Act: send two fragments and ack them
     NPFPacket fragment1 = sender.createPacket(512, senderQueue, senderKey, false);
     assertEquals(1, fragment1.getFragments().size());
     receiver.handleDecryptedPacket(fragment1, receiverKey);
@@ -101,7 +132,6 @@ public class NewPacketFormatTest {
     assertEquals(1, fragment2.getFragments().size());
     receiver.handleDecryptedPacket(fragment2, receiverKey);
 
-    Thread.sleep(NewPacketFormatKeyContext.MAX_ACK_DELAY * 2);
     NPFPacket ack1 = receiver.createPacket(512, receiverQueue, receiverKey, false);
     assertEquals(2, ack1.getAcks().size());
     assertEquals(0, (int) ack1.getAcks().getFirst());
@@ -111,29 +141,26 @@ public class NewPacketFormatTest {
     NPFPacket fragment3 = sender.createPacket(512, senderQueue, senderKey, false);
     assertEquals(1, fragment3.getFragments().size());
     receiver.handleDecryptedPacket(fragment3, receiverKey);
-    Thread.sleep(NewPacketFormatKeyContext.MAX_ACK_DELAY * 2);
-    receiver.createPacket(512, senderQueue, receiverKey, false); // Sent, but lost
+    receiver.createPacket(512, senderQueue, receiverKey, false); // Simulate lost ack-only
 
-    try {
-      Thread.sleep(2000); // RTT is 250ms by default since there is no PeerNode to track it
-    } catch (InterruptedException e) {
-      fail();
-    }
+    // Force loss detection without sleeping by backdating sent times
+    backdateAllSentTimes(senderKey.packetContext);
 
     NPFPacket resend1 = sender.createPacket(512, senderQueue, senderKey, false);
     if (resend1 == null) fail("No packet to resend");
     assertEquals(0, receiver.handleDecryptedPacket(resend1, receiverKey).size());
 
-    // Make sure an ack is sent
-    Thread.sleep(NewPacketFormatKeyContext.MAX_ACK_DELAY * 2);
+    // Assert: receiver sends an ack-only packet for the resend (keepalive path)
     NPFPacket ack2 = receiver.createPacket(512, receiverQueue, receiverKey, false);
     assertNotNull(ack2);
     assertEquals(1, ack2.getAcks().size());
-    assertEquals(0, ack2.getFragments().size());
+    NewPacketFormat.doKeepalives = keepalivesOrig;
   }
 
   @Test
-  public void testOutOfOrderDelivery() throws BlockedTooLongException {
+  void handleDecryptedPacket_whenFragmentsOutOfOrder_completesOnMissingPiece()
+      throws BlockedTooLongException {
+    // Arrange
     NullBasePeerNode senderNode = new NullBasePeerNode();
     NewPacketFormat sender = new NewPacketFormat(senderNode, 0, 0);
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
@@ -158,13 +185,19 @@ public class NewPacketFormatTest {
     NPFPacket fragment3 = sender.createPacket(512, senderQueue, senderKey, false);
     assertEquals(1, fragment3.getFragments().size());
 
+    // Act: deliver 1 and 3, then the missing middle 2
     receiver.handleDecryptedPacket(fragment1, receiverKey);
     receiver.handleDecryptedPacket(fragment3, receiverKey);
-    assertEquals(1, receiver.handleDecryptedPacket(fragment2, receiverKey).size());
+    int completed = receiver.handleDecryptedPacket(fragment2, receiverKey).size();
+
+    // Assert
+    assertEquals(1, completed);
   }
 
   @Test
-  public void testReceiveUnknownMessageLength() throws BlockedTooLongException {
+  void handleDecryptedPacket_whenFirstFragmentArrivesLater_completesMessage()
+      throws BlockedTooLongException {
+    // Arrange
     NullBasePeerNode senderNode = new NullBasePeerNode();
     NewPacketFormat sender = new NewPacketFormat(senderNode, 0, 0);
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
@@ -187,13 +220,19 @@ public class NewPacketFormatTest {
     NPFPacket fragment3 = sender.createPacket(512, senderQueue, senderKey, false);
     assertEquals(1, fragment3.getFragments().size());
 
+    // Act: receive non-first fragments first, then the first fragment carrying message length
     receiver.handleDecryptedPacket(fragment3, receiverKey);
     receiver.handleDecryptedPacket(fragment2, receiverKey);
-    assertEquals(1, receiver.handleDecryptedPacket(fragment1, receiverKey).size());
+    int completed = receiver.handleDecryptedPacket(fragment1, receiverKey).size();
+
+    // Assert
+    assertEquals(1, completed);
   }
 
   @Test
-  public void testResendAlreadyCompleted() throws BlockedTooLongException, InterruptedException {
+  void handleDecryptedPacket_whenDuplicateOrResend_doesNotReDeliver()
+      throws BlockedTooLongException {
+    // Arrange
     NullBasePeerNode senderNode = new NullBasePeerNode();
     NewPacketFormat sender = new NewPacketFormat(senderNode, 0, 0);
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
@@ -206,24 +245,30 @@ public class NewPacketFormatTest {
         new SessionKey(
             null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
 
+    // Queue two messages so total queued size exceeds maxPacketSize (512) and triggers immediate
+    // send.
     senderQueue.queueAndEstimateSize(
-        new MessageItem(new byte[128], null, false, null, (short) 0), 1024);
+        new MessageItem(new byte[400], null, false, null, (short) 0), 1024);
+    senderQueue.queueAndEstimateSize(
+        new MessageItem(new byte[200], null, false, null, (short) 0), 1024);
 
-    Thread.sleep(PacketSender.MAX_COALESCING_DELAY * 2);
+    // Act
     NPFPacket packet1 = sender.createPacket(512, senderQueue, senderKey, false);
-    assertEquals(1, receiver.handleDecryptedPacket(packet1, receiverKey).size());
+    int first = receiver.handleDecryptedPacket(packet1, receiverKey).size();
+    int duplicate = receiver.handleDecryptedPacket(packet1, receiverKey).size();
+    int resend = receiver.handleDecryptedPacket(packet1, receiverKey).size();
 
-    // Receiving the same packet twice should work
-    assertEquals(0, receiver.handleDecryptedPacket(packet1, receiverKey).size());
-
-    // Same message, new sequence number ie. resend
-    assertEquals(0, receiver.handleDecryptedPacket(packet1, receiverKey).size());
+    // Assert
+    assertEquals(1, first);
+    assertEquals(0, duplicate);
+    assertEquals(0, resend);
   }
 
   /* This checks the output of the sequence number encryption function to
    * make sure it doesn't change accidentally. */
   @Test
-  public void testSequenceNumberEncryption() {
+  void encryptSequenceNumber_whenFixedInputs_matchesGoldenBytes() {
+    // Arrange
     BlockCipher ivCipher = new Rijndael();
     ivCipher.initialize(
         new byte[] {
@@ -247,19 +292,18 @@ public class NewPacketFormatTest {
     SessionKey sessionKey =
         new SessionKey(null, null, null, incommingCipher, null, ivCipher, ivNonce, null, null, -1);
 
+    // Act
     byte[] encrypted = NewPacketFormat.encryptSequenceNumber(0, sessionKey);
 
-    /* This result has not been checked, but it was the output when
-     * this test was added and we are (in this test) only
-     * interested in making sure the output doesn't change. */
+    // Assert (golden value)
     byte[] correct = new byte[] {(byte) 0xF7, (byte) 0x95, (byte) 0xBD, (byte) 0x4A};
-
     assertArrayEquals(correct, encrypted);
   }
 
   @Test
-  public void testEncryption()
-      throws BlockedTooLongException, UnknownHostException, InterruptedException {
+  void handleReceivedPacket_whenCiphertextValid_deliversOneMessage()
+      throws BlockedTooLongException, UnknownHostException {
+    // Arrange
     Random random = new Random(120116);
     NullBasePeerNode senderNode = new NullBasePeerNode();
     NullBasePeerNode receiverNode = new NullBasePeerNode();
@@ -323,26 +367,283 @@ public class NewPacketFormatTest {
 
     PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
 
-    byte[] message = new byte[1024];
+    byte[] message = new byte[700];
     random.nextBytes(message);
     byte[] copyOfMessage = Arrays.copyOf(message, message.length);
 
-    senderQueue.queueAndEstimateSize(new MessageItem(message, null, false, null, (short) 0), 1024);
+    // Queue two messages so total exceeds maxPacketSize (1280) and triggers immediate send.
+    byte[] other = new byte[700];
+    random.nextBytes(other);
+    senderQueue.queueAndEstimateSize(new MessageItem(message, null, false, null, (short) 0), 4096);
+    senderQueue.queueAndEstimateSize(new MessageItem(other, null, false, null, (short) 0), 4096);
 
     senderNode.messageQueue = senderQueue;
-    Thread.sleep(PacketSender.MAX_COALESCING_DELAY * 2);
     senderNPF.maybeSendPacket(false, senderSessionKey);
 
-    FreenetInetAddress LOCALHOST = new FreenetInetAddress("127.0.0.1", true);
-    Peer PEER = new Peer(LOCALHOST, 1234);
+    FreenetInetAddress localhost = new FreenetInetAddress("127.0.0.1", true);
+    Peer peer = new Peer(localhost, 1234);
 
     byte[] data = senderNode.sentEncryptedPacket;
 
+    // Act
     receiverNode.decryptedMessages = new ArrayList<>();
-    receiverNPF.handleReceivedPacket(data, 0, data.length, System.currentTimeMillis(), PEER);
+    receiverNPF.handleReceivedPacket(data, 0, data.length, System.currentTimeMillis(), peer);
 
+    // Assert
     assertEquals(1, receiverNode.decryptedMessages.size());
     assertArrayEquals(message, copyOfMessage);
     assertArrayEquals(receiverNode.decryptedMessages.getFirst(), message);
+  }
+
+  @Test
+  @DisplayName("onDisconnect returns queued-but-unsent items and clears buffer")
+  @Timeout(5)
+  void onDisconnect_whenWrappersInFlight_returnsItems() throws BlockedTooLongException {
+    NullBasePeerNode pn = new NullBasePeerNode();
+    NewPacketFormat npf = new NewPacketFormat(pn, /*ourInitial*/ 123, /*theirInitial*/ 456);
+    PeerMessageQueue q = new PeerMessageQueue(new DummyRandomSource(42));
+    pn.messageQueue = q;
+
+    // Queue a single small message and build a packet fragment to move it into startedByPrio.
+    byte[] payload = new byte[1024];
+    q.queueAndEstimateSize(new MessageItem(payload, null, false, null, (short) 0), 1024);
+    SessionKey key =
+        new SessionKey(
+            null, null, null, null, null, null, null, null, new NewPacketFormatKeyContext(0, 0), 1);
+
+    NPFPacket p = npf.createPacket(512, q, key, /*ackOnly*/ false);
+    assertNotNull(p, "Expected a packet with one fragment before disconnect");
+    assertEquals(1, p.getFragments().size());
+
+    // Now disconnect and ensure the item is returned for requeueing by the caller.
+    List<MessageItem> returned = npf.onDisconnect();
+    assertEquals(1, returned.size());
+    assertEquals(payload.length, returned.getFirst().getLength());
+  }
+
+  @Test
+  @DisplayName("fullPacketQueued reflects message-queue size thresholds")
+  void fullPacketQueued_threshold() {
+    NullBasePeerNode pn = new NullBasePeerNode();
+    pn.messageQueue = new PeerMessageQueue(new DummyRandomSource(7));
+    NewPacketFormat npf = new NewPacketFormat(pn, 0, 0);
+
+    int maxPacket = 512;
+    // Below threshold: HMAC(10) + 100 < 512 => false
+    pn.messageQueue.queueAndEstimateSize(
+        new MessageItem(new byte[100], null, false, null, (short) 0), 1024);
+    assertFalse(npf.fullPacketQueued(maxPacket));
+    // Above threshold: add enough to cross maxPacket
+    pn.messageQueue.queueAndEstimateSize(
+        new MessageItem(new byte[450], null, false, null, (short) 0), 1024);
+    assertTrue(npf.fullPacketQueued(maxPacket));
+  }
+
+  @Test
+  @DisplayName("handleDecryptedPacket: no fragments => don't ack and no messages")
+  void handleDecryptedPacket_whenEmpty_dontAck() {
+    NullBasePeerNode pn = new NullBasePeerNode();
+    NewPacketFormat npf = new NewPacketFormat(pn, 0, 0);
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    SessionKey key = new SessionKey(null, null, null, null, null, null, null, null, ctx, 1);
+    pn.currentKey = key; // So timeSendAcks() can see the same ctx
+
+    NPFPacket empty = new NPFPacket();
+    List<byte[]> finished = npf.handleDecryptedPacket(empty, key);
+    assertTrue(finished.isEmpty(), "No fragments -> no completed messages");
+    assertEquals(Long.MAX_VALUE, npf.timeSendAcks(), "No ack queued for empty packet");
+  }
+
+  @Test
+  @DisplayName("maybeSendPacket prioritizes previous key for ack-only packets")
+  @Timeout(5)
+  void maybeSendPacket_ackOnly_usesPreviousKey() throws Exception {
+    // Build crypto materials as in testEncryption for deterministic encryption.
+    Random rnd = new Random(1337);
+    NullBasePeerNode pn = new NullBasePeerNode();
+    byte[] keyA = new byte[32];
+    rnd.nextBytes(keyA);
+    byte[] keyB = new byte[32];
+    rnd.nextBytes(keyB);
+    byte[] ivKey = new byte[32];
+    rnd.nextBytes(ivKey);
+    byte[] ivNonce = new byte[16];
+    rnd.nextBytes(ivNonce);
+    byte[] hmac = new byte[32];
+    rnd.nextBytes(hmac);
+
+    BlockCipher out = new Rijndael();
+    out.initialize(keyA);
+    BlockCipher in = new Rijndael();
+    in.initialize(keyB);
+    BlockCipher iv = new Rijndael();
+    iv.initialize(ivKey);
+
+    NewPacketFormatKeyContext prevCtx = new NewPacketFormatKeyContext(10, 20);
+    SessionKey prev = new SessionKey(null, out, keyA, in, keyB, iv, ivNonce, hmac, prevCtx, 99);
+    pn.previousKey = prev;
+
+    // Ack something on the previous key by simulating a decrypted packet with one fragment.
+    NewPacketFormat npf = new NewPacketFormat(pn, 0, 0);
+    NPFPacket received = new NPFPacket();
+    received.setSequenceNumber(123);
+    received.addMessageFragment(
+        new MessageFragment(true, false, true, 1, 1, 1, 0, new byte[] {1}, null));
+    List<byte[]> finished = npf.handleDecryptedPacket(received, prev);
+    assertEquals(1, finished.size());
+
+    // Now ask NPF to maybe send an ack-only packet. It should use the previous key.
+    // Make the ack urgent by backdating its timestamp instead of sleeping.
+    backdateAllAcks(prevCtx);
+    boolean sent = npf.maybeSendPacket(System.currentTimeMillis(), /*ackOnly*/ true);
+    assertTrue(sent, "Expected an ack-only packet to be sent on the previous key");
+    assertNotNull(pn.sentEncryptedPacket, "Encrypted packet bytes should be produced");
+  }
+
+  @Test
+  @DisplayName("handleReceivedPacket: invalid HMAC -> false")
+  @Timeout(5)
+  void handleReceivedPacket_whenHmacInvalid_returnsFalse() throws Exception {
+    // Prepare a valid encrypted packet as in testEncryption, then corrupt it and expect false.
+    Random random = new Random(2024);
+    NullBasePeerNode senderNode = new NullBasePeerNode();
+    NullBasePeerNode receiverNode = new NullBasePeerNode();
+
+    byte[] outgoingKey = new byte[32];
+    random.nextBytes(outgoingKey);
+    BlockCipher outgoingCipher = new Rijndael();
+    outgoingCipher.initialize(outgoingKey);
+    byte[] incomingKey = new byte[32];
+    random.nextBytes(incomingKey);
+    BlockCipher incomingCipher = new Rijndael();
+    incomingCipher.initialize(incomingKey);
+    BlockCipher ivCipher = new Rijndael();
+    byte[] ivKey = new byte[32];
+    random.nextBytes(ivKey);
+    ivCipher.initialize(ivKey);
+    byte[] ivNonce = new byte[16];
+    random.nextBytes(ivNonce);
+    byte[] hmacKey = new byte[32];
+    random.nextBytes(hmacKey);
+
+    int senderStartSeq = 111;
+    int receiverStartSeq = 222;
+    NewPacketFormatKeyContext senderCtx =
+        new NewPacketFormatKeyContext(senderStartSeq, receiverStartSeq);
+    NewPacketFormatKeyContext receiverCtx =
+        new NewPacketFormatKeyContext(receiverStartSeq, senderStartSeq);
+
+    SessionKey senderSessionKey =
+        new SessionKey(
+            null,
+            outgoingCipher,
+            outgoingKey,
+            incomingCipher,
+            incomingKey,
+            ivCipher,
+            ivNonce,
+            hmacKey,
+            senderCtx,
+            0);
+    SessionKey receiverSessionKey =
+        new SessionKey(
+            null,
+            incomingCipher,
+            incomingKey,
+            outgoingCipher,
+            outgoingKey,
+            ivCipher,
+            ivNonce,
+            hmacKey,
+            receiverCtx,
+            0);
+    senderNode.currentKey = senderSessionKey;
+    receiverNode.currentKey = receiverSessionKey;
+
+    NewPacketFormat senderNPF = new NewPacketFormat(senderNode, senderStartSeq, receiverStartSeq);
+    NewPacketFormat receiverNPF =
+        new NewPacketFormat(receiverNode, receiverStartSeq, senderStartSeq);
+
+    PeerMessageQueue senderQueue = new PeerMessageQueue(new DummyRandomSource(1234));
+    // Queue two messages so total exceeds maxPacketSize and triggers immediate send.
+    byte[] m1 = new byte[700];
+    byte[] m2 = new byte[700];
+    random.nextBytes(m1);
+    random.nextBytes(m2);
+    senderQueue.queueAndEstimateSize(new MessageItem(m1, null, false, null, (short) 0), 4096);
+    senderQueue.queueAndEstimateSize(new MessageItem(m2, null, false, null, (short) 0), 4096);
+    senderNode.messageQueue = senderQueue;
+
+    // Send one packet and capture its ciphertext (first message)
+    senderNPF.maybeSendPacket(false, senderSessionKey);
+    byte[] data = senderNode.sentEncryptedPacket.clone();
+    assertNotNull(data);
+
+    // Corrupt the HMAC so verification fails (flip one bit in the first HMAC byte)
+    data[0] ^= 0x01;
+    FreenetInetAddress localhost = new FreenetInetAddress("127.0.0.1", true);
+    Peer peer = new Peer(localhost, 1234);
+
+    boolean ok =
+        receiverNPF.handleReceivedPacket(data, 0, data.length, System.currentTimeMillis(), peer);
+    assertFalse(ok, "Invalid HMAC must cause handleReceivedPacket() to return false");
+  }
+
+  @Mock private BasePeerNode mockPeer;
+
+  /** Backdates all in-flight sent packets so loss detection triggers without waiting. */
+  private static void backdateAllSentTimes(NewPacketFormatKeyContext ctx) {
+    try {
+      java.lang.reflect.Field f = NewPacketFormatKeyContext.class.getDeclaredField("sentPackets");
+      f.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      java.util.HashMap<Integer, NewPacketFormat.SentPacket> map =
+          (java.util.HashMap<Integer, NewPacketFormat.SentPacket>) f.get(ctx);
+      long newSent = System.currentTimeMillis() - 5000L; // ample to exceed retransmit threshold
+      for (NewPacketFormat.SentPacket sp : map.values()) {
+        java.lang.reflect.Field sf = NewPacketFormat.SentPacket.class.getDeclaredField("sentTime");
+        sf.setAccessible(true);
+        sf.setLong(sp, newSent);
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to backdate sentTimes via reflection", e);
+    }
+  }
+
+  /** Backdates all queued ack timestamps so they are considered urgent without waiting. */
+  private static void backdateAllAcks(NewPacketFormatKeyContext ctx) {
+    try {
+      java.lang.reflect.Field f = NewPacketFormatKeyContext.class.getDeclaredField("acks");
+      f.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      java.util.TreeMap<Integer, Long> map = (java.util.TreeMap<Integer, Long>) f.get(ctx);
+      java.util.ArrayList<Integer> keys = new java.util.ArrayList<>(map.keySet());
+      long newTime = System.currentTimeMillis() - (NewPacketFormatKeyContext.MAX_ACK_DELAY * 2L);
+      for (Integer k : keys) {
+        map.put(k, newTime);
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to backdate acks via reflection", e);
+    }
+  }
+
+  @Test
+  @DisplayName("canSend: throttle window exhausted -> false (Mockito)")
+  void canSend_whenThrottleWindowExhausted_returnsFalse() {
+    // Minimal NPF with mocked peer reporting a tiny window.
+    PacketThrottle throttle = Mockito.mock(PacketThrottle.class);
+    Mockito.when(throttle.getWindowSize()).thenReturn(1.0);
+    Mockito.when(mockPeer.getThrottle()).thenReturn(throttle);
+
+    NewPacketFormat npf = new NewPacketFormat(mockPeer, 0, 0);
+    NewPacketFormatKeyContext ctx = new NewPacketFormatKeyContext(0, 0);
+    SessionKey key = new SessionKey(null, null, null, null, null, null, null, null, ctx, 1);
+
+    // Simulate one in-flight packet so countSentPackets() == 1 and equals the window size.
+    NewPacketFormat.SentPacket sp = new NewPacketFormat.SentPacket(npf, key);
+    ctx.sent(sp, /*seq*/ 5, /*len*/ 100);
+
+    boolean can = npf.canSend(key);
+    assertFalse(can, "Window fully used (1 in flight of 1) -> cannot send");
   }
 }


### PR DESCRIPTION
Summary
- Tighten NewPacketFormat sequence-number/ack handling and make control flow explicit.
- Extract decryption tracker selection into a dedicated helper returning a compact record; parameterize logging.
- Separate concerns in decrypted-packet handling: processAcks(), shouldAckPacket(), handleLossyMessagesIfAny(), processFragments(), and maybeQueueAck().
- Improve Javadoc/KDoc across NewPacketFormat; clarify locking, invariants, and time units.
- Rename a few internal constants/fields for clarity (e.g., doKeepalives), keep behavior intact.
- Add targeted tests: NewPacketFormatKeyContextTest (allocation/acks/loss/disconnect) and extend NewPacketFormatTest.

Diff Overview
- Files changed under src/: 4
  - src/main/java/network/crypta/node/NewPacketFormat.java
  - src/main/java/network/crypta/node/NewPacketFormatKeyContext.java
  - src/test/java/network/crypta/node/NewPacketFormatKeyContextTest.java (new)
  - src/test/java/network/crypta/node/NewPacketFormatTest.java
- Rough scope: +1,679 / −806 (per diffstat).

Implementation Highlights
- New helper tryDecryptOnAnyTracker() consolidates decryption attempts against current/previous/unverified trackers and returns a record DecryptionResult (packet + sessionKey).
- Ack processing is performed up-front; ack scheduling is conditional on presence of non-error fragments and fragment processing outcome.
- Lossy messages are parsed with care and do not suppress acks improperly.
- Logging uses SLF4J placeholders instead of string concatenation; debug/trace messages are more informative.
- Javadoc documents locks, buffer accounting, and window pointers more precisely.

Behavior & Compatibility
- No wire format changes; behavior is stricter in ack/seqnum bookkeeping but remains backwards compatible.
- Keepalive toggles remain (renamed for style); defaults unchanged.

Testing
- JUnit 6 with new/updated tests:
  - NewPacketFormatKeyContextTest: allocation, acks, loss scenarios, disconnect path.
  - NewPacketFormatTest: extended coverage for fragment/ack flows.
- Local run example: ./gradlew test

Notes
- Commit history ahead of develop:
  - fix(npf): tighten seqnum/ack logic and add tests
  - docs(NewPacketFormat): improve API docs, inline comments, and log messages; apply Spotless formatting

Request
- Please review the refactor and test coverage. Focus especially on ack scheduling and tracker selection paths.