### PR TITLE
refactor(node): improve UptimeEstimator docs/log messages; add focused tests

### DIFF
--- a/src/main/java/network/crypta/node/UptimeEstimator.java
+++ b/src/main/java/network/crypta/node/UptimeEstimator.java
@@ -10,6 +10,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.text.DecimalFormat;
 import network.crypta.support.Fields;
 import network.crypta.support.Ticker;
@@ -17,9 +18,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A class to estimate the node's average uptime. Every 5 minutes (with a fixed offset), we write an
- * integer (the number of minutes since the epoch) to the end of a file. We rotate it when it gets
- * huge. We read it to figure out how many of the 5 minute slots in the last X period are occupied.
+ * Estimates the node's average uptime over fixed 5-minute intervals.
+ *
+ * <p>The estimator samples once every five minutes (aligned by a per-node offset) and appends the
+ * current {@code 5-minute-since-epoch} integer to an on-disk log. The last 48 hours and the last 7
+ * days are tracked in circular buffers to compute recent uptime fractions. When the active log gets
+ * large, it is rotated to a previous file and a new log is created.
+ *
+ * <p>Units: the sampling period is {@code PERIOD = 5 minutes}. The derived {@code timeOffset} is in
+ * milliseconds and lies in {@code [0, PERIOD)}.
+ *
+ * <p>Threading: sampling is scheduled via {@link Ticker}. Public query methods are synchronized.
+ * This class writes to {@code uptime.dat} and may rotate to {@code uptime.old.dat}.
  *
  * @author toad
  */
