### PR TITLE
docs(client): doclint-clean Javadocs for async callbacks

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientBaseCallback.java
+++ b/src/main/java/network/crypta/client/async/ClientBaseCallback.java
@@ -4,22 +4,61 @@ import network.crypta.node.RequestClient;
 import network.crypta.support.io.ResumeFailedException;
 
 /**
- * A client process. Something that initiates requests, and can cancel them. FCP, FProxy, and the
- * GlobalPersistentClient, implement this somewhere.
+ * Callback contract for client-side components that initiate and manage requests.
+ *
+ * <p>Implementations represent higher-level clients such as the FCP bridge, FProxy, or the {@code
+ * GlobalPersistentClient}. The node uses this interface to coordinate life‑cycle events for
+ * persistent requests and to obtain a stable {@link network.crypta.node.RequestClient} identity for
+ * scheduling. Typical usage is to implement this interface on a client object that owns one or more
+ * requests and can therefore re‑establish any necessary persistent state after a restart.
+ *
+ * <p>When the node restarts, {@link #onResume(ClientContext)} is invoked so the client can
+ * re-register with the persistence infrastructure (for example {@code PersistentRequestRoot},
+ * persistent temporary buckets, or trackers) before normal processing continues. The returned
+ * {@link #getRequestClient()} value is consulted by the schedulers to group related work and apply
+ * per‑client limits, persistence, and real‑time flags. Implementations should be lightweight and
+ * thread-safe for read access; the scheduler may call {@link #getRequestClient()} frequently.
+ *
+ * <p><b>Responsibilities</b>
+ *
+ * <ul>
+ *   <li>Re-attach persistent requests and resources after a node restart.
+ *   <li>Expose a stable {@link network.crypta.node.RequestClient} describing persistence and
+ *       real-time characteristics for scheduling.
+ * </ul>
+ *
+ * @see ClientContext
+ * @see network.crypta.node.RequestClient
  */
 public interface ClientBaseCallback {
 
   /**
-   * Called for a persistent request when the node is restarted. Must re-register with whatever
-   * infrastructure the request is using, e.g. PersistentRequestRoot, persistent temp buckets etc.
+   * Resumes a persistent request after a node restart.
    *
-   * @param context
+   * <p>This method is invoked during node recovery so the client can re-register any durable
+   * resources and state needed by the request, such as entries under {@code PersistentRequestRoot},
+   * persistent temporary buckets, or file trackers. Implementations should treat repeated calls as
+   * safe and avoid expensive work unless required to restore correctness. Heavy I/O or long‑running
+   * computations should be minimized to keep startup responsive.
+   *
+   * @param context Non-null execution context providing access to schedulers, persistence roots,
+   *     bucket factories, file trackers, and other services necessary to reattach state.
+   * @throws network.crypta.support.io.ResumeFailedException If persisted state is missing,
+   *     incompatible, or corrupt such that the request cannot be safely resumed by this client.
    */
   void onResume(ClientContext context) throws ResumeFailedException;
 
   /**
-   * Get the RequestClient context object used to indicate which requests are related to each other
-   * for scheduling purposes.
+   * Returns the scheduling identity for this client.
+   *
+   * <p>The returned {@link network.crypta.node.RequestClient} describes attributes used by the
+   * scheduler to group and prioritize work, including whether requests are persistent and whether
+   * they carry the real‑time flag. Implementations must return a stable instance whose properties
+   * do not change over the lifetime of the associated requests. The value is read frequently and
+   * should be inexpensive to obtain.
+   *
+   * @return Non-null {@link network.crypta.node.RequestClient} representing this client’s stable
+   *     scheduling attributes used for grouping and prioritization.
    */
   RequestClient getRequestClient();
 }

