### PR TITLE
docs(java): doclint-clean Javadoc for DataStoreInstanceType

### DIFF
--- a/src/main/java/network/crypta/node/stats/DataStoreInstanceType.java
+++ b/src/main/java/network/crypta/node/stats/DataStoreInstanceType.java
@@ -3,8 +3,8 @@ package network.crypta.node.stats;
 /**
  * Immutable descriptor identifying a single logical data store instance.
  *
- * <p>A {@code DataStoreInstanceType} pairs a {@link DataStoreKeyType key type} with a {@link
- * DataStoreType store type} to describe which class of keys is kept in which kind of store (for
+ * <p>A {@code DataStoreInstanceType} pairs a {@link DataStoreKeyType} key type with a {@link
+ * DataStoreType} store type to describe which class of keys is kept in which kind of store (for
  * example, {@code CHK} entries in the main {@code STORE}, or {@code SSK} entries in the {@code
  * CACHE}). Code that aggregates statistics, maintains per-store counters, or routes operations can
  * use this value object as a compact, strongly-typed identifier.

--- a/src/main/java/network/crypta/node/stats/DataStoreInstanceType.java
+++ b/src/main/java/network/crypta/node/stats/DataStoreInstanceType.java
@@ -1,20 +1,67 @@
 package network.crypta.node.stats;
 
 /**
- * This class represents one instance of data store. Instance is described by two properties: key
- * type and store type.
+ * Immutable descriptor identifying a single logical data store instance.
  *
- * <p>User: nikotyan Date: Apr 16, 2010
+ * <p>A {@code DataStoreInstanceType} pairs a {@link DataStoreKeyType key type} with a {@link
+ * DataStoreType store type} to describe which class of keys is kept in which kind of store (for
+ * example, {@code CHK} entries in the main {@code STORE}, or {@code SSK} entries in the {@code
+ * CACHE}). Code that aggregates statistics, maintains per-store counters, or routes operations can
+ * use this value object as a compact, strongly-typed identifier.
+ *
+ * <p>The class is immutable and value-based: two instances are equal when both their key type and
+ * store type are equal. This makes it safe to use as a key in maps or as an element in sets. The
+ * {@link #hashCode()} implementation combines both components, and {@link #toString()} produces a
+ * concise human-readable representation helpful for logging and diagnostics.
+ *
+ * <ul>
+ *   <li><strong>Immutability:</strong> both fields are {@code final}; instances are thread-safe.
+ *   <li><strong>Identity:</strong> equality and hash code derive from key and store only.
+ *   <li><strong>Typical use:</strong> grouping measurements or selecting per-store behavior.
+ * </ul>
+ *
+ * <pre>{@code
+ * // Example: create a descriptor for CHK entries in the main store
+ * var id = new DataStoreInstanceType(DataStoreKeyType.CHK, DataStoreType.STORE);
+ * }</pre>
+ *
+ * @see DataStoreKeyType
+ * @see DataStoreType
  */
 public class DataStoreInstanceType {
+  /**
+   * Store category that holds the entries for this instance. Values include main store, cache,
+   * slashdot, and client-specific stores. The value never changes after construction and is
+   * suitable for use in equality and hashing.
+   */
   public final DataStoreType store;
+
+  /**
+   * Key category indicating which kind of keys populate the addressed store. Typical values are
+   * {@code CHK}, {@code SSK}, or public key variants. The value is immutable and participates in
+   * equality and hashing semantics.
+   */
   public final DataStoreKeyType key;
 
+  /**
+   * Creates a new descriptor that uniquely identifies a combination of key type and store type.
+   *
+   * <p>The resulting object is immutable and value-based. It can be safely shared across threads
+   * and used as a key in hash-based collections. Neither argument may be {@code null}; callers
+   * should pass explicit enum values reflecting the targeted store and key domain.
+   *
+   * @param key the {@link DataStoreKeyType} describing the kind of keys kept in the store; must be
+   *     a non-null enum value such as {@code CHK} or {@code SSK} that matches the intended domain
+   *     of entries.
+   * @param store the {@link DataStoreType} indicating which storage category is addressed; must be
+   *     a non-null enum value such as {@code STORE}, {@code CACHE}, or other supported variants.
+   */
   public DataStoreInstanceType(DataStoreKeyType key, DataStoreType store) {
     this.store = store;
     this.key = key;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -26,6 +73,7 @@ public class DataStoreInstanceType {
     return store == that.store;
   }
 
+  /** {@inheritDoc} */
   @Override
   public int hashCode() {
     int result = store.hashCode();
@@ -33,6 +81,7 @@ public class DataStoreInstanceType {
     return result;
   }
 
+  /** {@inheritDoc} */
   @Override
   public String toString() {
     return "DataStoreInstanceType{" + "store=" + store + ", key=" + key + '}';

--- a/src/test/java/network/crypta/node/stats/DataStoreInstanceTypeTest.java
+++ b/src/test/java/network/crypta/node/stats/DataStoreInstanceTypeTest.java
@@ -1,0 +1,194 @@
+package network.crypta.node.stats;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100")
+class DataStoreInstanceTypeTest {
+
+  @Test
+  @DisplayName("constructor_whenValid_expectFieldsAssigned")
+  void constructor_whenValid_expectFieldsAssigned() {
+    // Arrange
+    DataStoreKeyType key = DataStoreKeyType.CHK;
+    DataStoreType store = DataStoreType.STORE;
+
+    // Act
+    DataStoreInstanceType instance = new DataStoreInstanceType(key, store);
+
+    // Assert
+    assertNotNull(instance);
+    assertSame(store, instance.store);
+    assertSame(key, instance.key);
+  }
+
+  @Test
+  @DisplayName("equals_whenSameReference_expectTrue")
+  void equals_whenSameReference_expectTrue() {
+    // Arrange
+    DataStoreInstanceType instance =
+        new DataStoreInstanceType(DataStoreKeyType.CHK, DataStoreType.STORE);
+
+    // Act & Assert
+    //noinspection EqualsWithItself
+    assertEquals(instance, instance);
+  }
+
+  @Test
+  @DisplayName("equals_whenNull_expectFalse")
+  void equals_whenNull_expectFalse() {
+    // Arrange
+    DataStoreInstanceType instance =
+        new DataStoreInstanceType(DataStoreKeyType.CHK, DataStoreType.STORE);
+
+    // Act & Assert (does call instance.equals(null) under the hood without Sonar warning)
+    assertNotEquals(null, instance);
+  }
+
+  // Note: The "different class" behavior is covered by the subclass test below
+  // (equals uses getClass() check). A direct equals comparison with a String/Object
+  // is avoided to keep SonarLint clean (inconvertible types warning).
+
+  private static class SubType extends DataStoreInstanceType {
+    SubType(DataStoreKeyType key, DataStoreType store) {
+      super(key, store);
+    }
+  }
+
+  @Test
+  @DisplayName("equals_whenSubclassSameFields_expectFalseDueToClassCheck")
+  void equals_whenSubclassSameFields_expectFalseDueToClassCheck() {
+    // Arrange
+    DataStoreInstanceType base =
+        new DataStoreInstanceType(DataStoreKeyType.CHK, DataStoreType.STORE);
+    DataStoreInstanceType sub = new SubType(DataStoreKeyType.CHK, DataStoreType.STORE);
+
+    // Act & Assert
+    assertNotEquals(base, sub);
+    assertNotEquals(sub, base);
+  }
+
+  static Stream<Arguments> allStoreKeyPairs() {
+    return Arrays.stream(DataStoreType.values())
+        .flatMap(
+            store -> Arrays.stream(DataStoreKeyType.values()).map(key -> Arguments.of(store, key)));
+  }
+
+  @ParameterizedTest(name = "equals/hashCode with store={0}, key={1}")
+  @MethodSource("allStoreKeyPairs")
+  @DisplayName("equals_whenSameFields_expectTrueAndHashCodesEqual")
+  void equals_whenSameFields_expectTrueAndHashCodesEqual(
+      DataStoreType store, DataStoreKeyType key) {
+    // Arrange
+    DataStoreInstanceType a = new DataStoreInstanceType(key, store);
+    DataStoreInstanceType b = new DataStoreInstanceType(key, store);
+
+    // Act & Assert
+    assertTrue(a.equals(b) && b.equals(a));
+    assertEquals(a.hashCode(), b.hashCode());
+
+    // hashCode consistency
+    int first = a.hashCode();
+    int second = a.hashCode();
+    assertEquals(first, second);
+  }
+
+  static Stream<Arguments> sameStore_differentKey() {
+    DataStoreType[] stores = DataStoreType.values();
+    DataStoreKeyType[] keys = DataStoreKeyType.values();
+    return Arrays.stream(stores)
+        .flatMap(
+            store -> {
+              // For each key, pair with the next key (cyclic) to ensure difference
+              return Arrays.stream(keys)
+                  .map(
+                      key ->
+                          Arguments.of(
+                              store,
+                              key, // first
+                              store,
+                              keys[(key.ordinal() + 1) % keys.length] // second with diff key
+                              ));
+            });
+  }
+
+  @ParameterizedTest(name = "not equals when same store {0} but different keys {1}!={3}")
+  @MethodSource("sameStore_differentKey")
+  @DisplayName("equals_whenDifferentKey_expectFalse")
+  void equals_whenDifferentKey_expectFalse(
+      DataStoreType store1, DataStoreKeyType key1, DataStoreType store2, DataStoreKeyType key2) {
+    // Arrange
+    DataStoreInstanceType a = new DataStoreInstanceType(key1, store1);
+    DataStoreInstanceType b = new DataStoreInstanceType(key2, store2);
+
+    // Act & Assert
+    assertNotEquals(a, b);
+  }
+
+  static Stream<Arguments> sameKey_differentStore() {
+    DataStoreType[] stores = DataStoreType.values();
+    DataStoreKeyType[] keys = DataStoreKeyType.values();
+    return Arrays.stream(keys)
+        .flatMap(
+            key ->
+                Arrays.stream(stores)
+                    .map(
+                        store ->
+                            Arguments.of(
+                                store,
+                                key, // first
+                                stores[(store.ordinal() + 1) % stores.length],
+                                key // second with diff store
+                                )));
+  }
+
+  @ParameterizedTest(name = "not equals when same key {1} but different stores {0}!={2}")
+  @MethodSource("sameKey_differentStore")
+  @DisplayName("equals_whenDifferentStore_expectFalse")
+  void equals_whenDifferentStore_expectFalse(
+      DataStoreType store1, DataStoreKeyType key1, DataStoreType store2, DataStoreKeyType key2) {
+    // Arrange
+    DataStoreInstanceType a = new DataStoreInstanceType(key1, store1);
+    DataStoreInstanceType b = new DataStoreInstanceType(key2, store2);
+
+    // Act
+    boolean ab = a.equals(b);
+    boolean ba = b.equals(a);
+
+    // Assert: inequality is symmetric and fields reflect the scenario
+    assertFalse(ab);
+    assertFalse(ba);
+    assertSame(store1, a.store);
+    assertSame(store2, b.store);
+    assertNotEquals(store1, store2);
+    assertSame(key1, a.key);
+    assertSame(key2, b.key);
+    assertSame(key1, key2); // same key, different store
+  }
+
+  @Test
+  @DisplayName("toString_whenCalled_expectDeterministicFormat")
+  void toString_whenCalled_expectDeterministicFormat() {
+    // Arrange
+    DataStoreInstanceType instance =
+        new DataStoreInstanceType(DataStoreKeyType.CHK, DataStoreType.STORE);
+
+    // Act
+    String s = instance.toString();
+
+    // Assert
+    assertEquals("DataStoreInstanceType{store=STORE, key=CHK}", s);
+  }
+}


### PR DESCRIPTION
Summary
- Doclint-clean Javadoc for src/main/java/network/crypta/node/stats/DataStoreInstanceType.java.
- Long-form API docs: detailed class overview, field docs, and constructor tags; added {@inheritDoc} to overrides.
- No behavior changes; value semantics (equals/hashCode) untouched.
- Ran Spotless formatting on Java/Kotlin/Gradle files.

Details
- Expanded class documentation with usage context, immutability and identity notes, and a short code example.
- Added Javadoc to public fields (store, key) describing purpose and immutability.
- Added constructor Javadoc with non-null expectations and explicit @param tags.
- Verified doclint locally: javadoc -Xdoclint:all reports 0 warnings for this file.

Tests
- DataStoreInstanceTypeTest.java included and aligned (assertions clarified, stream iteration via Arrays.stream). No functional changes to production code.

Why
- Keeps public API documentation accurate and compliant with doclint.
- Improves discoverability for callers aggregating store/key statistics or routing per-store behavior.

Notes
- Java 21+ project; Spotless applied successfully. No additional code changes beyond comments/docs.

CI
- No known CI-specific impacts. Regular build and tests should pass as before.
