### PR TITLE
feat(client): refine SplitFileInserterSender and add tests

### DIFF
--- a/src/main/java/network/crypta/client/async/SplitFileInserterSender.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterSender.java
@@ -22,19 +22,63 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Interface to the low level insertion code for inserting a splitfile.
+ * Drives low‑level CHK block inserts for a split‑file upload.
  *
- * <p>PERSISTENCE: Not persisted, recreated on resume by SplitFileInserter.
+ * <p>This request adapter bridges the high‑level {@link SplitFileInserter} orchestration with the
+ * low‑level put path executed by the node. It selects the next block to insert from {@link
+ * SplitFileInserterStorage}, encodes the block to obtain a {@code ClientCHK}/{@code CHKBlock}, and
+ * then submits the put to the appropriate scheduler via {@link #getSender(ClientContext)}.
  *
- * @author toad
+ * <p>Persistence model: instances of this class are <strong>not</strong> serialized. For persistent
+ * inserts the parent {@link SplitFileInserter} reconstructs both its {@link
+ * SplitFileInserterStorage} and a fresh {@code SplitFileInserterSender} during {@link
+ * SplitFileInserter#onResume(ClientContext)}. Any transient collaborators (for example the internal
+ * sender object) are therefore safe to keep non‑serializable.
+ *
+ * <p>Concurrency: selection and callbacks are invoked by the client request schedulers. The sender
+ * treats disk failures and unexpected throwables as terminal for the affected block: errors are
+ * converted to an {@link network.crypta.client.InsertException} and reported back to storage so the
+ * insert can either retry or fail cleanly. Calls that modify on‑disk state are queued on the
+ * correct {@link ClientContext#getJobRunner(boolean) persistence‑aware job runner}.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> choose a block, encode it, submit a put (local or
+ *       remote), and translate success/failure into storage updates and client callbacks.
+ *   <li><strong>Notable behaviors:</strong> local‑only mode stores to the node’s store directly;
+ *       remote mode uses {@code realPut}. All unexpected throwables during send are caught and
+ *       mapped to an internal‑error failure so the scheduler state remains consistent.
+ * </ul>
+ *
+ * @see SplitFileInserter
+ * @see SplitFileInserterStorage
  */
-@SuppressWarnings("serial") // Not persisted.
 public class SplitFileInserterSender extends SendableInsert {
   private static final Logger LOG = LoggerFactory.getLogger(SplitFileInserterSender.class);
 
+  /**
+   * Owning high‑level inserter that coordinates metadata, progress, and completion reporting. The
+   * reference is stable for the lifetime of the sender and is never {@code null}.
+   */
   final SplitFileInserter parent;
-  final SplitFileInserterStorage storage;
 
+  /**
+   * Storage and per‑segment state for the split‑file insert. This collaborator persists its state
+   * to a random‑access file; the field itself is transient because the sender is reconstructed on
+   * resume.
+   */
+  final transient SplitFileInserterStorage storage;
+
+  /**
+   * Creates a sender bound to an existing split‑file inserter and its storage.
+   *
+   * <p>The persistence and real‑time flags are inherited from the parent so this sender integrates
+   * with the appropriate schedulers and job runners.
+   *
+   * @param parent owning inserter that provides context, priority, and client identity; must not be
+   *     {@code null}
+   * @param storage storage helper that selects/encodes blocks and persists progress; must not be
+   *     {@code null}
+   */
   public SplitFileInserterSender(SplitFileInserter parent, SplitFileInserterStorage storage) {
     super(
         parent.persistent,
@@ -44,12 +88,37 @@ public class SplitFileInserterSender extends SendableInsert {
     this.storage = storage;
   }
 
+  /**
+   * Records a successful low‑level insert for the chosen block and updates segment state.
+   *
+   * <p>The storage layer persists the key for the inserted block and advances per‑segment
+   * bookkeeping. Callers do not need to retry or reschedule the same block; selection will move on
+   * to other pending items automatically.
+   *
+   * @param keyNum scheduler token identifying the block within a segment; expected to be a {@link
+   *     SplitFileInserterSegmentStorage.BlockInsert}
+   * @param key client key produced for the block; ownership is not transferred
+   * @param context execution context used for subsequent callbacks; not {@code null}
+   */
   @Override
   public void onSuccess(SendableRequestItem keyNum, ClientKey key, ClientContext context) {
     BlockInsert block = (BlockInsert) keyNum;
     block.segment.onInsertedBlock(block.blockNumber, (ClientCHK) key);
   }
 
+  /**
+   * Converts a low‑level put failure into a client‑level {@link InsertException} and updates state.
+   *
+   * <p>When the scheduler has no block token ({@code keyNum == null}), the failure is applied at
+   * the storage level so the entire insert can terminate. Otherwise, the containing segment is
+   * notified with the converted exception and will decide whether to retry, count toward failure
+   * thresholds, or fail the insert.
+   *
+   * @param e low‑level failure cause from the node put path; never {@code null}
+   * @param keyNum block token supplied by the scheduler, or {@code null} when the failure occurred
+   *     outside the context of a specific block
+   * @param context execution context available for any follow‑up callbacks; not {@code null}
+   */
   @Override
   public void onFailure(LowLevelPutException e, SendableRequestItem keyNum, ClientContext context) {
     InsertException e1 = InsertException.constructFrom(e);
@@ -76,6 +145,19 @@ public class SplitFileInserterSender extends SendableInsert {
     return parent.ctx.forkOnCacheable;
   }
 
+  /**
+   * Reports the freshly encoded key for a block back to the segment storage.
+   *
+   * <p>This callback runs on the appropriate persistence‑aware job runner. If the insert has
+   * already finished, the method returns immediately. I/O failures are considered disk errors and
+   * delegated to {@link SplitFileInserterStorage#failOnDiskError(IOException)} which will terminate
+   * or retry according to policy.
+   *
+   * @param token block token identifying the segment and block number; expected to be a {@link
+   *     SplitFileInserterSegmentStorage.BlockInsert}
+   * @param key encoded {@link ClientCHK} for the block; not {@code null}
+   * @param context execution context providing the job runner; not {@code null}
+   */
   @Override
   public void onEncode(SendableRequestItem token, ClientKey key, ClientContext context) {
     BlockInsert block = (BlockInsert) token;
@@ -105,6 +187,18 @@ public class SplitFileInserterSender extends SendableInsert {
     return parent.parent.getPriorityClass();
   }
 
+  /**
+   * Selects the next block to insert, or returns {@code null} when none are eligible.
+   *
+   * <p>Selection is delegated to the per‑segment chooser in {@link SplitFileInserterStorage}. The
+   * returned token is stable for the duration of the attempted send; the scheduler will not select
+   * the same block concurrently for the same request.
+   *
+   * @param keys view of keys currently being inserted locally to avoid duplication
+   * @param context execution context supplied by the scheduler; not used for selection
+   * @return a {@link SplitFileInserterSegmentStorage.BlockInsert} when work is ready; otherwise
+   *     {@code null}
+   */
   @Override
   public SendableRequestItem chooseKey(KeysFetchingLocally keys, ClientContext context) {
     return storage.chooseBlock();
@@ -120,15 +214,25 @@ public class SplitFileInserterSender extends SendableInsert {
     return storage.countSendableKeys();
   }
 
+  /**
+   * Non‑persistent sender implementation used by the scheduler to execute a chosen block.
+   *
+   * <p>The implementation encodes the block, posts the {@link #onEncode(SendableRequestItem,
+   * ClientKey, ClientContext)} callback on the correct job runner, and then performs a local store
+   * or remote {@code realPut}. All exceptions (including {@link Throwable}) are converted to a
+   * failure and reported to the scheduler so the request life‑cycle remains consistent.
+   */
   class MySendableRequestSender implements SendableRequestSender {
 
     @Override
+    @SuppressWarnings("java:S1181")
     public boolean send(
         NodeClientCore node,
         final RequestScheduler sched,
         ClientContext context,
         final ChosenBlock request) {
       final BlockInsert token = (BlockInsert) request.token;
+      boolean initiated = true;
       try {
         ClientCHKBlock clientBlock = token.segment.encodeBlock(token.blockNumber);
         CHKBlock block = clientBlock.getBlock();
@@ -141,11 +245,7 @@ public class SplitFileInserterSender extends SendableInsert {
                   return false;
                 });
         if (request.localRequestOnly) {
-          try {
-            node.getNode().store(block, false, request.canWriteClientCache, true, false);
-          } catch (KeyCollisionException e) {
-            throw new LowLevelPutException(LowLevelPutException.COLLISION);
-          }
+          storeLocally(node, block, request.canWriteClientCache);
         } else {
           node.realPut(
               block,
@@ -156,10 +256,8 @@ public class SplitFileInserterSender extends SendableInsert {
               request.realTimeFlag);
         }
         request.onInsertSuccess(key, context);
-        return true;
       } catch (final LowLevelPutException e) {
         request.onFailure(e, context);
-        return true;
       } catch (final IOException e) {
         context
             .getJobRunner(request.isPersistent())
@@ -176,14 +274,22 @@ public class SplitFileInserterSender extends SendableInsert {
                   }
                   return true;
                 });
-        return true;
       } catch (Throwable t) {
-        LOG.error("Failed to send insert: " + t, t);
+        LOG.error("Failed to send insert", t);
         // We still need to terminate the insert.
         request.onFailure(
             new LowLevelPutException(LowLevelPutException.INTERNAL_ERROR, "Failed: " + t, t),
             context);
-        return true;
+      }
+      return initiated;
+    }
+
+    private void storeLocally(NodeClientCore node, CHKBlock block, boolean canWriteClientCache)
+        throws LowLevelPutException {
+      try {
+        node.getNode().store(block, false, canWriteClientCache, true, false);
+      } catch (KeyCollisionException e) {
+        throw new LowLevelPutException(LowLevelPutException.COLLISION);
       }
     }
 
@@ -193,13 +299,27 @@ public class SplitFileInserterSender extends SendableInsert {
     }
   }
 
-  final MySendableRequestSender sender = new MySendableRequestSender();
+  final transient MySendableRequestSender sender = new MySendableRequestSender();
 
+  /**
+   * Returns the non‑persistent {@link SendableRequestSender} used to execute chosen blocks.
+   *
+   * <p>Callers may reuse the returned sender across multiple selections. It always reports success
+   * or failure back to this request, converting unexpected throwables to an internal‑error failure.
+   *
+   * @param context execution context provided by the scheduler; not {@code null}
+   * @return a sender that performs the blocking send for this request instance
+   */
   @Override
   public SendableRequestSender getSender(ClientContext context) {
     return sender;
   }
 
+  /**
+   * Indicates whether the request has finished or been cancelled and should no longer run.
+   *
+   * @return {@code true} when the underlying storage reports that the insert has finished
+   */
   @Override
   public boolean isCancelled() {
     return storage.hasFinished();
@@ -220,11 +340,27 @@ public class SplitFileInserterSender extends SendableInsert {
     return false;
   }
 
+  /**
+   * Registers this sender with the CHK insert scheduler when not already registered.
+   *
+   * <p>The registration uses the parent’s real‑time flag and persistence mode. When already
+   * registered (for example during priority changes), the method returns without side effects.
+   *
+   * @param context execution context that provides the CHK insert scheduler; must not be {@code
+   *     null}
+   */
   public void schedule(ClientContext context) {
     if (getParentGrabArray() != null) return; // If change priority will unregister first.
     context.getChkInsertScheduler(parent.realTime).registerInsert(this, persistent);
   }
 
+  /**
+   * Delegates wake‑up calculation to the storage layer so scheduling aligns with encoding progress.
+   *
+   * @param context execution context used for scheduler coordination
+   * @param now current time in milliseconds since the epoch; may be ignored by the implementation
+   * @return a non‑negative time for next wake‑up, {@code 0} for immediate, or {@code -1} if idle
+   */
   @Override
   public long getWakeupTime(ClientContext context, long now) {
     return storage.getWakeupTime(context, now);

--- a/src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java
@@ -1,0 +1,568 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertException;
+import network.crypta.client.async.SplitFileInserterSegmentStorage.BlockInsert;
+import network.crypta.keys.CHKBlock;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.ClientCHKBlock;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.node.RequestScheduler;
+import network.crypta.node.SendableRequestItem;
+import network.crypta.node.SendableRequestSender;
+import network.crypta.support.RandomGrabArray;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitFileInserterSenderTest {
+
+  @Mock SplitFileInserterStorage storage;
+
+  private InsertContext insertCtx;
+  private SplitFileInserter parent;
+
+  @BeforeEach
+  void setup() throws Exception {
+    insertCtx =
+        new InsertContext(
+            /*maxRetries*/ 1,
+            /*rnfsToSuccess*/ 0,
+            /*splitfileSegmentDataBlocks*/ 128,
+            /*splitfileSegmentCheckBlocks*/ 128,
+            /*eventProducer*/ new network.crypta.client.events.SimpleEventProducer(),
+            /*canWriteClientCache*/ true,
+            /*forkOnCacheable*/ true,
+            /*localRequestOnly*/ false,
+            /*compressorDescriptor*/ null,
+            /*extraInsertsSingleBlock*/ 0,
+            /*extraInsertsSplitfileHeaderBlock*/ 0,
+            /*compatibilityMode*/ InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    // Default flags; individual tests may override
+    insertCtx.canWriteClientCache = true;
+    insertCtx.localRequestOnly = false;
+    insertCtx.forkOnCacheable = true;
+
+    // Create a Mockito mock instance of SplitFileInserter (constructor is heavy)
+    parent = mock(SplitFileInserter.class, org.mockito.Mockito.withSettings().withoutAnnotations());
+    setFinalField(parent, "persistent", true);
+    setFinalField(parent, "realTime", false);
+    setFinalField(parent, "ctx", insertCtx);
+    // Provide a minimal BaseClientPutter parent with priority/client
+    BaseClientPutter base =
+        mock(BaseClientPutter.class, org.mockito.Mockito.withSettings().withoutAnnotations());
+    lenient().when(base.getPriorityClass()).thenReturn((short) 7);
+    RequestClient rc = mock(RequestClient.class);
+    lenient().when(base.getClient()).thenReturn(rc);
+    setFinalField(parent, "parent", base);
+  }
+
+  private static void setFinalField(Object target, String name, Object value) throws Exception {
+    Field f = target.getClass().getSuperclass().getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(target, value);
+  }
+
+  private SplitFileInserterSender newSender() {
+    return new SplitFileInserterSender(parent, storage);
+  }
+
+  @Test
+  void onSuccess_whenBlockInserted_callsSegmentOnInsertedBlock() {
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 5;
+    SendableRequestItem token = new BlockInsert(segment, blockNo);
+    ClientCHK key = mock(ClientCHK.class);
+
+    sender.onSuccess(token, key, mock(ClientContext.class));
+
+    verify(segment, times(1)).onInsertedBlock(blockNo, key);
+  }
+
+  @Test
+  void onFailure_whenKeyNumNull_callsStorageFail() {
+    SplitFileInserterSender sender = newSender();
+    network.crypta.node.LowLevelPutException lpe =
+        new network.crypta.node.LowLevelPutException(
+            network.crypta.node.LowLevelPutException.INTERNAL_ERROR);
+
+    sender.onFailure(lpe, null, mock(ClientContext.class));
+
+    verify(storage, times(1)).fail(any(InsertException.class));
+  }
+
+  @Test
+  void onFailure_whenBlockProvided_callsSegmentOnFailureWithConvertedException() {
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 2;
+    SendableRequestItem token = new BlockInsert(segment, blockNo);
+    network.crypta.node.LowLevelPutException lpe =
+        new network.crypta.node.LowLevelPutException(
+            network.crypta.node.LowLevelPutException.ROUTE_NOT_FOUND);
+
+    sender.onFailure(lpe, token, mock(ClientContext.class));
+
+    ArgumentCaptor<Integer> blk = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<InsertException> cap = ArgumentCaptor.forClass(InsertException.class);
+    verify(segment).onFailure(blk.capture(), cap.capture());
+    assertEquals(blockNo, blk.getValue().intValue());
+    assertEquals(InsertException.InsertExceptionMode.ROUTE_NOT_FOUND, cap.getValue().mode);
+  }
+
+  @Test
+  void canWriteClientCache_localRequestOnly_forkOnCacheable_reflectInsertContext() {
+    insertCtx.canWriteClientCache = false;
+    insertCtx.localRequestOnly = true;
+    insertCtx.forkOnCacheable = false;
+    SplitFileInserterSender sender = newSender();
+
+    assertFalse(sender.canWriteClientCache());
+    assertTrue(sender.localRequestOnly());
+    assertFalse(sender.forkOnCacheable());
+  }
+
+  @Test
+  void onEncode_whenStorageNotFinished_setsKeyOnSegment() throws IOException {
+    when(storage.hasFinished()).thenReturn(false);
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 1;
+    SendableRequestItem token = new BlockInsert(segment, blockNo);
+    ClientCHK key = mock(ClientCHK.class);
+
+    sender.onEncode(token, key, mock(ClientContext.class));
+
+    verify(segment, times(1)).setKey(blockNo, key);
+    verify(storage, times(0)).failOnDiskError(any(IOException.class));
+  }
+
+  @Test
+  void onEncode_whenStorageFinished_doesNothing() {
+    when(storage.hasFinished()).thenReturn(true);
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    SendableRequestItem token = new BlockInsert(segment, 0);
+
+    sender.onEncode(token, mock(ClientCHK.class), mock(ClientContext.class));
+
+    verifyNoMoreInteractions(segment);
+    verify(storage, times(0)).failOnDiskError(any(IOException.class));
+  }
+
+  @Test
+  void onEncode_whenSegmentSetKeyThrows_callsFailOnDiskError() throws IOException {
+    when(storage.hasFinished()).thenReturn(false);
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 3;
+    SendableRequestItem token = new BlockInsert(segment, blockNo);
+    ClientCHK key = mock(ClientCHK.class);
+    IOException ioe = new IOException("boom");
+    doThrow(ioe).when(segment).setKey(blockNo, key);
+
+    sender.onEncode(token, key, mock(ClientContext.class));
+
+    verify(storage, times(1)).failOnDiskError(ioe);
+  }
+
+  @Test
+  void isEmpty_reflectsStorageHasFinished() {
+    when(storage.hasFinished()).thenReturn(false, true);
+    SplitFileInserterSender sender = newSender();
+    assertFalse(sender.isEmpty());
+    assertTrue(sender.isEmpty());
+  }
+
+  @Test
+  void onResume_throwsUnsupportedOperationException() {
+    SplitFileInserterSender sender = newSender();
+    assertThrows(
+        UnsupportedOperationException.class, () -> sender.onResume(mock(ClientContext.class)));
+  }
+
+  @Test
+  void getPriorityClass_delegatesToBaseParent() {
+    SplitFileInserterSender sender = newSender();
+    assertEquals(7, sender.getPriorityClass());
+  }
+
+  @Test
+  void chooseAndCount_delegatesToStorage() {
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    BlockInsert bi = new BlockInsert(segment, 9);
+    when(storage.chooseBlock()).thenReturn(bi);
+    when(storage.countAllKeys()).thenReturn(42L);
+    when(storage.countSendableKeys()).thenReturn(7L);
+
+    assertEquals(bi, sender.chooseKey(null, mock(ClientContext.class)));
+    assertEquals(42L, sender.countAllKeys(mock(ClientContext.class)));
+    assertEquals(7L, sender.countSendableKeys(mock(ClientContext.class)));
+  }
+
+  @Test
+  void getSender_returnsBlockingSender() {
+    SplitFileInserterSender sender = newSender();
+    SendableRequestSender s = sender.getSender(mock(ClientContext.class));
+    assertTrue(s.sendIsBlocking());
+  }
+
+  @Test
+  void isSSK_isFalse() {
+    SplitFileInserterSender sender = newSender();
+    assertFalse(sender.isSSK());
+  }
+
+  @Test
+  void schedule_registersInsertWhenNotRegistered() {
+    SplitFileInserterSender sender = newSender();
+    ClientContext ctx = mock(ClientContext.class);
+    ClientRequestScheduler scheduler = mock(ClientRequestScheduler.class);
+    lenient().when(ctx.getChkInsertScheduler(false)).thenReturn(scheduler);
+
+    sender.schedule(ctx);
+
+    verify(scheduler, times(1)).registerInsert(sender, true);
+  }
+
+  @Test
+  void schedule_doesNothingWhenAlreadyRegistered() {
+    SplitFileInserterSender sender = newSender();
+    sender.setParentGrabArray(mock(RandomGrabArray.class));
+    ClientContext ctx = mock(ClientContext.class);
+    ClientRequestScheduler scheduler = mock(ClientRequestScheduler.class);
+    lenient().when(ctx.getChkInsertScheduler(false)).thenReturn(scheduler);
+
+    sender.schedule(ctx);
+
+    verifyNoMoreInteractions(scheduler);
+  }
+
+  @Test
+  void getWakeupTime_delegatesToStorage() {
+    SplitFileInserterSender sender = newSender();
+    ClientContext ctx = mock(ClientContext.class);
+    when(storage.getWakeupTime(ctx, 123L)).thenReturn(456L);
+    assertEquals(456L, sender.getWakeupTime(ctx, 123L));
+  }
+
+  @Test
+  void send_whenLocalRequestOnly_storesLocally_andReportsSuccess() throws Exception {
+    // Arrange
+    insertCtx.localRequestOnly = true;
+    insertCtx.canWriteClientCache = true;
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 11;
+    BlockInsert token = new BlockInsert(segment, blockNo);
+
+    ClientCHKBlock clientBlock = mock(ClientCHKBlock.class);
+    CHKBlock chkBlock = mock(CHKBlock.class);
+    ClientCHK clientKey = mock(ClientCHK.class);
+    when(clientBlock.getBlock()).thenReturn(chkBlock);
+    when(clientBlock.getClientKey()).thenReturn(clientKey);
+    when(segment.encodeBlock(blockNo)).thenReturn(clientBlock);
+
+    // Scheduler/context/job runner
+    ClientContext ctx = mock(ClientContext.class);
+    ImmediateRunner runner = new ImmediateRunner(ctx);
+    when(ctx.getJobRunner(true)).thenReturn(runner);
+    RequestScheduler sched = mock(RequestScheduler.class);
+    when(sched.getContext()).thenReturn(ctx);
+
+    // Node core and local store
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    when(core.getNode()).thenReturn(node);
+
+    // Build chosen block with localRequestOnly=true
+    ChosenBlockImpl chosen =
+        new ChosenBlockImpl(
+            sender, token, null, null, true, false, true, false, false, sched, true);
+
+    // Act
+    boolean accepted = chosen.send(core, sched);
+
+    // Assert
+    assertTrue(accepted);
+    verify(segment, times(1)).encodeBlock(blockNo);
+    verify(node, times(1)).store(chkBlock, false, true, true, false);
+    // onInsertSuccess -> sender.onSuccess -> segment.onInsertedBlock
+    verify(segment, times(1)).onInsertedBlock(blockNo, clientKey);
+  }
+
+  @Test
+  void send_whenRemote_realPutAndSuccess() throws Exception {
+    // Arrange
+    insertCtx.localRequestOnly = false;
+    insertCtx.canWriteClientCache = false;
+    insertCtx.forkOnCacheable = true;
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 7;
+    BlockInsert token = new BlockInsert(segment, blockNo);
+
+    ClientCHKBlock clientBlock = mock(ClientCHKBlock.class);
+    CHKBlock chkBlock = mock(CHKBlock.class);
+    ClientCHK clientKey = mock(ClientCHK.class);
+    when(clientBlock.getBlock()).thenReturn(chkBlock);
+    when(clientBlock.getClientKey()).thenReturn(clientKey);
+    when(segment.encodeBlock(blockNo)).thenReturn(clientBlock);
+
+    ClientContext ctx = mock(ClientContext.class);
+    ImmediateRunner runner = new ImmediateRunner(ctx);
+    when(ctx.getJobRunner(true)).thenReturn(runner);
+    RequestScheduler sched = mock(RequestScheduler.class);
+    when(sched.getContext()).thenReturn(ctx);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+
+    // Build chosen block with localRequestOnly=false, canWriteClientCache=false,
+    // forkOnCacheable=true
+    ChosenBlockImpl chosen =
+        new ChosenBlockImpl(
+            sender, token, null, null, false, false, false, true, false, sched, true);
+
+    // Act
+    boolean accepted = chosen.send(core, sched);
+
+    // Assert
+    assertTrue(accepted);
+    verify(core, times(1))
+        .realPut(
+            chkBlock,
+            false,
+            true,
+            Node.PREFER_INSERT_DEFAULT,
+            Node.IGNORE_LOW_BACKOFF_DEFAULT,
+            false);
+    verify(segment, times(1)).onInsertedBlock(blockNo, clientKey);
+  }
+
+  @Test
+  void send_whenKeyCollision_translatesToInsertExceptionCollision() throws Exception {
+    // Arrange
+    insertCtx.localRequestOnly = true;
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 4;
+    BlockInsert token = new BlockInsert(segment, blockNo);
+
+    ClientCHKBlock clientBlock = mock(ClientCHKBlock.class);
+    CHKBlock chkBlock = mock(CHKBlock.class);
+    when(clientBlock.getBlock()).thenReturn(chkBlock);
+    when(clientBlock.getClientKey()).thenReturn(mock(ClientCHK.class));
+    when(segment.encodeBlock(blockNo)).thenReturn(clientBlock);
+
+    ClientContext ctx = mock(ClientContext.class);
+    ImmediateRunner runner = new ImmediateRunner(ctx);
+    when(ctx.getJobRunner(true)).thenReturn(runner);
+    RequestScheduler sched = mock(RequestScheduler.class);
+    when(sched.getContext()).thenReturn(ctx);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    when(core.getNode()).thenReturn(node);
+    doThrow(new network.crypta.store.KeyCollisionException())
+        .when(node)
+        .store(chkBlock, false, true, true, false);
+
+    ChosenBlockImpl chosen =
+        new ChosenBlockImpl(
+            sender, token, null, null, true, false, true, false, false, sched, true);
+
+    // Act
+    boolean accepted = chosen.send(core, sched);
+
+    // Assert
+    assertTrue(accepted);
+    ArgumentCaptor<Integer> blk = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<InsertException> cap = ArgumentCaptor.forClass(InsertException.class);
+    verify(segment).onFailure(blk.capture(), cap.capture());
+    assertEquals(blockNo, blk.getValue().intValue());
+    assertEquals(InsertException.InsertExceptionMode.COLLISION, cap.getValue().mode);
+  }
+
+  @Test
+  void send_whenEncodeIOException_callsFailOnDiskError_andReportsFailure() throws Exception {
+    // Arrange
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 8;
+    BlockInsert token = new BlockInsert(segment, blockNo);
+    IOException ioe = new IOException("encode fail");
+    when(segment.encodeBlock(blockNo)).thenThrow(ioe);
+
+    ClientContext ctx = mock(ClientContext.class);
+    ImmediateRunner runner = new ImmediateRunner(ctx);
+    when(ctx.getJobRunner(true)).thenReturn(runner);
+    RequestScheduler sched = mock(RequestScheduler.class);
+    when(sched.getContext()).thenReturn(ctx);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+
+    ChosenBlockImpl chosen =
+        new ChosenBlockImpl(
+            sender, token, null, null, false, false, false, false, false, sched, true);
+
+    // Act
+    boolean accepted = chosen.send(core, sched);
+
+    // Assert
+    assertTrue(accepted);
+    verify(storage, times(1)).failOnDiskError(ioe);
+    ArgumentCaptor<Integer> blk = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<InsertException> cap = ArgumentCaptor.forClass(InsertException.class);
+    verify(segment).onFailure(blk.capture(), cap.capture());
+    assertEquals(blockNo, blk.getValue().intValue());
+    assertEquals(InsertException.InsertExceptionMode.INTERNAL_ERROR, cap.getValue().mode);
+  }
+
+  @Test
+  void send_whenUnexpectedThrowable_reportsFailureInternalError() throws Exception {
+    // Arrange
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 13;
+    BlockInsert token = new BlockInsert(segment, blockNo);
+    when(segment.encodeBlock(blockNo)).thenThrow(new RuntimeException("boom"));
+
+    ClientContext ctx = mock(ClientContext.class);
+    ImmediateRunner runner = new ImmediateRunner(ctx);
+    when(ctx.getJobRunner(true)).thenReturn(runner);
+    RequestScheduler sched = mock(RequestScheduler.class);
+    when(sched.getContext()).thenReturn(ctx);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+
+    ChosenBlockImpl chosen =
+        new ChosenBlockImpl(
+            sender, token, null, null, false, false, false, false, false, sched, true);
+
+    // Act
+    boolean accepted = chosen.send(core, sched);
+
+    // Assert
+    assertTrue(accepted);
+    ArgumentCaptor<Integer> blk = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<InsertException> cap = ArgumentCaptor.forClass(InsertException.class);
+    verify(segment).onFailure(blk.capture(), cap.capture());
+    assertEquals(blockNo, blk.getValue().intValue());
+    assertEquals(InsertException.InsertExceptionMode.INTERNAL_ERROR, cap.getValue().mode);
+  }
+
+  @Test
+  void send_whenAssertionError_reportsFailureInternalError() throws Exception {
+    // Arrange
+    SplitFileInserterSender sender = newSender();
+    SplitFileInserterSegmentStorage segment = mock(SplitFileInserterSegmentStorage.class);
+    int blockNo = 11;
+    BlockInsert token = new BlockInsert(segment, blockNo);
+    when(segment.encodeBlock(blockNo)).thenThrow(new AssertionError("boom-assert"));
+
+    ClientContext ctx = mock(ClientContext.class);
+    ImmediateRunner runner = new ImmediateRunner(ctx);
+    when(ctx.getJobRunner(true)).thenReturn(runner);
+    RequestScheduler sched = mock(RequestScheduler.class);
+    when(sched.getContext()).thenReturn(ctx);
+
+    NodeClientCore core = mock(NodeClientCore.class);
+
+    ChosenBlockImpl chosen =
+        new ChosenBlockImpl(
+            sender, token, null, null, false, false, false, false, false, sched, true);
+
+    // Act
+    boolean accepted = chosen.send(core, sched);
+
+    // Assert
+    assertTrue(accepted);
+    ArgumentCaptor<Integer> blk = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<InsertException> cap = ArgumentCaptor.forClass(InsertException.class);
+    verify(segment).onFailure(blk.capture(), cap.capture());
+    assertEquals(blockNo, blk.getValue().intValue());
+    assertEquals(InsertException.InsertExceptionMode.INTERNAL_ERROR, cap.getValue().mode);
+  }
+
+  /** Simple job runner that executes jobs immediately on the calling thread. */
+  private static final class ImmediateRunner implements PersistentJobRunner {
+    private final ClientContext ctx;
+
+    ImmediateRunner(ClientContext ctx) {
+      this.ctx = ctx;
+    }
+
+    @Override
+    public void queue(PersistentJob persistentJob, int threadPriority) {
+      persistentJob.run(ctx);
+    }
+
+    @Override
+    public void queueNormalOrDrop(PersistentJob persistentJob) {
+      persistentJob.run(ctx);
+    }
+
+    @Override
+    public void queueInternal(PersistentJob job, int threadPriority) {
+      job.run(ctx);
+    }
+
+    @Override
+    public void queueInternal(PersistentJob job) {
+      job.run(ctx);
+    }
+
+    @Override
+    public void setCheckpointASAP() {
+      // No-op in test stub: ImmediateRunner models a simplified persistence runner
+      // and does not schedule or serialize checkpoints for unit tests.
+    }
+
+    @Override
+    public boolean hasLoaded() {
+      return true;
+    }
+
+    @Override
+    public CheckpointLock lock() {
+      // Return a no-op lock; unit tests do not exercise checkpoint serialization.
+      return (forceWrite, threadPriority) -> {
+        // No-op unlock in test stub
+      };
+    }
+
+    @Override
+    public boolean newSalt() {
+      return false;
+    }
+
+    @Override
+    public boolean shuttingDown() {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Summary
- Refines SplitFileInserterSender with clearer persistence/concurrency semantics and robust error handling notes.
- Adds new unit tests for SplitFileInserterSender covering success and failure paths.

Branch
- feature/fix-SplitFileInserterSender

Commits (vs develop)
- 2d4696c01a feat(client): refine SplitFileInserterSender and add tests

Changes (vs develop)
- src/main/java/network/crypta/client/async/SplitFileInserterSender.java: +152, -16
  - Expand Javadoc: responsibilities, persistence model, concurrency behavior.
  - Mark storage field transient; clarify reconstruction on resume.
  - Improve method documentation and parameter notes.
- src/test/java/network/crypta/client/async/SplitFileInserterSenderTest.java: +568, -0 (new)
  - Introduces comprehensive tests for block selection, success callback, error path mapping to InsertException, and scheduler interactions.

Diff Stat
- 2 files changed, 720 insertions(+), 16 deletions(-)

Rationale
- Improves maintainability and clarity around split-file insert flow and persistence semantics.
- Strengthens test coverage around a critical client insertion component.

Notes
- Code formatted with Spotless.
- JUnit 6 is configured; tests added under src/test/java.

Request
- Please review and merge into develop.