@@ -31,20 +41,20 @@ public class UptimeEstimator implements Runnable {
 
   Ticker ticker;
 
-  /** For each 5 minute slot in the last 48 hours, were we online? */
+  /** For each 5-minute slot in the last 48 hours, whether the node was online. */
   private final boolean[] wasOnline = new boolean[48 * 12]; // 48 hours * 12 5-minute slots/hour
 
-  /** Whether the node was online for each 5 minute slot in the last week, */
+  /** Whether the node was online for each 5-minute slot in the last week. */
   private final boolean[] wasOnlineWeek =
       new boolean[7 * 24 * 12]; // 7 days/week * 24 hours/day * 12 5-minute slots/hour
 
   /**
-   * Which slot are we up to? We rotate around the array. Slots before us are before us, slots after
-   * us are also before us (it wraps around).
+   * Circular index of the next slot to mark. The arrays wrap around; elements after {@code slot}
+   * refer to earlier times in the window.
    */
   private int slot;
 
-  /** The file we are writing to */
+  /** Active log file to which new samples are appended. */
   private final File logFile;
 
   /**
@@ -53,9 +63,16 @@ public class UptimeEstimator implements Runnable {
    */
   private final File prevFile;
 
-  /** We write to disk every 5 minutes. The offset is derived from the node's identity. */
+  /** Sampling offset within the 5-minute period; derived from the node identity. */
   private final long timeOffset;
 
+  /**
+   * Create a new uptime estimator.
+   *
+   * @param runDir program directory; used to store {@code uptime.dat} and {@code uptime.old.dat}
+   * @param ticker scheduler that queues time-based sampling callbacks
+   * @param bs node identity bytes used to deterministically derive the sampling offset
+   */
   public UptimeEstimator(ProgramDirectory runDir, Ticker ticker, byte[] bs) {
     this.ticker = ticker;
     logFile = runDir.file("uptime.dat");
@@ -67,6 +84,12 @@ public class UptimeEstimator implements Runnable {
                 * PERIOD);
   }
 
+  /**
+   * Initialize in-memory windows and schedule the first sample.
+   *
+   * <p>This reads any existing log files into the 48-hour and 7-day windows, computes the initial
+   * uptime, and schedules the recurring task aligned to {@code timeOffset}.
+   */
   public void start() {
     long now = System.currentTimeMillis();
     int fiveMinutesSinceEpoch = (int) (now / PERIOD);
@@ -75,11 +98,11 @@ public class UptimeEstimator implements Runnable {
     readData(prevFile, base);
     readData(logFile, base);
     schedule(System.currentTimeMillis());
-    System.out.println(
-        "Created uptime estimator, time offset is "
-            + timeOffset
-            + " uptime at startup is "
-            + new DecimalFormat("0.00").format(getUptime()));
+    LOG.atInfo()
+        .setMessage("Created uptime estimator: timeOffset={} ms, uptime at startup={}")
+        .addArgument(timeOffset)
+        .addArgument(() -> new DecimalFormat("0.00").format(getUptime()))
+        .log();
   }
 
   private void readData(File file, int base) {
@@ -87,32 +110,35 @@ public class UptimeEstimator implements Runnable {
         DataInputStream dis = new DataInputStream(fis)) {
       while (true) {
         int offset = dis.readInt();
-        if (offset < base) continue;
-        int slotNo = offset - base;
-        if (slotNo == wasOnlineWeek.length)
-          break; // Reached the end, restarted within the same timeslot.
-        if (slotNo > wasOnlineWeek.length || slotNo < 0) {
-          LOG.error(
-              "Corrupt data read from uptime file "
-                  + file
-                  + ": 5-minutes-from-epoch is now "
-                  + (base + wasOnlineWeek.length)
-                  + " but read "
-                  + slotNo);
-          break;
+        if (offset >= base) {
+          int slotNo = offset - base;
+          if (slotNo >= wasOnlineWeek.length) {
+            if (slotNo > wasOnlineWeek.length) {
+              LOG.error(
+                  "Corrupt uptime data in {}: window upper bound={}, read slot={}",
+                  file,
+                  (base + wasOnlineWeek.length),
+                  slotNo);
+            }
+            break; // Reached the end or corrupt data beyond the window.
+          }
+          // slotNo is non-negative because offset >= base.
+          wasOnline[slotNo % wasOnline.length] = wasOnlineWeek[slotNo] = true;
         }
-        wasOnline[slotNo % wasOnline.length] = wasOnlineWeek[slotNo] = true;
       }
     } catch (EOFException e) {
-      // Finished
+      // Reached end of file; no more samples to load.
     } catch (IOException e) {
-      LOG.error(
-          "Unable to read old uptime file: "
-              + file
-              + " - we will assume we weren't online during that period");
+      LOG.error("Read old uptime file failed: {}; treating slots as offline", file);
     }
   }
 
+  /**
+   * Perform one sampling tick.
+   *
+   * <p>Marks the current slot as online, rotates the on-disk log if it exceeds the window size,
+   * appends the current 5-minute counter, and schedules the next tick.
+   */
   @Override
   public void run() {
     synchronized (this) {
@@ -122,33 +148,42 @@ public class UptimeEstimator implements Runnable {
     }
     long now = System.currentTimeMillis();
     if (logFile.length() > wasOnlineWeek.length * 4L) {
-      prevFile.delete();
-      logFile.renameTo(prevFile);
+      try {
+        Files.deleteIfExists(prevFile.toPath());
+      } catch (IOException e) {
+        LOG.warn("Delete previous uptime file failed for {}: {}", prevFile, e.toString());
+      }
+      try {
+        Files.move(logFile.toPath(), prevFile.toPath());
+      } catch (IOException e) {
+        LOG.warn("Uptime file rotation failed {} -> {}: {}", logFile, prevFile, e.toString());
+      }
     }
     int fiveMinutesSinceEpoch = (int) (now / PERIOD);
     try (FileOutputStream fos = new FileOutputStream(logFile, true);
         DataOutputStream dos = new DataOutputStream(fos)) {
       dos.writeInt(fiveMinutesSinceEpoch);
     } catch (FileNotFoundException e) {
-      LOG.error("Unable to create or access " + logFile + " : " + e, e);
+      LOG.error("Create or open uptime file failed for {}: {}", logFile, e, e);
     } catch (IOException e) {
-      LOG.error("Unable to write to uptime estimator log file: " + logFile);
+      LOG.error("Write to uptime log failed: {}", logFile);
     } finally {
-      // Schedule next time
+      // Schedule the next sample.
       schedule(now);
     }
   }
 
   private void schedule(long now) {
-    long nextTime = (((now / PERIOD)) * (PERIOD)) + timeOffset;
+    long nextTime = (now / PERIOD) * PERIOD + timeOffset;
     if (nextTime < now) nextTime += PERIOD;
     ticker.queueTimedJob(this, nextTime - System.currentTimeMillis());
   }
 
   /**
-   * Get the node's uptime fraction over the selected uptime array.
+   * Compute the uptime fraction for the provided window.
    *
-   * @return fraction between 0.0 and 1.0.
+   * @param uptime circular window of 5-minute samples where {@code true} means online
+   * @return fraction between 0.0 and 1.0
    */
   private synchronized double getUptime(boolean[] uptime) {
     int upCount = 0;
@@ -157,18 +192,18 @@ public class UptimeEstimator implements Runnable {
   }
 
   /**
-   * Get the node's uptime fraction over the past 48 hours.
+   * Get the node's uptime fraction over the past 48 hours (576 slots).
    *
-   * @return fraction between 0.0 and 1.0.
+   * @return fraction between 0.0 and 1.0
    */
   public synchronized double getUptime() {
     return getUptime(wasOnline);
   }
 
   /**
-   * Get the node's uptime fraction over the past 168 hours.
+   * Get the node's uptime fraction over the past 7 days (2016 slots).
    *
-   * @return fraction between 0.0 and 1.0.
+   * @return fraction between 0.0 and 1.0
    */
   public synchronized double getUptimeWeek() {
     return getUptime(wasOnlineWeek);

--- a/src/test/java/network/crypta/node/UptimeEstimatorTest.java
+++ b/src/test/java/network/crypta/node/UptimeEstimatorTest.java
@@ -1,0 +1,170 @@
+package network.crypta.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Path;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class UptimeEstimatorTest {
+
+  @TempDir Path tempDir;
+
+  @Mock Ticker ticker;
+
+  private static byte[] zeroBytes(int n) {
+    return new byte[n];
+  }
+
+  private ProgramDirectory programDirectory() throws Exception {
+    ProgramDirectory pd = new ProgramDirectory();
+    pd.move(tempDir.toString());
+    return pd;
+  }
+
+  @Test
+  void start_whenNoExistingData_expectZeroUptimeAndSchedules() throws Exception {
+    // Arrange
+    ProgramDirectory pd = programDirectory();
+    UptimeEstimator est = new UptimeEstimator(pd, ticker, zeroBytes(32));
+
+    // Act
+    est.start();
+
+    // Assert
+    // Uptime arrays are empty until run() marks the first slot
+    assertEquals(0.0, est.getUptime(), 0.0);
+    assertEquals(0.0, est.getUptimeWeek(), 0.0);
+
+    // One scheduling call is made
+    verify(ticker, times(1)).queueTimedJob(eq(est), any(Long.class));
+  }
+
+  @Test
+  void run_whenCalledOnce_marksCurrentSlotAndWrites() throws Exception {
+    // Arrange
+    ProgramDirectory pd = programDirectory();
+    UptimeEstimator est = new UptimeEstimator(pd, ticker, zeroBytes(16));
+    est.start();
+
+    // Act
+    est.run();
+
+    // Assert
+    // One slot out of the arrays becomes true
+    double expected48h = 1.0 / (48.0 * 12.0); // 576
+    double expectedWeek = 1.0 / (7.0 * 24.0 * 12.0); // 2016
+    assertEquals(expected48h, est.getUptime(), 1e-12);
+    assertEquals(expectedWeek, est.getUptimeWeek(), 1e-12);
+
+    // Two scheduling calls in total: from start() and from run()
+    verify(ticker, times(2)).queueTimedJob(eq(est), any(Long.class));
+
+    // And a log file exists with a single 4-byte integer written
+    File log = pd.file("uptime.dat");
+    assertTrue(log.exists());
+    assertEquals(4L, log.length());
+  }
+
+  @Test
+  void start_whenPreexistingFilesWithOffsets_setsExpectedFractions() throws Exception {
+    // Arrange
+    ProgramDirectory pd = programDirectory();
+    File prev = pd.file("uptime.old.dat");
+    File log = pd.file("uptime.dat");
+
+    // Base in five-minute slots as used by UptimeEstimator.start()
+    final long periodMillis = 5L * 60L * 1000L;
+    int nowSlots = (int) (System.currentTimeMillis() / periodMillis);
+    int base = nowSlots - (7 * 24 * 12); // one week window length
+
+    // Choose four valid slot numbers within [0, 2015], none at edges to avoid boundary races
+    int[] slotNos = new int[] {1, 1440, 2013, 2014};
+
+    try (DataOutputStream d1 = new DataOutputStream(new FileOutputStream(prev));
+        DataOutputStream d2 = new DataOutputStream(new FileOutputStream(log))) {
+      // Two in prev, two in current
+      d1.writeInt(base + slotNos[0]);
+      d1.writeInt(base + slotNos[1]);
+      d2.writeInt(base + slotNos[2]);
+      d2.writeInt(base + slotNos[3]);
+    }
+
+    UptimeEstimator est = new UptimeEstimator(pd, ticker, zeroBytes(8));
+
+    // Act
+    est.start();
+
+    // Assert
+    double expectedWeek = 4.0 / (7.0 * 24.0 * 12.0); // 4 out of 2016
+    double expected48h = 4.0 / (48.0 * 12.0); // chosen slots occupy 4 distinct 48h indices
+    assertEquals(expectedWeek, est.getUptimeWeek(), 1e-9);
+    assertEquals(expected48h, est.getUptime(), 1e-9);
+  }
+
+  @Test
+  void run_whenLogExceedsThreshold_rotatesToPrevAndAppendsFresh() throws Exception {
+    // Arrange
+    ProgramDirectory pd = programDirectory();
+    UptimeEstimator est = new UptimeEstimator(pd, ticker, zeroBytes(4));
+    est.start();
+
+    // Threshold bytes == 2016 * 4
+    final int writesToExceed = 2016 + 1; // +1 to make length > threshold
+
+    // Perform enough runs to exceed threshold
+    for (int i = 0; i < writesToExceed; i++) {
+      est.run();
+    }
+
+    // This next run will observe length > threshold and rotate
+    est.run();
+
+    // Assert
+    File prev = pd.file("uptime.old.dat");
+    File log = pd.file("uptime.dat");
+    assertTrue(prev.exists());
+    assertTrue(prev.length() > 0L);
+    assertTrue(log.exists());
+    assertEquals(4L, log.length(), "new log should start fresh after rotation");
+  }
+
+  @Test
+  void start_whenCorruptSlotBeyondWindow_ignoresAndLeavesZero() throws Exception {
+    // Arrange
+    ProgramDirectory pd = programDirectory();
+    File log = pd.file("uptime.dat");
+
+    final long periodMillis = 5L * 60L * 1000L;
+    int nowSlots = (int) (System.currentTimeMillis() / periodMillis);
+    int base = nowSlots - (7 * 24 * 12);
+
+    // Write a single bogus entry strictly beyond the week window
+    try (DataOutputStream d = new DataOutputStream(new FileOutputStream(log))) {
+      d.writeInt(base + (7 * 24 * 12) + 123);
+    }
+
+    UptimeEstimator est = new UptimeEstimator(pd, ticker, zeroBytes(12));
+
+    // Act
+    est.start();
+
+    // Assert
+    assertEquals(0.0, est.getUptimeWeek(), 0.0);
+    assertEquals(0.0, est.getUptime(), 0.0);
+  }
+}


### PR DESCRIPTION
Summary
- Clarify and expand Javadoc for UptimeEstimator (units, windows, threading, files)
- Tighten log messages: one-line, active voice, placeholders preserved, explicit units
- Improve inline comments: invariants and rationale for circular windows, rotation behavior
- Add unit tests covering: initial load, single tick behavior, preexisting data load, rotation threshold, and corrupt record beyond window

Details
- start(): replace println with structured SLF4J info and include explicit units for timeOffset
- readData(): clarify corruption logs (window bound vs read slot), keep placeholder order
- run(): rotation logs are clearer; file rotation uses NIO operations with warnings and preserves behavior
- getUptime()/getUptimeWeek(): document window sizes (576/2016 slots) and return range

Notes
- No changes to public API signatures.
- Spotless applied across Java/Kotlin/Gradle files.
- Tests use JUnit 6 and Mockito (Ticker mocked). Temporary directories via @TempDir.

Scope
- src/main/java/network/crypta/node/UptimeEstimator.java
- src/test/java/network/crypta/node/UptimeEstimatorTest.java

Target
- Base: develop
- Head: feature/fix-UptimeEstimator
