### PR TITLE
fix(client-async): CompressionOutput refactor + tests

### DIFF
--- a/src/main/java/network/crypta/client/async/CompressionOutput.java
+++ b/src/main/java/network/crypta/client/async/CompressionOutput.java
@@ -1,18 +1,81 @@
 package network.crypta.client.async;
 
+import java.util.Arrays;
+import java.util.Objects;
 import network.crypta.crypt.HashResult;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import org.jetbrains.annotations.NotNull;
 
-class CompressionOutput {
-  public CompressionOutput(
-      RandomAccessBucket bestCompressedData, COMPRESSOR_TYPE bestCodec2, HashResult[] hashes) {
-    this.data = bestCompressedData;
-    this.bestCodec = bestCodec2;
-    this.hashes = hashes;
+/**
+ * Immutable container for the outcome of a single compression attempt.
+ *
+ * <p>This record bundles three pieces of information that downstream callers typically need
+ * together: a {@link RandomAccessBucket} holding the resulting bytes, the chosen compressor
+ * (represented by {@link network.crypta.support.compress.Compressor.COMPRESSOR_TYPE}), and an
+ * optional array of {@link HashResult} describing content hashes computed while producing the
+ * output. The codec may be {@code null} to indicate that compression was not applied or did not
+ * produce a smaller result; in that case the {@code data} contains the original bytes.
+ *
+ * <p>Instances are shallowly immutable: the reference to {@code data} and the {@code hashes} array
+ * are stored as provided and are not defensively copied. Callers are expected to respect the
+ * immutability contract and avoid mutating the referenced objects after construction when they are
+ * shared.
+ *
+ * <ul>
+ *   <li>Data: random-access storage for the produced payload, ready for reading or further
+ *       processing.
+ *   <li>Codec: the compressor that yielded the best result, or {@code null} when none was used.
+ *   <li>Hashes: zero or more content digests computed during processing; may be {@code null}.
+ * </ul>
+ *
+ * <p>Typical usage is to construct this as the return value of a compression routine and then hand
+ * the bucket and metadata to subsequent persistence or transmission layers.
+ *
+ * <pre>{@code
+ * // Example: pass compression output to a writer
+ * var out = new CompressionOutput(bucket, codec, hashes);
+ * writer.write(out.data());
+ * }</pre>
+ *
+ * @param data the {@link RandomAccessBucket} containing the bytes produced by compression; never
+ *     wrapped or copied, and may reference uncompressed data when no codec is selected
+ * @param bestCodec the {@link network.crypta.support.compress.Compressor.COMPRESSOR_TYPE} selected
+ *     as most effective for this content, or {@code null} when compression was not applied
+ * @param hashes an optional array of {@link HashResult} values describing computed content digests;
+ *     may be {@code null} or empty, and is stored without defensive copying
+ */
+record CompressionOutput(RandomAccessBucket data, COMPRESSOR_TYPE bestCodec, HashResult[] hashes) {
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) return true;
+    return (o
+            instanceof
+            CompressionOutput(RandomAccessBucket od, COMPRESSOR_TYPE oc, HashResult[] oh))
+        && Objects.equals(this.data, od)
+        && this.bestCodec == oc
+        && Arrays.equals(this.hashes, oh);
   }
 
-  final RandomAccessBucket data;
-  final COMPRESSOR_TYPE bestCodec;
-  final HashResult[] hashes;
+  @Override
+  public int hashCode() {
+    int result = 1;
+    result = 31 * result + Objects.hashCode(this.data);
+    result = 31 * result + Objects.hashCode(this.bestCodec);
+    result = 31 * result + Arrays.hashCode(this.hashes);
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "CompressionOutput["
+        + "data="
+        + data
+        + ", bestCodec="
+        + bestCodec
+        + ", hashes="
+        + Arrays.toString(hashes)
+        + "]";
+  }
 }

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -193,7 +193,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
   }
 
   void onCompressedInner(CompressionOutput output, ClientContext context) throws InsertException {
-    HashResult[] hashes = output.hashes;
+    HashResult[] hashes = output.hashes();
     long origSize = block.getData().size();
     byte[] hashThisLayerOnly = null;
     if (hashes != null && metadata) {
@@ -216,10 +216,10 @@ class SingleFileInserter implements ClientPutState, Serializable {
     } else {
       hashes = origHashes; // Inherit so it goes all the way to the top.
     }
-    RandomAccessBucket bestCompressedData = output.data;
+    RandomAccessBucket bestCompressedData = output.data();
     long bestCompressedDataSize = bestCompressedData.size();
     RandomAccessBucket data = bestCompressedData;
-    COMPRESSOR_TYPE bestCodec = output.bestCodec;
+    COMPRESSOR_TYPE bestCodec = output.bestCodec();
 
     boolean shouldFreeData = freeData;
     if (bestCodec != null) {

--- a/src/test/java/network/crypta/client/async/CompressionOutputTest.java
+++ b/src/test/java/network/crypta/client/async/CompressionOutputTest.java
@@ -1,0 +1,299 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.DataOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import network.crypta.crypt.HashResult;
+import network.crypta.crypt.HashType;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link CompressionOutput}. */
+@SuppressWarnings("java:S100") // test method naming: method_whenCondition_expectOutcome
+class CompressionOutputTest {
+
+  // ------------------ Helpers ------------------
+
+  private static byte[] bytes(int len, byte value) {
+    byte[] b = new byte[len];
+    Arrays.fill(b, value);
+    return b;
+  }
+
+  private static HashResult hr(HashType t, byte fill) {
+    return new HashResult(t, bytes(t.hashLength, fill));
+  }
+
+  /**
+   * Minimal deterministic {@link RandomAccessBucket} for equality/toString testing. Implements the
+   * interface but all I/O methods throw {@link UnsupportedOperationException} as tests never call
+   * them.
+   */
+  private static final class FakeBucket implements RandomAccessBucket {
+    private final String id;
+
+    FakeBucket(String id) {
+      this.id = id;
+    }
+
+    @Override
+    public String toString() {
+      return "FakeBucket(" + id + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof FakeBucket other)) return false;
+      return this.id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+      return id.hashCode();
+    }
+
+    // ---- Bucket / RandomAccessBucket API (unused here) ----
+    @Override
+    public OutputStream getOutputStream() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OutputStream getOutputStreamUnbuffered() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+      return id;
+    }
+
+    @Override
+    public long size() {
+      return 0;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return true;
+    }
+
+    @Override
+    public void setReadOnly() {
+      // Intentionally unused in tests; FakeBucket models an immutable, read-only bucket.
+      // Throwing to surface accidental calls during future refactors.
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void free() {
+      // Intentionally unused in tests; nothing to release for the fake implementation.
+      // Throwing to surface accidental calls during future refactors.
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RandomAccessBucket createShadow() {
+      return this;
+    }
+
+    @Override
+    public LockableRandomAccessBuffer toRandomAccessBuffer() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void onResume(ClientContext context) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeTo(DataOutputStream dos) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  // ------------------ equals/hashCode ------------------
+
+  @Test
+  void equals_whenAllFieldsEqual_expectTrueAndHashCodeEqual() {
+    // Arrange
+    RandomAccessBucket bucket = new FakeBucket("A");
+    COMPRESSOR_TYPE codec = COMPRESSOR_TYPE.GZIP;
+    HashResult hA = hr(HashType.SHA256, (byte) 1);
+    HashResult hB = hr(HashType.SHA1, (byte) 2);
+    // Use the SAME HashResult instances in both arrays to ensure element hashCodes match.
+    HashResult[] h1 = new HashResult[] {hA, hB};
+    HashResult[] h2 = new HashResult[] {hA, hB};
+
+    CompressionOutput co1 = new CompressionOutput(bucket, codec, h1);
+    CompressionOutput co2 = new CompressionOutput(bucket, codec, h2);
+
+    // Act + Assert
+    assertEquals(co1, co2);
+    assertEquals(co1.hashCode(), co2.hashCode());
+  }
+
+  @Test
+  void equals_whenEqualHashesDifferentInstances_expectTrue() {
+    // Arrange
+    RandomAccessBucket bucket = new FakeBucket("A");
+    COMPRESSOR_TYPE codec = COMPRESSOR_TYPE.GZIP;
+    HashResult[] h1 = new HashResult[] {hr(HashType.SHA256, (byte) 5), hr(HashType.SHA1, (byte) 6)};
+    // New instances with same type/content
+    HashResult[] h2 = new HashResult[] {hr(HashType.SHA256, (byte) 5), hr(HashType.SHA1, (byte) 6)};
+
+    CompressionOutput co1 = new CompressionOutput(bucket, codec, h1);
+    CompressionOutput co2 = new CompressionOutput(bucket, codec, h2);
+
+    // Act + Assert
+    assertEquals(co1, co2);
+  }
+
+  @Test
+  void equals_whenDifferentData_expectFalse() {
+    // Arrange
+    CompressionOutput a =
+        new CompressionOutput(
+            new FakeBucket("A"),
+            COMPRESSOR_TYPE.GZIP,
+            new HashResult[] {hr(HashType.SHA1, (byte) 7)});
+    CompressionOutput b =
+        new CompressionOutput(
+            new FakeBucket("B"),
+            COMPRESSOR_TYPE.GZIP,
+            new HashResult[] {hr(HashType.SHA1, (byte) 7)});
+
+    // Act + Assert
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void equals_whenDifferentCodec_expectFalse() {
+    // Arrange
+    RandomAccessBucket bucket = new FakeBucket("Z");
+    HashResult[] hashes = new HashResult[] {hr(HashType.SHA512, (byte) 3)};
+    CompressionOutput a = new CompressionOutput(bucket, COMPRESSOR_TYPE.GZIP, hashes);
+    CompressionOutput b = new CompressionOutput(bucket, COMPRESSOR_TYPE.BZIP2, hashes);
+
+    // Act + Assert
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void equals_whenDifferentHashesContent_expectFalse() {
+    // Arrange
+    RandomAccessBucket bucket = new FakeBucket("Q");
+    CompressionOutput a =
+        new CompressionOutput(
+            bucket, COMPRESSOR_TYPE.LZMA_NEW, new HashResult[] {hr(HashType.SHA256, (byte) 1)});
+    CompressionOutput b =
+        new CompressionOutput(
+            bucket, COMPRESSOR_TYPE.LZMA_NEW, new HashResult[] {hr(HashType.SHA256, (byte) 2)});
+
+    // Act + Assert
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void equals_whenSameHashesDifferentOrder_expectFalse() {
+    // Arrange
+    RandomAccessBucket bucket = new FakeBucket("Q");
+    HashResult h1 = hr(HashType.SHA1, (byte) 1);
+    HashResult h2 = hr(HashType.SHA256, (byte) 2);
+    CompressionOutput a =
+        new CompressionOutput(bucket, COMPRESSOR_TYPE.GZIP, new HashResult[] {h1, h2});
+    CompressionOutput b =
+        new CompressionOutput(bucket, COMPRESSOR_TYPE.GZIP, new HashResult[] {h2, h1});
+
+    // Act + Assert
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void equals_whenBothHashesNull_expectTrueAndHashCodeEqual() {
+    // Arrange
+    CompressionOutput a = new CompressionOutput(null, null, null);
+    CompressionOutput b = new CompressionOutput(null, null, null);
+
+    // Act + Assert
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void equals_whenOneHashesNullOtherEmpty_expectFalse() {
+    // Arrange
+    CompressionOutput a = new CompressionOutput(new FakeBucket("X"), COMPRESSOR_TYPE.GZIP, null);
+    CompressionOutput b =
+        new CompressionOutput(new FakeBucket("X"), COMPRESSOR_TYPE.GZIP, new HashResult[0]);
+
+    // Act + Assert
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  void equals_whenComparedWithNullOrDifferentType_expectFalse() {
+    // Arrange
+    CompressionOutput a = new CompressionOutput(null, COMPRESSOR_TYPE.BZIP2, null);
+
+    // Act + Assert
+    assertNotEquals(null, a);
+    assertNotEquals(new Object(), a);
+  }
+
+  // ------------------ toString ------------------
+
+  @Test
+  void toString_whenTypicalFields_expectContainsKeySegments() {
+    // Arrange
+    CompressionOutput out =
+        new CompressionOutput(
+            new FakeBucket("B1"),
+            COMPRESSOR_TYPE.GZIP,
+            new HashResult[] {hr(HashType.SHA256, (byte) 9), hr(HashType.SHA1, (byte) 8)});
+
+    // Act
+    String s = out.toString();
+
+    // Assert (structure only; element toStrings may vary)
+    assertNotNull(s);
+    assertTrue(s.startsWith("CompressionOutput["));
+    assertTrue(s.contains("data=FakeBucket(B1)"));
+    assertTrue(s.contains("bestCodec=GZIP"));
+    assertTrue(s.contains("hashes=["));
+    assertTrue(s.endsWith("]"));
+  }
+
+  @Test
+  void toString_whenNullFields_expectContainsNullIndicators() {
+    // Arrange
+    CompressionOutput out = new CompressionOutput(null, null, null);
+
+    // Act
+    String s = out.toString();
+
+    // Assert
+    assertTrue(s.contains("bestCodec=null"));
+    assertTrue(s.contains("hashes=null"));
+  }
+}


### PR DESCRIPTION
Summary
- Convert CompressionOutput to a Java record with equals/hashCode/toString and richer Javadoc.
- Update SingleFileInserter to consume the new CompressionOutput API.
- Add CompressionOutputTest with comprehensive equality/hash behavior tests.
- Applied Spotless formatting across touched files.

Rationale
- CompressionOutput was a mutable/POJO-like holder with manual fields; migrating to a record clarifies immutability intent and provides value semantics.
- equals/hashCode ensure safe use in collections and simplify testing.
- Tests validate record semantics across data/codec/hash array combinations, including null/empty cases and order sensitivity.

Files Changed
- src/main/java/network/crypta/client/async/CompressionOutput.java
  - Rewritten as a record: data (RandomAccessBucket), bestCodec (COMPRESSOR_TYPE), hashes (HashResult[])
  - Added Javadoc and overrides for equals/hashCode/toString.
- src/main/java/network/crypta/client/async/SingleFileInserter.java
  - Adjusted code-paths to use record accessors and deal with optional hashes.
- src/test/java/network/crypta/client/async/CompressionOutputTest.java
  - New tests for equality and hashCode scenarios.

How to Test
- Build + run tests: ./gradlew test
- Focused test: ./gradlew test --tests '*CompressionOutputTest'

Notes
- No public API removals beyond the internal representation change.
- Spotless applied to maintain consistent formatting and imports.

Change History (branch)
- cf99f63220 fix(client-async): update CompressionOutput and SingleFileInserter; add CompressionOutputTest
