### PR TITLE
docs(node): improve Javadoc for PacketFormat interface

### DIFF
--- a/src/main/java/network/crypta/node/PacketFormat.java
+++ b/src/main/java/network/crypta/node/PacketFormat.java
@@ -3,65 +3,102 @@ package network.crypta.node;
 import java.util.List;
 import network.crypta.io.comm.Peer;
 
+/**
+ * Packet formatting and scheduling contract for peer transports.
+ *
+ * <p>Implementations encapsulate send/receive state, fragment assembly, acknowledgment handling,
+ * retransmission checks, and scheduling hints consumed by higher-level components such as {@link
+ * PacketSender}. Time values are in milliseconds unless stated otherwise.
+ */
 public interface PacketFormat {
 
+  /**
+   * Processes a received packet.
+   *
+   * <p>The implementation attempts to decrypt, validate, and parse the packet, apply any
+   * acknowledgments, and deliver completed messages to the owning peer. When applicable, it may
+   * schedule an acknowledgment in response.
+   *
+   * @param buf buffer containing the packet bytes
+   * @param offset start offset in {@code buf}
+   * @param length number of bytes to read from {@code buf}
+   * @param now current time in milliseconds (epoch)
+   * @param replyTo peer that sent the packet; may be {@code null} for non-addressable transports
+   * @return {@code true} if the packet was accepted and processed; {@code false} if it did not
+   *     match any active session or failed validation
+   */
   boolean handleReceivedPacket(byte[] buf, int offset, int length, long now, Peer replyTo);
 
   /**
-   * Maybe send something. A SINGLE PACKET. Don't send everything at once, for two reasons:
+   * Attempts to send at most one packet.
    *
-   * <ol>
-   *   <li>It is possible for a node to have a very long backlog.
-   *   <li>Sometimes sending a packet can take a long time.
-   *   <li>In the near future PacketSender will be responsible for output bandwidth throttling. So
-   *       it makes sense to send a single packet and round-robin.
-   * </ol>
+   * <p>Sending a single packet promotes fairness across peers and prevents long blocking on large
+   * queues. The caller typically invokes this in a round‑robin loop.
    *
-   * @param ackOnly
+   * @param now current time in milliseconds (epoch)
+   * @param ackOnly when {@code true}, restricts the packet to acknowledgments/keepalives
+   * @return {@code true} if a packet was sent; {@code false} if nothing was emitted
+   * @throws BlockedTooLongException if internal constraints (for example, sequence allocation) are
+   *     blocked beyond the allowed threshold
    */
   boolean maybeSendPacket(long now, boolean ackOnly) throws BlockedTooLongException;
 
   /**
-   * Called when the peer has been disconnected. THE CALLER SHOULD STOP USING THE PACKET FORMAT
-   * OBJECT AFTER CALLING THIS FUNCTION!
+   * Notifies the formatter that the peer disconnected and returns any queued items to requeue.
+   *
+   * <p>After this method returns, the instance is considered terminated and must not be used by the
+   * caller.
+   *
+   * @return outstanding {@link MessageItem}s that were not fully sent; may be empty
    */
   List<MessageItem> onDisconnect();
 
   /**
-   * Returns {@code false} if the packet format can't send new messages because it must wait for
-   * some internal event. For example, if a packet sequence number can not be allocated this method
-   * should return {@code false}, but if nothing can be sent because there is no (external) data to
-   * send it should not. Note that this only applies to packets being created from messages on
-   * the @see PeerMessageQueue. Note also that there may already be messages in flight, but it may
-   * return false in that case, so you need to check timeNextUrgent() as well.
+   * Returns whether a new data packet can be created now using the given session key.
    *
-   * @return {@code false} if the packet format can't send packets
+   * <p>This governs packets built from messages queued in {@link PeerMessageQueue}. It may return
+   * {@code false} when the implementation must wait for an internal event (for example, sequence
+   * number allocation). There may already be packets in flight; consult {@link
+   * #timeNextUrgent(boolean, long)} for the next required action time.
+   *
+   * @param key session key on which the packet would be sent
+   * @return {@code true} if a new data packet can be constructed; {@code false} otherwise
    */
   boolean canSend(SessionKey key);
 
   /**
-   * @return The time at which the packet format will want to send an ack, finish sending a message,
-   *     retransmit a packet, or similar. Long.MAX_VALUE if not supported or if there is nothing to
-   *     ack and nothing in flight.
-   * @param canSend If false, canSend() has returned false. Some transports will want to send a
-   *     packet anyway e.g. an ack, a resend in some cases.
+   * Returns the earliest time an urgent action is required (ack, finish, retransmit, etc.).
+   *
+   * @param canSend whether {@link #canSend(SessionKey)} currently permits sending data
+   * @param now current time in milliseconds (epoch)
+   * @return epoch time in milliseconds, or {@link Long#MAX_VALUE} if nothing is pending
    */
   long timeNextUrgent(boolean canSend, long now);
 
   /**
-   * @return The time at which the packet format will want to send an ack. Resends etc don't count,
-   *     only acks. The reason acks are special is they are needed for the other side to recognise
-   *     that their packets have been received and thus avoid retransmission.
+   * Returns the scheduled time to send acknowledgments only.
+   *
+   * <p>Retransmissions and data do not affect this value.
+   *
+   * @return epoch time in milliseconds for the next ack send, or {@link Long#MAX_VALUE} if none
    */
   long timeSendAcks();
 
   /**
-   * Is there enough data queued to justify sending a packet immediately? Ideally this should take
-   * into account transport level headers.
+   * Indicates whether there is enough queued data to justify sending a packet immediately.
+   *
+   * @param maxPacketSize maximum packet size in bytes, including transport overhead
+   * @return {@code true} if at least one near‑full packet can be formed; {@code false} otherwise
    */
   boolean fullPacketQueued(int maxPacketSize);
 
+  /** Scans in‑flight state for losses and schedules any required retransmissions. */
   void checkForLostPackets();
 
+  /**
+   * Returns the next time a loss check should run.
+   *
+   * @return epoch time in milliseconds, or {@link Long#MAX_VALUE} if not needed
+   */
   long timeCheckForLostPackets();
 }


### PR DESCRIPTION
Summary
- Enhance Javadoc for PacketFormat interface and methods
- Clarify purpose, inputs/outputs, time units (ms), and side‑effects
- Add links to related types (PacketSender, PeerMessageQueue)
- No code or logic changes; comments/docstrings only

Rationale
- Make API usage clearer for implementers and callers
- Align docs with current scheduling/ack/loss‑check behavior
- Improve consistency of terminology and return semantics

Formatting
- Ran `./gradlew spotlessApply` before committing per project guidelines

Change Scope
- src/main/java/network/crypta/node/PacketFormat.java
  - 64 insertions, 27 deletions (comments/docstrings only)

Branch
- feature/docs-packetformat (based on develop)

Diff Summary (relative to develop)
- Commit: 26530b63ea docs(node): improve Javadoc and comments for PacketFormat interface
- Files changed: 1 (PacketFormat.java)

Notes
- No runtime behavior change
- No logging changes (this file has none)
- Ready for review