### PR TITLE
refactor(client): SplitFileInserter Options builder; update callers

### DIFF
--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -649,31 +649,29 @@ class SingleFileInserter implements ClientPutState, Serializable {
       throw new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null);
     }
     if (reportMetadataOnly) {
+      SplitFileInserter.Options opts =
+          new SplitFileInserter.Options.Builder()
+              .ctx(ctx)
+              .context(context)
+              .decompressedLength(origSize)
+              .compressionCodec(bestCodec)
+              .meta(block.clientMetadata)
+              .isMetadata(metadata)
+              .archiveType(archiveType)
+              .splitfileCryptoAlgorithm(cryptoAlgorithm)
+              .splitfileCryptoKey(forceCryptoKey)
+              .hashThisLayerOnly(hashThisLayerOnly)
+              .hashes(hashes)
+              .topDontCompress((ctx.dontCompress || this.dontCompress))
+              .topRequiredBlocks(parent.getMinSuccessFetchBlocks())
+              .topTotalBlocks(parent.getTotalBlocks())
+              .origDataSize(origDataLength)
+              .origCompressedDataSize(origCompressedDataLength)
+              .realTime(realTimeFlag)
+              .token(token)
+              .build();
       SplitFileInserter sfi =
-          new SplitFileInserter(
-              persistent,
-              parent,
-              cb,
-              dataRAF,
-              shouldFreeData,
-              ctx,
-              context,
-              origSize,
-              bestCodec,
-              block.clientMetadata,
-              metadata,
-              archiveType,
-              cryptoAlgorithm,
-              forceCryptoKey,
-              hashThisLayerOnly,
-              hashes,
-              (ctx.dontCompress || this.dontCompress),
-              parent.getMinSuccessFetchBlocks(),
-              parent.getTotalBlocks(),
-              origDataLength,
-              origCompressedDataLength,
-              realTimeFlag,
-              token);
+          new SplitFileInserter(persistent, parent, cb, dataRAF, shouldFreeData, opts);
       if (LOG.isTraceEnabled()) LOG.trace("Inserting as splitfile: {} for {}", sfi, this);
       cb.onTransition(this, sfi, context);
       sfi.schedule(context);
@@ -690,31 +688,29 @@ class SingleFileInserter implements ClientPutState, Serializable {
               || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal());
       if (metadata) allowSizes = false;
       SplitHandler sh = new SplitHandler(origSize, data.size(), allowSizes);
+      SplitFileInserter.Options opts =
+          new SplitFileInserter.Options.Builder()
+              .ctx(ctx)
+              .context(context)
+              .decompressedLength(origSize)
+              .compressionCodec(bestCodec)
+              .meta(block.clientMetadata)
+              .isMetadata(metadata)
+              .archiveType(archiveType)
+              .splitfileCryptoAlgorithm(cryptoAlgorithm)
+              .splitfileCryptoKey(forceCryptoKey)
+              .hashThisLayerOnly(hashThisLayerOnly)
+              .hashes(hashes)
+              .topDontCompress((ctx.dontCompress || this.dontCompress))
+              .topRequiredBlocks(parent.getMinSuccessFetchBlocks())
+              .topTotalBlocks(parent.getTotalBlocks())
+              .origDataSize(origDataLength)
+              .origCompressedDataSize(origCompressedDataLength)
+              .realTime(realTimeFlag)
+              .token(token)
+              .build();
       SplitFileInserter sfi =
-          new SplitFileInserter(
-              persistent,
-              parent,
-              sh,
-              dataRAF,
-              shouldFreeData,
-              ctx,
-              context,
-              origSize,
-              bestCodec,
-              block.clientMetadata,
-              metadata,
-              archiveType,
-              cryptoAlgorithm,
-              forceCryptoKey,
-              hashThisLayerOnly,
-              hashes,
-              (ctx.dontCompress || this.dontCompress),
-              parent.getMinSuccessFetchBlocks(),
-              parent.getTotalBlocks(),
-              origDataLength,
-              origCompressedDataLength,
-              realTimeFlag,
-              token);
+          new SplitFileInserter(persistent, parent, sh, dataRAF, shouldFreeData, opts);
       sh.sfi = sfi;
       if (LOG.isTraceEnabled())
         LOG.trace("Inserting as splitfile: {} for {} for {}", sfi, sh, this);

--- a/src/main/java/network/crypta/client/async/SplitFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserter.java
@@ -3,6 +3,7 @@ package network.crypta.client.async;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
@@ -21,18 +22,43 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Top level class for a splitfile insert. Note that Storage is not persistent, it will be recreated
- * here on resume, like in splitfile fetches. The actual status is stored in a RAF.
+ * Coordinates a split-file insert from caller-provided data into the network.
+ *
+ * <p>A split-file insert encodes the original content into segments and blocks, computes the
+ * necessary checksums and keys, and then schedules network inserts for those pieces. The {@code
+ * SplitFileInserter} orchestrates this high-level flow while delegating the heavy lifting to {@link
+ * SplitFileInserterStorage} (encoding and state persistence) and {@link SplitFileInserterSender}
+ * (network scheduling). Storage is not kept as a persistent object instance across restarts;
+ * instead, its state is reconstructed from a random-access file (RAF) on resume, similar to the
+ * fetch path.
+ *
+ * <p>Typical usage is: construct the inserter with an {@link InsertContext} and options, call
+ * {@link #schedule(ClientContext)} to begin, and then react to completion via the provided {@link
+ * PutCompletionCallback}. When resuming a persistent insert, call {@link #onResume(ClientContext)}
+ * to rehydrate state and continue. The inserter reports metadata once keys are available and
+ * ensures buffers are closed/freed on success or failure.
+ *
+ * <p>Concurrency: this class is used from the client layer and from worker callbacks. It relies on
+ * {@link AtomicReference} fields for thread-safe publication of its storage and sender helpers, and
+ * performs scheduling through the {@link ClientContext} job runners. Instances are not generally
+ * thread-safe for arbitrary concurrent calls; callers should follow the lifecycle entry points
+ * ({@link #schedule(ClientContext)}, {@link #cancel(ClientContext)}, {@link
+ * #onResume(ClientContext)}).
+ *
+ * <ul>
+ *   <li>Persists progress in an RAF to enable reliable resume.
+ *   <li>Streams metadata to the caller early when configured to do so.
+ *   <li>Honors real-time priority settings via the provided {@link InsertContext}.
+ * </ul>
  *
  * @author toad
+ * @see SplitFileInserterStorage
+ * @see SplitFileInserterSender
  */
 public class SplitFileInserter
     implements ClientPutState, Serializable, SplitFileInserterStorageCallback {
 
   private static final Logger LOG = LoggerFactory.getLogger(SplitFileInserter.class);
-
-  static {
-  }
 
   @Serial private static final long serialVersionUID = 1L;
 
@@ -61,10 +87,10 @@ public class SplitFileInserter
    * Stores the state of the insert and does most of the work. Created in onResume() or in the
    * constructor, so must be volatile.
    */
-  private transient volatile SplitFileInserterStorage storage;
+  private transient AtomicReference<SplitFileInserterStorage> storageRef;
 
   /** Actually does the insert. Created in onResume() or in the constructor, so must be volatile. */
-  private transient volatile SplitFileInserterSender sender;
+  private transient AtomicReference<SplitFileInserterSender> senderRef;
 
   /** Used any time a callback from storage needs us to do something higher level */
   private transient ClientContext context;
@@ -80,105 +106,470 @@ public class SplitFileInserter
 
   private transient boolean resumed;
 
+  /* ===== Options to reduce constructor parameter count (Sonar S107) ===== */
+
+  /**
+   * Immutable bundle of options used to construct a {@link SplitFileInserter}. Using a builder
+   * avoids overly long constructors while keeping call sites explicit and readable. The values are
+   * captured at build time and are not subsequently mutated.
+   *
+   * <p>Unless otherwise noted, sizes are in bytes and counts are non-negative. Callers should
+   * ensure that referenced buffers and contexts outlive the construction phase and remain valid
+   * until the insert is started or resumed.
+   */
+  public static final class Options implements Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
+    /** Insert behavior, scheduling and encoding options used by the client layer. */
+    final InsertContext ctx;
+
+    /** Execution context and facilities; transient and provided by the runtime. */
+    final transient ClientContext context;
+
+    /** Length of the content after decompression; used when the original is compressed. */
+    final long decompressedLength;
+
+    /** Compression algorithm to apply at the top level, or {@code null} for none. */
+    final COMPRESSOR_TYPE compressionCodec;
+
+    /** Optional client metadata to embed or return with the insert result. */
+    final ClientMetadata meta;
+
+    /** Whether the payload itself represents metadata rather than regular file content. */
+    final boolean isMetadata;
+
+    /** Archive format for bundling, when applicable; controls how data is framed. */
+    final ARCHIVE_TYPE archiveType;
+
+    /** Splitfile crypto algorithm identifier used for key derivation and block protection. */
+    final byte splitfileCryptoAlgorithm;
+
+    /** Opaque splitfile crypto key material; ownership remains with the caller. */
+    final byte[] splitfileCryptoKey;
+
+    /** Optional layer-local hash; limits hashing to the current layer when non-null. */
+    final byte[] hashThisLayerOnly;
+
+    /** Precomputed hash results for segments/blocks used to speed up verification. */
+    final HashResult[] hashes;
+
+    /** If {@code true}, skip top-level compression even when a codec is present. */
+    final boolean topDontCompress;
+
+    /** Minimum number of blocks that must succeed at the top layer. */
+    final int topRequiredBlocks;
+
+    /** Total number of blocks at the top layer; includes redundant blocks. */
+    final int topTotalBlocks;
+
+    /** Size of the original (uncompressed) data in bytes for reporting and checks. */
+    final long origDataSize;
+
+    /** Size of the original compressed form, when available; zero when unknown. */
+    final long origCompressedDataSize;
+
+    /** If {@code true}, use real-time insertion priorities; otherwise use background scheduling. */
+    final boolean realTime;
+
+    /** Opaque caller token associated with this insert; returned unchanged in callbacks. */
+    final transient Object token;
+
+    private Options(Builder b) {
+      this.ctx = b.ctx;
+      this.context = b.context;
+      this.decompressedLength = b.decompressedLength;
+      this.compressionCodec = b.compressionCodec;
+      this.meta = b.meta;
+      this.isMetadata = b.isMetadata;
+      this.archiveType = b.archiveType;
+      this.splitfileCryptoAlgorithm = b.splitfileCryptoAlgorithm;
+      this.splitfileCryptoKey = b.splitfileCryptoKey;
+      this.hashThisLayerOnly = b.hashThisLayerOnly;
+      this.hashes = b.hashes;
+      this.topDontCompress = b.topDontCompress;
+      this.topRequiredBlocks = b.topRequiredBlocks;
+      this.topTotalBlocks = b.topTotalBlocks;
+      this.origDataSize = b.origDataSize;
+      this.origCompressedDataSize = b.origCompressedDataSize;
+      this.realTime = b.realTime;
+      this.token = b.token;
+    }
+
+    /**
+     * Builder for {@link Options}.
+     *
+     * <p>The builder is mutable and not thread-safe. Callers typically set the desired fields using
+     * the fluent setters below and finish with {@link Builder#build()} to create an immutable
+     * {@link Options} instance suitable for constructing a {@link SplitFileInserter}.
+     */
+    public static final class Builder {
+      private InsertContext ctx;
+      private ClientContext context;
+      private long decompressedLength;
+      private COMPRESSOR_TYPE compressionCodec;
+      private ClientMetadata meta;
+      private boolean isMetadata;
+      private ARCHIVE_TYPE archiveType;
+      private byte splitfileCryptoAlgorithm;
+      private byte[] splitfileCryptoKey;
+      private byte[] hashThisLayerOnly;
+      private HashResult[] hashes;
+      private boolean topDontCompress;
+      private int topRequiredBlocks;
+      private int topTotalBlocks;
+      private long origDataSize;
+      private long origCompressedDataSize;
+      private boolean realTime;
+      private Object token;
+
+      /**
+       * Creates a new builder with default values.
+       *
+       * <p>All fields are initialized to their language defaults. Call the fluent setters to
+       * customize options and then {@link #build()} to create an immutable snapshot.
+       */
+      public Builder() {
+        // Intentionally empty: the builder uses language-default field values and is
+        // configured via the fluent setters before creating an immutable Options snapshot.
+      }
+
+      /**
+       * Sets the high-level insert context controlling encoding, priorities, and callbacks.
+       *
+       * @param v context instance; must remain valid for the lifetime of the insert; never {@code
+       *     null}
+       * @return this builder for fluent chaining; the instance is reused
+       */
+      public Builder ctx(InsertContext v) {
+        this.ctx = v;
+        return this;
+      }
+
+      /**
+       * Sets the execution context providing job runners, buffers, and utilities.
+       *
+       * @param v client execution context; provides schedulers and factories; never {@code null}
+       * @return this builder for fluent chaining; modifies internal state
+       */
+      public Builder context(ClientContext v) {
+        this.context = v;
+        return this;
+      }
+
+      /**
+       * Specifies the decompressed byte length when the input is compressed.
+       *
+       * @param v size in bytes; non-negative; use {@code 0} when the value is unknown
+       * @return this builder for fluent chaining; leaves other fields unchanged
+       */
+      public Builder decompressedLength(long v) {
+        this.decompressedLength = v;
+        return this;
+      }
+
+      /**
+       * Selects the compression codec to use at the top layer.
+       *
+       * @param v codec enum value or {@code null} to disable top-level compression
+       * @return this builder for fluent chaining; sets the compression preference
+       */
+      public Builder compressionCodec(COMPRESSOR_TYPE v) {
+        this.compressionCodec = v;
+        return this;
+      }
+
+      /**
+       * Provides optional client metadata to be returned with the result.
+       *
+       * @param v arbitrary metadata to associate with the insert; may be {@code null}
+       * @return this builder for fluent chaining; does not copy the reference
+       */
+      public Builder meta(ClientMetadata v) {
+        this.meta = v;
+        return this;
+      }
+
+      /**
+       * Indicates that the payload is metadata rather than regular content.
+       *
+       * @param v {@code true} when the data represents metadata for a higher-level object
+       * @return this builder for fluent chaining; toggles a simple boolean flag
+       */
+      public Builder isMetadata(boolean v) {
+        this.isMetadata = v;
+        return this;
+      }
+
+      /**
+       * Sets the archive format to use when framing or bundling the payload.
+       *
+       * @param v archive type; determines container behavior; may be {@code null}
+       * @return this builder for fluent chaining; updates the archive preference
+       */
+      public Builder archiveType(ARCHIVE_TYPE v) {
+        this.archiveType = v;
+        return this;
+      }
+
+      /**
+       * Configures the splitfile crypto algorithm identifier.
+       *
+       * @param v algorithm id as a small numeric value; accepted range depends on runtime
+       * @return this builder for fluent chaining; stores the provided value verbatim
+       */
+      public Builder splitfileCryptoAlgorithm(byte v) {
+        this.splitfileCryptoAlgorithm = v;
+        return this;
+      }
+
+      /**
+       * Supplies the splitfile crypto key material.
+       *
+       * @param v key bytes; caller retains ownership; array content may be read but not modified
+       * @return this builder for fluent chaining; references the provided array
+       */
+      public Builder splitfileCryptoKey(byte[] v) {
+        this.splitfileCryptoKey = v;
+        return this;
+      }
+
+      /**
+       * Restricts hashing to the current layer by providing a layer-local hash.
+       *
+       * @param v optional hash bytes indicating current-layer hashing only; may be {@code null}
+       * @return this builder for fluent chaining; replaces any prior value
+       */
+      public Builder hashThisLayerOnly(byte[] v) {
+        this.hashThisLayerOnly = v;
+        return this;
+      }
+
+      /**
+       * Provides precomputed hash results for segments or blocks to accelerate verification.
+       *
+       * @param v array of hash results; elements may be {@code null} if unavailable
+       * @return this builder for fluent chaining; stores the array reference
+       */
+      public Builder hashes(HashResult[] v) {
+        this.hashes = v;
+        return this;
+      }
+
+      /**
+       * Disables compression at the top level when set to {@code true}.
+       *
+       * @param v {@code true} to skip compression even if a codec is configured
+       * @return this builder for fluent chaining; flips a boolean control
+       */
+      public Builder topDontCompress(boolean v) {
+        this.topDontCompress = v;
+        return this;
+      }
+
+      /**
+       * Sets the required number of blocks that must succeed at the top layer.
+       *
+       * @param v non-negative number of mandatory blocks; must be ≤ total blocks
+       * @return this builder for fluent chaining; validates later in construction
+       */
+      public Builder topRequiredBlocks(int v) {
+        this.topRequiredBlocks = v;
+        return this;
+      }
+
+      /**
+       * Sets the total number of top-layer blocks including redundancy.
+       *
+       * @param v non-negative total blocks; must be ≥ required blocks to be valid
+       * @return this builder for fluent chaining; used to compute redundancy
+       */
+      public Builder topTotalBlocks(int v) {
+        this.topTotalBlocks = v;
+        return this;
+      }
+
+      /**
+       * Records the uncompressed size of the original input.
+       *
+       * @param v byte length of the input data; non-negative; {@code 0} when unknown
+       * @return this builder for fluent chaining; informational only
+       */
+      public Builder origDataSize(long v) {
+        this.origDataSize = v;
+        return this;
+      }
+
+      /**
+       * Records the compressed size of the original input when available.
+       *
+       * @param v byte length of the compressed form; non-negative; {@code 0} when unavailable
+       * @return this builder for fluent chaining; used for progress reporting when present
+       */
+      public Builder origCompressedDataSize(long v) {
+        this.origCompressedDataSize = v;
+        return this;
+      }
+
+      /**
+       * Requests real-time scheduling for the insert when {@code true}.
+       *
+       * @param v {@code true} to prioritize latency over throughput; otherwise background behavior
+       * @return this builder for fluent chaining; maps to scheduler selection
+       */
+      public Builder realTime(boolean v) {
+        this.realTime = v;
+        return this;
+      }
+
+      /**
+       * Associates an opaque caller-defined token with this insert.
+       *
+       * @param v token object; returned unchanged in callbacks; may be {@code null}
+       * @return this builder for fluent chaining; stores the reference only
+       */
+      public Builder token(Object v) {
+        this.token = v;
+        return this;
+      }
+
+      /**
+       * Builds an immutable {@link Options} snapshot from the current builder values.
+       *
+       * <p>This method does not deep-copy mutable inputs; callers should avoid mutating arrays or
+       * objects after building. Validation, when required, is performed by downstream constructors.
+       *
+       * @return a new {@link Options} instance containing the configured values
+       */
+      public Options build() {
+        return new Options(this);
+      }
+    }
+  }
+
   SplitFileInserter(
       boolean persistent,
       BaseClientPutter parent,
       PutCompletionCallback cb,
       LockableRandomAccessBuffer originalData,
       boolean freeData,
-      InsertContext ctx,
-      ClientContext context,
-      long decompressedLength,
-      COMPRESSOR_TYPE compressionCodec,
-      ClientMetadata meta,
-      boolean isMetadata,
-      ARCHIVE_TYPE archiveType,
-      byte splitfileCryptoAlgorithm,
-      byte[] splitfileCryptoKey,
-      byte[] hashThisLayerOnly,
-      HashResult[] hashes,
-      boolean topDontCompress,
-      int topRequiredBlocks,
-      int topTotalBlocks,
-      long origDataSize,
-      long origCompressedDataSize,
-      boolean realTime,
-      Object token)
+      Options options)
       throws InsertException {
     this.persistent = persistent;
     this.parent = parent;
     this.cb = cb;
     this.originalData = originalData;
-    this.context = context;
+    this.context = options.context;
     this.freeData = freeData;
+    SplitFileInserterStorage s;
     try {
-      storage =
+      SplitFileInserterStorage storage =
           new SplitFileInserterStorage(
               originalData,
-              decompressedLength,
+              options.decompressedLength,
               this,
-              compressionCodec,
-              meta,
-              isMetadata,
-              archiveType,
-              context.getRandomAccessBufferFactory(persistent),
+              options.compressionCodec,
+              options.meta,
+              options.isMetadata,
+              options.archiveType,
+              options.context.getRandomAccessBufferFactory(persistent),
               persistent,
-              ctx,
-              splitfileCryptoAlgorithm,
-              splitfileCryptoKey,
-              hashThisLayerOnly,
-              hashes,
-              context.tempBucketFactory /* only used for temporaries within constructor */,
+              options.ctx,
+              options.splitfileCryptoAlgorithm,
+              options.splitfileCryptoKey,
+              options.hashThisLayerOnly,
+              options.hashes,
+              options.context.tempBucketFactory /* only used for temporaries within constructor */,
               new CRCChecksumChecker(),
-              context.fastWeakRandom,
-              context.memoryLimitedJobRunner,
-              context.getJobRunner(persistent),
-              context.ticker,
-              context.getChkInsertScheduler(realTime).fetchingKeys(),
-              topDontCompress,
-              topRequiredBlocks,
-              topTotalBlocks,
-              origDataSize,
-              origCompressedDataSize);
-      int mustSucceed = storage.topRequiredBlocks - topRequiredBlocks;
+              options.context.fastWeakRandom,
+              options.context.memoryLimitedJobRunner,
+              options.context.getJobRunner(persistent),
+              options.context.ticker,
+              options.context.getChkInsertScheduler(options.realTime).fetchingKeys(),
+              options.topDontCompress,
+              options.topRequiredBlocks,
+              options.topTotalBlocks,
+              options.origDataSize,
+              options.origCompressedDataSize);
+      int mustSucceed = storage.topRequiredBlocks - options.topRequiredBlocks;
       parent.addMustSucceedBlocks(mustSucceed);
-      parent.addRedundantBlocksInsert(storage.topTotalBlocks - topTotalBlocks - mustSucceed);
-      parent.notifyClients(context);
+      parent.addRedundantBlocksInsert(
+          storage.topTotalBlocks - options.topTotalBlocks - mustSucceed);
+      parent.notifyClients(options.context);
+      s = storage;
     } catch (IOException e) {
       throw new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null);
     }
-    this.raf = storage.getRAF();
-    this.sender = new SplitFileInserterSender(this, storage);
-    this.realTime = realTime;
-    this.token = token;
-    this.ctx = ctx;
+    this.raf = s.getRAF();
+    this.storageRef = new AtomicReference<>();
+    this.senderRef = new AtomicReference<>();
+    this.storageRef.set(s);
+    this.senderRef.set(new SplitFileInserterSender(this, s));
+    this.realTime = options.realTime;
+    this.token = options.token;
+    this.ctx = options.ctx;
   }
 
+  /** {@inheritDoc} */
   @Override
   public BaseClientPutter getParent() {
     return parent;
   }
 
+  /**
+   * Requests cancellation of the insert and fails the operation.
+   *
+   * <p>This method propagates a {@link InsertExceptionMode#CANCELLED} to the underlying storage,
+   * which triggers cleanup and completion callbacks. It is safe to call multiple times; subsequent
+   * calls have no additional effect once failure handling has begun.
+   *
+   * @param context execution context used by the caller; ignored for cancellation semantics
+   */
   @Override
   public void cancel(ClientContext context) {
-    storage.fail(new InsertException(InsertExceptionMode.CANCELLED));
+    storageRef.get().fail(new InsertException(InsertExceptionMode.CANCELLED));
   }
 
+  /**
+   * Starts or continues the insert by encoding data and scheduling network activity.
+   *
+   * <p>Notifies the callback that block selection is finished, starts the storage encoding
+   * pipeline, and, when not in CHK-only mode, schedules the sender to insert any available blocks.
+   * Callers may invoke this after construction or from progress callbacks to advance work.
+   *
+   * @param context execution context providing schedulers and timing; never {@code null}
+   * @throws InsertException if scheduling or storage start fails for a recoverable reason
+   */
   @Override
   public void schedule(ClientContext context) throws InsertException {
     cb.onBlockSetFinished(this, context);
-    storage.start();
+    storageRef.get().start();
     if (!ctx.getCHKOnly) {
-      sender.clearWakeupTime(context);
-      sender.schedule(context);
+      senderRef.get().clearWakeupTime(context);
+      senderRef.get().schedule(context);
     }
   }
 
+  /**
+   * Returns the opaque token originally provided by the caller.
+   *
+   * @return caller-supplied token associated with this insert; may be {@code null}
+   */
   @Override
   public Object getToken() {
     return token;
   }
 
+  /**
+   * Resumes a previously persistent insert by restoring state from disk and re-scheduling work.
+   *
+   * <p>This method re-initializes transient collaborators, replays storage state from the RAF,
+   * updates internals, and then calls {@link #schedule(ClientContext)} to continue. It is
+   * idempotent: only the first call takes effect; subsequent calls are ignored.
+   *
+   * @param context execution context for persistent resumes; must be a persistent-capable context
+   * @throws InsertException if a storage or scheduling error occurs during resume
+   * @throws ResumeFailedException if on-disk state is corrupt or cannot be reconciled
+   */
   @Override
   public void onResume(ClientContext context) throws InsertException, ResumeFailedException {
     assert (persistent);
@@ -190,7 +581,7 @@ public class SplitFileInserter
     try {
       raf.onResume(context);
       originalData.onResume(context);
-      this.storage =
+      SplitFileInserterStorage storage =
           new SplitFileInserterStorage(
               raf,
               originalData,
@@ -204,29 +595,17 @@ public class SplitFileInserter
               context.getPersistentFileTracker(),
               context.getPersistentMasterSecret());
       storage.onResume(context);
-      this.sender = new SplitFileInserterSender(this, storage);
+      this.storageRef = new AtomicReference<>();
+      this.senderRef = new AtomicReference<>();
+      this.storageRef.set(storage);
+      this.senderRef.set(new SplitFileInserterSender(this, storage));
       schedule(context);
-    } catch (IOException e) {
-      LOG.error("Resume failed: " + e, e);
+    } catch (IOException | StorageFormatException | ChecksumFailedException e) {
       raf.close();
       raf.free();
       originalData.close();
       if (freeData) originalData.free();
-      throw new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null);
-    } catch (StorageFormatException e) {
-      LOG.error("Resume failed: " + e, e);
-      raf.close();
-      raf.free();
-      originalData.close();
-      if (freeData) originalData.free();
-      throw new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null);
-    } catch (ChecksumFailedException e) {
-      LOG.error("Resume failed: " + e, e);
-      raf.close();
-      raf.free();
-      originalData.close();
-      if (freeData) originalData.free();
-      throw new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null);
+      throw new InsertException(InsertExceptionMode.BUCKET_ERROR, "Resume failed", e, null);
     }
   }
 
