### PR TITLE
docs(node): improve Javadoc and log messages for UnqueueMessageOnAckCallback; add unit tests

### DIFF
--- a/src/main/java/network/crypta/node/UnqueueMessageOnAckCallback.java
+++ b/src/main/java/network/crypta/node/UnqueueMessageOnAckCallback.java
@@ -4,47 +4,73 @@ import network.crypta.io.comm.AsyncMessageCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** If the send fails, queue the given message for the given node. Otherwise do nothing. */
+/**
+ * Callback that removes a queued node-to-node message once an acknowledgement is received.
+ *
+ * <p>This is used for N2NM sends that are kept in a resend queue until the remote peer acknowledges
+ * receipt. When {@link #acknowledged()} is invoked, it calls {@link
+ * DarknetPeerNode#unqueueN2NM(int)} with the provided file number. Other lifecycle methods are
+ * no-ops so the message remains queued until an acknowledgement arrives.
+ *
+ * <p>Logging: construction logs at DEBUG for traceability.
+ */
 public class UnqueueMessageOnAckCallback implements AsyncMessageCallback {
   private static final Logger LOG = LoggerFactory.getLogger(UnqueueMessageOnAckCallback.class);
 
-  static {
-  }
-
+  /** Returns a concise representation including the destination and file number. */
   @Override
   public String toString() {
     return super.toString() + ": " + dest + ' ' + extraPeerDataFileNumber;
   }
 
+  // Destination peer associated with the queued message; may be null for tests.
   DarknetPeerNode dest;
+  // File number identifying the queued N2NM message in the peer's resend queue.
   int extraPeerDataFileNumber;
 
+  /**
+   * Create a callback that unqueues the given file number from the specified peer on
+   * acknowledgement.
+   *
+   * @param pn the destination peer that holds the resend queue; must be non-null when {@link
+   *     #acknowledged()} is invoked
+   * @param extraPeerDataFileNumber the file number of the queued message to remove on
+   *     acknowledgement
+   */
   public UnqueueMessageOnAckCallback(DarknetPeerNode pn, int extraPeerDataFileNumber) {
     this.dest = pn;
     this.extraPeerDataFileNumber = extraPeerDataFileNumber;
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Created " + this);
+      LOG.debug("Create UnqueueMessageOnAckCallback {}", this);
     }
   }
 
+  /** No-op; acknowledgement controls removal from the resend queue. */
   @Override
   public void sent() {
-    // Ignore
+    // No action here; only acknowledged() unqueues.
   }
 
+  /**
+   * Unqueues the message after the remote peer acknowledges receipt.
+   *
+   * @throws NullPointerException if the destination peer is {@code null}
+   */
   @Override
   public void acknowledged() {
-    // the message was received, no need to try again.
+    // Message is acknowledged; remove it from the resend queue.
     dest.unqueueN2NM(extraPeerDataFileNumber);
   }
 
+  /** No-op; disconnection does not change queue state. */
   @Override
   public void disconnected() {
-    // ignore
+    // No action; the message remains queued for retry logic elsewhere.
   }
 
+  /** No-op; fatal send errors are handled by higher-level logic. */
   @Override
   public void fatalError() {
-    // ignore
+    // No action here; this callback only unqueues on acknowledgement.
   }
 }

--- a/src/test/java/network/crypta/node/UnqueueMessageOnAckCallbackTest.java
+++ b/src/test/java/network/crypta/node/UnqueueMessageOnAckCallbackTest.java
@@ -1,0 +1,93 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class UnqueueMessageOnAckCallbackTest {
+
+  @Mock private DarknetPeerNode dest;
+
+  @Test
+  void acknowledged_whenCalled_unqueuesExpectedFile() {
+    // Arrange
+    int fileNumber = 42;
+    UnqueueMessageOnAckCallback cb = new UnqueueMessageOnAckCallback(dest, fileNumber);
+
+    // Act
+    cb.acknowledged();
+
+    // Assert
+    verify(dest).unqueueN2NM(fileNumber);
+    verifyNoMoreInteractions(dest);
+  }
+
+  @Test
+  void sent_whenCalled_doesNothing() {
+    // Arrange
+    UnqueueMessageOnAckCallback cb = new UnqueueMessageOnAckCallback(dest, 7);
+
+    // Act
+    cb.sent();
+
+    // Assert
+    verifyNoInteractions(dest);
+  }
+
+  @Test
+  void disconnected_whenCalled_doesNothing() {
+    // Arrange
+    UnqueueMessageOnAckCallback cb = new UnqueueMessageOnAckCallback(dest, 9);
+
+    // Act
+    cb.disconnected();
+
+    // Assert
+    verifyNoInteractions(dest);
+  }
+
+  @Test
+  void fatalError_whenCalled_doesNothing() {
+    // Arrange
+    UnqueueMessageOnAckCallback cb = new UnqueueMessageOnAckCallback(dest, 11);
+
+    // Act
+    cb.fatalError();
+
+    // Assert
+    verifyNoInteractions(dest);
+  }
+
+  @Test
+  void toString_whenConstructed_containsDestAndFileNumber() {
+    // Arrange
+    int fileNumber = 7;
+    UnqueueMessageOnAckCallback cb = new UnqueueMessageOnAckCallback(dest, fileNumber);
+
+    // Act
+    String s = cb.toString();
+    String destString = dest.toString();
+
+    // Assert
+    assertTrue(s.contains(destString));
+    assertTrue(s.endsWith(" " + fileNumber));
+  }
+
+  @Test
+  void acknowledged_whenDestNull_throwsNullPointerException() {
+    // Arrange
+    UnqueueMessageOnAckCallback cb = new UnqueueMessageOnAckCallback(null, 3);
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, cb::acknowledged);
+  }
+}


### PR DESCRIPTION
Summary
- Improve and complete API documentation, inline comments, and log messages for `UnqueueMessageOnAckCallback`.
- Add focused unit tests to validate expected callback behavior.

Changes
- src/main/java/network/crypta/node/UnqueueMessageOnAckCallback.java
  - Replace brief comment with detailed Javadoc documenting purpose, lifecycle, and preconditions.
  - Document constructor parameters and `@throws` on `acknowledged()`.
  - Clarify no-op behavior for `sent()`, `disconnected()`, and `fatalError()`.
  - Refine DEBUG log message text (same placeholders/arguments; clearer wording).
- src/test/java/network/crypta/node/UnqueueMessageOnAckCallbackTest.java
  - New tests covering:
    - `acknowledged()` unqueues the expected file number and performs no extra interactions.
    - `sent()`, `disconnected()`, and `fatalError()` perform no interactions.
    - `toString()` includes destination and file number.
    - `acknowledged()` throws `NullPointerException` when destination is null (reflects current contract).

Notes
- No production logic changes; only comments/Javadoc/log message text were updated in main sources.
- Spotless applied; test suite passes locally via `./gradlew test`.

Motivation
- Clarify intent and contracts for maintainers and plugin authors.
- Make debug logs more actionable and consistent with project logging style.

Risk
- Low; comments and log text only. Existing behavior is unchanged and covered by tests.
