### PR TITLE
docs(java): expand DataStore stats Javadoc; add tests for stats components

### DIFF
--- a/src/main/java/network/crypta/node/stats/DataStoreKeyType.java
+++ b/src/main/java/network/crypta/node/stats/DataStoreKeyType.java
@@ -1,12 +1,58 @@
 package network.crypta.node.stats;
 
 /**
- * enum for key types of existing data stores
+ * Categorizes the logical key type used by a data store.
  *
- * @author nikotyan
+ * <p>This enumeration is used by the node statistics and diagnostics code to tag metrics and
+ * counters with the kind of key a particular store operates on. Some stores persist entries
+ * addressed by content-derived hashes, while others group entries under keys associated with
+ * signing or publishing identities. Consumers of {@code network.crypta.node.stats} can use this
+ * type to render human-readable labels, aggregate metrics by key family, or switch behavior when a
+ * feature applies only to a subset of key kinds.
+ *
+ * <p>The values are intentionally high level and stable. They abstract over any on-disk
+ * representation or wire format and do not prescribe a specific encoding or bit length. The enum is
+ * immutable and thread-safe; it carries no state beyond the constant identity and can be freely
+ * shared between threads without synchronization.
+ *
+ * <ul>
+ *   <li>{@link #CHK} — keys derived from the content itself (content-addressed).
+ *   <li>{@link #SSK} — keys associated with signed/identity-scoped data.
+ *   <li>{@link #PUB_KEY} — keys that directly refer to public keys or key material.
+ * </ul>
+ *
+ * @see network.crypta.node.stats.DataStoreType
+ * @see network.crypta.node.stats.DataStoreStats
  */
 public enum DataStoreKeyType {
+  /**
+   * Content-addressed key type used for stores where the key is derived from the data.
+   *
+   * <p>Entries indexed under this category are typically immutable and retrievable by providing a
+   * hash or similar content-derived identifier. This is a good default for caches, chunk stores, or
+   * other structures where the identity of the content is sufficient to locate and validate the
+   * record. Reporting that references this constant usually assumes read-mostly access patterns and
+   * high deduplication potential.
+   */
   CHK,
+
+  /**
+   * Signed or identity-scoped key type used for stores that group data under a signing identity.
+   *
+   * <p>Entries indexed under this category are commonly used for data that may evolve under an
+   * identity or namespace. While the exact cryptographic scheme is out of scope here, consumers can
+   * treat this constant as an indicator that validation and routing often involve both a key and a
+   * signature or metadata bound to an identity.
+   */
   SSK,
+
+  /**
+   * Public-key reference used where the store is keyed directly by public key material.
+   *
+   * <p>Use this for statistics and labels associated with stores whose primary lookup is the public
+   * key itself (for example, registries of publisher keys or caches of verification keys). Values
+   * under this category are generally read-mostly, relatively small per entry, and serve as
+   * auxiliary indexes for other stores.
+   */
   PUB_KEY
 }

