### PR TITLE
Refactor NodeGetPubkey lookup flow and add unit tests

### DIFF
--- a/src/main/java/network/crypta/node/NodeGetPubkey.java
+++ b/src/main/java/network/crypta/node/NodeGetPubkey.java
@@ -1,4 +1,4 @@
-/** Public Key Store (with LRU memory cache) */
+/** Public key lookups with an in‑memory LRU cache. */
 package network.crypta.node;
 
 import java.io.IOException;
@@ -12,14 +12,22 @@ import network.crypta.support.LRUMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Resolves and caches DSA public keys for content blocks.
+ *
+ * <p>This class consults multiple sources in a defined order and maintains a small in-memory LRU
+ * cache to avoid repeated datastore or disk lookups. All accesses to the in-memory cache are
+ * synchronized because the underlying {@link LRUMap} is not thread-safe.
+ *
+ * <p>Lookup order (when applicable): memory cache → client caches (including legacy) → main
+ * datastore (including legacy) → datacache (including legacy) → slashdot cache (when requested).
+ */
 public class NodeGetPubkey implements GetPubkey {
   private static final Logger LOG = LoggerFactory.getLogger(NodeGetPubkey.class);
 
-  static {
-  }
-
-  // Debugging stuff
+  // Enable the small RAM-backed pubkey cache for hot entries.
   private static final boolean USE_RAM_PUBKEYS_CACHE = true;
+  // Upper bound for entries kept in the in-memory LRU cache.
   private static final int MAX_MEMORY_CACHED_PUBKEYS = 1000;
 
   private final LRUMap<ByteArrayWrapper, DSAPublicKey> cachedPubKeys;
@@ -41,80 +49,66 @@ public class NodeGetPubkey implements GetPubkey {
     this.pubKeyDatacache = pubKeyDatacache;
   }
 
-  /* (non-Javadoc)
-   * @see freenet.node.GetPubkey#getKey(byte[], boolean, boolean, freenet.store.BlockMetadata)
+  /**
+   * Returns the {@link DSAPublicKey} identified by {@code hash}.
+   *
+   * <p>The method consults sources in priority order and may populate the in-memory cache on a hit.
+   * When {@code canReadClientCache} is {@code true}, legacy client caches are also consulted. When
+   * {@code forULPR} is {@code true}, the slashdot cache is consulted as the last step.
+   *
+   * <p>Lookup order: memory cache → client caches (when allowed) → datastore (and legacy) →
+   * datacache (and legacy) → slashdot cache (when {@code forULPR}).
+   *
+   * @param hash 32-byte key hash; method treats it as non-null and does not copy the array.
+   * @param canReadClientCache whether client caches may be used for reading.
+   * @param forULPR whether the request targets ULPR paths and may consult the slashdot cache.
+   * @param meta optional metadata sink; implementations append read information when non-null.
+   * @return the resolved public key, or {@code null} when not found.
    */
   @Override
   public DSAPublicKey getKey(
       byte[] hash, boolean canReadClientCache, boolean forULPR, BlockMetadata meta) {
-    boolean ignoreOldBlocks = !node.getWriteLocalToDatastore();
-    if (canReadClientCache) ignoreOldBlocks = false;
-    ByteArrayWrapper w = new ByteArrayWrapper(hash);
-    if (LOG.isDebugEnabled()) LOG.debug("Getting pubkey: " + HexUtil.bytesToHex(hash));
+    boolean ignoreOldBlocks = shouldIgnoreOldBlocks(canReadClientCache);
+    if (LOG.isDebugEnabled()) LOG.debug("Get pubkey for hash={}", HexUtil.bytesToHex(hash));
 
-    if (USE_RAM_PUBKEYS_CACHE) {
-      synchronized (cachedPubKeys) {
-        DSAPublicKey key = cachedPubKeys.get(w);
-        if (key != null) {
-          cachedPubKeys.push(w, key);
-          if (LOG.isDebugEnabled())
-            LOG.debug("Got " + HexUtil.bytesToHex(hash) + " from in-memory cache");
-          return key;
-        }
-      }
-    }
+    DSAPublicKey fromRam = getFromRamCache(hash);
+    if (fromRam != null) return fromRam;
     try {
-      DSAPublicKey key = null;
-      if (pubKeyClientcache != null && canReadClientCache)
-        key = pubKeyClientcache.fetch(hash, false, false, meta);
-      if (node.getOldPKClientCache() != null && canReadClientCache && key == null) {
-        PubkeyStore pks = node.getOldPKClientCache();
-        if (pks != null) key = pks.fetch(hash, false, false, meta);
-        if (key != null && LOG.isDebugEnabled())
-          LOG.debug("Got " + HexUtil.bytesToHex(hash) + " from old client cache");
-      }
-      // We can *read* from the datastore even if nearby, but we cannot promote in that case.
-      if (key == null) {
-        key = pubKeyDatastore.fetch(hash, false, ignoreOldBlocks, meta);
-        if (key != null && LOG.isDebugEnabled())
-          LOG.debug("Got " + HexUtil.bytesToHex(hash) + " from store");
-      }
-      if (key == null) {
-        PubkeyStore pks = node.getOldPK();
-        if (pks != null) key = pks.fetch(hash, false, ignoreOldBlocks, meta);
-        if (key != null && LOG.isDebugEnabled())
-          LOG.debug("Got " + HexUtil.bytesToHex(hash) + " from old store");
-      }
-      if (key == null) {
-        key = pubKeyDatacache.fetch(hash, false, ignoreOldBlocks, meta);
-        if (key != null && LOG.isDebugEnabled())
-          LOG.debug("Got " + HexUtil.bytesToHex(hash) + " from cache");
-      }
-      if (key == null) {
-        PubkeyStore pks = node.getOldPKCache();
-        if (pks != null) key = pks.fetch(hash, false, ignoreOldBlocks, meta);
-        if (key != null && LOG.isDebugEnabled())
-          LOG.debug("Got " + HexUtil.bytesToHex(hash) + " from old cache");
-      }
-      if (key == null && pubKeySlashdotcache != null && forULPR) {
-        key = pubKeySlashdotcache.fetch(hash, false, ignoreOldBlocks, meta);
-        if (LOG.isDebugEnabled())
-          LOG.debug("Got " + HexUtil.bytesToHex(hash) + " from slashdot cache");
-      }
+      DSAPublicKey key =
+          orElse(
+              tryClientCaches(hash, canReadClientCache, meta),
+              () ->
+                  orElse(
+                      tryStores(hash, ignoreOldBlocks, meta),
+                      () ->
+                          orElse(
+                              tryDataCaches(hash, ignoreOldBlocks, meta),
+                              () -> trySlashdot(hash, forULPR, ignoreOldBlocks, meta))));
       if (key != null) {
-        // Just put into the in-memory cache
+        // Populate the in-memory cache for subsequent lookups.
         cacheKey(hash, key, false, false, false, false, false);
       }
       return key;
     } catch (IOException e) {
-      // FIXME deal with disk full, access perms etc; tell user about it.
-      LOG.error("Error accessing pubkey store: " + e, e);
+      // Surface the I/O error; stack trace is attached via the throwable parameter.
+      LOG.error("Pubkey store access error (cause={})", e, e);
       return null;
     }
   }
 
-  /* (non-Javadoc)
-   * @see freenet.node.GetPubkey#cacheKey(byte[], freenet.crypt.DSAPublicKey, boolean, boolean, boolean, boolean, boolean)
+  /**
+   * Caches a key in memory and, when permitted, writes it to backing stores.
+   *
+   * <p>This method updates the RAM LRU cache unconditionally. Depending on the flags, it may also
+   * write to the client cache, slashdot cache, datacache, and optionally the main datastore.
+   *
+   * @param hash 32-byte key hash; method treats it as non-null and does not copy the array.
+   * @param key non-null public key to cache.
+   * @param deep when {@code true}, writes to the main datastore in addition to the datacache.
+   * @param canWriteClientCache whether the client cache may be updated.
+   * @param canWriteDatastore whether writing to the main datastore is allowed.
+   * @param forULPR whether the slashdot cache may also be updated.
+   * @param writeLocalToDatastore when {@code true}, treat writes as local-to-datastore operations.
    */
   @Override
   public void cacheKey(
@@ -125,44 +119,141 @@ public class NodeGetPubkey implements GetPubkey {
       boolean canWriteDatastore,
       boolean forULPR,
       boolean writeLocalToDatastore) {
-    if (LOG.isDebugEnabled()) LOG.debug("Cache key: " + HexUtil.bytesToHex(hash) + " : " + key);
+    if (LOG.isDebugEnabled())
+      LOG.debug("Cache pubkey hash={} key={}", HexUtil.bytesToHex(hash), key);
     ByteArrayWrapper w = new ByteArrayWrapper(hash);
     synchronized (cachedPubKeys) {
       DSAPublicKey key2 = cachedPubKeys.get(w);
       if ((key2 != null) && !key2.equals(key))
         throw new IllegalArgumentException(
             "Wrong hash?? Already have different key with same hash!");
+      // Touch/insert to keep LRU order fresh.
       cachedPubKeys.push(w, key);
       while (cachedPubKeys.size() > MAX_MEMORY_CACHED_PUBKEYS) cachedPubKeys.popKey();
     }
     try {
-      if (canWriteClientCache && !(canWriteDatastore || writeLocalToDatastore)) {
-        if (pubKeyClientcache != null) {
-          pubKeyClientcache.put(key, false);
-        }
+      if (canWriteClientCache
+          && !(canWriteDatastore || writeLocalToDatastore)
+          && pubKeyClientcache != null) {
+        pubKeyClientcache.put(key, false);
       }
-      if (forULPR && !(canWriteDatastore || writeLocalToDatastore)) {
-        if (pubKeySlashdotcache != null) {
-          pubKeySlashdotcache.put(key, false);
-        }
+      if (forULPR && !(canWriteDatastore || writeLocalToDatastore) && pubKeySlashdotcache != null) {
+        pubKeySlashdotcache.put(key, false);
       }
-      // Cannot write to the store or cache if request started nearby.
+      // If the request originated nearby, avoid persisting to stores or caches.
       if (!(canWriteDatastore || writeLocalToDatastore)) return;
       if (deep) {
         pubKeyDatastore.put(key, !canWriteDatastore);
       }
       pubKeyDatacache.put(key, !canWriteDatastore);
     } catch (IOException e) {
-      // FIXME deal with disk full, access perms etc; tell user about it.
-      LOG.error("Error accessing pubkey store: " + e, e);
+      // Surface the I/O error; stack trace is attached via the throwable parameter.
+      LOG.error("Pubkey store access error (cause={})", e, e);
     }
   }
 
+  /** Sets the client-local pubkey store used for reads/writes when permitted. */
   public void setLocalDataStore(PubkeyStore pubKeyClientcache) {
     this.pubKeyClientcache = pubKeyClientcache;
   }
 
+  /** Sets the slashdot cache used for ULPR-related reads/writes when permitted. */
   public void setLocalSlashdotcache(PubkeyStore pubKeySlashdotcache) {
     this.pubKeySlashdotcache = pubKeySlashdotcache;
+  }
+
+  private boolean shouldIgnoreOldBlocks(boolean canReadClientCache) {
+    boolean ignoreOldBlocks = !node.getWriteLocalToDatastore();
+    if (canReadClientCache) ignoreOldBlocks = false;
+    return ignoreOldBlocks;
+  }
+
+  private DSAPublicKey getFromRamCache(byte[] hash) {
+    if (!USE_RAM_PUBKEYS_CACHE) return null;
+    ByteArrayWrapper w = new ByteArrayWrapper(hash);
+    synchronized (cachedPubKeys) {
+      DSAPublicKey key = cachedPubKeys.get(w);
+      if (key != null) {
+        cachedPubKeys.push(w, key);
+        if (LOG.isDebugEnabled())
+          LOG.debug("Memory cache hit for hash={}", HexUtil.bytesToHex(hash));
+        return key;
+      }
+    }
+    return null;
+  }
+
+  private DSAPublicKey tryClientCaches(byte[] hash, boolean canReadClientCache, BlockMetadata meta)
+      throws IOException {
+    if (pubKeyClientcache != null && canReadClientCache) {
+      DSAPublicKey key = pubKeyClientcache.fetch(hash, false, false, meta);
+      if (key != null) return key;
+    }
+    if (node.getOldPKClientCache() != null && canReadClientCache) {
+      PubkeyStore pks = node.getOldPKClientCache();
+      DSAPublicKey key = (pks != null) ? pks.fetch(hash, false, false, meta) : null;
+      if (key != null) {
+        if (LOG.isDebugEnabled())
+          LOG.debug("Client cache (legacy) hit for hash={}", HexUtil.bytesToHex(hash));
+        return key;
+      }
+    }
+    return null;
+  }
+
+  private DSAPublicKey tryStores(byte[] hash, boolean ignoreOldBlocks, BlockMetadata meta)
+      throws IOException {
+    DSAPublicKey key = pubKeyDatastore.fetch(hash, false, ignoreOldBlocks, meta);
+    if (key != null) {
+      if (LOG.isDebugEnabled()) LOG.debug("Datastore hit for hash={}", HexUtil.bytesToHex(hash));
+      return key;
+    }
+    PubkeyStore pks = node.getOldPK();
+    if (pks != null) key = pks.fetch(hash, false, ignoreOldBlocks, meta);
+    if (key != null) {
+      if (LOG.isDebugEnabled())
+        LOG.debug("Datastore (legacy) hit for hash={}", HexUtil.bytesToHex(hash));
+      return key;
+    }
+    return null;
+  }
+
+  private DSAPublicKey tryDataCaches(byte[] hash, boolean ignoreOldBlocks, BlockMetadata meta)
+      throws IOException {
+    DSAPublicKey key = pubKeyDatacache.fetch(hash, false, ignoreOldBlocks, meta);
+    if (key != null) {
+      if (LOG.isDebugEnabled()) LOG.debug("Datacache hit for hash={}", HexUtil.bytesToHex(hash));
+      return key;
+    }
+    PubkeyStore pks = node.getOldPKCache();
+    if (pks != null) key = pks.fetch(hash, false, ignoreOldBlocks, meta);
+    if (key != null) {
+      if (LOG.isDebugEnabled())
+        LOG.debug("Datacache (legacy) hit for hash={}", HexUtil.bytesToHex(hash));
+      return key;
+    }
+    return null;
+  }
+
+  private DSAPublicKey trySlashdot(
+      byte[] hash, boolean forULPR, boolean ignoreOldBlocks, BlockMetadata meta)
+      throws IOException {
+    if (pubKeySlashdotcache != null && forULPR) {
+      DSAPublicKey key = pubKeySlashdotcache.fetch(hash, false, ignoreOldBlocks, meta);
+      if (LOG.isDebugEnabled())
+        LOG.debug("Slashdot cache hit for hash={}", HexUtil.bytesToHex(hash));
+      return key;
+    }
+    return null;
+  }
+
+  @FunctionalInterface
+  private interface DSAPubkeySupplier {
+    DSAPublicKey get() throws IOException;
+  }
+
+  private static DSAPublicKey orElse(DSAPublicKey first, DSAPubkeySupplier fallback)
+      throws IOException {
+    return (first != null) ? first : fallback.get();
   }
 }

--- a/src/test/java/network/crypta/node/NodeGetPubkeyTest.java
+++ b/src/test/java/network/crypta/node/NodeGetPubkeyTest.java
@@ -1,0 +1,223 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import network.crypta.crypt.DSAPublicKey;
+import network.crypta.crypt.Global;
+import network.crypta.store.PubkeyStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class NodeGetPubkeyTest {
+
+  private static final byte[] HASH = new byte[] {1, 2, 3, 4, 5};
+
+  @Mock private Node node;
+  @Mock private PubkeyStore store;
+  @Mock private PubkeyStore cache;
+  @Mock private PubkeyStore clientCache;
+  @Mock private PubkeyStore slashdotCache;
+  @Mock private PubkeyStore oldClientCache;
+  @Mock private PubkeyStore oldStore;
+  @Mock private PubkeyStore oldCache;
+
+  private NodeGetPubkey uut;
+
+  private static DSAPublicKey newKey(int y) {
+    return new DSAPublicKey(Global.DSAgroupBigA, BigInteger.valueOf(y));
+  }
+
+  @BeforeEach
+  void setUp() {
+    uut = new NodeGetPubkey(node);
+    uut.setDataStore(store, cache);
+  }
+
+  @Test
+  void getKey_whenFirstFromStore_thenMemoryCacheOnSecondCall() throws Exception {
+    DSAPublicKey k = newKey(10);
+    when(node.getWriteLocalToDatastore()).thenReturn(false);
+    org.mockito.Mockito.doReturn(k).when(store).fetch(any(), anyBoolean(), anyBoolean(), any());
+
+    DSAPublicKey first =
+        uut.getKey(HASH, /* canReadClientCache= */ false, /* forULPR= */ false, null);
+    assertSame(k, first, "should return key from store on first resolution");
+    verify(store).fetch(HASH, false, true, null);
+    verifyNoInteractions(cache);
+
+    // Second call should hit in-memory LRU without touching stores
+    clearInvocations(store, cache);
+    DSAPublicKey second =
+        uut.getKey(HASH, /* canReadClientCache= */ false, /* forULPR= */ false, null);
+    assertSame(k, second, "should return same instance from RAM cache");
+    verifyNoInteractions(store, cache);
+  }
+
+  @Test
+  void getKey_whenClientCacheEnabled_prefersClientCache() throws Exception {
+    uut.setLocalDataStore(clientCache);
+    when(node.getWriteLocalToDatastore()).thenReturn(true); // value ignored when reading client
+    DSAPublicKey k = newKey(11);
+    org.mockito.Mockito.doReturn(k)
+        .when(clientCache)
+        .fetch(any(), anyBoolean(), anyBoolean(), any());
+
+    DSAPublicKey got = uut.getKey(HASH, /* canReadClientCache= */ true, /* forULPR= */ false, null);
+    assertSame(k, got, "should return key from client cache when allowed");
+    verify(clientCache).fetch(HASH, false, false, null);
+    verifyNoInteractions(store, cache);
+  }
+
+  @Test
+  void getKey_whenClientCacheMiss_usesOldClientCacheBeforeStores() throws Exception {
+    uut.setLocalDataStore(clientCache);
+    when(node.getWriteLocalToDatastore()).thenReturn(true);
+    when(node.getOldPKClientCache()).thenReturn(oldClientCache);
+    DSAPublicKey k = newKey(12);
+    org.mockito.Mockito.doReturn(null)
+        .when(clientCache)
+        .fetch(any(), anyBoolean(), anyBoolean(), any());
+    org.mockito.Mockito.doReturn(k)
+        .when(oldClientCache)
+        .fetch(any(), anyBoolean(), anyBoolean(), any());
+
+    DSAPublicKey got = uut.getKey(HASH, /* canReadClientCache= */ true, /* forULPR= */ false, null);
+    assertSame(k, got, "should fall back to old client cache");
+    verify(clientCache).fetch(HASH, false, false, null);
+    verify(oldClientCache).fetch(HASH, false, false, null);
+    verifyNoInteractions(store, cache);
+  }
+
+  @Test
+  void getKey_whenOnlySlashdotHas_itIsUsedForULPR() throws Exception {
+    // No client cache reading; stores miss
+    when(node.getWriteLocalToDatastore()).thenReturn(false);
+    org.mockito.Mockito.doReturn(null).when(store).fetch(any(), anyBoolean(), anyBoolean(), any());
+    org.mockito.Mockito.doReturn(null).when(cache).fetch(any(), anyBoolean(), anyBoolean(), any());
+    when(node.getOldPK()).thenReturn(oldStore);
+    when(node.getOldPKCache()).thenReturn(oldCache);
+    org.mockito.Mockito.doReturn(null)
+        .when(oldStore)
+        .fetch(any(), anyBoolean(), anyBoolean(), any());
+    org.mockito.Mockito.doReturn(null)
+        .when(oldCache)
+        .fetch(any(), anyBoolean(), anyBoolean(), any());
+
+    uut.setLocalSlashdotcache(slashdotCache);
+    DSAPublicKey k = newKey(13);
+    org.mockito.Mockito.doReturn(k)
+        .when(slashdotCache)
+        .fetch(any(), anyBoolean(), anyBoolean(), any());
+
+    DSAPublicKey got = uut.getKey(HASH, /* canReadClientCache= */ false, /* forULPR= */ true, null);
+    assertSame(k, got, "should read from slashdot cache when forULPR");
+    verify(slashdotCache).fetch(HASH, false, true, null);
+  }
+
+  @Test
+  void cacheKey_whenClientAndSlashdotOnly_writesOnlyThose() throws Exception {
+    uut.setLocalDataStore(clientCache);
+    uut.setLocalSlashdotcache(slashdotCache);
+
+    DSAPublicKey k = newKey(20);
+    uut.cacheKey(
+        HASH,
+        k,
+        /* deep= */ false,
+        /* canWriteClientCache= */ true,
+        /* canWriteDatastore= */ false,
+        /* forULPR= */ true,
+        /* writeLocalToDatastore= */ false);
+
+    verify(clientCache).put(k, false);
+    verify(slashdotCache).put(k, false);
+    verifyNoInteractions(store, cache);
+
+    // Verify the key is now available from the in-memory cache (no store access)
+    when(node.getWriteLocalToDatastore()).thenReturn(false);
+    DSAPublicKey got =
+        uut.getKey(HASH, /* canReadClientCache= */ false, /* forULPR= */ false, null);
+    assertSame(k, got, "should come from RAM cache without store fetch");
+    verifyNoInteractions(store, cache);
+  }
+
+  @Test
+  void cacheKey_whenDeepAndCanWriteDatastore_writesStoreAndDataCache() throws Exception {
+    DSAPublicKey k = newKey(21);
+    uut.cacheKey(
+        HASH,
+        k,
+        /* deep= */ true,
+        /* canWriteClientCache= */ false,
+        /* canWriteDatastore= */ true,
+        /* forULPR= */ false,
+        /* writeLocalToDatastore= */ false);
+
+    verify(store).put(k, false);
+    verify(cache).put(k, false);
+    verifyNoInteractions(clientCache, slashdotCache);
+  }
+
+  @Test
+  void cacheKey_whenWriteLocalToDatastoreTrue_setsOldFlagOnPuts() throws Exception {
+    DSAPublicKey k = newKey(22);
+
+    uut.cacheKey(
+        HASH,
+        k,
+        /* deep= */ true,
+        /* canWriteClientCache= */ false,
+        /* canWriteDatastore= */ false,
+        /* forULPR= */ false,
+        /* writeLocalToDatastore= */ true);
+
+    // When writeLocalToDatastore == true, we still write, but mark entries as old
+    // (!canWriteDatastore)
+    verify(store).put(k, true);
+    verify(cache).put(k, true);
+    verifyNoInteractions(clientCache, slashdotCache);
+  }
+
+  @Test
+  void cacheKey_whenDifferentKeyForSameHash_throws() {
+    DSAPublicKey k1 = newKey(30);
+    DSAPublicKey k2 = newKey(31);
+
+    uut.cacheKey(HASH, k1, false, false, false, false, false);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> uut.cacheKey(HASH, k2, false, false, false, false, false));
+    assertNotNull(ex.getMessage());
+  }
+
+  @Test
+  void getKey_whenUnderlyingThrowsIOException_returnsNull() throws Exception {
+    when(node.getWriteLocalToDatastore()).thenReturn(false);
+    org.mockito.Mockito.doThrow(new IOException("disk error"))
+        .when(store)
+        .fetch(any(), anyBoolean(), anyBoolean(), any());
+    DSAPublicKey got =
+        uut.getKey(HASH, /* canReadClientCache= */ false, /* forULPR= */ false, null);
+    assertNull(got, "should swallow IOExceptions and return null");
+    // No further fetches attempted after an IOException
+    verify(cache, never()).fetch(any(), anyBoolean(), anyBoolean(), any());
+  }
+}

--- a/src/test/java/network/crypta/store/CHKStoreTest.java
+++ b/src/test/java/network/crypta/store/CHKStoreTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -209,10 +210,10 @@ class CHKStoreTest {
     when(mockStore.fetch(
             any(byte[].class),
             any(byte[].class),
-            any(Boolean.class),
-            any(Boolean.class),
-            any(Boolean.class),
-            any(Boolean.class),
+            anyBoolean(),
+            anyBoolean(),
+            anyBoolean(),
+            anyBoolean(),
             any(BlockMetadata.class)))
         .thenReturn(expected);
 


### PR DESCRIPTION
Summary
- Reworked `NodeGetPubkey` to clarify and harden the lookup path.
- Extracted helpers for client caches, main datastore, data cache, and slashdot cache, reducing nested conditionals and improving readability.
- Added detailed Javadoc and more structured debug logging.
- Introduced `NodeGetPubkeyTest` to verify:
  - In‑memory LRU cache hit path (second-call fast path)
  - Preference for client cache when enabled, falling back to legacy client cache
  - Fallback order across datastore → legacy → datacache → legacy → slashdot (ULPR only)
  - Error handling when an underlying store throws `IOException`
- Fixed `CHKStoreTest` to use `anyBoolean()` matchers consistently with the method signature.

Motivation
- Make the pubkey resolution logic easier to reason about and test.
- Ensure thread-safe access to the in‑memory LRU while keeping the public API unchanged.
- Add coverage for common and failure paths.

Details
- `NodeGetPubkey.java`: extracted `shouldIgnoreOldBlocks`, `getFromRamCache`, `tryClientCaches`, `tryStores`, `tryDataCaches`, `trySlashdot`, and a small `orElse` functional helper.
- Logging now uses parameterized messages, aiding structured logging and avoiding string concatenation when disabled.
- Javadoc documents lookup order and parameter effects.
- `CHKStoreTest.java`: migrate to `anyBoolean()` for Mockito stubs.
- `NodeGetPubkeyTest.java`: comprehensive tests for cache order, ULPR slashdot behavior, deep writes, and IOException handling.

Risk/Compatibility
- No behavior change intended beyond clearer ordering and added logs; public API unchanged.
- RAM cache size and toggle remain as before; synchronization retained around `LRUMap`.

Testing
- Spotless applied before commit.
- Unit tests compile locally; full suite not run in this PR step.

Notes
- Target base: `develop`.
- Branch: `feature/fix-NodeGetPubkey`.
