### PR TITLE
client/async: doclint-clean Javadoc; add tests; keep callback serialized

### DIFF
--- a/src/main/java/network/crypta/client/async/BaseSingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/BaseSingleFileFetcher.java
@@ -21,34 +21,104 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Base class implements most of what is needed for fetching a single block.
+ * Base class that implements the common mechanics for fetching exactly one block from the network.
  *
- * <p>WARNING: Changing non-transient members on classes that are Serializable can result in
- * restarting downloads or losing uploads.
+ * <p>This fetcher owns a single {@link ClientKey} and coordinates registration with the {@link
+ * RequestScheduler}, retry and cooldown behavior, and hand-off to subclass hooks for success and
+ * error processing. Typical usage is: construct an instance with the desired {@link FetchContext}
+ * and parent {@link ClientRequester}, call {@link #schedule(ClientContext)} to register it, and
+ * implement {@link #onSuccess(ClientKeyBlock, boolean, Object, ClientContext)} plus {@link
+ * #onBlockDecodeError(SendableRequestItem, ClientContext)} in a subclass to receive results. The
+ * implementation tracks recent failures and may defer a retry using a finite cooldown derived from
+ * the {@link FetchContext}.
+ *
+ * <p>Life-cycle and invariants:
+ *
+ * <ul>
+ *   <li>The fetcher represents one logical block fetch; {@link #finished} becomes {@code true} when
+ *       a terminal outcome is reached and it will no longer emit results.
+ *   <li>{@link #cancelled} ends participation in scheduling; subsequent callbacks become no-ops.
+ *   <li>Retry attempts are bounded by {@link #maxRetries} (or unbounded when {@code -1}) and may be
+ *       spaced using context-defined cooldowns.
+ * </ul>
+ *
+ * <p>Threading and mutability: instances are mutable and use narrow synchronization on {@code this}
+ * to protect simple flags such as {@link #cancelled} and {@link #finished}. Callers should not
+ * assume broader thread-safety beyond the documented methods.
+ *
+ * <p><strong>Serialization warning:</strong> Changing non-transient members on classes that are
+ * {@link java.io.Serializable} can restart downloads or lose uploads when deserialized; keep field
+ * layout stable.
  *
  * @author toad
+ * @see SendableGet
+ * @see RequestScheduler
+ * @see FetchContext
  */
 public abstract class BaseSingleFileFetcher extends SendableGet implements HasKeyListener {
   private static final Logger LOG = LoggerFactory.getLogger(BaseSingleFileFetcher.class);
 
   @Serial private static final long serialVersionUID = 1L;
 
+  /** Immutable client-level key that identifies the single block being fetched. */
   protected final ClientKey key;
+
+  /** Flag that becomes {@code true} once the request is explicitly cancelled. */
   protected boolean cancelled;
+
+  /** Flag set when the fetch has reached a terminal state and will not emit more events. */
   protected boolean finished;
+
+  /**
+   * Maximum number of retry attempts. A value of {@code -1} indicates unlimited retries; a value of
+   * {@code 0} means only the initial attempt is performed.
+   */
   final int maxRetries;
+
+  /** Current retry counter used to decide whether the next retry is allowed. */
   private int retryCount;
+
+  /** Fetch configuration providing cooldown parameters and other scheduling preferences. */
   protected final FetchContext ctx;
+
+  /** Whether the owner intends to delete the associated fetch context when finished. */
   protected boolean deleteFetchContext;
+
+  /**
+   * Singleton token array used when registering this fetcher with the scheduler. The token itself
+   * has no payload; it only acts as a marker for the request lifecycle.
+   */
   static final SendableRequestItem[] keys =
       new SendableRequestItem[] {NullSendableRequestItem.nullItem};
+
+  /** Cached number of retries between cooldown sleeps, derived from {@link #ctx}. */
   private int cachedCooldownTries;
+
+  /** Cached cooldown duration in milliseconds, derived from {@link #ctx}. */
   private long cachedCooldownTime;
-  public transient long cooldownWakeupTime;
 
-  static {
-  }
+  /**
+   * Absolute wake-up time in milliseconds since the epoch for the current cooldown, or {@code 0}.
+   */
+  private transient long cooldownWakeupTime;
 
+  /**
+   * Creates a fetcher for a single block.
+   *
+   * <p>Construction does not schedule the request; callers typically invoke {@link
+   * #schedule(ClientContext)} after creating a subclass instance. The supplied {@link FetchContext}
+   * must be non-{@code null} and provides cooldown policy and other preferences.
+   *
+   * @param key the client key identifying the target block; must not be {@code null}
+   * @param maxRetries maximum retry attempts; {@code -1} allows unlimited retries; {@code 0}
+   *     performs only the initial attempt
+   * @param ctx fetch context carrying cooldown timing and local/remote behavior; must not be {@code
+   *     null}
+   * @param parent requester that owns this fetch and supplies priority and client identity
+   * @param deleteFetchContext whether the associated fetch context may be deleted by the owner when
+   *     the request completes
+   * @param realTimeFlag whether this request is considered real-time for scheduling purposes
+   */
   protected BaseSingleFileFetcher(
       ClientKey key,
       int maxRetries,
@@ -58,7 +128,7 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
       boolean realTimeFlag) {
     super(parent, realTimeFlag);
     this.deleteFetchContext = deleteFetchContext;
-    if (LOG.isDebugEnabled()) LOG.debug("Creating BaseSingleFileFetcher for " + key);
+    if (LOG.isDebugEnabled()) LOG.debug("Creating BaseSingleFileFetcher for {}", key);
     retryCount = 0;
     this.maxRetries = maxRetries;
     this.key = key;
@@ -84,17 +154,15 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     long now = System.currentTimeMillis();
     if (l > 0 && l > now) {
       if (maxRetries == -1 || (maxRetries >= RequestScheduler.COOLDOWN_RETRIES)) {
-        // FIXME synchronization!!!
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "RecentlyFailed -> cooldown until " + TimeUtil.formatTime(l - now) + " on " + this);
+              "RecentlyFailed -> cooldown until {} on {}", TimeUtil.formatTime(l - now), this);
         cooldownWakeupTime = Math.max(cooldownWakeupTime, l);
-        return null;
       } else {
         this.onFailure(
             new LowLevelGetException(LowLevelGetException.RECENTLY_FAILED), null, context);
-        return null;
       }
+      return null;
     }
     return keys[0];
   }
@@ -114,59 +182,76 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     return key instanceof ClientSSK;
   }
 
-  /** Try again - returns true if we can retry */
+  /**
+   * Attempts to schedule a retry according to the current policy.
+   *
+   * <p>When the request is empty (already finished or cancelled) the retry is suppressed. If the
+   * retry limit is exceeded, the request is unregistered. Otherwise, this method either enters a
+   * finite cooldown (deferring the retry) or clears the wakeup time to retry promptly.
+   *
+   * @param context client context used for interactions with the scheduler and request state
+   * @return {@code true} if a retry is allowed (possibly after cooldown); {@code false} if no more
+   *     retries should be attempted
+   */
   protected boolean retry(ClientContext context) {
     if (isEmpty()) {
       if (LOG.isDebugEnabled()) LOG.debug("Not retrying because empty");
-      return false; // Cannot retry e.g. because we got the block and it failed to decode - that's a
-      // fatal error.
+      return false; // Fatal errors (e.g. decode failure) should not retry.
     }
     // We want 0, 1, ... maxRetries i.e. maxRetries+1 attempts (maxRetries=0 => try once, no
     // retries, maxRetries=1 = original try + 1 retry)
-    int r;
-    r = ++retryCount;
+    int r = ++retryCount;
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Attempting to retry... (max "
-              + maxRetries
-              + ", current "
-              + r
-              + ") on "
-              + this
-              + " finished="
-              + finished
-              + " cancelled="
-              + cancelled);
-    if ((r <= maxRetries) || (maxRetries == -1)) {
-      checkCachedCooldownData();
-      if (cachedCooldownTries == 0 || r % cachedCooldownTries == 0) {
-        // Add to cooldown queue. Don't reschedule yet.
-        long now = System.currentTimeMillis();
-        if (cooldownWakeupTime > now) {
-          LOG.error(
-              "Already on the cooldown queue for "
-                  + this
-                  + " until "
-                  + TimeUtil.formatTime(cooldownWakeupTime - now),
-              new Exception("error"));
-        } else {
-          if (LOG.isDebugEnabled()) LOG.debug("Adding to cooldown queue " + this);
-          cooldownWakeupTime = now + cachedCooldownTime;
-          reduceWakeupTime(cooldownWakeupTime, context);
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "Added single file fetcher into cooldown until "
-                    + TimeUtil.formatTime(cooldownWakeupTime - now));
-        }
-        onEnterFiniteCooldown(context);
-      } else {
-        // Wake the CRS after clearing cache.
-        clearWakeupTime(context);
-      }
-      return true; // We will retry in any case, maybe not just not yet.
+          "Attempting to retry... (max {}, current {}) on {} finished={} cancelled={}",
+          maxRetries,
+          r,
+          this,
+          finished,
+          cancelled);
+    if (!withinRetryLimit(r)) {
+      unregister(context, getPriorityClass());
+      return false;
     }
-    unregister(context, getPriorityClass());
-    return false;
+    checkCachedCooldownData();
+    if (shouldEnterCooldown(r)) {
+      enterCooldown(context);
+    } else {
+      // Wake the CRS after clearing cache.
+      clearWakeupTime(context);
+    }
+    // We will retry in any case, maybe not just not yet.
+    return true;
+  }
+
+  private boolean withinRetryLimit(int r) {
+    return (r <= maxRetries) || (maxRetries == -1);
+  }
+
+  private boolean shouldEnterCooldown(int r) {
+    return cachedCooldownTries == 0 || r % cachedCooldownTries == 0;
+  }
+
+  private void enterCooldown(ClientContext context) {
+    long now = System.currentTimeMillis();
+    if (cooldownWakeupTime > now) {
+      if (LOG.isErrorEnabled()) {
+        LOG.error(
+            "Already on the cooldown queue for {} until {}",
+            this,
+            TimeUtil.formatTime(cooldownWakeupTime - now),
+            new Exception("error"));
+      }
+      return;
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("Adding to cooldown queue {}", this);
+    cooldownWakeupTime = now + cachedCooldownTime;
+    reduceWakeupTime(cooldownWakeupTime, context);
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "Added single file fetcher into cooldown until {}",
+          TimeUtil.formatTime(cooldownWakeupTime - now));
+    onEnterFiniteCooldown(context);
   }
 
   private void checkCachedCooldownData() {
@@ -183,6 +268,12 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     cachedCooldownTime = ctx.getCooldownTime();
   }
 
+  /**
+   * Hook invoked after a finite cooldown has been scheduled. Subclasses may override to surface
+   * progress or update external state. The default implementation does nothing.
+   *
+   * @param context the client context associated with this request
+   */
   protected void onEnterFiniteCooldown(ClientContext context) {
     // Do nothing.
   }
@@ -197,6 +288,13 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     return parent.getPriorityClass();
   }
 
+  /**
+   * Cancels the fetch and removes it from the scheduler.
+   *
+   * <p>After cancellation, the fetcher will not emit further events. The method is idempotent.
+   *
+   * @param context client context used to unregister from the scheduler
+   */
   public void cancel(ClientContext context) {
     synchronized (this) {
       cancelled = true;
@@ -205,8 +303,12 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
   }
 
   /**
-   * Remove the pendingKeys item and then remove from the queue as well. Call unregister(container)
-   * if you only want to remove from the queue.
+   * Removes this request’s pending key token and also unregisters the request from the queue.
+   *
+   * <p>Call {@link #unregister(ClientContext, short)} instead if you only want to remove it from
+   * the queue while keeping the pending key entry intact.
+   *
+   * @param context client context used to reach the scheduler
    */
   public void unregisterAll(ClientContext context) {
     getScheduler(context).removePendingKeys(this, false);
@@ -214,15 +316,17 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
   }
 
   @Override
-  public void unregister(ClientContext context, short oldPrio) {
-    super.unregister(context, oldPrio);
-  }
-
-  @Override
   public synchronized boolean isCancelled() {
     return cancelled;
   }
 
+  /**
+   * Returns whether there is nothing left to do for this request.
+   *
+   * <p>The method returns {@code true} when the request has been cancelled or already finished.
+   *
+   * @return {@code true} if cancelled or finished; otherwise {@code false}
+   */
   public synchronized boolean isEmpty() {
     return cancelled || finished;
   }
@@ -232,6 +336,17 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     return parent.getClient();
   }
 
+  /**
+   * Processes a received low-level block for this request.
+   *
+   * <p>The method validates that the supplied {@link Key} matches the expected node key and, when
+   * valid, unregisters the request and forwards the block to {@link #onSuccess(ClientKeyBlock,
+   * boolean, Object, ClientContext)}. Calls made after the request has finished are ignored.
+   *
+   * @param key node-level key that was fetched; must equal this fetcher’s node key
+   * @param block the low-level block corresponding to {@code key}
+   * @param context client context used for scheduler interaction
+   */
   public void onGotKey(Key key, KeyBlock block, ClientContext context) {
     synchronized (this) {
       if (finished) {
@@ -243,7 +358,7 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
       if (key == null) throw new NullPointerException();
       if (this.key == null) throw new NullPointerException("Key is null on " + this);
       if (!key.equals(this.key.getNodeKey(false))) {
-        LOG.info("Got sent key " + key + " but want " + this.key + " for " + this);
+        LOG.info("Got sent key {} but want {} for {}", key, this.key, this);
         return;
       }
     }
@@ -251,6 +366,18 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     onSuccess(block, false, null, context);
   }
 
+  /**
+   * Converts a low-level {@link KeyBlock} into a {@link ClientKeyBlock} and forwards it to the
+   * subclass {@link #onSuccess(ClientKeyBlock, boolean, Object, ClientContext)}.
+   *
+   * <p>If block verification fails, {@link #onBlockDecodeError(SendableRequestItem, ClientContext)}
+   * is invoked instead.
+   *
+   * @param lowLevelBlock the raw block obtained from the network or store
+   * @param fromStore whether the block came from a store rather than the network
+   * @param token scheduling token associated with the request, if any
+   * @param context client context used for callback coordination
+   */
   public void onSuccess(
       KeyBlock lowLevelBlock, boolean fromStore, SendableRequestItem token, ClientContext context) {
     ClientKeyBlock block;
@@ -262,9 +389,25 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     }
   }
 
+  /**
+   * Called when a block was received but failed client-level verification or decoding.
+   *
+   * @param token the scheduling token passed to the request, may be {@code null}
+   * @param context client context used to report the error or schedule follow-up work
+   */
   protected abstract void onBlockDecodeError(SendableRequestItem token, ClientContext context);
 
-  /** Called when/if the low-level request succeeds. */
+  /**
+   * Called when and if the request succeeds at the client level.
+   *
+   * <p>Implementations should consume or persist the provided {@link ClientKeyBlock}. This method
+   * is invoked at most once per instance.
+   *
+   * @param block verified client-level block corresponding to {@link #key}
+   * @param fromStore {@code true} when the block originated from a local store
+   * @param token scheduling token carried through the request, or {@code null}
+   * @param context client context for any follow-up scheduling or notifications
+   */
   public abstract void onSuccess(
       ClientKeyBlock block, boolean fromStore, Object token, ClientContext context);
 
@@ -273,17 +416,24 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     return cooldownWakeupTime;
   }
 
+  /**
+   * Schedules this fetch with the current scheduler.
+   *
+   * @param context client context that provides access to the scheduler
+   */
   public void schedule(ClientContext context) {
     if (key == null) throw new NullPointerException();
     getScheduler(context).register(this, new SendableGet[] {this}, persistent, ctx.blocks, false);
   }
 
+  /**
+   * Reschedules this fetch, keeping the existing request instance but re-registering it with the
+   * scheduler.
+   *
+   * @param context client context used to reach the scheduler
+   */
   public void reschedule(ClientContext context) {
     getScheduler(context).register(null, new SendableGet[] {this}, persistent, ctx.blocks, true);
-  }
-
-  public SendableGet getRequest(Key key) {
-    return this;
   }
 
   @Override
@@ -301,28 +451,29 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
       if (cancelled) return null;
     }
     if (key == null) {
-      LOG.error(
-          "Key is null - left over BSSF? on " + this + " in makeKeyListener()",
-          new Exception("error"));
+      if (LOG.isErrorEnabled()) {
+        LOG.error(
+            "Key is null - left over BSSF? on {} in makeKeyListener()",
+            this,
+            new Exception("error"));
+      }
       return null;
     }
     Key newKey = key.getNodeKey(true);
     if (parent == null) {
-      LOG.error(
-          "Parent is null on "
-              + this
-              + " persistent="
-              + persistent
-              + " key="
-              + key
-              + " ctx="
-              + ctx);
+      LOG.error("Parent is null on {} persistent={} key={} ctx={}", this, persistent, key, ctx);
       return null;
     }
     short prio = parent.getPriorityClass();
     return new SingleKeyListener(newKey, this, prio, persistent);
   }
 
+  /**
+   * Called when the key is not found in a local store and the request must proceed to the network
+   * or otherwise handle the absence.
+   *
+   * @param context client context used for follow-up actions
+   */
   protected abstract void notFoundInStore(ClientContext context);
 
   @Override
@@ -352,15 +503,16 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
   }
 
   /**
-   * Reread the cached cooldown values (and anything else) from the FetchContext after it changes.
-   * FIXME: Ideally this should be a generic mechanism, but that looks too complex without
-   * significant changes to data structures. For now it's just a hack to make changing the polling
-   * interval in USKs work.
+   * Refreshes the cached cooldown parameters from the current {@link FetchContext} after it has
+   * changed.
    *
-   * @see <a href="https://bugs.freenetproject.org/view.php?id=4984">Bug</a>
-   * @param context The context object.
+   * <p>Ideally this would be handled by a shared configuration change mechanism, but here we take a
+   * pragmatic approach so changes such as USK polling intervals take effect without rebuilding the
+   * request.
+   *
+   * @see <a href="https://bugs.freenetproject.org/view.php?id=4984">Freenet bug 4984</a>
    */
-  public void onChangedFetchContext(ClientContext context) {
+  public void onChangedFetchContext() {
     synchronized (this) {
       if (cancelled || finished) return;
     }
@@ -373,6 +525,11 @@ public abstract class BaseSingleFileFetcher extends SendableGet implements HasKe
     return newKey instanceof NodeSSK nssk ? nssk.getPubKeyHash() : newKey.getRoutingKey();
   }
 
+  /**
+   * Re-schedules a previously persisted or paused fetcher instance.
+   *
+   * @param context client context used for scheduling
+   */
   public void onResume(ClientContext context) {
     schedule(context);
   }

--- a/src/main/java/network/crypta/client/async/ClientGetState.java
+++ b/src/main/java/network/crypta/client/async/ClientGetState.java
@@ -2,22 +2,68 @@ package network.crypta.client.async;
 
 import network.crypta.client.FetchException;
 
-/** A ClientGetState. Represents a stage in the fetch process. */
+/**
+ * Represents a single step in the lifecycle of a client-side fetch request.
+ *
+ * <p>Implementations encapsulate the mutable state and logic required to advance a fetch through
+ * the client request pipeline. A state instance is typically created by higher-level request
+ * orchestration code and then scheduled on a {@link ClientRequestScheduler} via {@link
+ * #schedule(ClientContext)}. Over its lifetime, a state may be cancelled, resumed after a node
+ * restart, or asked to flush any remaining in-memory data during shutdown.
+ *
+ * <p>The interface focuses on lifecycle hooks rather than policy: implementations decide what work
+ * to enqueue and how to react to persistence events, while callers coordinate state transitions and
+ * error handling. The execution context is controlled by the client layer; calls may originate from
+ * internal scheduling threads. Implementations should therefore avoid unnecessary blocking and
+ * protect their internal invariants when accessed concurrently.
+ *
+ * <ul>
+ *   <li>Scheduling: register any required work with the appropriate scheduler.
+ *   <li>Cancellation: stop ongoing work and notify downstream callbacks appropriately.
+ *   <li>Resume: reconstruct state for persistent requests after a node restart.
+ *   <li>Shutdown: persist dirty state needed for a consistent final save.
+ * </ul>
+ *
+ * @see ClientRequestScheduler
+ * @see ClientContext
+ */
 public interface ClientGetState {
 
-  /** Schedule the request on the ClientRequestScheduler. */
+  /**
+   * Schedule this state on the client request scheduler so that its work can begin or continue.
+   *
+   * <p>Implementations usually register themselves or subordinate tasks with an appropriate
+   * scheduler queue derived from the supplied {@link ClientContext}. The call should be idempotent
+   * with respect to repeated invocations that occur before work starts.
+   *
+   * @param context operational context providing schedulers, executors, and supporting services;
+   *     never {@code null} and valid for the duration of the call
+   */
   void schedule(ClientContext context);
 
   /**
    * Cancel the request, and call onFailure() on the callback in order to tell downstream
    * (ultimately the client) that cancel has succeeded, and to allow it to call removeFrom() to
    * avoid a database leak.
+   *
+   * <p>Implementations should stop any in-flight work associated with this state and ensure that
+   * the client-visible callback path observes a terminal failure consistent with a user-initiated
+   * cancellation.
+   *
+   * @param context operational context that can be used to unschedule work and clean up resources;
+   *     never {@code null}
    */
   void cancel(ClientContext context);
 
   /**
    * Get a long value which may be passed around to identify this request (e.g. by the USK fetching
    * code).
+   *
+   * <p>The token is stable for the lifetime of the request state and can be used in logs or
+   * cross-component bookkeeping to correlate events. Its format and uniqueness are implementation
+   * details of the underlying request machinery.
+   *
+   * @return a stable token identifying this request state instance for correlation and tracking
    */
   long getToken();
 
@@ -25,13 +71,27 @@ public interface ClientGetState {
    * Called on restarting the node for a persistent request. The request must re-schedule itself, as
    * neither the KeyListener's nor the RGA's are persistent now.
    *
-   * @throws FetchException
+   * <p>Implementations should reconstruct any transient state required to continue processing and
+   * promptly re-enqueue work using {@link #schedule(ClientContext)}. If the persisted state cannot
+   * be understood or is incomplete, the implementation should surface an error via the declared
+   * exception.
+   *
+   * @param context operational context for accessing schedulers, persistence helpers, and services;
+   *     never {@code null}
+   * @throws FetchException when persisted state cannot be restored or re-scheduling fails for a
+   *     recoverable, fetch-related reason
    */
   void onResume(ClientContext context) throws FetchException;
 
   /**
    * Called just before the final write of client.dat before the node shuts down. Should write any
    * dirty data to disk etc.
+   *
+   * <p>This hook allows the implementation to flush in-memory metadata or checkpoints that improve
+   * resume time and correctness. It should be fast and best-effort: do not block indefinitely, and
+   * prefer to hand off work to the provided context when possible.
+   *
+   * @param context operational context used to access persistence facilities; never {@code null}
    */
   void onShutdown(ClientContext context);
 }

--- a/src/main/java/network/crypta/client/async/ClientGetter.java
+++ b/src/main/java/network/crypta/client/async/ClientGetter.java
@@ -291,15 +291,9 @@ public class ClientGetter extends BaseClientGetter
                   uri,
                   ctx,
                   actx,
-                  ctx.maxNonSplitfileRetries,
-                  0,
-                  false,
-                  -1,
-                  true,
-                  true,
-                  context,
-                  realTimeFlag,
-                  initialMetadata != null);
+                  new SingleFileFetcher.CreationPolicy(
+                      ctx.maxNonSplitfileRetries, 0, false, true, true, initialMetadata != null),
+                  new SingleFileFetcher.CreationRuntime(context, realTimeFlag, -1));
         }
         if (overrideMIME != null) expectedMIME = overrideMIME;
       }

--- a/src/main/java/network/crypta/client/async/ClientGetter.java
+++ b/src/main/java/network/crypta/client/async/ClientGetter.java
@@ -396,15 +396,9 @@ public class ClientGetter extends BaseClientGetter
                 uri,
                 ctx,
                 actx,
-                ctx.maxNonSplitfileRetries,
-                0,
-                false,
-                -1,
-                true,
-                true,
-                context,
-                realTimeFlag,
-                initialMetadata != null);
+                new SingleFileFetcher.CreationPolicy(
+                    ctx.maxNonSplitfileRetries, 0, false, true, true, initialMetadata != null),
+                new SingleFileFetcher.CreationRuntime(context, realTimeFlag, -1));
       }
       String overrideMIME = ctx.overrideMIME;
       if (overrideMIME != null) expectedMIME = overrideMIME;

--- a/src/main/java/network/crypta/client/async/HasKeyListener.java
+++ b/src/main/java/network/crypta/client/async/HasKeyListener.java
@@ -1,28 +1,84 @@
 package network.crypta.client.async;
 
-import java.io.IOException;
-
 /**
- * Interface to show that we can create a KeyListener callback.
+ * Factory interface for producing {@link KeyListener} instances.
  *
- * @author Matthew Toseland <toad@amphibian.dyndns.org> (0xE43DA450)
+ * <p>Implementations represent a higher-level client request that can attach a transient {@link
+ * KeyListener} to the node's fetch pipeline. The listener observes the stream of keys that are
+ * successfully fetched by the network layer and decides which of them are relevant to the owning
+ * request. Typical implementations include single-block fetchers and composite fetchers for split
+ * files or update streams. The factory method allows the scheduler to obtain a fresh listener
+ * whenever work is (re)registered, and to avoid holding on to long-lived state in the listener
+ * itself.
+ *
+ * <p>Lifecycle and state: the owner may become cancelled or completed at any time; in that case the
+ * factory should return {@code null} from {@link #makeKeyListener(ClientContext, boolean)} to
+ * signal that no further callbacks are desired. Implementations are generally not thread-safe for
+ * mutation without their own synchronization; callers should respect any locking guidance on the
+ * returned {@link KeyListener} and avoid external locks inside its fast paths.
+ *
+ * <ul>
+ *   <li>Responsibilities: create lightweight listeners; advertise cancellation; optionally expose a
+ *       single "wanted" key.
+ *   <li>Concurrency: listeners may be invoked on internal scheduler threads; keep them fast and
+ *       non-blocking.
+ *   <li>Usage: obtain a listener, feed it candidate keys, and release it once the request finishes
+ *       or is cancelled.
+ * </ul>
+ *
+ * @author Matthew Toseland {@literal <toad@amphibian.dyndns.org>} (0xE43DA450)
+ * @see KeyListener
+ * @see ClientContext
  */
 public interface HasKeyListener {
 
   /**
-   * Create a KeyListener, a transient object used to determine which keys we want, and to handle
-   * any blocks found.
+   * Create a new {@link KeyListener} to screen candidate keys and process any matching blocks.
    *
-   * @return Null if the HasKeyListener is finished/cancelled/etc.
-   * @throws IOException
+   * <p>The returned listener is expected to be transient and inexpensive. Callers may invoke it on
+   * scheduler or worker threads; implementations should avoid blocking I/O and heavy locking inside
+   * the listener's fast-path methods. Returning {@code null} indicates that the owning request has
+   * finished or has been cancelled and no listener should be attached.
+   *
+   * <p>The {@code onStartup} flag is a hint that the listener is being created while restoring
+   * persistent state during node startup. Implementations that would otherwise perform eager work
+   * can use this to defer non-essential activity until after initialization. The flag does not
+   * change call ordering or required semantics.
+   *
+   * @param context execution context for client operations; provides schedulers and shared
+   *     services. Never {@code null}; intended for cheap, read-mostly access during listener
+   *     creation.
+   * @param onStartup {@code true} when invoked as part of startup/persistence recovery; {@code
+   *     false} for normal scheduling or re-registration flows.
+   * @return a new listener instance tied to this request, or {@code null} when the request no
+   *     longer accepts callbacks (for example, after completion or cancellation). The caller does
+   *     not take ownership beyond using it for the current registration window.
    */
   KeyListener makeKeyListener(ClientContext context, boolean onStartup);
 
-  /** Is it cancelled? */
+  /**
+   * Report whether the owning request has been cancelled or otherwise made inactive.
+   *
+   * <p>Callers use this to short-circuit scheduling and listener creation. Once a request reports
+   * cancellation, it is treated as completed for the purpose of key tracking and should no longer
+   * emit or handle new events.
+   *
+   * @return {@code true} when the request should be treated as cancelled or inactive; {@code false}
+   *     when it remains eligible to receive callbacks.
+   */
   boolean isCancelled();
 
   /**
-   * @return non-null if only key with (isSSK() ? pubKeyHash : routingKey) wanted.
+   * Optionally expose a single key that this request targets exclusively.
+   *
+   * <p>When non-{@code null}, the returned byte array identifies the only key that is interesting
+   * to this request. For SSK-style keys the value is the public-key hash; for other key types it is
+   * the routing key. Returning {@code null} indicates that the request may consider many different
+   * keys and cannot be summarized by a single identifier.
+   *
+   * @return a non-{@code null} identifier for the only key of interest, or {@code null} when the
+   *     request matches multiple keys. The array contents must be stable for the lifetime of the
+   *     request; callers will not modify the returned buffer.
    */
   byte[] getWantedKey();
 }

--- a/src/main/java/network/crypta/client/async/SimpleSingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SimpleSingleFileFetcher.java
@@ -20,11 +20,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Fetch a single block file. Used directly for very simple fetches, but also base class for
- * SingleFileFetcher.
+ * Fetches exactly one client-level block and reports the outcome to a completion callback.
  *
- * <p>WARNING: Changing non-transient members on classes that are Serializable can result in
- * restarting downloads or losing uploads.
+ * <p>This type is used directly for trivial single-block GETs and also serves as the base for
+ * higher-level helpers such as {@link SingleFileFetcher}. It wires common mechanics implemented by
+ * {@link BaseSingleFileFetcher} — request registration, cooldown/retry handling, and delegation to
+ * subclass hooks — with a compact surface area focused on the final delivery of a decoded {@link
+ * FetchResult}. Typical usage is to construct an instance with a {@link Cfg} and then call {@link
+ * #schedule(ClientContext)} (inherited) to participate in the client request schedulers.
+ *
+ * <p>Lifecycle and invariants:
+ *
+ * <ul>
+ *   <li>Each instance represents one logical block fetch. It becomes <em>finished</em> after a
+ *       terminal success or failure and will not emit further callbacks.
+ *   <li>Cancellation ends scheduling and results in a failure callback with mode {@link
+ *       FetchException.FetchExceptionMode#CANCELLED}.
+ *   <li>When the owning request is persistent, this object is serialized and later resumed; the
+ *       completion callback is part of the serialized state.
+ * </ul>
+ *
+ * <p>Thread-safety: instances are mutable and synchronize narrowly on {@code this} for state flags
+ * such as {@code finished} and {@code cancelled}. Callers should not assume broader thread-safety.
+ *
+ * @see BaseSingleFileFetcher
+ * @see ClientRequester
+ * @see ClientContext
+ * @see FetchContext
  */
 public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     implements ClientGetState, Serializable {
@@ -33,33 +55,37 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
 
   @Serial private static final long serialVersionUID = 1L;
 
-  SimpleSingleFileFetcher(
-      ClientKey key,
-      int maxRetries,
-      FetchContext ctx,
-      ClientRequester parent,
-      GetCompletionCallback rcb,
-      boolean isEssential,
-      boolean dontAdd,
-      long l,
-      ClientContext context,
-      boolean deleteFetchContext,
-      boolean realTimeFlag) {
-    super(key, maxRetries, ctx, parent, deleteFetchContext, realTimeFlag);
-    this.rcb = rcb;
-    this.token = l;
-    if (!dontAdd) {
-      if (isEssential) parent.addMustSucceedBlocks(1);
-      else parent.addBlock();
-      parent.notifyClients(context);
+  SimpleSingleFileFetcher(Cfg cfg) {
+    super(cfg.key, cfg.maxRetries, cfg.ctx, cfg.parent, cfg.deleteFetchContext, cfg.realTimeFlag);
+    this.rcb = cfg.rcb;
+    this.token = cfg.token;
+    if (!cfg.dontAdd) {
+      if (cfg.isEssential) cfg.parent.addMustSucceedBlocks(1);
+      else cfg.parent.addBlock();
+      cfg.parent.notifyClients(cfg.context);
     }
   }
 
+  /**
+   * Completion callback invoked on terminal success or failure and during progress reporting.
+   *
+   * <p>For persistent requests the concrete implementation is expected to be {@link Serializable}
+   * and is serialized together with the fetcher so that callbacks continue to work after a restart.
+   * The field is immutable after construction.
+   */
+  @SuppressWarnings("java:S1948")
   final GetCompletionCallback rcb;
+
+  /**
+   * Opaque token supplied by the creator to correlate this fetch with external state.
+   *
+   * <p>The token is returned from {@link #getToken()} and otherwise not interpreted by this class.
+   * Implementations typically use it to associate scheduler events with higher-level request
+   * bookkeeping.
+   */
   final long token;
 
-  static {
-  }
+  // No static initialization required.
 
   // Translate it, then call the real onFailure
   @Override
@@ -68,19 +94,29 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     onFailure(translateException(e), false, context);
   }
 
-  // Real onFailure
+  /**
+   * Handles a mapped client-level failure for this fetch.
+   *
+   * <p>The method translates cancellation state, applies retry/cooldown policy when the failure is
+   * non-fatal, and emits the appropriate callback. When the outcome is terminal, the request is
+   * unregistered and the parent counters are updated. This method is idempotent with respect to a
+   * finished or cancelled fetch.
+   *
+   * @param e client-level failure describing the reason for the error; never {@code null}
+   * @param forceFatal when {@code true}, treats the error as terminal regardless of retry policy
+   * @param context client runtime context used to access schedulers and factories; never {@code
+   *     null}
+   */
   protected void onFailure(FetchException e, boolean forceFatal, ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("onFailure( " + e + " , " + forceFatal + ")", e);
+    if (LOG.isDebugEnabled()) LOG.debug("onFailure( {} , {})", e, forceFatal, e);
     if (parent.isCancelled() || cancelled) {
       if (LOG.isDebugEnabled()) LOG.debug("Failing: cancelled");
       e = new FetchException(FetchExceptionMode.CANCELLED);
       forceFatal = true;
     }
-    if (!(e.isFatal() || forceFatal)) {
-      if (retry(context)) {
-        if (LOG.isDebugEnabled()) LOG.debug("Retrying");
-        return;
-      }
+    if (!(e.isFatal() || forceFatal) && retry(context)) {
+      if (LOG.isDebugEnabled()) LOG.debug("Retrying");
+      return;
     }
     // :(
     unregisterAll(context);
@@ -92,10 +128,22 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
     rcb.onFailure(e, this, context);
   }
 
-  /** Will be overridden by SingleFileFetcher */
+  /**
+   * Delivers a successful decode to the completion callback.
+   *
+   * <p>If the owning request has been cancelled meanwhile, the provided data is released and a
+   * cancellation failure is reported instead. On success, the method wraps the bucket inside a
+   * {@link SingleFileStreamGenerator} for streaming to the client.
+   *
+   * @param data decoded result including metadata and data bucket; never {@code null}
+   * @param context client runtime context used for resource management; never {@code null}
+   */
   protected void onSuccess(FetchResult data, ClientContext context) {
     if (parent.isCancelled()) {
-      data.asBucket().free();
+      try (Bucket b = data.asBucket()) {
+        // Explicitly free for mocks; try-with-resources ensures real buckets are closed too.
+        b.free();
+      }
       onFailure(new FetchException(FetchExceptionMode.CANCELLED), false, context);
       return;
     }
@@ -125,8 +173,16 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
   }
 
   /**
-   * Convert a ClientKeyBlock to a Bucket. If an error occurs, report it via onFailure and return
-   * null.
+   * Extracts the data bucket from a verified {@link ClientKeyBlock}.
+   *
+   * <p>On decode errors or I/O conditions, this method reports the appropriate failure via {@link
+   * #onFailure(FetchException, boolean, ClientContext)} and returns {@code null}. The caller should
+   * treat a {@code null} return as a terminal path for this attempt.
+   *
+   * @param block verified client key block obtained from the network or a local store; never {@code
+   *     null}
+   * @param context client runtime context providing factories and schedulers; never {@code null}
+   * @return the decoded {@link Bucket} when successful; {@code null} when a failure was reported
    */
   protected Bucket extract(ClientKeyBlock block, ClientContext context) {
     Bucket data;
@@ -137,7 +193,7 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
               (int) (Math.min(ctx.maxOutputLength, Integer.MAX_VALUE)),
               false);
     } catch (KeyDecodeException e1) {
-      if (LOG.isDebugEnabled()) LOG.debug("Decode failure: " + e1, e1);
+      if (LOG.isDebugEnabled()) LOG.debug("Decode failure: {}", e1, e1);
       onFailure(
           new FetchException(FetchExceptionMode.BLOCK_DECODE_ERROR, e1.getMessage()),
           false,
@@ -150,30 +206,40 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
       onFailure(new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE), false, context);
       return null;
     } catch (IOException e) {
-      LOG.error("Could not capture data - disk full?: " + e, e);
+      LOG.error("Could not capture data - disk full?: {}", e, e);
       onFailure(new FetchException(FetchExceptionMode.BUCKET_ERROR, e), false, context);
       return null;
     }
     return data;
   }
 
-  /** getToken() is not supported */
+  /**
+   * Returns the opaque token associated with this fetcher.
+   *
+   * <p>The value originates from the {@link Cfg} used at construction time and can be used by
+   * callers to correlate callbacks with external bookkeeping.
+   *
+   * @return the creator-supplied token value; no semantics are attached by this class
+   */
   @Override
   public long getToken() {
     return token;
   }
 
+  /** {@inheritDoc} */
   @Override
   public void cancel(ClientContext context) {
     super.cancel(context);
     rcb.onFailure(new FetchException(FetchExceptionMode.CANCELLED), this, context);
   }
 
+  /** {@inheritDoc} */
   @Override
   protected void notFoundInStore(ClientContext context) {
     this.onFailure(new FetchException(FetchExceptionMode.DATA_NOT_FOUND), true, context);
   }
 
+  /** {@inheritDoc} */
   @Override
   protected void onBlockDecodeError(SendableRequestItem token, ClientContext context) {
     onFailure(
@@ -185,13 +251,126 @@ public class SimpleSingleFileFetcher extends BaseSingleFileFetcher
         context);
   }
 
+  /** {@inheritDoc} */
   @Override
   public void onShutdown(ClientContext context) {
     // Do nothing.
   }
 
+  /** {@inheritDoc} */
   @Override
   protected ClientGetState getClientGetState() {
     return this;
+  }
+
+  /**
+   * Builder-style configuration used to construct a {@link SimpleSingleFileFetcher}.
+   *
+   * <p>The configuration collects all constructor inputs to avoid long parameter lists. Instances
+   * are created via {@link #create(ClientKey, int, FetchContext, ClientRequester,
+   * GetCompletionCallback, long, ClientContext)} and can be refined through fluent setters before
+   * being passed to the constructor.
+   */
+  public static final class Cfg {
+    final ClientKey key;
+    final int maxRetries;
+    final FetchContext ctx;
+    final ClientRequester parent;
+    final GetCompletionCallback rcb;
+    final long token;
+    final ClientContext context;
+    boolean isEssential;
+    boolean dontAdd;
+    boolean deleteFetchContext;
+    boolean realTimeFlag;
+
+    private Cfg(
+        ClientKey key,
+        int maxRetries,
+        FetchContext ctx,
+        ClientRequester parent,
+        GetCompletionCallback rcb,
+        long token,
+        ClientContext context) {
+      this.key = key;
+      this.maxRetries = maxRetries;
+      this.ctx = ctx;
+      this.parent = parent;
+      this.rcb = rcb;
+      this.token = token;
+      this.context = context;
+    }
+
+    /**
+     * Creates a configuration instance with the required parameters.
+     *
+     * @param key client key identifying the block to fetch; must not be {@code null}
+     * @param maxRetries maximum number of retry attempts; use {@code -1} for unlimited retries
+     * @param ctx fetch context carrying limits, cooldown policy, and preferences; must not be
+     *     {@code null}
+     * @param parent owning requester used for accounting and notifications; must not be {@code
+     *     null}
+     * @param rcb completion callback to receive results and progress; for persistent requests the
+     *     implementation must be {@link Serializable}
+     * @param token opaque token associated with this fetch; returned by {@link #getToken()}
+     * @param context client runtime context used for scheduling and factories; must not be {@code
+     *     null}
+     * @return a new configuration instance ready to be refined via fluent setters
+     */
+    public static Cfg create(
+        ClientKey key,
+        int maxRetries,
+        FetchContext ctx,
+        ClientRequester parent,
+        GetCompletionCallback rcb,
+        long token,
+        ClientContext context) {
+      return new Cfg(key, maxRetries, ctx, parent, rcb, token, context);
+    }
+
+    /**
+     * Marks the fetch as essential for the parent’s success accounting.
+     *
+     * @param value when {@code true}, the parent increments “must succeed” counters; otherwise a
+     *     regular block is added
+     * @return this configuration instance for chaining
+     */
+    public Cfg essential(boolean value) {
+      this.isEssential = value;
+      return this;
+    }
+
+    /**
+     * Controls whether the constructor updates the parent’s block counters and notifies clients.
+     *
+     * @param value when {@code true}, suppresses the add/notify side effects during construction
+     * @return this configuration instance for chaining
+     */
+    public Cfg dontAdd(boolean value) {
+      this.dontAdd = value;
+      return this;
+    }
+
+    /**
+     * Requests deletion of the associated fetch context after the request completes.
+     *
+     * @param value when {@code true}, the fetch context is deleted on terminal completion
+     * @return this configuration instance for chaining
+     */
+    public Cfg deleteFetchContext(boolean value) {
+      this.deleteFetchContext = value;
+      return this;
+    }
+
+    /**
+     * Sets whether the fetch should use the real-time scheduling lane.
+     *
+     * @param value {@code true} to use the real-time schedulers; {@code false} for the bulk lane
+     * @return this configuration instance for chaining
+     */
+    public Cfg realTime(boolean value) {
+      this.realTimeFlag = value;
+      return this;
+    }
   }
 }

--- a/src/main/java/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SingleFileFetcher.java
@@ -2153,7 +2153,8 @@ public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGe
 
     @Serial private static final long serialVersionUID = 1L;
     final ClientRequester parent;
-    final transient GetCompletionCallback cb;
+    // Must be serializable to preserve persistent USK fetch completion after restart
+    final GetCompletionCallback cb;
     final USK usk;
     private final List<String> metaStrings;
     final FetchContext ctx;

--- a/src/main/java/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SingleFileFetcher.java
@@ -154,17 +154,11 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
       boolean hasInitialMetadata)
       throws FetchException {
     super(
-        key,
-        maxRetries,
-        ctx,
-        parent,
-        cb,
-        isEssential,
-        false,
-        l,
-        context,
-        deleteFetchContext,
-        realTimeFlag);
+        SimpleSingleFileFetcher.Cfg.create(key, maxRetries, ctx, parent, cb, l, context)
+            .essential(isEssential)
+            .dontAdd(false)
+            .deleteFetchContext(deleteFetchContext)
+            .realTime(realTimeFlag));
     if (LOG.isDebugEnabled())
       LOG.debug(
           "Creating SingleFileFetcher for "
@@ -232,17 +226,18 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     // Don't add a block, we have already fetched the data, we are just handling the metadata in a
     // different fetcher.
     super(
-        persistent ? fetcher.key.cloneKey() : fetcher.key,
-        fetcher.maxRetries,
-        ctx2,
-        fetcher.parent,
-        callback,
-        false,
-        true,
-        fetcher.token,
-        context,
-        deleteFetchContext,
-        fetcher.realTimeFlag);
+        SimpleSingleFileFetcher.Cfg.create(
+                persistent ? fetcher.key.cloneKey() : fetcher.key,
+                fetcher.maxRetries,
+                ctx2,
+                fetcher.parent,
+                callback,
+                fetcher.token,
+                context)
+            .essential(false)
+            .dontAdd(true)
+            .deleteFetchContext(deleteFetchContext)
+            .realTime(fetcher.realTimeFlag));
     if (LOG.isDebugEnabled())
       LOG.debug(
           "Creating SingleFileFetcher for "
@@ -1535,17 +1530,11 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
         && key instanceof ClientKey clientKey
         && (!hasInitialMetadata))
       return new SimpleSingleFileFetcher(
-          clientKey,
-          maxRetries,
-          ctx,
-          requester,
-          cb,
-          isEssential,
-          false,
-          l,
-          context,
-          false,
-          realTimeFlag);
+          SimpleSingleFileFetcher.Cfg.create(clientKey, maxRetries, ctx, requester, cb, l, context)
+              .essential(isEssential)
+              .dontAdd(false)
+              .deleteFetchContext(false)
+              .realTime(realTimeFlag));
     if (key instanceof ClientKey || hasInitialMetadata)
       return new SingleFileFetcher(
           requester,

--- a/src/main/java/network/crypta/client/async/SingleFileFetcher.java
+++ b/src/main/java/network/crypta/client/async/SingleFileFetcher.java
@@ -10,6 +10,7 @@ import java.io.PipedOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -36,7 +37,12 @@ import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientKeyBlock;
 import network.crypta.keys.ClientSSK;
 import network.crypta.keys.FreenetURI;
+import network.crypta.keys.KeyDecodeException;
+import network.crypta.keys.TooBigException;
 import network.crypta.keys.USK;
+import network.crypta.node.LowLevelGetException;
+import network.crypta.node.SendableGet;
+import network.crypta.node.SendableRequestItem;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.compress.Compressor;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
@@ -47,26 +53,55 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Does most of the complicated metadata handling for fetching single files.
+ * Performs single-file fetches including redirects, manifests, splitfiles, and archive entries.
+ *
+ * <p>This state object drives the full life cycle of fetching a single logical file from the
+ * network. It decodes the first retrieved block, parses {@link Metadata}, follows any redirects or
+ * manifests, and transitions to other states (for example {@link SplitFileFetcher}) when the
+ * content is a splitfile. When the target is inside a container, it cooperates with an {@link
+ * ArchiveHandler} to read metadata or extract data. Callers typically construct a SingleFileFetcher
+ * from a {@link ClientGetter} or via {@link #create(ClientRequester, GetCompletionCallback,
+ * FreenetURI, FetchContext, ArchiveContext, CreationPolicy, CreationRuntime)} and then schedule it.
+ *
+ * <p>State and invariants: instances are created for one logical request; after a terminal callback
+ * (success or failure) the instance is considered finished. The object is not intended to be reused
+ * or shared across concurrent fetches. Some fields are persisted for long‑lived requests; changing
+ * non‑transient members of serializable classes can cause restarts of queued work.
+ *
+ * <p>Concurrency: callbacks can execute on worker threads, and archive extraction may use helper
+ * threads. The class coordinates transitions carefully, but callers should treat it as not
+ * thread‑safe beyond the documented callback contract.
+ *
+ * <ul>
+ *   <li>Parses and interprets metadata, including simple and archive manifests.
+ *   <li>Follows internal/external redirects and enforces path component limits.
+ *   <li>Builds a decompressor chain when the target is compressed.
+ *   <li>Streams large files through buckets to avoid excessive memory overhead.
+ * </ul>
  *
  * <p>WARNING: Changing non-transient members on classes that are Serializable can result in
  * restarting downloads or losing uploads.
  *
  * @author toad
