### PR TITLE
client(async): Clean up Javadoc for ChosenBlock, introduce Options record, and add unit tests

### DIFF
--- a/src/main/java/network/crypta/client/async/ChosenBlock.java
+++ b/src/main/java/network/crypta/client/async/ChosenBlock.java
@@ -10,76 +10,232 @@ import network.crypta.node.SendableRequestItem;
 import network.crypta.node.SendableRequestSender;
 
 /**
- * A single selected request, including everything needed to execute it. Most important functions
- * are the callbacks, which run off-thread, call the upstream callbacks on the SendableGet etc, and
- * remove the fetching keys from the KeysFetchingLocally.
+ * Represents a single, already-selected unit of work in the client request pipeline. A {@code
+ * ChosenBlock} bundles the scheduling token and any request-specific keys together with the
+ * execution options required by the {@link RequestScheduler} and the {@link SendableRequestSender}
+ * to actually perform the operation. Implementations provide a {@linkplain
+ * #getSender(ClientContext) sender}, drive sending via {@link #send(NodeClientCore,
+ * RequestScheduler)}, and receive success and failure callbacks.
  *
- * @author Matthew Toseland <toad@amphibian.dyndns.org> (0xE43DA450)
+ * <p>Callbacks typically run off-thread. They are expected to trigger the higher-level callbacks
+ * owned by the request (for example, on a sendable get/put) and to perform any associated
+ * bookkeeping such as removing keys from local in-flight tracking. The {@linkplain #token token} is
+ * never {@code null} and uniquely identifies the sub-request inside a larger multipart operation.
+ * The {@linkplain #key key} and {@linkplain #ckey client key} may be {@code null} depending on the
+ * request type.
+ *
+ * <p>Threading and state: instances are effectively immutable after construction. The only mutable
+ * state is the internal flag that records whether the last {@link #send(NodeClientCore,
+ * RequestScheduler) send} blocks. Implementations should document any additional concurrency
+ * expectations. Typical usage is:
+ *
+ * <ul>
+ *   <li>Obtain a {@link SendableRequestSender} via {@link #getSender(ClientContext)}.
+ *   <li>Invoke {@link #send(NodeClientCore, RequestScheduler)} to enqueue or perform the work.
+ *   <li>Handle {@link #onFetchSuccess(ClientContext)} or the {@code onFailure(...)} callbacks.
+ *   <li>Use {@link #getPriority()} and {@link #isPersistent()} to inform scheduling decisions.
+ * </ul>
+ *
+ * @author Matthew Toseland &lt;toad@amphibian.dyndns.org&gt; (0xE43DA450)
+ * @see SendableRequestItem
+ * @see SendableRequestSender
+ * @see RequestScheduler
+ * @see NodeClientCore
  */
 public abstract class ChosenBlock {
+
+  /**
+   * Options controlling request execution semantics.
+   *
+   * <p>The flags influence how a request is evaluated against local storage and whether certain
+   * caches are consulted or written. The precise interpretation is defined by the concrete
+   * request/sender implementation and storage layer.
+   *
+   * @param localRequestOnly when {@code true}, restricts work to local resources only; do not
+   *     contact peers.
+   * @param ignoreStore when {@code true}, bypass normal on-disk store lookups for reads where
+   *     supported.
+   * @param canWriteClientCache when {@code true}, allow writing client-level caches if the result
+   *     is cacheable for this request.
+   * @param forkOnCacheable when {@code true}, allow the scheduler/sender to fork the work when the
+   *     result is cacheable, e.g., to improve throughput.
+   * @param realTimeFlag when {@code true}, mark the work as real-time, enabling lower latency
+   *     choices where applicable.
+   */
+  public record Options(
+      boolean localRequestOnly,
+      boolean ignoreStore,
+      boolean canWriteClientCache,
+      boolean forkOnCacheable,
+      boolean realTimeFlag) {}
 
   /**
    * The token indicating the key within the request to be fetched/inserted. Meaning is entirely
    * defined by the request.
    */
-  public final transient SendableRequestItem token;
+  public final SendableRequestItem token;
 
-  /** The key to be fetched, null if not a BaseSendableGet */
-  public final transient Key key;
+  /**
+   * The low-level key to be fetched or inserted. It may be {@code null} for request types that do
+   * not operate on a raw {@link Key}; see the concrete request for details.
+   */
+  public final Key key;
 
-  /** The client-layer key to be fetched, null if not a SendableGet */
-  public final transient ClientKey ckey;
+  /**
+   * The client-layer key associated with the operation. It may be {@code null} for request types
+   * that do not use a {@link ClientKey} abstraction.
+   */
+  public final ClientKey ckey;
 
-  public final transient boolean localRequestOnly;
-  public final transient boolean ignoreStore;
-  public final transient boolean canWriteClientCache;
-  public final transient boolean forkOnCacheable;
-  public final transient boolean realTimeFlag;
+  /**
+   * If {@code true}, executes without contacting peers and confines itself to local resources only
+   * (e.g., caches and stores). Exact behavior is request-specific.
+   */
+  public final boolean localRequestOnly;
 
-  public ChosenBlock(
-      SendableRequestItem token,
-      Key key,
-      ClientKey ckey,
-      boolean localRequestOnly,
-      boolean ignoreStore,
-      boolean canWriteClientCache,
-      boolean forkOnCacheable,
-      boolean realTimeFlag,
-      RequestScheduler sched) {
+  /**
+   * If {@code true}, bypasses normal store lookups during reads where that behavior is supported by
+   * the underlying sender/storage implementation.
+   */
+  public final boolean ignoreStore;
+
+  /**
+   * If {@code true}, allows the client cache to be populated when the result is considered
+   * cacheable for this request type.
+   */
+  public final boolean canWriteClientCache;
+
+  /**
+   * If {@code true}, permits forking behavior on cacheable results in order to improve throughput
+   * or responsiveness. The concrete sender decides when and how to fork.
+   */
+  public final boolean forkOnCacheable;
+
+  /**
+   * If {@code true}, marks the work as real-time. Scheduling and timeouts may prefer lower latency
+   * strategies over maximum throughput.
+   */
+  public final boolean realTimeFlag;
+
+  /**
+   * Creates a new {@code ChosenBlock} with the given scheduling token, optional keys, and execution
+   * options.
+   *
+   * <p>The {@code token} must be non-{@code null}. The {@code key} and {@code ckey} may be {@code
+   * null} for request types that do not operate with those abstractions. All options are copied as
+   * value semantics from the provided {@link Options} record.
+   *
+   * @param token the non-{@code null} sub-request token used by the scheduler and sender.
+   * @param key an optional low-level {@link Key} for the operation; may be {@code null}.
+   * @param ckey an optional client-layer {@link ClientKey}; may be {@code null} depending on type.
+   * @param options execution options affecting local-only behavior, cache usage, and real-time
+   *     hints; must be non-{@code null}.
+   * @throws NullPointerException if {@code token} is {@code null}.
+   */
+  protected ChosenBlock(SendableRequestItem token, Key key, ClientKey ckey, Options options) {
     this.token = token;
     if (token == null) throw new NullPointerException();
     this.key = key;
     this.ckey = ckey;
-    this.localRequestOnly = localRequestOnly;
-    this.ignoreStore = ignoreStore;
-    this.canWriteClientCache = canWriteClientCache;
-    this.forkOnCacheable = forkOnCacheable;
-    this.realTimeFlag = realTimeFlag;
+    this.localRequestOnly = options.localRequestOnly();
+    this.ignoreStore = options.ignoreStore();
+    this.canWriteClientCache = options.canWriteClientCache();
+    this.forkOnCacheable = options.forkOnCacheable();
+    this.realTimeFlag = options.realTimeFlag();
   }
 
+  /**
+   * Indicates whether the underlying request persists across node restarts or failure recovery.
+   *
+   * @return {@code true} if the request is persisted by the client layer; otherwise {@code false}.
+   */
   public abstract boolean isPersistent();
 
+  /**
+   * Indicates whether this block has been canceled and will not be sent or re-sent by the
+   * scheduler.
+   *
+   * @return {@code true} if the block is canceled and should not proceed; otherwise {@code false}.
+   */
   public abstract boolean isCancelled();
 
+  /**
+   * Called when an insert operation fails at a low level.
+   *
+   * <p>Implementations should translate or forward the error to higher-level callbacks owned by the
+   * request, and perform any necessary local clean-up. This method is invoked off-thread relative
+   * to the scheduler loop.
+   *
+   * @param e the low-level put exception describing the cause and any diagnostic information.
+   * @param context the client execution context associated with the scheduler and request flow.
+   */
   public abstract void onFailure(LowLevelPutException e, ClientContext context);
 
+  /**
+   * Called when an insert operation succeeds.
+   *
+   * <p>Implementations should trigger higher-level success callbacks and update any relevant
+   * caches/stores according to the configured {@link Options}.
+   *
+   * @param key the client-level key that was successfully inserted; never {@code null} for insert
+   *     paths.
+   * @param context the client execution context associated with the scheduler and request flow.
+   */
   public abstract void onInsertSuccess(ClientKey key, ClientContext context);
 
+  /**
+   * Called when a fetch operation fails at a low level.
+   *
+   * <p>Implementations should translate or forward the error to higher-level callbacks owned by the
+   * request, and perform any necessary local clean-up. This method is invoked off-thread relative
+   * to the scheduler loop.
+   *
+   * @param e the low-level get exception describing the cause and any diagnostic information.
+   * @param context the client execution context associated with the scheduler and request flow.
+   */
   public abstract void onFailure(LowLevelGetException e, ClientContext context);
 
   /**
    * The actual data delivery goes through CRS.tripPendingKey(). This is just a notification for
-   * book-keeping purposes. We call the scheduler to tell it that the request succeeded, so that it
+   * bookkeeping purposes. We call the scheduler to tell it that the request succeeded, so that it
    * can be rescheduled soon for more requests.
    *
-   * @param context Might be useful.
+   * <p>Implementations may use this to update caches or to schedule follow-on work. It is invoked
+   * off-thread relative to the scheduler loop.
+   *
+   * @param context the client execution context associated with the scheduler and request flow.
    */
   public abstract void onFetchSuccess(ClientContext context);
 
+  /**
+   * Returns the scheduling priority for this block. Higher values typically indicate greater
+   * urgency; the exact scale and policy are determined by the scheduler.
+   *
+   * @return a short integer representing the scheduler priority for this block.
+   */
   public abstract short getPriority();
 
   private boolean sendIsBlocking;
 
+  /**
+   * Sends this block using the sender obtained from {@link #getSender(ClientContext)}.
+   *
+   * <p>The method acquires the current {@link ClientContext} from the provided scheduler,
+   * determines whether the underlying sender is blocking, records that state, and then delegates
+   * the actual work to the sender. The return value reflects whether the sender accepted the work
+   * immediately or deferred it.
+   *
+   * <pre>{@code
+   * // Example: initiate sending inside a scheduler decision
+   * boolean accepted = block.send(core, scheduler);
+   * if (block.sendIsBlocking()) { // adjust scheduling if necessary }
+   * }</pre>
+   *
+   * @param core the node client core used to access runtime services and network plumbing.
+   * @param sched the request scheduler orchestrating priorities and execution flow.
+   * @return {@code true} if the sender initiated or queued the work successfully; {@code false}
+   *     otherwise.
+   */
   public boolean send(NodeClientCore core, RequestScheduler sched) {
     ClientContext context = sched.getContext();
     SendableRequestSender sender = getSender(context);
@@ -87,13 +243,31 @@ public abstract class ChosenBlock {
     return sender.send(core, sched, context, this);
   }
 
+  /**
+   * Returns the sender responsible for executing this block under the given context.
+   *
+   * @param context the client execution context to use when creating or configuring the sender.
+   * @return a non-{@code null} sender that knows how to perform this block's work.
+   */
   public abstract SendableRequestSender getSender(ClientContext context);
 
+  /**
+   * Invoked when the scheduler discards this block (for example, due to cancellation or queue
+   * management). The default implementation delegates to {@link SendableRequestItem#dump()} on the
+   * {@link #token} to release any associated resources.
+   */
   public void onDumped() {
     token.dump();
   }
 
-  /** Call this after send() */
+  /**
+   * Indicates whether the last call to {@link #send(NodeClientCore, RequestScheduler)} used a
+   * blocking sender. Call this accessor only after {@code send(...)} has been invoked.
+   *
+   * @return {@code true} if the underlying sender reports that sending blocks the caller; otherwise
+   *     {@code false}.
+   */
+  @SuppressWarnings("unused")
   public boolean sendIsBlocking() {
     return sendIsBlocking;
   }

--- a/src/main/java/network/crypta/client/async/ChosenBlockImpl.java
+++ b/src/main/java/network/crypta/client/async/ChosenBlockImpl.java
@@ -42,12 +42,8 @@ public class ChosenBlockImpl extends ChosenBlock {
         token,
         key,
         ckey,
-        localRequestOnly,
-        ignoreStore,
-        canWriteClientCache,
-        forkOnCacheable,
-        realTimeFlag,
-        sched);
+        new Options(
+            localRequestOnly, ignoreStore, canWriteClientCache, forkOnCacheable, realTimeFlag));
     this.request = req;
     this.sched = sched;
     this.persistent = persistent;

--- a/src/main/java/network/crypta/client/async/ChosenBlockImpl.java
+++ b/src/main/java/network/crypta/client/async/ChosenBlockImpl.java
@@ -14,18 +14,81 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Matthew Toseland <toad@amphibian.dyndns.org> (0xE43DA450)
+ * Concrete {@link ChosenBlock} that binds a specific {@link network.crypta.node.SendableRequest}
+ * instance to a {@link RequestScheduler}. It wires low-level success and failure callbacks to the
+ * originating request and performs the required scheduler bookkeeping (e.g., removing running
+ * tokens and waking the starter thread) so subsequent work can proceed.
+ *
+ * <p>Use this implementation when a request has already selected a concrete block/token to process,
+ * and the scheduler is ready to execute it. The instance captures execution options via the
+ * base-class {@link Options} and remembers whether the work is {@linkplain #isPersistent()
+ * persistent}. The object is effectively immutable after construction; it is safe to pass across
+ * threads as callbacks schedule work back onto the appropriate {@code JobRunner} based on the
+ * persistence flag.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Delegates all user-visible outcomes to the underlying request (get/insert) instance.
+ *   <li>Removes in-flight tracking in the scheduler before waking the starter thread.
+ *   <li>Chooses the persistent or transient job runner to queue follow-up work.
+ * </ul>
+ *
+ * @author Matthew Toseland &lt;toad@amphibian.dyndns.org&gt; (0xE43DA450)
+ * @see ChosenBlock
+ * @see RequestScheduler
  */
 public class ChosenBlockImpl extends ChosenBlock {
   private static final Logger LOG = LoggerFactory.getLogger(ChosenBlockImpl.class);
 
-  static {
-  }
-
+  /**
+   * The originating {@link SendableRequest} whose sub-request (identified by {@link #token}) is
+   * being executed. The reference is stable for the lifetime of this object and is not mutated by
+   * this class. Implementations use it to dispatch success/failure callbacks.
+   */
   public final SendableRequest request;
+
+  /**
+   * The scheduler responsible for tracking in-flight work and queuing subsequent tasks. It is used
+   * to remove running inserts/fetches and to wake the starter thread after completion or failure so
+   * that other waiting work can progress.
+   */
   public final RequestScheduler sched;
+
+  /**
+   * Whether the block belongs to a persistent request. When {@code true}, callbacks are queued on
+   * the persistent job runner; when {@code false}, the transient runner is used. This influences
+   * durability and shutdown semantics but not the logical outcome of the operation itself.
+   */
   public final boolean persistent;
 
+  /**
+   * Creates a new block for a selected token and keys, binding it to a concrete request and
+   * scheduler. The provided flags control locality, store interaction, client cache writes, and
+   * real-time behavior passed to the base {@link Options}.
+   *
+   * @param req the originating {@link SendableRequest}; not {@code null}; receives callbacks for
+   *     success or failure.
+   * @param token the scheduling token for the sub-request within the larger operation; not {@code
+   *     null}.
+   * @param key the low-level key to fetch/insert; may be {@code null} for request types that do not
+   *     operate on a raw key.
+   * @param ckey the client-layer key associated with this operation; may be {@code null} when not
+   *     applicable.
+   * @param localRequestOnly when {@code true}, perform work using only local resources; do not
+   *     contact peers.
+   * @param ignoreStore when {@code true}, bypass normal on-disk store lookups for reads where
+   *     supported.
+   * @param canWriteClientCache when {@code true}, allow writing client-level caches when the result
+   *     is cacheable.
+   * @param forkOnCacheable when {@code true}, permit sender/scheduler to fork on cacheable results
+   *     to improve throughput.
+   * @param realTimeFlag when {@code true}, mark work as real-time to prefer lower-latency
+   *     strategies where possible.
+   * @param sched the {@link RequestScheduler} coordinating this block; not {@code null}.
+   * @param persistent {@code true} for persistent requests queued on the persistent runner;
+   *     otherwise use the transient runner.
+   */
   public ChosenBlockImpl(
       SendableRequest req,
       SendableRequestItem token,
@@ -49,27 +112,45 @@ public class ChosenBlockImpl extends ChosenBlock {
     this.persistent = persistent;
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Created "
-              + this
-              + " for "
-              + (persistent ? "persistent" : "transient")
-              + " block "
-              + token
-              + " for key "
-              + key,
+          "Created {} for {} block {} for key {}",
+          this,
+          persistent ? "persistent" : "transient",
+          token,
+          key,
           new Exception("debug"));
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean isCancelled() {
     return request.isCancelled();
   }
 
+  /**
+   * Returns whether this block is part of a persistent request. Persistent requests queue follow-up
+   * work on the persistent job runner, which affects durability and shutdown handling, but does not
+   * change the logical semantics of the request.
+   *
+   * @return {@code true} if persistent job runner semantics apply; {@code false} for transient
+   *     execution.
+   */
   @Override
   public boolean isPersistent() {
     return persistent;
   }
 
+  /**
+   * Handles an insert failure by delegating to the underlying {@link SendableInsert} and then
+   * updating scheduler state. The token is removed from the running-insert set, and the starter
+   * thread is woken so other queued work can proceed.
+   *
+   * <p>This method enqueues the callback onto the appropriate job runner (persistent or transient)
+   * to avoid executing heavy logic on scheduling threads.
+   *
+   * @param e the low-level put exception describing why the insert failed; never {@code null}.
+   * @param context the client execution context used by the request to finalize failure handling;
+   *     not {@code null}.
+   */
   @Override
   public void onFailure(final LowLevelPutException e, ClientContext context) {
     context
@@ -89,6 +170,16 @@ public class ChosenBlockImpl extends ChosenBlock {
             });
   }
 
+  /**
+   * Handles a successful insert by notifying the underlying {@link SendableInsert} and performing
+   * scheduler cleanup. The running-insert entry is removed, then the starter is woken to allow any
+   * dependent or waiting work to continue.
+   *
+   * @param key the {@link ClientKey} produced or confirmed by the insert; may be {@code null}
+   *     depending on request type.
+   * @param context the client execution context made available to the request callback; not {@code
+   *     null}.
+   */
   @Override
   public void onInsertSuccess(final ClientKey key, ClientContext context) {
     context
@@ -108,6 +199,14 @@ public class ChosenBlockImpl extends ChosenBlock {
             });
   }
 
+  /**
+   * Handles a fetch failure by delegating to the underlying {@link SendableGet} and updating
+   * scheduler state. The key is removed from the fetch-in-flight set and the starter thread is
+   * woken to ensure progress on other work.
+   *
+   * @param e the low-level get exception indicating why the fetch failed; never {@code null}.
+   * @param context the client execution context for the callback; not {@code null}.
+   */
   @Override
   public void onFailure(final LowLevelGetException e, ClientContext context) {
     context
@@ -127,6 +226,14 @@ public class ChosenBlockImpl extends ChosenBlock {
             });
   }
 
+  /**
+   * Handles a successful fetch by informing the scheduler and removing the in-flight tracking for
+   * the key. Any waiting work is unblocked by waking the starter thread. The underlying request is
+   * considered complete for this token.
+   *
+   * @param context the client execution context used by the scheduler and callbacks; not {@code
+   *     null}.
+   */
   @Override
   public void onFetchSuccess(ClientContext context) {
     context
@@ -146,11 +253,25 @@ public class ChosenBlockImpl extends ChosenBlock {
             });
   }
 
