### PR TITLE
Improve NodeDispatcher concurrency and add JUnit tests

### DIFF
--- a/src/main/java/network/crypta/node/NodeDispatcher.java
+++ b/src/main/java/network/crypta/node/NodeDispatcher.java
@@ -2,9 +2,9 @@ package network.crypta.node;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import network.crypta.crypt.HMAC;
 import network.crypta.io.comm.ByteCounter;
 import network.crypta.io.comm.DMT;
@@ -28,32 +28,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author amphibian
- *     <p>Dispatcher for unmatched FNP messages.
- *     <p>What can we get?
- *     <p>SwapRequests
- *     <p>DataRequests
- *     <p>InsertRequests
- *     <p>Probably a few others; those are the important bits.
- *     <p>Requests: - Loop detection only works when the request is actually running. We do NOT
- *     remember what UID's we have routed in the past. Hence there is no possibility of an attacker
- *     probing for old UID's. Also, even in the rare-ish case where a request forks because an
- *     Accepted is delayed, this isn't a big problem: Since we moved on, we're not waiting for it,
- *     there will be no timeout/snarl-up beyond what has already happened. - We should parse the
- *     message completely before checking the UID, overload, and passing it to the handler. Invalid
- *     requests should never be accepted. However, because of inserts, we cannot guarantee that we
- *     never check the UID before we know the request is fully routable.
+ * Dispatches unmatched FNP messages and coordinates routed message flow.
+ *
+ * <p>This dispatcher is the entry point for messages not claimed by other subsystems. It handles
+ * control messages (ping/pong, time/uptime, visibility), location and load updates, swap flows,
+ * data/insert requests, announcement flows, and the small routed-to-node family (routed ping/pong
+ * and rejections).
+ *
+ * <p>Threading: instances are shared across multiple I/O and worker threads. Incoming data requests
+ * may be processed off-thread via {@code queueRunner}. Ephemeral routed message state is tracked in
+ * {@code routedContexts} and pruned periodically.
  */
 public class NodeDispatcher implements Dispatcher, Runnable {
 
+  /** Milliseconds after which a routed context expires and can be removed. */
   private static final long STALE_CONTEXT = 20000;
+
+  /** Milliseconds between successive prune checks for stale routed contexts. */
   private static final long STALE_CONTEXT_CHECK = 20000;
+
   private static final Logger LOG = LoggerFactory.getLogger(NodeDispatcher.class);
+  private static final String LOG_ALREADY_RUNNING =
+      "Lock contention for id {}; reject (already running)";
 
   final Node node;
   final RequestTracker tracker;
   final Probe probe;
-  final Hashtable<Long, RoutedContext> routedContexts = new Hashtable<>();
+  final Map<Long, RoutedContext> routedContexts = new ConcurrentHashMap<>();
   private final ArrayBlockingQueue<Message> requestQueue = new ArrayBlockingQueue<>(100);
   ByteCounter pingCounter =
       new ByteCounter() {
@@ -79,13 +80,15 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 
         @Override
         public void run() {
-          while (true) {
+          // Exit when the thread is interrupted; keeps queue processing bounded to daemon life.
+          while (!Thread.currentThread().isInterrupted()) {
             try {
               Message msg = requestQueue.take();
               boolean isSSK = msg.getSpec() == DMT.FNPSSKDataRequest;
               innerHandleDataRequest(msg, (PeerNode) msg.getSource(), isSSK);
             } catch (InterruptedException e) {
-              // Ignore
+              Thread.currentThread().interrupt();
+              return;
             }
           }
         }
@@ -95,6 +98,158 @@ public class NodeDispatcher implements Dispatcher, Runnable {
           // Slightly less than the actual requests themselves because accepting requests increases
           // load.
           return NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1;
+        }
+
+        private void innerHandleDataRequest(Message m, PeerNode source, boolean isSSK) {
+          if (preconditionsFail(m, source, isSSK)) return;
+
+          long id = m.getLong(DMT.UID);
+          ByteCounter ctr =
+              isSSK
+                  ? NodeDispatcher.this.node.getNodeStats().sskRequestCtr
+                  : NodeDispatcher.this.node.getNodeStats().chkRequestCtr;
+          short htl = normalizedHtl(m.getShort(DMT.HTL));
+          Key key = (Key) m.getObject(DMT.FREENET_ROUTING_KEY);
+          boolean realTimeFlag = DMT.getRealTimeFlag(m);
+          final RequestTag tag =
+              new RequestTag(
+                  isSSK,
+                  RequestTag.START.REMOTE,
+                  source,
+                  realTimeFlag,
+                  id,
+                  NodeDispatcher.this.node);
+
+          if (rejectAlreadyRunningData(id, isSSK, source, ctr, key, htl, tag)) return;
+
+          KeyBlock block = tryFetchBlock(key, tag);
+          if (rejectIfOverloadedData(source, isSSK, id, ctr, realTimeFlag, tag, block)) return;
+
+          NodeDispatcher.this.nodeStats.reportIncomingRequestLocation(key.toNormalizedDouble());
+
+          boolean needsPubKey = key instanceof NodeSSK && m.getBoolean(DMT.NEED_PUB_KEY);
+          RequestHandler rh =
+              new RequestHandler(
+                  source,
+                  id,
+                  NodeDispatcher.this.node,
+                  htl,
+                  key,
+                  tag,
+                  block,
+                  realTimeFlag,
+                  needsPubKey);
+          rh.receivedBytes(m.receivedByteCount());
+          NodeDispatcher.this
+              .node
+              .getExecutor()
+              .execute(
+                  rh,
+                  "RequestHandler for UID "
+                      + id
+                      + " on "
+                      + NodeDispatcher.this.node.getDarknetPortNumber());
+        }
+
+        private boolean preconditionsFail(Message m, PeerNode source, boolean isSSK) {
+          if (!source.isConnected()) {
+            if (LOG.isDebugEnabled())
+              LOG.debug(
+                  "Skip off-thread handling; source disconnected (source={}, msg={})", source, m);
+            return true;
+          }
+          if (!source.isRoutable()) {
+            if (LOG.isDebugEnabled())
+              LOG.debug(
+                  "Skip off-thread handling; source not routable (source={}, msg={})", source, m);
+            NodeDispatcher.this.rejectRequest(
+                m,
+                isSSK
+                    ? NodeDispatcher.this.node.getNodeStats().sskRequestCtr
+                    : NodeDispatcher.this.node.getNodeStats().chkRequestCtr);
+            return true;
+          }
+          return false;
+        }
+
+        private short normalizedHtl(short htl) {
+          return (htl <= 0) ? (short) 1 : htl;
+        }
+
+        private boolean rejectAlreadyRunningData(
+            long id,
+            boolean isSSK,
+            PeerNode source,
+            ByteCounter ctr,
+            Key key,
+            short htl,
+            RequestTag tag) {
+          if (NodeDispatcher.this.tracker.lockUID(
+              id, isSSK, false, false, false, tag.realTimeFlag, tag)) {
+            if (LOG.isDebugEnabled()) LOG.debug("Lock acquired for id {}", id);
+            return false;
+          }
+          if (LOG.isDebugEnabled()) LOG.debug(LOG_ALREADY_RUNNING, id);
+          Message rejected = DMT.createFNPRejectedLoop(id);
+          try {
+            source.sendAsync(rejected, null, ctr);
+          } catch (NotConnectedException e) {
+            LOG.info(
+                "Reject request; sendAsync failed (peer={}, error={})",
+                source.getPeer(),
+                e.toString());
+          }
+          NodeDispatcher.this
+              .node
+              .getFailureTable()
+              .onFinalFailure(key, null, htl, htl, -1, -1, source);
+          return true;
+        }
+
+        private KeyBlock tryFetchBlock(Key key, RequestTag tag) {
+          BlockMetadata meta = new BlockMetadata();
+          KeyBlock block = NodeDispatcher.this.node.fetch(key, false, false, false, false, meta);
+          if (block != null) tag.setNotRoutedOnwards();
+          return block;
+        }
+
+        private boolean rejectIfOverloadedData(
+            PeerNode source,
+            boolean isSSK,
+            long id,
+            ByteCounter ctr,
+            boolean realTimeFlag,
+            RequestTag tag,
+            KeyBlock block) {
+          RejectReason rejectReason =
+              NodeDispatcher.this.nodeStats.shouldRejectRequest(
+                  !isSSK,
+                  false,
+                  isSSK,
+                  false,
+                  false,
+                  source,
+                  block != null,
+                  false,
+                  realTimeFlag,
+                  tag);
+          if (rejectReason == null) return false;
+          LOG.info(
+              "Reject {} request preemptively (peer={}, reason={})",
+              (isSSK ? "SSK" : "CHK"),
+              source.getPeer(),
+              rejectReason);
+          Message rejected = DMT.createFNPRejectedOverload(id, true);
+          if (rejectReason.soft()) rejected.addSubMessage(DMT.createFNPRejectIsSoft());
+          try {
+            source.sendAsync(rejected, null, ctr);
+          } catch (NotConnectedException e) {
+            LOG.info(
+                "Rejecting (overload) data request from {}: {}", source.getPeer(), e.toString());
+          }
+          tag.setRejected();
+          tag.unlockHandler(rejectReason.soft());
+          return true;
         }
       };
   private NodeDispatcherCallback callback;
@@ -139,138 +294,178 @@ public class NodeDispatcher implements Dispatcher, Runnable {
       // Node has been disconnected and garbage collected already! Ouch.
       return true;
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Dispatching {} from {}", m, source);
+    if (LOG.isDebugEnabled()) LOG.debug("Dispatch {} from {}", m, source);
     if (callback != null) {
       try {
         callback.snoop(m, node);
-      } catch (Throwable t) {
-        LOG.error("Callback threw", t);
+      } catch (Exception e) {
+        LOG.error("Callback threw exception", e);
       }
     }
     MessageType spec = m.getSpec();
+
+    // Fast-path handlers that don't depend on routability
+    if (handlePreRoutabilityMessages(m, source, spec)) return true;
+
+    // Reject early when the source is not routable
+    if (!source.isRoutable()) return handleNotRoutableMessages(m, spec);
+
+    // Remaining message families
+    if (handleSwapMessages(m, source, spec)) return true;
+    if (handleDataOrInsertRequests(m, source, spec)) return true;
+    if (handleRoutedMessages(m, source, spec)) return true;
+    if (handleOfferAndNoderef(m, source, spec)) return true;
+    return handleProbe(m, source, spec);
+  }
+
+  private boolean handlePreRoutabilityMessages(Message m, PeerNode source, MessageType spec) {
+    return handleSimpleControlMessages(m, source, spec)
+        || handleUomMessages(m, source, spec)
+        || handleAnnounceOrRoutingStatus(m, source, spec)
+        || handleLocationChangeIfRealConnection(m, source, spec)
+        || handlePeerLoadStatuses(m, source, spec);
+  }
+
+  private boolean handleSimpleControlMessages(Message m, PeerNode source, MessageType spec) {
     if (spec == DMT.FNPPing) {
-      // Send an FNPPong
       Message reply = DMT.createFNPPong(m.getInt(DMT.PING_SEQNO));
       try {
-        source.sendAsync(reply, null, pingCounter); // nothing we can do if can't contact source
+        source.sendAsync(reply, null, pingCounter);
       } catch (NotConnectedException e) {
-        if (LOG.isDebugEnabled()) LOG.debug("Lost connection replying to {}", m);
+        if (LOG.isDebugEnabled()) LOG.debug("Lost connection while replying to {}", m);
       }
       return true;
-    } else if (spec == DMT.FNPDetectedIPAddress) {
+    }
+    if (spec == DMT.FNPDetectedIPAddress) {
       Peer p = (Peer) m.getObject(DMT.EXTERNAL_ADDRESS);
       source.setRemoteDetectedPeer(p);
       node.getIpDetector().redetectAddress();
       return true;
-    } else if (spec == DMT.FNPTime) {
-      return handleTime(m, source);
-    } else if (spec == DMT.FNPUptime) {
-      return handleUptime(m, source);
-    } else if (spec == DMT.FNPVisibility && source instanceof DarknetPeerNode peerNode1) {
+    }
+    if (spec == DMT.FNPTime) return handleTime(m, source);
+    if (spec == DMT.FNPUptime) return handleUptime(m, source);
+    if (spec == DMT.FNPVisibility && source instanceof DarknetPeerNode peerNode1) {
       peerNode1.handleVisibility(m);
       return true;
-    } else if (spec == DMT.FNPVoid) {
-      return true;
-    } else if (spec == DMT.FNPDisconnect) {
+    }
+    if (spec == DMT.FNPVoid) return true;
+    if (spec == DMT.FNPDisconnect) {
       handleDisconnect(m, source);
       return true;
-    } else if (spec == DMT.nodeToNodeMessage) {
+    }
+    if (spec == DMT.nodeToNodeMessage) {
       node.receivedNodeToNodeMessage(m, source);
       return true;
-    } else if (spec == DMT.CryptadUOMAnnouncement && source.isRealConnection()) {
+    }
+    return false;
+  }
+
+  private boolean handleUomMessages(Message m, PeerNode source, MessageType spec) {
+    if (spec == DMT.CryptadUOMAnnouncement && source.isRealConnection()) {
       return node.getNodeUpdater().getUpdateOverMandatory().handleAnnounce(m, source);
-    } else if (spec == DMT.CryptadUOMRequestRevocation && source.isRealConnection()) {
+    }
+    if (spec == DMT.CryptadUOMRequestRevocation && source.isRealConnection()) {
       return node.getNodeUpdater().getUpdateOverMandatory().handleRequestRevocation(m, source);
-    } else if (spec == DMT.CryptadUOMSendingRevocation && source.isRealConnection()) {
+    }
+    if (spec == DMT.CryptadUOMSendingRevocation && source.isRealConnection()) {
       return node.getNodeUpdater().getUpdateOverMandatory().handleSendingRevocation(m, source);
-    } else if (spec == DMT.CryptadUOMRequestMainJar
+    }
+    if (spec == DMT.CryptadUOMRequestMainJar
         && node.getNodeUpdater().supportsJarUOM()
         && source.isRealConnection()) {
       node.getNodeUpdater().getUpdateOverMandatory().handleRequestJar(m, source);
       return true;
-    } else if (spec == DMT.CryptadUOMSendingMainJar
+    }
+    if (spec == DMT.CryptadUOMSendingMainJar
         && node.getNodeUpdater().supportsJarUOM()
         && source.isRealConnection()) {
       return node.getNodeUpdater().getUpdateOverMandatory().handleSendingMain(m, source);
-    } else if (spec == DMT.CryptadUOMFetchDependency
+    }
+    if (spec == DMT.CryptadUOMFetchDependency
         && node.getNodeUpdater().supportsJarUOM()
         && source.isRealConnection()) {
       node.getNodeUpdater().getUpdateOverMandatory().handleFetchDependency(m, source);
       return true;
-    } else if (spec == DMT.FNPOpennetAnnounceRequest) {
-      return handleAnnounceRequest(m, source);
-    } else if (spec == DMT.FNPRoutingStatus) {
+    }
+    return false;
+  }
+
+  private boolean handleAnnounceOrRoutingStatus(Message m, PeerNode source, MessageType spec) {
+    if (spec == DMT.FNPOpennetAnnounceRequest) {
+      handleAnnounceRequest(m, source);
+      return true;
+    }
+    if (spec == DMT.FNPRoutingStatus) {
       if (source instanceof DarknetPeerNode peerNode) {
         boolean value = m.getBoolean(DMT.ROUTING_ENABLED);
-        if (LOG.isDebugEnabled())
-          LOG.debug("The peer ({}) asked us to set routing={}", source, value);
+        if (LOG.isDebugEnabled()) LOG.debug("Peer {} requests routing={}", source, value);
         peerNode.setRoutingStatus(value, false);
       }
-      // We claim it in any case
       return true;
-    } else if (source.isRealConnection() && spec == DMT.FNPLocChangeNotificationNew) {
-      double newLoc = m.getDouble(DMT.LOCATION);
-      ShortBuffer buffer = ((ShortBuffer) m.getObject(DMT.PEER_LOCATIONS));
-      double[] locs = Fields.bytesToDoubles(buffer.getData());
+    }
+    return false;
+  }
 
-      /**
-       * Do *NOT* remove the sanity check below!
-       *
-       * @see http://archives.freenetproject.org/message/20080718.144240.359e16d3.en.html
-       */
-      if ((OpennetManager.MAX_PEERS_FOR_SCALING < locs.length) && (source.isOpennet())) {
-        if (locs.length > OpennetManager.PANIC_MAX_PEERS) {
-          // This can't happen by accident
-          LOG.error(
-              "We received {} locations from {}! That should *NOT* happen! Possible attack!",
-              locs.length,
-              source);
-          source.forceDisconnect();
-          return true;
-        } else {
-          // A few extra can happen by accident. Just use the first 20.
-          LOG.info(
-              "Too many locations from {} : {} could be an accident, using the first {}",
-              source,
-              Integer.valueOf(locs.length),
-              Integer.valueOf(OpennetManager.MAX_PEERS_FOR_SCALING));
-          locs = Arrays.copyOf(locs, OpennetManager.MAX_PEERS_FOR_SCALING);
-        }
+  private boolean handleLocationChangeIfRealConnection(
+      Message m, PeerNode source, MessageType spec) {
+    if (!(source.isRealConnection() && spec == DMT.FNPLocChangeNotificationNew)) return false;
+
+    double newLoc = m.getDouble(DMT.LOCATION);
+    ShortBuffer buffer = ((ShortBuffer) m.getObject(DMT.PEER_LOCATIONS));
+    double[] locs = Fields.bytesToDoubles(buffer.getData());
+
+    // See: http://archives.freenetproject.org/message/20080718.144240.359e16d3.en.html
+    if ((OpennetManager.MAX_PEERS_FOR_SCALING < locs.length) && (source.isOpennet())) {
+      if (locs.length > OpennetManager.PANIC_MAX_PEERS) {
+        LOG.error(
+            "Received {} locations from {}; unexpected count; possible attack",
+            locs.length,
+            source);
+        source.forceDisconnect();
+        return true;
+      } else {
+        LOG.info(
+            "Received locations from {}: count={}; using first {}",
+            source,
+            locs.length,
+            OpennetManager.MAX_PEERS_FOR_SCALING);
+        locs = Arrays.copyOf(locs, OpennetManager.MAX_PEERS_FOR_SCALING);
       }
-      // We are on darknet and we trust our peers OR we are on opennet
-      // and the amount of locations sent to us seems reasonable
-      source.updateLocation(newLoc, locs);
+    }
+    source.updateLocation(newLoc, locs);
+    return true;
+  }
 
-      return true;
-    } else if (spec == DMT.FNPPeerLoadStatusByte
+  private boolean handlePeerLoadStatuses(Message m, PeerNode source, MessageType spec) {
+    if (spec == DMT.FNPPeerLoadStatusByte
         || spec == DMT.FNPPeerLoadStatusShort
         || spec == DMT.FNPPeerLoadStatusInt) {
-      // Must be handled before doing the routable check!
-      // We may not have received the Location yet, etc.
       return handlePeerLoadStatus(m, source);
     }
+    return false;
+  }
 
-    if (!source.isRoutable()) {
-      if (LOG.isTraceEnabled()) LOG.trace("Not routable");
-
-      if (spec == DMT.FNPCHKDataRequest) {
-        rejectRequest(m, node.getNodeStats().chkRequestCtr);
-      } else if (spec == DMT.FNPSSKDataRequest) {
-        rejectRequest(m, node.getNodeStats().sskRequestCtr);
-      } else if (spec == DMT.FNPInsertRequest) {
-        rejectRequest(m, node.getNodeStats().chkInsertCtr);
-      } else if (spec == DMT.FNPSSKInsertRequest) {
-        rejectRequest(m, node.getNodeStats().sskInsertCtr);
-      } else if (spec == DMT.FNPSSKInsertRequestNew) {
-        rejectRequest(m, node.getNodeStats().sskInsertCtr);
-      } else if (spec == DMT.FNPGetOfferedKey) {
-        rejectRequest(m, node.getFailureTable().senderCounter);
-      } else {
-        return false;
-      }
-      return true;
+  private boolean handleNotRoutableMessages(Message m, MessageType spec) {
+    if (LOG.isTraceEnabled()) LOG.trace("Peer not routable");
+    if (spec == DMT.FNPCHKDataRequest) {
+      rejectRequest(m, node.getNodeStats().chkRequestCtr);
+    } else if (spec == DMT.FNPSSKDataRequest) {
+      rejectRequest(m, node.getNodeStats().sskRequestCtr);
+    } else if (spec == DMT.FNPInsertRequest) {
+      rejectRequest(m, node.getNodeStats().chkInsertCtr);
+    } else if (spec == DMT.FNPSSKInsertRequest) {
+      rejectRequest(m, node.getNodeStats().sskInsertCtr);
+    } else if (spec == DMT.FNPSSKInsertRequestNew) {
+      rejectRequest(m, node.getNodeStats().sskInsertCtr);
+    } else if (spec == DMT.FNPGetOfferedKey) {
+      rejectRequest(m, node.getFailureTable().senderCounter);
+    } else {
+      return false;
     }
+    return true;
+  }
 
+  private boolean handleSwapMessages(Message m, PeerNode source, MessageType spec) {
     if (spec == DMT.FNPSwapRequest) {
       node.getLocationManager().handleSwapRequest(m, source);
       return true;
@@ -282,39 +477,57 @@ public class NodeDispatcher implements Dispatcher, Runnable {
       return node.getLocationManager().handleSwapCommit(m, source);
     } else if (spec == DMT.FNPSwapComplete) {
       return node.getLocationManager().handleSwapComplete(m, source);
-    } else if (spec == DMT.FNPCHKDataRequest) {
-      handleDataRequest(m, source, false);
+    }
+    return false;
+  }
+
+  private boolean handleDataOrInsertRequests(Message m, PeerNode source, MessageType spec) {
+    if (spec == DMT.FNPCHKDataRequest) {
+      handleDataRequest(m, false);
       return true;
     } else if (spec == DMT.FNPSSKDataRequest) {
-      handleDataRequest(m, source, true);
+      handleDataRequest(m, true);
       return true;
     } else if (spec == DMT.FNPInsertRequest) {
       handleInsertRequest(m, source, false);
       return true;
-    } else if (spec == DMT.FNPSSKInsertRequest) {
+    } else if (spec == DMT.FNPSSKInsertRequest || spec == DMT.FNPSSKInsertRequestNew) {
       handleInsertRequest(m, source, true);
       return true;
-    } else if (spec == DMT.FNPSSKInsertRequestNew) {
-      handleInsertRequest(m, source, true);
+    }
+    return false;
+  }
+
+  private boolean handleRoutedMessages(Message m, PeerNode source, MessageType spec) {
+    if (spec == DMT.FNPRoutedPing) {
+      handleRouted(m, source);
       return true;
-    } else if (spec == DMT.FNPRoutedPing) {
-      return handleRouted(m, source);
     } else if (spec == DMT.FNPRoutedPong) {
       return handleRoutedReply(m);
     } else if (spec == DMT.FNPRoutedRejected) {
       return handleRoutedRejected(m);
-    } else if (spec == DMT.FNPOfferKey) {
+    }
+    return false;
+  }
+
+  private boolean handleOfferAndNoderef(Message m, PeerNode source, MessageType spec) {
+    if (spec == DMT.FNPOfferKey) {
       return handleOfferKey(m, source);
     } else if (spec == DMT.FNPGetOfferedKey) {
-      return handleGetOfferedKey(m, source);
+      handleGetOfferedKey(m, source);
+      return true;
     } else if (spec == DMT.FNPGetYourFullNoderef && source instanceof DarknetPeerNode peerNode1) {
       peerNode1.sendFullNoderef();
       return true;
     } else if (spec == DMT.FNPMyFullNoderef && source instanceof DarknetPeerNode peerNode) {
       peerNode.handleFullNoderef(m);
       return true;
-    } else if (spec == DMT.ProbeRequest) {
-      // Response is handled by callbacks within probe.
+    }
+    return false;
+  }
+
+  private boolean handleProbe(Message m, PeerNode source, MessageType spec) {
+    if (spec == DMT.ProbeRequest) {
       probe.request(m, source);
       return true;
     }
@@ -350,43 +563,65 @@ public class NodeDispatcher implements Dispatcher, Runnable {
     return true;
   }
 
-  private boolean handleGetOfferedKey(Message m, PeerNode source) {
+  private void handleGetOfferedKey(Message m, PeerNode source) {
     Key key = (Key) m.getObject(DMT.KEY);
     byte[] authenticator = ((ShortBuffer) m.getObject(DMT.OFFER_AUTHENTICATOR)).getData();
     long uid = m.getLong(DMT.UID);
-    if (!HMAC.verifyWithSHA256(
-        node.getFailureTable().offerAuthenticatorKey, key.getFullKey(), authenticator)) {
-      LOG.error("Invalid offer request from {} : authenticator did not verify", source);
-      try {
-        source.sendAsync(
-            DMT.createFNPGetOfferedKeyInvalid(uid, DMT.GET_OFFERED_KEY_REJECTED_BAD_AUTHENTICATOR),
-            null,
-            node.getFailureTable().senderCounter);
-      } catch (NotConnectedException e) {
-        // Too bad.
-      }
-      return true;
-    }
-    if (LOG.isDebugEnabled()) LOG.debug("Valid GetOfferedKey for {} from {}", key, source);
+    if (invalidOfferAuthenticator(source, key, authenticator, uid)) return;
+    if (LOG.isDebugEnabled()) LOG.debug("Valid GetOfferedKey (key={}, source={})", key, source);
 
-    // Do we want it? We can RejectOverload if we don't have the bandwidth...
     boolean isSSK = key instanceof NodeSSK;
     boolean realTimeFlag = DMT.getRealTimeFlag(m);
     OfferReplyTag tag = new OfferReplyTag(isSSK, source, realTimeFlag, uid, node);
+    if (rejectAlreadyRunning(uid, isSSK, source, tag)) return;
 
-    if (!tracker.lockUID(uid, isSSK, false, true, false, realTimeFlag, tag)) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Could not lock ID {} -> rejecting (already running)", uid);
-      Message rejected = DMT.createFNPRejectedLoop(uid);
-      try {
-        source.sendAsync(rejected, null, node.getFailureTable().senderCounter);
-      } catch (NotConnectedException e) {
-        LOG.info("Rejecting request from {}: {}", source.getPeer(), e.toString());
-      }
-      return true;
-    } else {
-      if (LOG.isDebugEnabled()) LOG.debug("Locked {}", uid);
+    processOfferWithLock(m, source, key, isSSK, uid, tag, realTimeFlag);
+  }
+
+  private boolean invalidOfferAuthenticator(
+      PeerNode source, Key key, byte[] authenticator, long uid) {
+    if (HMAC.verifyWithSHA256(
+        node.getFailureTable().offerAuthenticatorKey, key.getFullKey(), authenticator)) {
+      return false;
     }
+    LOG.error("Invalid GetOfferedKey; authenticator does not verify (source={})", source);
+    try {
+      source.sendAsync(
+          DMT.createFNPGetOfferedKeyInvalid(uid, DMT.GET_OFFERED_KEY_REJECTED_BAD_AUTHENTICATOR),
+          null,
+          node.getFailureTable().senderCounter);
+    } catch (NotConnectedException e) {
+      // Too bad.
+    }
+    return true;
+  }
+
+  private boolean rejectAlreadyRunning(
+      long uid, boolean isSSK, PeerNode source, OfferReplyTag tag) {
+    if (tracker.lockUID(uid, isSSK, false, true, false, tag.realTimeFlag, tag)) {
+      if (LOG.isDebugEnabled()) LOG.debug("Lock acquired for id {}", uid);
+      return false;
+    }
+    if (LOG.isDebugEnabled()) LOG.debug(LOG_ALREADY_RUNNING, uid);
+    Message rejected = DMT.createFNPRejectedLoop(uid);
+    try {
+      source.sendAsync(rejected, null, node.getFailureTable().senderCounter);
+    } catch (NotConnectedException e) {
+      LOG.info(
+          "Reject request; sendAsync failed (peer={}, error={})", source.getPeer(), e.toString());
+    }
+    return true;
+  }
+
+  @SuppressWarnings("java:S1181")
+  private void processOfferWithLock(
+      Message m,
+      PeerNode source,
+      Key key,
+      boolean isSSK,
+      long uid,
+      OfferReplyTag tag,
+      boolean realTimeFlag) {
     boolean needPubKey;
     try {
       needPubKey = m.getBoolean(DMT.NEED_PUB_KEY);
@@ -394,31 +629,35 @@ public class NodeDispatcher implements Dispatcher, Runnable {
           nodeStats.shouldRejectRequest(
               true, false, isSSK, false, true, source, false, false, realTimeFlag, tag);
       if (reject != null) {
-        LOG.info("Rejecting FNPGetOfferedKey from {} for {} : {}", source, key, reject);
+        LOG.info("Reject FNPGetOfferedKey (source={}, key={}, reason={})", source, key, reject);
         Message rejected = DMT.createFNPRejectedOverload(uid, true);
         if (reject.soft()) rejected.addSubMessage(DMT.createFNPRejectIsSoft());
-        try {
-          source.sendAsync(rejected, null, node.getFailureTable().senderCounter);
-        } catch (NotConnectedException e) {
-          LOG.info("Rejecting (overload) data request from {}: {}", source.getPeer(), e.toString());
-        }
+        sendAsyncIgnoreNotConnected(source, rejected, node.getFailureTable().senderCounter);
         tag.unlockHandler(reject.soft());
-        return true;
+        return;
       }
-
     } catch (Error | RuntimeException e) {
       tag.unlockHandler();
       throw e;
-    } // Otherwise, sendOfferedKey is responsible for unlocking.
-
-    // Accept it.
+    }
 
     try {
       node.getFailureTable().sendOfferedKey(key, isSSK, needPubKey, uid, source, tag, realTimeFlag);
     } catch (NotConnectedException e) {
       // Too bad.
     }
-    return true;
+  }
+
+  private void sendAsyncIgnoreNotConnected(PeerNode peer, Message msg, ByteCounter ctr) {
+    try {
+      peer.sendAsync(msg, null, ctr);
+    } catch (NotConnectedException e) {
+      if (LOG.isInfoEnabled())
+        LOG.info(
+            "Reject (overload) request; sendAsync failed (peer={}, error={})",
+            peer.getPeer(),
+            e.toString());
+    }
   }
 
   // We need to check the datastore before deciding whether to accept a request.
@@ -433,20 +672,18 @@ public class NodeDispatcher implements Dispatcher, Runnable {
   private void finishDisconnect(final Message m, final PeerNode source) {
     source.disconnected(true, true);
     // If true, remove from active routing table, likely to be down for a while.
-    // Otherwise just dump all current connection state and keep trying to connect.
+    // Otherwise, just dump all current connection state and keep trying to connect.
     boolean remove = m.getBoolean(DMT.REMOVE);
     if (remove) {
       node.getPeers().disconnectAndRemove(source, false, false, false);
       if (source instanceof DarknetPeerNode peerNode)
-        // FIXME remove, dirty logs.
-        // FIXME add a useralert?
-        System.out.println(
-            "Disconnecting permanently from your friend \""
-                + peerNode.getName()
-                + "\" because they asked us to remove them.");
+        LOG.info(
+            "Disconnecting permanently from your friend \"{}\" because they asked us to remove"
+                + " them.",
+            peerNode.getName());
     }
     // If true, purge all references to this node. Otherwise, we can keep the node
-    // around in secondary tables etc in order to more easily reconnect later.
+    // around in secondary tables etc. in order to more easily reconnect later.
     // (Mostly used on opennet)
     boolean purge = m.getBoolean(DMT.PURGE);
     if (purge) {
@@ -467,10 +704,9 @@ public class NodeDispatcher implements Dispatcher, Runnable {
     return true;
   }
 
-  private void handleDataRequest(Message m, PeerNode source, boolean isSSK) {
-    // FIXME check probablyInStore and if not, we can handle it inline.
-    // This and DatastoreChecker require that method be implemented...
-    // For now just handle everything on the thread...
+  private void handleDataRequest(Message m, boolean isSSK) {
+    // Note: could check probablyInStore and handle inline when available.
+    // This and DatastoreChecker would need support for that path.
     if (!requestQueue.offer(m)) {
       rejectRequest(
           m, isSSK ? node.getNodeStats().sskRequestCtr : node.getNodeStats().chkRequestCtr);
@@ -478,93 +714,8 @@ public class NodeDispatcher implements Dispatcher, Runnable {
   }
 
   /**
-   * Handle an incoming FNPDataRequest. We should parse it and determine whether it is valid before
-   * we accept it.
-   */
-  private void innerHandleDataRequest(Message m, PeerNode source, boolean isSSK) {
-    if (!source.isConnected()) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Handling request off thread, source disconnected: {} for {}", source, m);
-      return;
-    }
-    if (!source.isRoutable()) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Handling request off thread, source no longer routable: {} for {}", source, m);
-      rejectRequest(
-          m, isSSK ? node.getNodeStats().sskRequestCtr : node.getNodeStats().chkRequestCtr);
-      return;
-    }
-    long id = m.getLong(DMT.UID);
-    ByteCounter ctr = isSSK ? node.getNodeStats().sskRequestCtr : node.getNodeStats().chkRequestCtr;
-    short htl = m.getShort(DMT.HTL);
-    if (htl <= 0) htl = 1;
-    Key key = (Key) m.getObject(DMT.FREENET_ROUTING_KEY);
-    boolean realTimeFlag = DMT.getRealTimeFlag(m);
-    final RequestTag tag =
-        new RequestTag(isSSK, RequestTag.START.REMOTE, source, realTimeFlag, id, node);
-    if (!tracker.lockUID(id, isSSK, false, false, false, realTimeFlag, tag)) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Could not lock ID {} -> rejecting (already running)", id);
-      Message rejected = DMT.createFNPRejectedLoop(id);
-      try {
-        source.sendAsync(rejected, null, ctr);
-      } catch (NotConnectedException e) {
-        LOG.info("Rejecting request from {}: {}", source.getPeer(), e.toString());
-      }
-      node.getFailureTable().onFinalFailure(key, null, htl, htl, -1, -1, source);
-      return;
-    } else {
-      if (LOG.isDebugEnabled()) LOG.debug("Locked {}", id);
-    }
-
-    // There are at least 2 threads that call this function.
-    // DO NOT reuse the meta object, unless on a per-thread basis.
-    // Object allocation is pretty cheap in modern Java anyway...
-    // If we do reuse it, call reset().
-    BlockMetadata meta = new BlockMetadata();
-    KeyBlock block = node.fetch(key, false, false, false, false, meta);
-    if (block != null) tag.setNotRoutedOnwards();
-
-    RejectReason rejectReason =
-        nodeStats.shouldRejectRequest(
-            !isSSK, false, isSSK, false, false, source, block != null, false, realTimeFlag, tag);
-    if (rejectReason != null) {
-      // can accept 1 CHK request every so often, but not with SSKs because they aren't throttled so
-      // won't sort out bwlimitDelayTime, which was the whole reason for accepting them when
-      // overloaded...
-      LOG.info(
-          "Rejecting {} request from {} preemptively because {}",
-          (isSSK ? "SSK" : "CHK"),
-          source.getPeer(),
-          rejectReason);
-      Message rejected = DMT.createFNPRejectedOverload(id, true);
-      if (rejectReason.soft()) rejected.addSubMessage(DMT.createFNPRejectIsSoft());
-      try {
-        source.sendAsync(rejected, null, ctr);
-      } catch (NotConnectedException e) {
-        LOG.info("Rejecting (overload) data request from {}: {}", source.getPeer(), e.toString());
-      }
-      tag.setRejected();
-      tag.unlockHandler(rejectReason.soft());
-      // Do not tell failure table.
-      // Otherwise an attacker can flood us with requests very cheaply and purge our
-      // failure table even though we didn't accept any of them.
-      return;
-    }
-    nodeStats.reportIncomingRequestLocation(key.toNormalizedDouble());
-    // if(!node.lockUID(id)) return false;
-    boolean needsPubKey = false;
-    if (key instanceof NodeSSK) needsPubKey = m.getBoolean(DMT.NEED_PUB_KEY);
-    RequestHandler rh =
-        new RequestHandler(source, id, node, htl, key, tag, block, realTimeFlag, needsPubKey);
-    rh.receivedBytes(m.receivedByteCount());
-    node.getExecutor()
-        .execute(rh, "RequestHandler for UID " + id + " on " + node.getDarknetPortNumber());
-  }
-
-  /**
    * Handle an incoming insert. We should parse it and determine whether it is valid before we
-   * accept it. However in the case of inserts it *IS* possible for the request sender to cause it
+   * accept it. However, in the case of inserts it *IS* possible for the request sender to cause it
    * to fail later during the receive of the data or the DataInsert.
    *
    * @param m The incoming message.
@@ -576,17 +727,53 @@ public class NodeDispatcher implements Dispatcher, Runnable {
     long id = m.getLong(DMT.UID);
     boolean realTimeFlag = DMT.getRealTimeFlag(m);
     InsertTag tag = new InsertTag(isSSK, InsertTag.START.REMOTE, source, realTimeFlag, id, node);
-    if (!tracker.lockUID(id, isSSK, true, false, false, realTimeFlag, tag)) {
-      if (LOG.isDebugEnabled())
-        LOG.debug("Could not lock ID {} -> rejecting (already running)", id);
-      Message rejected = DMT.createFNPRejectedLoop(id);
+    if (rejectAlreadyRunningInsert(id, isSSK, source, ctr, tag)) return;
+
+    InsertOptions opts = parseInsertOptions(m);
+    // SSKs don't fix bwlimitDelayTime so shouldn't be accepted when overloaded.
+    RejectReason rejectReason =
+        nodeStats.shouldRejectRequest(
+            !isSSK, true, isSSK, false, false, source, false, opts.preferInsert, realTimeFlag, tag);
+    if (rejectReason != null) {
+      LOG.info("Reject insert preemptively (peer={}, reason={})", source.getPeer(), rejectReason);
+      Message rejected = DMT.createFNPRejectedOverload(id, true);
+      if (rejectReason.soft()) rejected.addSubMessage(DMT.createFNPRejectIsSoft());
       try {
         source.sendAsync(rejected, null, ctr);
       } catch (NotConnectedException e) {
-        LOG.info("Rejecting insert request from {}: {}", source.getPeer(), e.toString());
+        LOG.info(
+            "Reject (overload) insert request; sendAsync failed (peer={}, error={})",
+            source.getPeer(),
+            e.toString());
       }
+      tag.unlockHandler(rejectReason.soft());
       return;
     }
+
+    scheduleInsertHandlers(m, source, id, realTimeFlag, tag, opts);
+    if (LOG.isDebugEnabled()) LOG.debug("Start InsertHandler for {}", id);
+  }
+
+  private boolean rejectAlreadyRunningInsert(
+      long id, boolean isSSK, PeerNode source, ByteCounter ctr, InsertTag tag) {
+    if (tracker.lockUID(id, isSSK, true, false, false, tag.realTimeFlag, tag)) return false;
+    if (LOG.isDebugEnabled()) LOG.debug(LOG_ALREADY_RUNNING, id);
+    Message rejected = DMT.createFNPRejectedLoop(id);
+    try {
+      source.sendAsync(rejected, null, ctr);
+    } catch (NotConnectedException e) {
+      LOG.info(
+          "Reject insert request; sendAsync failed (peer={}, error={})",
+          source.getPeer(),
+          e.toString());
+    }
+    return true;
+  }
+
+  private record InsertOptions(
+      boolean preferInsert, boolean ignoreLowBackoff, boolean forkOnCacheable) {}
+
+  private InsertOptions parseInsertOptions(Message m) {
     boolean preferInsert = Node.PREFER_INSERT_DEFAULT;
     boolean ignoreLowBackoff = Node.IGNORE_LOW_BACKOFF_DEFAULT;
     boolean forkOnCacheable = Node.FORK_ON_CACHEABLE_DEFAULT;
@@ -597,22 +784,16 @@ public class NodeDispatcher implements Dispatcher, Runnable {
     if (lowBackoff != null) ignoreLowBackoff = lowBackoff.getBoolean(DMT.IGNORE_LOW_BACKOFF);
     Message preference = m.getSubMessage(DMT.FNPSubInsertPreferInsert);
     if (preference != null) preferInsert = preference.getBoolean(DMT.PREFER_INSERT);
-    // SSKs don't fix bwlimitDelayTime so shouldn't be accepted when overloaded.
-    RejectReason rejectReason =
-        nodeStats.shouldRejectRequest(
-            !isSSK, true, isSSK, false, false, source, false, preferInsert, realTimeFlag, tag);
-    if (rejectReason != null) {
-      LOG.info("Rejecting insert from {} preemptively because {}", source.getPeer(), rejectReason);
-      Message rejected = DMT.createFNPRejectedOverload(id, true);
-      if (rejectReason.soft()) rejected.addSubMessage(DMT.createFNPRejectIsSoft());
-      try {
-        source.sendAsync(rejected, null, ctr);
-      } catch (NotConnectedException e) {
-        LOG.info("Rejecting (overload) insert request from {}: {}", source.getPeer(), e.toString());
-      }
-      tag.unlockHandler(rejectReason.soft());
-      return;
-    }
+    return new InsertOptions(preferInsert, ignoreLowBackoff, forkOnCacheable);
+  }
+
+  private void scheduleInsertHandlers(
+      Message m,
+      PeerNode source,
+      long id,
+      boolean realTimeFlag,
+      InsertTag tag,
+      InsertOptions opts) {
     long now = System.currentTimeMillis();
     if (m.getSpec().equals(DMT.FNPSSKInsertRequest)) {
       NodeSSK key = (NodeSSK) m.getObject(DMT.FREENET_ROUTING_KEY);
@@ -632,9 +813,9 @@ public class NodeDispatcher implements Dispatcher, Runnable {
               now,
               tag,
               node.canWriteDatastoreInsert(htl),
-              forkOnCacheable,
-              preferInsert,
-              ignoreLowBackoff,
+              opts.forkOnCacheable,
+              opts.preferInsert,
+              opts.ignoreLowBackoff,
               realTimeFlag);
       rh.receivedBytes(m.receivedByteCount());
       node.getExecutor()
@@ -655,9 +836,9 @@ public class NodeDispatcher implements Dispatcher, Runnable {
               now,
               tag,
               node.canWriteDatastoreInsert(htl),
-              forkOnCacheable,
-              preferInsert,
-              ignoreLowBackoff,
+              opts.forkOnCacheable,
+              opts.preferInsert,
+              opts.ignoreLowBackoff,
               realTimeFlag);
       rh.receivedBytes(m.receivedByteCount());
       node.getExecutor()
@@ -675,253 +856,259 @@ public class NodeDispatcher implements Dispatcher, Runnable {
               node,
               now,
               tag,
-              forkOnCacheable,
-              preferInsert,
-              ignoreLowBackoff,
+              opts.forkOnCacheable,
+              opts.preferInsert,
+              opts.ignoreLowBackoff,
               realTimeFlag);
       rh.receivedBytes(m.receivedByteCount());
       node.getExecutor()
           .execute(rh, "CHKInsertHandler for " + id + " on " + node.getDarknetPortNumber());
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Started InsertHandler for {}", id);
   }
 
-  private boolean handleAnnounceRequest(Message m, PeerNode source) {
+  private void handleAnnounceRequest(Message m, PeerNode source) {
     long uid = m.getLong(DMT.UID);
-    double target = m.getDouble(DMT.TARGET_LOCATION); // FIXME validate
+    double target = m.getDouble(DMT.TARGET_LOCATION);
     short htl = (short) Math.min(m.getShort(DMT.HTL), node.maxHTL());
     long xferUID = m.getLong(DMT.TRANSFER_UID);
     int noderefLength = m.getInt(DMT.NODEREF_LENGTH);
     int paddedLength = m.getInt(DMT.PADDED_LENGTH);
 
-    // Only accept a valid message. See comments at top of NodeDispatcher, but it's a good idea
-    // anyway.
-    if (target < 0.0
-        || target >= 1.0
-        || htl <= 0
-        || paddedLength < 0
-        || paddedLength > OpennetManager.MAX_OPENNET_NODEREF_LENGTH
-        || noderefLength > paddedLength) {
-      Message msg = DMT.createFNPRejectedOverload(uid, true);
-      try {
-        source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
-      } catch (NotConnectedException e) {
-        // OK
-      }
-      if (LOG.isDebugEnabled()) LOG.debug("Got bogus announcement message from {}", source);
-      return true;
-    }
+    if (rejectIfInvalidAnnounce(source, uid, target, htl, noderefLength, paddedLength)) return;
 
     OpennetManager om = node.getOpennet();
-    if (om == null || !source.canAcceptAnnouncements()) {
-      if (om != null && source instanceof SeedClientPeerNode peerNode)
-        om.getSeedTracker().rejectedAnnounce(peerNode);
-      Message msg = DMT.createFNPOpennetDisabled(uid);
-      try {
-        source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
-      } catch (NotConnectedException e) {
-        // OK
-      }
-      if (LOG.isDebugEnabled())
-        LOG.debug("Rejected announcement (opennet or announcement disabled) from {}", source);
-      return true;
-    }
+    if (rejectIfAnnouncementsDisabled(om, source, uid)) return;
+
     boolean success = false;
     try {
-      // UIDs for announcements are separate from those for requests.
-      // So we don't need to, and should not, ask Node.
-      NodeStats.AnnouncementDecision shouldAcceptAnnouncement =
-          node.getNodeStats().shouldAcceptAnnouncement(uid);
-      if (!(NodeStats.AnnouncementDecision.ACCEPT == shouldAcceptAnnouncement)) {
-        if (om != null && source instanceof SeedClientPeerNode peerNode)
-          om.getSeedTracker().rejectedAnnounce(peerNode);
-        Message msg = null;
-        if (NodeStats.AnnouncementDecision.OVERLOAD == shouldAcceptAnnouncement) {
-          msg = DMT.createFNPRejectedOverload(uid, true);
-          if (LOG.isDebugEnabled())
-            LOG.debug("Rejected announcement (overall overload) from {}", source);
-        } else if (NodeStats.AnnouncementDecision.LOOP == shouldAcceptAnnouncement) {
-          msg = DMT.createFNPRejectedLoop(uid);
-          if (LOG.isDebugEnabled()) LOG.debug("Rejected announcement (loop) from {}", source);
-        } else {
-          throw new Error("This shouldn't happen. Please report");
-        }
-
-        try {
-          source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
-        } catch (NotConnectedException e) {
-          // OK
-        }
-        return true;
-      }
-      if (!source.shouldAcceptAnnounce(uid)) {
-        if (om != null && source instanceof SeedClientPeerNode peerNode)
-          om.getSeedTracker().rejectedAnnounce(peerNode);
-        node.getNodeStats().endAnnouncement(uid);
-        Message msg = DMT.createFNPRejectedOverload(uid, true);
-        try {
-          source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
-        } catch (NotConnectedException e) {
-          // OK
-        }
-        if (LOG.isDebugEnabled()) LOG.debug("Rejected announcement (peer limit) from {}", source);
-        return true;
-      }
-      if (om != null && source instanceof SeedClientPeerNode peerNode) {
-        if (!om.getSeedTracker().acceptAnnounce(peerNode, node.getFastWeakRandom())) {
-          node.getNodeStats().endAnnouncement(uid);
-          Message msg = DMT.createFNPRejectedOverload(uid, true);
-          try {
-            source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
-          } catch (NotConnectedException e) {
-            // OK
-          }
-          if (LOG.isDebugEnabled())
-            LOG.debug("Rejected announcement (seednode limit) from {}", source);
-          return true;
-        }
-      }
-      if (source instanceof SeedClientPeerNode) {
-        short maxHTL = node.maxHTL();
-        if (htl < maxHTL - 1) {
-          LOG.error("Announcement from seed client not at max HTL: {} for {}", htl, source);
-          htl = maxHTL;
-        }
-      }
-      AnnouncementCallback cb = null;
-      if (LOG.isDebugEnabled()) {
-        final String origin = source + " (htl " + htl + ")";
-        // Log the progress of the announcement.
-        // This is similar to Announcer's logging.
-        cb =
-            new AnnouncementCallback() {
-              private int totalAdded;
-              private int totalNotWanted;
-              private boolean acceptedSomewhere;
-
-              @Override
-              public synchronized void acceptedSomewhere() {
-                acceptedSomewhere = true;
-              }
-
-              @Override
-              public void addedNode(PeerNode pn) {
-                synchronized (this) {
-                  totalAdded++;
-                }
-                LOG.debug(
-                    "Announcement from {} added node {}{}",
-                    origin,
-                    pn,
-                    (pn instanceof SeedClientPeerNode
-                        ? " (seed server added the peer directly)"
-                        : ""));
-              }
-
-              @Override
-              public void bogusNoderef(String reason) {
-                LOG.debug(
-                    "Announcement from {} got bogus noderef: {}",
-                    origin,
-                    reason,
-                    new Exception("debug"));
-              }
-
-              @Override
-              public void completed() {
-                synchronized (this) {
-                  LOG.debug("Announcement from {} completed", origin);
-                }
-                int shallow = node.maxHTL() - (totalAdded + totalNotWanted);
-                if (acceptedSomewhere)
-                  LOG.debug(
-                      "Announcement from {} completed ({} added, {} not wanted, {} shallow)",
-                      origin,
-                      Integer.valueOf(totalAdded),
-                      Integer.valueOf(totalNotWanted),
-                      Integer.valueOf(shallow));
-                else LOG.debug("Announcement from {} not accepted anywhere.", origin);
-              }
-
-              @Override
-              public void nodeFailed(PeerNode pn, String reason) {
-                LOG.debug("Announcement from {} failed: {}", origin, reason);
-              }
-
-              @Override
-              public void noMoreNodes() {
-                LOG.debug("Announcement from {} ran out of nodes (route not found)", origin);
-              }
-
-              @Override
-              public void nodeNotWanted() {
-                synchronized (this) {
-                  totalNotWanted++;
-                }
-                LOG.debug(
-                    "Announcement from {} returned node not wanted for a total of {} from this"
-                        + " announcement)",
-                    origin,
-                    Integer.valueOf(totalNotWanted));
-              }
-
-              @Override
-              public void nodeNotAdded() {
-                LOG.debug(
-                    "Announcement from {} : node not wanted (maybe already have it, opennet just"
-                        + " turned off, etc)",
-                    origin);
-              }
-
-              @Override
-              public void relayedNoderef() {
-                synchronized (this) {
-                  totalAdded++;
-                  LOG.debug(
-                      "Announcement from {} accepted by a downstream node, relaying noderef for a"
-                          + " total of {} from this announcement)",
-                      origin,
-                      Integer.valueOf(totalAdded));
-                }
-              }
-            };
-      }
+      NodeStats.AnnouncementDecision decision = node.getNodeStats().shouldAcceptAnnouncement(uid);
+      if (rejectBasedOnDecision(om, source, uid, decision)) return;
+      if (rejectIfPeerLimit(om, source, uid)) return;
+      if (rejectIfSeedTrackerLimit(om, source, uid)) return;
+      htl = normalizeHtlForSeedClient(source, htl);
+      AnnouncementCallback cb = buildAnnounceCallback(source, htl);
       AnnounceSender sender =
           new AnnounceSender(
               target, htl, uid, source, om, node, xferUID, noderefLength, paddedLength, cb);
       node.getExecutor().execute(sender, "Announcement sender for " + uid);
       success = true;
       if (LOG.isDebugEnabled()) LOG.debug("Accepted announcement from {}", source);
-      return true;
     } finally {
       if (!success) source.completedAnnounce(uid);
     }
   }
 
-  /** Cleanup any old/stale routing contexts and reschedule execution. */
+  private boolean rejectIfInvalidAnnounce(
+      PeerNode source, long uid, double target, short htl, int noderefLength, int paddedLength) {
+    if (target >= 0.0
+        && target < 1.0
+        && htl > 0
+        && paddedLength >= 0
+        && paddedLength <= OpennetManager.MAX_OPENNET_NODEREF_LENGTH
+        && noderefLength <= paddedLength) {
+      return false;
+    }
+    Message msg = DMT.createFNPRejectedOverload(uid, true);
+    try {
+      source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
+    } catch (NotConnectedException e) {
+      // OK
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("Got bogus announcement message from {}", source);
+    return true;
+  }
+
+  private boolean rejectIfAnnouncementsDisabled(OpennetManager om, PeerNode source, long uid) {
+    if (om != null && source.canAcceptAnnouncements()) return false;
+    if (om != null && source instanceof SeedClientPeerNode peerNode)
+      om.getSeedTracker().rejectedAnnounce(peerNode);
+    Message msg = DMT.createFNPOpennetDisabled(uid);
+    try {
+      source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
+    } catch (NotConnectedException e) {
+      // OK
+    }
+    if (LOG.isDebugEnabled())
+      LOG.debug("Reject announcement; opennet or announcements disabled (source={})", source);
+    return true;
+  }
+
+  private boolean rejectBasedOnDecision(
+      OpennetManager om, PeerNode source, long uid, NodeStats.AnnouncementDecision decision) {
+    if (NodeStats.AnnouncementDecision.ACCEPT == decision) return false;
+    if (om != null && source instanceof SeedClientPeerNode peerNode)
+      om.getSeedTracker().rejectedAnnounce(peerNode);
+    Message msg;
+    switch (decision) {
+      case NodeStats.AnnouncementDecision.OVERLOAD -> {
+        msg = DMT.createFNPRejectedOverload(uid, true);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Reject announcement due to overall overload (source={})", source);
+        }
+      }
+      case NodeStats.AnnouncementDecision.LOOP -> {
+        msg = DMT.createFNPRejectedLoop(uid);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Reject announcement due to loop (source={})", source);
+        }
+      }
+      default -> throw new IllegalStateException("This shouldn't happen. Please report");
+    }
+    try {
+      source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
+    } catch (NotConnectedException e) {
+      // OK
+    }
+    return true;
+  }
+
+  private boolean rejectIfPeerLimit(OpennetManager om, PeerNode source, long uid) {
+    if (source.shouldAcceptAnnounce(uid)) return false;
+    if (om != null && source instanceof SeedClientPeerNode peerNode)
+      om.getSeedTracker().rejectedAnnounce(peerNode);
+    node.getNodeStats().endAnnouncement(uid);
+    Message msg = DMT.createFNPRejectedOverload(uid, true);
+    try {
+      source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
+    } catch (NotConnectedException e) {
+      // OK
+    }
+    if (LOG.isDebugEnabled())
+      LOG.debug("Reject announcement due to peer limit (source={})", source);
+    return true;
+  }
+
+  private boolean rejectIfSeedTrackerLimit(OpennetManager om, PeerNode source, long uid) {
+    if (!(om != null && source instanceof SeedClientPeerNode peerNode)) return false;
+    if (om.getSeedTracker().acceptAnnounce(peerNode, node.getFastWeakRandom())) return false;
+    node.getNodeStats().endAnnouncement(uid);
+    Message msg = DMT.createFNPRejectedOverload(uid, true);
+    try {
+      source.sendAsync(msg, null, node.getNodeStats().announceByteCounter);
+    } catch (NotConnectedException e) {
+      // OK
+    }
+    if (LOG.isDebugEnabled())
+      LOG.debug("Reject announcement due to seednode limit (source={})", source);
+    return true;
+  }
+
+  private short normalizeHtlForSeedClient(PeerNode source, short htl) {
+    if (source instanceof SeedClientPeerNode) {
+      short maxHTL = node.maxHTL();
+      if (htl < maxHTL - 1) {
+        LOG.error("Seed client announcement not at max HTL: {} (source={})", htl, source);
+        return maxHTL;
+      }
+    }
+    return htl;
+  }
+
+  private AnnouncementCallback buildAnnounceCallback(PeerNode source, short htl) {
+    if (!LOG.isDebugEnabled()) return null;
+    final String origin = source + " (htl " + htl + ")";
+    return new AnnouncementCallback() {
+      private int totalAdded;
+      private int totalNotWanted;
+      private boolean acceptedSomewhere;
+
+      @Override
+      public synchronized void acceptedSomewhere() {
+        acceptedSomewhere = true;
+      }
+
+      @Override
+      public void addedNode(PeerNode pn) {
+        synchronized (this) {
+          totalAdded++;
+        }
+        LOG.debug(
+            "Announcement {} adds node {}{}",
+            origin,
+            pn,
+            (pn instanceof SeedClientPeerNode ? " (seed server added the peer directly)" : ""));
+      }
+
+      @Override
+      public void bogusNoderef(String reason) {
+        LOG.debug(
+            "Announcement {} has invalid noderef: {}", origin, reason, new Exception("debug"));
+      }
+
+      @Override
+      public void completed() {
+        synchronized (this) {
+          LOG.debug("Announcement {} completes", origin);
+        }
+        int shallow = node.maxHTL() - (totalAdded + totalNotWanted);
+        if (acceptedSomewhere)
+          LOG.debug(
+              "Announcement {} completes (added={}, notWanted={}, shallow={})",
+              origin,
+              totalAdded,
+              totalNotWanted,
+              shallow);
+        else LOG.debug("Announcement {} not accepted anywhere.", origin);
+      }
+
+      @Override
+      public void nodeFailed(PeerNode pn, String reason) {
+        LOG.debug("Announcement {} fails: {}", origin, reason);
+      }
+
+      @Override
+      public void noMoreNodes() {
+        LOG.debug("Announcement {} runs out of nodes (route not found)", origin);
+      }
+
+      @Override
+      public void nodeNotWanted() {
+        synchronized (this) {
+          totalNotWanted++;
+        }
+        LOG.debug("Announcement {}: node not wanted; total={}", origin, totalNotWanted);
+      }
+
+      @Override
+      public void nodeNotAdded() {
+        LOG.debug("Announcement {}: node not added (already present or routing disabled)", origin);
+      }
+
+      @Override
+      public void relayedNoderef() {
+        synchronized (this) {
+          totalAdded++;
+          LOG.debug(
+              "Announcement from {} accepted by a downstream node, relaying noderef for a total of"
+                  + " {} from this announcement)",
+              origin,
+              totalAdded);
+        }
+      }
+    };
+  }
+
+  /**
+   * Prunes stale routed contexts and reschedules the next check.
+   *
+   * <p>Removes entries older than {@link #STALE_CONTEXT} and schedules the next run after {@link
+   * #STALE_CONTEXT_CHECK} milliseconds.
+   */
   @Override
   public void run() {
     long now = System.currentTimeMillis();
-    synchronized (routedContexts) {
-      Iterator<RoutedContext> i = routedContexts.values().iterator();
-      while (i.hasNext()) {
-        RoutedContext rc = i.next();
-        if (now - rc.createdTime > STALE_CONTEXT) {
-          i.remove();
-        }
-      }
-    }
+    routedContexts.values().removeIf(rc -> now - rc.createdTime > STALE_CONTEXT);
     node.getTicker().queueTimedJob(this, STALE_CONTEXT_CHECK);
   }
 
-  /** Handle an FNPRoutedRejected message. */
+  /** Handle a routed rejection (FNPRoutedRejected). */
   private boolean handleRoutedRejected(Message m) {
     if (!node.enableRoutedPing()) return true;
     long id = m.getLong(DMT.UID);
     RoutedContext rc = routedContexts.get(id);
     if (rc == null) {
-      // Gah
-      LOG.error("Unrecognized FNPRoutedRejected");
+      // No matching context; likely expired or local.
+      LOG.error("Unrecognized FNPRoutedRejected; missing context");
       return false; // locally originated??
     }
     short htl = rc.lastHtl;
@@ -936,8 +1123,7 @@ public class NodeDispatcher implements Dispatcher, Runnable {
           rc.source.sendAsync(
               DMT.createFNPRoutedRejected(id, (short) 0), null, nodeStats.routedMessageCtr);
         } catch (NotConnectedException e) {
-          // Ouch.
-          LOG.error("Unable to relay probe DNF: peer disconnected: {}", rc.source);
+          LOG.error("Relay of probe DNF failed; peer disconnected: {}", rc.source);
         }
       }
     } else {
@@ -948,62 +1134,86 @@ public class NodeDispatcher implements Dispatcher, Runnable {
   }
 
   /**
-   * Handle a routed-to-a-specific-node message.
+   * Handles a message addressed to a specific node ("routed" family).
    *
-   * @param m The message to handle
-   * @param source The peer node that sent the message
-   * @return False if we want the message put back on the queue.
+   * <p>Always consumes the message by one of: local dispatch, forward to a next hop, or send an
+   * explicit rejection. The method does not return a status; callers should treat the message as
+   * handled on return.
+   *
+   * @param m the message to handle
+   * @param source the peer node that sent the message (may be {@code null} during disconnects)
    */
-  boolean handleRouted(Message m, PeerNode source) {
-    if (!node.enableRoutedPing()) return true;
-    if (LOG.isDebugEnabled()) LOG.debug("handleRouted({})", m);
+  void handleRouted(Message m, PeerNode source) {
+    if (!node.enableRoutedPing()) return;
+    if (LOG.isDebugEnabled()) LOG.debug("Handle routed message: {}", m);
 
     long id = m.getLong(DMT.UID);
     short htl = m.getShort(DMT.HTL);
     byte[] identity = ((ShortBuffer) m.getObject(DMT.NODE_IDENTITY)).getData();
     if (source != null) htl = source.decrementHTL(htl);
-    RoutedContext ctx;
-    ctx = routedContexts.get(id);
-    if (ctx != null) {
-      try {
-        source.sendAsync(DMT.createFNPRoutedRejected(id, htl), null, nodeStats.routedMessageCtr);
-      } catch (NotConnectedException e) {
-        if (LOG.isDebugEnabled()) LOG.debug("Lost connection rejecting {}", m);
-      }
-      return true;
-    }
-    ctx = new RoutedContext(m, source, identity);
-    synchronized (routedContexts) {
-      routedContexts.put(id, ctx);
-    }
-    // source == null => originated locally, keep full htl
+
+    if (rejectDuplicateRoutedIfAny(id, htl, source, m)) return;
+
+    RoutedContext ctx = new RoutedContext(m, source, identity);
+    routedContexts.put(id, ctx);
+
     double target = m.getDouble(DMT.TARGET_LOCATION);
-    if (LOG.isDebugEnabled()) LOG.debug("id {} from {} htl {} target {}", id, source, htl, target);
-    if (Math.abs(node.getLocationManager().getLocation() - target) <= Double.MIN_VALUE) {
+    if (LOG.isDebugEnabled())
+      LOG.debug("Routed id={} from {} htl={} target={}", id, source, htl, target);
+    processRoutedDispatchOrForward(m, source, id, htl, target, ctx, identity);
+  }
+
+  private boolean rejectDuplicateRoutedIfAny(long id, short htl, PeerNode source, Message m) {
+    RoutedContext ctx = routedContexts.get(id);
+    if (ctx == null) return false;
+    try {
+      source.sendAsync(DMT.createFNPRoutedRejected(id, htl), null, nodeStats.routedMessageCtr);
+    } catch (NotConnectedException e) {
+      if (LOG.isDebugEnabled()) LOG.debug("Lost connection rejecting {}", m);
+    }
+    return true;
+  }
+
+  private void processRoutedDispatchOrForward(
+      Message m,
+      PeerNode source,
+      long id,
+      short htl,
+      double target,
+      RoutedContext ctx,
+      byte[] identity) {
+    if (isLocalTarget(target)) {
       if (LOG.isDebugEnabled())
         LOG.debug("Dispatching {} on {}", m.getSpec(), node.getDarknetPortNumber());
-      // Handle locally
-      // Message type specific processing
       dispatchRoutedMessage(m, source, id);
-      return true;
-    } else if (htl == 0) {
-      Message reject = DMT.createFNPRoutedRejected(id, (short) 0);
-      if (source != null)
-        try {
-          source.sendAsync(reject, null, nodeStats.routedMessageCtr);
-        } catch (NotConnectedException e) {
-          if (LOG.isDebugEnabled()) LOG.debug("Lost connection rejecting {}", m);
-        }
-      return true;
-    } else {
-      return forward(m, id, source, htl, target, ctx, identity);
+      return;
     }
+    if (htl == 0) {
+      sendRoutedReject(source, id, m);
+      return;
+    }
+    forward(m, id, source, htl, target, ctx, identity);
+  }
+
+  private boolean isLocalTarget(double target) {
+    return Math.abs(node.getLocationManager().getLocation() - target)
+        <= Double.MIN_VALUE; // exact match
+  }
+
+  private void sendRoutedReject(PeerNode source, long id, Message m) {
+    Message reject = DMT.createFNPRoutedRejected(id, (short) 0);
+    if (source != null)
+      try {
+        source.sendAsync(reject, null, nodeStats.routedMessageCtr);
+      } catch (NotConnectedException e) {
+        if (LOG.isDebugEnabled()) LOG.debug("Lost connection while sending reject for {}", m);
+      }
   }
 
   boolean handleRoutedReply(Message m) {
     if (!node.enableRoutedPing()) return true;
     long id = m.getLong(DMT.UID);
-    if (LOG.isDebugEnabled()) LOG.debug("Got reply: {}", m);
+    if (LOG.isDebugEnabled()) LOG.debug("Received routed reply: {}", m);
     RoutedContext ctx = routedContexts.get(id);
     if (ctx == null) {
       LOG.error("Unrecognized routed reply: {}", m);
@@ -1014,12 +1224,12 @@ public class NodeDispatcher implements Dispatcher, Runnable {
     try {
       pn.sendAsync(m.cloneAndDropSubMessages(), null, nodeStats.routedMessageCtr);
     } catch (NotConnectedException e) {
-      if (LOG.isDebugEnabled()) LOG.debug("Lost connection forwarding {} to {}", m, pn);
+      if (LOG.isDebugEnabled()) LOG.debug("Lost connection while forwarding {} to {}", m, pn);
     }
     return true;
   }
 
-  private boolean forward(
+  private void forward(
       Message m,
       long id,
       PeerNode pn,
@@ -1027,58 +1237,69 @@ public class NodeDispatcher implements Dispatcher, Runnable {
       double target,
       RoutedContext ctx,
       byte[] targetIdentity) {
-    if (LOG.isDebugEnabled()) LOG.debug("Should forward");
-    // Forward
+    if (LOG.isDebugEnabled()) LOG.debug("Evaluate forwarding decision");
     m = preForward(m, htl);
     while (true) {
-      PeerNode next = node.getPeers().getByPubKeyHash(targetIdentity);
-      if (next != null && !next.isConnected()) {
-        LOG.error("Found target but disconnected!: {}", next);
-        next = null;
-      }
-      if (next == null)
-        next =
-            node.getPeers()
-                .closerPeer(
-                    pn,
-                    ctx.routedTo,
-                    target,
-                    true,
-                    node.isAdvancedModeEnabled(),
-                    -1,
-                    null,
-                    null,
-                    htl,
-                    0,
-                    pn == null,
-                    false,
-                    false);
-      if (LOG.isDebugEnabled()) LOG.debug("Next: {} message: {}", next, m);
+      PeerNode next = selectNextHop(pn, htl, target, ctx, targetIdentity);
+      if (LOG.isDebugEnabled()) LOG.debug("Next hop={} message={}", next, m);
       if (next != null) {
-        // next is connected, or at least has been => next.getPeer() CANNOT be null.
         if (LOG.isDebugEnabled())
-          LOG.debug("Forwarding {} to {}", m.getSpec(), next.getPeer().getPort());
+          LOG.debug("Forward {} to {}", m.getSpec(), next.getPeer().getPort());
         ctx.addSent(next);
-        try {
-          next.sendAsync(m, null, nodeStats.routedMessageCtr);
-        } catch (NotConnectedException e) {
-          continue;
-        }
+        if (!trySendToNext(next, m)) continue;
       } else {
-        if (LOG.isDebugEnabled())
-          LOG.debug("Reached dead end for {} on {}", m.getSpec(), node.getDarknetPortNumber());
-        // Reached a dead end...
-        Message reject = DMT.createFNPRoutedRejected(id, htl);
-        if (pn != null)
-          try {
-            pn.sendAsync(reject, null, nodeStats.routedMessageCtr);
-          } catch (NotConnectedException e) {
-            LOG.error("Cannot send reject message back to source {}", pn);
-            return true;
-          }
+        sendDeadEndReject(pn, id, htl, m);
       }
-      return true;
+      return;
     }
+  }
+
+  private PeerNode selectNextHop(
+      PeerNode pn, short htl, double target, RoutedContext ctx, byte[] targetIdentity) {
+    PeerNode next = node.getPeers().getByPubKeyHash(targetIdentity);
+    if (next != null && !next.isConnected()) {
+      LOG.error("Target found but disconnected: {}", next);
+      next = null;
+    }
+    if (next == null)
+      next =
+          node.getPeers()
+              .closerPeer(
+                  pn,
+                  ctx.routedTo,
+                  target,
+                  true,
+                  node.isAdvancedModeEnabled(),
+                  -1,
+                  null,
+                  null,
+                  htl,
+                  0,
+                  pn == null,
+                  false,
+                  false);
+    return next;
+  }
+
+  private boolean trySendToNext(PeerNode next, Message m) {
+    try {
+      next.sendAsync(m, null, nodeStats.routedMessageCtr);
+      return true;
+    } catch (NotConnectedException e) {
+      return false;
+    }
+  }
+
+  private void sendDeadEndReject(PeerNode pn, long id, short htl, Message m) {
+    if (LOG.isDebugEnabled())
+      LOG.debug("Reach dead end for {} on {}", m.getSpec(), node.getDarknetPortNumber());
+    Message reject = DMT.createFNPRoutedRejected(id, htl);
+    if (pn != null)
+      try {
+        pn.sendAsync(reject, null, nodeStats.routedMessageCtr);
+      } catch (NotConnectedException e) {
+        LOG.error("Send reject back to source {} failed", pn);
+      }
   }
 
   /** Prepare a routed-to-node message for forwarding. */
@@ -1100,38 +1321,59 @@ public class NodeDispatcher implements Dispatcher, Runnable {
    * @param m The message to dispatch
    * @param src The source peer node
    * @param id The message ID
-   * @return True if the message was handled successfully
    */
-  private boolean dispatchRoutedMessage(Message m, PeerNode src, long id) {
+  private void dispatchRoutedMessage(Message m, PeerNode src, long id) {
     if (m.getSpec() == DMT.FNPRoutedPing) {
-      if (LOG.isDebugEnabled()) LOG.debug("RoutedPing reached other side! ({})", id);
+      if (LOG.isDebugEnabled()) LOG.debug("RoutedPing reaches target ({})", id);
       int x = m.getInt(DMT.COUNTER);
       Message reply = DMT.createFNPRoutedPong(id, x);
-      if (LOG.isDebugEnabled()) LOG.debug("Replying - counter = {} for {}", Integer.valueOf(x), id);
+      if (LOG.isDebugEnabled()) LOG.debug("Reply routed pong; counter={} id={}", x, id);
       try {
         src.sendAsync(reply, null, nodeStats.routedMessageCtr);
       } catch (NotConnectedException e) {
         if (LOG.isDebugEnabled())
-          LOG.debug("Lost connection replying to {} in dispatchRoutedMessage", m);
+          LOG.debug("Lost connection while replying to {} in dispatchRoutedMessage", m);
       }
-      return true;
     }
-    return false;
   }
 
+  /**
+   * Initializes runtime stats and starts the off-thread request runner.
+   *
+   * <p>Schedules {@code queueRunner} on the node executor to process data requests taken from the
+   * internal queue. Safe to call once during node initialization.
+   *
+   * @param stats runtime counters and load information used by this dispatcher
+   */
   void start(NodeStats stats) {
     this.nodeStats = stats;
     node.getExecutor().execute(queueRunner);
   }
 
+  /**
+   * Sets an optional callback to inspect messages as they pass through the dispatcher.
+   *
+   * <p>Intended for tests and instrumentation. The callback runs on the caller's thread and should
+   * return quickly.
+   *
+   * @param cb callback invoked for each handled message; may be {@code null} to clear
+   */
   public void setHook(NodeDispatcherCallback cb) {
     this.callback = cb;
   }
 
+  /** Callback interface for observing dispatcher traffic. */
   public interface NodeDispatcherCallback {
+    /**
+     * Invoked for each message handled by the dispatcher.
+     *
+     * @param m the message being processed (never {@code null})
+     * @param n the node owning this dispatcher (never {@code null})
+     */
     void snoop(Message m, Node n);
   }
 
+  /** Per-UID state for routed message handling. */
   static class RoutedContext {
     final HashSet<PeerNode> routedTo;
     final byte[] identity;
@@ -1150,6 +1392,7 @@ public class NodeDispatcher implements Dispatcher, Runnable {
       this.identity = identity;
     }
 
+    // Tracks peers the message has been forwarded to; used to avoid loops when choosing next hop.
     void addSent(PeerNode n) {
       routedTo.add(n);
     }

--- a/src/test/java/network/crypta/node/NodeDispatcherTest.java
+++ b/src/test/java/network/crypta/node/NodeDispatcherTest.java
@@ -1,0 +1,406 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.io.comm.ByteCounter;
+import network.crypta.io.comm.DMT;
+import network.crypta.io.comm.Message;
+import network.crypta.io.comm.NotConnectedException;
+import network.crypta.io.comm.Peer;
+import network.crypta.keys.NodeCHK;
+import network.crypta.node.NodeDispatcher.NodeDispatcherCallback;
+import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.node.updater.UpdateOverMandatoryManager;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.ShortBuffer;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class NodeDispatcherTest {
+
+  @Mock Node node;
+  @Mock RequestTracker tracker;
+  @Mock NodeStats stats;
+  @Mock Ticker ticker;
+  @Mock PriorityAwareExecutor executor;
+
+  private NodeDispatcher dispatcher;
+
+  @BeforeEach
+  void setUp() {
+    // Common node wiring required by the constructor
+    when(node.getTracker()).thenReturn(tracker);
+    when(node.getNodeStats()).thenReturn(stats);
+    when(node.getTicker()).thenReturn(ticker);
+    // The constructor schedules a periodic task; execute nothing in tests.
+    doAnswer(inv -> null).when(ticker).queueTimedJob(any(Runnable.class), anyLong());
+    // Minimal config tree so Probe(node) can register options under the "node" SubConfig
+    network.crypta.config.PersistentConfig cfg = new network.crypta.config.PersistentConfig(null);
+    cfg.createSubConfig("node");
+    when(node.getConfig()).thenReturn(cfg);
+    // Provide a minimal RandomSource so Probe's identifier setter can call nextLong()
+    network.crypta.crypt.RandomSource rnd =
+        new network.crypta.crypt.RandomSource() {
+          @Override
+          public int acceptEntropy(
+              network.crypta.crypt.EntropySource source, long data, int entropyGuess) {
+            return 0;
+          }
+
+          @Override
+          public int acceptTimerEntropy(network.crypta.crypt.EntropySource timer) {
+            return 0;
+          }
+
+          @Override
+          public int acceptTimerEntropy(
+              network.crypta.crypt.EntropySource fnpTimingSource, double bias) {
+            return 0;
+          }
+
+          @Override
+          public int acceptEntropyBytes(
+              network.crypta.crypt.EntropySource myPacketDataSource,
+              byte[] buf,
+              int offset,
+              int length,
+              double bias) {
+            return 0;
+          }
+
+          @Override
+          public void close() {
+            // Test stub: RandomSource has no background collectors or OS handles here.
+            // Intentionally a no-op to satisfy static analysis of empty methods.
+          }
+        };
+    when(node.getRandom()).thenReturn(rnd);
+    dispatcher = new NodeDispatcher(node);
+  }
+
+  // ---- helpers ----
+
+  private static Message withSource(Message m, PeerNode source) {
+    byte[] encoded = m.encodeToPacket();
+    // Decode to attach a source peer context to the message instance used by the dispatcher
+    return Message.decodeMessageLax(encoded, source, 0);
+  }
+
+  private static PeerNode peerMock() {
+    PeerNode pn = mock(PeerNode.class);
+    org.mockito.Mockito.lenient().when(pn.getPeer()).thenReturn(mock(Peer.class));
+    org.mockito.Mockito.lenient().when(pn.isConnected()).thenReturn(true);
+    org.mockito.Mockito.lenient().when(pn.isRoutable()).thenReturn(true);
+    org.mockito.Mockito.lenient().when(pn.isRealConnection()).thenReturn(true);
+    java.lang.ref.WeakReference<PeerNode> ref = new java.lang.ref.WeakReference<>(pn);
+    org.mockito.Mockito.lenient().when(pn.getWeakRef()).thenReturn(ref);
+    return pn;
+  }
+
+  // ---- peersUIDsToString ----
+
+  @Test
+  @DisplayName("peersUIDsToString when lengths equal -> pairs with pipe")
+  void peersUIDsToString_whenLengthsEqual_expectPairsDelimited() {
+    long[] uids = {1L, 2L};
+    double[] locs = {0.1, 0.2};
+    String s = NodeDispatcher.peersUIDsToString(uids, locs);
+    assertEquals("0.1=1|0.2=2", s);
+  }
+
+  @Test
+  @DisplayName("peersUIDsToString when extra UIDs -> U sections appended")
+  void peersUIDsToString_whenExtraUIDs_expectUSections() {
+    long[] uids = {10L, 20L, 30L};
+    double[] locs = {0.5};
+    String s = NodeDispatcher.peersUIDsToString(uids, locs);
+    assertEquals("0.5=10|U:20|U:30", s);
+  }
+
+  @Test
+  @DisplayName("peersUIDsToString when extra locs -> L sections appended")
+  void peersUIDsToString_whenExtraLocs_expectLSections() {
+    long[] uids = {10L};
+    double[] locs = {0.5, 0.6};
+    String s = NodeDispatcher.peersUIDsToString(uids, locs);
+    assertEquals("0.5=10|L:0.6", s);
+  }
+
+  // ---- basic message handling branches ----
+
+  @Captor ArgumentCaptor<Message> msgCaptor;
+  @Captor ArgumentCaptor<ByteCounter> ctrCaptor;
+
+  @Test
+  void handleMessage_whenPing_expectPongSentAndTrue() throws NotConnectedException {
+    PeerNode src = peerMock();
+    Message ping = withSource(DMT.createFNPPing(1234), src);
+    org.junit.jupiter.api.Assertions.assertNotNull(ping.getSource());
+
+    boolean handled = dispatcher.handleMessage(ping);
+
+    assertTrue(handled);
+    verify(src).sendAsync(msgCaptor.capture(), eq(null), ctrCaptor.capture());
+
+    Message reply = msgCaptor.getValue();
+    assertEquals(DMT.FNPPong, reply.getSpec());
+    assertEquals(1234, reply.getInt(DMT.PING_SEQNO));
+
+    // Prove the ByteCounter is wired to NodeStats.pingCounterSent by invoking it.
+    ByteCounter ctr = ctrCaptor.getValue();
+    ctr.sentBytes(42);
+    verify(stats, times(1)).pingCounterSent(42);
+  }
+
+  @Test
+  void handleMessage_whenDetectedIP_expectPeerUpdatedAndRedetect() {
+    PeerNode src = peerMock();
+    Peer detected = new Peer(java.net.InetAddress.getLoopbackAddress(), 12345);
+    Message m = withSource(DMT.createFNPDetectedIPAddress(detected), src);
+    org.junit.jupiter.api.Assertions.assertNotNull(m.getSource());
+
+    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
+    when(node.getIpDetector()).thenReturn(ipDetector);
+
+    boolean handled = dispatcher.handleMessage(m);
+
+    assertTrue(handled);
+    verify(src).setRemoteDetectedPeer(detected);
+    verify(ipDetector).redetectAddress();
+  }
+
+  @Test
+  void handleMessage_whenTime_expectDeltaSet() {
+    PeerNode src = peerMock();
+    long future = System.currentTimeMillis() + 500; // ~0.5s ahead
+    Message m = withSource(DMT.createFNPTime(future), src);
+
+    boolean handled = dispatcher.handleMessage(m);
+
+    assertTrue(handled);
+    ArgumentCaptor<Long> deltaCap = ArgumentCaptor.forClass(Long.class);
+    verify(src).setTimeDelta(deltaCap.capture());
+    long delta = deltaCap.getValue();
+    // Allow generous tolerance for CI jitter
+    assertTrue(Math.abs(delta - 500) <= 250, "delta within 250ms of expected");
+  }
+
+  @Test
+  void handleMessage_whenUptime_expectSetUptime() {
+    PeerNode src = peerMock();
+    byte uptime = 77;
+    Message m = withSource(DMT.createFNPUptime(uptime), src);
+
+    assertTrue(dispatcher.handleMessage(m));
+    verify(src).setUptime(uptime);
+  }
+
+  @Test
+  void handleMessage_whenVisibilityFromDarknetPeer_expectHandled() {
+    DarknetPeerNode src = mock(DarknetPeerNode.class);
+    org.mockito.Mockito.lenient().when(src.getPeer()).thenReturn(mock(Peer.class));
+    org.mockito.Mockito.lenient().when(src.isConnected()).thenReturn(true);
+    org.mockito.Mockito.lenient().when(src.isRoutable()).thenReturn(true);
+    org.mockito.Mockito.lenient().when(src.isRealConnection()).thenReturn(true);
+    java.lang.ref.WeakReference<PeerNode> ref = new java.lang.ref.WeakReference<>(src);
+    org.mockito.Mockito.lenient().when(src.getWeakRef()).thenReturn(ref);
+
+    Message m = withSource(DMT.createFNPVisibility((short) 1), src);
+    assertTrue(dispatcher.handleMessage(m));
+    verify(src).handleVisibility(m);
+  }
+
+  @Test
+  void handleMessage_whenDisconnect_expectFinishDisconnectEffects() {
+    // Arrange ticker to capture the scheduled runnable and run it synchronously
+    AtomicReference<Runnable> scheduled = new AtomicReference<>();
+    doAnswer(
+            inv -> {
+              scheduled.set(inv.getArgument(0));
+              return null;
+            })
+        .when(ticker)
+        .queueTimedJob(any(Runnable.class), anyLong());
+
+    PeerNode src = peerMock();
+    Message m = new Message(DMT.FNPDisconnect);
+    m.set(DMT.REMOVE, true);
+    m.set(DMT.PURGE, false);
+    m.set(DMT.NODE_TO_NODE_MESSAGE_TYPE, 9);
+    m.set(DMT.NODE_TO_NODE_MESSAGE_DATA, new ShortBuffer(new byte[] {1}));
+    m = withSource(m, src);
+
+    PeerManager pm = mock(PeerManager.class);
+    when(node.getPeers()).thenReturn(pm);
+
+    boolean handled = dispatcher.handleMessage(m);
+    assertTrue(handled);
+
+    // Execute the scheduled finishDisconnect() work
+    scheduled.get().run();
+
+    verify(src).disconnected(true, true);
+    verify(pm).disconnectAndRemove(src, false, false, false);
+    verify(node).receivedNodeToNodeMessage(eq(src), eq(9), any(ShortBuffer.class), eq(true));
+  }
+
+  @Test
+  void handleMessage_whenNonRoutableAndNonRequest_expectFalse() {
+    PeerNode src = peerMock();
+    when(src.isRoutable()).thenReturn(false);
+    Message m = withSource(DMT.createFNPGetYourFullNoderef(), src);
+
+    assertFalse(dispatcher.handleMessage(m));
+  }
+
+  @Test
+  void handleMessage_whenNonRoutableChkRequest_expectRejectAndTrue() throws NotConnectedException {
+    PeerNode src = peerMock();
+    when(src.isRoutable()).thenReturn(false);
+    NodeCHK key = new NodeCHK(new byte[NodeCHK.KEY_LENGTH], (byte) 1);
+    Message m = withSource(DMT.createFNPCHKDataRequest(123L, (short) 3, key), src);
+
+    assertTrue(dispatcher.handleMessage(m));
+    verify(src).sendAsync(msgCaptor.capture(), eq(null), eq(stats.chkRequestCtr));
+    Message rejected = msgCaptor.getValue();
+    assertEquals(DMT.FNPRejectedOverload, rejected.getSpec());
+    assertEquals(123L, rejected.getLong(DMT.UID));
+  }
+
+  @Test
+  void setHook_whenCallbackSet_expectSnoopInvokedOnMessage() {
+    PeerNode src = peerMock();
+    Message m = withSource(DMT.createFNPVoid(), src);
+
+    NodeDispatcherCallback cb = mock(NodeDispatcherCallback.class);
+    dispatcher.setHook(cb);
+
+    assertTrue(dispatcher.handleMessage(m));
+    verify(cb).snoop(m, node);
+  }
+
+  @Test
+  void start_whenInvoked_expectQueueRunnerSubmitted() {
+    when(node.getExecutor()).thenReturn(executor);
+    dispatcher.start(stats);
+    verify(executor).execute(any(Runnable.class));
+  }
+
+  // ---- Routed-to-node handling ----
+
+  @Test
+  void handleRouted_whenTargetsLocal_expectPongSent() throws NotConnectedException {
+    when(node.enableRoutedPing()).thenReturn(true);
+
+    LocationManager lm = mock(LocationManager.class);
+    when(lm.getLocation()).thenReturn(0.5);
+    when(node.getLocationManager()).thenReturn(lm);
+
+    PeerNode src = peerMock();
+    when(src.decrementHTL(anyShort())).thenAnswer(i -> (short) ((short) i.getArgument(0) - 1));
+
+    long uid = 42L;
+    Message routedPing = DMT.createFNPRoutedPing(uid, 0.5, (short) 3, 7, new byte[] {9});
+    routedPing = withSource(routedPing, src);
+
+    dispatcher.handleRouted(routedPing, src);
+    // Expect immediate pong to the source with same uid/counter
+    verify(src).sendAsync(msgCaptor.capture(), eq(null), eq(stats.routedMessageCtr));
+    Message sent = msgCaptor.getValue();
+    assertEquals(DMT.FNPRoutedPong, sent.getSpec());
+    assertEquals(uid, sent.getLong(DMT.UID));
+    assertEquals(7, sent.getInt(DMT.COUNTER));
+  }
+
+  @Test
+  void handleRouted_whenDuplicateId_expectRejectedSent() throws NotConnectedException {
+    when(node.enableRoutedPing()).thenReturn(true);
+    LocationManager lm = mock(LocationManager.class);
+    when(lm.getLocation()).thenReturn(0.0);
+    when(node.getLocationManager()).thenReturn(lm);
+
+    PeerNode src = peerMock();
+    long uid = 99L;
+    Message first = DMT.createFNPRoutedPing(uid, 1.0, (short) 2, 1, new byte[] {1});
+    first = withSource(first, src);
+    dispatcher.handleRouted(first, src);
+
+    Message dup = DMT.createFNPRoutedPing(uid, 1.0, (short) 2, 2, new byte[] {1});
+    dup = withSource(dup, src);
+    dispatcher.handleRouted(dup, src);
+
+    verify(src, times(2)).sendAsync(msgCaptor.capture(), eq(null), eq(stats.routedMessageCtr));
+    Message last = msgCaptor.getAllValues().get(1);
+    assertEquals(DMT.FNPRoutedRejected, last.getSpec());
+    assertEquals(uid, last.getLong(DMT.UID));
+  }
+
+  @Test
+  void handleRoutedReply_whenContextExists_expectForwardedToSource() throws NotConnectedException {
+    when(node.enableRoutedPing()).thenReturn(true);
+    LocationManager lm = mock(LocationManager.class);
+    when(lm.getLocation()).thenReturn(0.5);
+    when(node.getLocationManager()).thenReturn(lm);
+
+    PeerNode src = peerMock();
+    long uid = 7L;
+    Message routed = DMT.createFNPRoutedPing(uid, 0.5, (short) 2, 3, new byte[] {4});
+    routed = withSource(routed, src);
+    dispatcher.handleRouted(routed, src);
+
+    Message reply = DMT.createFNPRoutedPong(uid, 3);
+    assertTrue(dispatcher.handleRoutedReply(reply));
+    verify(src, times(2)).sendAsync(any(Message.class), eq(null), eq(stats.routedMessageCtr));
+  }
+
+  // ---- UOM delegation ----
+
+  @Test
+  void uomAnnouncement_whenRealConnection_expectDelegated() {
+    PeerNode src = peerMock();
+    Message ann =
+        new DMT.UOMAnnouncementBuilder()
+            .mainKey("K")
+            .revocationKey("R")
+            .haveRevocation(true)
+            .mainJarVersion(1)
+            .timeLastTriedRevocationFetch(0)
+            .revocationDNFCount(0)
+            .revocationKeyLength(1)
+            .mainJarLength(1)
+            .pingTime(10)
+            .bwlimitDelayTime(0)
+            .build();
+    ann = withSource(ann, src);
+
+    NodeUpdateManager upd = mock(NodeUpdateManager.class);
+    UpdateOverMandatoryManager uom = mock(UpdateOverMandatoryManager.class);
+    when(node.getNodeUpdater()).thenReturn(upd);
+    when(upd.getUpdateOverMandatory()).thenReturn(uom);
+    when(uom.handleAnnounce(any(Message.class), any(PeerNode.class))).thenReturn(true);
+
+    assertTrue(dispatcher.handleMessage(ann));
+    verify(uom).handleAnnounce(ann, src);
+  }
+}


### PR DESCRIPTION
Summary
- Replace Hashtable with ConcurrentHashMap for routedContexts to reduce contention and improve concurrency safety.
- Clarify class-level Javadoc and document threading model and lifecycle.
- Queue runner: honor thread interruption and exit cleanly; avoid spin on InterruptedException.
- Extract innerHandleDataRequest(...) for readability; normalize HTL and select correct ByteCounter from NodeStats.
- Add comprehensive JUnit 6 test class NodeDispatcherTest covering:
  - peersUIDsToString edge cases (equal, extra UIDs, extra locs)
  - Basic control flows (ping→pong, detected IP, time delta)
  - ByteCounter wiring to NodeStats for ping replies
- Apply Spotless formatting across touched sources.

Scope
- Changes are limited to:
  - src/main/java/network/crypta/node/NodeDispatcher.java (refactor/cleanup)
  - src/test/java/network/crypta/node/NodeDispatcherTest.java (new tests)

Comparison
- Branch: feature/fix-NodeDispatcher → Base: develop
- Merge-base compare (origin/develop...HEAD): 2 files changed, 1227 insertions, 578 deletions.
- Unique commit included: a735115118 test(node): add NodeDispatcherTest; style: apply Spotless

Rationale
- The dispatcher is shared across I/O and worker threads; ConcurrentHashMap avoids coarse locking of Hashtable for routedContexts.
- Clean interruption handling prevents stuck threads during shutdown.
- Improved logging and structure make contention paths and state handling easier to trace.

Testing
- New JUnit 6 tests added; they mock PeerNode/Message and verify reply specs and ByteCounter plumbing.
- No changes to external APIs.

Notes
- Formatting performed via `./gradlew spotlessApply` before commit.
- Branch may be behind develop in unrelated areas; using three-dot comparison ensures this PR contains only the dispatcher/test changes. A follow-up rebase can be done if preferred.
