### PR TITLE
fix(client): improve metadata dump logging (SnoopMetadata)

### DIFF
--- a/src/main/java/network/crypta/client/async/DumperSnoopMetadata.java
+++ b/src/main/java/network/crypta/client/async/DumperSnoopMetadata.java
@@ -1,12 +1,87 @@
 package network.crypta.client.async;
 
 import network.crypta.client.Metadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Snoop implementation that emits a diagnostic metadata dump for in-flight client requests.
+ *
+ * <p>This implementation is intended for troubleshooting and operational diagnostics. When the
+ * client surfaces metadata for a pending fetch, this class renders a human‑readable dump produced
+ * by {@link Metadata#dump()} and emits it at the error logging level. Environments that do not
+ * provide an SLF4J backend or have the error level disabled still receive the dump on the process
+ * standard error stream to preserve the historical behavior of always surfacing the diagnostic
+ * output.
+ *
+ * <p>Typical usage attaches an instance to a request to observe headers, sizes, and other
+ * descriptive attributes before any payload bytes are transferred. The class performs no policy
+ * decisions; it never cancels the request and therefore has no effect on the normal control flow of
+ * the client pipeline. It is thread‑safe for concurrent use because it maintains no mutable state.
+ *
+ * <ul>
+ *   <li><strong>Purpose:</strong> Visibility into per‑request metadata for debugging and support.
+ *   <li><strong>Behavior:</strong> Logs at {@code ERROR}; falls back to {@code System.err} when
+ *       logging is unavailable or disabled.
+ *   <li><strong>Cancellation:</strong> Always returns {@code false}; never requests early abort.
+ *   <li><strong>Thread‑safety:</strong> Stateless; safe to share across requests.
+ * </ul>
+ *
+ * @see SnoopMetadata
+ * @see Metadata
+ * @see ClientContext
+ */
 public class DumperSnoopMetadata implements SnoopMetadata {
 
+  private static final Logger LOG = LoggerFactory.getLogger(DumperSnoopMetadata.class);
+
+  /**
+   * Constructs a new, stateless dumper.
+   *
+   * <p>Instances keep no per‑request state and may be shared freely across multiple concurrent
+   * operations. Creating additional instances has negligible cost; however, most callers can reuse
+   * a single instance wherever a {@link SnoopMetadata} is required.
+   */
+  public DumperSnoopMetadata() {
+    // no state
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation unconditionally permits the request to continue (it never cancels) and
+   * emits the metadata dump for diagnostics. If the SLF4J backend reports that the {@code ERROR}
+   * level is enabled, the dump is written via the logger; otherwise, the dump is written directly
+   * to {@code System.err} so visibility is preserved even without a logging binding.
+   *
+   * <p>The method does not mutate the provided arguments and performs no blocking I/O. It should be
+   * considered idempotent with respect to its return value. The size of the dump depends on the
+   * information exposed by {@link Metadata#dump()} and may be large for complex items; callers who
+   * attach this snoop in production should ensure log routing and retention are configured
+   * appropriately.
+   *
+   * <pre>{@code
+   * // Attach a dumper to a request to aid debugging
+   * request.setMetaSnoop(new DumperSnoopMetadata());
+   * }</pre>
+   *
+   * @param meta descriptive information about the in‑flight request; never {@code null}. The dump
+   *     string is derived from this object and written to the configured output.
+   * @param context per‑request context; never {@code null}. This implementation does not read from
+   *     or write to the context and ignores it entirely.
+   * @return always {@code false}, indicating that the request must proceed without cancellation,
+   *     regardless of the metadata contents.
+   */
   @Override
+  @SuppressWarnings("java:S106")
   public boolean snoopMetadata(Metadata meta, ClientContext context) {
-    System.err.print(meta.dump());
+    // Prefer logging at ERROR, but preserve stderr dump when backend is absent or ERROR disabled.
+    String dump = String.valueOf(meta.dump());
+    if (LOG.isErrorEnabled()) {
+      LOG.error(dump);
+    } else {
+      System.err.print(dump);
+    }
     return false;
   }
 }

--- a/src/main/java/network/crypta/client/async/SnoopMetadata.java
+++ b/src/main/java/network/crypta/client/async/SnoopMetadata.java
@@ -2,8 +2,54 @@ package network.crypta.client.async;
 
 import network.crypta.client.Metadata;
 
+/**
+ * Callback interface for observing metadata during an asynchronous fetch operation.
+ *
+ * <p>Implementations of this interface are invoked when the client obtains descriptive information
+ * about the requested content, typically before any payload bytes are delivered to the caller. This
+ * early signal allows a client to make a policy decision — for example, rejecting content that is
+ * too large, of an unexpected type, or otherwise unsuitable — without incurring the cost of
+ * downloading the body. Returning {@code true} from the callback requests that the in‑flight fetch
+ * be cancelled immediately; returning {@code false} permits the fetch to proceed normally.
+ *
+ * <p>The interface is intentionally minimal so it can be implemented as a lambda or method
+ * reference. Implementations should keep work bounded and avoid blocking, as the callback may be
+ * executed on an internal I/O or scheduler thread used by other requests. If an instance is shared
+ * across multiple concurrent fetches, treat it as effectively stateless or ensure appropriate
+ * external synchronization.
+ *
+ * <ul>
+ *   <li>Inspect metadata exposed by {@link network.crypta.client.Metadata}.
+ *   <li>Optionally signal early cancellation to conserve bandwidth and resources.
+ *   <li>May record telemetry or tracing using the provided {@link ClientContext}.
+ * </ul>
+ *
+ * @see network.crypta.client.Metadata
+ * @see ClientContext
+ */
 public interface SnoopMetadata {
 
-  /** Spy on the metadata as a file is being fetched. Return true to cancel the request. */
+  /**
+   * Inspects the fetched metadata and optionally cancels the request.
+   *
+   * <p>The client calls this method when metadata for a pending fetch becomes available. The method
+   * should be fast and side‑effect free aside from the decision to continue or abort. It may be
+   * invoked on a background worker thread; implementations must avoid long‑running operations and
+   * should tolerate being called in close proximity to other I/O events. Treat the callback as
+   * idempotent: repeated invocations with the same arguments should lead to the same outcome.
+   *
+   * <pre>{@code
+   * // Example: cancel when an expected type is not present
+   * SnoopMetadata sn = (meta, ctx) -> !"application/octet-stream".equals(meta.contentType());
+   * }</pre>
+   *
+   * @param meta descriptive information about the item being fetched; never {@code null}. It may
+   *     include type hints, sizes, or other attributes that inform early acceptance decisions.
+   * @param context per-request context and facilities for the ongoing operation; never {@code
+   *     null}. May expose logging, tracing, or scheduling helpers; do not retain beyond this
+   *     invocation.
+   * @return {@code true} to request immediate cancellation of the fetch, suppressing payload
+   *     download; {@code false} to continue the fetch according to the configured pipeline.
+   */
   boolean snoopMetadata(Metadata meta, ClientContext context);
 }

--- a/src/test/java/network/crypta/client/async/DumperSnoopMetadataTest.java
+++ b/src/test/java/network/crypta/client/async/DumperSnoopMetadataTest.java
@@ -1,0 +1,143 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import network.crypta.client.Metadata;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class DumperSnoopMetadataTest {
+
+  private Logger getLogger() {
+    return (Logger) LoggerFactory.getLogger(DumperSnoopMetadata.class);
+  }
+
+  private ListAppender<ILoggingEvent> attachListAppender(Logger logger) {
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  @Test
+  void snoopMetadata_whenCalled_logsDumpAtErrorAndReturnsFalse() {
+    // Arrange
+    DumperSnoopMetadata dumper = new DumperSnoopMetadata();
+    Metadata meta = mock(Metadata.class);
+    when(meta.dump()).thenReturn("TEST-DUMP-LINES\nline2\n");
+    ClientContext ctx = mock(ClientContext.class);
+
+    Logger logger = getLogger();
+    ListAppender<ILoggingEvent> appender = attachListAppender(logger);
+    try {
+      // Act
+      boolean cancel = dumper.snoopMetadata(meta, ctx);
+
+      // Assert
+      assertFalse(cancel, "DumperSnoopMetadata should never request cancellation");
+      List<ILoggingEvent> events = appender.list;
+      assertEquals(1, events.size());
+      assertEquals(Level.ERROR, events.getFirst().getLevel());
+      assertEquals("TEST-DUMP-LINES\nline2\n", events.getFirst().getFormattedMessage());
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void snoopMetadata_whenMetaDumpEmpty_logsEmptyMessageAndReturnsFalse() {
+    // Arrange
+    DumperSnoopMetadata dumper = new DumperSnoopMetadata();
+    Metadata meta = mock(Metadata.class);
+    when(meta.dump()).thenReturn("");
+
+    Logger logger = getLogger();
+    ListAppender<ILoggingEvent> appender = attachListAppender(logger);
+    try {
+      // Act
+      boolean cancel = dumper.snoopMetadata(meta, mock(ClientContext.class));
+
+      // Assert
+      assertFalse(cancel);
+      List<ILoggingEvent> events = appender.list;
+      assertEquals(1, events.size());
+      assertEquals("", events.getFirst().getFormattedMessage());
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void snoopMetadata_whenMetaIsNull_throwsNullPointerException() {
+    // Arrange
+    DumperSnoopMetadata dumper = new DumperSnoopMetadata();
+
+    // Act + Assert
+    //noinspection DataFlowIssue
+    assertThrows(
+        NullPointerException.class, () -> dumper.snoopMetadata(null, mock(ClientContext.class)));
+  }
+
+  @Test
+  void snoopMetadata_whenContextIsNull_logsDumpAndReturnsFalse() {
+    // Arrange
+    DumperSnoopMetadata dumper = new DumperSnoopMetadata();
+    Metadata meta = mock(Metadata.class);
+    when(meta.dump()).thenReturn("ABC");
+
+    Logger logger = getLogger();
+    ListAppender<ILoggingEvent> appender = attachListAppender(logger);
+    try {
+      // Act
+      boolean cancel = dumper.snoopMetadata(meta, null);
+
+      // Assert
+      assertFalse(cancel);
+      List<ILoggingEvent> events = appender.list;
+      assertEquals(1, events.size());
+      assertEquals("ABC", events.getFirst().getFormattedMessage());
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void snoopMetadata_whenDumpReturnsNull_logsLiteralNullAndReturnsFalse() {
+    // Arrange
+    DumperSnoopMetadata dumper = new DumperSnoopMetadata();
+    Metadata meta = mock(Metadata.class);
+    when(meta.dump()).thenReturn(null);
+
+    Logger logger = getLogger();
+    ListAppender<ILoggingEvent> appender = attachListAppender(logger);
+    try {
+      // Act
+      boolean cancel = dumper.snoopMetadata(meta, mock(ClientContext.class));
+
+      // Assert
+      assertFalse(cancel);
+      List<ILoggingEvent> events = appender.list;
+      assertEquals(1, events.size());
+      assertEquals("null", events.getFirst().getFormattedMessage());
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Switch DumperSnoopMetadata to SLF4J logging at ERROR with stderr fallback to preserve visibility when a backend is absent/disabled.
- Refine SnoopMetadata Javadoc for purpose, behavior, and thread-safety.
- Add DumperSnoopMetadataTest to validate logging behavior and return contract.

Motivation
- Prior behavior wrote directly to stderr, which bypasses configured logging and is harder to route/observe in production.
- Using SLF4J integrates with existing logging pipelines while still keeping the legacy stderr behavior when logging is unavailable.

Details
- DumperSnoopMetadata
  - Introduces `private static final Logger LOG = LoggerFactory.getLogger(DumperSnoopMetadata.class);`
  - Emits `meta.dump()` via `LOG.error(...)` when ERROR level is enabled; otherwise writes to `System.err`.
  - Remains stateless and always returns `false` (never cancels the request).
  - Expanded Javadoc with usage and behavior notes.
- SnoopMetadata
  - Expanded interface docs for clarity around lifecycle and expectations.
- Tests: DumperSnoopMetadataTest
  - Verifies ERROR-level logging with an attached ListAppender.
  - Covers empty dump, null dump (logged as the literal "null"), null context handling, and that the method never requests cancellation.

Diffstat
- src/main/java/network/crypta/client/async/DumperSnoopMetadata.java (logic + Javadoc)
- src/main/java/network/crypta/client/async/SnoopMetadata.java (Javadoc)
- src/test/java/network/crypta/client/async/DumperSnoopMetadataTest.java (new tests)

Notes
- Spotless was applied prior to commit.
- No behavior change to request cancellation; only logging path is updated.
- Backward compatibility: stderr fallback keeps historical visibility when logging backend is missing.

Checks
- Builds locally; tests pass under JUnit 6 setup.
- No config or API breakage expected.

Please review. Targeting base `develop` from `feature/fix-SnoopMetadata`.