### PR TITLE
refactor(node): UPPER_SNAKE_CASE for NodeFile + Javadoc

### DIFF
--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -1377,7 +1377,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
     HTMLNode addressRow = peerRow.addChild("td", "class", "peer-address");
     // Ip to country + Flags
-    IPConverter ipc = IPConverter.getInstance(NodeFile.IPv4ToCountry.getFile(node));
+    IPConverter ipc = IPConverter.getInstance(NodeFile.IPV4_TO_COUNTRY.getFile(node));
     byte[] addr = peerNodeStatus.getPeerAddressBytes();
 
     Country country = ipc.locateIP(addr);

--- a/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
@@ -29,7 +29,7 @@ public class DarknetAddRefToadlet extends Toadlet {
     if (!ctx.checkFullAccess(this)) return;
 
     String path = uri.getPath();
-    if (path.endsWith(NodeFile.InstallerWindows.getFilename())) {
+    if (path.endsWith(NodeFile.INSTALLER_WINDOWS.getFilename())) {
       File installer = node.getNodeUpdater().getInstallerWindows();
       if (installer != null) {
         FileBucket bucket = new FileBucket(installer, true, false, false, false);
@@ -38,7 +38,7 @@ public class DarknetAddRefToadlet extends Toadlet {
       }
     }
 
-    if (path.endsWith(NodeFile.InstallerNonWindows.getFilename())) {
+    if (path.endsWith(NodeFile.INSTALLER_NON_WINDOWS.getFilename())) {
       File installer = node.getNodeUpdater().getInstallerNonWindows();
       if (installer != null) {
         FileBucket bucket = new FileBucket(installer, true, false, false, false);
@@ -65,7 +65,7 @@ public class DarknetAddRefToadlet extends Toadlet {
     boxContent.addChild("p", l10n("explainBox2"));
 
     File installer = node.getNodeUpdater().getInstallerWindows();
-    String shortFilename = NodeFile.InstallerWindows.getFilename();
+    String shortFilename = NodeFile.INSTALLER_WINDOWS.getFilename();
 
     HTMLNode p = boxContent.addChild("p");
 
@@ -89,7 +89,7 @@ public class DarknetAddRefToadlet extends Toadlet {
               });
 
     installer = node.getNodeUpdater().getInstallerNonWindows();
-    shortFilename = NodeFile.InstallerNonWindows.getFilename();
+    shortFilename = NodeFile.INSTALLER_NON_WINDOWS.getFilename();
 
     boxContent.addChild("#", " ");
 

--- a/src/main/java/network/crypta/node/Announcer.java
+++ b/src/main/java/network/crypta/node/Announcer.java
@@ -172,7 +172,7 @@ public class Announcer {
     if (!node.isOpennetEnabled()) return;
     boolean announceNow;
     if (LOG.isDebugEnabled()) LOG.debug("Connecting some seednodes...");
-    List<SimpleFieldSet> seeds = Announcer.readSeednodes(NodeFile.Seednodes.getFile(node));
+    List<SimpleFieldSet> seeds = Announcer.readSeednodes(NodeFile.SEEDNODES.getFile(node));
     LOG.info("Trying to connect to {} seednodes...", seeds.size());
     long now = System.currentTimeMillis();
     if (prepareSeedsAndRegister(seeds, now)) return;
@@ -351,7 +351,7 @@ public class Announcer {
    * <p>The parser continues after recoverable I/O errors and logs them; successfully parsed entries
    * that follow are still returned. Resources are closed on exit.
    *
-   * @param file path to the seed nodes file (for example, {@code NodeFile.Seednodes.getFile(node)})
+   * @param file path to the seed nodes file (for example, {@code NodeFile.SEEDNODES.getFile(node)})
    * @return a list of parsed {@link SimpleFieldSet} objects; empty if the file is missing or could
    *     not be read
    */

--- a/src/main/java/network/crypta/node/NodeFile.java
+++ b/src/main/java/network/crypta/node/NodeFile.java
@@ -2,27 +2,78 @@ package network.crypta.node;
 
 import java.io.File;
 
-/** Mapping of files managed by the node to their respective locations. */
+/**
+ * Enumerates well-known files used by the node and the base directory where each resides.
+ *
+ * <p>This enum centralizes the mapping between logical files (for example, the seed node list) and
+ * their location relative to a {@link ProgramDirectory} for a specific {@link Node} instance.
+ * Helper methods resolve the absolute {@link File} or return the short filename.
+ *
+ * <p>Thread-safety: the enum is immutable and thread-safe. Resolution methods are pure and allocate
+ * no resources.
+ */
 public enum NodeFile {
-  Seednodes(InstallDirectory.Node, "seednodes.fref"),
-  InstallerWindows(InstallDirectory.Run, "freenet-latest-installer-windows.exe"),
-  InstallerNonWindows(InstallDirectory.Run, "freenet-latest-installer-nonwindows.jar"),
-  IPv4ToCountry(InstallDirectory.Run, "IpToCountry.dat");
+  /**
+   * Seed server references list stored under the node directory.
+   *
+   * <p>File name: {@code seednodes.fref}. Used by opennet bootstrap and tools that need the
+   * canonical seed reference set.
+   */
+  SEEDNODES(InstallDirectory.NODE, "seednodes.fref"),
+
+  /**
+   * Cached Windows installer binary under the runtime directory.
+   *
+   * <p>File name: {@code freenet-latest-installer-windows.exe}. Populated by the updater and
+   * exposed by the HTTP UI for convenience.
+   */
+  INSTALLER_WINDOWS(InstallDirectory.RUN, "freenet-latest-installer-windows.exe"),
+
+  /**
+   * Cached cross-platform installer JAR under the runtime directory.
+   *
+   * <p>File name: {@code freenet-latest-installer-nonwindows.jar}. Populated by the updater and
+   * exposed by the HTTP UI for convenience.
+   */
+  INSTALLER_NON_WINDOWS(InstallDirectory.RUN, "freenet-latest-installer-nonwindows.jar"),
+
+  /**
+   * IPv4 geo-IP mapping database under the runtime directory.
+   *
+   * <p>File name: {@code IpToCountry.dat}. Consumed by {@code IPConverter} to render country flags
+   * and metadata for peer addresses.
+   */
+  IPV4_TO_COUNTRY(InstallDirectory.RUN, "IpToCountry.dat");
 
   private final InstallDirectory dir;
   private final String filename;
 
-  /** Gets the absolute file path associated with this file for the given node instance. */
+  /**
+   * Resolves the absolute path for this logical file within the given node's directories.
+   *
+   * @param node node whose directory layout determines the base path; must not be {@code null}
+   * @return absolute {@link File} under the mapped {@link ProgramDirectory}; the file may not exist
+   *     yet
+   */
   public File getFile(Node node) {
     return dir.getDir(node).file(filename);
   }
 
-  /** Gets the filename associated with this file. */
+  /**
+   * Returns the short file name without any directory components.
+   *
+   * @return base name such as {@code seednodes.fref}
+   */
   public String getFilename() {
     return filename;
   }
 
-  /** Gets the base directory with this file for the given node instance. */
+  /**
+   * Returns the base directory that contains this file for the given node.
+   *
+   * @param node node whose directory layout determines the base path; must not be {@code null}
+   * @return {@link ProgramDirectory} where the file resides
+   */
   public ProgramDirectory getProgramDirectory(Node node) {
     return dir.getDir(node);
   }
@@ -33,43 +84,43 @@ public enum NodeFile {
   }
 
   private enum InstallDirectory {
-    // node.install.nodeDir
-    Node() {
+    /* Maps to Node.nodeDir() (the persistent node directory). */
+    NODE() {
       @Override
       ProgramDirectory getDir(Node node) {
         return node.nodeDir();
       }
     },
-    // node.install.cfgDir
-    Cfg() {
+    /* Maps to Node.cfgDir() (configuration files). */
+    CFG() {
       @Override
       ProgramDirectory getDir(Node node) {
         return node.cfgDir();
       }
     },
-    // node.install.userDir
-    User() {
+    /* Maps to Node.userDir() (user-specific data outside the node dir). */
+    USER() {
       @Override
       ProgramDirectory getDir(Node node) {
         return node.userDir();
       }
     },
-    // node.install.runDir
-    Run() {
+    /* Maps to Node.runDir() (ephemeral runtime files and caches). */
+    RUN() {
       @Override
       ProgramDirectory getDir(Node node) {
         return node.runDir();
       }
     },
-    // node.install.storeDir
-    Store() {
+    /* Maps to Node.storeDir() (content store and indexes). */
+    STORE() {
       @Override
       ProgramDirectory getDir(Node node) {
         return node.storeDir();
       }
     },
-    // node.install.pluginDir
-    Plugin() {
+    /* Maps to Node.pluginDir() (installed plugins). */
+    PLUGIN() {
       @Override
       ProgramDirectory getDir(Node node) {
         return node.pluginDir();

--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -570,7 +570,7 @@ public class NodeStarter implements WrapperListener {
       // Ensure seednodes.fref exists at node.install.nodeDir. Install from packaged resource if
       // missing.
       try {
-        File seedFile = NodeFile.Seednodes.getFile(node);
+        File seedFile = NodeFile.SEEDNODES.getFile(node);
         if (!seedFile.exists()) {
           try (java.io.InputStream in =
               NodeStarter.class.getResourceAsStream("/seednodes/seednodes.fref")) {

--- a/src/main/java/network/crypta/node/simulator/SeednodePingTest.java
+++ b/src/main/java/network/crypta/node/simulator/SeednodePingTest.java
@@ -81,7 +81,7 @@ public class SeednodePingTest extends RealNodeTest {
       // Connect & ping
       List<SeedServerTestPeerNode> seedNodes = new ArrayList<>();
       List<SimpleFieldSet> seedNodesAsSFS =
-          Announcer.readSeednodes(new File("/tmp/", NodeFile.Seednodes.getFilename()));
+          Announcer.readSeednodes(new File("/tmp/", NodeFile.SEEDNODES.getFilename()));
       int numberOfNodesInTheFile = 0;
       for (SimpleFieldSet sfs : seedNodesAsSFS) {
         numberOfNodesInTheFile++;

--- a/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdateManager.java
@@ -369,7 +369,7 @@ public class NodeUpdateManager {
   }
 
   public File getInstallerWindows() {
-    File f = NodeFile.InstallerWindows.getFile(node);
+    File f = NodeFile.INSTALLER_WINDOWS.getFile(node);
     if (!(f.exists() && f.canRead() && f.length() > 0)) {
       return null;
     } else {
@@ -378,7 +378,7 @@ public class NodeUpdateManager {
   }
 
   public File getInstallerNonWindows() {
-    File f = NodeFile.InstallerNonWindows.getFile(node);
+    File f = NodeFile.INSTALLER_NON_WINDOWS.getFile(node);
     if (!(f.exists() && f.canRead() && f.length() > 0)) {
       return null;
     } else {
@@ -411,23 +411,23 @@ public class NodeUpdateManager {
     // Fetch seednodes to the nodeDir.
     if (updateSeednodes) {
 
-      SimplePuller seedrefsGetter = new SimplePuller(getSeednodesURI(), NodeFile.Seednodes);
+      SimplePuller seedrefsGetter = new SimplePuller(getSeednodesURI(), NodeFile.SEEDNODES);
       seedrefsGetter.start(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, MAX_SEEDNODES_LENGTH);
     }
 
     // Fetch installers and IP-to-country files to the runDir.
     if (updateInstallers) {
       SimplePuller installerGetter =
-          new SimplePuller(getInstallerNonWindowsURI(), NodeFile.InstallerNonWindows);
+          new SimplePuller(getInstallerNonWindowsURI(), NodeFile.INSTALLER_NON_WINDOWS);
       SimplePuller wininstallerGetter =
-          new SimplePuller(getInstallerWindowsURI(), NodeFile.InstallerWindows);
+          new SimplePuller(getInstallerWindowsURI(), NodeFile.INSTALLER_WINDOWS);
 
       installerGetter.start(RequestStarter.UPDATE_PRIORITY_CLASS, MAX_JAVA_INSTALLER_LENGTH);
       wininstallerGetter.start(RequestStarter.UPDATE_PRIORITY_CLASS, MAX_WINDOWS_INSTALLER_LENGTH);
     }
 
     // FIXME make updateIPToCountry configurable
-    SimplePuller ip4Getter = new SimplePuller(getIPv4ToCountryURI(), NodeFile.IPv4ToCountry);
+    SimplePuller ip4Getter = new SimplePuller(getIPv4ToCountryURI(), NodeFile.IPV4_TO_COUNTRY);
     ip4Getter.start(RequestStarter.UPDATE_PRIORITY_CLASS, MAX_IP_TO_COUNTRY_LENGTH);
   }
 


### PR DESCRIPTION
Summary
- Rename NodeFile enum constants to UPPER_SNAKE_CASE to satisfy constant naming rules and improve readability.
- Update all in-repo call sites accordingly (no behavior changes).
- Expand and clarify Javadoc in NodeFile, and replace terse inline comments with precise mappings for InstallDirectory.
- Run Spotless to keep formatting consistent.

Changes
- src/main/java/network/crypta/node/NodeFile.java
  - SEEDNODES, INSTALLER_WINDOWS, INSTALLER_NON_WINDOWS, IPV4_TO_COUNTRY
  - Detailed class/method/constant Javadoc; concise InstallDirectory mapping comments
- src/main/java/network/crypta/node/NodeStarter.java
- src/main/java/network/crypta/node/Announcer.java
- src/main/java/network/crypta/node/updater/NodeUpdateManager.java
- src/main/java/network/crypta/node/simulator/SeednodePingTest.java
- src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
- src/main/java/network/crypta/clients/http/ConnectionsToadlet.java

Rationale
- Aligns with static analysis rule: ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$.
- Improves API clarity; NodeFile acts as the single source of truth for well-known files.

Compatibility
- Internal rename only; all in-repo usages updated. External code that referenced old names should migrate to the new constants.

Testing
- Compiles cleanly (compileJava) and tests pass locally (test). Spotless applied.

Notes
- No functional changes. Only naming, documentation, and formatting updates.