+ * @see ClientGetter
+ * @see SplitFileFetcher
+ * @see ArchiveManager
+ * @see Metadata
+ * @see FetchResult
  */
-public class SingleFileFetcher extends SimpleSingleFileFetcher {
+public class SingleFileFetcher extends BaseSingleFileFetcher implements ClientGetState {
   private static final Logger LOG = LoggerFactory.getLogger(SingleFileFetcher.class);
+  private static final String LOG_META_LABEL = " meta=";
+  private static final String LOG_FOR_LABEL = " for ";
+  private static final String LOG_RETURNING_DATA = "Returning data";
 
   @Serial private static final long serialVersionUID = 1L;
-
-  static {
-  }
 
   /** Original URI */
   final FreenetURI uri;
 
   /** Meta-strings. (Path elements that aren't part of a key type) */
-  private final ArrayList<String> metaStrings;
+  private final List<String> metaStrings;
 
   /**
    * Number of metaStrings which were added by redirects etc. They are added to the start, so this
@@ -74,20 +109,52 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
    */
   private int addedMetaStrings;
 
+  /**
+   * Client-provided or derived metadata associated with the current fetch. Carries MIME type and
+   * other hints that are forwarded to callbacks and used for policy checks.
+   */
   final ClientMetadata clientMetadata;
+
+  /**
+   * Working metadata for the current step. May be a manifest, redirect, or splitfile descriptor
+   * depending on progress through the state machine.
+   */
   private Metadata metadata;
+
+  /**
+   * Metadata for the enclosing archive when the requested item lives inside a container. Populated
+   * when entering archive flows so subsequent steps can proceed without re-fetching.
+   */
   private Metadata archiveMetadata;
+
+  /**
+   * Archive processing context (loop detection, handler configuration) shared across archive steps
+   * in the current request.
+   */
   final ArchiveContext actx;
 
   /** Archive handler. We can only have one archive handler at a time. */
-  private ArchiveHandler ah;
+  private transient ArchiveHandler ah;
 
+  /**
+   * Guard against unbounded traversal through redirects/containers. Each transition increases the
+   * recursion level and failures occur once the configured maximum is exceeded.
+   */
   private final int recursionLevel;
 
   /** The URI of the currently-being-processed data, for archives etc. */
   private FreenetURI thisKey;
 
+  /**
+   * Stack of decompressors to apply to the eventual data stream. Elements are appended as metadata
+   * indicates compression layers and consumed when streaming to the client.
+   */
   private final LinkedList<COMPRESSOR_TYPE> decompressors;
+
+  /**
+   * When {@code true}, suppresses certain notifications to {@code ClientGet} during transitions to
+   * keep higher-level progress reporting stable.
+   */
   private final boolean dontTellClientGet;
 
   /**
@@ -96,37 +163,38 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
    */
   private final boolean isFinal;
 
-  private final SnoopMetadata metaSnoop;
-  private final SnoopBucket bucketSnoop;
+  private final transient SnoopMetadata metaSnoop;
+  private final transient SnoopBucket bucketSnoop;
 
   /**
    * Create a new SingleFileFetcher and register self. Called when following a redirect, or direct
-   * from ClientGet. FIXME: Many times where this is called internally we might be better off using
-   * a copy constructor?
+   * from ClientGet. Note: Many times when this is called internally we might be better off using a
+   * copy constructor?
    *
-   * @param parent The parent ClientRequester
-   * @param cb The completion callback
-   * @param metadata Client metadata for the fetch
-   * @param key The client key to fetch
-   * @param metaStrings List of metadata strings
-   * @param origURI The original URI
-   * @param addedMetaStrings Number of added metadata strings
-   * @param ctx The fetch context
-   * @param deleteFetchContext Whether to delete the fetch context
-   * @param realTimeFlag Whether this is a real-time fetch
-   * @param actx The archive context
-   * @param ah The archive handler
-   * @param archiveMetadata Archive metadata
-   * @param maxRetries Maximum number of retries
-   * @param recursionLevel Current recursion level
-   * @param dontTellClientGet Whether to tell the client getter
-   * @param l Length parameter
-   * @param isEssential Whether this fetch is essential
-   * @param isFinal Whether this is the final fetch
-   * @param topDontCompress Whether to avoid compression
-   * @param topCompatibilityMode The compatibility mode
-   * @param context The client context
-   * @param hasInitialMetadata Whether initial metadata is available
+   * @param parent the owning requester responsible for accounting and notifications
+   * @param cb completion callback receiving progress, success, and failure events
+   * @param metadata initial client metadata; {@code null} creates an empty instance
+   * @param key the starting key to fetch (CHK/SSK/USK-derived)
+   * @param metaStrings path-like metadata elements applied to the URI
+   * @param origURI the original URI used to report redirects and errors
+   * @param addedMetaStrings count of meta strings added due to redirects or processing
+   * @param ctx fetch context defining limits, policies, and allowed MIME types
+   * @param deleteFetchContext whether to delete the fetch context after completion
+   * @param realTimeFlag whether the request should use real‑time scheduling/latency trade‑offs
+   * @param actx archive context used when a container must be read or extracted
+   * @param ah existing archive handler, or {@code null} to create one when needed
+   * @param archiveMetadata pre-existing container metadata, {@code null} when not in a container
+   * @param maxRetries maximum number of retries before surfacing a fatal error
+   * @param recursionLevel current recursion depth used to detect cycles
+   * @param dontTellClientGet whether to suppress some ClientGet notifications during transitions
+   * @param l opaque token propagated to callbacks for request correlation
+   * @param isEssential whether this request contributes to must‑succeed block accounting
+   * @param isFinal whether this leg is final with respect to path component enforcement
+   * @param topDontCompress top-level splitfile compression preference propagated to the client
+   * @param topCompatibilityMode splitfile compatibility mode reported by a top block
+   * @param context client context used for notification side effects during construction
+   * @param hasInitialMetadata whether the caller already has initial metadata for {@code key}
+   * @throws FetchException if recursion limits are exceeded or policy checks fail during setup
    */
   public SingleFileFetcher(
       ClientRequester parent,
@@ -153,42 +221,39 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
       ClientContext context,
       boolean hasInitialMetadata)
       throws FetchException {
-    super(
-        SimpleSingleFileFetcher.Cfg.create(key, maxRetries, ctx, parent, cb, l, context)
-            .essential(isEssential)
-            .dontAdd(false)
-            .deleteFetchContext(deleteFetchContext)
-            .realTime(realTimeFlag));
+    super(key, maxRetries, ctx, parent, deleteFetchContext, realTimeFlag);
+    // Completion callback + token as used by SimpleSingleFileFetcher
+    this.rcb = cb;
+    this.token = l;
+    // Mirror SimpleSingleFileFetcher constructor side effects (dontAdd == false)
+    if (isEssential) parent.addMustSucceedBlocks(1);
+    else parent.addBlock();
+    parent.notifyClients(context);
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Creating SingleFileFetcher for "
-              + key
-              + " from "
-              + origURI
-              + " meta="
-              + metaStrings.toString()
-              + " persistent="
-              + persistent,
+          "Creating SingleFileFetcher"
+              + LOG_FOR_LABEL
+              + "{} from {}"
+              + LOG_META_LABEL
+              + "{} persistent={}",
+          key,
+          origURI,
+          metaStrings.toString(),
+          persistent,
           new Exception("debug"));
     this.isFinal = isFinal;
     this.cancelled = false;
     this.dontTellClientGet = dontTellClientGet;
-    if (persistent && ah != null) ah = ah.cloneHandler();
-    this.ah = ah;
+    // Archive handler
+    this.ah = selectArchiveHandler(ah);
     this.archiveMetadata = archiveMetadata;
-    // this.uri = uri;
-    // this.key = ClientKey.getBaseKey(uri);
-    // metaStrings = uri.listMetaStrings();
-    if (metaStrings instanceof ArrayList && !persistent)
-      this.metaStrings = (ArrayList<String>) metaStrings;
-    else
-      // Always copy if persistent
-      this.metaStrings = new ArrayList<>(metaStrings);
+
+    // Meta strings
+    this.metaStrings = prepareMetaStrings(metaStrings);
     this.addedMetaStrings = addedMetaStrings;
-    if (LOG.isDebugEnabled()) LOG.debug("Metadata: " + metadata);
+    if (LOG.isDebugEnabled()) LOG.debug("Metadata: {}", metadata);
     this.clientMetadata = (metadata != null ? metadata.clone() : new ClientMetadata());
-    if (hasInitialMetadata) thisKey = FreenetURI.EMPTY_CHK_URI;
-    else thisKey = key.getURI();
+    thisKey = hasInitialMetadata ? FreenetURI.EMPTY_CHK_URI : key.getURI();
     if (origURI == null) throw new NullPointerException();
     this.uri = persistent ? new FreenetURI(origURI) : origURI;
     this.actx = actx;
@@ -200,19 +265,175 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     this.decompressors = new LinkedList<>();
     this.topDontCompress = topDontCompress;
     this.topCompatibilityMode = topCompatibilityMode;
-    if (parent instanceof ClientGetter getter) {
-      metaSnoop = getter.getMetaSnoop();
-      bucketSnoop = getter.getBucketSnoop();
-    } else {
-      metaSnoop = null;
-      bucketSnoop = null;
+    metaSnoop = metaSnoopFrom(parent);
+    bucketSnoop = bucketSnoopFrom(parent);
+  }
+
+  private ArchiveHandler selectArchiveHandler(ArchiveHandler handler) {
+    return (persistent && handler != null) ? handler.cloneHandler() : handler;
+  }
+
+  private List<String> prepareMetaStrings(List<String> strings) {
+    // Always copy if persistent
+    return (strings instanceof ArrayList && !persistent) ? strings : new ArrayList<>(strings);
+  }
+
+  // this.uri is final and must be assigned in the constructor
+
+  private static SnoopMetadata metaSnoopFrom(ClientRequester parent) {
+    return (parent instanceof ClientGetter getter) ? getter.getMetaSnoop() : null;
+  }
+
+  private static SnoopBucket bucketSnoopFrom(ClientRequester parent) {
+    return (parent instanceof ClientGetter getter) ? getter.getBucketSnoop() : null;
+  }
+
+  private static FetchException wrapToFetchException(Exception e) {
+    if (e instanceof ArchiveFailureException afe) {
+      return new FetchException(afe);
     }
+    if (e instanceof ArchiveRestartException are) {
+      return new FetchException(are);
+    }
+    if (e instanceof MetadataParseException mpe) {
+      return new FetchException(mpe);
+    }
+    // Fallback: should not happen for declared multi-catch types
+    return new FetchException(FetchExceptionMode.INTERNAL_ERROR, e);
+  }
+
+  // Methods required after switching to BaseSingleFileFetcher
+  @Override
+  public void onFailure(
+      LowLevelGetException e, SendableRequestItem reqTokenIgnored, ClientContext context) {
+    onFailure(SendableGet.translateException(e), false, context);
   }
 
   /**
-   * Copy constructor, modifies a few given fields, don't call schedule(). Used for things like
-   * slave fetchers for MultiLevelMetadata, therefore does not remember returnBucket, metaStrings
-   * etc.
+   * Handle a failure from this state, deciding whether to retry or surface the error.
+   *
+   * <p>When {@code forceFatal} is {@code true} or the exception is inherently fatal, the request is
+   * finalized and the completion callback is notified. Otherwise, a retry is attempted subject to
+   * the configured policy. If the parent has already been cancelled, the error is converted to
+   * {@link FetchExceptionMode#CANCELLED} and treated as fatal.
+   *
+   * @param e the failure that occurred while processing this state
+   * @param forceFatal set to {@code true} to bypass retry and finalize immediately
+   * @param context client context for unregistering and scheduling follow‑up work
+   */
+  protected void onFailure(FetchException e, boolean forceFatal, ClientContext context) {
+    if (LOG.isDebugEnabled()) LOG.debug("onFailure( {} , {})", e, forceFatal, e);
+    if (parent.isCancelled() || cancelled) {
+      if (LOG.isDebugEnabled()) LOG.debug("Failing: cancelled");
+      e = new FetchException(FetchExceptionMode.CANCELLED);
+      forceFatal = true;
+    }
+    if (!(e.isFatal() || forceFatal) && retry(context)) {
+      if (LOG.isDebugEnabled()) LOG.debug("Retrying");
+      return;
+    }
+    unregisterAll(context);
+    synchronized (this) {
+      finished = true;
+    }
+    if (e.isFatal() || forceFatal) parent.fatallyFailedBlock(context);
+    else parent.failedBlock(context);
+    rcb.onFailure(e, this, context);
+  }
+
+  @Override
+  public long getToken() {
+    return token;
+  }
+
+  @Override
+  public void cancel(ClientContext context) {
+    super.cancel(context);
+    rcb.onFailure(new FetchException(FetchExceptionMode.CANCELLED), this, context);
+  }
+
+  @Override
+  protected void notFoundInStore(ClientContext context) {
+    this.onFailure(new FetchException(FetchExceptionMode.DATA_NOT_FOUND), true, context);
+  }
+
+  @Override
+  protected void onBlockDecodeError(SendableRequestItem token, ClientContext context) {
+    onFailure(
+        new FetchException(
+            FetchExceptionMode.BLOCK_DECODE_ERROR,
+            "Could not decode block with the URI given, probably invalid as inserted, possible the"
+                + " URI is wrong"),
+        true,
+        context);
+  }
+
+  @Override
+  public void onShutdown(ClientContext context) {
+    // Do nothing.
+  }
+
+  @Override
+  protected ClientGetState getClientGetState() {
+    return this;
+  }
+
+  /**
+   * Decode the provided client key block into a {@link Bucket} for downstream processing.
+   *
+   * <p>The returned bucket contains either plaintext data or metadata depending on the block type.
+   * If any decode or resource error occurs, this method reports the failure via {@link
+   * #onFailure(FetchException, boolean, ClientContext)} and returns {@code null}. Callers must free
+   * the bucket when no longer needed.
+   *
+   * @param block the decoded block from the network; must not be {@code null}
+   * @param context client context providing factories and disk limits; must not be {@code null}
+   * @return a newly allocated bucket with the decoded contents, or {@code null} on failure
+   */
+  protected Bucket extract(ClientKeyBlock block, ClientContext context) {
+    Bucket data;
+    try {
+      data =
+          block.decode(
+              context.getBucketFactory(parent.persistent()),
+              (int) (Math.min(ctx.maxOutputLength, Integer.MAX_VALUE)),
+              false);
+    } catch (KeyDecodeException e1) {
+      if (LOG.isDebugEnabled()) LOG.debug("Decode failure: {}", e1, e1);
+      onFailure(
+          new FetchException(FetchExceptionMode.BLOCK_DECODE_ERROR, e1.getMessage()),
+          false,
+          context);
+      return null;
+    } catch (TooBigException e) {
+      onFailure(new FetchException(FetchExceptionMode.TOO_BIG, e), false, context);
+      return null;
+    } catch (InsufficientDiskSpaceException e) {
+      onFailure(new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE), false, context);
+      return null;
+    } catch (IOException e) {
+      LOG.error("Could not capture data - disk full?: {}", e, e);
+      onFailure(new FetchException(FetchExceptionMode.BUCKET_ERROR, e), false, context);
+      return null;
+    }
+    return data;
+  }
+
+  /**
+   * Copy constructor for continuing processing with a different metadata focus. Do not call {@code
+   * schedule()} on the original instance after creating a copy.
+   *
+   * <p>This form is used for scenarios such as handling multi‑level metadata where the data has
+   * already been obtained but needs to be interpreted in a separate state object. The new fetcher
+   * intentionally does not duplicate transient state like path components.
+   *
+   * @param fetcher the original fetcher whose state seeds this instance; must not be {@code null}
+   * @param persistent whether this instance should persist across restarts like the parent
+   * @param deleteFetchContext whether to delete the fetch context after completion
+   * @param newMeta metadata to process as the starting point of this copy
+   * @param callback completion callback that receives results and failures
+   * @param ctx2 fetch context to use for resource limits and policy decisions
+   * @throws FetchException if recursion limits are exceeded or setup fails for policy reasons
    */
   public SingleFileFetcher(
       SingleFileFetcher fetcher,
@@ -220,30 +441,24 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
       boolean deleteFetchContext,
       Metadata newMeta,
       GetCompletionCallback callback,
-      FetchContext ctx2,
-      ClientContext context)
+      FetchContext ctx2)
       throws FetchException {
     // Don't add a block, we have already fetched the data, we are just handling the metadata in a
     // different fetcher.
     super(
-        SimpleSingleFileFetcher.Cfg.create(
-                persistent ? fetcher.key.cloneKey() : fetcher.key,
-                fetcher.maxRetries,
-                ctx2,
-                fetcher.parent,
-                callback,
-                fetcher.token,
-                context)
-            .essential(false)
-            .dontAdd(true)
-            .deleteFetchContext(deleteFetchContext)
-            .realTime(fetcher.realTimeFlag));
+        persistent ? fetcher.key.cloneKey() : fetcher.key,
+        fetcher.maxRetries,
+        ctx2,
+        fetcher.parent,
+        deleteFetchContext,
+        fetcher.realTimeFlag);
+    this.rcb = callback;
+    this.token = fetcher.token;
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Creating SingleFileFetcher for "
-              + fetcher.key
-              + " meta="
-              + fetcher.metaStrings.toString(),
+          "Creating SingleFileFetcher" + LOG_FOR_LABEL + "{}" + LOG_META_LABEL + "{}",
+          fetcher.key,
+          fetcher.metaStrings.toString(),
           new Exception("debug"));
     // We expect significant further processing in the parent
     this.isFinal = false;
@@ -273,6 +488,17 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     this.topCompatibilityMode = fetcher.topCompatibilityMode;
   }
 
+  // Completion callback + token (needed now that we don't extend SimpleSingleFileFetcher)
+  /** Completion callback used to surface success, failure, and progress to the requester. */
+  @SuppressWarnings("java:S1948")
+  final GetCompletionCallback rcb;
+
+  /**
+   * Opaque token supplied by the caller and echoed in callbacks so clients can correlate events
+   * with higher‑level requests or UI elements.
+   */
+  final long token;
+
   // Process the completed data. May result in us going to a
   // splitfile, or another SingleFileFetcher, etc.
   @Override
@@ -283,8 +509,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     // Extract data
 
     if (block == null) {
-      LOG.error(
-          "block is null! fromStore=" + fromStore + ", token=" + token, new Exception("error"));
+      LOG.error("block is null! fromStore={}, token={}", fromStore, token, new Exception("error"));
       return;
     }
     Bucket data = extract(block, context);
@@ -297,15 +522,12 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
       return;
     }
     if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Block " + (block.isMetadata() ? "is metadata" : "is not metadata") + " on " + this);
+      LOG.debug("Block {} on {}", (block.isMetadata() ? "is metadata" : "is not metadata"), this);
 
-    if (bucketSnoop != null) {
-      if (bucketSnoop.snoopBucket(data, block.isMetadata(), context)) {
-        cancel(context);
-        data.free();
-        return;
-      }
+    if (bucketSnoop != null && bucketSnoop.snoopBucket(data, block.isMetadata(), context)) {
+      cancel(context);
+      data.free();
+      return;
     }
 
     if (!block.isMetadata()) {
@@ -361,7 +583,16 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     }
   }
 
-  @Override
+  /**
+   * Finalize a successful fetch by enforcing policy and delivering the data to the callback.
+   *
+   * <p>This method validates path component rules and size limits, converts any violations into a
+   * {@link FetchException}, and otherwise streams the data to the requester. The underlying bucket
+   * is always closed by this method regardless of outcome to prevent resource leaks.
+   *
+   * @param result the completed result bundle containing client metadata and a data bucket
+   * @param context client context used for scheduling and follow‑up transitions
+   */
   protected void onSuccess(final FetchResult result, final ClientContext context) {
     synchronized (this) {
       // So a SingleKeyListener isn't created.
@@ -369,88 +600,145 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     }
     if (parent.isCancelled()) {
       if (LOG.isDebugEnabled()) LOG.debug("Parent is cancelled");
-      result.asBucket().free();
+      closeResultBucket(result);
       onFailure(new FetchException(FetchExceptionMode.CANCELLED), false, context);
       return;
     }
-    if ((!ctx.ignoreTooManyPathComponents) && (!metaStrings.isEmpty()) && isFinal) {
-      // Some meta-strings left
-      if (addedMetaStrings > 0) {
-        // Should this be an error?
-        // It would be useful to be able to fetch the data ...
-        // On the other hand such inserts could cause unpredictable results?
-        // Would be useful to make a redirect to the key we actually fetched.
-        rcb.onFailure(
-            new FetchException(
-                FetchExceptionMode.INVALID_METADATA,
-                "Invalid metadata: too many path components in redirects",
-                thisKey),
-            this,
-            context);
-      } else {
-        // TOO_MANY_PATH_COMPONENTS
-        // report to user
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Too many path components: for " + uri + " meta=" + metaStrings);
-        }
-        FreenetURI tryURI = uri;
-        tryURI = tryURI.dropLastMetaStrings(metaStrings.size());
-        rcb.onFailure(
-            new FetchException(
-                FetchExceptionMode.TOO_MANY_PATH_COMPONENTS,
-                result.size(),
-                (rcb == parent),
-                result.getMimeType(),
-                tryURI),
-            this,
-            context);
-      }
-      result.asBucket().free();
-    } else if (result.size() > ctx.maxOutputLength) {
+    if (isTooManyPathComponentsFinal()) {
+      handleTooManyPathComponentsResult(result, context);
+      closeResultBucket(result);
+      return;
+    }
+    if (isResultTooBig(result)) {
+      failTooBig(result, context);
+      closeResultBucket(result);
+      return;
+    }
+    copyToJobRunnerAndFree(result, context);
+  }
+
+  private boolean isTooManyPathComponentsFinal() {
+    return (!ctx.ignoreTooManyPathComponents) && (!metaStrings.isEmpty()) && isFinal;
+  }
+
+  private void handleTooManyPathComponentsResult(FetchResult result, ClientContext context) {
+    if (addedMetaStrings > 0) {
       rcb.onFailure(
           new FetchException(
-              FetchExceptionMode.TOO_BIG, result.size(), (rcb == parent), result.getMimeType()),
+              FetchExceptionMode.INVALID_METADATA,
+              "Invalid metadata: too many path components in redirects",
+              thisKey),
           this,
           context);
-      result.asBucket().free();
-    } else {
-      // Break locks, don't run filtering on FEC thread etc etc.
-      // Create a defensive copy of the bucket to prevent "Already freed" race condition
-      Bucket originalBucket = result.asBucket();
-      Bucket bucketCopy;
-      try {
-        bucketCopy = context.getBucketFactory(persistent()).makeBucket(originalBucket.size());
-        BucketTools.copy(originalBucket, bucketCopy);
-      } catch (IOException e) {
-        LOG.error("Failed to create defensive copy of bucket: " + e, e);
-        originalBucket.free();
-        rcb.onFailure(
-            new FetchException(FetchExceptionMode.BUCKET_ERROR, "Failed to copy bucket", e),
-            this,
-            context);
-        return;
-      }
+      return;
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "Too many path components:" + LOG_FOR_LABEL + "{}" + LOG_META_LABEL + "{}",
+          uri,
+          metaStrings);
+    }
+    FreenetURI tryURI = uri.dropLastMetaStrings(metaStrings.size());
+    rcb.onFailure(
+        new FetchException(
+            FetchExceptionMode.TOO_MANY_PATH_COMPONENTS,
+            result.size(),
+            (rcb == parent),
+            result.getMimeType(),
+            tryURI),
+        this,
+        context);
+  }
 
-      context
-          .getJobRunner(persistent())
-          .queueInternal(
-              context1 -> {
-                rcb.onSuccess(
-                    new SingleFileStreamGenerator(bucketCopy, persistent),
-                    result.getMetadata(),
-                    decompressors,
-                    SingleFileFetcher.this,
-                    context1);
-                return true;
-              });
+  private boolean isResultTooBig(FetchResult result) {
+    return result.size() > ctx.maxOutputLength;
+  }
 
-      // Free the original bucket now that we have a copy
+  private void failTooBig(FetchResult result, ClientContext context) {
+    rcb.onFailure(
+        new FetchException(
+            FetchExceptionMode.TOO_BIG, result.size(), (rcb == parent), result.getMimeType()),
+        this,
+        context);
+  }
+
+  private void copyToJobRunnerAndFree(FetchResult result, ClientContext context) {
+    // Break locks, don't run filtering on FEC thread etc.
+    // Create a defensive copy of the bucket to prevent "Already freed" race condition
+    Bucket originalBucket = result.asBucket();
+    Bucket bucketCopy;
+    try {
+      bucketCopy = context.getBucketFactory(persistent()).makeBucket(originalBucket.size());
+      BucketTools.copy(originalBucket, bucketCopy);
+    } catch (IOException e) {
+      LOG.error("Failed to create defensive copy of bucket: {}", e, e);
       originalBucket.free();
+      rcb.onFailure(
+          new FetchException(FetchExceptionMode.BUCKET_ERROR, "Failed to copy bucket", e),
+          this,
+          context);
+      return;
+    }
+
+    context
+        .getJobRunner(persistent())
+        .queueInternal(
+            context1 -> {
+              rcb.onSuccess(
+                  new SingleFileStreamGenerator(bucketCopy, persistent),
+                  result.getMetadata(),
+                  decompressors,
+                  SingleFileFetcher.this,
+                  context1);
+              return true;
+            });
+
+    // Free the original bucket now that we have a copy
+    originalBucket.free();
+  }
+
+  private void closeResultBucket(FetchResult result) {
+    try (Bucket b = result.asBucket()) {
+      if (LOG.isDebugEnabled()) LOG.debug("Discarding result bucket {}", b.getName());
+      // Explicitly free to satisfy tests that verify free() is invoked on the bucket
+      b.free();
     }
   }
 
