### PR TITLE
refactor(async): introduce ContainerInserter.Options; update callers; add tests

### DIFF
--- a/src/main/java/network/crypta/client/async/BaseManifestPutter.java
+++ b/src/main/java/network/crypta/client/async/BaseManifestPutter.java
@@ -120,14 +120,14 @@ public abstract class BaseManifestPutter extends ManifestPutter {
               data,
               insertURI,
               ctx,
-              false,
-              false,
-              null,
-              ARCHIVE_TYPE.TAR,
-              false,
-              forceCryptoKey,
-              cryptoAlgorithm,
-              realTimeFlag);
+              new ContainerInserter.Options(
+                  false,
+                  false,
+                  null,
+                  ARCHIVE_TYPE.TAR,
+                  forceCryptoKey,
+                  cryptoAlgorithm,
+                  realTimeFlag));
     }
 
     @Override
@@ -199,14 +199,14 @@ public abstract class BaseManifestPutter extends ManifestPutter {
               data,
               insertURI,
               ctx,
-              false,
-              false,
-              null,
-              ARCHIVE_TYPE.TAR,
-              false,
-              forceCryptoKey,
-              cryptoAlgorithm,
-              realTimeFlag);
+              new ContainerInserter.Options(
+                  false,
+                  false,
+                  null,
+                  ARCHIVE_TYPE.TAR,
+                  forceCryptoKey,
+                  cryptoAlgorithm,
+                  realTimeFlag));
     }
 
     @Override

--- a/src/main/java/network/crypta/client/async/ContainerInserter.java
+++ b/src/main/java/network/crypta/client/async/ContainerInserter.java
@@ -34,11 +34,32 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Insert a bunch of files as single Archive with .metadata pack the container/archive, then hand it
- * off to SimpleFileInserter
+ * Inserts a set of files as a single archive with an embedded {@code .metadata} manifest and hands
+ * it off to {@link SingleFileInserter} for the actual network insertion.
  *
- * <p>TODO persistence TODO add a MAX_SIZE for the final container(file)
+ * <p>This class is a thin coordinator that builds a container (either {@code .tar} or {@code .zip})
+ * containing the provided content plus the metadata entries required by the manifest/redirect
+ * layer. The resulting archive is converted into a single {@link InsertBlock} and then delegated to
+ * a {@link SingleFileInserter}. Typical usage is to construct a {@code ContainerInserter} with a
+ * manifest-like map (values of {@link Metadata}, {@link ManifestElement}, or nested {@link
+ * java.util.Map}) and then schedule it. Persistence is handled via Java serialization; on resume we
+ * reattach transient runtime state where applicable.
  *
