### PR TITLE
docs(client-async): doclint-clean Javadoc for PersistenceDisabledException

### DIFF
--- a/src/main/java/network/crypta/client/async/PersistenceDisabledException.java
+++ b/src/main/java/network/crypta/client/async/PersistenceDisabledException.java
@@ -2,6 +2,51 @@ package network.crypta.client.async;
 
 import java.io.Serial;
 
+/**
+ * Signals that an operation requiring on-disk persistence is unavailable because persistence is
+ * disabled by configuration or current runtime policy.
+ *
+ * <p>This exception is used to fail fast when a caller attempts to schedule, persist, or resume a
+ * client operation that relies on durable storage (for example, queuing requests for recovery
+ * across restarts) while the node or client API is running in a non-persistent mode. Library users
+ * should treat this as a non-retryable condition unless they can enable persistence and
+ * reinitialize the relevant components. Typical call patterns are:
+ *
+ * <ul>
+ *   <li>Validate capability before enqueueing asynchronous requests that need persistence.
+ *   <li>Catching this exception at API boundaries to present a clear user-facing error message and
+ *       an optional remediation hint (enable persistence, restart, or downgrade functionality).
+ *   <li>Falling back to ephemeral/in-memory flows when durable behavior is not essential.
+ * </ul>
+ *
+ * <p>The type is immutable and carries no additional state beyond the standard exception message
+ * and cause. It is safe to instantiate and throw from any thread. There are no side effects other
+ * than control flow; the presence of this exception does not change the persistence setting—it only
+ * reports it.
+ *
+ * @see Exception
+ */
 public class PersistenceDisabledException extends Exception {
   @Serial private static final long serialVersionUID = -992316133570818146L;
+
+  /**
+   * Creates an exception indicating that persistence is disabled.
+   *
+   * <p>Use this constructor when no additional context is required beyond the fact that the
+   * attempted operation depends on persistence. The detail message is {@code null} and no cause is
+   * set, which is appropriate for simple guard checks where the failure reason is self‑evident from
+   * the call site and surrounding logs. Callers typically throw this directly from capability
+   * checks or translate it into a user‑facing message at API boundaries.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * if (!persistenceEnabled) {
+   *     throw new PersistenceDisabledException();
+   * }
+   * }</pre>
+   */
+  public PersistenceDisabledException() {
+    super();
+  }
 }


### PR DESCRIPTION
Summary
- Add comprehensive class-level Javadoc for client async exception `PersistenceDisabledException`.
- Introduce explicit no-arg constructor with detailed documentation and usage example.
- Verified zero warnings using `javadoc -Xdoclint:all` for this file.
- Ran `./gradlew spotlessApply` to align formatting.

Motivation
Doclint reported warnings for the default constructor on this public exception type and there was only minimal class documentation. This PR upgrades the docs to be doclint-clean and offers substantive guidance for users: when and how the exception is thrown, typical call patterns, immutability/thread-safety behavior, and remediation suggestions.

Changes
- src/main/java/network/crypta/client/async/PersistenceDisabledException.java
  - Add extended top-level Javadoc describing purpose, usage patterns, and behavior.
  - Add explicit public no-arg constructor with a richer Javadoc and a short example snippet.

Doclint Verification
- Ran:
  - `javadoc -quiet -Xdoclint:all -d /tmp/doclint-out -sourcepath . src/main/java/network/crypta/client/async/PersistenceDisabledException.java`
- Result: 0 warnings for this file.

Formatting
- Ran `./gradlew spotlessApply` (no functional changes beyond formatting).

Compatibility & Risk
- No functional changes (comments only, default no-arg constructor made explicit with identical behavior).
- Very low risk.

Testing
- No code behavior changes to test; verified doclint and formatting locally.

Related Work
- Keeps consistency with recent doclint/documentation improvements for async/client APIs.