-  private boolean topDontCompress = false;
-  private short topCompatibilityMode = 0;
+  private ClientGetWorkerThread makeAndStartWorker(
+      InputStream input, OutputStream output, ClientContext context) {
+    try {
+      ClientGetWorkerThread worker =
+          new ClientGetWorkerThread(
+              new BufferedInputStream(input),
+              output,
+              null,
+              null,
+              ctx.getSchemeHostAndPort(),
+              null,
+              false,
+              null,
+              null,
+              null,
+              context.linkFilterExceptionProvider);
+      worker.start();
+      return worker;
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /**
+   * Whether the top layer of a splitfile should avoid compression when reassembled. Propagated to
+   * the client when the top block provides this hint.
+   */
+  private boolean topDontCompress;
+
+  /**
+   * Compatibility mode derived from the top block, used to negotiate splitfile decoding details
+   * between writer and reader.
+   */
+  private short topCompatibilityMode;
 
   /**
    * Handle the current metadata. I.e. do something with it: transition to a splitfile, look up a
@@ -460,10 +748,12 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
    * stuff to happen on other objects, eventually ClientRequestScheduler gets locked -> deadlock.
    * This is irrelevant for persistent requests however, as they are single thread.
    *
-   * @throws FetchException
-   * @throws MetadataParseException
-   * @throws ArchiveFailureException
-   * @throws ArchiveRestartException
+   * @throws FetchException if policy or size checks fail, resources are insufficient, or decoding
+   *     and I/O produce a non‑recoverable fetch error during planning.
+   * @throws MetadataParseException if metadata bytes cannot be parsed into a valid structure.
+   * @throws ArchiveFailureException if container access or extraction fails with a permanent,
+   *     non‑retryable error.
+   * @throws ArchiveRestartException if container processing requires a restart before continuing.
    */
   private synchronized void handleMetadata(final ClientContext context)
       throws FetchException,
@@ -479,612 +769,138 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
       finished = true;
     }
     while (true) {
-      if (metaSnoop != null) {
-        if (metaSnoop.snoopMetadata(metadata, context)) {
-          cancel(context);
+      if (snoopAndMaybeCancel(context)) return;
+      handleTopDataAndHashesIfNoMetaStrings(context);
+      StepDecision step = processNextMetadataStep(context);
+      switch (step) {
+        case RETURN -> {
           return;
         }
-      }
-      if (metaStrings.isEmpty()) {
-        if (metadata.hasTopData()) {
-          if ((metadata.topSize > ctx.maxOutputLength)
-              || (metadata.topCompressedSize > ctx.maxTempLength)) {
-            // Just in case...
-            if (metadata.isSimpleRedirect() || metadata.isSplitfile())
-              clientMetadata.mergeNoOverwrite(
-                  metadata.getClientMetadata()); // even splitfiles can have mime types!
-            throw new FetchException(
-                FetchExceptionMode.TOO_BIG, metadata.topSize, true, clientMetadata.getMIMEType());
-          }
-          rcb.onExpectedTopSize(
-              metadata.topSize,
-              metadata.topCompressedSize,
-              metadata.topBlocksRequired,
-              metadata.topBlocksTotal,
-              context);
-          topCompatibilityMode = metadata.getTopCompatibilityCode();
-          topDontCompress = metadata.getTopDontCompress();
+        case CONTINUE -> {
+          // no-op, continue loop
         }
-        HashResult[] hashes = metadata.getHashes();
-        if (hashes != null) {
-          rcb.onHashes(hashes, context);
+        case UNKNOWN -> {
+          LOG.error("Don't know what to do with metadata: {}", metadata);
+          throw new FetchException(FetchExceptionMode.UNKNOWN_METADATA);
         }
-      }
-      if (metadata.isSimpleManifest()) {
-        if (LOG.isDebugEnabled()) LOG.debug("Is simple manifest");
-        String name;
-        if (metadata.countDocuments() == 1
-            && metadata.getDocument("") != null
-            && metadata.getDocument("").isSimpleManifest()) {
-          LOG.error("Manifest is called \"\" for {}", this);
-          name = "";
-        } else if (metaStrings.isEmpty()) {
-          FreenetURI u = uri;
-          String last = u.lastMetaString();
-          if (last == null || !last.isEmpty()) u = u.addMetaStrings(new String[] {""});
-          else u = null;
-          throw new FetchException(
-              FetchExceptionMode.NOT_ENOUGH_PATH_COMPONENTS, -1, false, null, u);
-        } else name = removeMetaString();
-        // Since metadata is a document, we just replace metadata here
-        if (LOG.isDebugEnabled())
-          LOG.debug("Next meta-string: " + name + " length " + name.length() + " for " + this);
-        if (name == null) {
-          if (!persistent) {
-            metadata = metadata.getDefaultDocument();
-          } else {
-            metadata = metadata.grabDefaultDocument();
-          }
-          if (metadata == null)
-            throw new FetchException(
-                FetchExceptionMode.NOT_ENOUGH_PATH_COMPONENTS,
-                -1,
-                false,
-                null,
-                uri.addMetaStrings(new String[] {""}));
-        } else {
-          if (!persistent) {
-            Metadata origMd = metadata;
-            metadata = origMd.getDocument(name);
-            if (metadata != null && metadata.isSymbolicShortlink()) {
-              String oldName = name;
-              name = metadata.getSymbolicShortlinkTargetName();
-              if (oldName.equals(name))
-                throw new FetchException(
-                    FetchExceptionMode.INVALID_METADATA, "redirect loop: " + name);
-              metadata = origMd.getDocument(name);
-            }
-            thisKey = thisKey.pushMetaString(name);
-          } else {
-            Metadata newMeta = metadata.grabDocument(name);
-            if (newMeta != null && newMeta.isSymbolicShortlink()) {
-              String oldName = name;
-              name = newMeta.getSymbolicShortlinkTargetName();
-              if (oldName.equals(name))
-                throw new FetchException(
-                    FetchExceptionMode.INVALID_METADATA, "redirect loop: " + name);
-              newMeta = metadata.getDocument(name);
-            }
-            metadata = newMeta;
-            thisKey = thisKey.pushMetaString(name);
-          }
-          if (metadata == null)
-            throw new FetchException(FetchExceptionMode.NOT_IN_ARCHIVE, "can't find " + name);
-        }
-        // loop
-      } else if (metadata.isArchiveManifest()) {
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "Is archive manifest (type="
-                  + metadata.getArchiveType()
-                  + " codec="
-                  + metadata.getCompressionCodec()
-                  + ')');
-        if (metaStrings.isEmpty() && ctx.returnZIPManifests) {
-          // Just return the archive, whole.
-          metadata.setSimpleRedirect();
-          continue;
-        }
-        // First we need the archive metadata.
-        // Then parse it. Then we may need to fetch something from inside the archive.
-        // It's more efficient to keep the existing ah if we can, and it is vital in
-        // the case of binary blobs.
-        if (ah == null || !ah.getKey().equals(thisKey)) {
-          // Do loop detection on the archive that we are about to fetch.
-          actx.doLoopDetection(thisKey);
-          ah =
-              context.archiveManager.makeHandler(
-                  thisKey,
-                  metadata.getArchiveType(),
-                  metadata.getCompressionCodec(),
-                  (parent instanceof ClientGetter cg && cg.collectingBinaryBlob()),
-                  persistent);
-        }
-        archiveMetadata = metadata;
-        metadata = null; // Copied to archiveMetadata, so do not need to clear it
-        // ah is set. This means we are currently handling an archive.
-        Bucket metadataBucket;
-        metadataBucket = ah.getMetadata(actx, context.archiveManager);
-        if (metadataBucket != null) {
-          try {
-            metadata = Metadata.construct(metadataBucket);
-            metadataBucket.free();
-          } catch (InsufficientDiskSpaceException e) {
-            throw new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE);
-          } catch (IOException e) {
-            // Bucket error?
-            throw new FetchException(FetchExceptionMode.BUCKET_ERROR, e);
-          }
-        } else {
-          final boolean persistent = this.persistent;
-          fetchArchive(
-              false,
-              archiveMetadata,
-              ArchiveManager.METADATA_NAME,
-              new ArchiveExtractCallback() {
-                @Serial private static final long serialVersionUID = 1L;
-
-                @Override
-                public void gotBucket(Bucket data, ClientContext context) {
-                  if (LOG.isDebugEnabled())
-                    LOG.debug(
-                        "gotBucket on " + SingleFileFetcher.this + " persistent=" + persistent);
-                  try {
-                    metadata = Metadata.construct(data);
-                    innerWrapHandleMetadata(true, context);
-                  } catch (MetadataParseException e) {
-                    // Invalid metadata
-                    onFailure(
-                        new FetchException(FetchExceptionMode.INVALID_METADATA, e), false, context);
-                  } catch (IOException e) {
-                    // Bucket error?
-                    onFailure(
-                        new FetchException(FetchExceptionMode.BUCKET_ERROR, e), false, context);
-                  } finally {
-                    data.free();
-                  }
-                }
-
-                @Override
-                public void notInArchive(ClientContext context) {
-                  onFailure(
-                      new FetchException(
-                          FetchExceptionMode.INTERNAL_ERROR,
-                          "No metadata in container! Cannot happen as ArchiveManager should"
-                              + " synthesise some!"),
-                      false,
-                      context);
-                }
-
-                @Override
-                public void onFailed(ArchiveRestartException e, ClientContext context) {
-                  SingleFileFetcher.this.onFailure(new FetchException(e), false, context);
-                }
-
-                @Override
-                public void onFailed(ArchiveFailureException e, ClientContext context) {
-                  SingleFileFetcher.this.onFailure(new FetchException(e), false, context);
-                }
-              },
-              context); // will result in this function being called again
-          return;
-        }
-        metadataBucket.free();
-      } else if (metadata.isArchiveMetadataRedirect()) {
-        if (LOG.isDebugEnabled()) LOG.debug("Is archive-metadata");
-        // Fetch it from the archive
-        if (ah == null)
-          throw new FetchException(
-              FetchExceptionMode.UNKNOWN_METADATA, "Archive redirect not in an archive manifest");
-        String filename = metadata.getArchiveInternalName();
-        if (LOG.isDebugEnabled()) LOG.debug("Fetching " + filename);
-        Bucket dataBucket = ah.get(filename, actx, context.archiveManager);
-        if (dataBucket != null) {
-          if (LOG.isDebugEnabled()) LOG.debug("Returning data");
-          final Metadata newMetadata;
-          try {
-
-            newMetadata = Metadata.construct(dataBucket);
-            dataBucket.free();
-          } catch (InsufficientDiskSpaceException e) {
-            throw new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE);
-          } catch (IOException e) {
-            throw new FetchException(FetchExceptionMode.BUCKET_ERROR);
-          }
-          synchronized (this) {
-            metadata = newMetadata;
-          }
-        } else {
-          if (LOG.isDebugEnabled()) LOG.debug("Fetching archive (thisKey=" + thisKey + ')');
-          // Metadata cannot contain pointers to files which don't exist.
-          // We enforce this in ArchiveHandler.
-          // Therefore, the archive needs to be fetched.
-          fetchArchive(
-              true,
-              archiveMetadata,
-              filename,
-              new ArchiveExtractCallback() {
-                @Serial private static final long serialVersionUID = 1L;
-
-                @Override
-                public void gotBucket(Bucket data, ClientContext context) {
-                  if (LOG.isDebugEnabled()) LOG.debug("Returning data");
-                  final Metadata newMetadata;
-                  try {
-                    newMetadata = Metadata.construct(data);
-                    synchronized (SingleFileFetcher.this) {
-                      metadata = newMetadata;
-                    }
-                    innerWrapHandleMetadata(true, context);
-                  } catch (IOException e) {
-                    onFailure(new FetchException(FetchExceptionMode.BUCKET_ERROR), false, context);
-                  } catch (MetadataParseException e) {
-                    onFailure(
-                        new FetchException(FetchExceptionMode.INVALID_METADATA), false, context);
-                  } finally {
-                    data.free();
-                  }
-                }
-
-                @Override
-                public void notInArchive(ClientContext context) {
-                  onFailure(new FetchException(FetchExceptionMode.NOT_IN_ARCHIVE), false, context);
-                }
-
-                @Override
-                public void onFailed(ArchiveRestartException e, ClientContext context) {
-                  SingleFileFetcher.this.onFailure(new FetchException(e), false, context);
-                }
-
-                @Override
-                public void onFailed(ArchiveFailureException e, ClientContext context) {
-                  SingleFileFetcher.this.onFailure(new FetchException(e), false, context);
-                }
-              },
-              context);
-          // Will call back into this function when it has been fetched.
-          return;
-        }
-      } else if (metadata.isArchiveInternalRedirect()) {
-        if (LOG.isDebugEnabled()) LOG.debug("Is archive-internal redirect");
-        clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
-        String mime = clientMetadata.getMIMEType();
-        if (mime != null) rcb.onExpectedMIME(clientMetadata, context);
-        if (metaStrings.isEmpty()
-            && isFinal
-            && clientMetadata.getMIMETypeNoParams() != null
-            && ctx.allowedMIMETypes != null
-            && !ctx.allowedMIMETypes.contains(clientMetadata.getMIMETypeNoParams())) {
-          throw new FetchException(
-              FetchExceptionMode.WRONG_MIME_TYPE, -1, false, clientMetadata.getMIMEType());
-        }
-        // Fetch it from the archive
-        if (ah == null)
-          throw new FetchException(
-              FetchExceptionMode.UNKNOWN_METADATA, "Archive redirect not in an archive manifest");
-        String filename = metadata.getArchiveInternalName();
-        if (LOG.isDebugEnabled()) LOG.debug("Fetching " + filename);
-        Bucket dataBucket = ah.get(filename, actx, context.archiveManager);
-        if (dataBucket != null) {
-          if (LOG.isDebugEnabled()) LOG.debug("Returning data");
-          final Bucket out;
-          try {
-            // Data will not be freed until client is finished with it.
-            if (persistent) {
-              out = context.persistentBucketFactory.makeBucket(dataBucket.size());
-              BucketTools.copy(dataBucket, out);
-              dataBucket.free();
-            } else {
-              out = dataBucket;
-            }
-          } catch (InsufficientDiskSpaceException e) {
-            throw new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE);
-          } catch (IOException e) {
-            throw new FetchException(FetchExceptionMode.BUCKET_ERROR);
-          }
-          // Return the data
-          onSuccess(new FetchResult(clientMetadata, out), context);
-
-          return;
-        } else {
-          if (LOG.isDebugEnabled()) LOG.debug("Fetching archive (thisKey=" + thisKey + ')');
-          // Metadata cannot contain pointers to files which don't exist.
-          // We enforce this in ArchiveHandler.
-          // Therefore, the archive needs to be fetched.
-          fetchArchive(
-              true,
-              archiveMetadata,
-              filename,
-              new ArchiveExtractCallback() {
-                @Serial private static final long serialVersionUID = 1L;
-
-                @Override
-                public void gotBucket(Bucket data, ClientContext context) {
-                  if (LOG.isDebugEnabled()) LOG.debug("Returning data");
-                  // Because this will be processed immediately, and because the callback uses a
-                  // StreamGenerator,
-                  // we can simply pass in the output bucket, even if it is not persistent.
-                  // If we ever change it so a StreamGenerator can be saved, we'll have to copy
-                  // here.
-                  // Transient buckets should throw if attempted to store.
-                  onSuccess(new FetchResult(clientMetadata, data), context);
-                }
-
-                @Override
-                public void notInArchive(ClientContext context) {
-                  onFailure(new FetchException(FetchExceptionMode.NOT_IN_ARCHIVE), false, context);
-                }
-
-                @Override
-                public void onFailed(ArchiveRestartException e, ClientContext context) {
-                  SingleFileFetcher.this.onFailure(new FetchException(e), false, context);
-                }
-
-                @Override
-                public void onFailed(ArchiveFailureException e, ClientContext context) {
-                  SingleFileFetcher.this.onFailure(new FetchException(e), false, context);
-                }
-              },
-              context);
-          // Will call back into this function when it has been fetched.
-          return;
-        }
-      } else if (metadata.isMultiLevelMetadata()) {
-        if (LOG.isDebugEnabled()) LOG.debug("Is multi-level metadata");
-        // Fetch on a second SingleFileFetcher, like with archives.
-        metadata.setSimpleRedirect();
-        final SingleFileFetcher f =
-            new SingleFileFetcher(
-                this, persistent, false, metadata, new MultiLevelMetadataCallback(), ctx, context);
-        // Clear our own metadata so it can be garbage collected, it will be replaced by whatever is
-        // fetched.
-        // The new fetcher has our metadata so we don't need to removeMetadata().
-        this.metadata = null;
-        // We must transition to the sub-fetcher so that if the request is cancelled, it will get
-        // deleted.
-        parent.onTransition(this, f, context);
-
-        // Break locks. Must not call onFailure(), etc, from within SFF lock.
-        context
-            .getJobRunner(persistent)
-            .queueInternal(
-                context1 -> {
-                  f.innerWrapHandleMetadata(true, context1);
-                  return true;
-                });
-        return;
-      } else if (metadata.isSingleFileRedirect()) {
-        if (LOG.isDebugEnabled()) LOG.debug("Is single-file redirect");
-        clientMetadata.mergeNoOverwrite(
-            metadata.getClientMetadata()); // even splitfiles can have mime types!
-        if (clientMetadata != null && !clientMetadata.isTrivial()) {
-          rcb.onExpectedMIME(clientMetadata, context);
-          if (LOG.isDebugEnabled()) LOG.debug("MIME type is " + clientMetadata);
-        }
-
-        String mimeType = clientMetadata.getMIMETypeNoParams();
-        if (mimeType != null
-            && ArchiveManager.ARCHIVE_TYPE.isUsableArchiveType(mimeType)
-            && !metaStrings.isEmpty()) {
-          // Looks like an implicit archive, handle as such
-          metadata.setArchiveManifest();
-          // Pick up MIME type from inside archive
-          clientMetadata.clear();
-          if (LOG.isDebugEnabled()) LOG.debug("Handling implicit container... (redirect)");
-          continue;
-        }
-
-        if (metaStrings.isEmpty()
-            && isFinal
-            && mimeType != null
-            && ctx.allowedMIMETypes != null
-            && !ctx.allowedMIMETypes.contains(mimeType)) {
-          throw new FetchException(
-              FetchExceptionMode.WRONG_MIME_TYPE, -1, false, clientMetadata.getMIMEType());
-        }
-
-        // Simple redirect
-        // Just create a new SingleFileFetcher
-        // Which will then fetch the target URI, and call the rcd.success
-        // Hopefully!
-        FreenetURI newURI = metadata.getSingleTarget();
-        if (LOG.isDebugEnabled()) LOG.debug("Redirecting to " + newURI);
-        ClientKey redirectedKey;
-        try {
-          BaseClientKey k = BaseClientKey.getBaseKey(newURI);
-          if (k instanceof ClientKey clientKey) redirectedKey = clientKey;
-          else
-            // FIXME do we want to allow redirects to USKs?
-            // Without redirects to USKs, all SSK and CHKs are static.
-            // This may be a desirable property.
-            throw new FetchException(FetchExceptionMode.UNKNOWN_METADATA, "Redirect to a USK");
-        } catch (MalformedURLException e) {
-          throw new FetchException(FetchExceptionMode.INVALID_URI, e);
-        }
-        List<String> newMetaStrings = newURI.listMetaStrings();
-
-        // Move any new meta strings to beginning of our list of remaining meta strings
-        while (!newMetaStrings.isEmpty()) {
-          String o = newMetaStrings.removeLast();
-          metaStrings.addFirst(o);
-          addedMetaStrings++;
-        }
-
-        final SingleFileFetcher f =
-            new SingleFileFetcher(
-                parent,
-                rcb,
-                clientMetadata,
-                redirectedKey,
-                metaStrings,
-                this.uri,
-                addedMetaStrings,
-                ctx,
-                deleteFetchContext,
-                realTimeFlag,
-                actx,
-                ah,
-                archiveMetadata,
-                maxRetries,
-                recursionLevel,
-                false,
-                token,
-                true,
-                isFinal,
-                topDontCompress,
-                topCompatibilityMode,
-                context,
-                false);
-        this.deleteFetchContext = false;
-        if ((redirectedKey instanceof ClientCHK hK1) && !hK1.isMetadata()) {
-          rcb.onBlockSetFinished(this, context);
-          byte[] redirectedCryptoKey = hK1.getCryptoKey();
-          if (key instanceof ClientCHK hK && !Arrays.equals(hK.getCryptoKey(), redirectedCryptoKey))
-            redirectedCryptoKey = null;
-          // not splitfile, synthesize CompatibilityMode event
-          rcb.onSplitfileCompatibilityMode(
-              metadata.getMinCompatMode(),
-              metadata.getMaxCompatMode(),
-              redirectedCryptoKey,
-              !hK1.isCompressed(),
-              true,
-              true,
-              context);
-        }
-        if (metadata.isCompressed()) {
-          COMPRESSOR_TYPE codec = metadata.getCompressionCodec();
-          f.addDecompressor(codec);
-        }
-        parent.onTransition(this, f, context);
-        f.schedule(context);
-        // All done! No longer our problem!
-        archiveMetadata = null; // passed on
-        return;
-      } else if (metadata.isSplitfile()) {
-        if (LOG.isDebugEnabled()) LOG.debug("Fetching splitfile");
-
-        clientMetadata.mergeNoOverwrite(
-            metadata.getClientMetadata()); // even splitfiles can have mime types!
-
-        String mimeType = clientMetadata.getMIMETypeNoParams();
-        if (mimeType != null
-            && ArchiveManager.ARCHIVE_TYPE.isUsableArchiveType(mimeType)
-            && !metaStrings.isEmpty()) {
-          // Looks like an implicit archive, handle as such
-          metadata.setArchiveManifest();
-          // Pick up MIME type from inside archive
-          clientMetadata.clear();
-          if (LOG.isDebugEnabled()) LOG.debug("Handling implicit container... (splitfile)");
-          continue;
-        } else {
-          if (clientMetadata != null && !clientMetadata.isTrivial())
-            rcb.onExpectedMIME(clientMetadata, context);
-        }
-
-        if (metaStrings.isEmpty()
-            && isFinal
-            && mimeType != null
-            && ctx.allowedMIMETypes != null
-            && !ctx.allowedMIMETypes.contains(mimeType)) {
-          // Just in case...
-          long len = metadata.uncompressedDataLength();
-          throw new FetchException(
-              FetchExceptionMode.WRONG_MIME_TYPE, len, false, clientMetadata.getMIMEType());
-        }
-
-        // Splitfile (possibly compressed)
-
-        if (metadata.isCompressed()) {
-          COMPRESSOR_TYPE codec = metadata.getCompressionCodec();
-          addDecompressor(codec);
-        }
-
-        if (isFinal && !ctx.ignoreTooManyPathComponents) {
-          if (!metaStrings.isEmpty()) {
-            // Some meta-strings left
-            if (addedMetaStrings > 0) {
-              // Should this be an error?
-              // It would be useful to be able to fetch the data ...
-              // On the other hand such inserts could cause unpredictable results?
-              // Would be useful to make a redirect to the key we actually fetched.
-              rcb.onFailure(
-                  new FetchException(
-                      FetchExceptionMode.INVALID_METADATA,
-                      "Invalid metadata: too many path components in redirects",
-                      thisKey),
-                  this,
-                  context);
-            } else {
-              // TOO_MANY_PATH_COMPONENTS
-              // report to user
-              FreenetURI tryURI = uri;
-              tryURI = tryURI.dropLastMetaStrings(metaStrings.size());
-              rcb.onFailure(
-                  new FetchException(
-                      FetchExceptionMode.TOO_MANY_PATH_COMPONENTS,
-                      metadata.uncompressedDataLength(),
-                      (rcb == parent),
-                      clientMetadata.getMIMEType(),
-                      tryURI),
-                  this,
-                  context);
-            }
-            // Just in case...
-            return;
-          }
-        } else if (LOG.isDebugEnabled()) LOG.debug("Not finished: rcb=" + rcb + " for " + this);
-
-        final long len = metadata.dataLength();
-        final long uncompressedLen =
-            metadata.isCompressed() ? metadata.uncompressedDataLength() : len;
-
-        if ((uncompressedLen > ctx.maxOutputLength) || (len > ctx.maxTempLength)) {
-          // Just in case...
-          boolean compressed = metadata.isCompressed();
-          throw new FetchException(
-              FetchExceptionMode.TOO_BIG,
-              uncompressedLen,
-              isFinal && decompressors.size() <= (compressed ? 1 : 0),
-              clientMetadata.getMIMEType());
-        }
-
-        ClientGetState sf;
-        boolean reallyFinal = isFinal;
-        if (isFinal && !parent.isCurrentState(this)) {
-          LOG.error("isFinal but not the current state for {}", this);
-          reallyFinal = false;
-        }
-        sf =
-            new SplitFileFetcher(
-                metadata,
-                rcb,
-                parent,
-                ctx,
-                realTimeFlag,
-                decompressors,
-                clientMetadata,
-                token,
-                topDontCompress,
-                topCompatibilityMode,
-                persistent,
-                thisKey,
-                reallyFinal,
-                context);
-        this.deleteFetchContext = false;
-        parent.onTransition(this, sf, context);
-        sf.schedule(context);
-        rcb.onBlockSetFinished(this, context);
-        // Clear our own metadata, we won't need it any more.
-        // Note that SplitFileFetcher() above will have used the keys from the metadata,
-        // and will have removed them from it so they don't get removed here.
-        // Lack of garbage collection in db4o is a PITA!
-        // For multi-level metadata etc see above.
-        return;
-      } else {
-        LOG.error("Don't know what to do with metadata: " + metadata);
-        throw new FetchException(FetchExceptionMode.UNKNOWN_METADATA);
       }
     }
+  }
+
+  private boolean snoopAndMaybeCancel(ClientContext context) {
+    if (metaSnoop != null && metaSnoop.snoopMetadata(metadata, context)) {
+      cancel(context);
+      return true;
+    }
+    return false;
+  }
+
+  private void handleTopDataAndHashesIfNoMetaStrings(ClientContext context) throws FetchException {
+    if (!metaStrings.isEmpty()) return;
+    if (metadata.hasTopData()) {
+      if ((metadata.topSize > ctx.maxOutputLength)
+          || (metadata.topCompressedSize > ctx.maxTempLength)) {
+        if (metadata.isSimpleRedirect() || metadata.isSplitfile())
+          clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
+        throw new FetchException(
+            FetchExceptionMode.TOO_BIG, metadata.topSize, true, clientMetadata.getMIMEType());
+      }
+      rcb.onExpectedTopSize(
+          metadata.topSize,
+          metadata.topCompressedSize,
+          metadata.topBlocksRequired,
+          metadata.topBlocksTotal,
+          context);
+      topCompatibilityMode = metadata.getTopCompatibilityCode();
+      topDontCompress = metadata.getTopDontCompress();
+    }
+    HashResult[] hashes = metadata.getHashes();
+    if (hashes != null) {
+      rcb.onHashes(hashes, context);
+    }
+  }
+
+  // Metadata kinds to dispatch on
+  private enum MetaKind {
+    SIMPLE_MANIFEST,
+    ARCHIVE_MANIFEST,
+    ARCHIVE_METADATA_REDIRECT,
+    ARCHIVE_INTERNAL_REDIRECT,
+    MULTI_LEVEL_METADATA,
+    SINGLE_FILE_REDIRECT,
+    SPLITFILE,
+    UNKNOWN
+  }
+
+  private MetaKind detectMetaKind() {
+    if (metadata.isSimpleManifest()) return MetaKind.SIMPLE_MANIFEST;
+    if (metadata.isArchiveManifest()) return MetaKind.ARCHIVE_MANIFEST;
+    if (metadata.isArchiveMetadataRedirect()) return MetaKind.ARCHIVE_METADATA_REDIRECT;
+    if (metadata.isArchiveInternalRedirect()) return MetaKind.ARCHIVE_INTERNAL_REDIRECT;
+    if (metadata.isMultiLevelMetadata()) return MetaKind.MULTI_LEVEL_METADATA;
+    if (metadata.isSingleFileRedirect()) return MetaKind.SINGLE_FILE_REDIRECT;
+    if (metadata.isSplitfile()) return MetaKind.SPLITFILE;
+    return MetaKind.UNKNOWN;
+  }
+
+  private enum StepDecision {
+    CONTINUE,
+    RETURN,
+    UNKNOWN
+  }
+
+  // Decide the next action: CONTINUE, RETURN, or UNKNOWN
+  private StepDecision processNextMetadataStep(final ClientContext context)
+      throws FetchException,
+          MetadataParseException,
+          ArchiveFailureException,
+          ArchiveRestartException {
+    MetaKind kind = detectMetaKind();
+    if (kind == MetaKind.UNKNOWN) return StepDecision.UNKNOWN;
+    if (isArchiveKind(kind)) return handleArchiveKind(kind, context);
+    return handleOtherKind(kind, context);
+  }
+
+  private boolean isArchiveKind(MetaKind kind) {
+    return kind == MetaKind.ARCHIVE_MANIFEST
+        || kind == MetaKind.ARCHIVE_METADATA_REDIRECT
+        || kind == MetaKind.ARCHIVE_INTERNAL_REDIRECT;
+  }
+
+  private StepDecision handleArchiveKind(MetaKind kind, ClientContext context)
+      throws FetchException,
+          MetadataParseException,
+          ArchiveFailureException,
+          ArchiveRestartException {
+    return switch (kind) {
+      case ARCHIVE_MANIFEST ->
+          processArchiveManifestStep(context) ? StepDecision.RETURN : StepDecision.CONTINUE;
+      case ARCHIVE_METADATA_REDIRECT ->
+          processArchiveMetadataRedirectStep(context) ? StepDecision.RETURN : StepDecision.CONTINUE;
+      case ARCHIVE_INTERNAL_REDIRECT -> {
+        processArchiveInternalRedirectStep(context);
+        yield StepDecision.RETURN;
+      }
+      default -> StepDecision.UNKNOWN;
+    };
+  }
+
+  private StepDecision handleOtherKind(MetaKind kind, ClientContext context)
+      throws FetchException, MetadataParseException {
+    return switch (kind) {
+      case SIMPLE_MANIFEST -> {
+        processSimpleManifestStep();
+        yield StepDecision.CONTINUE;
+      }
+      case MULTI_LEVEL_METADATA -> {
+        processMultiLevelMetadataStep(context);
+        yield StepDecision.RETURN;
+      }
+      case SINGLE_FILE_REDIRECT ->
+          processSingleFileRedirectStep(context) ? StepDecision.RETURN : StepDecision.CONTINUE;
+      case SPLITFILE -> processSplitfileStep(context) ? StepDecision.RETURN : StepDecision.CONTINUE;
+      default -> StepDecision.UNKNOWN;
+    };
   }
 
   private String removeMetaString() {
@@ -1098,16 +914,587 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     decompressors.add(codec);
   }
 
+  // Returns true if this method should return to caller; false to continue outer loop
+  private boolean processArchiveManifestStep(final ClientContext context)
+      throws FetchException,
+          ArchiveFailureException,
+          ArchiveRestartException,
+          MetadataParseException {
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "Is archive manifest (type={} codec={})",
+          metadata.getArchiveType(),
+          metadata.getCompressionCodec());
+    if (metaStrings.isEmpty() && ctx.returnZIPManifests) {
+      metadata.setSimpleRedirect();
+      return false; // continue outer loop
+    }
+    ensureArchiveHandler(context);
+    archiveMetadata = metadata;
+    metadata = null;
+    Bucket metadataBucket = ah.getMetadata(actx, context.archiveManager);
+    return handleArchiveManifestBucketOrSchedule(metadataBucket, context);
+  }
+
+  private void ensureArchiveHandler(ClientContext context) throws ArchiveFailureException {
+    if (ah == null || !ah.getKey().equals(thisKey)) {
+      actx.doLoopDetection(thisKey);
+      ah =
+          context.archiveManager.makeHandler(
+              thisKey,
+              metadata.getArchiveType(),
+              metadata.getCompressionCodec(),
+              (parent instanceof ClientGetter cg && cg.collectingBinaryBlob()),
+              persistent);
+    }
+  }
+
+  private boolean handleArchiveManifestBucketOrSchedule(
+      Bucket metadataBucket, ClientContext context) throws FetchException, MetadataParseException {
+    if (metadataBucket != null) {
+      try {
+        metadata = Metadata.construct(metadataBucket);
+      } catch (InsufficientDiskSpaceException e) {
+        throw new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE);
+      } catch (IOException e) {
+        throw new FetchException(FetchExceptionMode.BUCKET_ERROR, e);
+      } finally {
+        metadataBucket.free();
+      }
+      return false;
+    }
+    final boolean persistentLocal = this.persistent;
+    fetchArchive(
+        false,
+        archiveMetadata,
+        ArchiveManager.METADATA_NAME,
+        new ArchiveExtractCallback() {
+          @Serial private static final long serialVersionUID = 1L;
+
+          @Override
+          public void gotBucket(Bucket data, ClientContext ctx1) {
+            if (LOG.isDebugEnabled())
+              LOG.debug("gotBucket on {} persistent={}", SingleFileFetcher.this, persistentLocal);
+            try {
+              metadata = Metadata.construct(data);
+              innerWrapHandleMetadata(true, ctx1);
+            } catch (MetadataParseException e) {
+              onFailure(new FetchException(FetchExceptionMode.INVALID_METADATA, e), false, ctx1);
+            } catch (IOException e) {
+              onFailure(new FetchException(FetchExceptionMode.BUCKET_ERROR, e), false, ctx1);
+            } finally {
+              data.free();
+            }
+          }
+
+          @Override
+          public void notInArchive(ClientContext ctx1) {
+            onFailure(
+                new FetchException(
+                    FetchExceptionMode.INTERNAL_ERROR,
+                    "No metadata in container! Cannot happen as ArchiveManager should synthesise"
+                        + " some!"),
+                false,
+                ctx1);
+          }
+
+          @Override
+          public void onFailed(ArchiveRestartException e, ClientContext ctx1) {
+            SingleFileFetcher.this.onFailure(new FetchException(e), false, ctx1);
+          }
+
+          @Override
+          public void onFailed(ArchiveFailureException e, ClientContext ctx1) {
+            SingleFileFetcher.this.onFailure(new FetchException(e), false, ctx1);
+          }
+        },
+        context);
+    return true;
+  }
+
+  private boolean processArchiveMetadataRedirectStep(final ClientContext context)
+      throws FetchException {
+    if (LOG.isDebugEnabled()) LOG.debug("Is archive-metadata");
+    if (ah == null)
+      throw new FetchException(
+          FetchExceptionMode.UNKNOWN_METADATA, "Archive redirect not in an archive manifest");
+    String filename = metadata.getArchiveInternalName();
+    if (LOG.isDebugEnabled()) LOG.debug("Fetching {}", filename);
+    Bucket dataBucket;
+    try {
+      dataBucket = ah.get(filename, actx, context.archiveManager);
+    } catch (ArchiveFailureException | ArchiveRestartException | MetadataParseException e) {
+      throw wrapToFetchException(e);
+    }
+    if (dataBucket != null) {
+      handleArchiveMetadataBucket(dataBucket);
+      return false;
+    }
+    scheduleFetchArchiveForMetadata(filename, context);
+    return true;
+  }
+
+  private void handleArchiveMetadataBucket(Bucket dataBucket) throws FetchException {
+    if (LOG.isDebugEnabled()) LOG.debug(LOG_RETURNING_DATA);
+    try {
+      Metadata newMetadata = Metadata.construct(dataBucket);
+      synchronized (this) {
+        metadata = newMetadata;
+      }
+    } catch (InsufficientDiskSpaceException e) {
+      throw new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE);
+    } catch (MetadataParseException e) {
+      throw new FetchException(FetchExceptionMode.INVALID_METADATA, e);
+    } catch (IOException e) {
+      throw new FetchException(FetchExceptionMode.BUCKET_ERROR);
+    } finally {
+      dataBucket.free();
+    }
+  }
+
+  private void scheduleFetchArchiveForMetadata(String filename, final ClientContext context)
+      throws FetchException {
+    if (LOG.isDebugEnabled()) LOG.debug("Fetching archive (thisKey={})", thisKey);
+    fetchArchive(
+        true,
+        archiveMetadata,
+        filename,
+        new ArchiveExtractCallback() {
+          @Serial private static final long serialVersionUID = 1L;
+
+          @Override
+          public void gotBucket(Bucket data, ClientContext ctx1) {
+            if (LOG.isDebugEnabled()) LOG.debug(LOG_RETURNING_DATA);
+            try {
+              Metadata newMetadata = Metadata.construct(data);
+              synchronized (SingleFileFetcher.this) {
+                metadata = newMetadata;
+              }
+              innerWrapHandleMetadata(true, ctx1);
+            } catch (IOException e) {
+              onFailure(new FetchException(FetchExceptionMode.BUCKET_ERROR), false, ctx1);
+            } catch (MetadataParseException e) {
+              onFailure(new FetchException(FetchExceptionMode.INVALID_METADATA), false, ctx1);
+            } finally {
+              data.free();
+            }
+          }
+
+          @Override
+          public void notInArchive(ClientContext ctx1) {
+            onFailure(new FetchException(FetchExceptionMode.NOT_IN_ARCHIVE), false, ctx1);
+          }
+
+          @Override
+          public void onFailed(ArchiveRestartException e, ClientContext ctx1) {
+            SingleFileFetcher.this.onFailure(new FetchException(e), false, ctx1);
+          }
+
+          @Override
+          public void onFailed(ArchiveFailureException e, ClientContext ctx1) {
+            SingleFileFetcher.this.onFailure(new FetchException(e), false, ctx1);
+          }
+        },
+        context);
+  }
+
+  private void processArchiveInternalRedirectStep(final ClientContext context)
+      throws FetchException {
+    if (LOG.isDebugEnabled()) LOG.debug("Is archive-internal redirect");
+    clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
+    String mime = clientMetadata.getMIMEType();
+    if (mime != null) rcb.onExpectedMIME(clientMetadata, context);
+    validateAllowedMimeForArchiveInternal();
+    if (ah == null)
+      throw new FetchException(
+          FetchExceptionMode.UNKNOWN_METADATA, "Archive redirect not in an archive manifest");
+    String filename = metadata.getArchiveInternalName();
+    if (LOG.isDebugEnabled()) LOG.debug("Fetching {}", filename);
+    Bucket dataBucket;
+    try {
+      dataBucket = ah.get(filename, actx, context.archiveManager);
+    } catch (ArchiveFailureException | ArchiveRestartException | MetadataParseException e) {
+      throw wrapToFetchException(e);
+    }
+    if (dataBucket != null) {
+      if (LOG.isDebugEnabled()) LOG.debug(LOG_RETURNING_DATA);
+      final Bucket out = copyOrAdoptBucketForReturn(dataBucket, context);
+      onSuccess(new FetchResult(clientMetadata, out), context);
+      return; // returned data, method should return
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("Fetching archive (thisKey={})", thisKey);
+    fetchArchive(
+        true,
+        archiveMetadata,
+        filename,
+        new ArchiveExtractCallback() {
+          @Serial private static final long serialVersionUID = 1L;
+
+          @Override
+          public void gotBucket(Bucket data, ClientContext ctx1) {
+            if (LOG.isDebugEnabled()) LOG.debug(LOG_RETURNING_DATA);
+            onSuccess(new FetchResult(clientMetadata, data), ctx1);
+          }
+
+          @Override
+          public void notInArchive(ClientContext ctx1) {
+            onFailure(new FetchException(FetchExceptionMode.NOT_IN_ARCHIVE), false, ctx1);
+          }
+
+          @Override
+          public void onFailed(ArchiveRestartException e, ClientContext ctx1) {
+            SingleFileFetcher.this.onFailure(new FetchException(e), false, ctx1);
+          }
+
+          @Override
+          public void onFailed(ArchiveFailureException e, ClientContext ctx1) {
+            SingleFileFetcher.this.onFailure(new FetchException(e), false, ctx1);
+          }
+        },
+        context);
+    // scheduled
+  }
+
+  private void validateAllowedMimeForArchiveInternal() throws FetchException {
+    if (metaStrings.isEmpty()
+        && isFinal
+        && clientMetadata.getMIMETypeNoParams() != null
+        && ctx.allowedMIMETypes != null
+        && !ctx.allowedMIMETypes.contains(clientMetadata.getMIMETypeNoParams())) {
+      throw new FetchException(
+          FetchExceptionMode.WRONG_MIME_TYPE, -1, false, clientMetadata.getMIMEType());
+    }
+  }
+
+  private Bucket copyOrAdoptBucketForReturn(Bucket dataBucket, ClientContext context)
+      throws FetchException {
+    try {
+      if (persistent) {
+        Bucket out = context.persistentBucketFactory.makeBucket(dataBucket.size());
+        BucketTools.copy(dataBucket, out);
+        dataBucket.free();
+        return out;
+      } else {
+        return dataBucket;
+      }
+    } catch (InsufficientDiskSpaceException e) {
+      throw new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE);
+    } catch (IOException e) {
+      throw new FetchException(FetchExceptionMode.BUCKET_ERROR);
+    }
+  }
+
+  private void processMultiLevelMetadataStep(final ClientContext context) throws FetchException {
+    if (LOG.isDebugEnabled()) LOG.debug("Is multi-level metadata");
+    metadata.setSimpleRedirect();
+    final SingleFileFetcher f =
+        new SingleFileFetcher(
+            this, persistent, false, metadata, new MultiLevelMetadataCallback(), ctx);
+    this.metadata = null;
+    parent.onTransition(this, f, context);
+    context
+        .getJobRunner(persistent)
+        .queueInternal(
+            context1 -> {
+              f.innerWrapHandleMetadata(true, context1);
+              return true;
+            });
+    // continue outer loop
+  }
+
+  private boolean processSingleFileRedirectStep(final ClientContext context) throws FetchException {
+    if (LOG.isDebugEnabled()) LOG.debug("Is single-file redirect");
+    clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
+    emitExpectedMimeIfPresent(context);
+    String mimeType = clientMetadata.getMIMETypeNoParams();
+    if (mimeType != null
+        && ArchiveManager.ARCHIVE_TYPE.isUsableArchiveType(mimeType)
+        && !metaStrings.isEmpty()) {
+      metadata.setArchiveManifest();
+      clientMetadata.clear();
+      if (LOG.isDebugEnabled()) LOG.debug("Handling implicit container... (redirect)");
+      return false; // continue loop
+    }
+    validateAllowedMimeForSingleRedirect(mimeType);
+    FreenetURI newURI = metadata.getSingleTarget();
+    if (LOG.isDebugEnabled()) LOG.debug("Redirecting to {}", newURI);
+    ClientKey redirectedKey = resolveRedirectedKey(newURI);
+    addNewMetaStringsFrom(newURI);
+    final SingleFileFetcher f =
+        new SingleFileFetcher(
+            parent,
+            rcb,
+            clientMetadata,
+            redirectedKey,
+            metaStrings,
+            this.uri,
+            addedMetaStrings,
+            ctx,
+            deleteFetchContext,
+            realTimeFlag,
+            actx,
+            ah,
+            archiveMetadata,
+            maxRetries,
+            recursionLevel,
+            false,
+            token,
+            true,
+            isFinal,
+            topDontCompress,
+            topCompatibilityMode,
+            context,
+            false);
+    this.deleteFetchContext = false;
+    if ((redirectedKey instanceof ClientCHK hK1) && !hK1.isMetadata()) {
+      rcb.onBlockSetFinished(this, context);
+      byte[] redirectedCryptoKey = hK1.getCryptoKey();
+      if (key instanceof ClientCHK hK && !Arrays.equals(hK.getCryptoKey(), redirectedCryptoKey))
+        redirectedCryptoKey = null;
+      rcb.onSplitfileCompatibilityMode(
+          metadata.getMinCompatMode(),
+          metadata.getMaxCompatMode(),
+          redirectedCryptoKey,
+          !hK1.isCompressed(),
+          true,
+          true,
+          context);
+    }
+    if (metadata.isCompressed()) {
+      COMPRESSOR_TYPE codec = metadata.getCompressionCodec();
+      f.addDecompressor(codec);
+    }
+    parent.onTransition(this, f, context);
+    f.schedule(context);
+    archiveMetadata = null;
+    return true;
+  }
+
+  private void emitExpectedMimeIfPresent(ClientContext context) throws FetchException {
+    if (clientMetadata != null && !clientMetadata.isTrivial()) {
+      rcb.onExpectedMIME(clientMetadata, context);
+      if (LOG.isDebugEnabled()) LOG.debug("MIME type is {}", clientMetadata);
+    }
+  }
+
+  private void validateAllowedMimeForSingleRedirect(String mimeType) throws FetchException {
+    if (metaStrings.isEmpty()
+        && isFinal
+        && mimeType != null
+        && ctx.allowedMIMETypes != null
+        && !ctx.allowedMIMETypes.contains(mimeType)) {
+      throw new FetchException(
+          FetchExceptionMode.WRONG_MIME_TYPE, -1, false, clientMetadata.getMIMEType());
+    }
+  }
+
+  private ClientKey resolveRedirectedKey(FreenetURI newURI) throws FetchException {
+    try {
+      BaseClientKey k = BaseClientKey.getBaseKey(newURI);
+      if (k instanceof ClientKey clientKey) return clientKey;
+      throw new FetchException(FetchExceptionMode.UNKNOWN_METADATA, "Redirect to a USK");
+    } catch (MalformedURLException e) {
+      throw new FetchException(FetchExceptionMode.INVALID_URI, e);
+    }
+  }
+
+  private void addNewMetaStringsFrom(FreenetURI newURI) {
+    List<String> newMetaStrings = newURI.listMetaStrings();
+    while (!newMetaStrings.isEmpty()) {
+      String o = newMetaStrings.removeLast();
+      metaStrings.addFirst(o);
+      addedMetaStrings++;
+    }
+  }
+
+  private boolean processSplitfileStep(final ClientContext context)
+      throws FetchException, MetadataParseException {
+    if (LOG.isDebugEnabled()) LOG.debug("Fetching splitfile");
+    clientMetadata.mergeNoOverwrite(metadata.getClientMetadata());
+    String mimeType = clientMetadata.getMIMETypeNoParams();
+    if (mimeType != null
+        && ArchiveManager.ARCHIVE_TYPE.isUsableArchiveType(mimeType)
+        && !metaStrings.isEmpty()) {
+      metadata.setArchiveManifest();
+      clientMetadata.clear();
+      if (LOG.isDebugEnabled()) LOG.debug("Handling implicit container... (splitfile)");
+      return false; // continue loop
+    } else {
+      emitExpectedMimeIfPresent(context);
+    }
+    validateAllowedMimeForSplitfile(mimeType);
+    applyDecompressorIfCompressed();
+    if (handleTooManyPathComponentsIfNeeded(context)) return true;
+    final long len = metadata.dataLength();
+    final long uncompressedLen = metadata.isCompressed() ? metadata.uncompressedDataLength() : len;
+    if ((uncompressedLen > ctx.maxOutputLength) || (len > ctx.maxTempLength)) {
+      boolean compressed = metadata.isCompressed();
+      throw new FetchException(
+          FetchExceptionMode.TOO_BIG,
+          uncompressedLen,
+          isFinal && decompressors.size() <= (compressed ? 1 : 0),
+          clientMetadata.getMIMEType());
+    }
+    boolean reallyFinal = isFinal;
+    if (isFinal && !parent.isCurrentState(this)) {
+      LOG.error("isFinal but not the current state for {}", this);
+      reallyFinal = false;
+    }
+    ClientGetState sf =
+        new SplitFileFetcher(
+            metadata,
+            rcb,
+            parent,
+            ctx,
+            realTimeFlag,
+            decompressors,
+            clientMetadata,
+            token,
+            topDontCompress,
+            topCompatibilityMode,
+            persistent,
+            thisKey,
+            reallyFinal,
+            context);
+    this.deleteFetchContext = false;
+    parent.onTransition(this, sf, context);
+    sf.schedule(context);
+    rcb.onBlockSetFinished(this, context);
+    return true;
+  }
+
+  private void applyDecompressorIfCompressed() {
+    if (metadata.isCompressed()) {
+      COMPRESSOR_TYPE codec = metadata.getCompressionCodec();
+      addDecompressor(codec);
+    }
+  }
+
+  private void validateAllowedMimeForSplitfile(String mimeType) throws FetchException {
+    if (metaStrings.isEmpty()
+        && isFinal
+        && mimeType != null
+        && ctx.allowedMIMETypes != null
+        && !ctx.allowedMIMETypes.contains(mimeType)) {
+      long len = metadata.uncompressedDataLength();
+      throw new FetchException(
+          FetchExceptionMode.WRONG_MIME_TYPE, len, false, clientMetadata.getMIMEType());
+    }
+  }
+
+  private boolean handleTooManyPathComponentsIfNeeded(ClientContext context) {
+    if (isFinal && !ctx.ignoreTooManyPathComponents) {
+      if (!metaStrings.isEmpty()) {
+        if (addedMetaStrings > 0) {
+          rcb.onFailure(
+              new FetchException(
+                  FetchExceptionMode.INVALID_METADATA,
+                  "Invalid metadata: too many path components in redirects",
+                  thisKey),
+              this,
+              context);
+        } else {
+          FreenetURI tryURI = uri.dropLastMetaStrings(metaStrings.size());
+          rcb.onFailure(
+              new FetchException(
+                  FetchExceptionMode.TOO_MANY_PATH_COMPONENTS,
+                  metadata.uncompressedDataLength(),
+                  (rcb == parent),
+                  clientMetadata.getMIMEType(),
+                  tryURI),
+              this,
+              context);
+        }
+        return true;
+      }
+    } else if (LOG.isDebugEnabled()) {
+      LOG.debug("Not finished: rcb={}" + LOG_FOR_LABEL + "{}", rcb, this);
+    }
+    return false;
+  }
+
+  // Extracted from handleMetadata() to reduce complexity.
+  // Returns true to indicate the outer loop should continue.
+  private void processSimpleManifestStep() throws FetchException {
+    if (LOG.isDebugEnabled()) LOG.debug("Is simple manifest");
+    String name = resolveManifestName();
+    if (LOG.isDebugEnabled())
+      LOG.debug("Next meta-string: {} length {}" + LOG_FOR_LABEL + "{}", name, name.length(), this);
+    if (name == null) {
+      selectDefaultManifestDocument();
+    } else {
+      selectManifestDocumentByName(name);
+    }
+    // continue outer loop
+  }
+
+  private String resolveManifestName() throws FetchException {
+    if (metadata.countDocuments() == 1
+        && metadata.getDocument("") != null
+        && metadata.getDocument("").isSimpleManifest()) {
+      LOG.error("Manifest is called \"\" for {}", this);
+      return "";
+    } else if (metaStrings.isEmpty()) {
+      FreenetURI u = uri;
+      String last = u.lastMetaString();
+      if (last == null || !last.isEmpty()) u = u.addMetaStrings(new String[] {""});
+      else u = null;
+      throw new FetchException(FetchExceptionMode.NOT_ENOUGH_PATH_COMPONENTS, -1, false, null, u);
+    } else {
+      return removeMetaString();
+    }
+  }
+
+  private void selectDefaultManifestDocument() throws FetchException {
+    if (!persistent) {
+      metadata = metadata.getDefaultDocument();
+    } else {
+      metadata = metadata.grabDefaultDocument();
+    }
+    if (metadata == null)
+      throw new FetchException(
+          FetchExceptionMode.NOT_ENOUGH_PATH_COMPONENTS,
+          -1,
+          false,
+          null,
+          uri.addMetaStrings(new String[] {""}));
+  }
+
+  private void selectManifestDocumentByName(String name) throws FetchException {
+    if (!persistent) {
+      Metadata origMd = metadata;
+      metadata = origMd.getDocument(name);
+      if (metadata != null && metadata.isSymbolicShortlink()) {
+        String oldName = name;
+        name = metadata.getSymbolicShortlinkTargetName();
+        if (oldName.equals(name))
+          throw new FetchException(FetchExceptionMode.INVALID_METADATA, "redirect loop: " + name);
+        metadata = origMd.getDocument(name);
+      }
+      thisKey = thisKey.pushMetaString(name);
+    } else {
+      Metadata newMeta = metadata.grabDocument(name);
+      if (newMeta != null && newMeta.isSymbolicShortlink()) {
+        String oldName = name;
+        name = newMeta.getSymbolicShortlinkTargetName();
+        if (oldName.equals(name))
+          throw new FetchException(FetchExceptionMode.INVALID_METADATA, "redirect loop: " + name);
+        newMeta = metadata.getDocument(name);
+      }
+      metadata = newMeta;
+      thisKey = thisKey.pushMetaString(name);
+    }
+    if (metadata == null)
+      throw new FetchException(FetchExceptionMode.NOT_IN_ARCHIVE, "can't find " + name);
+  }
+
   private void fetchArchive(
       boolean forData,
       Metadata meta,
       String element,
       ArchiveExtractCallback callback,
       final ClientContext context)
