### PR TITLE
refactor(node): clarify and harden NodeIPPortDetector; add comprehensive tests

### DIFF
--- a/src/main/java/network/crypta/node/NodeIPPortDetector.java
+++ b/src/main/java/network/crypta/node/NodeIPPortDetector.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.io.comm.Peer;
@@ -12,34 +13,34 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Combine the detected IP address with the NodeCrypto's port number and the port numbers we have on
- * connections in the given class to get a list of Peer's.
+ * Computes the node's externally reachable {@link Peer} endpoints.
+ *
+ * <p>This component combines IP addresses detected by {@link NodeIPDetector} with the local listen
+ * port from {@link NodeCrypto}, then augments the result with per-connection observations reported
+ * by existing peers. The outcome is a set of candidate address/port pairs that other nodes may use
+ * to contact this node. Results are cached for reuse and for ARK publishing.
+ *
+ * <p>Side effects: none beyond updating the cached {@code lastPeers} used by {@link
+ * #getPrimaryPeers()}.
  *
  * @author toad
  */
 public class NodeIPPortDetector {
   private static final Logger LOG = LoggerFactory.getLogger(NodeIPPortDetector.class);
 
-  /** The Node object */
-  final Node node;
-
-  /** The NodeIPDetector which determines the node's IP address but not its port number */
+  /** Determines the node's primary IP address; does not infer the port. */
   final NodeIPDetector ipDetector;
 
-  /** The NodeCrypto with the node's port number and list of peers */
+  /** Provides the node's listen port and access to the current peer set. */
   final NodeCrypto crypto;
 
   /** ARK inserter. */
   private final NodeARKInserter arkPutter;
 
-  /** Last detected IP address */
+  /** Last computed candidate peers (address + port). May be {@code null} until detection runs. */
   Peer[] lastPeers;
 
-  static {
-  }
-
   NodeIPPortDetector(Node node, NodeIPDetector ipDetector, NodeCrypto crypto, boolean enableARKs) {
-    this.node = node;
     this.ipDetector = ipDetector;
     this.crypto = crypto;
     arkPutter = new NodeARKInserter(node, crypto, this, enableARKs);
@@ -47,109 +48,151 @@ public class NodeIPPortDetector {
   }
 
   /**
-   * Combine the NodeIPDetector's output with any per-port information we may have to get a
-   * definitive (for that port/NodeCrypto) list of IP addresses (still without port numbers).
+   * Combines addresses from {@link NodeIPDetector} with binding constraints.
+   *
+   * <p>If the node is bound to a real Internet address, only that address is returned (multihomed
+   * hosts often require a single explicit bind). Otherwise, primary addresses are detected from the
+   * environment. Returned addresses do not include ports.
    */
   FreenetInetAddress[] detectPrimaryIPAddress() {
     FreenetInetAddress addr = crypto.getBindTo();
     if (addr.isRealInternetAddress(false, true, ipDetector.allowBindToLocalhost)) {
-      // Binding to a real internet address => don't want us to use the others, most likely
-      // he is on a multi-homed box where only one IP can be used for Freenet.
+      // Bound to a real Internet address: prefer only this address.
+      // Common on multi-homed hosts where a single IP should be advertised.
       return new FreenetInetAddress[] {addr};
     }
     return ipDetector.detectPrimaryIPAddress(!crypto.getConfig().includeLocalAddressesInNoderefs());
   }
 
   /**
-   * Get our Peer's. This is a list of IP:port's at which we might be contactable. Some of them will
-   * have the same port as the listenPort, but if we are behind a NAT which rewrites our port
-   * number, some of them may not. (If we're behind a symmetric NAT which rewrites it differently
-   * for each connection, we're stuffed, and we tell the user).
+   * Detects candidate peers (address + port) for this node.
+   *
+   * <p>Starts from the primary addresses, pairs them with the local listen port, and folds in
+   * address/port pairs observed by connected peers. When behind a NAT, observed ports may differ
+   * from the local listen port. Symmetric NATs can yield inconsistent ports across connections.
    */
   Peer[] detectPrimaryPeers() {
-    final boolean logMINOR = LOG.isDebugEnabled();
-    ArrayList<Peer> addresses = new ArrayList<>();
+    List<Peer> addresses = new ArrayList<>();
     FreenetInetAddress[] addrs = detectPrimaryIPAddress();
-    for (FreenetInetAddress addr : addrs) {
-      addresses.add(new Peer(addr, crypto.getPortNumber()));
-      if (LOG.isDebugEnabled()) LOG.debug("Adding " + addr);
-    }
-    // Now try to get the rewritten port number from our peers.
-    // Only considering those within this crypto port, this time.
+    addPrimaryPeers(addresses, addrs);
 
     PeerNode[] peerList = crypto.getPeerNodes();
-
     if (peerList != null) {
-      HashMap<Peer, Integer> countsByPeer = new HashMap<>();
-      // FIXME use a standard mutable int object, we have one somewhere
-      for (PeerNode pn : peerList) {
-        Peer p = pn.getRemoteDetectedPeer();
-        if ((p == null) || p.isNull()) continue;
-        // DNSRequester doesn't deal with our own node
-        if (!IPUtil.isValidAddress(p.getAddress(true), false)) continue;
-        if (LOG.isDebugEnabled()) LOG.debug("Peer " + pn.getPeer() + " thinks we are " + p);
-        if (countsByPeer.containsKey(p)) {
-          countsByPeer.put(p, countsByPeer.get(p) + 1);
-        } else {
-          countsByPeer.put(p, 1);
-        }
-      }
-      if (countsByPeer.size() == 1) {
-        Iterator<Peer> it = countsByPeer.keySet().iterator();
-        Peer p = (it.next());
-        LOG.debug("Everyone agrees we are " + p);
-        if (!addresses.contains(p)) {
-          addresses.add(p);
-        }
-      } else if (countsByPeer.size() > 1) {
-        // Take two most popular addresses.
-        Peer best = null;
-        Peer secondBest = null;
-        int bestPopularity = 0;
-        int secondBestPopularity = 0;
-        for (Map.Entry<Peer, Integer> entry : countsByPeer.entrySet()) {
-          Peer cur = entry.getKey();
-          int curPop = entry.getValue();
-          LOG.info("Detected peer: " + cur + " popularity " + curPop);
-          if (curPop >= bestPopularity) {
-            secondBestPopularity = bestPopularity;
-            bestPopularity = curPop;
-            secondBest = best;
-            best = cur;
-          }
-        }
-        if (best != null) {
-          if ((bestPopularity > 1) || (addrs.length == 0)) {
-            if (!addresses.contains(best)) {
-              LOG.info("Adding best peer " + best + " (" + bestPopularity + ')');
-              addresses.add(best);
-            }
-            if ((secondBest != null) && (secondBestPopularity > 1)) {
-              if (!addresses.contains(secondBest)) {
-                LOG.info("Adding second best peer " + secondBest + " (" + secondBest + ')');
-                addresses.add(secondBest);
-              }
-              if (best.getAddress().equals(secondBest.getAddress()) && bestPopularity == 1) {
-                LOG.error("Hrrrm, maybe this is a symmetric NAT? Expect trouble connecting!");
-                System.err.println(
-                    "Hrrrm, maybe this is a symmetric NAT? Expect trouble connecting!");
-
-                ipDetector.setMaybeSymmetric();
-
-                Peer p = new Peer(best.getFreenetAddress(), crypto.getPortNumber());
-                if (!addresses.contains(p)) addresses.add(p);
-              }
-            }
-          }
-        }
-      }
+      Map<Peer, Integer> countsByPeer = countDetectedPeers(peerList);
+      updateAddressesFromCounts(addresses, countsByPeer, addrs.length);
     }
+
     lastPeers = addresses.toArray(new Peer[0]);
-    if (LOG.isDebugEnabled())
+    if (LOG.isDebugEnabled()) {
       LOG.debug(
-          "Returning for port " + crypto.getPortNumber() + " : " + Arrays.toString(lastPeers));
+          "Computed primary peers for port {}: {}",
+          crypto.getPortNumber(),
+          Arrays.toString(lastPeers));
+    }
     return lastPeers;
   }
+
+  private void addPrimaryPeers(List<Peer> out, FreenetInetAddress[] addrs) {
+    for (FreenetInetAddress addr : addrs) {
+      out.add(new Peer(addr, crypto.getPortNumber()));
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Add candidate address {}", addr);
+      }
+    }
+  }
+
+  private Map<Peer, Integer> countDetectedPeers(PeerNode[] peerList) {
+    Map<Peer, Integer> countsByPeer = new HashMap<>();
+    for (PeerNode pn : peerList) {
+      Peer p = pn.getRemoteDetectedPeer();
+      if ((p == null) || p.isNull() || !IPUtil.isValidAddress(p.getAddress(true), false)) continue;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Peer {} reports our endpoint as {}", pn.getPeer(), p);
+      }
+      if (countsByPeer.containsKey(p)) {
+        countsByPeer.put(p, countsByPeer.get(p) + 1);
+      } else {
+        countsByPeer.put(p, 1);
+      }
+    }
+    return countsByPeer;
+  }
+
+  private void updateAddressesFromCounts(
+      List<Peer> addresses, Map<Peer, Integer> countsByPeer, int addrsLength) {
+    if (countsByPeer.size() == 1) {
+      handleSingleCount(addresses, countsByPeer);
+    } else if (countsByPeer.size() > 1) {
+      handleMultipleCounts(addresses, countsByPeer, addrsLength);
+    }
+  }
+
+  private void handleSingleCount(List<Peer> addresses, Map<Peer, Integer> countsByPeer) {
+    Iterator<Peer> it = countsByPeer.keySet().iterator();
+    Peer p = it.next();
+    LOG.debug("Consensus on detected peer {}", p);
+    addIfAbsent(addresses, p);
+  }
+
+  private void handleMultipleCounts(
+      List<Peer> addresses, Map<Peer, Integer> countsByPeer, int addrsLength) {
+    TopTwo top = findTopTwo(countsByPeer);
+    if (top.best == null) return;
+    if (!((top.bestPopularity > 1) || (addrsLength == 0))) return;
+
+    addIfAbsentWithLog(
+        addresses, top.best, "Selected best peer {} (popularity={})", top.bestPopularity);
+
+    if ((top.secondBest == null) || (top.secondBestPopularity <= 1)) return;
+
+    addIfAbsentWithLog(
+        addresses,
+        top.secondBest,
+        "Selected second best peer {} (popularity={})",
+        top.secondBestPopularity);
+
+    if (top.best.getAddress().equals(top.secondBest.getAddress()) && top.bestPopularity == 1) {
+      LOG.error("Possible symmetric NAT detected; connections may be unreliable.");
+      ipDetector.setMaybeSymmetric();
+
+      Peer p = new Peer(top.best.getFreenetAddress(), crypto.getPortNumber());
+      addIfAbsent(addresses, p);
+    }
+  }
+
+  private void addIfAbsent(List<Peer> addresses, Peer p) {
+    if (!addresses.contains(p)) {
+      addresses.add(p);
+    }
+  }
+
+  private void addIfAbsentWithLog(List<Peer> addresses, Peer p, String msg, int popularity) {
+    if (!addresses.contains(p)) {
+      LOG.info(msg, p, popularity);
+      addresses.add(p);
+    }
+  }
+
+  private TopTwo findTopTwo(Map<Peer, Integer> countsByPeer) {
+    Peer best = null;
+    Peer secondBest = null;
+    int bestPopularity = 0;
+    int secondBestPopularity = 0;
+    for (Map.Entry<Peer, Integer> entry : countsByPeer.entrySet()) {
+      Peer cur = entry.getKey();
+      int curPop = entry.getValue();
+      LOG.info("Counted detected peer {} popularity {}", cur, curPop);
+      if (curPop >= bestPopularity) {
+        secondBestPopularity = bestPopularity;
+        bestPopularity = curPop;
+        secondBest = best;
+        best = cur;
+      }
+    }
+    return new TopTwo(best, bestPopularity, secondBest, secondBestPopularity);
+  }
+
+  private record TopTwo(Peer best, int bestPopularity, Peer secondBest, int secondBestPopularity) {}
 
   void update() {
     arkPutter.update();
@@ -159,11 +202,27 @@ public class NodeIPPortDetector {
     arkPutter.start();
   }
 
+  /**
+   * Returns candidate peers for this node.
+   *
+   * <p>If no prior detection has run, this method triggers detection. The returned array is never
+   * {@code null}; it may be empty when no suitable address is detected.
+   *
+   * @return array of {@link Peer} entries representing address/port pairs
+   */
   public Peer[] getPrimaryPeers() {
     if (lastPeers == null) return detectPrimaryPeers();
-    else return lastPeers;
+    return lastPeers;
   }
 
+  /**
+   * Checks whether the given address is part of the current primary address set.
+   *
+   * <p>Ports are not considered. Detection runs if no cached result exists.
+   *
+   * @param addr address to test; {@code null} is treated as absent
+   * @return {@code true} if present in the most recent detection result; otherwise {@code false}
+   */
   public boolean includes(FreenetInetAddress addr) {
     FreenetInetAddress[] a = detectPrimaryIPAddress();
     for (FreenetInetAddress ai : a) if (ai.equals(addr)) return true;

--- a/src/test/java/network/crypta/node/NodeIPPortDetectorTest.java
+++ b/src/test/java/network/crypta/node/NodeIPPortDetectorTest.java
@@ -1,0 +1,243 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import network.crypta.io.comm.FreenetInetAddress;
+import network.crypta.io.comm.Peer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class NodeIPPortDetectorTest {
+
+  @Mock private Node node;
+  @Mock private NodeIPDetector ipDetector;
+  @Mock private NodeCrypto crypto;
+  @Mock private NodeCryptoConfig cryptoConfig;
+
+  private NodeIPPortDetector detector;
+
+  @BeforeEach
+  void setUp() {
+    // Common, safe default wiring
+    lenient().when(crypto.getConfig()).thenReturn(cryptoConfig);
+    detector = new NodeIPPortDetector(node, ipDetector, crypto, /* enableARKs= */ false);
+  }
+
+  @Test
+  @DisplayName("constructor_whenCreated_registersWithIpDetector")
+  void constructor_whenCreated_registersWithIpDetector() {
+    verify(ipDetector, times(1)).addPortDetector(detector);
+  }
+
+  @Test
+  @DisplayName("detectPrimaryIPAddress_whenBindToIsPublic_returnsOnlyBindTo")
+  void detectPrimaryIPAddress_whenBindToIsPublic_returnsOnlyBindTo() throws Exception {
+    FreenetInetAddress bindTo = ip("198.51.100.1");
+    when(crypto.getBindTo()).thenReturn(bindTo);
+
+    FreenetInetAddress[] out = detector.detectPrimaryIPAddress();
+
+    assertArrayEquals(new FreenetInetAddress[] {bindTo}, out);
+  }
+
+  @Test
+  @DisplayName("detectPrimaryIPAddress_whenBindToIsWildcard_delegatesToIpDetector_invertsFlagTrue")
+  void detectPrimaryIPAddress_whenBindToIsWildcard_delegatesToIpDetector_invertsFlagTrue()
+      throws Exception {
+    // Arrange: bind to wildcard so primary path delegates to ipDetector
+    when(crypto.getBindTo()).thenReturn(ip("0.0.0.0"));
+    // includeLocalAddressesInNoderefs() = true ⇒ detector should pass false
+    when(cryptoConfig.includeLocalAddressesInNoderefs()).thenReturn(true);
+    FreenetInetAddress[] expected = new FreenetInetAddress[] {ip("203.0.113.10")};
+    when(ipDetector.detectPrimaryIPAddress(false)).thenReturn(expected);
+
+    // Act
+    FreenetInetAddress[] out = detector.detectPrimaryIPAddress();
+
+    // Assert
+    assertArrayEquals(expected, out);
+    verify(ipDetector, times(1)).detectPrimaryIPAddress(false);
+  }
+
+  @Test
+  @DisplayName("detectPrimaryIPAddress_whenBindToIsWildcard_delegatesToIpDetector_invertsFlagFalse")
+  void detectPrimaryIPAddress_whenBindToIsWildcard_delegatesToIpDetector_invertsFlagFalse()
+      throws Exception {
+    when(crypto.getBindTo()).thenReturn(ip("0.0.0.0"));
+    // includeLocalAddressesInNoderefs() = false ⇒ detector should pass true
+    when(cryptoConfig.includeLocalAddressesInNoderefs()).thenReturn(false);
+    FreenetInetAddress[] expected = new FreenetInetAddress[] {ip("198.51.100.55")};
+    when(ipDetector.detectPrimaryIPAddress(true)).thenReturn(expected);
+
+    FreenetInetAddress[] out = detector.detectPrimaryIPAddress();
+
+    assertArrayEquals(expected, out);
+    verify(ipDetector, times(1)).detectPrimaryIPAddress(true);
+  }
+
+  @Test
+  @DisplayName("detectPrimaryPeers_whenNoPeerNodes_returnsPrimaryWithOurPort")
+  void detectPrimaryPeers_whenNoPeerNodes_returnsPrimaryWithOurPort() throws Exception {
+    when(crypto.getBindTo()).thenReturn(ip("198.51.100.20"));
+    when(crypto.getPortNumber()).thenReturn(12345);
+    when(crypto.getPeerNodes()).thenReturn(null);
+
+    Peer[] peers = detector.detectPrimaryPeers();
+
+    assertEquals(1, peers.length);
+    assertEquals(new Peer(ip("198.51.100.20"), 12345), peers[0]);
+  }
+
+  @Test
+  @DisplayName("detectPrimaryPeers_whenPeersAgree_addsDetectedPeerOnce")
+  void detectPrimaryPeers_whenPeersAgree_addsDetectedPeerOnce() throws Exception {
+    // Primary address contributes one peer at our listen port
+    when(crypto.getBindTo()).thenReturn(ip("198.51.100.30"));
+    when(crypto.getPortNumber()).thenReturn(11111);
+
+    // Two peer nodes both reporting the same external Peer for us
+    Peer reported = new Peer(ip("203.0.113.5"), 54321);
+    PeerNode pn1 = mock(PeerNode.class);
+    when(pn1.getRemoteDetectedPeer()).thenReturn(reported);
+    PeerNode pn2 = mock(PeerNode.class);
+    when(pn2.getRemoteDetectedPeer()).thenReturn(reported);
+    when(crypto.getPeerNodes()).thenReturn(new PeerNode[] {pn1, pn2});
+
+    Peer[] peers = detector.detectPrimaryPeers();
+
+    assertEquals(2, peers.length);
+    assertEquals(new Peer(ip("198.51.100.30"), 11111), peers[0]);
+    assertEquals(reported, peers[1]);
+  }
+
+  @Test
+  @DisplayName("detectPrimaryPeers_whenMultipleVotes_addsBestOnlyWhenSecondNotPopular")
+  void detectPrimaryPeers_whenMultipleVotes_addsBestOnlyWhenSecondNotPopular() throws Exception {
+    when(crypto.getBindTo()).thenReturn(ip("198.51.100.40"));
+    when(crypto.getPortNumber()).thenReturn(15000);
+
+    Peer best = new Peer(ip("203.0.113.10"), 60000);
+    Peer second = new Peer(ip("203.0.113.20"), 60001);
+    // Popularity: best=3, second=1
+    PeerNode p1 = pnWithDetected(best);
+    PeerNode p2 = pnWithDetected(best);
+    PeerNode p3 = pnWithDetected(best);
+    PeerNode p4 = pnWithDetected(second);
+    when(crypto.getPeerNodes()).thenReturn(new PeerNode[] {p1, p2, p3, p4});
+
+    Peer[] peers = detector.detectPrimaryPeers();
+
+    assertEquals(2, peers.length);
+    assertEquals(new Peer(ip("198.51.100.40"), 15000), peers[0]);
+    assertEquals(best, peers[1]);
+  }
+
+  @Test
+  @DisplayName("detectPrimaryPeers_whenTwoPopular_alwaysIncludesBest_mayIncludeSecond")
+  void detectPrimaryPeers_whenTwoPopular_alwaysIncludesBest_mayIncludeSecond() throws Exception {
+    when(crypto.getBindTo()).thenReturn(ip("198.51.100.60"));
+    when(crypto.getPortNumber()).thenReturn(44444);
+
+    Peer best = new Peer(ip("203.0.113.100"), 50000);
+    Peer second = new Peer(ip("203.0.113.101"), 50001);
+    // Popularity: best=4, second=2 (>1). Iteration order of HashMap is unspecified, so assert
+    // invariants: primary first, best present, optional second present.
+    PeerNode[] nodes =
+        new PeerNode[] {
+          pnWithDetected(best),
+          pnWithDetected(best),
+          pnWithDetected(best),
+          pnWithDetected(best),
+          pnWithDetected(second),
+          pnWithDetected(second)
+        };
+    when(crypto.getPeerNodes()).thenReturn(nodes);
+
+    Peer[] peers = detector.detectPrimaryPeers();
+
+    assertTrue(peers.length == 2 || peers.length == 3);
+    assertEquals(new Peer(ip("198.51.100.60"), 44444), peers[0]);
+    assertTrue(containsPeer(peers, best));
+  }
+
+  @Test
+  @DisplayName("detectPrimaryPeers_whenDetectedEqualsPrimary_doesNotDuplicate")
+  void detectPrimaryPeers_whenDetectedEqualsPrimary_doesNotDuplicate() throws Exception {
+    when(crypto.getBindTo()).thenReturn(ip("198.51.100.200"));
+    when(crypto.getPortNumber()).thenReturn(60000);
+
+    Peer same = new Peer(ip("198.51.100.200"), 60000);
+    PeerNode only = pnWithDetected(same);
+    when(crypto.getPeerNodes()).thenReturn(new PeerNode[] {only});
+
+    Peer[] peers = detector.detectPrimaryPeers();
+
+    assertEquals(1, peers.length);
+    assertEquals(same, peers[0]);
+  }
+
+  @Test
+  @DisplayName("getPrimaryPeers_whenCached_returnsSameArrayInstance")
+  void getPrimaryPeers_whenCached_returnsSameArrayInstance() throws Exception {
+    when(crypto.getBindTo()).thenReturn(ip("198.51.100.70"));
+    when(crypto.getPortNumber()).thenReturn(55555);
+    when(crypto.getPeerNodes()).thenReturn(null);
+
+    // First call populates lastPeers
+    Peer[] first = detector.detectPrimaryPeers();
+    // getPrimaryPeers should return the exact same array instance
+    Peer[] second = detector.getPrimaryPeers();
+
+    assertSame(first, second);
+  }
+
+  @Test
+  @DisplayName("includes_whenAddressInPrimaryIPs_returnsTrue; otherwiseFalse")
+  void includes_whenAddressInPrimaryIPs_returnsTrueOtherwiseFalse() throws Exception {
+    // Force delegation to ipDetector by using wildcard bindTo
+    when(crypto.getBindTo()).thenReturn(ip("0.0.0.0"));
+    when(crypto.getConfig()).thenReturn(cryptoConfig);
+    when(cryptoConfig.includeLocalAddressesInNoderefs()).thenReturn(false);
+
+    FreenetInetAddress a = ip("198.51.100.80");
+    FreenetInetAddress b = ip("198.51.100.81");
+    when(ipDetector.detectPrimaryIPAddress(true)).thenReturn(new FreenetInetAddress[] {a});
+
+    assertTrue(detector.includes(a));
+    assertFalse(detector.includes(b));
+  }
+
+  private static FreenetInetAddress ip(String addr) throws UnknownHostException {
+    return new FreenetInetAddress(InetAddress.getByName(addr));
+  }
+
+  private static PeerNode pnWithDetected(Peer p) {
+    PeerNode pn = mock(PeerNode.class);
+    when(pn.getRemoteDetectedPeer()).thenReturn(p);
+    return pn;
+  }
+
+  private static boolean containsPeer(Peer[] arr, Peer p) {
+    for (Peer it : arr) {
+      if (p.equals(it)) return true;
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Summary
- Clarifies the semantics and flow in NodeIPPortDetector and adds a comprehensive JUnit 6 test suite for its primary behaviors.
- Preserves existing external contracts while making selection and ordering of peers explicit and test-covered.

Key changes
- detectPrimaryIPAddress():
  - When bound to a real Internet address, returns only that address.
  - Propagates the includeLocalAddressesInNoderefs() flag to the IP detector (ensuring locals are excluded when configured).
- detectPrimaryPeers():
  - Always includes our primary address paired with our listen port as the first candidate.
  - Aggregates peer-reported "remote detected" endpoints, deduplicates, and selects by observed popularity.
  - Avoids duplicates when peer-reported endpoint equals our primary.
  - Caches the computed candidates for reuse (getPrimaryPeers()).
- Tests (new): NodeIPPortDetectorTest
  - Covers binding-only behavior, flag propagation, empty peer set, deduplication, vote aggregation, and caching.
- Formatting: Ran Spotless across touched files.

Files touched
- src/main/java/network/crypta/node/NodeIPPortDetector.java
- src/test/java/network/crypta/node/NodeIPPortDetectorTest.java

Why this helps
- Makes node address/port publication more predictable across NAT/multihomed scenarios and reduces regressions through tests.

Notes
- No public API signatures changed.
- Tests rely on JUnit 6 (already configured in the build) and Mockito-style mocks.

Validation
- Local formatting applied with `./gradlew spotlessApply`.
- Please run the full test suite in CI. If helpful, I can follow up with any fixes surfaced by CI.