### PR TITLE
client/async: doclint cleanup, KeyListener improvements, and test refactors

### DIFF
--- a/src/main/java/network/crypta/client/async/KeyListener.java
+++ b/src/main/java/network/crypta/client/async/KeyListener.java
@@ -5,76 +5,198 @@ import network.crypta.keys.KeyBlock;
 import network.crypta.node.SendableGet;
 
 /**
- * Transient object created on startup for persistent requests (or at creation time for
- * non-persistent requests), to monitor the stream of successfully fetched keys. If a key appears
- * interesting, we schedule a job on the database thread to double-check and process the data if we
- * still want it.
+ * Listener that screens and optionally consumes keys fetched by the node.
  *
- * @author Matthew Toseland <toad@amphibian.dyndns.org> (0xE43DA450)
- *     <p>saltedKey is the routing key from the key, salted globally (concat a global salt value and
- *     then SHA) in order to save some cycles. Implementations that use two internal bloom filters
- *     may need to have an additional local salt, as in SplitFileFetcherKeyListener.
+ * <p>A {@code KeyListener} is a transient, lightweight object attached to a higher-level client
+ * request in order to monitor the stream of successfully fetched keys and quickly decide whether a
+ * given key is relevant. It is created on startup for persistent requests or on demand for
+ * ephemeral ones. Implementations typically use one or more Bloom filters to provide a near-O(1)
+ * rejection path in {@link #probablyWantKey(Key, byte[])}, followed by a definitive decision in
+ * {@link #definitelyWantKey(Key, byte[], ClientContext)} and eventual processing via {@link
+ * #handleBlock(Key, byte[], KeyBlock, ClientContext)}. Expensive work is deferred to the
+ * appropriate background thread(s) supplied by the {@link ClientContext}.
+ *
+ * <p>Concurrency and locking: fast-path methods may be invoked while holding internal scheduler
+ * locks. Implementations should avoid external locking and blocking I/O inside these paths. The
+ * listener is short-lived and should not retain large state; long-lived ownership remains with the
+ * parent {@link HasKeyListener}. The {@code saltedKey} argument is the globally salted routing key
+ * (concatenate a global salt and then hash) supplied to eliminate re-computation in the hot path.
+ * Some implementations also apply a secondary, local salt when using multiple Bloom filters.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> quickly filter candidates, confirm interest, and handle
+ *       matching blocks.
+ *   <li><strong>Typical usage:</strong> obtain from {@link HasKeyListener}, call {@link
+ *       #probablyWantKey(Key, byte[])}, then either escalate to {@link #definitelyWantKey(Key,
+ *       byte[], ClientContext)} or directly to {@link #handleBlock(Key, byte[], KeyBlock,
+ *       ClientContext)} depending on the caller.
+ *   <li><strong>Lifecycle:</strong> the listener may be deactivated at any time via {@link
+ *       #onRemove()} or when {@link #isEmpty()} becomes {@code true}.
+ * </ul>
+ *
+ * @author Matthew Toseland {@literal <toad@amphibian.dyndns.org>} (0xE43DA450)
+ * @see HasKeyListener
+ * @see KeyListenerTracker
+ * @see ClientContext
+ * @see SendableGet
  */
 public interface KeyListener {
 
   /**
-   * Fast guess at whether we want a key or not. Usually implemented by a bloom filter. LOCKING:
-   * Should avoid external locking if possible. Will be called within the CRSBase lock.
+   * Make a fast, approximate decision about whether the key is of interest.
    *
-   * @return True if we probably want the key. False if we definitely don't want it.
+   * <p>This method is expected to be extremely cheap and is commonly backed by one or more Bloom
+   * filters. Callers may execute it while holding internal scheduler locks, therefore
+   * implementations should avoid external synchronization and any blocking operations. The {@code
+   * saltedKey} is the globally salted routing key provided by the caller to avoid repeated hashing
+   * in hot paths.
+   *
+   * @param key the candidate key object as received from the fetch pipeline; never {@code null}
+   * @param saltedKey the globally salted routing key bytes for {@code key}; the buffer is read-only
+   *     to the callee and must not be retained or modified
+   * @return {@code true} when the listener likely wants the key (subject to false positives);
+   *     {@code false} when the key is definitely not relevant to this listener
    */
   boolean probablyWantKey(Key key, byte[] saltedKey);
 
   /**
-   * Do we want the key? This is called by the ULPR code, because fetching the key will involve
-   * significant work. tripPendingKey() on the other hand will go straight to handleBlock().
+   * Confirm interest in the key and return the associated request priority.
    *
-   * @return -1 if we don't want the key, otherwise the priority of the request interested in the
-   *     key.
+   * <p>Unlike {@link #probablyWantKey(Key, byte[])}, this method is consulted before initiating
+   * work that may be expensive (e.g., scheduling fetch attempts or decoding). It must produce a
+   * stable answer for the current state. Implementations should remain fast and avoid external
+   * locking. A negative return value signals that the listener is not interested.
+   *
+   * @param key the candidate key to confirm; same object previously screened by {@link
+   *     #probablyWantKey(Key, byte[])}
+   * @param saltedKey the globally salted routing key corresponding to {@code key}; provided for
+   *     reuse and not for retention or mutation by the callee
+   * @param context execution context for client operations; provides schedulers and shared services
+   *     required for deeper checks
+   * @return the priority class of the interested request when the key is desired; {@code -1} when
+   *     the key is not wanted by this listener
    */
   short definitelyWantKey(Key key, byte[] saltedKey, ClientContext context);
 
   /**
-   * Find the requests related to a specific key, used in retrying after cooldown. Caller should
-   * call probablyWantKey() first.
+   * Return the concrete requests associated with the specified key, if any.
+   *
+   * <p>This hook is used by retry/cooldown logic to map a key back to one or more concrete {@link
+   * SendableGet} instances. Callers should first filter using {@link #probablyWantKey(Key,
+   * byte[])}. Implementations may return {@code null} when unused by a specific listener type.
+   *
+   * @param key the candidate key under consideration; never {@code null}
+   * @param saltedKey the globally salted routing key bytes for {@code key}; read-only to the callee
+   * @param context execution context supplying shared services and schedulers
+   * @return an array of {@link SendableGet} requests related to {@code key}, or {@code null} when
+   *     not applicable or when no requests are currently linked
    */
   SendableGet[] getRequestsForKey(Key key, byte[] saltedKey, ClientContext context);
 
-  /** Handle the found data, if we really want it. */
+  /**
+   * Consume a fetched block when the key is confirmed to be relevant.
+   *
+   * <p>Callers should only invoke this after a positive decision from {@link #probablyWantKey(Key,
+   * byte[])} (and optionally {@link #definitelyWantKey(Key, byte[], ClientContext)}).
+   * Implementations decode/validate the {@link KeyBlock} and update any associated request state.
+   * The method should avoid expensive operations on hot-path threads; heavy work should be
+   * delegated to background components from {@code context}.
+   *
+   * @param key the key that produced the block; never {@code null}
+   * @param saltedKey the globally salted routing key for {@code key}; provided for fast removal
+   *     from filters and similar structures
+   * @param found the successfully fetched block corresponding to {@code key}; must be treated as
+   *     read-only by the listener
+   * @param context execution context with facilities for scheduling and persistence interactions
+   * @return {@code true} when the block was recognized and processed by this listener; {@code
+   *     false} when it was ignored (e.g., a false positive or non-matching segment)
+   */
   boolean handleBlock(Key key, byte[] saltedKey, KeyBlock found, ClientContext context);
 
-  /** Is this related to a persistent request? */
+  /**
+   * Report whether this listener belongs to a persistent request.
+   *
+   * <p>Persistent requests are restored across restarts and may retain lightweight state for the
+   * duration. Callers can use this signal to decide when to write metadata and how aggressively to
+   * reuse listeners during startup.
+   *
+   * @return {@code true} when the owning request is persistent and may outlive the current process
+   *     session; {@code false} for transient/ephemeral requests
+   */
   boolean persistent();
 
   /**
-   * Priority of the associated request. LOCKING: Should avoid external locking if possible. Will be
-   * called within the CRSBase lock.
+   * Return the priority class associated with the owning request.
+   *
+   * <p>Callers may invoke this inside internal locks; implementations should avoid external
+   * synchronization. The priority value is used by schedulers to order work relative to other
+   * requests.
+   *
+   * @return the priority class value that should be used when scheduling related work
    */
   short getPriorityClass();
 
+  /**
+   * Count the number of keys that remain of interest to this listener.
+   *
+   * <p>Implementations for persistent fetches may report the number of outstanding keys. Some
+   * ephemeral listeners can return trivial values. The result is advisory and intended for metrics
+   * and housekeeping only.
+   *
+   * @return a non-negative count of remaining candidate or outstanding keys tracked by the listener
+   */
   long countKeys();
 
   /**
-   * @return The parent HasKeyListener. This does mean it will be pinned in RAM, but it can be
-   *     deactivated so it's not a big deal. LOCKING: Should avoid external locking if possible.
-   *     Will be called within the CRSBase lock.
+   * Return the factory/owner that produced this listener.
+   *
+   * <p>The owner remains active while the listener is attached, which implies it may be retained in
+   * memory. Owners can be deactivated independently, in which case callers should stop invoking the
+   * listener.
+   *
+   * @return the non-{@code null} {@link HasKeyListener} that created and owns this listener
    */
   HasKeyListener getHasKeyListener();
 
-  /** Deactivate the request once it has been removed. */
+  /**
+   * Notification that the listener is being removed from tracking structures.
+   *
+   * <p>Implementations should promptly release transient state and mark themselves inactive. No
+   * further callbacks are guaranteed after this point.
+   */
   void onRemove();
 
   /**
-   * Has the request finished? If every key has been found, or enough keys have been found, return
-   * true so that the caller can remove it from the list.
+   * Indicate whether the listener has no further work to perform.
+   *
+   * <p>Return {@code true} when all required keys have been found or when sufficient progress has
+   * been made for the owning request to be considered complete. Callers may use this to remove the
+   * listener from internal registries.
+   *
+   * @return {@code true} when no keys remain of interest; {@code false} otherwise
    */
   boolean isEmpty();
 
+  /**
+   * Report whether this listener exclusively targets SSK-style keys.
+   *
+   * <p>This is a convenience flag for callers that need to distinguish between key families, for
+   * example to interpret {@link #getWantedKey()} correctly.
+   *
+   * @return {@code true} when this listener concerns SSK keys; {@code false} otherwise
+   */
   boolean isSSK();
 
   /**
-   * @return non-null if only key with (isSSK() ? pubKeyHash : routingKey) wanted. Must match
-   *     getHasKeyListener().getWantedKey().
+   * Optionally expose the single key identifier this listener is interested in.
+   *
+   * <p>When non-{@code null}, the returned value identifies the only key of interest using one of
+   * two encodings: if {@link #isSSK()} is {@code true}, the value is the public-key hash; otherwise
+   * it is the routing key. The value must be consistent with {@link HasKeyListener#getWantedKey()}
+   * for the owning request.
+   *
+   * @return a non-{@code null} byte array when exactly one key is targeted, or {@code null} when
+   *     the listener matches multiple keys. Callers must treat the returned buffer as immutable.
    */
   byte[] getWantedKey();
 }

--- a/src/main/java/network/crypta/client/async/KeyListenerTracker.java
+++ b/src/main/java/network/crypta/client/async/KeyListenerTracker.java
@@ -20,48 +20,129 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tracks exactly which keys we are listening for. This is decoupled from actually requesting them
- * because we want to pick up the data even if we didn't request it - some nearby node requested it,
- * it got inserted through this node, it was offered via ULPRs some time after we requested it etc.
+ * Tracks listeners interested in specific keys and coordinates notification when data becomes
+ * available. Tracking is intentionally decoupled from the act of scheduling and issuing network
+ * requests so that locally observed traffic (e.g., neighbor requests, inserts routed through this
+ * node, or late ULPR announcements) can satisfy pending interest even if this scheduler did not
+ * originate a fetch for the same key.
  *
- * <p>The queue of requests to run, and the algorithm to choose which to start, is in
+ * <p>Typical usage is:
  *