@@ -235,6 +614,12 @@ public class SplitFileInserter
     // Ignore.
   }
 
+  /**
+   * Called when additional encoding progress is available.
+   *
+   * <p>If not in CHK-only mode, this reschedules the sender so newly created blocks can be inserted
+   * as soon as possible. In CHK-only mode, it returns immediately and waits for key availability.
+   */
   @Override
   public void encodingProgress() {
     // We've encoded a segment. Start inserting the blocks we have immediately.
@@ -246,104 +631,196 @@ public class SplitFileInserter
       // Reschedule to insert the new check blocks.
       schedule(context);
     } catch (InsertException e) {
-      storage.fail(e);
+      storageRef.get().fail(e);
     }
   }
 
+  /**
+   * Called when keys for the split-file are available.
+   *
+   * <p>When early-encode or CHK-only modes are enabled, encodes metadata on a background runner and
+   * reports it to the callback, short-circuiting to success in CHK-only mode.
+   */
   @Override
   public void onHasKeys() {
     if (ctx.earlyEncode || ctx.getCHKOnly) {
       context
           .getJobRunner(persistent)
           .queueNormalOrDrop(
-              context -> {
+              jobCtx -> {
                 try {
-                  Metadata metadata = storage.encodeMetadata();
+                  Metadata metadata = storageRef.get().encodeMetadata();
                   reportMetadata(metadata);
                   if (ctx.getCHKOnly) onSucceeded(metadata);
                 } catch (IOException e) {
-                  storage.fail(new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null));
+                  storageRef
+                      .get()
+                      .fail(new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null));
                 } catch (MissingKeyException e) {
-                  storage.fail(
-                      new InsertException(
-                          InsertExceptionMode.BUCKET_ERROR, "Lost one or more keys", e, null));
+                  storageRef
+                      .get()
+                      .fail(
+                          new InsertException(
+                              InsertExceptionMode.BUCKET_ERROR, "Lost one or more keys", e, null));
                 }
                 return false;
               });
     }
   }
 
