### PR TITLE
Improve shutdown hook robustness; add tests; tidy GET sender

### DIFF
--- a/src/main/java/network/crypta/node/SemiOrderedShutdownHook.java
+++ b/src/main/java/network/crypta/node/SemiOrderedShutdownHook.java
@@ -3,12 +3,33 @@ package network.crypta.node;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.ArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * JVM shutdown hook that executes registered jobs in two phases (early, then late).
+ *
+ * <p>On shutdown, this hook starts all early jobs concurrently and joins each with a fixed
+ * per-thread timeout. It then starts late jobs and joins them with the same timeout. If an
+ * interruption occurs while joining, it is remembered and the interrupted status is restored after
+ * both join loops complete. This allows the remaining joins to proceed while still propagating the
+ * interrupt to callers.
+ *
+ * <p>Thread safety: registration methods are synchronized. Snapshots of job lists are taken at
+ * {@link #run()} time to avoid holding locks during joins. Callers should register jobs before
+ * shutdown begins.
+ *
+ * <p>Usage: obtain the singleton via {@link #get()} and register unstarted threads with {@link
+ * #addEarlyJob(Thread)} or {@link #addLateJob(Thread)}. The hook calls {@link Thread#start()}.
+ */
+@SuppressWarnings({"java:S6548", "java:S2142"})
 public class SemiOrderedShutdownHook extends Thread {
 
+  // Join timeout per thread in milliseconds.
   private static final long TIMEOUT = SECONDS.toMillis(100);
   private final ArrayList<Thread> earlyJobs;
   private final ArrayList<Thread> lateJobs;
+  private static final Logger LOG = LoggerFactory.getLogger(SemiOrderedShutdownHook.class);
 
   public static final SemiOrderedShutdownHook singleton = new SemiOrderedShutdownHook();
 
@@ -16,6 +37,11 @@ public class SemiOrderedShutdownHook extends Thread {
     Runtime.getRuntime().addShutdownHook(singleton);
   }
 
+  /**
+   * Returns the process-wide singleton shutdown hook instance registered with the runtime.
+   *
+   * @return the singleton shutdown hook
+   */
   public static SemiOrderedShutdownHook get() {
     return singleton;
   }
@@ -25,54 +51,81 @@ public class SemiOrderedShutdownHook extends Thread {
     lateJobs = new ArrayList<>();
   }
 
+  /**
+   * Registers a job to run in the early phase of shutdown.
+   *
+   * <p>The hook starts the thread and waits up to the per-thread timeout for completion.
+   *
+   * @param r unstarted thread to execute during the early phase
+   */
   public synchronized void addEarlyJob(Thread r) {
     earlyJobs.add(r);
   }
 
+  /**
+   * Registers a job to run in the late phase of shutdown.
+   *
+   * <p>The hook starts the thread and waits up to the per-thread timeout for completion.
+   *
+   * @param r unstarted thread to execute during the late phase
+   */
   public synchronized void addLateJob(Thread r) {
     lateJobs.add(r);
   }
 
   @Override
   public void run() {
-    System.err.println("Shutting down...");
-    // First run early jobs, all at once, and wait for them to all complete.
+    LOG.info("Shutdown hook starts; running early and late jobs.");
+    // Start early jobs concurrently, then wait up to the per-thread timeout for each to finish.
+
+    boolean wasInterrupted = false;
 
     Thread[] early = getEarlyJobs();
 
+    // Start all early jobs.
     for (Thread r : early) {
       r.start();
     }
+    // Join early jobs; remember interruptions but continue joining remaining threads.
     for (Thread r : early) {
       try {
         r.join(TIMEOUT);
       } catch (InterruptedException e) {
-        // :(
-        // May as well move on
+        // Remember interruption and continue joining remaining threads.
+        wasInterrupted = true;
       }
     }
 
     Thread[] late = getLateJobs();
 
-    // Then run late jobs, all at once, and wait for them to all complete (JVM will exit when we
-    // return).
+    // Then start late jobs concurrently and wait up to the per-thread timeout for each (the JVM
+    // exits when this method returns).
     for (Thread r : late) {
       r.start();
     }
+    // Join late jobs; remember interruptions but continue joining remaining threads.
     for (Thread r : late) {
       try {
         r.join(TIMEOUT);
       } catch (InterruptedException e) {
-        // :(
-        // May as well move on
+        // Remember interruption and continue joining remaining threads.
+        wasInterrupted = true;
       }
+    }
+
+    if (wasInterrupted) {
+      // Restore the interrupted status after all joins so callers can observe it
+      // without causing subsequent joins in this method to fail immediately.
+      Thread.currentThread().interrupt();
     }
   }
 
+  // Return a snapshot to avoid holding the monitor while joining.
   private synchronized Thread[] getEarlyJobs() {
     return earlyJobs.toArray(new Thread[0]);
   }
 
+  // Return a snapshot to avoid holding the monitor while joining.
   private synchronized Thread[] getLateJobs() {
     return lateJobs.toArray(new Thread[0]);
   }

--- a/src/main/java/network/crypta/node/SendableGetRequestSender.java
+++ b/src/main/java/network/crypta/node/SendableGetRequestSender.java
@@ -10,9 +10,7 @@ import org.slf4j.LoggerFactory;
 public class SendableGetRequestSender implements SendableRequestSender {
   private static final Logger LOG = LoggerFactory.getLogger(SendableGetRequestSender.class);
 
-  static {
-  }
-
+  @Override
   public boolean sendIsBlocking() {
     return false;
   }
@@ -42,33 +40,27 @@ public class SendableGetRequestSender implements SendableRequestSender {
       return false;
     }
     try {
-      try {
-        final Key k = key.getNodeKey();
-        core.asyncGet(
-            k,
-            false,
-            new RequestCompletionListener() {
+      final Key k = key.getNodeKey();
+      core.asyncGet(
+          k,
+          false,
+          new RequestCompletionListener() {
 
-              @Override
-              public void onSucceeded() {
-                req.onFetchSuccess(context);
-              }
+            @Override
+            public void onSucceeded() {
+              req.onFetchSuccess(context);
+            }
 
-              @Override
-              public void onFailed(LowLevelGetException e) {
-                req.onFailure(e, context);
-              }
-            },
-            !req.ignoreStore,
-            req.canWriteClientCache,
-            req.realTimeFlag,
-            req.localRequestOnly,
-            req.ignoreStore);
-      } catch (Throwable t) {
-        LOG.error("Caught " + t, t);
-        req.onFailure(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR), context);
-        return true;
-      }
+            @Override
+            public void onFailed(LowLevelGetException e) {
+              req.onFailure(e, context);
+            }
+          },
+          !req.ignoreStore,
+          req.canWriteClientCache,
+          req.realTimeFlag,
+          req.localRequestOnly,
+          req.ignoreStore);
     } catch (Throwable t) {
       LOG.error("Caught " + t, t);
       req.onFailure(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR), context);

--- a/src/test/java/network/crypta/node/SemiOrderedShutdownHookTest.java
+++ b/src/test/java/network/crypta/node/SemiOrderedShutdownHookTest.java
@@ -1,0 +1,199 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SemiOrderedShutdownHookTest {
+
+  // No global cleanup needed; each test controls its own threads via latches and joins.
+
+  @Test
+  void get_whenCalledMultipleTimes_returnsSameSingletonInstance() {
+    // Arrange & Act
+    SemiOrderedShutdownHook h1 = SemiOrderedShutdownHook.get();
+    SemiOrderedShutdownHook h2 = SemiOrderedShutdownHook.get();
+
+    // Assert
+    assertSame(h1, h2, "get() must return the same singleton instance");
+  }
+
+  @Test
+  void run_whenEarlyAndLateJobsAdded_lateStartsOnlyAfterAllEarlyFinish() throws Exception {
+    // Arrange
+    SemiOrderedShutdownHook hook = new SemiOrderedShutdownHookAccessor().instance();
+    List<String> events = Collections.synchronizedList(new ArrayList<>());
+
+    Thread early1 =
+        new Thread(
+            () -> {
+              events.add("early1-start");
+              events.add("early1-done");
+            },
+            "early1");
+
+    Thread early2 =
+        new Thread(
+            () -> {
+              events.add("early2-start");
+              events.add("early2-done");
+            },
+            "early2");
+
+    Thread late1 =
+        new Thread(
+            () -> {
+              events.add("late1-start");
+              events.add("late1-done");
+            },
+            "late1");
+
+    Thread late2 =
+        new Thread(
+            () -> {
+              events.add("late2-start");
+              events.add("late2-done");
+            },
+            "late2");
+
+    hook.addEarlyJob(early1);
+    hook.addEarlyJob(early2);
+    hook.addLateJob(late1);
+    hook.addLateJob(late2);
+
+    // Act: execute the hook in its own thread, as it would run at JVM shutdown
+    hook.start();
+    hook.join(2000);
+
+    // Assert
+    // All early jobs must fully complete before any late job starts, because run() joins early jobs
+    // before starting late ones.
+    int posEarly1Done = events.indexOf("early1-done");
+    int posEarly2Done = events.indexOf("early2-done");
+    int posFirstLateStart = Math.min(events.indexOf("late1-start"), events.indexOf("late2-start"));
+
+    assertTrue(posEarly1Done >= 0 && posEarly2Done >= 0, "early jobs must record completion");
+    assertTrue(
+        posFirstLateStart > posEarly1Done && posFirstLateStart > posEarly2Done,
+        "No late job may start before all early jobs finish");
+  }
+
+  @Test
+  void run_whenInterruptedDuringEarlyJoin_startsLateJobsEvenIfAnEarlyIsStillRunning()
+      throws Exception {
+    // Arrange
+    SemiOrderedShutdownHook hook = new SemiOrderedShutdownHookAccessor().instance();
+    List<String> events = Collections.synchronizedList(new ArrayList<>());
+    CountDownLatch allowEarlySlowToFinish = new CountDownLatch(1);
+
+    Thread earlySlow =
+        new Thread(
+            () -> {
+              events.add("earlySlow-start");
+              try {
+                allowEarlySlowToFinish.await();
+              } catch (InterruptedException ignored) {
+                // ignored for test: we want deterministic completion ordering
+              }
+              events.add("earlySlow-done");
+            },
+            "earlySlow");
+
+    Thread earlyFast =
+        new Thread(
+            () -> {
+              events.add("earlyFast-start");
+              events.add("earlyFast-done");
+            },
+            "earlyFast");
+
+    Thread late =
+        new Thread(
+            () -> {
+              events.add("late-start");
+              events.add("late-done");
+            },
+            "late");
+
+    // Register the slow early job first so the first join() in run() targets it and throws
+    // immediately when the current thread's interrupt flag is set below.
+    hook.addEarlyJob(earlySlow);
+    hook.addEarlyJob(earlyFast);
+    hook.addLateJob(late);
+
+    // Act: mark the hook thread interrupted before it starts so its first join() throws
+    hook.interrupt();
+    hook.start();
+    hook.join(2000);
+
+    // Assert: late started before earlySlow was allowed to finish
+    int posLateStart = events.indexOf("late-start");
+    int posEarlySlowDone = events.indexOf("earlySlow-done");
+    assertTrue(posLateStart >= 0, "late job must have started");
+    assertTrue(
+        posEarlySlowDone == -1 || posLateStart < posEarlySlowDone,
+        "late must start before earlySlow completes due to interrupted join");
+
+    // Cleanup the blocked earlySlow thread to avoid leaks
+    allowEarlySlowToFinish.countDown();
+    earlySlow.join(2000);
+  }
+
+  @Test
+  void run_whenSameThreadAddedToEarlyAndLate_throwsIllegalThreadStateException() throws Exception {
+    // Arrange
+    SemiOrderedShutdownHook hook = new SemiOrderedShutdownHookAccessor().instance();
+    List<String> events = Collections.synchronizedList(new ArrayList<>());
+
+    Thread t =
+        new Thread(
+            () -> {
+              events.add("t-start");
+              events.add("t-done");
+            },
+            "dup-thread");
+
+    hook.addEarlyJob(t);
+    hook.addLateJob(t); // starting the same Thread twice is illegal
+
+    // Act: capture the uncaught exception from the hook thread when it attempts to start the
+    // same thread twice (once in early, then again in late phase).
+    final Throwable[] thrown = new Throwable[1];
+    hook.setUncaughtExceptionHandler((tThread, ex) -> thrown[0] = ex);
+    hook.start();
+    hook.join(2000);
+
+    // Assert
+    assertInstanceOf(
+        IllegalThreadStateException.class,
+        thrown[0],
+        "Starting the same Thread twice should fail with IllegalThreadStateException");
+  }
+
+  /**
+   * Isolates tests from the JVM-registered singleton to avoid cross-test interference while still
+   * exercising the production logic. The accessor creates a fresh instance via reflection to avoid
+   * depending on the static, globally registered shutdown hook.
+   */
+  static final class SemiOrderedShutdownHookAccessor {
+    SemiOrderedShutdownHook instance() {
+      try {
+        var ctor = SemiOrderedShutdownHook.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        return ctor.newInstance();
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError("Failed to construct SemiOrderedShutdownHook for test", e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Strengthens JVM shutdown behavior and adds coverage for ordering/interrupt cases.
- Cleans up the GET request sender implementation without behavior changes.

Changes
- src/main/java/network/crypta/node/SemiOrderedShutdownHook.java:1
  - Replace System.err prints with SLF4J (`LOG`).
  - Add clear Javadoc on phases, timeouts, and thread-safety.
  - Start early jobs concurrently; join each with a fixed per-thread timeout.
  - Start late jobs after early joins; join with the same timeout.
  - On InterruptedException during any join, continue joining remaining threads and restore the interrupted status at the end so callers observe it without short‑circuiting subsequent joins.
  - Take snapshots of job lists to avoid holding monitors while joining.

- src/main/java/network/crypta/node/SendableGetRequestSender.java:1
  - Remove empty static initializer; add @Override where appropriate.
  - Flatten nested try/catch; retain outer Throwable handling and existing return semantics (`true` when a request was executed or handled).
  - No functional changes intended beyond cleanup and readability.

- src/test/java/network/crypta/node/SemiOrderedShutdownHookTest.java:1
  - New JUnit 6 tests covering:
    - `get()` returns the same singleton instance.
    - Early/late phase ordering: all early jobs complete before any late job starts.
    - Interrupted join path: late jobs still start even if an early join is interrupted.
    - Duplicate thread in early+late phases triggers IllegalThreadStateException when started twice.
  - Tests isolate from the JVM-registered singleton via a small reflective accessor that creates a fresh instance to avoid cross-test interference.

Notes
- Formatting applied via Spotless beforehand; working tree was clean when opening this PR.
- No broader behavior changes expected. Logging provides better observability during shutdown.

Motivation
- Make shutdown more resilient to interrupts and easier to diagnose.
- Increase confidence via unit tests and minor code hygiene in a hot path.
