### PR TITLE
docs,test(node): RequestClientBuilder docs + tests

### DIFF
--- a/src/main/java/network/crypta/node/RequestClient.java
+++ b/src/main/java/network/crypta/node/RequestClient.java
@@ -1,24 +1,33 @@
 package network.crypta.node;
 
 /**
- * Must be implemented by any client object returned by SendableRequest.getClient(). Mostly this is
- * for scheduling, but it does have one key purpose: to identify whether a request is persistent or
- * not.
+ * Describes client-level attributes used by the scheduler to classify and prioritize a request.
  *
- * <p>Use a {@link RequestClientBuilder} to conveniently build {@code RequestClient}s.
+ * <p>Implementations are returned by {@code SendableRequest.getClient()} and provide stable
+ * metadata that guides scheduling decisions. The results of {@link #persistent()} and {@link
+ * #realTimeFlag()} must remain constant for the lifetime of the enclosing request. Methods are side
+ * effect free and expected to execute quickly.
+ *
+ * <p>Use a {@link RequestClientBuilder} to conveniently build {@code RequestClient} instances.
  *
  * @author toad
  */
 public interface RequestClient {
 
-  /** Is this request persistent? **Must not change!** */
+  /**
+   * Returns whether the request is persistent. The value is consulted by the scheduler to treat the
+   * request as durable versus ephemeral and must not change once constructed.
+   *
+   * @return {@code true} if the request is persistent; {@code false} otherwise
+   */
   boolean persistent();
 
   /**
-   * Send the request with the real time flag enabled? Real-time requests are given a higher
-   * priority in data transfers, but fewer of them are accepted. They are optimised for latency
-   * rather than throughput, and are expected to be bursty rather than continual. **Must not
-   * change!**
+   * Returns whether the request uses the real-time flag. Real-time requests receive latency-
+   * oriented handling and a higher priority in data transfers, but fewer are admitted and overall
+   * throughput may be lower. The value must not change over the lifetime of the request.
+   *
+   * @return {@code true} for real-time scheduling; {@code false} for normal scheduling
    */
   boolean realTimeFlag();
 }

--- a/src/main/java/network/crypta/node/RequestClientBuilder.java
+++ b/src/main/java/network/crypta/node/RequestClientBuilder.java
@@ -1,8 +1,27 @@
 package network.crypta.node;
 
 /**
- * Fluent-style builder for {@link RequestClient} implementations. The default {@code RequestClient}
- * built by this builder is not persistent and not real-time.
+ * Builder for {@link RequestClient} instances.
+ *
+ * <p>This builder creates lightweight, immutable {@code RequestClient} snapshots that the scheduler
+ * can query for client-level attributes. Unless configured otherwise, the produced clients are
+ * non-persistent and do not use the real-time flag. The builder itself is mutable and reusable; it
+ * is not thread-safe.
+ *
+ * <p>Defaults
+ *
+ * <ul>
+ *   <li>{@link #persistent()} → {@code false}
+ *   <li>{@link #realTime()} → {@code false}
+ * </ul>
+ *
+ * <p>Usage example:
+ *
+ * <pre>{@code
+ * RequestClient bulk = new RequestClientBuilder().build();
+ * RequestClient rt   = new RequestClientBuilder().realTime().build();
+ * }</code>
+ * </pre>
  *
  * @author <a href="mailto:bombe@freenetproject.org">David ‘Bombe’ Roden</a>
  */
