### PR TITLE
chore(client): USKDateHint docs/tests; apply Spotless

### DIFF
--- a/src/main/java/network/crypta/client/async/USKDateHint.java
+++ b/src/main/java/network/crypta/client/async/USKDateHint.java
@@ -11,15 +11,61 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableUSK;
 import network.crypta.keys.USK;
 
-/** Utility class for date-based edition hints */
+/**
+ * Builds and describes date-based edition "hints" for updatable SSK/USK keys.
+ *
+ * <p>This helper encapsulates the logic used by the client to derive readable, stable suffixes that
+ * encode a point in time at different granularities (year, month, day, and a week representation).
+ * These suffixes are embedded into document names and small hint payloads so that producers and
+ * consumers can rendezvous on likely editions without scanning the entire namespace.
+ *
+ * <p>Instances are immutable and thread-safe. Each instance is bound to a UTC {@link
+ * java.time.LocalDate} captured at construction. Typical usage is to obtain a hint anchored to
+ * "today" in UTC via {@link #now()} and then render one or more representations via {@link
+ * #get(Type)} or the compact wire format via {@link #getData(long)}. Consumers such as the USK
+ * fetcher use these forms to schedule and interpret background requests.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities</strong>: provide date-derived suffixes and a minimal wire payload
+ *       that carries a suggested edition and the most precise date form.
+ *   <li><strong>Precision</strong>: {@link Type#DAY} is strictly more precise than other types;
+ *       {@link Type#MONTH} and {@link Type#WEEK} are not strictly ordered, but both are more
+ *       precise than {@link Type#YEAR}.
+ *   <li><strong>Newline policy</strong>: the {@linkplain #getData(long) payload} uses LF-only
+ *       ("\n") line endings, regardless of platform, because it is a cross-platform wire format.
+ * </ul>
+ */
 public class USKDateHint {
 
+  /**
+   * Precision levels available when rendering a date.
+   *
+   * <p>The values express an ordering used by scheduling logic. See {@link
+   * #alwaysMorePreciseThan(Type)} for details on how one value compares to another for precision.
+   */
   public enum Type {
+    /** Year-only precision, for example {@code 2023}. Lowest precision. */
     YEAR,
+    /** Month precision using a zero-indexed month, for example {@code 2023-5} for June. */
     MONTH,
+    /** Day precision, for example {@code 2023-5-1} for 2023-06-01. Highest non-week precision. */
     DAY,
+    /** Week-based year and week of year, for example {@code 2023-WEEK-1}. */
     WEEK;
 
+    /**
+     * Report whether this precision is strictly more precise than another.
+     *
+     * <p>The ordering reflects scheduling semantics: {@link #DAY} is more precise than all other
+     * types. {@link #MONTH} and {@link #WEEK} are each strictly more precise than {@link #YEAR} but
+     * are not strictly ordered relative to one another because weeks and months cross boundaries
+     * differently. {@link #YEAR} is never strictly more precise.
+     *
+     * @param type the other precision to compare against; may be {@code null}, which is treated as
+     *     unspecified and therefore not strictly less precise than any value.
+     * @return {@code true} if this value is strictly more precise than {@code type}; otherwise
+     *     {@code false}.
+     */
     public boolean alwaysMorePreciseThan(Type type) {
       if (this.equals(type)) return false;
       if (this.equals(DAY)) { // Day beats everything.
@@ -29,8 +75,9 @@ public class USKDateHint {
         return type.equals(YEAR);
       } else if (this.equals(WEEK)) {
         return type.equals(YEAR);
-      } else // if(this.equals(YEAR)) - everything beats year
-      return false;
+      } else { // YEAR: everything else is more precise
+        return false;
+      }
     }
   }
 
@@ -43,10 +90,35 @@ public class USKDateHint {
     this.dateUtc = dateUtc;
   }
 
+  /**
+   * Create a new hint instance anchored to the current date in UTC.
+   *
+   * <p>The resulting object is immutable. All derived strings are computed from the captured date
+   * and do not change after creation.
+   *
+   * <pre>{@code
+   * USKDateHint hint = USKDateHint.now();
+   * String day = hint.get(USKDateHint.Type.DAY);
+   * }</pre>
+   *
+   * @return a new {@code USKDateHint} bound to "today" in UTC.
+   */
   public static USKDateHint now() {
     return new USKDateHint(LocalDate.now(ZoneOffset.UTC));
   }
 
+  /**
+   * Render the date using the requested precision.
+   *
+   * <p>For {@link Type#WEEK}, the result is the week-based year and week-of-year encoded as {@code
+   * <year>-WEEK-<week>}, using US week fields (weeks start on Sunday). For the other values, the
+   * format is {@code <year>[-<zeroIndexedMonth>[-<day>]]} where the month is zero-indexed to
+   * preserve historical behavior. When {@code type} is {@code null}, the method behaves like
+   * requesting the most precise non-week form and returns the day string.
+   *
+   * @param type desired precision; may be {@code null} to request the day form.
+   * @return a non-empty string encoding the date at the requested precision; never {@code null}.
+   */
   public String get(Type type) {
     if (type == Type.WEEK) {
       return dateUtc.get(WEEK_YEAR) + "-WEEK-" + dateUtc.get(WEEK_OF_YEAR);
@@ -69,19 +141,55 @@ public class USKDateHint {
     return sb.toString();
   }
 
-  /** Return the data to insert to each hint slot. */
+  /**
+   * Build the compact wire-format payload for a hint insertion.
+   *
+   * <p>The payload consists of three LF-terminated lines using UTF-8 content: a literal {@code
+   * HINT}, the decimal edition number, and the {@link #get(Type) day} representation of the date.
+   * Newlines are always LF ("\n"), regardless of the host platform, so the payload is portable and
+   * consistently parsed by all nodes.
+   *
+   * <pre>{@code
+   * String data = USKDateHint.now().getData(12345);
+   * // HINT\n12345\nYYYY-M-D\n
+   * }</pre>
+   *
+   * @param edition the suggested absolute edition number to advertise; non-negative values are
+   *     expected by consumers.
+   * @return a three-line LF-terminated string suitable for insertion and remote parsing.
+   */
+  @SuppressWarnings("java:S3457")
   public String getData(long edition) {
     return "HINT\n%d\n%s\n".formatted(edition, get(Type.DAY));
   }
 
-  /** Return the URL's to insert hint data to */
+  /**
+   * Compute insert-capable SSK URIs for each precision variant.
+   *
+   * <p>The returned array contains four entries in the {@link Type#values()} order (year, month,
+   * day, week). Each URI refers to a document name suffixed with {@code -DATEHINT-<suffix>}, where
+   * {@code <suffix>} is the string produced by {@link #get(Type)} for the corresponding precision.
+   *
+   * @param key the insertable USK used to derive per-precision SSK insert URIs; must not be {@code
+   *     null}.
+   * @return a new array of length four containing insert URIs in deterministic order.
+   */
   public FreenetURI[] getInsertURIs(InsertableUSK key) {
     return Arrays.stream(Type.values())
         .map(type -> key.getInsertableSSK(getDocName(key, type)).getInsertURI())
         .toArray(FreenetURI[]::new);
   }
 
-  /** Return the URL's to fetch hint data from */
+  /**
+   * Compute request-capable SSK URIs for each precision variant.
+   *
+   * <p>The returned array contains four entries in the {@link Type#values()} order (year, month,
+   * day, week). Each entry targets the corresponding document name suffixed with {@code
+   * -DATEHINT-<suffix>}.
+   *
+   * @param key the USK used to derive per-precision SSK request URIs; must not be {@code null}.
+   * @return a new array of length four containing request URIs in deterministic order.
+   */
   public ClientSSK[] getRequestURIs(USK key) {
     return Arrays.stream(Type.values())
         .map(type -> key.getSSK(getDocName(key, type)))

--- a/src/test/java/network/crypta/client/async/USKDateHintTest.java
+++ b/src/test/java/network/crypta/client/async/USKDateHintTest.java
@@ -4,42 +4,226 @@ import static network.crypta.client.async.USKDateHint.Type.DAY;
 import static network.crypta.client.async.USKDateHint.Type.MONTH;
 import static network.crypta.client.async.USKDateHint.Type.WEEK;
 import static network.crypta.client.async.USKDateHint.Type.YEAR;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
+import java.time.temporal.TemporalField;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+import java.util.stream.Stream;
+import network.crypta.client.async.USKDateHint.Type;
+import network.crypta.keys.ClientSSK;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.InsertableClientSSK;
+import network.crypta.keys.InsertableUSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.NodeSSK;
+import network.crypta.keys.USK;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class USKDateHintTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class USKDateHintTest {
+
+  // ---- Existing behavior checks (kept) ----
 
   @Test
-  public void getYear() {
+  void get_whenYear_expectYearString() {
+    // Arrange
     USKDateHint hint = new USKDateHint(LocalDate.parse("2023-06-01"));
-    assertEquals(hint.get(YEAR), "2023");
+    // Act
+    String value = hint.get(YEAR);
+    // Assert
+    assertEquals("2023", value);
   }
 
   @Test
-  public void getMonth() {
+  void get_whenMonth_expectZeroIndexedMonthString() {
+    // Arrange
     USKDateHint hint = new USKDateHint(LocalDate.parse("2023-06-01"));
-    assertEquals(hint.get(MONTH), "2023-5");
+    // Act
+    String value = hint.get(MONTH);
+    // Assert
+    assertEquals("2023-5", value);
   }
 
   @Test
-  public void getDay() {
+  void get_whenDay_expectFullDateString() {
+    // Arrange
     USKDateHint hint = new USKDateHint(LocalDate.parse("2023-06-01"));
-    assertEquals(hint.get(DAY), "2023-5-1");
+    // Act
+    String value = hint.get(DAY);
+    // Assert
+    assertEquals("2023-5-1", value);
   }
 
   @Test
-  public void getWeek() {
+  void get_whenWeek_expectWeekBasedYearAndWeekOfYear() {
+    // Arrange
     USKDateHint hintStartOfYear = new USKDateHint(LocalDate.parse("2023-01-01"));
     USKDateHint hintEndOfYear = new USKDateHint(LocalDate.parse("2023-12-31"));
-    assertEquals(hintStartOfYear.get(WEEK), "2023-WEEK-1");
-    assertEquals(hintEndOfYear.get(WEEK), "2024-WEEK-1");
+    // Act & Assert
+    assertEquals("2023-WEEK-1", hintStartOfYear.get(WEEK));
+    assertEquals("2024-WEEK-1", hintEndOfYear.get(WEEK));
   }
 
   @Test
-  public void getData() {
+  void getData_whenEditionProvided_expectFormattedPayload() {
+    // Arrange
     USKDateHint hint = new USKDateHint(LocalDate.parse("2023-06-01"));
-    assertEquals(hint.getData(12345), "HINT\n12345\n2023-5-1\n");
+    // Act
+    String data = hint.getData(12345);
+    // Assert
+    assertEquals("HINT\n12345\n2023-5-1\n", data);
+  }
+
+  // ---- New tests ----
+
+  @Test
+  void get_whenNullType_expectDayPrecisionString() {
+    // Arrange
+    LocalDate date = LocalDate.of(2025, 1, 2); // Jan to also verify zero-based month handling
+    USKDateHint hint = new USKDateHint(date);
+    // Act
+    String value = hint.get(null);
+    // Assert (null behaves like requesting the most precise non-week form, i.e., day)
+    assertEquals(
+        "%d-%d-%d".formatted(date.getYear(), date.getMonthValue() - 1, date.getDayOfMonth()),
+        value);
+  }
+
+  @Test
+  void get_whenJanuary_expectZeroIndexedMonthZero() {
+    // Arrange
+    LocalDate date = LocalDate.of(2024, 1, 15);
+    USKDateHint hint = new USKDateHint(date);
+    // Act
+    String month = hint.get(MONTH);
+    String day = hint.get(DAY);
+    // Assert
+    assertEquals("2024-0", month);
+    assertEquals("2024-0-15", day);
+  }
+
+  @Test
+  void get_whenWeek_usesUSLocaleWeekFields() {
+    // Arrange
+    LocalDate date = LocalDate.of(2024, 12, 29); // A Sunday near year boundary (US weeks start Sun)
+    USKDateHint hint = new USKDateHint(date);
+    TemporalField weekOfYear = WeekFields.of(Locale.US).weekOfWeekBasedYear();
+    TemporalField weekYear = WeekFields.of(Locale.US).weekBasedYear();
+    String expected = "%d-WEEK-%d".formatted(date.get(weekYear), date.get(weekOfYear));
+    // Act
+    String actual = hint.get(WEEK);
+    // Assert
+    assertEquals(expected, actual);
+  }
+
+  @ParameterizedTest
+  @MethodSource("alwaysMorePreciseThanCases")
+  void alwaysMorePreciseThan_variousPairs_expectDefinedOrdering(boolean expected, Type a, Type b) {
+    // Arrange
+    // Act
+    boolean result = a.alwaysMorePreciseThan(b);
+    // Assert
+    assertEquals(expected, result, () -> "%s > %s".formatted(a, b));
+  }
+
+  static Stream<Arguments> alwaysMorePreciseThanCases() {
+    return Stream.of(
+        // Same type never strictly more precise
+        Arguments.of(false, YEAR, YEAR),
+        Arguments.of(false, MONTH, MONTH),
+        Arguments.of(false, DAY, DAY),
+        Arguments.of(false, WEEK, WEEK),
+        // Day beats everything else
+        Arguments.of(true, DAY, YEAR),
+        Arguments.of(true, DAY, MONTH),
+        Arguments.of(true, DAY, WEEK),
+        // Month and week only beat year
+        Arguments.of(true, MONTH, YEAR),
+        Arguments.of(false, MONTH, WEEK),
+        Arguments.of(false, WEEK, MONTH),
+        Arguments.of(true, WEEK, YEAR),
+        // Year beats nothing
+        Arguments.of(false, YEAR, MONTH),
+        Arguments.of(false, YEAR, WEEK),
+        Arguments.of(false, YEAR, DAY));
+  }
+
+  @Test
+  void getRequestURIs_whenValidUSK_expectFourSSKsWithExpectedDocNamesInOrder() {
+    // Arrange (construct a minimal, valid USK)
+    byte[] pubKeyHash = new byte[NodeSSK.PUBKEY_HASH_SIZE];
+    byte[] cryptoKey = new byte[ClientSSK.CRYPTO_KEY_LENGTH];
+    USK usk = new TestUSK(pubKeyHash, cryptoKey, "mysite", 0L, Key.ALGO_AES_PCFB_256_SHA256);
+
+    LocalDate date = LocalDate.of(2023, 7, 15);
+    USKDateHint hint = new USKDateHint(date);
+
+    String[] expectedDocNames =
+        new String[] {
+          // YEAR, MONTH, DAY, WEEK (Type.values() order)
+          "mysite-DATEHINT-" + hint.get(YEAR),
+          "mysite-DATEHINT-" + hint.get(MONTH),
+          "mysite-DATEHINT-" + hint.get(DAY),
+          "mysite-DATEHINT-" + hint.get(WEEK)
+        };
+
+    // Act
+    ClientSSK[] uris = hint.getRequestURIs(usk);
+
+    // Assert
+    assertEquals(4, uris.length);
+    String[] actualDocNames =
+        new String[] {uris[0].docName, uris[1].docName, uris[2].docName, uris[3].docName};
+    assertArrayEquals(expectedDocNames, actualDocNames);
+  }
+
+  @Test
+  void getInsertURIs_whenInsertableUSKProvided_expectFourURIsWithCorrectSuffixesAndOrder() {
+    // Arrange: mock InsertableUSK.getInsertableSSK(String) to return an InsertableClientSSK whose
+    // getInsertURI() doc name equals the provided argument. siteName is field-accessed in
+    // USKDateHint; a mock yields null, so we assert on the suffix which is the interesting part.
+    var insertable = Mockito.mock(InsertableUSK.class);
+    Mockito.when(insertable.getInsertableSSK(Mockito.anyString()))
+        .thenAnswer(
+            inv -> {
+              String docName = inv.getArgument(0, String.class);
+              InsertableClientSSK ssk = Mockito.mock(InsertableClientSSK.class);
+              Mockito.when(ssk.getInsertURI()).thenReturn(new FreenetURI("SSK", docName));
+              return ssk;
+            });
+
+    LocalDate date = LocalDate.of(2023, 7, 15);
+    USKDateHint hint = new USKDateHint(date);
+
+    // Act
+    FreenetURI[] uris = hint.getInsertURIs(insertable);
+
+    // Assert
+    assertEquals(4, uris.length);
+    String[] suffixes =
+        new String[] {hint.get(YEAR), hint.get(MONTH), hint.get(DAY), hint.get(WEEK)};
+    for (int i = 0; i < uris.length; i++) {
+      String dn = uris[i].getDocName();
+      assertTrue(dn.endsWith("-DATEHINT-" + suffixes[i]), "docName=" + dn);
+    }
+  }
+
+  /** Minimal subclass to access the protected USK constructor for tests. */
+  private static final class TestUSK extends USK {
+    TestUSK(
+        byte[] pubKeyHash, byte[] cryptoKey, String siteName, long suggestedEdition, byte algo) {
+      super(pubKeyHash, cryptoKey, siteName, suggestedEdition, algo);
+    }
   }
 }


### PR DESCRIPTION
Summary
- Clarifies behavior and intent of USKDateHint with richer Javadoc, including precision semantics and LF-only newline policy for hint payloads.
- Expands unit tests for USKDateHint to improve coverage and codify expected behavior.
- Applies Spotless formatting across touched files.

Changes
- src/main/java/network/crypta/client/async/USKDateHint.java
  - Add detailed Javadoc: responsibilities, precision ordering, null handling for get(Type), and LF-only newline policy for getData(long).
  - Minor code tidy in alwaysMorePreciseThan(Type) and a suppression for S3457 on String.format usage.
  - No functional behavior changes intended.
- src/test/java/network/crypta/client/async/USKDateHintTest.java
  - Convert to JUnit 6-style method names and add parameterized tests for alwaysMorePreciseThan ordering.
  - Add tests for:
    - null type -> day precision string
    - January zero-indexed month handling
    - WEEK form using US week fields (WeekFields.of(Locale.US))
    - getRequestURIs: returns four SSKs with expected doc names and order
    - getInsertURIs: Mockito-based verification that docName suffixes match expected order

Diff scope
- 2 files changed, 310 insertions, 18 deletions

Commit(s) on this branch
- c8c097cbef chore(client): apply Spotless and update USKDateHint docs/tests

Rationale
- Improves documentation for maintainers and contributors.
- Strengthens test coverage for date precision behavior and URI derivation without altering production semantics.

Validation
- Spotless applied successfully prior to commit.
- Tests compile locally; Mockito is already used elsewhere in the repo.

Notes
- Base: develop
- Head: feature/fix-USKDateHint
- No public API changes; risk is low and limited to docs/tests.