--- a/src/main/java/network/crypta/node/stats/DataStoreStats.java
+++ b/src/main/java/network/crypta/node/stats/DataStoreStats.java
@@ -1,31 +1,172 @@
 package network.crypta.node.stats;
 
 /**
- * This interface represents the data we can publish on our stats page for a given instance of a
- * data store.
+ * Provides aggregate statistics for a specific instance of a data store.
  *
+ * <p>Implementations expose summary counters and derived metrics that are suitable for publishing
+ * in administrative dashboards, telemetry collectors, or troubleshooting tools. Typical consumers
+ * poll these values periodically to visualize utilization trends, capacity headroom, and
+ * effectiveness of lookups or insertions. The interface does not prescribe units for every metric;
+ * where units are not obvious, they are explicitly documented as implementation-defined so
+ * deployments can select representations that best match their storage model (for example, entries,
+ * bytes, or logical capacity).
+ *
+ * <p>Methods that depend on live sampling may temporarily be unavailable and signal this via {@link
+ * StatsNotAvailableException}. The interface itself is read-only; implementations should be safe to
+ * invoke concurrently from multiple threads. Values are snapshots at the time of the call and may
+ * change between invocations, especially in busy nodes. For short-lived sessions, the session
+ * access metrics offer a focused view, while the total access metrics can include persisted or
+ * long-horizon aggregates when supported.
+ *
+ * <ul>
+ *   <li>Use for dashboards, alerting inputs, and periodic telemetry exports.
+ *   <li>Interpret values comparatively over time; avoid hard-coding absolute thresholds without
+ *       calibration.
+ *   <li>Handle {@code StatsNotAvailableException} gracefully to cover startup and shutdown windows.
+ * </ul>
+ *
+ * @see network.crypta.node.stats.StoreAccessStats
+ * @see network.crypta.node.stats.StoreLocationStats
+ * @see network.crypta.node.stats.DataStoreType
+ * @see network.crypta.node.stats.DataStoreKeyType
  * @author nikotyan
  */
 public interface DataStoreStats {
+  /**
+   * Returns the number of keys or entries currently tracked by the store.
+   *
+   * <p>The exact meaning of a “key” can vary across implementations (for example, content chunks or
+   * identity-scoped records). The returned value is non-negative and reflects a point-in-time view
+   * that may change as background maintenance or client requests progress.
+   *
+   * @return the current count of stored entries; the unit is implementation-defined but consistent
+   *     within a given deployment and store type.
+   */
   long keys();
 
+  /**
+   * Returns the logical capacity of the store according to its configuration.
+   *
+   * <p>Capacity can represent a maximum number of entries, a byte budget, or another limit
+   * depending on the storage engine and policy. Unbounded stores may report a sentinel value as
+   * defined by the implementation.
+   *
+   * @return the configured capacity limit in implementation-defined units; non-negative when a
+   *     limit is enforced.
+   */
   long capacity();
 
+  /**
+   * Returns the size of data currently held by the store.
+   *
+   * <p>Implementations commonly report bytes on disk or in memory, but alternate units are
+   * permitted. Use this together with {@link #capacity()} and {@link #utilization()} to understand
+   * growth over time and headroom for new data.
+   *
+   * @return the current data size in an implementation-defined unit; non-negative and monotonic
+   *     between immediate successive calls only in the absence of deletions or compaction.
+   */
   long dataSize();
 
+  /**
+   * Returns the store utilization as a normalized fraction when available.
+   *
+   * <p>Utilization represents how much of the configured capacity is currently in use. The value is
+   * typically in the range {@code [0.0, 1.0]} but implementations may choose a different scale if
+   * appropriate. Prefer reading this metric alongside {@link #capacity()} and {@link #dataSize()}
+   * to obtain a complete picture.
+   *
+   * @return a utilization value representing used capacity relative to the configured limit; the
+   *     scale is implementation-defined but consistent per implementation and version.
+   */
   double utilization();
 
+  /**
+   * Returns the average observed location metric for recent operations.
+   *
+   * <p>The definition of location is implementation-specific (for example, a position in a logical
+   * key or node space). The average is aggregated over a recent window or all-time and is intended
+   * for relative comparison within the same deployment.
+   *
+   * @return a double representing the average location across samples; units and scale are
+   *     implementation-defined and should be interpreted with companion metrics.
+   * @throws StatsNotAvailableException if the location samples are not available at this time (for
+   *     example, during startup, shutdown, or when statistics are disabled).
+   */
   double avgLocation() throws StatsNotAvailableException;
 
+  /**
+   * Returns an average success indicator for operations attributed to this store.
+   *
+   * <p>Implementations may compute this as a ratio, probability estimate, or smoothed metric over a
+   * defined period. Treat this as a directional indicator; use longer-term trends for alerts.
+   *
+   * @return a double summarizing success over the chosen window; units and bounds are
+   *     implementation-defined and may be normalized.
+   * @throws StatsNotAvailableException if success data cannot be produced at call time.
+   */
   double avgSuccess() throws StatsNotAvailableException;
 
+  /**
+   * Returns a metric for the most distant successful operation in the observed period.
+   *
+   * <p>This highlights tail behavior relative to the implementation’s distance notion and helps
+   * identify outliers or long routing paths that still succeed.
+   *
+   * @return a double representing the distance of the furthest successful operation; units and
+   *     normalization are implementation-defined.
+   * @throws StatsNotAvailableException if distance or success samples are unavailable.
+   */
   double furthestSuccess() throws StatsNotAvailableException;
 
+  /**
+   * Returns the average distance metric across recent operations.
+   *
+   * <p>Distance is defined by the implementation (for example, difference in a logical key space)
+   * and the average may be computed over a sliding window with optional smoothing.
+   *
+   * @return a double representing the average distance; interpretation requires context from the
+   *     same implementation and configuration.
+   * @throws StatsNotAvailableException if distance statistics are not currently available.
+   */
   double avgDist() throws StatsNotAvailableException;
 
+  /**
+   * Returns a composite distance statistic that summarizes distribution characteristics.
+   *
+   * <p>Providers may expose a moment (such as variance), a trimmed statistic, or another derived
+   * value capturing the shape of the distance distribution, complementing the simple average.
+   *
+   * @return a double capturing a composite or higher-order property of the distance distribution;
+   *     semantics are implementation-defined and intended for relative comparison.
+   * @throws StatsNotAvailableException if the underlying distribution cannot be sampled or computed
+   *     at this time.
+   */
   double distanceStats() throws StatsNotAvailableException;
 
+  /**
+   * Returns access statistics for the current process session.
+   *
+   * <p>Session access stats typically reset on node restart and are useful for debugging short-term
+   * behaviors without historical carryover. Implementations should ensure this method never throws
+   * and instead report empty/zeroed metrics when inactive.
+   *
+   * @return a {@link StoreAccessStats} instance representing access patterns for the current
+   *     process lifetime; returned objects are read-only snapshots or views depending on
+   *     implementation.
+   */
   StoreAccessStats getSessionAccessStats();
 
+  /**
+   * Returns access statistics aggregated across the full lifetime of the store when supported.
+   *
+   * <p>Depending on configuration, this may include persisted history or long-horizon aggregates.
+   * Some implementations may not retain such data and will signal unavailability.
+   *
+   * @return a {@link StoreAccessStats} instance representing long-horizon or total access behavior;
+   *     immutability guarantees are implementation-specific.
+   * @throws StatsNotAvailableException if total access statistics are not recorded or cannot be
+   *     retrieved at this time.
+   */
   StoreAccessStats getTotalAccessStats() throws StatsNotAvailableException;
 }

--- a/src/main/java/network/crypta/node/stats/DataStoreType.java
+++ b/src/main/java/network/crypta/node/stats/DataStoreType.java
@@ -1,13 +1,69 @@
 package network.crypta.node.stats;
 
 /**
- * Enum for data store types
+ * Categorizes the high-level type of data store used by the node.
  *
+ * <p>This enumeration is used by statistics, diagnostics, and administrative views to group and
+ * label stores that share similar behavior and lifecycle characteristics. It abstracts over
+ * implementation details and storage engines and focuses on how the store is expected to be used:
+ * whether as a durable repository, a transient cache, a specialized policy-driven cache, or a
+ * client-scoped store. The constants are stable, immutable descriptors and can be used safely for
+ * aggregation keys, UI labels, or conditional logic in reporting.
+ *
+ * <p>All enum constants are thread-safe and carry no mutable state. They are suitable for use in
+ * concurrent contexts and may be freely cached or shared. The classification is intentionally
+ * minimal to avoid coupling node internals to the statistics model; additional per-store metadata
+ * should be obtained from {@link DataStoreStats} or related metric views.
+ *
+ * <ul>
+ *   <li>{@link #STORE} — durable, authoritative persistent storage.
+ *   <li>{@link #CACHE} — transient cache with eviction and best-effort retention.
+ *   <li>{@link #SLASHDOT} — specialized cache with custom aging/retention policy.
+ *   <li>{@link #CLIENT} — client-scoped store for request or session-related data.
+ * </ul>
+ *
+ * @see network.crypta.node.stats.DataStoreKeyType
+ * @see network.crypta.node.stats.DataStoreStats
  * @author nikotyan
  */
 public enum DataStoreType {
+  /**
+   * Durable, authoritative persistent storage for long-lived data and indexes.
+   *
+   * <p>Stores classified as {@code STORE} are typically the canonical source of truth for
+   * content-addressed or identity-scoped data. They prioritize durability and integrity over
+   * eviction and may employ validation and compaction routines. Reporting for these stores often
+   * focuses on capacity utilization, on-disk size, and read/write performance over longer windows.
+   */
   STORE,
+
+  /**
+   * Transient cache intended to accelerate reads or reduce load on authoritative stores.
+   *
+   * <p>Caches commonly implement size- or time-based eviction and do not guarantee retention. They
+   * are best-effort and can be reconstructed from upstream sources when entries are missing.
+   * Statistics for caches typically emphasize hit/miss ratios, eviction rates, and short-term
+   * throughput rather than long-term durability metrics.
+   */
   CACHE,
+
+  /**
+   * Specialized cache that applies a policy tailored for bursty access patterns.
+   *
+   * <p>Often used for smoothing sudden popularity spikes, these stores may rely on custom aging or
+   * prioritization heuristics distinct from general-purpose caches. While still non-authoritative,
+   * their behavior is tuned for specific traffic profiles, and statistics may highlight temporary
+   * retention effectiveness and mitigation of hotspot amplification.
+   */
   SLASHDOT,
+
+  /**
+   * Client-scoped store used for metadata, request coordination, or session-adjacent state.
+   *
+   * <p>Entries in client stores are generally smaller and more numerous, with lifecycles tied to
+   * client activity rather than global network retention. They may be ephemeral or persisted for
+   * recovery, depending on configuration. Metrics often surface queue sizes, callback counts, and
+   * per-client access patterns.
+   */
   CLIENT
 }

