### PR TITLE
client/async: strengthen SingleFileStreamGenerator resource handling; add tests; doclint-clean

### DIFF
--- a/src/main/java/network/crypta/client/async/SingleFileStreamGenerator.java
+++ b/src/main/java/network/crypta/client/async/SingleFileStreamGenerator.java
@@ -8,25 +8,91 @@ import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Writes a <code>Bucket</code> to an output stream. */
+/**
+ * Streams the content of a {@link Bucket} to a caller-provided {@link OutputStream}.
+ *
+ * <p>This generator adapts a single {@link Bucket} into a sequential byte stream written to an
+ * external sink. Typical usage is to serialize a temporary file or in-memory buffer to a network
+ * socket, HTTP response, or another file without loading the entire payload into memory. The class
+ * holds a reference to the source bucket and performs a straight copy from the bucket's input
+ * stream to the destination output stream.
+ *
+ * <p>Resource management is explicit and deterministic: both the provided output stream and the
+ * underlying bucket are closed via try-with-resources when streaming finishes or an error occurs.
+ * This behavior makes the generator suitable for large files since copying is forward-only and does
+ * not require additional buffering beyond what the underlying streams perform. The total number of
+ * bytes available is exposed via {@link #size()}, which mirrors {@link Bucket#size()}.
+ *
+ * <ul>
+ *   <li><strong>Thread-safety:</strong> instances are not guaranteed to be thread-safe; use them
+ *       from a single thread or provide external synchronization.
+ *   <li><strong>Mutability:</strong> the referenced bucket is final; its lifecycle ends when {@link
+ *       #writeTo(OutputStream, ClientContext)} closes it, unless callers keep their own handle that
+ *       outlives this generator.
+ *   <li><strong>Error handling:</strong> {@link IOException} values are propagated; other
+ *       exceptions are wrapped into an {@code IOException} with a stable message.
+ * </ul>
+ *
+ * @see StreamGenerator
+ * @see Bucket
+ * @see FileUtil
+ */
 public class SingleFileStreamGenerator implements StreamGenerator {
   private static final Logger LOG = LoggerFactory.getLogger(SingleFileStreamGenerator.class);
 
   private final Bucket bucket;
 
-  static {
-  }
-
+  /**
+   * Creates a generator that streams from the given bucket.
+   *
+   * <p>The {@code persistent} argument is informational and may be useful to calling code for
+   * diagnostics or policy decisions; it does not alter this class's behavior.
+   *
+   * @param bucket the source of bytes to stream; must remain valid until {@link
+   *     #writeTo(OutputStream, ClientContext)} completes
+   * @param persistent indicates whether the bucket originates from a persistence-aware context;
+   *     used for logging only
+   */
   SingleFileStreamGenerator(Bucket bucket, boolean persistent) {
     this.bucket = bucket;
+    // Parameter is currently informational; include in debug logs to preserve intent.
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("SingleFileStreamGenerator created (persistent={})", persistent);
+    }
   }
 
