### PR TITLE
docs(node): improve NodePinger Javadoc, comments, and logs; add focused tests

### DIFF
--- a/src/main/java/network/crypta/node/NodePinger.java
+++ b/src/main/java/network/crypta/node/NodePinger.java
@@ -7,22 +7,32 @@ import network.crypta.node.NodeStats.PeerLoadStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Track average round-trip time for each peer node, get a geometric mean. */
+/**
+ * Periodically samples connected peers to maintain latency and capacity summaries.
+ *
+ * <p>This component computes the median round-trip time (RTT) across currently connected peers and
+ * derives capacity quartiles for realtime and bulk directions (input/output) using the latest
+ * {@link PeerLoadStats} advertised by each peer. Results are stored in volatile fields so readers
+ * see the most recent values without additional synchronization.
+ *
+ * <p>Threading and scheduling: {@link #run()} executes on the node's ticker/executor. It grabs a
+ * snapshot of the connected peers under {@code PeerManager}'s lock and then performs all
+ * calculations without holding locks.
+ */
 public class NodePinger implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(NodePinger.class);
-
-  static {
-  }
 
   private final Node node;
   private volatile double meanPing = 0;
 
+  /** One year in milliseconds; used by callers as an upper sanity bound for ping. */
   public static final double CRAZY_MAX_PING_TIME = 365.25 * DAYS.toMillis(1);
 
   NodePinger(Node n) {
     this.node = n;
   }
 
+  // Starts a single sampling pass immediately; callers typically schedule via the ticker.
   void start() {
     run();
   }