--- a/src/main/java/network/crypta/node/stats/NotAvailNodeStoreStats.java
+++ b/src/main/java/network/crypta/node/stats/NotAvailNodeStoreStats.java
@@ -1,32 +1,112 @@
 package network.crypta.node.stats;
 
 /**
- * This implementation is used for data stores that have no aggregated stats
+ * Store stats placeholder used when aggregate location metrics are not available.
  *
+ * <p>This implementation of {@link StoreLocationStats} represents a data store (or a runtime
+ * situation) where location-/distance-based statistics cannot be produced. Typical reasons include
+ * stores that do not track such metrics, components that are still initializing or shutting down,
+ * or deployments where statistics collection is disabled. Every method throws {@link
+ * StatsNotAvailableException} to make the absence of data explicit and to prevent consumers from
+ * misinterpreting missing samples as zero or default values.
+ *
+ * <p>Use this class as a safe, explicit sentinel in places where a stats object is required by the
+ * API but no measurements are possible. Callers should catch the exception and fall back to
+ * coarse-grained health indicators or omit the affected widgets. The class is stateless and
+ * thread-safe; instances can be reused across threads without synchronization.
+ *
+ * <ul>
+ *   <li>Provides a consistent signaling mechanism for unavailable metrics.
+ *   <li>Avoids returning partial or misleading values during lifecycle transitions.
+ *   <li>Encourages callers to handle unavailability as a normal, recoverable condition.
+ * </ul>
+ *
+ * @see StoreLocationStats
+ * @see StatsNotAvailableException
  * @author nikotyan
  */
 public class NotAvailNodeStoreStats implements StoreLocationStats {
+  /**
+   * Constructs a stats placeholder that always signals unavailability.
+   *
+   * <p>The class is stateless; constructing multiple instances has no observable effect beyond
+   * allocating objects. Prefer reusing a single instance where convenient.
+   */
+  public NotAvailNodeStoreStats() {}
+
   @Override
+  /**
+   * Always throws because the average location metric is not available for this store.
+   *
+   * <p>This sentinel implementation does not compute or retain location samples. Callers should
+   * catch the exception and either retry later, display an "unavailable" state, or skip rendering
+   * this metric.
+   *
+   * @return never returns; the method always throws.
+   * @throws StatsNotAvailableException unconditionally, to indicate the metric cannot be provided
+   *     by this implementation.
+   */
   public double avgLocation() throws StatsNotAvailableException {
     throw new StatsNotAvailableException();
   }
 
   @Override
+  /**
+   * Always throws because the average success metric is not available for this store.
+   *
+   * <p>No success history is maintained by this implementation. Treat this as a normal, expected
+   * condition for stores that do not expose success ratios.
+   *
+   * @return never returns; the method always throws.
+   * @throws StatsNotAvailableException unconditionally, to indicate the metric cannot be provided
+   *     by this implementation.
+   */
   public double avgSuccess() throws StatsNotAvailableException {
     throw new StatsNotAvailableException();
   }
 
   @Override
+  /**
+   * Always throws because the furthest success distance is not available for this store.
+   *
+   * <p>Distance-based tail behavior is not tracked by this implementation. Callers should display a
+   * placeholder or omit the metric when this exception is raised.
+   *
+   * @return never returns; the method always throws.
+   * @throws StatsNotAvailableException unconditionally, to indicate the metric cannot be provided
+   *     by this implementation.
+   */
   public double furthestSuccess() throws StatsNotAvailableException {
     throw new StatsNotAvailableException();
   }
 
   @Override
+  /**
+   * Always throws because the average distance metric is not available for this store.
+   *
+   * <p>This implementation does not record or compute distance values. Consumers should handle this
+   * exception as a benign unavailability signal.
+   *
+   * @return never returns; the method always throws.
+   * @throws StatsNotAvailableException unconditionally, to indicate the metric cannot be provided
+   *     by this implementation.
+   */
   public double avgDist() throws StatsNotAvailableException {
     throw new StatsNotAvailableException();
   }
 
   @Override
+  /**
+   * Always throws because composite distance statistics are not available for this store.
+   *
+   * <p>Higher-order distribution metrics (such as variance or percentiles) are not computed by this
+   * implementation. Prefer summarizing available counters or indicating that distance stats are
+   * unavailable.
+   *
+   * @return never returns; the method always throws.
+   * @throws StatsNotAvailableException unconditionally, to indicate the metric cannot be provided
+   *     by this implementation.
+   */
   public double distanceStats() throws StatsNotAvailableException {
     throw new StatsNotAvailableException();
   }

--- a/src/main/java/network/crypta/node/stats/StatsNotAvailableException.java
+++ b/src/main/java/network/crypta/node/stats/StatsNotAvailableException.java
@@ -3,22 +3,86 @@ package network.crypta.node.stats;
 import java.io.Serial;
 
 /**
+ * Signals that node or store statistics are not currently available to be read.
+ *
+ * <p>This checked exception communicates that a statistics provider cannot fulfill a request at
+ * this time. Typical reasons include a store that is still initializing, a component that has been
+ * shut down, metrics that are disabled by configuration, or a data source that is temporarily
+ * inaccessible. Throwing an explicit exception is preferred over returning partial data because it
+ * forces callers to handle the absence of metrics explicitly and avoids conflating "zero" with
+ * "unknown".
+ *
+ * <p>The class is immutable and thread-safe. Instances may carry a human-readable message and/or a
+ * cause describing the underlying condition; callers should not rely on specific message wording as
+ * part of control flow. In boundary layers (e.g., HTTP endpoints or CLI tools) consider translating
+ * this exception into a transient failure status so that users understand that the system remains
+ * functional but cannot report statistics yet.
+ *
+ * <ul>
+ *   <li>Startup/shutdown windows when stores are not initialized or are being torn down.
+ *   <li>Metrics collection explicitly disabled or not compiled into the current build profile.
+ *   <li>Access restrictions in sandboxed environments that block probing or file access.
+ *   <li>Plugin-provided statistics while the plugin is missing, disabled, or reloading.
+ * </ul>
+ *
+ * @see network.crypta.node.stats.DataStoreStats
+ * @see network.crypta.node.stats.StoreAccessStats
  * @author nikotyan
  */
+@SuppressWarnings("unused")
 public class StatsNotAvailableException extends Exception {
 
   @Serial private static final long serialVersionUID = -7349859507599514672L;
 
+  /**
+   * Creates an exception with no detail message or cause.
+   *
+   * <p>Use this constructor when the absence of statistics is expected and no further context is
+   * necessary. Downstream handlers may convert this into a generic "stats unavailable" response or
+   * retry later depending on the calling policy.
+   */
   public StatsNotAvailableException() {}
 
+  /**
+   * Creates an exception with a human-readable message.
+   *
+   * <p>The message should describe the observed condition succinctly (for example, {@code "Store
+   * still initializing"}). Do not depend on the exact text for control flow; treat it as diagnostic
+   * information for logs and user-facing messages.
+   *
+   * @param s detail message explaining why statistics cannot be provided; may be {@code null} when
+   *     the reason is implicit or obvious from context.
+   */
   public StatsNotAvailableException(String s) {
     super(s);
   }
 
+  /**
+   * Creates an exception with a message and an underlying cause.
+   *
+   * <p>Use this when the unavailability stems from another failure (I/O, permissions, lifecycle
+   * state). The cause is preserved and accessible via {@link Throwable#getCause()} for diagnostics
+   * and logging.
+   *
+   * @param s detail message describing the high-level condition; may be {@code null} if the cause
+   *     is sufficiently descriptive on its own.
+   * @param throwable the underlying cause that prevented providing statistics; may be {@code null}
+   *     if unknown or not applicable.
+   */
   public StatsNotAvailableException(String s, Throwable throwable) {
     super(s, throwable);
   }
 
+  /**
+   * Creates an exception that wraps an underlying cause with no standalone message.
+   *
+   * <p>This is useful when the cause already carries a clear explanation. Callers should still
+   * avoid treating specific exception types as stable interfaces and prefer coarse-grained handling
+   * at higher layers.
+   *
+   * @param throwable the underlying cause indicating why statistics are unavailable; may be {@code
+   *     null} to indicate the reason is unspecified.
+   */
   public StatsNotAvailableException(Throwable throwable) {
     super(throwable);
   }

--- a/src/main/java/network/crypta/node/stats/StoreAccessStats.java
+++ b/src/main/java/network/crypta/node/stats/StoreAccessStats.java
@@ -1,33 +1,154 @@
 package network.crypta.node.stats;
 
+/**
+ * Summarizes read/write access statistics for a data store.
+ *
+ * <p>Instances of this abstract type expose read-oriented counters (hits, misses, false positives)
+ * and write counters as observed by a particular store. Implementations typically back these values
+ * with thread-safe counters updated by the store’s I/O path and may compute derived rates from the
+ * exposed primitives. The contract is deliberately minimal so it can model both in-memory caches
+ * and persistent stores with different eviction and validation strategies.
+ *
+ * <p>The methods are intended for metrics dashboards, admin endpoints, and diagnostics. Values
+ * represent point-in-time readings; they may change between calls. Implementations should be safe
+ * to query concurrently from multiple threads without additional synchronization requirements.
+ * Derived methods such as {@link #successRate()} document their preconditions and failure modes to
+ * avoid conflating "no data" with a meaningful rate.
+ *
+ * <ul>
+ *   <li>Use the primitive counters for precise alerting and long-term trends.
+ *   <li>Prefer rates for visualizing traffic patterns; calibrate for your deployment scale.
+ *   <li>Handle unavailability explicitly (for example, at startup or with empty histories).
+ * </ul>
+ *
+ * @see network.crypta.node.stats.DataStoreStats
+ * @see network.crypta.node.stats.StatsNotAvailableException
+ */
 public abstract class StoreAccessStats {
+  /**
+   * Initializes the statistics container for subclass implementations.
+   *
+   * <p>This constructor exists so that the default, no-argument constructor is explicitly
+   * documented. The class is abstract and cannot be instantiated directly; the constructor is
+   * invoked only by subclasses.
+   */
+  protected StoreAccessStats() {}
 
+  /**
+   * Returns the number of successful read requests (cache hits or equivalent).
+   *
+   * <p>This counter increases when a requested object can be satisfied from the store without
+   * fallback work. The exact definition of a hit depends on the store type (for example, direct
+   * lookup success for caches, or validated presence for persistent stores).
+   *
+   * @return non-negative count of read hits observed so far; monotonically non-decreasing per
+   *     process unless counters are reset by the implementation.
+   */
   public abstract long hits();
 
+  /**
+   * Returns the number of read requests that could not be served directly by the store.
+   *
+   * <p>A miss typically implies that an upstream fetch, recomputation, or alternative path was
+   * required. For persistent stores, a miss may indicate true absence; for caches, it commonly
+   * leads to a refill.
+   *
+   * @return non-negative count of read misses observed so far; monotonically non-decreasing per
+   *     process unless counters are reset by the implementation.
+   */
   public abstract long misses();
 
+  /**
+   * Returns the number of false positives detected during lookups.
+   *
+   * <p>False positives generally occur when a preliminary test (such as a probabilistic filter)
+   * indicates presence, yet the object is not actually retrievable. This counter helps assess
+   * filter tuning and its impact on unnecessary follow-on work.
+   *
+   * @return non-negative count of false positives observed so far; monotonically non-decreasing per
+   *     process unless counters are reset by the implementation.
+   */
   public abstract long falsePos();
 
+  /**
+   * Returns the number of write operations issued to the store.
+   *
+   * <p>Depending on the store, a write may represent an insert, update, or a completed fill after a
+   * miss. The counter reflects successfully issued writes; failures may or may not be included
+   * based on implementation policy.
+   *
+   * @return non-negative count of writes observed so far; monotonically non-decreasing per process
+   *     unless counters are reset by the implementation.
+   */
   public abstract long writes();
 
+  /**
+   * Returns the total number of read requests seen by the store.
+   *
+   * <p>Computed as {@code hits() + misses()}. This is a convenience method used for rate
+   * calculations and basic throughput charts.
+   *
+   * @return non-negative count of read requests; equals the sum of hits and misses.
+   */
   public long readRequests() {
     return hits() + misses();
   }
 
+  /**
+   * Returns the number of successful reads, or zero when no reads have occurred yet.
+   *
+   * <p>This avoids implying success when no traffic has been observed. Prefer this method over
+   * directly calling {@link #hits()} when rendering early-startup states.
+   *
+   * @return non-negative count of successful reads; zero when {@link #readRequests()} is zero.
+   */
   public long successfulReads() {
     if (readRequests() > 0) return hits();
     else return 0;
   }
 
+  /**
+   * Returns the read success rate as a percentage of total reads.
+   *
+   * <p>Calculated as {@code (100.0 * hits() / readRequests())}. When no reads have been observed
+   * yet, the rate is undefined and this method signals unavailability rather than returning a value
+   * that could be misinterpreted.
+   *
+   * @return a percentage in the range {@code [0.0, 100.0]} when at least one read has been
+   *     observed. The exact rounding behavior follows IEEE-754 double arithmetic.
+   * @throws StatsNotAvailableException if {@link #readRequests()} is zero and a rate would be
+   *     undefined.
+   */
   public double successRate() throws StatsNotAvailableException {
     if (readRequests() > 0) return (100.0 * hits() / readRequests());
     else throw new StatsNotAvailableException();
   }
 
+  /**
+   * Returns the average read request rate per second for the node uptime period.
+   *
+   * <p>Computed as {@code readRequests() / nodeUptimeSeconds}. Callers should pass a strictly
+   * positive uptime. If zero is supplied, the result follows IEEE-754 semantics (for example,
+   * {@code Infinity} or {@code NaN}) and should not be used for alerting.
+   *
+   * @param nodeUptimeSeconds total node uptime in seconds over which to average; must be greater
+   *     than zero for a meaningful finite rate.
+   * @return average reads per second as a double; the value may be fractional.
+   */
   public double accessRate(long nodeUptimeSeconds) {
     return (1.0 * readRequests() / nodeUptimeSeconds);
   }
 
+  /**
+   * Returns the average write rate per second for the node uptime period.
+   *
+   * <p>Computed as {@code writes() / nodeUptimeSeconds}. As with {@link #accessRate(long)}, callers
+   * should provide a strictly positive uptime to avoid undefined ratios at startup.
+   *
+   * @param nodeUptimeSeconds total node uptime in seconds over which to average; must be greater
+   *     than zero for a meaningful finite rate.
+   * @return average writes per second as a double; the value may be fractional.
+   */
   public double writeRate(long nodeUptimeSeconds) {
     return (1.0 * writes() / nodeUptimeSeconds);
   }

--- a/src/main/java/network/crypta/node/stats/StoreCallbackStats.java
+++ b/src/main/java/network/crypta/node/stats/StoreCallbackStats.java
@@ -3,19 +3,68 @@ package network.crypta.node.stats;
 import network.crypta.store.StoreCallback;
 
 /**
- * This class wraps StoreCallback instance to provide methods required to display stats
+ * Adapter that exposes a {@link StoreCallback} and companion location metrics as {@link
+ * DataStoreStats}.
  *
+ * <p>Instances of this class present a read-only, aggregated view of an underlying store's capacity
+ * and access behavior together with network-location statistics. The adapter obtains the
+ * storage-specific counters (key count, maximum keys, element size) from the provided {@link
+ * StoreCallback} and delegates locality/"distance" metrics to a {@link StoreLocationStats}
+ * provider. This makes it suitable for administrative dashboards, telemetry exporters, and other
+ * diagnostics that expect the unified {@link DataStoreStats} contract.
+ *
+ * <p>The adapter is intentionally lightweight and performs no background sampling. Values reflect
+ * the moment they are queried and may change between calls as the node processes requests. The
+ * access-statistics fields are captured from the delegate at construction time so the caller can
+ * obtain stable references for the current process session and, when supported by the store, the
+ * all-time or persisted totals.
+ *
+ * <ul>
+ *   <li>Thread-safety: instances are immutable after construction and safe for concurrent reads.
+ *   <li>Units: counts are expressed in <em>keys</em>; size derives from {@link
+ *       StoreCallback#dataLength()} and therefore shares its unit (typically bytes per entry).
+ *   <li>Division by zero: methods that compute ratios (for example, {@link #utilization()}) follow
+ *       IEEE-754 semantics; callers should handle {@code NaN} or infinities at startup.
+ * </ul>
+ *
+ * @see DataStoreStats
+ * @see StoreAccessStats
+ * @see StoreLocationStats
  * @author nikotyan
  */
 public class StoreCallbackStats implements DataStoreStats {
 
   private final StoreCallback<?> storeStats;
   private final StoreLocationStats nodeStats;
+
+  /**
+   * Access statistics scoped to the current process session.
+   *
+   * <p>This reference is captured from the delegate callback during construction so listeners have
+   * a stable handle for the lifetime of the adapter. Implementations typically reset session stats
+   * on node restart. The referenced object is expected to be thread-safe for reads.
+   */
   public final StoreAccessStats sessionAccessStats;
 
-  /** If the store type does not support this, it will be null, to avoid producing bogus numbers. */
+  /**
+   * Access statistics accumulated across sessions or persisted by the store when available.
+   *
+   * <p>If the store type does not support long-horizon totals, this field is {@code null}. In that
+   * case {@link #getTotalAccessStats()} throws {@link StatsNotAvailableException} to avoid
+   * producing misleading values. When non-null, the referenced object is expected to be thread-safe
+   * for reads.
+   */
   public final StoreAccessStats totalAccessStats;
 
+  /**
+   * Creates a new adapter that delegates storage counters and access stats to the given callback
+   * and locality metrics to the supplied location-stats provider.
+   *
+   * @param delegate store-specific adapter providing counters, sizes, and access metrics; must not
+   *     be {@code null} and should remain valid for the lifetime of this instance.
+   * @param nodeStats provider of location and distance metrics associated with the same store; must
+   *     not be {@code null} and may throw when statistics are temporarily unavailable.
+   */
   public StoreCallbackStats(StoreCallback<?> delegate, StoreLocationStats nodeStats) {
     this.storeStats = delegate;
     this.nodeStats = nodeStats;
@@ -23,56 +72,133 @@ public class StoreCallbackStats implements DataStoreStats {
     this.totalAccessStats = delegate.getTotalAccessStats();
   }
 
+  /**
+   * Returns the number of keys currently tracked by the underlying store.
+   *
+   * @return a non-negative count of entries at the time of the call; may change as background work
+   *     proceeds.
+   */
   @Override
   public long keys() {
     return storeStats.keyCount();
   }
 
+  /**
+   * Returns the configured capacity limit, expressed in keys, for the underlying store.
+   *
+   * @return the maximum number of keys the store is configured to hold; implementations may choose
+   *     sentinel values for unbounded stores.
+   */
   @Override
   public long capacity() {
     return storeStats.getMaxKeys();
   }
 
+  /**
+   * Returns the aggregate data size implied by the current key count.
+   *
+   * <p>The value is computed as {@code keys() * delegate.dataLength()}. It reflects a logical size
+   * defined by the block type and does not include headers or metadata unless the callback's data
+   * length encodes them.
+   *
+   * @return an implementation-defined size unit consistent with {@link StoreCallback#dataLength()}.
+   */
   @Override
   public long dataSize() {
     return keys() * storeStats.dataLength();
   }
 
+  /**
+   * Delegates to the provided {@link StoreLocationStats} to report the average location metric.
+   *
+   * @return a double representing the average location over the provider's sampling window.
+   * @throws StatsNotAvailableException if the location statistics are not available at call time.
+   */
   @Override
   public double avgLocation() throws StatsNotAvailableException {
     return nodeStats.avgLocation();
   }
 
+  /**
+   * Returns the utilization of the store as a ratio of keys to capacity.
+   *
+   * <p>Computed as {@code 1.0 * keys() / capacity()}. At startup or when capacity is zero, the
+   * result follows IEEE-754 semantics ({@code NaN} or infinities) and should be treated accordingly
+   * by callers.
+   *
+   * @return a ratio in {@code [0.0, 1.0]} under normal operation; see notes for exceptional cases.
+   */
   @Override
   public double utilization() {
     return (1.0 * keys() / capacity());
   }
 
+  /**
+   * Delegates to {@link StoreLocationStats} to report an average success indicator.
+   *
+   * @return a double summarizing success over a provider-defined window or history.
+   * @throws StatsNotAvailableException if success data cannot be produced at this time.
+   */
   @Override
   public double avgSuccess() throws StatsNotAvailableException {
     return nodeStats.avgSuccess();
   }
 
+  /**
+   * Delegates to {@link StoreLocationStats} to report the most distant successful operation.
+   *
+   * @return a double representing the provider-defined distance of the furthest success.
+   * @throws StatsNotAvailableException if distance or success samples are unavailable.
+   */
   @Override
   public double furthestSuccess() throws StatsNotAvailableException {
     return nodeStats.furthestSuccess();
   }
 
+  /**
+   * Delegates to {@link StoreLocationStats} to report the average distance metric.
+   *
+   * @return a double representing the provider-defined average distance across observed samples.
+   * @throws StatsNotAvailableException if distance statistics are not currently available.
+   */
   @Override
   public double avgDist() throws StatsNotAvailableException {
     return nodeStats.avgDist();
   }
 
+  /**
+   * Delegates to {@link StoreLocationStats} to report a composite distance statistic.
+   *
+   * @return a double capturing an implementation-defined characteristic of the distance
+   *     distribution (for example, variance or a trimmed measure).
+   * @throws StatsNotAvailableException if the distribution cannot be computed or sampled.
+   */
   @Override
   public double distanceStats() throws StatsNotAvailableException {
     return nodeStats.distanceStats();
   }
 
+  /**
+   * Returns the per-session access statistics captured at construction time.
+   *
+   * @return a thread-safe {@link StoreAccessStats} view representing access behavior for the
+   *     current process session; the reference is stable for this adapter's lifetime.
+   */
   @Override
   public StoreAccessStats getSessionAccessStats() {
     return sessionAccessStats;
   }
 
+  /**
+   * Returns access statistics accumulated beyond the current session when supported.
+   *
+   * <p>If the underlying store does not provide total access metrics, this method signals
+   * unavailability via an exception to avoid conflating "unknown" with a meaningful value.
+   *
+   * @return a thread-safe {@link StoreAccessStats} view representing long-horizon or persisted
+   *     access behavior.
+   * @throws StatsNotAvailableException if the store does not support total access statistics.
+   */
   @Override
   public StoreAccessStats getTotalAccessStats() throws StatsNotAvailableException {
     if (totalAccessStats == null) throw new StatsNotAvailableException();

--- a/src/main/java/network/crypta/node/stats/StoreLocationStats.java
+++ b/src/main/java/network/crypta/node/stats/StoreLocationStats.java
@@ -1,19 +1,101 @@
 package network.crypta.node.stats;
 
 /**
- * This interface represents aggregated stats for data store
+ * Exposes aggregate location/distance success metrics for a data store.
  *
+ * <p>Implementations provide summary statistics that describe how requests associated with a given
+ * store distribute over the network "location" space and how successful those requests are. The
+ * exact definitions of <em>location</em> and <em>distance</em> depend on the store and routing
+ * algorithm in use; values are typically normalized to implementation-defined units so they can be
+ * compared within the same deployment. Callers should treat these numbers as descriptive indicators
+ * useful for trend analysis and health dashboards rather than strict SLAs.
+ *
+ * <p>Methods may throw {@link StatsNotAvailableException} during initialization, shutdown, or when
+ * statistics are disabled. The interface is read-only; implementations must be safe to invoke from
+ * multiple threads concurrently. Returned values represent snapshots at call time and do not imply
+ * any guarantees about future behavior.
+ *
+ * <ul>
+ *   <li>Use to visualize locality and routing efficacy for a store.
+ *   <li>Integrate into periodic telemetry collectors or admin endpoints.
+ *   <li>Prefer coarse-grained alerts; avoid tight control loops on single readings.
+ * </ul>
+ *
+ * @see network.crypta.node.stats.DataStoreStats
+ * @see network.crypta.node.stats.DataStoreType
+ * @see network.crypta.node.stats.StatsNotAvailableException
  * @author nikotyan
  */
 public interface StoreLocationStats {
 
+  /**
+   * Returns the average observed location metric for recent store operations.
+   *
+   * <p>The location metric is defined by the implementation and may represent a position in a
+   * logical key space or node space. The average aggregates over a recent window or all-time,
+   * depending on the provider. Callers must not assume specific bounds or a particular
+   * normalization; compare values produced by the same implementation and version.
+   *
+   * @return a double representing the average location across observed samples; the unit and scale
+   *     are implementation-defined and should be interpreted relative to companion metrics.
+   * @throws StatsNotAvailableException if the provider cannot compute the metric at this time, for
+   *     example during initialization, shutdown, or when statistics collection is disabled.
+   */
   double avgLocation() throws StatsNotAvailableException;
 
+  /**
+   * Returns the average success metric for requests attributed to this store.
+   *
+   * <p>Implementations may compute this as a ratio, a percentile, or a smoothed probability over a
+   * defined period. Consumers should treat it as a directional indicator of effective success
+   * rather than an exact probability unless the implementation explicitly documents otherwise.
+   *
+   * @return a double summarizing success over the chosen window; exact units and bounds depend on
+   *     the implementation and may be normalized or smoothed.
+   * @throws StatsNotAvailableException if success data is not currently available or the subsystem
+   *     producing it is inactive.
+   */
   double avgSuccess() throws StatsNotAvailableException;
 
+  /**
+   * Returns a metric describing the most distant successful retrieval or write.
+   *
+   * <p>This value highlights the furthest point in the measured period at which an operation still
+   * succeeded according to the implementation’s notion of distance. It is useful for spotting
+   * outliers and understanding the tail behavior of routing or lookup paths.
+   *
+   * @return a double representing the distance of the furthest successful operation; units and
+   *     normalization are implementation-defined and intended for relative comparison.
+   * @throws StatsNotAvailableException if distance/success samples are unavailable or incomplete at
+   *     call time.
+   */
   double furthestSuccess() throws StatsNotAvailableException;
 
+  /**
+   * Returns the average distance metric across observed operations.
+   *
+   * <p>The distance is measured according to the implementation’s definition (for example,
+   * difference in a logical key space). The average is typically computed over a sliding window and
+   * may employ smoothing. Consumers should interpret changes over time rather than rely on absolute
+   * thresholds unless they are calibrated for a specific deployment.
+   *
+   * @return a double representing the average distance across samples; interpretation requires
+   *     context from the same implementation and configuration.
+   * @throws StatsNotAvailableException if distance statistics cannot be produced at this time.
+   */
   double avgDist() throws StatsNotAvailableException;
 
+  /**
+   * Returns a composite distance statistic summarizing distribution characteristics.
+   *
+   * <p>Depending on the provider this may be a moment (e.g., variance), a trimmed statistic, or
+   * another summary value derived from the underlying distance distribution. It complements the
+   * simple average with additional shape information for dashboards and anomaly detection.
+   *
+   * @return a double capturing a composite or higher-order property of the distance distribution;
+   *     semantics are implementation-defined and should be used for relative comparison.
+   * @throws StatsNotAvailableException if the underlying distribution cannot be computed or sampled
+   *     at this time.
+   */
   double distanceStats() throws StatsNotAvailableException;
 }

--- a/src/test/java/network/crypta/node/stats/NotAvailNodeStoreStatsTest.java
+++ b/src/test/java/network/crypta/node/stats/NotAvailNodeStoreStatsTest.java
@@ -1,0 +1,35 @@
+package network.crypta.node.stats;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100") // Test method naming convention per instructions
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NotAvailNodeStoreStatsTest {
+
+  private Stream<Executable> unavailableInvocations() {
+    return Stream.of(
+        () -> new NotAvailNodeStoreStats().avgLocation(),
+        () -> new NotAvailNodeStoreStats().avgSuccess(),
+        () -> new NotAvailNodeStoreStats().furthestSuccess(),
+        () -> new NotAvailNodeStoreStats().avgDist(),
+        () -> new NotAvailNodeStoreStats().distanceStats());
+  }
+
+  @ParameterizedTest(name = "method throws StatsNotAvailableException")
+  @MethodSource("unavailableInvocations")
+  @DisplayName("All StoreLocationStats methods throw when stats are unavailable")
+  void methods_whenCalled_expectStatsNotAvailableException(Executable invocation) {
+    StatsNotAvailableException ex = assertThrows(StatsNotAvailableException.class, invocation);
+    // Default constructor is used, so message and cause are expected to be null.
+    assertAll(() -> assertNull(ex.getMessage()), () -> assertNull(ex.getCause()));
+  }
+}

--- a/src/test/java/network/crypta/node/stats/StoreCallbackStatsTest.java
+++ b/src/test/java/network/crypta/node/stats/StoreCallbackStatsTest.java
@@ -1,0 +1,323 @@
+package network.crypta.node.stats;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import network.crypta.store.StoreCallback;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class StoreCallbackStatsTest {
+
+  @Mock StoreCallback<network.crypta.store.StorableBlock> storeCallback;
+  @Mock StoreLocationStats nodeStats;
+  @Mock StoreAccessStats sessionAccessStats;
+  @Mock StoreAccessStats totalAccessStats;
+
+  @Test
+  @DisplayName("keys_whenDelegateReturnsValue_expectSame")
+  void keys_whenDelegateReturnsValue_expectSame() {
+    // Arrange
+    when(storeCallback.keyCount()).thenReturn(42L);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    long result = stats.keys();
+
+    // Assert
+    assertEquals(42L, result);
+  }
+
+  @Test
+  @DisplayName("capacity_whenDelegateReturnsValue_expectSame")
+  void capacity_whenDelegateReturnsValue_expectSame() {
+    // Arrange
+    when(storeCallback.getMaxKeys()).thenReturn(1_000L);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    long result = stats.capacity();
+
+    // Assert
+    assertEquals(1_000L, result);
+  }
+
+  @Test
+  @DisplayName("dataSize_whenMultipleKeysAndDataLength_expectProduct")
+  void dataSize_whenMultipleKeysAndDataLength_expectProduct() {
+    // Arrange
+    when(storeCallback.keyCount()).thenReturn(7L);
+    when(storeCallback.dataLength()).thenReturn(2_048);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    long result = stats.dataSize();
+
+    // Assert
+    assertEquals(7L * 2_048L, result);
+  }
+
+  @Test
+  @DisplayName("utilization_whenNominal_expectFractionOfCapacity")
+  void utilization_whenNominal_expectFractionOfCapacity() {
+    // Arrange
+    when(storeCallback.keyCount()).thenReturn(50L);
+    when(storeCallback.getMaxKeys()).thenReturn(200L);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    double result = stats.utilization();
+
+    // Assert
+    assertEquals(0.25d, result, 1.0e-12);
+  }
+
+  @Test
+  @DisplayName("utilization_whenZeroCapacityAndZeroKeys_expectNaN")
+  void utilization_whenZeroCapacityAndZeroKeys_expectNaN() {
+    // Arrange
+    when(storeCallback.keyCount()).thenReturn(0L);
+    when(storeCallback.getMaxKeys()).thenReturn(0L);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    double result = stats.utilization();
+
+    // Assert
+    assertTrue(Double.isNaN(result));
+  }
+
+  @Test
+  @DisplayName("utilization_whenZeroCapacityAndPositiveKeys_expectPositiveInfinity")
+  void utilization_whenZeroCapacityAndPositiveKeys_expectPositiveInfinity() {
+    // Arrange
+    when(storeCallback.keyCount()).thenReturn(10L);
+    when(storeCallback.getMaxKeys()).thenReturn(0L);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    double result = stats.utilization();
+
+    // Assert
+    assertTrue(Double.isInfinite(result) && result > 0);
+  }
+
+  @Test
+  @DisplayName("avgLocation_whenNodeProvidesValue_expectSame")
+  void avgLocation_whenNodeProvidesValue_expectSame() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.avgLocation()).thenReturn(0.123);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    double result = stats.avgLocation();
+
+    // Assert
+    assertEquals(0.123, result, 0.0);
+  }
+
+  @Test
+  @DisplayName("avgLocation_whenNodeThrows_expectPropagatedException")
+  void avgLocation_whenNodeThrows_expectPropagatedException() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.avgLocation()).thenThrow(new StatsNotAvailableException("not ready"));
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act + Assert
+    assertThrows(StatsNotAvailableException.class, stats::avgLocation);
+  }
+
+  @Test
+  @DisplayName("avgSuccess_whenNodeProvidesValue_expectSame")
+  void avgSuccess_whenNodeProvidesValue_expectSame() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.avgSuccess()).thenReturn(77.7);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    double result = stats.avgSuccess();
+
+    // Assert
+    assertEquals(77.7, result, 0.0);
+  }
+
+  @Test
+  @DisplayName("avgSuccess_whenNodeThrows_expectPropagatedException")
+  void avgSuccess_whenNodeThrows_expectPropagatedException() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.avgSuccess()).thenThrow(new StatsNotAvailableException());
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act + Assert
+    assertThrows(StatsNotAvailableException.class, stats::avgSuccess);
+  }
+
+  @Test
+  @DisplayName("furthestSuccess_whenNodeProvidesValue_expectSame")
+  void furthestSuccess_whenNodeProvidesValue_expectSame() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.furthestSuccess()).thenReturn(9.5);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    double result = stats.furthestSuccess();
+
+    // Assert
+    assertEquals(9.5, result, 0.0);
+  }
+
+  @Test
+  @DisplayName("furthestSuccess_whenNodeThrows_expectPropagatedException")
+  void furthestSuccess_whenNodeThrows_expectPropagatedException()
+      throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.furthestSuccess()).thenThrow(new StatsNotAvailableException());
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act + Assert
+    assertThrows(StatsNotAvailableException.class, stats::furthestSuccess);
+  }
+
+  @Test
+  @DisplayName("avgDist_whenNodeProvidesValue_expectSame")
+  void avgDist_whenNodeProvidesValue_expectSame() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.avgDist()).thenReturn(0.333);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    double result = stats.avgDist();
+
+    // Assert
+    assertEquals(0.333, result, 0.0);
+  }
+
+  @Test
+  @DisplayName("avgDist_whenNodeThrows_expectPropagatedException")
+  void avgDist_whenNodeThrows_expectPropagatedException() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.avgDist()).thenThrow(new StatsNotAvailableException());
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act + Assert
+    assertThrows(StatsNotAvailableException.class, stats::avgDist);
+  }
+
+  @Test
+  @DisplayName("distanceStats_whenNodeProvidesValue_expectSame")
+  void distanceStats_whenNodeProvidesValue_expectSame() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.distanceStats()).thenReturn(1.234);
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act
+    double result = stats.distanceStats();
+
+    // Assert
+    assertEquals(1.234, result, 0.0);
+  }
+
+  @Test
+  @DisplayName("distanceStats_whenNodeThrows_expectPropagatedException")
+  void distanceStats_whenNodeThrows_expectPropagatedException() throws StatsNotAvailableException {
+    // Arrange
+    when(nodeStats.distanceStats()).thenThrow(new StatsNotAvailableException());
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act + Assert
+    assertThrows(StatsNotAvailableException.class, stats::distanceStats);
+  }
+
+  @Test
+  @DisplayName("getSessionAccessStats_whenConstructed_returnsSnapshot")
+  void getSessionAccessStats_whenConstructed_returnsSnapshot() {
+    // Arrange
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Change delegate to a different object after construction to ensure snapshot semantics
+    StoreAccessStats anotherSessionStats = org.mockito.Mockito.mock(StoreAccessStats.class);
+    org.mockito.Mockito.lenient()
+        .when(storeCallback.getSessionAccessStats())
+        .thenReturn(anotherSessionStats);
+
+    // Act
+    StoreAccessStats result = stats.getSessionAccessStats();
+
+    // Assert
+    assertEquals(sessionAccessStats, result);
+  }
+
+  @Test
+  @DisplayName("getTotalAccessStats_whenSupported_returnsSnapshot")
+  void getTotalAccessStats_whenSupported_returnsSnapshot() throws StatsNotAvailableException {
+    // Arrange
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(totalAccessStats);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Change delegate to a different object after construction to ensure snapshot semantics
+    StoreAccessStats anotherTotal = org.mockito.Mockito.mock(StoreAccessStats.class);
+    org.mockito.Mockito.lenient()
+        .when(storeCallback.getTotalAccessStats())
+        .thenReturn(anotherTotal);
+
+    // Act
+    StoreAccessStats result = stats.getTotalAccessStats();
+
+    // Assert
+    assertEquals(totalAccessStats, result);
+  }
+
+  @Test
+  @DisplayName("getTotalAccessStats_whenUnsupported_expectStatsNotAvailableException")
+  void getTotalAccessStats_whenUnsupported_expectStatsNotAvailableException() {
+    // Arrange
+    when(storeCallback.getSessionAccessStats()).thenReturn(sessionAccessStats);
+    when(storeCallback.getTotalAccessStats()).thenReturn(null);
+    StoreCallbackStats stats = new StoreCallbackStats(storeCallback, nodeStats);
+
+    // Act + Assert
+    assertThrows(StatsNotAvailableException.class, stats::getTotalAccessStats);
+  }
+}


