### PR TITLE
docs(test): SimpleBlockSet Javadoc expansion and unit tests; doclint-clean BlockSet

### DIFF
--- a/src/main/java/network/crypta/client/async/BlockSet.java
+++ b/src/main/java/network/crypta/client/async/BlockSet.java
@@ -7,35 +7,100 @@ import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
 
 /**
- * A set of KeyBlock's.
+ * Represents a logical set of blocks addressable by their keys.
+ *
+ * <p>This interface abstracts a lightweight mapping from {@link Key} or {@link ClientKey} to the
+ * corresponding {@link KeyBlock} or {@link ClientKeyBlock}. Implementations may back the set with
+ * an in-memory cache, a persistent index, or a remote lookup service. The abstraction is
+ * intentionally small so calling code can retrieve, add, and enumerate keys without depending on
+ * any particular storage layout. A typical call pattern is to {@link #add(KeyBlock)} new blocks as
+ * they become available and to {@link #get(Key)} or {@link #get(ClientKey)} them later when needed.
+ *
+ * <p>Unless otherwise specified by an implementation, mutability and concurrency guarantees are
+ * minimal: reads and writes may interleave, and {@link #keys()} may reflect a snapshot at some
+ * unspecified point in time. Clients should treat returned collections as read-only views and must
+ * not attempt structural modification. Implementations are encouraged, but not required, to be
+ * thread-safe if they are shared across threads.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Lookup methods return {@code null} when no block is associated with the provided key.
+ *   <li>The {@link #keys()} result is not guaranteed to stay updated as the set changes.
+ *   <li>Blocks are identified exclusively by their keys; duplicate adds typically overwrite.
+ * </ul>
  *
  * @author toad
+ * @see Key
+ * @see KeyBlock
+ * @see ClientKey
+ * @see ClientKeyBlock
  */
 public interface BlockSet {
 
   /**
-   * Get a block by its key.
+   * Returns the low-level block mapped to the given low-level key.
    *
-   * @param key The key of the block to get.
-   * @return A block, or null if there is no block with that key.
+   * <p>Performs a direct lookup using the binary {@link Key} representation typically associated
+   * with internal storage. Implementations may serve the result from an in-memory cache or a
+   * backing store. If no block is present for the supplied key, this method returns {@code null}
+   * rather than throwing. Callers should treat the returned {@link KeyBlock} as immutable or
+   * read-only from the perspective of the {@code BlockSet}; mutating it does not alter the stored
+   * mapping unless explicitly defined by the implementation.
+   *
+   * @param key the low-level key used for addressable lookup; must not be {@code null}; values
+   *     outside the accepted domain for the implementation result in no match and a {@code null}
+   *     return rather than an exception.
+   * @return the associated {@link KeyBlock} when present; otherwise {@code null}. The ownership of
+   *     the returned object remains with the implementation; treat it as read-only and do not
+   *     retain long-term if the implementation documents eviction.
    */
   KeyBlock get(Key key);
 
   /**
-   * Add a block.
+   * Adds the provided block to the set, making it available for subsequent lookups.
    *
-   * @param block The block to add.
+   * <p>The block is stored under the key it carries. If a block with the same key already exists,
+   * the typical behavior is to replace the previous entry; implementations may also treat the
+   * operation as idempotent when the content is identical. This method does not return a value and
+   * should not throw on duplicates; callers interested in prior state should query with {@link
+   * #get(Key)} beforehand if needed.
+   *
+   * @param block the {@link KeyBlock} to add to the set; must not be {@code null}. Implementations
+   *     may copy or retain a reference; callers should not modify the instance after passing it in
+   *     if the implementation expects immutability.
    */
   void add(KeyBlock block);
 
   /**
-   * Get the set of all the keys of all the blocks.
+   * Returns a view of all keys currently known to this set.
    *
-   * @return A set of the keys of the blocks in the BlockSet. Not guaranteed to be kept up to date.
-   *     Read only.
+   * <p>The returned {@link Set} is intended for enumeration and membership checks. It is read-only
+   * from the caller’s perspective and is not guaranteed to stay synchronized with future mutations
+   * of the underlying set. Some implementations may return a snapshot taken at call time, while
+   * others may return a live but unmodifiable view whose contents can change between iterations. Do
+   * not attempt structural modifications.
+   *
+   * @return a read-only set of {@link Key} values representing blocks in this set. The view is not
+   *     guaranteed to remain up to date across subsequent calls or concurrent modifications and may
+   *     be a snapshot or a live, unmodifiable view depending on the implementation.
    */
   Set<Key> keys();
 
-  /** Get a high level block, given a high level key */
+  /**
+   * Returns the high-level block mapped to the given high-level key.
+   *
+   * <p>This overload accepts a {@link ClientKey}, which is typically the key form used by external
+   * clients or higher layers. Implementations may resolve the corresponding {@link ClientKeyBlock}
+   * via an index distinct from the low-level {@link Key}/{@link KeyBlock} mapping. If no block is
+   * present for the supplied key, this method returns {@code null}. As with the low-level variant,
+   * callers should treat the returned block as read-only in the context of this set.
+   *
+   * @param key the high-level client key used for lookup; must not be {@code null}. Keys that are
+   *     syntactically valid but unknown simply result in {@code null} without throwing.
+   * @return the associated {@link ClientKeyBlock} when present; otherwise {@code null}. The object
+   *     should be treated as immutable by callers and not held indefinitely when implementations
+   *     document cache eviction or reuse.
+   */
   ClientKeyBlock get(ClientKey key);
 }

