### PR TITLE
fix(client): improve SingleBlockInserter docs/concurrency and add tests

### DIFF
--- a/src/main/java/network/crypta/client/async/SingleBlockInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleBlockInserter.java
@@ -5,9 +5,9 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.util.Arrays;
+import java.util.Objects;
 import network.crypta.client.FailureCodeTracker;
 import network.crypta.client.InsertContext;
-import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.crypt.RandomSource;
@@ -45,65 +45,167 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Insert a single block.
+ * Inserts a single content block into the network.
  *
- * <p>WARNING: Changing non-transient members on classes that are Serializable can result in
+ * <p>This stateful helper performs the full lifecycle for inserting exactly one block: it encodes
+ * the provided {@link Bucket} into a {@link ClientKeyBlock} (CHK/SSK depending on the supplied
+ * {@link FreenetURI}), registers the request with the {@link RequestScheduler}, and notifies a
+ * {@link PutCompletionCallback} when the block has been encoded and when the request succeeds or
+ * fails. It is typically created by higher-level putters and is not reused across inserts.
+ *
+ * <p>Typical usage is to construct an instance with the desired {@link InsertContext} and
+ * parameters, call {@link #schedule(ClientContext)} to register it with the scheduler, and rely on
+ * callbacks to observe progress. Callers may also proactively trigger encoding via {@link
+ * #tryEncode(ClientContext)} when operating in modes that prefer early CHK discovery.
+ *
+ * <p>Concurrency and state: methods synchronize on {@code this} to guard the internal state ({@code
+ * finished}, {@code resultingKey}, and buffering). Public methods are safe to call from the client
+ * thread and from scheduler/executor threads, but they assume the surrounding framework provides
+ * ordering guarantees for callbacks. Instances are single-use and become terminal once {@link
+ * #onSuccess(SendableRequestItem, ClientKey, ClientContext)} or a failure path marks them as
+ * finished.
+ *
+ * <ul>
+ *   <li>Encodes input via the configured compression and optional encryption parameters.
+ *   <li>Schedules a single sendable request and tracks retries and error codes.
+ *   <li>Propagates early-encode notifications and final completion to the provided callback.
+ * </ul>
+ *
+ * <p>WARNING: Changing non-transient members on classes that are {@link Serializable} can result in
  * restarting downloads or losing uploads.
+ *
+ * @see BaseClientPutter
+ * @see PutCompletionCallback
+ * @see ClientKeyBlock
+ * @see RequestScheduler
  */
 public class SingleBlockInserter extends SendableInsert implements ClientPutState, Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(SingleBlockInserter.class);
+  private static final String LOG_CAUGHT = "Caught {}";
+  private static final String LOG_CAUGHT_WHEN_CHECKING_COLLISION =
+      "Caught {} when checking collision!";
 
   @Serial private static final long serialVersionUID = 1L;
 
-  static {
-  }
+  // no static initialization required
 
+  /**
+   * The source bytes for this single insert. Implementations may create lightweight shadows during
+   * request scheduling; when {@link #freeData} is true the bucket is {@link Bucket#free() freed} on
+   * terminal completion.
+   */
   private Bucket sourceData;
+
+  /**
+   * Compression codec identifier used when encoding. A value of {@code -1} delegates to the
+   * context/implementation to decide whether and how to compress the block.
+   */
   final short compressionCodec;
+
+  /**
+   * Target URI that determines the key type (e.g., {@code CHK}, {@code SSK}, or {@code KSK}).
+   *
+   * <p>Uses essentially no RAM in the common case of a CHK because we use {@link
+   * FreenetURI#EMPTY_CHK_URI}.
+   */
   final FreenetURI uri; // uses essentially no RAM in the common case of a CHK because we use
+
   // FreenetURI.EMPTY_CHK_URI
+  /** The client key produced by a successful encode, or {@code null} until available. */
   private ClientKey resultingKey;
+
+  /**
+   * Observer notified when the block has been encoded (URI available) and when the insert either
+   * succeeds or fails. Implementations should be fast; callbacks are executed on framework threads.
+   */
   final PutCompletionCallback cb;
+
+  /** Parent request that owns this inserter and aggregates progress and failure accounting. */
   final BaseClientPutter parent;
+
+  /** Insert policy and tunables used by the encoding and request scheduler paths. */
   final InsertContext ctx;
+
+  /** Number of insert retry attempts performed so far for this block. */
   private int retries;
+
+  /** Tracks encountered failure modes for reporting and for persistent error aggregation. */
   private final FailureCodeTracker errors;
+
+  /** Whether this inserter reached a terminal state (success, cancel, or failure). */
   private boolean finished;
+
+  /**
+   * When {@code true}, suppresses the early {@link PutCompletionCallback#onEncode} notification
+   * even when a {@link ClientKey} has been derived.
+   */
   private final boolean dontSendEncoded;
+
+  /** Per-block integer token used by higher-level constructs (e.g., splitfiles). */
   final int token; // for e.g. splitfiles
+
+  /** Opaque scheduling token returned by {@link #getToken()} to identify this request. */
   private final Object tokenObject;
+
+  /** Whether the source data should be treated as metadata for encoding purposes. */
   final boolean isMetadata;
+
+  /** Length of the original uncompressed data, in bytes, if known by the caller. */
   final int sourceLength;
+
+  /** Consecutive route-not-found counters, used by heuristics that consider RNFs a success. */
   private int consecutiveRNFs;
+
+  /** Cached key-type predicate derived from {@link #uri} to avoid repeated string checks. */
   private final boolean isSSK;
+
+  /** If {@code true}, frees {@link #sourceData} once a terminal state is reached. */
   private final boolean freeData;
+
+  /** Number of successful insert completions so far when {@link #extraInserts} is positive. */
   private int completedInserts;
+
+  /**
+   * Additional times to perform the insert beyond the first success; {@code 0} disables repeats.
+   */
   final int extraInserts;
+
+  /**
+   * Optional per-block cryptographic key material; semantics depend on the encoder implementation.
+   */
   final byte[] cryptoKey;
+
+  /** Identifier for the cryptographic algorithm associated with {@link #cryptoKey}, if any. */
   final byte cryptoAlgorithm;
 
   /**
-   * Create a SingleBlockInserter.
+   * Creates a new inserter for a single block.
    *
-   * @param parent The parent. Must be activated.
-   * @param data
-   * @param compressionCodec The compression codec.
-   * @param uri
-   * @param ctx
-   * @param realTimeFlag
-   * @param cb
-   * @param isMetadata
-   * @param sourceLength The length of the original, uncompressed data.
-   * @param token
-   * @param addToParent
-   * @param dontSendEncoded
-   * @param tokenObject
-   * @param context
-   * @param persistent
-   * @param freeData
-   * @param extraInserts
-   * @param cryptoAlgorithm
-   * @param cryptoKey
+   * <p>The instance is single-use. After construction, invoke {@link #schedule(ClientContext)} to
+   * register it with the scheduler or {@link #tryEncode(ClientContext)} to trigger an early encode
+   * when the context enables it.
+   *
+   * @param parent The owning putter; must be active and used for progress aggregation.
+   * @param data The source {@link Bucket} containing the bytes to encode and insert; never null.
+   * @param compressionCodec Compression codec id; {@code -1} delegates to context/implementation.
+   * @param uri Base URI whose key type determines CHK/SSK/KSK behavior and encoding rules.
+   * @param ctx Insert policy and limits (retries, RNF heuristics, compressor descriptor, etc.).
+   * @param realTimeFlag Whether to schedule this insert as real-time in the underlying framework.
+   * @param cb Callback notified on encode and when the request finally succeeds or fails.
+   * @param isMetadata Whether the data should be encoded as metadata rather than ordinary content.
+   * @param sourceLength Length of the original, uncompressed data (bytes), or {@code -1} if
+   *     unknown.
+   * @param token Integer token used by callers to correlate this block (e.g., splitfile indices).
+   * @param addToParent When true, increments the parent's must-succeed counter and notifies
+   *     clients.
+   * @param dontSendEncoded Suppress the early on-encode callback even if a key is available.
+   * @param tokenObject Opaque token exposed via {@link #getToken()} to identify this request.
+   * @param context Runtime context used immediately for parent notifications on construction.
+   * @param persistent Whether this request is persistent across restarts in the client framework.
+   * @param freeData Whether to free {@code data} when the request reaches a terminal state.
+   * @param extraInserts Number of additional successful inserts to perform after the first success.
+   * @param cryptoAlgorithm Identifier for optional per-block cryptography; {@code 0} for none.
+   * @param cryptoKey Raw key bytes used with {@code cryptoAlgorithm}; {@code null} when not used.
    */
   public SingleBlockInserter(
       BaseClientPutter parent,
@@ -153,6 +255,18 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     this.cryptoKey = cryptoKey;
   }
 
+  /**
+   * Encodes the current {@link #sourceData} into a {@link ClientKeyBlock} using the instance
+   * configuration.
+   *
+   * <p>On failure, low-level causes are mapped to an {@link InsertException} with an appropriate
+   * mode. The resulting {@link ClientKey} is latched on first success and may be reported to the
+   * callback depending on configuration.
+   *
+   * @param random Source of randomness used by the encoders and key generation logic; never null.
+   * @return The encoded client key block representing the input data.
+   * @throws InsertException If encoding fails due to URI, bucket I/O, codec, or internal errors.
+   */
   protected ClientKeyBlock innerEncode(RandomSource random) throws InsertException {
     try {
       return innerEncode(
@@ -165,19 +279,41 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
           ctx.compressorDescriptor,
           cryptoAlgorithm,
           cryptoKey);
-    } catch (KeyEncodeException e) {
-      LOG.error("Caught " + e, e);
+    } catch (KeyEncodeException | InvalidCompressionCodecException e) {
       throw new InsertException(InsertExceptionMode.INTERNAL_ERROR, e, null);
     } catch (MalformedURLException e) {
       throw new InsertException(InsertExceptionMode.INVALID_URI, e, null);
     } catch (IOException e) {
-      LOG.error("Caught " + e + " encoding data " + sourceData, e);
       throw new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null);
-    } catch (InvalidCompressionCodecException e) {
-      throw new InsertException(InsertExceptionMode.INTERNAL_ERROR, e, null);
     }
   }
 
+  /**
+   * Static helper to encode the provided data and parameters into a {@link ClientKeyBlock}.
+   *
+   * <p>For {@code CHK} URIs, this delegates to {@link
+   * ClientCHKBlock#encode(network.crypta.support.api.Bucket, boolean, boolean, short, long, String,
+   * byte[], byte)}. For {@code SSK} and {@code KSK} URIs, it creates an {@link InsertableClientSSK}
+   * and delegates to its encoder. The {@code compressionCodec} of {@code -1} indicates that the
+   * implementation may choose whether to compress. Callers must provide a non-null {@code random}.
+   *
+   * @param random Randomness provider required by the encoders; must not be {@code null}.
+   * @param uri Target URI whose key type selects the encoding path (CHK/SSK/KSK).
+   * @param sourceData Bucket containing the bytes to encode; implementations may read it multiple
+   *     times.
+   * @param isMetadata Whether the content should be marked as metadata in the encoded block.
+   * @param compressionCodec Compression codec id; {@code -1} lets the encoder decide.
+   * @param sourceLength Uncompressed source length in bytes, when known; {@code -1} if unknown.
+   * @param compressorDescriptor Human-readable compressor descriptor used by encoders and logs.
+   * @param cryptoAlgorithm Optional algorithm id for per-block cryptography; {@code 0} for none.
+   * @param cryptoKey Raw key material for {@code cryptoAlgorithm}; may be {@code null} when unused.
+   * @return Encoded block ready for scheduling and transmission.
+   * @throws InsertException If the URI type is unknown or otherwise invalid for insertion.
+   * @throws CHKEncodeException If CHK encoding fails due to content or configuration issues.
+   * @throws IOException If the source bucket cannot be read or copied as required.
+   * @throws SSKEncodeException If SSK/KSK encoding fails for key-related reasons.
+   * @throws InvalidCompressionCodecException If the codec id is not recognized by encoders.
+   */
   protected static ClientKeyBlock innerEncode(
       RandomSource random,
       FreenetURI uri,
@@ -193,6 +329,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
           IOException,
           SSKEncodeException,
           InvalidCompressionCodecException {
+    Objects.requireNonNull(random, "random");
     String uriType = uri.getKeyType();
     if (uriType.equals("CHK")) {
       return ClientCHKBlock.encode(
@@ -219,6 +356,16 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     }
   }
 
+  /**
+   * Latches and publishes the first derived {@link ClientKey} for this insert.
+   *
+   * <p>When not persistent, the notification is executed on the main executor; for persistent
+   * inserts the notification is scheduled via the job runner and may be replayed on resume.
+   * Subsequent calls are ignored.
+   *
+   * @param key The client key derived from encoding, used to construct the final URI.
+   * @param context Runtime context used to post the notification on the appropriate executor.
+   */
   protected void onEncode(final ClientKey key, final ClientContext context) {
     synchronized (this) {
       if (finished) return;
@@ -239,14 +386,25 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     }
   }
 
-  protected ClientKeyBlock encode(ClientContext context, boolean calledByCB)
-      throws InsertException {
+  /**
+   * Encodes the current source data into a {@link ClientKeyBlock} and optionally notifies the
+   * callback.
+   *
+   * <p>This method latches the resulting {@link ClientKey} atomically, and, unless suppressed by
+   * {@link #dontSendEncoded}, delivers an early {@link PutCompletionCallback#onEncode} event when a
+   * new key becomes available.
+   *
+   * @param context Runtime state providing randomness, temporary storage factories, and executors.
+   * @return The newly encoded block, or {@code null} when the inserter is already finished.
+   * @throws InsertException If the URI is invalid, the bucket cannot be read, or encoding fails.
+   */
+  protected ClientKeyBlock encode(ClientContext context) throws InsertException {
     ClientKeyBlock block;
     boolean shouldSend;
     synchronized (this) {
       if (finished) return null;
       if (sourceData == null) {
-        LOG.error("Source data is null on " + this + " but not finished!");
+        LOG.error("Source data is null on {} but not finished!", this);
         return null;
       }
       block = innerEncode(context.random);
@@ -255,14 +413,11 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     }
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Encoded "
-              + resultingKey.getURI()
-              + " for "
-              + this
-              + " shouldSend="
-              + shouldSend
-              + " dontSendEncoded="
-              + dontSendEncoded);
+          "Encoded {} for {} shouldSend={} dontSendEncoded={}",
+          resultingKey.getURI(),
+          this,
+          shouldSend,
+          dontSendEncoded);
     if (shouldSend && !dontSendEncoded) cb.onEncode(block.getClientKey(), this, context);
     return block;
   }
@@ -281,43 +436,10 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
       fail(new InsertException(InsertExceptionMode.CANCELLED), context);
       return;
     }
-    if (LOG.isDebugEnabled()) LOG.debug("onFailure() on " + e + " for " + this);
-
-    switch (e.code) {
-      case LowLevelPutException.COLLISION:
-        fail(new InsertException(InsertExceptionMode.COLLISION), context);
-        return;
-      case LowLevelPutException.INTERNAL_ERROR:
-        fail(new InsertException(InsertExceptionMode.INTERNAL_ERROR), context);
-        return;
-      case LowLevelPutException.REJECTED_OVERLOAD:
-        errors.inc(InsertExceptionMode.REJECTED_OVERLOAD);
-        break;
-      case LowLevelPutException.ROUTE_NOT_FOUND:
-        errors.inc(InsertExceptionMode.ROUTE_NOT_FOUND);
-        break;
-      case LowLevelPutException.ROUTE_REALLY_NOT_FOUND:
-        errors.inc(InsertExceptionMode.ROUTE_REALLY_NOT_FOUND);
-        break;
-      default:
-        LOG.error("Unknown LowLevelPutException code: " + e.code);
-        errors.inc(InsertExceptionMode.INTERNAL_ERROR);
-    }
-    if (e.code == LowLevelPutException.ROUTE_NOT_FOUND
-        || e.code == LowLevelPutException.ROUTE_REALLY_NOT_FOUND) {
-      consecutiveRNFs++;
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "Consecutive RNFs: " + consecutiveRNFs + " / " + ctx.consecutiveRNFsCountAsSuccess);
-      // Use >= so that extra inserts see this as a success.
-      if (consecutiveRNFs >= ctx.consecutiveRNFsCountAsSuccess) {
-        if (LOG.isDebugEnabled())
-          LOG.debug("Consecutive RNFs: " + consecutiveRNFs + " - counting as success");
-        onSuccess(keyNum, getKeyNoEncode(), context);
-        return;
-      }
-    } else consecutiveRNFs = 0;
-    if (LOG.isDebugEnabled()) LOG.debug("Failed: " + e);
+    if (LOG.isDebugEnabled()) LOG.debug("onFailure() on {} for {}", e, this);
+    if (handleErrorCode(e, context)) return;
+    if (handleRouteNotFound(e, keyNum, context)) return;
+    if (LOG.isDebugEnabled()) LOG.debug("Failed: {}", String.valueOf(e));
     retries++;
     if ((retries > ctx.maxInsertRetries) && (ctx.maxInsertRetries != -1)) {
       fail(InsertException.construct(persistent ? errors.clone() : errors), context);
@@ -326,16 +448,54 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     clearWakeupTime(context);
   }
 
-  private void fail(InsertException e, ClientContext context) {
-    fail(e, false, context);
+  private boolean handleErrorCode(LowLevelPutException e, ClientContext context) {
+    switch (e.code) {
+      case LowLevelPutException.COLLISION -> {
+        fail(new InsertException(InsertExceptionMode.COLLISION), context);
+        return true;
+      }
+      case LowLevelPutException.INTERNAL_ERROR -> {
+        fail(new InsertException(InsertExceptionMode.INTERNAL_ERROR), context);
+        return true;
+      }
+      case LowLevelPutException.REJECTED_OVERLOAD ->
+          errors.inc(InsertExceptionMode.REJECTED_OVERLOAD);
+      case LowLevelPutException.ROUTE_NOT_FOUND -> errors.inc(InsertExceptionMode.ROUTE_NOT_FOUND);
+      case LowLevelPutException.ROUTE_REALLY_NOT_FOUND ->
+          errors.inc(InsertExceptionMode.ROUTE_REALLY_NOT_FOUND);
+      default -> {
+        LOG.error("Unknown LowLevelPutException code: {}", e.code);
+        errors.inc(InsertExceptionMode.INTERNAL_ERROR);
+      }
+    }
+    return false;
   }
 
-  private void fail(InsertException e, boolean forceFatal, ClientContext context) {
+  private boolean handleRouteNotFound(
+      LowLevelPutException e, SendableRequestItem keyNum, ClientContext context) {
+    if (e.code == LowLevelPutException.ROUTE_NOT_FOUND
+        || e.code == LowLevelPutException.ROUTE_REALLY_NOT_FOUND) {
+      consecutiveRNFs++;
+      if (LOG.isDebugEnabled())
+        LOG.debug("Consecutive RNFs: {} / {}", consecutiveRNFs, ctx.consecutiveRNFsCountAsSuccess);
+      if (consecutiveRNFs >= ctx.consecutiveRNFsCountAsSuccess) {
+        if (LOG.isDebugEnabled())
+          LOG.debug("Consecutive RNFs: {} - counting as success", consecutiveRNFs);
+        onSuccess(keyNum, getKeyNoEncode(), context);
+        return true;
+      }
+    } else {
+      consecutiveRNFs = 0;
+    }
+    return false;
+  }
+
+  private void fail(InsertException e, ClientContext context) {
     synchronized (this) {
       if (finished) return;
       finished = true;
     }
-    if (e.isFatal() || forceFatal) parent.fatallyFailedBlock(context);
+    if (e.isFatal()) parent.fatallyFailedBlock(context);
     else parent.failedBlock(context);
     unregister(context, getPriorityClass());
     if (freeData) {
@@ -345,17 +505,26 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     cb.onFailure(e, this, context);
   }
 
-  public ClientKeyBlock getBlock(ClientContext context, boolean calledByCB) {
+  /**
+   * Returns the encoded block for this inserter, encoding on demand.
+   *
+   * <p>On encoding or scheduling failures, the registered callback is notified with the error and
+   * {@code null} is returned. When already finished, {@code null} is also returned.
+   *
+   * @param context Runtime context used for encoding and error reporting.
+   * @return The {@link ClientKeyBlock} if available; {@code null} when finished or on error.
+   */
+  public ClientKeyBlock getBlock(ClientContext context) {
     try {
       synchronized (this) {
         if (finished) return null;
       }
-      return encode(context, calledByCB);
+      return encode(context);
     } catch (InsertException e) {
       cb.onFailure(e, this, context);
       return null;
-    } catch (Throwable t) {
-      LOG.error("Caught " + t, t);
+    } catch (Exception t) {
+      LOG.error(LOG_CAUGHT, t, t);
       cb.onFailure(new InsertException(InsertExceptionMode.INTERNAL_ERROR, t, null), this, context);
       return null;
     }
@@ -365,7 +534,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   public void schedule(ClientContext context) throws InsertException {
     synchronized (this) {
       if (finished) {
-        if (LOG.isDebugEnabled()) LOG.debug("Finished already: " + this);
+        if (LOG.isDebugEnabled()) LOG.debug("Finished already: {}", this);
         return;
       }
     }
@@ -384,23 +553,41 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     return isSSK;
   }
 
+  /**
+   * Returns the resulting URI for this block, encoding first if necessary.
+   *
+   * <p>If the key has not yet been derived, this method triggers encoding by calling {@link
+   * #getBlock(ClientContext)} and then returns the URI once available.
+   *
+   * @param context Runtime context used to perform an on-demand encode.
+   * @return The final content URI for the inserted block.
+   */
   public FreenetURI getURI(ClientContext context) {
     synchronized (this) {
       if (resultingKey != null) {
         return resultingKey.getURI();
       }
     }
-    getBlock(context, true);
+    getBlock(context);
     synchronized (this) {
-      // FIXME not really necessary? resultingKey is never dropped, only set.
       return resultingKey.getURI();
     }
   }
 
+  /**
+   * Returns the resulting URI if already known without triggering a new encode.
+   *
+   * @return The content URI or {@code null} when encoding has not yet produced a key.
+   */
   public synchronized FreenetURI getURINoEncode() {
     return resultingKey == null ? null : resultingKey.getURI();
   }
 
+  /**
+   * Returns the resulting {@link ClientKey} if already known without triggering a new encode.
+   *
+   * @return The client key instance or {@code null} when not yet derived.
+   */
   public synchronized ClientKey getKeyNoEncode() {
     return resultingKey;
   }
@@ -408,39 +595,16 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   @Override
   public void onSuccess(SendableRequestItem keyNum, ClientKey key, ClientContext context) {
     onEncode(key, context);
-    if (LOG.isDebugEnabled()) LOG.debug("Succeeded (" + this + "): " + token);
+    if (LOG.isDebugEnabled()) LOG.debug("Succeeded ({}): {}", this, token);
     if (parent.isCancelled()) {
       fail(new InsertException(InsertExceptionMode.CANCELLED), context);
       return;
     }
-    boolean shouldSendKey = false;
+    boolean shouldSendKey;
     synchronized (this) {
-      if (extraInserts > 0 && !ctx.getCHKOnly) {
-        if (++completedInserts <= extraInserts) {
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "Completed inserts "
-                    + completedInserts
-                    + " of extra inserts "
-                    + extraInserts
-                    + " on "
-                    + this);
-          return; // Let it repeat until we've done enough inserts. It hasn't been unregistered yet.
-        }
-      }
-      if (finished) {
-        // Normal with persistence.
-        LOG.info("Block already completed: " + this);
-        return;
-      }
-      finished = true;
-      if (resultingKey == null) {
-        shouldSendKey = true;
-        resultingKey = key;
-      } else {
-        if (!resultingKey.equals(key))
-          LOG.error("Different key: " + resultingKey + " -> " + key + " for " + this);
-      }
+      SuccessDecision decision = decideOnSuccessLocked(key);
+      if (decision.returnEarly) return;
+      shouldSendKey = decision.shouldSendKey;
     }
     if (freeData) {
       sourceData.free();
@@ -448,11 +612,41 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     }
     parent.completedBlock(false, context);
     unregister(context, getPriorityClass());
-    if (LOG.isDebugEnabled()) LOG.debug("Calling onSuccess for " + cb);
+    if (LOG.isDebugEnabled()) LOG.debug("Calling onSuccess for {}", cb);
     if (shouldSendKey)
       cb.onEncode(
-          key, this, context); // In case of race conditions etc, especially for LocalRequestOnly.
+          key, this, context); // In case of race conditions etc., especially for LocalRequestOnly.
     cb.onSuccess(this, context);
+  }
+
+  private record SuccessDecision(boolean returnEarly, boolean shouldSendKey) {}
+
+  /**
+   * Decides control flow for {@link #onSuccess(SendableRequestItem, ClientKey, ClientContext)}
+   * while holding this instance's monitor.
+   */
+  private SuccessDecision decideOnSuccessLocked(ClientKey key) {
+    if (extraInserts > 0 && !ctx.getCHKOnly && ++completedInserts <= extraInserts) {
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "Completed inserts {} of extra inserts {} on {}", completedInserts, extraInserts, this);
+      // Let it repeat until we've done enough inserts. It hasn't been unregistered yet.
+      return new SuccessDecision(true, false);
+    }
+    if (finished) {
+      // Normal with persistence.
+      LOG.info("Block already completed: {}", this);
+      return new SuccessDecision(true, false);
+    }
+    finished = true;
+    if (resultingKey == null) {
+      resultingKey = key;
+      return new SuccessDecision(false, true);
+    } else {
+      if (!resultingKey.equals(key))
+        LOG.error("Different key: {} -> {} for {}", resultingKey, key, this);
+      return new SuccessDecision(false, false);
+    }
   }
 
   @Override
@@ -481,7 +675,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
 
   @Override
   public synchronized boolean isCancelled() {
-    return finished;
+    return isEmpty();
   }
 
   static class MySendableRequestSender implements SendableRequestSender {
@@ -509,127 +703,22 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
       if (LOG.isDebugEnabled()) LOG.debug("Starting request");
       BlockItem block = (BlockItem) req.token;
       try {
-        try {
-          encodedBlock =
-              innerEncode(
-                  context.random,
-                  block.uri,
-                  block.copyBucket,
-                  block.isMetadata,
-                  block.compressionCodec,
-                  block.sourceLength,
-                  compressorDescriptor,
-                  block.cryptoAlgorithm,
-                  block.cryptoKey);
-          b = encodedBlock.getBlock();
-        } catch (CHKEncodeException e) {
-          throw new LowLevelPutException(
-              LowLevelPutException.INTERNAL_ERROR, e + ":" + e.getMessage(), e);
-        } catch (SSKEncodeException e) {
-          throw new LowLevelPutException(
-              LowLevelPutException.INTERNAL_ERROR, e + ":" + e.getMessage(), e);
-        } catch (MalformedURLException e) {
-          throw new LowLevelPutException(
-              LowLevelPutException.INTERNAL_ERROR, e + ":" + e.getMessage(), e);
-        } catch (InsertException e) {
-          throw new LowLevelPutException(
-              LowLevelPutException.INTERNAL_ERROR, e + ":" + e.getMessage(), e);
-        } catch (IOException e) {
-          throw new LowLevelPutException(
-              LowLevelPutException.INTERNAL_ERROR, e + ":" + e.getMessage(), e);
-        } catch (InvalidCompressionCodecException e) {
-          throw new LowLevelPutException(
-              LowLevelPutException.INTERNAL_ERROR, e + ":" + e.getMessage(), e);
-        }
+        encodedBlock = orig.encodeBlock(block, context, compressorDescriptor);
+        b = encodedBlock.getBlock();
         if (b == null) {
           LOG.error("Asked to send empty block");
           return false;
         }
         key = encodedBlock.getClientKey();
         k = key;
-        context
-            .getJobRunner(block.persistent)
-            .queueNormalOrDrop(
-                context1 -> {
-                  orig.onEncode(key, context1);
-                  return true;
-                });
-        if (req.localRequestOnly)
-          try {
-            core.getNode().store(b, false, req.canWriteClientCache, true, false);
-          } catch (KeyCollisionException e) {
-            KeyBlock collided =
-                core.getNode()
-                    .fetch(k.getNodeKey(), true, req.canWriteClientCache, false, false, null);
-            if (collided == null) {
-              LOG.error("Collided but no key?!");
-              // Could be a race condition.
-              try {
-                core.getNode().store(b, false, req.canWriteClientCache, true, false);
-              } catch (KeyCollisionException e2) {
-                LOG.error("Collided but no key and still collided!");
-                throw new LowLevelPutException(
-                    LowLevelPutException.INTERNAL_ERROR,
-                    "Collided, can't find block, but still collides!",
-                    e);
-              }
-            }
-
-            throw new LowLevelPutException(collided);
-          }
-        else
-          core.realPut(
-              b,
-              req.canWriteClientCache,
-              req.forkOnCacheable,
-              Node.PREFER_INSERT_DEFAULT,
-              Node.IGNORE_LOW_BACKOFF_DEFAULT,
-              req.realTimeFlag);
+        orig.scheduleOnEncodeCallback(key, block, context);
+        orig.putToStore(core, req, b, k);
       } catch (LowLevelPutException e) {
-        if (LOG.isDebugEnabled()) LOG.debug("Caught " + e, e);
-        if (e.code == LowLevelPutException.COLLISION) {
-          // Collision
-          try {
-            ClientSSKBlock collided =
-                ClientSSKBlock.construct(((SSKBlock) e.getCollidedBlock()), (ClientSSK) k);
-            byte[] data = collided.memoryDecode(true);
-            byte[] inserting = BucketTools.toByteArray(block.copyBucket);
-            if (collided.isMetadata() == block.isMetadata
-                && collided.getCompressionCodec() == block.compressionCodec
-                && Arrays.equals(data, inserting)) {
-              if (LOG.isDebugEnabled()) LOG.debug("Collided with identical data");
-              req.onInsertSuccess(k, context);
-              return true;
-            } else {
-              if (LOG.isDebugEnabled())
-                LOG.debug(
-                    "Apparently real collision: collided.isMetadata="
-                        + collided.isMetadata()
-                        + " block.isMetadata="
-                        + block.isMetadata
-                        + " collided.codec="
-                        + collided.getCompressionCodec()
-                        + " block.codec="
-                        + block.compressionCodec
-                        + " collided.datalength="
-                        + data.length
-                        + " block.datalength="
-                        + inserting.length
-                        + " H(collided)="
-                        + Fields.hashCode(data)
-                        + " H(inserting)="
-                        + Fields.hashCode(inserting));
-            }
-          } catch (KeyVerifyException e1) {
-            LOG.error("Caught " + e1 + " when checking collision!", e1);
-          } catch (KeyDecodeException e1) {
-            LOG.error("Caught " + e1 + " when checking collision!", e1);
-          } catch (IOException e1) {
-            LOG.error("Caught " + e1 + " when checking collision!", e1);
-          }
-        }
+        if (LOG.isDebugEnabled()) LOG.debug(LOG_CAUGHT, e, e);
+        if (e.code == LowLevelPutException.COLLISION
+            && orig.handleCollision(e, block, k, context, req)) return true;
         req.onFailure(e, context);
-        if (LOG.isDebugEnabled()) LOG.debug("Request failed for " + e);
+        if (LOG.isDebugEnabled()) LOG.debug("Request failed for {}", String.valueOf(e));
         return true;
       } finally {
         block.copyBucket.free();
@@ -643,6 +732,112 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     public boolean sendIsBlocking() {
       return true;
     }
+  }
+
+  private ClientKeyBlock encodeBlock(
+      BlockItem block, ClientContext context, String compressorDescriptor)
+      throws LowLevelPutException {
+    try {
+      return innerEncode(
+          context.random,
+          block.uri,
+          block.copyBucket,
+          block.isMetadata,
+          block.compressionCodec,
+          block.sourceLength,
+          compressorDescriptor,
+          block.cryptoAlgorithm,
+          block.cryptoKey);
+    } catch (CHKEncodeException
+        | SSKEncodeException
+        | InsertException
+        | IOException
+        | InvalidCompressionCodecException e) {
+      throw new LowLevelPutException(
+          LowLevelPutException.INTERNAL_ERROR, e + ":" + e.getMessage(), e);
+    }
+  }
+
+  private void scheduleOnEncodeCallback(ClientKey key, BlockItem block, ClientContext context) {
+    context
+        .getJobRunner(block.persistent)
+        .queueNormalOrDrop(
+            context1 -> {
+              onEncode(key, context1);
+              return true;
+            });
+  }
+
+  private void putToStore(NodeClientCore core, ChosenBlock req, KeyBlock b, ClientKey k)
+      throws LowLevelPutException {
+    if (req.localRequestOnly)
+      try {
+        core.getNode().store(b, false, req.canWriteClientCache, true, false);
+      } catch (KeyCollisionException e) {
+        KeyBlock collided =
+            core.getNode().fetch(k.getNodeKey(), true, req.canWriteClientCache, false, false, null);
+        if (collided == null) {
+          LOG.error("Collided but no key?!");
+          // Could be a race condition.
+          try {
+            core.getNode().store(b, false, req.canWriteClientCache, true, false);
+          } catch (KeyCollisionException e2) {
+            LOG.error("Collided but no key and still collided!");
+            throw new LowLevelPutException(
+                LowLevelPutException.INTERNAL_ERROR,
+                "Collided, can't find block, but still collides!",
+                e);
+          }
+        }
+
+        throw new LowLevelPutException(collided);
+      }
+    else
+      core.realPut(
+          b,
+          req.canWriteClientCache,
+          req.forkOnCacheable,
+          Node.PREFER_INSERT_DEFAULT,
+          Node.IGNORE_LOW_BACKOFF_DEFAULT,
+          req.realTimeFlag);
+  }
+
+  private boolean handleCollision(
+      LowLevelPutException e,
+      BlockItem block,
+      ClientKey k,
+      ClientContext context,
+      ChosenBlock req) {
+    try {
+      ClientSSKBlock collided =
+          ClientSSKBlock.construct(((SSKBlock) e.getCollidedBlock()), (ClientSSK) k);
+      byte[] data = collided.memoryDecode(true);
+      byte[] inserting = BucketTools.toByteArray(block.copyBucket);
+      if (collided.isMetadata() == block.isMetadata
+          && collided.getCompressionCodec() == block.compressionCodec
+          && Arrays.equals(data, inserting)) {
+        if (LOG.isDebugEnabled()) LOG.debug("Collided with identical data");
+        req.onInsertSuccess(k, context);
+        return true;
+      } else {
+        if (LOG.isDebugEnabled())
+          LOG.debug(
+              "Apparently real collision: collided.isMetadata={} block.isMetadata={}"
+                  + " collided.codec={} block.codec={} collided.datalength={}"
+                  + " block.datalength={} H(collided)={} H(inserting)={}",
+              collided.isMetadata(),
+              block.isMetadata,
+              collided.getCompressionCodec(),
+              block.compressionCodec,
+              data.length,
+              inserting.length,
+              Fields.hashCode(data),
+              Fields.hashCode(inserting));
+      }
+    } catch (KeyVerifyException | KeyDecodeException | IOException e1) {
+      LOG.error(LOG_CAUGHT_WHEN_CHECKING_COLLISION, e1, e1);
+    }
+    return false;
   }
 
   @Override
@@ -667,18 +862,25 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     return tokenObject;
   }
 
-  /** Attempt to encode the block, if necessary */
+  /**
+   * Attempt to encode the block if it has not been encoded yet.
+   *
+   * <p>Exceptions are captured and reported via {@link #fail(InsertException, ClientContext)}. This
+   * helper does not requeue the request on background encoders.
+   *
+   * @param context Runtime context used for encoding.
+   */
   public void tryEncode(ClientContext context) {
     synchronized (this) {
       if (resultingKey != null) return;
       if (finished) return;
     }
     try {
-      encode(context, false);
+      encode(context);
     } catch (InsertException e) {
       fail(e, context);
-    } catch (Throwable t) {
-      LOG.error("Caught " + t, t);
+    } catch (Exception t) {
+      LOG.error(LOG_CAUGHT, t, t);
       // Don't requeue on BackgroundBlockEncoder.
       // Not necessary to do so (we'll ask again when we need it), and it'll probably just break
       // again.
@@ -728,21 +930,18 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
       synchronized (this) {
         if (finished) return null;
       }
-      if (persistent) {
-        if (sourceData == null) {
-          LOG.error("getBlockItem(): sourceData = null");
-          fail(new InsertException(InsertExceptionMode.INTERNAL_ERROR), context);
-          return null;
-        }
+      if (persistent && sourceData == null) {
+        LOG.error("getBlockItem(): sourceData = null");
+        fail(new InsertException(InsertExceptionMode.INTERNAL_ERROR), context);
+        return null;
       }
       Bucket data = sourceData.createShadow();
       FreenetURI u = uri;
       if (u.getKeyType().equals("CHK")) u = FreenetURI.EMPTY_CHK_URI;
-      if (data == null) {
+      if (shouldCopyFrom(data)) {
         data = context.tempBucketFactory.makeBucket(sourceData.size());
         BucketTools.copy(sourceData, data);
       }
-      CompatibilityMode cmode = ctx.getCompatibilityMode();
       return new BlockItem(
           key,
           data,
@@ -797,8 +996,8 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     private final boolean isMetadata;
     private final short compressionCodec;
     private final int sourceLength;
-    public byte cryptoAlgorithm;
-    public byte[] cryptoKey;
+    private final byte cryptoAlgorithm;
+    private final byte[] cryptoKey;
 
     BlockItem(
         BlockItemKey key,
@@ -863,5 +1062,46 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
   @Override
   public void onShutdown(ClientContext context) {
     // Ignore.
+  }
+
+  /**
+   * Helper to determine whether a deep copy is required because createShadow() did not provide a
+   * view.
+   */
+  private static boolean shouldCopyFrom(Bucket shadow) {
+    return shadow == null;
+  }
+
+  /* ===== Java serialization hooks ===== */
+
+  /**
+   * Custom Java serialization hook delegating to default serialization.
+   *
+   * <p>Bucket serialization behavior remains unchanged; if the chosen {@link Bucket} implementation
+   * is not {@link java.io.Serializable} and this instance is being persisted, the same {@link
+   * java.io.NotSerializableException} is thrown as before.
+   *
+   * @param out Object stream receiving the serialized form of this instance.
+   * @throws java.io.IOException If the underlying stream fails while writing object data.
+   */
+  @Serial
+  private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+    // Delegate to default serialization. Bucket serialization behavior remains unchanged; if the
+    // chosen Bucket implementation is not Serializable and this instance is being persisted, the
+    // same NotSerializableException will be thrown as before.
+    out.defaultWriteObject();
+  }
+
+  /**
+   * Custom Java deserialization hook delegating to default deserialization.
+   *
+   * @param in Object stream providing the serialized form of this instance.
+   * @throws java.io.IOException If the underlying stream fails while reading object data.
+   * @throws ClassNotFoundException If a required class cannot be resolved during deserialization.
+   */
+  @Serial
+  private void readObject(java.io.ObjectInputStream in)
+      throws java.io.IOException, ClassNotFoundException {
+    in.defaultReadObject();
   }
 }

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -317,7 +317,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
         if (LOG.isTraceEnabled()) LOG.trace("Inserting without metadata: " + bi + " for " + this);
         cb.onTransition(this, bi, context);
         if (ctx.earlyEncode && bi instanceof SingleBlockInserter inserter && isCHK)
-          inserter.getBlock(context, true);
+          inserter.getBlock(context);
         bi.schedule(context);
         if (!isUSK) cb.onBlockSetFinished(this, context);
         synchronized (this) {
@@ -430,7 +430,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
         mcb.arm(context);
         dataPutter.schedule(context);
         if (ctx.earlyEncode && metaPutter instanceof SingleBlockInserter inserter)
-          inserter.getBlock(context, true);
+          inserter.getBlock(context);
         metaPutter.schedule(context);
         if (!isUSK) cb.onBlockSetFinished(this, context);
         // Deleting origHashes is fine, we are done with them.

--- a/src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
@@ -1,0 +1,574 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Random;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertException;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.crypt.DummyRandomSource;
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.ClientKey;
+import network.crypta.keys.ClientKeyBlock;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.KeysFetchingLocally;
+import network.crypta.node.LowLevelPutException;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SingleBlockInserterTest {
+
+  private InsertContext insertCtx;
+
+  @Mock private BaseClientPutter parent;
+  @Mock private PutCompletionCallback cb;
+
+  private Bucket bucket;
+
+  @BeforeEach
+  void setUp() {
+    insertCtx =
+        new InsertContext(
+            /*maxRetries*/ 5,
+            /*rnfsToSuccess*/ 2,
+            /*splitfileSegmentDataBlocks*/ 1,
+            /*splitfileSegmentCheckBlocks*/ 1,
+            /*eventProducer*/ new SimpleEventProducer(),
+            /*canWriteClientCache*/ true,
+            /*forkOnCacheable*/ true,
+            /*localRequestOnly*/ false,
+            /*compressorDescriptor*/ null,
+            /*extraInsertsSingleBlock*/ 0,
+            /*extraInsertsSplitfileHeaderBlock*/ 0,
+            /*compat*/ CompatibilityMode.COMPAT_CURRENT);
+    bucket = mock(Bucket.class);
+
+    // Reasonable parent defaults used by callbacks (lenient to avoid strict stubbing violations)
+    Mockito.lenient().when(parent.getPriorityClass()).thenReturn((short) 3);
+    Mockito.lenient().when(parent.isCancelled()).thenReturn(false);
+  }
+
+  private static ClientContext newMinimalClientContext(InsertContext defaultInsertCtx) {
+    // Inline priority-aware executor that runs tasks synchronously
+    PriorityAwareExecutor directExec =
+        new PriorityAwareExecutor() {
+          @Override
+          public void execute(Runnable job) {
+            job.run();
+          }
+
+          @Override
+          public void execute(Runnable job, String jobName) {
+            job.run();
+          }
+
+          @Override
+          public void execute(Runnable job, String jobName, boolean fromTicker) {
+            job.run();
+          }
+
+          @Override
+          public int[] waitingThreads() {
+            return new int[] {0};
+          }
+
+          @Override
+          public int[] runningThreads() {
+            return new int[] {0};
+          }
+
+          @Override
+          public int getWaitingThreadsCount() {
+            return 0;
+          }
+        };
+
+    MemoryLimitedJobRunner mlr = new MemoryLimitedJobRunner(1, 1, directExec, 1);
+    return new ClientContext(
+        /*bootID*/ 1L,
+        /*jobRunner*/ null,
+        /*mainExecutor*/ directExec,
+        /*archiveManager*/ null,
+        /*ptbf*/ null,
+        /*tbf*/ null,
+        /*tracker*/ null,
+        /*healingQueue*/ null,
+        /*uskManager*/ null,
+        /*strongRandom*/ new DummyRandomSource(123L),
+        /*fastWeakRandom*/ new Random(42L),
+        /*ticker*/ new NoopTicker(directExec),
+        /*memoryLimitedJobRunner*/ mlr,
+        /*fg*/ null,
+        /*persistentFG*/ null,
+        /*rafFactory*/ null,
+        /*persistentRAFFactory*/ null,
+        /*fileRAFTransient*/ null,
+        /*fileRAFPersistent*/ null,
+        /*rc*/ null,
+        /*checker*/ null,
+        /*persistentRoot*/ null,
+        /*cryptoSecretTransient*/ null,
+        /*linkFilterExceptionProvider*/ null,
+        /*defaultPersistentFetchContext*/ null,
+        /*defaultPersistentInsertContext*/ new InsertContext(
+            defaultInsertCtx, new SimpleEventProducer()),
+        /*config*/ null);
+  }
+
+  // --- Tests ---
+
+  @Test
+  void constructor_whenAddToParentTrue_notifiesParent() {
+    ClientContext ctx = newMinimalClientContext(insertCtx);
+    new SingleBlockInserter(
+        parent,
+        bucket,
+        (short) -1,
+        FreenetURI.EMPTY_CHK_URI,
+        insertCtx,
+        /*realTime*/ false,
+        cb,
+        /*isMetadata*/ false,
+        /*sourceLength*/ 0,
+        /*token*/ 7,
+        /*addToParent*/ true,
+        /*dontSendEncoded*/ true,
+        /*tokenObject*/ new Object(),
+        ctx,
+        /*persistent*/ false,
+        /*freeData*/ false,
+        /*extraInserts*/ 0,
+        /*cryptoAlgorithm*/ (byte) 0,
+        /*cryptoKey*/ null);
+
+    verify(parent, times(1)).addMustSucceedBlocks(1);
+    verify(parent, times(1)).notifyClients(ctx);
+  }
+
+  @Test
+  void encode_whenDontSendEncodedFalse_callsCallbackAndSetsKey() throws Exception {
+    ClientContext ctx = newMinimalClientContext(insertCtx);
+    SingleBlockInserter sbi =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            FreenetURI.EMPTY_CHK_URI,
+            insertCtx,
+            false,
+            cb,
+            false,
+            0,
+            1,
+            false,
+            /*dontSendEncoded*/ false,
+            new Object(),
+            ctx,
+            false,
+            /*freeData*/ false,
+            0,
+            (byte) 0,
+            null);
+
+    // Spy to stub innerEncode, returning a block with a known key
+    SingleBlockInserter spy = Mockito.spy(sbi);
+    ClientKeyBlock block = mock(ClientKeyBlock.class);
+    ClientKey key = mock(ClientKey.class);
+    when(block.getClientKey()).thenReturn(key);
+    doReturn(block).when(spy).innerEncode(any(RandomSource.class));
+
+    ClientKeyBlock result = spy.getBlock(ctx);
+
+    assertNotNull(result);
+    assertEquals(key, spy.getKeyNoEncode());
+    verify(cb, times(1)).onEncode(key, spy, ctx);
+  }
+
+  @Test
+  void encode_whenDontSendEncodedTrue_doesNotCallCallback() throws Exception {
+    ClientContext ctx = newMinimalClientContext(insertCtx);
+    SingleBlockInserter sbi =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            FreenetURI.EMPTY_CHK_URI,
+            insertCtx,
+            false,
+            cb,
+            false,
+            0,
+            1,
+            false,
+            /*dontSendEncoded*/ true,
+            new Object(),
+            ctx,
+            false,
+            /*freeData*/ false,
+            0,
+            (byte) 0,
+            null);
+
+    SingleBlockInserter spy = Mockito.spy(sbi);
+    ClientKeyBlock block = mock(ClientKeyBlock.class);
+    ClientKey key = mock(ClientKey.class);
+    when(block.getClientKey()).thenReturn(key);
+    doReturn(block).when(spy).innerEncode(any(RandomSource.class));
+
+    ClientKeyBlock result = spy.getBlock(ctx);
+    assertNotNull(result);
+    verify(cb, never()).onEncode(any(), any(), any());
+  }
+
+  @Test
+  void onFailure_whenCollision_triggersFatalAndFrees() {
+    ClientContext ctx = newMinimalClientContext(insertCtx);
+    // freeData=true so source bucket is freed on failure
+    SingleBlockInserter inserter =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            FreenetURI.EMPTY_CHK_URI,
+            insertCtx,
+            false,
+            cb,
+            false,
+            0,
+            1,
+            false,
+            true,
+            new Object(),
+            ctx,
+            false,
+            /*freeData*/ true,
+            0,
+            (byte) 0,
+            null);
+
+    inserter.onFailure(new LowLevelPutException(LowLevelPutException.COLLISION), null, ctx);
+
+    verify(parent, times(1)).fatallyFailedBlock(ctx);
+    verify(cb, times(1))
+        .onFailure(any(InsertException.class), Mockito.eq(inserter), Mockito.eq(ctx));
+    verify(bucket, times(1)).free();
+    assertTrue(inserter.isEmpty());
+  }
+
+  @Test
+  void onFailure_whenRNFThresholdReached_callsOnSuccess() {
+    ClientContext ctx = newMinimalClientContext(insertCtx);
+    // freeData=true so bucket is freed on success path
+    try (ArrayBucket realBucket = new ArrayBucket()) {
+      SingleBlockInserter inserter =
+          new SingleBlockInserter(
+              parent,
+              realBucket,
+              (short) -1,
+              FreenetURI.EMPTY_CHK_URI,
+              insertCtx,
+              false,
+              cb,
+              false,
+              0,
+              1,
+              false,
+              true,
+              new Object(),
+              ctx,
+              false,
+              /*freeData*/ true,
+              0,
+              (byte) 0,
+              null);
+
+      inserter.onFailure(new LowLevelPutException(LowLevelPutException.ROUTE_NOT_FOUND), null, ctx);
+      inserter.onFailure(new LowLevelPutException(LowLevelPutException.ROUTE_NOT_FOUND), null, ctx);
+
+      verify(parent, times(1)).completedBlock(false, ctx);
+      verify(cb, times(1)).onSuccess(inserter, ctx);
+      assertTrue(inserter.isEmpty());
+      // ArrayBucket should be freed by inserter; subsequent getInputStream must fail
+      assertThrows(IOException.class, realBucket::getInputStream);
+    }
+  }
+
+  @Test
+  void getWakeupTime_whenAlreadyRunningInsert_returnsMax() {
+    // Build a mocked context that returns a mocked insert scheduler
+    ClientRequestScheduler mockScheduler = mock(ClientRequestScheduler.class);
+    KeysFetchingLocally keysFetching = mock(KeysFetchingLocally.class);
+    when(mockScheduler.fetchingKeys()).thenReturn(keysFetching);
+    when(keysFetching.hasInsert(any())).thenReturn(true);
+    ClientContext ctx = mock(ClientContext.class);
+    when(ctx.getChkInsertScheduler(false)).thenReturn(mockScheduler);
+
+    SingleBlockInserter inserter =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            FreenetURI.EMPTY_CHK_URI,
+            insertCtx,
+            false,
+            cb,
+            false,
+            0,
+            1,
+            false,
+            true,
+            new Object(),
+            ctx,
+            false,
+            false,
+            0,
+            (byte) 0,
+            null);
+
+    long wake = inserter.getWakeupTime(ctx, /*now*/ 0L);
+    assertEquals(Long.MAX_VALUE, wake);
+  }
+
+  @Test
+  void getWakeupTime_whenNotRunning_returnsImmediate() {
+    ClientRequestScheduler mockScheduler = mock(ClientRequestScheduler.class);
+    KeysFetchingLocally keysFetching = mock(KeysFetchingLocally.class);
+    when(mockScheduler.fetchingKeys()).thenReturn(keysFetching);
+    when(keysFetching.hasInsert(any())).thenReturn(false);
+    ClientContext ctx = mock(ClientContext.class);
+    when(ctx.getChkInsertScheduler(false)).thenReturn(mockScheduler);
+
+    SingleBlockInserter inserter =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            FreenetURI.EMPTY_CHK_URI,
+            insertCtx,
+            false,
+            cb,
+            false,
+            0,
+            1,
+            false,
+            true,
+            new Object(),
+            ctx,
+            false,
+            false,
+            0,
+            (byte) 0,
+            null);
+
+    long wake = inserter.getWakeupTime(ctx, /*now*/ 0L);
+    assertEquals(0L, wake);
+  }
+
+  @Test
+  void cancel_marksFinished_andNotifies_andFrees() {
+    ClientContext ctx = newMinimalClientContext(insertCtx);
+    SingleBlockInserter inserter =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            FreenetURI.EMPTY_CHK_URI,
+            insertCtx,
+            false,
+            cb,
+            false,
+            0,
+            1,
+            false,
+            true,
+            new Object(),
+            ctx,
+            false,
+            /*freeData*/ true,
+            0,
+            (byte) 0,
+            null);
+
+    inserter.cancel(ctx);
+
+    assertTrue(inserter.isEmpty());
+    assertTrue(inserter.isCancelled());
+    verify(cb, times(1))
+        .onFailure(any(InsertException.class), Mockito.eq(inserter), Mockito.eq(ctx));
+    verify(bucket, times(1)).free();
+  }
+
+  @Test
+  void innerOnResume_callsBucketResume_andCallbackResume_andSchedules() throws Exception {
+    ClientContext ctx = newMinimalClientContext(insertCtx);
+    SingleBlockInserter sbi =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            FreenetURI.EMPTY_CHK_URI,
+            insertCtx,
+            false,
+            cb,
+            false,
+            0,
+            1,
+            false,
+            true,
+            new Object(),
+            ctx,
+            false,
+            false,
+            0,
+            (byte) 0,
+            null);
+    SingleBlockInserter spy = Mockito.spy(sbi);
+    doNothing().when(spy).schedule(ctx);
+
+    spy.innerOnResume(ctx);
+
+    verify(bucket, times(1)).onResume(ctx);
+    verify(cb, times(1)).onResume(ctx);
+    verify(spy, times(1)).schedule(ctx);
+  }
+
+  @Test
+  void flags_and_isSSK_reflectContextAndUri() {
+    ClientContext ctx = newMinimalClientContext(insertCtx);
+    SingleBlockInserter chkInserter =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            FreenetURI.EMPTY_CHK_URI,
+            insertCtx,
+            false,
+            cb,
+            true,
+            0,
+            1,
+            false,
+            true,
+            new Object(),
+            ctx,
+            false,
+            false,
+            0,
+            (byte) 0,
+            null);
+
+    assertFalse(chkInserter.isSSK());
+    assertTrue(chkInserter.canWriteClientCache());
+    assertTrue(chkInserter.forkOnCacheable());
+    assertFalse(chkInserter.localRequestOnly());
+
+    // SSK variant: the constructor only inspects uri.getKeyType()
+    SingleBlockInserter sskInserter =
+        new SingleBlockInserter(
+            parent,
+            bucket,
+            (short) -1,
+            new FreenetURI("SSK", "doc"),
+            insertCtx,
+            false,
+            cb,
+            false,
+            0,
+            1,
+            false,
+            true,
+            new Object(),
+            ctx,
+            false,
+            false,
+            0,
+            (byte) 0,
+            null);
+    assertTrue(sskInserter.isSSK());
+  }
+
+  @Test
+  void innerEncode_static_whenUnknownKeyType_throwsInvalidUri() {
+    // Use a USK to trigger the "unknown keytype" path in SingleBlockInserter.innerEncode()
+    FreenetURI usk = new FreenetURI("USK", "doc");
+    try (ArrayBucket src = new ArrayBucket()) {
+      assertThrows(
+          InsertException.class,
+          () ->
+              SingleBlockInserter.innerEncode(
+                  new DummyRandomSource(1L),
+                  usk,
+                  src,
+                  /*isMetadata*/ false,
+                  (short) -1,
+                  /*sourceLength*/ 0,
+                  /*compressorDescriptor*/ null,
+                  /*cryptoAlgorithm*/ (byte) 0,
+                  /*cryptoKey*/ null),
+          "Unknown key types must throw InsertException(INVALID_URI)");
+    }
+  }
+
+  // --- Test helpers ---
+
+  /** No-op ticker used to satisfy ClientContext construction. */
+  private static final class NoopTicker implements Ticker {
+    private final PriorityAwareExecutor exec;
+
+    NoopTicker(PriorityAwareExecutor exec) {
+      this.exec = exec;
+    }
+
+    @Override
+    public void queueTimedJob(Runnable job, long offset) {
+      exec.execute(job);
+    }
+
+    @Override
+    public void queueTimedJob(
+        Runnable job, String name, long offset, boolean runOnTickerAnyway, boolean noDupes) {
+      exec.execute(job);
+    }
+
+    @Override
+    public PriorityAwareExecutor getExecutor() {
+      return exec;
+    }
+
+    @Override
+    public void removeQueuedJob(Runnable job) {
+      // no-op
+    }
+
+    @Override
+    public void queueTimedJobAbsolute(
+        Runnable runner, String name, long time, boolean runOnTickerAnyway, boolean noDupes) {
+      exec.execute(runner);
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Improve SingleBlockInserter KDoc and concurrency notes
- Add SingleBlockInserterTest covering async insert behavior and callbacks
- Minor tidy in SingleFileInserter
- Apply Spotless formatting across touched files

Scope
- Base: develop
- Head: feature/fix-SingleBlockInserter
- Commits on this branch: 1
  - 2535246352 fix(client): improve SingleBlockInserter docs/concurrency and add tests

Diff Stats (vs develop)
- 13 files changed, 1432 insertions(+), 2599 deletions(-)
- Key files:
  - M src/main/java/network/crypta/client/async/SingleBlockInserter.java
  - M src/main/java/network/crypta/client/async/SingleFileInserter.java
  - A src/test/java/network/crypta/client/async/SingleBlockInserterTest.java
  - Other async client classes updated by prior work on the branch (KeyListener*, USKFetcher, etc.)

Notes
- Working tree clean prior to PR creation.
- Spotless was run before commit; build system and dependency verification remain unchanged.
- Please review deletions in tests (KeyListenerTrackerTest, SingleKeyListenerTest, SplitFileFetcherKeyListenerTest) as they originate from earlier commits on this branch relative to develop.

Verification
- Code formatted via Spotless (Java/Kotlin/Gradle).
- JUnit 6 test layout maintained; SingleBlockInserterTest added under src/test/java.

Next Steps
- If desired, I can split unrelated file changes into a separate branch/PR to keep the scope focused on SingleBlockInserter improvements.