### PR TITLE
docs,test(node): document SessionKey and add unit tests

### DIFF
--- a/src/main/java/network/crypta/node/SessionKey.java
+++ b/src/main/java/network/crypta/node/SessionKey.java
@@ -3,35 +3,86 @@ package network.crypta.node;
 import network.crypta.crypt.BlockCipher;
 
 /**
- * Class representing a single session key.
+ * Holds the cryptographic materials and per-key context for a single peer session.
+ *
+ * <p>The fields expose the block ciphers and raw key bytes used by the {@link NewPacketFormat}
+ * pipeline for encrypting/decrypting packets and computing message authentication. Array fields are
+ * stored by reference; they are not defensively copied. Treat all keying material as sensitive and
+ * avoid modifying it after construction.
+ *
+ * <p>Thread safety: instances are immutable with respect to field references. The referenced arrays
+ * themselves are mutable. The {@link #packetContext} manages its own synchronization.
  *
  * @author Matthew Toseland <toad@amphibian.dyndns.org> (0xE43DA450)
  */
 public class SessionKey {
 
-  /** Parent PeerNode */
+  /**
+   * Owning peer for this session key. May be {@code null} in tests or during construction in
+   * transitional states.
+   */
   public final PeerNode pn;
 
-  /** Cipher to encrypt outgoing packets with */
+  /** Cipher used to encrypt outgoing packets for this session. */
   public final BlockCipher outgoingCipher;
 
-  /** Key for outgoingCipher, so far for debugging */
+  /**
+   * Raw key bytes associated with {@link #outgoingCipher}. Stored by reference; not defensively
+   * copied. Handle as secret material.
+   */
   public final byte[] outgoingKey;
 
-  /** Cipher to decrypt incoming packets */
+  /** Cipher used to decrypt incoming packets for this session. */
   public final BlockCipher incommingCipher;
 
-  /** Key for incommingCipher, so far for debugging */
+  /**
+   * Raw key bytes associated with {@link #incommingCipher}. Stored by reference; not defensively
+   * copied. Handle as secret material.
+   */
   public final byte[] incommingKey;
 
+  /** Cipher used when deriving or masking per-packet IV material. */
   public final BlockCipher ivCipher;
+
+  /**
+   * Base nonce used together with {@link #ivCipher} for IV-related operations. Stored by reference;
+   * not defensively copied.
+   */
   public final byte[] ivNonce;
+
+  /** Key material used for per-packet authentication (HMAC). Stored by reference. */
   public final byte[] hmacKey;
 
+  /**
+   * Opaque tracker identifier for diagnostics. Semantics are defined by the creator; the value is
+   * not interpreted by this class.
+   */
   final long trackerID;
 
+  /**
+   * Per-key packet context that tracks sequence numbers, acknowledgments, and in-flight packets.
+   * Must be non-null when {@link #disconnected()} is invoked.
+   */
   public final NewPacketFormatKeyContext packetContext;
 
+  /**
+   * Creates a new {@code SessionKey} with the provided ciphers, key bytes, and context.
+   *
+   * <p>All array parameters are stored by reference and are not defensively copied. Callers should
+   * avoid modifying them after construction.
+   *
+   * @param parent owning peer (may be {@code null} in tests).
+   * @param outgoingCipher cipher for encrypting outgoing packets.
+   * @param outgoingKey raw key bytes for {@code outgoingCipher}; stored by reference.
+   * @param incommingCipher cipher for decrypting incoming packets.
+   * @param incommingKey raw key bytes for {@code incommingCipher}; stored by reference.
+   * @param ivCipher cipher used for IV-related operations.
+   * @param ivNonce base nonce used with {@code ivCipher}; stored by reference.
+   * @param hmacKey key material used for message authentication; stored by reference.
+   * @param context per-key packet context; must be non-null if {@link #disconnected()} will be
+   *     called.
+   * @param trackerID opaque identifier for diagnostics.
+   */
   SessionKey(
       PeerNode parent,
       BlockCipher outgoingCipher,
@@ -55,6 +106,14 @@ public class SessionKey {
     this.trackerID = trackerID;
   }
 
+  /**
+   * Notifies the per-key context that this session key is no longer active.
+   *
+   * <p>Delegates to {@link NewPacketFormatKeyContext#disconnected()} so that any in-flight packets
+   * are marked lost and per-key state is cleared.
+   *
+   * <p>Precondition: {@link #packetContext} is non-null.
+   */
   public void disconnected() {
     packetContext.disconnected();
   }

--- a/src/test/java/network/crypta/node/SessionKeyTest.java
+++ b/src/test/java/network/crypta/node/SessionKeyTest.java
@@ -1,0 +1,143 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import network.crypta.crypt.BlockCipher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SessionKeyTest {
+
+  @Test
+  void constructor_whenGivenValidInputs_assignsFieldsCorrectly() {
+    // Arrange
+    PeerNode parent = mock(PeerNode.class);
+    BlockCipher outgoing = mock(BlockCipher.class);
+    BlockCipher incoming = mock(BlockCipher.class);
+    BlockCipher iv = mock(BlockCipher.class);
+    byte[] outgoingKey = new byte[] {1, 2, 3};
+    byte[] incomingKey = new byte[] {4, 5, 6};
+    byte[] ivNonce = new byte[] {7, 8};
+    byte[] hmacKey = new byte[] {9, 10, 11, 12};
+    NewPacketFormatKeyContext ctx = mock(NewPacketFormatKeyContext.class);
+    long trackerId = 42L;
+
+    // Act
+    SessionKey key =
+        new SessionKey(
+            parent,
+            outgoing,
+            outgoingKey,
+            incoming,
+            incomingKey,
+            iv,
+            ivNonce,
+            hmacKey,
+            ctx,
+            trackerId);
+
+    // Assert
+    assertSame(parent, key.pn, "Parent PeerNode should be stored by reference");
+    assertSame(outgoing, key.outgoingCipher, "Outgoing cipher should match reference");
+    assertSame(incoming, key.incommingCipher, "Incoming cipher should match reference");
+    assertSame(iv, key.ivCipher, "IV cipher should match reference");
+    assertSame(ctx, key.packetContext, "Packet context should match reference");
+    assertArrayEquals(outgoingKey, key.outgoingKey, "Outgoing key bytes should match");
+    assertArrayEquals(incomingKey, key.incommingKey, "Incoming key bytes should match");
+    assertArrayEquals(ivNonce, key.ivNonce, "IV nonce bytes should match");
+    assertArrayEquals(hmacKey, key.hmacKey, "HMAC key bytes should match");
+    assertEquals(trackerId, key.trackerID, "Tracker ID should match");
+  }
+
+  @Test
+  void disconnected_whenCalled_delegatesToContext() {
+    // Arrange
+    NewPacketFormatKeyContext ctx = mock(NewPacketFormatKeyContext.class);
+    SessionKey key =
+        new SessionKey(
+            /*parent*/ null,
+            /*outgoingCipher*/ null,
+            /*outgoingKey*/ null,
+            /*incommingCipher*/ null,
+            /*incommingKey*/ null,
+            /*ivCipher*/ null,
+            /*ivNonce*/ null,
+            /*hmacKey*/ null,
+            /*context*/ ctx,
+            /*trackerID*/ 7L);
+
+    // Act
+    key.disconnected();
+
+    // Assert
+    verify(ctx).disconnected();
+    verifyNoMoreInteractions(ctx);
+  }
+
+  @Test
+  void constructor_whenNullValuesProvided_storesNulls() {
+    // Arrange
+    // All optional dependencies set to null; only trackerId is meaningful
+    long trackerId = -123L;
+
+    // Act
+    SessionKey key =
+        new SessionKey(
+            /*parent*/ null,
+            /*outgoingCipher*/ null,
+            /*outgoingKey*/ null,
+            /*incommingCipher*/ null,
+            /*incommingKey*/ null,
+            /*ivCipher*/ null,
+            /*ivNonce*/ null,
+            /*hmacKey*/ null,
+            /*context*/ null,
+            trackerId);
+
+    // Assert
+    assertNull(key.pn, "Parent should be null");
+    assertNull(key.outgoingCipher, "Outgoing cipher should be null");
+    assertNull(key.incommingCipher, "Incoming cipher should be null");
+    assertNull(key.ivCipher, "IV cipher should be null");
+    assertNull(key.outgoingKey, "Outgoing key should be null");
+    assertNull(key.incommingKey, "Incoming key should be null");
+    assertNull(key.ivNonce, "IV nonce should be null");
+    assertNull(key.hmacKey, "HMAC key should be null");
+    assertNull(key.packetContext, "Context should be null");
+    assertEquals(trackerId, key.trackerID, "Tracker ID should match");
+  }
+
+  @Test
+  void constructor_doesNotDefensivelyCopyArrays_mutationReflectsInFields() {
+    // Arrange
+    byte[] outgoingKey = new byte[] {1, 2, 3};
+    byte[] incomingKey = new byte[] {4, 5, 6};
+    byte[] ivNonce = new byte[] {7, 8};
+    byte[] hmacKey = new byte[] {9, 10, 11, 12};
+
+    SessionKey key =
+        new SessionKey(
+            null, null, outgoingKey, null, incomingKey, null, ivNonce, hmacKey, null, 0L);
+
+    // Act
+    outgoingKey[0] = 99;
+    incomingKey[1] = 88;
+    ivNonce[0] = 77;
+    hmacKey[3] = 66;
+
+    // Assert
+    assertEquals(99, key.outgoingKey[0], "Outgoing key reference should not be copied");
+    assertEquals(88, key.incommingKey[1], "Incoming key reference should not be copied");
+    assertEquals(77, key.ivNonce[0], "IV nonce reference should not be copied");
+    assertEquals(66, key.hmacKey[3], "HMAC key reference should not be copied");
+  }
+}


### PR DESCRIPTION
Summary
- Clarifies Javadoc and field-level documentation for SessionKey, including thread-safety notes and parameter semantics.
- Adds SessionKeyTest to validate constructor field assignments and disconnected() delegation to the context.

Scope
- Documentation only in main sources; no functional code changes.
- New tests only; verifies existing behavior.

Files
- src/main/java/network/crypta/node/SessionKey.java:1
- src/test/java/network/crypta/node/SessionKeyTest.java:1

Commits
- 7374a12 docs(node): improve Javadoc and field docs for SessionKey
- 1dc1849 test(node): add SessionKeyTest validating constructor and context delegation

Notes
- Spotless was run before commits (spotlessApply).
- No build or runtime logic modified.

Validation
- Changes compile as part of the existing build. Tests added are focused and do not alter existing contracts.

Request
- Please review; if acceptable, merge into develop.