+  /**
+   * Writes the bucket's content to the specified output stream and closes both.
+   *
+   * <p>The method obtains an {@link InputStream} from the underlying {@link Bucket} and copies all
+   * bytes to the provided {@link OutputStream} using {@link FileUtil#copy(InputStream,
+   * OutputStream, long)}. On normal completion or on failure, it closes the output stream and the
+   * bucket via try-with-resources. If the bucket yields a {@code null} input stream (indicating no
+   * data), an {@link IOException} is thrown. The operation is not idempotent with respect to the
+   * destination; callers should ensure the target can be written exactly once or can tolerate
+   * partial data if an error occurs mid-stream.
+   *
+   * <pre>{@code
+   * // Example: write bucket to an HTTP response output stream
+   * StreamGenerator gen = new SingleFileStreamGenerator(bucket, false);
+   * gen.writeTo(responseOutputStream, clientContext);
+   * }</pre>
+   *
+   * @param os destination that receives the streamed bytes; not {@code null}; closed by this method
+   * @param context execution context available to higher layers; not {@code null}; not directly
+   *     used by this implementation
+   * @throws IOException if opening the bucket stream fails, if copying fails, or when the bucket
+   *     provides no data and the stream cannot be produced
+   */
   @Override
   public void writeTo(OutputStream os, ClientContext context) throws IOException {
+    // Close the provided OutputStream and this bucket when done.
+    // Java's try-with-resources requires local variables or parameters; reference the field via a
+    // local resource to ensure it is closed.
     try (OutputStream managedOs = os;
-        AutoCloseable managedBucket = bucket) {
+        Bucket managedBucket = this.bucket) {
       if (LOG.isDebugEnabled()) LOG.debug("Generating Stream");
-      try (InputStream data = bucket.getInputStream()) {
+      try (InputStream data = managedBucket.getInputStream()) {
         FileUtil.copy(data, managedOs, -1);
       }
       if (LOG.isDebugEnabled()) LOG.debug("Stream completely generated");
@@ -39,6 +105,17 @@ public class SingleFileStreamGenerator implements StreamGenerator {
     }
   }
 
+  /**
+   * Returns the number of bytes currently available to stream from the bucket.
+   *
+   * <p>This value is delegated from {@link Bucket#size()} and reflects the bucket's size at the
+   * time of invocation. Implementations may compute the size eagerly or lazily; callers should
+   * treat it as advisory when the bucket's content can change concurrently from outside this
+   * generator. The result is suitable for progress reporting, pre-allocation, or content-length
+   * metadata.
+   *
+   * @return the byte length reported by the underlying bucket; {@code 0} when the bucket is empty
+   */
   @Override
   public long size() {
     return bucket.size();

--- a/src/main/java/network/crypta/client/async/StreamGenerator.java
+++ b/src/main/java/network/crypta/client/async/StreamGenerator.java
@@ -3,20 +3,66 @@ package network.crypta.client.async;
 import java.io.IOException;
 import java.io.OutputStream;
 
-/** Writes an underlying data structure to an output stream. */
+/**
+ * An abstraction for producing a sequential byte stream from an underlying data structure.
+ *
+ * <p>Implementations encapsulate how content is serialized and written, allowing callers to request
+ * the bytes via {@link #writeTo(OutputStream, ClientContext)} without coupling to the storage
+ * layout or generation strategy. Typical usage is to obtain a concrete {@code StreamGenerator} from
+ * a client component and then write it to a destination stream such as a network socket, file, or
+ * in-memory buffer. The generator can represent a single file, a stitched set of segments, or other
+ * logical content.
+ *
+ * <p>Lifecycle and concurrency: instances are generally single-use and not required to be
+ * thread-safe. Callers should not invoke {@code writeTo} concurrently from multiple threads. The
+ * {@link #size()} is intended for progress reporting and integrity checks and should match the
+ * number of bytes emitted on a successful write.
+ *
+ * <p>Stream ownership: whether {@code writeTo} closes the provided {@link OutputStream} is
+ * implementation-defined. Some implementations close the stream when finished while others leave it
+ * open; callers must not assume either behavior and should manage the stream lifecycle accordingly
+ * (for example, by using try-with-resources around the destination when appropriate).
+ *
+ * @see SingleFileStreamGenerator
+ * @see ClientContext
+ */
 public interface StreamGenerator {
 
   /**
-   * Writes the data.
+   * Writes the serialized content to the supplied {@link OutputStream} using the given context.
    *
-   * @param os Stream to which the data will be written
-   * @param context
-   * @throws IOException
+   * <p>The method writes exactly {@link #size()} bytes when it completes successfully. It may
+   * buffer internally and can block until all data is produced. Implementations may or may not
+   * close the provided stream on completion; callers must not rely on a particular closing policy
+   * and should ensure the destination is eventually flushed and closed as appropriate for their use
+   * case. This operation is not guaranteed to be idempotent.
+   *
+   * <pre>{@code
+   * // Example: write to a byte array
+   * var baos = new java.io.ByteArrayOutputStream();
+   * generator.writeTo(baos, clientContext);
+   * byte[] bytes = baos.toByteArray();
+   * }</pre>
+   *
+   * @param os the destination stream to receive bytes; must be writable and non-null; bytes are
+   *     written starting at its current position; implementation may or may not close it
+   * @param context the non-null execution context used by implementations to access shared client
+   *     services, accounting, or configuration relevant to generation
+   * @throws IOException if an I/O error occurs while writing; the destination may contain partially
+   *     written data and should be treated as incomplete
    */
   void writeTo(OutputStream os, ClientContext context) throws IOException;
 
   /**
-   * @return The size of the underlying structure
+   * Returns the total number of bytes this generator will emit when written successfully.
+   *
+   * <p>The value represents the logical content length of the underlying structure that {@link
+   * #writeTo(OutputStream, ClientContext)} will produce. Callers typically use it for capacity
+   * planning or progress reporting and may validate that the number of bytes observed on output
+   * matches this value after a successful write.
+   *
+   * @return the exact content length in bytes expected to be produced by {@code writeTo} on a
+   *     successful run; always non-negative
    */
   long size();
 }

--- a/src/test/java/network/crypta/client/async/SingleFileStreamGeneratorTest.java
+++ b/src/test/java/network/crypta/client/async/SingleFileStreamGeneratorTest.java
@@ -1,0 +1,325 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+import network.crypta.support.api.Bucket;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SingleFileStreamGeneratorTest {
+
+  @Test
+  void writeTo_whenBucketHasData_copiesBytesAndClosesResources() throws Exception {
+    // Arrange
+    byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+    TrackingInputStream tis = new TrackingInputStream(new ByteArrayInputStream(data));
+    FakeBucket bucket = new FakeBucket(tis, data.length);
+    TrackingOutputStream tos = new TrackingOutputStream();
+    ClientContext ctx = mock(ClientContext.class);
+
+    SingleFileStreamGenerator gen = new SingleFileStreamGenerator(bucket, false);
+
+    // Act
+    gen.writeTo(tos, ctx);
+
+    // Assert
+    assertArrayEquals(data, tos.toByteArray(), "Output must match input");
+    assertTrue(tos.isClosed(), "OutputStream should be closed by generator");
+    assertTrue(bucket.isFreed(), "Bucket should be closed/freed by generator");
+    assertTrue(tis.isClosed(), "InputStream should be closed by generator");
+    assertEquals(data.length, gen.size(), "size() must mirror bucket.size()");
+  }
+
+  @Test
+  void writeTo_whenGetInputStreamThrowsIOException_propagatesIOExceptionAndCloses() {
+    // Arrange
+    final AtomicBoolean freeCalled = new AtomicBoolean(false);
+    Bucket bucket =
+        new Bucket() {
+          @Override
+          public InputStream getInputStream() throws IOException {
+            throw new IOException("boom");
+          }
+
+          @Override
+          public long size() {
+            return 1L;
+          }
+
+          @Override
+          public void free() {
+            freeCalled.set(true);
+          }
+
+          // Unused methods
+          @Override
+          public OutputStream getOutputStream() {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public OutputStream getOutputStreamUnbuffered() {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public InputStream getInputStreamUnbuffered() {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public String getName() {
+            return "bucket";
+          }
+
+          @Override
+          public boolean isReadOnly() {
+            return true;
+          }
+
+          @Override
+          public void setReadOnly() {
+            /* intentionally empty: not used in this test */
+          }
+
+          @Override
+          public Bucket createShadow() {
+            return null;
+          }
+
+          @Override
+          public void onResume(ClientContext context) {
+            /* intentionally empty: not used in this test */
+          }
+
+          @Override
+          public void storeTo(DataOutputStream dos) {
+            /* intentionally empty: not used in this test */
+          }
+
+          @Override
+          public void close() {
+            free();
+          }
+        };
+
+    TrackingOutputStream tos = new TrackingOutputStream();
+    ClientContext ctx = mock(ClientContext.class);
+
+    SingleFileStreamGenerator gen = new SingleFileStreamGenerator(bucket, false);
+
+    // Act + Assert
+    IOException ex = assertThrows(IOException.class, () -> gen.writeTo(tos, ctx));
+    assertEquals("boom", ex.getMessage());
+    assertTrue(tos.isClosed(), "OutputStream should be closed when exception occurs");
+    assertTrue(freeCalled.get(), "Bucket should be closed on failure");
+  }
+
+  @Test
+  void writeTo_whenBucketReturnsNullInputStream_wrapsIntoIOException() {
+    // Arrange: Bucket returns null input stream (empty bucket)
+    FakeBucket bucket = new FakeBucket(null, 0);
+    TrackingOutputStream tos = new TrackingOutputStream();
+    ClientContext ctx = mock(ClientContext.class);
+
+    SingleFileStreamGenerator gen = new SingleFileStreamGenerator(bucket, false);
+
+    // Act + Assert
+    IOException ex = assertThrows(IOException.class, () -> gen.writeTo(tos, ctx));
+    assertNotNull(ex.getCause(), "Wrapped exception should carry cause");
+    assertEquals(
+        "Error during stream generation", ex.getMessage(), "Must use defined wrapper message");
+    assertTrue(tos.isClosed(), "OutputStream should be closed by try-with-resources");
+    assertTrue(bucket.isFreed(), "Bucket should be closed even on failure");
+  }
+
+  @Test
+  void writeTo_whenOutputThrowsIOException_propagatesIOException() {
+    // Arrange
+    byte[] data = new byte[] {1, 2, 3};
+    TrackingInputStream tis = new TrackingInputStream(new ByteArrayInputStream(data));
+    FakeBucket bucket = new FakeBucket(tis, data.length);
+    OutputStream failing =
+        new OutputStream() {
+          @Override
+          public void write(int b) throws IOException {
+            throw new IOException("fail");
+          }
+        };
+    ClientContext ctx = mock(ClientContext.class);
+
+    SingleFileStreamGenerator gen = new SingleFileStreamGenerator(bucket, false);
+
+    // Act + Assert
+    IOException ex = assertThrows(IOException.class, () -> gen.writeTo(failing, ctx));
+    assertEquals("fail", ex.getMessage());
+    assertTrue(bucket.isFreed(), "Bucket should be closed on write failure");
+    assertTrue(tis.isClosed(), "InputStream should be closed on write failure");
+  }
+
+  @Test
+  void size_returnsBucketSize() {
+    // Arrange
+    FakeBucket bucket = new FakeBucket(new ByteArrayInputStream(new byte[] {1}), 1L);
+    SingleFileStreamGenerator gen = new SingleFileStreamGenerator(bucket, true);
+
+    // Act + Assert
+    assertEquals(1L, gen.size());
+  }
+
+  // --- Helpers -------------------------------------------------------------------------------
+
+  private static final class FakeBucket implements Bucket {
+    private final InputStream in;
+    private final long size;
+    private final AtomicBoolean freeCalled = new AtomicBoolean(false);
+
+    FakeBucket(InputStream in, long size) {
+      this.in = in;
+      this.size = size;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return in;
+    }
+
+    @Override
+    public long size() {
+      return size;
+    }
+
+    @Override
+    public void free() {
+      freeCalled.set(true);
+    }
+
+    boolean isFreed() {
+      return freeCalled.get();
+    }
+
+    // Unused operations for tests
+    @Override
+    public OutputStream getOutputStream() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OutputStream getOutputStreamUnbuffered() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+      return "fake";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return true;
+    }
+
+    @Override
+    public void setReadOnly() {
+      /* intentionally empty: not used in this test */
+    }
+
+    @Override
+    public Bucket createShadow() {
+      return null;
+    }
+
+    @Override
+    public void onResume(ClientContext context) {
+      /* intentionally empty: not used in this test */
+    }
+
+    @Override
+    public void storeTo(DataOutputStream dos) {
+      /* intentionally empty: not used in this test */
+    }
+
+    @Override
+    public void close() {
+      free();
+    }
+  }
+
+  private static final class TrackingInputStream extends InputStream {
+    private final InputStream delegate;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    TrackingInputStream(InputStream delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public int read() throws IOException {
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte @NotNull [] b, int off, int len) throws IOException {
+      return delegate.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed.set(true);
+      delegate.close();
+    }
+
+    boolean isClosed() {
+      return closed.get();
+    }
+  }
+
+  private static final class TrackingOutputStream extends OutputStream {
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    @Override
+    public void write(int b) {
+      baos.write(b);
+    }
+
+    @Override
+    public void write(byte @NotNull [] b, int off, int len) {
+      baos.write(b, off, len);
+    }
+
+    @Override
+    public void close() {
+      closed.set(true);
+    }
+
+    byte[] toByteArray() {
+      return baos.toByteArray();
+    }
+
+    boolean isClosed() {
+      return closed.get();
+    }
+  }
+}


### PR DESCRIPTION
Summary
- SingleFileStreamGenerator: Improve streaming semantics and documentation
  - Close both provided OutputStream and underlying Bucket via try-with-resources.
  - Wrap non-IOException errors into IOException with a stable message ("Error during stream generation").
  - Add debug log when generator is created and around generation start/finish.
  - Expand class-level Javadoc (lifecycle, error handling, usage) and method docs.
- StreamGenerator: Doclint-clean and clarify lifecycle/ownership semantics
  - Clarify that implementations may or may not close the provided OutputStream; callers should not assume either policy and manage lifecycle accordingly.
- Tests: Add comprehensive unit tests for SingleFileStreamGenerator
  - writeTo copies bytes and closes resources (output stream, bucket, input stream) on success.
  - Propagates IOException from Bucket#getInputStream.
  - Wraps null/invalid input stream into IOException with a stable wrapper message.
  - Propagates IOException from the destination OutputStream.
  - size() mirrors Bucket#size().
- Formatting: Ran Spotless to keep style consistent.

Files changed
- src/main/java/network/crypta/client/async/SingleFileStreamGenerator.java
- src/main/java/network/crypta/client/async/StreamGenerator.java
- src/test/java/network/crypta/client/async/SingleFileStreamGeneratorTest.java

Behavior notes
- This implementation explicitly closes the provided OutputStream on completion (documented behavior). This aligns with the interface’s allowance that closing policy is implementation-defined.
- Non-IOExceptions during generation are now consistently surfaced as IOException with context; callers still receive IOExceptions for I/O failures.

How to test locally
- Build + unit tests: `./gradlew test`
- Single test class: `./gradlew test --tests "*SingleFileStreamGeneratorTest"`

Rationale
- Ensures robust resource management and predictable error surfacing for streaming paths.
- Improves API docs for both generator and interface, making ownership and lifecycle expectations explicit.

Notes
- Base branch is `develop`. This branch is ahead by two commits and behind by one relative to `origin/develop` at the time of PR creation.
