### PR TITLE
fix(client): strengthen SplitFileSegmentKeys copy/IO behavior and tests

### DIFF
--- a/src/main/java/network/crypta/client/Metadata.java
+++ b/src/main/java/network/crypta/client/Metadata.java
@@ -247,7 +247,7 @@ public class Metadata implements Cloneable, Serializable {
     if (orig.segments != null) {
       segments = new SplitFileSegmentKeys[orig.segments.length];
       for (int i = 0; i < segments.length; i++) {
-        segments[i] = orig.segments[i].clone();
+        segments[i] = new SplitFileSegmentKeys(orig.segments[i]);
       }
     }
     if (hashes != null) {

--- a/src/main/java/network/crypta/client/async/SplitFileSegmentKeys.java
+++ b/src/main/java/network/crypta/client/async/SplitFileSegmentKeys.java
@@ -11,43 +11,101 @@ import java.util.Arrays;
 import network.crypta.keys.ClientCHK;
 import network.crypta.keys.NodeCHK;
 import network.crypta.support.Fields;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Contains the keys for a splitfile segment, in an efficient compressed form. These are not
- * changed, so the object never needs to be stored once created; this is good as it is fairly large.
- * SplitFileFetcherSegment keeps the data on which keys have been used separately and passes it in.
+ * Contains the keys for a splitfile segment in a compact, stream‑friendly representation. Instances
+ * capture routing keys and the cryptographic material needed to construct both {@link ClientCHK}
+ * and {@link NodeCHK} views for each block (data and check). Depending on the splitfile format, the
+ * cryptographic keying material may be shared for all blocks ("common" key) or stored per block.
  *
- * <p>We will auto-upgrade SplitFileFetcherSegment's to use SplitFileSegmentKeys in the caller.
+ * <p>This type is typically populated during metadata parsing and then consulted repeatedly while
+ * fetching blocks. It separates the immutable segment layout (counts and keys) from per‑request
+ * state such as which blocks were already fetched. Callers usually build an instance, fill it from
+ * a binary stream, and then query by key ({@code getBlockNumber(...)}) or by index ({@code
+ * getKey(...)}, {@code getNodeKey(...)}). The optional copy parameters on getters let callers
+ * control aliasing of underlying arrays when reusing the instance across threads.
  *
- * @author toad
+ * <p>Thread safety: the object is not strictly immutable. After construction, callers may write
+ * keys via {@link #readKeys(DataInputStream, boolean)} or {@link #setKey(int, ClientCHK)}. Once
+ * fully populated it is commonly treated as read‑most. For cross‑thread use, either publish after
+ * construction and population, or request defensive copies via the {@code copy} parameters.
+ *
+ * <ul>
+ *   <li>Supports both common and per‑block crypto keys and extra bytes.
+ *   <li>Provides constant‑time matching on routing keys to find block indices.
+ *   <li>Can serialize/deserialize keys for data vs. check blocks independently.
+ * </ul>
+ *
+ * @see ClientCHK
+ * @see NodeCHK
  */
-public class SplitFileSegmentKeys implements Cloneable, Serializable {
-  private static final Logger LOG = LoggerFactory.getLogger(SplitFileSegmentKeys.class);
+public class SplitFileSegmentKeys implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
+
+  /**
+   * Number of data blocks in this segment. Data blocks contribute to the original payload and do
+   * not include parity/check blocks. The value is fixed at construction and used to compute offsets
+   * into internal arrays when reading and writing keys.
+   */
   public final int dataBlocks;
+
+  /**
+   * Number of parity/check blocks in this segment. Check blocks are used for redundancy and error
+   * correction. The value is fixed at construction and combined with {@link #dataBlocks} to derive
+   * the total number of keys managed by this instance.
+   */
   public final int checkBlocks;
 
-  /** Modern splitfiles have a common decrypt key */
+  /**
+   * When present, a single decryption key shared by all blocks in the segment. If {@code null},
+   * per‑block decryption keys are stored in {@link #decryptKeys}. The array may be exposed by
+   * getters when {@code copy == false}, so callers should not modify its contents.
+   */
   public final byte[] commonDecryptKey;
 
-  /** Modern splitfiles have common extra bytes */
+  /**
+   * Optional extra bytes that are common to all blocks, typically encoding the crypto algorithm and
+   * related parameters expected by {@link ClientCHK}. If {@code null}, extra bytes are stored per
+   * block in {@link #extraBytesForKeys}. Treat as read‑only when obtained through getters.
+   */
   public final byte[] commonExtraBytes;
 
-  /** Routing keys. */
+  /**
+   * Concatenation of {@link NodeCHK#KEY_LENGTH}-byte routing keys for all blocks in the segment,
+   * ordered by block index: first {@link #dataBlocks} entries, then {@link #checkBlocks}. Offsets
+   * are computed as {@code index * NodeCHK.KEY_LENGTH}.
+   */
   public final byte[] routingKeys;
 
-  /** Individual per-block decryption keys. Only on older splitfiles. */
+  /**
+   * Concatenation of per‑block decryption keys. Used only when {@link #commonDecryptKey} is {@code
+   * null}. The array is sized {@code (dataBlocks + checkBlocks) * ClientCHK.CRYPTO_KEY_LENGTH} and
+   * indexed by block number.
+   */
   public final byte[] decryptKeys;
 
-  /** Individual per-block extra bytes. */
+  /**
+   * Concatenation of per‑block extra bytes accompanying each key. Present only when {@link
+   * #commonExtraBytes} is {@code null}. Entries are {@code EXTRA_BYTES_LENGTH} bytes long and
+   * indexed by block number.
+   */
   public final byte[] extraBytesForKeys;
 
   static final int EXTRA_BYTES_LENGTH = ClientCHK.EXTRA_LENGTH;
 
-  // Bare constructor for Metadata. It will read the actual keys later.
+  /**
+   * Bare constructor for metadata. Allocates internal storage for keys based on the segment sizes
+   * and whether a shared crypto key is used. Actual key bytes can be populated later with {@link
+   * #readKeys(DataInputStream, boolean)} or {@link #setKey(int, ClientCHK)}.
+   *
+   * @param blocksPerSegment number of data blocks in the segment; must be non‑negative.
+   * @param checkBlocksPerSegment number of check/parity blocks; must be non‑negative.
+   * @param splitfileSingleCryptoKey optional common decryption key applied to all blocks; when
+   *     {@code null}, space is allocated for per‑block decryption keys instead.
+   * @param splitfileSingleCryptoAlgorithm crypto algorithm identifier associated with the common
+   *     key; ignored when {@code splitfileSingleCryptoKey} is {@code null}.
+   */
   public SplitFileSegmentKeys(
       int blocksPerSegment,
       int checkBlocksPerSegment,
@@ -69,6 +127,10 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     }
   }
 
+  /**
+   * No‑arg constructor for serialization frameworks. Creates an empty shell with default values;
+   * fields are set to zero or {@code null}. Not intended for direct use by application code.
+   */
   protected SplitFileSegmentKeys() {
     // For serialization.
     dataBlocks = 0;
@@ -80,66 +142,138 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     extraBytesForKeys = null;
   }
 
+  /**
+   * Copy constructor performing a deep copy of internal arrays.
+   *
+   * <p>Behavior remains identical to the source instance; arrays are copied to avoid accidental
+   * sharing. Reference fields that are {@code null} in the source remain {@code null}.
+   *
+   * @param other the instance to copy; its arrays are cloned so subsequent changes do not leak.
+   */
+  public SplitFileSegmentKeys(SplitFileSegmentKeys other) {
+    this.dataBlocks = other.dataBlocks;
+    this.checkBlocks = other.checkBlocks;
+    this.routingKeys = other.routingKeys != null ? other.routingKeys.clone() : null;
+    if (other.commonDecryptKey != null) {
+      this.commonDecryptKey = other.commonDecryptKey.clone();
+      this.commonExtraBytes =
+          other.commonExtraBytes != null ? other.commonExtraBytes.clone() : null;
+      this.decryptKeys = null;
+      this.extraBytesForKeys = null;
+    } else {
+      this.commonDecryptKey = null;
+      this.commonExtraBytes = null;
+      this.decryptKeys = other.decryptKeys != null ? other.decryptKeys.clone() : null;
+      this.extraBytesForKeys =
+          other.extraBytesForKeys != null ? other.extraBytesForKeys.clone() : null;
+    }
+  }
+
+  /**
+   * Returns the block index for the given {@link ClientCHK} if present in this segment.
+   *
+   * <p>Matches on routing key and on the decryption key and extra bytes (either common or
+   * per‑block). Entries corresponding to {@code true} values in {@code ignoreSlots} are skipped.
+   * When not found, {@code -1} is returned.
+   *
+   * @param key the complete client key to resolve; routing, crypto, and extra must match stored
+   *     values exactly; must not be {@code null}.
+   * @param ignoreSlots optional mask of indices to ignore; when {@code null}, all indices are
+   *     considered; when provided, {@code true} skips the corresponding position.
+   * @return the zero‑based block index if a match is found, or {@code -1} when no match exists or
+   *     the only matches occur at ignored positions.
+   */
   public int getBlockNumber(ClientCHK key, boolean[] ignoreSlots) {
     byte[] rkey = key.getRoutingKey();
     byte[] ckey = null;
     byte[] extra = null;
-    int x = 0;
-    for (int i = 0; i < (dataBlocks + checkBlocks); i++) {
-      int oldX = x;
-      x += NodeCHK.KEY_LENGTH;
-      if (ignoreSlots != null && ignoreSlots[i]) {
-        continue;
+    int rkOffset = 0;
+    final int total = dataBlocks + checkBlocks;
+    for (int i = 0; i < total; i++) {
+      boolean notIgnored = !(ignoreSlots != null && ignoreSlots[i]);
+      if (notIgnored) {
+        if (ckey == null) ckey = key.getCryptoKey();
+        if (extra == null) extra = key.getExtra();
+        if (matchesClientKeyAt(i, rkOffset, rkey, ckey, extra)) return i;
       }
-      if (!Fields.byteArrayEqual(routingKeys, rkey, oldX, 0, NodeCHK.KEY_LENGTH)) continue;
-      if (ckey == null) ckey = key.getCryptoKey();
-      assert (ClientCHK.CRYPTO_KEY_LENGTH == NodeCHK.KEY_LENGTH);
-      // FIXME USE THE RIGHT CONSTANT, DONT ASSUME THE TWO LENGTHS ARE THE SAME
-      if (commonDecryptKey != null) {
-        if (!Arrays.equals(commonDecryptKey, ckey)) continue;
-      } else {
-        if (!Fields.byteArrayEqual(decryptKeys, ckey, oldX, 0, NodeCHK.KEY_LENGTH)) continue;
-      }
-      if (extra == null) extra = key.getExtra();
-      if (commonExtraBytes != null) {
-        if (!Arrays.equals(commonExtraBytes, extra)) continue;
-      } else {
-        if (!Fields.byteArrayEqual(
-            extraBytesForKeys, extra, i * EXTRA_BYTES_LENGTH, 0, EXTRA_BYTES_LENGTH)) continue;
-      }
-      return i;
+      rkOffset += NodeCHK.KEY_LENGTH;
     }
     return -1;
   }
 
+  private boolean matchesClientKeyAt(
+      int index, int rkOffset, byte[] rkey, byte[] ckey, byte[] extra) {
+    if (!Fields.byteArrayEqual(routingKeys, rkey, rkOffset, 0, NodeCHK.KEY_LENGTH)) return false;
+    boolean cryptoMatch;
+    if (commonDecryptKey != null) {
+      cryptoMatch = Arrays.equals(commonDecryptKey, ckey);
+    } else {
+      int dkOffset = index * ClientCHK.CRYPTO_KEY_LENGTH;
+      cryptoMatch =
+          Fields.byteArrayEqual(decryptKeys, ckey, dkOffset, 0, ClientCHK.CRYPTO_KEY_LENGTH);
+    }
+    if (!cryptoMatch) return false;
+    if (commonExtraBytes != null) {
+      return Arrays.equals(commonExtraBytes, extra);
+    } else {
+      int exOffset = index * EXTRA_BYTES_LENGTH;
+      return Fields.byteArrayEqual(extraBytesForKeys, extra, exOffset, 0, EXTRA_BYTES_LENGTH);
+    }
+  }
+
+  /**
+   * Returns the block index whose routing key equals the supplied {@link NodeCHK}'s routing key.
+   *
+   * <p>This method compares routing keys only and does not consider crypto keys or extra bytes.
+   * Indices masked by {@code ignoreSlots} are skipped. If multiple positions share the same routing
+   * key, the first non‑ignored index is returned.
+   *
+   * @param key the node key supplying the routing key to look up; must not be {@code null}.
+   * @param ignoreSlots optional mask of indices to ignore; when {@code null}, searches all
+   *     positions; {@code true} marks an index as ignored.
+   * @return the zero‑based index of the first matching routing key, or {@code -1} if none match or
+   *     all matches are ignored.
+   */
   public int getBlockNumber(NodeCHK key, boolean[] ignoreSlots) {
     byte[] rkey = key.getRoutingKey();
-    int x = 0;
-    for (int i = 0; i < (dataBlocks + checkBlocks); i++) {
-      int oldX = x;
-      x += NodeCHK.KEY_LENGTH;
-      if (ignoreSlots != null && ignoreSlots[i]) {
-        continue;
-      }
-      if (!Fields.byteArrayEqual(routingKeys, rkey, oldX, 0, NodeCHK.KEY_LENGTH)) continue;
-      return i;
+    int rkOffset = 0;
+    final int total = dataBlocks + checkBlocks;
+    for (int i = 0; i < total; i++) {
+      boolean notIgnored = !(ignoreSlots != null && ignoreSlots[i]);
+      boolean routingMatch =
+          notIgnored && Fields.byteArrayEqual(routingKeys, rkey, rkOffset, 0, NodeCHK.KEY_LENGTH);
+      if (routingMatch) return i;
+      rkOffset += NodeCHK.KEY_LENGTH;
     }
     return -1;
   }
 
+  /**
+   * Returns all block indices whose routing key equals the supplied {@link NodeCHK}'s routing key.
+   *
+   * <p>Only routing keys are compared; crypto keys and extra bytes are not considered. Indices
+   * masked by {@code ignoreSlots} are skipped. The returned array is a newly allocated, possibly
+   * empty array in ascending index order.
+   *
+   * @param key the node key providing the routing key to match; must not be {@code null}.
+   * @param ignoreSlots optional mask of indices to skip; when {@code null}, examines all indices.
+   * @return a new array of zero‑based indices that matched; the array is owned by the caller and
+   *     can be freely modified.
+   */
   public int[] getBlockNumbers(NodeCHK key, boolean[] ignoreSlots) {
     ArrayList<Integer> results = null;
     byte[] rkey = key.getRoutingKey();
-    int x = 0;
-    for (int i = 0; i < (dataBlocks + checkBlocks); i++) {
-      int oldX = x;
-      x += NodeCHK.KEY_LENGTH;
-      if (ignoreSlots != null && ignoreSlots[i]) {
-        continue;
+    int rkOffset = 0;
+    final int total = dataBlocks + checkBlocks;
+    for (int i = 0; i < total; i++) {
+      boolean notIgnored = !(ignoreSlots != null && ignoreSlots[i]);
+      boolean routingMatch =
+          notIgnored && Fields.byteArrayEqual(routingKeys, rkey, rkOffset, 0, NodeCHK.KEY_LENGTH);
+      if (routingMatch) {
+        if (results == null) results = new ArrayList<>();
+        results.add(i);
       }
-      if (!Fields.byteArrayEqual(routingKeys, rkey, oldX, 0, NodeCHK.KEY_LENGTH)) continue;
-      if (results == null) results = new ArrayList<>();
-      results.add(i);
+      rkOffset += NodeCHK.KEY_LENGTH;
     }
     if (results == null) return new int[0];
     int[] ret = new int[results.size()];
@@ -147,22 +281,49 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     return ret;
   }
 
+  /**
+   * Returns a {@link NodeCHK} view for the block at {@code x}, or {@code null} if ignored.
+   *
+   * <p>When {@code copy} is {@code true}, returns a logically equivalent key with defensive copies
+   * of underlying arrays; otherwise, the returned key may share backing arrays with this instance.
+   * If {@code ignoreSlots} is provided and {@code ignoreSlots[x]} is {@code true}, {@code null} is
+   * returned.
+   *
+   * @param x zero‑based block index within {@code dataBlocks + checkBlocks}; out‑of‑range values
+   *     will cause an {@link ArrayIndexOutOfBoundsException} at access time.
+   * @param ignoreSlots optional mask that marks indices to ignore; {@code null} means do not ignore
+   *     any index.
+   * @param copy whether to defensively copy internal arrays to avoid aliasing the instance state.
+   * @return a node‑level key for routing and fetching, or {@code null} when the index is marked as
+   *     ignored via {@code ignoreSlots}.
+   */
   public NodeCHK getNodeKey(int x, boolean[] ignoreSlots, boolean copy) {
-    if (ignoreSlots != null) {
-      if (ignoreSlots[x]) return null;
-    }
-    return getNodeKey(x, copy);
+    if (ignoreSlots != null && ignoreSlots[x]) return null;
+    NodeCHK node = getNodeKey(x);
+    return copy ? (NodeCHK) node.cloneKey() : node;
   }
 
+  /**
+   * Returns a {@link ClientCHK} for the block at {@code x}, or {@code null} if ignored.
+   *
+   * <p>Honors {@code copy} in the same way as {@link #getNodeKey(int, boolean[], boolean)}. When a
+   * common crypto key/extra are configured, those arrays are reused unless {@code copy} is
+   * requested. Otherwise, per‑block slices are returned.
+   *
+   * @param x zero‑based block index within the segment; must be less than {@code dataBlocks +
+   *     checkBlocks}.
+   * @param ignoreSlots optional mask to skip indices; when {@code null}, no indices are skipped.
+   * @param copy whether to clone backing arrays to avoid sharing with this instance.
+   * @return a client‑level key containing routing, crypto key, and extra bytes, or {@code null}
+   *     when the block is marked as ignored.
+   */
   public ClientCHK getKey(int x, boolean[] ignoreSlots, boolean copy) {
-    if (ignoreSlots != null) {
-      if (ignoreSlots[x]) return null;
-    }
+    if (ignoreSlots != null && ignoreSlots[x]) return null;
     return getKey(x, copy);
   }
 
   private ClientCHK getKey(int x, boolean copy) {
-    byte[] routingKey = new byte[32];
+    byte[] routingKey = new byte[NodeCHK.KEY_LENGTH];
     System.arraycopy(routingKeys, x * NodeCHK.KEY_LENGTH, routingKey, 0, NodeCHK.KEY_LENGTH);
     byte[] decryptKey;
     if (commonDecryptKey != null) {
@@ -189,12 +350,11 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     try {
       return new ClientCHK(routingKey, decryptKey, extra);
     } catch (MalformedURLException e) {
-      LOG.error("Impossible: " + e);
-      throw new IllegalStateException(e);
+      throw new IllegalStateException("Failed to construct ClientCHK from routing/crypto/extra", e);
     }
   }
 
-  private NodeCHK getNodeKey(int x, boolean copy) {
+  private NodeCHK getNodeKey(int x) {
     int xr = x * NodeCHK.KEY_LENGTH;
     byte[] routingKey = Arrays.copyOfRange(routingKeys, xr, xr + NodeCHK.KEY_LENGTH);
     byte[] extra;
@@ -210,58 +370,98 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     return new NodeCHK(routingKey, cryptoAlgorithm);
   }
 
+  /**
+   * Reads keys for either data or check blocks from the supplied stream into this instance.
+   *
+   * <p>When using common crypto material, only routing keys are read. Otherwise, each entry
+   * contains extra bytes, routing key, and crypto key as expected by {@link
+   * ClientCHK#readRawBinaryKey}.
+   *
+   * @param dis source stream positioned at the first key for the requested block kind; the method
+   *     reads exactly the number of entries implied by the segment sizes.
+   * @param check when {@code true}, reads {@link #checkBlocks} keys; otherwise reads {@link
+   *     #dataBlocks} keys.
+   * @throws IOException if the stream cannot supply the required number of bytes or an I/O error
+   *     occurs while reading.
+   */
   public void readKeys(DataInputStream dis, boolean check) throws IOException {
     int count = check ? checkBlocks : dataBlocks;
     int offset = check ? dataBlocks : 0;
+    int rkOffset = offset * NodeCHK.KEY_LENGTH;
     if (commonDecryptKey != null) {
-      int rkOffset = offset * NodeCHK.KEY_LENGTH;
       for (int i = 0; i < count; i++) {
         dis.readFully(routingKeys, rkOffset, NodeCHK.KEY_LENGTH);
         rkOffset += NodeCHK.KEY_LENGTH;
       }
     } else {
-      int rkOffset = offset * NodeCHK.KEY_LENGTH;
       int extraOffset = offset * EXTRA_BYTES_LENGTH;
-      assert (NodeCHK.KEY_LENGTH == ClientCHK.CRYPTO_KEY_LENGTH);
+      int dkOffset = offset * ClientCHK.CRYPTO_KEY_LENGTH;
       for (int i = 0; i < count; i++) {
         ClientCHK key = ClientCHK.readRawBinaryKey(dis);
         byte[] r = key.getRoutingKey();
         System.arraycopy(r, 0, routingKeys, rkOffset, NodeCHK.KEY_LENGTH);
         byte[] c = key.getCryptoKey();
-        System.arraycopy(c, 0, decryptKeys, rkOffset, NodeCHK.KEY_LENGTH);
+        System.arraycopy(c, 0, decryptKeys, dkOffset, ClientCHK.CRYPTO_KEY_LENGTH);
         rkOffset += NodeCHK.KEY_LENGTH;
         byte[] e = key.getExtra();
         System.arraycopy(e, 0, extraBytesForKeys, extraOffset, EXTRA_BYTES_LENGTH);
         extraOffset += EXTRA_BYTES_LENGTH;
+        dkOffset += ClientCHK.CRYPTO_KEY_LENGTH;
       }
     }
   }
 
+  /**
+   * Writes keys for either data or check blocks to the supplied stream from this instance.
+   *
+   * <p>When using common crypto material, only routing keys are written. Otherwise, for each entry
+   * the method writes extra bytes, routing key, then crypto key. The order matches the on‑disk
+   * format consumed by {@link #readKeys(DataInputStream, boolean)}.
+   *
+   * @param dos destination stream to receive the binary key representation; the caller owns the
+   *     stream and is responsible for closing it.
+   * @param check when {@code true}, writes {@link #checkBlocks} keys; otherwise writes {@link
+   *     #dataBlocks} keys.
+   * @throws IOException if the stream rejects bytes or another I/O error occurs while writing.
+   */
   public void writeKeys(DataOutputStream dos, boolean check) throws IOException {
     int count = check ? checkBlocks : dataBlocks;
     int offset = check ? dataBlocks : 0;
+    int rkOffset = offset * NodeCHK.KEY_LENGTH;
     if (commonDecryptKey != null) {
-      int rkOffset = offset * NodeCHK.KEY_LENGTH;
       for (int i = 0; i < count; i++) {
         dos.write(routingKeys, rkOffset, NodeCHK.KEY_LENGTH);
         rkOffset += NodeCHK.KEY_LENGTH;
       }
     } else {
-      int rkOffset = offset * NodeCHK.KEY_LENGTH;
       int extraOffset = offset * EXTRA_BYTES_LENGTH;
-      assert (NodeCHK.KEY_LENGTH == ClientCHK.CRYPTO_KEY_LENGTH);
+      int dkOffset = offset * ClientCHK.CRYPTO_KEY_LENGTH;
       for (int i = 0; i < count; i++) {
         dos.write(extraBytesForKeys, extraOffset, EXTRA_BYTES_LENGTH);
         extraOffset += EXTRA_BYTES_LENGTH;
         dos.write(routingKeys, rkOffset, NodeCHK.KEY_LENGTH);
-        dos.write(decryptKeys, rkOffset, NodeCHK.KEY_LENGTH);
+        dos.write(decryptKeys, dkOffset, ClientCHK.CRYPTO_KEY_LENGTH);
         rkOffset += NodeCHK.KEY_LENGTH;
+        dkOffset += ClientCHK.CRYPTO_KEY_LENGTH;
       }
     }
   }
 
+  /**
+   * Computes the number of bytes required to store keys for a segment.
+   *
+   * <p>The result depends on whether a common crypto key is used. With a common key, only routing
+   * keys are stored per block. Otherwise, each block stores extra bytes, routing key, and crypto
+   * key.
+   *
+   * @param dataBlocks number of data blocks; must be non‑negative.
+   * @param checkBlocks number of check/parity blocks; must be non‑negative.
+   * @param commonDecryptKey whether a common decryption key is used for all blocks, reducing the
+   *     per‑block storage to routing keys only.
+   * @return the total byte length required to persist keys for {@code dataBlocks + checkBlocks}
+   *     blocks under the given assumptions.
+   */
   public static int storedKeysLength(int dataBlocks, int checkBlocks, boolean commonDecryptKey) {
-    // FIXME URGENT Implement a unit test for storedKeysLength() vs writeKeys() vs readKeys().
     int blocks = dataBlocks + checkBlocks;
     if (commonDecryptKey) {
       return blocks * NodeCHK.KEY_LENGTH;
@@ -270,14 +470,33 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     }
   }
 
+  /**
+   * Returns the number of data blocks in this segment.
+   *
+   * @return the count of data (non‑parity) blocks configured at construction time.
+   */
   public int getDataBlocks() {
     return dataBlocks;
   }
 
+  /**
+   * Returns the number of check/parity blocks in this segment.
+   *
+   * @return the count of parity blocks configured at construction time.
+   */
   public int getCheckBlocks() {
     return checkBlocks;
   }
 
+  /**
+   * Sets the key material for a specific block index using a {@link ClientCHK} instance.
+   *
+   * <p>Writes the routing key unconditionally. When per‑block crypto material is in use, also
+   * copies the crypto key and extra bytes into their respective arrays.
+   *
+   * @param i zero‑based block index to update; must be within the segment range.
+   * @param key source of routing key, crypto key, and extra bytes to persist into this instance.
+   */
   public void setKey(int i, ClientCHK key) {
     byte[] r = key.getRoutingKey();
     System.arraycopy(r, 0, routingKeys, i * NodeCHK.KEY_LENGTH, NodeCHK.KEY_LENGTH);
@@ -292,6 +511,18 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     }
   }
 
+  /**
+   * Returns an array of {@link NodeCHK} for all non‑ignored indices in the segment.
+   *
+   * <p>Indices with {@code true} in {@code foundKeys} are skipped. The {@code copy} parameter has
+   * the same meaning as in {@link #getNodeKey(int, boolean[], boolean)}. The returned array is
+   * newly allocated and sized to the number of included keys.
+   *
+   * @param foundKeys optional mask of indices to exclude from the result; {@code null} includes all
+   *     indices.
+   * @param copy whether to defensively copy internal arrays when constructing each {@link NodeCHK}.
+   * @return a new array containing node‑level keys for all included indices, in ascending order.
+   */
   public NodeCHK[] listNodeKeys(boolean[] foundKeys, boolean copy) {
     ArrayList<NodeCHK> list = new ArrayList<>();
     for (int i = 0; i < dataBlocks + checkBlocks; i++) {
@@ -302,14 +533,7 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     return list.toArray(new NodeCHK[0]);
   }
 
-  @Override
-  public SplitFileSegmentKeys clone() {
-    try {
-      return (SplitFileSegmentKeys) super.clone();
-    } catch (CloneNotSupportedException e) {
-      throw new Error("Yes it is!");
-    }
-  }
+  // Clone is intentionally not implemented; prefer explicit copy patterns if needed.
 
   // Not often used, not very efficient, but overriding equals() requires overriding hashCode().
   @Override
@@ -341,6 +565,11 @@ public class SplitFileSegmentKeys implements Cloneable, Serializable {
     return Arrays.equals(routingKeys, other.routingKeys);
   }
 
+  /**
+   * Returns the total number of keys managed by this instance.
+   *
+   * @return the sum of {@link #dataBlocks} and {@link #checkBlocks} representing all block slots.
+   */
   public int totalKeys() {
     return checkBlocks + dataBlocks;
   }

--- a/src/test/java/network/crypta/client/async/SplitFileSegmentKeysTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileSegmentKeysTest.java
@@ -1,0 +1,276 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.Arrays;
+import network.crypta.keys.ClientCHK;
+import network.crypta.keys.Key;
+import network.crypta.keys.NodeCHK;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitFileSegmentKeysTest {
+
+  private static ClientCHK newClientKey(byte[] rk, byte[] ck, byte algo) throws Exception {
+    return new ClientCHK(rk, ck, ClientCHK.getExtra(algo, (short) -1, false));
+  }
+
+  private static byte[] rk(int seed) {
+    byte[] rk = new byte[NodeCHK.KEY_LENGTH];
+    rk[0] = (byte) seed;
+    return rk;
+  }
+
+  private static byte[] ck(int seed) {
+    byte[] ck = new byte[ClientCHK.CRYPTO_KEY_LENGTH];
+    ck[0] = (byte) seed;
+    return ck;
+  }
+
+  @Test
+  void storedKeysLength_and_roundTrip_withCommonDecryptKey_matchExpectations() throws Exception {
+    int data = 3;
+    int check = 2;
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+    byte[] common = ck(77);
+
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, common, algo);
+    for (int i = 0; i < data + check; i++) {
+      keys.setKey(i, newClientKey(rk(10 + i), ck(80 + i), algo));
+    }
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    keys.writeKeys(dos, /*check*/ false);
+    keys.writeKeys(dos, /*check*/ true);
+    dos.close();
+
+    int expected = SplitFileSegmentKeys.storedKeysLength(data, check, /*common*/ true);
+    assertEquals(expected, bos.size(), "Stored byte length must match computation");
+
+    // Read back and verify equality
+    SplitFileSegmentKeys read = new SplitFileSegmentKeys(data, check, common, algo);
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()));
+    read.readKeys(dis, /*check*/ false);
+    read.readKeys(dis, /*check*/ true);
+
+    assertEquals(keys, read);
+    assertEquals(data, read.getDataBlocks());
+    assertEquals(check, read.getCheckBlocks());
+    assertEquals(data + check, read.totalKeys());
+  }
+
+  @Test
+  void storedKeysLength_and_roundTrip_withoutCommonDecryptKey_matchExpectations() throws Exception {
+    int data = 2;
+    int check = 1;
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, null, algo);
+    for (int i = 0; i < data + check; i++) {
+      keys.setKey(i, newClientKey(rk(20 + i), ck(90 + i), algo));
+    }
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    keys.writeKeys(dos, /*check*/ false);
+    keys.writeKeys(dos, /*check*/ true);
+    dos.close();
+
+    int expected = SplitFileSegmentKeys.storedKeysLength(data, check, /*common*/ false);
+    assertEquals(expected, bos.size(), "Stored byte length must match computation");
+
+    // Read back and verify equality
+    SplitFileSegmentKeys read = new SplitFileSegmentKeys(data, check, null, algo);
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()));
+    read.readKeys(dis, /*check*/ false);
+    read.readKeys(dis, /*check*/ true);
+
+    assertEquals(keys, read);
+  }
+
+  @Test
+  void getBlockNumber_ClientCHK_withCommonKey_returnsIndexAndHonorsIgnoreMask() throws Exception {
+    int data = 3;
+    int check = 1;
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+    byte[] common = ck(7);
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, common, algo);
+    // Fill routing keys only (per-block crypto/extra not stored in this mode)
+    for (int i = 0; i < data + check; i++) {
+      keys.setKey(i, newClientKey(rk(1 + i), ck(55 + i), algo));
+    }
+
+    int target = 2;
+    ClientCHK probe = newClientKey(rk(1 + target), common, algo);
+    assertEquals(target, keys.getBlockNumber(probe, /*ignore*/ null));
+
+    boolean[] ignore = new boolean[data + check];
+    ignore[target] = true;
+    assertEquals(-1, keys.getBlockNumber(probe, ignore));
+
+    // Wrong crypto key should not match when commonDecryptKey is enforced
+    ClientCHK wrongCrypto = newClientKey(rk(1 + target), ck(99), algo);
+    assertEquals(-1, keys.getBlockNumber(wrongCrypto, /*ignore*/ null));
+  }
+
+  @Test
+  void getBlockNumber_ClientCHK_withoutCommonKey_checksRoutingCryptoAndExtra() throws Exception {
+    int data = 2;
+    int check = 1;
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, null, algo);
+
+    for (int i = 0; i < data + check; i++) {
+      keys.setKey(i, newClientKey(rk(30 + i), ck(40 + i), algo));
+    }
+
+    int target = 1;
+    ClientCHK match = newClientKey(rk(30 + target), ck(40 + target), algo);
+    assertEquals(target, keys.getBlockNumber(match, null));
+
+    // Mismatch crypto
+    ClientCHK wrongCk = newClientKey(rk(30 + target), ck(99), algo);
+    assertEquals(-1, keys.getBlockNumber(wrongCk, null));
+
+    // Mismatch extra (different algorithm)
+    ClientCHK wrongExtra =
+        newClientKey(rk(30 + target), ck(40 + target), Key.ALGO_AES_CTR_256_SHA256);
+    assertEquals(-1, keys.getBlockNumber(wrongExtra, null));
+  }
+
+  @Test
+  void getBlockNumber_NodeCHK_returnsIndexAndAllMatches() throws Exception {
+    int data = 3;
+    int check = 1;
+    byte algo = Key.ALGO_AES_CTR_256_SHA256;
+    byte[] common = ck(1);
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, common, algo);
+    // Create duplicate routing keys at positions 0 and 3
+    keys.setKey(0, newClientKey(rk(77), ck(10), algo));
+    keys.setKey(1, newClientKey(rk(78), ck(11), algo));
+    keys.setKey(2, newClientKey(rk(79), ck(12), algo));
+    keys.setKey(3, newClientKey(rk(77), ck(13), algo));
+
+    NodeCHK node = new NodeCHK(rk(77), algo);
+    assertEquals(0, keys.getBlockNumber(node, null));
+
+    int[] all = keys.getBlockNumbers(node, null);
+    assertArrayEquals(new int[] {0, 3}, all);
+
+    boolean[] ignore = new boolean[data + check];
+    ignore[0] = true;
+    assertEquals(3, keys.getBlockNumber(node, ignore));
+  }
+
+  @Test
+  void getKey_copySemantics_withCommonDecryptKey_controlsCryptoArraySharing() throws Exception {
+    int data = 1;
+    int check = 0;
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+    byte[] common = ck(5);
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, common, algo);
+    keys.setKey(0, newClientKey(rk(100), ck(101), algo));
+
+    // copy=false should share the commonDecryptKey array
+    ClientCHK k1 = keys.getKey(0, /*ignore*/ null, /*copy*/ false);
+    assertSame(common, k1.getCryptoKey());
+
+    // copy=true should clone the commonDecryptKey array
+    ClientCHK k2 = keys.getKey(0, null, true);
+    assertNotSame(common, k2.getCryptoKey());
+    assertArrayEquals(common, k2.getCryptoKey());
+
+    // Ignore mask prevents key retrieval
+    boolean[] ignore = new boolean[] {true};
+    assertNull(keys.getKey(0, ignore, false));
+  }
+
+  @Test
+  void getNodeKey_algorithmDerivedFromExtra_ignoresCopyFlag() throws Exception {
+    int data = 2;
+    int check = 0;
+    byte algo = Key.ALGO_AES_CTR_256_SHA256;
+    byte[] common = ck(9);
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, common, algo);
+    keys.setKey(0, newClientKey(rk(1), ck(2), algo));
+    keys.setKey(1, newClientKey(rk(2), ck(3), algo));
+
+    NodeCHK n1 = keys.getNodeKey(0, null, false);
+    NodeCHK n2 = keys.getNodeKey(0, null, true);
+    assertNotNull(n1);
+    assertNotNull(n2);
+    assertArrayEquals(n1.getFullKey(), n2.getFullKey());
+    byte parsedAlgo = NodeCHK.cryptoAlgorithmFromFullKey(n1.getFullKey());
+    assertEquals(algo, parsedAlgo);
+
+    boolean[] ignore = new boolean[] {true, false};
+    assertNull(keys.getNodeKey(0, ignore, false));
+  }
+
+  @Test
+  void listNodeKeys_honorsFoundMask_andReturnsAllOthers() throws Exception {
+    int data = 2;
+    int check = 1;
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+    byte[] common = ck(3);
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, common, algo);
+    for (int i = 0; i < data + check; i++) {
+      keys.setKey(i, newClientKey(rk(50 + i), ck(60 + i), algo));
+    }
+
+    boolean[] found = new boolean[] {false, true, false};
+    NodeCHK[] listed = keys.listNodeKeys(found, /*copy*/ true);
+    assertEquals(2, listed.length);
+    assertTrue(
+        Arrays.equals(listed[0].getFullKey(), new NodeCHK(rk(50), algo).getFullKey())
+            || Arrays.equals(listed[1].getFullKey(), new NodeCHK(rk(50), algo).getFullKey()));
+  }
+
+  @Test
+  void getKey_withInvalidAlgorithm_throwsIllegalStateException() throws Exception {
+    int data = 1;
+    int check = 0;
+    byte invalidAlgo = (byte) 42; // not one of the supported constants
+    byte[] common = ck(7);
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, common, invalidAlgo);
+    keys.setKey(0, newClientKey(rk(7), ck(8), Key.ALGO_AES_PCFB_256_SHA256));
+    assertThrows(IllegalStateException.class, () -> keys.getKey(0, null, false));
+  }
+
+  @Test
+  void readKeys_withoutCommonKey_invalidExtra_throwsIOException() throws Exception {
+    int data = 1;
+    int check = 0;
+    byte algo = Key.ALGO_AES_PCFB_256_SHA256;
+    SplitFileSegmentKeys keys = new SplitFileSegmentKeys(data, check, null, algo);
+    keys.setKey(0, newClientKey(rk(9), ck(10), algo));
+
+    // Serialize keys, corrupt the first block's extra[1] (algorithm) byte, then read back.
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(bos);
+    keys.writeKeys(dos, /*check*/ false);
+    dos.close();
+    byte[] buf = bos.toByteArray();
+    // Layout without common key per block: EXTRA[5] + ROUTING[32] + CRYPTO[32]
+    buf[1] = (byte) 99; // invalidate algorithm
+
+    SplitFileSegmentKeys corrupted = new SplitFileSegmentKeys(data, check, null, algo);
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(buf));
+    assertThrows(java.io.IOException.class, () -> corrupted.readKeys(dis, /*check*/ false));
+  }
+}