--- a/src/main/java/network/crypta/client/async/ClientGetCallback.java
+++ b/src/main/java/network/crypta/client/async/ClientGetCallback.java
@@ -4,20 +4,61 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
 
 /**
- * Internal callback interface for requests. Methods are called on the database thread if the
- * request is persistent, otherwise on whatever thread completed the request (therefore with a null
- * container).
+ * Callback contract for client fetch operations.
+ *
+ * <p>Implementations receive success and failure notifications for fetch requests initiated through
+ * the client layer. When a request is persistent, callbacks run on the database thread so that
+ * state can be updated consistently with persistence. For transient requests, the callback executes
+ * on the thread that completed the work (in that case, the surrounding container may be {@code
+ * null}). Typical usage is for a higher‑level client component to implement this interface together
+ * with {@link ClientBaseCallback} so it can resume state after restarts and report results back to
+ * the application boundary.
+ *
+ * <p>Callbacks should remain lightweight. If substantial processing is required—such as indexing,
+ * parsing, or downstream requests—schedule the work onto the {@code Ticker} or the main executor
+ * available from {@link ClientContext} to avoid blocking internal scheduler threads.
+ * Implementations must be robust to being called at most once per request for each terminal outcome
+ * and should perform any necessary cleanup of resources they own.
+ *
+ * <ul>
+ *   <li>Delivers a terminal success with a {@link FetchResult} describing the retrieved data.
+ *   <li>Delivers a terminal failure with a {@link FetchException} describing what went wrong.
+ *   <li>Advises clients to offload heavy work to appropriate executors to keep callbacks fast.
+ * </ul>
+ *
+ * @see ClientBaseCallback
+ * @see ClientContext
  */
 public interface ClientGetCallback extends ClientBaseCallback {
   /**
-   * Called on successful fetch. Caller should schedule a job on the Ticker or Executor (on the
-   * ClientContext) if it needs to do much work.
+   * Signals that the fetch completed successfully.
+   *
+   * <p>The provided {@link FetchResult} carries the fetched payload and associated metadata. This
+   * is a terminal event for the request. If processing the content is expected to be expensive,
+   * schedule the work on the {@code Ticker} or the main executor from {@link ClientContext} rather
+   * than blocking the scheduler thread that delivers this callback. Implementations should treat
+   * the result as read‑only and promptly hand it off to downstream components.
+   *
+   * @param result Non-null {@link FetchResult} describing the fetched content and any related
+   *     metadata; ownership is not transferred and callers should avoid mutating internal buffers.
+   * @param state The original {@link ClientGetter} that initiated the fetch; may be used to inspect
+   *     request parameters or correlate logging and application-level state.
    */
   void onSuccess(FetchResult result, ClientGetter state);
 
   /**
-   * Called on failed/canceled fetch. Caller should schedule a job on the Ticker or Executor (on the
-   * ClientContext) if it needs to do much work.
+   * Signals that the fetch failed or was canceled.
+   *
+   * <p>This is a terminal event for the request. The {@link FetchException} conveys details about
+   * the failure and may include nested causes or categorized error information. Implementations may
+   * choose to retry according to their own policy by scheduling follow‑up work on the {@code
+   * Ticker} or the main executor from {@link ClientContext}. Avoid heavy work on the callback
+   * thread to keep the system responsive.
+   *
+   * @param e The {@link FetchException} describing why the fetch did not complete successfully; it
+   *     may include causes and structured error codes for diagnostics and policy decisions.
+   * @param state The original {@link ClientGetter} that initiated the fetch; useful for correlating
+   *     application state, logging, and potential retry logic.
    */
   void onFailure(FetchException e, ClientGetter state);
 }