+  /**
+   * Signals successful completion of the insert, performs cleanup, and notifies the callback.
+   *
+   * <p>Ensures the sender is unregistered, reports metadata if it has not already been reported,
+   * then closes and frees owned buffers. Runs on a job runner suitable for the persistence mode.
+   *
+   * @param metadata final metadata describing the inserted split-file; never {@code null}
+   */
   @Override
   public void onSucceeded(final Metadata metadata) {
     context
         .getJobRunner(persistent)
         .queueNormalOrDrop(
-            new PersistentJob() {
-
-              @Override
-              public boolean run(ClientContext context) {
-                if (LOG.isDebugEnabled()) LOG.debug("Succeeding on " + SplitFileInserter.this);
-                unregisterSender();
-                if (!(ctx.earlyEncode || ctx.getCHKOnly)) {
-                  reportMetadata(metadata);
-                }
-                cb.onSuccess(SplitFileInserter.this, context);
-                raf.close();
-                raf.free();
-                originalData.close();
-                if (freeData) originalData.free();
-                return true;
+            jobCtx -> {
+              if (LOG.isDebugEnabled()) LOG.debug("Succeeding on {}", SplitFileInserter.this);
+              unregisterSender();
+              if (!(ctx.earlyEncode || ctx.getCHKOnly)) {
+                reportMetadata(metadata);
               }
+              cb.onSuccess(SplitFileInserter.this, jobCtx);
+              raf.close();
+              raf.free();
+              originalData.close();
+              if (freeData) originalData.free();
+              return true;
             });
   }
 
+  /**
+   * Unregisters the sender with schedulers so it no longer participates in network activity.
+   *
+   * <p>This helper is invoked on success and failure paths to ensure resources are released and the
+   * scheduler state is updated consistently.
+   */
   protected void unregisterSender() {
-    sender.unregister(context, parent.getPriorityClass());
+    SplitFileInserterSender s = senderRef.get();
+    if (s != null) s.unregister(context, parent.getPriorityClass());
   }
 
+  /**
+   * Reports the metadata for this insert to the completion callback.
+   *
+   * <p>Split-file inserts always operate in a “report metadata only” mode at this layer: the
+   * metadata is returned to the parent, which may persist it to a bucket and perform any follow-up
+   * insert.
+   *
+   * @param metadata the computed metadata describing the encoded split-file; never {@code null}
+   */
   protected void reportMetadata(Metadata metadata) {
-    // Splitfile insert is always reportMetadataOnly, i.e. it always passes the metadata back
-    // to the parent SingleFileInserter, which will write it to a Bucket and probably insert it.
+    // Splitfile insert is always reportMetadataOnly: metadata is returned to the parent
+    // SingleFileInserter, which will persist it and likely insert it as needed.
     cb.onMetadata(metadata, this, context);
   }
 
+  /**
+   * Signals a terminal failure, performs cleanup, and notifies the callback.
+   *
+   * <p>Unregisters the sender, releases resources, and calls the completion callback with the
+   * encountered exception. Runs on a job runner suitable for the persistence mode.
+   *
+   * @param e the reason for failure
+   */
   @Override
   public void onFailed(final InsertException e) {
     context
         .getJobRunner(persistent)
         .queueNormalOrDrop(
-            context -> {
+            jobCtx -> {
               unregisterSender();
               raf.close();
               raf.free();
               originalData.close();
               if (freeData) originalData.free();
-              cb.onFailure(e, SplitFileInserter.this, context);
+              cb.onFailure(e, SplitFileInserter.this, jobCtx);
               return true;
             });
   }
 
+  /**
+   * Returns the total length in bytes of the original data being inserted.
+   *
+   * <p>The value reflects the authoritative length recorded by the storage layer and may be used by
+   * callers for progress reporting and validation.
+   *
+   * @return original data length in bytes; non-negative and constant for the lifetime of the insert
+   */
   public long getLength() {
-    return storage.dataLength;
+    return storageRef.get().dataLength;
   }
 
+  /** Notifies the parent that a block has been inserted so progress can be updated. */
   @Override
   public void onInsertedBlock() {
     parent.completedBlock(false, context);
   }
 
+  /**
+   * Propagates shutdown to the storage layer so it can quiesce and persist state.
+   *
+   * @param context execution context used for shutdown; never {@code null}
+   */
   @Override
   public void onShutdown(ClientContext context) {
-    storage.onShutdown(context);
+    storageRef.get().onShutdown(context);
   }
 
+  /** Clears any sender backoff so scheduling can proceed without delay. */
   @Override
   public void clearCooldown() {
-    sender.clearWakeupTime(context);
+    senderRef.get().clearWakeupTime(context);
   }
 
+  /**
+   * Returns the priority class associated with this insert as defined by the parent.
+   *
+   * @return a priority class identifier; larger values typically indicate lower priority
+   */
   @Override
   public short getPriorityClass() {
     return parent.getPriorityClass();
+  }
+
+  /* ===== Java serialization support ===== */
+
+  /**
+   * Custom Java serialization hook to persist non-transient state.
+   *
+   * <p>Writes the default serial form; transient collaborators are reconstructed on resume rather
+   * than serialized directly.
+   *
+   * @param out target output stream used by the Java serialization mechanism
+   * @throws IOException if an I/O error occurs while writing the default serial form
+   */
+  @Serial
+  private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+  }
+
+  /**
+   * Custom Java deserialization hook to restore transient holders.
+   *
+   * <p>Reads the default serial form and recreates transient {@link AtomicReference} fields. Actual
+   * operational state is re-established later in {@link #onResume(ClientContext)}.
+   *
+   * @param in source input stream used by the Java serialization mechanism
+   * @throws IOException if an I/O error occurs while reading the default serial form
+   * @throws ClassNotFoundException if a class for a serialized field cannot be located
+   */
+  @Serial
+  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    // Recreate transient holders; actual values are restored on resume.
+    this.storageRef = new AtomicReference<>();
+    this.senderRef = new AtomicReference<>();
   }
 }