-      throws FetchException,
-          MetadataParseException,
-          ArchiveFailureException,
-          ArchiveRestartException {
+      throws FetchException {
     if (LOG.isDebugEnabled()) LOG.debug("fetchArchive()");
     // Fetch the archive
     // How?
@@ -1118,7 +1505,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     Metadata newMeta = (Metadata) meta.clone();
     newMeta.setSimpleRedirect();
     final SingleFileFetcher f;
-    // FIXME arguable archive data is "temporary", but
+    // Note: arguably archive data is "temporary", but
     // this will use ctx.maxOutputLength
     f =
         new SingleFileFetcher(
@@ -1127,9 +1514,8 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
             true,
             newMeta,
             new ArchiveFetcherCallback(forData, element, callback),
-            new FetchContext(ctx, FetchContext.SET_RETURN_ARCHIVES, true, null),
-            context);
-    if (LOG.isDebugEnabled()) LOG.debug("fetchArchive(): " + f);
+            new FetchContext(ctx, FetchContext.SET_RETURN_ARCHIVES, true, null));
+    if (LOG.isDebugEnabled()) LOG.debug("fetchArchive(): {}", f);
     // Fetch the archive. The archive fetcher callback will unpack it, and either call the element
     // callback, or just go back around handleMetadata() on this, which will see that the data is
     // now
@@ -1150,6 +1536,17 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
   }
 
   // LOCKING: If transient, DO NOT call this method from within handleMetadata.
+  /**
+   * Invoke {@link #handleMetadata(ClientContext)} and convert errors into {@link FetchException}
+   * callbacks.
+   *
+   * <p>When {@code notFinalizedSize} is {@code true}, any sizes previously reported to the client
+   * are marked as provisional to avoid over‑committing. Archive and parsing failures are wrapped
+   * and forwarded to the completion callback.
+   *
+   * @param notFinalizedSize set to {@code true} to mark reported sizes as provisional
+   * @param context the client context used by nested operations and callbacks
+   */
   protected void innerWrapHandleMetadata(boolean notFinalizedSize, ClientContext context) {
     try {
       handleMetadata(context);
@@ -1158,10 +1555,8 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     } catch (FetchException e) {
       if (notFinalizedSize) e.setNotFinalizedSize();
       onFailure(e, false, context);
-    } catch (ArchiveFailureException e) {
-      onFailure(new FetchException(e), false, context);
-    } catch (ArchiveRestartException e) {
-      onFailure(new FetchException(e), false, context);
+    } catch (ArchiveFailureException | ArchiveRestartException e) {
+      onFailure(wrapToFetchException(e), false, context);
     }
   }
 
@@ -1173,7 +1568,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     private final ArchiveExtractCallback callback;
 
     /**
-     * For activation we need to know whether we are persistent even though the parent may not have
+     * For activation, we need to know whether we are persistent even though the parent may not have
      * been activated yet
      */
     private final boolean persistent;
@@ -1197,8 +1592,8 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
         List<? extends Compressor> decompressors,
         ClientGetState state,
         ClientContext context) {
-      Bucket data = null;
-      // FIXME not strictly correct and unnecessary - archive size already checked against
+      Bucket data;
+      // Note: not strictly correct and unnecessary - archive size already checked against
       // ctx.max*Length inside SingleFileFetcher
       long maxLen = Math.min(ctx.maxTempLength, ctx.maxOutputLength);
       try {
@@ -1213,20 +1608,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
             DecompressorThreadManager decompressorManager =
                 new DecompressorThreadManager(pipeIn, decompressors, maxLen);
             try (PipedInputStream newPipeIn = decompressorManager.execute()) {
-              ClientGetWorkerThread worker =
-                  new ClientGetWorkerThread(
-                      new BufferedInputStream(newPipeIn),
-                      output,
-                      null,
-                      null,
-                      ctx.getSchemeHostAndPort(),
-                      null,
-                      false,
-                      null,
-                      null,
-                      null,
-                      context.linkFilterExceptionProvider);
-              worker.start();
+              ClientGetWorkerThread worker = makeAndStartWorker(newPipeIn, output, context);
               streamGenerator.writeTo(pipeOut, context);
               decompressorManager.waitFinished();
               worker.waitFinished();
@@ -1236,7 +1618,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
           }
         }
       } catch (Throwable t) {
-        LOG.error("Caught " + t, t);
+        LOG.error("Caught {}", t, t);
         onFailure(new FetchException(FetchExceptionMode.INTERNAL_ERROR, t), state, context);
         return;
       }
@@ -1252,48 +1634,56 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     }
 
     private void innerSuccess(Bucket data, ClientContext context) {
+      boolean ok = true;
       try {
-        if (hashes != null) {
-          try (InputStream is = data.getInputStream();
-              MultiHashInputStream hasher =
-                  new MultiHashInputStream(is, HashResult.makeBitmask(hashes))) {
-
-            byte[] buf = new byte[32768];
-            while (hasher.read(buf) > 0)
-              ;
-            HashResult[] results = hasher.getResults();
-            if (!HashResult.strictEquals(results, hashes)) {
-              onFailure(
-                  new FetchException(FetchExceptionMode.CONTENT_HASH_FAILED),
-                  SingleFileFetcher.this,
-                  context);
-              return;
-            }
-          } catch (InsufficientDiskSpaceException e) {
-            onFailure(
-                new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE),
-                SingleFileFetcher.this,
-                context);
-          } catch (IOException e) {
-            onFailure(
-                new FetchException(FetchExceptionMode.BUCKET_ERROR, e),
-                SingleFileFetcher.this,
-                context);
-            return;
-          }
+        if (hashes != null) ok = verifyHashes(data, context);
+        if (ok) {
+          ah.extractToCache(data, actx, element, callback, context.archiveManager, context);
         }
-        ah.extractToCache(data, actx, element, callback, context.archiveManager, context);
-      } catch (ArchiveFailureException e) {
-        SingleFileFetcher.this.onFailure(new FetchException(e), false, context);
-        return;
-      } catch (ArchiveRestartException e) {
-        SingleFileFetcher.this.onFailure(new FetchException(e), false, context);
-        return;
+      } catch (ArchiveFailureException | ArchiveRestartException e) {
+        SingleFileFetcher.this.onFailure(wrapToFetchException(e), false, context);
+        ok = false;
       } finally {
         data.free();
       }
+      if (!ok) {
+        return;
+      }
       if (callback != null) return;
       innerWrapHandleMetadata(true, context);
+    }
+
+    private boolean verifyHashes(Bucket data, ClientContext context) {
+      try (InputStream is = data.getInputStream();
+          MultiHashInputStream hasher =
+              new MultiHashInputStream(is, HashResult.makeBitmask(hashes))) {
+        byte[] buf = new byte[32768];
+        int read;
+        do {
+          read = hasher.read(buf);
+        } while (read > 0);
+        HashResult[] results = hasher.getResults();
+        if (!HashResult.strictEquals(results, hashes)) {
+          onFailure(
+              new FetchException(FetchExceptionMode.CONTENT_HASH_FAILED),
+              SingleFileFetcher.this,
+              context);
+          return false;
+        }
+        return true;
+      } catch (InsufficientDiskSpaceException e) {
+        onFailure(
+            new FetchException(FetchExceptionMode.NOT_ENOUGH_DISK_SPACE),
+            SingleFileFetcher.this,
+            context);
+        return false;
+      } catch (IOException e) {
+        onFailure(
+            new FetchException(FetchExceptionMode.BUCKET_ERROR, e),
+            SingleFileFetcher.this,
+            context);
+        return false;
+      }
     }
 
     @Override
@@ -1345,9 +1735,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
         boolean bottomLayer,
         boolean definitiveAnyway,
         ClientContext context) {
-      // This is fetching an archive, which may or may not contain the file we are looking for (it
-      // includes metadata).
-      // So we are definitely not the bottom layer nor definitive.
+      // Not the bottom layer nor definitive when fetching container metadata.
       rcb.onSplitfileCompatibilityMode(min, max, splitfileKey, dontCompress, false, false, context);
     }
 
@@ -1375,11 +1763,8 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
         List<? extends Compressor> decompressors,
         ClientGetState state,
         ClientContext context) {
-      Bucket finalData = null;
-      // does matter only on pre-1255 keys (1255 keys have top block sizes)
-      // FIXME would save at most few tics on decompression
-      // and block allocation;
-      // To be effective should try guess minimal possible size earlier by the number of segments
+      Bucket finalData;
+      // Pre-1255 keys lack top block sizes; only minor decompression/alloc perf impact.
       long maxLen = Math.min(ctx.maxTempLength, ctx.maxOutputLength);
       try {
         finalData = context.getBucketFactory(persistent).makeBucket(maxLen);
@@ -1393,20 +1778,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
             DecompressorThreadManager decompressorManager =
                 new DecompressorThreadManager(pipeIn, decompressors, maxLen);
             try (PipedInputStream newPipeIn = decompressorManager.execute()) {
-              ClientGetWorkerThread worker =
-                  new ClientGetWorkerThread(
-                      new BufferedInputStream(newPipeIn),
-                      output,
-                      null,
-                      null,
-                      ctx.getSchemeHostAndPort(),
-                      null,
-                      false,
-                      null,
-                      null,
-                      null,
-                      context.linkFilterExceptionProvider);
-              worker.start();
+              ClientGetWorkerThread worker = makeAndStartWorker(newPipeIn, output, context);
               streamGenerator.writeTo(pipeOut, context);
               decompressorManager.waitFinished();
               worker.waitFinished();
@@ -1417,14 +1789,14 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
           }
         }
       } catch (Throwable t) {
-        LOG.error("Caught " + t, t);
+        LOG.error("Caught {}", t, t);
         onFailure(new FetchException(FetchExceptionMode.INTERNAL_ERROR, t), state, context);
         return;
       }
 
       try {
         parent.onTransition(state, SingleFileFetcher.this, context);
-        // FIXME: Pass an InputStream here, and save ourselves a Bucket
+        // Note: Pass an InputStream here, and save ourselves a Bucket
         Metadata meta = Metadata.construct(finalData);
         synchronized (SingleFileFetcher.this) {
           metadata = meta;
@@ -1494,7 +1866,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
         boolean definitiveAnyway,
         ClientContext context) {
       // Pass through definitiveAnyway as the top block may include the details.
-      // Hence we can get them straight away rather than waiting for the bottom layer.
+      // Hence, we can get them straight away rather than waiting for the bottom layer.
       rcb.onSplitfileCompatibilityMode(
           min, max, splitfileKey, dontCompress, false, definitiveAnyway, context);
     }
@@ -1505,37 +1877,116 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
     }
   }
 
-  /** Create a fetcher for a key. */
+  /** Encapsulates policy and limits for creation. */
+  public static final class CreationPolicy {
+    final int maxRetries;
+    final int recursionLevel;
+    final boolean dontTellClientGet;
+    final boolean isEssential;
+    final boolean isFinal;
+    final boolean hasInitialMetadata;
+
+    /**
+     * Create a new {@code CreationPolicy} describing retry, recursion and reporting behavior.
+     *
+     * @param maxRetries maximum number of retries permitted before surfacing failure
+     * @param recursionLevel current recursion depth used to guard against cycles
+     * @param dontTellClientGet whether to suppress some ClientGetter notifications
+     * @param isEssential whether this request should count toward must‑succeed accounting
+     * @param isFinal whether this leg is final with respect to path component checks
+     * @param hasInitialMetadata whether the caller already holds initial metadata
+     */
+    public CreationPolicy(
+        int maxRetries,
+        int recursionLevel,
+        boolean dontTellClientGet,
+        boolean isEssential,
+        boolean isFinal,
+        boolean hasInitialMetadata) {
+      this.maxRetries = maxRetries;
+      this.recursionLevel = recursionLevel;
+      this.dontTellClientGet = dontTellClientGet;
+      this.isEssential = isEssential;
+      this.isFinal = isFinal;
+      this.hasInitialMetadata = hasInitialMetadata;
+    }
+  }
+
+  /** Encapsulates runtime parameters for creation. */
+  public static final class CreationRuntime {
+    final ClientContext context;
+    final boolean realTimeFlag;
+    final long token;
+
+    /**
+     * Create a new {@code CreationRuntime} that carries per-run values.
+     *
+     * @param context runtime client context providing factories, caches, and schedulers
+     * @param realTimeFlag whether this request prefers real‑time scheduling and timeouts
+     * @param token opaque token propagated to callbacks so clients can correlate events
+     */
+    public CreationRuntime(ClientContext context, boolean realTimeFlag, long token) {
+      this.context = context;
+      this.realTimeFlag = realTimeFlag;
+      this.token = token;
+    }
+  }
+
+  /** Compact arguments holder for USK create helpers. */
+  static final class UskCreateArgs {
+    ClientRequester requester;
+    GetCompletionCallback cb;
+    USK usk;
+    List<String> metaStrings;
+    FetchContext ctx;
+    ArchiveContext actx;
+    CreationPolicy policy;
+    CreationRuntime runtime;
+  }
+
+  /**
+   * Create a fetch state for a URI.
+   *
+   * <p>This helper inspects the URI and context to choose an efficient path: it may create a {@link
+   * SimpleSingleFileFetcher} when redirects and splitfiles are disabled, return a {@link
+   * SingleFileFetcher} for regular cases, or initiate a USK flow when the URI resolves to a USK.
+   * The decision is based solely on the provided inputs and does not perform network I/O.
+   *
+   * @param requester parent requester that owns accounting and notifies clients
+   * @param cb completion callback receiving progress, success, or failure signals
+   * @param uri the original request URI including any meta‑strings
+   * @param ctx fetch context governing limits, policy, and allowed MIME types
+   * @param actx archive context used when the target lives inside a container
+   * @param policy creation policy including retries, recursion and notifications
+   * @param runtime runtime parameters such as real‑time flag and opaque token
+   * @return a new {@link ClientGetState} appropriate for the URI and policy
+   * @throws MalformedURLException if {@code uri} cannot be parsed into a client key
+   * @throws FetchException if recursion limits or policy checks fail during planning
+   */
   public static ClientGetState create(
       ClientRequester requester,
       GetCompletionCallback cb,
       FreenetURI uri,
       FetchContext ctx,
       ArchiveContext actx,
-      int maxRetries,
-      int recursionLevel,
-      boolean dontTellClientGet,
-      long l,
-      boolean isEssential,
-      boolean isFinal,
-      ClientContext context,
-      boolean realTimeFlag,
-      boolean hasInitialMetadata)
+      CreationPolicy policy,
+      CreationRuntime runtime)
       throws MalformedURLException, FetchException {
     BaseClientKey key = null;
-    if (!hasInitialMetadata) key = BaseClientKey.getBaseKey(uri);
+    if (!policy.hasInitialMetadata) key = BaseClientKey.getBaseKey(uri);
     if ((!uri.hasMetaStrings())
         && !ctx.allowSplitfiles
         && !ctx.followRedirects
-        && key instanceof ClientKey clientKey
-        && (!hasInitialMetadata))
+        && key instanceof ClientKey clientKey) {
       return new SimpleSingleFileFetcher(
-          SimpleSingleFileFetcher.Cfg.create(clientKey, maxRetries, ctx, requester, cb, l, context)
-              .essential(isEssential)
+          SimpleSingleFileFetcher.Cfg.create(
+                  clientKey, policy.maxRetries, ctx, requester, cb, runtime.token, runtime.context)
+              .essential(policy.isEssential)
               .dontAdd(false)
               .deleteFetchContext(false)
-              .realTime(realTimeFlag));
-    if (key instanceof ClientKey || hasInitialMetadata)
+              .realTime(runtime.realTimeFlag));
+    }
+    if (key instanceof ClientKey || policy.hasInitialMetadata)
       return new SingleFileFetcher(
           requester,
           cb,
@@ -1546,178 +1997,164 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
           0,
           ctx,
           false,
-          realTimeFlag,
+          runtime.realTimeFlag,
           actx,
           null,
           null,
-          maxRetries,
-          recursionLevel,
-          dontTellClientGet,
-          l,
-          isEssential,
-          isFinal,
+          policy.maxRetries,
+          policy.recursionLevel,
+          policy.dontTellClientGet,
+          runtime.token,
+          policy.isEssential,
+          policy.isFinal,
           false,
           (short) 0,
-          context,
-          hasInitialMetadata);
+          runtime.context,
+          policy.hasInitialMetadata);
     else {
-      return uskCreate(
-          requester,
-          realTimeFlag,
-          cb,
-          (USK) key,
-          new ArrayList<>(uri.listMetaStrings()),
-          ctx,
-          actx,
-          maxRetries,
-          recursionLevel,
-          dontTellClientGet,
-          l,
-          isEssential,
-          isFinal,
-          context);
+      UskCreateArgs a = new UskCreateArgs();
+      a.requester = requester;
+      a.cb = cb;
+      a.usk = (USK) key;
+      a.metaStrings = new ArrayList<>(uri.listMetaStrings());
+      a.ctx = ctx;
+      a.actx = actx;
+      a.policy = policy;
+      a.runtime = runtime;
+      return uskCreate(a);
     }
   }
 
-  private static ClientGetState uskCreate(
-      ClientRequester requester,
-      boolean realTimeFlag,
-      GetCompletionCallback cb,
-      USK usk,
-      ArrayList<String> metaStrings,
-      FetchContext ctx,
-      ArchiveContext actx,
-      int maxRetries,
-      int recursionLevel,
-      boolean dontTellClientGet,
-      long l,
-      boolean isEssential,
-      boolean isFinal,
-      ClientContext context)
-      throws FetchException {
-    if (usk.suggestedEdition >= 0) {
-      // Return the latest known version but at least suggestedEdition.
-      long edition = context.uskManager.lookupKnownGood(usk);
-      if (edition <= usk.suggestedEdition) {
-        context.uskManager.startTemporaryBackgroundFetcher(usk, context, ctx, true, realTimeFlag);
-        edition = context.uskManager.lookupKnownGood(usk);
-        if (edition > usk.suggestedEdition) {
-          if (LOG.isDebugEnabled()) LOG.debug("Redirecting to edition " + edition);
-          cb.onFailure(
-              new FetchException(
-                  FetchExceptionMode.PERMANENT_REDIRECT,
-                  usk.copy(edition).getURI().addMetaStrings(metaStrings)),
-              null,
-              context);
-          return null;
-        } else if (edition == -1
-            && context.uskManager.lookupLatestSlot(usk)
-                == -1) { // We do not want to be going round and round here!
-          // Check the datastore first.
-          USKFetcherTag tag =
-              context.uskManager.getFetcher(
-                  usk.copy(usk.suggestedEdition),
-                  ctx,
-                  false,
-                  requester.persistent(),
-                  realTimeFlag,
-                  new MyUSKFetcherCallback(
-                      requester,
-                      cb,
-                      usk,
-                      metaStrings,
-                      ctx,
-                      actx,
-                      realTimeFlag,
-                      maxRetries,
-                      recursionLevel,
-                      dontTellClientGet,
-                      l,
-                      requester.persistent(),
-                      true),
-                  false,
-                  context,
-                  true);
-          if (isEssential) requester.addMustSucceedBlocks(1);
-          return tag;
-
-        } else {
-          // Transition to SingleFileFetcher
-          GetCompletionCallback myCB =
-              new USKProxyCompletionCallback(usk, cb, requester.persistent());
-          // Want to update the latest known good iff the fetch succeeds.
-          return new SingleFileFetcher(
-              requester,
-              myCB,
-              null,
-              usk.getSSK(),
-              metaStrings,
-              usk.getURI().addMetaStrings(metaStrings),
-              0,
-              ctx,
-              false,
-              realTimeFlag,
-              actx,
-              null,
-              null,
-              maxRetries,
-              recursionLevel,
-              dontTellClientGet,
-              l,
-              isEssential,
-              isFinal,
-              false,
-              (short) 0,
-              context,
-              false);
-        }
-      } else {
-        cb.onFailure(
-            new FetchException(
-                FetchExceptionMode.PERMANENT_REDIRECT,
-                usk.copy(edition).getURI().addMetaStrings(metaStrings)),
-            null,
-            context);
-        return null;
-      }
+  private static ClientGetState uskCreate(UskCreateArgs a) throws FetchException {
+    if (a.usk.suggestedEdition >= 0) {
+      return uskCreateKnownGood(a);
     } else {
-      // Do a thorough, blocking search
+      return uskCreateThoroughSearch(a);
+    }
+  }
+
+  private static ClientGetState uskCreateKnownGood(UskCreateArgs a) throws FetchException {
+    long edition = a.runtime.context.uskManager.lookupKnownGood(a.usk);
+    if (edition > a.usk.suggestedEdition) {
+      if (LOG.isDebugEnabled()) LOG.debug("Redirecting to edition {}", edition);
+      a.cb.onFailure(
+          new FetchException(
+              FetchExceptionMode.PERMANENT_REDIRECT,
+              a.usk.copy(edition).getURI().addMetaStrings(a.metaStrings)),
+          null,
+          a.runtime.context);
+      return null;
+    }
+    a.runtime.context.uskManager.startTemporaryBackgroundFetcher(
+        a.usk, a.runtime.context, a.ctx, true, a.runtime.realTimeFlag);
+    edition = a.runtime.context.uskManager.lookupKnownGood(a.usk);
+    return decideAfterBackgroundFetcher(a, edition);
+  }
+
+  private static ClientGetState decideAfterBackgroundFetcher(UskCreateArgs a, long edition)
+      throws FetchException {
+    if (edition > a.usk.suggestedEdition) {
+      if (LOG.isDebugEnabled()) LOG.debug("Redirecting to edition {}", edition);
+      a.cb.onFailure(
+          new FetchException(
+              FetchExceptionMode.PERMANENT_REDIRECT,
+              a.usk.copy(edition).getURI().addMetaStrings(a.metaStrings)),
+          null,
+          a.runtime.context);
+      return null;
+    }
+    if (edition == -1 && a.runtime.context.uskManager.lookupLatestSlot(a.usk) == -1) {
       USKFetcherTag tag =
-          context.uskManager.getFetcher(
-              usk.copy(-usk.suggestedEdition),
-              ctx,
+          a.runtime.context.uskManager.getFetcher(
+              a.usk.copy(a.usk.suggestedEdition),
+              a.ctx,
               false,
-              requester.persistent(),
-              realTimeFlag,
+              a.requester.persistent(),
+              a.runtime.realTimeFlag,
               new MyUSKFetcherCallback(
-                  requester,
-                  cb,
-                  usk,
-                  metaStrings,
-                  ctx,
-                  actx,
-                  realTimeFlag,
-                  maxRetries,
-                  recursionLevel,
-                  dontTellClientGet,
-                  l,
-                  requester.persistent(),
-                  false),
+                  a.requester,
+                  a.cb,
+                  a.usk,
+                  a.metaStrings,
+                  a.ctx,
+                  a.actx,
+                  a.runtime.realTimeFlag,
+                  a.policy.maxRetries,
+                  a.policy.recursionLevel,
+                  a.policy.dontTellClientGet,
+                  a.runtime.token,
+                  a.requester.persistent(),
+                  true),
               false,
-              context,
-              false);
-      if (isEssential) requester.addMustSucceedBlocks(1);
+              a.runtime.context,
+              true);
+      if (a.policy.isEssential) a.requester.addMustSucceedBlocks(1);
       return tag;
     }
+    GetCompletionCallback myCB =
+        new USKProxyCompletionCallback(a.usk, a.cb, a.requester.persistent());
+    return new SingleFileFetcher(
+        a.requester,
+        myCB,
+        null,
+        a.usk.getSSK(),
+        a.metaStrings,
+        a.usk.getURI().addMetaStrings(a.metaStrings),
+        0,
+        a.ctx,
+        false,
+        a.runtime.realTimeFlag,
+        a.actx,
+        null,
+        null,
+        a.policy.maxRetries,
+        a.policy.recursionLevel,
+        a.policy.dontTellClientGet,
+        a.runtime.token,
+        a.policy.isEssential,
+        a.policy.isFinal,
+        false,
+        (short) 0,
+        a.runtime.context,
+        false);
   }
 
-  public static class MyUSKFetcherCallback implements USKFetcherTagCallback, Serializable {
+  private static ClientGetState uskCreateThoroughSearch(UskCreateArgs a) {
+    USKFetcherTag tag =
+        a.runtime.context.uskManager.getFetcher(
+            a.usk.copy(-a.usk.suggestedEdition),
+            a.ctx,
+            false,
+            a.requester.persistent(),
+            a.runtime.realTimeFlag,
+            new MyUSKFetcherCallback(
+                a.requester,
+                a.cb,
+                a.usk,
+                a.metaStrings,
+                a.ctx,
+                a.actx,
+                a.runtime.realTimeFlag,
+                a.policy.maxRetries,
+                a.policy.recursionLevel,
+                a.policy.dontTellClientGet,
+                a.runtime.token,
+                a.requester.persistent(),
+                false),
+            false,
+            a.runtime.context,
+            false);
+    if (a.policy.isEssential) a.requester.addMustSucceedBlocks(1);
+    return tag;
+  }
+
+  static class MyUSKFetcherCallback implements USKFetcherTagCallback, Serializable {
 
     @Serial private static final long serialVersionUID = 1L;
     final ClientRequester parent;
-    final GetCompletionCallback cb;
+    final transient GetCompletionCallback cb;
     final USK usk;
-    final ArrayList<String> metaStrings;
+    private final List<String> metaStrings;
     final FetchContext ctx;
     final ArchiveContext actx;
     final int maxRetries;
@@ -1739,7 +2176,7 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
         ClientRequester requester,
         GetCompletionCallback cb,
         USK usk,
-        ArrayList<String> metaStrings,
+        List<String> metaStrings,
         FetchContext ctx,
         ArchiveContext actx,
         boolean realTimeFlag,
@@ -1765,19 +2202,22 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
       this.realTimeFlag = realTimeFlag;
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Created "
-                + this
-                + " for "
-                + usk
-                + " and "
-                + cb
-                + " datastore only = "
-                + datastoreOnly);
+            "Created {}" + LOG_FOR_LABEL + "{} and {} datastore only = {}",
+            this,
+            usk,
+            cb,
+            datastoreOnly);
     }
 
     @Override
     public int hashCode() {
       return hashCode;
+    }
+
+    @Override
+    @SuppressWarnings("RedundantMethodOverride")
+    public boolean equals(Object obj) {
+      return this == obj;
     }
 
     @Override
@@ -1845,12 +2285,12 @@ public class SingleFileFetcher extends SimpleSingleFileFetcher {
         try {
           onFoundEdition(usk.suggestedEdition, usk, context, false, (short) -1, null, false, false);
           return;
-        } catch (Throwable t) {
+        } catch (Exception t) {
           e = new FetchException(FetchExceptionMode.INTERNAL_ERROR, t);
         }
       }
       if (e == null) e = new FetchException(FetchExceptionMode.DATA_NOT_FOUND, "No USK found");
