### PR TITLE
Refactor: remove unused parameter in RecentlyFailedReturn.fail; add tests and docs

### DIFF
--- a/src/main/java/network/crypta/node/PeerManager.java
+++ b/src/main/java/network/crypta/node/PeerManager.java
@@ -1317,7 +1317,7 @@ public class PeerManager {
                   until = now + FailureTable.RECENTLY_FAILED_TIME;
                 }
                 if (!node.getFailureTable().hadAnyOffers(key)) {
-                  recentlyFailed.fail(countWaiting, until);
+                  recentlyFailed.fail(until);
                   return null;
                 } else {
                   if (LOG.isDebugEnabled())

--- a/src/main/java/network/crypta/node/RecentlyFailedReturn.java
+++ b/src/main/java/network/crypta/node/RecentlyFailedReturn.java
@@ -4,24 +4,45 @@ import network.crypta.support.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Contains information on why we can't route a request. Initially just a flag and a time. */
+/**
+ * Tracks a short-lived routing backoff decision.
+ *
+ * <p>This class records that routing recently failed and stores an absolute wakeup time
+ * (milliseconds since epoch) after which routing may be attempted again. The state is intentionally
+ * minimal: a boolean flag and a wakeup timestamp. All public methods are synchronized to provide
+ * simple thread-safety when accessed from multiple threads.
+ */
 public class RecentlyFailedReturn {
   private static final Logger LOG = LoggerFactory.getLogger(RecentlyFailedReturn.class);
 
-  static {
-  }
-
+  // True while a recent-failure window is active. Overwritten by subsequent calls to fail(...).
   private boolean recentlyFailed;
+  // Absolute timestamp (milliseconds since epoch) when the recent-failure window ends.
   private long wakeup;
 
-  public synchronized void fail(int countWaiting, long wakeupTime) {
+  /**
+   * Mark this instance as recently failed until the provided wakeup time.
+   *
+   * <p>The {@code wakeupTime} is an absolute timestamp in milliseconds since the epoch. A later
+   * invocation overwrites the previous value.
+   *
+   * @param wakeupTime absolute timestamp (milliseconds since epoch) when the failure window ends
+   */
+  public synchronized void fail(long wakeupTime) {
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "RecentlyFailed until " + TimeUtil.formatTime(wakeupTime - System.currentTimeMillis()));
+          "RecentlyFailed active for {}",
+          TimeUtil.formatTime(wakeupTime - System.currentTimeMillis()));
     this.wakeup = wakeupTime;
     this.recentlyFailed = true;
   }
 
+  /**
+   * Return the absolute wakeup time if a recent failure is active.
+   *
+   * @return the absolute wakeup time (milliseconds since epoch) when routing may be retried, or
+   *     {@code -1} when no recent failure is active
+   */
   public synchronized long recentlyFailed() {
     if (recentlyFailed) return wakeup;
     else return -1;

--- a/src/test/java/network/crypta/node/RecentlyFailedReturnTest.java
+++ b/src/test/java/network/crypta/node/RecentlyFailedReturnTest.java
@@ -1,0 +1,76 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+
+@SuppressWarnings("java:S100")
+class RecentlyFailedReturnTest {
+
+  @Test
+  @DisplayName("recentlyFailed when never failed returns -1 sentinel")
+  void recentlyFailed_whenNeverFailed_returnsMinusOne() {
+    // Arrange
+    RecentlyFailedReturn rfr = new RecentlyFailedReturn();
+
+    // Act
+    long result = rfr.recentlyFailed();
+
+    // Assert
+    assertEquals(-1L, result, "Expected sentinel -1 when no failure recorded");
+  }
+
+  @ParameterizedTest(name = "wakeup={0}")
+  @org.junit.jupiter.params.provider.ValueSource(longs = {123456789L, 1L, 987654321L})
+  @DisplayName("fail sets flag and exact wakeup")
+  void fail_whenCalled_setsFlagAndWakeupExactly(long wakeup) {
+    // Arrange
+    RecentlyFailedReturn rfr = new RecentlyFailedReturn();
+
+    // Act
+    rfr.fail(wakeup);
+
+    // Assert
+    assertEquals(
+        wakeup,
+        rfr.recentlyFailed(),
+        "recentlyFailed should return the exact wakeup value that was set");
+  }
+
+  @Test
+  @DisplayName("fail called multiple times updates to latest wakeup")
+  void fail_whenCalledMultipleTimes_updatesWakeupToLatest() {
+    // Arrange
+    RecentlyFailedReturn rfr = new RecentlyFailedReturn();
+    long first = 100L;
+    long second = 200L;
+
+    // Act
+    rfr.fail(first);
+    long afterFirst = rfr.recentlyFailed();
+    rfr.fail(second);
+    long afterSecond = rfr.recentlyFailed();
+
+    // Assert
+    assertEquals(first, afterFirst, "Should return first wakeup after initial fail");
+    assertEquals(second, afterSecond, "Should return latest wakeup after subsequent fail");
+  }
+
+  @Test
+  @DisplayName("fail accepts negative wakeup and returns it when recently failed")
+  void recentlyFailed_whenNegativeWakeup_returnsThatNegativeValue() {
+    // Arrange
+    RecentlyFailedReturn rfr = new RecentlyFailedReturn();
+    long negativeWakeup = -42L;
+
+    // Act
+    rfr.fail(negativeWakeup);
+    long value = rfr.recentlyFailed();
+
+    // Assert
+    assertEquals(
+        negativeWakeup, value, "Should return the negative wakeup value that was set explicitly");
+  }
+}


### PR DESCRIPTION
**Summary**
- Remove an unused parameter from `RecentlyFailedReturn.fail(...)` and update the single call site.
- Add focused unit tests for `RecentlyFailedReturn` to cover initial state, setting wakeup time, multiple updates, and negative values.
- Improve Javadoc, inline comments, and clarify debug log wording.

**Motivation**
- Clean up API by removing a parameter (`countWaiting`) that was never used.
- Address SonarLint maintainability issues (unused parameter, empty block) while keeping behavior unchanged.
- Strengthen test coverage for a small but central helper used in routing decisions.

**Changes**
- `src/main/java/network/crypta/node/RecentlyFailedReturn.java`
  - Signature change: `fail(long wakeupTime)` (removed unused `countWaiting`).
  - Javadoc added for class and methods; concise inline comments.
  - Debug log text clarified to reflect duration semantics; placeholders/arguments preserved.
- `src/main/java/network/crypta/node/PeerManager.java`
  - Updated call site: `recentlyFailed.fail(until);`.
- `src/test/java/network/crypta/node/RecentlyFailedReturnTest.java`
  - New tests for initial state (`-1`), exact wakeup persistence, multiple updates, and negative wakeup values.

**Behavior**
- No functional changes beyond removing the unused parameter from a private API usage. The effective runtime behavior remains the same.

**SonarLint**
- `RecentlyFailedReturn`: no issues after updates.

**Testing**
- Focused test: `./gradlew test --tests 'network.crypta.node.RecentlyFailedReturnTest'` → PASS
- Full test suite: `./gradlew test` → PASS

**Diff Stats**
- 3 files changed, 104 insertions(+), 7 deletions(-)

**Risk / Compatibility**
- Low. Only one internal call site existed and was updated in the same change. No public API consumers affected.

**Checklist**
- [x] Spotless formatting applied (`./gradlew spotlessApply`)
- [x] Tests added and passing
- [x] SonarLint clean for touched file(s)
