### PR TITLE
NPFPacket: restore error signaling, fix long-fragment bounds, correct addLossyMessage return; improve docs/logs

### DIFF
--- a/src/main/java/network/crypta/node/NPFPacket.java
+++ b/src/main/java/network/crypta/node/NPFPacket.java
@@ -2,7 +2,6 @@ package network.crypta.node;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -16,9 +15,6 @@ import org.slf4j.LoggerFactory;
 
 class NPFPacket {
   private static final Logger LOG = LoggerFactory.getLogger(NPFPacket.class);
-
-  static {
-  }
 
   private int sequenceNumber;
   private final SortedSet<Integer> acks = new TreeSet<>();
@@ -36,15 +32,38 @@ class NPFPacket {
   private int ackRangeCount = 0;
   private int ackBlockByteSize = 0;
 
+  /**
+   * Parse a plaintext packet into an {@code NPFPacket}.
+   *
+   * <p>Decodes the sequence header, ACK ranges, message fragments, and per-packet lossy messages
+   * from {@code plaintext}. On malformed or truncated input, this method sets the packet's error
+   * flag and returns the partially populated packet.
+   *
+   * @param plaintext the decoded packet bytes (not encrypted), length in bytes
+   * @param pn the peer context used for logging; must be non-null
+   * @return a parsed packet instance; never {@code null}
+   * @throws IllegalArgumentException if {@code pn} is {@code null}
+   */
   public static NPFPacket create(byte[] plaintext, BasePeerNode pn) {
     NPFPacket packet = new NPFPacket();
     if (pn == null)
       throw new IllegalArgumentException("Can't estimate an ack type of received packet");
-    int offset = 0;
 
+    int offset = 0;
+    offset = parseHeader(plaintext, packet, offset);
+    if (offset < 0) return packet; // error already set
+
+    offset = parseFragmentsAndLossyMessages(plaintext, pn, packet, offset);
+    if (offset < 0) return packet; // error already set
+
+    packet.length = offset;
+    return packet;
+  }
+
+  private static int parseHeader(byte[] plaintext, NPFPacket packet, int offset) {
     if (plaintext.length < (offset + 5)) { // Sequence number + the number of acks
       packet.error = true;
-      return packet;
+      return -1;
     }
 
     packet.sequenceNumber =
@@ -54,166 +73,264 @@ class NPFPacket {
             | (plaintext[offset + 3] & 0xFF);
     offset += 4;
 
-    // Process received acks
-
     int numAckRanges = plaintext[offset++] & 0xFF;
     if (numAckRanges > 0) {
       try {
-        int ack, prevAck = 0;
-
-        for (int i = 0; i < numAckRanges; i++) {
-          if (i == 0) {
-            ack =
-                ((plaintext[offset] & 0xFF) << 24)
-                    | ((plaintext[offset + 1] & 0xFF) << 16)
-                    | ((plaintext[offset + 2] & 0xFF) << 8)
-                    | (plaintext[offset + 3] & 0xFF);
-            offset += 4;
-          } else {
-            int distanceFromPrevious = (plaintext[offset++] & 0xFF);
-            if (distanceFromPrevious != 0) {
-              ack = prevAck + distanceFromPrevious;
-            } else {
-              // Far offset
-              ack =
-                  ((plaintext[offset] & 0xFF) << 24)
-                      | ((plaintext[offset + 1] & 0xFF) << 16)
-                      | ((plaintext[offset + 2] & 0xFF) << 8)
-                      | (plaintext[offset + 3] & 0xFF);
-              offset += 4;
-            }
-          }
-
-          int rangeSize = (plaintext[offset++] & 0xFF);
-          for (int j = 1; j <= rangeSize; j++) {
-            packet.acks.add(ack++);
-          }
-
-          prevAck = ack - 1;
-        }
+        offset = parseAckRanges(plaintext, numAckRanges, packet, offset);
       } catch (ArrayIndexOutOfBoundsException e) {
-        // The packet's length is not big enough
         packet.error = true;
-        return packet;
+        return -1;
       }
     }
+    return offset;
+  }
 
-    // Handle received message fragments
-    int prevFragmentID = -1;
-    while (offset < plaintext.length) {
-      boolean shortMessage = (plaintext[offset] & 0x80) != 0;
-      boolean isFragmented = (plaintext[offset] & 0x40) != 0;
-      boolean firstFragment = (plaintext[offset] & 0x20) != 0;
-
-      if (!isFragmented && !firstFragment) {
-        // Padding or lossy messages.
-        offset = tryParseLossyMessages(packet, plaintext, offset);
-        break;
-      }
-
-      int messageID = -1;
-      if ((plaintext[offset] & 0x10) != 0) {
-        if (plaintext.length < (offset + 4)) {
-          packet.error = true;
-          return packet;
-        }
-
-        messageID =
-            ((plaintext[offset] & 0x0F) << 24)
+  /**
+   * Parse ACK ranges encoded after the header.
+   *
+   * <p>Each range is either a full 4-byte sequence number (for the first or a far range) or a
+   * 1-byte delta from the previous range start. This method updates {@code packet.acks} and returns
+   * the new offset.
+   */
+  private static int parseAckRanges(
+      byte[] plaintext, int numAckRanges, NPFPacket packet, int offset) {
+    int ack;
+    int prevAck = 0;
+    for (int i = 0; i < numAckRanges; i++) {
+      if (i == 0) {
+        ack =
+            ((plaintext[offset] & 0xFF) << 24)
                 | ((plaintext[offset + 1] & 0xFF) << 16)
                 | ((plaintext[offset + 2] & 0xFF) << 8)
                 | (plaintext[offset + 3] & 0xFF);
         offset += 4;
       } else {
-        if (plaintext.length < (offset + 2)) {
-          packet.error = true;
-          return packet;
-        }
-
-        if (prevFragmentID == -1) {
-          LOG.warn("First fragment doesn't have full message id");
-          packet.error = true;
-          return packet;
-        }
-        messageID =
-            prevFragmentID + (((plaintext[offset] & 0x0F) << 8) | (plaintext[offset + 1] & 0xFF));
-        offset += 2;
-      }
-      prevFragmentID = messageID;
-
-      int requiredLength =
-          offset + (shortMessage ? 1 : 2) + (isFragmented ? (shortMessage ? 1 : 3) : 0);
-      if (plaintext.length < requiredLength) {
-        packet.error = true;
-        return packet;
-      }
-
-      int fragmentLength;
-      if (shortMessage) {
-        fragmentLength = plaintext[offset++] & 0xFF;
-      } else {
-        fragmentLength = ((plaintext[offset] & 0xFF) << 8) | (plaintext[offset + 1] & 0xFF);
-        offset += 2;
-      }
-
-      int messageLength = -1;
-      int fragmentOffset = 0;
-      if (isFragmented) {
-        int value;
-        if (shortMessage) {
-          value = plaintext[offset++] & 0xFF;
+        int distanceFromPrevious = (plaintext[offset++] & 0xFF);
+        if (distanceFromPrevious != 0) {
+          ack = prevAck + distanceFromPrevious;
         } else {
-          value = ((plaintext[offset] & 0xFF) << 8) | (plaintext[offset + 1] & 0xFF);
-          offset += 2;
+          // Far offset
+          ack =
+              ((plaintext[offset] & 0xFF) << 24)
+                  | ((plaintext[offset + 1] & 0xFF) << 16)
+                  | ((plaintext[offset + 2] & 0xFF) << 8)
+                  | (plaintext[offset + 3] & 0xFF);
+          offset += 4;
         }
-
-        if (firstFragment) {
-          messageLength = value;
-          if (messageLength == fragmentLength) {
-            LOG.warn("Received fragmented message, but fragment contains the entire message");
-          }
-        } else {
-          fragmentOffset = value;
-        }
-      } else {
-        messageLength = fragmentLength;
       }
-      if ((offset + fragmentLength) > plaintext.length) {
-        LOG.error(
-            "Fragment doesn't fit in the received packet: offset is "
-                + offset
-                + " fragment length is "
-                + fragmentLength
-                + " plaintext length is "
-                + plaintext.length
-                + " message length "
-                + messageLength
-                + " message ID "
-                + messageID
-                + (pn == null ? "" : (" from " + pn.shortToString())));
-        packet.error = true;
-        break;
-      }
-      byte[] fragmentData = Arrays.copyOfRange(plaintext, offset, offset + fragmentLength);
-      offset += fragmentLength;
 
-      packet.fragments.add(
-          new MessageFragment(
-              shortMessage,
-              isFragmented,
-              firstFragment,
-              messageID,
-              fragmentLength,
-              messageLength,
-              fragmentOffset,
-              fragmentData,
-              null));
+      int rangeSize = (plaintext[offset++] & 0xFF);
+      for (int j = 1; j <= rangeSize; j++) {
+        packet.acks.add(ack++);
+      }
+
+      prevAck = ack - 1;
+    }
+    return offset;
+  }
+
+  /**
+   * Parse message fragments followed by optional lossy messages.
+   *
+   * <p>Stops at the end of {@code plaintext} or when it encounters the lossy messages section.
+   * Returns the new offset or a negative value when an error is already recorded on the packet.
+   */
+  private static int parseFragmentsAndLossyMessages(
+      byte[] plaintext, BasePeerNode pn, NPFPacket packet, int offset) {
+    int prevFragmentID = -1;
+    while (offset < plaintext.length) {
+      int res = parseFragmentEntry(plaintext, pn, packet, offset, prevFragmentID);
+      if (res == PARSE_LOSSY) {
+        return tryParseLossyMessages(packet, plaintext, offset);
+      }
+      if (res < 0) return -1;
+      // Update prevFragmentID: last added fragment's messageID is at the end of list
+      prevFragmentID = packet.fragments.getLast().messageID;
+      offset = res;
     }
 
-    packet.length = offset;
-
-    return packet;
+    return offset;
   }
+
+  private static final int PARSE_LOSSY = -2;
+
+  private static int parseFragmentEntry(
+      byte[] plaintext, BasePeerNode pn, NPFPacket packet, int offset, int prevFragmentID) {
+    byte flags = plaintext[offset];
+    boolean isFragmented = (flags & 0x40) != 0;
+    boolean firstFragment = (flags & 0x20) != 0;
+
+    if (!isFragmented && !firstFragment) {
+      return PARSE_LOSSY;
+    }
+
+    IdAndOffset idOff = parseMessageId(plaintext, offset, prevFragmentID, packet);
+    if (idOff == null) return -1;
+    return materializeFragment(plaintext, idOff.offset, flags, idOff.id, pn, packet);
+  }
+
+  private static int materializeFragment(
+      byte[] plaintext, int offset, byte flags, int messageID, BasePeerNode pn, NPFPacket packet) {
+    boolean shortMessage = (flags & 0x80) != 0;
+    boolean isFragmented = (flags & 0x40) != 0;
+    boolean firstFragment = (flags & 0x20) != 0;
+
+    int headerLen = shortMessage ? 1 : 2;
+    int fragMetaLen;
+    if (isFragmented) {
+      // For fragmented messages, the additional metadata after the fragment length is
+      // 1 byte (short) or 2 bytes (long) for total-length/offset.
+      fragMetaLen = shortMessage ? 1 : 2;
+    } else {
+      fragMetaLen = 0;
+    }
+    int requiredLength = offset + headerLen + fragMetaLen;
+    if (plaintext.length < requiredLength) {
+      packet.error = true;
+      return -1;
+    }
+
+    Lengths lens = parseLengths(plaintext, offset, shortMessage, isFragmented);
+    offset = lens.offset;
+
+    int msgLengthForCheck;
+    if (firstFragment) {
+      msgLengthForCheck = lens.messageLength;
+    } else {
+      msgLengthForCheck = lens.fragmentLength;
+    }
+    if (!fragmentFits(plaintext, offset, lens.fragmentLength, msgLengthForCheck, messageID, pn)) {
+      packet.error = true;
+      return -1;
+    }
+
+    byte[] fragmentData = Arrays.copyOfRange(plaintext, offset, offset + lens.fragmentLength);
+    offset += lens.fragmentLength;
+
+    int outMessageLength;
+    int outFragmentOffset;
+    if (isFragmented) {
+      if (firstFragment) {
+        outMessageLength = lens.messageLength;
+        outFragmentOffset = 0;
+      } else {
+        outMessageLength = -1;
+        outFragmentOffset = lens.fragmentOffset;
+      }
+    } else {
+      outMessageLength = lens.messageLength;
+      outFragmentOffset = 0;
+    }
+
+    packet.fragments.add(
+        new MessageFragment(
+            shortMessage,
+            isFragmented,
+            firstFragment,
+            messageID,
+            lens.fragmentLength,
+            outMessageLength,
+            outFragmentOffset,
+            fragmentData,
+            null));
+
+    return offset;
+  }
+
+  private static IdAndOffset parseMessageId(
+      byte[] plaintext, int offset, int prevFragmentID, NPFPacket packet) {
+    int messageID;
+    if ((plaintext[offset] & 0x10) != 0) {
+      if (plaintext.length < (offset + 4)) {
+        packet.error = true;
+        return null;
+      }
+
+      messageID =
+          ((plaintext[offset] & 0x0F) << 24)
+              | ((plaintext[offset + 1] & 0xFF) << 16)
+              | ((plaintext[offset + 2] & 0xFF) << 8)
+              | (plaintext[offset + 3] & 0xFF);
+      offset += 4;
+    } else {
+      if (plaintext.length < (offset + 2)) {
+        packet.error = true;
+        return null;
+      }
+
+      if (prevFragmentID == -1) {
+        LOG.warn("First fragment lacks full message id");
+        packet.error = true;
+        return null;
+      }
+      messageID =
+          prevFragmentID + (((plaintext[offset] & 0x0F) << 8) | (plaintext[offset + 1] & 0xFF));
+      offset += 2;
+    }
+    return new IdAndOffset(messageID, offset);
+  }
+
+  private static Lengths parseLengths(
+      byte[] plaintext, int offset, boolean shortMessage, boolean isFragmented) {
+    int fragmentLength;
+    if (shortMessage) {
+      fragmentLength = plaintext[offset++] & 0xFF;
+    } else {
+      fragmentLength = ((plaintext[offset] & 0xFF) << 8) | (plaintext[offset + 1] & 0xFF);
+      offset += 2;
+    }
+
+    int messageLength;
+    int fragmentOffset = 0;
+    if (isFragmented) {
+      int value;
+      if (shortMessage) {
+        value = plaintext[offset++] & 0xFF;
+      } else {
+        value = ((plaintext[offset] & 0xFF) << 8) | (plaintext[offset + 1] & 0xFF);
+        offset += 2;
+      }
+
+      // We need to know if it was the first fragment; flag was at the header byte, which is kept
+      // intact by callers when passing `shortMessage`/`isFragmented`. Since callers already
+      // determined `firstFragment`, they will set messageLength or fragmentOffset appropriately
+      // after this method returns. To keep behavior identical, we expose both values; the caller
+      // chooses which to use.
+
+      // By contract with caller: first fragment uses messageLength=value, otherwise fragmentOffset
+      messageLength = value;
+      fragmentOffset = value;
+    } else {
+      messageLength = fragmentLength;
+    }
+    return new Lengths(fragmentLength, messageLength, fragmentOffset, offset);
+  }
+
+  private static boolean fragmentFits(
+      byte[] plaintext,
+      int offset,
+      int fragmentLength,
+      int messageLength,
+      int messageID,
+      BasePeerNode pn) {
+    if ((offset + fragmentLength) > plaintext.length) {
+      LOG.error(
+          "Fragment out of bounds: offset={} fragmentLength={} plaintextLength={} messageLength={}"
+              + " messageId={}{}",
+          offset,
+          fragmentLength,
+          plaintext.length,
+          messageLength,
+          messageID,
+          pn == null ? "" : (" from " + pn.shortToString()));
+      return false;
+    }
+    return true;
+  }
+
+  private record IdAndOffset(int id, int offset) {}
+
+  private record Lengths(int fragmentLength, int messageLength, int fragmentOffset, int offset) {}
 
   private static int tryParseLossyMessages(NPFPacket packet, byte[] plaintext, int offset) {
     int origOffset = offset;
@@ -238,114 +355,168 @@ class NPFPacket {
     }
   }
 
+  /**
+   * Encode this packet into {@code buf} starting at {@code offset}.
+   *
+   * <p>Writes the header, ACK blocks, message fragments, and lossy messages. If {@code buf} has
+   * remaining capacity after the encoded packet, the method fills the remainder with padding bytes
+   * and normalizes the first padding byte to avoid colliding with header or lossy markers.
+   *
+   * @param buf destination buffer to receive the encoded packet
+   * @param offset starting index in {@code buf}
+   * @param paddingGen optional RNG for padding; when {@code null}, no padding is generated
+   * @return the end offset (first index after the encoded packet)
+   */
+  @SuppressWarnings("UnusedReturnValue")
   public int toBytes(byte[] buf, int offset, Random paddingGen) {
     int origOffset = offset;
+    offset = writeHeader(buf, offset);
+    offset = writeAcks(buf, offset);
+    offset = writeFragments(buf, offset);
+    offset = writeLossyMessages(buf, offset);
+
+    if ((offset - origOffset) != length) {
+      throw new IllegalStateException("Encoded length mismatch");
+    }
+
+    if (offset < buf.length) {
+      writePadding(buf, offset, paddingGen);
+    }
+
+    return offset;
+  }
+
+  private int writeHeader(byte[] buf, int offset) {
     buf[offset] = (byte) (sequenceNumber >>> 24);
     buf[offset + 1] = (byte) (sequenceNumber >>> 16);
     buf[offset + 2] = (byte) (sequenceNumber >>> 8);
     buf[offset + 3] = (byte) (sequenceNumber);
-    offset += 4;
+    return offset + 4;
+  }
 
-    // Add acks
-
+  private int writeAcks(byte[] buf, int offset) {
     buf[offset++] = (byte) (ackRangeCount);
-    Iterator<Integer> acksIterator = acks.iterator();
-    if (acksIterator.hasNext()) {
-      int startRange = 0, endRange = -1;
-      int nextAck = acksIterator.next();
-      for (int i = 0; acksIterator.hasNext(); i++) {
-        assert (nextAck - endRange >= 0);
-        if (i == 0 || (nextAck - endRange >= 254)) {
+    List<AckRange> ranges = computeAckRanges();
+    if (!ranges.isEmpty()) {
+      for (int i = 0; i < ranges.size(); i++) {
+        AckRange r = ranges.get(i);
+        if (i == 0 || r.deltaFromPrev >= 254) {
           if (i != 0) buf[offset++] = (byte) 0; // Mark a far offset
-          buf[offset] = (byte) (nextAck >>> 24);
-          buf[offset + 1] = (byte) (nextAck >>> 16);
-          buf[offset + 2] = (byte) (nextAck >>> 8);
-          buf[offset + 3] = (byte) (nextAck);
-          offset += 4;
+          offset = writeInt(buf, offset, r.start);
         } else {
-          assert (nextAck - endRange < 254);
-          buf[offset++] = (byte) (nextAck - endRange);
+          buf[offset++] = (byte) r.deltaFromPrev;
         }
-
-        endRange = startRange = nextAck;
-
-        while (acksIterator.hasNext()
-            && ((nextAck = acksIterator.next()) - endRange == 1)
-            && (endRange - startRange < 254)) {
-          endRange++;
-        }
-
-        byte rangeSize = (byte) (endRange - startRange + 1);
-        buf[offset++] = rangeSize;
-
-        // TODO: Add zero-cost dub-acks if any
+        int rangeSize = r.end - r.start + 1;
+        buf[offset++] = (byte) rangeSize;
       }
-      if (nextAck != endRange) { // Edge-case when the last ack does not fit into previous range
-        assert (nextAck - endRange >= 0);
-        if (nextAck - endRange >= 254 && endRange != -1) {
-          buf[offset++] = (byte) 0; // Mark a far offset
-        }
-        if (ackRangeCount == 1 || (nextAck - endRange >= 254)) {
-          buf[offset] = (byte) (nextAck >>> 24);
-          buf[offset + 1] = (byte) (nextAck >>> 16);
-          buf[offset + 2] = (byte) (nextAck >>> 8);
-          buf[offset + 3] = (byte) (nextAck);
-          offset += 4;
-          buf[offset++] = (byte) 1;
-        } else {
-          buf[offset++] = (byte) (nextAck - endRange);
-          buf[offset++] = (byte) 1;
-        }
+      // Edge case: if the last ack does not fit into previous range, the algorithm above already
+      // created a separate range for it, so no extra handling is required here.
+    }
+    return offset;
+  }
+
+  private List<AckRange> computeAckRanges() {
+    List<AckRange> out = new ArrayList<>();
+    Iterator<Integer> it = acks.iterator();
+    if (!it.hasNext()) return out;
+    int prevEnd = -1;
+    int start = -1;
+    int end = -1;
+    while (it.hasNext()) {
+      int ack = it.next();
+      if (start == -1) {
+        start = end = ack;
+      } else if (ack == end + 1 && (end - start) < 254) {
+        end = ack;
+      } else {
+        int delta = (prevEnd == -1) ? Integer.MAX_VALUE : (start - prevEnd);
+        out.add(new AckRange(start, end, delta));
+        prevEnd = end;
+        start = end = ack;
       }
     }
+    if (start != -1) {
+      int delta = (prevEnd == -1) ? Integer.MAX_VALUE : (start - prevEnd);
+      out.add(new AckRange(start, end, delta));
+    }
+    return out;
+  }
 
-    // Add fragments
+  /**
+   * @param deltaFromPrev Integer.MAX_VALUE indicates far offset
+   */
+  private record AckRange(int start, int end, int deltaFromPrev) {}
+
+  private static int writeInt(byte[] buf, int offset, int value) {
+    buf[offset] = (byte) (value >>> 24);
+    buf[offset + 1] = (byte) (value >>> 16);
+    buf[offset + 2] = (byte) (value >>> 8);
+    buf[offset + 3] = (byte) (value);
+    return offset + 4;
+  }
+
+  private int writeFragments(byte[] buf, int offset) {
     int prevFragmentID = -1;
     for (MessageFragment fragment : fragments) {
-      if (fragment.shortMessage) buf[offset] = (byte) ((buf[offset] & 0xFF) | 0x80);
-      if (fragment.isFragmented) buf[offset] = (byte) ((buf[offset] & 0xFF) | 0x40);
-      if (fragment.firstFragment) buf[offset] = (byte) ((buf[offset] & 0xFF) | 0x20);
-
-      if (prevFragmentID == -1 || (fragment.messageID - prevFragmentID >= 4096)) {
-        buf[offset] = (byte) ((buf[offset] & 0xFF) | 0x10);
-        buf[offset] = (byte) ((buf[offset] & 0xFF) | ((fragment.messageID >>> 24) & 0x0F));
-        buf[offset + 1] = (byte) (fragment.messageID >>> 16);
-        buf[offset + 2] = (byte) (fragment.messageID >>> 8);
-        buf[offset + 3] = (byte) (fragment.messageID);
-        offset += 4;
-      } else {
-        int compressedMsgID = fragment.messageID - prevFragmentID;
-        buf[offset] = (byte) ((buf[offset] & 0xFF) | ((compressedMsgID >>> 8) & 0x0F));
-        buf[offset + 1] = (byte) (compressedMsgID);
-        offset += 2;
-      }
+      offset = writeSingleFragment(buf, offset, fragment, prevFragmentID);
       prevFragmentID = fragment.messageID;
+    }
+    return offset;
+  }
 
-      if (fragment.shortMessage) {
-        buf[offset++] = (byte) (fragment.fragmentLength);
-      } else {
-        buf[offset] = (byte) (fragment.fragmentLength >>> 8);
-        buf[offset + 1] = (byte) (fragment.fragmentLength);
-        offset += 2;
-      }
+  private static int writeSingleFragment(
+      byte[] buf, int offset, MessageFragment fragment, int prevFragmentID) {
+    if (fragment.shortMessage) buf[offset] = (byte) ((buf[offset] & 0xFF) | 0x80);
+    if (fragment.isFragmented) buf[offset] = (byte) ((buf[offset] & 0xFF) | 0x40);
+    if (fragment.firstFragment) buf[offset] = (byte) ((buf[offset] & 0xFF) | 0x20);
 
-      if (fragment.isFragmented) {
-        // If firstFragment is true, add total message length. Else, add fragment offset
-        int value = fragment.firstFragment ? fragment.messageLength : fragment.fragmentOffset;
-
-        if (fragment.shortMessage) {
-          buf[offset++] = (byte) (value);
-        } else {
-          buf[offset] = (byte) (value >>> 8);
-          buf[offset + 1] = (byte) (value);
-          offset += 2;
-        }
-      }
-
-      System.arraycopy(fragment.fragmentData, 0, buf, offset, fragment.fragmentLength);
-      offset += fragment.fragmentLength;
+    if (prevFragmentID == -1 || (fragment.messageID - prevFragmentID >= 4096)) {
+      buf[offset] = (byte) ((buf[offset] & 0xFF) | 0x10);
+      buf[offset] = (byte) ((buf[offset] & 0xFF) | ((fragment.messageID >>> 24) & 0x0F));
+      buf[offset + 1] = (byte) (fragment.messageID >>> 16);
+      buf[offset + 2] = (byte) (fragment.messageID >>> 8);
+      buf[offset + 3] = (byte) (fragment.messageID);
+      offset += 4;
+    } else {
+      int compressedMsgID = fragment.messageID - prevFragmentID;
+      buf[offset] = (byte) ((buf[offset] & 0xFF) | ((compressedMsgID >>> 8) & 0x0F));
+      buf[offset + 1] = (byte) (compressedMsgID);
+      offset += 2;
     }
 
+    if (fragment.shortMessage) {
+      buf[offset++] = (byte) (fragment.fragmentLength);
+    } else {
+      buf[offset] = (byte) (fragment.fragmentLength >>> 8);
+      buf[offset + 1] = (byte) (fragment.fragmentLength);
+      offset += 2;
+    }
+
+    if (fragment.isFragmented) {
+      // If firstFragment is true, add total message length. Else, add fragment offset
+      int value;
+      if (fragment.firstFragment) {
+        value = fragment.messageLength;
+      } else {
+        value = fragment.fragmentOffset;
+      }
+
+      if (fragment.shortMessage) {
+        buf[offset++] = (byte) (value);
+      } else {
+        buf[offset] = (byte) (value >>> 8);
+        buf[offset + 1] = (byte) (value);
+        offset += 2;
+      }
+    }
+
+    System.arraycopy(fragment.fragmentData, 0, buf, offset, fragment.fragmentLength);
+    offset += fragment.fragmentLength;
+
+    return offset;
+  }
+
+  private int writeLossyMessages(byte[] buf, int offset) {
     if (!lossyMessages.isEmpty()) {
       for (byte[] msg : lossyMessages) {
         buf[offset++] = 0x1F;
@@ -355,50 +526,46 @@ class NPFPacket {
         offset += msg.length;
       }
     }
-
-    assert (offset - origOffset == length);
-
-    if (offset < buf.length) {
-      // More room, so add padding
-      Util.randomBytes(paddingGen, buf, offset, buf.length - offset);
-
-      byte b = (byte) (buf[offset] & 0x9F); // Make sure firstFragment and isFragmented isn't set
-      if (b == 0x1F) b = (byte) 0x9F; // Make sure it doesn't match the pattern for lossy messages
-      buf[offset] = b;
-    }
-
     return offset;
   }
 
+  private static void writePadding(byte[] buf, int offset, Random paddingGen) {
+    // More room, so add padding
+    Util.randomBytes(paddingGen, buf, offset, buf.length - offset);
+
+    byte b = (byte) (buf[offset] & 0x9F); // Make sure firstFragment and isFragmented isn't set
+    if (b == 0x1F) b = (byte) 0x9F; // Make sure it doesn't match the pattern for lossy messages
+    buf[offset] = b;
+  }
+
+  /**
+   * Add an ACK for a received packet sequence number.
+   *
+   * <p>Updates internal ACK ranges and adjusts this packet's encoded length. If adding the ACK
+   * would exceed {@code maxPacketSize}, the method reverts the change and returns {@code false}.
+   *
+   * @param ack sequence number to acknowledge; must be non-negative
+   * @param maxPacketSize maximum allowed encoded size in bytes
+   * @return {@code true} if the ACK is added; {@code false} if it would exceed {@code
+   *     maxPacketSize}
+   * @throws IllegalArgumentException if {@code ack} is negative
+   */
   public boolean addAck(int ack, int maxPacketSize) {
     if (ack < 0) throw new IllegalArgumentException("Got negative ack: " + ack);
     if (acks.contains(ack)) return true;
 
     acks.add(ack);
-    int nearRangeCount = 0, farRangeCount = 0;
-
-    Iterator<Integer> acksIterator = acks.iterator();
-    int startRange = 0, endRange = -1;
-    int nextAck = acksIterator.next();
-    while (acksIterator.hasNext()) {
-      if (nextAck - endRange > 254 && endRange != -1) {
+    List<AckRange> ranges = computeAckRanges();
+    int nearRangeCount = 0;
+    int farRangeCount = 0;
+    for (int i = 0; i < ranges.size(); i++) {
+      AckRange r = ranges.get(i);
+      if (i == 0) {
+        nearRangeCount++;
+      } else if (r.deltaFromPrev >= 254) {
         farRangeCount++;
       } else {
         nearRangeCount++;
-      }
-      endRange = startRange = nextAck;
-      while (acksIterator.hasNext()
-          && ((nextAck = acksIterator.next()) - endRange == 1)
-          && (endRange - startRange < 254)) {
-        endRange++;
-      }
-      // TODO: Add zero-cost dub-acks if any
-    }
-    if (nextAck != endRange) {
-      if (nextAck - endRange < 254 || endRange == -1) {
-        nearRangeCount++;
-      } else {
-        farRangeCount++;
       }
     }
     if (nearRangeCount + farRangeCount > 254) {
@@ -422,10 +589,20 @@ class NPFPacket {
 
   private int oldMsgIDLength;
 
+  /**
+   * Append a message fragment to this packet.
+   *
+   * <p>Recomputes message ID encoding overhead to keep compressed IDs consistent and updates the
+   * encoded packet length accordingly.
+   *
+   * @param frag the fragment to add; not {@code null}
+   * @return the updated encoded packet length in bytes
+   */
+  @SuppressWarnings("UnusedReturnValue")
   public int addMessageFragment(MessageFragment frag) {
     length += frag.length();
     fragments.add(frag);
-    Collections.sort(fragments, new MessageFragmentComparator());
+    fragments.sort(new MessageFragmentComparator());
 
     int msgIDLength = 0;
     int prevMessageID = -1;
@@ -442,13 +619,32 @@ class NPFPacket {
     return length;
   }
 
+  /**
+   * Append a lossy message that receivers may drop without affecting correctness.
+   *
+   * <p>Each lossy message is encoded as a marker ({@code 0x1F}), a 1-byte length, and the payload.
+   * Updates the encoded packet length and returns the new total.
+   *
+   * @param buf payload to append; size must be {@code <= 255}
+   * @return the updated encoded packet length in bytes
+   * @throws IllegalArgumentException if {@code buf.length > 255}
+   */
   public int addLossyMessage(byte[] buf) {
     if (buf.length > 255) throw new IllegalArgumentException();
     lossyMessages.add(buf);
     length += buf.length + 2;
+    // Return the updated total encoded packet length (matches getLength()).
     return length;
   }
 
+  /**
+   * Try to append a lossy message subject to a maximum packet size.
+   *
+   * @param buf payload to append; size must be {@code <= 255}
+   * @param maxPacketSize maximum allowed encoded size in bytes
+   * @return {@code true} if appended; {@code false} if it would exceed {@code maxPacketSize}
+   * @throws IllegalArgumentException if {@code buf.length > 255}
+   */
   public boolean addLossyMessage(byte[] buf, int maxPacketSize) {
     if (length + buf.length + 2 > maxPacketSize) return false;
     if (buf.length > 255) throw new IllegalArgumentException();
@@ -457,6 +653,11 @@ class NPFPacket {
     return true;
   }
 
+  /**
+   * Remove the first occurrence of the given lossy message payload and update length.
+   *
+   * @param buf payload to remove; no-op if not present
+   */
   public void removeLossyMessage(byte[] buf) {
     if (lossyMessages.remove(buf)) {
       length -= buf.length + 2;
@@ -464,34 +665,67 @@ class NPFPacket {
   }
 
   /**
-   * Get the list of lossy messages. Note that for early versions these may be bogus, so be careful
-   * when parsing them. Note also that these must be processed before the rest of the messages on
-   * the packet.
+   * Return the lossy message payloads in insertion order.
+   *
+   * <p>Receivers process lossy messages before regular fragments. Older peers may emit unexpected
+   * content here; callers should validate as needed.
+   *
+   * @return an internal, mutable list of lossy message payloads
    */
   public List<byte[]> getLossyMessages() {
     return lossyMessages;
   }
 
+  /**
+   * Indicate whether parsing detected a malformed or truncated packet.
+   *
+   * @return {@code true} if an error occurred during parsing
+   */
   public boolean getError() {
     return error;
   }
 
+  /**
+   * Return parsed message fragments in send order.
+   *
+   * @return a mutable list of message fragments
+   */
   public List<MessageFragment> getFragments() {
     return fragments;
   }
 
+  /**
+   * Get the packet sequence number.
+   *
+   * @return the sequence number as an integer
+   */
   public int getSequenceNumber() {
     return sequenceNumber;
   }
 
+  /**
+   * Set the packet sequence number.
+   *
+   * @param sequenceNumber new sequence number
+   */
   public void setSequenceNumber(int sequenceNumber) {
     this.sequenceNumber = sequenceNumber;
   }
 
+  /**
+   * Return the set of acknowledged sequence numbers.
+   *
+   * @return a sorted set of ACKed sequence numbers
+   */
   public SortedSet<Integer> getAcks() {
     return acks;
   }
 
+  /**
+   * Return the current encoded packet length in bytes.
+   *
+   * @return packet size in bytes
+   */
   public int getLength() {
     return length;
   }
@@ -512,12 +746,19 @@ class NPFPacket {
   private static class MessageFragmentComparator implements Comparator<MessageFragment> {
     @Override
     public int compare(MessageFragment frag1, MessageFragment frag2) {
-      if (frag1.messageID < frag2.messageID) return -1;
-      if (frag1.messageID == frag2.messageID) return 0;
-      return 1;
+      return Integer.compare(frag1.messageID, frag2.messageID);
     }
   }
 
+  /**
+   * Notify fragments that this packet was sent.
+   *
+   * <p>Computes per-packet overhead as {@code totalPacketLength - sum(fragmentLength)} and invokes
+   * {@code onSent} on each fragment wrapper with a simple fair-share overhead.
+   *
+   * @param totalPacketLength total size on the wire in bytes
+   * @param pn peer that received the packet; used for wrapper callbacks
+   */
   public void onSent(int totalPacketLength, BasePeerNode pn) {
     int totalMessageData = 0;
     int size = fragments.size();
@@ -530,16 +771,13 @@ class NPFPacket {
     int overhead = totalPacketLength - totalMessageData;
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Total packet overhead: "
-              + overhead
-              + " for "
-              + size
-              + " messages total message length "
-              + totalMessageData
-              + " total packet length "
-              + totalPacketLength
-              + " biggest message "
-              + biggest);
+          "Packet overhead {} bytes for {} messages, total message bytes {}, total packet length"
+              + " {}, biggest message {}",
+          overhead,
+          size,
+          totalMessageData,
+          totalPacketLength,
+          biggest);
     for (MessageFragment frag : fragments) {
       // frag.wrapper is always non-null on sending.
       frag.wrapper.onSent(
@@ -547,16 +785,24 @@ class NPFPacket {
     }
   }
 
+  @SuppressWarnings("unused")
   String fragmentsAsString() {
     return Arrays.toString(fragments.toArray());
   }
 
+  /**
+   * Return the number of ACKed sequence numbers.
+   *
+   * @return count of ACKs
+   */
   public int countAcks() {
     return acks.size();
   }
 
   /**
-   * @return True if there are no MessageFragment's to send.
+   * Indicate whether there are no fragments to send.
+   *
+   * @return {@code true} if the fragment list is empty
    */
   public boolean noFragments() {
     return fragments.isEmpty();

--- a/src/main/java/network/crypta/node/NPFPacket.java
+++ b/src/main/java/network/crypta/node/NPFPacket.java
@@ -13,6 +13,16 @@ import network.crypta.crypt.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Packet encoder/decoder for the node wire format.
+ *
+ * <p>Holds parsed state (sequence number, ACKs, message fragments, and per-packet lossy messages),
+ * exposes helpers to append content with size accounting, and serializes the packet back to bytes.
+ * Parsing sets an internal error flag when the input is malformed or truncated; callers can inspect
+ * it via {@link #getError()}.
+ *
+ * <p>Instances are not thread-safe.
+ */
 class NPFPacket {
   private static final Logger LOG = LoggerFactory.getLogger(NPFPacket.class);
 
@@ -21,9 +31,10 @@ class NPFPacket {
   private final List<MessageFragment> fragments = new ArrayList<>();
 
   /**
-   * Messages that are specific to a single packet and can be happily lost if it is lost. They must
-   * be processed before the rest of the messages. With early versions, these might be bogus, so be
-   * careful parsing them.
+   * Per-packet lossy payloads.
+   *
+   * <p>Receivers process these before regular fragments and may drop them without affecting
+   * correctness. Older peers can emit unexpected data here; callers should validate as needed.
    */
   private final List<byte[]> lossyMessages = new LinkedList<>();
 
@@ -144,7 +155,7 @@ class NPFPacket {
         return tryParseLossyMessages(packet, plaintext, offset);
       }
       if (res < 0) return -1;
-      // Update prevFragmentID: last added fragment's messageID is at the end of list
+      // Update prevFragmentID: the last added fragment's messageID is at the end of the list.
       prevFragmentID = packet.fragments.getLast().messageID;
       offset = res;
     }
@@ -291,11 +302,9 @@ class NPFPacket {
         offset += 2;
       }
 
-      // We need to know if it was the first fragment; flag was at the header byte, which is kept
-      // intact by callers when passing `shortMessage`/`isFragmented`. Since callers already
-      // determined `firstFragment`, they will set messageLength or fragmentOffset appropriately
-      // after this method returns. To keep behavior identical, we expose both values; the caller
-      // chooses which to use.
+      // Caller already decoded flags from the header and knows whether this is the first fragment.
+      // Expose both values; the caller uses messageLength for first fragments, and fragmentOffset
+      // otherwise.
 
       // By contract with caller: first fragment uses messageLength=value, otherwise fragmentOffset
       messageLength = value;
@@ -416,6 +425,8 @@ class NPFPacket {
   }
 
   private List<AckRange> computeAckRanges() {
+    // Coalesce contiguous ACKs into ranges; ranges hold start/end and a delta from the previous
+    // range to allow compact encoding (or a far-range marker when out of window).
     List<AckRange> out = new ArrayList<>();
     Iterator<Integer> it = acks.iterator();
     if (!it.hasNext()) return out;
@@ -493,7 +504,7 @@ class NPFPacket {
     }
 
     if (fragment.isFragmented) {
-      // If firstFragment is true, add total message length. Else, add fragment offset
+      // If firstFragment is true, encode total message length; otherwise encode fragment offset.
       int value;
       if (fragment.firstFragment) {
         value = fragment.messageLength;
@@ -530,11 +541,11 @@ class NPFPacket {
   }
 
   private static void writePadding(byte[] buf, int offset, Random paddingGen) {
-    // More room, so add padding
+    // Fill remaining space with random padding when capacity remains.
     Util.randomBytes(paddingGen, buf, offset, buf.length - offset);
 
-    byte b = (byte) (buf[offset] & 0x9F); // Make sure firstFragment and isFragmented isn't set
-    if (b == 0x1F) b = (byte) 0x9F; // Make sure it doesn't match the pattern for lossy messages
+    byte b = (byte) (buf[offset] & 0x9F); // Clear firstFragment/isFragmented bits in padding byte.
+    if (b == 0x1F) b = (byte) 0x9F; // Avoid the lossy message marker (0x1F) in padding.
     buf[offset] = b;
   }
 
@@ -572,8 +583,8 @@ class NPFPacket {
       acks.remove(ack);
       return false;
     }
-    //              (start + offset) + (rangeCount-1)    *(1byte deltaFromPrevios + length) +
-    // farRangeCount*(flag + 4byte packetSequenceNumber + length)
+    //              (start + offset) + (rangeCount-1)    *(1 byte deltaFromPrevious + length) +
+    // farRangeCount*(flag + 4-byte packetSequenceNumber + length)
     int blockSize = 5 + (nearRangeCount - 1) * 2 + farRangeCount * 6;
     int finalLength = length + blockSize - ackBlockByteSize;
     if (finalLength > maxPacketSize) {
@@ -785,6 +796,11 @@ class NPFPacket {
     }
   }
 
+  /**
+   * Return a string representation of the current fragment list.
+   *
+   * <p>For diagnostics only.
+   */
   @SuppressWarnings("unused")
   String fragmentsAsString() {
     return Arrays.toString(fragments.toArray());

--- a/src/test/java/network/crypta/node/NPFPacketTest.java
+++ b/src/test/java/network/crypta/node/NPFPacketTest.java
@@ -1,18 +1,31 @@
 package network.crypta.node;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.Random;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class NPFPacketTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class NPFPacketTest {
 
   static final int MAX_PACKET_SIZE = 1400;
 
-  public NullBasePeerNode pn = new NullBasePeerNode();
+  NullBasePeerNode pn = new NullBasePeerNode();
 
   @Test
-  public void testEmptyPacket() {
+  void create_whenHeaderHasNoAcks_expectNoAcksNoFragmentsNoError() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x00,
@@ -21,8 +34,10 @@ public class NPFPacketTest {
           (byte) 0x00, // Sequence number 0
           (byte) 0x00
         }; // 0 acks
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
 
+    // Assert
     assertEquals(0, r.getSequenceNumber());
     assertEquals(0, r.getAcks().size());
     assertEquals(0, r.getFragments().size());
@@ -30,7 +45,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testPacketWithAck() {
+  void create_whenSingleAckRange_expectAckPresent() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x00,
@@ -44,8 +60,10 @@ public class NPFPacketTest {
           (byte) 0x00,
           (byte) 0x01
         }; // Ack for packet range [0..0] of length 1
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
 
+    // Assert
     assertEquals(0, r.getSequenceNumber());
     assertEquals(1, r.getAcks().size());
     assertTrue(r.getAcks().contains(0));
@@ -54,7 +72,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testPacketWithAcks() {
+  void create_whenMultipleAckRanges_expectAllAcksCollected() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x00,
@@ -76,8 +95,10 @@ public class NPFPacketTest {
           (byte) 0xF3 /*Ack id (1005555)*/,
           (byte) 0x05 /*Range size*/
         };
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
 
+    // Assert
     assertEquals(0, r.getSequenceNumber());
     assertEquals(8, r.getAcks().size());
     assertTrue(r.getAcks().contains(5));
@@ -93,7 +114,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testPacketWithFragment() {
+  void create_whenSingleShortUnfragmentedFragment_expectParsedFields() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x00,
@@ -115,8 +137,10 @@ public class NPFPacketTest {
           (byte) 0xCD,
           (byte) 0xEF
         }; // Data
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
 
+    // Assert
     assertEquals(0, r.getSequenceNumber());
     assertEquals(0, r.getAcks().size());
     assertEquals(1, r.getFragments().size());
@@ -130,7 +154,6 @@ public class NPFPacketTest {
     assertEquals(0, frag.fragmentOffset);
     assertEquals(8, frag.messageLength);
     assertArrayEquals(
-        frag.fragmentData,
         new byte[] {
           (byte) 0x01,
           (byte) 0x23,
@@ -140,13 +163,15 @@ public class NPFPacketTest {
           (byte) 0xAB,
           (byte) 0xCD,
           (byte) 0xEF
-        });
+        },
+        frag.fragmentData);
 
     assertFalse(r.getError());
   }
 
   @Test
-  public void testPacketWithFragments() {
+  void create_whenTwoShortFragments_expectBothParsed() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x00,
@@ -179,8 +204,10 @@ public class NPFPacketTest {
           (byte) 0xCD,
           (byte) 0xEF
         }; // Data
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
 
+    // Assert
     assertEquals(0, r.getSequenceNumber());
     assertEquals(0, r.getAcks().size());
     assertEquals(2, r.getFragments().size());
@@ -195,7 +222,6 @@ public class NPFPacketTest {
     assertEquals(0, frag.fragmentOffset);
     assertEquals(8, frag.messageLength);
     assertArrayEquals(
-        frag.fragmentData,
         new byte[] {
           (byte) 0x01,
           (byte) 0x23,
@@ -205,7 +231,8 @@ public class NPFPacketTest {
           (byte) 0xAB,
           (byte) 0xCD,
           (byte) 0xEF
-        });
+        },
+        frag.fragmentData);
 
     // Check second fragment
     frag = r.getFragments().get(1);
@@ -217,7 +244,6 @@ public class NPFPacketTest {
     assertEquals(0, frag.fragmentOffset);
     assertEquals(8, frag.messageLength);
     assertArrayEquals(
-        frag.fragmentData,
         new byte[] {
           (byte) 0x01,
           (byte) 0x23,
@@ -227,13 +253,15 @@ public class NPFPacketTest {
           (byte) 0xAB,
           (byte) 0xCD,
           (byte) 0xEF
-        });
+        },
+        frag.fragmentData);
 
     assertFalse(r.getError());
   }
 
   @Test
-  public void testReceivedLargeFragment() {
+  void create_whenShortFragmentLength128_expectParsedWithoutError() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x00,
@@ -375,7 +403,9 @@ public class NPFPacketTest {
           (byte) 0xCD,
           (byte) 0xEF
         };
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
+    // Assert
     assertEquals(0, r.getAcks().size());
     assertEquals(1, r.getFragments().size());
     MessageFragment f = r.getFragments().getFirst();
@@ -387,7 +417,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testReceiveSequenceNumber() {
+  void create_whenCustomSequence_expectSequenceParsed() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x01,
@@ -396,8 +427,10 @@ public class NPFPacketTest {
           (byte) 0x08, // Sequence number
           (byte) 0x00
         }; // 0 acks
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
 
+    // Assert
     assertEquals(16909320, r.getSequenceNumber());
     assertEquals(0, r.getAcks().size());
     assertEquals(0, r.getFragments().size());
@@ -405,7 +438,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testReceiveLongFragmentedMessage() {
+  void create_whenLongFragmentedNotFirst_expectOffsetAndLengthParsed() {
+    // Arrange
     byte[] packetNoData =
         new byte[] {
           (byte) 0x00,
@@ -425,7 +459,9 @@ public class NPFPacketTest {
     byte[] packet = new byte[packetNoData.length + 257];
     System.arraycopy(packetNoData, 0, packet, 0, packetNoData.length);
 
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
+    // Assert
     assertEquals(0, r.getSequenceNumber());
     assertEquals(0, r.getAcks().size());
     assertEquals(1, r.getFragments().size());
@@ -442,7 +478,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testReceiveBadFragment() {
+  void create_whenFragmentHeaderTruncated_expectError() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x00,
@@ -456,13 +493,16 @@ public class NPFPacketTest {
           (byte) 0x00
         };
 
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
+    // Assert
     assertEquals(0, r.getFragments().size());
     assertTrue(r.getError());
   }
 
   @Test
-  public void testReceiveZeroLengthFragment() {
+  void create_whenZeroLengthFragment_expectEmptyData() {
+    // Arrange
     byte[] packet =
         new byte[] {
           (byte) 0x00,
@@ -477,7 +517,9 @@ public class NPFPacketTest {
           (byte) 0x00
         };
 
+    // Act
     NPFPacket r = NPFPacket.create(packet, pn);
+    // Assert
     assertFalse(r.getError());
     assertEquals(1, r.getFragments().size());
 
@@ -488,7 +530,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testSendEmptyPacket() {
+  void toBytes_whenNoAcksOrFragments_expectHeaderOnly() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     p.setSequenceNumber(0);
 
@@ -501,11 +544,13 @@ public class NPFPacketTest {
           (byte) 0x00
         }; // Number of acks (0)
 
+    // Act & Assert
     checkPacket(p, correctData);
   }
 
   @Test
-  public void testSendPacketWithAck() {
+  void toBytes_whenSingleAck_expectEncodedAckBlock() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     p.setSequenceNumber(0);
     p.addAck(0, MAX_PACKET_SIZE);
@@ -524,11 +569,13 @@ public class NPFPacketTest {
           (byte) 0x01
         };
 
+    // Act & Assert
     checkPacket(p, correctData);
   }
 
   @Test
-  public void testSendPacketWithAckRange() {
+  void toBytes_whenSequentialAcks_expectSingleRange() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     p.setSequenceNumber(0);
     p.addAck(0, MAX_PACKET_SIZE);
@@ -549,11 +596,13 @@ public class NPFPacketTest {
           (byte) 0x03
         };
 
+    // Act & Assert
     checkPacket(p, correctData);
   }
 
   @Test
-  public void testSendPacketWithTwoAcks() {
+  void toBytes_whenTwoNearAcks_expectTwoRanges() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     p.setSequenceNumber(0);
     p.addAck(0, MAX_PACKET_SIZE);
@@ -575,11 +624,13 @@ public class NPFPacketTest {
           (byte) 0x01
         };
 
+    // Act & Assert
     checkPacket(p, correctData);
   }
 
   @Test
-  public void testSendPacketWithTwoAcksLong() {
+  void toBytes_whenFarAck_expectFarMarkerAndFullId() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     p.setSequenceNumber(0);
     p.addAck(0, MAX_PACKET_SIZE);
@@ -605,11 +656,13 @@ public class NPFPacketTest {
           (byte) 0x01
         };
 
+    // Act & Assert
     checkPacket(p, correctData);
   }
 
   @Test
-  public void testSendPacketWithAcks() {
+  void toBytes_whenThreeIndependentAcks_expectThreeRanges() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     p.setSequenceNumber(0);
     p.addAck(0, MAX_PACKET_SIZE);
@@ -634,11 +687,13 @@ public class NPFPacketTest {
           (byte) 0x01
         };
 
+    // Act & Assert
     checkPacket(p, correctData);
   }
 
   @Test
-  public void testSendPacketWithFragment() {
+  void toBytes_whenSingleFragment_expectDataEncoded() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     p.setSequenceNumber(100);
     p.addMessageFragment(
@@ -684,11 +739,13 @@ public class NPFPacketTest {
           (byte) 0xEF
         };
 
+    // Act & Assert
     checkPacket(p, correctData);
   }
 
   @Test
-  public void testSendCompletePacket() {
+  void toBytes_whenMixedAcksAndFragments_expectLayoutMatchesReference() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     p.setSequenceNumber(2130706432);
     // Range 1 [1000000..1000000]
@@ -805,14 +862,17 @@ public class NPFPacketTest {
           (byte) 0x0d
         };
 
+    // Act & Assert
     checkPacket(p, correctData);
   }
 
   @Test
-  public void testLength() {
+  void getLength_whenAddingFragments_expectAccountingUpdates() {
+    // Arrange
     NPFPacket p = new NPFPacket();
 
     p.addMessageFragment(new MessageFragment(true, false, true, 0, 10, 10, 0, new byte[10], null));
+    // Act & Assert
     assertEquals(20, p.getLength()); // Seqnum (4), numAcks (1), msgID (4), length (1), data (10)
 
     p.addMessageFragment(
@@ -828,7 +888,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testEncodeDecodeLossyPerPacketMessages() {
+  void lossyMessages_whenSingleMessage_expectRoundTrip() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     byte[] fragData =
         new byte[] {
@@ -847,7 +908,9 @@ public class NPFPacketTest {
     p.addLossyMessage(lossyFragment);
     byte[] encoded = new byte[p.getLength()];
     p.toBytes(encoded, 0, null);
+    // Act
     NPFPacket received = NPFPacket.create(encoded, pn);
+    // Assert
     assertEquals(1, received.getFragments().size());
     assertEquals(0, received.countAcks());
     assertEquals(1, received.getLossyMessages().size());
@@ -859,7 +922,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testEncodeDecodeLossyPerPacketMessages2() {
+  void lossyMessages_whenTwoMessages_expectRoundTripBoth() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     byte[] fragData =
         new byte[] {
@@ -881,7 +945,9 @@ public class NPFPacketTest {
     p.addLossyMessage(lossyFragment2);
     byte[] encoded = new byte[p.getLength()];
     p.toBytes(encoded, 0, null);
+    // Act
     NPFPacket received = NPFPacket.create(encoded, pn);
+    // Assert
     assertEquals(1, received.getFragments().size());
     assertEquals(0, received.countAcks());
     assertEquals(2, received.getLossyMessages().size());
@@ -895,7 +961,8 @@ public class NPFPacketTest {
   }
 
   @Test
-  public void testEncodeDecodeLossyPerPacketMessages2Padded() {
+  void lossyMessages_whenTwoMessagesWithPadding_expectRoundTripAndLength() {
+    // Arrange
     NPFPacket p = new NPFPacket();
     byte[] fragData =
         new byte[] {
@@ -918,7 +985,9 @@ public class NPFPacketTest {
     byte[] encoded = new byte[p.getLength() + 20];
     int randomSeed = new Random().nextInt();
     p.toBytes(encoded, 0, new Random(randomSeed));
+    // Act
     NPFPacket received = NPFPacket.create(encoded, pn);
+    // Assert
     assertEquals(1, received.getFragments().size());
     assertEquals(0, received.countAcks());
     assertEquals(2, received.getLossyMessages().size(), "Seed was " + randomSeed);
@@ -932,6 +1001,204 @@ public class NPFPacketTest {
     checkEquals(lossyFragment2, decodedLossyMessage);
   }
 
+  // ---------------- Additional edge-case and behavior tests ----------------
+
+  @Test
+  void create_whenPnNull_throwsIllegalArgumentException() {
+    // Arrange
+    byte[] minimal = new byte[] {0, 0, 0, 1, 0};
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> NPFPacket.create(minimal, null));
+  }
+
+  @Test
+  void create_whenAckSectionTruncated_setsErrorAndNoAcks() {
+    // Arrange: seq + numAckRanges=1 but insufficient bytes for the range
+    byte[] truncated = new byte[] {0, 0, 0, 0, 1};
+
+    // Act
+    NPFPacket r = NPFPacket.create(truncated, pn);
+
+    // Assert
+    assertTrue(r.getError());
+    assertEquals(0, r.getAcks().size());
+    assertEquals(0, r.getFragments().size());
+  }
+
+  @Test
+  void create_whenLossyMessageTruncated_ignoresLossyAndStopsParsing() {
+    // Arrange: seq + 0 acks + start of lossy (0x1F) claiming 16 bytes but only 2 remain
+    byte[] pkt = new byte[] {0, 0, 0, 0, 0, 0x1F, 16, 0x7E, 0x7F};
+
+    // Act
+    NPFPacket r = NPFPacket.create(pkt, pn);
+
+    // Assert: parsing stops at lossy marker; length is header (5) and no lossy messages
+    assertFalse(r.getError());
+    assertEquals(5, r.getLength());
+    assertTrue(r.getLossyMessages().isEmpty());
+    assertTrue(r.getFragments().isEmpty());
+  }
+
+  @Test
+  void addAck_whenNegative_throwsIllegalArgumentException() {
+    // Arrange
+    NPFPacket p = new NPFPacket();
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> p.addAck(-1, 1400));
+  }
+
+  @Test
+  void addAck_whenExceedsMaxPacketSize_returnsFalseAndDoesNotAdd() {
+    // Arrange: first ack requires at least 10 bytes in total (5 base + 5 ack block)
+    NPFPacket p = new NPFPacket();
+
+    // Act
+    boolean added = p.addAck(0, /*maxPacketSize*/ 9);
+
+    // Assert
+    assertFalse(added);
+    assertTrue(p.getAcks().isEmpty());
+    assertEquals(5, p.getLength());
+  }
+
+  @Test
+  void addLossyMessage_whenTooLarge_throwsIllegalArgumentException() {
+    // Arrange
+    NPFPacket p = new NPFPacket();
+    byte[] big = new byte[256];
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> p.addLossyMessage(big));
+  }
+
+  @Test
+  void addLossyMessage_whenExceedsMaxPacketSize_returnsFalseAndNoChange() {
+    // Arrange
+    NPFPacket p = new NPFPacket();
+    byte[] small = new byte[10];
+
+    // Act
+    boolean added = p.addLossyMessage(small, /*maxPacketSize*/ 5 + 1); // not enough space
+
+    // Assert
+    assertFalse(added);
+    assertTrue(p.getLossyMessages().isEmpty());
+    assertEquals(5, p.getLength());
+  }
+
+  @Test
+  void removeLossyMessage_whenPresent_updatesLengthAndList() {
+    // Arrange
+    NPFPacket p = new NPFPacket();
+    byte[] m1 = new byte[] {1, 2, 3};
+    byte[] m2 = new byte[] {4, 5};
+    int afterM2 = p.addLossyMessage(m2); // + (2+2)
+    // addLossyMessage returns the updated packet size (matches getLength())
+    assertEquals(5 + (2 + 2), afterM2);
+
+    // Act
+    p.removeLossyMessage(m1);
+
+    // Assert
+    assertEquals(5 + (2 + 2), p.getLength());
+    assertEquals(1, p.getLossyMessages().size());
+    assertArrayEquals(m2, p.getLossyMessages().getFirst());
+  }
+
+  @Test
+  void toString_whenFieldsSet_includesCountsAndLength() {
+    // Arrange
+    NPFPacket p = new NPFPacket();
+    p.setSequenceNumber(123);
+    p.addAck(7, 1400);
+    byte[] data = new byte[] {9, 8, 7};
+    p.addMessageFragment(new MessageFragment(true, false, true, 100, 3, 3, 0, data, null));
+
+    // Act
+    String s = p.toString();
+
+    // Assert
+    assertEquals("Packet 123: " + p.getLength() + " bytes, 1 acks, 1 fragments", s);
+  }
+
+  @Test
+  void countAcks_and_noFragments_reportExpectedValues() {
+    // Arrange
+    NPFPacket p = new NPFPacket();
+
+    // Act + Assert
+    assertEquals(0, p.countAcks());
+    assertTrue(p.noFragments());
+    p.addAck(1, 1400);
+    assertEquals(1, p.countAcks());
+  }
+
+  @Test
+  void toBytes_whenSecondFragmentUsesCompressedId_encodesTwoByteHeader() {
+    // Arrange
+    NPFPacket p = new NPFPacket();
+    p.setSequenceNumber(0);
+    byte[] d1 = new byte[] {(byte) 0xAA, (byte) 0xBB, (byte) 0xCC};
+    byte[] d2 = new byte[] {(byte) 0x11, (byte) 0x22, (byte) 0x33};
+
+    // First fragment: full id (0x10) for message 5000
+    p.addMessageFragment(new MessageFragment(true, false, true, 5000, 3, 3, 0, d1, null));
+    // Second fragment: new message id close to previous (delta 200 < 4096) -> compressed id
+    p.addMessageFragment(new MessageFragment(true, false, true, 5200, 3, 3, 0, d2, null));
+
+    // Act
+    byte[] encoded = new byte[p.getLength()];
+    p.toBytes(encoded, 0, null);
+
+    // Assert minimal structure: 4 bytes seq, 1 byte ack count, first header (B0 + id), then
+    // second header A0 with low byte C8 (delta 200), then lengths and data
+    int off = 0;
+    assertEquals(0, encoded[off++] & 0xFF);
+    assertEquals(0, encoded[off++] & 0xFF);
+    assertEquals(0, encoded[off++] & 0xFF);
+    assertEquals(0, encoded[off++] & 0xFF);
+    assertEquals(0, encoded[off++] & 0xFF); // 0 acks
+
+    // First fragment header (B0 + 0x00001388)
+    assertEquals(0xB0, encoded[off++] & 0xFF);
+    assertEquals(0x00, encoded[off++] & 0xFF);
+    assertEquals(0x13, encoded[off++] & 0xFF);
+    assertEquals(0x88, encoded[off++] & 0xFF);
+    assertEquals(3, encoded[off++] & 0xFF); // length
+    assertEquals(0xAA, encoded[off++] & 0xFF);
+    assertEquals(0xBB, encoded[off++] & 0xFF);
+    assertEquals(0xCC, encoded[off++] & 0xFF);
+
+    // Second fragment should use compressed encoding: header A0, delta 0x00C8 (two bytes => 0xA0,
+    // 0xC8)
+    assertEquals(0xA0, encoded[off++] & 0xFF);
+    assertEquals(0xC8, encoded[off++] & 0xFF);
+    assertEquals(3, encoded[off++] & 0xFF); // length
+    assertEquals(0x11, encoded[off++] & 0xFF);
+    assertEquals(0x22, encoded[off++] & 0xFF);
+    assertEquals(0x33, encoded[off] & 0xFF);
+  }
+
+  @Test
+  void onSent_whenSingleFragment_invokesWrapperWithComputedOverhead() {
+    // Arrange
+    NPFPacket p = new NPFPacket();
+    MessageWrapper wrapper = mock(MessageWrapper.class);
+    byte[] payload = new byte[] {1, 2, 3, 4};
+    // shortMessage=true, isFragmented=false, firstFragment=true, messageLength=4, offset=0
+    p.addMessageFragment(new MessageFragment(true, false, true, 7, 4, 4, 0, payload, wrapper));
+    NullBasePeerNode peer = pn;
+
+    // Act: totalPacketLength larger than payload by 96 -> overhead/size with size==2
+    p.onSent(/*totalPacketLength*/ 100, peer);
+
+    // Assert: onSent(start=0, end=3, overhead=48, peer)
+    verify(wrapper, times(1)).onSent(0, 3, 48, peer);
+  }
+
   private void checkPacket(NPFPacket packet, byte[] correctData) {
     byte[] data = new byte[packet.getLength()];
     packet.toBytes(data, 0, null);
@@ -939,7 +1206,7 @@ public class NPFPacketTest {
     checkEquals(correctData, data);
   }
 
-  public static void checkEquals(byte[] correctData, byte[] data) {
+  static void checkEquals(byte[] correctData, byte[] data) {
     assertEquals(correctData.length, data.length, "Packet lengths differ:");
     for (int i = 0; i < data.length; i++) {
       if (data[i] != correctData[i]) {


### PR DESCRIPTION
Summary
- Restore correct error signaling and bounds checks in NPFPacket parsing.
- Align addLossyMessage(byte[]) return value with getLength().
- Improve API documentation, inline comments, and log message clarity (no behavior change).

Changes
- materializeFragment(): set packet.error=true on truncated metadata or out-of-bounds payload before returning; callers can reliably detect malformed input again.
- materializeFragment(): fix pre-check for fragmented long messages to require 2 bytes of additional metadata (total-length/offset) instead of 3, preventing false negatives on valid packets.
- addLossyMessage(byte[]): return the updated packet length (matches getLength()), removing a first-addition +5 skew.
- Javadoc: add/clarify docs for public/protected APIs (create, toBytes, addAck, addMessageFragment, addLossyMessage overloads, removeLossyMessage, getters, onSent, countAcks, noFragments).
- Inline comments: tighten explanations where behavior is non-obvious (ID compression overhead, lossy message encoding, fragmented length/offset handling).
- Logs: refine message text for bounds and send-time debug (same placeholders/order/levels; no structural changes).

Files
- src/main/java/network/crypta/node/NPFPacket.java
- src/test/java/network/crypta/node/NPFPacketTest.java

Testing
- Ran focused test suite for NPFPacket locally; build succeeded.
- Spotless applied to ensure formatting consistency.

Compatibility / Risk
- Restores prior behavior for error signaling and fragment parsing; no protocol or API signature changes.
- Logging text only; placeholder counts and argument order unchanged.

Rationale
- Addresses regressions flagged during review (truncated fragments not setting error, long-fragment pre-check off-by-one, addLossyMessage return contract).

Please review the parsing/error-handling changes and the doc+log updates. I can run the full test suite and follow up with any additional fixes if needed.