### PR TITLE
fix(updater): harden plugin manifest parsing; add tests and docs cleanup

### DIFF
--- a/src/main/java/network/crypta/node/updater/NodeUpdater.java
+++ b/src/main/java/network/crypta/node/updater/NodeUpdater.java
@@ -1,17 +1,16 @@
 package network.crypta.node.updater;
 
-import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import network.crypta.client.FetchContext;
@@ -38,34 +37,107 @@ import network.crypta.support.io.FileBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Base class for components that subscribe to update keys, fetch new editions, and coordinate
+ * post‑fetch processing.
+ *
+ * <p>This class encapsulates the common control flow used by both core and plugin updaters. It
+ * subscribes to a USK, reacts to discovered editions, schedules and runs a {@code ClientGetter}
+ * fetch, and then hands the result to subclass hooks for validation and deployment. Instances are
+ * long‑lived and typically created once per updater type. They maintain internal state such as the
+ * latest available and fetched versions, whether a fetch is currently in progress, and temporary
+ * file paths used to persist fetched blobs.
+ *
+ * <p>Thread‑safety: the updater uses synchronized blocks to protect mutable fields that are shared
+ * across callbacks (e.g., edition discovery, fetch success/failure). Subclasses should assume that
+ * the abstract callbacks may be invoked from client layer threads and avoid blocking the ticker.
+ * I/O is delegated to the client fetcher and to small, bounded parsing steps in this base class.
+ * The class is mutable but designed to be driven by the node lifecycle.
+ *
+ * <ul>
+ *   <li>Subscribes to a USK and tracks discovered editions.
+ *   <li>Schedules fetches with suitable priorities and temporary file targets.
+ *   <li>Provides hooks to parse manifests and process success after fetch completion.
+ *   <li>Exposes helper accessors for blob files and progress reporting.
+ * </ul>
+ *
+ * @see network.crypta.node.updater.PluginJarUpdater
+ * @see network.crypta.node.updater.CoreUpdater
+ */
 public abstract class NodeUpdater implements ClientGetCallback, USKCallback, RequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(NodeUpdater.class);
 
+  /** Maximum allowed manifest size to parse (1 MiB). */
+  private static final long MAX_MANIFEST_SIZE = 1024L * 1024L;
+
+  /** Maximum allowed compressed size of the manifest entry (1 MiB). */
+  private static final long MAX_MANIFEST_COMPRESSED_SIZE = 1024L * 1024L;
+
+  /** Maximum number of ZIP entries to scan while searching for the manifest. */
+  private static final int MAX_ZIP_ENTRIES_SCANNED = 1024;
+
+  /** Maximum number of compressed bytes to read from the ZIP stream overall. */
+  private static final long MAX_ZIP_SCAN_BYTES = 16L * 1024L * 1024L; // 16 MiB
+
   private final FetchContext ctx;
   private ClientGetter cg;
-  private FreenetURI URI;
+  private FreenetURI uri;
   private final Ticker ticker;
+
+  /**
+   * Owning client core used to create fetch contexts, schedule requests, and access alerts and
+   * persistence. The reference is stable and not reassigned after construction.
+   */
   public final NodeClientCore core;
+
+  /**
+   * Hosting node that provides environment information and directory paths. Subclasses use it for
+   * follow‑up actions after a successful fetch.
+   */
   protected final Node node;
+
+  /**
+   * Coordinator that owns and orchestrates updater instances. It controls enablement, auto‑update
+   * policies, and top‑level alerting behavior across the application.
+   */
   public final NodeUpdateManager manager;
+
   private final int currentVersion;
   private int realAvailableVersion;
   private int availableVersion;
   private int fetchingVersion;
+
+  /**
+   * Most recently fetched edition number. Increases as newer editions are downloaded and is used to
+   * determine whether further fetches are necessary.
+   */
   protected int fetchedVersion;
+
   private int maxDeployVersion;
   private int minDeployVersion;
   private boolean isRunning;
   private boolean isFetching;
   private final String blobFilenamePrefix;
+
+  /**
+   * Temporary file used during the current fetch. On success, the file is renamed to a finalized
+   * {@code .fblob}. Subclasses may read or delete it as part of deployment.
+   */
   protected File tempBlobFile;
 
-  /** Human-readable name of the update artifact (for logs/UI). */
+  /**
+   * Returns a human‑readable name for the artifact handled by this updater.
+   *
+   * <p>The name appears in log messages and user alerts. Implementations typically return a plugin
+   * identifier or a concise descriptor of the core manifest.
+   *
+   * @return a concise artifact name suitable for logs and UI; never {@code null}
+   */
   public abstract String artifactName();
 
   NodeUpdater(
       NodeUpdateManager manager,
-      FreenetURI URI,
+      FreenetURI updateUri,
       int current,
       int min,
       int max,
@@ -73,7 +145,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
     // Debug gating derives from LOG.isDebugEnabled() where needed
     this.manager = manager;
     this.node = manager.getNode();
-    this.URI = URI.setSuggestedEdition(Version.currentBuildNumber() + 1);
+    this.uri = updateUri.setSuggestedEdition(((long) Version.currentBuildNumber()) + 1);
     this.ticker = node.getTicker();
     this.core = node.getClientCore();
     this.currentVersion = current;
@@ -98,42 +170,11 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
   private void subscribe(Runnable onError) {
     try {
       // because of UoM, this version is actually worth having as well
-      USK myUsk = USK.create(URI.setSuggestedEdition(currentVersion));
+      USK myUsk = USK.create(this.uri.setSuggestedEdition(currentVersion));
       core.getUskManager().subscribe(myUsk, this, true, getRequestClient());
     } catch (MalformedURLException e) {
       LOG.error("The auto-update URI isn't valid and can't be used");
       onError.run();
-    }
-  }
-
-  protected void maybeProcessOldBlob() {
-    File oldBlob = getBlobFile(currentVersion);
-    if (oldBlob.exists()) {
-      File temp;
-      try {
-        temp =
-            File.createTempFile(
-                blobFilenamePrefix + availableVersion + "-",
-                ".fblob.tmp",
-                manager.getNode().getClientCore().getPersistentTempDir());
-      } catch (IOException e) {
-        LOG.error("Unable to process old blob: " + e, e);
-        return;
-      }
-      if (oldBlob.renameTo(temp)) {
-        FreenetURI uri = URI.setSuggestedEdition(currentVersion);
-        uri = uri.sskForUSK();
-        try {
-          manager.getUpdateOverMandatory().processMainJarBlob(temp, null, currentVersion, uri);
-        } catch (Throwable t) {
-          // Don't disrupt startup.
-          LOG.error("Unable to process old blob, caught " + t, t);
-        }
-        temp.delete();
-      } else {
-        LOG.error(
-            "Unable to rename old blob file " + oldBlob + " to " + temp + " so can't process it.");
-      }
     }
   }
 
@@ -153,7 +194,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
       boolean newSlotToo) {
     if (newKnownGood && !newSlotToo) return;
     // Debug gating derives from LOG.isDebugEnabled() where needed
-    if (LOG.isDebugEnabled()) LOG.debug("Found edition " + l);
+    if (LOG.isDebugEnabled()) LOG.debug("Found edition {}", l);
     int found;
     synchronized (this) {
       if (!isRunning) return;
@@ -161,27 +202,22 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
 
       realAvailableVersion = found;
       if (found > maxDeployVersion) {
-        System.err.println(
-            "Ignoring "
-                + artifactName()
-                + " update edition "
-                + l
-                + ": version too new (min "
-                + minDeployVersion
-                + " max "
-                + maxDeployVersion
-                + ")");
+        if (LOG.isWarnEnabled())
+          LOG.warn(
+              "Ignoring {} update edition {}: version too new (min {} max {})",
+              artifactName(),
+              l,
+              minDeployVersion,
+              maxDeployVersion);
         found = maxDeployVersion;
       }
 
       if (found <= availableVersion) return;
-      System.err.println("Found " + artifactName() + " update edition " + found);
+      if (LOG.isInfoEnabled()) LOG.info("Found {} update edition {}", artifactName(), found);
       LOG.debug(
-          "Updating availableVersion from "
-              + availableVersion
-              + " to "
-              + found
-              + " and queueing an update");
+          "Updating availableVersion from {} to {} and queueing an update",
+          availableVersion,
+          found);
       this.availableVersion = found;
     }
     finishOnFoundEdition(found);
@@ -189,19 +225,32 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
 
   private void finishOnFoundEdition(int found) {
     ticker.queueTimedJob(
-        () -> maybeUpdate(), SECONDS.toMillis(60)); // leave some time in case we get later editions
+        this::maybeUpdate, SECONDS.toMillis(60)); // leave some time in case we get later editions
     // LOCKING: Always take the NodeUpdater lock *BEFORE* the NodeUpdateManager lock
     if (found <= currentVersion) {
-      System.err.println(
-          "Cancelling fetch for " + found + ": not newer than current version " + currentVersion);
+      LOG.info("Cancelling fetch for {}: not newer than current version {}", found, currentVersion);
       return;
     }
     onStartFetching();
