### PR TITLE
docs(node): improve ProgramDirectory Javadoc and comments; add ProgramDirectoryTest; fix shadowing in move()

### DIFF
--- a/src/main/java/network/crypta/node/ProgramDirectory.java
+++ b/src/main/java/network/crypta/node/ProgramDirectory.java
@@ -8,17 +8,24 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.support.api.StringCallback;
 
 /**
- * * Represents a program directory, and keeps track of the files that freenet * stores there. *
- * * @author infinity0 * @see <a href=http://new-wiki.freenetproject.org/Program_files>New wiki
- * program files documentation</a> * @see <a href=http://wiki.freenetproject.org/Program_files>Old
- * wiki program files documentation</a>
+ * Represents the node's program directory and tracks files stored under it.
+ *
+ * <p>This type holds the directory {@link File} and a set of basenames for files that code creates
+ * beneath it. It exposes a {@link StringCallback} so configuration code can read or update the
+ * directory path. Runtime moves are intentionally restricted: changing the path after initial
+ * assignment is not supported except where explicitly allowed by the read/write callback variant.
+ *
+ * @author infinity0
+ * @see <a href="http://new-wiki.freenetproject.org/Program_files">Program files documentation
+ *     (new)</a>
+ * @see <a href="http://wiki.freenetproject.org/Program_files">Program files documentation (old)</a>
  */
 public class ProgramDirectory {
 
-  /** Directory path */
+  /** Absolute or relative directory path; {@code null} until initialized. */
   protected File dir = null;
 
-  /** Keeps track of all the files saved in this directory */
+  /** Basenames of files created or requested via {@link #file(String)}. */
   protected final HashSet<String> files = new HashSet<>();
 
   private final StringCallback callback;
@@ -26,37 +33,75 @@ public class ProgramDirectory {
 
   private static int sortOrder = 0;
 
+  /**
+   * Return a monotonically increasing order value.
+   *
+   * <p>Thread-safe via synchronization. Each call increments the internal counter by one and
+   * returns the previous value.
+   *
+   * @return the next order value starting from zero
+   */
   protected static synchronized int nextOrder() {
     return sortOrder++;
   }
 
+  /**
+   * Create a ProgramDirectory with a read-only {@link StringCallback}.
+   *
+   * <p>The callback refuses path changes after the first assignment.
+   */
   public ProgramDirectory() {
     this(null);
   }
 
+  /**
+   * Create a ProgramDirectory with a read-write {@link StringCallback} when {@code moveErrMsg} is
+   * non-{@code null}.
+   *
+   * <p>When writable, the callback attempts to create missing directories and, on failure, throws
+   * an {@link InvalidConfigValueException} containing the localized message resolved from {@code
+   * moveErrMsg}.
+   *
+   * @param moveErrMsg localization key for move errors; when {@code null}, the callback is
+   *     read-only
+   */
   public ProgramDirectory(String moveErrMsg) {
     this.moveErrMsg = moveErrMsg;
     this.callback = (moveErrMsg != null) ? new RWDirectoryCallback() : new DirectoryCallback();
   }
 
-  /** * Move the directory. Currently not implemented, except in the * initialisation case. */
+  /**
+   * Assign or move the directory path.
+   *
+   * <p>Initial assignment sets the directory, creating it if necessary. Moving to a different path
+   * after initialization is not implemented and throws an exception.
+   *
+   * @param file path to use as the program directory (absolute or relative)
+   * @throws IOException if moving an initialized directory, or if the path exists but is not a
+   *     directory and cannot be created
+   */
   public void move(String file) throws IOException {
-    File dir = new File(file);
-    if (this.dir != null && !dir.equals(this.dir)) {
+    File newDir = new File(file);
+    if (this.dir != null && !newDir.equals(this.dir)) {
       throw new IOException("move not implemented");
     }
 
-    if (!((dir.exists() && dir.isDirectory()) || (dir.mkdir()))) {
+    if (!((newDir.exists() && newDir.isDirectory()) || (newDir.mkdir()))) {
       throw new IOException("Could not find or make a directory called: " + l10n(file));
     }
 
-    this.dir = dir;
+    this.dir = newDir;
   }
 
   public StringCallback getStringCallback() {
     return callback;
   }
 
+  /**
+   * Read-only configuration callback for the directory path.
+   *
+   * <p>Allows the first assignment and accepts idempotent writes; rejects changes thereafter.
+   */
   public class DirectoryCallback extends StringCallback {
     @Override
     public String get() {
@@ -70,8 +115,7 @@ public class ProgramDirectory {
         return;
       }
       if (dir.equals(new File(val))) return;
-      // FIXME support it
-      // Don't need to translate the below as very few users will use it.
+      // Disallow changing the path at runtime; keep message in English intentionally.
       throw new InvalidConfigValueException(
           "Moving program directory on the fly not supported at present");
     }
@@ -82,6 +126,12 @@ public class ProgramDirectory {
     }
   }
 
+  /**
+   * Read-write configuration callback for the directory path.
+   *
+   * <p>Accepts changes and creates the target directory if it does not exist. On failure, throws an
+   * {@link InvalidConfigValueException} with a localized message.
+   */
   public class RWDirectoryCallback extends DirectoryCallback {
     @Override
     public void set(String val) throws InvalidConfigValueException {
@@ -92,8 +142,8 @@ public class ProgramDirectory {
       if (dir.equals(new File(val))) return;
       File f = new File(val);
       if (!((f.exists() && f.isDirectory()) || (f.mkdir())))
-        // Relatively commonly used, despite being advanced (i.e. not something we want to show to
-        // newbies). So translate it.
+        // Used in advanced setups; still common enough to translate.
+        // Keep message localized for user-facing configuration errors.
         throw new InvalidConfigValueException(l10n(moveErrMsg));
       dir = new File(val);
     }
@@ -104,12 +154,22 @@ public class ProgramDirectory {
     }
   }
 
-  /** * Return a {@link File} object from the given string basename. */
+  /**
+   * Resolve a child file under the program directory and record its basename.
+   *
+   * @param base basename of the file to resolve; must not contain path separators
+   * @return file under {@link #dir} with the provided basename
+   */
   public File file(String base) {
     files.add(base);
     return new File(dir, base);
   }
 
+  /**
+   * Return the current program directory.
+   *
+   * @return current directory, or {@code null} if not yet assigned
+   */
   public File dir() {
     return dir;
   }

--- a/src/test/java/network/crypta/node/ProgramDirectoryTest.java
+++ b/src/test/java/network/crypta/node/ProgramDirectoryTest.java
@@ -1,0 +1,167 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.api.StringCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class ProgramDirectoryTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void move_whenFirstSetToNewDirectory_expectDirCreatedAndSet() throws IOException {
+    // Arrange
+    ProgramDirectory pd = new ProgramDirectory();
+    Path newDir = tempDir.resolve("initial");
+
+    // Act
+    pd.move(newDir.toString());
+
+    // Assert
+    assertEquals(newDir.toFile().getCanonicalFile(), pd.dir().getCanonicalFile());
+    assertTrue(Files.isDirectory(newDir));
+  }
+
+  @Test
+  void move_whenMovingToDifferentDirectoryLater_expectIOExceptionNotImplemented()
+      throws IOException {
+    // Arrange
+    ProgramDirectory pd = new ProgramDirectory();
+    Path dir1 = tempDir.resolve("d1");
+    Path dir2 = tempDir.resolve("d2");
+    pd.move(dir1.toString());
+
+    // Act + Assert
+    IOException ex = assertThrows(IOException.class, () -> pd.move(dir2.toString()));
+    assertEquals("move not implemented", ex.getMessage());
+  }
+
+  @Test
+  void move_whenTargetIsExistingFile_expectIOExceptionWithL10nPathAppended() throws IOException {
+    // Arrange
+    ProgramDirectory pd = new ProgramDirectory();
+    Path targetFile = Files.createTempFile(tempDir, "file", ".txt");
+
+    // Act
+    IOException ex = assertThrows(IOException.class, () -> pd.move(targetFile.toString()));
+
+    // Assert
+    assertTrue(
+        ex.getMessage().startsWith("Could not find or make a directory called: "),
+        "message should include the fixed prefix");
+    assertTrue(
+        ex.getMessage().contains(targetFile.toString()),
+        "message should include the localized path (key or translation) value");
+  }
+
+  @Test
+  void getStringCallback_whenDefaultConstructor_expectReadOnlyBehavior() throws Exception {
+    // Arrange
+    ProgramDirectory pd = new ProgramDirectory();
+    StringCallback cb = pd.getStringCallback();
+    Path path1 = tempDir.resolve("ro1");
+    Path path2 = tempDir.resolve("ro2");
+
+    // Act
+    cb.set(path1.toString());
+
+    // Assert
+    assertTrue(cb.isReadOnly(), "Default callback must be read-only");
+    assertEquals(new File(path1.toString()).getPath(), cb.get());
+
+    // Setting to same path is a no-op
+    assertDoesNotThrow(() -> cb.set(path1.toString()));
+
+    // Changing to a different path is rejected
+    InvalidConfigValueException ex =
+        assertThrows(InvalidConfigValueException.class, () -> cb.set(path2.toString()));
+    assertEquals("Moving program directory on the fly not supported at present", ex.getMessage());
+  }
+
+  @Test
+  void getStringCallback_whenRWConstructor_expectWritableAndCreatesDirectory() throws Exception {
+    // Arrange
+    final String errorKey = "____TEST_DO_NOT_TRANSLATE____";
+    ProgramDirectory pd = new ProgramDirectory(errorKey);
+    StringCallback cb = pd.getStringCallback();
+    Path path1 = tempDir.resolve("rw1");
+    Path path2 = tempDir.resolve("rw2"); // does not exist yet
+
+    // Act + Assert
+    assertFalse(cb.isReadOnly(), "RW callback must be writable");
+
+    // Initial set succeeds; RWDirectoryCallback does not create the directory on first set
+    cb.set(path1.toString());
+    assertEquals(new File(path1.toString()).getPath(), cb.get());
+    assertFalse(Files.exists(path1), "Initial path is not created by first set call");
+
+    // Setting same path again is a no-op
+    assertDoesNotThrow(() -> cb.set(path1.toString()));
+
+    // Change to a different path: directory should be created and accepted
+    cb.set(path2.toString());
+    assertEquals(new File(path2.toString()).getPath(), cb.get());
+    assertTrue(Files.isDirectory(path2));
+  }
+
+  @Test
+  void rwCallback_whenTargetIsFile_expectInvalidConfigWithL10nMessage() throws Exception {
+    // Arrange
+    final String errorKey = "____TEST_DO_NOT_TRANSLATE____";
+    ProgramDirectory pd = new ProgramDirectory(errorKey);
+    StringCallback cb = pd.getStringCallback();
+    Path initial = tempDir.resolve("rw_init");
+    Path filePath = Files.createTempFile(tempDir, "as_file", ".bin");
+    cb.set(initial.toString());
+
+    // Act
+    InvalidConfigValueException ex =
+        assertThrows(InvalidConfigValueException.class, () -> cb.set(filePath.toString()));
+
+    // Assert — message equals localized string for the error key
+    assertEquals(NodeL10n.getBase().getString(errorKey), ex.getMessage());
+  }
+
+  @Test
+  void file_whenCalled_expectChildAndTrackedBasename() throws IOException {
+    // Arrange
+    ProgramDirectory pd = new ProgramDirectory();
+    Path dir = tempDir.resolve("base");
+    pd.move(dir.toString());
+
+    String basename = "test.txt";
+
+    // Act
+    File f = pd.file(basename);
+
+    // Assert
+    assertNotNull(f);
+    assertEquals(new File(dir.toFile(), basename).getCanonicalFile(), f.getCanonicalFile());
+    // Access to protected field is allowed within the same package
+    assertTrue(pd.files.contains(basename), "basename must be tracked in files set");
+  }
+
+  @Test
+  void nextOrder_whenCalledTwice_expectMonotonicIncreaseByOne() {
+    // Arrange + Act
+    int a = ProgramDirectory.nextOrder();
+    int b = ProgramDirectory.nextOrder();
+
+    // Assert
+    assertEquals(a + 1, b);
+  }
+}


### PR DESCRIPTION
Summary
- Improve and complete API documentation and inline comments for ProgramDirectory.
- Add focused JUnit 6 tests for ProgramDirectory covering move semantics, callbacks, and file tracking.
- Fix SonarLint issue java:S1117 by renaming a shadowing local variable in move().

Changes
- src/main/java/network/crypta/node/ProgramDirectory.java
  - Rewrite class-level Javadoc: purpose, behavior, and links.
  - Add method Javadocs for constructors, move(String), getStringCallback(), file(String), dir(), and nextOrder().
  - Clarify inline comments (runtime move restrictions, user-facing localization in errors).
  - Behavior-neutral fix: replace local variable name `dir` with `newDir` in move(String) to avoid field shadowing.
- src/test/java/network/crypta/node/ProgramDirectoryTest.java
  - New tests (JUnit 6 + TempDir):
    - move_whenFirstSetToNewDirectory_expectDirCreatedAndSet
    - move_whenMovingToDifferentDirectoryLater_expectIOExceptionNotImplemented
    - move_whenTargetIsExistingFile_expectIOExceptionWithL10nPathAppended
    - getStringCallback_whenDefaultConstructor_expectReadOnlyBehavior
    - getStringCallback_whenRWConstructor_expectWritableAndCreatesDirectory
    - rwCallback_whenTargetIsFile_expectInvalidConfigWithL10nMessage
    - file_whenCalled_expectChildAndTrackedBasename
    - nextOrder_whenCalledTwice_expectMonotonicIncreaseByOne

Rationale
- Documentation brings clarity to configuration callbacks and restrictions on moving the directory at runtime.
- Tests capture current contract and edge cases, ensuring regressions are caught.
- SonarLint cleanup removes shadowing and keeps codebase warning-free.

Testing
- Ran focused tests: `./gradlew test --tests 'network.crypta.node.ProgramDirectoryTest'` → success.
- Ran full test suite: `./gradlew test` → success.
- Ran SonarLint (file-scoped): `./gradlew --quiet sonarlintFile -Psonarlint.file=src/main/java/network/crypta/node/ProgramDirectory.java` → no issues reported.

Risk
- Changes are documentation and naming only; no functional behavior added or altered.
- Tests are isolated to TempDir and do not affect global state.

Files
- src/main/java/network/crypta/node/ProgramDirectory.java
- src/test/java/network/crypta/node/ProgramDirectoryTest.java

Notes
- No TODO/FIXME placeholders were added; previous FIXME was reworded and removed.
- No changes to logging calls (none present in this class).