--- a/src/main/java/network/crypta/client/async/ClientPutCallback.java
+++ b/src/main/java/network/crypta/client/async/ClientPutCallback.java
@@ -5,57 +5,104 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 
 /**
- * Internal callback interface for inserts (including site inserts). Methods are called on the
- * database thread if the request is persistent, otherwise on whatever thread completed the request
- * (therefore with a null container).
+ * Callback contract for client put operations, including site inserts.
+ *
+ * <p>Implementations receive progress and completion notifications for ongoing insert operations.
+ * Calls occur on the database thread when the request is persistent; transient requests invoke the
+ * callbacks on the thread that completes the work (in that case the container may be {@code null}).
+ * Typical usage is for a higher‑level client component to implement this interface alongside {@link
+ * ClientBaseCallback} so it can resume state after restarts and report insert progress back to the
+ * application boundary.
+ *
+ * <p>Events are advisory unless otherwise stated. For example, {@link
+ * #onFetchable(BaseClientPutter)} is a hint that the data is likely retrievable, but callers must
+ * still handle races and visibility delays. Implementations should be quick and avoid blocking
+ * scheduler threads for extended periods. Where applicable, callers are responsible for freeing any
+ * {@link Bucket} instances as documented below to avoid resource leaks.
+ *
+ * <ul>
+ *   <li>Emits a final success or failure signal with associated cleanup responsibilities.
+ *   <li>Optionally reports a generated {@link FreenetURI} or early metadata in lieu of a URI.
+ *   <li>May indicate that content has become fetchable before overall completion.
+ * </ul>
+ *
+ * @see BaseClientPutter
+ * @see ClientBaseCallback
+ * @see ClientContext
  */
 public interface ClientPutCallback extends ClientBaseCallback {
   /**
-   * Called when URI is known (e.g. after encode all CHK blocks). Won't be called if we are
-   * returning metadata instead.
+   * Notifies that the final insert {@link FreenetURI} is known.
    *
-   * @param state The original BaseClientPutter object which was returned by the .insert() method
-   *     which started this insert. Can be casted to the return type of that .insert().
+   * <p>This callback is typically invoked once the encoder has produced the required top‑level
+   * blocks (for example, after encoding all CHK blocks) and a stable URI can be determined. It is
+   * not invoked if the operation is configured to return metadata instead of a URI. Implementations
+   * may use the URI for user display, caching, or to enqueue dependent tasks. The method is not
+   * guaranteed to be the final notification; success or failure is delivered separately.
+   *
+   * @param uri Non-null {@link FreenetURI} representing the content address produced by the insert;
+   *     callers should treat it as immutable and suitable for later retrieval.
+   * @param state The original {@link BaseClientPutter} returned by the {@code insert()} that
+   *     started this operation; can be downcast to the concrete putter type used by the caller.
    */
   void onGeneratedURI(FreenetURI uri, BaseClientPutter state);
 
   /**
-   * Called when we are returning metadata rather than a URI. This only happens if the originator
-   * specified a metadata threshold, and we can get the metadata below that threshold without
-   * inserting a single top block.
+   * Notifies that metadata is returned instead of a URI.
    *
-   * @param metadata Bucket containing the metadata. Persistent if the insert is persistent.
-   *     Recipient may keep it, but must eventually free it. The caller will not free it.
-   * @param state The original BaseClientPutter object which was returned by the .insert() method
-   *     which started this insert. Can be casted to the return type of that .insert().
+   * <p>This path is used when the originator supplied a metadata threshold and the metadata became
+   * available below that threshold, avoiding the need to insert a top block. The provided {@link
+   * Bucket} contains the metadata payload. Ownership is transferred to the recipient, who may
+   * retain it temporarily but must eventually free it to release resources. The caller of this
+   * method does not free the bucket.
+   *
+   * @param metadata A {@link Bucket} holding the returned metadata; persistent if the insert is
+   *     persistent; the recipient assumes responsibility for freeing it when no longer needed.
+   * @param state The original {@link BaseClientPutter} returned by the {@code insert()} that
+   *     started this operation; can be downcast to the concrete putter type used by the caller.
    */
   void onGeneratedMetadata(Bucket metadata, BaseClientPutter state);
 
   /**
-   * Called when the inserted data is fetchable (just a hint, don't rely on this).
+   * Hints that the inserted data has become fetchable.
    *
-   * @param state The original BaseClientPutter object which was returned by the .insert() method
-   *     which started this insert. Can be casted to the return type of that .insert().
+   * <p>This is an advisory signal and may arrive before overall completion. Clients should treat it
+   * as a best‑effort indication and still handle races, eventual consistency, or caching delays
+   * when attempting to fetch. Ordering relative to other callbacks is not strictly guaranteed.
+   *
+   * @param state The original {@link BaseClientPutter} returned by the {@code insert()} that
+   *     started this operation; can be downcast to the concrete putter type used by the caller.
    */
   void onFetchable(BaseClientPutter state);
 
   /**
-   * Called on successful insert. In this callback you must free the Bucket which you specified for
-   * the insert!
+   * Signals that the insert completed successfully.
    *
-   * @param state The original BaseClientPutter object which was returned by the .insert() method
-   *     which started this insert. Can be casted to the return type of that .insert() (to obtain
-   *     the Bucket).
+   * <p>Implementations should perform any final bookkeeping and resource cleanup. In particular, if
+   * the caller provided an input {@link Bucket} for the insert, it must be freed here to prevent
+   * leaks. This method represents terminal success for the operation; no further callbacks for this
+   * putter are expected after invocation.
+   *
+   * @param state The original {@link BaseClientPutter} returned by the {@code insert()} that
+   *     started this operation; may be cast to the concrete type to access the input {@link
+   *     Bucket}.
    */
   void onSuccess(BaseClientPutter state);
 
   /**
-   * Called on failed/canceled insert. In this callback you must free the Bucket which you specified
-   * for the insert!
+   * Signals that the insert failed or was canceled.
    *
-   * @param state The original BaseClientPutter object which was returned by the .insert() method
-   *     which started this insert. Can be casted to the return type of that .insert() (to obtain
-   *     the Bucket).
+   * <p>Implementations should perform final cleanup, including freeing any input {@link Bucket}
+   * associated with the request. The provided {@link InsertException} describes the failure reason
+   * and may be surfaced to a user or logged for diagnostics. This method represents terminal
+   * completion for the operation; no further callbacks for this putter are expected after
+   * invocation.
+   *
+   * @param e The {@link InsertException} detailing why the insert failed or was canceled; may
+   *     include nested causes and error codes for higher-level handling.
+   * @param state The original {@link BaseClientPutter} returned by the {@code insert()} that
+   *     started this operation; may be cast to the concrete type to access the input {@link
+   *     Bucket}.
    */
   void onFailure(InsertException e, BaseClientPutter state);
 }