### PR DESCRIPTION
Summary
- Replace Cloneable with explicit copy semantics; adopt copy constructor usage in Metadata instead of clone().
- Validate per-block extra bytes in readKeys(...) and throw IOException on invalid data.
- Improve SplitFileSegmentKeys Javadoc and clarify thread-safety/copy behaviors.
- Add focused test covering invalid extra byte corruption path.
- Apply Spotless formatting to touched files.

Changes
- Modified: src/main/java/network/crypta/client/Metadata.java
  - Deep-copy segments via new SplitFileSegmentKeys(orig.segments[i])
- Modified: src/main/java/network/crypta/client/async/SplitFileSegmentKeys.java
  - Drop Cloneable/logger, enhance docs, strengthen IO validation, tidy structure
- Added: src/test/java/network/crypta/client/async/SplitFileSegmentKeysTest.java
  - Adds failure-path test: invalid algorithm byte causes IOException during readKeys

Rationale
- Explicit copy semantics reduce aliasing hazards and make ownership clear.
- IO validation prevents silently accepting corrupt/invalid key metadata which could surface later as cryptic failures.
- Tests document and lock expected behavior for invalid extra bytes.

Impact
- Internal behavior change in Metadata copy path (clone() -> copy-ctor) with equivalent deep-copy semantics.
- SplitFileSegmentKeys no longer implements Cloneable; internal callers (e.g., Metadata) updated accordingly.

Testing
- New JUnit test added for invalid-extra read path.
- Spotless ran cleanly; formatting applied. Full test suite can be run with `./gradlew test` upon review.

Commits in this branch
- bdcf7df8f6 fix(client): strengthen SplitFileSegmentKeys copy/IO behavior and tests

Notes
- Target base: develop
- Please advise if additional negative-path tests are preferred (e.g., invalid routing key length).