### PR DESCRIPTION
Summary
- Expand and clarify Javadoc for DataStore stats interfaces and types.
- Clarify units/semantics, error signaling (StatsNotAvailableException), and thread-safety expectations.
- Align naming/comments across DataStore* and Store* stats classes.
- Add tests for NotAvailNodeStoreStats and StoreCallbackStats.
- Applied Spotless formatting before commit.

Details
- Javadoc enriched for: DataStoreStats, DataStoreKeyType, DataStoreType, StoreAccessStats, StoreCallbackStats, StoreLocationStats, StatsNotAvailableException, NotAvailNodeStoreStats.
- New/updated tests:
  - src/test/java/network/crypta/node/stats/NotAvailNodeStoreStatsTest.java
  - src/test/java/network/crypta/node/stats/StoreCallbackStatsTest.java

Rationale
- Improve API contracts and docs for dashboards/telemetry consumers.
- Document units and the behavior of live-sampled metrics that may be temporarily unavailable.
- Provide test coverage for basic behavior and edge cases.

Formatting & Conventions
- Ran `./gradlew spotlessApply` before commit.
- Follows project docs: Conventional commits and Javadoc/KDoc improvements.

Scope
- No behavior changes beyond documentation and tests; main source changes are non-functional (Javadoc) and clarifications.

Target Branch
- Base: develop
- Head: feature/doc-stats