--- a/src/main/java/network/crypta/client/async/PersistentClientCallback.java
+++ b/src/main/java/network/crypta/client/async/PersistentClientCallback.java
@@ -5,27 +5,59 @@ import java.io.IOException;
 import network.crypta.crypt.ChecksumChecker;
 
 /**
- * Fetches which may be persistent need getClientDetail() so that we can save that data to the file
- * a splitfile download is using, so that it can be recovered later.
+ * Callback contract for persistent client requests that must be recoverable across restarts.
  *
- * @author toad
+ * <p>Persistent fetches and inserts need to serialize a high‑level description of the request so it
+ * can be restored even when full object serialization is unavailable or fails. Implementations use
+ * {@link #getClientDetail(DataOutputStream, ChecksumChecker)} to emit a compact representation that
+ * captures both how to restart the request from scratch and, when applicable, a summary of the
+ * final outcome. The data can be stored alongside artifacts such as splitfile downloads so recovery
+ * does not depend solely on database state.
+ *
+ * <p>Typical usage includes two scenarios. First, during checkpointing the node writes this summary
+ * so a request can be recovered even if serializer state is inconsistent at that moment. Second,
+ * when creating a splitfile, the summary is stored with the file so the request can be restarted
+ * using only the splitfile. Because the summary is not incrementally updated, values that users can
+ * change after start (for example, priority or client token) may be stale when restored.
+ *
+ * <ul>
+ *   <li>Encodes sufficient information to restart the request from scratch.
+ *   <li>When complete, may include outcome details (e.g., MIME type, final storage location).
+ *   <li>For simple final states (e.g., splitfile downloads), includes resume information such as a
+ *       filename and basic metadata.
+ * </ul>
+ *
+ * @see ClientBaseCallback
+ * @see ChecksumChecker
  */
 public interface PersistentClientCallback extends ClientBaseCallback {
 
   /**
-   * Called to get a high level representation of the request. This will include: - Enough
-   * information to restart the request from scratch, including fields that can be changed manually
-   * after starting it (priority and client token). - If the request has completed, full data on its
-   * completion, i.e. the MIME type, where it was eventually stored etc. - If the request has
-   * reached a *simple* final state, i.e. a splitfile download, enough information to resume the
-   * request. This does NOT apply to single block fetches, multi-level metadata fetches, container
-   * fetches etc; it's basically the filename of the splitfile download plus the metadata that the
-   * splitfile may not have (MIME type etc).
+   * Writes a high‑level representation of the request for recovery.
    *
-   * <p>This is called in two cases: 1) When checkpointing, we write this data so that a request can
-   * be recovered even if serialization fails. 2) When creating a splitfile, we store it, so that a
-   * request can be recovered just from the splitfile. We do not update this data later on, so when
-   * it is restored it may have an out of date priority or client token.
+   * <p>The serialized form should include:
+   *
+   * <ul>
+   *   <li>Enough information to restart the request from scratch, including values that users may
+   *       change manually after start (for example, priority and client token).
+   *   <li>If the request has completed, details describing the outcome such as MIME type and final
+   *       storage location.
+   *   <li>For <em>simple</em> final states (e.g., splitfile downloads), sufficient data to resume
+   *       the request later—typically the splitfile filename plus metadata not carried by the
+   *       splitfile (e.g., MIME type). Single‑block fetches, multi‑level metadata fetches, and
+   *       container fetches are out of scope for this shortcut.
+   * </ul>
+   *
+   * <p>Called when checkpointing and when creating a splitfile. The written summary is not updated
+   * after initial emission; when restored, fields such as priority or client token might therefore
+   * be stale relative to the latest in‑memory state.
+   *
+   * @param dos destination stream to receive the recovery summary; must be open and writable for
+   *     the duration of the call; callers manage its lifecycle including closing and flushing.
+   * @param checker checksum helper to accompany the emitted data; implementations may consult it to
+   *     compute or append checksums that protect the summary against corruption during storage.
+   * @throws IOException if writing to {@code dos} fails or the summary cannot be produced due to an
+   *     underlying I/O error.
    */
   void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException;
 }


