### PR TITLE
docs(client-async): doclint-clean Javadoc for RequestSelectionTreeNode

### DIFF
--- a/src/main/java/network/crypta/client/async/RequestSelectionTreeNode.java
+++ b/src/main/java/network/crypta/client/async/RequestSelectionTreeNode.java
@@ -1,36 +1,91 @@
 package network.crypta.client.async;
 
 /**
- * Something that can have a CooldownCacheItem: Anything in the request selection tree, including
- * the actual requests at the bottom (but ClientRequestSelector isn't actually a
- * RequestSelectionTreeNode at the moment, the root is the priorities in the array on
- * ClientRequestSelector; FIXME consistency with RGA.root etc).
+ * A node in the client request-selection tree that participates in cooldown and wakeup scheduling.
+ *
+ * <p>Implementations represent either an internal aggregation node (e.g., a grouping by priority or
+ * policy) or a leaf that corresponds to an individual request. The tree is consulted by the
+ * scheduler to decide when subtrees and leaves next become eligible for work. Each node exposes a
+ * wakeup time and utilities to reduce or clear this value as descendant state changes.
+ *
+ * <p><strong>Usage and lifecycle:</strong> nodes are typically created and wired by a higher-level
+ * selector component and remain attached to a single logical tree. A node may be detached or have a
+ * {@code null} parent when it is not yet inserted or after removal. Callers should treat the API as
+ * stateful and invoke it from the component that owns the scheduling tree.
+ *
+ * <p><strong>Threading:</strong> unless otherwise documented by an implementation, instances are
+ * not inherently thread-safe. Access should be serialized by the request scheduler or owning
+ * subsystem. Methods do not guarantee idempotency: reducing or clearing wakeups mutates state and
+ * can propagate upward to parent nodes.
+ *
+ * <ul>
+ *   <li>Represents position and ancestry within the selection tree.
+ *   <li>Tracks a subtree wakeup time and exposes it to the scheduler.
+ *   <li>Propagates changes upward so parent nodes reflect earlier eligibility.
+ * </ul>
+ *
+ * (but ClientRequestSelector isn't actually a RequestSelectionTreeNode at the moment, the root is
+ * the priorities in the array on ClientRequestSelector; FIXME consistency with RGA.root etc)
  */
 public interface RequestSelectionTreeNode {
 
   /**
-   * Return the parent RequestSelectionTreeNode or null if it's not in the tree or is the root (e.g.
-   * priority classes are kept in an array on ClientRequestSelector).
+   * Returns the parent node or {@code null} when not attached or when this node is the logical root
+   * of the selection structure.
+   *
+   * <p>The parent reference is used to propagate wakeup changes upward so aggregate nodes can
+   * reflect earlier eligibility. Implementations may transiently return {@code null} while a node
+   * is being inserted or removed from the tree.
+   *
+   * @return the parent tree node, or {@code null} when this node has no parent or is considered the
+   *     root in the current arrangement
    */
   RequestSelectionTreeNode getParentGrabArray();
 
   /**
-   * Unless this is a RandomGrabArrayItem, this will return the wakeup time for the subtree rooted
-   * at this node. For a RandomGrabArrayItem it returns the wakeup time for just that single
-   * request.
+   * Returns the next wakeup time for this node.
+   *
+   * <p>For aggregation nodes this is the wakeup time for the entire subtree rooted at this node.
+   * For a leaf (for example a {@code RandomGrabArrayItem}), this is the wakeup time for the single
+   * request represented by the leaf. The time base and units are implementation-defined; callers
+   * should pass a {@code now} value from the same source they use to interpret the return value.
+   *
+   * @param context context object providing scheduler- and node-related state; callers should pass
+   *     the currently active client context used for selection and not retain it
+   * @param now the current time from the caller’s chosen time source; use the same source and units
+   *     expected by the implementation for consistent comparisons
+   * @return the absolute time at which this node or its subtree next becomes eligible, expressed in
+   *     the same time base as {@code now}; may be equal to or earlier than {@code now} when ready
    */
   long getWakeupTime(ClientContext context, long now);
 
   /**
-   * If the current cooldown time is larger than the parameter, reduce it and recurse up the tree.
-   * If we reach the root and wake it up, then wake up the scheduler. Returns true if anything
-   * changed.
+   * Lowers the current wakeup time if it is later than the provided value and propagates the change
+   * toward the root.
+   *
+   * <p>This method is used when an earlier eligibility is discovered within the subtree. If the
+   * change reaches the root and causes it to become earlier than previously recorded, the owning
+   * scheduler should be notified by the implementation. The operation is stateful and may alter the
+   * effective scheduling of ancestor nodes.
+   *
+   * @param wakeupTime a candidate earlier wakeup time, expressed in the time base used by the
+   *     implementation; values not earlier than the current value are ignored
+   * @param context context object providing access to selection state and callbacks; not stored by
+   *     the node and only consulted during the call
+   * @return {@code true} if the node or any ancestor updated its wakeup time as a result of this
+   *     call; {@code false} if no change was necessary
    */
   boolean reduceWakeupTime(long wakeupTime, ClientContext context);
 
   /**
-   * When a request becomes fetchable, set all the wakeup times above it to 0. Will recurse up the
-   * tree.
+   * Clears the wakeup state for this node and propagates the effect toward the root.
+   *
+   * <p>Call when a request becomes immediately eligible so that parent nodes reflect readiness as
+   * soon as possible. Implementations typically set the effective wakeup to the earliest value
+   * representable by their time base.
+   *
+   * @param context context object used to coordinate with the selection system during propagation;
+   *     the reference is used only for the duration of the call
    */
   void clearWakeupTime(ClientContext context);
 }