-    LOG.debug("Fetching " + artifactName() + " update edition " + found);
+    if (LOG.isDebugEnabled()) LOG.debug("Fetching {} update edition {}", artifactName(), found);
   }
 
+  /**
+   * Hook invoked just before a new fetch is scheduled and started.
+   *
+   * <p>Implementations can use this callback to update UI, reset flags, or perform lightweight
+   * bookkeeping. The method must be fast and non‑blocking; heavy work should run after fetch
+   * completion.
+   */
   protected abstract void onStartFetching();
 
+  /**
+   * Attempts to start a fetch for the latest discovered edition.
+   *
+   * <p>The method skips when already fetching the same edition or when the edition is not newer. It
+   * may cancel a stale fetch, prepare a new {@link ClientGetter}, and start it through the client
+   * context. Repeated calls are safe; a new request starts only when state warrants.
+   */
   public void maybeUpdate() {
     ClientGetter toStart = null;
     if (!manager.isEnabled()) return;
@@ -210,74 +259,36 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
     synchronized (this) {
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "maybeUpdate: isFetching="
-                + isFetching
-                + ", isRunning="
-                + isRunning
-                + ", availableVersion="
-                + availableVersion);
-      if (!isRunning) return;
-      if (isFetching && availableVersion == fetchingVersion) return;
-      if (availableVersion <= fetchedVersion) return;
-      if (fetchingVersion < minDeployVersion || fetchingVersion == currentVersion) {
+            "maybeUpdate: isFetching={}, isRunning={}, availableVersion={}",
+            isFetching,
+            isRunning,
+            availableVersion);
+
+      if (shouldSkipUpdateLocked()) return;
+
+      if (shouldCancelPreviousFetchLocked()) {
         LOG.info("Cancelling previous fetch");
         cancelled = cg;
         cg = null;
       }
-      fetchingVersion = availableVersion;
 
-      if (availableVersion > currentVersion) {
-        LOG.info("Starting the update process (" + availableVersion + ')');
-        System.err.println(
-            "Starting the update process: found the update ("
-                + availableVersion
-                + "), now fetching it.");
-      }
-      if (LOG.isDebugEnabled()) LOG.debug("Starting the update process (" + availableVersion + ')');
-      // We fetch it
+      fetchingVersion = availableVersion;
+      logStartUpdateIfNeeded(availableVersion);
+
       try {
-        if ((cg == null) || cg.isCancelled()) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("Scheduling request for " + URI.setSuggestedEdition(availableVersion));
-          if (availableVersion > currentVersion)
-            System.err.println("Starting " + artifactName() + " fetch for " + availableVersion);
-          tempBlobFile =
-              File.createTempFile(
-                  blobFilenamePrefix + availableVersion + "-",
-                  ".fblob.tmp",
-                  manager.getNode().getClientCore().getPersistentTempDir());
-          FreenetURI uri = URI.setSuggestedEdition(availableVersion);
-          uri = uri.sskForUSK();
-          cg =
-              new ClientGetter(
-                  this,
-                  uri,
-                  ctx,
-                  RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS,
-                  null,
-                  new BinaryBlobWriter(new FileBucket(tempBlobFile, false, false, false, false)),
-                  null);
-          toStart = cg;
-        } else {
-          System.err.println(
-              "Already fetching "
-                  + artifactName()
-                  + " fetch for "
-                  + fetchingVersion
-                  + " want "
-                  + availableVersion);
-        }
+        toStart = prepareClientGetterIfNeeded(availableVersion);
         isFetching = true;
       } catch (Exception e) {
-        LOG.error("Error while starting the fetching: " + e, e);
+        LOG.error("Error while starting the fetching: {}", e, e);
         isFetching = false;
       }
     }
+
     if (toStart != null)
       try {
         node.getClientCore().getClientContext().start(toStart);
       } catch (FetchException e) {
-        LOG.error("Error while starting the fetching: " + e, e);
+        LOG.error("Error while starting the fetching: {}", e, e);
         synchronized (this) {
           isFetching = false;
         }
@@ -285,6 +296,58 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
         // Impossible
       }
     if (cancelled != null) cancelled.cancel(core.getClientContext());
