### PR TITLE
fix(diagnostics): stabilize thread CPU sampling; filter idle workers

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -1,6 +1,9 @@
 import name.remal.gradle_plugins.sonarlint.SonarLint
 import name.remal.gradle_plugins.sonarlint.SonarLintSettings
+import org.gradle.api.JavaVersion
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 plugins {
   // Apply SonarQube/SonarCloud and SonarLint centrally via convention plugin
@@ -47,6 +50,15 @@ extensions.configure<SonarLintSettings>("sonarLint") {
     // Use Sonar's standard inclusions property so the engine narrows the scope
     sonarProperty("sonar.inclusions", value)
   }
+
+  // Ensure Java language level is explicitly provided so rules that depend on
+  // the runtime version (e.g., java:S6204 requiring Java 16+) are evaluated
+  // consistently, including for single-file analyses.
+  val javaExt = project.extensions.findByType(JavaPluginExtension::class.java)
+  val sourceVersion = (javaExt?.sourceCompatibility ?: JavaVersion.current()).majorVersion
+  val targetVersion = (javaExt?.targetCompatibility ?: JavaVersion.current()).majorVersion
+  sonarProperty("sonar.java.source", sourceVersion)
+  sonarProperty("sonar.java.target", targetVersion)
 }
 
 // Convenience task: run SonarLint on a single file
