### PR TITLE
refactor(node): improve SendableInsert and SimpleSendableInsert docs/logging

### DIFF
--- a/src/main/java/network/crypta/node/SendableInsert.java
+++ b/src/main/java/network/crypta/node/SendableInsert.java
@@ -11,30 +11,63 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Callback interface for a low level insert, which is immediately sendable. These should be
- * registered on the ClientRequestScheduler when we want to send them. It will then, when it is time
- * to send, create a thread, send the request, and call the callback below.
+ * Abstract base for immediately sendable insert requests.
+ *
+ * <p>Instances are registered on a {@link ClientRequestScheduler}. When scheduled, the
+ * implementation runs on a worker thread, performs the low‑level insert, and then calls one of the
+ * callbacks: {@link #onSuccess(SendableRequestItem, ClientKey, ClientContext)} or {@link
+ * #onFailure(LowLevelPutException, SendableRequestItem, ClientContext)}.
+ *
+ * <p>Subclasses define whether the request can interact with the client cache, whether it is
+ * local‑only, and any resume behavior after persistence.
  */
 public abstract class SendableInsert extends SendableRequest {
   private static final Logger LOG = LoggerFactory.getLogger(SendableInsert.class);
 
   @Serial private static final long serialVersionUID = 1L;
 
-  public SendableInsert(boolean persistent, boolean realTimeFlag) {
+  /**
+   * Create a new sendable insert.
+   *
+   * @param persistent whether the request participates in persistence across restarts
+   * @param realTimeFlag whether the request uses the real‑time scheduler variant
+   */
+  protected SendableInsert(boolean persistent, boolean realTimeFlag) {
     super(persistent, realTimeFlag);
   }
 
-  /** Called when we successfully insert the data */
+  /**
+   * Called after a successful low‑level insert.
+   *
+   * @param keyNum scheduler token associated with this request
+   * @param key client key that identifies the inserted data
+   * @param context client execution context used by the scheduler
+   */
   public abstract void onSuccess(SendableRequestItem keyNum, ClientKey key, ClientContext context);
 
-  /** Called when we don't! */
+  /**
+   * Called when the insert fails.
+   *
+   * @param e failure cause from the low‑level put path
+   * @param keyNum scheduler token associated with this request
+   * @param context client execution context used by the scheduler
+   */
   public abstract void onFailure(
       LowLevelPutException e, SendableRequestItem keyNum, ClientContext context);
 
+  /**
+   * Handle an unexpected internal error by logging and delegating failure to the scheduler.
+   *
+   * @param t thrown error
+   * @param sched scheduler to notify
+   * @param context client execution context
+   * @param persistent whether the request is persistent
+   */
   @Override
   public void internalError(
       Throwable t, RequestScheduler sched, ClientContext context, boolean persistent) {
-    LOG.error("Internal error on " + this + " : " + t, t);
+    // Avoid duplicating exception details in the message; the throwable argument carries them.
+    LOG.error("Internal error in {} (details={})", this, t, t);
     sched.callFailure(
         this,
         new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR, t.getMessage(), t),
@@ -42,36 +75,95 @@ public abstract class SendableInsert extends SendableRequest {
         persistent);
   }
 
+  /**
+   * Identify this request as an insert.
+   *
+   * @return always {@code true}
+   */
   @Override
   public final boolean isInsert() {
     return true;
   }
 
+  /**
+   * Select the appropriate scheduler based on key type and real‑time mode.
+   *
+   * @param context client execution context used to resolve schedulers
+   * @return an insert scheduler for SSK or CHK, respecting {@code realTimeFlag}
+   */
   @Override
   public ClientRequestScheduler getScheduler(ClientContext context) {
     if (isSSK()) return context.getSskInsertScheduler(realTimeFlag);
     else return context.getChkInsertScheduler(realTimeFlag);
   }
 
+  /**
+   * Whether the insert may write to the client cache as part of processing.
+   *
+   * @return {@code true} if writing the client cache is allowed
+   */
   public abstract boolean canWriteClientCache();
 
+  /**
+   * Whether this request should operate only against the local node.
+   *
+   * @return {@code true} if the request is local‑only
+   */
   public abstract boolean localRequestOnly();
 
+  /**
+   * Whether the scheduler may fork this request when the data is cacheable.
+   *
+   * @return {@code true} if forking is permitted on cacheable data
+   */
   public abstract boolean forkOnCacheable();
 
-  /** Encoded a key */
+  /**
+   * Called after the key has been encoded for transmission.
+   *
+   * @param token scheduler token associated with this request
+   * @param key client key produced by the encoder
+   * @param context client execution context used by the scheduler
+   */
   public abstract void onEncode(SendableRequestItem token, ClientKey key, ClientContext context);
 
+  /**
+   * Whether there is any work to perform (e.g., no blocks remain to send).
+   *
+   * @return {@code true} if the request has no pending work
+   */
   public abstract boolean isEmpty();
 
+  /**
+   * Next wakeup time used by the scheduler.
+   *
+   * <p>Returns {@code -1} when the request is dormant (no work to do). Returns {@code 0} to
+   * indicate immediate scheduling. The {@code now} parameter is not used by this implementation.
+   *
+   * @param context client execution context
+   * @param now current scheduler time reference
+   * @return {@code -1} for dormant, or {@code 0} for immediate execution
+   */
   @Override
   public long getWakeupTime(ClientContext context, long now) {
     if (isEmpty()) return -1;
     return 0;
   }
 
+  // Ensure resume logic runs at most once per instance; not serialized.
   private transient boolean resumed = false;
 
+  /**
+   * Ensure resume logic runs once per instance and delegate to {@link
+   * #innerOnResume(ClientContext)}.
+   *
+   * <p>This method is idempotent and thread‑safe; subsequent calls return immediately after the
+   * first successful invocation.
+   *
+   * @param context client execution context
+   * @throws InsertException if resume detects an insert‑level problem
+   * @throws ResumeFailedException if state restoration fails
+   */
   public final void onResume(ClientContext context) throws InsertException, ResumeFailedException {
     synchronized (this) {
       if (resumed) return;
@@ -80,6 +172,13 @@ public abstract class SendableInsert extends SendableRequest {
     innerOnResume(context);
   }
 
+  /**
+   * Subclass hook to restore any necessary state before scheduling continues.
+   *
+   * @param context client execution context
+   * @throws InsertException if resume detects an insert‑level problem
+   * @throws ResumeFailedException if state restoration fails
+   */
   protected abstract void innerOnResume(ClientContext context)
       throws InsertException, ResumeFailedException;
 }

--- a/src/main/java/network/crypta/node/SimpleSendableInsert.java
+++ b/src/main/java/network/crypta/node/SimpleSendableInsert.java
@@ -15,23 +15,51 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Simple SendableInsert implementation. No feedback, no retries, just insert the block. Not
- * designed for use by the client layer (and not persistent). Used by the node layer for the 1 in
- * every 200 successful requests which starts an insert.
+ * Inserts a single block without retries or client feedback.
+ *
+ * <p>This lightweight {@link SendableInsert} variant is used internally by the node to
+ * opportunistically insert one block roughly once per 200 successful requests. It is not persistent
+ * and is not intended for the external client API.
+ *
+ * <p>Behavior:
+ *
+ * <ul>
+ *   <li>Schedules exactly one block ({@link #block}).
+ *   <li>Runs synchronously from the sender ({@code sendIsBlocking() == true}).
+ *   <li>Does not retry on failure and does not emit client callbacks.
+ * </ul>
+ *
+ * <p>Threading and state: the {@code finished} flag gates rescheduling and cancelation. Several
+ * key-count and selection methods are synchronized to avoid racing with cancelation.
  */
 public class SimpleSendableInsert extends SendableInsert {
   private static final Logger LOG = LoggerFactory.getLogger(SimpleSendableInsert.class);
 
   @Serial private static final long serialVersionUID = 1L;
+
+  /** The block to be inserted (CHK or SSK). Never null. */
   public final KeyBlock block;
+
+  /** Priority class as interpreted by the scheduler. */
   public final short prioClass;
+
   private boolean finished;
+
+  /** Non-persistent client used for internal bulk inserts. */
   public final RequestClient client;
+
+  /** Scheduler responsible for this insert; must be an insert scheduler. */
   public final ClientRequestScheduler scheduler;
 
-  static {
-  }
-
+  /**
+   * Creates a simple insert bound to the appropriate bulk put scheduler.
+   *
+   * @param core node client core used to resolve client and schedulers
+   * @param block block to insert; must be a {@link CHKBlock} or {@link SSKBlock}
+   * @param prioClass scheduler priority class
+   * @throws IllegalArgumentException if {@code block} is of an unsupported type
+   * @throws IllegalStateException if the resolved scheduler is not an insert scheduler
+   */
   public SimpleSendableInsert(NodeClientCore core, KeyBlock block, short prioClass) {
     super(false, false);
     this.block = block;
@@ -44,6 +72,14 @@ public class SimpleSendableInsert extends SendableInsert {
       throw new IllegalStateException("Scheduler " + scheduler + " is not an insert scheduler!");
   }
 
+  /**
+   * Creates a simple insert with explicit client and scheduler.
+   *
+   * @param block block to insert (CHK or SSK)
+   * @param prioClass scheduler priority class
+   * @param client request client to attribute the work to
+   * @param scheduler scheduler used to run this insert; must be an insert scheduler
+   */
   public SimpleSendableInsert(
       KeyBlock block, short prioClass, RequestClient client, ClientRequestScheduler scheduler) {
     super(false, false);
@@ -55,13 +91,13 @@ public class SimpleSendableInsert extends SendableInsert {
 
   @Override
   public void onSuccess(SendableRequestItem keyNum, ClientKey key, ClientContext context) {
-    // Yay!
-    if (LOG.isDebugEnabled()) LOG.debug("Finished insert of " + block);
+    // Successful completion; no client-visible feedback.
+    if (LOG.isDebugEnabled()) LOG.debug("Insert completed for {}", block);
   }
 
   @Override
   public void onFailure(LowLevelPutException e, SendableRequestItem keyNum, ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("Failed insert of " + block + ": " + e);
+    if (LOG.isDebugEnabled()) LOG.debug("Insert failed for {}: {}", block, e, e);
   }
 
   @Override
@@ -76,10 +112,10 @@ public class SimpleSendableInsert extends SendableInsert {
       @Override
       public boolean send(
           NodeClientCore core, RequestScheduler sched, ClientContext context, ChosenBlock req) {
-        // Ignore keyNum, key, since this is a single block
+        // Ignore keyNum/key; this insert handles a single block.
         try {
-          if (LOG.isDebugEnabled()) LOG.debug("Starting request: " + this);
-          // FIXME bulk flag
+          if (LOG.isDebugEnabled()) LOG.debug("Starting request: {}", this);
+          // FIXME: bulk flag — clarify whether background inserts should set bulk=true
           core.realPut(
               block,
               req.canWriteClientCache,
@@ -89,12 +125,12 @@ public class SimpleSendableInsert extends SendableInsert {
               false);
         } catch (LowLevelPutException e) {
           onFailure(e, req.token, context);
-          if (LOG.isDebugEnabled()) LOG.debug("Request failed: " + this + " for " + e);
+          if (LOG.isDebugEnabled()) LOG.debug("Request failed for {}: {}", this, e, e);
           return true;
         } finally {
           finished = true;
         }
-        if (LOG.isDebugEnabled()) LOG.debug("Request succeeded: " + this);
+        if (LOG.isDebugEnabled()) LOG.debug("Request succeeded: {}", this);
         onSuccess(req.token, null, context);
         sched.removeRunningInsert(SimpleSendableInsert.this, req.token.getKey());
         return true;
@@ -132,11 +168,24 @@ public class SimpleSendableInsert extends SendableInsert {
     return finished;
   }
 
+  /**
+   * Registers this insert with the scheduler.
+   *
+   * <p>Resets the internal {@code finished} flag to allow scheduling again and enqueues the insert
+   * with the configured {@link #scheduler}.
+   */
   public void schedule() {
     finished = false; // can reschedule
     scheduler.registerInsert(this, false);
   }
 
+  /**
+   * Cancels the insert if it has not yet completed.
+   *
+   * <p>Marks the insert as finished and unregisters from queues using the base implementation.
+   *
+   * @param context request context used for unregister bookkeeping
+   */
   public void cancel(ClientContext context) {
     synchronized (this) {
       if (finished) return;
@@ -157,7 +206,7 @@ public class SimpleSendableInsert extends SendableInsert {
     return 1;
   }
 
-  // FIXME share with SingleBlockInserter???
+  // FIXME: share with SingleBlockInserter to avoid duplication?
   private static class MySendableRequestItem
       implements SendableRequestItem, SendableRequestItemKey {
 
@@ -169,7 +218,7 @@ public class SimpleSendableInsert extends SendableInsert {
 
     @Override
     public void dump() {
-      // Ignore.
+      // No-op for this single-block insert type.
     }
 
     @Override
@@ -223,7 +272,7 @@ public class SimpleSendableInsert extends SendableInsert {
 
   @Override
   public void onEncode(SendableRequestItem token, ClientKey key, ClientContext context) {
-    // Ignore.
+    // No-op; nothing to encode for this insert.
   }
 
   @Override
@@ -231,8 +280,16 @@ public class SimpleSendableInsert extends SendableInsert {
     return false;
   }
 
+  /**
+   * No-op resume hook.
+   *
+   * <p>This insert is not persistent and does not support resuming.
+   *
+   * @param context request context (unused)
+   * @throws InsertException never thrown by this implementation
+   */
   @Override
   protected void innerOnResume(ClientContext context) throws InsertException {
-    // Do nothing.
+    // No-op: non-persistent insert does not resume.
   }
 }

--- a/src/test/java/network/crypta/node/SimpleSendableInsertTest.java
+++ b/src/test/java/network/crypta/node/SimpleSendableInsertTest.java
@@ -1,0 +1,343 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.client.async.ChosenBlockImpl;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequestScheduler;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.SSKBlock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SimpleSendableInsertTest {
+
+  @Mock private RequestClient requestClient;
+  @Mock private ClientRequestScheduler insertScheduler;
+  @Mock private RequestScheduler requestScheduler;
+  @Mock private ClientContext clientContext;
+
+  private CHKBlock chkBlock;
+  private SSKBlock sskBlock;
+
+  @BeforeEach
+  void setUp() {
+    chkBlock = mock(CHKBlock.class);
+    sskBlock = mock(SSKBlock.class);
+  }
+
+  @Test
+  void getPriorityClass_whenConstructed_returnsProvidedPriority() {
+    short prio = 3;
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, prio, requestClient, insertScheduler);
+
+    assertEquals(prio, insert.getPriorityClass());
+  }
+
+  @Test
+  void schedule_whenCalled_registersInsert_andResetsFinished() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, (short) 2, requestClient, insertScheduler);
+    // Mark finished first via cancel(); no parent array is registered, so unregister is a no-op.
+    insert.cancel(clientContext);
+    assertTrue(insert.isCancelled());
+
+    insert.schedule();
+
+    verify(insertScheduler, times(1)).registerInsert(insert, false);
+    assertFalse(insert.isCancelled());
+  }
+
+  @Test
+  void getSender_send_whenSuccess_callsRealPut_onSuccess_andRemovesRunningInsert()
+      throws Exception {
+    // Arrange
+    SimpleSendableInsert real =
+        new SimpleSendableInsert(chkBlock, (short) 1, requestClient, insertScheduler);
+    SimpleSendableInsert insert = spy(real);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    // Make realPut succeed (do nothing)
+    doNothing()
+        .when(core)
+        .realPut(
+            chkBlock,
+            true,
+            Node.FORK_ON_CACHEABLE_DEFAULT,
+            Node.PREFER_INSERT_DEFAULT,
+            Node.IGNORE_LOW_BACKOFF_DEFAULT,
+            false);
+
+    // Build a token and chosen block
+    SendableRequestItemKey tokenKey = new SendableRequestItemKey() {};
+    SendableRequestItem token =
+        new SendableRequestItem() {
+          @Override
+          public void dump() {}
+
+          @Override
+          public SendableRequestItemKey getKey() {
+            return tokenKey;
+          }
+        };
+
+    var chosen =
+        new ChosenBlockImpl(
+            insert,
+            token,
+            null,
+            null,
+            false,
+            false,
+            true, // canWriteClientCache propagated into realPut
+            Node.FORK_ON_CACHEABLE_DEFAULT,
+            false,
+            requestScheduler,
+            false);
+
+    // Act
+    boolean sent =
+        insert.getSender(clientContext).send(core, requestScheduler, clientContext, chosen);
+
+    // Assert
+    assertTrue(sent);
+    verify(core, times(1))
+        .realPut(
+            chkBlock,
+            true,
+            Node.FORK_ON_CACHEABLE_DEFAULT,
+            Node.PREFER_INSERT_DEFAULT,
+            Node.IGNORE_LOW_BACKOFF_DEFAULT,
+            false);
+    verify(insert, times(1)).onSuccess(token, null, clientContext);
+    verify(requestScheduler, times(1)).removeRunningInsert(insert, tokenKey);
+    assertTrue(insert.isCancelled());
+    assertTrue(insert.isEmpty());
+    verifyNoMoreInteractions(requestScheduler);
+  }
+
+  @Test
+  void getSender_send_whenRealPutThrows_callsOnFailure_setsFinished_andSkipsRemove()
+      throws Exception {
+    // Arrange
+    SimpleSendableInsert real =
+        new SimpleSendableInsert(sskBlock, (short) 2, requestClient, insertScheduler);
+    SimpleSendableInsert insert = spy(real);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    doThrow(new LowLevelPutException(LowLevelPutException.REJECTED_OVERLOAD))
+        .when(core)
+        .realPut(
+            eq(sskBlock),
+            any(Boolean.class),
+            eq(Node.FORK_ON_CACHEABLE_DEFAULT),
+            eq(Node.PREFER_INSERT_DEFAULT),
+            eq(Node.IGNORE_LOW_BACKOFF_DEFAULT),
+            eq(false));
+
+    SendableRequestItemKey tokenKey = new SendableRequestItemKey() {};
+    SendableRequestItem token =
+        new SendableRequestItem() {
+          @Override
+          public void dump() {}
+
+          @Override
+          public SendableRequestItemKey getKey() {
+            return tokenKey;
+          }
+        };
+
+    var chosen =
+        new ChosenBlockImpl(
+            insert,
+            token,
+            null,
+            null,
+            false,
+            false,
+            false,
+            Node.FORK_ON_CACHEABLE_DEFAULT,
+            false,
+            requestScheduler,
+            false);
+
+    // Act
+    boolean sent =
+        insert.getSender(clientContext).send(core, requestScheduler, clientContext, chosen);
+
+    // Assert
+    assertTrue(sent);
+    verify(insert, times(1))
+        .onFailure(any(LowLevelPutException.class), eq(token), eq(clientContext));
+    // removeRunningInsert() is not called on failure in this sender path
+    verifyNoInteractions(insertScheduler);
+    verifyNoMoreInteractions(requestScheduler);
+    assertTrue(insert.isCancelled());
+    assertTrue(insert.isEmpty());
+  }
+
+  @Test
+  void chooseKey_whenAlreadyInFlight_returnsNull() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, (short) 1, requestClient, insertScheduler);
+
+    KeysFetchingLocally keys = mock(KeysFetchingLocally.class);
+    when(keys.hasInsert(any())).thenReturn(true);
+
+    assertNull(insert.chooseKey(keys, clientContext));
+  }
+
+  @Test
+  void chooseKey_whenFinished_returnsNull() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, (short) 1, requestClient, insertScheduler);
+    insert.cancel(clientContext);
+
+    KeysFetchingLocally keys = mock(KeysFetchingLocally.class);
+    when(keys.hasInsert(any())).thenReturn(false);
+
+    assertNull(insert.chooseKey(keys, clientContext));
+  }
+
+  @Test
+  void chooseKey_whenEligible_returnsItemAndStableKey() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(sskBlock, (short) 5, requestClient, insertScheduler);
+
+    KeysFetchingLocally keys = mock(KeysFetchingLocally.class);
+    when(keys.hasInsert(any())).thenReturn(false);
+
+    SendableRequestItem a = insert.chooseKey(keys, clientContext);
+    SendableRequestItem b = insert.chooseKey(keys, clientContext);
+    assertNotNull(a);
+    assertNotNull(b);
+    // Identity should differ, equality should be based on the parent; hashCode should match.
+    assertNotSame(a, b);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertSame(a, a.getKey());
+  }
+
+  @Test
+  void getWakeupTime_whenEmpty_returnsMinusOne() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, (short) 1, requestClient, insertScheduler);
+    insert.cancel(clientContext);
+
+    long wake = insert.getWakeupTime(clientContext, 0L);
+    assertEquals(-1L, wake);
+  }
+
+  @Test
+  void getWakeupTime_whenRunningSameToken_returnsLongMax() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, (short) 1, requestClient, insertScheduler);
+    // Not finished
+
+    KeysFetchingLocally keys = mock(KeysFetchingLocally.class);
+    when(keys.hasInsert(any())).thenReturn(true);
+    when(insertScheduler.fetchingKeys()).thenReturn(keys);
+
+    long wake = insert.getWakeupTime(clientContext, 0L);
+    assertEquals(Long.MAX_VALUE, wake);
+  }
+
+  @Test
+  void getWakeupTime_whenReady_returnsZero() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(sskBlock, (short) 4, requestClient, insertScheduler);
+
+    KeysFetchingLocally keys = mock(KeysFetchingLocally.class);
+    when(keys.hasInsert(any())).thenReturn(false);
+    when(insertScheduler.fetchingKeys()).thenReturn(keys);
+
+    long wake = insert.getWakeupTime(clientContext, 0L);
+    assertEquals(0L, wake);
+  }
+
+  @Test
+  void isSSK_whenBlockTypeVaries_reportsAccurately() {
+    SimpleSendableInsert chkInsert =
+        new SimpleSendableInsert(chkBlock, (short) 1, requestClient, insertScheduler);
+    SimpleSendableInsert sskInsert =
+        new SimpleSendableInsert(sskBlock, (short) 1, requestClient, insertScheduler);
+    assertFalse(chkInsert.isSSK());
+    assertTrue(sskInsert.isSSK());
+  }
+
+  @Test
+  void cacheAndForkFlags_matchDefaults() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, (short) 1, requestClient, insertScheduler);
+    assertFalse(insert.canWriteClientCache());
+    assertFalse(insert.localRequestOnly());
+    assertEquals(Node.FORK_ON_CACHEABLE_DEFAULT, insert.forkOnCacheable());
+  }
+
+  @Test
+  void countKeys_whenFinishedAndNotFinished_reflectsState() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(sskBlock, (short) 1, requestClient, insertScheduler);
+    assertEquals(1L, insert.countAllKeys(clientContext));
+    assertEquals(1L, insert.countSendableKeys(clientContext));
+
+    insert.cancel(clientContext);
+    assertEquals(0L, insert.countAllKeys(clientContext));
+    assertEquals(0L, insert.countSendableKeys(clientContext));
+  }
+
+  @Test
+  void basicAccessors_returnExpectedValues() {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, (short) 7, requestClient, insertScheduler);
+    assertEquals(requestClient, insert.getClient());
+    assertNull(insert.getClientRequest());
+    assertNull(insert.getSchedulerGroup());
+  }
+
+  @Test
+  void ctor_withUnknownBlockType_throwsIllegalArgumentException() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    when(core.getNode()).thenReturn(node);
+    when(node.getNonPersistentClientBulk()).thenReturn(requestClient);
+
+    KeyBlock unknown = mock(KeyBlock.class); // not CHK or SSK
+
+    assertThrows(
+        IllegalArgumentException.class, () -> new SimpleSendableInsert(core, unknown, (short) 1));
+  }
+
+  @Test
+  void innerOnResume_doesNothing_andDoesNotThrow() throws Exception {
+    SimpleSendableInsert insert =
+        new SimpleSendableInsert(chkBlock, (short) 1, requestClient, insertScheduler);
+    // Do not expect any exception from innerOnResume via public onResume.
+    insert.onResume(clientContext);
+  }
+}