--- a/src/main/java/network/crypta/client/async/SimpleBlockSet.java
+++ b/src/main/java/network/crypta/client/async/SimpleBlockSet.java
@@ -11,30 +11,108 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Simple BlockSet implementation, keeps all keys in RAM.
+ * In‑memory {@link BlockSet} implementation that stores every block entirely in RAM.
+ *
+ * <p>This class provides a compact, thread-safe mapping from {@link Key} to {@link KeyBlock} and a
+ * convenience lookup for {@link ClientKey} to {@link ClientKeyBlock}. It is designed for
+ * lightweight use cases such as small working sets, unit tests, short‑lived tools, and scenarios
+ * where the number of blocks is bounded and predictable. All data lives in a single process-local
+ * {@link HashMap}, so lookups and inserts are fast but memory consumption grows with the number and
+ * size of stored entries. There is no persistence, eviction policy, or size limit.
+ *
+ * <p>Concurrency: operations are synchronized on the instance to provide a simple safety model for
+ * concurrent callers. The {@link #keys()} method returns a view backed by the internal map; callers
+ * should not rely on snapshot semantics and must tolerate changes when iterating concurrently. The
+ * overload {@link #get(ClientKey)} delegates to the low‑level {@link #get(Key)} and may return
+ * {@code null} when the backing block is missing or fails verification.
+ *
+ * <ul>
+ *   <li>Fast, in‑memory reads and writes; no I/O.
+ *   <li>No persistence; contents are lost when the instance is discarded.
+ *   <li>Duplicate adds overwrite by key; enumeration order is unspecified.
+ * </ul>
  *
  * @author toad
+ * @see BlockSet
+ * @see Key
+ * @see KeyBlock
+ * @see ClientKey
+ * @see ClientKeyBlock
  */
 public class SimpleBlockSet implements BlockSet {
   private static final Logger LOG = LoggerFactory.getLogger(SimpleBlockSet.class);
 
   private final HashMap<Key, KeyBlock> blocksByKey = new HashMap<>();
 
+  /**
+   * Creates an empty in‑memory block set.
+   *
+   * <p>The new instance does not impose a capacity limit and performs no persistence. All methods
+   * are safe to invoke from multiple threads; internal synchronization serializes basic operations.
+   * Typical usage is to create a single instance, populate it via {@link #add(KeyBlock)}, and
+   * perform lookups with {@link #get(Key)} or {@link #get(ClientKey)}.
+   */
+  public SimpleBlockSet() {
+    // Intentionally empty: all state is initialized via field declarations
+    // no additional setup or persistence hooks are required for this in-memory implementation.
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation stores the block using the {@link Key} embedded within {@code block}. If
+   * a block with the same key already exists, it is replaced.
+   *
+   * @param block the block to add; must not be {@code null}. The instance may be retained
+   *     internally; callers should treat it as effectively immutable after passing it in.
+   */
   @Override
   public synchronized void add(KeyBlock block) {
     blocksByKey.put(block.getKey(), block);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns {@code null} when no mapping exists. The returned {@link KeyBlock} is owned by this
+   * set; callers should not modify it in ways that could violate invariants of the stored mapping.
+   *
+   * @param key the low‑level key to resolve; must not be {@code null}.
+   * @return the associated block when present; otherwise {@code null}. The object should be treated
+   *     as read‑only by callers.
+   */
   @Override
   public synchronized KeyBlock get(Key key) {
     return blocksByKey.get(key);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned view is backed by the internal map and may reflect concurrent updates. Do not
+   * attempt structural modification; behavior is unspecified and may throw.
+   *
+   * @return a view of keys currently known to this set; contents may change over time.
+   */
   @Override
   public synchronized Set<Key> keys() {
     return blocksByKey.keySet();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This method converts the provided {@link ClientKey} to the corresponding node {@link Key}
+   * and, when present, wraps the stored {@link KeyBlock} into a {@link ClientKeyBlock}. If the
+   * backing block is missing or its contents fail verification, this method returns {@code null}.
+   * The verification failure is logged at error level.
+   *
+   * @param key the high‑level key used for lookup; must not be {@code null}. Unknown keys result in
+   *     {@code null} without throwing.
+   * @return a verified {@link ClientKeyBlock} for the supplied key, or {@code null} when no mapping
+   *     exists or verification fails. The returned object should be treated as immutable by
+   *     callers.
+   */
   @Override
   public ClientKeyBlock get(ClientKey key) {
     KeyBlock block = get(key.getNodeKey(false));
@@ -42,7 +120,7 @@ public class SimpleBlockSet implements BlockSet {
     try {
       return Key.createKeyBlock(key, block);
     } catch (KeyVerifyException e) {
-      LOG.error("Caught decoding block with " + key + " : " + e, e);
+      LOG.error("Caught decoding block with {} : {}", key, e, e);
       return null;
     }
   }

--- a/src/test/java/network/crypta/client/async/SimpleBlockSetTest.java
+++ b/src/test/java/network/crypta/client/async/SimpleBlockSetTest.java
@@ -1,0 +1,175 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.ClientKeyBlock;
+import network.crypta.keys.Key;
+import network.crypta.keys.KeyVerifyException;
+import network.crypta.keys.NodeCHK;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SimpleBlockSetTest {
+
+  private static final byte ALGO = Key.ALGO_AES_CTR_256_SHA256;
+
+  private static CHKBlock newUncheckedCHKBlock(NodeCHK key, byte fill) {
+    byte[] headers = new byte[CHKBlock.TOTAL_HEADERS_LENGTH];
+    byte[] data = new byte[CHKBlock.DATA_LENGTH];
+    // When verify=false and a key is provided, CHKBlock trusts the key and skips content hashing.
+    // Header content is irrelevant then; still set a valid hash id (0x0001) for clarity.
+    headers[0] = 0x00;
+    headers[1] = 0x01;
+    Arrays.fill(data, fill);
+    try {
+      return new CHKBlock(data, headers, key, /* verify= */ false, ALGO);
+    } catch (Exception e) {
+      throw new AssertionError("Unexpected CHKBlock construction failure", e);
+    }
+  }
+
+  private static CHKBlock newVerifiedCHKBlock(byte fill) {
+    byte[] headers = new byte[CHKBlock.TOTAL_HEADERS_LENGTH];
+    byte[] data = new byte[CHKBlock.DATA_LENGTH];
+    headers[0] = 0x00;
+    headers[1] = 0x01; // HASH_SHA256
+    Arrays.fill(data, fill);
+    try {
+      return CHKBlock.construct(data, headers, ALGO);
+    } catch (Exception e) {
+      throw new AssertionError("Unexpected CHKBlock construct() failure", e);
+    }
+  }
+
+  @Test
+  void add_and_get_byKey_returnsSameBlock() {
+    SimpleBlockSet set = new SimpleBlockSet();
+    NodeCHK key = new NodeCHK(new byte[NodeCHK.KEY_LENGTH], ALGO);
+    CHKBlock block = newUncheckedCHKBlock(key, (byte) 7);
+
+    set.add(block);
+
+    assertSame(block, set.get(key));
+  }
+
+  @Test
+  void keys_afterAddingTwo_containsBothKeys_andReflectsSize() {
+    SimpleBlockSet set = new SimpleBlockSet();
+    NodeCHK key1 = new NodeCHK(new byte[NodeCHK.KEY_LENGTH], ALGO);
+    NodeCHK key2 = new NodeCHK(new byte[NodeCHK.KEY_LENGTH], ALGO);
+    // Ensure keys differ
+    key2.getRoutingKey()[0] = 1;
+    CHKBlock block1 = newUncheckedCHKBlock(key1, (byte) 1);
+    CHKBlock block2 = newUncheckedCHKBlock(key2, (byte) 2);
+
+    set.add(block1);
+    set.add(block2);
+
+    assertEquals(2, set.keys().size());
+    // The set view should contain both keys
+    // Use get() to check presence deterministically
+    assertSame(block1, set.get(key1));
+    assertSame(block2, set.get(key2));
+  }
+
+  @Test
+  void add_whenSameKey_overwritesPreviousBlock() {
+    SimpleBlockSet set = new SimpleBlockSet();
+    NodeCHK sharedKey = new NodeCHK(new byte[NodeCHK.KEY_LENGTH], ALGO);
+    CHKBlock first = newUncheckedCHKBlock(sharedKey, (byte) 3);
+    CHKBlock second = newUncheckedCHKBlock(sharedKey, (byte) 4);
+
+    set.add(first);
+    set.add(second);
+
+    assertSame(second, set.get(sharedKey));
+    assertEquals(1, set.keys().size());
+  }
+
+  @Test
+  void get_whenKeyNull_returnsNull() {
+    SimpleBlockSet set = new SimpleBlockSet();
+    assertNull(set.get((Key) null));
+  }
+
+  @Test
+  void add_whenBlockNull_throwsNullPointerException() {
+    SimpleBlockSet set = new SimpleBlockSet();
+    assertThrows(NullPointerException.class, () -> set.add(null));
+  }
+
+  @Test
+  void getClientKey_whenNull_throwsNullPointerException() {
+    SimpleBlockSet set = new SimpleBlockSet();
+    //noinspection DataFlowIssue
+    assertThrows(NullPointerException.class, () -> set.get((ClientKey) null));
+  }
+
+  @Test
+  void getClientKey_whenBlockPresent_returnsClientKeyBlock() {
+    // Arrange: build a real CHK block and matching ClientCHK key
+    CHKBlock block = newVerifiedCHKBlock((byte) 9);
+    NodeCHK nodeKey = block.getKey();
+    ClientCHK clientKey =
+        new ClientCHK(
+            nodeKey.getRoutingKey(),
+            new byte[ClientCHK.CRYPTO_KEY_LENGTH],
+            false,
+            ALGO,
+            (short) -1);
+
+    SimpleBlockSet set = new SimpleBlockSet();
+    set.add(block);
+
+    // Act
+    ClientKeyBlock ckb = set.get(clientKey);
+
+    // Assert
+    assertNotNull(ckb);
+    // A new CHKBlock instance is constructed internally; compare by value.
+    assertEquals(nodeKey, ckb.getKey());
+    assertEquals(block, ckb.getBlock());
+  }
+
+  @Test
+  void getClientKey_whenCreateKeyBlockThrows_returnsNull() {
+    // Arrange
+    CHKBlock block = newVerifiedCHKBlock((byte) 5);
+    NodeCHK nodeKey = block.getKey();
+    ClientCHK clientKey =
+        new ClientCHK(
+            nodeKey.getRoutingKey(),
+            new byte[ClientCHK.CRYPTO_KEY_LENGTH],
+            false,
+            ALGO,
+            (short) -1);
+
+    SimpleBlockSet set = new SimpleBlockSet();
+    set.add(block);
+
+    try (MockedStatic<Key> mocked = Mockito.mockStatic(Key.class)) {
+      mocked
+          .when(() -> Key.createKeyBlock(clientKey, block))
+          .thenThrow(new KeyVerifyException("boom"));
+
+      // Act
+      ClientKeyBlock result = set.get(clientKey);
+
+      // Assert
+      assertNull(result);
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Expand Javadoc for in-memory SimpleBlockSet covering concurrency/behavior and API contracts.
- Doclint-clean BlockSet Javadoc with a fuller API description and usage notes.
- Add/refine unit tests for SimpleBlockSet (CHK/ClientKey flows, null contracts).
- Ran Spotless to keep formatting consistent.

Notes
- No runtime behavior changes intended; this is documentation + test coverage.
- Branch contains two commits from feature/fix-BlockSet.

Validation
- Builds locally; Spotless applied successfully; tests compile.

Request
- Please review docs for clarity and any misstatements.
