### PR TITLE
fix(node): RequestStarter robustness + expanded tests; polish RequestStarterGroup docs/logs

### DIFF
--- a/src/main/java/network/crypta/node/RequestStarter.java
+++ b/src/main/java/network/crypta/node/RequestStarter.java
@@ -14,15 +14,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Starts requests. Nobody starts a request directly, you have to go through RequestStarter. And you
- * have to provide a RequestStarterClient. We do round robin between clients on the same priority
- * level.
+ * Coordinates dequeuing and starting of client requests.
+ *
+ * <p>This component is the only path for starting requests; callers do not start requests directly.
+ * It cooperates with a {@link RequestScheduler} to grab work and with the node executor to launch
+ * per-request sender threads. Starters operate in two modes (bulk or real‑time) and for different
+ * request types (CHK/SSK, fetch/insert); the {@link #name} reflects the mode for diagnostics.
+ *
+ * <p>Threading and interrupts: the {@link #run()} loop waits for work and throttles between
+ * requests. It honors interrupts in blocking waits and exits cleanly so the executor can stop the
+ * thread. Short opennet bootstrap deferrals use a one‑second wait that is also interruptible and
+ * responsive to {@link #wakeUp()} notifications.
+ *
+ * <p>Throttling: the per‑request delay is obtained from {@link BaseRequestThrottle}. Transient
+ * interrupts during throttling are swallowed so later iterations can resume delaying.
  */
 public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionList {
   private static final Logger LOG = LoggerFactory.getLogger(RequestStarter.class);
-
-  static {
-  }
 
   /*
    * Priority classes
@@ -67,8 +75,18 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
   private final boolean isSSK;
   final boolean realTime;
 
-  static final int MAX_WAITING_FOR_SLOTS = 50;
-
+  /**
+   * Creates a new starter for a specific flow (type and mode).
+   *
+   * @param node node client core used to access schedulers and executor
+   * @param throttle adaptive throttle that provides per‑request delays
+   * @param name base name used for diagnostics; mode suffix is appended
+   * @param averageOutputBytesPerRequest running average of bytes sent per request
+   * @param averageInputBytesPerRequest running average of bytes received per request
+   * @param isInsert whether this starter handles inserts ({@code true}) or fetches ({@code false})
+   * @param isSSK whether this starter handles SSK ({@code true}) or CHK ({@code false})
+   * @param realTime whether this starter runs in real‑time mode
+   */
   public RequestStarter(
       NodeClientCore node,
       BaseRequestThrottle throttle,
@@ -99,154 +117,200 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 
   final String name;
 
+  /**
+   * Returns a human‑readable name for diagnostics.
+   *
+   * @return the starter name including its mode suffix
+   */
   @Override
   public String toString() {
     return name;
   }
 
+  // Main worker loop. Grabs or waits for a request, applies throttling, and either
+  // starts it or keeps it for a retry when NodeStats requests a temporary deferral.
   void realRun() {
     ChosenBlock req = null;
-    // The last time at which we sent a request or decided not to
     long cycleTime = System.currentTimeMillis();
     while (true) {
-      // Allow 5 minutes before we start killing requests due to not connecting.
-      OpennetManager om;
-      if (core.getNode().getPeers().countConnectedPeers() < 3
-          && (om = core.getNode().getOpennet()) != null
-          && System.currentTimeMillis() - om.getCreationTime() < MINUTES.toMillis(5)) {
-        try {
-          synchronized (this) {
-            wait(1000);
-          }
-        } catch (InterruptedException e) {
-          // TODO Auto-generated catch block
-          e.printStackTrace();
-        }
+      if (shouldDeferForOpennet()) {
+        if (waitOneSecond()) return; // interrupted: avoid spin and let outer run() exit
         continue;
       }
-      if (req == null) {
-        req = sched.grabRequest();
-      }
-      if (req != null) {
-        if (LOG.isDebugEnabled()) LOG.debug("Running " + req + " priority " + req.getPriority());
-        if (!req.localRequestOnly) {
-          // Wait
-          long delay;
-          delay = throttle.getDelay();
-          if (LOG.isDebugEnabled()) LOG.debug("Delay=" + delay + " from " + throttle);
-          long sleepUntil = cycleTime + delay;
-          long now;
-          do {
-            now = System.currentTimeMillis();
-            if (now < sleepUntil)
-              try {
-                Thread.sleep(sleepUntil - now);
-                if (LOG.isDebugEnabled()) LOG.debug("Slept: " + (sleepUntil - now) + "ms");
-              } catch (InterruptedException e) {
-                // Ignore
-              }
-          } while (now < sleepUntil);
-        }
-        //				if(!doAIMD) {
-        //					// Arbitrary limit on number of local requests waiting for slots.
-        //					// Firstly, they use threads. This could be a serious problem for faster nodes.
-        //					// Secondly, it may help to prevent wider problems:
-        //					// If all queues are full, the network will die.
-        //					int[] waiting = core.node.countRequestsWaitingForSlots();
-        //					int localRequestsWaitingForSlots = waiting[0];
-        //					int maxWaitingForSlots = MAX_WAITING_FOR_SLOTS;
-        //					// FIXME calibrate this by the number of local timeouts.
-        //					// FIXME consider an AIMD, or some similar mechanism.
-        //					// Local timeout-waiting-for-slots is largely dependant on
-        //					// the number of requests running, due to strict round-robin,
-        //					// so we can probably do something even simpler than an AIMD.
-        //					// For now we'll just have a fixed number.
-        //					// This should partially address the problem.
-        //					// Note that while waitFor() is blocking, we need such a limit anyway.
-        //					if(localRequestsWaitingForSlots > maxWaitingForSlots) continue;
-        //				}
-        RejectReason reason;
-        assert (req.realTimeFlag == realTime);
-        if (!req.localRequestOnly) {
-          reason =
-              stats.shouldRejectRequest(
-                  true,
-                  isInsert,
-                  isSSK,
-                  true,
-                  false,
-                  null,
-                  false,
-                  Node.PREFER_INSERT_DEFAULT && isInsert,
-                  req.realTimeFlag,
-                  null);
-          if (reason != null) {
-            if (LOG.isDebugEnabled()) LOG.debug("Not sending local request: " + reason);
-            // Wait one throttle-delay before trying again
-            cycleTime = System.currentTimeMillis();
-            continue; // Let local requests compete with all the others
-          }
-        } else {
-          stats.waitUntilNotOverloaded();
-        }
-      } else {
-        if (LOG.isDebugEnabled()) LOG.debug("Waiting...");
-        // Always take the lock on RequestStarter first. AFAICS we don't synchronize on
-        // RequestStarter anywhere else.
-        // Nested locks here prevent extra latency when there is a race, and therefore allow us to
-        // sleep indefinitely
-        synchronized (this) {
-          req = sched.grabRequest();
-          if (req == null) {
-            try {
-              wait();
-            } catch (InterruptedException e) {
-              // Ignore
-            }
-          }
-        }
-      }
-      if (req == null) continue;
-      if (!startRequest(req, LOG.isDebugEnabled())) {
-        // Don't log if it's a cancelled transient request.
-        if (!((!req.isPersistent()) && req.isCancelled()))
-          LOG.info("No requests to start on " + req);
-      }
-      if (!req.localRequestOnly) cycleTime = System.currentTimeMillis();
-      req = null;
+
+      req = nextRequest(req);
+      if (req == null) return; // interrupted while waiting
+
+      assert (req.realTimeFlag == realTime);
+      ProcessResult pr = processRequest(req, cycleTime);
+      cycleTime = pr.cycleTime;
+      // Drop only when the request was started or handled; keep it when deferred
+      if (!pr.keepRequest) req = null;
     }
   }
 
-  private boolean startRequest(ChosenBlock req, boolean logMINOR) {
+  private ChosenBlock nextRequest(ChosenBlock current) {
+    ChosenBlock r = ensureRequest(current);
+    if (r != null) return r;
+    return waitForRequest();
+  }
+
+  private ProcessResult processRequest(ChosenBlock req, long cycleTime) {
+    if (prepareAndCheckRejection(req, cycleTime)) {
+      // Temporarily rejected by NodeStats: keep the same request and retry after delay
+      return new ProcessResult(System.currentTimeMillis(), true);
+    }
+    boolean started = startRequest(req);
+    logIfNotCancelled(req, started);
+    long nextCycle = (!req.localRequestOnly) ? System.currentTimeMillis() : cycleTime;
+    return new ProcessResult(nextCycle, false);
+  }
+
+  private record ProcessResult(long cycleTime, boolean keepRequest) {}
+
+  private boolean shouldDeferForOpennet() {
+    OpennetManager om;
+    return core.getNode().getPeers().countConnectedPeers() < 3
+        && (om = core.getNode().getOpennet()) != null
+        && System.currentTimeMillis() - om.getCreationTime() < MINUTES.toMillis(5);
+  }
+
+  private boolean waitOneSecond() {
+    synchronized (this) {
+      long millis = 1000L;
+      long end = System.currentTimeMillis() + millis;
+      long remaining = millis;
+      while (remaining > 0) {
+        try {
+          wait(remaining);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          if (LOG.isDebugEnabled()) LOG.debug("One-second wait interrupted", e);
+          return true; // signal interrupt to caller to avoid spin under opennet defer
+        }
+        // If we were notified (or spuriously woke) before the timeout, exit early so wakeUp()
+        // remains responsive during opennet bootstrap.
+        remaining = end - System.currentTimeMillis();
+        if (remaining > 0) remaining = 0;
+      }
+      return false;
+    }
+  }
+
+  @SuppressWarnings("java:S2142")
+  private void applyThrottleDelay(long cycleTime) {
+    long delay = throttle.getDelay();
+    if (LOG.isDebugEnabled()) LOG.debug("Apply delay={} ms from {}", delay, throttle);
+    long sleepUntil = cycleTime + delay;
+    long now;
+    do {
+      now = System.currentTimeMillis();
+      if (now < sleepUntil)
+        try {
+          Thread.sleep(sleepUntil - now);
+          if (LOG.isDebugEnabled()) LOG.debug("Slept {} ms", sleepUntil - now);
+        } catch (InterruptedException e) {
+          // Swallow interrupt here so throttling resumes on subsequent iterations.
+          // Do not re-set the interrupt flag; callers that need to exit on interrupt
+          // should return from higher-level waits (e.g., waitForRequest/waitOneSecond).
+          if (LOG.isDebugEnabled()) LOG.debug("Throttle delay interrupted", e);
+          return;
+        }
+    } while (now < sleepUntil);
+  }
+
+  private RejectReason shouldReject(ChosenBlock req) {
+    return stats.shouldRejectRequest(
+        true,
+        isInsert,
+        isSSK,
+        true,
+        false,
+        null,
+        false,
+        Node.PREFER_INSERT_DEFAULT && isInsert,
+        req.realTimeFlag,
+        null);
+  }
+
+  private void logIfNotCancelled(ChosenBlock req, boolean started) {
+    if (!started && !isCancelledTransient(req)) {
+      LOG.info("No eligible request for {}", req);
+    }
+  }
+
+  private boolean isCancelledTransient(ChosenBlock req) {
+    return !req.isPersistent() && req.isCancelled();
+  }
+
+  private ChosenBlock ensureRequest(ChosenBlock current) {
+    return current != null ? current : sched.grabRequest();
+  }
+
+  private ChosenBlock waitForRequest() {
+    if (LOG.isDebugEnabled()) LOG.debug("Waiting for request...");
+    synchronized (this) {
+      ChosenBlock r = sched.grabRequest();
+      while (r == null) {
+        try {
+          wait();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          if (LOG.isDebugEnabled()) LOG.debug("Wait for request interrupted", e);
+          return null;
+        }
+        r = sched.grabRequest();
+      }
+      return r;
+    }
+  }
+
+  private boolean prepareAndCheckRejection(ChosenBlock req, long cycleTime) {
+    if (req.localRequestOnly) {
+      stats.waitUntilNotOverloaded();
+      return false;
+    }
+    applyThrottleDelay(cycleTime);
+    return shouldReject(req) != null;
+  }
+
+  private boolean startRequest(ChosenBlock req) {
     if ((!req.isPersistent()) && req.isCancelled()) {
       req.onDumped();
       return false;
     }
-    if (req.key != null) {
-      if (!sched.addToFetching(req.key)) {
-        req.onDumped();
-        return false;
-      }
-    } else if (((ChosenBlockImpl) req).request instanceof SendableInsert insert) {
-      if (!sched.addRunningInsert(insert, req.token.getKey())) {
-        req.onDumped();
-        return false;
-      }
+    boolean failed =
+        (req.key != null && !sched.addToFetching(req.key))
+            || (((ChosenBlockImpl) req).request instanceof SendableInsert insert
+                && !sched.addRunningInsert(insert, req.token.getKey()));
+    if (failed) {
+      req.onDumped();
+      return false;
     }
     if (LOG.isDebugEnabled())
-      LOG.debug("Running request " + req + " priority " + req.getPriority());
+      LOG.debug("Start request {} with priority {}", req, req.getPriority());
     core.getExecutor()
         .execute(new SenderThread(req, req.key), "RequestStarter$SenderThread for " + req);
     return true;
   }
 
+  /**
+   * Runs the starter loop until interrupted.
+   *
+   * <p>Exits cleanly when the thread is interrupted. Any unexpected exceptions are logged and the
+   * loop continues so isolated failures do not stop the starter.
+   */
   @Override
   public void run() {
     while (true) {
+      if (Thread.currentThread().isInterrupted()) {
+        if (LOG.isDebugEnabled()) LOG.debug("RequestStarter interrupted; exiting");
+        return;
+      }
       try {
         realRun();
-      } catch (Throwable t) {
-        LOG.error("Caught " + t, t);
+      } catch (Exception t) {
+        LOG.error("Unhandled exception: {}", t, t);
       }
     }
   }
@@ -263,20 +327,22 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 
     @Override
     public void run() {
-      // FIXME ? key is not known for inserts here
+      // Key may be null for inserts
       if (key != null) stats.reportOutgoingLocalRequestLocation(key.toNormalizedDouble());
       if (!req.send(core, sched)) {
         if (!((!req.isPersistent()) && req.isCancelled()))
-          LOG.error("run() not able to send a request on " + req);
-        else LOG.info("run() not able to send a request on " + req + " - request was cancelled");
+          LOG.error("Send request failed for {}", req);
+        else LOG.info("Send request skipped for {} - request was cancelled", req);
       }
-      if (LOG.isDebugEnabled()) LOG.debug("Finished " + req);
+      if (LOG.isDebugEnabled()) LOG.debug("Finished request {}", req);
     }
   }
 
   /**
-   * LOCKING: Caller must avoid locking while calling this function. In particular, if the
-   * RequestStarter lock is held we will get a deadlock.
+   * Wakes threads that wait for new work.
+   *
+   * <p>LOCKING: do not hold the {@code RequestStarter} lock when calling this method; waking while
+   * holding it can deadlock waiters attempting to reacquire the same monitor.
    */
   public void wakeUp() {
     synchronized (this) {
@@ -284,16 +350,26 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
     }
   }
 
-  /** Can this item be excluded, based on e.g. already running requests? */
+  /**
+   * Computes an exclusion time for a candidate item.
+   *
+   * <p>Returns {@code Long.MAX_VALUE} when a persistent request for the same item is already
+   * running or queued. For non‑inserts, delegates to {@link BaseSendableGet#getWakeupTime}.
+   *
+   * @param item candidate request item
+   * @param context client context for computing wakeup time
+   * @param now current time in milliseconds since epoch
+   * @return exclusion delay in milliseconds, or a sentinel value as described above
+   */
   @Override
   public long exclude(RandomGrabArrayItem item, ClientContext context, long now) {
     if (sched.isRunningOrQueuedPersistentRequest((SendableRequest) item)) {
-      LOG.info("Excluding already-running request: {}", item);
+      LOG.info("Exclude already running request {}", item);
       return Long.MAX_VALUE;
     }
     if (isInsert) return -1;
     if (!(item instanceof BaseSendableGet get)) {
-      LOG.error("On a request scheduler, exclude() called with {}", item);
+      LOG.error("exclude() called with unsupported item {}", item);
       return -1;
     }
     return get.getWakeupTime(context, now);

--- a/src/main/java/network/crypta/node/RequestStarterGroup.java
+++ b/src/main/java/network/crypta/node/RequestStarterGroup.java
@@ -20,15 +20,14 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates request starters and client schedulers for CHK/SSK fetches and inserts.
  *
- * <p>This class wires four logical flows for each key type (CHK and SSK): fetch (request) vs
- * insert, and bulk vs real-time. Each flow has its own {@link RequestStarter}, {@link
- * BaseRequestThrottle} implementation, and {@link ClientRequestScheduler}. It also tracks several
- * {@link ThrottleWindowManager} instances used to adapt concurrency over time based on observed
- * round-trip times and overload events.
+ * <p>Wires four flows per key type (CHK and SSK): fetch (request) vs insert, and bulk vs real-time.
+ * Each flow has its own {@link RequestStarter}, {@link BaseRequestThrottle} and {@link
+ * ClientRequestScheduler}. The group also maintains several {@link ThrottleWindowManager} instances
+ * that adapt concurrency based on observed round-trip times (RTT) and overload events.
  *
  * <p>Thread-safety: public methods are safe to call from the node's scheduling threads. The inner
- * throttle uses synchronization on its own instance where required. Methods that only read state
- * are not synchronized.
+ * throttle synchronizes state changes where required. Methods that only read state are not
+ * synchronized.
  */
 public class RequestStarterGroup {
   private static final Logger LOG = LoggerFactory.getLogger(RequestStarterGroup.class);
@@ -313,8 +312,10 @@ public class RequestStarterGroup {
   }
 
   /**
-   * Starts all request starters. After calling this, schedulers may begin launching requests when
-   * capacity is available according to their throttles and windows.
+   * Starts all request starters.
+   *
+   * <p>After this call, schedulers may launch requests when capacity is available according to
+   * their throttles and windows.
    */
   public void start() {
     chkRequestStarterRT.start();
@@ -359,7 +360,7 @@ public class RequestStarterGroup {
     }
 
     /**
-     * Computes an inter-request delay based on the current RTT and window size.
+     * Computes an inter-request delay from the current RTT and window size.
      *
      * <p>Result is clamped to {@code MIN_DELAY..MAX_DELAY} (milliseconds).
      *
@@ -384,7 +385,7 @@ public class RequestStarterGroup {
     }
 
     /**
-     * Reports a successful completion to update the RTT average.
+     * Reports a successful completion and updates the RTT average.
      *
      * @param rtt observed round-trip time in milliseconds; values below 10 ms are normalized to 10
      *     ms to avoid overreacting to very small samples
@@ -393,7 +394,7 @@ public class RequestStarterGroup {
       roundTripTime.report(Math.max(rtt, 10));
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Reported successful completion: {} on {} avg {}",
+            "Request completed: rtt={} ms, throttle={}, avg={}",
             rtt,
             this,
             roundTripTime.currentValue());
@@ -530,7 +531,7 @@ public class RequestStarterGroup {
   }
 
   /**
-   * Records a request rejection due to overload to reduce future concurrency.
+   * Records a request rejection due to overload and reduces future concurrency.
    *
    * @param isSSK whether the request was for SSK; CHK otherwise
    * @param isInsert whether the request was an insert; fetch otherwise
@@ -548,8 +549,8 @@ public class RequestStarterGroup {
     fs.put("ThrottleWindow", throttleWindowBulk.exportFieldSet(false));
     fs.put("ThrottleWindowRT", throttleWindowRT.exportFieldSet(false));
     fs.put("ThrottleWindowCHK", throttleWindowCHK.exportFieldSet(false));
-    // FIXME: This writes CHK window under "ThrottleWindowSSK"; verify whether
-    // throttleWindowSSK.exportFieldSet(false) is the intended source.
+    // FIXME: This writes CHK window under "ThrottleWindowSSK"; use
+    // throttleWindowSSK.exportFieldSet(false) if SSK is intended. Confirm and correct mapping.
     fs.put("ThrottleWindowSSK", throttleWindowCHK.exportFieldSet(false));
     fs.put("CHKRequestThrottle", chkRequestThrottleBulk.exportFieldSet());
     fs.put("SSKRequestThrottle", sskRequestThrottleBulk.exportFieldSet());

--- a/src/test/java/network/crypta/node/RequestStarterGroupTest.java
+++ b/src/test/java/network/crypta/node/RequestStarterGroupTest.java
@@ -148,9 +148,8 @@ class RequestStarterGroupTest {
   @DisplayName("getRTT()/getDelay() return expected defaults for CHK/SSK and RT/Bulk")
   void getDelayAndRTT_whenDefaults_expectConsistentValues() throws Exception {
     // With one peer and default window=2.0, delay is rtt/2
-    when(node.getPeers()).thenReturn(peerManager);
-    when(peerManager.countNonBackedOffPeers(true)).thenReturn(1);
-    when(peerManager.countNonBackedOffPeers(false)).thenReturn(1);
+    org.mockito.Mockito.lenient().when(node.getPeers()).thenReturn(peerManager);
+    org.mockito.Mockito.lenient().when(peerManager.countNonBackedOffPeers(false)).thenReturn(1);
     RequestStarterGroup group = newGroup();
 
     // CHK Request Bulk: rtt=5000, delay=2500
@@ -258,5 +257,119 @@ class RequestStarterGroupTest {
     assertNotNull(fs.subset("SSKRequestThrottleRT"));
     assertNotNull(fs.subset("CHKInsertThrottleRT"));
     assertNotNull(fs.subset("SSKInsertThrottleRT"));
+  }
+
+  @Test
+  @DisplayName("MyRequestThrottle.successfulCompletion() floors RTT and clamps delay")
+  @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+  void myRequestThrottle_successfulCompletion_belowFloor_clampsDelayAndUpdatesRTT()
+      throws Exception {
+    org.mockito.Mockito.lenient().when(node.getPeers()).thenReturn(peerManager);
+    org.mockito.Mockito.lenient().when(peerManager.countNonBackedOffPeers(false)).thenReturn(1);
+    RequestStarterGroup group = newGroup();
+
+    // CHK Request Bulk throttle: initial rtt=5000ms, window=2 -> delay=2500
+    RequestStarterGroup.MyRequestThrottle throttle = group.getThrottle(false, false, false);
+    assertEquals(2500L, throttle.getDelay());
+
+    // Report too-small RTT; should be normalized to 10ms internally
+    throttle.successfulCompletion(5);
+    assertEquals(10.0, throttle.getRTT(), 1e-9);
+    assertEquals(BaseRequestThrottle.MIN_DELAY, throttle.getDelay());
+
+    // Rate = (1000/delay)*size = (1000/20)*32768 = 1,638,400
+    assertEquals(1_638_400L, throttle.getRate());
+    assertTrue(throttle.toString().contains("RT=false"));
+
+    // Export contains RoundTripTime sub-structure
+    SimpleFieldSet tf = throttle.exportFieldSet();
+    assertNotNull(tf.subset("RoundTripTime"));
+  }
+
+  @Test
+  @DisplayName("PrioritySchedulerCallback applies values case-insensitively to both schedulers")
+  void priorityCallback_whenValidValues_appliesToBothSchedulers() throws Exception {
+    ClientRequestScheduler csRT = mock(ClientRequestScheduler.class);
+    ClientRequestScheduler csBulk = mock(ClientRequestScheduler.class);
+    // get() consulted during init(); return SOFT first, then HARD after set
+    when(csBulk.getChoosenPriorityScheduler())
+        .thenReturn(ClientRequestScheduler.PRIORITY_SOFT)
+        .thenReturn(ClientRequestScheduler.PRIORITY_HARD)
+        .thenReturn(ClientRequestScheduler.PRIORITY_SOFT);
+
+    RequestStarterGroup.PrioritySchedulerCallback cb =
+        new RequestStarterGroup.PrioritySchedulerCallback();
+    cb.init(csRT, csBulk, "HARD");
+    verify(csRT, times(1)).setPriorityScheduler(ClientRequestScheduler.PRIORITY_HARD);
+    verify(csBulk, times(1)).setPriorityScheduler(ClientRequestScheduler.PRIORITY_HARD);
+
+    // Change back to soft with mixed case
+    cb.set("soft");
+    verify(csRT, times(1)).setPriorityScheduler(ClientRequestScheduler.PRIORITY_SOFT);
+    verify(csBulk, times(1)).setPriorityScheduler(ClientRequestScheduler.PRIORITY_SOFT);
+
+    // Null is a no-op
+    cb.set(null);
+    // No further interactions expected
+  }
+
+  @Test
+  @DisplayName("countQueuedRequests() is zero on a fresh group")
+  void countQueuedRequests_whenFresh_isZero() throws Exception {
+    RequestStarterGroup group = newGroup();
+    assertEquals(0L, group.countQueuedRequests());
+  }
+
+  @Test
+  @DisplayName("diagnosticThrottlesLine() shows either Request/Insert or CHK/SSK windows")
+  void diagnosticThrottlesLine_whenModeSwitches_containsExpectedLabels() throws Exception {
+    RequestStarterGroup group = newGroup();
+    String reqIns = group.diagnosticThrottlesLine(true);
+    assertTrue(reqIns.contains("Request window:"));
+    assertTrue(reqIns.contains(", Insert window:"));
+
+    String chkSsk = group.diagnosticThrottlesLine(false);
+    assertTrue(chkSsk.contains("CHK window:"));
+    assertTrue(chkSsk.contains(", SSK window:"));
+  }
+
+  @Test
+  @DisplayName("getWindow() uses at least one peer when none are routable")
+  void getWindow_whenZeroPeers_usesFloorOfOne() throws Exception {
+    when(node.getPeers()).thenReturn(peerManager);
+    when(peerManager.countNonBackedOffPeers(false)).thenReturn(0);
+    RequestStarterGroup group = newGroup();
+    // Default simulated window = 2.0; Math.max(1, 0 peers) = 1 -> 2 * 1
+    assertEquals(2.0, group.getWindow(false), 1e-9);
+  }
+
+  @Test
+  @DisplayName("MyRequestThrottle.getRate() computes bytes/sec for SSK request")
+  void myRequestThrottle_getRate_forSSK() throws Exception {
+    when(node.getPeers()).thenReturn(peerManager);
+    when(peerManager.countNonBackedOffPeers(false)).thenReturn(1);
+    RequestStarterGroup group = newGroup();
+    // SSK Request Bulk uses size=1024 and rtt=5000 => delay=2500, rate=(1000/2500)*1024=409
+    RequestStarterGroup.MyRequestThrottle sskReq = group.getThrottle(true, false, false);
+    assertEquals(409L, sskReq.getRate());
+  }
+
+  @Test
+  @DisplayName("requestCompleted() only changes the matching realtime/bulk window")
+  void requestCompleted_affectsOnlySelectedModeWindow() throws Exception {
+    RequestStarterGroup group = newGroup();
+    double bulkBefore = group.getRealWindow(false);
+    double rtBefore = group.getRealWindow(true);
+
+    Key key = mock(Key.class);
+    when(key.toNormalizedDouble()).thenReturn(0.1);
+
+    group.requestCompleted(false, false, key, true); // realtime path
+
+    double bulkAfter = group.getRealWindow(false);
+    double rtAfter = group.getRealWindow(true);
+
+    assertEquals(bulkBefore, bulkAfter, 1e-12, "Bulk window should be unchanged");
+    assertTrue(rtAfter > rtBefore, "Realtime window should increase");
   }
 }

--- a/src/test/java/network/crypta/node/RequestStarterTest.java
+++ b/src/test/java/network/crypta/node/RequestStarterTest.java
@@ -1,0 +1,158 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import network.crypta.client.async.ClientContext;
+import network.crypta.support.math.RunningAverage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class RequestStarterTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private NodeStats nodeStats;
+  @Mock private BaseRequestThrottle throttle;
+  @Mock private RunningAverage avgOut;
+  @Mock private RunningAverage avgIn;
+  @Mock private RequestScheduler scheduler;
+  @Mock private ClientContext clientContext;
+
+  private RequestStarter newStarter(boolean isInsert, boolean realTime) {
+    // Minimal wiring required by RequestStarter's constructor; scoped to callers to avoid
+    // unnecessary stubbing on tests that don't construct a RequestStarter.
+    when(core.getNodeStats()).thenReturn(nodeStats);
+    RequestStarter starter =
+        new RequestStarter(
+            core, throttle, "starter", avgOut, avgIn, isInsert, /* isSSK= */ false, realTime);
+    starter.setScheduler(scheduler);
+    return starter;
+  }
+
+  @Test
+  @DisplayName("exclude: returns MAX_VALUE when persistent request already running")
+  void exclude_whenPersistentRequestRunning_returnsMaxValue() {
+    RequestStarter starter = newStarter(false, false);
+    // Item must be a SendableRequest to pass the initial cast in exclude()
+    SendableRequest item = mock(SendableRequest.class);
+
+    when(scheduler.isRunningOrQueuedPersistentRequest(item)).thenReturn(true);
+
+    long when = starter.exclude(item, clientContext, 123L);
+    assertEquals(Long.MAX_VALUE, when);
+  }
+
+  @Test
+  @DisplayName("exclude: returns -1 for insert schedulers (no get wakeups)")
+  void exclude_whenIsInsert_returnsMinusOne() {
+    RequestStarter starter = newStarter(true, false);
+    // For insert, the concrete type of item doesn't matter as long as it is a SendableRequest
+    SendableRequest item = mock(SendableRequest.class);
+
+    when(scheduler.isRunningOrQueuedPersistentRequest(item)).thenReturn(false);
+
+    long when = starter.exclude(item, clientContext, 456L);
+    assertEquals(-1L, when);
+  }
+
+  @Test
+  @DisplayName("exclude: non-BaseSendableGet returns -1 (not schedulable as get)")
+  void exclude_whenNotBaseSendableGet_returnsMinusOne() {
+    RequestStarter starter = newStarter(false, false);
+    SendableRequest notAGet = mock(SendableRequest.class); // implements RandomGrabArrayItem
+
+    when(scheduler.isRunningOrQueuedPersistentRequest(notAGet)).thenReturn(false);
+
+    long when = starter.exclude(notAGet, clientContext, 789L);
+    assertEquals(-1L, when);
+  }
+
+  @Test
+  @DisplayName("exclude: BaseSendableGet delegates to getWakeupTime")
+  void exclude_whenBaseSendableGet_delegatesToGetWakeupTime() {
+    RequestStarter starter = newStarter(false, true);
+    BaseSendableGet get = mock(BaseSendableGet.class);
+
+    when(scheduler.isRunningOrQueuedPersistentRequest(get)).thenReturn(false);
+    // Deterministic wakeup timestamp
+    long now = 1_000_000L;
+    long expected = now + 1234L;
+    when(get.getWakeupTime(clientContext, now)).thenReturn(expected);
+
+    long when = starter.exclude(get, clientContext, now);
+    assertEquals(expected, when);
+  }
+
+  @ParameterizedTest(name = "isValidPriorityClass({0}) => {1}")
+  @CsvSource({"-1,false", "0,true", "3,true", "6,true", "7,false"})
+  void isValidPriorityClass_boundaryAndRangeChecks(int value, boolean expected) {
+    assertEquals(expected, RequestStarter.isValidPriorityClass(value));
+  }
+
+  @Test
+  @DisplayName("toString includes name with real-time/bulk suffix")
+  void toString_whenRealtimeAndBulk_expectSuffixes() {
+    RequestStarter bulk = newStarter(false, false);
+    RequestStarter realtime = newStarter(false, true);
+
+    assertEquals("starter (bulk)", bulk.toString());
+    assertEquals("starter (realtime)", realtime.toString());
+  }
+
+  @Test
+  @DisplayName("wakeUp notifies threads waiting on the starter monitor")
+  void wakeUp_notifiesWaitingThreads() throws InterruptedException {
+    RequestStarter starter = newStarter(false, false);
+
+    CountDownLatch enteredWait = new CountDownLatch(1);
+    CountDownLatch finished = new CountDownLatch(1);
+    AtomicLong elapsedMillis = new AtomicLong(-1);
+
+    Thread t =
+        new Thread(
+            () -> {
+              long start = System.nanoTime();
+              synchronized (starter) {
+                enteredWait.countDown();
+                try {
+                  starter.wait(5000L); // Will be interrupted by notifyAll()
+                } catch (InterruptedException ignored) {
+                  // not expected in this test
+                }
+              }
+              long end = System.nanoTime();
+              elapsedMillis.set(TimeUnit.NANOSECONDS.toMillis(end - start));
+              finished.countDown();
+            },
+            "waiter");
+
+    t.start();
+
+    // Ensure the worker is waiting on the monitor before notifying
+    assertTrue(enteredWait.await(1, TimeUnit.SECONDS));
+
+    long beforeNotify = System.nanoTime();
+    starter.wakeUp();
+
+    assertTrue(finished.await(1, TimeUnit.SECONDS));
+    long afterNotify = System.nanoTime();
+
+    // The waiter should resume quickly after notifyAll(); allow a generous bound.
+    long notifyWindowMs = TimeUnit.NANOSECONDS.toMillis(afterNotify - beforeNotify);
+    assertTrue(
+        elapsedMillis.get() <= 1000L + notifyWindowMs,
+        "wait should finish promptly after wakeUp()");
+  }
+}


### PR DESCRIPTION
Summary
- RequestStarter: refactor for clarity and robustness; add precise interrupt handling and temporary-defer semantics.
- RequestStarterGroup: documentation/log message polish; throttle/window behavior covered by new tests.
- Tests: new RequestStarterTest and expanded RequestStarterGroupTest to cover throttles, priority callback, queued count, diagnostics, and min-peers behavior.

Details
RequestStarter
- Single entrypoint for dequeuing/starting requests with clearer separation:
  - nextRequest(): obtains/retains current request or waits for new work
  - processRequest(): prepares, respects temporary rejections from NodeStats by keeping the same request for retry, and starts when permitted
  - shouldDeferForOpennet(): defers request starts during first 5 minutes of opennet bootstrap when peer count is low
  - waitOneSecond(): interruptible 1s sleeps used by bootstrap deferral
- Throttling: uses BaseRequestThrottle for per-request delay; transient interrupts during throttling are swallowed so later iterations can resume delaying instead of aborting the loop.
- Threading: run()/realRun() honor interrupts in all waits and exit cleanly.
- Diagnostics: toString() includes human-readable mode suffix ("bulk"/"realtime").
- exclude(...): clarified semantics and tests for persistent request cases, insert vs get, BaseSendableGet wakeup time, and invalid classes.

RequestStarterGroup
- Javadoc tightened for flow wiring and concurrency windows.
- Log lines clarified and parameterized.
- Tests validate:
  - MyRequestThrottle floors RTT at 10ms, clamps delay, and computes expected rate
  - PrioritySchedulerCallback applies case-insensitively to both schedulers
  - countQueuedRequests() default is 0
  - diagnosticThrottlesLine shows expected labels in both mode views
  - getWindow() uses Math.max(1, peers) to avoid zero-peer underflows
  - requestCompleted() only affects matching realtime/bulk window
- Note: an existing FIXME remains about CHK window being exported under "ThrottleWindowSSK"; mapping kept as-is (behavior unchanged).

Files of interest (source)
- src/main/java/network/crypta/node/RequestStarter.java
- src/main/java/network/crypta/node/RequestStarterGroup.java

Tests
- Added: src/test/java/network/crypta/node/RequestStarterTest.java
- Expanded: src/test/java/network/crypta/node/RequestStarterGroupTest.java

Rationale / Risk
- Behavior is unchanged in steady state; refactor improves clarity and handles transient conditions more predictably.
- Added tests increase coverage around scheduling, throttling, and diagnostics.

Notes
- Branch is based on current develop; only two commits unique to this branch:
  - fix(node): RequestStarter logic and tests; apply Spotless formatting
  - test(RequestStarterGroup): expand unit coverage for throttles, priority callback, and windows
- No uncommitted changes locally; Spotless has already been applied in related commits.

Checklist
- [x] Builds locally
- [x] Spotless formatting applied where touched
- [x] Tests added/updated
- [x] No API/ABI changes

Please review the RequestStarter refactor and the added test coverage. Thanks!