+  /**
+   * Returns the request priority class used by the scheduler. The numeric value is interpreted by
+   * the scheduling policy; lower numbers may represent higher priority depending on configuration.
+   *
+   * @return a short priority class value from the underlying {@link SendableRequest} instance.
+   */
   @Override
   public short getPriority() {
     return request.getPriorityClass();
   }
 
+  /**
+   * Obtains the sender capable of executing this block under the provided context. The returned
+   * sender defines whether sending blocks and performs the actual network/storage interaction.
+   *
+   * @param context the client execution context to use when building or selecting the sender; not
+   *     {@code null}.
+   * @return a non-{@code null} {@link SendableRequestSender} suitable for sending this block.
+   */
   @Override
   public SendableRequestSender getSender(ClientContext context) {
     return request.getSender(context);

--- a/src/test/java/network/crypta/client/async/ChosenBlockImplTest.java
+++ b/src/test/java/network/crypta/client/async/ChosenBlockImplTest.java
@@ -1,0 +1,262 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.Key;
+import network.crypta.node.LowLevelGetException;
+import network.crypta.node.LowLevelPutException;
+import network.crypta.node.RequestScheduler;
+import network.crypta.node.SendableGet;
+import network.crypta.node.SendableInsert;
+import network.crypta.node.SendableRequest;
+import network.crypta.node.SendableRequestItem;
+import network.crypta.node.SendableRequestItemKey;
+import network.crypta.node.SendableRequestSender;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ChosenBlockImplTest {
+
+  @Mock private RequestScheduler sched;
+  @Mock private ClientContext clientContext;
+  @Mock private PersistentJobRunner persistentRunner;
+  @Mock private PersistentJobRunner transientRunner;
+
+  @Mock private SendableRequestItem token;
+  @Mock private SendableRequestItemKey tokenKey;
+  @Mock private Key nodeKey;
+  @Mock private ClientKey clientKey;
+
+  @Test
+  void isCancelled_whenDelegated_returnsUnderlyingRequestState() {
+    // Arrange
+    SendableRequest req = org.mockito.Mockito.mock(SendableRequest.class);
+    when(req.isCancelled()).thenReturn(true);
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            req, token, nodeKey, clientKey, false, false, false, false, false, sched, false);
+
+    // Act + Assert
+    Assertions.assertTrue(block.isCancelled());
+  }
+
+  @Test
+  void isPersistent_whenConstructed_reflectsFlag() {
+    SendableRequest req = org.mockito.Mockito.mock(SendableRequest.class);
+
+    ChosenBlockImpl ptrue =
+        new ChosenBlockImpl(
+            req, token, nodeKey, clientKey, false, false, false, false, false, sched, true);
+    ChosenBlockImpl pfalse =
+        new ChosenBlockImpl(
+            req, token, nodeKey, clientKey, false, false, false, false, false, sched, false);
+
+    Assertions.assertTrue(ptrue.isPersistent());
+    Assertions.assertFalse(pfalse.isPersistent());
+  }
+
+  @Test
+  void getPriority_whenCalled_delegatesToRequest() {
+    SendableRequest req = org.mockito.Mockito.mock(SendableRequest.class);
+    when(req.getPriorityClass()).thenReturn((short) 42);
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            req, token, nodeKey, clientKey, false, false, false, false, true, sched, true);
+
+    assertEquals(42, block.getPriority());
+  }
+
+  @Test
+  void getSender_whenCalled_delegatesToRequest() {
+    SendableRequest req = org.mockito.Mockito.mock(SendableRequest.class);
+    SendableRequestSender sender = org.mockito.Mockito.mock(SendableRequestSender.class);
+    when(req.getSender(clientContext)).thenReturn(sender);
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            req, token, nodeKey, clientKey, false, true, false, false, false, sched, false);
+
+    SendableRequestSender got = block.getSender(clientContext);
+    assertSame(sender, got);
+    verify(req, times(1)).getSender(clientContext);
+  }
+
+  @Test
+  void onFailure_put_whenInsert_callsOnFailure_removesRunningInsert_andWakesStarter() {
+    // Arrange
+    SendableInsert insert = org.mockito.Mockito.mock(SendableInsert.class);
+    when(token.getKey()).thenReturn(tokenKey);
+    when(clientContext.getJobRunner(true)).thenReturn(persistentRunner);
+
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            insert, token, nodeKey, clientKey, false, false, false, false, false, sched, true);
+
+    LowLevelPutException ex = new LowLevelPutException(LowLevelPutException.REJECTED_OVERLOAD);
+
+    ArgumentCaptor<PersistentJob> captor = ArgumentCaptor.forClass(PersistentJob.class);
+
+    // Act: enqueue and then run the captured job
+    block.onFailure(ex, clientContext);
+    verify(clientContext, times(1)).getJobRunner(true);
+    verify(persistentRunner, times(1)).queueNormalOrDrop(captor.capture());
+
+    boolean result = captor.getValue().run(clientContext);
+
+    // Assert: request failure called, insert removed, starter awakened, returns false
+    verify(insert, times(1)).onFailure(ex, token, clientContext);
+    verify(sched, times(1)).removeRunningInsert(same(insert), same(tokenKey));
+    verify(sched, times(1)).wakeStarter();
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  void onInsertSuccess_whenCalled_callsOnSuccess_removesRunningInsert_andWakesStarter() {
+    // Arrange
+    SendableInsert insert = org.mockito.Mockito.mock(SendableInsert.class);
+    when(token.getKey()).thenReturn(tokenKey);
+    when(clientContext.getJobRunner(true)).thenReturn(persistentRunner);
+
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            insert, token, nodeKey, clientKey, false, false, false, false, true, sched, true);
+
+    ArgumentCaptor<PersistentJob> captor = ArgumentCaptor.forClass(PersistentJob.class);
+
+    // Act
+    block.onInsertSuccess(clientKey, clientContext);
+    verify(clientContext, times(1)).getJobRunner(true);
+    verify(persistentRunner, times(1)).queueNormalOrDrop(captor.capture());
+
+    boolean result = captor.getValue().run(clientContext);
+
+    // Assert
+    verify(insert, times(1)).onSuccess(token, clientKey, clientContext);
+    verify(sched, times(1)).removeRunningInsert(same(insert), same(tokenKey));
+    verify(sched, times(1)).wakeStarter();
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  void onFailure_get_whenCalled_callsGetFailure_removesFetchingKey_andWakesStarter() {
+    // Arrange
+    SendableGet get = org.mockito.Mockito.mock(SendableGet.class);
+    when(clientContext.getJobRunner(false)).thenReturn(transientRunner);
+
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            get, token, nodeKey, clientKey, true, false, false, false, false, sched, false);
+
+    LowLevelGetException ex = new LowLevelGetException(LowLevelGetException.ROUTE_NOT_FOUND);
+
+    ArgumentCaptor<PersistentJob> captor = ArgumentCaptor.forClass(PersistentJob.class);
+
+    // Act
+    block.onFailure(ex, clientContext);
+    verify(clientContext, times(1)).getJobRunner(false);
+    verify(transientRunner, times(1)).queueNormalOrDrop(captor.capture());
+
+    boolean result = captor.getValue().run(clientContext);
+
+    // Assert
+    verify(get, times(1)).onFailure(ex, token, clientContext);
+    verify(sched, times(1)).removeFetchingKey(nodeKey);
+    verify(sched, times(1)).wakeStarter();
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  void onFetchSuccess_whenCalled_marksSucceeded_removesFetchingKey_andWakesStarter() {
+    // Arrange
+    SendableGet get = org.mockito.Mockito.mock(SendableGet.class);
+    when(clientContext.getJobRunner(false)).thenReturn(transientRunner);
+
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            get, token, nodeKey, clientKey, false, true, false, false, false, sched, false);
+
+    ArgumentCaptor<PersistentJob> captor = ArgumentCaptor.forClass(PersistentJob.class);
+
+    // Act
+    block.onFetchSuccess(clientContext);
+    verify(clientContext, times(1)).getJobRunner(false);
+    verify(transientRunner, times(1)).queueNormalOrDrop(captor.capture());
+
+    boolean result = captor.getValue().run(clientContext);
+
+    // Assert
+    verify(sched, times(1)).succeeded(get, false);
+    verify(sched, times(1)).removeFetchingKey(nodeKey);
+    verify(sched, times(1)).wakeStarter();
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  void onFailure_get_whenRequestCallbackThrows_removesFetchingKey_andPropagates() {
+    // Arrange
+    SendableGet get = org.mockito.Mockito.mock(SendableGet.class);
+    when(clientContext.getJobRunner(false)).thenReturn(transientRunner);
+
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            get, token, nodeKey, clientKey, false, false, false, false, false, sched, false);
+
+    LowLevelGetException ex = new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR, "boom");
+
+    ArgumentCaptor<PersistentJob> captor = ArgumentCaptor.forClass(PersistentJob.class);
+
+    block.onFailure(ex, clientContext);
+    verify(transientRunner, times(1)).queueNormalOrDrop(captor.capture());
+
+    // Cause the request-level callback to throw
+    RuntimeException thrown = new RuntimeException("fail");
+    org.mockito.Mockito.doThrow(thrown).when(get).onFailure(ex, token, clientContext);
+
+    // Act + Assert: exception propagates out of the job, but removal still happens (finally)
+    PersistentJob job = captor.getValue();
+    assertThrows(RuntimeException.class, () -> job.run(clientContext));
+    verify(sched, times(1)).removeFetchingKey(nodeKey);
+    // Wake is after try/finally; since the exception escapes the lambda, wakeStarter is not called.
+    verify(sched, never()).wakeStarter();
+  }
+
+  @Test
+  void onFailure_put_whenRequestCallbackThrows_removesRunningInsert_andPropagates() {
+    // Arrange
+    SendableInsert insert = org.mockito.Mockito.mock(SendableInsert.class);
+    when(token.getKey()).thenReturn(tokenKey);
+    when(clientContext.getJobRunner(true)).thenReturn(persistentRunner);
+
+    ChosenBlockImpl block =
+        new ChosenBlockImpl(
+            insert, token, nodeKey, clientKey, false, false, false, false, false, sched, true);
+
+    LowLevelPutException ex = new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR);
+
+    ArgumentCaptor<PersistentJob> captor = ArgumentCaptor.forClass(PersistentJob.class);
+
+    block.onFailure(ex, clientContext);
+    verify(persistentRunner, times(1)).queueNormalOrDrop(captor.capture());
+
+    RuntimeException thrown = new RuntimeException("insert-fail");
+    org.mockito.Mockito.doThrow(thrown).when(insert).onFailure(ex, token, clientContext);
+
+    PersistentJob job = captor.getValue();
+    assertThrows(RuntimeException.class, () -> job.run(clientContext));
+    verify(sched, times(1)).removeRunningInsert(same(insert), same(tokenKey));
+    verify(sched, never()).wakeStarter();
+  }
+}