### PR DESCRIPTION
Summary
- Improve Javadoc and parameterized logging in SendableInsert and SimpleSendableInsert.
- Keep behaviors unchanged; focus on clarity and diagnostics.
- Add/update unit tests for SimpleSendableInsert.
- Spotless applied.

Branch
- Source: feature/fix-SendableInsert
- Target: develop

Commits in this branch (relative to develop)
- db68e38f2f refactor(node): improve SendableInsert and SimpleSendableInsert docs/logging
  - style: apply Spotless formatting
  - test: update SimpleSendableInsertTest assertions and coverage

Diff overview vs develop
- Modified: src/main/java/network/crypta/node/SendableInsert.java
  - Expanded Javadoc; constructor visibility tightened to protected; parameterized logging and small consistency tweaks.
- Modified: src/main/java/network/crypta/node/SimpleSendableInsert.java
  - Expanded Javadoc/comments; parameterized logging; clarified sender comments; no behavior changes intended.
- Added: src/test/java/network/crypta/node/SimpleSendableInsertTest.java
  - Tests sender success/failure path, scheduling/cancelation, equals/hashCode of token key, and null assertions.

Additional diffs present vs develop
Note: This branch currently differs from develop on a few other files. These changes predate the refactor commit but are part of the branch’s diff and will be included in this PR unless rebased:
- Modified: src/main/java/network/crypta/node/SemiOrderedShutdownHook.java
- Modified: src/main/java/network/crypta/node/SendableGetRequestSender.java
- Deleted: src/test/java/network/crypta/node/SemiOrderedShutdownHookTest.java

If desired, I can rebase feature/fix-SendableInsert on the latest develop to isolate the SendableInsert changes and avoid the unrelated diffs above.

Verification
- Spotless ran clean locally (./gradlew spotlessApply).
- No uncommitted changes remain.

Request
- Please review the docs/logging adjustments and the new test coverage for SimpleSendableInsert.
- Advise if you’d prefer this branch rebased to drop unrelated diffs vs develop before merge.