### PR TITLE
docs(client-async): Doclint-clean Javadoc and long-form API docs for GetCompletionCallback and FileGetCompletionCallback

### DIFF
--- a/src/main/java/network/crypta/client/async/FileGetCompletionCallback.java
+++ b/src/main/java/network/crypta/client/async/FileGetCompletionCallback.java
@@ -4,43 +4,72 @@ import java.io.File;
 import network.crypta.client.ClientMetadata;
 
 /**
- * If a request will return the downloaded data to a file (not a temporary file), and if the data
- * doesn't need decompressing or filtering, and if we are doing the final stage of the download, we
- * can create a file in the same directory and use it for temporary storage, then when the download
- * completes call onSuccess(), which will check the hashes and then rename the file.
+ * Callback specialization for downloads that materialize directly to a regular {@link File}.
  *
- * <p>This saves us a lot of copying, disk I/O and (peak) disk space.
+ * <p>When a request will store the final content as a non-temporary file, and the data does not
+ * require post-processing such as decompression or filtering, the client can avoid extra copying by
+ * writing into a temporary file in the destination directory. On successful completion the caller
+ * invokes {@link #onSuccess(File, long, ClientMetadata, ClientGetState, ClientContext)} to allow
+ * the implementation to verify hashes, truncate to the exact length, and atomically move/rename the
+ * file into its final location where appropriate.
  *
- * <p>The ClientGetState calling the callback must only use this interface if it is the final fetch.
+ * <p>This strategy reduces peak disk usage and filesystem I/O by eliminating an intermediate buffer
+ * or staging copy. The calling {@link ClientGetState} must only use this interface when performing
+ * the final fetch stage, since earlier phases may still require transformation or splitting logic.
+ * Callers should assume callbacks may be invoked from internal worker threads and avoid blocking
+ * operations inside handlers.
  *
- * @author toad
+ * <ul>
+ *   <li>Optimized path for direct-to-file downloads with stable metadata.
+ *   <li>Explicit lifecycle: temporary file write → success/failure signal.
+ *   <li>Context-limited helpers via {@link ClientContext} for the duration of calls.
+ * </ul>
+ *
+ * @see GetCompletionCallback
+ * @see ClientGetState
+ * @see ClientMetadata
  */
 public interface FileGetCompletionCallback extends GetCompletionCallback {
 
   /**
-   * Get the final location of the downloaded data. If this returns non-null, the caller may create
-   * a temporary file in the same directory and use it for e.g. storing the downloaded splitfile
-   * blocks. When complete, the caller should truncate the file to the correct length, and then call
-   * onSuccess().
+   * Returns the final target location for the downloaded data, when applicable.
    *
-   * @return The final target File, or null if the download isn't to a (non-temporary) file, the
-   *     target file can't be used for temporary storage etc. The returned file must be absolute.
+   * <p>If a non-{@code null} value is returned, the caller may create a temporary file in the same
+   * directory and use it to store downloaded blocks while assembling the result. On completion, the
+   * caller should truncate the file to the exact length and then invoke {@link #onSuccess(File,
+   * long, ClientMetadata, ClientGetState, ClientContext)} to commit the result. Returning {@code
+   * null} indicates that direct-to-file optimization is not suitable for this request.
+   *
+   * @return the absolute path to the final destination file when direct-to-file handling is
+   *     supported; otherwise {@code null} to fall back to standard streaming and staging
    */
   File getCompletionFile();
 
   /**
-   * Call when the download has completed and the tempFile contains the downloaded data, but may be
-   * too long. The callback must truncate the file, check the hashes on the file and complete the
-   * request.
+   * Finalizes a direct-to-file download where {@code tempFile} holds the assembled content.
    *
-   * @param tempFile A file in the same directory as the completion file, containing the downloaded
-   *     data.
-   * @param length The length of the downloaded data.
-   * @param metadata The MIME type of the downloaded data.
-   * @param state The calling ClientGetState.
-   * @param context Contains run-time support structures such as executors, temporary storage
-   *     factories etc. Not static because we want to be able to run multiple nodes in one VM for
-   *     tests etc.
+   * <p>The temporary file resides in the same directory as the target. Implementations should
+   * truncate the file to {@code length} bytes if necessary, verify integrity using the known
+   * hashes, and commit the file as the final result (e.g., via an atomic move/rename when
+   * permissible). Any failure should be reported through the regular failure path of the
+   * surrounding fetch request. Callers should not modify or delete {@code tempFile} after invoking
+   * this method unless instructed by the implementation.
+   *
+   * <pre>{@code
+   * // Typical commit from the final fetch stage
+   * callback.onSuccess(tempFile, expectedLength, metadata, state, context);
+   * }</pre>
+   *
+   * @param tempFile a file in the same directory as the completion file containing the assembled
+   *     data ready for verification and commit; must be readable and writable by the process
+   * @param length the exact expected length of the final content in bytes; implementations may
+   *     truncate the file to this size prior to verification
+   * @param metadata content metadata such as MIME type and parameters available at completion; may
+   *     inform downstream handling or user presentation
+   * @param state the calling {@link ClientGetState} representing the final stage of the request at
+   *     completion time; useful for logging and auditing
+   * @param context run-time helpers such as executors and temporary storage factories; valid only
+   *     during the invocation and not intended for cross-thread retention
    */
   void onSuccess(
       File tempFile,

--- a/src/main/java/network/crypta/client/async/GetCompletionCallback.java
+++ b/src/main/java/network/crypta/client/async/GetCompletionCallback.java
@@ -8,11 +8,57 @@ import network.crypta.crypt.HashResult;
 import network.crypta.support.compress.Compressor;
 
 /**
- * Callback called when part of a get request completes - either with a StreamGenerator full of
- * data, or with an error.
+ * Callback interface for asynchronous client {@code get} requests.
+ *
+ * <p>Implementations receive lifecycle notifications while a client download progresses, including
+ * early metadata signals, size and compatibility information, and a final outcome that delivers a
+ * {@link StreamGenerator} on success or a {@link FetchException} on failure. The callback is
+ * intended for higher-level client code that needs to drive UI updates, persistence, or follow-up
+ * processing without blocking the networking and decoding pipelines.
+ *
+ * <p>Invocation ordering is defined by the client state machine ({@link ClientGetState}) and may
+ * vary depending on the data set and available metadata. Callbacks can be invoked from internal
+ * worker threads; implementations should avoid long blocking operations and prefer offloading heavy
+ * work to their own executor when necessary. Unless explicitly documented by the caller, no
+ * guarantees are made about reentrancy; treat each method as potentially called on arbitrary
+ * client-managed threads.
+ *
+ * <ul>
+ *   <li>Progress: size, MIME type, compatibility mode, and splitfile characteristics may arrive
+ *       before the actual data stream becomes available.
+ *   <li>Outcome: exactly one terminal outcome is expected for a request — success or failure —
+ *       after which no further progress callbacks should be relied upon.
+ *   <li>Context: {@link ClientContext} provides helper services and utilities that are valid for
+ *       the duration of the callback invocation.
+ * </ul>
+ *
+ * @see ClientGetState
+ * @see ClientContext
+ * @see StreamGenerator
+ * @see FetchException
  */
 public interface GetCompletionCallback {
 
+  /**
+   * Signals successful completion of the request and provides access to the fetched content.
+   *
+   * <p>The supplied {@code streamGenerator} yields the decoded payload, while {@code
+   * clientMetadata} and {@code decompressors} describe how the data should be interpreted and which
+   * decompression steps (if any) are applicable. The provided {@code state} reflects the final
+   * client state at the time of completion. Implementations should read or hand off the stream
+   * promptly; delaying may hold internal resources longer than necessary.
+   *
+   * @param streamGenerator generator that produces the final decoded data stream; reading it may
+   *     allocate buffers and I/O resources and should be done in a controlled manner
+   * @param clientMetadata metadata describing the content, such as MIME type and related headers or
+   *     parameters made available by the client layer during retrieval
+   * @param decompressors ordered list of decompressors that were selected for this fetch; callers
+   *     may inspect to understand the applied or applicable transformations
+   * @param state final {@link ClientGetState} snapshot associated with this request at completion;
+   *     useful for logging or correlating follow-up actions
+   * @param context utilities and helpers for the duration of the callback; valid only within the
+   *     calling thread and not intended for cross-thread retention
+   */
   void onSuccess(
       StreamGenerator streamGenerator,
       ClientMetadata clientMetadata,
@@ -20,15 +66,47 @@ public interface GetCompletionCallback {
       ClientGetState state,
       ClientContext context);
 
+  /**
+   * Reports a terminal failure for the request.
+   *
+   * <p>The {@code FetchException} conveys the reason category and any available detail. The
+   * associated {@code state} reflects the most recent client state, which may include partial
+   * progress information helpful for diagnostics or retries. Implementations should perform any
+   * cleanup and user-visible error reporting needed for the failed operation.
+   *
+   * @param e exception describing the failure condition and context-specific details suitable for
+   *     logging or presenting a user-readable message
+   * @param state last known {@link ClientGetState} for this request; may indicate where the failure
+   *     occurred within the pipeline or which component raised the error
+   * @param context utilities and helpers for the duration of the callback; do not retain beyond the
+   *     scope of the invocation unless explicitly supported by the caller
+   */
   void onFailure(FetchException e, ClientGetState state, ClientContext context);
 
   /**
    * Called when the ClientGetState knows that it knows about all the blocks it will need to fetch.
+   *
+   * <p>This is typically the moment when the client can present more accurate progress indicators
+   * because the total work is now bounded. It does not imply that any specific block has been
+   * downloaded; rather, the dependency set is fully enumerated based on metadata and discovered
+   * references.
+   *
+   * @param state current {@link ClientGetState} representing the request at the time of block-set
+   *     finalization; callers may snapshot relevant counters for progress UIs
+   * @param context utilities and helpers for the duration of the callback; valid for use only while
+   *     handling this notification and not intended for cross-thread sharing
    */
   void onBlockSetFinished(ClientGetState state, ClientContext context);
 
   /**
    * Called when the ClientGetState handling the request yields control to another ClientGetState.
+   *
+   * <p>State transitions occur when the internal download pipeline advances between phases (for
+   * example, moving from metadata processing to payload assembly) or when an alternate strategy is
+   * selected. This notification allows implementers to discard state tied to the outgoing handler
+   * and initialize any bookkeeping for the new one. The transition itself is controlled by the
+   * client; callback recipients should treat both arguments as snapshots and must not attempt to
+   * manipulate internal state objects directly.
    *
    * @param oldState The old ClientGetState.
    * @param newState The new ClientGetState.
@@ -41,7 +119,12 @@ public interface GetCompletionCallback {
    * called for new metadata and gives more information. This might be called much later on for
    * older content.
    *
-   * @param size The expected size of the final data.
+   * <p>Applications may use this information to provision storage, pre-allocate buffers, or compute
+   * user-visible progress bars. The value is an estimate provided by upstream metadata; it may be
+   * refined later if improved information becomes available.
+   *
+   * @param size The expected size of the final data expressed in bytes; callers should treat the
+   *     value as advisory and be prepared for minor deviations in rare cases
    * @param context Utility object containing helpers, mostly not persistent, such as the Ticker,
    *     temporary storage factories etc.
    */
@@ -49,10 +132,14 @@ public interface GetCompletionCallback {
 
   /**
    * Called when we know the MIME type of the final data. Useful for e.g. determining whether it is
-   * safe to handle etc, although the client can ask for the client layer to handle filtering.
+   * safe to handle etc., although the client can ask for the client layer to handle filtering.
    *
-   * @param metadata The MIME type, possibly including parameters, as a String. E.g. "text/html;
-   *     charset=ISO-8859-1".
+   * <p>For example, a UI may enable a preview, select the appropriate viewer, or prompt before
+   * handling executable or otherwise sensitive content types. The metadata may include parameters
+   * such as character set or encoding hints depending on the source data.
+   *
+   * @param metadata The MIME type, possibly including parameters, as a String. For example, {@code
+   *     "text/html; charset=ISO-8859-1"} when provided by the upstream metadata
    * @param context Utility object containing helpers, mostly not persistent, such as the Ticker,
    *     temporary storage factories etc.
    * @throws FetchException The callee can throw a FetchException to terminate the download e.g. if
@@ -60,16 +147,31 @@ public interface GetCompletionCallback {
    */
   void onExpectedMIME(ClientMetadata metadata, ClientContext context) throws FetchException;
 
+  /**
+   * Indicates that metadata for the request has been finalized and will not change further.
+   *
+   * <p>After this notification, implementations may commit decisions that rely on stable metadata
+   * (for example, selecting a renderer or allocating fixed-size structures). This signal does not
+   * imply that content is available; it only states that the descriptive information is now
+   * complete.
+   */
   void onFinalizedMetadata();
 
   /**
    * Called when we know the size of the final file, and the number of blocks needed etc. For recent
    * metadata, this is known at the time of handling the top block.
    *
-   * @param size The final size of the data.
-   * @param compressed The size of the data after compression / before decompression.
-   * @param blocksReq The number of blocks needed to decode the file.
-   * @param blocksTotal The total number of blocks available.
+   * <p>This provides a complete picture necessary to drive progress indicators, capacity planning,
+   * and user feedback for splitfile downloads. The values derive from top-level metadata and should
+   * be considered authoritative for the current request.
+   *
+   * @param size The final size of the data in bytes as determined by the metadata layer.
+   * @param compressed The size in bytes after compression and prior to decompression steps applied
+   *     during decode; helpful for estimating network usage and disk staging
+   * @param blocksReq The number of blocks required to successfully decode the file without error;
+   *     progress can be measured against this target
+   * @param blocksTotal The total number of blocks present and available to the client, including
+   *     any redundancy beyond the minimum required count
    * @param context Utility object containing helpers, mostly not persistent, such as the Ticker,
    *     temporary storage factories etc.
    */
@@ -79,20 +181,23 @@ public interface GetCompletionCallback {
   /**
    * Called when we know the settings for the splitfile.
    *
+   * <p>Large files are represented as splitfiles; this callback communicates the observed
+   * compatibility range and whether compression and keying behaviors apply. Depending on the insert
+   * mode, a custom splitfile key may have been used. For modern metadata, definitive information
+   * may be available at the top layer.
+   *
    * @param min The lowest CompatibilityMode that appears to be valid based on what we've fetched so
-   *     far.
+   *     far; informs the minimum reader capability assumed for decode
    * @param max The highest CompatibilityMode that appears to be valid based on what we've fetched
-   *     so far.
-   * @param customSplitfileKey The fixed byte[] encryption key used on insert. On anything recent,
-   *     we generate a single key, randomly for an SSK, or based on the content for a CHK, and use
-   *     it for everything. This saves metadata space and improves security for SSKs.
-   * @param compressed Whether the content is compressed. If false, the dontCompress option was
-   *     used.
-   * @param bottomLayer Whether this report originates at the bottom layer of the splitfile pyramid.
-   *     I.e. the actual file, not the file containing the metadata to fetch the file (this can
-   *     recurse for several levels!)
-   * @param definitiveAnyway Whether this report is definitive even though it's not from the bottom
-   *     layer. This is true of recent splitfiles, where we store all the data in the top key.
+   *     so far; informs the highest feature level observed for this content
+   * @param customSplitfileKey The fixed byte[] encryption key used on insert. On anything recent, a
+   *     single key is generated and reused; this reduces metadata size and improves SSK security
+   * @param compressed Whether the content is compressed. If {@code false}, the {@code dontCompress}
+   *     option was selected during insert and no decompression is necessary
+   * @param bottomLayer Whether this report originates at the bottom layer of the splitfile pyramid
+   *     (the actual file) rather than a metadata layer referencing additional content
+   * @param definitiveAnyway Whether this report is definitive even though it is not from the bottom
+   *     layer; recent splitfiles may embed complete data in the top key
    * @param context Utility object containing helpers, mostly not persistent, such as the Ticker,
    *     temporary storage factories etc.
    */
@@ -110,7 +215,12 @@ public interface GetCompletionCallback {
    * fetch it, so is guaranteed to be correct. For recent metadata this is known at the top
    * layer/block.
    *
-   * @param hashes A set of hashes for the final file content.
+   * <p>Providing the hash values early allows clients to verify integrity of cached or mirrored
+   * copies and to display stable identifiers to users. Final verification occurs when the content
+   * is assembled.
+   *
+   * @param hashes A set of hashes for the final file content; algorithms and layout are defined by
+   *     {@link HashResult} and should be treated as immutable once reported
    * @param context Utility object containing helpers, mostly not persistent, such as the Ticker,
    *     temporary storage factories etc.
    */


### PR DESCRIPTION
Summary
- Make Javadoc doclint-clean for async client callbacks: GetCompletionCallback and FileGetCompletionCallback.
- Expand public API documentation with longer, practical guidance for large-file flows and direct-to-file completion.
- No code behavior changes; comments only. Applied Spotless formatting.

Details
- GetCompletionCallback
  - Added comprehensive type-level docs: lifecycle, ordering, threading expectations, and context usage.
  - Enriched method docs: onSuccess, onFailure, onBlockSetFinished, onTransition, onExpectedSize, onExpectedMIME, onExpectedTopSize, onSplitfileCompatibilityMode, onHashes.
  - All parameters documented with ranges/units where applicable; examples use {@code} blocks.
- FileGetCompletionCallback
  - Clarified direct-to-file optimization path and when it is safe to use.
  - getCompletionFile(): clarified absolute path requirement and null semantics.
  - onSuccess(File,...): added truncation/integrity/commit semantics and a short usage snippet.

Validation
- Ran javadoc with -Xdoclint:all for the two files; zero warnings.
- Ran ./gradlew spotlessApply; build successful.

Scope
- Only Javadoc/comments were changed; no signatures, logic, imports, or visibility changed.

Motivation
- Improves public API usability and future maintainability, and aligns with recent efforts to keep async client documentation doclint-clean.

Checklist
- [x] Spotless applied
- [x] Doclint: zero warnings for the touched files
- [x] No functional changes
