### PR TITLE
chore(client): remove unused NoValidBlocksException

### DIFF
--- a/src/main/java/network/crypta/client/async/NoValidBlocksException.java
+++ b/src/main/java/network/crypta/client/async/NoValidBlocksException.java
@@ -1,8 +1,0 @@
-package network.crypta.client.async;
-
-import java.io.Serial;
-
-public class NoValidBlocksException extends Exception {
-
-  @Serial private static final long serialVersionUID = 1056057448877395180L;
-}


### PR DESCRIPTION
Summary
- Remove `NoValidBlocksException` which is unused across the codebase.
- Verified via repository-wide search (ripgrep) that there are no references.
- Ran `./gradlew spotlessApply` before commit.
- Built and ran tests locally to validate (no failures).

Rationale
- Eliminates dead code and reduces maintenance surface.
- Clarifies client async API surface; the exception was never thrown nor caught.

Change Details
- Deleted: `src/main/java/network/crypta/client/async/NoValidBlocksException.java`

Local Validation
- `./gradlew spotlessApply` — up to date / applied as needed.
- `./gradlew test` — passed locally.

Branch History (develop..HEAD)
- 9f7525972c chore(client): remove unused NoValidBlocksException

Diffstat
- 1 file changed, 8 deletions

Risk/Compatibility
- Low risk. File removal only; no references elsewhere.

Notes
- If desired, I can also run `./gradlew build` to regenerate distributions as a sanity check.