@@ -60,6 +72,20 @@ tasks.register("sonarlintFile", SonarLint::class.java) {
   description = "Run SonarLint on a single file (-Psonarlint.file=<path>)."
   // Analyze against main sources by default
   setSource(sourceSets.named("main").get().allSource)
+  // Propagate Java language level explicitly for single-file analysis
+  val javaExt = project.extensions.findByType(JavaPluginExtension::class.java)
+  val sourceVersion = (javaExt?.sourceCompatibility ?: JavaVersion.current()).majorVersion
+  val targetVersion = (javaExt?.targetCompatibility ?: JavaVersion.current()).majorVersion
+  // Configure task-scoped Java release for the SonarLint engine
+  java { release.set(JavaLanguageVersion.of(sourceVersion.toInt())) }
+
+  // Provide classpath and output directories so Java rules that require
+  // semantic information are enabled even for single-file analysis.
+  val mainSourceSet = sourceSets.named("main").get()
+  java {
+    mainOutputDirectories.from(mainSourceSet.output.classesDirs)
+    mainClasspath.from(mainSourceSet.runtimeClasspath)
+  }
   // Pick a file pattern from properties
   val fileProp =
     providers

--- a/src/main/java/network/crypta/node/diagnostics/ThreadDiagnostics.java
+++ b/src/main/java/network/crypta/node/diagnostics/ThreadDiagnostics.java
@@ -2,6 +2,27 @@ package network.crypta.node.diagnostics;
 
 import network.crypta.node.diagnostics.threads.NodeThreadSnapshot;
 
+/**
+ * Exposes lightweight diagnostics for threads running in the node.
+ *
+ * <p>Implementations provide a periodically refreshed, point-in-time view of active threads and
+ * related metrics suitable for UI pages and support tooling. Unless stated otherwise by a specific
+ * implementation, instances are safe to use from multiple threads.
+ */
 public interface ThreadDiagnostics {
+
+  /**
+   * Returns the most recent snapshot of node threads.
+   *
+   * <p>The returned {@link NodeThreadSnapshot} represents a single sampling interval collected by
+   * the implementation. It typically includes a list of thread/job entries and the sampling
+   * interval used to compute recent CPU deltas. When no data has been collected yet, the snapshot
+   * may contain no threads.
+   *
+   * <p>Thread-safety: Callers may invoke this method from any thread. Implementations should return
+   * the latest available snapshot without blocking for long-running work.
+   *
+   * @return a snapshot object describing currently known threads
+   */
   NodeThreadSnapshot getThreadSnapshot();
 }

--- a/src/main/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnostics.java
+++ b/src/main/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnostics.java
@@ -9,22 +9,46 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import network.crypta.node.NodeStats;
 import network.crypta.node.diagnostics.ThreadDiagnostics;
 import network.crypta.support.PooledExecutor;
 import network.crypta.support.Ticker;
 
 /**
- * Runnable thread to retrieve node thread's information and compiling it into an array of
- * NodeThreadInfo objects.
+ * Periodically samples JVM threads and produces lightweight diagnostics snapshots.
+ *
+ * <p>This implementation polls the JVM {@link ThreadMXBean} and internal executor metadata to
+ * capture a point-in-time view of active threads. For worker threads managed by {@link
+ * network.crypta.support.PooledExecutor.MyThread}, a stable <em>job id</em> is obtained so
+ * successive samples can be correlated even when the underlying thread object is reused by the
+ * pool. For non-pooled threads, the operating system thread id is used as the identifier.
+ *
+ * <p>The instance schedules itself at a fixed sampling interval using the provided {@link
+ * network.crypta.support.Ticker}. Each execution computes per-thread CPU deltas since the previous
+ * run and updates a {@link NodeThreadSnapshot} that can be retrieved at any time via {@link
+ * #getThreadSnapshot()}. The snapshot is immutable from the caller’s perspective and is safe to
+ * read concurrently.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities</strong>: schedule sampling, compute CPU deltas, expose snapshots.
+ *   <li><strong>Thread-safety</strong>: reading the snapshot is lock-free; internal mutable state
+ *       is confined to this sampler’s execution.
+ *   <li><strong>Lifecycle</strong>: call {@link #start()} once to begin periodic sampling, and
+ *       {@link #stop()} to cancel future runs.
+ * </ul>
  */
 public class DefaultThreadDiagnostics implements Runnable, ThreadDiagnostics {
   /**
-   * @param nodeStats Used to retrieve data points
-   * @param ticker Used to queue timed jobs
-   * @param name Thread name
-   * @param monitorInterval Sleep intervals to retrieve CPU usage
+   * Creates a diagnostics sampler with explicit scheduling name and interval.
+   *
+   * @param nodeStats the node statistics provider used to enumerate live JVM threads; never null
+   *     and expected to return a stable snapshot for the duration of a single sampling pass
+   * @param ticker the timing facility used to queue periodic executions; must invoke this runnable
+   *     roughly every {@code monitorInterval} seconds and support cancellation
+   * @param name the logical name under which the job is queued in the ticker so operators can
+   *     identify it in logs or admin tooling
+   * @param monitorInterval the sampling period in seconds; larger values reduce overhead but make
+   *     computed CPU deltas less granular
    */
   public DefaultThreadDiagnostics(
       NodeStats nodeStats, Ticker ticker, String name, int monitorInterval) {
@@ -35,47 +59,83 @@ public class DefaultThreadDiagnostics implements Runnable, ThreadDiagnostics {
   }
 
   /**
-   * @param nodeStats Used to retrieve data points
-   * @param ticker Used to queue timed jobs
+   * Creates a diagnostics sampler that uses default naming and interval.
+   *
+   * <p>The job is queued under a default human-readable name and sampled every {@link
+   * #DEFAULT_MONITOR_INTERVAL} milliseconds.
+   *
+   * @param nodeStats the node statistics provider used to enumerate live JVM threads; never null
+   * @param ticker the timing facility used to schedule periodic executions; never null
    */
   public DefaultThreadDiagnostics(NodeStats nodeStats, Ticker ticker) {
     this(nodeStats, ticker, DEFAULT_MONITOR_THREAD_NAME, DEFAULT_MONITOR_INTERVAL);
   }
 
   /**
-   * @return Current snapshot.
+   * Returns the most recently computed snapshot of thread diagnostics.
+   *
+   * <p>The snapshot aggregates entries for the latest sampling interval and contains per-thread CPU
+   * time deltas measured in nanoseconds along with descriptive fields such as name, priority, group
+   * and state. The returned object is a stable view and does not change after this method returns.
+   *
+   * @return a new {@link NodeThreadSnapshot} instance representing the most recent sampling pass;
+   *     may reference an empty list when sampling has not yet observed any eligible threads
    */
   public NodeThreadSnapshot getThreadSnapshot() {
     return nodeThreadSnapshot.get();
   }
 
-  /** Start the execution. */
+  /**
+   * Starts periodic sampling by enqueueing the first run immediately.
+   *
+   * <p>This method is idempotent with respect to multiple invocations that occur before {@link
+   * #stop()} is called; the ticker is asked to schedule this runnable, and subsequent runs will
+   * re-queue themselves at the configured interval.
+   */
   public void start() {
     scheduleNext(0);
   }
 
+  /**
+   * Cancels future sampling executions.
+   *
+   * <p>No in-flight run is interrupted. After this call returns, the ticker will no longer invoke
+   * this runnable unless {@link #start()} is called again. The last computed snapshot remains
+   * available via {@link #getThreadSnapshot()}.
+   */
   public void stop() {
     ticker.removeQueuedJob(this);
   }
 
+  /**
+   * Performs a single sampling pass and updates the published snapshot.
+   *
+   * <p>This method fetches the current list of live threads from {@code nodeStats}, samples each
+   * eligible thread to compute its recent CPU delta, and publishes a new {@link NodeThreadSnapshot}
+   * to callers. It also purges bookkeeping for threads that have disappeared and finally schedules
+   * the next execution based on the configured interval.
+   */
   @Override
   public void run() {
     List<NodeThreadInfo> threads =
         Arrays.stream(nodeStats.getThreads())
             .filter(Objects::nonNull)
             .filter(thread -> thread.getThreadGroup() != null)
-            .filter(thread -> getJobId(thread) != 0)
             .map(
-                thread ->
-                    new NodeThreadInfo(
-                        thread.threadId(),
-                        getJobId(thread),
-                        getCpuTimeDelta(thread),
-                        getJobName(thread),
-                        thread.getPriority(),
-                        thread.getThreadGroup().getName(),
-                        thread.getState().toString()))
-            .collect(Collectors.toList());
+                thread -> {
+                  Sample s = sampleThread(thread);
+                  if (s.jobId() == 0) return null; // skip workers with no job assigned yet
+                  return new NodeThreadInfo(
+                      thread.threadId(),
+                      s.jobId(),
+                      s.cpuDelta(),
+                      s.name(),
+                      thread.getPriority(),
+                      thread.getThreadGroup().getName(),
+                      thread.getState().toString());
+                })
+            .filter(Objects::nonNull)
+            .toList();
 
     nodeThreadSnapshot.set(new NodeThreadSnapshot(threads, monitorInterval));
 
@@ -94,33 +154,6 @@ public class DefaultThreadDiagnostics implements Runnable, ThreadDiagnostics {
 
   private void scheduleNext() {
     scheduleNext(monitorInterval);
-  }
-
-  /**
-   * Calculate the "delta" CPU time for a given thread. This method keeps track of the previous CPU
-   * Time and calculates the difference between that snapshot and the current CPU Time.
-   *
-   * <p>If there's no previous snapshot of CPU Time for the thread this method will return 0.
-   *
-   * @param thread Thread object to get the CPU usage
-   * @return Delta CPU time (nanoseconds)
-   */
-  private long getCpuTimeDelta(Thread thread) {
-    long jobId, current;
-    String name;
-    // Synchronizing thread to avoid PoolerExecutor to change thread name
-    // while we're measuring it.
-    synchronized (thread) {
-      name = thread.getName();
-      current = threadMxBean.getThreadCpuTime(thread.threadId());
-      jobId = getJobId(thread);
-    }
-
-    ThreadSnapshot snapshot = threadSnapshot.get(jobId);
-    long cpuUsage = current - (snapshot != null ? snapshot.getCpu() : 0);
-    threadSnapshot.put(jobId, new ThreadSnapshot(current, name));
-
-    return cpuUsage;
   }
 
   /**
@@ -153,39 +186,42 @@ public class DefaultThreadDiagnostics implements Runnable, ThreadDiagnostics {
   }
 
   /**
-   * Get thread (jobs) name at the time of measurement or default to current's thread name.
-   *
-   * @param thread
-   * @return Thread's name
-   */
-  private String getJobName(Thread thread) {
-    ThreadSnapshot ts = threadSnapshot.get(getJobId(thread));
-    return ts != null ? ts.getName() : thread.getName();
-  }
-
-  /**
    * Class holder for cpu and thread name at the moment of measurement. This is necessary as the
    * threads are pooled and may change name right after measurement.
    */
-  private static class ThreadSnapshot {
-    public ThreadSnapshot(long cpu, String name) {
-      this.cpu = cpu;
-      this.name = name;
-    }
+  private record ThreadSnapshot(long cpu, String name) {}
 
-    public String getName() {
-      return name;
-    }
+  /** Immutable sample of a single thread measurement. */
+  private record Sample(long jobId, long cpuDelta, String name) {}
 
-    public long getCpu() {
-      return cpu;
+  /**
+   * Takes an atomic sample of a thread's diagnostics, ensuring the job id and name are consistent.
+   *
+   * <p>For pooled workers this method queries {@link PooledExecutor.MyThread#diagSample()} to read
+   * a coherent tuple of job id, thread name and CPU time. For other threads it falls back to the
+   * JVM {@link ThreadMXBean} and the thread’s current name.
+   */
+  private Sample sampleThread(Thread thread) {
+    long jobId;
+    long current;
+    String sampleName;
+    if (thread instanceof PooledExecutor.MyThread my) {
+      PooledExecutor.DiagSample ds = my.diagSample();
+      sampleName = ds.name();
+      current = ds.cpuTime();
+      jobId = ds.jobId();
+    } else {
+      sampleName = thread.getName();
+      current = threadMxBean.getThreadCpuTime(thread.threadId());
+      jobId = getJobId(thread);
     }
-
-    private final long cpu;
-    private final String name;
+    ThreadSnapshot prev = threadSnapshot.get(jobId);
+    long delta = current - (prev != null ? prev.cpu() : 0);
+    threadSnapshot.put(jobId, new ThreadSnapshot(current, sampleName));
+    return new Sample(jobId, delta, sampleName);
   }
 
-  /** Sleep interval to calculate % CPU used by each thread */
+  /** Sleep interval to calculate % CPU used by each thread. */
   private static final int DEFAULT_MONITOR_INTERVAL = 1000;
 
   private static final String DEFAULT_MONITOR_THREAD_NAME = "NodeDiagnostics: thread monitor";
@@ -194,12 +230,12 @@ public class DefaultThreadDiagnostics implements Runnable, ThreadDiagnostics {
   private final NodeStats nodeStats;
   private final Ticker ticker;
 
-  /** Initialising with an empty NodeThreadSnapshot to avoid possible race conditions */
+  /** Initialising with an empty NodeThreadSnapshot to avoid possible race conditions. */
   private final AtomicReference<NodeThreadSnapshot> nodeThreadSnapshot =
       new AtomicReference<>(new NodeThreadSnapshot(new ArrayList<>(), DEFAULT_MONITOR_INTERVAL));
 
   private final ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 
-  /** Map to track thread's CPU differences between intervals of time */
+  /** Map to track thread's CPU differences between intervals of time. */
   private final Map<Long, ThreadSnapshot> threadSnapshot = new HashMap<>();
 }

--- a/src/main/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnostics.java
+++ b/src/main/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnostics.java
@@ -159,8 +159,9 @@ public class DefaultThreadDiagnostics implements Runnable, ThreadDiagnostics {
   /**
    * Gets the job's ID from the thread (PooledExecutor.MyThread) or defaults to the thread's ID.
    *
-   * @param thread
-   * @return Job ID or Thread ID.
+   * @param thread the thread for which to resolve a stable job identifier; for pooled workers this
+   *     is the current job id, otherwise the OS thread id
+   * @return job id when the thread is a pooled worker with an assigned job; otherwise the thread id
    */
   private long getJobId(Thread thread) {
     long jobId = thread.threadId();

--- a/src/main/java/network/crypta/support/PooledExecutor.java
+++ b/src/main/java/network/crypta/support/PooledExecutor.java
@@ -2,6 +2,7 @@ package network.crypta.support;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -277,6 +278,9 @@ public class PooledExecutor implements PriorityAwareExecutor {
     }
   }
 
+  /** Immutable diagnostic sample for a worker thread. */
+  public static record DiagSample(int jobId, String name, long cpuTime) {}
+
   /**
    * Worker that executes tasks and returns to an idle state when finished.
    *
@@ -324,6 +328,22 @@ public class PooledExecutor implements PriorityAwareExecutor {
       if (job != null) return job.id;
       if (nextJob != null) return nextJob.id;
       return 0;
+    }
+
+    /**
+     * Take a consistent snapshot of this worker's current diagnostic identifiers under the worker's
+     * monitor, aligning the job id with the current thread name.
+     *
+     * <p>Includes the current CPU time for this Java thread from {@link ManagementFactory}'s {@link
+     * java.lang.management.ThreadMXBean} so callers can compute deltas keyed by job id.
+     */
+    public DiagSample diagSample() {
+      synchronized (this) {
+        int jid = getJobId();
+        String nm = getName();
+        long cpu = ManagementFactory.getThreadMXBean().getThreadCpuTime(this.threadId());
+        return new DiagSample(jid, nm, cpu);
+      }
     }
 
     /**

--- a/src/test/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnosticsTest.java
+++ b/src/test/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnosticsTest.java
@@ -1,0 +1,175 @@
+package network.crypta.node.diagnostics.threads;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.node.NodeStats;
+import network.crypta.support.PooledExecutor;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // test method naming style
+class DefaultThreadDiagnosticsTest {
+
+  @Mock private NodeStats nodeStats;
+  @Mock private Ticker ticker;
+
+  @Captor private ArgumentCaptor<Runnable> runnableCaptor;
+
+  @BeforeAll
+  static void enableThreadCpuTimeIfSupported() {
+    ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+    if (bean.isThreadCpuTimeSupported() && !bean.isThreadCpuTimeEnabled()) {
+      try {
+        bean.setThreadCpuTimeEnabled(true);
+      } catch (UnsupportedOperationException ignored) {
+        // If the platform forbids enabling, tests still run asserting non-negative deltas where
+        // possible.
+      }
+    }
+  }
+
+  @Test
+  void start_whenCalled_schedulesImmediateRunWithDefaultName() {
+    // Arrange
+    DefaultThreadDiagnostics diag = new DefaultThreadDiagnostics(nodeStats, ticker);
+
+    // Act
+    diag.start();
+
+    // Assert
+    verify(ticker, times(1))
+        .queueTimedJob(
+            runnableCaptor.capture(),
+            org.mockito.ArgumentMatchers.eq("NodeDiagnostics: thread monitor"),
+            org.mockito.ArgumentMatchers.eq(0L),
+            org.mockito.ArgumentMatchers.eq(false),
+            org.mockito.ArgumentMatchers.eq(true));
+    assertSame(
+        runnableCaptor.getValue(), diag, "Ticker should be scheduled with the same instance");
+  }
+
+  @Test
+  void stop_whenCalled_removesQueuedJob() {
+    // Arrange
+    DefaultThreadDiagnostics diag = new DefaultThreadDiagnostics(nodeStats, ticker);
+
+    // Act
+    diag.stop();
+
+    // Assert
+    verify(ticker, times(1)).removeQueuedJob(diag);
+  }
+
+  @Test
+  void run_whenThreadsPresent_buildsSnapshotAndReschedules() {
+    // Arrange
+    Thread testThread = new Thread(() -> {});
+    testThread.setName("TestThread-A");
+    // Priority may be constrained by the JVM/security manager; rely on default
+    when(nodeStats.getThreads()).thenReturn(new Thread[] {testThread, null});
+
+    final String customName = "MyDiag";
+    final int intervalMs = 321;
+    DefaultThreadDiagnostics diag =
+        new DefaultThreadDiagnostics(nodeStats, ticker, customName, intervalMs);
+
+    // Act
+    diag.run();
+
+    // Assert snapshot content
+    NodeThreadSnapshot snap = diag.getThreadSnapshot();
+    assertNotNull(snap, "Snapshot must not be null");
+    assertEquals(intervalMs, snap.getInterval(), "Snapshot interval should match monitor interval");
+    assertEquals(1, snap.getThreads().size(), "Exactly one thread should be reported");
+
+    NodeThreadInfo info = snap.getThreads().getFirst();
+    assertEquals(testThread.threadId(), info.getId(), "Thread id should match");
+    assertEquals(
+        testThread.threadId(), info.getJobId(), "Non-pooled threads map jobId to thread id");
+    assertEquals(testThread.getName(), info.getName(), "Name should be captured");
+    assertEquals(testThread.getPriority(), info.getPrio(), "Priority should match");
+    assertEquals(testThread.getThreadGroup().getName(), info.getGroupName(), "Group should match");
+    assertEquals(testThread.getState().toString(), info.getState(), "State should match");
+    assertTrue(info.getCpuTime() >= -1, "CPU delta should be non-negative or -1 if unsupported");
+
+    // Assert reschedule with the specified interval
+    verify(ticker, times(1))
+        .queueTimedJob(
+            org.mockito.ArgumentMatchers.same(diag),
+            org.mockito.ArgumentMatchers.eq(customName),
+            org.mockito.ArgumentMatchers.eq((long) intervalMs),
+            org.mockito.ArgumentMatchers.eq(false),
+            org.mockito.ArgumentMatchers.eq(true));
+  }
+
+  @Test
+  void run_whenIdlePooledThread_filtersOutJobIdZero() throws Exception {
+    // Arrange: create a pooled worker and capture its MyThread instance
+    PooledExecutor exec = new PooledExecutor();
+    CountDownLatch ran = new CountDownLatch(1);
+    AtomicReference<PooledExecutor.MyThread> workerRef = new AtomicReference<>();
+
+    exec.execute(
+        () -> {
+          Thread t = Thread.currentThread();
+          if (t instanceof PooledExecutor.MyThread mt) {
+            workerRef.set(mt);
+          }
+          ran.countDown();
+        },
+        "capture-worker");
+
+    assertTrue(ran.await(5, TimeUnit.SECONDS), "Worker job should complete");
+    PooledExecutor.MyThread worker = workerRef.get();
+    assertNotNull(worker, "Should capture pooled worker instance");
+
+    // Wait until the worker is idle (jobId becomes 0)
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+    while (System.nanoTime() < deadline && worker.getJobId() != 0) {
+      Thread.onSpinWait();
+    }
+    assertEquals(0, worker.getJobId(), "Worker jobId should be 0 when idle");
+
+    // Stub NodeStats to include the idle pooled thread and a null terminator
+    when(nodeStats.getThreads()).thenReturn(new Thread[] {worker, null});
+
+    DefaultThreadDiagnostics diag = new DefaultThreadDiagnostics(nodeStats, ticker, "X", 100);
+
+    // Act
+    diag.run();
+
+    // Assert: filtered out -> no entries
+    NodeThreadSnapshot snap = diag.getThreadSnapshot();
+    assertNotNull(snap);
+    assertTrue(snap.getThreads().isEmpty(), "Idle pooled thread must be filtered out (jobId=0)");
+
+    // Also ensure we rescheduled
+    verify(ticker, times(1))
+        .queueTimedJob(
+            org.mockito.ArgumentMatchers.same(diag),
+            org.mockito.ArgumentMatchers.eq("X"),
+            org.mockito.ArgumentMatchers.eq(100L),
+            org.mockito.ArgumentMatchers.eq(false),
+            org.mockito.ArgumentMatchers.eq(true));
+
+    // Cleanup: there's no explicit shutdown; worker exits on its own after idle timeout
+  }
+}


### PR DESCRIPTION
Summary
- Stabilizes thread diagnostics by sampling CPU time coherently and filtering idle pooled workers (jobId=0).
- Adds a diagnostic sample API to the pooled executor for atomic jobId/name/CPU reads.
- Improves SonarLint configuration to set explicit Java language level and classpath for single-file analysis.
- Adds unit tests covering start/stop behavior, snapshot content, and idle worker filtering.

Changes
- build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
  - Provide `sonar.java.source/target` and configure `sonarlintFile` with Java release + classpath.
- src/main/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnostics.java
  - Compute CPU deltas per stable job id; skip idle pooled workers; expand Javadoc; replace inner class with records.
- src/main/java/network/crypta/support/PooledExecutor.java
  - Add `DiagSample` record and `MyThread.diagSample()` for atomic sampling of jobId/name/CPU.
- src/test/java/network/crypta/node/diagnostics/threads/DefaultThreadDiagnosticsTest.java
  - New tests for scheduling, snapshot contents, and idle worker filtering.
- src/main/java/network/crypta/node/diagnostics/ThreadDiagnostics.java (prior commit on this branch)
  - Clarify Javadoc around snapshot semantics and thread-safety.

Commits on this branch
- 7da849d5a6 fix(diagnostics): stabilize thread CPU sampling and filter idle workers
- 227d2baec5 docs(diagnostics): improve Javadoc for ThreadDiagnostics interface

Compatibility & Risk
- No public API changes outside of internal `PooledExecutor` additions; existing behavior for consumers is preserved.
- Idle pooled workers (jobId=0) are intentionally filtered from snapshots.

Testing
- JUnit 6 tests added and pass locally.
- Spotless applied across touched files.

Notes
- Base branch: develop
- Please request any additional diagnostics fields if needed for UI/ops.