@@ -30,31 +40,40 @@ public class NodePinger implements Runnable {
   @Override
   public void run() {
     try {
-      PeerNode[] peers = null;
+      PeerNode[] peers;
       synchronized (node.getPeers()) {
         peers = node.getPeers().connectedPeers();
       }
       if (peers == null || peers.length == 0) return;
 
-      // Now we don't have to care about synchronization anymore
+      // Operate on the snapshot without holding PeerManager locks
       recalculateMean(peers);
       capacityInputRealtime.calculate(peers);
       capacityInputBulk.calculate(peers);
       capacityOutputRealtime.calculate(peers);
       capacityOutputBulk.calculate(peers);
     } finally {
-      // Requeue after to avoid exacerbating overload
+      // Requeue after work completes to avoid exacerbating overload
       node.getTicker().queueTimedJob(this, 200);
     }
   }
 
-  /** Recalculate the mean ping time */
+  /**
+   * Recomputes the median RTT from the provided peer snapshot.
+   *
+   * @param peers snapshot of connected peers; must not be modified while in use
+   */
   private void recalculateMean(PeerNode[] peers) {
     if (peers.length == 0) return;
     meanPing = calculateMedianPing(peers);
-    if (LOG.isDebugEnabled()) LOG.debug("Median ping: " + meanPing);
+    if (LOG.isDebugEnabled()) LOG.debug("Median ping (ms): {}", meanPing);
   }
 
+  /**
+   * Returns the upper-median RTT in milliseconds.
+   *
+   * <p>For an even number of samples, the element at {@code length/2} after sorting is used.
+   */
   private double calculateMedianPing(PeerNode[] peers) {
     double[] allPeers = new double[peers.length];
     for (int i = 0; i < peers.length; i++) {
@@ -66,6 +85,11 @@ public class NodePinger implements Runnable {
     return allPeers[peers.length / 2];
   }
 
+  /**
+   * Gets the current median RTT across connected peers.
+   *
+   * @return median ping in milliseconds; {@code 0} until the first calculation completes
+   */
   public double averagePingTime() {
     return meanPing;
   }
@@ -75,6 +99,12 @@ public class NodePinger implements Runnable {
   final CapacityChecker capacityOutputRealtime = new CapacityChecker(false, true);
   final CapacityChecker capacityOutputBulk = new CapacityChecker(false, false);
 
+  /**
+   * Maintains capacity quartiles for a given direction and class (input/output × realtime/bulk).
+   *
+   * <p>Values come from {@link PeerLoadStats#peerLimit(boolean)} of peers that provided a recent
+   * load status for the selected class. Units are the same as reported by peers.
+   */
   class CapacityChecker {
     final boolean isInput;
     final boolean isRealtime;
@@ -89,6 +119,7 @@ public class NodePinger implements Runnable {
       isRealtime = realtime;
     }
 
+    // Updates quartiles from the given peer snapshot. Ignores peers without recent load stats.
     void calculate(PeerNode[] peers) {
       double[] allPeers = new double[peers.length];
       int x = 0;
@@ -110,23 +141,31 @@ public class NodePinger implements Runnable {
         max = allPeers[x - 1];
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "Quartiles for peer capacities: "
-                  + (isInput ? "input " : "output ")
-                  + (isRealtime ? "realtime: " : "bulk: ")
-                  + Arrays.toString(getQuartiles()));
+              "Peer capacity quartiles: {}{}{}",
+              isInput ? "input " : "output ",
+              isRealtime ? "realtime: " : "bulk: ",
+              Arrays.toString(getQuartiles()));
       }
     }
 
+    /** Returns a snapshot of quartiles in ascending order: min, Q1, median, Q3, max. */
     synchronized double[] getQuartiles() {
       return new double[] {min, firstQuartile, median, lastQuartile, max};
     }
 
-    /** Get min(half the median, first quartile). Used as a threshold. */
+    /** Returns {@code min(median/2, firstQuartile)} for fair sharing thresholding. */
     synchronized double getThreshold() {
       return Math.min(median / 2, firstQuartile);
     }
   }
 
+  /**
+   * Gets the per-class capacity threshold derived from peer quartiles.
+   *
+   * @param isRealtime whether to use realtime ({@code true}) or bulk ({@code false}) metrics
+   * @param isInput whether to use input ({@code true}) or output ({@code false}) metrics
+   * @return threshold equal to {@code min(median/2, Q1)} in peer-reported units
+   */
   public double capacityThreshold(boolean isRealtime, boolean isInput) {
     return capacityChecker(isRealtime, isInput).getThreshold();
   }

--- a/src/test/java/network/crypta/node/NodePingerTest.java
+++ b/src/test/java/network/crypta/node/NodePingerTest.java
@@ -1,0 +1,231 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // test method naming convention per project rules
+class NodePingerTest {
+
+  @Mock private Node node;
+  @Mock private PeerManager peerManager;
+  @Mock private network.crypta.support.Ticker ticker;
+
+  private static PeerNode mockPeerWithPing(double pingMs) {
+    PeerNode peer = Mockito.mock(PeerNode.class, Answers.RETURNS_DEEP_STUBS);
+    when(peer.averagePingTime()).thenReturn(pingMs);
+    // For capacity calculations we return trackers whose last stats are null unless overridden
+    PeerNode.OutputLoadTracker rt =
+        Mockito.mock(
+            PeerNode.OutputLoadTracker.class,
+            Mockito.withSettings()
+                .useConstructor(true)
+                .outerInstance(peer)
+                .defaultAnswer(Answers.CALLS_REAL_METHODS));
+    PeerNode.OutputLoadTracker bulk =
+        Mockito.mock(
+            PeerNode.OutputLoadTracker.class,
+            Mockito.withSettings()
+                .useConstructor(false)
+                .outerInstance(peer)
+                .defaultAnswer(Answers.CALLS_REAL_METHODS));
+    Mockito.lenient().doReturn(null).when(rt).getLastIncomingLoadStats();
+    Mockito.lenient().doReturn(null).when(bulk).getLastIncomingLoadStats();
+    when(peer.outputLoadTracker(true)).thenReturn(rt);
+    when(peer.outputLoadTracker(false)).thenReturn(bulk);
+    return peer;
+  }
+
+  @Test
+  void run_whenNoPeers_schedulesNextRunAndLeavesMeanPingUnchanged() {
+    when(node.getPeers()).thenReturn(peerManager);
+    when(node.getTicker()).thenReturn(ticker);
+    when(peerManager.connectedPeers()).thenReturn(new PeerNode[0]);
+
+    NodePinger pinger = new NodePinger(node);
+
+    // Before run, average ping defaults to 0
+    assertEquals(0.0, pinger.averagePingTime(), 0.000001);
+
+    pinger.run();
+
+    // Mean ping remains unchanged and job is re-queued
+    assertEquals(0.0, pinger.averagePingTime(), 0.000001);
+    verify(ticker, times(1)).queueTimedJob(pinger, 200L);
+    verifyNoMoreInteractions(ticker);
+  }
+
+  @Test
+  void run_withOddPeers_calculatesMedianPing() {
+    when(node.getPeers()).thenReturn(peerManager);
+    when(node.getTicker()).thenReturn(ticker);
+
+    PeerNode p1 = mockPeerWithPing(100);
+    PeerNode p2 = mockPeerWithPing(300);
+    PeerNode p3 = mockPeerWithPing(50);
+    PeerNode p4 = mockPeerWithPing(1000);
+    PeerNode p5 = mockPeerWithPing(400);
+    when(peerManager.connectedPeers()).thenReturn(new PeerNode[] {p1, p2, p3, p4, p5});
+
+    NodePinger pinger = new NodePinger(node);
+    pinger.run();
+
+    // Sorted pings: [50, 100, 300, 400, 1000] -> median index 2 => 300
+    assertEquals(300.0, pinger.averagePingTime(), 0.000001);
+    verify(ticker).queueTimedJob(pinger, 200L);
+  }
+
+  @Test
+  void run_withEvenPeers_usesUpperMedianIndex() {
+    when(node.getPeers()).thenReturn(peerManager);
+    when(node.getTicker()).thenReturn(ticker);
+
+    PeerNode p1 = mockPeerWithPing(10);
+    PeerNode p2 = mockPeerWithPing(40);
+    PeerNode p3 = mockPeerWithPing(20);
+    PeerNode p4 = mockPeerWithPing(30);
+    when(peerManager.connectedPeers()).thenReturn(new PeerNode[] {p1, p2, p3, p4});
+
+    NodePinger pinger = new NodePinger(node);
+    pinger.run();
+
+    // Sorted pings: [10, 20, 30, 40]; length/2 = 2 -> element at index 2 is 30
+    assertEquals(30.0, pinger.averagePingTime(), 0.000001);
+    verify(ticker).queueTimedJob(pinger, 200L);
+  }
+
+  @Test
+  void capacityThreshold_whenStatsAvailable_computesThresholdsForAllCombinations() {
+    when(node.getPeers()).thenReturn(peerManager);
+    when(node.getTicker()).thenReturn(ticker);
+
+    // Prepare four peers with explicit per-tracker stats.
+    PeerNode[] peers = new PeerNode[4];
+    for (int i = 0; i < peers.length; i++) {
+      peers[i] = mockPeerWithPing(100 + i); // ping values irrelevant for this test
+    }
+    when(peerManager.connectedPeers()).thenReturn(peers);
+
+    // Values per combination (already chosen to make math easy):
+    double[] rtInput = {10, 20, 30, 40}; // threshold min(30/2, 20) = 15
+    double[] rtOutput = {15, 25, 35, 100}; // threshold min(35/2, 25) = 17.5
+    double[] bulkInput = {50, 5, 70, 60}; // sorted [5,50,60,70] -> min(60/2, 50) = 30
+    double[] bulkOutput = {2, 4, 6, 8}; // min(6/2, 4) = 3
+
+    for (int i = 0; i < peers.length; i++) {
+      PeerNode peer = peers[i];
+
+      PeerNode.OutputLoadTracker rt = peer.outputLoadTracker(true);
+      PeerNode.OutputLoadTracker bulk = peer.outputLoadTracker(false);
+
+      NodeStats.PeerLoadStats statsRt =
+          Mockito.mock(NodeStats.PeerLoadStats.class, Answers.RETURNS_DEFAULTS);
+      NodeStats.PeerLoadStats statsBulk =
+          Mockito.mock(NodeStats.PeerLoadStats.class, Answers.RETURNS_DEFAULTS);
+
+      // Stub the method used by NodePinger
+      when(statsRt.peerLimit(true)).thenReturn(rtInput[i]);
+      when(statsRt.peerLimit(false)).thenReturn(rtOutput[i]);
+      when(statsBulk.peerLimit(true)).thenReturn(bulkInput[i]);
+      when(statsBulk.peerLimit(false)).thenReturn(bulkOutput[i]);
+
+      Mockito.doReturn(statsRt).when(rt).getLastIncomingLoadStats();
+      Mockito.doReturn(statsBulk).when(bulk).getLastIncomingLoadStats();
+    }
+
+    NodePinger pinger = new NodePinger(node);
+    pinger.run();
+
+    assertEquals(15.0, pinger.capacityThreshold(true, true), 0.000001); // realtime input
+    assertEquals(17.5, pinger.capacityThreshold(true, false), 0.000001); // realtime output
+    assertEquals(30.0, pinger.capacityThreshold(false, true), 0.000001); // bulk input
+    assertEquals(3.0, pinger.capacityThreshold(false, false), 0.000001); // bulk output
+
+    verify(ticker).queueTimedJob(pinger, 200L);
+  }
+
+  @Test
+  void capacityThreshold_whenSomeStatsAreNull_ignoresThem() {
+    when(node.getPeers()).thenReturn(peerManager);
+    when(node.getTicker()).thenReturn(ticker);
+
+    PeerNode p1 = mockPeerWithPing(1);
+    PeerNode p2 = mockPeerWithPing(2);
+    PeerNode p3 = mockPeerWithPing(3);
+    PeerNode p4 = mockPeerWithPing(4);
+    when(peerManager.connectedPeers()).thenReturn(new PeerNode[] {p1, p2, p3, p4});
+
+    // Prepare stats only for three peers on realtime tracker; the fourth returns null
+    NodeStats.PeerLoadStats s1 =
+        Mockito.mock(NodeStats.PeerLoadStats.class, Answers.RETURNS_DEFAULTS);
+    NodeStats.PeerLoadStats s2 =
+        Mockito.mock(NodeStats.PeerLoadStats.class, Answers.RETURNS_DEFAULTS);
+    NodeStats.PeerLoadStats s3 =
+        Mockito.mock(NodeStats.PeerLoadStats.class, Answers.RETURNS_DEFAULTS);
+
+    when(s1.peerLimit(true)).thenReturn(5.0);
+    when(s2.peerLimit(true)).thenReturn(10.0);
+    when(s3.peerLimit(true)).thenReturn(15.0);
+
+    PeerNode.OutputLoadTracker t1 = p1.outputLoadTracker(true);
+    PeerNode.OutputLoadTracker t2 = p2.outputLoadTracker(true);
+    PeerNode.OutputLoadTracker t3 = p3.outputLoadTracker(true);
+    PeerNode.OutputLoadTracker t4 = p4.outputLoadTracker(true);
+    Mockito.doReturn(s1).when(t1).getLastIncomingLoadStats();
+    Mockito.doReturn(s2).when(t2).getLastIncomingLoadStats();
+    Mockito.doReturn(s3).when(t3).getLastIncomingLoadStats();
+    Mockito.doReturn(null).when(t4).getLastIncomingLoadStats();
+
+    NodePinger pinger = new NodePinger(node);
+    pinger.run();
+
+    // Values considered: [5,10,15] -> median (index 1) = 10, Q1 (index 0) = 5
+    assertEquals(5.0, pinger.capacityThreshold(true, true), 0.000001);
+    verify(ticker).queueTimedJob(pinger, 200L);
+  }
+
+  @Test
+  void capacityThreshold_whenNoStats_returnsZero() {
+    when(node.getPeers()).thenReturn(peerManager);
+    when(node.getTicker()).thenReturn(ticker);
+
+    PeerNode p1 = mockPeerWithPing(42);
+    PeerNode p2 = mockPeerWithPing(43);
+    when(peerManager.connectedPeers()).thenReturn(new PeerNode[] {p1, p2});
+
+    // Ensure trackers have no stats
+    PeerNode.OutputLoadTracker p1rt = p1.outputLoadTracker(true);
+    PeerNode.OutputLoadTracker p1bulk = p1.outputLoadTracker(false);
+    PeerNode.OutputLoadTracker p2rt = p2.outputLoadTracker(true);
+    PeerNode.OutputLoadTracker p2bulk = p2.outputLoadTracker(false);
+    Mockito.doReturn(null).when(p1rt).getLastIncomingLoadStats();
+    Mockito.doReturn(null).when(p1bulk).getLastIncomingLoadStats();
+    Mockito.doReturn(null).when(p2rt).getLastIncomingLoadStats();
+    Mockito.doReturn(null).when(p2bulk).getLastIncomingLoadStats();
+
+    NodePinger pinger = new NodePinger(node);
+    pinger.run();
+
+    assertEquals(0.0, pinger.capacityThreshold(true, true), 0.000001);
+    assertEquals(0.0, pinger.capacityThreshold(true, false), 0.000001);
+    assertEquals(0.0, pinger.capacityThreshold(false, true), 0.000001);
+    assertEquals(0.0, pinger.capacityThreshold(false, false), 0.000001);
+    verify(ticker).queueTimedJob(pinger, 200L);
+  }
+
+  @Test
+  void constant_crazyMaxPingTime_isOneYearInMillis() {
+    // 365.25 days * DAY millis, ensure constant is wired as expected
+    assertEquals(NodePinger.CRAZY_MAX_PING_TIME, 365.25 * 24 * 60 * 60 * 1000.0, 0.000001);
+  }
+}


### PR DESCRIPTION
Summary
- Improve and complete API documentation, inline comments, and log message text in NodePinger without changing behavior.
- Add focused JUnit 6 + Mockito tests for NodePinger covering median computation, capacity thresholds, and edge paths.

Branch
- Source: feature/fix-NodePinger
- Target: develop

Details
- src/main/java/network/crypta/node/NodePinger.java
  - Class Javadoc now explains purpose (median RTT + capacity quartiles), threading model (snapshot under PeerManager lock, compute outside), and data visibility (volatile fields).
  - Added method Javadocs for recalculateMean(...), calculateMedianPing(...), averagePingTime(), capacityThreshold(...), and inner class CapacityChecker including getQuartiles() and getThreshold().
  - Clarified inline comments where concurrency or rationale is non-obvious (operating on snapshot; requeue semantics).
  - Refined log message strings for precision and units while preserving placeholders and levels (e.g., "Median ping (ms): {}", "Peer capacity quartiles: {}{}{}").
  - No code/behavior changes; only comments and strings in existing log calls revised.

- src/test/java/network/crypta/node/NodePingerTest.java (new)
  - Deterministic tests verifying:
    - Median ping calculation for odd/even peer counts.
    - Requeue behavior via Ticker.queueTimedJob(...).
    - Capacity thresholds for realtime/bulk and input/output combinations with explicit peer limits.
    - Handling of null/absent PeerLoadStats and no peers.
    - Constant sanity: CRAZY_MAX_PING_TIME equals one year in ms.
  - Uses Mockito with outerInstance/useConstructor for PeerNode.OutputLoadTracker.
  - No sleeps; fixed inputs; isolated collaborators.

Quality
- Ran formatting: `./gradlew spotlessApply`.
- Ran tests:
  - Targeted: `./gradlew test --tests 'network.crypta.node.NodePingerTest'` → SUCCESS.
  - Full suite: `./gradlew test` → SUCCESS.
- SonarLint (file-scoped): `./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/node/NodePinger.java` → no issues for this file.

Rationale
- Documentation upgrades improve maintainability and developer onboarding without changing runtime behavior.
- The tests provide regression coverage around NodePinger’s public API and common edge cases.

Checklist
- [x] No behavior or API changes.
- [x] Unit tests deterministic and isolated; pass locally.
- [x] Spotless formatting applied.
- [x] SonarLint clean for the changed production file.