### PR DESCRIPTION
Summary
- Improves and doclint-cleans Javadoc across async client callback interfaces.
- Clarifies persistence recovery semantics and scheduling identity expectations.
- No functional or behavioral changes.

Changes
- src/main/java/network/crypta/client/async/ClientBaseCallback.java
  - Expand class-level contract: purpose, responsibilities, and scheduler identity.
  - Document onResume(ClientContext) with explicit expectations and ResumeFailedException.
  - Clarify RequestClient lifetime/stability and real-time/persistence roles.

- src/main/java/network/crypta/client/async/ClientGetCallback.java
  - Define threading context: DB thread for persistent requests; worker thread for transient.
  - Elaborate success/failure notifications and typical usage with ClientBaseCallback.

- src/main/java/network/crypta/client/async/ClientPutCallback.java
  - Clarify insert lifecycle, expected callbacks, and parameter semantics.
  - Improve error documentation and persistence/resume considerations.

- src/main/java/network/crypta/client/async/PersistentClientCallback.java
  - Expand recovery semantics, idempotency guidance, and invariants for persistence.

Commit History (branch-only)
- 454c8c3d61 docs(client): doclint-clean Javadoc for PersistentClientCallback; expand recovery semantics
- 193601f609 docs(client): doclint-clean Javadoc for ClientGetCallback; expand API docs
- 2def5ca0b2 docs(client): doclint-clean Javadoc for ClientPutCallback; expand API docs
- 6e94e22645 docs(client): doclint-clean Javadoc for ClientBaseCallback; expand API docs

Diff Summary
- 4 files changed, ~216 insertions, ~57 deletions
  - M src/main/java/network/crypta/client/async/ClientBaseCallback.java
  - M src/main/java/network/crypta/client/async/ClientGetCallback.java
  - M src/main/java/network/crypta/client/async/ClientPutCallback.java
  - M src/main/java/network/crypta/client/async/PersistentClientCallback.java

Testing & Risk
- Docs-only changes; no code or signatures changed.
- Builds and tests unaffected. Spotless is clean; no additional commits were required.

Notes
- Javadoc updates align with the project’s doclint conventions and clarify API usage for persistence and scheduling.