- * @see ClientRequestSchedulerSelector . PERSISTENCE: This class is NOT serialized, it is recreated
- *     on every startup, and downloads are re-registered with this class (for KeyListeners) and
- *     downloads and uploads are re-registered with the ClientRequestSelector.
- * @author toad
+ * <ol>
+ *   <li>Register a {@code KeyListener} via {@link #addPendingKeys(KeyListener)}. A listener may
+ *       target a single salted key or a set of keys, depending on the implementation.
+ *   <li>As blocks are received or discovered, call {@link #tripPendingKey(Key, KeyBlock,
+ *       ClientContext)}. Matching listeners are asked to handle the block and may remove themselves
+ *       once complete.
+ *   <li>Use {@link #getKeyPrio(Key, short, ClientContext)} to adjust priorities for keys that are
+ *       definitely wanted by registered listeners.
+ * </ol>
+ *
+ * <p>Instances are created per scheduler flavor (insert/CHK/SSK/real-time) and are not persisted.
+ * On startup, they are rebuilt and active downloads re-register their listeners. This class is not
+ * thread-safe by default; methods that mutate internal collections either synchronize on {@code
+ * this} or constrain access patterns to avoid concurrent modification.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>SSK schedulers do not salt keys; CHK schedulers salt with a per-instance random salt.
+ *   <li>Retry counts are normalized by {@link #fixRetryCount(int)} so lightly tried requests do not
+ *       starve other clients.
+ *   <li>Listeners can be registered for a single key or as a catch-all; both sources are consulted
+ *       when checking interest or dispatching blocks.
+ * </ul>
+ *
+ * @see ClientRequestScheduler
  */
 class KeyListenerTracker implements KeySalter {
   private static final Logger LOG = LoggerFactory.getLogger(KeyListenerTracker.class);
 
-  static {
-  }
+  // No static initialization required
 
   /**
-   * Minimum number of retries at which we start to hold it against a request. See the comments on
-   * fixRetryCount; we don't want many untried requests to prevent us from trying requests which
-   * have only been tried once (e.g. USK checkers), from other clients (and we DO want retries to
-   * take precedence over client round robin IF the request has been tried many times already).
+   * Minimum number of retries after which additional retries start to affect priority decisions.
+   * Below this threshold, requests are treated as if they have zero retries for scheduling
+   * purposes. This avoids large batches of lightly tried requests starving other clients while
+   * still allowing genuinely hard-to-fetch keys to gain precedence once they have been tried
+   * several times.
    */
   private static final int MIN_RETRY_COUNT = 3;
 
+  /**
+   * Indicates that this tracker is associated with an insert scheduler, where insert-related events
+   * may influence interest tracking. This flag is immutable for the lifetime of the instance and
+   * primarily affects {@link #toString()} diagnostics.
+   */
   final boolean isInsertScheduler;
+
+  /**
+   * True when this tracker is bound to an SSK scheduler. When set, keys are not salted (SSK uses
+   * the raw routing/public key material). When false, CHK routing keys are salted to reduce
+   * cross-scheduler interference.
+   */
   final boolean isSSKScheduler;
+
+  /**
+   * True for real-time scheduling mode. Real-time schedulers may prioritize differently at higher
+   * layers; the tracker itself uses the flag only for identification and logging.
+   */
   final boolean isRTScheduler;
 
+  /**
+   * Owning scheduler that decides when and how requests are executed. The tracker does not issue
+   * requests directly; instead, it exposes listener interest and potential requests that the
+   * scheduler can query.
+   */
   protected final ClientRequestScheduler sched;
 
   /** Transient even for persistent scheduler. There is one for each of transient, persistent. */
   protected final ArrayList<KeyListener> keyListeners;
 
+  /**
+   * Map of salted key to either a single {@code KeyListener} or an array of listeners. Lookups are
+   * by salted key; for SSK schedulers no salting occurs. Values are intentionally stored as either
+   * a single instance or an array to minimize allocation when only one listener exists.
+   */
   protected final Map<ByteArrayWrapper, Object> singleKeyListeners;
 
+  /**
+   * Whether this tracker belongs to the persistent scheduler. The tracker itself is not serialized;
+   * this flag communicates the intended lifecycle to callers and is exposed via {@link
+   * #persistent()}.
+   */
   final boolean persistent;
 
+  /**
+   * Returns whether the owning scheduler is persistent. This does not imply that the tracker or its
+   * internal state is serialized; tracker instances are recreated on startup and callers are
+   * expected to re-register their listeners.
+   *
+   * @return {@code true} when associated with the persistent scheduler, {@code false} otherwise.
+   */
   public boolean persistent() {
     return persistent;
   }
 
+  /**
+   * Creates a tracker bound to a specific scheduler flavor.
+   *
+   * <p>When {@code forSSKs} is {@code false}, a 32-byte per-instance salt is used to salt CHK
+   * routing keys. If {@code globalSalt} is {@code null}, a new random salt is generated using the
+   * provided {@code random} source. The salt remains constant for the lifetime of this instance.
+   *
+   * @param forInserts {@code true} when attached to an insert scheduler; affects diagnostics only.
+   * @param forSSKs {@code true} for SSK schedulers; disables key salting and expects SSK keys.
+   * @param forRT {@code true} for real-time mode; used for identification and logging.
+   * @param random source of randomness for generating a salt when {@code globalSalt} is {@code
+   *     null}. Must be non-{@code null} when {@code globalSalt} is {@code null}.
+   * @param sched owning {@link ClientRequestScheduler} that queries interest and potential
+   *     requests. Must not be {@code null}.
+   * @param globalSalt optional 32-byte salt used for CHK key salting; when {@code null}, a new salt
+   *     is generated.
+   * @param persistent whether this tracker is associated with the persistent scheduler (see {@link
+   *     #persistent()}).
+   */
   protected KeyListenerTracker(
       boolean forInserts,
       boolean forSSKs,
@@ -86,11 +167,14 @@ class KeyListenerTracker implements KeySalter {
   }
 
   /**
-   * Mangle the retry count. Below a certain number of attempts, we don't prefer one request to
-   * another just because it's been tried more times. The reason for this is to prevent floods of
-   * low-retry-count requests from starving other clients' requests which need to be retried. The
-   * other solution would be to sort by client before retry count, but that would be excessive IMHO;
-   * we DO want to avoid rerequesting keys we've tried many times before.
+   * Normalizes a raw retry count for scheduling comparisons.
+   *
+   * <p>Counts below {@link #MIN_RETRY_COUNT} are treated as zero so that recently started or
+   * lightly retried requests do not dominate scheduling decisions. Only once a request has reached
+   * the threshold do additional retries make it more urgent relative to other clients' work.
+   *
+   * @param retryCount the raw number of attempts already made; negative values are treated as zero.
+   * @return a non-negative normalized count suitable for comparing request urgency.
    */
   protected static int fixRetryCount(int retryCount) {
     return Math.max(0, retryCount - MIN_RETRY_COUNT);
@@ -103,11 +187,321 @@ class KeyListenerTracker implements KeySalter {
     return false;
   }
 
+  /**
+   * Registers a listener as interested in one or more keys.
+   *
+   * <p>If the listener targets a single key, it is stored under that key's salted form (for CHK) or
+   * raw form (for SSK). Otherwise, it is added to the general list. Duplicate registrations are
+   * ignored.
+   *
+   * @param listener the listener to register; must not be {@code null}. Its owner must report a
+   *     consistent wanted key if a single-key listener.
+   */
   public void addPendingKeys(KeyListener listener) {
     if (listener == null) throw new NullPointerException();
     byte[] wantedKey = listener.getWantedKey();
     ByteArrayWrapper wrapper = wantedKey != null ? new ByteArrayWrapper(saltKey(wantedKey)) : null;
-    assert (Arrays.equals(wantedKey, listener.getHasKeyListener().getWantedKey()));
+    // Ensure the KeyListener's owner reports the same wanted key if present
+    if (wantedKey != null
+        && !Arrays.equals(wantedKey, listener.getHasKeyListener().getWantedKey())) {
+      throw new IllegalStateException("Listener wantedKey mismatch with owner");
+    }
+    registerListener(wantedKey, wrapper, listener);
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "Added pending keys to {} : size now {}/{} : {}",
+          this,
+          this.keyListeners.size(),
+          singleKeyListeners.size(),
+          listener);
+  }
+
+  /**
+   * Removes a previously registered listener.
+   *
+   * <p>Both single-key and general listeners are supported. This method invokes {@code onRemove()}
+   * on the listener to allow cleanup. The method is idempotent; removing a listener that is not
+   * present returns {@code false}.
+   *
+   * @param listener the listener to remove; must not be {@code null}.
+   * @return {@code true} if a registration was removed, {@code false} if no matching registration
+   *     existed.
+   */
+  public boolean removePendingKeys(KeyListener listener) {
+    boolean ret;
+    byte[] wantedKey = listener.getWantedKey();
+    ByteArrayWrapper wrapper = wantedKey != null ? new ByteArrayWrapper(saltKey(wantedKey)) : null;
+    synchronized (this) {
+      ret =
+          (wantedKey != null) ? removeSingleListener(wrapper, listener) : removeFromList(listener);
+      // Intentionally call onRemove() once here and once below, matching existing behavior.
+      listener.onRemove();
+    }
+    listener.onRemove();
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "Removed pending keys from {} : size now {}/{} : {}",
+          this,
+          this.keyListeners.size(),
+          singleKeyListeners.size(),
+          listener);
+    return ret;
+  }
+
+  /**
+   * Removes all registrations owned by a given listener owner.
+   *
+   * <p>This scans both the single-key map and the general list, removing any listeners whose owner
+   * matches the supplied instance. For each removed listener, {@code onRemove()} is invoked.
+   *
+   * @param hasListener the owner whose listeners should be removed.
+   * @return {@code true} if at least one listener was removed; {@code false} otherwise.
+   */
+  public boolean removePendingKeys(HasKeyListener hasListener) {
+    boolean ret;
+    byte[] wantedKey = hasListener.getWantedKey();
+    ByteArrayWrapper wrapper = wantedKey != null ? new ByteArrayWrapper(saltKey(wantedKey)) : null;
+    synchronized (this) {
+      if (wantedKey != null) {
+        ret = removeSingleByOwner(hasListener, wrapper);
+        return ret;
+      }
+      ret = removeListByOwner(hasListener);
+    }
+    return ret;
+  }
+
+  private synchronized ArrayList<KeyListener> probablyMatches(Key key, byte[] saltedKey) {
+    ArrayList<KeyListener> matches;
+    final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
+    matches = appendSingleMatches(wrapper, key, saltedKey);
+    matches = appendListMatches(matches, key, saltedKey);
+    return matches;
+  }
+
+  /**
+   * Computes an adjusted priority for a key based on registered interest.
+   *
+   * <p>If the key type does not match this scheduler (e.g., CHK on an SSK scheduler), the supplied
+   * priority is returned unchanged. Otherwise, listeners that definitely want the key may lower the
+   * priority (numerically) to signal higher urgency.
+   *
+   * @param key the key being considered; must be of the correct type for this scheduler.
+   * @param priority the current priority; smaller values represent higher priority.
+   * @param context request context supplied to listeners when evaluating interest.
+   * @return the possibly reduced priority reflecting definite listener interest.
+   */
+  public short getKeyPrio(Key key, short priority, ClientContext context) {
+    if ((key instanceof NodeSSK) != isSSKScheduler) {
+      return priority;
+    }
+    byte[] saltedKey = saltKey(key);
+    ArrayList<KeyListener> matches = probablyMatches(key, saltedKey);
+    if (matches == null) return priority;
+    for (KeyListener listener : matches) {
+      short prio;
+      try {
+        prio = listener.definitelyWantKey(key, saltedKey, context);
+      } catch (Exception t) {
+        LOG.error("Error in definitelyWantKey callback for {}", listener, t);
+        prio = -1;
+      }
+      if (prio != -1 && prio < priority) priority = prio;
+    }
+    return priority;
+  }
+
+  /**
+   * Counts the total number of pending keys across all registered listeners.
+   *
+   * <p>Both single-key and general listeners are included. Exceptions thrown by individual
+   * listeners are logged and ignored.
+   *
+   * @return the sum of {@code countKeys()} across all listeners; never negative.
+   */
+  public synchronized long countWaitingKeys() {
+    long count = 0;
+    for (Object o : singleKeyListeners.values()) {
+      if (o instanceof KeyListener listener1) {
+        count += listener1.countKeys();
+      } else if (o instanceof KeyListener[] listeners) {
+        for (KeyListener listener : listeners) count += listener.countKeys();
+      }
+    }
+    for (KeyListener listener : keyListeners) {
+      try {
+        count += listener.countKeys();
+      } catch (Exception t) {
+        LOG.error("Error in countKeys callback for {}", listener, t);
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Returns whether any listener definitely wants the specified key.
+   *
+   * <p>If the key type does not match this scheduler, {@code false} is returned. Otherwise, all
+   * probable matches are asked whether they definitely want the key using their context-aware
+   * heuristic; a non-negative response indicates interest.
+   *
+   * @param key the key to test; must match the scheduler's key type.
+   * @param context execution context supplied to listeners.
+   * @return {@code true} if at least one listener definitely wants the key; {@code false}
+   *     otherwise.
+   */
+  public boolean anyWantKey(Key key, ClientContext context) {
+    if ((key instanceof NodeSSK) != isSSKScheduler) {
+      return false;
+    }
+    byte[] saltedKey = saltKey(key);
+    List<KeyListener> matches = probablyWantKey(key, saltedKey);
+    if (!matches.isEmpty()) {
+      for (KeyListener listener : matches) {
+        try {
+          if (listener.definitelyWantKey(key, saltedKey, context) >= 0) {
+            return true;
+          }
+        } catch (Exception t) {
+          LOG.error("Error in definitelyWantKey callback for {}", listener, t);
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns whether any listener probably wants the specified key.
+   *
+   * <p>This performs a faster check that does not ask listeners to provide a definitive priority.
+   * It is useful as a preliminary filter before more expensive evaluation.
+   *
+   * @param key the key to test; must match the scheduler's key type.
+   * @param context execution context used for validation only; must not be {@code null}.
+   * @return {@code true} if any listener indicates probable interest; {@code false} otherwise.
+   */
+  public synchronized boolean anyProbablyWantKey(Key key, ClientContext context) {
+    java.util.Objects.requireNonNull(context, "context");
+    if ((key instanceof NodeSSK) != isSSKScheduler) {
+      return false;
+    }
+    byte[] saltedKey = saltKey(key);
+    if (anySingleProbablyWant(key, saltedKey)) return true;
+    return anyListProbablyWant(key, saltedKey);
+  }
+
+  /**
+   * Notifies matching listeners that a block for {@code key} is available.
+   *
+   * <p>If the key type does not match this scheduler, the call is ignored and {@code false} is
+   * returned. Otherwise, matching listeners are invoked. Listeners that become empty after handling
+   * the block are removed.
+   *
+   * @param key the key for which a block is available; must match the scheduler's key type.
+   * @param block the block data associated with the key.
+   * @param context request context propagated to listeners.
+   * @return {@code true} if any listener handled the block successfully; {@code false} otherwise.
+   */
+  public boolean tripPendingKey(Key key, KeyBlock block, ClientContext context) {
+    if ((key instanceof NodeSSK) != isSSKScheduler) {
+      LOG.warn("Key {} on scheduler ssk={}", key, isSSKScheduler);
+      return false;
+    }
+    byte[] saltedKey = saltKey(key);
+    ArrayList<KeyListener> matches = probablyMatches(key, saltedKey);
+    boolean ret = false;
+    if (matches != null) ret = processTripMatches(key, saltedKey, block, context, matches);
+    return ret;
+  }
+
+  /**
+   * Returns any concrete {@link SendableGet} requests that should be issued for the given key.
+   *
+   * <p>If the key type does not match this scheduler or no listener proposes requests, {@code null}
+   * is returned. Otherwise, the returned array contains one or more requests collected from
+   * matching listeners. The array is a snapshot; callers should not modify it.
+   *
+   * @param key the key to request.
+   * @param context request context supplied to listeners.
+   * @return an array of requests to issue, or {@code null} if none were proposed.
+   */
+  @SuppressWarnings("java:S1168")
+  public SendableGet[] requestsForKey(Key key, ClientContext context) {
+    ArrayList<SendableGet> list = new ArrayList<>();
+    if ((key instanceof NodeSSK) != isSSKScheduler) {
+      return null;
+    }
+    byte[] saltedKey = saltKey(key);
+    List<KeyListener> matches = probablyWantKey(key, saltedKey);
+    for (KeyListener listener : matches) {
+      SendableGet[] reqs = null;
+      try {
+        reqs = listener.getRequestsForKey(key, saltedKey, context);
+      } catch (Exception t) {
+        LOG.error("Error in getRequestsForKey callback for {}", listener, t);
+      }
+      if (reqs != null) {
+        Collections.addAll(list, reqs);
+      }
+    }
+    if (list.isEmpty()) {
+      return null;
+    }
+    return list.toArray(new SendableGet[0]);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(super.toString());
+    sb.append(':');
+    if (isInsertScheduler) sb.append("insert:");
+    if (isSSKScheduler) sb.append("SSK");
+    else sb.append("CHK");
+    return sb.toString();
+  }
+
+  private final byte[] globalSalt;
+
+  /**
+   * Returns the salted routing key used for listener maps.
+   *
+   * <p>For SSK schedulers the original key material is returned unchanged. For CHK schedulers a
+   * per-instance salt is mixed with the routing key via {@link SHA256}.
+   *
+   * @param key the key whose routing bytes should be salted as appropriate for the scheduler.
+   * @return a byte array containing the salted or raw routing key; never {@code null}.
+   */
+  public byte[] saltKey(Key key) {
+    return saltKey(key instanceof NodeSSK nssk ? nssk.getPubKeyHash() : key.getRoutingKey());
+  }
+
+  private byte[] saltKey(byte[] key) {
+    if (isSSKScheduler) return key;
+    MessageDigest md = SHA256.getMessageDigest();
+    md.update(key);
+    md.update(globalSalt);
+    return md.digest();
+  }
+
+  /** Returns all KeyListeners that return true on probablyWantKey(key, saltedKey) */
+  private List<KeyListener> probablyWantKey(Key key, byte[] saltedKey) {
+    ArrayList<KeyListener> matches = new ArrayList<>();
+    synchronized (this) {
+      for (KeyListener listener : keyListeners) {
+        try {
+          if (listener.probablyWantKey(key, saltedKey)) {
+            matches.add(listener);
+          }
+        } catch (Exception t) {
+          LOG.error("Error in probablyWantKey callback for {}", listener, t);
+        }
+      }
+    }
+    return matches;
+  }
+
+  private void registerListener(byte[] wantedKey, ByteArrayWrapper wrapper, KeyListener listener) {
     synchronized (this) {
       // We have to register before checking the disk, so it may well get registered twice.
       if (wantedKey != null) {
@@ -129,367 +523,232 @@ class KeyListenerTracker implements KeySalter {
         keyListeners.add(listener);
       }
     }
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Added pending keys to "
-              + this
-              + " : size now "
-              + this.keyListeners.size()
-              + "/"
-              + singleKeyListeners.size()
-              + " : "
-              + listener);
   }
 
-  public boolean removePendingKeys(KeyListener listener) {
-    boolean ret = false;
-    byte[] wantedKey = listener.getWantedKey();
-    ByteArrayWrapper wrapper = wantedKey != null ? new ByteArrayWrapper(saltKey(wantedKey)) : null;
-    synchronized (this) {
-      if (wantedKey != null) {
-        Object o = singleKeyListeners.get(wrapper);
-        if (o != null) {
-          if (o instanceof KeyListener) {
-            ret = (listener == o);
-            if (ret) singleKeyListeners.remove(wrapper);
-          } else {
-            KeyListener[] listeners = (KeyListener[]) o;
-            KeyListener[] newListeners = new KeyListener[listeners.length - 1];
-            int x = 0;
-            for (KeyListener l : listeners) {
-              if (listener == l) {
-                assert (!ret);
-                ret = true;
-                continue;
-              }
-              if (x == newListeners.length) {
-                assert (!ret);
-                break;
-              }
-              newListeners[x++] = l;
-            }
-            if (ret) {
-              assert (x == newListeners.length);
-              if (newListeners.length == 0) {
-                singleKeyListeners.remove(wrapper);
-              } else if (newListeners.length == 1) {
-                singleKeyListeners.put(wrapper, newListeners[0]);
-              } else {
-                singleKeyListeners.put(wrapper, newListeners);
-              }
-            }
-          }
-        }
-      } else {
-        ret = keyListeners.remove(listener);
-      }
-      listener.onRemove();
-    }
-    listener.onRemove();
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Removed pending keys from "
-              + this
-              + " : size now "
-              + this.keyListeners.size()
-              + "/"
-              + singleKeyListeners.size()
-              + " : "
-              + listener,
-          new Exception("debug"));
-    return ret;
-  }
-
-  public boolean removePendingKeys(HasKeyListener hasListener) {
-    boolean ret = false;
-    byte[] wantedKey = hasListener.getWantedKey();
-    ByteArrayWrapper wrapper = wantedKey != null ? new ByteArrayWrapper(saltKey(wantedKey)) : null;
-    synchronized (this) {
-      if (wantedKey != null) {
-        Object o = singleKeyListeners.get(wrapper);
-        if (o != null) {
-          if (o instanceof KeyListener listener) {
-            ret = (listener.getHasKeyListener() == hasListener);
-            if (ret) {
-              singleKeyListeners.remove(wrapper);
-              listener.onRemove();
-            }
-          } else {
-            KeyListener[] listeners = (KeyListener[]) o;
-            KeyListener[] newListeners = new KeyListener[listeners.length - 1];
-            int x = 0;
-            String msg = LOG.isDebugEnabled() ? "" : null;
-            for (KeyListener l : listeners) {
-              if (l.getHasKeyListener() == hasListener) {
-                ret = true;
-                l.onRemove();
-                if (LOG.isDebugEnabled()) msg = "%s : %s".formatted(msg, l);
-                continue;
-              }
-              if (x == newListeners.length) {
-                assert (!ret);
-                break;
-              }
-              newListeners[x++] = l;
-            }
-            if (ret) {
-              if (x < newListeners.length) newListeners = Arrays.copyOf(newListeners, x);
-              if (newListeners.length == 0) {
-                singleKeyListeners.remove(wrapper);
-              } else if (newListeners.length == 1) {
-                singleKeyListeners.put(wrapper, newListeners[0]);
-              } else {
-                singleKeyListeners.put(wrapper, newListeners);
-              }
-              if (LOG.isDebugEnabled())
-                LOG.debug(
-                    "Removed pending keys from "
-                        + this
-                        + " : size now "
-                        + this.keyListeners.size()
-                        + "/"
-                        + singleKeyListeners.size()
-                        + msg);
-            }
-          }
-        }
-        return ret;
-      }
-      for (Iterator<KeyListener> i = keyListeners.iterator(); i.hasNext(); ) {
-        KeyListener listener = i.next();
-        if (listener.getHasKeyListener() == hasListener) {
-          ret = true;
-          i.remove();
-          listener.onRemove();
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "Removed pending keys from "
-                    + this
-                    + " : size now "
-                    + this.keyListeners.size()
-                    + "/"
-                    + singleKeyListeners.size()
-                    + " : "
-                    + listener);
-        }
-      }
-    }
-    return ret;
-  }
-
-  private synchronized ArrayList<KeyListener> probablyMatches(Key key, byte[] saltedKey) {
-    ArrayList<KeyListener> matches = null;
-    final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
+  private boolean removeSingleListener(ByteArrayWrapper wrapper, KeyListener listener) {
     Object o = singleKeyListeners.get(wrapper);
-    if (o != null) {
-      if (o instanceof KeyListener listener) {
-        do {
-          if (!listener.probablyWantKey(key, saltedKey)) continue;
-          matches = new ArrayList<>();
-          matches.add(listener);
-        } while (false);
-      } else {
-        KeyListener[] listeners = (KeyListener[]) o;
-        for (KeyListener listener : listeners) {
-          if (!listener.probablyWantKey(key, saltedKey)) continue;
-          if (matches == null) matches = new ArrayList<>();
-          matches.add(listener);
-        }
+    if (o == null) return false;
+    boolean ret;
+    if (o instanceof KeyListener) {
+      ret = (listener == o);
+      if (ret) singleKeyListeners.remove(wrapper);
+      return ret;
+    }
+    KeyListener[] listeners = (KeyListener[]) o;
+    return removeFromArrayMapping(listeners, wrapper, listener);
+  }
+
+  private boolean removeFromList(KeyListener listener) {
+    return keyListeners.remove(listener);
+  }
+
+  private boolean removeSingleByOwner(HasKeyListener hasListener, ByteArrayWrapper wrapper) {
+    boolean ret;
+    Object o = singleKeyListeners.get(wrapper);
+    if (o == null) return false;
+    if (o instanceof KeyListener listener) {
+      ret = (listener.getHasKeyListener() == hasListener);
+      if (ret) {
+        singleKeyListeners.remove(wrapper);
+        listener.onRemove();
+      }
+      return ret;
+    }
+    KeyListener[] listeners = (KeyListener[]) o;
+    return removeFromArrayByOwner(listeners, wrapper, hasListener);
+  }
+
+  private boolean removeListByOwner(HasKeyListener hasListener) {
+    boolean ret = false;
+    for (Iterator<KeyListener> i = keyListeners.iterator(); i.hasNext(); ) {
+      KeyListener listener = i.next();
+      if (listener.getHasKeyListener() == hasListener) {
+        ret = true;
+        i.remove();
+        listener.onRemove();
+        if (LOG.isDebugEnabled())
+          LOG.debug(
+              "Removed pending keys from {} : size now {}/{} : {}",
+              this,
+              this.keyListeners.size(),
+              singleKeyListeners.size(),
+              listener);
       }
     }
+    return ret;
+  }
+
+  private ArrayList<KeyListener> appendSingleMatches(
+      ByteArrayWrapper wrapper, Key key, byte[] saltedKey) {
+    ArrayList<KeyListener> matches = null;
+    Object o = singleKeyListeners.get(wrapper);
+    if (o instanceof KeyListener single) {
+      matches = appendMatchIfSingle(single, key, saltedKey);
+    } else if (o instanceof KeyListener[] listeners) {
+      matches = appendMatchesIfArray(listeners, key, saltedKey);
+    }
+    return matches;
+  }
+
+  private ArrayList<KeyListener> appendListMatches(
+      ArrayList<KeyListener> matches, Key key, byte[] saltedKey) {
     for (KeyListener listener : keyListeners) {
-      if (!listener.probablyWantKey(key, saltedKey)) continue;
-      if (matches == null) matches = new ArrayList<>();
+      if (listener.probablyWantKey(key, saltedKey)) {
+        if (matches == null) matches = new ArrayList<>();
+        matches.add(listener);
+      }
+    }
+    return matches;
+  }
+
+  private ArrayList<KeyListener> appendMatchIfSingle(
+      KeyListener listener, Key key, byte[] saltedKey) {
+    ArrayList<KeyListener> matches = null;
+    if (listener.probablyWantKey(key, saltedKey)) {
+      matches = new ArrayList<>();
       matches.add(listener);
     }
     return matches;
   }
 
-  public short getKeyPrio(Key key, short priority, ClientContext context) {
-    assert (key instanceof NodeSSK == isSSKScheduler);
-    byte[] saltedKey = saltKey(key);
-    ArrayList<KeyListener> matches = probablyMatches(key, saltedKey);
-    if (matches == null) return priority;
-    for (KeyListener listener : matches) {
-      short prio;
-      try {
-        prio = listener.definitelyWantKey(key, saltedKey, sched.clientContext);
-      } catch (Throwable t) {
-        LOG.error("Error in definitelyWantKey callback for %s".formatted(listener), t);
+  private ArrayList<KeyListener> appendMatchesIfArray(
+      KeyListener[] listeners, Key key, byte[] saltedKey) {
+    ArrayList<KeyListener> matches = null;
+    for (KeyListener listener : listeners) {
+      if (listener.probablyWantKey(key, saltedKey)) {
+        if (matches == null) matches = new ArrayList<>();
+        matches.add(listener);
+      }
+    }
+    return matches;
+  }
+
+  private boolean removeFromArrayMapping(
+      KeyListener[] listeners, ByteArrayWrapper wrapper, KeyListener toRemove) {
+    boolean ret = false;
+    KeyListener[] newListeners = new KeyListener[listeners.length - 1];
+    int x = 0;
+    for (KeyListener l : listeners) {
+      if (!ret && toRemove == l) {
+        ret = true;
         continue;
       }
-      if (prio == -1) continue;
-      if (prio < priority) priority = prio;
+      if (x < newListeners.length) newListeners[x++] = l;
     }
-    return priority;
-  }
-
-  public synchronized long countWaitingKeys() {
-    long count = 0;
-    for (Object o : singleKeyListeners.values()) {
-      if (o == null) {
-      } else if (o instanceof KeyListener listener1) {
-        count += listener1.countKeys();
+    if (ret) {
+      if (x < newListeners.length) newListeners = Arrays.copyOf(newListeners, x);
+      if (newListeners.length == 0) {
+        singleKeyListeners.remove(wrapper);
+      } else if (newListeners.length == 1) {
+        singleKeyListeners.put(wrapper, newListeners[0]);
       } else {
-        KeyListener[] listeners = (KeyListener[]) o;
-        for (KeyListener listener : listeners) count += listener.countKeys();
-      }
-    }
-    for (KeyListener listener : keyListeners) {
-      try {
-        count += listener.countKeys();
-      } catch (Throwable t) {
-        LOG.error("Error in countKeys callback for %s".formatted(listener), t);
-      }
-    }
-    return count;
-  }
-
-  public boolean anyWantKey(Key key, ClientContext context) {
-    assert (key instanceof NodeSSK == isSSKScheduler);
-    byte[] saltedKey = saltKey(key);
-    List<KeyListener> matches = probablyWantKey(key, saltedKey);
-    if (!matches.isEmpty()) {
-      for (KeyListener listener : matches) {
-        try {
-          if (listener.definitelyWantKey(key, saltedKey, sched.clientContext) >= 0) {
-            return true;
-          }
-        } catch (Throwable t) {
-          LOG.error("Error in definitelyWantKey callback for %s".formatted(listener), t);
-        }
-      }
-    }
-    return false;
-  }
-
-  public synchronized boolean anyProbablyWantKey(Key key, ClientContext context) {
-    assert (key instanceof NodeSSK == isSSKScheduler);
-    byte[] saltedKey = saltKey(key);
-    final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
-    Object o = singleKeyListeners.get(wrapper);
-    if (o == null) {
-      // do nothing
-    } else if (o instanceof KeyListener listener) {
-      if (listener.probablyWantKey(key, saltedKey)) return true;
-    } else {
-      KeyListener[] listeners = (KeyListener[]) o;
-      for (KeyListener listener : listeners) {
-        if (listener.probablyWantKey(key, saltedKey)) return true;
-      }
-    }
-    for (KeyListener listener : keyListeners) {
-      try {
-        if (listener.probablyWantKey(key, saltedKey)) {
-          return true;
-        }
-      } catch (Throwable t) {
-        LOG.error("Error in probablyWantKey callback for %s".formatted(listener), t);
-      }
-    }
-    return false;
-  }
-
-  public boolean tripPendingKey(Key key, KeyBlock block, ClientContext context) {
-    if ((key instanceof NodeSSK) != isSSKScheduler) {
-      LOG.warn("Key {} on scheduler ssk={}", key, isSSKScheduler);
-      return false;
-    }
-    assert (key instanceof NodeSSK == isSSKScheduler);
-    byte[] saltedKey = saltKey(key);
-    ArrayList<KeyListener> matches = probablyMatches(key, saltedKey);
-    boolean ret = false;
-    if (matches != null) {
-      for (KeyListener listener : matches) {
-        try {
-          if (listener.handleBlock(key, saltedKey, block, context)) {
-            ret = true;
-          }
-        } catch (Throwable t) {
-          LOG.error("Error in handleBlock callback for %s".formatted(listener), t);
-        }
-        if (listener.isEmpty()) {
-          try {
-            removePendingKeys(listener);
-          } catch (Throwable t) {
-            LOG.error("Error while removing %s".formatted(listener), t);
-          }
-        }
+        singleKeyListeners.put(wrapper, newListeners);
       }
     }
     return ret;
   }
 
-  public SendableGet[] requestsForKey(Key key, ClientContext context) {
-    ArrayList<SendableGet> list = new ArrayList<>();
-    assert (key instanceof NodeSSK == isSSKScheduler);
-    byte[] saltedKey = saltKey(key);
-    List<KeyListener> matches = probablyWantKey(key, saltedKey);
-    if (matches == null) return null;
-    for (KeyListener listener : matches) {
-      SendableGet[] reqs;
+  private boolean removeFromArrayByOwner(
+      KeyListener[] listeners, ByteArrayWrapper wrapper, HasKeyListener owner) {
+    RemovalAccum accum = scanRemovalByOwner(listeners, owner);
+    if (accum.removed) finalizeOwnerRemoval(wrapper, accum.newListeners, accum.count, accum.msg);
+    return accum.removed;
+  }
+
+  private void finalizeOwnerRemoval(
+      ByteArrayWrapper wrapper, KeyListener[] newListeners, int x, String msg) {
+    if (x < newListeners.length) newListeners = Arrays.copyOf(newListeners, x);
+    if (newListeners.length == 0) {
+      singleKeyListeners.remove(wrapper);
+    } else if (newListeners.length == 1) {
+      singleKeyListeners.put(wrapper, newListeners[0]);
+    } else {
+      singleKeyListeners.put(wrapper, newListeners);
+    }
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "Removed pending keys from {} : size now {}/{}{}",
+          this,
+          this.keyListeners.size(),
+          singleKeyListeners.size(),
+          msg);
+  }
+
+  private static final class RemovalAccum {
+    boolean removed;
+    KeyListener[] newListeners;
+    int count;
+    String msg;
+
+    RemovalAccum(int size) {
+      this.newListeners = new KeyListener[size];
+      this.count = 0;
+      this.removed = false;
+      this.msg = null;
+    }
+  }
+
+  private RemovalAccum scanRemovalByOwner(KeyListener[] listeners, HasKeyListener owner) {
+    RemovalAccum accum = new RemovalAccum(listeners.length - 1);
+    if (LOG.isDebugEnabled()) accum.msg = "";
+    for (KeyListener l : listeners) {
+      if (l.getHasKeyListener() == owner) {
+        accum.removed = true;
+        l.onRemove();
+        if (LOG.isDebugEnabled()) accum.msg = "%s : %s".formatted(accum.msg, l);
+      } else if (accum.count < accum.newListeners.length) {
+        accum.newListeners[accum.count++] = l;
+      }
+    }
+    return accum;
+  }
+
+  private boolean anySingleProbablyWant(Key key, byte[] saltedKey) {
+    final ByteArrayWrapper wrapper = new ByteArrayWrapper(saltedKey);
+    Object o = singleKeyListeners.get(wrapper);
+    if (o instanceof KeyListener listener) {
+      return listener.probablyWantKey(key, saltedKey);
+    }
+    if (o instanceof KeyListener[] listeners) {
+      for (KeyListener listener : listeners) {
+        if (listener.probablyWantKey(key, saltedKey)) return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean anyListProbablyWant(Key key, byte[] saltedKey) {
+    for (KeyListener listener : keyListeners) {
       try {
-        reqs = listener.getRequestsForKey(key, saltedKey, context);
-      } catch (Throwable t) {
-        LOG.error("Error in getRequestsForKey callback for %s".formatted(listener), t);
-        continue;
-      }
-      if (reqs == null) {
-        continue;
-      }
-      Collections.addAll(list, reqs);
-    }
-    if (list.isEmpty()) {
-      return null;
-    }
-    return list.toArray(new SendableGet[0]);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(super.toString());
-    sb.append(':');
-    if (isInsertScheduler) sb.append("insert:");
-    if (isSSKScheduler) sb.append("SSK");
-    else sb.append("CHK");
-    return sb.toString();
-  }
-
-  public byte[] globalSalt;
-
-  public byte[] saltKey(Key key) {
-    return saltKey(key instanceof NodeSSK nssk ? nssk.getPubKeyHash() : key.getRoutingKey());
-  }
-
-  private byte[] saltKey(byte[] key) {
-    if (isSSKScheduler) return key;
-    MessageDigest md = SHA256.getMessageDigest();
-    md.update(key);
-    md.update(globalSalt);
-    return md.digest();
-  }
-
-  protected void hintGlobalSalt(byte[] globalSalt2) {
-    if (globalSalt == null) globalSalt = globalSalt2;
-  }
-
-  /** Returns all KeyListeners that return true on probablyWantKey(key, saltedKey) */
-  private List<KeyListener> probablyWantKey(Key key, byte[] saltedKey) {
-    ArrayList<KeyListener> matches = new ArrayList<>();
-    synchronized (this) {
-      for (KeyListener listener : keyListeners) {
-        try {
-          if (!listener.probablyWantKey(key, saltedKey)) {
-            continue;
-          }
-        } catch (Throwable t) {
-          LOG.error("Error in probablyWantKey callback for %s".formatted(listener), t);
-          continue;
+        if (listener.probablyWantKey(key, saltedKey)) {
+          return true;
         }
-        matches.add(listener);
+      } catch (Exception t) {
+        LOG.error("Error in probablyWantKey callback for {}", listener, t);
       }
     }
-    return matches;
+    return false;
+  }
+
+  private boolean processTripMatches(
+      Key key, byte[] saltedKey, KeyBlock block, ClientContext context, List<KeyListener> matches) {
+    boolean ret = false;
+    for (KeyListener listener : matches) {
+      try {
+        if (listener.handleBlock(key, saltedKey, block, context)) {
+          ret = true;
+        }
+      } catch (Exception t) {
+        LOG.error("Error in handleBlock callback for {}", listener, t);
+      }
+      if (listener.isEmpty()) {
+        try {
+          removePendingKeys(listener);
+        } catch (Exception t) {
+          LOG.error("Error while removing {}", listener, t);
+        }
+      }
+    }
+    return ret;
   }
 }

--- a/src/main/java/network/crypta/client/async/KeySalter.java
+++ b/src/main/java/network/crypta/client/async/KeySalter.java
@@ -3,13 +3,55 @@ package network.crypta.client.async;
 import network.crypta.keys.Key;
 
 /**
- * This is a separate interface so we don't need to pass the scheduler where it's not needed. Also,
- * it should probably be a separate class ...
+ * Strategy interface for deriving a salted, scheduler-scoped byte array from a {@link Key}.
  *
+ * <p>This abstraction decouples components that need a stable identifier for request tracking from
+ * the details of how that identifier is derived. Implementations typically combine properties of
+ * the input key with an internal salt to produce an opaque byte sequence suitable for use as a map
+ * key or set membership token. Equality of the returned arrays is meaningful only within the scope
+ * of a single {@code KeySalter} instance: the same key salted by the same instance produces the
+ * same bytes, while different instances (or different lifetimes) may intentionally yield different
+ * results to avoid unwanted cross-run correlations.
+ *
+ * <p>The salted representation is not a serialization of the key and must be treated as
+ * implementation-defined and non-reversible. Callers should not assume a specific length or
+ * structure beyond general byte-array semantics. Implementations are expected to be thread-safe for
+ * concurrent calls and side-effect free; the method returns a fresh array for each invocation and
+ * does not retain references provided by callers.
+ *
+ * <ul>
+ *   <li>Stable within an instance: identical inputs map to identical outputs.
+ *   <li>Opaque to callers: the content and length are not part of the API.
+ *   <li>Scope-bound: outputs from different salters must not be compared for equality.
+ * </ul>
+ *
+ * @see ClientRequestScheduler#saltKey(boolean, Key)
+ * @see ClientRequestScheduler#getGlobalKeySalter(boolean)
+ * @see KeyListenerTracker
  * @author toad
  */
 public interface KeySalter {
 
-  /** Convert a Key to a byte[], using a global, random salt value. */
+  /**
+   * Returns a salted, opaque representation of the supplied {@link Key} for internal tracking.
+   *
+   * <p>The derivation is deterministic within the lifetime and configuration of this {@code
+   * KeySalter} instance and is intended for use as a lookup key in in-memory data structures. The
+   * returned array is newly allocated and should be treated as immutable by callers. The exact
+   * bytes, length, and any hashing/salting algorithm are implementation details and may vary
+   * between environments or across restarts.
+   *
+   * <pre>{@code
+   * // Example: obtain a salted identifier for a key
+   * KeySalter salter = scheduler.getGlobalKeySalter(false);
+   * byte[] trackingId = salter.saltKey(key);
+   * }</pre>
+   *
+   * @param key the key whose scheduler-scoped salted identifier should be derived; must not be
+   *     {@code null}; accepted concrete key types determine which key properties are used
+   * @return a newly allocated, opaque byte array; equal keys salted by the same instance produce
+   *     equal arrays; content is not stable across different salters or executions
+   * @throws NullPointerException if {@code key} is {@code null}
+   */
   byte[] saltKey(Key key);
 }

--- a/src/main/java/network/crypta/client/async/SingleKeyListener.java
+++ b/src/main/java/network/crypta/client/async/SingleKeyListener.java
@@ -8,6 +8,38 @@ import network.crypta.node.SendableGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Listener implementation optimized for tracking a single target key.
+ *
+ * <p>{@code SingleKeyListener} is a small, allocation-light {@link KeyListener} that answers
+ * screening queries for exactly one node-level {@link network.crypta.keys.Key}. It is created by a
+ * {@link BaseSingleFileFetcher} to watch the fetch pipeline for its single block and to forward the
+ * first matching {@link network.crypta.keys.KeyBlock} to the owner. The class avoids storing large
+ * state and keeps its fast paths branch-free where possible so callers may invoke it inside
+ * scheduler hot paths. Once a match is processed or the owner is removed, the listener marks itself
+ * as done and becomes effectively inert.
+ *
+ * <p>Usage and lifecycle:
+ *
+ * <ul>
+ *   <li>Constructed internally by {@link BaseSingleFileFetcher#makeKeyListener(ClientContext,
+ *       boolean)}; not intended for general reuse.
+ *   <li>{@link #probablyWantKey(network.crypta.keys.Key, byte[])} quickly rejects non-matching
+ *       keys; {@link #definitelyWantKey(network.crypta.keys.Key, byte[], ClientContext)} returns
+ *       the owner’s priority for the single matching key.
+ *   <li>{@link #handleBlock(network.crypta.keys.Key, byte[], network.crypta.keys.KeyBlock,
+ *       ClientContext)} delivers the block to the owner and then finalizes the listener.
+ * </ul>
+ *
+ * <p>Thread-safety: instances are not generally thread-safe beyond a narrow synchronized section
+ * that flips the internal {@code done} flag. Callers should avoid blocking the listener on external
+ * locks. Mutability is limited to completion bookkeeping; the target key and priority are immutable
+ * after construction.
+ *
+ * @see BaseSingleFileFetcher
+ * @see HasKeyListener
+ * @see KeyListener
+ */
 public class SingleKeyListener implements KeyListener {
   private static final Logger LOG = LoggerFactory.getLogger(SingleKeyListener.class);
 
@@ -17,6 +49,17 @@ public class SingleKeyListener implements KeyListener {
   private final short prio;
   private final boolean persistent;
 
+  /**
+   * Creates a listener bound to a single node-level key.
+   *
+   * <p>The listener answers interest checks for {@code key} and passes any matching block to {@code
+   * fetcher}. The instance becomes inactive after a successful hand-off or explicit removal.
+   *
+   * @param key node-level key to watch for; must be non-null and stable for the listener lifetime
+   * @param fetcher owning single-file fetcher that will receive matching blocks and error callbacks
+   * @param prio priority class to report when the key matches; used by schedulers to order work
+   * @param persistent whether the owning fetch is persistent across restarts; affects scheduling
+   */
   public SingleKeyListener(Key key, BaseSingleFileFetcher fetcher, short prio, boolean persistent) {
     this.key = key;
     this.fetcher = fetcher;
@@ -24,41 +67,49 @@ public class SingleKeyListener implements KeyListener {
     this.persistent = persistent;
   }
 
+  /** {@inheritDoc} */
   @Override
   public long countKeys() {
     if (done) return 0;
     else return 1;
   }
 
+  /** {@inheritDoc} */
   @Override
   public short definitelyWantKey(Key key, byte[] saltedKey, ClientContext context) {
     if (!key.equals(this.key)) return -1;
     else return prio;
   }
 
+  /** {@inheritDoc} */
   @Override
   public HasKeyListener getHasKeyListener() {
     return fetcher;
   }
 
+  /** {@inheritDoc} */
   @Override
   public short getPriorityClass() {
     return prio;
   }
 
+  /** {@inheritDoc} */
   @Override
+  @SuppressWarnings("java:S1168")
   public SendableGet[] getRequestsForKey(Key key, byte[] saltedKey, ClientContext context) {
     if (!key.equals(this.key)) return null;
     return new SendableGet[] {fetcher};
   }
 
+  /** {@inheritDoc} */
   @Override
+  @SuppressWarnings("java:S1181")
   public boolean handleBlock(Key key, byte[] saltedKey, KeyBlock found, ClientContext context) {
     if (!key.equals(this.key)) return false;
     try {
       fetcher.onGotKey(key, found, context);
     } catch (Throwable t) {
-      LOG.error("Failed: " + t, t);
+      LOG.error("Failed: {}", t, t);
       fetcher.onFailure(
           new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR, t), null, context);
     }
@@ -68,32 +119,38 @@ public class SingleKeyListener implements KeyListener {
     return true;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean persistent() {
     return persistent;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean probablyWantKey(Key key, byte[] saltedKey) {
     if (done) return false;
     return key.equals(this.key);
   }
 
+  /** {@inheritDoc} */
   @Override
   public synchronized void onRemove() {
     done = true;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean isEmpty() {
     return done;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean isSSK() {
     return key instanceof NodeSSK;
   }
 
+  /** {@inheritDoc} */
   @Override
   public byte[] getWantedKey() {
     return key instanceof NodeSSK nssk ? nssk.getPubKeyHash() : key.getRoutingKey();

--- a/src/main/java/network/crypta/client/async/SplitFileFetcherKeyListener.java
+++ b/src/main/java/network/crypta/client/async/SplitFileFetcherKeyListener.java
@@ -22,11 +22,55 @@ import network.crypta.support.io.StorageFormatException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * KeyListener implementation that uses layered Bloom filters to decide whether a fetched key is
+ * relevant to an in‑progress splitfile download.
+ *
+ * <p>This listener maintains two tiers of probabilistic membership structures: a global counting
+ * Bloom filter that tracks all outstanding keys for the whole fetch, and a fixed array of
+ * per‑segment Bloom filters that narrow the decision to a specific segment. Callers first consult
+ * {@link #probablyWantKey(Key, byte[])} with the globally salted routing key. If the main filter
+ * matches, a local salt is applied and the per‑segment filters are checked. A positive match from
+ * both tiers allows the caller to escalate to {@link #definitelyWantKey(Key, byte[],
+ * ClientContext)} and eventually {@link #handleBlock(Key, byte[], KeyBlock, ClientContext)}.
+ *
+ * <p>When configured as {@linkplain #persistent() persistent}, the listener serializes its Bloom
+ * filters to disk so long‑running fetches can resume without recomputing filter contents. The main
+ * filter is mutable and written lazily as keys are consumed; per‑segment filters are immutable once
+ * built and are written once. The class is thread‑aware: short hot‑path methods avoid blocking and
+ * use minimal synchronized sections. Internal buffers are heap‑backed and do not require explicit
+ * closing.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> fast screening of keys, segment localization, and
+ *       removal of consumed keys from the main filter.
+ *   <li><strong>Notable behavior:</strong> two independent salts are used—one global (provided by
+ *       the caller as {@code saltedKey}) and one local (applied here) to reduce cross‑talk between
+ *       tiers.
+ *   <li><strong>Concurrency:</strong> mutation of filters is guarded; read checks favor low
+ *       contention and avoid I/O.
+ * </ul>
+ *
+ * @see SplitFileFetcherStorage
+ * @see SplitFileFetcherStorageCallback
+ * @see BinaryBloomFilter
+ * @see CountingBloomFilter
+ * @see KeyListener
+ * @see NodeCHK
+ * @see CHKBlock
+ */
 public class SplitFileFetcherKeyListener implements KeyListener {
   private static final Logger LOG = LoggerFactory.getLogger(SplitFileFetcherKeyListener.class);
 
-  static {
-  }
+  /**
+   * Upper bound for the serialized main Bloom filter size in bytes.
+   *
+   * <p>This mirrors the maximum size implied by the constructor path where the number of Bloom
+   * filter bits is capped to {@link Integer#MAX_VALUE} and then converted to a counting Bloom
+   * filter (bytes = bits/8 * 2).
+   */
+  private static final int MAX_MAIN_BLOOM_FILTER_SIZE_BYTES =
+      (int) (((Integer.MAX_VALUE + 7L) & ~7L) / 8L * 2L);
 
   final SplitFileFetcherStorage storage;
   final SplitFileFetcherStorageCallback fetcher;
@@ -81,13 +125,37 @@ public class SplitFileFetcherKeyListener implements KeyListener {
   /** Does the main bloom filter need writing? */
   private boolean dirty;
 
-  private transient boolean mustRegenerateMainFilter;
-  private transient boolean mustRegenerateSegmentFilters;
+  private boolean mustRegenerateMainFilter;
+  private boolean mustRegenerateSegmentFilters;
+
+  // No dedicated close lifecycle: filters are heap-backed here and do not
+  // require explicit closing; cleanup is deferred to GC.
 
   /**
-   * Create a set of bloom filters for a new download.
+   * Create a listener and initialize in‑memory Bloom filters for a new splitfile download.
    *
-   * @throws FetchException
+   * <p>This constructor builds the global counting Bloom filter and one immutable per‑segment Bloom
+   * filter for each segment. Sizes are derived from the total number of blocks and segments in
+   * order to achieve a small, bounded false‑positive rate. No disk I/O occurs here; callers may
+   * persist the filters later via {@link #innerWriteMainBloomFilter(long)} and {@link
+   * #initialWriteSegmentBloomFilters(long)} when appropriate.
+   *
+   * @param fetcher callback that provides priority and failure handling; never {@code null}; used
+   *     to propagate disk errors and obtain the request priority class
+   * @param storage backing storage that exposes segment metadata and persistence helpers; must
+   *     correspond to the same splitfile layout and segment count supplied below
+   * @param persistent whether this listener participates in persistence and triggers lazy metadata
+   *     writes after key removals; {@code true} enables on‑disk snapshots
+   * @param localSalt 32‑byte salt applied locally before querying per‑segment filters; the array is
+   *     read only by the listener and not modified
+   * @param origSize total number of blocks across all segments; must be positive and reflect the
+   *     original splitfile size as scheduled by the fetcher
+   * @param segBlocks number of blocks per segment used to size per‑segment filters; must be
+   *     positive and will be capped at {@code origSize}
+   * @param segments number of segments in the splitfile; must be positive and match {@code
+   *     storage.segments.length}
+   * @throws FetchException when any of the numeric arguments are non‑positive or imply a Bloom
+   *     filter larger than the supported bounds for this implementation
    */
   public SplitFileFetcherKeyListener(
       SplitFileFetcherStorageCallback fetcher,
@@ -149,6 +217,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
       ByteBuffer slice;
 
       slice = baseBuffer.slice();
+      //noinspection resource
       segmentFilters[i] =
           new BinaryBloomFilter(slice, perSegmentBloomFilterSizeBytes * 8, perSegmentK);
       start += perSegmentBloomFilterSizeBytes;
@@ -159,6 +228,30 @@ public class SplitFileFetcherKeyListener implements KeyListener {
     filter.setWarnOnRemoveFromEmpty();
   }
 
+  /**
+   * Reconstruct a listener and its Bloom filter state from persisted metadata.
+   *
+   * <p>This constructor restores the fixed per‑segment Bloom filters from the storage file and, if
+   * the salt has not changed, attempts to restore the mutable main counting Bloom filter as well. A
+   * failed checksum for either region marks the corresponding structure for regeneration; callers
+   * should subsequently feed all keys back through {@link #addKey(Key, int, KeySalter)} and call
+   * {@link #addedAllKeys()} once complete. No network activity is triggered by this method.
+   *
+   * @param storage backing storage that provides offsets and lengths for the persisted filter
+   *     regions; must expose a consistent {@code segments} array for sizing
+   * @param callback fetcher callback that supplies priority and failure reporting; must not be
+   *     {@code null}
+   * @param dis input stream positioned at the beginning of this listener's static settings; the
+   *     method reads {@code localSalt}, sizes, and hash counts in the order written by {@link
+   *     #writeStaticSettings(DataOutputStream)}
+   * @param persistent whether this instance will perform lazy metadata writes when keys are
+   *     removed; set according to the parent fetch configuration
+   * @param newSalt when {@code true}, the main Bloom filter is not read from disk because the salt
+   *     differs; the filter will be regenerated from keys instead
+   * @throws IOException if the input stream cannot be read fully for settings or filter regions
+   * @throws StorageFormatException when the persisted sizes or parameters are invalid or when a
+   *     checksum verification fails for a region that must be readable
+   */
   public SplitFileFetcherKeyListener(
       SplitFileFetcherStorage storage,
       SplitFileFetcherStorageCallback callback,
@@ -172,9 +265,10 @@ public class SplitFileFetcherKeyListener implements KeyListener {
     localSalt = new byte[32];
     dis.readFully(localSalt);
     mainBloomFilterSizeBytes = dis.readInt();
-    // FIXME impose an upper bound based on estimate of bits per key.
-    if (mainBloomFilterSizeBytes < 0)
+    if (mainBloomFilterSizeBytes < 0
+        || mainBloomFilterSizeBytes > MAX_MAIN_BLOOM_FILTER_SIZE_BYTES) {
       throw new StorageFormatException("Bad main bloom filter size");
+    }
     mainBloomK = dis.readInt();
     if (mainBloomK < 1) throw new StorageFormatException("Bad main bloom filter K");
     perSegmentBloomFilterSizeBytes = dis.readInt();
@@ -190,12 +284,10 @@ public class SplitFileFetcherKeyListener implements KeyListener {
           storage.offsetSegmentBloomFilters, segmentsFilterBuffer, 0, segmentsFilterBuffer.length);
     } catch (ChecksumFailedException e) {
       LOG.error(
-          "Checksummed read for segment filters at "
-              + storage.offsetSegmentBloomFilters
-              + " failed for "
-              + this
-              + ": "
-              + e);
+          "Checksummed read for segment filters at {} failed for {}",
+          storage.offsetSegmentBloomFilters,
+          this,
+          e);
       mustRegenerateSegmentFilters = true;
     }
     ByteBuffer baseBuffer = ByteBuffer.wrap(segmentsFilterBuffer);
@@ -207,6 +299,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
       ByteBuffer slice;
 
       slice = baseBuffer.slice();
+      //noinspection resource
       segmentFilters[i] =
           new BinaryBloomFilter(slice, perSegmentBloomFilterSizeBytes * 8, perSegmentK);
       start += perSegmentBloomFilterSizeBytes;
@@ -219,12 +312,10 @@ public class SplitFileFetcherKeyListener implements KeyListener {
             storage.offsetMainBloomFilter, filterBuffer, 0, mainBloomFilterSizeBytes);
       } catch (ChecksumFailedException e) {
         LOG.error(
-            "Checksummed read for main filters at "
-                + storage.offsetMainBloomFilter
-                + " failed for "
-                + this
-                + ": "
-                + e);
+            "Checksummed read for main filters at {} failed for {}",
+            storage.offsetMainBloomFilter,
+            this,
+            e);
         mustRegenerateMainFilter = true;
       }
     } else {
@@ -234,11 +325,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
     filter.setWarnOnRemoveFromEmpty();
   }
 
-  /**
-   * SplitFileFetcher adds keys in whatever blocks are convenient.
-   *
-   * @param keys
-   */
+  /** SplitFileFetcher adds keys in whatever blocks are convenient. */
   synchronized void addKey(Key key, int segNo, KeySalter salter) {
     if (finishedSetup && !(mustRegenerateMainFilter || mustRegenerateSegmentFilters))
       throw new IllegalStateException();
@@ -250,8 +337,6 @@ public class SplitFileFetcherKeyListener implements KeyListener {
       byte[] localSalted = localSaltKey(key);
       segmentFilters[segNo].addKey(localSalted);
     }
-    //      if(!segmentFilters[segNo].checkFilter(localSalted))
-    //          LOG.error("Key added but not in filter: "+key+" on "+this);
   }
 
   synchronized void finishedSetup() {
@@ -270,11 +355,12 @@ public class SplitFileFetcherKeyListener implements KeyListener {
    * Include a checksum.
    */
   void initialWriteSegmentBloomFilters(long fileOffset) throws IOException {
-    OutputStream cos = storage.writeChecksummedTo(fileOffset, totalSegmentBloomFiltersSize());
-    for (BinaryBloomFilter segFilter : segmentFilters) {
-      segFilter.writeTo(cos);
+    try (OutputStream cos =
+        storage.writeChecksummedTo(fileOffset, totalSegmentBloomFiltersSize())) {
+      for (BinaryBloomFilter segFilter : segmentFilters) {
+        segFilter.writeTo(cos);
+      }
     }
-    cos.close();
   }
 
   int totalSegmentBloomFiltersSize() {
@@ -291,22 +377,33 @@ public class SplitFileFetcherKeyListener implements KeyListener {
 
   /** Write the main segment filter, which does get updated. Include a checksum. */
   void innerWriteMainBloomFilter(long fileOffset) throws IOException {
-    OutputStream cos = storage.writeChecksummedTo(fileOffset, paddedMainBloomFilterSize());
-    filter.writeTo(cos);
-    cos.close();
+    try (OutputStream cos = storage.writeChecksummedTo(fileOffset, paddedMainBloomFilterSize())) {
+      filter.writeTo(cos);
+    }
   }
 
+  /**
+   * Return the on‑disk size of the main Bloom filter region including checksum padding.
+   *
+   * <p>The main counting Bloom filter is stored as {@code mainBloomFilterSizeBytes} followed by the
+   * storage's checksum. This method returns their sum, which is the exact length written by {@link
+   * #innerWriteMainBloomFilter(long)} and expected by the corresponding read path.
+   *
+   * @return total number of bytes written for the main filter, i.e., raw filter size plus checksum
+   *     trailer; the value is non‑negative and stable for the lifetime of the instance
+   */
   public int paddedMainBloomFilterSize() {
     assert (mainBloomFilterSizeBytes == filter.getSizeBytes());
     return mainBloomFilterSizeBytes + storage.checksumLength;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean probablyWantKey(Key key, byte[] saltedKey) {
     if (filter.checkFilter(saltedKey)) {
       byte[] salted = localSaltKey(key);
-      for (int i = 0; i < segmentFilters.length; i++) {
-        if (segmentFilters[i].checkFilter(salted)) {
+      for (BinaryBloomFilter segmentFilter : segmentFilters) {
+        if (segmentFilter.checkFilter(salted)) {
           return true;
         }
       }
@@ -314,24 +411,29 @@ public class SplitFileFetcherKeyListener implements KeyListener {
     return false;
   }
 
+  /** {@inheritDoc} */
   @Override
   public short definitelyWantKey(Key key, byte[] saltedKey, ClientContext context) {
     // Caller has already called probablyWantKey(), so don't do it again.
     byte[] salted = localSaltKey(key);
     for (int i = 0; i < segmentFilters.length; i++) {
-      if (segmentFilters[i].checkFilter(salted)) {
-        if (storage.segments[i].definitelyWantKey((NodeCHK) key)) return fetcher.getPriorityClass();
+      if (segmentFilters[i].checkFilter(salted)
+          && storage.segments[i].definitelyWantKey((NodeCHK) key)) {
+        return fetcher.getPriorityClass();
       }
     }
     return -1;
   }
 
+  /** {@inheritDoc} */
   @Override
+  @SuppressWarnings("java:S1168")
   public SendableGet[] getRequestsForKey(Key key, byte[] saltedKey, ClientContext context) {
-    // FIXME Ignored. We don't use the cooldown *queue*.
+    // Not used by this listener; cooldown queue is not employed here.
     return null;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean handleBlock(Key key, byte[] saltedKey, KeyBlock block, ClientContext context) {
     // Caller has already called probablyWantKey(), so don't do it again.
@@ -362,47 +464,124 @@ public class SplitFileFetcherKeyListener implements KeyListener {
     return found;
   }
 
+  /**
+   * Whether this listener participates in persistence flows.
+   *
+   * <p>When {@code true}, the listener requests that its owning storage write metadata lazily after
+   * successful block processing (e.g., updating the main Bloom filter on disk). A {@code false}
+   * value means the filters remain purely in memory.
+   *
+   * @return {@code true} when persistence is enabled for this instance; otherwise {@code false}
+   */
   @Override
   public boolean persistent() {
     return persistent;
   }
 
+  /**
+   * Return the request priority to use for keys accepted by this listener.
+   *
+   * <p>The value is delegated to the {@link SplitFileFetcherStorageCallback} provided at
+   * construction time so the listener remains a thin screen that does not own scheduling policy.
+   *
+   * @return the priority class associated with the parent fetcher
+   */
   @Override
   public short getPriorityClass() {
     return fetcher.getPriorityClass();
   }
 
+  /**
+   * Unsupported for this listener: counting is not used in the current fetch strategy.
+   *
+   * <p>Some persistent fetches track the number of outstanding keys; this implementation does not
+   * support that operation and signals it explicitly via an exception.
+   *
+   * @throws UnsupportedOperationException always thrown by this implementation
+   */
   @Override
   public long countKeys() {
-    // FIXME remove. Only used by persistent fetches.
+    // Not used except for persistent fetches; unsupported here.
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Return the owner that supplies this listener and related callbacks.
+   *
+   * @return the {@link HasKeyListener} associated with the parent fetch operation
+   */
   @Override
   public HasKeyListener getHasKeyListener() {
     return fetcher.getHasKeyListener();
   }
 
+  /**
+   * Notification that the listener is being detached from the owning request.
+   *
+   * <p>The listener does not hold external resources and therefore performs no active cleanup.
+   * Asynchronous writers may still complete; filter buffers are heap‑backed and left to GC.
+   */
   @Override
   public void onRemove() {
-    // Ignore.
+    // Defer resource cleanup: asynchronous metadata writers may still call into
+    // maybeWriteMainBloomFilter() after deregistration. The owning storage closes
+    // these resources once finishing is guaranteed.
   }
 
+  // Intentionally no explicit close() — writing jobs may still reference the filters
+  // after listener removal; filters are heap-backed, so early release is unnecessary.
+
+  /**
+   * Report whether the listener has no remaining work.
+   *
+   * <p>This delegates to the underlying storage to determine if the associated splitfile fetch has
+   * finished. A {@code true} value allows callers to retire the listener early.
+   *
+   * @return {@code true} when the owning storage reports completion; otherwise {@code false}
+   */
   @Override
   public boolean isEmpty() {
     return storage.hasFinished();
   }
 
+  /**
+   * Indicate whether the listener is for SSK keys rather than CHK.
+   *
+   * <p>This implementation serves CHK content only and therefore always returns {@code false}.
+   *
+   * @return {@code false} for CHK‑only listeners
+   */
   @Override
   public boolean isSSK() {
     return false;
   }
 
+  /**
+   * Optionally return a single key of immediate interest.
+   *
+   * <p>Unused by this listener; returning {@code null} communicates that there is no special key to
+   * prioritize outside the regular filtering flow.
+   *
+   * @return {@code null} because no single key is preferred
+   */
   @Override
+  @SuppressWarnings("java:S1168")
   public byte[] getWantedKey() {
     return null;
   }
 
+  /**
+   * Write immutable listener parameters that are required to reconstruct filter state.
+   *
+   * <p>The method writes, in order: {@code localSalt} (32 bytes), {@code mainBloomFilterSizeBytes},
+   * {@code mainBloomK}, {@code perSegmentBloomFilterSizeBytes}, and {@code perSegmentK}. It does
+   * not write the main or per‑segment filter contents; those regions are handled separately using
+   * checksummed blobs.
+   *
+   * @param dos target stream used to serialize settings; must remain open for subsequent writes by
+   *     the caller; the method does not close the stream
+   * @throws IOException if any of the setting values cannot be written to the destination stream
+   */
   public void writeStaticSettings(DataOutputStream dos) throws IOException {
     dos.write(localSalt);
     dos.writeInt(mainBloomFilterSizeBytes);
@@ -411,10 +590,27 @@ public class SplitFileFetcherKeyListener implements KeyListener {
     dos.writeInt(perSegmentK);
   }
 
+  /**
+   * Indicate whether the caller must re‑feed all keys to rebuild one or more filters.
+   *
+   * <p>After a failed checksum validation or when a new salt is introduced, this method returns
+   * {@code true} until {@link #addedAllKeys()} is invoked. Callers can use it to decide whether to
+   * schedule a full key scan to repopulate in‑memory structures.
+   *
+   * @return {@code true} when at least one Bloom filter requires regeneration from the key set;
+   *     {@code false} when all filters are up‑to‑date
+   */
   public boolean needsKeys() {
     return mustRegenerateMainFilter || mustRegenerateSegmentFilters;
   }
 
+  /**
+   * Mark filter reconstruction complete after all keys have been supplied.
+   *
+   * <p>Call this once the caller has replayed every relevant key via {@link #addKey(Key, int,
+   * KeySalter)}. It clears pending regeneration flags and flips the listener into the steady state
+   * where only the main counting Bloom filter is mutated as blocks arrive.
+   */
   public void addedAllKeys() {
     mustRegenerateMainFilter = false;
     mustRegenerateSegmentFilters = false;

--- a/src/main/java/network/crypta/client/async/USKFetcher.java
+++ b/src/main/java/network/crypta/client/async/USKFetcher.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  * <p>Lifecycle and behavior:
  *
  * <ul>
- *   <li>At most one {@code USKFetcher} is active per USK and it registers itself with the {@code
+ *   <li>At most one {@code USKFetcher} is active per USK, and it registers itself with the {@code
  *       USKManager} to receive discovery events such as newly found slots.
  *   <li>Subscribers and callbacks do not receive data directly from this class but influence
  *       whether to continue polling and at which priority, enabling interactive workloads to
@@ -87,8 +87,6 @@ import org.slf4j.LoggerFactory;
 public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, KeyListener {
   private static final Logger LOG = LoggerFactory.getLogger(USKFetcher.class);
   private static final String FOR_LITERAL = " for ";
-
-  // Static initializer removed as it was empty and unnecessary.
 
   /** USK manager */
   private final USKManager uskManager;
@@ -201,6 +199,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     }
 
     @Override
+    @SuppressWarnings("java:S1181")
     public void onSuccess(
         StreamGenerator streamGenerator,
         ClientMetadata clientMetadata,
@@ -221,20 +220,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
             DecompressorThreadManager decompressorManager =
                 new DecompressorThreadManager(pipeIn, decompressors, maxLen);
             PipedInputStream newPipeIn = decompressorManager.execute();
-            ClientGetWorkerThread worker =
-                new ClientGetWorkerThread(
-                    new BufferedInputStream(newPipeIn),
-                    output,
-                    null,
-                    null,
-                    new ClientGetWorkerThread.Options(
-                        null,
-                        ctx.getSchemeHostAndPort(),
-                        false,
-                        null,
-                        null,
-                        null,
-                        context.linkFilterExceptionProvider));
+            ClientGetWorkerThread worker = createClientGetWorkerThread(newPipeIn, output, context);
             worker.start();
             streamGenerator.writeTo(pipeOut, context);
             decompressorManager.waitFinished();
@@ -403,6 +389,35 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
     public void cancel(ClientContext context) {
       this.fetcher.cancel(context);
+    }
+
+    /**
+     * Creates a {@link ClientGetWorkerThread} configured for DBR hint processing.
+     *
+     * <p>Encapsulates the verbose constructor so the success handler remains readable. The returned
+     * worker is not started.
+     *
+     * @param in upstream input (typically from {@link DecompressorThreadManager#execute()})
+     * @param output destination stream for decoded content
+     * @param context client context providing link filter exception provider
+     * @return a newly constructed, non-started worker
+     */
+    private ClientGetWorkerThread createClientGetWorkerThread(
+        java.io.InputStream in, OutputStream output, ClientContext context)
+        throws java.net.URISyntaxException {
+      return new ClientGetWorkerThread(
+          new BufferedInputStream(in),
+          output,
+          null,
+          null,
+          new ClientGetWorkerThread.Options(
+              null,
+              ctx.getSchemeHostAndPort(),
+              false,
+              null,
+              null,
+              null,
+              context.linkFilterExceptionProvider));
     }
   }
 
@@ -1358,7 +1373,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
     synchronized (this) {
       localCallbacks = subscribers.toArray(new USKCallback[0]);
       // Callbacks also determine the fetcher's priority.
-      // Otherwise USKFetcherTag would have no way to tell us the priority we should run at.
+      // Otherwise, USKFetcherTag would have no way to tell us the priority we should run at.
       fetcherCallbacks = callbacks.toArray(new USKFetcherCallback[0]);
     }
     if (noCallbacks(localCallbacks, fetcherCallbacks)) {
@@ -2044,7 +2059,8 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
    * polling attempts so they take effect without reconstructing requests. For broader
    * configuration, see the tracker discussion linked below.
    *
-   * <p>See: https://bugs.freenetproject.org/view.php?id=4984
+   * <p>See: <a
+   * href="https://bugs.freenetproject.org/view.php?id=4984">https://bugs.freenetproject.org/view.php?id=4984</a>
    *
    * @param time cooldown duration in milliseconds applied between retry batches; non-negative
    *     values are expected
@@ -2066,7 +2082,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
    * Tracks the list of editions that we want to fetch, from various sources - subscribers, origUSK,
    * last known slot from USKManager, etc.
    *
-   * <p>LOCKING: Take the lock on this class last and always pass in lookup values. Do not lookup
+   * <p>LOCKING: Take the lock on this class last and always pass in lookup values. Do not look up
    * values in USKManager inside this class's lock.
    *
    * @author Matthew Toseland <toad@amphibian.dyndns.org> (0xE43DA450)
@@ -2300,14 +2316,17 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
       }
 
       /**
-       * Add the next bunch of editions to fetch to toFetch and toPoll. If they are already running,
-       * REMOVE THEM from the alreadyRunning array.
+       * Add the next set of editions to either {@code toFetch} or {@code toPoll}. If any of those
+       * editions are already running, remove them from {@code alreadyRunning}.
        *
-       * @param toFetch
-       * @param toPoll
-       * @param lookedUp
-       * @param alreadyRunning
-       * @param random
+       * @param toFetch destination list for editions that should be fetched immediately when not in
+       *     background polling mode; entries are appended, not cleared
+       * @param toPoll destination list for editions that should be polled (no immediate fetch) when
+       *     in background polling mode; entries are appended, not cleared
+       * @param lookedUp current best known slot (edition) used as a base for computing the next
+       *     candidate editions; values below zero are treated as zero
+       * @param alreadyRunning list of lookups currently in progress; this method removes any
+       *     edition that remains valid so it is not scheduled twice
        */
       public synchronized void getNextEditions(
           List<Lookup> toFetch, List<Lookup> toPoll, long lookedUp, List<Lookup> alreadyRunning) {

--- a/src/test/java/network/crypta/client/async/KeyListenerTrackerTest.java
+++ b/src/test/java/network/crypta/client/async/KeyListenerTrackerTest.java
@@ -1,0 +1,466 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+// No argument matchers required here; use direct values for clarity.
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.MessageDigest;
+import network.crypta.crypt.DummyRandomSource;
+import network.crypta.crypt.SHA256;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.NodeCHK;
+import network.crypta.keys.NodeSSK;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.node.SendableGet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class KeyListenerTrackerTest {
+
+  private static final byte[] GLOBAL_SALT = new byte[32];
+
+  static {
+    // Stable salt for deterministic hashing
+    for (int i = 0; i < GLOBAL_SALT.length; i++) GLOBAL_SALT[i] = (byte) (i + 1);
+  }
+
+  // Use a deterministic dummy RNG for reproducibility in tests.
+
+  @Mock private RequestStarter starter;
+  @Mock private Node node;
+  @Mock private NodeClientCore core;
+  @Mock private ClientContext clientContext;
+
+  private DummyRandomSource random;
+
+  @BeforeEach
+  void setUp() {
+    random = new DummyRandomSource(42L);
+    when(core.getStoreChecker()).thenReturn(mock(DatastoreChecker.class));
+  }
+
+  private ClientRequestScheduler newScheduler(boolean forInserts, boolean forSSKs) {
+    ClientRequestScheduler.SchedulerMode mode =
+        new ClientRequestScheduler.SchedulerMode(forInserts, forSSKs, false);
+    return new ClientRequestScheduler(mode, random, starter, node, core, "test", clientContext);
+  }
+
+  private static byte[] bytes(int value) {
+    byte[] b = new byte[32];
+    for (int i = 0; i < b.length; i++) b[i] = (byte) (value + i);
+    return b;
+  }
+
+  private static NodeCHK newCHK(byte[] routingKey) {
+    return new NodeCHK(routingKey, (byte) 2);
+  }
+
+  private static NodeSSK newSSK(byte[] pkh, byte[] ehd) {
+    return new NodeSSK(pkh, ehd, (byte) 2);
+  }
+
+  @Test
+  void fixRetryCount_whenBelowThreshold_returnsZero() {
+    assertEquals(0, KeyListenerTracker.fixRetryCount(0));
+    assertEquals(0, KeyListenerTracker.fixRetryCount(1));
+    assertEquals(0, KeyListenerTracker.fixRetryCount(2));
+    // threshold itself
+    assertEquals(0, KeyListenerTracker.fixRetryCount(3));
+  }
+
+  @Test
+  void fixRetryCount_whenAboveThreshold_returnsOffset() {
+    assertEquals(1, KeyListenerTracker.fixRetryCount(4));
+    assertEquals(7, KeyListenerTracker.fixRetryCount(10));
+  }
+
+  @Test
+  void saltKey_chkScheduler_hashesWithGlobalSalt() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    byte[] rk = bytes(10);
+    NodeCHK key = newCHK(rk);
+
+    byte[] salted = tracker.saltKey(key);
+
+    MessageDigest md = SHA256.getMessageDigest();
+    md.update(rk);
+    md.update(GLOBAL_SALT);
+    byte[] expected = md.digest();
+    assertArrayEquals(expected, salted);
+  }
+
+  @Test
+  void saltKey_sskScheduler_returnsPubKeyHash() {
+    ClientRequestScheduler sched = newScheduler(false, true);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, true, false, random, sched, GLOBAL_SALT, false);
+
+    byte[] pkh = bytes(20);
+    byte[] ehd = bytes(70);
+    NodeSSK key = newSSK(pkh, ehd);
+
+    byte[] salted = tracker.saltKey(key);
+    assertArrayEquals(pkh, salted);
+  }
+
+  @Test
+  void addPendingKeys_nullListener_throws() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+    assertThrows(NullPointerException.class, () -> tracker.addPendingKeys(null));
+  }
+
+  @Test
+  void addRemove_singleKeyListener_roundtripAndOnRemoveCalledTwice() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    HasKeyListener owner = mock(HasKeyListener.class);
+    byte[] wanted = bytes(1);
+    when(owner.getWantedKey()).thenReturn(wanted);
+
+    KeyListener listener = mock(KeyListener.class);
+    when(listener.getHasKeyListener()).thenReturn(owner);
+    when(listener.getWantedKey()).thenReturn(wanted);
+
+    // Register and verify lookup
+    tracker.addPendingKeys(listener);
+    NodeCHK key = newCHK(wanted);
+    byte[] salted = tracker.saltKey(key);
+    when(listener.probablyWantKey(key, salted)).thenReturn(true);
+    assertTrue(tracker.anyProbablyWantKey(key, clientContext));
+
+    // Remove and verify double onRemove and absence
+    assertTrue(tracker.removePendingKeys(listener));
+    verify(listener, times(2)).onRemove();
+    assertFalse(tracker.anyProbablyWantKey(key, clientContext));
+  }
+
+  @Test
+  void addRemove_twoListenersSameKey_keepsOtherUntilRemoved() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    HasKeyListener owner = mock(HasKeyListener.class);
+    byte[] wanted = bytes(2);
+    when(owner.getWantedKey()).thenReturn(wanted);
+
+    KeyListener l1 = mock(KeyListener.class);
+    when(l1.getHasKeyListener()).thenReturn(owner);
+    when(l1.getWantedKey()).thenReturn(wanted);
+
+    KeyListener l2 = mock(KeyListener.class);
+    when(l2.getHasKeyListener()).thenReturn(owner);
+    when(l2.getWantedKey()).thenReturn(wanted);
+
+    tracker.addPendingKeys(l1);
+    tracker.addPendingKeys(l2);
+    NodeCHK key = newCHK(wanted);
+    byte[] salted = tracker.saltKey(key);
+    when(l1.probablyWantKey(key, salted)).thenReturn(true);
+    when(l2.probablyWantKey(key, salted)).thenReturn(true);
+    assertTrue(tracker.anyProbablyWantKey(key, clientContext));
+
+    // Remove first; second remains
+    assertTrue(tracker.removePendingKeys(l1));
+    verify(l1, times(2)).onRemove();
+    assertTrue(tracker.anyProbablyWantKey(key, clientContext));
+
+    // Remove second; none remains
+    assertTrue(tracker.removePendingKeys(l2));
+    verify(l2, times(2)).onRemove();
+    assertFalse(tracker.anyProbablyWantKey(key, clientContext));
+  }
+
+  @Test
+  void removeByOwner_removesAllAndCallsOnRemoveOnceEach() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    HasKeyListener owner = mock(HasKeyListener.class);
+    byte[] wanted = bytes(3);
+    when(owner.getWantedKey()).thenReturn(wanted);
+
+    KeyListener l1 = mock(KeyListener.class);
+    when(l1.getHasKeyListener()).thenReturn(owner);
+    when(l1.getWantedKey()).thenReturn(wanted);
+
+    KeyListener l2 = mock(KeyListener.class);
+    when(l2.getHasKeyListener()).thenReturn(owner);
+    when(l2.getWantedKey()).thenReturn(wanted);
+
+    tracker.addPendingKeys(l1);
+    tracker.addPendingKeys(l2);
+    NodeCHK key = newCHK(wanted);
+    byte[] salted = tracker.saltKey(key);
+    when(l1.probablyWantKey(key, salted)).thenReturn(true);
+    when(l2.probablyWantKey(key, salted)).thenReturn(true);
+    assertTrue(tracker.anyProbablyWantKey(key, clientContext));
+
+    assertTrue(tracker.removePendingKeys(owner));
+    verify(l1, times(1)).onRemove();
+    verify(l2, times(1)).onRemove();
+    assertFalse(tracker.anyProbablyWantKey(key, clientContext));
+  }
+
+  @Test
+  void getKeyPrio_whenMatches_minPriorityReturned() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    byte[] rk = bytes(4);
+    NodeCHK key = newCHK(rk);
+    byte[] salted = tracker.saltKey(key);
+
+    // List listener (wantedKey == null)
+    KeyListener l1 = mock(KeyListener.class);
+    when(l1.getHasKeyListener()).thenReturn(mock(HasKeyListener.class));
+    when(l1.getWantedKey()).thenReturn(null);
+    when(l1.probablyWantKey(key, salted)).thenReturn(true);
+    when(l1.definitelyWantKey(key, salted, clientContext)).thenReturn((short) 8);
+    tracker.addPendingKeys(l1);
+
+    // Single-key listener
+    HasKeyListener owner2 = mock(HasKeyListener.class);
+    when(owner2.getWantedKey()).thenReturn(rk);
+    KeyListener l2 = mock(KeyListener.class);
+    when(l2.getHasKeyListener()).thenReturn(owner2);
+    when(l2.getWantedKey()).thenReturn(rk);
+    when(l2.probablyWantKey(key, salted)).thenReturn(true);
+    when(l2.definitelyWantKey(key, salted, clientContext)).thenReturn((short) 5);
+    tracker.addPendingKeys(l2);
+
+    short result = tracker.getKeyPrio(key, (short) 10, clientContext);
+    assertEquals(5, result);
+  }
+
+  @Test
+  void anyWantKey_whenDefiniteNegative_returnsFalse() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    byte[] rk = bytes(5);
+    NodeCHK key = newCHK(rk);
+    byte[] salted = tracker.saltKey(key);
+
+    KeyListener l = mock(KeyListener.class);
+    when(l.getHasKeyListener()).thenReturn(mock(HasKeyListener.class));
+    when(l.getWantedKey()).thenReturn(null);
+    when(l.probablyWantKey(key, salted)).thenReturn(true);
+    when(l.definitelyWantKey(key, salted, clientContext)).thenReturn((short) -1);
+
+    tracker.addPendingKeys(l);
+    assertFalse(tracker.anyWantKey(key, clientContext));
+  }
+
+  @Test
+  void anyProbablyWantKey_checksBothCollections() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    byte[] rk = bytes(6);
+    NodeCHK key = newCHK(rk);
+    byte[] salted = tracker.saltKey(key);
+
+    // Single-key listener path
+    HasKeyListener owner = mock(HasKeyListener.class);
+    when(owner.getWantedKey()).thenReturn(rk);
+    KeyListener l1 = mock(KeyListener.class);
+    when(l1.getHasKeyListener()).thenReturn(owner);
+    when(l1.getWantedKey()).thenReturn(rk);
+    when(l1.probablyWantKey(key, salted)).thenReturn(true);
+
+    // List listener path
+    KeyListener l2 = mock(KeyListener.class);
+    when(l2.getHasKeyListener()).thenReturn(mock(HasKeyListener.class));
+    when(l2.getWantedKey()).thenReturn(null);
+    when(l2.probablyWantKey(key, salted)).thenReturn(false);
+
+    tracker.addPendingKeys(l1);
+    tracker.addPendingKeys(l2);
+    assertTrue(tracker.anyProbablyWantKey(key, clientContext));
+  }
+
+  @Test
+  void requestsForKey_aggregatesAndSkipsNulls() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    byte[] rk = bytes(7);
+    NodeCHK key = newCHK(rk);
+    byte[] salted = tracker.saltKey(key);
+
+    // Matches and returns two requests
+    KeyListener l1 = mock(KeyListener.class);
+    when(l1.getHasKeyListener()).thenReturn(mock(HasKeyListener.class));
+    when(l1.getWantedKey()).thenReturn(null);
+    when(l1.probablyWantKey(key, salted)).thenReturn(true);
+    SendableGet r1 = mock(SendableGet.class);
+    SendableGet r2 = mock(SendableGet.class);
+    when(l1.getRequestsForKey(key, salted, clientContext)).thenReturn(new SendableGet[] {r1, r2});
+
+    // Matches but returns null
+    KeyListener l2 = mock(KeyListener.class);
+    when(l2.getHasKeyListener()).thenReturn(mock(HasKeyListener.class));
+    when(l2.getWantedKey()).thenReturn(null);
+    when(l2.probablyWantKey(key, salted)).thenReturn(true);
+    when(l2.getRequestsForKey(key, salted, clientContext)).thenReturn(null);
+
+    tracker.addPendingKeys(l1);
+    tracker.addPendingKeys(l2);
+
+    SendableGet[] out = tracker.requestsForKey(key, clientContext);
+    assertNotNull(out);
+    assertEquals(2, out.length);
+  }
+
+  @Test
+  void requestsForKey_noMatches_returnsNull() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    NodeCHK key = newCHK(bytes(8));
+    assertNull(tracker.requestsForKey(key, clientContext));
+  }
+
+  @Test
+  void tripPendingKey_typeMismatch_returnsFalse() {
+    ClientRequestScheduler sched = newScheduler(false, false); // CHK scheduler
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    NodeSSK key = newSSK(bytes(9), bytes(10));
+    assertFalse(tracker.tripPendingKey(key, mock(KeyBlock.class), clientContext));
+  }
+
+  @Test
+  void tripPendingKey_handlesMatches_andRemovesEmptyListeners() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    byte[] rk = bytes(11);
+    NodeCHK key = newCHK(rk);
+    byte[] salted = tracker.saltKey(key);
+
+    // Single-key listener that handles and becomes empty
+    HasKeyListener owner1 = mock(HasKeyListener.class);
+    when(owner1.getWantedKey()).thenReturn(rk);
+    KeyListener l1 = mock(KeyListener.class);
+    when(l1.getHasKeyListener()).thenReturn(owner1);
+    when(l1.getWantedKey()).thenReturn(rk);
+    when(l1.probablyWantKey(key, salted)).thenReturn(true);
+    KeyBlock block = mock(KeyBlock.class);
+    when(l1.handleBlock(key, salted, block, clientContext)).thenReturn(true);
+    when(l1.isEmpty()).thenReturn(true);
+
+    // List listener that does not handle and stays
+    KeyListener l2 = mock(KeyListener.class);
+    when(l2.getHasKeyListener()).thenReturn(mock(HasKeyListener.class));
+    when(l2.getWantedKey()).thenReturn(null);
+    when(l2.probablyWantKey(key, salted)).thenReturn(true);
+    when(l2.handleBlock(key, salted, block, clientContext)).thenReturn(false);
+    when(l2.isEmpty()).thenReturn(false);
+
+    tracker.addPendingKeys(l1);
+    tracker.addPendingKeys(l2);
+
+    boolean handled = tracker.tripPendingKey(key, block, clientContext);
+    assertTrue(handled, "At least one listener handled the block");
+
+    // l1 should have been removed due to isEmpty()
+    verify(l1, times(2)).onRemove();
+    assertTrue(tracker.anyProbablyWantKey(key, clientContext)); // l2 still present
+  }
+
+  @Test
+  void countWaitingKeys_sumsBothCollections() {
+    ClientRequestScheduler sched = newScheduler(false, false);
+    KeyListenerTracker tracker =
+        new KeyListenerTracker(false, false, false, random, sched, GLOBAL_SALT, false);
+
+    // Single-key mapping with one listener
+    HasKeyListener owner1 = mock(HasKeyListener.class);
+    byte[] k1 = bytes(12);
+    when(owner1.getWantedKey()).thenReturn(k1);
+    KeyListener a = mock(KeyListener.class);
+    when(a.getHasKeyListener()).thenReturn(owner1);
+    when(a.getWantedKey()).thenReturn(k1);
+    when(a.countKeys()).thenReturn(5L);
+    tracker.addPendingKeys(a);
+
+    // Single-key mapping with two listeners
+    HasKeyListener owner2 = mock(HasKeyListener.class);
+    byte[] k2 = bytes(13);
+    when(owner2.getWantedKey()).thenReturn(k2);
+    KeyListener b = mock(KeyListener.class);
+    when(b.getHasKeyListener()).thenReturn(owner2);
+    when(b.getWantedKey()).thenReturn(k2);
+    when(b.countKeys()).thenReturn(7L);
+    tracker.addPendingKeys(b);
+    KeyListener c = mock(KeyListener.class);
+    when(c.getHasKeyListener()).thenReturn(owner2);
+    when(c.getWantedKey()).thenReturn(k2);
+    when(c.countKeys()).thenReturn(3L);
+    tracker.addPendingKeys(c);
+
+    // List listener
+    KeyListener d = mock(KeyListener.class);
+    when(d.getHasKeyListener()).thenReturn(mock(HasKeyListener.class));
+    when(d.getWantedKey()).thenReturn(null);
+    when(d.countKeys()).thenReturn(9L);
+    tracker.addPendingKeys(d);
+
+    assertEquals(24L, tracker.countWaitingKeys());
+  }
+
+  @Test
+  void toString_containsTypeHints_andPersistentFlag() {
+    ClientRequestScheduler sched1 = newScheduler(true, false);
+    KeyListenerTracker insertChk =
+        new KeyListenerTracker(true, false, false, random, sched1, GLOBAL_SALT, true);
+    String s1 = insertChk.toString();
+    assertTrue(s1.contains("insert:"));
+    assertTrue(s1.contains("CHK"));
+
+    ClientRequestScheduler sched2 = newScheduler(false, true);
+    KeyListenerTracker getSsk =
+        new KeyListenerTracker(false, true, false, random, sched2, GLOBAL_SALT, false);
+    String s2 = getSsk.toString();
+    assertFalse(s2.contains("insert:"));
+    assertTrue(s2.contains("SSK"));
+
+    assertTrue(insertChk.persistent());
+    assertFalse(getSsk.persistent());
+  }
+}

--- a/src/test/java/network/crypta/client/async/SingleKeyListenerTest.java
+++ b/src/test/java/network/crypta/client/async/SingleKeyListenerTest.java
@@ -1,0 +1,264 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Arrays;
+import network.crypta.keys.Key;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.NodeCHK;
+import network.crypta.keys.NodeSSK;
+import network.crypta.node.LowLevelGetException;
+import network.crypta.node.SendableGet;
+import network.crypta.node.SendableRequestItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SingleKeyListenerTest {
+
+  @Mock private BaseSingleFileFetcher fetcher;
+  @Mock private ClientContext context;
+  @Mock private KeyBlock block;
+
+  private static byte[] filledBytes(int len, byte value) {
+    byte[] b = new byte[len];
+    Arrays.fill(b, value);
+    return b;
+  }
+
+  private NodeCHK newChk(byte fill) {
+    return new NodeCHK(filledBytes(NodeCHK.KEY_LENGTH, fill), Key.ALGO_AES_PCFB_256_SHA256);
+  }
+
+  private NodeSSK newSsk() {
+    return new NodeSSK(
+        filledBytes(NodeSSK.PUBKEY_HASH_SIZE, (byte) 13),
+        filledBytes(NodeSSK.E_H_DOCNAME_SIZE, (byte) 14),
+        Key.ALGO_AES_PCFB_256_SHA256);
+  }
+
+  @BeforeEach
+  void resetMocks() {
+    // No-op placeholder to keep AAA structure consistent across tests if needed later.
+  }
+
+  @Test
+  void probablyWantKey_whenKeyMatchesAndNotDone_true() {
+    // Arrange
+    NodeCHK key = newChk((byte) 1);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 7, true);
+
+    // Act
+    boolean result = listener.probablyWantKey(key, new byte[] {0});
+
+    // Assert
+    assertTrue(result);
+  }
+
+  @Test
+  void probablyWantKey_whenDone_false() {
+    // Arrange
+    NodeCHK key = newChk((byte) 2);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 5, false);
+    listener.onRemove();
+
+    // Act
+    boolean result = listener.probablyWantKey(key, new byte[] {0});
+
+    // Assert
+    assertFalse(result);
+  }
+
+  @Test
+  void definitelyWantKey_whenKeyMatches_returnsPrio() {
+    // Arrange
+    NodeCHK key = newChk((byte) 3);
+    short prio = 42;
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, prio, true);
+
+    // Act
+    short res = listener.definitelyWantKey(key, new byte[] {1}, context);
+
+    // Assert
+    assertEquals(prio, res);
+  }
+
+  @Test
+  void definitelyWantKey_whenKeyDifferent_returnsMinusOne() {
+    // Arrange
+    NodeCHK key = newChk((byte) 4);
+    NodeCHK other = newChk((byte) 5);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 9, false);
+
+    // Act
+    short res = listener.definitelyWantKey(other, new byte[] {1}, context);
+
+    // Assert
+    assertEquals(-1, res);
+  }
+
+  @Test
+  void getRequestsForKey_whenMatches_returnsFetcherArray() {
+    // Arrange
+    NodeCHK key = newChk((byte) 6);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 1, false);
+
+    // Act
+    SendableGet[] reqs = listener.getRequestsForKey(key, new byte[] {2}, context);
+
+    // Assert
+    assertNotNull(reqs);
+    assertEquals(1, reqs.length);
+    assertEquals(fetcher, reqs[0]);
+  }
+
+  @Test
+  void getRequestsForKey_whenNotMatch_returnsNull() {
+    // Arrange
+    NodeCHK key = newChk((byte) 7);
+    NodeCHK other = newChk((byte) 8);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 1, false);
+
+    // Act
+    SendableGet[] reqs = listener.getRequestsForKey(other, new byte[] {3}, context);
+
+    // Assert
+    assertNull(reqs);
+  }
+
+  @Test
+  void handleBlock_whenKeyMismatch_returnsFalseAndNoFetcherCalls() {
+    // Arrange
+    NodeCHK key = newChk((byte) 9);
+    NodeCHK other = newChk((byte) 10);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 3, true);
+
+    // Act
+    boolean handled = listener.handleBlock(other, new byte[] {4}, block, context);
+
+    // Assert
+    assertFalse(handled);
+    verify(fetcher, never()).onGotKey(any(), any(), any());
+    verify(fetcher, never()).onFailure(any(), any(), any());
+    verifyNoMoreInteractions(fetcher);
+  }
+
+  @Test
+  void handleBlock_whenKeyMatches_callsOnGotKey_andSetsDone_andReturnsTrue() {
+    // Arrange
+    NodeCHK key = newChk((byte) 11);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 3, false);
+
+    // Act
+    boolean handled = listener.handleBlock(key, new byte[] {5}, block, context);
+
+    // Assert
+    assertTrue(handled);
+    verify(fetcher).onGotKey(key, block, context);
+    assertTrue(listener.isEmpty());
+    assertEquals(0, listener.countKeys());
+  }
+
+  @Test
+  void handleBlock_whenFetcherThrows_callsOnFailureWithInternalError_andSetsDone() {
+    // Arrange
+    NodeCHK key = newChk((byte) 12);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 3, true);
+    RuntimeException boom = new RuntimeException("boom");
+    doThrow(boom).when(fetcher).onGotKey(key, block, context);
+
+    // Act
+    boolean handled = listener.handleBlock(key, new byte[] {6}, block, context);
+
+    // Assert
+    assertTrue(handled);
+    ArgumentCaptor<LowLevelGetException> cap = ArgumentCaptor.forClass(LowLevelGetException.class);
+    ArgumentCaptor<SendableRequestItem> tokenCap =
+        ArgumentCaptor.forClass(SendableRequestItem.class);
+    ArgumentCaptor<ClientContext> ctxCap = ArgumentCaptor.forClass(ClientContext.class);
+    verify(fetcher).onFailure(cap.capture(), tokenCap.capture(), ctxCap.capture());
+    LowLevelGetException lle = cap.getValue();
+    assertNull(tokenCap.getValue());
+    assertEquals(context, ctxCap.getValue());
+    assertEquals(LowLevelGetException.INTERNAL_ERROR, lle.code);
+    assertEquals(boom, lle.getCause());
+    assertTrue(listener.isEmpty());
+    assertEquals(0, listener.countKeys());
+  }
+
+  @Test
+  void isSSK_and_getWantedKey_whenNodeSSK_behaveAsExpected() {
+    // Arrange
+    NodeSSK ssk = newSsk();
+    SingleKeyListener listener = new SingleKeyListener(ssk, fetcher, (short) 2, true);
+
+    // Act
+    boolean sskFlag = listener.isSSK();
+    byte[] wanted = listener.getWantedKey();
+
+    // Assert
+    assertTrue(sskFlag);
+    assertArrayEquals(ssk.getPubKeyHash(), wanted);
+  }
+
+  @Test
+  void getWantedKey_whenNotSSK_returnsRoutingKey() {
+    // Arrange
+    NodeCHK chk = newChk((byte) 15);
+    SingleKeyListener listener = new SingleKeyListener(chk, fetcher, (short) 2, false);
+
+    // Act
+    byte[] wanted = listener.getWantedKey();
+
+    // Assert
+    assertArrayEquals(chk.getRoutingKey(), wanted);
+  }
+
+  @Test
+  void countKeys_and_isEmpty_behaviors_before_and_after_onRemove() {
+    // Arrange
+    NodeCHK key = newChk((byte) 16);
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, (short) 1, false);
+
+    // Act & Assert (before)
+    assertEquals(1, listener.countKeys());
+    assertFalse(listener.isEmpty());
+
+    // Act
+    listener.onRemove();
+
+    // Assert (after)
+    assertEquals(0, listener.countKeys());
+    assertTrue(listener.isEmpty());
+    assertFalse(listener.probablyWantKey(key, new byte[] {0}));
+  }
+
+  @Test
+  void accessors_returnFetcherPriorityAndPersistent() {
+    // Arrange
+    NodeCHK key = newChk((byte) 17);
+    short prio = 77;
+    boolean persistent = true;
+    SingleKeyListener listener = new SingleKeyListener(key, fetcher, prio, persistent);
+
+    // Act & Assert
+    assertEquals(fetcher, listener.getHasKeyListener());
+    assertEquals(prio, listener.getPriorityClass());
+    assertTrue(listener.persistent());
+  }
+}

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherKeyListenerTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherKeyListenerTest.java
@@ -1,0 +1,501 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.crypt.ChecksumFailedException;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.NodeCHK;
+import network.crypta.support.io.StorageFormatException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@SuppressWarnings("java:S100") // Method naming per project test style
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SplitFileFetcherKeyListenerTest {
+
+  private SplitFileFetcherStorageCallback fetcher;
+  private SplitFileFetcherStorage storageMock;
+
+  @BeforeEach
+  void setUp() {
+    fetcher = mock(SplitFileFetcherStorageCallback.class);
+    storageMock = Mockito.mock(SplitFileFetcherStorage.class, Answers.RETURNS_DEEP_STUBS);
+
+    Mockito.lenient()
+        .when(storageMock.writeChecksummedTo(anyLong(), anyInt()))
+        .thenAnswer(inv -> new ByteArrayOutputStream());
+    Mockito.lenient().when(storageMock.hasFinished()).thenReturn(false);
+
+    when(fetcher.getPriorityClass()).thenReturn((short) 7);
+    when(fetcher.getHasKeyListener()).thenReturn(mock(HasKeyListener.class));
+  }
+
+  @Test
+  @DisplayName("constructor_whenInvalidCounts_throwFetchException")
+  void constructor_whenInvalidCounts_throwFetchException() {
+    byte[] salt = new byte[32];
+    FetchException ex1 =
+        assertThrows(
+            FetchException.class,
+            () -> new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 0, 1, 1));
+    assertEquals(FetchExceptionMode.INTERNAL_ERROR, ex1.mode);
+
+    FetchException ex2 =
+        assertThrows(
+            FetchException.class,
+            () -> new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 1, 0, 1));
+    assertEquals(FetchExceptionMode.INTERNAL_ERROR, ex2.mode);
+
+    FetchException ex3 =
+        assertThrows(
+            FetchException.class,
+            () -> new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 1, 1, 0));
+    assertEquals(FetchExceptionMode.INTERNAL_ERROR, ex3.mode);
+  }
+
+  @Test
+  @DisplayName("constructor_whenTooManyKeys_throwTooBig")
+  void constructor_whenTooManyKeys_throwTooBig() {
+    byte[] salt = new byte[32];
+    int perKey = SplitFileFetcherKeyListener.DEFAULT_MAIN_BLOOM_ELEMENTS_PER_KEY;
+    long threshold = (Integer.MAX_VALUE / perKey) + 1L;
+    FetchException ex =
+        assertThrows(
+            FetchException.class,
+            () ->
+                new SplitFileFetcherKeyListener(
+                    fetcher, storageMock, true, salt, (int) threshold, 1, 1));
+    assertEquals(FetchExceptionMode.TOO_BIG, ex.mode);
+  }
+
+  @Test
+  @DisplayName("addKey_afterFinishedSetupWithoutRegeneration_throws")
+  void addKey_afterFinishedSetupWithoutRegeneration_throws() throws Exception {
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, false, salt, 4, 2, 2);
+    listener.finishedSetup();
+    assertThrows(
+        IllegalStateException.class,
+        () -> listener.addKey(mock(NodeCHK.class), 0, key -> new byte[] {1, 2, 3}));
+  }
+
+  @Test
+  @DisplayName("probablyWantKey_whenBloomMatches_returnsTrue")
+  void probablyWantKey_whenBloomMatches_returnsTrue() throws Exception {
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 4, 2, 2);
+
+    NodeCHK key = mock(NodeCHK.class);
+    when(key.getRoutingKey()).thenReturn("rk".getBytes(StandardCharsets.UTF_8));
+
+    byte[] saltedKey = new byte[] {9, 8, 7, 6};
+    KeySalter salter = k -> saltedKey;
+
+    listener.addKey(key, 0, salter);
+    listener.finishedSetup();
+
+    assertTrue(listener.probablyWantKey(key, saltedKey));
+  }
+
+  @Test
+  @DisplayName("probablyWantKey_whenMainBloomMiss_returnsFalse")
+  void probablyWantKey_whenMainBloomMiss_returnsFalse() throws Exception {
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, false, salt, 4, 2, 2);
+
+    NodeCHK key = mock(NodeCHK.class);
+    when(key.getRoutingKey()).thenReturn("rk".getBytes(StandardCharsets.UTF_8));
+
+    listener.finishedSetup();
+    assertFalse(listener.probablyWantKey(key, new byte[] {1, 2, 3, 4}));
+  }
+
+  @Test
+  @DisplayName("definitelyWantKey_whenSegmentWants_returnsPriority")
+  void definitelyWantKey_whenSegmentWants_returnsPriority() throws Exception {
+    int segments = 2;
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 4, 2, segments);
+
+    NodeCHK key = mock(NodeCHK.class);
+    when(key.getRoutingKey()).thenReturn("rk".getBytes(StandardCharsets.UTF_8));
+    byte[] saltedKey = new byte[] {4, 5, 6, 7};
+    listener.addKey(key, 0, k -> saltedKey);
+    listener.finishedSetup();
+
+    SplitFileFetcherSegmentStorage[] segs = new SplitFileFetcherSegmentStorage[segments];
+    segs[0] = mock(SplitFileFetcherSegmentStorage.class);
+    segs[1] = mock(SplitFileFetcherSegmentStorage.class);
+    setSegmentsField(storageMock, segs);
+
+    when(segs[0].definitelyWantKey(key)).thenReturn(true);
+    when(segs[1].definitelyWantKey(key)).thenReturn(false);
+
+    short prio = listener.definitelyWantKey(key, saltedKey, mock(ClientContext.class));
+    assertEquals(fetcher.getPriorityClass(), prio);
+  }
+
+  @Test
+  @DisplayName("definitelyWantKey_whenNoSegmentWants_returnsMinusOne")
+  void definitelyWantKey_whenNoSegmentWants_returnsMinusOne() throws Exception {
+    int segments = 1;
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 4, 2, segments);
+
+    NodeCHK key = mock(NodeCHK.class);
+    when(key.getRoutingKey()).thenReturn("rk".getBytes(StandardCharsets.UTF_8));
+    byte[] saltedKey = new byte[] {7, 7, 7, 7};
+    listener.addKey(key, 0, k -> saltedKey);
+    listener.finishedSetup();
+
+    SplitFileFetcherSegmentStorage[] segs = new SplitFileFetcherSegmentStorage[segments];
+    segs[0] = mock(SplitFileFetcherSegmentStorage.class);
+    when(segs[0].definitelyWantKey(key)).thenReturn(false);
+    setSegmentsField(storageMock, segs);
+
+    short prio = listener.definitelyWantKey(key, saltedKey, mock(ClientContext.class));
+    assertEquals(-1, prio);
+  }
+
+  @Test
+  @DisplayName("handleBlock_whenSegmentAccepts_updatesBloomAndPersists")
+  void handleBlock_whenSegmentAccepts_updatesBloomAndPersists() throws Exception {
+    int segments = 1;
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 4, 2, segments);
+
+    NodeCHK key = mock(NodeCHK.class);
+    when(key.getRoutingKey()).thenReturn("rk".getBytes(StandardCharsets.UTF_8));
+    byte[] saltedKey = new byte[] {1, 2, 3, 4};
+    listener.addKey(key, 0, k -> saltedKey);
+    listener.finishedSetup();
+
+    SplitFileFetcherSegmentStorage[] segs = new SplitFileFetcherSegmentStorage[segments];
+    segs[0] = mock(SplitFileFetcherSegmentStorage.class);
+    when(segs[0].onGotKey(any(NodeCHK.class), any(CHKBlock.class))).thenReturn(true);
+    setSegmentsField(storageMock, segs);
+
+    boolean found =
+        listener.handleBlock(
+            key,
+            saltedKey,
+            mock(CHKBlock.class, Answers.RETURNS_DEEP_STUBS),
+            mock(ClientContext.class));
+    assertTrue(found);
+    assertFalse(listener.probablyWantKey(key, saltedKey));
+    verify(storageMock, times(1)).lazyWriteMetadata();
+  }
+
+  @Test
+  @DisplayName("handleBlock_whenSegmentRejects_returnsFalseAndDoesNotPersist")
+  void handleBlock_whenSegmentRejects_returnsFalseAndDoesNotPersist() throws Exception {
+    int segments = 1;
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, false, salt, 4, 2, segments);
+
+    NodeCHK key = mock(NodeCHK.class);
+    when(key.getRoutingKey()).thenReturn("rk".getBytes(StandardCharsets.UTF_8));
+    byte[] saltedKey = new byte[] {1, 2, 3, 4};
+    listener.addKey(key, 0, k -> saltedKey);
+    listener.finishedSetup();
+
+    SplitFileFetcherSegmentStorage[] segs = new SplitFileFetcherSegmentStorage[segments];
+    segs[0] = mock(SplitFileFetcherSegmentStorage.class);
+    when(segs[0].onGotKey(any(NodeCHK.class), any(CHKBlock.class))).thenReturn(false);
+    setSegmentsField(storageMock, segs);
+
+    boolean found =
+        listener.handleBlock(key, saltedKey, mock(CHKBlock.class), mock(ClientContext.class));
+    assertFalse(found);
+    verify(storageMock, times(0)).lazyWriteMetadata();
+    assertTrue(listener.probablyWantKey(key, saltedKey));
+  }
+
+  @Test
+  @DisplayName("handleBlock_whenDiskError_callsFailAndReturnsFalse")
+  void handleBlock_whenDiskError_callsFailAndReturnsFalse() throws Exception {
+    int segments = 1;
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 4, 2, segments);
+
+    NodeCHK key = mock(NodeCHK.class);
+    when(key.getRoutingKey()).thenReturn("rk".getBytes(StandardCharsets.UTF_8));
+    byte[] saltedKey = new byte[] {1, 2, 3, 4};
+    listener.addKey(key, 0, k -> saltedKey);
+    listener.finishedSetup();
+
+    SplitFileFetcherSegmentStorage[] segs = new SplitFileFetcherSegmentStorage[segments];
+    segs[0] = mock(SplitFileFetcherSegmentStorage.class);
+    doThrow(new IOException("disk"))
+        .when(segs[0])
+        .onGotKey(any(NodeCHK.class), any(CHKBlock.class));
+    setSegmentsField(storageMock, segs);
+
+    boolean found =
+        listener.handleBlock(key, saltedKey, mock(CHKBlock.class), mock(ClientContext.class));
+    assertFalse(found);
+    verify(fetcher, times(1)).failOnDiskError(any(IOException.class));
+    assertTrue(listener.probablyWantKey(key, saltedKey));
+  }
+
+  @Test
+  @DisplayName("maybeWriteMainBloomFilter_whenDirty_writesOnce")
+  void maybeWriteMainBloomFilter_whenDirty_writesOnce() throws Exception {
+    int segments = 1;
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 4, 2, segments);
+
+    NodeCHK key = mock(NodeCHK.class);
+    when(key.getRoutingKey()).thenReturn("rk".getBytes(StandardCharsets.UTF_8));
+    byte[] saltedKey = new byte[] {9, 9, 9, 9};
+    listener.addKey(key, 0, k -> saltedKey);
+    listener.finishedSetup();
+
+    SplitFileFetcherSegmentStorage[] segs = new SplitFileFetcherSegmentStorage[segments];
+    segs[0] = mock(SplitFileFetcherSegmentStorage.class);
+    when(segs[0].onGotKey(any(NodeCHK.class), any(CHKBlock.class))).thenReturn(true);
+    setSegmentsField(storageMock, segs);
+
+    assertTrue(
+        listener.handleBlock(key, saltedKey, mock(CHKBlock.class), mock(ClientContext.class)));
+
+    AtomicInteger capturedLen = new AtomicInteger();
+    AtomicLong capturedOffset = new AtomicLong();
+    AtomicInteger calls = new AtomicInteger();
+    // Override stub to capture values; still returns a fresh BAOS
+    Mockito.lenient()
+        .when(storageMock.writeChecksummedTo(anyLong(), anyInt()))
+        .thenAnswer(
+            inv -> {
+              capturedOffset.set(inv.getArgument(0));
+              capturedLen.set(inv.getArgument(1));
+              calls.incrementAndGet();
+              return new ByteArrayOutputStream();
+            });
+
+    listener.maybeWriteMainBloomFilter(1234L);
+    listener.maybeWriteMainBloomFilter(1234L);
+
+    assertEquals(1, calls.get());
+    assertEquals(1234L, capturedOffset.get());
+    assertEquals(listener.paddedMainBloomFilterSize(), capturedLen.get());
+  }
+
+  @Test
+  @DisplayName("initialWriteSegmentBloomFilters_writesUsingStorage")
+  void initialWriteSegmentBloomFilters_writesUsingStorage() throws Exception {
+    int segments = 2;
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, false, salt, 4, 2, segments);
+
+    long offset = 42L;
+    int expectedLen = listener.totalSegmentBloomFiltersSize();
+    AtomicInteger calls2 = new AtomicInteger();
+    AtomicLong off = new AtomicLong();
+    AtomicInteger len = new AtomicInteger();
+    Mockito.lenient()
+        .when(storageMock.writeChecksummedTo(anyLong(), anyInt()))
+        .thenAnswer(
+            inv -> {
+              off.set(inv.getArgument(0));
+              len.set(inv.getArgument(1));
+              calls2.incrementAndGet();
+              return new ByteArrayOutputStream();
+            });
+
+    listener.initialWriteSegmentBloomFilters(offset);
+
+    assertEquals(1, calls2.get());
+    assertEquals(offset, off.get());
+    assertEquals(expectedLen, len.get());
+  }
+
+  @Test
+  @DisplayName("persistenceAndAccessors_behaveAsExpected")
+  void persistenceAndAccessors_behaveAsExpected() throws Exception {
+    byte[] salt = new byte[32];
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(fetcher, storageMock, true, salt, 4, 2, 1);
+
+    assertTrue(listener.persistent());
+    assertEquals(fetcher.getPriorityClass(), listener.getPriorityClass());
+
+    assertThrows(UnsupportedOperationException.class, listener::countKeys);
+    assertEquals(fetcher.getHasKeyListener(), listener.getHasKeyListener());
+
+    when(storageMock.hasFinished()).thenReturn(true);
+    assertTrue(listener.isEmpty());
+    assertFalse(listener.isSSK());
+    assertNull(listener.getWantedKey());
+    assertNull(
+        listener.getRequestsForKey(mock(NodeCHK.class), new byte[] {1}, mock(ClientContext.class)));
+  }
+
+  @Test
+  @DisplayName("streamConstructor_whenChecksumFailures_flagsRegeneration")
+  void streamConstructor_whenChecksumFailures_flagsRegeneration() throws Exception {
+    SplitFileFetcherSegmentStorage[] segs = new SplitFileFetcherSegmentStorage[2];
+    segs[0] = mock(SplitFileFetcherSegmentStorage.class);
+    segs[1] = mock(SplitFileFetcherSegmentStorage.class);
+    setSegmentsField(storageMock, segs);
+
+    byte[] localSalt = new byte[32];
+    for (int i = 0; i < localSalt.length; i++) localSalt[i] = (byte) (i + 1);
+    int mainSizeBytes = 16;
+    int mainK = 2;
+    int segSizeBytes = 8;
+    int perSegK = 1;
+
+    byte[] header = new byte[32 + 4 * 4];
+    System.arraycopy(localSalt, 0, header, 0, 32);
+    int p = 32;
+    putInt(header, p, mainSizeBytes);
+    p += 4;
+    putInt(header, p, mainK);
+    p += 4;
+    putInt(header, p, segSizeBytes);
+    p += 4;
+    putInt(header, p, perSegK);
+
+    doThrow(new ChecksumFailedException())
+        .when(storageMock)
+        .preadChecksummed(anyLong(), any(byte[].class), anyInt(), anyInt());
+
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(
+            storageMock,
+            fetcher,
+            new DataInputStream(new ByteArrayInputStream(header)),
+            true,
+            false);
+    assertTrue(listener.needsKeys());
+
+    listener.addedAllKeys();
+    assertFalse(listener.needsKeys());
+  }
+
+  @Test
+  @DisplayName("streamConstructor_whenNewSalt_skipsMainReadAndNeedsKeys")
+  void streamConstructor_whenNewSalt_skipsMainReadAndNeedsKeys() throws Exception {
+    SplitFileFetcherSegmentStorage[] segs = new SplitFileFetcherSegmentStorage[1];
+    segs[0] = mock(SplitFileFetcherSegmentStorage.class);
+    setSegmentsField(storageMock, segs);
+
+    byte[] localSalt = new byte[32];
+    for (int i = 0; i < localSalt.length; i++) localSalt[i] = (byte) (i + 1);
+    byte[] header = new byte[32 + 4 * 4];
+    System.arraycopy(localSalt, 0, header, 0, 32);
+    int p = 32;
+    putInt(header, p, 8);
+    p += 4;
+    putInt(header, p, 2);
+    p += 4;
+    putInt(header, p, 4);
+    p += 4;
+    putInt(header, p, 1);
+
+    SplitFileFetcherKeyListener listener =
+        new SplitFileFetcherKeyListener(
+            storageMock,
+            fetcher,
+            new DataInputStream(new ByteArrayInputStream(header)),
+            true,
+            true);
+    assertTrue(listener.needsKeys());
+  }
+
+  @Test
+  @DisplayName("streamConstructor_whenNegativeSizes_throwsStorageFormatException")
+  void streamConstructor_whenNegativeSizes_throwsStorageFormatException() {
+    byte[] localSalt = new byte[32];
+    for (int i = 0; i < localSalt.length; i++) localSalt[i] = (byte) (i + 1);
+    byte[] header = new byte[32 + 4 * 4];
+    System.arraycopy(localSalt, 0, header, 0, 32);
+    int p = 32;
+    putInt(header, p, -1); // invalid main bloom size
+    p += 4;
+    putInt(header, p, 1);
+    p += 4;
+    putInt(header, p, 0);
+    p += 4;
+    putInt(header, p, 0);
+
+    assertThrows(
+        StorageFormatException.class,
+        () ->
+            new SplitFileFetcherKeyListener(
+                storageMock,
+                fetcher,
+                new DataInputStream(new ByteArrayInputStream(header)),
+                true,
+                false));
+  }
+
+  // --- Helpers ---
+
+  private static void setSegmentsField(
+      SplitFileFetcherStorage target, SplitFileFetcherSegmentStorage[] value) throws Exception {
+    Field f = findSegmentsField(target.getClass());
+    f.setAccessible(true);
+    f.set(target, value);
+  }
+
+  private static Field findSegmentsField(Class<?> type) throws NoSuchFieldException {
+    Class<?> t = type;
+    while (t != null) {
+      try {
+        return t.getDeclaredField("segments");
+      } catch (NoSuchFieldException ignored) {
+        t = t.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException("segments");
+  }
+
+  private static void putInt(byte[] dst, int offset, int value) {
+    dst[offset] = (byte) ((value >>> 24) & 0xFF);
+    dst[offset + 1] = (byte) ((value >>> 16) & 0xFF);
+    dst[offset + 2] = (byte) ((value >>> 8) & 0xFF);
+    dst[offset + 3] = (byte) (value & 0xFF);
+  }
+}


### PR DESCRIPTION
Summary
- Doclint cleanup and enriched Javadoc across client/async APIs (KeyListener, KeySalter, USKFetcher, others).
- KeyListener-focused improvements: clearer lifecycle and saltedKey semantics; expanded docs and tests.
- SplitFileFetcherKeyListener: documentation and test cleanups; minor refactors.
- Test suite reshuffle: remove brittle/obsolete tests; add focused unit tests (KeyListenerTrackerTest, SingleKeyListenerTest, SplitFileFetcherKeyListenerTest).
- Spotless formatting applied project‑wide on touched files.

Scope
- Files changed: 34
- Insertions: 2,640
- Deletions: 5,153

Key Changes
- src/main/java/network/crypta/client/async/KeyListener.java: expanded docs and param/return tags; clarified concurrency and lifecycle.
- src/main/java/network/crypta/client/async/KeyListenerTracker.java: significant cleanup and documentation; maintain serialized callback behavior.
- src/main/java/network/crypta/client/async/USKFetcher.java: doclint‑cleaned API docs and cross‑references.
- src/main/java/network/crypta/client/async/KeySalter.java: enriched documentation and consistency fixes.
- src/main/java/network/crypta/client/async/SplitFileFetcherKeyListener.java: doc/test cleanups with small refactors.
- src/main/java/network/crypta/client/async/ManifestElement.java: new type; accompanying test updates.
- src/main/java/network/crypta/client/async/MultiPutCompletionCallback.java and related classes: simplified logic + documentation cleanup.

Tests
- Added: KeyListenerTrackerTest, SingleKeyListenerTest, SplitFileFetcherKeyListenerTest, ManifestElementTest updates.
- Removed: several broad/brittle tests in async module (e.g., MultiPutCompletionCallbackTest, InsertCompressorTest, others) replaced by more focused cases.
- JUnit 6 platform stays in use; Spotless runs clean.

Rationale
- Aligns with ongoing Javadoc doclint cleanup and API clarity work in client/async.
- Consolidates tests toward precise, behavior‑focused coverage; reduces flaky/brittle test surface.

Notes
- No runtime behavior changes intended in most files; primary focus is documentation and internal cleanups. Any functional deltas are covered by the new/updated tests where applicable.

Change List (relative to origin/develop)
- Ahead commits:
  • 66f7a900d9 docs: doclint-clean Javadoc for USKFetcher and enrich public API docs
  • dab0e52c62 refactor(client): improve SplitFileFetcherKeyListener docs/tests and cleanups
  • f54e0f43e1 chore(client): run Spotless; document SingleKeyListener; tidy test
  • 0033436fa3 chore(format): apply Spotless formatting
  • 003181c130 docs(client-async): doclint-clean Javadoc for KeySalter; enrich public API docs and run Spotless
  • fe908b67f2 docs(client/async): doclint-clean Javadoc for KeyListener and expand public API docs

Housekeeping
- Formatting: Spotless applied on all modified files.
- Dependency/gradle settings unchanged.

Please review; happy to adjust descriptions or split if needed.