--- a/src/test/java/network/crypta/client/async/SplitFileInserterTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterTest.java
@@ -1,0 +1,609 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Random;
+import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertException;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.Metadata;
+import network.crypta.crypt.HashResult;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.RequestClient;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+class SplitFileInserterTest {
+
+  private BaseClientPutter parent;
+  private PutCompletionCallback cb;
+  private LockableRandomAccessBuffer originalData;
+  private LockableRandomAccessBuffer raf;
+  private ClientContext context;
+
+  @BeforeEach
+  void setUp() {
+    parent = Mockito.mock(BaseClientPutter.class);
+    cb = Mockito.mock(PutCompletionCallback.class);
+    originalData = Mockito.mock(LockableRandomAccessBuffer.class);
+    raf = Mockito.mock(LockableRandomAccessBuffer.class);
+
+    // Persistent runner that executes jobs immediately and inline for determinism.
+    // Persistent job runner used by ClientContext
+    ClientLayerPersister jobRunner = Mockito.mock(ClientLayerPersister.class);
+    doAnswer(
+            inv -> {
+              PersistentJob job = inv.getArgument(0);
+              // Use the context spy below; it will be initialized later in buildContext().
+              job.run(context);
+              return null;
+            })
+        .when(jobRunner)
+        .queueNormalOrDrop(any(PersistentJob.class));
+
+    context = buildContext(jobRunner);
+  }
+
+  private ClientContext buildContext(ClientLayerPersister runner) {
+    // Immediate executor for predictable behavior in tests.
+    PriorityAwareExecutor immediateExecutor =
+        new PriorityAwareExecutor() {
+          @Override
+          public void execute(Runnable job) {
+            job.run();
+          }
+
+          @Override
+          public void execute(Runnable job, String jobName) {
+            job.run();
+          }
+
+          @Override
+          public void execute(Runnable job, String jobName, boolean fromTicker) {
+            job.run();
+          }
+
+          @Override
+          public int[] waitingThreads() {
+            return new int[0];
+          }
+
+          @Override
+          public int[] runningThreads() {
+            return new int[0];
+          }
+
+          @Override
+          public int getWaitingThreadsCount() {
+            return 0;
+          }
+        };
+
+    Ticker ticker =
+        new Ticker() {
+          @Override
+          public void queueTimedJob(Runnable job, long offset) {
+            job.run();
+          }
+
+          @Override
+          public void queueTimedJob(
+              Runnable job, String name, long offset, boolean runOnTickerAnyway, boolean noDupes) {
+            job.run();
+          }
+
+          @Override
+          public PriorityAwareExecutor getExecutor() {
+            return immediateExecutor;
+          }
+
+          @Override
+          public void removeQueuedJob(Runnable job) {
+            // Intentionally no-op in tests: we run tasks immediately via the
+            // inline executor, so nothing is ever queued to remove.
+          }
+
+          @Override
+          public void queueTimedJobAbsolute(
+              Runnable runner2,
+              String name,
+              long time,
+              boolean runOnTickerAnyway,
+              boolean noDupes) {
+            runner2.run();
+          }
+        };
+
+    // Many collaborators are not used by SplitFileInserter directly; provide simple mocks.
+    var archiveManager = Mockito.mock(network.crypta.client.ArchiveManager.class);
+    var ptbf = Mockito.mock(network.crypta.support.io.PersistentTempBucketFactory.class);
+    var tbf = Mockito.mock(network.crypta.support.io.TempBucketFactory.class);
+    var tracker = Mockito.mock(network.crypta.support.io.PersistentFileTracker.class);
+    var hq = Mockito.mock(network.crypta.client.async.HealingQueue.class);
+    var uskManager = Mockito.mock(network.crypta.client.async.USKManager.class);
+    var strongRandom = Mockito.mock(RandomSource.class);
+    var fastWeakRandom = new Random(1234);
+    var memLimited = Mockito.mock(network.crypta.support.MemoryLimitedJobRunner.class);
+    var fg = Mockito.mock(network.crypta.support.io.FilenameGenerator.class);
+    var persistentFG = Mockito.mock(network.crypta.support.io.FilenameGenerator.class);
+    var rafFactory = Mockito.mock(LockableRandomAccessBufferFactory.class);
+    var persistentRAFFactory = Mockito.mock(LockableRandomAccessBufferFactory.class);
+    var fileRAFTransient =
+        Mockito.mock(network.crypta.support.io.FileRandomAccessBufferFactory.class);
+    var fileRAFPersistent =
+        Mockito.mock(network.crypta.support.io.FileRandomAccessBufferFactory.class);
+    var rc = Mockito.mock(network.crypta.support.compress.RealCompressor.class);
+    var dsChecker = Mockito.mock(network.crypta.client.async.DatastoreChecker.class);
+    var persistentRoot = Mockito.mock(network.crypta.clients.fcp.PersistentRequestRoot.class);
+    var masterSecret = Mockito.mock(network.crypta.crypt.MasterSecret.class);
+    var linkFilterProvider =
+        Mockito.mock(network.crypta.client.filter.LinkFilterExceptionProvider.class);
+    var fetchCtx = Mockito.mock(network.crypta.client.FetchContext.class);
+    var insertCtx =
+        new InsertContext(
+            0,
+            0,
+            128,
+            128,
+            new network.crypta.client.events.SimpleEventProducer(),
+            true,
+            false,
+            false,
+            null,
+            0,
+            0,
+            CompatibilityMode.COMPAT_CURRENT);
+    var config = Mockito.mock(network.crypta.config.Config.class);
+
+    ClientContext ctx =
+        new ClientContext(
+            1L,
+            runner,
+            immediateExecutor,
+            archiveManager,
+            ptbf,
+            tbf,
+            tracker,
+            hq,
+            uskManager,
+            strongRandom,
+            fastWeakRandom,
+            ticker,
+            memLimited,
+            fg,
+            persistentFG,
+            rafFactory,
+            persistentRAFFactory,
+            fileRAFTransient,
+            fileRAFPersistent,
+            rc,
+            dsChecker,
+            persistentRoot,
+            masterSecret,
+            linkFilterProvider,
+            fetchCtx,
+            insertCtx,
+            config);
+
+    // Spy to stub scheduler access used by SplitFileInserter's constructor.
+    ClientContext spyCtx = Mockito.spy(ctx);
+    ClientRequestScheduler insertScheduler = Mockito.mock(ClientRequestScheduler.class);
+    doReturn(insertScheduler).when(spyCtx).getChkInsertScheduler(Mockito.anyBoolean());
+    when(insertScheduler.fetchingKeys())
+        .thenReturn(Mockito.mock(network.crypta.node.KeysFetchingLocally.class));
+    return spyCtx;
+  }
+
+  private InsertContext newInsertContext() {
+    return new InsertContext(
+        0,
+        0,
+        128,
+        128,
+        new network.crypta.client.events.SimpleEventProducer(),
+        true,
+        false,
+        false,
+        null,
+        0,
+        0,
+        CompatibilityMode.COMPAT_CURRENT);
+  }
+
+  private SplitFileInserter newInserter(
+      boolean persistent,
+      boolean realTime,
+      InsertContext ctx,
+      MockedConstruction<SplitFileInserterStorage> storageConst,
+      MockedConstruction<SplitFileInserterSender> senderConst)
+      throws InsertException {
+    // Provide benign metadata and crypto parameters; constructor is intercepted by mocks.
+    ClientMetadata meta = new ClientMetadata();
+    byte[] cryptoKey = new byte[0];
+    byte[] hashThisLayer = new byte[0];
+    HashResult[] hashes = new HashResult[0];
+
+    // Parent defaults
+    when(parent.getClient()).thenReturn(Mockito.mock(RequestClient.class));
+
+    // Build the SUT; the mocked construction ensures heavy collaborators are not executed.
+    SplitFileInserter.Options opts =
+        new SplitFileInserter.Options.Builder()
+            .ctx(ctx)
+            .context(context)
+            .decompressedLength(0L)
+            .compressionCodec(COMPRESSOR_TYPE.GZIP)
+            .meta(meta)
+            .isMetadata(false)
+            .archiveType(ARCHIVE_TYPE.TAR)
+            .splitfileCryptoAlgorithm((byte) 0)
+            .splitfileCryptoKey(cryptoKey)
+            .hashThisLayerOnly(hashThisLayer)
+            .hashes(hashes)
+            .topDontCompress(false)
+            .topRequiredBlocks(0)
+            .topTotalBlocks(0)
+            .origDataSize(0L)
+            .origCompressedDataSize(0L)
+            .realTime(realTime)
+            .token("tok")
+            .build();
+
+    SplitFileInserter sfi =
+        new SplitFileInserter(persistent, parent, cb, originalData, /* freeData= */ true, opts);
+
+    // Verify constructor-level accounting interactions with parent when storage reports zeros.
+    verify(parent).addMustSucceedBlocks(0);
+    verify(parent).addRedundantBlocksInsert(0);
+    verify(parent, times(1)).notifyClients(context);
+
+    // Ensure we have a sender and storage mocks created.
+    assertNotNull(storageConst.constructed());
+    assertNotNull(senderConst.constructed());
+    return sfi;
+  }
+
+  @Test
+  void schedule_whenCHKOnlyFalse_expectStartAndSenderScheduled() throws Exception {
+    InsertContext ic = newInsertContext();
+    ic.getCHKOnly = false;
+
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(false, false, ic, storageConst, senderConst);
+
+      SplitFileInserterSender sender = senderConst.constructed().getFirst();
+
+      sfi.schedule(context);
+
+      verify(cb).onBlockSetFinished(sfi, context);
+      verify(storageConst.constructed().getFirst()).start();
+      verify(sender).clearWakeupTime(context);
+      verify(sender).schedule(context);
+    }
+  }
+
+  @Test
+  void schedule_whenCHKOnlyTrue_expectNoSenderScheduling() throws Exception {
+    InsertContext ic = newInsertContext();
+    ic.getCHKOnly = true;
+
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+
+      SplitFileInserterSender sender = senderConst.constructed().getFirst();
+
+      sfi.schedule(context);
+
+      verify(cb).onBlockSetFinished(sfi, context);
+      verify(storageConst.constructed().getFirst()).start();
+      verify(sender, never()).clearWakeupTime(context);
+      verify(sender, never()).schedule(context);
+    }
+  }
+
+  // schedule() currently does not throw checked exceptions; error handling is covered in
+  // encodingProgress_whenScheduleThrows_callsStorageFail via a spy.
+
+  @Test
+  void cancel_whenCalled_failsStorageWithCancelled() throws Exception {
+    InsertContext ic = newInsertContext();
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+
+      sfi.cancel(context);
+
+      var storage = storageConst.constructed().getFirst();
+      Mockito.verify(storage)
+          .fail(Mockito.argThat(e -> e.getMode() == InsertExceptionMode.CANCELLED));
+    }
+  }
+
+  @Test
+  void encodingProgress_whenCHKOnlyTrue_doesNothing() throws Exception {
+    InsertContext ic = newInsertContext();
+    ic.getCHKOnly = true;
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+      SplitFileInserterSender sender = senderConst.constructed().getFirst();
+
+      sfi.encodingProgress();
+
+      verify(sender, never()).clearWakeupTime(context);
+      verify(sender, never()).schedule(context);
+    }
+  }
+
+  @Test
+  void encodingProgress_whenScheduleThrows_callsStorageFail() throws Exception {
+    InsertContext ic = newInsertContext();
+    ic.getCHKOnly = false;
+    InsertException boom = new InsertException(InsertExceptionMode.INTERNAL_ERROR);
+
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter real = newInserter(true, false, ic, storageConst, senderConst);
+      SplitFileInserter spy = Mockito.spy(real);
+      Mockito.doThrow(boom).when(spy).schedule(any(ClientContext.class));
+
+      spy.encodingProgress();
+
+      verify(storageConst.constructed().getFirst()).fail(boom);
+    }
+  }
+
+  @Test
+  void onHasKeys_whenEarlyEncodeTrue_encodesAndReportsMetadata() throws Exception {
+    InsertContext ic = newInsertContext();
+    ic.earlyEncode = true;
+
+    Metadata md = Mockito.mock(Metadata.class);
+
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> {
+                  when(mock.getRAF()).thenReturn(raf);
+                  when(mock.encodeMetadata()).thenReturn(md);
+                });
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+
+      sfi.onHasKeys();
+
+      // queueNormalOrDrop runs inline (see jobRunner stub in setUp),
+      // so callbacks must be invoked synchronously.
+      verify(cb).onMetadata(md, sfi, context);
+      verify(cb, never()).onSuccess(any(), any());
+    }
+  }
+
+  @Test
+  void onHasKeys_whenCHKOnlyTrue_triggersSuccessAndFreesResources() throws Exception {
+    InsertContext ic = newInsertContext();
+    ic.getCHKOnly = true;
+
+    Metadata md = Mockito.mock(Metadata.class);
+
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> {
+                  when(mock.getRAF()).thenReturn(raf);
+                  when(mock.encodeMetadata()).thenReturn(md);
+                });
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+
+      sfi.onHasKeys();
+
+      // onHasKeys() -> onSucceeded() runs via jobRunner inline
+      verify(cb).onMetadata(md, sfi, context);
+      verify(cb).onSuccess(sfi, context);
+      verify(raf).close();
+      verify(raf).free();
+      verify(originalData).close();
+      verify(originalData).free();
+    }
+  }
+
+  @Test
+  void onSucceeded_whenNotEarlyEncode_reportsMetadataAndSuccess() throws Exception {
+    InsertContext ic = newInsertContext();
+    ic.earlyEncode = false;
+    ic.getCHKOnly = false;
+    Metadata md = Mockito.mock(Metadata.class);
+
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+
+      sfi.onSucceeded(md);
+
+      verify(cb).onMetadata(md, sfi, context);
+      verify(cb).onSuccess(sfi, context);
+      verify(senderConst.constructed().getFirst()).unregister(context, parent.getPriorityClass());
+    }
+  }
+
+  @Test
+  void onFailed_cleansUpAndCallsFailure() throws Exception {
+    InsertContext ic = newInsertContext();
+    InsertException ex = new InsertException(InsertExceptionMode.INTERNAL_ERROR);
+
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+
+      sfi.onFailed(ex);
+
+      verify(raf).close();
+      verify(raf).free();
+      verify(originalData).close();
+      verify(originalData).free();
+      verify(cb).onFailure(ex, sfi, context);
+    }
+  }
+
+  @Test
+  void getLength_returnsStorageLength() throws Exception {
+    InsertContext ic = newInsertContext();
+
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> {
+                  when(mock.getRAF()).thenReturn(raf);
+                  // Mockito mocks expose default 0 for fields; getLength() should mirror it.
+                });
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+
+      assertEquals(0L, sfi.getLength());
+    }
+  }
+
+  @Test
+  void onInsertedBlock_notifiesParent() throws Exception {
+    InsertContext ic = newInsertContext();
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+      sfi.onInsertedBlock();
+      verify(parent).completedBlock(false, context);
+    }
+  }
+
+  @Test
+  void onShutdown_delegatesToStorage() throws Exception {
+    InsertContext ic = newInsertContext();
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+      sfi.onShutdown(context);
+      verify(storageConst.constructed().getFirst()).onShutdown(context);
+    }
+  }
+
+  @Test
+  void clearCooldown_clearsSenderWakeup() throws Exception {
+    InsertContext ic = newInsertContext();
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+      SplitFileInserterSender sender = senderConst.constructed().getFirst();
+      sfi.clearCooldown();
+      verify(sender).clearWakeupTime(context);
+    }
+  }
+
+  @Test
+  void getPriorityClass_delegatesToParent() throws Exception {
+    InsertContext ic = newInsertContext();
+    when(parent.getPriorityClass()).thenReturn((short) 42);
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+      SplitFileInserter sfi = newInserter(true, false, ic, storageConst, senderConst);
+      assertEquals(42, sfi.getPriorityClass());
+    }
+  }
+
+  @Test
+  void simpleAccessors_returnConfiguredValues() throws Exception {
+    InsertContext ic = newInsertContext();
+    try (MockedConstruction<SplitFileInserterStorage> storageConst =
+            Mockito.mockConstruction(
+                SplitFileInserterStorage.class,
+                (mock, ctx) -> when(mock.getRAF()).thenReturn(raf));
+        MockedConstruction<SplitFileInserterSender> senderConst =
+            Mockito.mockConstruction(SplitFileInserterSender.class)) {
+      SplitFileInserter sfi = newInserter(true, true, ic, storageConst, senderConst);
+      assertSame(parent, sfi.getParent());
+      assertEquals("tok", sfi.getToken());
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Replace the long SplitFileInserter constructor with an immutable Options + Builder to address Sonar S107 and improve readability/maintainability.
- Use AtomicReference for storage/sender publication to clarify thread-safety and avoid volatile juggling.
- Update SingleFileInserter call sites to construct and pass Options.
- Add SplitFileInserterTest covering schedule/cancel/progress/shutdown paths and early metadata/success callbacks.
- Ran Spotless before committing.

Changes
- src/main/java/network/crypta/client/async/SplitFileInserter.java
  - Introduce public static final Options with Builder; constructor now accepts Options
  - Replace volatile fields with AtomicReference for storage/sender
  - Expand class Javadoc and keep lifecycle consistent
- src/main/java/network/crypta/client/async/SingleFileInserter.java
  - Build Options via builder and pass to new SplitFileInserter constructor in both construction paths
- src/test/java/network/crypta/client/async/SplitFileInserterTest.java
  - New tests verifying schedule(), cancel(), encodingProgress(), cooldown clear, shutdown, and callback wiring; uses Mockito MockedConstruction to isolate heavy collaborators

Rationale
- Large parameter lists are error-prone and reduce readability. The builder makes call sites explicit and future-proof for incremental options.
- AtomicReference improves publication/clarity without changing behavior.

Behavior/Risk
- No functional behavior change intended; constructor signature changed but only internal call sites are updated. Scheduling, accounting, and callbacks remain the same.
- Real-time flag, compression/archiving, and block math are unchanged.

Testing
- New unit tests added and pass locally. Spotless applied.

Notes
- Base: develop
- Head: feature/fix-SplitFileInserter

Checklist
- [x] Compiles locally
- [x] Spotless formatting applied
- [x] New tests added for core paths
- [x] No public API change beyond internal constructor usage