--- a/src/test/java/network/crypta/node/SendableGetRequestSenderTest.java
+++ b/src/test/java/network/crypta/node/SendableGetRequestSenderTest.java
@@ -51,12 +51,8 @@ class SendableGetRequestSenderTest {
                 token,
                 null, // node-level key not used for SendableGet
                 clientKey,
-                localOnly,
-                ignoreStore,
-                canWriteClientCache,
-                false, // forkOnCacheable (unused in these tests)
-                realTimeFlag,
-                scheduler)
+                new ChosenBlock.Options(
+                    localOnly, ignoreStore, canWriteClientCache, false, realTimeFlag))
             .defaultAnswer(org.mockito.Answers.CALLS_REAL_METHODS));
   }
 


### PR DESCRIPTION
Summary
- Improve doclint-compliant Javadoc for ChosenBlock and ChosenBlockImpl with clearer threading and behavior docs.
- Introduce ChosenBlock.Options record to encapsulate execution flags (localRequestOnly, ignoreStore, canWriteClientCache, forkOnCacheable, realTimeFlag).
- Refactor ChosenBlockImpl to use the new Options record and switch to parameterized logging.
- Add comprehensive unit tests for ChosenBlockImpl covering success/failure paths for get/insert, job runner selection, and scheduler bookkeeping.
- Update SendableGetRequestSenderTest to construct ChosenBlock with new Options API.