-      if (LOG.isDebugEnabled()) LOG.debug("Failing USK with " + e, e);
+      if (LOG.isDebugEnabled()) LOG.debug("Failing USK with {}", e, e);
       if (cb == null)
         throw new NullPointerException(
             "Callback is null in "

--- a/src/main/java/network/crypta/client/async/USKCallback.java
+++ b/src/main/java/network/crypta/client/async/USKCallback.java
@@ -3,23 +3,53 @@ package network.crypta.client.async;
 import network.crypta.keys.USK;
 
 /**
- * USK callback interface. Used for subscriptions to the USKManager, and extended for USKFetcher
- * callers.
+ * Callback interface for USK-related subscriptions and fetch operations.
+ *
+ * <p>Implementations receive notifications when a new or latest edition of a USK has been found and
+ * can influence how background polling proceeds by reporting preferred polling priorities. Typical
+ * usage is to implement this interface and pass the instance to the {@code USKManager}-based
+ * subscription APIs or to the {@code USKFetcher} when initiating a direct fetch. The {@link
+ * #onFoundEdition(long, network.crypta.keys.USK, ClientContext, boolean, short, byte[], boolean,
+ * boolean)} method is invoked once the fetcher completes its search, at which point it will not
+ * look for later editions during that cycle.
+ *
+ * <p>Callbacks may be invoked on threads managed by the client layer or its executors. Implementers
+ * should therefore avoid blocking for long periods and treat the provided arguments as read-only.
+ * State updates that affect subsequent polling can be performed in the callback, but heavy work is
+ * best delegated to application executors. No assumptions should be made about reentrancy beyond
+ * what the calling code guarantees.
+ *
+ * <ul>
+ *   <li>Edition discovery notifications with contextual data.
+ *   <li>Control over normal and "progress" polling priorities.
+ *   <li>Neutral about persistence; subscription owners decide durability.
+ * </ul>
+ *
+ * @see network.crypta.client.async.USKManager
+ * @see network.crypta.client.async.USKFetcher
  */
 public interface USKCallback {
 
   /**
-   * Found the latest edition. Called when the USKFetcher has finished, it won't search for any
-   * later editions.
+   * Reports that the latest edition has been found for the specified USK.
    *
-   * @param l The edition number.
-   * @param key A copy of the key with new edition set
-   * @param newKnownGood If the highest known good edition (which has actually been fetched with
-   *     what it pointed to) has increased. Otherwise, the highest known SSK slot has been
-   *     increased, from which searches will start, but we do not know whether it can actually be
-   *     fetched successfully.
-   * @param newSlotToo If newKnownGood is set, this indicates whether it is also a new highest known
-   *     SSK slot. If newKnownGood is not set, there is always a new highest known SSK slot.
+   * <p>Called when the fetcher completes its search cycle and will not look for later editions in
+   * that pass. Implementers can persist the result, update application state, and choose future
+   * polling priorities via the other methods of this interface. The supplied context exposes
+   * schedulers and supporting services should further work need to be scheduled.
+   *
+   * @param l the discovered edition number for the key; higher values represent newer editions
+   * @param key a key instance with the discovered edition applied; treated as read-only by callees
+   * @param context operational client context used for scheduling and services; never {@code null}
+   * @param metadata {@code true} when the accompanying bytes represent metadata rather than
+   *     content; exact meaning is defined by the caller
+   * @param codec opaque short identifying how to interpret {@code data}; semantics depend on caller
+   * @param data raw byte content or metadata bytes associated with this edition; treat as read-only
+   * @param newKnownGood whether the highest known good edition (successfully fetched and verified)
+   *     has increased; otherwise only the highest known slot has advanced for future searches
+   * @param newSlotToo when {@code newKnownGood} is {@code true}, indicates it is also a new highest
+   *     known slot; when {@code newKnownGood} is {@code false}, the highest known slot is always
+   *     considered new
    */
   void onFoundEdition(
       long l,
@@ -31,12 +61,25 @@ public interface USKCallback {
       boolean newKnownGood,
       boolean newSlotToo);
 
-  /** Priority at which the polling should run normally. See RequestScheduler for constants. */
+  /**
+   * Returns the polling priority used during normal, steady-state monitoring.
+   *
+   * <p>The value should correspond to a valid priority class constant used by the client request
+   * system (for example, the constants defined in {@link network.crypta.node.RequestStarter}). Call
+   * sites may map this to an appropriate scheduler or queue.
+   *
+   * @return a priority class value to use for regular polling cycles
+   */
   short getPollingPriorityNormal();
 
   /**
-   * Priority at which the polling should run when starting, or immediately after making some
-   * progress. See RequestScheduler for constants.
+   * Returns the polling priority to apply when starting or right after progress is observed.
+   *
+   * <p>This value is typically more aggressive than the normal priority to accelerate discovery
+   * after activity is detected. Use a valid priority class value (e.g., from {@link
+   * network.crypta.node.RequestStarter}).
+   *
+   * @return a priority class value for initial or post-progress polling phases
    */
   short getPollingPriorityProgress();
 }

--- a/src/main/java/network/crypta/client/async/USKChecker.java
+++ b/src/main/java/network/crypta/client/async/USKChecker.java
@@ -1,5 +1,6 @@
 package network.crypta.client.async;
 
+import java.io.Serial;
 import network.crypta.client.FetchContext;
 import network.crypta.keys.ClientKey;
 import network.crypta.keys.ClientKeyBlock;
@@ -10,22 +11,71 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Checks a single USK slot.
+ * Checks a single USK slot and reports the outcome to a caller-supplied callback.
  *
- * <p>Not persistent, used by USKFetcher.
+ * <p>This helper performs a short‑lived, one‑off probe of a specific Updateable Subspace Key (USK)
+ * slot. It is designed to be created by higher‑level orchestration (for example, a {@code
+ * USKFetcher}) to determine whether content is available at a given index, and to surface
+ * actionable results to the caller via {@link USKCheckerCallback}. The instance does not own any
+ * persistent state; it relies on the underlying single‑file fetch logic in the superclass and
+ * forwards results to the provided callback.
+ *
+ * <p>Behaviorally, the checker tracks basic failure classifications across retry attempts. Data not
+ * found conditions are accounted to a local counter and influence whether the final callback is
+ * reported as “data not found” versus a broader network failure once retries are exhausted. Certain
+ * error codes (for example, decode failures) are treated as fatal and are surfaced immediately. The
+ * checker itself is not thread‑safe beyond the guarantees of the surrounding request machinery; it
+ * should be used in the same scheduling context as the request that spawned it.
+ *
+ * <ul>
+ *   <li>Single purpose: probe one USK slot and notify via callback.
+ *   <li>Ephemeral: no persistence; lifecycle is bound to the probe.
+ *   <li>Retries: limited; classification distinguishes DNF from transport errors.
+ * </ul>
  */
-@SuppressWarnings("serial")
 class USKChecker extends BaseSingleFileFetcher {
+  /** Serial version for the transient helper; included for stream compatibility if needed. */
+  @Serial private static final long serialVersionUID = 1L;
+
+  /**
+   * Class logger used only for diagnostic output. Messages include the key and instance identity to
+   * aid tracing when multiple slot probes run concurrently under a coordinator.
+   */
   private static final Logger LOG = LoggerFactory.getLogger(USKChecker.class);
 
-  final USKCheckerCallback cb;
+  /**
+   * Callback invoked on success, cancellation, finite cooldown entry, and classified failure. The
+   * callback is provided by the orchestrating component and must remain valid for the lifetime of
+   * this checker instance.
+   */
+  final transient USKCheckerCallback cb;
+
+  /**
+   * Count of data‑not‑found style outcomes observed across retries. A positive value biases the
+   * final failure classification toward {@code onDNF} when retries are exhausted.
+   */
   private int dnfs;
 
-  private long cooldownWakeupTime;
-
-  static {
-  }
-
+  /**
+   * Creates a new checker bound to the given key and callback.
+   *
+   * <p>The checker issues a single‑slot fetch using the inherited single‑file request machinery.
+   * Retry behavior and scheduling characteristics are derived from the provided parameters and
+   * context. Results are always emitted through {@link #cb} and never retained internally.
+   *
+   * @param cb the recipient for success notifications, cooldown entry, and classified failures;
+   *     receives all terminal outcomes for this probe and determines priority
+   * @param key the USK‑derived key identifying the exact slot to check; used to construct the
+   *     underlying request and for diagnostic messages
+   * @param maxRetries maximum number of retry attempts permitted for transient conditions; values
+   *     at or below zero effectively disable retry and lead to immediate classification
+   * @param ctx the fetch context carrying tunables such as timeouts, caching policy, and
+   *     verification; forwarded to the underlying request layer unchanged
+   * @param parent the logical requester used for accounting and association with the spawning
+   *     client operation; not used for user‑visible state
+   * @param realTimeFlag when {@code true}, the request uses real‑time scheduling hints appropriate
+   *     for interactive or low‑latency operations; otherwise default background policies apply
+   */
   USKChecker(
       USKCheckerCallback cb,
       ClientKey key,
@@ -35,9 +85,25 @@ class USKChecker extends BaseSingleFileFetcher {
       boolean realTimeFlag) {
     super(key, maxRetries, ctx, parent, false, realTimeFlag);
     this.cb = cb;
-    if (LOG.isDebugEnabled()) LOG.debug("Created USKChecker for " + key + " : " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Created USKChecker for {} : {}", key, this);
   }
 
+  /**
+   * Handles a successful fetch and forwards it to the callback.
+   *
+   * <p>The retrieved block is expected to represent a USK slot and is down‑cast to a {@link
+   * network.crypta.keys.ClientSSKBlock} prior to delegation. Any values such as {@code token} and
+   * {@code fromStore} are accepted as part of the framework contract; this implementation does not
+   * use them and reports success solely through the callback.
+   *
+   * @param block the fetched key block containing the slot content; treated as an SSK block and
+   *     forwarded to the callback without mutation
+   * @param fromStore whether the result came from a local store cache; not used for decision-making
+   *     in this implementation
+   * @param token an opaque token associated with the request item; ignored here but may be provided
+   *     by the scheduler
+   * @param context execution context for the client request; forwarded to the callback unchanged
+   */
   @Override
   public void onSuccess(
       ClientKeyBlock block, boolean fromStore, Object token, ClientContext context) {
@@ -45,34 +111,47 @@ class USKChecker extends BaseSingleFileFetcher {
     cb.onSuccess((ClientSSKBlock) block, context);
   }
 
+  /**
+   * Handles a failed fetch, applying retry policy and failure classification.
+   *
+   * <p>Failure codes are mapped to retryability. Data‑not‑found style errors increment a local
+   * counter. If a retry is permitted, control is delegated to {@code retry(context)} and the method
+   * returns immediately. When retries are exhausted, the checker unregisters from further callbacks
+   * and emits one of: {@code onCancelled}, {@code onFatalAuthorError}, {@code onDNF}, or {@code
+   * onNetworkError}, depending on the final error code and whether any DNF was observed.
+   *
+   * @param e the low‑level failure including a stable numeric code used for policy decisions; never
+   *     modified
+   * @param token the request item associated with the failure; not inspected by this implementation
+   * @param context execution context for the client request; used for retry bookkeeping and passed
+   *     through to callbacks
+   */
   @Override
   public void onFailure(LowLevelGetException e, SendableRequestItem token, ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("onFailure: " + e + " for " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("onFailure: {} for {}", e, this);
     // Firstly, can we retry?
     boolean canRetry;
     switch (e.code) {
-      case LowLevelGetException.CANCELLED:
-      case LowLevelGetException.DECODE_FAILED:
-        // Cannot retry
-        canRetry = false;
-        break;
-      case LowLevelGetException.DATA_NOT_FOUND:
-      case LowLevelGetException.DATA_NOT_FOUND_IN_STORE:
-      case LowLevelGetException.RECENTLY_FAILED:
+      case LowLevelGetException.CANCELLED, LowLevelGetException.DECODE_FAILED ->
+          // Cannot retry
+          canRetry = false;
+      case LowLevelGetException.DATA_NOT_FOUND,
+          LowLevelGetException.DATA_NOT_FOUND_IN_STORE,
+          LowLevelGetException.RECENTLY_FAILED -> {
         dnfs++;
         canRetry = true;
-        break;
-      case LowLevelGetException.INTERNAL_ERROR:
-      case LowLevelGetException.REJECTED_OVERLOAD:
-      case LowLevelGetException.ROUTE_NOT_FOUND:
-      case LowLevelGetException.TRANSFER_FAILED:
-      case LowLevelGetException.VERIFY_FAILED:
-        // Can retry
-        canRetry = true;
-        break;
-      default:
+      }
+      case LowLevelGetException.INTERNAL_ERROR,
+          LowLevelGetException.REJECTED_OVERLOAD,
+          LowLevelGetException.ROUTE_NOT_FOUND,
+          LowLevelGetException.TRANSFER_FAILED,
+          LowLevelGetException.VERIFY_FAILED ->
+          // Can retry
+          canRetry = true;
+      default -> {
         LOG.error("Unknown low-level fetch error code: {}", e.code);
         canRetry = true;
+      }
     }
 
     if (canRetry && retry(context)) return;
@@ -82,43 +161,94 @@ class USKChecker extends BaseSingleFileFetcher {
     if (e.code == LowLevelGetException.CANCELLED) {
       cb.onCancelled(context);
       return;
-    } else if (e.code == LowLevelGetException.DECODE_FAILED) {
+    }
+    if (e.code == LowLevelGetException.DECODE_FAILED) {
       cb.onFatalAuthorError(context);
       return;
     }
-    // Rest are non-fatal. If have DNFs, DNF, else network error.
+    // Rest are non-fatal. If we have DNFs, DNF, else network error.
     if (dnfs > 0) cb.onDNF(context);
     else cb.onNetworkError(context);
   }
 
+  /**
+   * Returns a concise diagnostic string including the key and callback.
+   *
+   * @return a human‑readable identifier of the form {@code "USKChecker for <uri> for <callback>"}
+   *     suitable for logs and debugging; content is intended for diagnostics only
+   */
   @Override
   public String toString() {
     return "USKChecker for " + key.getURI() + " for " + cb;
   }
 
+  /**
+   * Reports the priority class to use for the request.
+   *
+   * <p>This delegates to the callback so the orchestrating component can control scheduling
+   * behavior across related probes.
+   *
+   * @return a priority class value as defined by the surrounding fetch framework; the value is not
+   *     validated here and is forwarded as‑is from the callback
+   */
   @Override
   public short getPriorityClass() {
     return cb.getPriority();
   }
 
+  /**
+   * Notifies the callback that the request entered a finite cooldown period.
+   *
+   * <p>The cooldown reflects backoff applied by the underlying request machinery after a transient
+   * condition. The checker does not modify or track the duration; it forwards the event so callers
+   * can observe progress or update UI.
+   *
+   * @param context execution context for the client request associated with this cooldown
+   */
   @Override
   protected void onEnterFiniteCooldown(ClientContext context) {
     cb.onEnterFiniteCooldown(context);
   }
 
+  /**
+   * Handles the case where the block was not found in any local store after retries.
+   *
+   * <p>The checker unregisters for further callbacks and classifies the terminal state as data not
+   * found. No additional retries are attempted from this point.
+   *
+   * @param context execution context for the client request at the time of classification
+   */
   @Override
   protected void notFoundInStore(ClientContext context) {
     // Ran out of retries.
     unregisterAll(context);
-    // Rest are non-fatal. If have DNFs, DNF, else network error.
+    // Rest are non-fatal. If we have DNFs, DNF, else network error.
     cb.onDNF(context);
   }
 
+  /**
+   * Treats a decode error as a terminal failure and reuses the failure path.
+   *
+   * <p>For consistency with other failure handling, this constructs a {@link LowLevelGetException}
+   * with the {@code DECODE_FAILED} code and forwards it to {@link #onFailure(LowLevelGetException,
+   * SendableRequestItem, ClientContext)}.
+   *
+   * @param token the request item whose decode failed; not inspected by this implementation
+   * @param context execution context for the client request; forwarded unchanged
+   */
   @Override
   protected void onBlockDecodeError(SendableRequestItem token, ClientContext context) {
     onFailure(new LowLevelGetException(LowLevelGetException.DECODE_FAILED), token, context);
   }
 
+  /**
+   * Returns the current client get state for inspection by callers.
+   *
+   * <p>This checker does not expose internal state and therefore returns {@code null}. Callers
+   * should rely on callbacks for progress and terminal notifications instead of polling.
+   *
+   * @return always {@code null}; this checker does not maintain a retrievable get state
+   */
   @Override
   protected ClientGetState getClientGetState() {
     return null;

--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -165,17 +165,12 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     DBRAttempt(ClientKey key, ClientContext context, USKDateHint.Type type) {
       fetcher =
           new SimpleSingleFileFetcher(
-              key,
-              ctxDBR.maxUSKRetries,
-              ctxDBR,
-              parent,
-              this,
-              false,
-              true,
-              0,
-              context,
-              false,
-              realTimeFlag) {
+              SimpleSingleFileFetcher.Cfg.create(
+                      key, ctxDBR.maxUSKRetries, ctxDBR, parent, this, 0, context)
+                  .essential(false)
+                  .dontAdd(true)
+                  .deleteFetchContext(false)
+                  .realTime(realTimeFlag)) {
             @Override
             public short getPriorityClass() {
               return progressPollPriority;

--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -556,7 +556,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
         c = checker;
       }
       if (c == null) return;
-      c.onChangedFetchContext(context);
+      c.onChangedFetchContext();
     }
   }
 

--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -54,46 +54,41 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * On 0.7, this shouldn't however take more than 10 seconds or so; these are SSKs we are talking
- * about. If this is fast enough then people will use the "-" form.
+ * Coordinates discovery and fetching of editions for a {@link USK}.
  *
- * <p>FProxy should cause USKs with negative edition numbers to be redirected to USKs with positive
- * edition numbers.
+ * <p>USKs (Unique SSKs) advance over time; this class drives the polling and discovery loop that
+ * identifies the latest available edition and optionally retrieves its data. It combines
+ * datastore-prechecks, targeted slot checks, and Date-Based Request (DBR) hint fetches to balance
+ * latency and load. The fetcher can run once for a specific request or continue in background
+ * polling mode to track updates over time.
  *
- * <p>If the number specified is up to date, we just do the fetch. If a more recent USK can be
- * found, then we fail with an exception with the new version. The client is expected to redirect to
- * this. The point here is that FProxy will then have the correct number in the location bar, so
- * that if the user copies the URL, it will keep the edition number hint.
+ * <p>Lifecycle and behavior:
  *
- * <p>A positive number fetch triggers a background fetch.
+ * <ul>
+ *   <li>At most one {@code USKFetcher} is active per USK and it registers itself with the {@code
+ *       USKManager} to receive discovery events such as newly found slots.
+ *   <li>Subscribers and callbacks do not receive data directly from this class but influence
+ *       whether to continue polling and at which priority, enabling interactive workloads to
+ *       promote progress checks.
+ *   <li>Scheduling begins with datastore checks and DBR hint fetches, then probes multiple nearby
+ *       editions. Four consecutive DNFs with no later pending work typically conclude a round.
+ *   <li>When running with background polling, the fetcher increases its sleep between rounds unless
+ *       progress is made, and can be re-armed after cancellation.
+ * </ul>
  *
- * <p>This class does both background fetches and negative number fetches.
+ * <p>Threading and state: instances are mutable and use fine-grained synchronization around shared
+ * fields to coordinate scheduling and callbacks. Cancellation short-circuits pending work and marks
+ * the instance as finished. This class is not persistent; persistence of intent is tracked by
+ * {@code USKFetcherTag} which recreates fetchers on startup as needed.
  *
- * <p>It does them in the same way.
- *
- * <p>There is one USKFetcher for a given USK, at most. They are registered on the USKManager. They
- * have a list of ClientGetState-implementing callbacks; these are all triggered on completion.
- *
- * <p>When a new suggestedEdition is added, if that is later than the currently searched-for
- * version, the USKFetcher will try to fetch that as well as its current pointer.
- *
- * <p>Current algorithm: - Fetch the next 5 editions all at once. - If we have four consecutive
- * editions with DNF, and no later pending fetches, then we finish with the last known good version.
- * (There are details relating to other error codes handled below in the relevant method). - We
- * immediately update the USKManager if we successfully fetch an edition. - If a new, higher
- * suggestion comes in, that is also fetched.
- *
- * <p>Future extensions: - Binary search. - Hierarchical DBRs. - TUKs (when we have TUKs). - Passive
- * requests (when we have passive requests).
- *
- * <p>PERSISTENCE: This class is not persistent. USKFetcherTag is used to mark persistent USK
- * fetches, which will be restarted on startup.
+ * @see USKManager
+ * @see USK
  */
 public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, KeyListener {
   private static final Logger LOG = LoggerFactory.getLogger(USKFetcher.class);
+  private static final String FOR_LITERAL = " for ";
 
-  static {
-  }
+  // Static initializer removed as it was empty and unnecessary.
 
   /** USK manager */
   private final USKManager uskManager;
@@ -136,16 +131,22 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
   private static final int WATCH_KEYS = 50;
 
   /**
-   * Callbacks are told when the USKFetcher finishes, and unless background poll is enabled, they
-   * are only sent onFoundEdition *once*, on completion.
+   * Registers a fetcher-level callback.
    *
-   * <p>However they do help to determine the fetcher's priority.
+   * <p>Callbacks are notified when the overall USK fetch cycle completes. Unless background polling
+   * is enabled, they receive {@code onFoundEdition(...)} at most once when the final decision for
+   * the current cycle is known. Callbacks also participate in determining the dynamic polling
+   * priority via {@link #updatePriorities()} so interactive callers can promote progress checks.
    *
-   * <p>FIXME: Don't allow callbacks if backgroundPoll is enabled??
+   * <p>Note: When continuous background polling is enabled, consider whether registering a callback
+   * is appropriate, as the cycle may not reach a terminal state for long periods.
    *
-   * @param cb
-   * @return
+   * @param cb the callback to add; must remain valid for the lifetime of this fetch cycle; {@code
+   *     null} is not permitted
+   * @return {@code true} when the callback was added successfully; {@code false} when the fetcher
+   *     has already completed and no further callbacks are accepted
    */
+  @SuppressWarnings("UnusedReturnValue")
   public boolean addCallback(USKFetcherCallback cb) {
     synchronized (this) {
       if (completed) return false;
@@ -155,45 +156,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     return true;
   }
 
-  @SuppressWarnings("serial")
-  class DBRFetcher extends SimpleSingleFileFetcher {
-
-    DBRFetcher(
-        ClientKey key,
-        int maxRetries,
-        FetchContext ctx,
-        ClientRequester parent,
-        GetCompletionCallback rcb,
-        boolean isEssential,
-        boolean dontAdd,
-        long l,
-        ClientContext context,
-        boolean deleteFetchContext,
-        boolean realTimeFlag) {
-      super(
-          key,
-          maxRetries,
-          ctx,
-          parent,
-          rcb,
-          isEssential,
-          dontAdd,
-          l,
-          context,
-          deleteFetchContext,
-          realTimeFlag);
-    }
-
-    @Override
-    public short getPriorityClass() {
-      return progressPollPriority;
-    }
-
-    @Override
-    public String toString() {
-      return super.objectToString() + " for " + USKFetcher.this + " for " + origUSK;
-    }
-  }
+  // DBRFetcher removed: use an anonymous SimpleSingleFileFetcher subclass at call site.
 
   class DBRAttempt implements GetCompletionCallback {
     final SimpleSingleFileFetcher fetcher;
@@ -201,7 +164,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
     DBRAttempt(ClientKey key, ClientContext context, USKDateHint.Type type) {
       fetcher =
-          new DBRFetcher(
+          new SimpleSingleFileFetcher(
               key,
               ctxDBR.maxUSKRetries,
               ctxDBR,
@@ -212,9 +175,34 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
               0,
               context,
               false,
-              realTimeFlag);
+              realTimeFlag) {
+            @Override
+            public short getPriorityClass() {
+              return progressPollPriority;
+            }
+
+            @Override
+            public KeyListener makeKeyListener(ClientContext context, boolean onStartup) {
+              synchronized (this) {
+                if (finished) return null;
+                if (cancelled) return null;
+              }
+              if (key == null) {
+                if (LOG.isErrorEnabled()) {
+                  LOG.error(
+                      "Key is null - left over BSSF? on {} in makeKeyListener()",
+                      this,
+                      new Exception("error"));
+                }
+                return null;
+              }
+              Key newKey = key.getNodeKey(true);
+              short prio = progressPollPriority;
+              return new SingleKeyListener(newKey, this, prio, persistent);
+            }
+          };
       this.type = type;
-      if (LOG.isDebugEnabled()) LOG.debug("Created " + this + " with " + fetcher);
+      if (LOG.isDebugEnabled()) LOG.debug("Created {} with {}", this, fetcher);
     }
 
     @Override
@@ -264,13 +252,13 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
         // Run directly - we are running on some thread somewhere, don't worry about it.
         innerSuccess(data, context);
       } catch (Throwable t) {
-        LOG.error("Caught " + t, t);
+        LOG.error("Caught {}", t, t);
         onFailure(new FetchException(FetchExceptionMode.INTERNAL_ERROR, t), state, context);
       } finally {
         boolean dbrsFinished;
         synchronized (USKFetcher.this) {
           dbrAttempts.remove(this);
-          if (LOG.isDebugEnabled()) LOG.debug("Remaining DBR attempts: " + dbrAttempts);
+          if (LOG.isDebugEnabled()) LOG.debug("Remaining DBR attempts: {}", dbrAttempts);
           dbrsFinished = dbrAttempts.isEmpty();
         }
         if (dbrsFinished) onDBRsFinished(context);
@@ -284,25 +272,25 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
         data = BucketTools.toByteArray(bucket);
       } catch (IOException e) {
         LOG.error(
-            "Unable to read hint data because of I/O error, maybe bad decompression?: " + e, e);
+            "Unable to read hint data because of I/O error, maybe bad decompression?: {}", e, e);
         return;
       }
       String line;
       try {
         line = new String(data, StandardCharsets.UTF_8);
-      } catch (Throwable t) {
+      } catch (Exception t) {
         // Something very bad happened, most likely bogus encoding.
         // Ignore it.
-        LOG.error("Impossible throwable - maybe bogus encoding?: " + t, t);
+        LOG.error("Impossible throwable - maybe bogus encoding?: {}", t, t);
         return;
       }
       String[] split = line.split("\n");
       if (split.length < 3) {
-        LOG.error("Unable to parse hint (not enough lines): \"" + line + "\"");
+        LOG.error("Unable to parse hint (not enough lines): \"{}\"", line);
         return;
       }
       if (!split[0].startsWith("HINT")) {
-        LOG.error("Unable to parse hint (first line doesn't start with HINT): \"" + line + "\"");
+        LOG.error("Unable to parse hint (first line doesn't start with HINT): \"{}\"", line);
         return;
       }
       String value = split[1];
@@ -310,18 +298,43 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       try {
         hint = Long.parseLong(value);
       } catch (NumberFormatException e) {
-        LOG.error("Unable to parse hint \"" + value + "\"", e);
+        LOG.error("Unable to parse hint \"{}\"", value, e);
         return;
       }
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Found DBR hint edition "
-                + hint
-                + " for "
-                + this.fetcher.getKey(null).getURI()
-                + " for "
-                + USKFetcher.this);
-      processDBRHint(hint, context, this);
+            "Found DBR hint edition {} for {} for {}",
+            hint,
+            this.fetcher.getKey(null).getURI(),
+            USKFetcher.this);
+      processHint(hint, context, this);
+    }
+
+    private void processHint(long hint, ClientContext context, DBRAttempt dbrAttempt) {
+      try {
+        updatePriorities();
+        short prio;
+        List<DBRAttempt> toCancel = null;
+        synchronized (USKFetcher.this) {
+          if (cancelled || completed) return;
+          dbrHintsFound++;
+          prio = progressPollPriority;
+          for (Iterator<DBRAttempt> i = dbrAttempts.iterator(); i.hasNext(); ) {
+            DBRAttempt a = i.next();
+            if (dbrAttempt.type.alwaysMorePreciseThan(a.type)) {
+              if (toCancel == null) toCancel = new ArrayList<>();
+              toCancel.add(a);
+              i.remove();
+            }
+          }
+        }
+        uskManager.hintUpdate(origUSK.copy(hint).getURI(), context, prio);
+        if (toCancel != null) {
+          for (DBRAttempt a : toCancel) a.cancel(context);
+        }
+      } catch (MalformedURLException e) {
+        // Impossible
+      }
     }
 
     @Override
@@ -329,16 +342,11 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       // Okay.
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Failed to fetch hint "
-                + fetcher.getKey(null)
-                + " for "
-                + this
-                + " for "
-                + USKFetcher.this);
+            "Failed to fetch hint {} for {} for {}", fetcher.getKey(null), this, USKFetcher.this);
       boolean dbrsFinished;
       synchronized (USKFetcher.this) {
         dbrAttempts.remove(this);
-        if (LOG.isDebugEnabled()) LOG.debug("Remaining DBR attempts: " + dbrAttempts);
+        if (LOG.isDebugEnabled()) LOG.debug("Remaining DBR attempts: {}", dbrAttempts);
         dbrsFinished = dbrAttempts.isEmpty();
       }
       if (dbrsFinished) onDBRsFinished(context);
@@ -361,7 +369,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     }
 
     @Override
-    public void onExpectedMIME(ClientMetadata meta, ClientContext context) throws FetchException {
+    public void onExpectedMIME(ClientMetadata meta, ClientContext context) {
       // Ignore
     }
 
@@ -420,7 +428,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     final boolean forever;
     private boolean everInCooldown;
 
-    public USKAttempt(Lookup l, boolean forever) {
+    private USKAttempt(Lookup l, boolean forever) {
       this.lookup = l;
       this.number = l.val;
       this.succeeded = false;
@@ -468,8 +476,8 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       synchronized (this) {
         checker = null;
       }
-      // Not a DNF
-      USKFetcher.this.onFail(this, context);
+      // Treat network error as DNF for scheduling purposes
+      USKFetcher.this.onDNF(this, context);
     }
 
     @Override
@@ -507,9 +515,9 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     public String toString() {
       return "USKAttempt for "
           + number
-          + " for "
+          + FOR_LITERAL
           + origUSK.getURI()
-          + " for "
+          + FOR_LITERAL
           + USKFetcher.this
           + (forever ? " (forever)" : "");
     }
@@ -550,7 +558,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       return everInCooldown;
     }
 
-    public void reloadPollParameters(ClientContext context) {
+    public void reloadPollParameters() {
       USKChecker c;
       synchronized (this) {
         c = checker;
@@ -569,9 +577,9 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
   final long origMinFailures;
   boolean firstLoop;
 
-  static final long origSleepTime = MINUTES.toMillis(30);
-  static final long maxSleepTime = HOURS.toMillis(24);
-  long sleepTime = origSleepTime;
+  static final long ORIG_SLEEP_TIME = MINUTES.toMillis(30);
+  static final long MAX_SLEEP_TIME = HOURS.toMillis(24);
+  long sleepTime = ORIG_SLEEP_TIME;
 
   private long valueAtSchedule;
 
@@ -593,16 +601,19 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
   private boolean scheduledDBRs;
   private boolean scheduleAfterDBRsDone;
 
-  // FIXME use this!
+  // Options flags for constructor to reduce parameter count
+  static final int OPT_POLL_FOREVER = 1;
+  static final int OPT_KEEP_LAST_DATA = 1 << 1;
+  static final int OPT_CHECK_STORE_ONLY = 1 << 2;
+
+  // Note: reserved for potential future use.
   USKFetcher(
       USK origUSK,
       USKManager manager,
       FetchContext ctx,
       ClientRequester requester,
       int minFailures,
-      boolean pollForever,
-      boolean keepLastData,
-      boolean checkStoreOnly) {
+      int options) {
     this.parent = requester;
     this.origUSK = origUSK;
     this.uskManager = manager;
@@ -613,6 +624,9 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     subscribers = new HashSet<>();
     lastFetchedEdition = -1;
     this.realTimeFlag = parent.realTimeFlag();
+    this.backgroundPoll = (options & OPT_POLL_FOREVER) != 0;
+    this.keepLastData = (options & OPT_KEEP_LAST_DATA) != 0;
+    this.checkStoreOnly = (options & OPT_CHECK_STORE_ONLY) != 0;
     ctxDBR = ctx.clone();
     if (ctx.followRedirects) {
       this.ctx = ctx.clone();
@@ -632,10 +646,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       ctxNoStore = this.ctx.clone();
       ctxNoStore.ignoreStore = true;
     }
-    this.backgroundPoll = pollForever;
-    this.keepLastData = keepLastData;
-    this.checkStoreOnly = checkStoreOnly;
-    if (checkStoreOnly && LOG.isDebugEnabled()) LOG.debug("Just checking store on " + this);
+    if (checkStoreOnly && LOG.isDebugEnabled()) LOG.debug("Just checking store on {}", this);
     // origUSK is a hint. We *do* want to check the edition given.
     // Whereas latestSlot we've definitely fetched, we don't want to re-check.
     watchingKeys =
@@ -643,10 +654,19 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     attemptsToStart = new ArrayList<>();
   }
 
+  /**
+   * Called when all outstanding DBR hint fetches have either completed or failed.
+   *
+   * <p>If the main scheduling path was waiting for DBR results, this method triggers the next
+   * scheduling step. It also checks whether the current polling round can be considered finished
+   * for now and notifies progress callbacks.
+   *
+   * @param context the client context used for scheduling follow-up work; must not be {@code null}
+   */
   public void onDBRsFinished(ClientContext context) {
     boolean needSchedule = false;
     synchronized (this) {
-      if (scheduleAfterDBRsDone) needSchedule = true; // FIXME other conditions???
+      if (scheduleAfterDBRsDone) needSchedule = true; // Note: additional conditions may apply.
     }
     if (needSchedule) schedule(context);
     checkFinishedForNow(context);
@@ -655,74 +675,22 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
   private int dbrHintsFound = 0;
   private int dbrHintsStarted = 0;
 
-  public void processDBRHint(long hint, ClientContext context, DBRAttempt dbrAttempt) {
-    // FIXME this is an inefficient first attempt!
-    // We should have a separate registry of latest DBR hint versions,
-    // like those for latest known good and latest slot.
-    // We should dump anything before it within USKFetcher, and fetch from
-    // the given slot onwards, inclusive (unlike elsewhere where we fetch
-    // from the last known exclusive).
-    try {
-      updatePriorities();
-      short prio;
-      List<DBRAttempt> toCancel = null;
-      synchronized (this) {
-        if (cancelled || completed) return;
-        dbrHintsFound++;
-        prio = progressPollPriority;
-        for (Iterator<DBRAttempt> i = dbrAttempts.iterator(); i.hasNext(); ) {
-          DBRAttempt a = i.next();
-          if (dbrAttempt.type.alwaysMorePreciseThan(a.type)) {
-            if (toCancel == null) toCancel = new ArrayList<>();
-            toCancel.add(a);
-            i.remove();
-          }
-        }
-      }
-      this.uskManager.hintUpdate(this.origUSK.copy(hint).getURI(), context, prio);
-      if (toCancel != null) {
-        for (DBRAttempt a : toCancel) a.cancel(context);
-      }
-    } catch (MalformedURLException e) {
-      // Impossible
-    }
-  }
-
+  /**
+   * Notifies that a USK slot check entered a finite cooldown.
+   *
+   * <p>This is used as a progress signal during a polling round to determine whether the round can
+   * be considered finished for now when all active checks have cooled down at least once.
+   *
+   * @param context client context used to perform completion checks; must not be {@code null}
+   */
   public void onCheckEnteredFiniteCooldown(ClientContext context) {
     checkFinishedForNow(context);
   }
 
   private void checkFinishedForNow(ClientContext context) {
-    USKAttempt[] attempts;
-    synchronized (this) {
-      if (cancelled || completed) return;
-      if (runningStoreChecker != null) {
-        if (LOG.isDebugEnabled())
-          LOG.debug("Not finished because still running store checker on " + this);
-        return; // Still checking the store
-      }
-      if (!runningAttempts.isEmpty()) {
-        if (LOG.isDebugEnabled())
-          LOG.debug("Not finished because running attempts (random probes) on " + this);
-        return; // Still running
-      }
-      if (pollingAttempts.isEmpty()) {
-        if (LOG.isDebugEnabled())
-          LOG.debug("Not finished because no polling attempts (not started???) on " + this);
-        return; // Not started yet
-      }
-      if (!dbrAttempts.isEmpty()) {
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "Not finished because still waiting for DBR attempts on "
-                  + this
-                  + " : "
-                  + dbrAttempts);
-        return; // DBRs
-      }
-      attempts = pollingAttempts.values().toArray(new USKAttempt[0]);
-    }
-    for (USKAttempt a : attempts) {
+    PollingResolution res = resolvePollingAttemptsIfAllChecksDone();
+    if (!res.ready) return;
+    for (USKAttempt a : res.attempts) {
       // All the polling attempts currently running must have entered cooldown once.
       // I.e. they must have done all their fetches at least once.
       // If we check whether they are *currently* in cooldown, then under heavy USK load (the common
@@ -730,21 +698,58 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       if (!a.everInCooldown()) {
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "Not finished because polling attempt " + a + " never entered cooldown on " + this);
+              "Not finished because polling attempt {} never entered cooldown on {}", a, this);
         return;
       }
     }
     notifyFinishedForNow(context);
   }
 
+  private static final class PollingResolution {
+    final boolean ready;
+    final USKAttempt[] attempts;
+
+    PollingResolution(boolean ready, USKAttempt[] attempts) {
+      this.ready = ready;
+      this.attempts = attempts;
+    }
+  }
+
+  private PollingResolution resolvePollingAttemptsIfAllChecksDone() {
+    synchronized (this) {
+      if (cancelled || completed) return new PollingResolution(false, new USKAttempt[0]);
+      if (runningStoreChecker != null) {
+        if (LOG.isDebugEnabled())
+          LOG.debug("Not finished because still running store checker on {}", this);
+        return new PollingResolution(false, new USKAttempt[0]); // Still checking the store
+      }
+      if (!runningAttempts.isEmpty()) {
+        if (LOG.isDebugEnabled())
+          LOG.debug("Not finished because running attempts (random probes) on {}", this);
+        return new PollingResolution(false, new USKAttempt[0]); // Still running
+      }
+      if (pollingAttempts.isEmpty()) {
+        if (LOG.isDebugEnabled())
+          LOG.debug("Not finished because no polling attempts (not started???) on {}", this);
+        return new PollingResolution(false, new USKAttempt[0]); // Not started yet
+      }
+      if (!dbrAttempts.isEmpty()) {
+        if (LOG.isDebugEnabled())
+          LOG.debug(
+              "Not finished because still waiting for DBR attempts on {} : {}", this, dbrAttempts);
+        return new PollingResolution(false, new USKAttempt[0]); // DBRs
+      }
+      return new PollingResolution(true, pollingAttempts.values().toArray(new USKAttempt[0]));
+    }
+  }
+
   private void notifyFinishedForNow(ClientContext context) {
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Notifying finished for now on "
-              + this
-              + " for "
-              + origUSK
-              + (this.realTimeFlag ? " (realtime)" : " (bulk)"));
+          "Notifying finished for now on {} for {}{}",
+          this,
+          origUSK,
+          this.realTimeFlag ? " (realtime)" : " (bulk)");
     USKCallback[] toCheck;
     synchronized (this) {
       if (cancelled || completed) return;
@@ -755,19 +760,10 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     }
   }
 
-  private void notifySendingToNetwork(ClientContext context) {
-    USKCallback[] toCheck;
-    synchronized (this) {
-      if (cancelled || completed) return;
-      toCheck = subscribers.toArray(new USKCallback[0]);
-    }
-    for (USKCallback cb : toCheck) {
-      if (cb instanceof USKProgressCallback callback) callback.onSendingToNetwork(context);
-    }
-  }
+  // moved into StoreCheckerGetter to satisfy S3398
 
   void onDNF(USKAttempt att, ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("DNF: " + att);
+    if (LOG.isDebugEnabled()) LOG.debug("DNF: {}", att);
     boolean finished = false;
     long curLatest = uskManager.lookupLatestSlot(origUSK);
     synchronized (this) {
@@ -777,16 +773,14 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       if (runningAttempts.isEmpty()) {
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "latest: "
-                  + curLatest
-                  + ", last fetched: "
-                  + lastFetchedEdition
-                  + ", curLatest+MIN_FAILURES: "
-                  + (curLatest + origMinFailures));
+              "latest: {}, last fetched: {}, curLatest+MIN_FAILURES: {}",
+              curLatest,
+              lastFetchedEdition,
+              curLatest + origMinFailures);
         if (started) {
           finished = true;
         }
-      } else if (LOG.isDebugEnabled()) LOG.debug("Remaining: " + runningAttempts());
+      } else if (LOG.isDebugEnabled()) LOG.debug("Remaining: {}", runningAttempts());
     }
     if (finished) {
       finishSuccess(context);
@@ -798,6 +792,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     boolean first = true;
     for (USKAttempt a : runningAttempts.values()) {
       if (!first) sb.append(", ");
+      first = false;
       sb.append(a.number);
       if (a.cancelled) sb.append("(cancelled)");
       if (a.succeeded) sb.append("(succeeded)");
@@ -806,84 +801,84 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
   }
 
   private void finishSuccess(ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("finishSuccess() on " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("finishSuccess() on {}", this);
     if (backgroundPoll) {
-      long valAtEnd = uskManager.lookupLatestSlot(origUSK);
-      long end;
-      long now = System.currentTimeMillis();
-      synchronized (this) {
-        started = false; // don't finish before have rescheduled
-
-        // Find out when we should check next ('end'), in an increasing delay (unless we make
-        // progress).
-        long newSleepTime = sleepTime * 2;
-        if (newSleepTime > maxSleepTime) newSleepTime = maxSleepTime;
-        sleepTime = newSleepTime;
-        end = now + context.random.nextInt((int) sleepTime);
-
-        if (valAtEnd > valueAtSchedule && valAtEnd > origUSK.suggestedEdition) {
-          // We have advanced; keep trying as if we just started.
-          // Only if we actually DO advance, not if we just confirm our suspicion (valueAtSchedule
-          // always starts at 0).
-          sleepTime = origSleepTime;
-          firstLoop = false;
-          end = now;
-          if (LOG.isDebugEnabled())
-            LOG.debug("We have advanced: at start, " + valueAtSchedule + " at end, " + valAtEnd);
-        }
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "Sleep time is " + sleepTime + " this sleep is " + (end - now) + " for " + this);
-      }
-      schedule(end - now, context);
-      checkFinishedForNow(context);
+      rescheduleBackgroundPoll(context);
     } else {
-      USKFetcherCallback[] cb;
-      synchronized (this) {
-        completed = true;
-        cb = callbacks.toArray(new USKFetcherCallback[0]);
+      completeCallbacks(context);
+    }
+  }
+
+  private void rescheduleBackgroundPoll(ClientContext context) {
+    long valAtEnd = uskManager.lookupLatestSlot(origUSK);
+    long end;
+    long now = System.currentTimeMillis();
+    synchronized (this) {
+      started = false; // don't finish before have rescheduled
+
+      // Find out when we should check next ('end'), in an increasing delay (unless we make
+      // progress).
+      long newSleepTime = sleepTime * 2;
+      if (newSleepTime > MAX_SLEEP_TIME) newSleepTime = MAX_SLEEP_TIME;
+      sleepTime = newSleepTime;
+      end = now + context.random.nextInt((int) sleepTime);
+
+      if (valAtEnd > valueAtSchedule && valAtEnd > origUSK.suggestedEdition) {
+        // We have advanced; keep trying as if we just started.
+        // Only if we actually DO advance, not if we just confirm our suspicion (valueAtSchedule
+        // always starts at 0).
+        sleepTime = ORIG_SLEEP_TIME;
+        firstLoop = false;
+        end = now;
+        if (LOG.isDebugEnabled())
+          LOG.debug("We have advanced: at start, {} at end, {}", valueAtSchedule, valAtEnd);
       }
-      uskManager.unsubscribe(origUSK, this);
-      uskManager.onFinished(this);
-      context
-          .getSskFetchScheduler(realTimeFlag)
-          .schedTransient
-          .removePendingKeys((KeyListener) this);
-      long ed = uskManager.lookupLatestSlot(origUSK);
-      byte[] data;
-      synchronized (this) {
-        if (lastRequestData == null) data = null;
-        else {
-          try {
-            data = BucketTools.toByteArray(lastRequestData);
-          } catch (IOException e) {
-            LOG.error("Unable to turn lastRequestData into byte[]: caught I/O exception: " + e, e);
-            data = null;
-          }
-          lastRequestData.free();
-        }
-      }
-      for (USKFetcherCallback c : cb) {
+      if (LOG.isDebugEnabled())
+        LOG.debug("Sleep time is {} this sleep is {} for {}", sleepTime, end - now, this);
+    }
+    schedule(end - now, context);
+    checkFinishedForNow(context);
+  }
+
+  private void completeCallbacks(ClientContext context) {
+    USKFetcherCallback[] cb;
+    synchronized (this) {
+      completed = true;
+      cb = callbacks.toArray(new USKFetcherCallback[0]);
+    }
+    uskManager.unsubscribe(origUSK, this);
+    uskManager.onFinished(this);
+    context.getSskFetchScheduler(realTimeFlag).schedTransient.removePendingKeys((KeyListener) this);
+    long ed = uskManager.lookupLatestSlot(origUSK);
+    byte[] data;
+    synchronized (this) {
+      if (lastRequestData == null) data = null;
+      else {
         try {
-          if (ed == -1) c.onFailure(context);
-          else
-            c.onFoundEdition(
-                ed,
-                origUSK.copy(ed),
-                context,
-                lastWasMetadata,
-                lastCompressionCodec,
-                data,
-                false,
-                false);
-        } catch (Exception e) {
-          LOG.error(
-              "An exception occured while dealing with a callback:"
-                  + c.toString()
-                  + "\n"
-                  + e.getMessage(),
-              e);
+          data = BucketTools.toByteArray(lastRequestData);
+        } catch (IOException e) {
+          LOG.error("Unable to turn lastRequestData into byte[]: caught I/O exception: {}", e, e);
+          data = null;
         }
+        lastRequestData.free();
+      }
+    }
+    for (USKFetcherCallback c : cb) {
+      try {
+        if (ed == -1) c.onFailure(context);
+        else
+          c.onFoundEdition(
+              ed,
+              origUSK.copy(ed),
+              context,
+              lastWasMetadata,
+              lastCompressionCodec,
+              data,
+              false,
+              false);
+      } catch (Exception e) {
+        LOG.error(
+            "An exception occured while dealing with a callback:{}\n{}", c, e.getMessage(), e);
       }
     }
   }
@@ -901,86 +896,119 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       final ClientContext context) {
     final long lastEd = uskManager.lookupLatestSlot(origUSK);
     if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Found edition "
-              + curLatest
-              + " for "
-              + origUSK
-              + " official is "
-              + lastEd
-              + " on "
-              + this);
-    boolean decode = false;
+      LOG.debug("Found edition {} for {} official is {} on {}", curLatest, origUSK, lastEd, this);
+
+    SuccessPlan plan = prepareSuccessPlan(att, curLatest, dontUpdate, block, context, lastEd);
+    if (plan == null) return; // finished or cancelled
+
+    finishCancelBefore(plan.killAttempts, context);
+
+    Bucket data = decodeBlockIfNeeded(plan.decode, block, context);
+
+    applyDecodedData(plan.decode, block, data);
+
+    if (!dontUpdate) uskManager.updateSlot(origUSK, plan.curLatest, context);
+    if (plan.registerNow) registerAttempts(context);
+  }
+
+  private Bucket decodeBlockIfNeeded(boolean decode, ClientSSKBlock block, ClientContext context) {
+    if (!decode || block == null) return null;
+    try {
+      return block.decode(
+          context.getBucketFactory(parent.persistent()), 1025 /* it's an SSK */, true);
+    } catch (KeyDecodeException e) {
+      return null;
+    } catch (IOException e) {
+      LOG.error("An IOE occured while decoding: {}", e.getMessage(), e);
+      return null;
+    }
+  }
+
+  private void applyDecodedData(boolean decode, ClientSSKBlock block, Bucket data) {
+    synchronized (this) {
+      if (!decode) return;
+      if (block != null) {
+        lastCompressionCodec = block.getCompressionCodec();
+        lastWasMetadata = block.isMetadata();
+        if (keepLastData) {
+          if (lastRequestData != null) lastRequestData.free();
+          lastRequestData = data;
+        } else if (data != null) {
+          data.free();
+        }
+      } else {
+        lastCompressionCodec = -1;
+        lastWasMetadata = false;
+        lastRequestData = null;
+      }
+    }
+  }
+
+  private SuccessPlan prepareSuccessPlan(
+      USKAttempt att,
+      long curLatest,
+      boolean dontUpdate,
+      ClientSSKBlock block,
+      ClientContext context,
+      long lastEd) {
+    boolean decode;
     List<USKAttempt> killAttempts = null;
     boolean registerNow;
-    // FIXME call uskManager.updateSlot BEFORE getEditionsToFetch, avoids a possible conflict, but
-    // creates another (with onFoundEdition) - we'd probably have to handle this there???
     synchronized (this) {
       if (att != null) runningAttempts.remove(att.number);
       if (completed || cancelled) {
         if (LOG.isDebugEnabled())
-          LOG.debug("Finished already: completed=" + completed + " cancelled=" + cancelled);
-        return;
+          LOG.debug("Finished already: completed={} cancelled={}", completed, cancelled);
+        return null;
       }
-      decode = curLatest >= lastEd && !(dontUpdate && block == null);
+      decode = shouldDecode(curLatest, lastEd, dontUpdate, block);
       curLatest = Math.max(lastEd, curLatest);
-      if (LOG.isDebugEnabled()) LOG.debug("Latest: " + curLatest + " in onSuccess");
+      if (LOG.isDebugEnabled()) LOG.debug("Latest: {} in onSuccess", curLatest);
       if (!checkStoreOnly) {
-        killAttempts = cancelBefore(curLatest, context);
-        USKWatchingKeys.ToFetch list =
-            watchingKeys.getEditionsToFetch(
-                curLatest,
-                context.random,
-                getRunningFetchEditions(),
-                shouldAddRandomEditions(context.random));
-        Lookup[] toPoll = list.toPoll;
-        Lookup[] toFetch = list.toFetch;
-        for (Lookup i : toPoll) {
-          if (LOG.isTraceEnabled()) LOG.trace("Polling " + i + " for " + this);
-          attemptsToStart.add(add(i, true));
-        }
-        for (Lookup i : toFetch) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("Adding checker for edition " + i + " for " + origUSK);
-          attemptsToStart.add(add(i, false));
-        }
+        killAttempts = cancelBefore(curLatest);
+        addNewAttempts(curLatest, context);
       }
       if ((!scheduleAfterDBRsDone) || dbrAttempts.isEmpty())
         registerNow = !fillKeysWatching(curLatest, context);
       else registerNow = false;
     }
-    finishCancelBefore(killAttempts, context);
-    Bucket data = null;
-    if (decode && block != null) {
-      try {
-        data =
-            block.decode(
-                context.getBucketFactory(parent.persistent()), 1025 /* it's an SSK */, true);
-      } catch (KeyDecodeException e) {
-        data = null;
-      } catch (IOException e) {
-        data = null;
-        LOG.error("An IOE occured while decoding: " + e.getMessage(), e);
-      }
+    SuccessPlan plan = new SuccessPlan();
+    plan.decode = decode;
+    plan.curLatest = curLatest;
+    plan.registerNow = registerNow;
+    plan.killAttempts = killAttempts;
+    return plan;
+  }
+
+  private static boolean shouldDecode(
+      long curLatest, long lastEd, boolean dontUpdate, ClientSSKBlock block) {
+    return curLatest >= lastEd && !(dontUpdate && block == null);
+  }
+
+  private void addNewAttempts(long curLatest, ClientContext context) {
+    USKWatchingKeys.ToFetch list =
+        watchingKeys.getEditionsToFetch(
+            curLatest,
+            context.random,
+            getRunningFetchEditions(),
+            shouldAddRandomEditions(context.random));
+    Lookup[] toPoll = list.poll;
+    Lookup[] toFetch = list.fetch;
+    for (Lookup i : toPoll) {
+      if (LOG.isTraceEnabled()) LOG.trace("Polling {} for {}", i, this);
+      attemptsToStart.add(add(i, true));
     }
-    synchronized (this) {
-      if (decode) {
-        if (block != null) {
-          lastCompressionCodec = block.getCompressionCodec();
-          lastWasMetadata = block.isMetadata();
-          if (keepLastData) {
-            if (lastRequestData != null) lastRequestData.free();
-            lastRequestData = data;
-          } else data.free();
-        } else {
-          lastCompressionCodec = -1;
-          lastWasMetadata = false;
-          lastRequestData = null;
-        }
-      }
+    for (Lookup i : toFetch) {
+      if (LOG.isDebugEnabled()) LOG.debug("Adding checker for edition {} for {}", i, origUSK);
+      attemptsToStart.add(add(i, false));
     }
-    if (!dontUpdate) uskManager.updateSlot(origUSK, curLatest, context);
-    if (registerNow) registerAttempts(context);
+  }
+
+  private static final class SuccessPlan {
+    boolean decode;
+    long curLatest;
+    boolean registerNow;
+    List<USKAttempt> killAttempts;
   }
 
   private boolean shouldAddRandomEditions(Random random) {
@@ -1006,15 +1034,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     for (USKFetcherCallback c : cb) c.onCancelled(context);
   }
 
-  public void onFail(USKAttempt attempt, ClientContext context) {
-    // FIXME what else can we do?
-    // Certainly we don't want to continue fetching indefinitely...
-    // ... e.g. RNFs don't indicate we should try a later slot, none of them
-    // really do.
-    onDNF(attempt, context);
-  }
-
-  private List<USKAttempt> cancelBefore(long curLatest, ClientContext context) {
+  private List<USKAttempt> cancelBefore(long curLatest) {
     List<USKAttempt> v = null;
     int count = 0;
     synchronized (this) {
@@ -1042,8 +1062,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
   private void finishCancelBefore(List<USKAttempt> v, ClientContext context) {
     if (v != null) {
-      for (int i = 0; i < v.size(); i++) {
-        USKAttempt att = v.get(i);
+      for (USKAttempt att : v) {
         att.cancel(context);
       }
     }
@@ -1054,45 +1073,82 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     long i = l.val;
     if (l.val < 0)
       throw new IllegalArgumentException(
-          "Can't check <0 for " + l.val + " on " + this + " for " + origUSK);
+          "Can't check <0" + FOR_LITERAL + l.val + " on " + this + FOR_LITERAL + origUSK);
     if (cancelled) return null;
     if (checkStoreOnly) return null;
-    if (LOG.isDebugEnabled()) LOG.debug("Adding USKAttempt for " + i + " for " + origUSK.getURI());
-    if (forever) {
-      if (pollingAttempts.containsKey(i)) {
-        if (LOG.isDebugEnabled()) LOG.debug("Already polling edition: " + i + " for " + this);
-        return null;
-      }
-    } else {
-      if (runningAttempts.containsKey(i)) {
-        if (LOG.isDebugEnabled())
-          LOG.debug("Returning because already running for " + origUSK.getURI());
-        return null;
-      }
-    }
+    if (LOG.isDebugEnabled()) LOG.debug("Adding USKAttempt for {} for {}", i, origUSK.getURI());
+    if (isDuplicateAttempt(forever, i)) return null;
     USKAttempt a = new USKAttempt(l, forever);
     if (forever) pollingAttempts.put(i, a);
     else {
       runningAttempts.put(i, a);
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Added " + a + " for " + origUSK);
+    if (LOG.isDebugEnabled()) LOG.debug("Added {} for {}", a, origUSK);
     return a;
   }
 
+  private boolean isDuplicateAttempt(boolean forever, long edition) {
+    if (forever) {
+      if (pollingAttempts.containsKey(edition)) {
+        if (LOG.isDebugEnabled()) LOG.debug("Already polling edition: {} for {}", edition, this);
+        return true;
+      }
+    } else {
+      if (runningAttempts.containsKey(edition)) {
+        if (LOG.isDebugEnabled())
+          LOG.debug("Returning because already running for {}", origUSK.getURI());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns the underlying {@link FreenetURI} of the original USK.
+   *
+   * @return an immutable URI identifying the USK being fetched; callers must not modify the
+   *     returned object
+   */
   public FreenetURI getURI() {
     return origUSK.getURI();
   }
 
+  /**
+   * Reports whether this fetcher has reached a terminal state.
+   *
+   * <p>Returns {@code true} once the fetcher has been cancelled or completed. After that point it
+   * no longer schedules work, though background pollers may be re-armed by {@link
+   * #schedule(ClientContext)} if applicable.
+   *
+   * @return {@code true} if cancelled or completed; otherwise {@code false}
+   */
   public boolean isFinished() {
     synchronized (this) {
       return completed || cancelled;
     }
   }
 
+  /**
+   * Returns the original {@link USK} descriptor associated with this fetcher.
+   *
+   * @return the non-null {@link USK} this instance tracks; the object is owned by the fetcher and
+   *     should be treated as read-only by callers
+   */
   public USK getOriginalUSK() {
     return origUSK;
   }
 
+  /**
+   * Schedules this fetcher immediately or after a delay.
+   *
+   * <p>When {@code delay <= 0}, scheduling happens synchronously on the caller's thread. For
+   * positive delays, the request is enqueued on the client's timer facility and will schedule later
+   * from that context.
+   *
+   * @param delay delay in milliseconds before scheduling; non-positive schedules immediately
+   * @param context client context used to reach the scheduler and timing facilities; must not be
+   *     {@code null}
+   */
   public void schedule(long delay, final ClientContext context) {
     if (delay <= 0) {
       schedule(context);
@@ -1101,80 +1157,97 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     }
   }
 
+  /**
+   * Schedules this fetcher to run immediately using the provided context.
+   *
+   * <p>The call registers this instance with the appropriate schedulers, subscribes to the {@link
+   * USKManager}, and, depending on configuration, may start DBR hint fetches and targeted edition
+   * checks. If the fetcher has already finished or has been cancelled, the method returns without
+   * scheduling new work. Repeated calls are safe; they re-apply the current dynamic priorities and
+   * ensure registration is in place.
+   *
+   * @param context client context that provides schedulers, timing, and factories required to run
+   *     the discovery loop; must not be {@code null}
+   */
   @Override
   public void schedule(ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("Scheduling " + this);
-    DBRAttempt[] atts = null;
-    synchronized (this) {
-      if (cancelled) return;
-      if (completed) return;
-      if (!scheduledDBRs && !ctx.ignoreUSKDatehints) {
-        atts = addDBRs(context);
-      }
-      scheduledDBRs = true;
-    }
+    if (LOG.isDebugEnabled()) LOG.debug("Scheduling {}", this);
+    if (shouldAbortSchedule()) return;
+    DBRAttempt[] atts = maybeAddDBRs(context);
     context.getSskFetchScheduler(realTimeFlag).schedTransient.addPendingKeys(this);
     updatePriorities();
     uskManager.subscribe(origUSK, this, false, parent.getClient());
     if (atts != null) startDBRs(atts, context);
     long lookedUp = uskManager.lookupLatestSlot(origUSK);
+    SchedulePlan plan = buildSchedulePlan(lookedUp, atts, context);
+    if (plan.registerNow) registerAttempts(context);
+    else if (plan.completeCheckingStore) {
+      this.finishSuccess(context);
+      return;
+    }
+    if (!plan.bye) return;
+    // We have been cancelled.
+    uskManager.unsubscribe(origUSK, this);
+    context.getSskFetchScheduler(realTimeFlag).schedTransient.removePendingKeys((KeyListener) this);
+    uskManager.onFinished(this, true);
+  }
+
+  private boolean shouldAbortSchedule() {
+    synchronized (this) {
+      return cancelled || completed;
+    }
+  }
+
+  private DBRAttempt[] maybeAddDBRs(ClientContext context) {
+    DBRAttempt[] atts = null;
+    synchronized (this) {
+      if (!scheduledDBRs && !ctx.ignoreUSKDatehints) {
+        atts = addDBRs(context);
+      }
+      scheduledDBRs = true;
+    }
+    return atts;
+  }
+
+  private SchedulePlan buildSchedulePlan(long lookedUp, DBRAttempt[] atts, ClientContext context) {
     boolean registerNow = false;
-    boolean bye = false;
+    boolean bye;
     boolean completeCheckingStore = false;
     synchronized (this) {
       valueAtSchedule = Math.max(lookedUp + 1, valueAtSchedule);
       bye = cancelled || completed;
       if (!bye) {
-
         // subscribe() above may have called onFoundEdition and thus added a load of stuff. If so,
         // we don't need to do so here.
         if ((!checkStoreOnly)
             && attemptsToStart.isEmpty()
             && runningAttempts.isEmpty()
             && pollingAttempts.isEmpty()) {
-          USKWatchingKeys.ToFetch list =
-              watchingKeys.getEditionsToFetch(
-                  lookedUp,
-                  context.random,
-                  getRunningFetchEditions(),
-                  shouldAddRandomEditions(context.random));
-          Lookup[] toPoll = list.toPoll;
-          Lookup[] toFetch = list.toFetch;
-          for (Lookup i : toPoll) {
-            if (LOG.isTraceEnabled()) LOG.trace("Polling " + i + " for " + this);
-            attemptsToStart.add(add(i, true));
-          }
-          for (Lookup i : toFetch) {
-            if (LOG.isDebugEnabled())
-              LOG.debug("Adding checker for edition " + i + " for " + origUSK);
-            attemptsToStart.add(add(i, false));
-          }
+          addNewAttempts(lookedUp, context);
         }
 
         started = true;
         if (lookedUp <= 0 && atts != null) {
           // If we don't know anything, do the DBRs first.
           scheduleAfterDBRsDone = true;
-          registerNow = false;
         } else if ((!scheduleAfterDBRsDone) || dbrAttempts.isEmpty()) {
           registerNow = !fillKeysWatching(lookedUp, context);
-        } else {
-          registerNow = false;
         }
         completeCheckingStore =
             checkStoreOnly && scheduleAfterDBRsDone && runningStoreChecker == null;
       }
     }
-    if (registerNow) registerAttempts(context);
-    else if (completeCheckingStore) {
-      this.finishSuccess(context);
-      return;
-    }
-    if (!bye) return;
-    // We have been cancelled.
-    uskManager.unsubscribe(origUSK, this);
-    context.getSskFetchScheduler(realTimeFlag).schedTransient.removePendingKeys((KeyListener) this);
-    uskManager.onFinished(this, true);
+    SchedulePlan plan = new SchedulePlan();
+    plan.registerNow = registerNow;
+    plan.bye = bye;
+    plan.completeCheckingStore = completeCheckingStore;
+    return plan;
+  }
+
+  private static final class SchedulePlan {
+    boolean registerNow;
+    boolean bye;
+    boolean completeCheckingStore;
   }
 
   /** Call synchronized, then call startDBRs() */
@@ -1197,9 +1270,25 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     for (DBRAttempt att : toStart) att.start(context);
   }
 
+  /**
+   * Cancels this fetcher and releases scheduler registrations.
+   *
+   * <p>After cancellation the fetcher stops scheduling any further datastore checks, DBR hint
+   * fetches, or edition probes, and it unsubscribes from the {@link USKManager}. In-flight attempts
+   * are cancelled when possible and subsequent calls that would otherwise schedule work become
+   * no-ops. This method is idempotent; calling it more than once has no additional effect beyond
+   * logging.
+   *
+   * <p>Cancellation does not delete any previously obtained data. If background polling was
+   * configured, it is disabled for the lifetime of this instance. A new {@code USKFetcher} must be
+   * created to resume discovery.
+   *
+   * @param context the client runtime context used to unregister listeners and cancel outstanding
+   *     work; must not be {@code null}
+   */
   @Override
   public void cancel(ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("Cancelling " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Cancelling {}", this);
     uskManager.unsubscribe(origUSK, this);
     context.getSskFetchScheduler(realTimeFlag).schedTransient.removePendingKeys((KeyListener) this);
     USKAttempt[] attempts;
@@ -1209,8 +1298,8 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     SendableGet storeChecker;
     Bucket data;
     synchronized (this) {
-      if (cancelled) LOG.error("Already cancelled " + this);
-      if (completed) LOG.error("Already completed " + this);
+      if (cancelled) LOG.error("Already cancelled {}", this);
+      if (completed) LOG.error("Already completed {}", this);
       cancelled = true;
       attempts = runningAttempts.values().toArray(new USKAttempt[0]);
       polling = pollingAttempts.values().toArray(new USKAttempt[0]);
@@ -1244,11 +1333,16 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
   final HashMap<USKCallback, Long> subscriberHints = new HashMap<>();
 
   /**
-   * Add a subscriber. Subscribers are not directly sent onFoundEdition()'s by the USKFetcher, we
-   * just use them to determine the priority of our requests and whether we should continue to
-   * request.
+   * Adds a subscriber and its current edition hint.
    *
-   * @param cb
+   * <p>Subscribers are not directly notified by this class; instead they influence whether and how
+   * aggressively the fetcher continues to probe for newer editions. Hints help bias the search and
+   * are folded into the key-watching window used for datastore checks and network probes.
+   *
+   * @param cb the subscriber whose interest influences polling priority and continuation; must not
+   *     be {@code null}
+   * @param hint the subscriber's best-known edition number; values less than or equal to the last
+   *     looked-up slot are ignored; larger values expand the search window
    */
   public void addSubscriber(USKCallback cb, long hint) {
     Long[] hints;
@@ -1262,11 +1356,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
   }
 
   private void updatePriorities() {
-    // FIXME should this be synchronized? IMHO it doesn't matter that much if we get the priority
-    // wrong for a few requests... also, we avoid any possible deadlock this way if the callbacks
-    // take locks...
-    short normalPrio = RequestStarter.PAUSED_PRIORITY_CLASS;
-    short progressPrio = RequestStarter.PAUSED_PRIORITY_CLASS;
+    Prio prio = initialPrio();
     USKCallback[] localCallbacks;
     USKFetcherCallback[] fetcherCallbacks;
     synchronized (this) {
@@ -1275,63 +1365,106 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       // Otherwise USKFetcherTag would have no way to tell us the priority we should run at.
       fetcherCallbacks = callbacks.toArray(new USKFetcherCallback[0]);
     }
-    if (localCallbacks.length == 0 && fetcherCallbacks.length == 0) {
-      normalPollPriority = DEFAULT_NORMAL_POLL_PRIORITY;
-      progressPollPriority = DEFAULT_PROGRESS_POLL_PRIORITY;
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Updating priorities: normal = "
-                + normalPollPriority
-                + " progress = "
-                + progressPollPriority
-                + " for "
-                + this
-                + " for "
-                + origUSK);
+    if (noCallbacks(localCallbacks, fetcherCallbacks)) {
+      setDefaultPriorities();
       return;
     }
 
-    for (USKCallback cb : localCallbacks) {
-      short prio = cb.getPollingPriorityNormal();
-      if (LOG.isTraceEnabled()) LOG.trace("Normal priority for " + cb + " : " + prio);
-      if (prio < normalPrio) normalPrio = prio;
-      if (LOG.isTraceEnabled()) LOG.trace("Progress priority for " + cb + " : " + prio);
-      prio = cb.getPollingPriorityProgress();
-      if (prio < progressPrio) progressPrio = prio;
-    }
-    for (USKFetcherCallback cb : fetcherCallbacks) {
-      short prio = cb.getPollingPriorityNormal();
-      if (LOG.isTraceEnabled()) LOG.trace("Normal priority for " + cb + " : " + prio);
-      if (prio < normalPrio) normalPrio = prio;
-      if (LOG.isTraceEnabled()) LOG.trace("Progress priority for " + cb + " : " + prio);
-      prio = cb.getPollingPriorityProgress();
-      if (prio < progressPrio) progressPrio = prio;
-    }
+    accumulatePriorities(localCallbacks, prio);
+    accumulatePriorities(fetcherCallbacks, prio);
+
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Updating priorities: normal="
-              + normalPrio
-              + " progress="
-              + progressPrio
-              + " for "
-              + this
-              + " for "
-              + origUSK);
+          "Updating priorities: normal={} progress={} for {} for {}",
+          prio.normal,
+          prio.progress,
+          this,
+          origUSK);
     synchronized (this) {
-      normalPollPriority = normalPrio;
-      progressPollPriority = progressPrio;
+      normalPollPriority = prio.normal;
+      progressPollPriority = prio.progress;
     }
   }
 
+  private static final class Prio {
+    short normal;
+    short progress;
+  }
+
+  private static Prio initialPrio() {
+    Prio p = new Prio();
+    p.normal = RequestStarter.PAUSED_PRIORITY_CLASS;
+    p.progress = RequestStarter.PAUSED_PRIORITY_CLASS;
+    return p;
+  }
+
+  private static boolean noCallbacks(
+      USKCallback[] localCallbacks, USKFetcherCallback[] fetcherCallbacks) {
+    return localCallbacks.length == 0 && fetcherCallbacks.length == 0;
+  }
+
+  private void setDefaultPriorities() {
+    normalPollPriority = DEFAULT_NORMAL_POLL_PRIORITY;
+    progressPollPriority = DEFAULT_PROGRESS_POLL_PRIORITY;
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "Updating priorities: normal = {} progress = {} for {} for {}",
+          normalPollPriority,
+          progressPollPriority,
+          this,
+          origUSK);
+  }
+
+  private void accumulatePriorities(USKCallback[] cbs, Prio prio) {
+    for (USKCallback cb : cbs) {
+      short n = cb.getPollingPriorityNormal();
+      if (LOG.isTraceEnabled()) LOG.trace("Normal priority for {} : {}", cb, n);
+      if (n < prio.normal) prio.normal = n;
+      if (LOG.isTraceEnabled()) LOG.trace("Progress priority for {} : {}", cb, n);
+      short p = cb.getPollingPriorityProgress();
+      if (p < prio.progress) prio.progress = p;
+    }
+  }
+
+  private void accumulatePriorities(USKFetcherCallback[] cbs, Prio prio) {
+    for (USKFetcherCallback cb : cbs) {
+      short n = cb.getPollingPriorityNormal();
+      if (LOG.isTraceEnabled()) LOG.trace("Normal priority for {} : {}", cb, n);
+      if (n < prio.normal) prio.normal = n;
+      if (LOG.isTraceEnabled()) LOG.trace("Progress priority for {} : {}", cb, n);
+      short p = cb.getPollingPriorityProgress();
+      if (p < prio.progress) prio.progress = p;
+    }
+  }
+
+  /**
+   * Returns whether any subscribers remain registered with this fetcher.
+   *
+   * @return {@code true} when one or more subscribers are present; {@code false} when none remain
+   */
   public synchronized boolean hasSubscribers() {
     return !subscribers.isEmpty();
   }
 
+  /**
+   * Returns whether any fetcher-level callbacks are registered.
+   *
+   * @return {@code true} when one or more callbacks are registered; otherwise {@code false}
+   */
+  @SuppressWarnings("unused")
   public synchronized boolean hasCallbacks() {
     return !callbacks.isEmpty();
   }
 
-  public void removeSubscriber(USKCallback cb, ClientContext context) {
+  /**
+   * Removes a previously added subscriber.
+   *
+   * <p>The subscriber will no longer influence polling priority or the set of editions watched in
+   * the datastore. Removing a non-existent subscriber has no effect.
+   *
+   * @param cb the subscriber to remove; {@code null} is ignored
+   */
+  public void removeSubscriber(USKCallback cb) {
     Long[] hints;
     synchronized (this) {
       subscribers.remove(cb);
@@ -1342,6 +1475,15 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     watchingKeys.updateSubscriberHints(hints, uskManager.lookupLatestSlot(origUSK));
   }
 
+  /**
+   * Removes a fetcher-level callback.
+   *
+   * <p>After removal, the callback will no longer receive notifications from this fetch cycle. It
+   * also stops contributing to dynamic priority calculations.
+   *
+   * @param cb the callback to remove; {@code null} is ignored
+   */
+  @SuppressWarnings("unused")
   public void removeCallback(USKCallback cb) {
     Long[] hints;
     synchronized (this) {
@@ -1352,21 +1494,69 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     watchingKeys.updateSubscriberHints(hints, uskManager.lookupLatestSlot(origUSK));
   }
 
+  /**
+   * Returns a scheduling token for this request when applicable.
+   *
+   * <p>This implementation does not use scheduler tokens and therefore always returns {@code -1}.
+   * Callers should not depend on a stable or meaningful value here and should instead rely on the
+   * registered key listeners and callbacks to observe progress.
+   *
+   * @return always {@code -1} because this fetcher does not expose a token
+   */
   @Override
   public long getToken() {
     return -1;
   }
 
+  /**
+   * Returns the normal polling priority.
+   *
+   * <p>Not supported for this class: priority is managed internally via {@link #getPriorityClass()}
+   * and dynamic adjustments based on subscribers and callbacks. This method is not expected to be
+   * called by production code and will throw an exception if invoked.
+   *
+   * @return never returns normally
+   * @throws UnsupportedOperationException always, because this operation is unsupported here
+   */
   @Override
   public short getPollingPriorityNormal() {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Returns the progress polling priority.
+   *
+   * <p>Not supported for this class: priority is determined by internal state and the current
+   * progress polling class reported by {@link #getPriorityClass()}. This method is not expected to
+   * be called by production code and will throw an exception if invoked.
+   *
+   * @return never returns normally
+   * @throws UnsupportedOperationException always, because this operation is unsupported here
+   */
   @Override
   public short getPollingPriorityProgress() {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When invoked with {@code newKnownGood == true} and {@code newSlotToo == false} the callback
+   * is ignored because slot (edition) discovery is the only driver for follow-up work here. For
+   * other cases, the method updates the manager and continues the discovery loop as appropriate for
+   * the configured mode.
+   *
+   * @param ed the edition that was discovered or confirmed; non-negative
+   * @param key the USK associated with the edition; must not be {@code null}
+   * @param context execution context used to schedule any follow-up actions; must not be {@code
+   *     null}
+   * @param metadata whether the payload represents metadata rather than content; used when decoding
+   * @param codec the compression codec identifier, if any, reported by the fetch pipeline
+   * @param data optional byte content of the edition when decoding was requested and succeeded; may
+   *     be {@code null}
+   * @param newKnownGood whether this edition is a new known-good for the USK
+   * @param newSlotToo whether a corresponding new slot has been discovered in the index
+   */
   @Override
   public void onFoundEdition(
       long ed,
@@ -1380,58 +1570,61 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     if (newKnownGood && !newSlotToo) return; // Only interested in slots
     // Because this is frequently run off-thread, it is actually possible that the looked up edition
     // is not the same as the edition we are being notified of.
+    FoundPlan plan = prepareFoundPlan(ed, data, context);
+    if (plan == null) return;
+    finishCancelBefore(plan.killAttempts, context);
+    if (plan.registerNow) registerAttempts(context);
+    applyFoundDecodedData(plan.decode, metadata, codec, data, context);
+  }
+
+  private FoundPlan prepareFoundPlan(long ed, byte[] data, ClientContext context) {
     final long lastEd = uskManager.lookupLatestSlot(origUSK);
-    boolean decode = false;
+    boolean decode;
     List<USKAttempt> killAttempts = null;
-    boolean registerNow = false;
+    boolean registerNow;
     synchronized (this) {
-      if (completed || cancelled) return;
+      if (completed || cancelled) return null;
       decode = lastEd == ed && data != null;
       ed = Math.max(lastEd, ed);
-      if (LOG.isDebugEnabled()) LOG.debug("Latest: " + ed + " in onFoundEdition");
+      if (LOG.isDebugEnabled()) LOG.debug("Latest: {} in onFoundEdition", ed);
 
       if (!checkStoreOnly) {
-        killAttempts = cancelBefore(ed, context);
-        USKWatchingKeys.ToFetch list =
-            watchingKeys.getEditionsToFetch(
-                ed,
-                context.random,
-                getRunningFetchEditions(),
-                shouldAddRandomEditions(context.random));
-        Lookup[] toPoll = list.toPoll;
-        Lookup[] toFetch = list.toFetch;
-        for (Lookup i : toPoll) {
-          if (LOG.isTraceEnabled())
-            LOG.trace("Polling " + i + " for " + this + " in onFoundEdition");
-          attemptsToStart.add(add(i, true));
-        }
-        for (Lookup i : toFetch) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("Adding checker for edition " + i + " for " + origUSK + " in onFoundEdition");
-          attemptsToStart.add(add(i, false));
-        }
+        killAttempts = cancelBefore(ed);
+        addNewAttempts(ed, context);
       }
       if ((!scheduleAfterDBRsDone) || dbrAttempts.isEmpty())
         registerNow = !fillKeysWatching(ed, context);
       else registerNow = false;
     }
-    finishCancelBefore(killAttempts, context);
-    if (registerNow) registerAttempts(context);
+    FoundPlan plan = new FoundPlan();
+    plan.decode = decode;
+    plan.killAttempts = killAttempts;
+    plan.registerNow = registerNow;
+    return plan;
+  }
+
+  private void applyFoundDecodedData(
+      boolean decode, boolean metadata, short codec, byte[] data, ClientContext context) {
     synchronized (this) {
-      if (decode) {
-        lastCompressionCodec = codec;
-        lastWasMetadata = metadata;
-        if (keepLastData) {
-          // FIXME inefficient to convert from bucket to byte[] to bucket
-          if (lastRequestData != null) lastRequestData.free();
-          try {
-            lastRequestData = BucketTools.makeImmutableBucket(context.tempBucketFactory, data);
-          } catch (IOException e) {
-            LOG.error("Caught " + e, e);
-          }
+      if (!decode) return;
+      lastCompressionCodec = codec;
+      lastWasMetadata = metadata;
+      if (keepLastData) {
+        // Note: converting bucket to byte[] and back is inefficient
+        if (lastRequestData != null) lastRequestData.free();
+        try {
+          lastRequestData = BucketTools.makeImmutableBucket(context.tempBucketFactory, data);
+        } catch (IOException e) {
+          LOG.error("Caught {}", e, e);
         }
       }
     }
+  }
+
+  private static final class FoundPlan {
+    boolean decode;
+    List<USKAttempt> killAttempts;
+    boolean registerNow;
   }
 
   private synchronized List<Lookup> getRunningFetchEditions() {
@@ -1456,19 +1649,16 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     if (attempts.length > 0) parent.toNetwork(context);
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Registering "
-              + attempts.length
-              + " USKChecker's for "
-              + this
-              + " running="
-              + runningAttempts.size()
-              + " polling="
-              + pollingAttempts.size());
+          "Registering {} USKChecker's for {} running={} polling={}",
+          attempts.length,
+          this,
+          runningAttempts.size(),
+          pollingAttempts.size());
     for (USKAttempt attempt : attempts) {
       // Look up on each iteration since scheduling can cause new editions to be found sometimes.
       long lastEd = uskManager.lookupLatestSlot(origUSK);
       synchronized (USKFetcher.this) {
-        // FIXME not sure this condition works, test it!
+        // Note: condition may require verification in broader contexts
         if (keepLastData && lastRequestData == null && lastEd == origUSK.suggestedEdition)
           lastEd--; // If we want the data, then get it for the known edition, so we always get the
         // data, so USKInserter can compare it and return the old edition if it is
@@ -1494,33 +1684,36 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       checkers = c.toArray(new USKWatchingKeys.KeyList.StoreSubChecker[0]);
     }
 
+    @SuppressWarnings("unused")
     public USKStoreChecker(USKWatchingKeys.KeyList.StoreSubChecker[] checkers2) {
       checkers = checkers2;
     }
 
     public Key[] getKeys() {
       if (checkers.length == 0) return new Key[0];
-      else if (checkers.length == 1) return checkers[0].keysToCheck;
-      else {
-        int x = 0;
-        for (USKWatchingKeys.KeyList.StoreSubChecker checker : checkers) {
-          x += checker.keysToCheck.length;
-        }
-        Key[] keys = new Key[x];
-        int ptr = 0;
-        // FIXME more intelligent (cheaper) merging algorithm, e.g. considering the ranges in each.
-        HashSet<Key> check = new HashSet<>();
-        for (USKWatchingKeys.KeyList.StoreSubChecker checker : checkers) {
-          for (Key k : checker.keysToCheck) {
-            if (!check.add(k)) continue;
-            keys[ptr++] = k;
-          }
-        }
-        if (keys.length != ptr) {
-          keys = Arrays.copyOf(keys, ptr);
-        }
-        return keys;
+      if (checkers.length == 1) return checkers[0].keysToCheck;
+      return mergeKeysFromCheckers();
+    }
+
+    private Key[] mergeKeysFromCheckers() {
+      int x = 0;
+      for (USKWatchingKeys.KeyList.StoreSubChecker checker : checkers) {
+        x += checker.keysToCheck.length;
       }
+      Key[] keys = new Key[x];
+      int ptr = 0;
+      // Note: a more efficient merging algorithm could consider ranges.
+      HashSet<Key> check = new HashSet<>();
+      for (USKWatchingKeys.KeyList.StoreSubChecker checker : checkers) {
+        for (Key k : checker.keysToCheck) {
+          if (!check.add(k)) continue;
+          keys[ptr++] = k;
+        }
+      }
+      if (keys.length != ptr) {
+        keys = Arrays.copyOf(keys, ptr);
+      }
+      return keys;
     }
 
     public void checked() {
@@ -1530,6 +1723,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     }
   }
 
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   private boolean fillKeysWatching(long ed, ClientContext context) {
     synchronized (this) {
       // Do not run a new one until this one has finished.
@@ -1548,22 +1742,21 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       context
           .getSskFetchScheduler(realTimeFlag)
           .register(null, new SendableGet[] {runningStoreChecker}, false, null, false);
-    } catch (Throwable t) {
+    } catch (Exception t) {
       synchronized (this) {
         runningStoreChecker = null;
       }
-      LOG.error("Unable to start: " + t, t);
+      LOG.error("Unable to start: {}", t, t);
       try {
         runningStoreChecker.unregister(context, progressPollPriority);
-      } catch (Throwable ignored) {
+      } catch (Exception ignored) {
         // Ignore, hopefully it's already unregistered
       }
     }
-    if (LOG.isDebugEnabled()) LOG.debug("Registered " + runningStoreChecker + " for " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Registered {} for {}", runningStoreChecker, this);
     return true;
   }
 
-  @SuppressWarnings("serial")
   class StoreCheckerGetter extends SendableGet {
 
     public StoreCheckerGetter(ClientRequester parent, USKStoreChecker c) {
@@ -1571,7 +1764,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       checker = c;
     }
 
-    public final USKStoreChecker checker;
+    public final transient USKStoreChecker checker;
 
     boolean done = false;
 
@@ -1602,35 +1795,74 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     }
 
     @Override
+    @SuppressWarnings("java:S3516")
     public boolean preRegister(ClientContext context, boolean toNetwork) {
-      unregister(context, getPriorityClass());
-      USKAttempt[] attempts;
-      synchronized (USKFetcher.this) {
-        runningStoreChecker = null;
-        // FIXME should we only start the USKAttempt's if the datastore check hasn't made progress?
-        attempts = attemptsToStart.toArray(new USKAttempt[0]);
-        attemptsToStart.clear();
+      if (USKFetcher.this.cancelled || USKFetcher.this.completed) {
+        unregister(context, getPriorityClass());
+        synchronized (USKFetcher.this) {
+          runningStoreChecker = null;
+        }
         done = true;
-        if (cancelled) return true;
+        if (LOG.isDebugEnabled())
+          LOG.debug("StoreChecker preRegister aborted: fetcher cancelled/completed");
+        return toNetwork; // cancel network send when scheduler planned to send
+        // value ignored by scheduler when toNetwork == false
       }
+      unregister(context, getPriorityClass());
+      USKAttempt[] attempts = captureAttemptsToStart();
       checker.checked();
 
+      logStoreChecked(attempts.length);
+      notifyNetworkIfNeeded(attempts, context);
+      processAttemptsAfterStoreCheck(attempts, context);
+
+      long lastEd = uskManager.lookupLatestSlot(origUSK);
+      if (!fillKeysWatching(lastEd, context) && checkStoreOnly) {
+        if (LOG.isDebugEnabled())
+          LOG.debug("Just checking store, terminating {} ...", USKFetcher.this);
+        if (shouldDeferUntilDBRs()) {
+          USKFetcher.this.scheduleAfterDBRsDone = true;
+        } else {
+          finishSuccess(context);
+        }
+      }
+      return toNetwork; // Store checker never sends network requests itself
+      // Value is ignored when toNetwork == false
+    }
+
+    private USKAttempt[] captureAttemptsToStart() {
+      synchronized (USKFetcher.this) {
+        runningStoreChecker = null;
+        // Note: optionally start USKAttempts only when datastore check shows no progress.
+        USKAttempt[] attempts = attemptsToStart.toArray(new USKAttempt[0]);
+        attemptsToStart.clear();
+        done = true;
+        if (cancelled) return new USKAttempt[0];
+        return attempts;
+      }
+    }
+
+    private void logStoreChecked(int attemptsCount) {
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Checked datastore, finishing registration for "
-                + attempts.length
-                + " checkers for "
-                + USKFetcher.this
-                + " for "
-                + origUSK);
+            "Checked datastore, finishing registration for {} checkers for {} for {}",
+            attemptsCount,
+            USKFetcher.this,
+            origUSK);
+    }
+
+    private void notifyNetworkIfNeeded(USKAttempt[] attempts, ClientContext context) {
       if (attempts.length > 0) {
         parent.toNetwork(context);
         notifySendingToNetwork(context);
       }
+    }
+
+    private void processAttemptsAfterStoreCheck(USKAttempt[] attempts, ClientContext context) {
       for (USKAttempt attempt : attempts) {
         long lastEd = uskManager.lookupLatestSlot(origUSK);
         synchronized (USKFetcher.this) {
-          // FIXME not sure this condition works, test it!
+          // Note: condition may need verification.
           if (keepLastData && lastRequestData == null && lastEd == origUSK.suggestedEdition)
             lastEd--; // If we want the data, then get it for the known edition, so we always get
           // the data, so USKInserter can compare it and return the old edition if it is
@@ -1645,23 +1877,23 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
           }
         }
       }
-      long lastEd = uskManager.lookupLatestSlot(origUSK);
-      // Do not check beyond WATCH_KEYS after the current slot.
-      if (!fillKeysWatching(lastEd, context)) {
-        if (checkStoreOnly) {
-          if (LOG.isDebugEnabled())
-            LOG.debug("Just checking store, terminating " + USKFetcher.this + " ...");
-          synchronized (this) {
-            if (!dbrAttempts.isEmpty()) {
-              USKFetcher.this.scheduleAfterDBRsDone = true;
-              return true;
-            }
-          }
-          finishSuccess(context);
-        }
-        // No need to call registerAttempts as we have already registered them.
+    }
+
+    private void notifySendingToNetwork(ClientContext context) {
+      USKCallback[] toCheck;
+      synchronized (USKFetcher.this) {
+        if (cancelled || completed) return;
+        toCheck = subscribers.toArray(new USKCallback[0]);
       }
-      return true;
+      for (USKCallback cb : toCheck) {
+        if (cb instanceof USKProgressCallback callback) callback.onSendingToNetwork(context);
+      }
+    }
+
+    private boolean shouldDeferUntilDBRs() {
+      synchronized (this) {
+        return !dbrAttempts.isEmpty();
+      }
     }
 
     @Override
@@ -1691,7 +1923,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
     @Override
     public short getPriorityClass() {
-      return progressPollPriority; // FIXME
+      return progressPollPriority; // Use progress polling priority
     }
 
     @Override
@@ -1762,7 +1994,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     long lastSlot = uskManager.lookupLatestSlot(origUSK) + 1;
     long edition = watchingKeys.match((NodeSSK) key, lastSlot);
     if (edition == -1) return false;
-    if (LOG.isDebugEnabled()) LOG.debug("Matched edition " + edition + " for " + origUSK);
+    if (LOG.isDebugEnabled()) LOG.debug("Matched edition {} for {}", edition, origUSK);
 
     ClientSSKBlock data;
     try {
@@ -1810,10 +2042,19 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
   }
 
   /**
-   * FIXME this is a special case hack For a generic solution see
-   * https://bugs.freenetproject.org/view.php?id=4984
+   * Updates the cooldown parameters used by USK polling.
+   *
+   * <p>This targeted mechanism applies updated cooldown values to the active contexts and live
+   * polling attempts so they take effect without reconstructing requests. For broader
+   * configuration, see the tracker discussion linked below.
+   *
+   * <p>See: https://bugs.freenetproject.org/view.php?id=4984
+   *
+   * @param time cooldown duration in milliseconds applied between retry batches; non-negative
+   *     values are expected
+   * @param tries number of retries before entering a cooldown; non-negative values are expected
    */
-  public void changeUSKPollParameters(long time, int tries, ClientContext context) {
+  public void changeUSKPollParameters(long time, int tries) {
     this.ctx.setCooldownRetries(tries);
     this.ctxNoStore.setCooldownRetries(tries);
     this.ctx.setCooldownTime(time);
@@ -1822,7 +2063,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     synchronized (this) {
       pollers = pollingAttempts.values().toArray(new USKAttempt[0]);
     }
-    for (USKAttempt a : pollers) a.reloadPollParameters(context);
+    for (USKAttempt a : pollers) a.reloadPollParameters();
   }
 
   /**
@@ -1845,16 +2086,14 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     private final TreeMap<Long, KeyList> fromSubscribers;
     private final TreeSet<Long> persistentHints = new TreeSet<>();
 
-    // private ArrayList<KeyList> fromCallbacks;
-
-    // FIXME add more WeakReference<KeyList>'s: one for the origUSK, one for each subscriber who
-    // gave an edition number. All of which should disappear on the subscriber going or on the last
-    // known superceding.
+    // Note: consider additional WeakReference<KeyList> instances: one for the origUSK and
+    // one per subscriber-provided edition. These should be cleared when the subscriber goes away
+    // or when superseded by the last known edition.
 
     public USKWatchingKeys(USK origUSK, long lookedUp) {
       this.pubKeyHash = origUSK.getPubKeyHash();
       this.cryptoAlgorithm = origUSK.cryptoAlgorithm;
-      if (LOG.isDebugEnabled()) LOG.debug("Creating KeyList from last known good: " + lookedUp);
+      if (LOG.isDebugEnabled()) LOG.debug("Creating KeyList from last known good: {}", lookedUp);
       fromLastKnownSlot = new KeyList(lookedUp);
       fromSubscribers = new TreeMap<>();
       if (origUSK.suggestedEdition > lookedUp)
@@ -1864,12 +2103,12 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     class ToFetch {
 
       public ToFetch(List<Lookup> toFetch2, List<Lookup> toPoll2) {
-        toFetch = toFetch2.toArray(new Lookup[0]);
-        toPoll = toPoll2.toArray(new Lookup[0]);
+        fetch = toFetch2.toArray(new Lookup[0]);
+        poll = toPoll2.toArray(new Lookup[0]);
       }
 
-      public final Lookup[] toFetch;
-      public final Lookup[] toPoll;
+      public final Lookup[] fetch;
+      public final Lookup[] poll;
     }
 
     /**
@@ -1886,7 +2125,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Get editions to fetch, latest slot is " + lookedUp + " running is " + alreadyRunning);
+            "Get editions to fetch, latest slot is {} running is {}", lookedUp, alreadyRunning);
 
       List<Lookup> toFetch = new ArrayList<>();
       List<Lookup> toPoll = new ArrayList<>();
@@ -1895,8 +2134,20 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
           lookedUp > -1 || (backgroundPoll && !firstLoop) || fromSubscribers.isEmpty();
 
       if (probeFromLastKnownGood)
-        fromLastKnownSlot.getNextEditions(toFetch, toPoll, lookedUp, alreadyRunning, random);
+        fromLastKnownSlot.getNextEditions(toFetch, toPoll, lookedUp, alreadyRunning);
 
+      collectFromSubscribers(lookedUp, toFetch, toPoll, alreadyRunning);
+
+      if (doRandom) {
+        collectRandomEditions(
+            probeFromLastKnownGood, lookedUp, random, toFetch, toPoll, alreadyRunning);
+      }
+
+      return new ToFetch(toFetch, toPoll);
+    }
+
+    private void collectFromSubscribers(
+        long lookedUp, List<Lookup> toFetch, List<Lookup> toPoll, List<Lookup> alreadyRunning) {
       // If we have moved past the origUSK, then clear the KeyList for it.
       for (Iterator<Entry<Long, KeyList>> it = fromSubscribers.entrySet().iterator();
           it.hasNext(); ) {
@@ -1910,60 +2161,77 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
           // Needed because we cannot set -0 for exhaustive search (-0 == 0 in Java).
           entry.getValue().getEditionIfNotAlreadyRunning(toFetch, alreadyRunning, l, false);
         }
-        entry.getValue().getNextEditions(toFetch, toPoll, l - 1, alreadyRunning, random);
+        entry.getValue().getNextEditions(toFetch, toPoll, l - 1, alreadyRunning);
+      }
+    }
+
+    private void collectRandomEditions(
+        boolean probeFromLastKnownGood,
+        long lookedUp,
+        Random random,
+        List<Lookup> toFetch,
+        List<Lookup> toPoll,
+        List<Lookup> alreadyRunning) {
+      // Now getRandomEditions
+      int runningRandom = countRunningRandom(alreadyRunning, toFetch, toPoll);
+
+      int allowedRandom = 1 + fromSubscribers.size();
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "Running random requests: {} total allowed: {} looked up is {} for {}",
+            runningRandom,
+            allowedRandom,
+            lookedUp,
+            USKFetcher.this);
+
+      allowedRandom -= runningRandom;
+
+      if (allowedRandom > 0 && probeFromLastKnownGood) {
+        fromLastKnownSlot.getRandomEditions(toFetch, lookedUp, alreadyRunning, random, 1);
+        allowedRandom -= 1;
       }
 
-      if (doRandom) {
-        // Now getRandomEditions
-        // But how many???
-        int runningRandom = 0;
-        for (Lookup l : alreadyRunning) {
-          if (toFetch.contains(l) || toPoll.contains(l)) continue;
-          runningRandom++;
-        }
-
-        int allowedRandom = 1 + fromSubscribers.size();
-        if (LOG.isDebugEnabled())
-          LOG.debug(
-              "Running random requests: "
-                  + runningRandom
-                  + " total allowed: "
-                  + allowedRandom
-                  + " looked up is "
-                  + lookedUp
-                  + " for "
-                  + USKFetcher.this);
-
-        allowedRandom -= runningRandom;
-
-        if (allowedRandom > 0 && probeFromLastKnownGood) {
-          fromLastKnownSlot.getRandomEditions(
-              toFetch, lookedUp, alreadyRunning, random, Math.min(1, allowedRandom));
-          allowedRandom -= 1;
-        }
-
-        for (Iterator<KeyList> it = fromSubscribers.values().iterator();
-            allowedRandom >= 2 && it.hasNext(); ) {
-          KeyList k = it.next();
-          k.getRandomEditions(
-              toFetch, lookedUp, alreadyRunning, random, Math.min(1, allowedRandom));
-          allowedRandom -= 1;
-        }
+      for (Iterator<KeyList> it = fromSubscribers.values().iterator();
+          allowedRandom >= 2 && it.hasNext(); ) {
+        KeyList k = it.next();
+        k.getRandomEditions(toFetch, lookedUp, alreadyRunning, random, 1);
+        allowedRandom -= 1;
       }
+    }
 
-      return new ToFetch(toFetch, toPoll);
+    private static int countRunningRandom(
+        List<Lookup> alreadyRunning, List<Lookup> toFetch, List<Lookup> toPoll) {
+      int runningRandom = 0;
+      for (Lookup l : alreadyRunning) {
+        if (toFetch.contains(l) || toPoll.contains(l)) continue;
+        runningRandom++;
+      }
+      return runningRandom;
     }
 
     public synchronized void updateSubscriberHints(Long[] hints, long lookedUp) {
+      List<Long> surviving = collectSurvivingHints(hints, lookedUp);
+      mergePersistentHints(surviving, lookedUp);
+      ensureSuggestedEditionIncluded(surviving, lookedUp);
+      reconcileSubscribersWithSurviving(surviving);
+    }
+
+    private static List<Long> collectSurvivingHints(Long[] hints, long lookedUp) {
       List<Long> surviving = new ArrayList<>();
       Arrays.sort(hints);
       long prev = -1;
       for (Long hint : hints) {
-        if (hint == prev) continue;
-        prev = hint;
-        if (hint <= lookedUp) continue;
-        surviving.add(hint);
+        if (hint <= lookedUp) {
+          prev = hint;
+        } else if (hint != prev) {
+          surviving.add(hint);
+          prev = hint;
+        }
       }
+      return surviving;
+    }
+
+    private void mergePersistentHints(List<Long> surviving, long lookedUp) {
       for (Iterator<Long> i = persistentHints.iterator(); i.hasNext(); ) {
         Long hint = i.next();
         if (hint <= lookedUp) {
@@ -1972,8 +2240,14 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
         if (surviving.contains(hint)) continue;
         surviving.add(hint);
       }
+    }
+
+    private void ensureSuggestedEditionIncluded(List<Long> surviving, long lookedUp) {
       if (origUSK.suggestedEdition > lookedUp && !surviving.contains(origUSK.suggestedEdition))
         surviving.add(origUSK.suggestedEdition);
+    }
+
+    private void reconcileSubscribersWithSurviving(List<Long> surviving) {
       for (Iterator<Long> it = fromSubscribers.keySet().iterator(); it.hasNext(); ) {
         Long l = it.next();
         if (surviving.contains(l)) continue;
@@ -1994,7 +2268,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
     public synchronized long size() {
       return WATCH_KEYS
-          + (long) fromSubscribers.size() * WATCH_KEYS; // FIXME take overlap into account
+          + (long) fromSubscribers.size() * WATCH_KEYS; // Note: does not account for overlap
     }
 
     /**
@@ -2018,7 +2292,10 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       public KeyList(long slot) {
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "Creating KeyList from " + slot + " on " + USKFetcher.this + " " + this,
+              "Creating KeyList from {} on {} {}",
+              slot,
+              USKFetcher.this,
+              this,
               new Exception("debug"));
         firstSlot = slot;
         RemoveRangeArrayList<byte[]> ehDocnames = new RemoveRangeArrayList<>(WATCH_KEYS);
@@ -2037,12 +2314,8 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
        * @param random
        */
       public synchronized void getNextEditions(
-          List<Lookup> toFetch,
-          List<Lookup> toPoll,
-          long lookedUp,
-          List<Lookup> alreadyRunning,
-          Random random) {
-        if (LOG.isDebugEnabled()) LOG.debug("Getting next editions from " + lookedUp);
+          List<Lookup> toFetch, List<Lookup> toPoll, long lookedUp, List<Lookup> alreadyRunning) {
+        if (LOG.isDebugEnabled()) LOG.debug("Getting next editions from {}", lookedUp);
         if (lookedUp < 0) lookedUp = 0;
         for (int i = 1; i <= origMinFailures; i++) {
           long ed = i + lookedUp;
@@ -2062,21 +2335,21 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
         Lookup l = new Lookup();
         l.val = ed;
         if (lookupList.contains(l)) {
-          if (LOG.isTraceEnabled()) LOG.trace("Ignoring " + l);
+          if (LOG.isTraceEnabled()) LOG.trace("Ignoring {}", l);
           return false;
         }
         if (alreadyRunning.remove(l)) {
-          if (LOG.isTraceEnabled()) LOG.trace("Ignoring (2): " + l);
+          if (LOG.isTraceEnabled()) LOG.trace("Ignoring (2): {}", l);
           return false;
         }
         ClientSSK key;
-        // FIXME reuse ehDocnames somehow
+        // Note: consider reusing ehDocnames where feasible
         // The problem is we need a ClientSSK for the high level stuff.
         key = origUSK.getSSK(ed);
         l.key = key;
         l.ignoreStore = ignoreStore;
         if (lookupList.contains(l)) {
-          if (LOG.isTraceEnabled()) LOG.trace("Ignoring (3): " + l);
+          if (LOG.isTraceEnabled()) LOG.trace("Ignoring (3): {}", l);
           return false;
         }
         return lookupList.add(l);
@@ -2091,28 +2364,40 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
         // Then add a couple of random editions for catch-up.
         long baseEdition = lookedUp + origMinFailures;
         for (int i = 0; i < allowed; i++) {
-          while (true) { // TODO switch to limited for-loop to ensure there can be no infinite loop
-            // Geometric distribution.
-            // 20% chance of mean 100, 80% chance of mean 10. Thanks evanbd.
-            int mean = random.nextInt(5) == 0 ? 100 : 10;
-            long fetch =
-                baseEdition
-                    + (long) Math.floor(Math.log(random.nextFloat()) / Math.log(1.0 - 1.0 / mean));
-            if (fetch < baseEdition) continue;
-            if (LOG.isDebugEnabled())
-              LOG.debug(
-                  "Trying random future edition "
-                      + fetch
-                      + " for "
-                      + origUSK
-                      + " current edition "
-                      + lookedUp);
-            if (getEditionIfNotAlreadyRunning(
-                toFetch, alreadyRunning, fetch, !(fetch - lookedUp >= WATCH_KEYS))) {
-              break;
-            }
+          while (true) { // Note: consider switching to limited for-loop to ensure there can be no
+            // infinite loop
+            long fetch = sampleGeometric(baseEdition, random);
+            if (tryAddRandomEdition(toFetch, lookedUp, alreadyRunning, fetch)) break;
           }
         }
+      }
+
+      private static long sampleGeometric(long baseEdition, Random random) {
+        // Geometric distribution.
+        // 20% chance of mean 100, 80% chance of mean 10. Thanks evanbd.
+        while (true) {
+          int mean = random.nextInt(5) == 0 ? 100 : 10;
+          double u = uniform01FromLong(random);
+          long fetch = baseEdition + (long) Math.floor(Math.log(u) / Math.log(1.0 - 1.0 / mean));
+          if (fetch >= baseEdition) return fetch;
+        }
+      }
+
+      private static double uniform01FromLong(Random random) {
+        long bits = random.nextLong() & Long.MAX_VALUE; // 0 .. 2^63-1
+        return (bits + 1.0) / (Long.MAX_VALUE + 1.0);
+      }
+
+      private boolean tryAddRandomEdition(
+          List<Lookup> toFetch, long lookedUp, List<Lookup> alreadyRunning, long fetch) {
+        if (LOG.isDebugEnabled())
+          LOG.debug(
+              "Trying random future edition {} for {} current edition {}",
+              fetch,
+              origUSK,
+              lookedUp);
+        return getEditionIfNotAlreadyRunning(
+            toFetch, alreadyRunning, fetch, (fetch - lookedUp) < WATCH_KEYS);
       }
 
       public class StoreSubChecker {
@@ -2132,40 +2417,30 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
           this.checkedTo = checkTo;
           if (LOG.isDebugEnabled())
             LOG.debug(
-                "Checking datastore from "
-                    + checkFrom
-                    + " to "
-                    + checkTo
-                    + " for "
-                    + USKFetcher.this
-                    + " on "
-                    + this);
+                "Checking datastore from {} to {} for {} on {}",
+                checkFrom,
+                checkTo,
+                USKFetcher.this,
+                this);
         }
 
         /** The keys have been checked. */
         void checked() {
           synchronized (KeyList.this) {
-            if (checkedDatastoreTo >= checkedFrom && checkedDatastoreFrom <= checkedFrom) {
-              // checkedFrom is unchanged
-              checkedDatastoreTo = checkedTo;
-            } else {
+            // Update the start bound only when the previous range does not already cover it.
+            if (!(checkedDatastoreTo >= checkedFrom && checkedDatastoreFrom <= checkedFrom)) {
               checkedDatastoreFrom = checkedFrom;
-              checkedDatastoreTo = checkedTo;
             }
+            checkedDatastoreTo = checkedTo;
             if (LOG.isDebugEnabled())
               LOG.debug(
-                  "Checked from "
-                      + checkedFrom
-                      + " to "
-                      + checkedTo
-                      + " (now overall is "
-                      + checkedDatastoreFrom
-                      + " to "
-                      + checkedDatastoreTo
-                      + ") for "
-                      + USKFetcher.this
-                      + " for "
-                      + origUSK);
+                  "Checked from {} to {} (now overall is {} to {}) for {} for {}",
+                  checkedFrom,
+                  checkedTo,
+                  checkedDatastoreFrom,
+                  checkedDatastoreTo,
+                  USKFetcher.this,
+                  origUSK);
           }
         }
       }
@@ -2177,7 +2452,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
        */
       public synchronized StoreSubChecker checkStore(long lastSlot) {
         if (LOG.isDebugEnabled())
-          LOG.debug("check store from " + lastSlot + " current first slot " + firstSlot);
+          LOG.debug("check store from {} current first slot {}", lastSlot, firstSlot);
         long checkFrom = lastSlot;
         long checkTo = lastSlot + WATCH_KEYS;
         if (checkedDatastoreTo >= checkFrom) {
@@ -2199,8 +2474,8 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
       synchronized RemoveRangeArrayList<byte[]> updateCache(long curBaseEdition) {
         if (LOG.isDebugEnabled())
-          LOG.debug("update cache from " + curBaseEdition + " current first slot " + firstSlot);
-        RemoveRangeArrayList<byte[]> ehDocnames = null;
+          LOG.debug("update cache from {} current first slot {}", curBaseEdition, firstSlot);
+        RemoveRangeArrayList<byte[]> ehDocnames;
         if (cache == null || (ehDocnames = cache.get()) == null) {
           ehDocnames = new RemoveRangeArrayList<>(WATCH_KEYS);
           cache = new WeakReference<>(ehDocnames);
@@ -2225,8 +2500,8 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
        */
       public synchronized long match(NodeSSK key, long curBaseEdition) {
         if (LOG.isDebugEnabled())
-          LOG.debug("match from " + curBaseEdition + " current first slot " + firstSlot);
-        RemoveRangeArrayList<byte[]> ehDocnames = null;
+          LOG.debug("match from {} current first slot {}", curBaseEdition, firstSlot);
+        RemoveRangeArrayList<byte[]> ehDocnames;
         if (cache == null || (ehDocnames = cache.get()) == null) {
           ehDocnames = new RemoveRangeArrayList<>(WATCH_KEYS);
           cache = new WeakReference<>(ehDocnames);
@@ -2252,46 +2527,50 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
           NodeSSK key, long curBaseEdition, RemoveRangeArrayList<byte[]> ehDocnames) {
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "Matching "
-                  + key
-                  + " cur base edition "
-                  + curBaseEdition
-                  + " first slot was "
-                  + firstSlot
-                  + " for "
-                  + origUSK
-                  + " on "
-                  + this);
+              "Matching {} cur base edition {} first slot was {} for {} on {}",
+              key,
+              curBaseEdition,
+              firstSlot,
+              origUSK,
+              this);
         if (firstSlot < curBaseEdition) {
-          if (firstSlot + ehDocnames.size() <= curBaseEdition) {
-            // No overlap. Clear it and start again.
-            ehDocnames.clear();
-            firstSlot = curBaseEdition;
-            generate(curBaseEdition, WATCH_KEYS, ehDocnames);
-            return key == null ? -1 : innerMatch(key, ehDocnames, 0, ehDocnames.size(), firstSlot);
-          } else {
-            // There is some overlap. Delete the first part of the array then add stuff at the end.
-            // ehDocnames[i] is slot firstSlot + i
-            // We want to get rid of anything before curBaseEdition
-            // So the first slot that is useful is the slot at i = curBaseEdition - firstSlot
-            // Which is the new [0], whose edition is curBaseEdition
-            ehDocnames.removeRange(0, (int) (curBaseEdition - firstSlot));
-            int size = ehDocnames.size();
-            firstSlot = curBaseEdition;
-            generate(curBaseEdition + size, WATCH_KEYS - size, ehDocnames);
-            return key == null
-                ? -1
-                : innerMatch(key, ehDocnames, WATCH_KEYS - size, size, firstSlot);
-          }
+          return handleFirstSlotBehind(key, curBaseEdition, ehDocnames);
         } else if (firstSlot > curBaseEdition) {
-          // Normal due to race conditions. We don't always report the new edition to the USKManager
-          // immediately.
-          // So ignore it.
-          if (LOG.isTraceEnabled())
-            LOG.trace("Ignoring regression in match() from " + curBaseEdition + " to " + firstSlot);
-          return key == null ? -1 : innerMatch(key, ehDocnames, 0, ehDocnames.size(), firstSlot);
+          return handleFirstSlotAhead(key, ehDocnames, curBaseEdition);
         }
         return -1;
+      }
+
+      private long handleFirstSlotBehind(
+          NodeSSK key, long curBaseEdition, RemoveRangeArrayList<byte[]> ehDocnames) {
+        if (firstSlot + ehDocnames.size() <= curBaseEdition) {
+          // No overlap. Clear it and start again.
+          ehDocnames.clear();
+          firstSlot = curBaseEdition;
+          generate(curBaseEdition, WATCH_KEYS, ehDocnames);
+          return key == null ? -1 : innerMatch(key, ehDocnames, 0, ehDocnames.size(), firstSlot);
+        } else {
+          // There is some overlap. Delete the first part of the array then add stuff at the end.
+          // ehDocnames[i] is slot firstSlot + i
+          // We want to get rid of anything before curBaseEdition
+          // So the first slot that is useful is the slot at i = curBaseEdition - firstSlot
+          // Which is the new [0], whose edition is curBaseEdition
+          ehDocnames.removeRange(0, (int) (curBaseEdition - firstSlot));
+          int size = ehDocnames.size();
+          firstSlot = curBaseEdition;
+          generate(curBaseEdition + size, WATCH_KEYS - size, ehDocnames);
+          return key == null ? -1 : innerMatch(key, ehDocnames, WATCH_KEYS - size, size, firstSlot);
+        }
+      }
+
+      private long handleFirstSlotAhead(
+          NodeSSK key, RemoveRangeArrayList<byte[]> ehDocnames, long curBaseEdition) {
+        // Normal due to race conditions. We don't always report the new edition to the USKManager
+        // immediately.
+        // So ignore it.
+        if (LOG.isTraceEnabled())
+          LOG.trace("Ignoring regression in match() from {} to {}", curBaseEdition, firstSlot);
+        return key == null ? -1 : innerMatch(key, ehDocnames, 0, ehDocnames.size(), firstSlot);
       }
 
       /**
@@ -2307,8 +2586,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
         byte[] data = key.getKeyBytes();
         for (int i = offset; i < (offset + size); i++) {
           if (Arrays.equals(data, ehDocnames.get(i))) {
-            if (LOG.isDebugEnabled())
-              LOG.debug("Found edition " + (firstSlot + i) + " for " + origUSK);
+            if (LOG.isDebugEnabled()) LOG.debug("Found edition {} for {}", firstSlot + i, origUSK);
             return firstSlot + i;
           }
         }
@@ -2322,7 +2600,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
        * @param keys The number of keys to add.
        */
       private void generate(long baseEdition, int keys, RemoveRangeArrayList<byte[]> ehDocnames) {
-        if (LOG.isDebugEnabled()) LOG.debug("generate() from " + baseEdition + " for " + origUSK);
+        if (LOG.isDebugEnabled()) LOG.debug("generate() from {} for {}", baseEdition, origUSK);
         assert (baseEdition >= 0);
         for (int i = 0; i < keys; i++) {
           long ed = baseEdition + i;
@@ -2333,15 +2611,13 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
     public synchronized USKStoreChecker getDatastoreChecker(long lastSlot) {
       // Check WATCH_KEYS from last known good slot.
-      // FIXME: Take into account origUSK, subscribers, etc.
+      // Note: does not currently take origUSK or subscribers into account.
       if (LOG.isDebugEnabled())
         LOG.debug(
-            "Getting datastore checker from "
-                + lastSlot
-                + " for "
-                + origUSK
-                + " on "
-                + USKFetcher.this,
+            "Getting datastore checker from {} for {} on {}",
+            lastSlot,
+            origUSK,
+            USKFetcher.this,
             new Exception("debug"));
       List<KeyList.StoreSubChecker> checkers = new ArrayList<>();
       KeyList.StoreSubChecker c = fromLastKnownSlot.checkStore(lastSlot + 1);
@@ -2361,13 +2637,15 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
     public ClientSSKBlock decode(SSKBlock block, long edition) throws SSKVerifyException {
       ClientSSK csk = origUSK.getSSK(edition);
-      assert (Arrays.equals(csk.ehDocname, block.getKey().getKeyBytes()));
+      if (!Arrays.equals(csk.ehDocname, block.getKey().getKeyBytes())) {
+        throw new SSKVerifyException("Docname hash mismatch for decoded block");
+      }
       return ClientSSKBlock.construct(block, csk);
     }
 
     public synchronized long match(NodeSSK key, long lastSlot) {
       if (LOG.isDebugEnabled())
-        LOG.debug("Trying to match " + key + " from slot " + lastSlot + " for " + origUSK);
+        LOG.debug("Trying to match {} from slot {} for {}", key, lastSlot, origUSK);
       long ret = fromLastKnownSlot.match(key, lastSlot);
       if (ret != -1) return ret;
 
@@ -2383,6 +2661,15 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     }
   }
 
+  /**
+   * Adds an edition hint to bias future fetch decisions.
+   *
+   * <p>Hints greater than the current last-known slot are remembered and may expand the search
+   * window. Duplicate or stale hints are ignored.
+   *
+   * @param suggestedEdition the edition number to add as a hint; must be greater than the last
+   *     looked-up slot to have any effect
+   */
   public void addHintEdition(long suggestedEdition) {
     watchingKeys.addHintEdition(suggestedEdition, uskManager.lookupLatestSlot(origUSK));
   }
@@ -2401,7 +2688,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
     @Override
     public int hashCode() {
-      return (int) (val ^ (val >>> 32));
+      return Long.hashCode(val);
     }
 
     @Override

--- a/src/main/java/network/crypta/client/async/USKManager.java
+++ b/src/main/java/network/crypta/client/async/USKManager.java
@@ -162,7 +162,10 @@ public class USKManager {
       ClientRequester requester,
       boolean keepLastData,
       boolean checkStoreOnly) {
-    return new USKFetcher(usk, this, ctx, requester, 3, false, keepLastData, checkStoreOnly);
+    int options = 0;
+    if (keepLastData) options |= USKFetcher.OPT_KEEP_LAST_DATA;
+    if (checkStoreOnly) options |= USKFetcher.OPT_CHECK_STORE_ONLY;
+    return new USKFetcher(usk, this, ctx, requester, 3, options);
   }
 
   public USKFetcherTag getFetcherForInsertDontSchedule(
@@ -362,6 +365,7 @@ public class USKManager {
       //			}
       USKFetcher f = temporaryBackgroundFetchersLRU.get(clear);
       if (f == null) {
+        int options = 0;
         f =
             new USKFetcher(
                 usk,
@@ -370,9 +374,7 @@ public class USKManager {
                 new USKFetcherWrapper(
                     usk, RequestStarter.UPDATE_PRIORITY_CLASS, realTimeFlag ? rcRT : rcBulk),
                 3,
-                false,
-                false,
-                false);
+                options);
         sched = f;
         temporaryBackgroundFetchersLRU.push(clear, f);
       } else {
@@ -665,6 +667,7 @@ public class USKManager {
       if (runBackgroundFetch) {
         USKFetcher f = backgroundFetchersByClearUSK.get(clear);
         if (f == null) {
+          int options = USKFetcher.OPT_POLL_FOREVER;
           f =
               new USKFetcher(
                   origUSK,
@@ -672,9 +675,7 @@ public class USKManager {
                   ignoreUSKDatehints ? backgroundFetchContextIgnoreDBR : backgroundFetchContext,
                   new USKFetcherWrapper(origUSK, RequestStarter.UPDATE_PRIORITY_CLASS, client),
                   3,
-                  true,
-                  false,
-                  false);
+                  options);
           sched = f;
           backgroundFetchersByClearUSK.put(clear, f);
         }
@@ -728,7 +729,7 @@ public class USKManager {
       }
       USKFetcher f = backgroundFetchersByClearUSK.get(clear);
       if (f != null) {
-        f.removeSubscriber(cb, context);
+        f.removeSubscriber(cb);
         if (!f.hasSubscribers()) {
           toCancel = f;
           backgroundFetchersByClearUSK.remove(clear);
@@ -791,16 +792,10 @@ public class USKManager {
     toSub = proxy;
     /* runBackgroundFetch=false -> ignoreUSKDatehints unused */
     subscribe(origUSK, toSub, false, client);
+    int options = USKFetcher.OPT_POLL_FOREVER;
     USKFetcher f =
         new USKFetcher(
-            origUSK,
-            this,
-            fctx,
-            new USKFetcherWrapper(origUSK, prio, client),
-            3,
-            true,
-            false,
-            false);
+            origUSK, this, fctx, new USKFetcherWrapper(origUSK, prio, client), 3, options);
     ret.setFetcher(f);
     return ret;
   }

--- a/src/main/java/network/crypta/client/async/USKRetriever.java
+++ b/src/main/java/network/crypta/client/async/USKRetriever.java
@@ -366,7 +366,7 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
       f = fetcher;
     }
     if (f == null) throw new IllegalStateException();
-    f.changeUSKPollParameters(time, tries, context);
+    f.changeUSKPollParameters(time, tries);
   }
 
   @Override

--- a/src/main/java/network/crypta/client/async/USKRetriever.java
+++ b/src/main/java/network/crypta/client/async/USKRetriever.java
@@ -100,15 +100,9 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
                   uri,
                   ctx,
                   new ArchiveContext(ctx.maxTempLength, ctx.maxArchiveLevels),
-                  ctx.maxNonSplitfileRetries,
-                  0,
-                  true,
-                  l,
-                  true,
-                  false,
-                  context,
-                  realTimeFlag,
-                  false);
+                  new SingleFileFetcher.CreationPolicy(
+                      ctx.maxNonSplitfileRetries, 0, true, true, false, false),
+                  new SingleFileFetcher.CreationRuntime(context, realTimeFlag, l));
       getter.schedule(context);
     } catch (MalformedURLException e) {
       LOG.error("Impossible: " + e, e);

--- a/src/test/java/network/crypta/client/async/SimpleSingleFileFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/SimpleSingleFileFetcherTest.java
@@ -1,0 +1,290 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchResult;
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.ClientKeyBlock;
+import network.crypta.keys.KeyDecodeException;
+import network.crypta.keys.TooBigException;
+import network.crypta.node.LowLevelGetException;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.io.InsufficientDiskSpaceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SimpleSingleFileFetcherTest {
+
+  @Mock private ClientRequester parent;
+  @Mock private GetCompletionCallback rcb;
+  @Mock private ClientKey key;
+  @Mock private FetchContext fetchCtx;
+  @Mock private ClientContext clientContext;
+  @Mock private ClientRequestScheduler scheduler;
+
+  @Captor private ArgumentCaptor<FetchException> fetchExceptionCaptor;
+
+  @BeforeEach
+  void setup() {
+    // Default (lenient to avoid UnnecessaryStubbing for tests not using these paths)
+    lenient().when(clientContext.getChkFetchScheduler(false)).thenReturn(scheduler);
+    lenient().when(parent.getPriorityClass()).thenReturn((short) 1);
+    // parent.persistent() is invoked by SendableGet's constructor; on a Mockito mock this returns
+    // default false (no special stubbing required). Keep default isCancelled=false unless tests
+    // override it.
+  }
+
+  private SimpleSingleFileFetcher newFetcher(
+      int maxRetries, boolean isEssential, boolean dontAdd, long token) {
+    // Spy to be able to stub unregister() in paths that call unregisterAll().
+    SimpleSingleFileFetcher f =
+        new SimpleSingleFileFetcher(
+            SimpleSingleFileFetcher.Cfg.create(
+                    key, maxRetries, fetchCtx, parent, rcb, token, clientContext)
+                .essential(isEssential)
+                .dontAdd(dontAdd)
+                .deleteFetchContext(false)
+                .realTime(false));
+    return spy(f);
+  }
+
+  @Test
+  void constructor_whenEssentialAndNotDontAdd_expectAddMustAndNotify() {
+    newFetcher(0, true, false, 123L);
+
+    verify(parent).addMustSucceedBlocks(1);
+    verify(parent).notifyClients(clientContext);
+    // No further interactions required for this constructor behavior
+  }
+
+  @Test
+  void constructor_whenNonEssentialAndNotDontAdd_expectAddBlockAndNotify() {
+    newFetcher(0, false, false, 456L);
+
+    verify(parent).addBlock();
+    verify(parent).notifyClients(clientContext);
+  }
+
+  @Test
+  void getToken_returnsProvidedToken() {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 987654321L);
+    assertEquals(987654321L, f.getToken());
+  }
+
+  @Test
+  void cancel_whenCalled_expectCallbackCancelledAndUnregisterAll() {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 42L);
+    // Avoid SendableGet.unregister(context, ...) calling into context.checker by stubbing it out
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+
+    f.cancel(clientContext);
+
+    verify(scheduler).removePendingKeys(f, false);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.CANCELLED, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void onFailure_whenLowLevelNonFatalAndNoRetriesLeft_expectFailedAndCallback() {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 7L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+
+    LowLevelGetException ll = new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND);
+    f.onFailure(ll, null, clientContext);
+
+    verify(scheduler).removePendingKeys(f, false);
+    verify(parent).failedBlock(clientContext);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.DATA_NOT_FOUND, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void onFailure_whenCancelled_expectCancelCallbackAndFatalCount() {
+    SimpleSingleFileFetcher f = newFetcher(1, false, true, 8L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+    // Simulate already-cancelled state
+    f.cancelled = true;
+
+    LowLevelGetException ll = new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND);
+    f.onFailure(ll, null, clientContext);
+
+    verify(scheduler).removePendingKeys(f, false);
+    verify(parent).fatallyFailedBlock(clientContext);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.CANCELLED, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void onSuccess_whenParentCancelled_expectBucketFreedAndCancelled() {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 9L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+    when(parent.isCancelled()).thenReturn(true);
+
+    Bucket bucket = mock(Bucket.class);
+    FetchResult fr = new FetchResult(new ClientMetadata(null), bucket);
+
+    f.onSuccess(fr, clientContext);
+
+    verify(bucket).free();
+    verify(scheduler).removePendingKeys(f, false);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.CANCELLED, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void onSuccess_whenOk_callsCallbackWithStreamGeneratorAndMetadata() {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 10L);
+    when(parent.isCancelled()).thenReturn(false);
+
+    Bucket bucket = mock(Bucket.class);
+    ClientMetadata meta = new ClientMetadata("text/plain");
+    FetchResult fr = new FetchResult(meta, bucket);
+
+    // Capture onSuccess parameters
+    ArgumentCaptor<StreamGenerator> sgCap = ArgumentCaptor.forClass(StreamGenerator.class);
+    ArgumentCaptor<ClientMetadata> mdCap = ArgumentCaptor.forClass(ClientMetadata.class);
+
+    f.onSuccess(fr, clientContext);
+
+    verify(rcb).onSuccess(sgCap.capture(), mdCap.capture(), isNull(), eq(f), eq(clientContext));
+    assertNotNull(sgCap.getValue());
+    assertEquals(meta, mdCap.getValue());
+  }
+
+  @Test
+  void extract_whenDecodeSucceeds_returnsBucketAndNoFailureCallback() throws Exception {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 11L);
+
+    BucketFactory bf = mock(BucketFactory.class);
+    when(clientContext.getBucketFactory(false)).thenReturn(bf);
+
+    Bucket bucket = mock(Bucket.class);
+    ClientKeyBlock block = mock(ClientKeyBlock.class);
+    when(block.decode(eq(bf), anyInt(), eq(false))).thenReturn(bucket);
+
+    Bucket ret = f.extract(block, clientContext);
+    assertEquals(bucket, ret);
+    verifyNoMoreInteractions(rcb);
+  }
+
+  @Test
+  void extract_whenDecodeThrowsKeyDecode_reportsBlockDecodeError() throws Exception {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 12L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+
+    BucketFactory bf = mock(BucketFactory.class);
+    when(clientContext.getBucketFactory(false)).thenReturn(bf);
+
+    ClientKeyBlock block = mock(ClientKeyBlock.class);
+    when(block.decode(eq(bf), anyInt(), eq(false))).thenThrow(new KeyDecodeException("bad"));
+
+    Bucket ret = f.extract(block, clientContext);
+    assertNull(ret);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.BLOCK_DECODE_ERROR, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void extract_whenDecodeThrowsTooBig_reportsTooBig() throws Exception {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 13L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+
+    BucketFactory bf = mock(BucketFactory.class);
+    when(clientContext.getBucketFactory(false)).thenReturn(bf);
+
+    ClientKeyBlock block = mock(ClientKeyBlock.class);
+    when(block.decode(eq(bf), anyInt(), eq(false))).thenThrow(new TooBigException("huge"));
+
+    Bucket ret = f.extract(block, clientContext);
+    assertNull(ret);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.TOO_BIG, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void extract_whenDecodeThrowsInsufficientDisk_reportsNotEnoughDiskSpace() throws Exception {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 14L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+
+    BucketFactory bf = mock(BucketFactory.class);
+    when(clientContext.getBucketFactory(false)).thenReturn(bf);
+
+    ClientKeyBlock block = mock(ClientKeyBlock.class);
+    when(block.decode(eq(bf), anyInt(), eq(false))).thenThrow(new InsufficientDiskSpaceException());
+
+    Bucket ret = f.extract(block, clientContext);
+    assertNull(ret);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(
+        FetchExceptionMode.NOT_ENOUGH_DISK_SPACE, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void extract_whenDecodeThrowsIO_reportsBucketError() throws Exception {
+    SimpleSingleFileFetcher f = newFetcher(0, false, true, 15L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+
+    BucketFactory bf = mock(BucketFactory.class);
+    when(clientContext.getBucketFactory(false)).thenReturn(bf);
+
+    ClientKeyBlock block = mock(ClientKeyBlock.class);
+    when(block.decode(eq(bf), anyInt(), eq(false))).thenThrow(new java.io.IOException("io"));
+
+    Bucket ret = f.extract(block, clientContext);
+    assertNull(ret);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.BUCKET_ERROR, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void notFoundInStore_whenCalled_forcesFatalDataNotFound() {
+    SimpleSingleFileFetcher f = newFetcher(1, false, true, 16L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+
+    f.notFoundInStore(clientContext);
+
+    verify(scheduler).removePendingKeys(f, false);
+    verify(parent).fatallyFailedBlock(clientContext);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.DATA_NOT_FOUND, fetchExceptionCaptor.getValue().getMode());
+  }
+
+  @Test
+  void onBlockDecodeError_whenCalled_forcesFatalBlockDecodeError() {
+    SimpleSingleFileFetcher f = newFetcher(1, false, true, 17L);
+    doNothing().when(f).unregister(any(ClientContext.class), anyShort());
+
+    f.onBlockDecodeError(null, clientContext);
+
+    verify(scheduler).removePendingKeys(f, false);
+    verify(parent).fatallyFailedBlock(clientContext);
+    verify(rcb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.BLOCK_DECODE_ERROR, fetchExceptionCaptor.getValue().getMode());
+  }
+}

--- a/src/test/java/network/crypta/client/async/SingleFileFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/SingleFileFetcherTest.java
@@ -1,0 +1,324 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchResult;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.keys.BaseClientKey;
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.compress.Compressor;
+import network.crypta.support.io.BucketTools;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SingleFileFetcherTest {
+
+  @Mock private ClientRequester parent;
+  @Mock private GetCompletionCallback cb;
+  @Mock private ClientKey key;
+  @Mock private ClientContext clientContext;
+  @Mock private PersistentJobRunner jobRunner;
+  @Mock private BucketFactory bucketFactory;
+
+  @Captor private ArgumentCaptor<FetchException> fetchExceptionCaptor;
+  @Captor private ArgumentCaptor<StreamGenerator> sgCaptor;
+  @Captor private ArgumentCaptor<ClientMetadata> metadataCaptor;
+  @Captor private ArgumentCaptor<List<? extends Compressor>> decompressorsCaptor;
+
+  private FetchContext newCtx(long maxOut, boolean ignoreTooMany) {
+    // Use simple, valid values for all required constructor parameters.
+    return new FetchContext(
+        maxOut, /* maxOutputLength */
+        Long.MAX_VALUE, /* maxTempLength */
+        1024 * 1024, /* maxMetadataSize */
+        8, /* maxRecursionLevel */
+        4, /* maxArchiveRestarts */
+        8, /* maxArchiveLevels */
+        false, /* dontEnterImplicitArchives */
+        0, /* maxSplitfileBlockRetries */
+        0, /* maxNonSplitfileRetries */
+        0, /* maxUSKRetries */
+        true, /* allowSplitfiles */
+        true, /* followRedirects */
+        false, /* localRequestOnly */
+        false, /* filterData */
+        0, /* maxDataBlocksPerSegment */
+        0, /* maxCheckBlocksPerSegment */
+        null, /* bucketFactory (unused here) */
+        new SimpleEventProducer(),
+        ignoreTooMany, /* ignoreTooManyPathComponents */
+        true, /* canWriteClientCache */
+        null, /* charset */
+        null, /* overrideMIME */
+        null /* schemeHostAndPort */);
+  }
+
+  @BeforeEach
+  void setup() {
+    lenient().when(parent.persistent()).thenReturn(false);
+    lenient().when(clientContext.getBucketFactory(false)).thenReturn(bucketFactory);
+    lenient().when(clientContext.getJobRunner(false)).thenReturn(jobRunner);
+  }
+
+  private SingleFileFetcher newFetcher(
+      List<String> metaStrings, int addedMetaStrings, boolean isFinal, FetchContext ctx, long token)
+      throws Exception {
+    // Minimal URI (no metastrings) is fine for these paths.
+    FreenetURI uri = new FreenetURI("CHK", null);
+    when(key.getURI()).thenReturn(uri);
+
+    return new SingleFileFetcher(
+        parent,
+        cb,
+        null, /* clientMetadata */
+        key,
+        new ArrayList<>(metaStrings),
+        uri,
+        addedMetaStrings,
+        ctx,
+        false, /* deleteFetchContext */
+        false, /* realTimeFlag */
+        null, /* actx */
+        null, /* ah */
+        null, /* archiveMetadata */
+        0, /* maxRetries */
+        0, /* recursionLevel */
+        false, /* dontTellClientGet */
+        token,
+        false, /* isEssential */
+        isFinal,
+        false, /* topDontCompress */
+        (short) 0, /* topCompatibilityMode */
+        clientContext,
+        false /* hasInitialMetadata */);
+  }
+
+  @Test
+  void onSuccess_whenTooManyPathComponentsAndFinal_reportsTooManyPathComponents() throws Exception {
+    FetchContext ctx = newCtx(1024, false /* ignoreTooMany */);
+    SingleFileFetcher f = newFetcher(List.of("extra"), 0, true, ctx, 123L);
+
+    Bucket original = mock(Bucket.class);
+    ClientMetadata md = new ClientMetadata("text/plain");
+
+    FetchResult result = new FetchResult(md, original);
+    f.onSuccess(result, clientContext);
+
+    verify(cb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(
+        FetchExceptionMode.TOO_MANY_PATH_COMPONENTS, fetchExceptionCaptor.getValue().getMode());
+    verify(original).free();
+  }
+
+  @Test
+  void onSuccess_whenAddedMetaStringsPositive_reportsInvalidMetadata() throws Exception {
+    // ignoreTooMany=false so the metaStrings check applies
+    FetchContext ctx = newCtx(1024, false);
+    // Simulate metaStrings present and that they were added via redirects (addedMetaStrings > 0)
+    SingleFileFetcher f = newFetcher(List.of("redir"), 1, true, ctx, 124L);
+
+    Bucket original = mock(Bucket.class);
+    ClientMetadata md = new ClientMetadata("text/plain");
+
+    f.onSuccess(new FetchResult(md, original), clientContext);
+
+    verify(cb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.INVALID_METADATA, fetchExceptionCaptor.getValue().getMode());
+    verify(original).free();
+  }
+
+  @Test
+  void onSuccess_whenResultTooBig_reportsTooBigAndFreesOriginal() throws Exception {
+    FetchContext ctx = newCtx(5 /* maxOut */, true /* ignoreTooMany */);
+    SingleFileFetcher f = newFetcher(List.of(), 0, true, ctx, 456L);
+
+    Bucket original = mock(Bucket.class);
+    when(original.size()).thenReturn(100L);
+    ClientMetadata md = new ClientMetadata("application/octet-stream");
+
+    FetchResult result = new FetchResult(md, original);
+    f.onSuccess(result, clientContext);
+
+    verify(cb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+    assertEquals(FetchExceptionMode.TOO_BIG, fetchExceptionCaptor.getValue().getMode());
+    verify(original).free();
+  }
+
+  @Test
+  void onSuccess_whenCopyOk_queuesJobAndCallsCallbackWithStream() throws Exception {
+    FetchContext ctx = newCtx(10_000, true);
+    SingleFileFetcher f = newFetcher(List.of(), 0, true, ctx, 789L);
+
+    Bucket original = mock(Bucket.class);
+    when(original.size()).thenReturn(20L);
+    RandomAccessBucket copy = mock(RandomAccessBucket.class);
+    when(bucketFactory.makeBucket(20L)).thenReturn(copy);
+
+    // Static mock for BucketTools.copy to avoid needing real streams.
+    try (MockedStatic<BucketTools> ignored = Mockito.mockStatic(BucketTools.class)) {
+      ClientMetadata md = new ClientMetadata("text/plain");
+      FetchResult result = new FetchResult(md, original);
+
+      // Execute job immediately when queued
+      doAnswer(
+              inv -> {
+                PersistentJob job = inv.getArgument(0);
+                job.run(clientContext);
+                return null;
+              })
+          .when(jobRunner)
+          .queueInternal(any(PersistentJob.class));
+
+      f.onSuccess(result, clientContext);
+
+      // Callback is invoked with a SingleFileStreamGenerator and same decompressors list reference
+      verify(cb)
+          .onSuccess(
+              sgCaptor.capture(),
+              metadataCaptor.capture(),
+              decompressorsCaptor.capture(),
+              eq(f),
+              eq(clientContext));
+
+      assertNotNull(sgCaptor.getValue());
+      assertEquals(md, metadataCaptor.getValue());
+
+      // Verify identity with internal 'decompressors' list via reflection
+      Field field = SingleFileFetcher.class.getDeclaredField("decompressors");
+      field.setAccessible(true);
+      Object internalList = field.get(f);
+      assertSame(internalList, decompressorsCaptor.getValue());
+
+      // Original bucket must be freed after scheduling
+      verify(original).free();
+    }
+  }
+
+  @Test
+  void onSuccess_whenBucketCopyFails_reportsBucketErrorAndFreesOriginal() throws Exception {
+    FetchContext ctx = newCtx(10_000, true);
+    SingleFileFetcher f = newFetcher(List.of(), 0, true, ctx, 101L);
+
+    Bucket original = mock(Bucket.class);
+    when(original.size()).thenReturn(20L);
+    RandomAccessBucket copy = mock(RandomAccessBucket.class);
+    when(bucketFactory.makeBucket(20L)).thenReturn(copy);
+
+    try (MockedStatic<BucketTools> bt = Mockito.mockStatic(BucketTools.class)) {
+      bt.when(() -> BucketTools.copy(eq(original), eq(copy)))
+          .thenThrow(new IOException("copy fail"));
+
+      ClientMetadata md = new ClientMetadata("text/plain");
+      FetchResult result = new FetchResult(md, original);
+
+      f.onSuccess(result, clientContext);
+
+      verify(cb).onFailure(fetchExceptionCaptor.capture(), eq(f), eq(clientContext));
+      assertEquals(FetchExceptionMode.BUCKET_ERROR, fetchExceptionCaptor.getValue().getMode());
+      verify(original).free();
+    }
+  }
+
+  @Test
+  void onSuccess_whenNotFinalAndMetaStringsRemain_stillSucceeds() throws Exception {
+    FetchContext ctx = newCtx(10_000, false /* ignoreTooMany */);
+    // metaStrings present but isFinal=false should allow success path
+    SingleFileFetcher f = newFetcher(List.of("leftover"), 0, false, ctx, 102L);
+
+    Bucket original = mock(Bucket.class);
+    when(original.size()).thenReturn(20L);
+    RandomAccessBucket copy = mock(RandomAccessBucket.class);
+    when(bucketFactory.makeBucket(20L)).thenReturn(copy);
+
+    try (MockedStatic<BucketTools> ignored = Mockito.mockStatic(BucketTools.class)) {
+      // Execute job immediately when queued
+      doAnswer(
+              inv -> {
+                PersistentJob job = inv.getArgument(0);
+                job.run(clientContext);
+                return null;
+              })
+          .when(jobRunner)
+          .queueInternal(any(PersistentJob.class));
+
+      ClientMetadata md = new ClientMetadata("text/plain");
+      f.onSuccess(new FetchResult(md, original), clientContext);
+
+      // We still should succeed because isFinal=false disables the TOO_MANY_PATH_COMPONENTS guard
+      verify(cb)
+          .onSuccess(
+              sgCaptor.capture(),
+              metadataCaptor.capture(),
+              decompressorsCaptor.capture(),
+              eq(f),
+              eq(clientContext));
+      assertNotNull(sgCaptor.getValue());
+      assertEquals(md, metadataCaptor.getValue());
+      verify(original).free();
+    }
+  }
+
+  @Test
+  void create_whenTrivialNoSplitNoRedirect_returnsSimpleFetcher() throws Exception {
+    // Uri without metastrings
+    FreenetURI uri = new FreenetURI("CHK", null);
+    FetchContext ctx = newCtx(10_000, true /* ignoreTooMany */);
+    ctx.allowSplitfiles = false;
+    ctx.followRedirects = false;
+
+    ClientKey mockKey = mock(ClientKey.class);
+    try (MockedStatic<BaseClientKey> bck = Mockito.mockStatic(BaseClientKey.class)) {
+      bck.when(() -> BaseClientKey.getBaseKey(eq(uri))).thenReturn(mockKey);
+
+      ClientGetState state =
+          SingleFileFetcher.create(
+              parent,
+              cb,
+              uri,
+              ctx,
+              null, /* actx */
+              new SingleFileFetcher.CreationPolicy(
+                  0, /* maxRetries */
+                  0, /* recursionLevel */
+                  false, /* dontTellClientGet */
+                  false, /* isEssential */
+                  true, /* isFinal */
+                  false /* hasInitialMetadata */),
+              new SingleFileFetcher.CreationRuntime(
+                  clientContext, false, /* realTime */ 1L /* token */));
+
+      assertInstanceOf(SimpleSingleFileFetcher.class, state);
+    }
+  }
+}

--- a/src/test/java/network/crypta/client/async/USKCheckerTest.java
+++ b/src/test/java/network/crypta/client/async/USKCheckerTest.java
@@ -1,0 +1,210 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.client.FetchContext;
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.ClientSSKBlock;
+import network.crypta.node.LowLevelGetException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class USKCheckerTest {
+
+  @Mock private USKCheckerCallback callback;
+  @Mock private ClientKey key;
+  @Mock private FetchContext fetchContext;
+  @Mock private ClientRequester parent;
+  @Mock private ClientContext clientContext;
+
+  @BeforeEach
+  void setup() {
+    when(fetchContext.getCooldownRetries()).thenReturn(1);
+    when(fetchContext.getCooldownTime()).thenReturn(1000L);
+    when(parent.getPriorityClass()).thenReturn((short) 17);
+    when(callback.getPriority()).thenReturn((short) 42);
+  }
+
+  private USKChecker newCheckerSpy(int maxRetries) {
+    USKChecker real = new USKChecker(callback, key, maxRetries, fetchContext, parent, false);
+    return Mockito.spy(real);
+  }
+
+  @Test
+  @DisplayName("onSuccess forwards ClientSSKBlock to callback")
+  void onSuccess_whenBlockProvided_callsOnSuccess() {
+    USKChecker checker = newCheckerSpy(0);
+    ClientSSKBlock block = Mockito.mock(ClientSSKBlock.class);
+    checker.onSuccess(block, false, null, clientContext);
+    verify(callback).onSuccess(block, clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  @DisplayName("getPriorityClass delegates to callback")
+  void getPriorityClass_whenCalled_returnsCallbackPriority() {
+    USKChecker checker = newCheckerSpy(0);
+    assertEquals(42, checker.getPriorityClass());
+  }
+
+  @Test
+  @DisplayName("onEnterFiniteCooldown delegates to callback")
+  void onEnterFiniteCooldown_whenCalled_invokesCallback() {
+    USKChecker checker = newCheckerSpy(0);
+    checker.onEnterFiniteCooldown(clientContext);
+    verify(callback).onEnterFiniteCooldown(clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  @DisplayName("onFailure CANCELLED triggers onCancelled and unregisters")
+  void onFailure_whenCancelled_callsOnCancelled() {
+    USKChecker checker = newCheckerSpy(0);
+    doNothing().when(checker).unregisterAll(any());
+
+    checker.onFailure(
+        new LowLevelGetException(LowLevelGetException.CANCELLED), null, clientContext);
+
+    verify(callback).onCancelled(clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  @DisplayName("onFailure DECODE_FAILED triggers onFatalAuthorError and unregisters")
+  void onFailure_whenDecodeFailed_callsOnFatalAuthorError() {
+    USKChecker checker = newCheckerSpy(0);
+    doNothing().when(checker).unregisterAll(any());
+
+    checker.onFailure(
+        new LowLevelGetException(LowLevelGetException.DECODE_FAILED), null, clientContext);
+
+    verify(callback).onFatalAuthorError(clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      ints = {
+        LowLevelGetException.DATA_NOT_FOUND,
+        LowLevelGetException.DATA_NOT_FOUND_IN_STORE,
+        LowLevelGetException.RECENTLY_FAILED
+      })
+  @DisplayName("onFailure DNF-ish errors with no retries call onDNF")
+  void onFailure_whenDNFAndNoRetry_callsOnDNF(int code) {
+    USKChecker checker = newCheckerSpy(0);
+    doNothing().when(checker).unregisterAll(any());
+    // Avoid BaseSingleFileFetcher.retry() side-effects (unregister) when retries are exhausted.
+    Mockito.doReturn(false).when(checker).retry(any());
+
+    checker.onFailure(new LowLevelGetException(code), null, clientContext);
+
+    verify(callback).onDNF(clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      ints = {
+        LowLevelGetException.INTERNAL_ERROR,
+        LowLevelGetException.REJECTED_OVERLOAD,
+        LowLevelGetException.ROUTE_NOT_FOUND,
+        LowLevelGetException.TRANSFER_FAILED,
+        LowLevelGetException.VERIFY_FAILED
+      })
+  @DisplayName("onFailure network-ish errors with no retries call onNetworkError")
+  void onFailure_whenNetworkErrorAndNoRetry_callsOnNetworkError(int code) {
+    USKChecker checker = newCheckerSpy(0);
+    doNothing().when(checker).unregisterAll(any());
+    Mockito.doReturn(false).when(checker).retry(any());
+
+    checker.onFailure(new LowLevelGetException(code), null, clientContext);
+
+    verify(callback).onNetworkError(clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  @DisplayName("onFailure unknown error code treated as network error when no retries")
+  void onFailure_whenUnknownCode_callsOnNetworkError() {
+    USKChecker checker = newCheckerSpy(0);
+    doNothing().when(checker).unregisterAll(any());
+    Mockito.doReturn(false).when(checker).retry(any());
+
+    checker.onFailure(new LowLevelGetException(999, "unknown"), null, clientContext);
+
+    verify(callback).onNetworkError(clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  @DisplayName("onFailure with retry allowed enters cooldown and returns early")
+  void onFailure_whenCanRetry_entersCooldownAndNoTerminalCallback() {
+    // Allow one retry so retry(context) returns true and we exit early.
+    USKChecker checker = newCheckerSpy(1);
+    doNothing().when(checker).unregisterAll(any());
+
+    checker.onFailure(
+        new LowLevelGetException(LowLevelGetException.DATA_NOT_FOUND), null, clientContext);
+
+    // Early return: no terminal callbacks, but cooldown hook fires via BaseSingleFileFetcher
+    verify(callback).onEnterFiniteCooldown(clientContext);
+    verify(callback, never()).onDNF(any());
+    verify(callback, never()).onNetworkError(any());
+    verify(callback, never()).onCancelled(any());
+    verify(callback, never()).onFatalAuthorError(any());
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  @DisplayName("notFoundInStore unregisters and reports DNF")
+  void notFoundInStore_whenCalled_unregistersAndCallsDNF() {
+    USKChecker checker = newCheckerSpy(0);
+    // We want to observe that unregisterAll is requested without executing heavy scheduler logic.
+    doNothing().when(checker).unregisterAll(any());
+
+    checker.notFoundInStore(clientContext);
+
+    verify(checker).unregisterAll(clientContext);
+    verify(callback).onDNF(clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  @DisplayName("onBlockDecodeError maps to DECODE_FAILED and triggers onFatalAuthorError")
+  void onBlockDecodeError_whenTriggered_callsOnFatalAuthorError() {
+    USKChecker checker = newCheckerSpy(0);
+    doNothing().when(checker).unregisterAll(any());
+
+    checker.onBlockDecodeError(null, clientContext);
+
+    verify(callback).onFatalAuthorError(clientContext);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  @DisplayName("toString contains class context")
+  void toString_whenCalled_containsClassContext() {
+    USKChecker checker = newCheckerSpy(0);
+    String s = checker.toString();
+    assertTrue(s.contains("USKChecker for"));
+  }
+}

--- a/src/test/java/network/crypta/client/async/USKFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTest.java
@@ -1,0 +1,210 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.util.Random;
+import network.crypta.client.FetchContext;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.crypt.DSAPublicKey;
+import network.crypta.crypt.Global;
+import network.crypta.crypt.SHA256;
+import network.crypta.keys.ClientSSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.NodeSSK;
+import network.crypta.keys.USK;
+import network.crypta.node.RequestStarter;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.io.ArrayBucketFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class USKFetcherTest {
+
+  private USK usk;
+  @Mock private USKManager uskManager;
+  @Mock private ClientRequester requester;
+  @Mock private ClientContext clientContext;
+
+  private FetchContext fetchContext;
+
+  // Deterministic key material for tests
+  private DSAPublicKey pubKey;
+  private byte[] pubKeyHash;
+  private byte cryptoAlgorithm;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // Deterministic public key (small, valid y)
+    pubKey = new DSAPublicKey(Global.DSAgroupBigA, BigInteger.valueOf(2));
+    pubKeyHash = SHA256.digest(pubKey.asBytes());
+    byte[] cryptoKey = new byte[ClientSSK.CRYPTO_KEY_LENGTH];
+    new Random(42).nextBytes(cryptoKey);
+    cryptoAlgorithm = Key.ALGO_AES_PCFB_256_SHA256;
+
+    // Build extras for SSK/USK (version, fetch URI marker, algorithm, HASH_SHA256)
+    byte[] extras =
+        new byte[] {NodeSSK.SSK_VERSION, 0, cryptoAlgorithm, 0, (byte) KeyBlock.HASH_SHA256};
+
+    // Construct a USK with deterministic material
+    usk = new USK(pubKeyHash, cryptoKey, extras, "testsite", 0L);
+
+    // Minimal real FetchContext (used/cloned by USKFetcher)
+    BucketFactory bf = new ArrayBucketFactory();
+    fetchContext =
+        new FetchContext(
+            64 * 1024,
+            64 * 1024,
+            1024,
+            1,
+            0,
+            0,
+            true,
+            0,
+            0,
+            3,
+            true,
+            false,
+            false,
+            false,
+            0,
+            0,
+            bf,
+            new SimpleEventProducer(),
+            true,
+            false,
+            null,
+            null,
+            null);
+
+    // Common requester stubs
+    when(requester.realTimeFlag()).thenReturn(false);
+  }
+
+  private USKFetcher newFetcher() {
+    // minFailures=3; no background poll; keepLastData=false; checkStoreOnly=false
+    return new USKFetcher(usk, uskManager, fetchContext, requester, 3, 0);
+  }
+
+  // Positive handleBlock path omitted: requires a fully-formed SSKBlock instance including valid
+  // structural header fields and crypto binding. We cover the negative branch and validate matcher
+  // logic via definitelyWantKey/probablyWantKey for deterministic behavior.
+
+  @Test
+  @DisplayName("handleBlock_whenNonSSKBlock_returnsFalse")
+  void handleBlock_whenNonSSKBlock_returnsFalse() {
+    USKFetcher fetcher = newFetcher();
+    KeyBlock nonSSK = mock(KeyBlock.class);
+    NodeSSK anyKey = mock(NodeSSK.class);
+
+    boolean handled = fetcher.handleBlock(anyKey, new byte[] {0x00}, nonSSK, clientContext);
+    assertFalse(handled, "Non-SSK blocks must be ignored");
+  }
+
+  @Test
+  @DisplayName("definitelyWantKey_whenMatching_returnsProgressPriority")
+  void definitelyWantKey_whenMatching_returnsProgressPriority() throws Exception {
+    USKFetcher fetcher = newFetcher();
+    ClientSSK cskEd1 = usk.getSSK(1L);
+    NodeSSK nodeKey = new NodeSSK(pubKeyHash, cskEd1.ehDocname, pubKey, cryptoAlgorithm);
+
+    when(uskManager.lookupLatestSlot(usk)).thenReturn(0L);
+    short prio = fetcher.definitelyWantKey(nodeKey, new byte[] {0x01}, clientContext);
+    assertEquals(
+        fetcher.getPriorityClass(),
+        prio,
+        "Matching key should be wanted at the fetcher's progress priority");
+  }
+
+  @Test
+  @DisplayName("probablyWantKey_whenWrongPubKeyHash_returnsFalse")
+  void probablyWantKey_whenWrongPubKeyHash_returnsFalse() throws Exception {
+    USKFetcher fetcher = newFetcher();
+    // Create a NodeSSK with a different public key hash
+    DSAPublicKey otherPk = new DSAPublicKey(Global.DSAgroupBigA, BigInteger.valueOf(3));
+    byte[] otherHash = SHA256.digest(otherPk.asBytes());
+    ClientSSK cskEd1 = usk.getSSK(1L);
+    NodeSSK wrong = new NodeSSK(otherHash, cskEd1.ehDocname, otherPk, cryptoAlgorithm);
+
+    assertFalse(
+        fetcher.probablyWantKey(wrong, new byte[] {0x02}),
+        "Mismatched pubkey hash must be rejected");
+  }
+
+  @Test
+  @DisplayName("getters_basicBehaviors")
+  void getters_basicBehaviors() {
+    USKFetcher fetcher = newFetcher();
+    assertEquals(usk.getURI(), fetcher.getURI(), "getURI should proxy the original USK URI");
+    assertEquals(usk, fetcher.getOriginalUSK(), "getOriginalUSK should return the same instance");
+    assertFalse(fetcher.isFinished(), "Fresh fetcher should not be finished");
+    assertTrue(fetcher.isSSK(), "USK fetchers operate on SSKs");
+    assertFalse(fetcher.persistent(), "USKFetcher is not persistent");
+    assertEquals(RequestStarter.UPDATE_PRIORITY_CLASS, fetcher.getPriorityClass());
+    assertArrayEquals(
+        usk.getPubKeyHash(), fetcher.getWantedKey(), "Wanted key should match USK pubkey hash");
+  }
+
+  @Test
+  @DisplayName("subscriber_add_and_remove")
+  void subscriber_add_and_remove() {
+    USKFetcher fetcher = newFetcher();
+
+    // Minimal USKCallback implementation
+    USKCallback cb =
+        new USKCallback() {
+          @Override
+          public short getPollingPriorityNormal() {
+            return RequestStarter.PREFETCH_PRIORITY_CLASS;
+          }
+
+          @Override
+          public short getPollingPriorityProgress() {
+            return RequestStarter.UPDATE_PRIORITY_CLASS;
+          }
+
+          @Override
+          public void onFoundEdition(
+              long ed,
+              USK key,
+              ClientContext context,
+              boolean metadata,
+              short codec,
+              byte[] data,
+              boolean newKnownGood,
+              boolean newSlotToo) {
+            // Intentionally empty for this test: the callback exists only to
+            // exercise subscriber add/remove mechanics. No behavior under test
+            // depends on receiving or handling edition notifications here.
+          }
+        };
+
+    fetcher.addSubscriber(cb, 5L);
+    assertTrue(fetcher.hasSubscribers(), "Fetcher should track the added subscriber");
+
+    when(uskManager.lookupLatestSlot(usk)).thenReturn(0L);
+    fetcher.removeSubscriber(cb);
+    assertFalse(fetcher.hasSubscribers(), "Subscriber removal should be reflected");
+  }
+
+  @Test
+  @DisplayName("getRequestsForKey_returnsEmptyArray")
+  void getRequestsForKey_returnsEmptyArray() throws Exception {
+    USKFetcher fetcher = newFetcher();
+    ClientSSK cskEd1 = usk.getSSK(1L);
+    NodeSSK nodeKey = new NodeSSK(pubKeyHash, cskEd1.ehDocname, pubKey, cryptoAlgorithm);
+    assertEquals(0, fetcher.getRequestsForKey(nodeKey, new byte[] {0}, clientContext).length);
+  }
+}

--- a/src/test/java/network/crypta/client/async/USKRetrieverTest.java
+++ b/src/test/java/network/crypta/client/async/USKRetrieverTest.java
@@ -544,7 +544,8 @@ class USKRetrieverTest {
 
     // changeUSKPollParameters should delegate when fetcher is set
     retriever.changeUSKPollParameters(30 * 60 * 1000L, 1, ctx);
-    verify(fetcher, times(1)).changeUSKPollParameters(30 * 60 * 1000L, 1, ctx);
+    // USKRetriever delegates to USKFetcher without passing ClientContext
+    verify(fetcher, times(1)).changeUSKPollParameters(30 * 60 * 1000L, 1);
   }
 
   @Test


### PR DESCRIPTION
Summary
- Doclint-clean and expand Javadoc across client async components: `BaseSingleFileFetcher`, `ClientGetState`, `ClientGetter`, `HasKeyListener`, `SimpleSingleFileFetcher`, `SingleFileFetcher`, `USKCallback`, `USKChecker`, `USKFetcher`, `USKManager`, `USKRetriever`.
- Tests added for key async fetchers: `SimpleSingleFileFetcherTest`, `SingleFileFetcherTest`, `USKCheckerTest`, `USKFetcherTest`.
- Minor behavior fix: keep callback serialized to avoid reentrancy/concurrency issues in async flows.
- Light refactor: consolidate `USKFetcher` options flags; comments clarified; no functional changes intended beyond the callback serialization fix.
- Spotless formatting applied.

Commits (since merge-base with `origin/develop`)
```
901883118a docs(client): doclint-clean Javadoc for USKChecker; fix dangling comments
3baf5b7d06 docs(client): doclint-clean SingleFileFetcher Javadoc; spotless formatting
cb67d32483 fix(async): keep callback serialized and doclint-clean Javadoc
f879bc4ac3 refactor(client/async): consolidate USKFetcher options flags; docs: doclint-clean Javadoc; format via Spotless
522efacba2 docs(client): doclint-clean Javadoc for USKCallback
900b33bc58 docs(client): doclint-clean Javadoc for ClientGetState
beabd8a59f docs(client): doclint-clean Javadoc for BaseSingleFileFetcher; apply Spotless formatting
 e3b6236d56 docs: doclint-clean Javadoc for HasKeyListener; add long-form API docs and apply Spotless formatting
```

Diff Stats
```
 .../crypta/client/async/BaseSingleFileFetcher.java |  329 ++-
 .../crypta/client/async/ClientGetState.java        |   66 +-
 .../network/crypta/client/async/ClientGetter.java  |   12 +-
 .../crypta/client/async/HasKeyListener.java        |   76 +-
 .../client/async/SimpleSingleFileFetcher.java      |  257 +-
 .../crypta/client/async/SingleFileFetcher.java     | 2497 ++++++++++++--------
 .../network/crypta/client/async/USKCallback.java   |   73 +-
 .../network/crypta/client/async/USKChecker.java    |  194 +-
 .../network/crypta/client/async/USKFetcher.java    | 1752 ++++++++------
 .../network/crypta/client/async/USKManager.java    |   27 +-
 .../network/crypta/client/async/USKRetriever.java  |   14 +-
 .../client/async/SimpleSingleFileFetcherTest.java  |  290 +++
 .../crypta/client/async/SingleFileFetcherTest.java |  324 +++
 .../crypta/client/async/USKCheckerTest.java        |  210 ++
 .../crypta/client/async/USKFetcherTest.java        |  210 ++
 15 files changed, 4342 insertions(+), 1989 deletions(-)
```

Compatibility & Risk
- No wire/storage format changes.
- Functional impact expected only in callback serialization behavior; otherwise documentation and formatting.

Notes
- CI should see improved coverage due to new tests.

Review Focus
- Correctness of the serialized callback behavior and any potential side-effects.
- Test coverage completeness for SingleFileFetcher and USKFetcher flows.
- Doc wording/clarity for public APIs.