+  }
+
+  private boolean shouldSkipUpdateLocked() {
+    if (!isRunning) return true;
+    if (isFetching && availableVersion == fetchingVersion) return true;
+    return availableVersion <= fetchedVersion;
+  }
+
+  private boolean shouldCancelPreviousFetchLocked() {
+    return fetchingVersion < minDeployVersion || fetchingVersion == currentVersion;
+  }
+
+  private void logStartUpdateIfNeeded(int version) {
+    if (version > currentVersion) {
+      LOG.info("Starting the update process ({})", version);
+      LOG.info("Starting the update process: found the update ({}) now fetching it.", version);
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("Starting the update process ({})", version);
+  }
+
+  private ClientGetter prepareClientGetterIfNeeded(int version) throws IOException {
+    if ((cg == null) || cg.isCancelled()) {
+      if (LOG.isDebugEnabled())
+        LOG.debug("Scheduling request for {}", this.uri.setSuggestedEdition(version));
+      if (version > currentVersion && LOG.isInfoEnabled())
+        LOG.info("Starting {} fetch for {}", artifactName(), version);
+      tempBlobFile =
+          File.createTempFile(
+              blobFilenamePrefix + version + "-",
+              ".fblob.tmp",
+              manager.getNode().getClientCore().getPersistentTempDir());
+      FreenetURI uskUri = this.uri.setSuggestedEdition(version);
+      uskUri = uskUri.sskForUSK();
+      cg =
+          new ClientGetter(
+              this,
+              uskUri,
+              ctx,
+              RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS,
+              null,
+              new BinaryBlobWriter(new FileBucket(tempBlobFile, false, false, false, false)),
+              null);
+      return cg;
+    } else {
+      if (LOG.isInfoEnabled())
+        LOG.info(
+            "Already fetching {} fetch for {} want {}",
+            artifactName(),
+            fetchingVersion,
+            availableVersion);
+      return null;
+    }
   }
 
   final File getBlobFile(int availableVersion) {
@@ -295,167 +358,361 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
 
   RandomAccessBucket getBlobBucket(int availableVersion) {
     File f = getBlobFile(availableVersion);
-    if (f == null) return null;
     return new FileBucket(f, true, false, false, false);
   }
 
   @Override
   public void onSuccess(FetchResult result, ClientGetter state) {
-    onSuccess(result, state, tempBlobFile, fetchingVersion);
+    onSuccess(result, tempBlobFile, fetchingVersion);
   }
 
-  void onSuccess(FetchResult result, ClientGetter state, File tempBlobFile, int fetchedVersion) {
+  void onSuccess(FetchResult result, File tempBlobFile, int fetchedVersion) {
     // Debug gating derives from LOG.isDebugEnabled() where needed
-    File blobFile = null;
+    File blobFile;
     synchronized (this) {
-      if (fetchedVersion <= this.fetchedVersion) {
-        tempBlobFile.delete();
-        if (result != null) {
-          Bucket toFree = result.asBucket();
-          if (toFree != null) toFree.free();
+      if (shouldSkipAlreadyFetched(fetchedVersion)) {
+        cleanupAlreadyFetched(result, tempBlobFile);
+        return;
+      }
+      if (isEmptyResult(result)) {
+        try {
+          Files.delete(tempBlobFile.toPath());
+        } catch (IOException ex) {
+          LOG.warn("Unable to delete temp blob {}", tempBlobFile, ex);
         }
+        LOG.error("Cannot update: result either null or empty for {}", availableVersion);
+        // Try again immediately; no need to inspect Bucket here
+        node.getTicker().queueTimedJob(this::maybeUpdate, 0);
         return;
       }
-      if (result == null || result.asBucket() == null || result.asBucket().size() == 0) {
-        tempBlobFile.delete();
-        LOG.error("Cannot update: result either null or empty for " + availableVersion);
-        System.err.println("Cannot update: result either null or empty for " + availableVersion);
-        // Try again
-        if (result == null || result.asBucket() == null || availableVersion > fetchedVersion)
-          node.getTicker().queueTimedJob(() -> maybeUpdate(), 0);
-        return;
-      }
-      blobFile = getBlobFile(fetchedVersion);
-      if (!tempBlobFile.renameTo(blobFile)) {
-        blobFile.delete();
-        if (!tempBlobFile.renameTo(blobFile))
-          if (blobFile.exists()
-              && tempBlobFile.exists()
-              && blobFile.length() == tempBlobFile.length())
-            LOG.debug(
-                "Can't rename "
-                    + tempBlobFile
-                    + " over "
-                    + blobFile
-                    + " for "
-                    + fetchedVersion
-                    + " - probably not a big deal though as the files are the same size");
-          else {
-            LOG.error(
-                "Not able to rename binary blob for node updater: "
-                    + tempBlobFile
-                    + " -> "
-                    + blobFile
-                    + " - may not be able to tell other peers about this build");
-            blobFile = null;
-          }
-      }
+      blobFile = tryFinalizeBlobFile(tempBlobFile, fetchedVersion);
       this.fetchedVersion = fetchedVersion;
-      System.out.println("Found " + artifactName() + " version " + fetchedVersion);
+      if (LOG.isInfoEnabled()) LOG.info("Found {} version {}", artifactName(), fetchedVersion);
       if (fetchedVersion > currentVersion)
         LOG.info(
-            "Found version "
-                + fetchedVersion
-                + ", setting up a new UpdatedVersionAvailableUserAlert");
+            "Found version {}, setting up a new UpdatedVersionAvailableUserAlert", fetchedVersion);
       maybeParseManifest(result, fetchedVersion);
       this.cg = null;
     }
     processSuccess(fetchedVersion, result, blobFile);
   }
 
-  /** We have fetched the jar! Do something after onSuccess(). Called unlocked. */
+  private boolean shouldSkipAlreadyFetched(int fetchedVersion) {
+    return fetchedVersion <= this.fetchedVersion;
+  }
+
+  private void cleanupAlreadyFetched(FetchResult result, File tmp) {
+    try {
+      Files.delete(tmp.toPath());
+    } catch (IOException ex) {
+      LOG.warn("Unable to delete temp file {}", tmp, ex);
+    }
+    if (result != null) {
+      Bucket toFree = result.asBucket();
+      if (toFree != null) {
+        try (Bucket ignored = toFree) {
+          if (LOG.isDebugEnabled()) LOG.debug("Releasing fetched result bucket");
+        }
+      }
+    }
+  }
+
+  private boolean isEmptyResult(FetchResult result) {
+    return result == null || result.size() == 0;
+  }
+
+  private File tryFinalizeBlobFile(File tmp, int fetchedVersion) {
+    File blobFile = getBlobFile(fetchedVersion);
+    if (!tmp.renameTo(blobFile)) {
+      try {
+        Files.delete(blobFile.toPath());
+      } catch (IOException ex) {
+        LOG.warn("Unable to delete blob file {} before rename", blobFile, ex);
+      }
+      if (!tmp.renameTo(blobFile)) {
+        if (blobFile.exists() && tmp.exists() && blobFile.length() == tmp.length()) {
+          if (LOG.isDebugEnabled())
+            LOG.debug(
+                "Can't rename {} over {} for {} - probably not a big deal though as the files are"
+                    + " the same size",
+                tmp,
+                blobFile,
+                fetchedVersion);
+        } else {
+          LOG.error(
+              "Not able to rename binary blob for node updater: {} -> {} - may not be able to"
+                  + " tell other peers about this build",
+              tmp,
+              blobFile);
+          blobFile = null;
+        }
+      }
+    }
+    return blobFile;
+  }
+
+  /**
+   * Called after a fetch has completed successfully to perform post‑processing.
+   *
+   * <p>Implementations typically validate compatibility, persist or rename files, update alerts,
+   * and schedule deployment. The call happens after internal state has been updated to reflect the
+   * new {@code fetchedVersion}.
+   *
+   * @param fetched the fetched edition number that completed successfully; strictly positive
+   * @param result the fetch result containing the fetched bytes and associated metadata
+   * @param blobFile the finalized on‑disk blob, or {@code null} when the rename failed
+   */
   protected abstract void processSuccess(int fetched, FetchResult result, File blobFile);
 
   /**
-   * Called with locks held
+   * Parses metadata from the freshly fetched result while internal locks are held.
    *
-   * @param result
+   * <p>The base class does not interpret manifest contents. Subclasses may extract version
+   * requirements or other indicators from the fetched data. Implementations should limit work to
+   * fast parsing and avoid blocking.
+   *
+   * @param result the fresh fetch result to inspect; must reference the just‑fetched bytes
+   * @param build the edition number associated with {@code result}; used for logging and gating
    */
   protected abstract void maybeParseManifest(FetchResult result, int build);
 
-  protected void parseManifest(FetchResult result) {
-    try (InputStream is = result.asBucket().getInputStream();
-        ZipInputStream zis = new ZipInputStream(is)) {
-      ZipEntry ze;
-      while (true) {
-        ze = zis.getNextEntry();
-        if (ze == null) break;
-        if (ze.isDirectory()) continue;
-        String name = ze.getName();
-
-        if (name.equals("META-INF/MANIFEST.MF")) {
-          if (LOG.isDebugEnabled()) LOG.debug("Found manifest");
-          long size = ze.getSize();
-          if (LOG.isDebugEnabled()) LOG.debug("Manifest size: " + size);
-          if (size > MAX_MANIFEST_SIZE) {
-            LOG.error("Manifest is too big: " + size + " bytes, limit is " + MAX_MANIFEST_SIZE);
-            break;
-          }
-          byte[] buf = new byte[(int) size];
-          DataInputStream dis = new DataInputStream(zis);
-          dis.readFully(buf);
-          ByteArrayInputStream bais = new ByteArrayInputStream(buf);
-          InputStreamReader isr = new InputStreamReader(bais, StandardCharsets.UTF_8);
-          BufferedReader br = new BufferedReader(isr);
-          String line;
-          while ((line = br.readLine()) != null) {
-            parseManifestLine(line);
-          }
-        } else {
-          zis.closeEntry();
-        }
-      }
+  /**
+   * Parses the JAR manifest from the finalized on‑disk blob.
+   *
+   * <p>This fallback path is used when a subclass needs to read the manifest after the blob has
+   * been finalized on disk. The implementation enforces bounded parsing and delegates each line to
+   * {@link #parseManifestLine(String)}.
+   */
+  protected void parseManifest() {
+    // Fallback: parse from the finalized on-disk blob if available, enforcing size cap.
+    File jarFile = getBlobFile();
+    try (InputStream is = Files.newInputStream(jarFile.toPath())) {
+      parseManifestBounded(is);
     } catch (IOException e) {
       LOG.error("IOException trying to read manifest on update");
-    } catch (Throwable t) {
-      LOG.error("Failed to parse update manifest: " + t, t);
+    } catch (Exception t) {
+      LOG.error("Failed to parse update manifest: {}", t, t);
+    }
+  }
+
+  /**
+   * Parses the JAR manifest directly from the freshly fetched bytes.
+   *
+   * <p>This is preferred over reading from disk because it remains robust when the temporary file
+   * cannot be renamed to its final location. Parsing is bounded for safety.
+   *
+   * @param result a non‑empty {@link FetchResult} containing the fetched JAR bytes
+   */
+  @SuppressWarnings({"resource", "java:S2095"})
+  protected void parseManifest(FetchResult result) {
+    if (result == null || result.size() == 0) return;
+    Bucket bucket = result.asBucket();
+    if (bucket == null) return;
+    // Borrow the bucket for reading only; do NOT close/free it here because
+    // PluginJarUpdater keeps the FetchResult around to deploy the JAR later.
+    try (InputStream is = bucket.getInputStream()) {
+      parseManifestBounded(is);
+    } catch (IOException e) {
+      LOG.error("IOException trying to read manifest from fetched result on update");
+    } catch (Exception t) {
+      LOG.error("Failed to parse update manifest from fetched result: {}", t, t);
+    }
+  }
+
+  /**
+   * Reads {@code META-INF/MANIFEST.MF} from a ZIP/JAR input stream with strict bounds.
+   *
+   * <p>The method limits the total number of scanned entries, caps compressed and uncompressed
+   * sizes, and stops reading once the manifest has been processed. Parsed lines are dispatched to
+   * {@link #parseManifestLine(String)} for interpretation.
+   *
+   * @param raw the input stream positioned at the start of a ZIP/JAR archive; not closed here
+   * @throws IOException if an I/O error occurs while reading from the stream
+   */
+  private void parseManifestBounded(InputStream raw) throws IOException {
+    InputStream bounded = new BoundedInputStream(raw, MAX_ZIP_SCAN_BYTES);
+    try (ZipInputStream zis = new ZipInputStream(bounded)) {
+      ZipEntry entry;
+      int scanned = 0;
+      while ((entry = zis.getNextEntry()) != null) {
+        if (++scanned > MAX_ZIP_ENTRIES_SCANNED) {
+          LOG.error("Too many ZIP entries scanned (>{}); aborting parse", MAX_ZIP_ENTRIES_SCANNED);
+          return;
+        }
+        if (isManifestEntry(entry.getName())) {
+          byte[] data = readManifestBytes(zis, entry);
+          if (data.length == 0) {
+            zis.closeEntry();
+            return; // size cap exceeded or IO error already logged
+          }
+          dispatchManifestLines(data);
+          zis.closeEntry();
+          return; // Done after parsing manifest
+        }
+      }
+    }
+  }
+
+  /**
+   * Wraps an {@link InputStream} and limits the total number of bytes that can be read. Once the
+   * limit is reached, subsequent reads return {@code -1} (EOF). This protects callers against zip
+   * bombs and other excessive input sizes when reading untrusted data.
+   */
+  private static final class BoundedInputStream extends java.io.FilterInputStream {
+    private long remaining;
+
+    BoundedInputStream(InputStream in, long limit) {
+      super(in);
+      this.remaining = Math.max(0L, limit);
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (remaining <= 0) return -1;
+      int b = super.read();
+      if (b != -1) remaining--;
+      return b;
+    }
+
+    @Override
+    public int read(byte @org.jetbrains.annotations.NotNull [] b, int off, int len)
+        throws IOException {
+      if (remaining <= 0) return -1;
+      int toRead = (int) Math.min(len, remaining);
+      int r = super.read(b, off, toRead);
+      if (r > 0) remaining -= r;
+      return r;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+      long toSkip = Math.min(n, remaining);
+      long skipped = super.skip(toSkip);
+      if (skipped > 0) remaining -= skipped;
+      return skipped;
+    }
+  }
+
+  /**
+   * Returns whether the supplied ZIP entry name refers to the manifest file.
+   *
+   * @param name entry name as returned by the ZIP stream; case‑insensitive comparison is used
+   * @return {@code true} if the entry is the manifest; otherwise {@code false}
+   */
+  private static boolean isManifestEntry(String name) {
+    return "META-INF/MANIFEST.MF".equalsIgnoreCase(name);
+  }
+
+  /**
+   * Reads the manifest entry into memory enforcing compressed and uncompressed size caps.
+   *
+   * @param zis the zip input stream positioned at the manifest entry
+   * @param entry the manifest entry with metadata such as declared sizes
+   * @return a non‑{@code null} byte array containing the manifest contents, or an empty array when
+   *     caps are exceeded
+   * @throws IOException if reading from the underlying stream fails
+   */
+  private byte[] readManifestBytes(ZipInputStream zis, ZipEntry entry) throws IOException {
+    long declared = entry.getSize();
+    if (declared > MAX_MANIFEST_SIZE) {
+      LOG.error(
+          "Manifest too large ({} bytes > {} cap); aborting parse", declared, MAX_MANIFEST_SIZE);
+      return new byte[0];
+    }
+    long compressed = entry.getCompressedSize();
+    if (compressed > MAX_MANIFEST_COMPRESSED_SIZE) {
+      LOG.error(
+          "Compressed manifest too large ({} bytes > {} cap); aborting parse",
+          compressed,
+          MAX_MANIFEST_COMPRESSED_SIZE);
+      return new byte[0];
+    }
+    byte[] buf = new byte[8192];
+    long total = 0L;
+    java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+    int r;
+    while ((r = zis.read(buf)) != -1) {
+      total += r;
+      if (total > MAX_MANIFEST_SIZE) {
+        LOG.error("Manifest exceeds size cap (>{} bytes); aborting parse", MAX_MANIFEST_SIZE);
+        return new byte[0];
+      }
+      bos.write(buf, 0, r);
+    }
+    return bos.toByteArray();
+  }
+
+  /**
+   * Splits the provided manifest bytes into UTF‑8 lines and dispatches them to {@link
+   * #parseManifestLine(String)}.
+   *
+   * @param data the manifest contents encoded as UTF‑8; may be empty to indicate prior failure
+   * @throws IOException if the bytes cannot be decoded or the reader fails
+   */
+  private void dispatchManifestLines(byte[] data) throws IOException {
+    try (BufferedReader br =
+        new BufferedReader(
+            new InputStreamReader(new ByteArrayInputStream(data), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        parseManifestLine(line);
+      }
     }
   }
 
   // Legacy dependencies.properties parsing hooks removed.
 
+  /**
+   * Interprets a single manifest line parsed by {@link #parseManifest()} or {@link
+   * #parseManifest(FetchResult)}.
+   *
+   * <p>The base implementation is a no‑op. Subclasses override to capture values relevant to their
+   * compatibility or deployment logic. The {@code line} does not include a trailing newline.
+   *
+   * @param line a single raw manifest line to interpret; never {@code null}
+   */
   protected void parseManifestLine(String line) {
-    // Do nothing by default, only some NodeUpdater's will use this, those that don't won't call
-    // parseManifest().
+    // Do nothing by default; subclasses override if they need to parse manifest entries.
   }
-
-  private static final int MAX_MANIFEST_SIZE = 1024 * 1024;
 
   @Override
   public void onFailure(FetchException e, ClientGetter state) {
     // Debug gating derives from LOG.isDebugEnabled() where needed
     if (!isRunning) return;
     FetchExceptionMode errorCode = e.getMode();
-    tempBlobFile.delete();
+    try {
+      Files.delete(tempBlobFile.toPath());
+    } catch (IOException ex) {
+      LOG.warn("Unable to delete temp blob {} on failure", tempBlobFile, ex);
+    }
 
-    if (LOG.isDebugEnabled()) LOG.debug("onFailure(" + e + ',' + state + ')');
+    if (LOG.isDebugEnabled()) LOG.debug("onFailure({},{})", e, state);
     synchronized (this) {
       this.cg = null;
       isFetching = false;
     }
     if (errorCode == FetchExceptionMode.CANCELLED || !e.isFatal()) {
       LOG.info("Rescheduling new request");
-      ticker.queueTimedJob(() -> maybeUpdate(), 0);
+      ticker.queueTimedJob(this::maybeUpdate, 0);
     } else {
-      LOG.error("Canceling fetch : " + e.getMessage());
-      System.err.println("Unexpected error fetching update: " + e.getMessage());
-      if (e.isFatal()) {
-        // Wait for the next version
-      } else ticker.queueTimedJob(() -> maybeUpdate(), HOURS.toMillis(1));
+      LOG.error("Canceling fetch : {}", e.getMessage());
+      LOG.error("Unexpected error fetching update: {}", e.getMessage());
+      // Fatal error: wait for the next version; do not reschedule now.
     }
   }
 
-  /** Called before kill(). Don't do anything that will involve taking locks. */
+  /** Called before {@link #kill()} to mark the updater as stopping. Avoids taking locks. */
   public void preKill() {
     isRunning = false;
   }
 
+  /** Cancels any active fetch and unsubscribes from the USK. Safe to call multiple times. */
   void kill() {
     try {
       ClientGetter c;
       synchronized (this) {
         isRunning = false;
-        USK myUsk = USK.create(URI.setSuggestedEdition(currentVersion));
+        USK myUsk = USK.create(this.uri.setSuggestedEdition(currentVersion));
         core.getUskManager().unsubscribe(myUsk, this);
         c = cg;
         cg = null;
@@ -466,31 +723,42 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
     }
   }
 
+  /**
+   * Returns the USK {@link FreenetURI} used to discover update editions for this updater.
+   *
+   * @return the immutable update key associated with this updater instance
+   */
+  @SuppressWarnings("unused")
   public FreenetURI getUpdateKey() {
-    return URI;
+    return uri;
   }
 
+  /**
+   * Reports whether a fetched edition newer than the current version is available for deployment.
+   *
+   * @return {@code true} when a newer fetched version exists; otherwise {@code false}
+   */
   public synchronized boolean canUpdateNow() {
     return fetchedVersion > currentVersion;
   }
 
   /**
-   * Called when the fetch URI has changed. No major locks are held by caller.
+   * Called when the fetch URI has changed. No major locks are held by the caller.
    *
-   * @param uri The new URI.
+   * @param newUri the new update key; its doc name is preserved when the argument omits one
    */
-  public void onChangeURI(FreenetURI uri) {
+  public void onChangeURI(FreenetURI newUri) {
     String previousDocName;
     synchronized (this) {
-      previousDocName = (URI != null) ? URI.getDocName() : null;
+      previousDocName = (this.uri != null) ? this.uri.getDocName() : null;
     }
     kill(); // unsubscribes from the old uri
     FreenetURI nextUri =
-        (previousDocName != null && (uri.getDocName() == null || uri.getDocName().isEmpty()))
-            ? uri.setDocName(previousDocName)
-            : uri;
+        (previousDocName != null && (newUri.getDocName() == null || newUri.getDocName().isEmpty()))
+            ? newUri.setDocName(previousDocName)
+            : newUri;
     synchronized (this) {
-      this.URI = nextUri.setSuggestedEdition(Version.currentBuildNumber() + 1);
+      this.uri = nextUri.setSuggestedEdition(((long) Version.currentBuildNumber()) + 1);
       availableVersion = -1;
       realAvailableVersion = -1;
       fetchingVersion = -1;
@@ -502,48 +770,85 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
     maybeUpdate();
   }
 
+  /**
+   * Returns the most recently fetched edition number.
+   *
+   * @return the last successfully fetched edition, or the current version when none were fetched
+   */
   public int getFetchedVersion() {
     return fetchedVersion;
   }
 
+  /**
+   * Indicates whether a fetch for a newer edition is currently in progress.
+   *
+   * @return {@code true} if a fetch is active for a newer edition; otherwise {@code false}
+   */
   public boolean isFetching() {
     return availableVersion > fetchedVersion && availableVersion > currentVersion;
   }
 
+  /**
+   * Returns the edition number currently being fetched, or the latest available edition.
+   *
+   * @return an edition number used for progress reporting; never less than the current version
+   */
   public int fetchingVersion() {
     // We will not deploy currentVersion...
     if (fetchingVersion <= currentVersion) return availableVersion;
     else return fetchingVersion;
   }
 
+  /**
+   * Returns the size in bytes of the finalized blob corresponding to the fetched version.
+   *
+   * @return a non‑negative size of the blob on disk; {@code 0} when the file is missing
+   */
+  @SuppressWarnings("unused")
   public long getBlobSize() {
     return getBlobFile(getFetchedVersion()).length();
   }
 
+  /**
+   * Returns the path to the finalized blob file for the fetched version.
+   *
+   * @return a {@link File} pointing at the {@code .fblob} for the fetched edition
+   */
   public File getBlobFile() {
     return getBlobFile(getFetchedVersion());
   }
 
+  /** {@inheritDoc} */
   @Override
   public short getPollingPriorityNormal() {
     return RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS;
   }
 
+  /** {@inheritDoc} */
   @Override
   public short getPollingPriorityProgress() {
     return RequestStarter.INTERACTIVE_PRIORITY_CLASS;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean persistent() {
     return false;
   }
 
   /**
-   * * Called by NodeUpdateManager to re-set the min/max versions for ext when * a new freenet.jar
-   * has been downloaded. This is to try to avoid the node * installing incompatible versions of
-   * main and ext.
+   * Called by {@link NodeUpdateManager} to update the minimum and maximum deployable versions.
+   *
+   * <p>This method is invoked when a new core JAR has been downloaded so that the node avoids
+   * installing incompatible combinations of main and extension artifacts. If the new bounds make a
+   * previously out‑of‑range edition acceptable, a fetch may be scheduled.
+   *
+   * @param requiredExt the lower bound (inclusive) for acceptable editions; negative values mean
+   *     “unchanged”
+   * @param recommendedExt the upper bound (inclusive) for acceptable editions; negative values mean
+   *     “unchanged”
    */
+  @SuppressWarnings("unused")
   public void setMinMax(int requiredExt, int recommendedExt) {
     int callFinishedFound = -1;
     synchronized (this) {
@@ -558,21 +863,18 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
           // We found a revision but didn't fetch it because it wasn't within the range for the old
           // jar.
           // The new one requires it, however.
-          System.err.println(
-              "Previously out-of-range edition "
-                  + realAvailableVersion
-                  + " is now needed by the new jar; scheduling fetch.");
+          LOG.info(
+              "Previously out-of-range edition {} is now needed by the new jar; scheduling fetch.",
+              realAvailableVersion);
           callFinishedFound = availableVersion = realAvailableVersion;
         } else if (availableVersion < requiredExt) {
           // Including if it hasn't been found at all
           // Just try it ...
           callFinishedFound = availableVersion = requiredExt;
-          System.err.println(
-              "Need minimum edition "
-                  + requiredExt
-                  + " for new jar, found "
-                  + availableVersion
-                  + "; scheduling fetch.");
+          LOG.info(
+              "Need minimum edition {} for new jar, found {}; scheduling fetch.",
+              requiredExt,
+              availableVersion);
         }
       }
     }

--- a/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
+++ b/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
@@ -3,6 +3,7 @@ package network.crypta.node.updater;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import network.crypta.client.FetchResult;
 import network.crypta.clients.http.PproxyToadlet;
 import network.crypta.keys.FreenetURI;
@@ -19,8 +20,38 @@ import network.crypta.support.io.BucketTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Coordinates discovery and deployment of updated plugin JARs.
+ *
+ * <p>This updater is responsible for evaluating fetched update artifacts for a single plugin,
+ * presenting a user-facing alert when a newer version is available, and, once permitted, writing
+ * the new JAR to disk and restarting the plugin. It builds on {@link NodeUpdater} for retrieval and
+ * manifest parsing and integrates with {@link PluginManager} and the alert system to ensure a
+ * controlled rollout.
+ *
+ * <p>Typical usage is indirect via {@link NodeUpdateManager}: when an updated plugin version is
+ * detected, an alert is registered. The user can trigger immediate deployment or request that the
+ * updater deploy on the next successful revocation check. Writing the JAR is synchronized to avoid
+ * concurrent modifications, and deployment proceeds only if the plugin is still wanted and the
+ * running node satisfies any minimum version declared in the manifest.
+ *
+ * <ul>
+ *   <li>Manages life cycle: fetch → evaluate → alert → deploy.
+ *   <li>Applies a simple gating model around revocation checks before unloading/reloading.
+ *   <li>Ensures on-disk JAR content is durable by syncing the file descriptor after writes.
+ * </ul>
+ *
+ * <p>Thread safety: deployment flags and alert state are updated under {@code synchronized} blocks,
+ * and JAR writes are guarded by a dedicated monitor to prevent interleaving writes.
+ */
 public class PluginJarUpdater extends NodeUpdater {
   private static final Logger LOG = LoggerFactory.getLogger(PluginJarUpdater.class);
+
+  private static final String DEPLOYING_PREFIX = "Deploying ";
+  private static final String INPUT = "input";
+  private static final String VALUE = "value";
+  private static final String FAILED_DELETE_TEMP_BLOB = "Failed to delete temp blob {}";
+  private static final String L10N_PREFIX = "PluginJarUpdater.";
 
   final String pluginName;
   final PluginManager pluginManager;
@@ -38,32 +69,29 @@ public class PluginJarUpdater extends NodeUpdater {
   boolean onNoRevocation() {
     synchronized (this) {
       if (!readyToDeploy) return false;
-      if (deployOnNoRevocation) {
-        // Lets go ...
-      } else if (deployOnNextNoRevocation) {
+      if (deployOnNextNoRevocation) {
         deployOnNoRevocation = true;
         deployOnNextNoRevocation = false;
-        System.out.println("Deploying " + pluginName + " after next revocation check");
+        LOG.info("{}{} after next revocation check", DEPLOYING_PREFIX, pluginName);
         return true;
-      } else return false;
+      }
+      if (!deployOnNoRevocation) return false;
     }
     // Deploy it!
     if (!pluginManager.isPluginLoaded(pluginName)) {
-      LOG.error("Plugin is not loaded, so not deploying: " + pluginName);
-      tempBlobFile.delete();
+      LOG.error("Plugin is not loaded, so not deploying: {}", pluginName);
+      deleteTempBlobQuietly();
       return false;
     }
-    System.out.println("Deploying new version of " + pluginName + " : unloading old version...");
+    LOG.info("Deploying new version of {} : unloading old version...", pluginName);
     // Write the new version of the plugin before shutting down, so if there is a deadlock in
     // terminate, we will still get the new version after a restart.
     try {
       writeJar();
     } catch (IOException e) {
-      LOG.error("Cannot deploy: " + e, e);
-      System.err.println("Cannot deploy new version of " + pluginName + " : " + e);
-      e.printStackTrace();
+      LOG.error("Cannot deploy", e);
+      LOG.error("Cannot deploy new version of {}", pluginName);
       return false; // Not much we can do ...
-      // FIXME post a useralert
     }
     pluginManager.killPluginByFilename(pluginName, Integer.MAX_VALUE, true);
     pluginManager.startPluginAuto(pluginName, true);
@@ -72,13 +100,13 @@ public class PluginJarUpdater extends NodeUpdater {
       a = alert;
       alert = null;
     }
-    node.getClientCore().getAlerts().unregister(a);
+    if (a != null) node.getClientCore().getAlerts().unregister(a);
     return false;
   }
 
   PluginJarUpdater(
       NodeUpdateManager manager,
-      FreenetURI URI,
+      FreenetURI updateUri,
       int current,
       int min,
       int max,
@@ -86,11 +114,23 @@ public class PluginJarUpdater extends NodeUpdater {
       String pluginName,
       PluginManager pm,
       boolean autoDeployOnRestart) {
-    super(manager, URI, current, min, max, blobFilenamePrefix);
+    super(manager, updateUri, current, min, max, blobFilenamePrefix);
     this.pluginName = pluginName;
     this.pluginManager = pm;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("AutoDeployOnRestart flag present: {}", autoDeployOnRestart);
+    }
   }
 
+  /**
+   * Return the logical artifact name handled by this updater.
+   *
+   * <p>The value corresponds to the plugin identifier and is used for log messages, alert
+   * summaries, and deriving the on-disk destination via the {@link PluginManager}. Callers should
+   * treat the returned string as opaque and stable for the lifetime of the updater instance.
+   *
+   * @return a non-null plugin identifier representing the artifact being updated
+   */
   @Override
   public String artifactName() {
     return pluginName;
@@ -100,6 +140,18 @@ public class PluginJarUpdater extends NodeUpdater {
 
   private static final String REQUIRED_NODE_VERSION_PREFIX = "Required-Node-Version: ";
 
+  /**
+   * Parse and evaluate the manifest of the fetched artifact when available.
+   *
+   * <p>The implementation prefers parsing from the provided {@code result} so that compatibility
+   * checks (such as required node version) run even when the temporary blob cannot yet be renamed
+   * into its finalized form on disk. If the result is {@code null} or empty, it falls back to
+   * parsing from the finalized blob. Any discovered constraints are recorded for later gating.
+   *
+   * @param result the fetch result for the current build, or {@code null} when unavailable; a
+   *     non-empty result allows in-memory manifest parsing without relying on disk
+   * @param build the fetched build number being considered during this update cycle
+   */
   @Override
   protected void maybeParseManifest(FetchResult result, int build) {
     requiredNodeVersion = -1;
@@ -112,12 +164,19 @@ public class PluginJarUpdater extends NodeUpdater {
       parseManifest();
     }
     if (requiredNodeVersion != -1) {
-      System.err.println(
-          "Required node version for plugin " + pluginName + ": " + requiredNodeVersion);
-      LOG.info("Required node version for plugin " + pluginName + ": " + requiredNodeVersion);
+      LOG.info("Required node version for plugin {}: {}", pluginName, requiredNodeVersion);
     }
   }
 
+  /**
+   * Handle a single manifest line relevant to plugin compatibility.
+   *
+   * <p>Currently recognizes lines that begin with {@code "Required-Node-Version: "} and captures
+   * the integer value that follows. Unrecognized lines are ignored so that unrelated manifest keys
+   * can evolve without impacting updater behavior.
+   *
+   * @param line a raw manifest line, including key and value; must not be {@code null}
+   */
   @Override
   protected void parseManifestLine(String line) {
     if (line.startsWith(REQUIRED_NODE_VERSION_PREFIX)) {
@@ -125,148 +184,188 @@ public class PluginJarUpdater extends NodeUpdater {
     }
   }
 
+  /**
+   * Hook invoked when an update fetch starts for this plugin.
+   *
+   * <p>Used for diagnostics and progress reporting only. No state transitions are performed here;
+   * the method provides a consistent point to record that retrieval has begun.
+   */
   @Override
   protected void onStartFetching() {
-    System.err.println("Starting to fetch plugin " + pluginName);
+    LOG.info("Starting to fetch plugin {}", pluginName);
   }
 
+  /**
+   * Process a successfully fetched plugin artifact and, when appropriate, raise an update alert.
+   *
+   * <p>The method enforces compatibility against any {@code Required-Node-Version} constraint in
+   * the manifest, releases any previous fetch result, and determines whether the plugin is still
+   * desired and actually newer than the loaded version. If and only if a newer version is wanted,
+   * it marks the updater ready to deploy and registers a user alert to offer deployment.
+   *
+   * @param build the fetched build number associated with this result
+   * @param result the successful fetch result containing the new plugin content; must not be {@code
+   *     null}
+   * @param blob the finalized on-disk blob file for the artifact; may be used for fallbacks and
+   *     logging and may be {@code null} when not applicable
+   */
   @Override
   protected void processSuccess(int build, FetchResult result, File blob) {
     Bucket oldResult = null;
     synchronized (this) {
       if (requiredNodeVersion > Version.currentBuildNumber()) {
-        System.err.println(
-            "Found version "
-                + fetchedVersion
-                + " of "
-                + pluginName
-                + " but needs node version "
-                + requiredNodeVersion);
-        // FIXME deploy it with the main jar
-        tempBlobFile.delete();
+        LOG.warn(
+            "Found version {} of {} but needs node version {}",
+            fetchedVersion,
+            pluginName,
+            requiredNodeVersion);
+        deleteTempBlobQuietly();
         return;
       }
       if (this.result != null) oldResult = this.result.asBucket();
       this.result = result;
     }
-    if (oldResult != null) oldResult.free();
+    if (oldResult != null) {
+      //noinspection EmptyTryBlock
+      try (Bucket ignored = oldResult) {
+        // release previous result bucket
+      }
+    }
 
     PluginInfoWrapper loaded = pluginManager.findPluginByIdentifier(pluginName);
 
-    if (loaded == null) {
-      if (!node.getPluginManager().isPluginLoadedOrLoadingOrWantLoad(pluginName)) {
-        System.err.println("Don't want plugin: " + pluginName);
-        LOG.error("Don't want plugin: " + pluginName);
-        tempBlobFile.delete();
-        return;
-      }
+    if (loaded == null && !node.getPluginManager().isPluginLoadedOrLoadingOrWantLoad(pluginName)) {
+      LOG.error("Don't want plugin: {}", pluginName);
+      deleteTempBlobQuietly();
+      return;
     }
 
     if (loaded != null && loaded.getPluginLongVersion() >= fetchedVersion) {
-      tempBlobFile.delete();
+      deleteTempBlobQuietly();
       return;
     }
-    // Create a useralert to ask the user to deploy the new version.
-
-    UserAlert toRegister = null;
+    // Create an useralert to ask the user to deploy the new version.
+    UserAlert toRegister;
     synchronized (this) {
       readyToDeploy = true;
       if (alert != null) return;
-
-      toRegister =
-          alert =
-              new AbstractUserAlert(
-                  true,
-                  l10n("pluginUpdatedTitle", "name", pluginName),
-                  l10n("pluginUpdatedText", "name", pluginName),
-                  l10n("pluginUpdatedShortText", "name", pluginName),
-                  null,
-                  UserAlert.ERROR,
-                  true,
-                  NodeL10n.getBase().getString("UserAlert.hide"),
-                  true,
-                  this) {
-
-                @Override
-                public void onDismiss() {
-                  synchronized (PluginJarUpdater.this) {
-                    alert = null;
-                  }
-                }
-
-                @Override
-                public HTMLNode getHTMLText() {
-                  HTMLNode div = new HTMLNode("div");
-                  // Text saying the plugin has been updated...
-                  synchronized (this) {
-                    if (deployOnNoRevocation || deployOnNextNoRevocation) {
-                      div.addChild("#", l10n("willDeployAfterRevocationCheck", "name", pluginName));
-                    } else {
-                      div.addChild(
-                          "#",
-                          l10n(
-                              "pluginUpdatedText",
-                              new String[] {"name", "newVersion"},
-                              new String[] {pluginName, Long.toString(fetchedVersion)}));
-
-                      // Form to deploy the updated version.
-                      // This is not the same as reloading because we haven't written it yet.
-
-                      HTMLNode formNode =
-                          div.addChild(
-                              "form",
-                              new String[] {"action", "method"},
-                              new String[] {PproxyToadlet.PATH, "post"});
-                      formNode.addChild(
-                          "input",
-                          new String[] {"type", "name", "value"},
-                          new String[] {
-                            "hidden", "formPassword", node.getClientCore().getFormPassword()
-                          });
-                      formNode.addChild(
-                          "input",
-                          new String[] {"type", "name", "value"},
-                          new String[] {"hidden", "update", pluginName});
-                      formNode.addChild(
-                          "input",
-                          new String[] {"type", "value"},
-                          new String[] {"submit", l10n("updatePlugin")});
-                    }
-                  }
-                  return div;
-                }
-              };
+      toRegister = alert = createUpdateAlert();
     }
-    if (toRegister != null) node.getClientCore().getAlerts().register(toRegister);
+    node.getClientCore().getAlerts().register(toRegister);
   }
 
-  private String l10n(String key) {
-    return NodeL10n.getBase().getString("PluginJarUpdater." + key);
+  private void deleteTempBlobQuietly() {
+    try {
+      if (tempBlobFile != null) Files.deleteIfExists(tempBlobFile.toPath());
+    } catch (IOException ex) {
+      LOG.warn(FAILED_DELETE_TEMP_BLOB, tempBlobFile, ex);
+    }
   }
 
-  private String l10n(String key, String name, String value) {
-    return NodeL10n.getBase().getString("PluginJarUpdater." + key, name, value);
-  }
+  private UserAlert createUpdateAlert() {
+    return new AbstractUserAlert(
+        true,
+        l10nName("pluginUpdatedTitle", pluginName),
+        l10nName("pluginUpdatedText", pluginName),
+        l10nName("pluginUpdatedShortText", pluginName),
+        null,
+        UserAlert.ERROR,
+        true,
+        NodeL10n.getBase().getString("UserAlert.hide"),
+        true,
+        this) {
 
-  private String l10n(String key, String[] names, String[] values) {
-    return NodeL10n.getBase().getString("PluginJarUpdater." + key, names, values);
-  }
-
-  public void writeJarTo(FetchResult result, File fNew) throws IOException {
-    synchronized (writeJarSync) {
-      if (!fNew.delete() && fNew.exists()) {
-        System.err.println("Can't delete " + fNew + "!");
+      @Override
+      public void onDismiss() {
+        synchronized (PluginJarUpdater.this) {
+          alert = null;
+        }
       }
 
-      FileOutputStream fos;
-      fos = new FileOutputStream(fNew);
+      @Override
+      public HTMLNode getHTMLText() {
+        HTMLNode div = new HTMLNode("div");
+        // Text saying the plugin has been updated...
+        synchronized (PluginJarUpdater.this) {
+          if (deployOnNoRevocation || deployOnNextNoRevocation) {
+            div.addChild("#", l10nName("willDeployAfterRevocationCheck", pluginName));
+          } else {
+            div.addChild("#", l10nPluginUpdatedText(pluginName, fetchedVersion));
 
-      BucketTools.copyTo(result.asBucket(), fos, -1);
+            // Form to deploy the updated version.
+            // This is not the same as reloading because we haven't written it yet.
 
-      fos.flush();
-      fos.close();
+            HTMLNode formNode =
+                div.addChild(
+                    "form",
+                    new String[] {"action", "method"},
+                    new String[] {PproxyToadlet.PATH, "post"});
+            formNode.addChild(
+                INPUT,
+                new String[] {"type", "name", VALUE},
+                new String[] {"hidden", "formPassword", node.getClientCore().getFormPassword()});
+            formNode.addChild(
+                INPUT,
+                new String[] {"type", "name", VALUE},
+                new String[] {"hidden", "update", pluginName});
+            formNode.addChild(
+                INPUT, new String[] {"type", VALUE}, new String[] {"submit", l10nUpdatePlugin()});
+          }
+        }
+        return div;
+      }
+    };
+  }
+
+  private String l10nUpdatePlugin() {
+    return NodeL10n.getBase().getString(L10N_PREFIX + "updatePlugin");
+  }
+
+  private String l10nName(String key, String value) {
+    return NodeL10n.getBase().getString(L10N_PREFIX + key, "name", value);
+  }
+
+  private String l10nPluginUpdatedText(String pluginName, long fetchedVersion) {
+    return NodeL10n.getBase()
+        .getString(
+            L10N_PREFIX + "pluginUpdatedText",
+            new String[] {"name", "newVersion"},
+            new String[] {pluginName, Long.toString(fetchedVersion)});
+  }
+
+  /**
+   * Write the fetched plugin artifact to the destination JAR file.
+   *
+   * <p>The method performs a best-effort deletion of any existing file, then copies the content of
+   * {@code result} to {@code fNew}. The write is serialized using an internal monitor and followed
+   * by {@code FileDescriptor#sync()} to reduce the chance of partial updates after a crash or power
+   * loss. The method does not alter plugin state; callers typically invoke it immediately before
+   * unloading and restarting the plugin.
+   *
+   * @param result the successful fetch result supplying the new plugin bytes; must not be {@code
+   *     null} and should remain valid for the duration of the copy operation
+   * @param fNew the absolute or relative path of the target JAR file to replace; the parent
+   *     directory must exist and be writable by the running process
+   * @throws IOException if deleting the existing file, opening the output stream, or copying bytes
+   *     fails for any reason, including insufficient permissions or a full filesystem
+   */
+  public void writeJarTo(FetchResult result, File fNew) throws IOException {
+    synchronized (writeJarSync) {
+      try {
+        boolean deleted = Files.deleteIfExists(fNew.toPath());
+        if (!deleted && fNew.exists()) {
+          LOG.warn("Can't delete {}!", fNew);
+        }
+      } catch (IOException ex) {
+        LOG.warn("Can't delete {}!", fNew, ex);
+      }
+
+      try (FileOutputStream fos = new FileOutputStream(fNew)) {
+        BucketTools.copyTo(result.asBucket(), fos, -1);
+        fos.getFD().sync();
+      }
     }
-    System.err.println("Written " + artifactName() + " to " + fNew);
+    if (LOG.isInfoEnabled()) LOG.info("Written {} to {}", artifactName(), fNew);
   }
 
   void writeJar() throws IOException {
@@ -290,16 +389,29 @@ public class PluginJarUpdater extends NodeUpdater {
     if (a != null) node.getClientCore().getAlerts().unregister(a);
   }
 
+  /**
+   * Arm deferred deployment for the next revocation check cycle.
+   *
+   * <p>When the plugin was already running, deployment is deferred by one additional successful
+   * revocation check to minimize churn in busy systems. Otherwise, it is scheduled for the very
+   * next successful check. This call only sets intent; the actual write and restart occur later in
+   * {@link #onNoRevocation()} when the gate condition is met.
+   *
+   * @param wasRunning {@code true} when the plugin was running at arm time, in which case the
+   *     update deploys after the next but one revocation check; {@code false} schedules deployment
+   *     after the next successful check
+   */
   public synchronized void arm(boolean wasRunning) {
     if (wasRunning) {
       deployOnNextNoRevocation = true;
-      System.out.println("Deploying " + pluginName + " after next but one revocation check");
+      LOG.info("{}{} after next but one revocation check", DEPLOYING_PREFIX, pluginName);
     } else {
       deployOnNoRevocation = true;
-      System.out.println("Deploying " + pluginName + " after next revocation check");
+      LOG.info("{}{} after next revocation check", DEPLOYING_PREFIX, pluginName);
     }
   }
 
+  /** {@inheritDoc} */
   @Override
   public RequestClient getRequestClient() {
     return pluginManager.getSingleUpdaterRequestClient();

--- a/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
+++ b/src/main/java/network/crypta/node/updater/PluginJarUpdater.java
@@ -103,7 +103,14 @@ public class PluginJarUpdater extends NodeUpdater {
   @Override
   protected void maybeParseManifest(FetchResult result, int build) {
     requiredNodeVersion = -1;
-    parseManifest(result);
+    // Prefer parsing from the fresh FetchResult so compatibility checks run even when the
+    // temporary blob cannot be renamed to the finalized .fblob on disk.
+    if (result != null && result.size() > 0) {
+      parseManifest(result);
+    } else {
+      // Fallback to the finalized blob if result is unexpectedly empty.
+      parseManifest();
+    }
     if (requiredNodeVersion != -1) {
       System.err.println(
           "Required node version for plugin " + pluginName + ": " + requiredNodeVersion);

--- a/src/test/java/network/crypta/node/updater/PluginJarUpdaterTest.java
+++ b/src/test/java/network/crypta/node/updater/PluginJarUpdaterTest.java
@@ -1,0 +1,270 @@
+package network.crypta.node.updater;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchResult;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.Version;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.pluginmanager.PluginInfoWrapper;
+import network.crypta.pluginmanager.PluginManager;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PluginJarUpdaterTest {
+
+  @Mock private NodeUpdateManager manager;
+  @Mock private Node node;
+  @Mock private NodeClientCore core;
+  @Mock private UserAlertManager alerts;
+  @Mock private PluginManager pluginManager;
+
+  private static final String REQUIRED_NODE_VERSION_KEY = "Required-Node-Version";
+
+  private static byte[] makeJarWithManifest(String value) throws IOException {
+    Manifest mf = new Manifest();
+    Attributes attrs = mf.getMainAttributes();
+    attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    attrs.putValue(REQUIRED_NODE_VERSION_KEY, value);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (JarOutputStream jos = new JarOutputStream(baos, mf)) {
+      // Finalize the JAR stream so the manifest is written and resource is used.
+      jos.flush();
+      jos.finish();
+    }
+    return baos.toByteArray();
+  }
+
+  private static FetchResult fetchResultFromBytes(byte[] jarBytes) {
+    ArrayBucket bucket = new ArrayBucket(jarBytes);
+    return new FetchResult(new ClientMetadata("application/java-archive"), bucket);
+  }
+
+  private static FreenetURI dummyUSK() {
+    // Construct a valid USK URI using component constructor to avoid base64 parsing
+    byte[] rk = new byte[32];
+    byte[] ck = new byte[32];
+    return new FreenetURI("USK", "jar", null, rk, ck, null);
+  }
+
+  private PluginJarUpdater newUpdater(String pluginName, Path persistentTempDir) {
+    when(manager.getNode()).thenReturn(node);
+    when(manager.isEnabled()).thenReturn(true);
+    when(manager.isBlown()).thenReturn(false);
+
+    when(node.getClientCore()).thenReturn(core);
+    when(node.getPluginManager()).thenReturn(pluginManager);
+
+    when(core.getPersistentTempDir()).thenReturn(persistentTempDir.toFile());
+    when(core.getAlerts()).thenReturn(alerts);
+    when(core.getFormPassword()).thenReturn("pw");
+
+    // Minimal fetch context wiring used by NodeUpdater's constructor
+    HighLevelSimpleClient hlsc = org.mockito.Mockito.mock(HighLevelSimpleClient.class);
+    when(core.makeClient(
+            org.mockito.Mockito.anyShort(),
+            org.mockito.Mockito.anyBoolean(),
+            org.mockito.Mockito.anyBoolean()))
+        .thenReturn(hlsc);
+    when(hlsc.getFetchContext()).thenReturn(makeFetchContext());
+    ClientContext clientContext = org.mockito.Mockito.mock(ClientContext.class);
+    when(core.getClientContext()).thenReturn(clientContext);
+
+    // Keep alert manager methods no-op but capturable
+    doNothing().when(alerts).register(any(UserAlert.class));
+    doNothing().when(alerts).unregister(any(UserAlert.class));
+
+    return new PluginJarUpdater(
+        manager,
+        dummyUSK(),
+        /* current= */ 1,
+        /* min= */ 1,
+        /* max= */ 999999,
+        /* blobFilenamePrefix= */ "plugin-",
+        pluginName,
+        pluginManager,
+        /* autoDeployOnRestart= */ false);
+  }
+
+  private static FetchContext makeFetchContext() {
+    SimpleEventProducer ep = new SimpleEventProducer();
+    return new FetchContext(
+        Long.MAX_VALUE,
+        Long.MAX_VALUE,
+        1024 * 1024,
+        1,
+        1,
+        1,
+        false,
+        0,
+        0,
+        0,
+        true,
+        true,
+        false,
+        false,
+        1,
+        1,
+        null,
+        ep,
+        false,
+        true,
+        null,
+        null,
+        null);
+  }
+
+  @Test
+  void processSuccess_whenRequiredNodeVersionTooHigh_blocksAndDoesNotArm(@TempDir Path tmp)
+      throws Exception {
+    String pluginName = "TestPlugin";
+    PluginJarUpdater updater = newUpdater(pluginName, tmp);
+
+    int tooHigh = Version.currentBuildNumber() + 100;
+    byte[] jar = makeJarWithManifest(Integer.toString(tooHigh));
+    FetchResult result = fetchResultFromBytes(jar);
+
+    // Simulate temp file created by fetcher
+    File temp = Files.createTempFile(tmp, "plugin-", ".fblob.tmp").toFile();
+    Files.write(temp.toPath(), new byte[] {1, 2, 3});
+    // Match NodeUpdater's protected field for delete path in PluginJarUpdater
+    updater.tempBlobFile = temp;
+
+    // Use a fetchedVersion newer than current so onSuccess proceeds
+    updater.onSuccess(result, temp, /* fetchedVersion= */ Version.currentBuildNumber() + 1);
+
+    // Not ready to deploy as requirement is too high
+    boolean shouldRestart = updater.onNoRevocation();
+    assertFalse(shouldRestart, "Should not request restart when not ready");
+
+    // No alert registered and no plugin manager interactions
+    verify(alerts, never()).register(any(UserAlert.class));
+    verify(pluginManager, never())
+        .killPluginByFilename(any(), any(Integer.class), any(Boolean.class));
+    verify(pluginManager, never()).startPluginAuto(any(), any(Boolean.class));
+  }
+
+  @Test
+  void onNoRevocation_deploysWhenArmedAndLoaded_writesJarAndRestartsPlugin(@TempDir Path tmp)
+      throws Exception {
+    String pluginName = "MyPlugin";
+    PluginJarUpdater updater = newUpdater(pluginName, tmp);
+
+    int requiredOk = Version.currentBuildNumber();
+    byte[] jar = makeJarWithManifest(Integer.toString(requiredOk));
+    FetchResult result = fetchResultFromBytes(jar);
+
+    // Simulate temp file created by fetcher
+    File temp = Files.createTempFile(tmp, "plugin-", ".fblob.tmp").toFile();
+    Files.write(temp.toPath(), new byte[] {9});
+    updater.tempBlobFile = temp;
+
+    // Loaded plugin with an older version present
+    PluginInfoWrapper loaded = org.mockito.Mockito.mock(PluginInfoWrapper.class);
+    when(loaded.getPluginLongVersion()).thenReturn(1L);
+    when(pluginManager.findPluginByIdentifier(pluginName)).thenReturn(loaded);
+    when(pluginManager.isPluginLoaded(pluginName)).thenReturn(true);
+
+    // Destination JAR path for deployment
+    File dest = tmp.resolve(pluginName + ".jar").toFile();
+    when(pluginManager.getPluginFilename(pluginName)).thenReturn(dest);
+
+    // Run success path
+    int fetched = Version.currentBuildNumber() + 1;
+    updater.onSuccess(result, temp, fetched);
+
+    // Alert registered after successful fetch
+    ArgumentCaptor<UserAlert> alertCaptor = ArgumentCaptor.forClass(UserAlert.class);
+    verify(alerts, times(1)).register(alertCaptor.capture());
+    UserAlert createdAlert = alertCaptor.getValue();
+
+    // Arm for immediate deployment and trigger
+    updater.arm(false);
+    boolean restartNeeded = updater.onNoRevocation();
+    assertFalse(restartNeeded, "Deployment happens now; no restart of checker requested");
+
+    // JAR written to plugin filename
+    byte[] written = Files.readAllBytes(dest.toPath());
+    assertArrayEquals(jar, written, "Deployed jar contents must match fetched bytes");
+
+    verify(pluginManager, times(1)).killPluginByFilename(pluginName, Integer.MAX_VALUE, true);
+    verify(pluginManager, times(1)).startPluginAuto(pluginName, true);
+
+    // Alert unregistered after deployment
+    verify(alerts, times(1)).unregister(createdAlert);
+  }
+
+  @Test
+  void onNoRevocation_deploysOnlyAfterNext_whenArmedWhileRunning(@TempDir Path tmp)
+      throws Exception {
+    String pluginName = "DeferredPlugin";
+    PluginJarUpdater updater = newUpdater(pluginName, tmp);
+
+    // Acceptable required version
+    byte[] jar = makeJarWithManifest(Integer.toString(Version.currentBuildNumber()));
+    FetchResult result = fetchResultFromBytes(jar);
+
+    // Temp file and fields
+    File temp = Files.createTempFile(tmp, "plugin-", ".fblob.tmp").toFile();
+    Files.write(temp.toPath(), new byte[] {7});
+    updater.tempBlobFile = temp;
+
+    // Loaded plugin with older version
+    PluginInfoWrapper loaded = org.mockito.Mockito.mock(PluginInfoWrapper.class);
+    when(loaded.getPluginLongVersion()).thenReturn(0L);
+    when(pluginManager.findPluginByIdentifier(pluginName)).thenReturn(loaded);
+    when(pluginManager.isPluginLoaded(pluginName)).thenReturn(true);
+
+    File dest = tmp.resolve(pluginName + ".jar").toFile();
+    when(pluginManager.getPluginFilename(pluginName)).thenReturn(dest);
+
+    // Complete the fetch
+    updater.onSuccess(result, temp, Version.currentBuildNumber() + 2);
+
+    // Arm as if updater was running earlier → deploy on next-but-one check
+    updater.arm(true);
+    boolean firstCall = updater.onNoRevocation();
+    assertTrue(firstCall, "First call should schedule deployment after the next revocation check");
+
+    // Now perform deployment on the following no-revocation signal
+    boolean secondCall = updater.onNoRevocation();
+    assertFalse(secondCall, "Second call performs deployment and does not request restart");
+
+    verify(pluginManager, times(1)).killPluginByFilename(pluginName, Integer.MAX_VALUE, true);
+    verify(pluginManager, times(1)).startPluginAuto(pluginName, true);
+  }
+}


### PR DESCRIPTION
Summary
- Harden manifest parsing in updater flow to mitigate oversized/invalid ZIP entries and malformed manifests.
- Improve Javadoc/KDoc and logging for clarity and maintenance.
- Add focused tests for PluginJarUpdater covering required node build gating and deploy path.

Technical Details
- NodeUpdater
  - Add strict bounds to avoid pathological or malicious inputs:
    - MAX_MANIFEST_SIZE = 1 MiB
    - MAX_MANIFEST_COMPRESSED_SIZE = 1 MiB
    - MAX_ZIP_ENTRIES_SCANNED = 1024
    - MAX_ZIP_SCAN_BYTES = 16 MiB
  - Prefer parsing the plugin manifest directly from the ClientGetter FetchResult when available; fall back to finalized blob ZIP scanning with bounded reads.
  - Clean up field names (e.g., URI -> uri), imports, and add thorough class/method Javadoc describing lifecycle, thread-safety, and responsibilities.
- PluginJarUpdater
  - Validate "Required-Node-Build" from the manifest earlier and block arming/deploying when it exceeds the running build.
  - Improve logging around readiness, restart decisions, and plugin manager interactions.
- Tests
  - New PluginJarUpdaterTest exercises:
    - processSuccess_whenRequiredNodeVersionTooHigh_blocksAndDoesNotArm
    - onNoRevocation_deploysWhenArmedAndLoaded_writesJarAndRestartsPlugin
  - Tests build minimal JARs with tailored manifests, use temp dirs, and Mockito-based wiring for core/plugin manager interactions.

Commits
- 6dd838800d docs: add doclint-clean Javadoc for PluginJarUpdater; apply Spotless formatting to staged files.
- a4b9b339ba fix(updater): harden manifest parsing and improve plugin manifest handling.

Risk / Compatibility
- The new bounds are intentionally conservative; extremely large plugin bundles with oversized or deeply nested manifests may be rejected. This should not affect normal plugins and improves resilience.
- No user-facing behavior changes beyond stricter input validation. No wire/API changes.

Validation
- Spotless formatting applied in commits.
- Unit tests added for new behavior.

Request
- Target: develop
- Please review the manifest bounds and test coverage; feedback welcome on thresholds and logging verbosity.