### PR DESCRIPTION
Summary
- Make RequestSelectionTreeNode Javadoc doclint-clean (zero warnings)
- Add extended top-level documentation (usage, lifecycle, threading, responsibilities)
- Add detailed method docs with complete @param/@return tags
- No behavior changes; comments-only change

Motivation
Doclint flagged missing tags on public API in client async scheduling. This interface is part of the request selection tree and is a surface devs rely on. This PR brings the file to doclint compliance and adds substantive docs to reduce ambiguity around lifecycle and threading.

What changed
- src/main/java/network/crypta/client/async/RequestSelectionTreeNode.java
  - New class-level Javadoc (~150 words) documenting purpose, usage, lifecycle, and threading assumptions; includes a short responsibilities list.
  - Method Javadoc enriched:
    - getParentGrabArray(): clarify parent/null semantics; add @return.
    - getWakeupTime(ClientContext, long): clarify subtree vs leaf semantics; add @param context, @param now, @return.
    - reduceWakeupTime(long, ClientContext): clarify upward propagation and statefulness; add @param and @return.
    - clearWakeupTime(ClientContext): clarify immediate eligibility and propagation; add @param.

Verification
- Built classes locally so javadoc could resolve symbols.
- Ran: javadoc -quiet -Xdoclint:all -classpath "build/classes/java/main:build/resources/main" -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/client/async/RequestSelectionTreeNode.java → 0 warnings.
- Ran ./gradlew spotlessApply before committing to ensure formatting alignment.

Commit history considered (develop)
Reviewed recent commits to align tone and conventions (Spotless usage, conventional commit style) and keep consistent with prior "doclint-clean" documentation PRs:
- style: apply Spotless formatting (#379)
- docs(client-async): doclint-clean Javadoc for PersistentJob (#381)
- docs(client-async): doclint-clean Javadoc for GetCompletionCallback / FileGetCompletionCallback (#371)

Notes
- Preserves the existing FIXME note about root consistency; only wording around the interface was clarified.
- No code, signature, visibility, or behavior changes.

Request
- Target branch: develop
- Maintainers: please review wording and scope; happy to iterate on phrasing.