@@ -11,46 +30,84 @@ public class RequestClientBuilder {
   private boolean persistent;
   private boolean realTime;
 
+  /**
+   * Enables persistence for subsequently {@link #build() built} clients.
+   *
+   * <p>This method sets the internal flag to {@code true}. It returns the same builder instance to
+   * allow fluent chaining.
+   *
+   * @return this builder (never {@code null})
+   */
   public RequestClientBuilder persistent() {
     persistent = true;
     return this;
   }
 
+  /**
+   * Sets the persistence flag for subsequently {@link #build() built} clients.
+   *
+   * <p>The most recent value provided wins. Calling {@code persistent(true).persistent(false)} will
+   * yield clients that report {@code false}.
+   *
+   * @param persistent {@code true} to mark clients as persistent; {@code false} otherwise
+   * @return this builder (never {@code null})
+   */
   public RequestClientBuilder persistent(boolean persistent) {
     this.persistent = persistent;
     return this;
   }
 
+  /**
+   * Enables the real-time scheduling flag for subsequently {@link #build() built} clients.
+   *
+   * <p>This method sets the internal flag to {@code true}. It returns the same builder instance to
+   * allow fluent chaining.
+   *
+   * @return this builder (never {@code null})
+   */
   public RequestClientBuilder realTime() {
     realTime = true;
     return this;
   }
 
+  /**
+   * Sets the real-time scheduling flag for subsequently {@link #build() built} clients.
+   *
+   * <p>The most recent value provided wins.
+   *
+   * @param realTime {@code true} to enable real-time handling; {@code false} for normal handling
+   * @return this builder (never {@code null})
+   */
   public RequestClientBuilder realTime(boolean realTime) {
     this.realTime = realTime;
     return this;
   }
 
   /**
-   * Builds a {@link RequestClient}. Once this method has been called the returned {@code
-   * RequestClient} is not connected to this builder anymore; the resulting {@code RequestClient}
-   * will never change. With this it’s possible to reuse this builder instances for creating more
-   * {@code RequestClient}s.
+   * Builds a {@link RequestClient} snapshot.
    *
-   * @return A new {@code RequestClient} with the given settings
+   * <p>The returned instance captures the builder state at call time. Subsequent mutations of this
+   * builder do not affect previously built clients. The resulting {@code RequestClient} is
+   * immutable and thread-safe to query.
+   *
+   * @return a new {@code RequestClient} reflecting the current builder settings
    */
   public RequestClient build() {
     return new RequestClient() {
+      // Capture a snapshot of the current builder state so later changes to the builder do not
+      // affect this instance.
       private final boolean persistent = RequestClientBuilder.this.persistent;
       private final boolean realTime = RequestClientBuilder.this.realTime;
 
       @Override
       public boolean persistent() {
+        // Stable for the lifetime of this instance.
         return persistent;
       }
 
       @Override
       public boolean realTimeFlag() {
+        // Stable for the lifetime of this instance.
         return realTime;
       }
     };

--- a/src/test/java/network/crypta/node/RequestClientBuilderTest.java
+++ b/src/test/java/network/crypta/node/RequestClientBuilderTest.java
@@ -1,0 +1,121 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class RequestClientBuilderTest {
+
+  @Test
+  @DisplayName("build_whenDefaults_expectNonPersistentNonRealtime")
+  void build_whenDefaults_expectNonPersistentNonRealtime() {
+    // Arrange
+    RequestClientBuilder builder = new RequestClientBuilder();
+
+    // Act
+    RequestClient client = builder.build();
+
+    // Assert
+    assertAll(
+        () -> assertFalse(client.persistent(), "Default persistent should be false"),
+        () -> assertFalse(client.realTimeFlag(), "Default realTime should be false"));
+  }
+
+  @Test
+  @DisplayName("persistent_whenCalled_expectTrue")
+  void persistent_whenCalled_expectTrue() {
+    // Arrange
+    RequestClientBuilder builder = new RequestClientBuilder().persistent();
+
+    // Act
+    RequestClient client = builder.build();
+
+    // Assert
+    assertTrue(client.persistent(), "Persistent flag should be true when set via persistent()");
+  }
+
+  @Test
+  @DisplayName("persistentFalse_afterTrue_expectFalse")
+  void persistentFalse_afterTrue_expectFalse() {
+    // Arrange
+    RequestClientBuilder builder = new RequestClientBuilder().persistent(true).persistent(false);
+
+    // Act
+    RequestClient client = builder.build();
+
+    // Assert
+    assertFalse(client.persistent(), "Explicit persistent(false) should override previous true");
+  }
+
+  @Test
+  @DisplayName("realTime_whenCalled_expectTrue")
+  void realTime_whenCalled_expectTrue() {
+    // Arrange
+    RequestClientBuilder builder = new RequestClientBuilder().realTime();
+
+    // Act
+    RequestClient client = builder.build();
+
+    // Assert
+    assertTrue(client.realTimeFlag(), "Real-time flag should be true when set via realTime()");
+  }
+
+  @Test
+  @DisplayName("realTimeFalse_afterTrue_expectFalse")
+  void realTimeFalse_afterTrue_expectFalse() {
+    // Arrange
+    RequestClientBuilder builder = new RequestClientBuilder().realTime(true).realTime(false);
+
+    // Act
+    RequestClient client = builder.build();
+
+    // Assert
+    assertFalse(client.realTimeFlag(), "Explicit realTime(false) should override previous true");
+  }
+
+  @Test
+  @DisplayName("build_reuseBuilder_expectSnapshotIndependence")
+  void build_reuseBuilder_expectSnapshotIndependence() {
+    // Arrange
+    RequestClientBuilder builder = new RequestClientBuilder().persistent(true).realTime(false);
+    RequestClient first = builder.build();
+
+    // Mutate builder after first build
+    builder.persistent(false).realTime(true);
+
+    // Act
+    RequestClient second = builder.build();
+
+    // Assert
+    assertAll(
+        () -> assertTrue(first.persistent(), "First snapshot should retain persistent=true"),
+        () -> assertFalse(first.realTimeFlag(), "First snapshot should retain realTime=false"),
+        () -> assertFalse(second.persistent(), "Second snapshot should see persistent=false"),
+        () -> assertTrue(second.realTimeFlag(), "Second snapshot should see realTime=true"));
+  }
+
+  @Test
+  @DisplayName("fluent_whenChained_expectSameBuilderAndSettings")
+  void fluent_whenChained_expectSameBuilderAndSettings() {
+    // Arrange & Act
+    RequestClientBuilder builder = new RequestClientBuilder();
+    RequestClientBuilder b1 = builder.persistent();
+    RequestClientBuilder b2 = builder.realTime();
+
+    // Assert
+    assertAll(
+        () -> assertSame(builder, b1, "persistent() should return the same builder instance"),
+        () -> assertSame(builder, b2, "realTime() should return the same builder instance"),
+        () -> {
+          RequestClient client = builder.build();
+          assertAll(
+              () -> assertTrue(client.persistent(), "Chained persistent() should be effective"),
+              () -> assertTrue(client.realTimeFlag(), "Chained realTime() should be effective"));
+        });
+  }
+}


### PR DESCRIPTION
Summary
- Improve Javadoc and inline comments for RequestClientBuilder and RequestClient without changing behavior.
- Add focused unit tests for RequestClientBuilder covering defaults, overrides, fluent chaining, and snapshot independence.

Details
- RequestClientBuilder Javadoc: clarify purpose, defaults (persistent=false, realTime=false), snapshot immutability, and non-thread-safe builder mutability. Add concise example usage.
- Method docs refined for persistent()/persistent(boolean) and realTime()/realTime(boolean), including override semantics and return values.
- build(): emphasize snapshot capture and that returned RequestClient is immutable and safe to query concurrently.
- Inline comments: note snapshot capture for fields and that getters are stable for lifetime.

Tests (JUnit 6)
- src/test/java/network/crypta/node/RequestClientBuilderTest.java
  - build_whenDefaults_expectNonPersistentNonRealtime
  - persistent_whenCalled_expectTrue
  - persistentFalse_afterTrue_expectFalse
  - realTime_whenCalled_expectTrue
  - realTimeFalse_afterTrue_expectFalse
  - build_reuseBuilder_expectSnapshotIndependence
  - fluent_whenChained_expectSameBuilderAndSettings

Notes
- Ran ./gradlew spotlessApply prior to commit.
- No production behavior changed; only documentation/comments plus new tests.