Details
- src/main/java/network/crypta/client/async/ChosenBlock.java: expanded Javadoc; fields are now non-transient; add public record Options(...).
- src/main/java/network/crypta/client/async/ChosenBlockImpl.java: improved class-level and method Javadoc; constructor now passes a new Options to super; use parameterized logging; preserve semantics for isPersistent, getPriority, sender selection, and scheduler interactions.
- src/test/java/network/crypta/client/async/ChosenBlockImplTest.java: new test suite (Mockito+JUnit 6) validates:
  - Delegation of cancel state and priority
  - getSender delegation
  - onFailure/onSuccess for insert remove running insert and wake starter
  - onFailure/onFetchSuccess for get remove fetching key and wake starter
  - Exception propagation while still performing scheduler cleanup in finally
- src/test/java/network/crypta/node/SendableGetRequestSenderTest.java: updated to use new Options constructor.

Motivation
- Clean up historical Javadoc to pass doclint and improve maintainability.
- Make execution flags explicit and type-safe via Options record rather than a long boolean parameter list.
- Increase unit test coverage for the async chosen block execution path.

Compatibility / Risk
- API change: ChosenBlock constructors now take an Options record instead of multiple booleans. All in-repo call sites have been updated; external callers (if any) must switch to Options.
- No runtime behavior changes intended; tests cover main success/failure flows for get/insert and scheduler handoff.

Testing
- Added new unit tests (ChosenBlockImplTest) and adjusted existing tests. All tests pass locally.

Notes
- No uncommitted changes; Spotless already applied in the branch.