+ * <p>Concurrency: instances are not thread-safe. Callers should synchronize externally if multiple
+ * threads may invoke lifecycle methods. Mutability: configuration is fixed at construction time;
+ * internal progress state advances as the inserter prepares the archive and transitions ownership
+ * to the created {@link SingleFileInserter}. Failure paths close streams and report via the
+ * provided callback.
+ *
+ * <ul>
+ *   <li>Builds {@code .metadata} and any additional unresolved metadata parts.
+ *   <li>Packages data and metadata into a TAR or ZIP archive.
+ *   <li>Delegates insertion to {@link SingleFileInserter} and reports transitions.
+ * </ul>
+ *
+ * @see SingleFileInserter
+ * @see Metadata
+ * @see ManifestElement
  * @author saces
  */
 public class ContainerInserter implements ClientPutState, Serializable {
@@ -46,88 +67,196 @@ public class ContainerInserter implements ClientPutState, Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
 
-  static {
-  }
+  /**
+   * Options used to configure a {@link ContainerInserter}. Reduces constructor parameter count and
+   * captures flags that influence archive creation and insertion behavior.
+   *
+   * <p>Instances of this class are serializable. The {@link #token} is marked {@code transient}
+   * because it is an application-supplied correlation object that may not be serializable and is
+   * not required to restore insertion state.
+   */
+  public static final class Options implements Serializable {
+    @Serial private static final long serialVersionUID = 1L;
 
-  private static class ContainerElement {
-    private final Bucket data;
-    private final String targetInArchive;
+    /**
+     * When {@code true}, disables content compression. For {@link ARCHIVE_TYPE#ZIP} this is forced
+     * to {@code true} regardless of the requested value so entries are stored uncompressed.
+     */
+    public final boolean dontCompress;
 
-    private ContainerElement(Bucket data2, String targetInArchive2) {
-      data = data2;
-      targetInArchive = targetInArchive2;
+    /**
+     * When {@code true}, perform the metadata preparation flow only and report results without
+     * starting the actual network insertion. Useful for dry-run or inspection scenarios.
+     */
+    public final boolean reportMetadataOnly;
+
+    /**
+     * Application correlation token passed through callbacks. It is never serialized; callers own
+     * its lifecycle and may supply any object (including {@code null}).
+     */
+    public final transient Object token;
+
+    /** Archive type to create for the container (e.g., TAR or ZIP). */
+    public final ARCHIVE_TYPE archiveType;
+
+    /**
+     * Optional explicit encryption key material. When non-{@code null}, it overrides derived keys
+     * in downstream inserters. Ownership is not transferred and the array is not defensively
+     * copied.
+     */
+    public final byte[] forceCryptoKey;
+
+    /**
+     * Crypto algorithm identifier consumed by downstream inserters. Acceptable values depend on the
+     * network configuration; unknown values will cause insertion to fail early.
+     */
+    public final byte cryptoAlgorithm;
+
+    /**
+     * Enables real-time insertion behavior when {@code true}. This can reduce latency at the cost
+     * of increased resource use depending on the insertion context.
+     */
+    public final boolean realTimeFlag;
+
+    /**
+     * Constructs an {@link Options} bundle describing how the container and downstream insertion
+     * should behave.
+     *
+     * @param dontCompress set to {@code true} to disable compression of the container contents; ZIP
+     *     containers are stored uncompressed regardless of this flag
+     * @param reportMetadataOnly set to {@code true} to prepare metadata and report it without
+     *     starting the network insertion; used for dry-run and diagnostics
+     * @param token arbitrary application token forwarded to callbacks; never serialized and may be
+     *     {@code null}
+     * @param archiveType the archive format to build for the container; typically TAR or ZIP
+     * @param forceCryptoKey optional explicit encryption key material; when non-{@code null},
+     *     overrides derived keys in downstream components
+     * @param cryptoAlgorithm algorithm identifier understood by downstream inserters; invalid
+     *     values will cause the insertion to fail
+     * @param realTimeFlag when {@code true}, requests lower-latency, real-time insertion behavior
+     */
+    public Options(
+        boolean dontCompress,
+        boolean reportMetadataOnly,
+        Object token,
+        ARCHIVE_TYPE archiveType,
+        byte[] forceCryptoKey,
+        byte cryptoAlgorithm,
+        boolean realTimeFlag) {
+      this.dontCompress = dontCompress;
+      this.reportMetadataOnly = reportMetadataOnly;
+      this.token = token;
+      this.archiveType = archiveType;
+      this.forceCryptoKey = forceCryptoKey;
+      this.cryptoAlgorithm = cryptoAlgorithm;
+      this.realTimeFlag = realTimeFlag;
     }
   }
 
-  private final ArrayList<ContainerElement> containerItems;
+  private record ContainerElement(Bucket data, String targetInArchive) {}
 
+  /** Items to include in the container archive; populated during metadata resolution. */
+  private transient ArrayList<ContainerElement> containerItems;
+
+  /** Owning client putter that created and coordinates this inserter. */
   private final BaseClientPutter parent;
+
+  /** Callback used to report failures, resumes, and state transitions. */
   private final PutCompletionCallback cb;
+
+  /** Indicates that {@link #cancel(ClientContext)} has been invoked. */
   private boolean cancelled;
+
+  /** True once a terminal state has been reached and callbacks have been issued. */
   private boolean finished;
+
+  /** Whether backing buckets should be persistent across restarts. */
   private final boolean persistent;
 
-  /** See ContainerBuilder._rootDir. */
+  /**
+   * Original manifest-like map used to build {@code .metadata} entries. See
+   * ContainerBuilder._rootDir.
+   */
   private final HashMap<String, Object> origMetadata;
 
+  /** Archive format to build ({@link ARCHIVE_TYPE#TAR} or {@link ARCHIVE_TYPE#ZIP}). */
   private final ARCHIVE_TYPE archiveType;
+
+  /** Target URI that will be used as the base for the inserted content. */
   private final FreenetURI targetURI;
+
+  /** Application token forwarded to downstream components and callbacks. */
   private final Object token;
+
+  /** Insertion context providing configuration and factories needed at runtime. */
   private final InsertContext ctx;
+
+  /** If set, prepares metadata and stops before starting the network insertion. */
   private final boolean reportMetadataOnly;
+
+  /** When {@code true}, disables compression for the generated archive. */
   private final boolean dontCompress;
+
+  /** Optional explicit encryption key; {@code null} to use default/derived keys. */
   final byte[] forceCryptoKey;
+
+  /** Crypto algorithm identifier used by downstream inserters. */
   final byte cryptoAlgorithm;
+
+  /** Requests real-time insertion behavior when {@code true}. */
   private final boolean realTimeFlag;
 
   /**
-   * Insert a bunch of files as single Archive with .metadata
+   * Creates a new {@link ContainerInserter} that will package the provided manifest-like map and
+   * data into an archive and delegate its insertion to a {@link SingleFileInserter}.
    *
-   * @param parent2
-   * @param cb2
-   * @param metadata2
-   * @param targetURI2 The caller need to clone it for persistance
-   * @param ctx2
-   * @param dontCompress2
-   * @param reportMetadataOnly2
-   * @param token2
-   * @param archiveType2
-   * @param freeData
-   * @param forceCryptoKey
-   * @param cryptoAlgorithm
-   * @param realTimeFlag
+   * <p>The constructor records the configuration and performs no I/O. Call {@link #schedule} to
+   * build the metadata, package the archive, and initiate the downstream insertion. The {@code
+   * metadata2} map may contain nested maps, {@link Metadata} instances, or {@link ManifestElement}
+   * entries, which are converted into {@code .metadata} and redirected paths within the container.
+   *
+   * @param parent2 parent putter that owns this inserter and provides persistence scope
+   * @param cb2 completion callback invoked for transitions, failures, and resume notifications; may
+   *     be the same instance as {@code parent2}
+   * @param metadata2 manifest structure (mutable map) describing the tree to embed; values can be
+   *     nested maps, {@link Metadata}, or {@link ManifestElement}
+   * @param targetURI2 target URI; callers should provide a cloned, persistent instance suitable for
+   *     serialization
+   * @param ctx2 insert context supplying bucket factories and operational settings
+   * @param options additional options configuring compression, report-only mode, crypto, and token
    */
   public ContainerInserter(
       BaseClientPutter parent2,
       PutCompletionCallback cb2,
-      HashMap<String, Object> metadata2,
+      Map<String, Object> metadata2,
       FreenetURI targetURI2,
       InsertContext ctx2,
-      boolean dontCompress2,
-      boolean reportMetadataOnly2,
-      Object token2,
-      ARCHIVE_TYPE archiveType2,
-      boolean freeData,
-      byte[] forceCryptoKey,
-      byte cryptoAlgorithm,
-      boolean realTimeFlag) {
+      Options options) {
     parent = parent2;
     cb = cb2;
     hashCode = super.hashCode();
     persistent = parent.persistent();
-    origMetadata = metadata2;
-    archiveType = archiveType2;
+    origMetadata = Metadata.forceMap(metadata2);
+    archiveType = options.archiveType;
     targetURI = targetURI2;
-    token = token2;
+    token = options.token;
     ctx = ctx2;
-    dontCompress = dontCompress2;
-    reportMetadataOnly = reportMetadataOnly2;
+    dontCompress = options.dontCompress;
+    reportMetadataOnly = options.reportMetadataOnly;
     containerItems = new ArrayList<>();
-    this.forceCryptoKey = forceCryptoKey;
-    this.cryptoAlgorithm = cryptoAlgorithm;
-    this.realTimeFlag = realTimeFlag;
+    this.forceCryptoKey = options.forceCryptoKey;
+    this.cryptoAlgorithm = options.cryptoAlgorithm;
+    this.realTimeFlag = options.realTimeFlag;
   }
 
+  /**
+   * Cancels the insertion before delegation to the downstream inserter or during preparation.
+   *
+   * <p>After cancellation, a failure is reported to the callback using {@link
+   * InsertExceptionMode#CANCELLED}. This method is idempotent and thread-safe.
+   *
+   * @param context client context used for callback notification
+   */
   @Override
   public void cancel(ClientContext context) {
     synchronized (this) {
@@ -138,23 +267,35 @@ public class ContainerInserter implements ClientPutState, Serializable {
     cb.onFailure(new InsertException(InsertExceptionMode.CANCELLED), this, context);
   }
 
+  /** Returns the owning {@link BaseClientPutter}. */
   @Override
   public BaseClientPutter getParent() {
     return parent;
   }
 
+  /** Returns the application-supplied correlation token, which may be {@code null}. */
   @Override
   public Object getToken() {
     return token;
   }
 
+  /**
+   * Schedules the preparation and delegation of the container insertion.
+   *
+   * <p>Creates the {@code .metadata} manifest, packages data and metadata into the configured
+   * archive type, and then constructs a {@link SingleFileInserter}. The downstream inserter is
+   * returned via {@link PutCompletionCallback#onTransition} and scheduled immediately.
+   *
+   * @param context insertion context used to obtain buckets and configuration
+   * @throws InsertException when preparation fails (e.g., bucket errors or metadata resolution)
+   */
   @Override
   public void schedule(ClientContext context) throws InsertException {
     start(context);
   }
 
   private void start(ClientContext context) {
-    if (LOG.isTraceEnabled()) LOG.trace("Atempt to start a container inserter");
+    if (LOG.isTraceEnabled()) LOG.trace("Attempt to start a container inserter");
 
     makeMetadata(context);
 
@@ -170,9 +311,9 @@ public class ContainerInserter implements ClientPutState, Serializable {
         mimeType = (archiveType == ARCHIVE_TYPE.TAR ? createTarBucket(os) : createZipBucket(os));
         // create*Bucket closes os through try-with-resources
       }
-      if (LOG.isDebugEnabled()) LOG.debug("Archive size is " + outputBucket.size());
+      if (LOG.isDebugEnabled()) LOG.debug("Archive size is {}", outputBucket.size());
 
-      if (LOG.isDebugEnabled()) LOG.debug("We are using " + archiveType);
+      if (LOG.isDebugEnabled()) LOG.debug("We are using {}", archiveType);
 
       // Now we have to insert the Archive we have generated.
 
@@ -185,35 +326,8 @@ public class ContainerInserter implements ClientPutState, Serializable {
       return;
     }
 
-    boolean dc = dontCompress;
-    if (!dontCompress) {
-      dc = (archiveType == ARCHIVE_TYPE.ZIP);
-    }
-
-    // Treat it as a splitfile for purposes of determining reinsert count.
-    SingleFileInserter sfi =
-        new SingleFileInserter(
-            parent,
-            cb,
-            block,
-            false,
-            ctx,
-            realTimeFlag,
-            dc,
-            reportMetadataOnly,
-            token,
-            archiveType,
-            true,
-            null,
-            true,
-            persistent,
-            0,
-            0,
-            null,
-            cryptoAlgorithm,
-            forceCryptoKey,
-            -1);
-    if (LOG.isDebugEnabled()) LOG.debug("Inserting container: " + sfi + " for " + this);
+    SingleFileInserter sfi = buildSingleFileInserter(block);
+    if (LOG.isDebugEnabled()) LOG.debug("Inserting container: {} for {}", sfi, this);
     cb.onTransition(this, sfi, context);
     try {
       sfi.schedule(context);
@@ -222,9 +336,46 @@ public class ContainerInserter implements ClientPutState, Serializable {
     }
   }
 
+  /**
+   * Builds the {@link SingleFileInserter} for the prepared archive {@link InsertBlock}.
+   *
+   * <p>Computes the effective compression flag for the archive type and returns a fully configured
+   * inserter. The returned instance is not scheduled; the caller is responsible for lifecycle
+   * management (logging, transition callback, and scheduling).
+   */
+  private SingleFileInserter buildSingleFileInserter(InsertBlock block) {
+    boolean dc = dontCompress;
+    if (!dontCompress) {
+      dc = (archiveType == ARCHIVE_TYPE.ZIP);
+    }
+
+    // Treat it as a splitfile for purposes of determining reinsert count.
+    return new SingleFileInserter(
+        parent,
+        cb,
+        block,
+        false,
+        ctx,
+        realTimeFlag,
+        dc,
+        reportMetadataOnly,
+        token,
+        archiveType,
+        true,
+        null,
+        true,
+        persistent,
+        0,
+        0,
+        null,
+        cryptoAlgorithm,
+        forceCryptoKey,
+        -1);
+  }
+
   private void makeMetadata(ClientContext context) {
 
-    Bucket bucket = null;
+    Bucket bucket;
     int x = 0;
 
     Metadata md = makeManifest(origMetadata, "");
@@ -236,7 +387,7 @@ public class ContainerInserter implements ClientPutState, Serializable {
         return;
       } catch (MetadataUnresolvedException e) {
         try {
-          x = resolve(e, x, null, null, context);
+          x = resolve(e, x, context);
         } catch (IOException e1) {
           fail(new InsertException(InsertExceptionMode.INTERNAL_ERROR, e, null), context);
           return;
@@ -248,8 +399,7 @@ public class ContainerInserter implements ClientPutState, Serializable {
     }
   }
 
-  private int resolve(
-      MetadataUnresolvedException e, int x, FreenetURI key, String element2, ClientContext context)
+  private int resolve(MetadataUnresolvedException e, int x, ClientContext context)
       throws IOException {
     Metadata[] metas = e.mustResolve;
     for (Metadata m : metas) {
@@ -259,7 +409,7 @@ public class ContainerInserter implements ClientPutState, Serializable {
         containerItems.add(new ContainerElement(bucket, nameInArchive));
         m.resolve(nameInArchive);
       } catch (MetadataUnresolvedException e1) {
-        x = resolve(e, x, key, element2, context);
+        x = resolve(e, x, context);
       }
     }
     return x;
@@ -277,31 +427,45 @@ public class ContainerInserter implements ClientPutState, Serializable {
   // A persistent hashCode is helpful in debugging, and also means we can put
   // these objects into sets etc when we need to.
 
+  /** Stable hash code captured at construction time to aid persistence and debugging. */
   private final int hashCode;
 
+  /**
+   * Returns the stable hash code captured at construction. The value does not change during the
+   * lifetime of the instance so it can be used in sets or as a persistent identifier.
+   */
   @Override
   public int hashCode() {
     return hashCode;
+  }
+
+  /**
+   * Identity-based equality. Two {@code ContainerInserter} instances are equal only when they are
+   * the same object reference.
+   *
+   * @param obj another object reference to compare
+   * @return {@code true} if and only if {@code this == obj}
+   */
+  @Override
+  public boolean equals(Object obj) {
+    return this == obj;
   }
 
   /** * OutputStream os will be close()d if this method returns successfully. */
   private String createTarBucket(OutputStream os) throws IOException {
     if (LOG.isDebugEnabled()) LOG.debug("Create a TAR Bucket");
 
-    TarArchiveOutputStream tarOS = new TarArchiveOutputStream(os);
-    try {
+    try (TarArchiveOutputStream tarOS = new TarArchiveOutputStream(os)) {
       tarOS.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
       TarArchiveEntry ze;
 
       for (ContainerElement ph : containerItems) {
         if (LOG.isDebugEnabled())
           LOG.debug(
-              "Putting into tar: "
-                  + ph
-                  + " data length "
-                  + ph.data.size()
-                  + " name "
-                  + ph.targetInArchive);
+              "Putting into tar: {} data length {} name {}",
+              ph,
+              ph.data.size(),
+              ph.targetInArchive);
         ze = new TarArchiveEntry(ph.targetInArchive);
         ze.setModTime(0);
         long size = ph.data.size();
@@ -310,8 +474,6 @@ public class ContainerInserter implements ClientPutState, Serializable {
         BucketTools.copyTo(ph.data, tarOS, size);
         tarOS.closeArchiveEntry();
       }
-    } finally {
-      tarOS.close();
     }
 
     return ARCHIVE_TYPE.TAR.mimeTypes[0];
@@ -320,8 +482,7 @@ public class ContainerInserter implements ClientPutState, Serializable {
   private String createZipBucket(OutputStream os) throws IOException {
     if (LOG.isDebugEnabled()) LOG.debug("Create a ZIP Bucket");
 
-    ZipOutputStream zos = new ZipOutputStream(os);
-    try {
+    try (ZipOutputStream zos = new ZipOutputStream(os)) {
       ZipEntry ze;
 
       for (ContainerElement ph : containerItems) {
@@ -331,8 +492,6 @@ public class ContainerInserter implements ClientPutState, Serializable {
         BucketTools.copyTo(ph.data, zos, ph.data.size());
         zos.closeEntry();
       }
-    } finally {
-      zos.close();
     }
 
     return ARCHIVE_TYPE.ZIP.mimeTypes[0];
@@ -341,43 +500,43 @@ public class ContainerInserter implements ClientPutState, Serializable {
   private Metadata makeManifest(HashMap<String, Object> manifestElements, String archivePrefix) {
     SimpleManifestComposer smc = new Metadata.SimpleManifestComposer();
     for (Map.Entry<String, Object> me : manifestElements.entrySet()) {
-      String name = me.getKey();
-      Object o = me.getValue();
-      if (o instanceof HashMap) {
-        HashMap<String, Object> hm = Metadata.forceMap(o);
-        // System.out.println("Decompose: "+name+" (SubDir)");
-        smc.addItem(name, makeManifest(hm, archivePrefix + name + '/'));
-        if (LOG.isTraceEnabled())
-          LOG.trace("Sub map for " + name + " : " + hm.size() + " elements");
-      } else if (o instanceof Metadata metadata) {
-        // already Metadata, take it as is
-        // System.out.println("Decompose: "+name+" (Metadata)");
-        smc.addItem(name, metadata);
-      } else {
-        ManifestElement element = (ManifestElement) o;
-        String mimeType = element.getMimeType();
-        ClientMetadata cm;
-        if (mimeType == null || mimeType.equals(DefaultMIMETypes.DEFAULT_MIME_TYPE)) cm = null;
-        else cm = new ClientMetadata(mimeType);
-        Metadata m;
-        if (element.targetURI != null) {
-          // System.out.println("Decompose: "+name+" (ManifestElement, Redirect)");
-          m = new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, element.targetURI, cm);
-        } else {
-          // System.out.println("Decompose: "+name+" (ManifestElement, Data)");
-          containerItems.add(new ContainerElement(element.getData(), archivePrefix + name));
-          m =
-              new Metadata(
-                  DocumentType.ARCHIVE_INTERNAL_REDIRECT,
-                  null,
-                  null,
-                  archivePrefix + element.fullName,
-                  cm);
-        }
-        smc.addItem(name, m);
-      }
+      addEntryToComposer(smc, me.getKey(), me.getValue(), archivePrefix);
     }
     return smc.getMetadata();
+  }
+
+  private void addEntryToComposer(
+      SimpleManifestComposer smc, String name, Object value, String archivePrefix) {
+    if (value instanceof HashMap<?, ?>) {
+      HashMap<String, Object> hm = Metadata.forceMap(value);
+      if (LOG.isTraceEnabled()) LOG.trace("Sub map for {} : {} elements", name, hm.size());
+      smc.addItem(name, makeManifest(hm, archivePrefix + name + '/'));
+      return;
+    }
+    if (value instanceof Metadata metadata) {
+      smc.addItem(name, metadata);
+      return;
+    }
+    ManifestElement element = (ManifestElement) value;
+    String mimeType = element.getMimeType();
+    ClientMetadata cm =
+        (mimeType == null || mimeType.equals(DefaultMIMETypes.DEFAULT_MIME_TYPE))
+            ? null
+            : new ClientMetadata(mimeType);
+    Metadata m;
+    if (element.targetURI != null) {
+      m = new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, element.targetURI, cm);
+    } else {
+      containerItems.add(new ContainerElement(element.getData(), archivePrefix + name));
+      m =
+          new Metadata(
+              DocumentType.ARCHIVE_INTERNAL_REDIRECT,
+              null,
+              null,
+              archivePrefix + element.fullName,
+              cm);
+    }
+    smc.addItem(name, m);
   }
 
   private transient boolean resumed = false;
@@ -398,13 +557,26 @@ public class ContainerInserter implements ClientPutState, Serializable {
     // Do not call start(). start() immediately transitions to another state.
   }
 
+  /**
+   * Recursively calls {@code onResume} on all resumable elements inside the manifest-like map.
+   *
+   * <p>The method walks nested maps, {@link ManifestElement} values, and {@link Metadata} entries
+   * (which are ignored because they hold no resumable state), and invokes {@link
+   * PutHandler#onResume} where present. Unknown value types cause an {@link
+   * IllegalArgumentException}.
+   *
+   * @param map manifest-like map containing nested maps, {@link Metadata}, {@link ManifestElement},
+   *     or {@link PutHandler} instances
+   * @param context resume context propagated to resumable elements
+   * @throws ResumeFailedException if any element signals that resuming state failed
+   */
   public static void resumeMetadata(Map<String, Object> map, ClientContext context)
       throws ResumeFailedException {
     for (Object o : map.values()) {
       switch (o) {
-        case HashMap hashMap -> resumeMetadata(Metadata.forceMap(o), context);
+        case Map<?, ?> sub -> resumeMetadata(Metadata.forceMap(sub), context);
         case ManifestElement e -> e.onResume(context);
-        case Metadata metadata -> {
+        case Metadata ignored -> {
           // Ignore
         }
         case PutHandler handler -> handler.onResume(context);
@@ -413,8 +585,37 @@ public class ContainerInserter implements ClientPutState, Serializable {
     }
   }
 
+  /** Called during shutdown; this implementation performs no action. */
   @Override
   public void onShutdown(ClientContext context) {
     // Ignore.
+  }
+
+  /* ===== Java serialization support ===== */
+
+  /**
+   * Custom Java serialization hook. Writes the default serial form; transient fields are skipped
+   * and reinitialized during {@link #readObject}.
+   *
+   * @param out stream to which the object state is written; must be open and writable
+   * @throws IOException if an I/O error occurs while writing the serial form
+   */
+  @Serial
+  private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+  }
+
+  /**
+   * Custom Java deserialization hook. Reads the default serial form and restores transient runtime
+   * fields to a safe initial state for later resume.
+   *
+   * @param in stream from which the object state is read; must be open and readable
+   * @throws IOException if an I/O error occurs while reading the serial form
+   * @throws ClassNotFoundException if a class required to restore the state cannot be found
+   */
+  @Serial
+  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    if (containerItems == null) containerItems = new ArrayList<>();
   }
 }

--- a/src/main/java/network/crypta/client/async/ContainerInserter.java
+++ b/src/main/java/network/crypta/client/async/ContainerInserter.java
@@ -425,7 +425,7 @@ public class ContainerInserter implements ClientPutState, Serializable {
   }
 
   // A persistent hashCode is helpful in debugging, and also means we can put
-  // these objects into sets etc when we need to.
+  // these objects into sets etc. when we need to.
 
   /** Stable hash code captured at construction time to aid persistence and debugging. */
   private final int hashCode;

--- a/src/test/java/network/crypta/client/async/ContainerInserterTest.java
+++ b/src/test/java/network/crypta/client/async/ContainerInserterTest.java
@@ -1,0 +1,679 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertException;
+import network.crypta.client.Metadata;
+import network.crypta.client.Metadata.DocumentType;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.node.RequestClientBuilder;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.ManifestElement;
+import network.crypta.support.api.RandomAccessBucket;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContainerInserterTest {
+  private static final String TEXT_PLAIN = "text/plain";
+  private static final String FILENAME_A = "a.txt";
+
+  private static final class InMemoryBucket implements RandomAccessBucket {
+    private final String name;
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    private boolean readOnly;
+    private final AtomicInteger resumeCalls;
+
+    InMemoryBucket(String name) {
+      this(name, null);
+    }
+
+    InMemoryBucket(String name, AtomicInteger resumeCalls) {
+      this.name = name;
+      this.resumeCalls = resumeCalls;
+    }
+
+    // No direct raw byte access is needed in tests
+
+    @Override
+    public OutputStream getOutputStream() {
+      if (readOnly) throw new IllegalStateException("Bucket is read-only");
+      return baos;
+    }
+
+    @Override
+    public OutputStream getOutputStreamUnbuffered() {
+      return getOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return new ByteArrayInputStream(baos.toByteArray());
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() {
+      return getInputStream();
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public long size() {
+      return baos.size();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return readOnly;
+    }
+
+    @Override
+    public void setReadOnly() {
+      readOnly = true;
+    }
+
+    @Override
+    public void free() {
+      baos.reset();
+    }
+
+    @Override
+    public RandomAccessBucket createShadow() {
+      return null; // not needed in tests
+    }
+
+    @Override
+    public void onResume(ClientContext context) {
+      if (resumeCalls != null) resumeCalls.incrementAndGet();
+    }
+
+    @Override
+    public void storeTo(DataOutputStream dos) {
+      throw new UnsupportedOperationException("Not needed in tests");
+    }
+
+    @Override
+    public LockableRandomAccessBuffer toRandomAccessBuffer() {
+      throw new UnsupportedOperationException("Not needed in tests");
+    }
+  }
+
+  private static final class FailingBucket implements RandomAccessBucket {
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+      throw new IOException("boom");
+    }
+
+    @Override
+    public OutputStream getOutputStreamUnbuffered() throws IOException {
+      throw new IOException("boom");
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() {
+      return getInputStream();
+    }
+
+    @Override
+    public String getName() {
+      return "failing";
+    }
+
+    @Override
+    public long size() {
+      return 0;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return false;
+    }
+
+    @Override
+    public void setReadOnly() {
+      // intentionally empty: read-only not relevant for this failing bucket stub
+    }
+
+    @Override
+    public void free() {
+      // intentionally empty: no resources to release in this stub
+    }
+
+    @Override
+    public RandomAccessBucket createShadow() {
+      return null;
+    }
+
+    @Override
+    public void onResume(ClientContext context) {
+      // intentionally empty: nothing to resume for this stub
+    }
+
+    @Override
+    public void storeTo(DataOutputStream dos) {
+      // intentionally empty: persistence not needed in tests
+    }
+
+    @Override
+    public LockableRandomAccessBuffer toRandomAccessBuffer() {
+      throw new UnsupportedOperationException("Not needed in tests");
+    }
+  }
+
+  private static final class TestPutter extends BaseClientPutter {
+    private final transient RequestClient rc;
+
+    TestPutter(RequestClient rc) {
+      super((short) 0, rc);
+      this.rc = rc;
+    }
+
+    @Override
+    public void onTransition(ClientPutState from, ClientPutState to, ClientContext context) {
+      // intentionally empty: test-only putter does not forward transitions
+    }
+
+    @Override
+    public void onTransition(
+        ClientGetState oldState, ClientGetState newState, ClientContext context) {
+      // intentionally empty: not used by tests
+    }
+
+    @Override
+    public int getMinSuccessFetchBlocks() {
+      return 0;
+    }
+
+    @Override
+    public boolean isFinished() {
+      return false;
+    }
+
+    @Override
+    public FreenetURI getURI() {
+      return null;
+    }
+
+    @Override
+    public void cancel(ClientContext context) {
+      // intentionally empty: not used by tests
+    }
+
+    @Override
+    protected void innerNotifyClients(ClientContext context) {
+      // no-op for tests
+    }
+
+    @Override
+    protected ClientBaseCallback getCallback() {
+      return new ClientBaseCallback() {
+        @Override
+        public void onResume(ClientContext context) {
+          // intentionally empty: callback resume not used in these tests
+        }
+
+        @Override
+        public RequestClient getRequestClient() {
+          return rc;
+        }
+      };
+    }
+
+    @Override
+    protected void innerToNetwork(ClientContext context) {
+      // no-op for tests
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      // identity semantics are sufficient for test helper; delegate to super
+      return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+      // delegate to super to preserve identity-based semantics
+      return super.hashCode();
+    }
+  }
+
+  private static InsertContext newInsertContext() {
+    return new InsertContext(
+        0,
+        0,
+        0,
+        0,
+        new SimpleEventProducer(),
+        true,
+        false,
+        false,
+        null,
+        0,
+        0,
+        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+  }
+
+  @Mock private PutCompletionCallback callback;
+
+  @Mock private ClientContext clientContext;
+
+  @Test
+  void cancel_whenCalled_invokesFailureOnceWithCancelledMode() {
+    // Arrange
+    RequestClient rc = new RequestClientBuilder().persistent(false).build();
+    BaseClientPutter parent = new TestPutter(rc);
+    HashMap<String, Object> manifest = new HashMap<>();
+    ContainerInserter inserter =
+        new ContainerInserter(
+            parent,
+            callback,
+            manifest,
+            new FreenetURI("CHK", null, (byte[]) null, null, null),
+            newInsertContext(),
+            new ContainerInserter.Options(
+                true, false, null, ARCHIVE_TYPE.ZIP, null, (byte) 0, false));
+
+    // Act
+    inserter.cancel(clientContext);
+    inserter.cancel(clientContext); // idempotent
+
+    // Assert
+    ArgumentCaptor<InsertException> cap = ArgumentCaptor.forClass(InsertException.class);
+    verify(callback, times(1))
+        .onFailure(cap.capture(), Mockito.eq(inserter), Mockito.eq(clientContext));
+    assertEquals(InsertException.InsertExceptionMode.CANCELLED, cap.getValue().mode);
+  }
+
+  @Test
+  void accessors_whenConstructed_returnParentAndToken() {
+    RequestClient rc = new RequestClientBuilder().persistent(false).build();
+    BaseClientPutter parent = new TestPutter(rc);
+    Object token = new Object();
+    ContainerInserter inserter =
+        new ContainerInserter(
+            parent,
+            callback,
+            new HashMap<>(),
+            new FreenetURI("CHK", null, (byte[]) null, null, null),
+            newInsertContext(),
+            new ContainerInserter.Options(
+                true, false, token, ARCHIVE_TYPE.ZIP, null, (byte) 0, false));
+
+    assertEquals(parent, inserter.getParent());
+    assertEquals(token, inserter.getToken());
+  }
+
+  @Test
+  void resumeMetadata_whenUnknownType_throwsIllegalArgumentException() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("bad", "unexpected");
+    assertThrows(
+        IllegalArgumentException.class, () -> ContainerInserter.resumeMetadata(map, clientContext));
+  }
+
+  @Test
+  void resumeMetadata_whenNestedElements_invokesOnResumeForElementAndHandler() throws Exception {
+    // Arrange: a ManifestElement with a bucket that counts onResume
+    AtomicInteger bucketResume = new AtomicInteger();
+    InMemoryBucket fileBucket = new InMemoryBucket("file", bucketResume);
+    fileBucket.getOutputStream().write("data".getBytes(StandardCharsets.UTF_8));
+    fileBucket.setReadOnly();
+    ManifestElement me = new ManifestElement("file.txt", fileBucket, TEXT_PLAIN, 4);
+
+    // Nested metadata (ignored by resumeMetadata)
+    Metadata nested =
+        new Metadata(
+            DocumentType.SIMPLE_REDIRECT,
+            null,
+            null,
+            new FreenetURI("CHK", null, (byte[]) null, null, null),
+            new ClientMetadata(TEXT_PLAIN));
+
+    // PutHandler mock should receive onResume
+    BaseManifestPutter.PutHandler handler = Mockito.mock(BaseManifestPutter.PutHandler.class);
+
+    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> sub = new HashMap<>();
+    sub.put("m", nested);
+    map.put("dir", sub);
+    map.put("file.txt", me);
+    map.put("handler", handler);
+
+    // Act
+    ContainerInserter.resumeMetadata(map, clientContext);
+
+    // Assert
+    assertEquals(1, bucketResume.get());
+    verify(handler, times(1)).onResume(clientContext);
+  }
+
+  @Test
+  void onResume_whenCalled_invokesCallbackAndResumesManifestElements() throws Exception {
+    // Arrange
+    RequestClient rc = new RequestClientBuilder().persistent(false).build();
+    BaseClientPutter parent = new TestPutter(rc);
+
+    AtomicInteger bucketResume = new AtomicInteger();
+    InMemoryBucket fileBucket = new InMemoryBucket("file", bucketResume);
+    try (OutputStream os = fileBucket.getOutputStream()) {
+      os.write("abc".getBytes(StandardCharsets.UTF_8));
+    }
+    fileBucket.setReadOnly();
+    ManifestElement me = new ManifestElement("f.txt", fileBucket, TEXT_PLAIN, 3);
+    HashMap<String, Object> manifest = new HashMap<>();
+    manifest.put("f.txt", me);
+
+    ContainerInserter inserter =
+        new ContainerInserter(
+            parent,
+            callback,
+            manifest,
+            new FreenetURI("CHK", null, (byte[]) null, null, null),
+            newInsertContext(),
+            new ContainerInserter.Options(
+                true, false, null, ARCHIVE_TYPE.TAR, null, (byte) 0, false));
+
+    // Act
+    inserter.onResume(clientContext);
+
+    // Assert: callback gets onResume, and bucket got resumed via resumeMetadata()
+    verify(callback, times(1)).onResume(clientContext);
+    assertEquals(1, bucketResume.get());
+  }
+
+  @Test
+  void createZipBucket_whenItemsPresent_writesEntriesAndReturnsMime() throws Exception {
+    // Arrange: build a manifest with a single file and use an in-memory bucket factory
+    RequestClient rc = new RequestClientBuilder().persistent(false).build();
+    BaseClientPutter parent = new TestPutter(rc);
+    InMemoryBucket file = new InMemoryBucket("file");
+    file.getOutputStream().write("hello".getBytes(StandardCharsets.UTF_8));
+    file.setReadOnly();
+
+    HashMap<String, Object> manifest = new HashMap<>();
+    manifest.put(FILENAME_A, new ManifestElement(FILENAME_A, file, null, 5));
+
+    when(clientContext.getBucketFactory(false))
+        .thenReturn(size -> new InMemoryBucket("bucket-" + java.util.UUID.randomUUID()));
+
+    // Callback captures the SingleFileInserter to inspect the produced archive and aborts the flow
+    PutCompletionCallback inspectingCb =
+        new PutCompletionCallback() {
+          @Override
+          public void onSuccess(ClientPutState state, ClientContext context) {
+            // intentionally empty: success not expected in this test
+          }
+
+          @Override
+          public void onTransition(ClientPutState from, ClientPutState to, ClientContext ctx) {
+            // Assert mime via block metadata
+            SingleFileInserter sfi = (SingleFileInserter) to;
+            assertEquals("application/zip", sfi.block.clientMetadata.getMIMEType());
+
+            // Safely enumerate entries without extracting to filesystem
+            Set<String> names = new HashSet<>();
+            try {
+              java.nio.file.Path tmp = java.nio.file.Files.createTempFile("ziptest", ".zip");
+              try {
+                try (InputStream is = sfi.block.getData().getInputStream()) {
+                  java.nio.file.Files.write(tmp, is.readAllBytes());
+                }
+                try (java.util.zip.ZipFile zf = new java.util.zip.ZipFile(tmp.toFile())) {
+                  java.util.Enumeration<? extends java.util.zip.ZipEntry> e = zf.entries();
+                  while (e.hasMoreElements()) {
+                    java.util.zip.ZipEntry ze = e.nextElement();
+                    String n = ze.getName();
+                    // Basic zip-slip guards even though we don't extract
+                    assertTrue(!n.startsWith("/") && !n.contains(".."));
+                    names.add(n);
+                  }
+                }
+              } finally {
+                java.nio.file.Files.deleteIfExists(tmp);
+              }
+            } catch (IOException ioe) {
+              throw new IllegalStateException(ioe);
+            }
+
+            assertTrue(names.contains(".metadata"));
+            assertTrue(names.contains(FILENAME_A));
+
+            // Abort further scheduling; this is expected by the test
+            throw new IllegalStateException("stop-after-inspection");
+          }
+
+          @Override
+          public void onFailure(InsertException e, ClientPutState state, ClientContext ctx) {
+            throw new AssertionError("Unexpected failure: " + e, e);
+          }
+
+          @Override
+          public void onFetchable(ClientPutState state) {
+            // intentionally empty: not asserted in this test
+          }
+
+          @Override
+          public void onEncode(
+              network.crypta.keys.BaseClientKey usk, ClientPutState state, ClientContext context) {
+            // intentionally empty: not expected in this test
+          }
+
+          @Override
+          public void onMetadata(
+              network.crypta.client.Metadata meta, ClientPutState state, ClientContext context) {
+            // intentionally empty
+          }
+
+          @Override
+          public void onMetadata(
+              network.crypta.support.api.Bucket meta, ClientPutState state, ClientContext context) {
+            // intentionally empty
+          }
+
+          @Override
+          public void onBlockSetFinished(ClientPutState state, ClientContext context) {
+            // intentionally empty: not relevant for this test
+          }
+
+          @Override
+          public void onResume(ClientContext context) {
+            // intentionally empty: resume callback not exercised in this test
+          }
+        };
+
+    // Recreate inserter with our inspecting callback
+    ContainerInserter inserter =
+        new ContainerInserter(
+            parent,
+            inspectingCb,
+            manifest,
+            new FreenetURI("CHK", null, (byte[]) null, null, null),
+            newInsertContext(),
+            new ContainerInserter.Options(
+                false, false, null, ARCHIVE_TYPE.ZIP, null, (byte) 0, false));
+
+    // Act: schedule and stop after inspection
+    try {
+      inserter.schedule(clientContext);
+    } catch (RuntimeException expected) {
+      assertEquals("stop-after-inspection", expected.getMessage());
+    }
+  }
+
+  @Test
+  void createTarBucket_whenItemsPresent_writesEntriesAndReturnsMime() throws Exception {
+    // Arrange: manifest with a single file, in-memory bucket factory
+    RequestClient rc = new RequestClientBuilder().persistent(false).build();
+    BaseClientPutter parent = new TestPutter(rc);
+
+    InMemoryBucket fileBucket = new InMemoryBucket("in");
+    try (OutputStream os = fileBucket.getOutputStream()) {
+      os.write("hello".getBytes(StandardCharsets.UTF_8));
+    }
+    fileBucket.setReadOnly();
+
+    HashMap<String, Object> manifest = new HashMap<>();
+    manifest.put(FILENAME_A, new ManifestElement(FILENAME_A, fileBucket, null, 5));
+
+    when(clientContext.getBucketFactory(false))
+        .thenReturn(size -> new InMemoryBucket("bucket-" + java.util.UUID.randomUUID()));
+
+    PutCompletionCallback inspectingCb =
+        new PutCompletionCallback() {
+          @Override
+          public void onSuccess(ClientPutState state, ClientContext context) {
+            // intentionally empty: success not expected in this test
+          }
+
+          @Override
+          public void onTransition(ClientPutState from, ClientPutState to, ClientContext ctx) {
+            SingleFileInserter sfi = (SingleFileInserter) to;
+            assertEquals("application/x-tar", sfi.block.clientMetadata.getMIMEType());
+
+            Set<String> names = new HashSet<>();
+            try (InputStream is = sfi.block.getData().getInputStream();
+                TarArchiveInputStream tis = new TarArchiveInputStream(is)) {
+              TarArchiveEntry te;
+              while ((te = tis.getNextEntry()) != null) {
+                if (!te.isDirectory()) names.add(te.getName());
+              }
+            } catch (IOException ioe) {
+              throw new IllegalStateException(ioe);
+            }
+
+            assertTrue(names.contains(FILENAME_A));
+            throw new IllegalStateException("stop-after-inspection");
+          }
+
+          @Override
+          public void onFailure(InsertException e, ClientPutState state, ClientContext ctx) {
+            throw new AssertionError("Unexpected failure: " + e, e);
+          }
+
+          @Override
+          public void onFetchable(ClientPutState state) {
+            // intentionally empty: not asserted in this test
+          }
+
+          @Override
+          public void onEncode(
+              network.crypta.keys.BaseClientKey usk, ClientPutState state, ClientContext context) {
+            // intentionally empty: not expected in this test
+          }
+
+          @Override
+          public void onMetadata(
+              network.crypta.client.Metadata meta, ClientPutState state, ClientContext context) {
+            // intentionally empty
+          }
+
+          @Override
+          public void onMetadata(
+              network.crypta.support.api.Bucket meta, ClientPutState state, ClientContext context) {
+            // intentionally empty
+          }
+
+          @Override
+          public void onBlockSetFinished(ClientPutState state, ClientContext context) {
+            // intentionally empty: not relevant for this test
+          }
+
+          @Override
+          public void onResume(ClientContext context) {
+            // intentionally empty: resume callback not exercised in this test
+          }
+        };
+
+    ContainerInserter inserter =
+        new ContainerInserter(
+            parent,
+            inspectingCb,
+            manifest,
+            new FreenetURI("CHK", null, (byte[]) null, null, null),
+            newInsertContext(),
+            new ContainerInserter.Options(
+                false, false, null, ARCHIVE_TYPE.TAR, null, (byte) 0, false));
+
+    try {
+      inserter.schedule(clientContext);
+    } catch (RuntimeException expected) {
+      assertEquals("stop-after-inspection", expected.getMessage());
+    }
+  }
+
+  @Test
+  void schedule_whenOutputBucketThrows_reportsBucketErrorAndNoTransition() throws Exception {
+    // Arrange
+    RequestClient rc = new RequestClientBuilder().persistent(false).build();
+    BaseClientPutter parent = new TestPutter(rc);
+    HashMap<String, Object> manifest = new HashMap<>();
+    // Include at least one file entry so makeManifest will add it; irrelevant here
+    InMemoryBucket fileBucket = new InMemoryBucket("in");
+    fileBucket.getOutputStream().write(new byte[] {1});
+    fileBucket.setReadOnly();
+    manifest.put("a.bin", new ManifestElement("a.bin", fileBucket, null, 1));
+
+    BucketFactory failing = size -> new FailingBucket();
+    when(clientContext.getBucketFactory(false)).thenReturn(failing);
+
+    ContainerInserter inserter =
+        new ContainerInserter(
+            parent,
+            callback,
+            manifest,
+            new FreenetURI("CHK", null, (byte[]) null, null, null),
+            newInsertContext(),
+            new ContainerInserter.Options(
+                false, false, null, ARCHIVE_TYPE.ZIP, null, (byte) 0, false));
+
+    // Act
+    inserter.schedule(clientContext);
+
+    // Assert: failure callback and no transition
+    ArgumentCaptor<InsertException> cap = ArgumentCaptor.forClass(InsertException.class);
+    verify(callback, times(1))
+        .onFailure(cap.capture(), Mockito.eq(inserter), Mockito.eq(clientContext));
+    assertEquals(InsertException.InsertExceptionMode.INTERNAL_ERROR, cap.getValue().mode);
+    verify(callback, never()).onTransition(any(), any(), any());
+  }
+}


### PR DESCRIPTION
Summary
- Replace boolean-heavy ContainerInserter constructor with a serializable Options bundle
- Update BaseManifestPutter to construct ContainerInserter via Options
- Add ContainerInserterTest exercising construction, cancel flow, token propagation, and archive prep
- Minor comment punctuation fix in ContainerInserter

Motivation
- Improve readability, maintainability, and serialization clarity by encapsulating flags
- Reduce call-site errors and make future extension of options safer

Key Changes
- src/main/java/network/crypta/client/async/ContainerInserter.java: introduce nested Options, documentation, persistence fields, and minor cleanups
- src/main/java/network/crypta/client/async/BaseManifestPutter.java: switch to new Options at call sites
- src/test/java/network/crypta/client/async/ContainerInserterTest.java: new tests with in-memory stubs

Commits
- 51b658a0c7 docs(client): fix comment punctuation in ContainerInserter
- 70c44f77c8 refactor(client): introduce ContainerInserter.Options, update callers, add tests; apply Spotless

Diff vs develop (summary)
- 7 files changed, 1467 insertions, 1189 deletions (includes upstream changes relative to develop)
- Primary scope: ContainerInserter, BaseManifestPutter, new ContainerInserterTest

Notes
- Formatting applied via Spotless
- No runtime behavior changes intended beyond construction API; downstream SingleFileInserter usage remains unchanged
- Please run the full test suite in CI; local run not included here
