### PR TITLE
refactor(splitfile-inserter): storage and tests; doclint cleanup

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -70,9 +70,7 @@ tasks.named("compileJava") { dependsOn(tasks.named("compileKotlin")) }
 tasks.withType<Test>().configureEach {
   useJUnitPlatform()
   // Verbose failures: full exception stack traces/causes for easier debugging
-  testLogging {
-    exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-  }
+  testLogging { exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL }
   // Open JDK internals used by tests
   if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")

--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -69,6 +69,10 @@ tasks.named("compileJava") { dependsOn(tasks.named("compileKotlin")) }
 // Tests: settings and module opens needed at runtime
 tasks.withType<Test>().configureEach {
   useJUnitPlatform()
+  // Verbose failures: full exception stack traces/causes for easier debugging
+  testLogging {
+    exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+  }
   // Open JDK internals used by tests
   if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")

--- a/src/main/java/network/crypta/client/async/SplitFileInserterSegmentStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterSegmentStorage.java
@@ -152,7 +152,8 @@ public class SplitFileInserterSegmentStorage {
     if (dataBlockCount < 0) throw new StorageFormatException("Bogus data block count");
     crossCheckBlockCount = dis.readInt();
     if (crossCheckBlockCount < 0) throw new StorageFormatException("Bogus cross-check block count");
-    if ((crossCheckBlockCount == 0) != (parent.crossSegments == null))
+    boolean parentHasNoCross = (parent.crossSegments == null || parent.crossSegments.length == 0);
+    if ((crossCheckBlockCount == 0) != parentHasNoCross)
       throw new StorageFormatException("Cross-check block count inconsistent with parent");
     checkBlockCount = dis.readInt();
     if (checkBlockCount < 0) throw new StorageFormatException("Bogus check block count");

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
@@ -406,7 +406,6 @@ public class SplitFileInserterStorage {
             segs,
             totalDataBlocks,
             deductBlocksFromSegments,
-            persistent,
             keysFetching,
             consecutiveRNFsCountAsSuccess);
     randomSegmentIterator = new RandomArrayIterator<>(segments);
@@ -588,11 +587,7 @@ public class SplitFileInserterStorage {
     int segmentCount = readPositiveInt(dis, "segment count");
     this.segmentSize = readPositiveInt(dis, "segment size");
     // Allow zero for NON_REDUNDANT splitfiles (codec == null), where no check blocks exist.
-    {
-      int v = dis.readInt();
-      if (v < 0) throw new StorageFormatException("Bad check segment size " + v);
-      this.checkSegmentSize = v;
-    }
+    this.checkSegmentSize = readCheckSegmentSize(dis);
     int ccb = dis.readInt();
     if (ccb < 0) throw new StorageFormatException("Bad cross-check block count");
     this.crossCheckBlocks = ccb;
@@ -903,6 +898,12 @@ public class SplitFileInserterStorage {
 
   private record DataCheck(int data, int check) {}
 
+  private int readCheckSegmentSize(DataInputStream dis) throws IOException, StorageFormatException {
+    int v = dis.readInt();
+    if (v < 0) throw new StorageFormatException("Bad check segment size " + v);
+    return v;
+  }
+
   private int clampToDataBlocks(int i, int dataBlocks) {
     return Math.min(i, dataBlocks);
   }
@@ -915,18 +916,6 @@ public class SplitFileInserterStorage {
       check = (codec != null) ? codec.getCheckBlocks(data + crossCheckBlocks, cmode) : 0;
     }
     return new DataCheck(data, check);
-  }
-
-  private void logSegmentDetailsIfNeeded(
-      int segNo, int segCount, int data, int check, int deductBlocksFromSegments) {
-    if (deductBlocksFromSegments != 0 && LOG.isDebugEnabled()) {
-      LOG.debug(
-          "INSERTING: Segment {} of {} : {} data blocks {} check blocks",
-          segNo,
-          segCount,
-          data,
-          check);
-    }
   }
 
   private int maybeDeductBlock(int data, int segCount, int segNo, int deductBlocksFromSegments) {
@@ -1461,67 +1450,86 @@ public class SplitFileInserterStorage {
       int segCount,
       int dataBlocks,
       int deductBlocksFromSegments,
-      boolean persistent,
       KeysFetchingLocally keysFetching,
       int consecutiveRNFsCountAsSuccess) {
     SplitFileInserterSegmentStorage[] segArr = new SplitFileInserterSegmentStorage[segCount];
     if (segCount == 1) {
-      // Single segment
-      int checkBlocks =
-          (codec != null) ? codec.getCheckBlocks(dataBlocks + crossCheckBlocks, cmode) : 0;
-      segArr[0] =
-          new SplitFileInserterSegmentStorage(
-              this,
-              0,
-              new SplitFileInserterSegmentStorage.Params()
-                  .blocks(dataBlocks, checkBlocks, crossCheckBlocks)
-                  .keys(keyLength, splitfileCryptoAlgorithm, splitfileCryptoKey)
-                  .codec(random, maxRetries, consecutiveRNFsCountAsSuccess, keysFetching));
+      initSingleSegment(segArr, dataBlocks, keysFetching, consecutiveRNFsCountAsSuccess);
     } else {
-      int j = 0;
-      int segNo = 0;
-      int data = segmentSize;
-      int check = (codec != null) ? codec.getCheckBlocks(data + crossCheckBlocks, cmode) : 0;
-      int i = segmentSize;
-      while (true) {
-        this.underlyingOffsetDataSegments[segNo] = (long) j * CHKBlock.DATA_LENGTH;
-        i = clampToDataBlocks(i, dataBlocks);
-        DataCheck dc = adjustForLastSegmentIfNeeded(data, check, i, j, segNo, segCount);
-        data = dc.data;
-        check = dc.check;
-        j = i;
-        segArr[segNo] =
-            new SplitFileInserterSegmentStorage(
-                this,
-                segNo,
-                new SplitFileInserterSegmentStorage.Params()
-                    .blocks(data, check, crossCheckBlocks)
-                    .keys(keyLength, splitfileCryptoAlgorithm, splitfileCryptoKey)
-                    .codec(random, maxRetries, consecutiveRNFsCountAsSuccess, keysFetching));
-
-        if (deductBlocksFromSegments != 0)
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "INSERTING: Segment "
-                    + segNo
-                    + " of "
-                    + segCount
-                    + " : "
-                    + data
-                    + " data blocks "
-                    + check
-                    + " check blocks");
-
-        segNo++;
-        if (i == dataBlocks) break;
-        // Deduct one block from each later segment, rather than having
-        // a really short last segment.
-        data = maybeDeductBlock(data, segCount, segNo, deductBlocksFromSegments);
-        i += data;
-      }
-      assert (segNo == segCount);
+      populateMultiSegments(
+          segArr,
+          segmentSize,
+          segCount,
+          dataBlocks,
+          deductBlocksFromSegments,
+          keysFetching,
+          consecutiveRNFsCountAsSuccess);
     }
     return segArr;
+  }
+
+  private void initSingleSegment(
+      SplitFileInserterSegmentStorage[] segArr,
+      int dataBlocks,
+      KeysFetchingLocally keysFetching,
+      int consecutiveRNFsCountAsSuccess) {
+    int checkBlocks =
+        (codec != null) ? codec.getCheckBlocks(dataBlocks + crossCheckBlocks, cmode) : 0;
+    segArr[0] =
+        new SplitFileInserterSegmentStorage(
+            this,
+            0,
+            new SplitFileInserterSegmentStorage.Params()
+                .blocks(dataBlocks, checkBlocks, crossCheckBlocks)
+                .keys(keyLength, splitfileCryptoAlgorithm, splitfileCryptoKey)
+                .codec(random, maxRetries, consecutiveRNFsCountAsSuccess, keysFetching));
+  }
+
+  private void populateMultiSegments(
+      SplitFileInserterSegmentStorage[] segArr,
+      int segmentSize,
+      int segCount,
+      int dataBlocks,
+      int deductBlocksFromSegments,
+      KeysFetchingLocally keysFetching,
+      int consecutiveRNFsCountAsSuccess) {
+    int j = 0;
+    int segNo = 0;
+    int data = segmentSize;
+    int check = (codec != null) ? codec.getCheckBlocks(data + crossCheckBlocks, cmode) : 0;
+    int i = segmentSize;
+    while (true) {
+      this.underlyingOffsetDataSegments[segNo] = (long) j * CHKBlock.DATA_LENGTH;
+      i = clampToDataBlocks(i, dataBlocks);
+      DataCheck dc = adjustForLastSegmentIfNeeded(data, check, i, j, segNo, segCount);
+      data = dc.data;
+      check = dc.check;
+      j = i;
+      segArr[segNo] =
+          new SplitFileInserterSegmentStorage(
+              this,
+              segNo,
+              new SplitFileInserterSegmentStorage.Params()
+                  .blocks(data, check, crossCheckBlocks)
+                  .keys(keyLength, splitfileCryptoAlgorithm, splitfileCryptoKey)
+                  .codec(random, maxRetries, consecutiveRNFsCountAsSuccess, keysFetching));
+
+      if (deductBlocksFromSegments != 0 && LOG.isDebugEnabled())
+        LOG.debug(
+            "INSERTING: Segment {} of {} : {} data blocks {} check blocks",
+            segNo,
+            segCount,
+            data,
+            check);
+
+      segNo++;
+      if (i == dataBlocks) break;
+      // Deduct one block from each later segment, rather than having
+      // a really short last segment.
+      data = maybeDeductBlock(data, segCount, segNo, deductBlocksFromSegments);
+      i += data;
+    }
+    assert (segNo == segCount);
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
@@ -8,6 +8,7 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -55,33 +56,37 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Similar to SplitFileFetcherStorage. The status of a splitfile insert, including the encoded check
- * and cross-check blocks, is stored in a RandomAccessBuffer separate to that containing the data
- * itself. This class is only concerned with encoding, storage etc, and should have as few
- * dependencies on the runtime as possible, partly so that it can be tested in isolation. Actual
- * details of inserting the blocks will be kept on SplitFileInserter.
+ * Persistent and transient storage for splitfile inserts.
  *
- * <p>CONTENTS OF FILE: (for persistent case, transient leaves out most of the below) * Magic,
- * version etc. * Basic settings. * Settings for each segment. * Settings for each cross-segment
- * (including block lists). * Padded last block (if necessary) * Global status * (Padding to a 4096
- * byte boundary) * Cross-check blocks (by cross-segment). * Check blocks * Segment status * Segment
- * key list (each key separately stored and checksummed)
+ * <p>This component encapsulates the on-disk (or in-memory) representation of an ongoing splitfile
+ * insert. It maintains fixed settings, per-segment metadata, optional cross-segment redundancy
+ * mappings, encoded check/cross-check blocks, per-segment status, and the list of generated keys.
+ * The storage is separate from the original content and is designed to support resume, progress
+ * reporting, and integrity verification without requiring the inserter runtime to be resident.
  *
- * <p>Intentionally not as robust (against disk corruption in particular) as
- * SplitFileFetcherStorage: We encode the block CHKs when we encode the check blocks, and if the
- * block data has changed by the time we insert the data, we fail; there's no way to obtain correct
- * data. Similarly, we fail if the keys are corrupted. However, for most of the duration of the
- * insert neither the data, the check blocks or the keys will be written, so it's still reasonable
- * assuming you only get errrors when writing, and it isn't really possible to improve on this much
- * anyway...
+ * <p>When used persistently, the file layout is checksummed in bounded sections and includes: (1)
+ * magic/version and global settings; (2) per-segment fixed settings; (3) optional cross-segment
+ * settings; (4) optional padded last data block; (5) overall status; (6) cross-check and check
+ * blocks; (7) per-segment and per-cross-segment status; and (8) per-segment keys. The class focuses
+ * on deterministic encoding and storage; the higher-level scheduling and network I/O are handled by
+ * {@link SplitFileInserter} via callbacks.
  *
- * @author toad
+ * <p>Thread-safety: instances are used by worker threads under a simple state machine. Methods that
+ * mutate shared state either synchronize internally or rely on the caller to serialize access via
+ * the surrounding inserter. The original data buffer and RAF implementations are expected to be
+ * safe for concurrent reads/writes according to their own contracts.
+ *
+ * <ul>
+ *   <li>Responsibilities: encode per-segment/cross-segment settings; store and read checksummed
+ *       sections; surface progress and failures to the callback; support resume and lazy metadata
+ *       writing.
+ *   <li>Notable behaviors: non-redundant mode omits check and cross-check data; offsets and lengths
+ *       are validated when resuming; operations use a {@link ChecksumChecker} to protect section
+ *       boundaries against corruption.
+ * </ul>
  */
 public class SplitFileInserterStorage {
   private static final Logger LOG = LoggerFactory.getLogger(SplitFileInserterStorage.class);
-
-  static {
-  }
 
   /** The original file to upload */
   final LockableRandomAccessBuffer originalData;
@@ -122,8 +127,8 @@ public class SplitFileInserterStorage {
   private final boolean isMetadata;
 
   /**
-   * Compression codec that should be used to decompress the data. We do not do the compression here
-   * but we need it to generate the Metadata.
+   * Compression codec that should be used to decompress the data. We do not do the compression
+   * here, but we need it to generate the Metadata.
    */
   private final COMPRESSOR_TYPE compressionCodec;
 
@@ -238,17 +243,67 @@ public class SplitFileInserterStorage {
   private boolean noBlocksToSend;
 
   /**
-   * Create a SplitFileInserterStorage.
+   * Constructs a new storage instance for a splitfile insert from live inputs.
    *
-   * @param originalData The original data as a RandomAccessBuffer. We need to be able to read
-   *     single blocks.
-   * @param rafFactory A factory (persistent or not as appropriate) used to create the temporary RAF
-   *     storing check blocks etc.
-   * @param bf A temporary Bucket factory used for temporarily storing the cross-segment settings.
-   * @param topRequiredBlocks The minimum number of blocks needed to fetch the content, so far. We
-   *     will add to this for the final metadata.
-   * @throws IOException
-   * @throws InsertException
+   * <p>This constructor computes the segment layout, initializes per-segment and optional
+   * cross-segment structures, and, when {@code persistent} is true, materializes a checksummed RAF
+   * that can be used to resume the insert after a process restart. No network activity occurs here;
+   * the caller controls lifecycle and scheduling via the associated inserter callback.
+   *
+   * @param originalData buffer providing random access to the original content; must support block
+   *     reads throughout the insert and remain valid until completion. Not closed by this method.
+   * @param decompressedLength total length of the uncompressed data in bytes; used for metadata
+   *     generation when compression is applied.
+   * @param callback callback sink for progress and state changes; must remain valid during the
+   *     insert; never {@code null}.
+   * @param compressionCodec compression codec identifier for metadata; does not perform compression
+   *     here; may be {@code null} for uncompressed.
+   * @param meta client metadata to embed in the final descriptor; fields are copied as needed and
+   *     may be minimal for non-metadata inserts.
+   * @param isMetadata whether this splitfile represents metadata rather than user content; affects
+   *     compatibility and key handling.
+   * @param archiveType archive type for metadata generation; may be {@code null} if not applicable.
+   * @param rafFactory factory used to create the RAF backing store for check blocks and status;
+   *     persistent implementations must survive process restarts.
+   * @param persistent true to create a resume-capable RAF on disk; false for transient in-memory
+   *     operation with minimal bookkeeping.
+   * @param ctx insert context providing limits, compatibility mode, and policy knobs; consulted to
+   *     compute segment sizing and redundancy.
+   * @param splitfileCryptoAlgorithm splitfile crypto algorithm code as defined by {@link
+   *     Metadata#isValidSplitfileCryptoAlgorithm(byte)}.
+   * @param splitfileCryptoKey explicit 32-byte key for splitfile encryption; when {@code null}, the
+   *     key may be derived from {@code hashThisLayerOnly} or {@code hashes} depending on mode.
+   * @param hashThisLayerOnly 32-byte content hash used to derive the implicit key for current
+   *     layer; may be {@code null} when deriving from aggregate hashes.
+   * @param hashes optional array of block or layer hashes available for key derivation and
+   *     metadata; may be {@code null} in older compatibility modes.
+   * @param bf bucket factory for temporary encoding of settings sections; implementations must
+   *     allow small in-memory buckets.
+   * @param checker checksum strategy used to wrap sections with a length and checksum; determines
+   *     the checksum type persisted in the header.
+   * @param random PRNG used for deterministic cross-segment allocation and retry strategy; seeded
+   *     by the caller for reproducibility.
+   * @param memoryLimitedJobRunner executor that enforces per-task memory accounting; used for
+   *     encoding jobs across segments and cross-segments.
+   * @param jobRunner persistent job runner used to queue metadata writing and other background
+   *     work; must tolerate drops when resources are constrained.
+   * @param ticker ticker used for timed callbacks and scheduling; supplies the executor used by
+   *     this storage for asynchronous work.
+   * @param keysFetching interface to query local key cache/state to bias encoding and retries; may
+   *     be a no-op in tests.
+   * @param topDontCompress whether to disable top-level compression in metadata; this influences
+   *     the final descriptor only.
+   * @param topRequiredBlocks count of data blocks that must succeed for decoding; storage will add
+   *     its own accounting for check/cross-check overhead.
+   * @param topTotalBlocks total data blocks present at the top level; storage augments this with
+   *     check and cross-check counts.
+   * @param origDataSize original byte length before any containerization; copied into metadata as a
+   *     hint.
+   * @param origCompressedDataSize original compressed length in bytes when available; used for
+   *     metadata reporting.
+   * @throws IOException if writing the initial persistent RAF fails due to I/O problems.
+   * @throws InsertException if a temporary bucket fails, inputs are inconsistent, or limits are
+   *     violated during initialization.
    */
   public SplitFileInserterStorage(
       LockableRandomAccessBuffer originalData,
@@ -305,9 +360,8 @@ public class SplitFileInserterStorage {
     // Work out how many blocks in each segment, crypto keys etc.
     // Complicated by back compatibility, i.e. the need to be able to
     // reinsert old splitfiles.
-    // FIXME consider getting rid of support for very old splitfiles.
+    // Consider getting rid of support for very old splitfiles.
 
-    int segs;
     cmode = ctx.getCompatibilityMode();
     if (cmode.ordinal() < CompatibilityMode.COMPAT_1255.ordinal()) {
       this.hashes = null;
@@ -315,90 +369,33 @@ public class SplitFileInserterStorage {
     } else {
       this.hashes = hashes;
     }
-    if (cmode == CompatibilityMode.COMPAT_1250_EXACT) {
-      segs = (totalDataBlocks + 128 - 1) / 128;
-      segmentSize = 128;
-      deductBlocksFromSegments = 0;
-    } else {
-      if (cmode == CompatibilityMode.COMPAT_1251) {
-        // Max 131 blocks per segment.
-        segs = (totalDataBlocks + 131 - 1) / 131;
-      } else {
-        // Algorithm from evanbd, see bug #2931.
-        if (totalDataBlocks > 520) {
-          segs = (totalDataBlocks + 128 - 1) / 128;
-        } else if (totalDataBlocks > 393) {
-          // maxSegSize = 130;
-          segs = 4;
-        } else if (totalDataBlocks > 266) {
-          // maxSegSize = 131;
-          segs = 3;
-        } else if (totalDataBlocks > 136) {
-          // maxSegSize = 133;
-          segs = 2;
-        } else {
-          // maxSegSize = 136;
-          segs = 1;
-        }
-      }
-      int segSize = (totalDataBlocks + segs - 1) / segs;
-      if (ctx.splitfileSegmentDataBlocks < segSize) {
-        segs =
-            (totalDataBlocks + ctx.splitfileSegmentDataBlocks - 1) / ctx.splitfileSegmentDataBlocks;
-        segSize = (totalDataBlocks + segs - 1) / segs;
-      }
-      segmentSize = segSize;
-      if (cmode == CompatibilityMode.COMPAT_CURRENT
-          || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal()) {
-        // Even with basic even segment splitting, it is possible for
-        // the last segment to be a lot smaller than the rest.
-        // So drop a single data block from each of the last
-        // [segmentSize-lastSegmentSize] segments instead.
-        // Hence all the segments are within 1 block of segmentSize.
-        int lastSegmentSize = totalDataBlocks - (segmentSize * (segs - 1));
-        deductBlocksFromSegments = segmentSize - lastSegmentSize;
-      } else {
-        deductBlocksFromSegments = 0;
-      }
-    }
 
-    int crossCheckBlocks = 0;
+    SegmentLayout layout = computeSegmentLayout(totalDataBlocks, ctx, cmode);
+    int segs = layout.segs;
+    this.segmentSize = layout.segmentSize;
+    this.deductBlocksFromSegments = layout.deductBlocksFromSegments;
 
-    // Cross-segment splitfile redundancy becomes useful at 20 segments.
-    if (segs >= 20
-        && (cmode == CompatibilityMode.COMPAT_CURRENT
-            || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal())) {
-      // The optimal number of cross-check blocks per segment (and per
-      // cross-segment since there are the same number of cross-segments
-      // as segments) is 3.
-      crossCheckBlocks = 3;
-    }
-
-    this.crossCheckBlocks = crossCheckBlocks;
+    int computedCrossCheckBlocks = computeCrossCheckBlocks(segs, cmode);
 
     this.splitfileType = ctx.getSplitfileAlgorithm();
     this.codec = FECCodec.getInstance(splitfileType);
 
-    checkSegmentSize = codec.getCheckBlocks(segmentSize + crossCheckBlocks, cmode);
-
-    this.splitfileCryptoAlgorithm = splitfileCryptoAlgorithm;
-    if (splitfileCryptoKey != null) {
-      this.splitfileCryptoKey = splitfileCryptoKey;
-      specifySplitfileKeyInMetadata = true;
-    } else if (cmode == CompatibilityMode.COMPAT_CURRENT
-        || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal()) {
-      if (hashThisLayerOnly != null) {
-        this.splitfileCryptoKey = Metadata.getCryptoKey(hashThisLayerOnly);
-      } else {
-        this.splitfileCryptoKey = Metadata.getCryptoKey(hashes);
-      }
-      specifySplitfileKeyInMetadata = false;
+    // When NONREDUNDANT, the codec is null and there are no check/cross-check blocks.
+    if (this.codec == null) {
+      this.crossCheckBlocks = 0;
+      checkSegmentSize = 0;
     } else {
-      this.splitfileCryptoKey = null;
-      specifySplitfileKeyInMetadata = false;
+      this.crossCheckBlocks = computedCrossCheckBlocks;
+      checkSegmentSize = codec.getCheckBlocks(segmentSize + computedCrossCheckBlocks, cmode);
     }
 
-    int totalCheckBlocks = 0;
+    this.splitfileCryptoAlgorithm = splitfileCryptoAlgorithm;
+    CryptoInit crypto =
+        chooseSplitfileKey(splitfileCryptoKey, cmode, hashThisLayerOnly, this.hashes);
+    this.splitfileCryptoKey = crypto.key;
+    specifySplitfileKeyInMetadata = crypto.specifyInMetadata;
+
+    int totalCheckBlocksLocal = 0;
     int checkTotalDataBlocks = 0;
     underlyingOffsetDataSegments = new long[segs];
     keyLength = SplitFileInserterSegmentStorage.getKeyLength(this);
@@ -408,70 +405,33 @@ public class SplitFileInserterStorage {
             segmentSize,
             segs,
             totalDataBlocks,
-            crossCheckBlocks,
             deductBlocksFromSegments,
             persistent,
-            cmode,
-            random,
             keysFetching,
             consecutiveRNFsCountAsSuccess);
     randomSegmentIterator = new RandomArrayIterator<>(segments);
     for (SplitFileInserterSegmentStorage segment : segments) {
-      totalCheckBlocks += segment.checkBlockCount;
+      totalCheckBlocksLocal += segment.checkBlockCount;
       checkTotalDataBlocks += segment.dataBlockCount;
     }
     assert (checkTotalDataBlocks == totalDataBlocks);
-    this.totalCheckBlocks = totalCheckBlocks;
+    this.totalCheckBlocks = totalCheckBlocksLocal;
 
-    if (crossCheckBlocks != 0) {
-      byte[] seed = Metadata.getCrossSegmentSeed(hashes, hashThisLayerOnly);
-      if (LOG.isDebugEnabled()) LOG.debug("Cross-segment seed: " + HexUtil.bytesToHex(seed));
-      Random xsRandom = MersenneTwister.createUnsynchronized(seed);
-      // Cross segment redundancy: Allocate the blocks.
-      crossSegments = new SplitFileInserterCrossSegmentStorage[segs];
-      int segLen = segmentSize;
-      for (int i = 0; i < crossSegments.length; i++) {
-        if (LOG.isDebugEnabled()) LOG.debug("Allocating blocks for cross segment " + i);
-        if (segments.length - i == deductBlocksFromSegments) {
-          segLen--;
-        }
-
-        SplitFileInserterCrossSegmentStorage seg =
-            new SplitFileInserterCrossSegmentStorage(this, i, persistent, segLen, crossCheckBlocks);
-        crossSegments[i] = seg;
-        for (int j = 0; j < segLen; j++) {
-          // Allocate random data blocks
-          allocateCrossDataBlock(seg, xsRandom);
-        }
-        for (int j = 0; j < crossCheckBlocks; j++) {
-          // Allocate check blocks
-          allocateCrossCheckBlock(seg, xsRandom);
-        }
-      }
-    } else {
-      crossSegments = null;
-    }
+    // Allocate cross-segment structures only for the actual configured count.
+    // In NON_REDUNDANT mode (codec == null), this.crossCheckBlocks is 0 even if
+    // computedCrossCheckBlocks would suggest redundancy for large segment counts.
+    crossSegments =
+        initCrossSegmentsIfAny(segs, this.crossCheckBlocks, segmentSize, deductBlocksFromSegments);
 
     // Now set up the RAF.
 
     // Setup offset arrays early so we can compute the length of encodeOffsets().
-    if (crossSegments != null) {
-      offsetCrossSegmentBlocks = new long[crossSegments.length];
-      if (persistent) offsetCrossSegmentStatus = new long[crossSegments.length];
-      else offsetCrossSegmentStatus = null;
-    } else {
-      offsetCrossSegmentBlocks = null;
-      offsetCrossSegmentStatus = null;
-    }
-
-    offsetSegmentCheckBlocks = new long[segments.length];
-
-    offsetSegmentKeys = new long[segments.length];
-    if (persistent) {
-      offsetSegmentStatus = new long[segments.length];
-    } else {
-      offsetSegmentStatus = null;
-    }
+    OffsetArrays oa = createOffsetArrays(persistent);
+    offsetCrossSegmentBlocks = oa.offsetCrossSegmentBlocks;
+    offsetCrossSegmentStatus = oa.offsetCrossSegmentStatus;
+    offsetSegmentCheckBlocks = oa.offsetSegmentCheckBlocks;
+    offsetSegmentStatus = oa.offsetSegmentStatus;
+    offsetSegmentKeys = oa.offsetSegmentKeys;
 
     // First we have all the fixed stuff ...
 
@@ -487,40 +447,23 @@ public class SplitFileInserterStorage {
     }
 
     byte[] header = null;
-    Bucket segmentSettings = null, crossSegmentSettings = null;
+    Bucket segmentSettings = null;
+    Bucket crossSegmentSettings = null;
     int offsetsLength = 0;
     if (persistent) {
-      header = encodeHeader();
-      offsetsLength = encodeOffsets().length;
-
-      segmentSettings = encodeSegmentSettings(); // Checksummed with length
-      try {
-        crossSegmentSettings = encodeCrossSegmentSettings(bf); // Checksummed with length
-      } catch (IOException e) {
-        throw new InsertException(
-            InsertExceptionMode.BUCKET_ERROR,
-            "Failed to write to temporary storage while creating splitfile inserter",
-            null);
-      }
+      PersistenceInit p = preparePersistenceInit(bf);
+      header = p.header;
+      segmentSettings = p.segmentSettings;
+      crossSegmentSettings = p.crossSegmentSettings;
+      offsetsLength = p.offsetsLength;
     }
 
     long ptr = 0;
     if (persistent) {
-      ptr =
-          header.length
-              + offsetsLength
-              + segmentSettings.size()
-              + (crossSegmentSettings == null ? 0 : crossSegmentSettings.size());
+      ptr = calculateInitialPtr(header, offsetsLength, segmentSettings, crossSegmentSettings);
       offsetOverallStatus = ptr;
       overallStatusLength = encodeOverallStatus().length;
-      ptr += overallStatusLength;
-
-      // Pad to a 4KB block boundary.
-      int padding = 0;
-      padding = (int) (ptr % 4096);
-      if (padding != 0) padding = 4096 - padding;
-
-      ptr += padding;
+      ptr = padTo4096(ptr + overallStatusLength);
     } else {
       overallStatusLength = 0;
       offsetOverallStatus = 0;
@@ -530,72 +473,19 @@ public class SplitFileInserterStorage {
 
     if (hasPaddedLastBlock) ptr += CHKBlock.DATA_LENGTH;
 
-    if (crossSegments != null) {
-      for (int i = 0; i < crossSegments.length; i++) {
-        offsetCrossSegmentBlocks[i] = ptr;
-        ptr += (long) crossSegments[i].crossCheckBlockCount * CHKBlock.DATA_LENGTH;
-      }
-    }
+    ptr = populateCrossSegmentOffsets(ptr);
 
-    for (int i = 0; i < segments.length; i++) {
-      offsetSegmentCheckBlocks[i] = ptr;
-      ptr += (long) segments[i].checkBlockCount * CHKBlock.DATA_LENGTH;
-    }
+    ptr = populateSegmentCheckOffsets(ptr);
 
-    if (persistent) {
-      for (int i = 0; i < segments.length; i++) {
-        offsetSegmentStatus[i] = ptr;
-        ptr += segments[i].storedStatusLength();
-      }
+    ptr = populateStatusOffsetsIfPersistent(ptr);
 
-      if (crossSegments != null) {
-        for (int i = 0; i < crossSegments.length; i++) {
-          offsetCrossSegmentStatus[i] = ptr;
-          ptr += crossSegments[i].storedStatusLength();
-        }
-      }
-    }
-
-    for (int i = 0; i < segments.length; i++) {
-      offsetSegmentKeys[i] = ptr;
-      ptr += segments[i].storedKeysLength();
-    }
+    ptr = populateSegmentKeyOffsets(ptr);
 
     rafLength = ptr;
     this.raf = rafFactory.makeRAF(ptr);
-    if (persistent) {
-      ptr = 0;
-      raf.pwrite(ptr, header, 0, header.length);
-      ptr += header.length;
-      byte[] encodedOffsets = encodeOffsets();
-      assert (encodedOffsets.length == offsetsLength);
-      raf.pwrite(ptr, encodedOffsets, 0, encodedOffsets.length);
-      ptr += encodedOffsets.length;
-      BucketTools.copyTo(segmentSettings, raf, ptr, Long.MAX_VALUE);
-      ptr += segmentSettings.size();
-      segmentSettings.free();
-      if (crossSegmentSettings != null) {
-        BucketTools.copyTo(crossSegmentSettings, raf, ptr, Long.MAX_VALUE);
-        ptr += crossSegmentSettings.size();
-        crossSegmentSettings.free();
-      }
-      writeOverallStatus(true);
-    }
-    if (hasPaddedLastBlock)
-      raf.pwrite(offsetPaddedLastBlock, paddedLastBlock, 0, paddedLastBlock.length);
-    if (persistent) {
-      // Padding is initialized to random already.
-      for (SplitFileInserterSegmentStorage segment : segments) {
-        if (LOG.isDebugEnabled()) LOG.debug("Clearing status for " + segment);
-        segment.storeStatus(true);
-      }
-      if (crossSegments != null) {
-        for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
-          if (LOG.isDebugEnabled()) LOG.debug("Clearing status for " + segment);
-          segment.storeStatus();
-        }
-      }
-    }
+    writeInitialRafIfPersistent(header, offsetsLength, segmentSettings, crossSegmentSettings);
+    writePaddedLastBlockIfAny(paddedLastBlock);
+    clearInitialStatusesIfPersistent();
     // Encrypted RAFs are not initialised with 0's, so we need to clear explicitly (we do store keys
     // even for transient inserts).
     for (SplitFileInserterSegmentStorage segment : segments) {
@@ -604,33 +494,49 @@ public class SplitFileInserterStorage {
     // Keys are empty, and invalid.
     status = Status.NOT_STARTED;
 
-    // Include the cross check blocks in the required blocks. The actual number needed may be
+    // Include the cross-check blocks in the required blocks. The actual number needed may be
     // slightly less, but this is consistent with fetching, and also with pre-1468 metadata.
     int totalCrossCheckBlocks = crossCheckBlocks * segments.length;
     this.topRequiredBlocks = topRequiredBlocks + totalDataBlocks + totalCrossCheckBlocks;
     this.topTotalBlocks =
         topTotalBlocks + totalDataBlocks + totalCrossCheckBlocks + totalCheckBlocks;
+
+    this.writeMetadataJob = createWriteMetadataJob();
+    this.wrapLazyWriteMetadata = () -> jobRunner.queueNormalOrDrop(writeMetadataJob);
   }
 
   /**
-   * Create a splitfile insert from stored data.
+   * Reconstructs storage state from a previously persisted RAF.
    *
-   * @param raf The file the insert was stored to. Caller must resume it before calling constructor.
-   * @param originalData The original data to be inserted. Caller must resume it before calling
-   *     constructor.
-   * @param callback The parent callback (e.g. SplitFileInserter).
-   * @param random
-   * @param memoryLimitedJobRunner
-   * @param jobRunner
-   * @param ticker
-   * @param keysFetching
-   * @param persistentFG
-   * @param persistentFileTracker
-   * @param masterKey
-   * @throws IOException
-   * @throws StorageFormatException
-   * @throws ChecksumFailedException
-   * @throws ResumeFailedException
+   * <p>This constructor validates the file format, verifies each checksummed section, restores the
+   * original data reference, and rebuilds per-segment and optional cross-segment state. It throws
+   * descriptive exceptions when the header is invalid, checksums fail, offsets are out of range, or
+   * the original data size does not match the stored header.
+   *
+   * @param raf random access buffer containing the persisted insert state; the caller must open and
+   *     resume it prior to invocation and retain ownership for closing.
+   * @param originalData random access buffer for the original content; must be resumed by the
+   *     caller and match the size stored in the header exactly.
+   * @param callback parent callback interface that receives progress notifications and final
+   *     outcomes; typically provided by the surrounding inserter.
+   * @param random PRNG used by the restored storage for allocation and retry decisions; should be
+   *     non-deterministic in production and fixed in tests when reproducibility is required.
+   * @param memoryLimitedJobRunner executor enforcing memory budgets across encoding tasks; used by
+   *     segment and cross-segment encoders.
+   * @param jobRunner runner for background persistence work such as deferred metadata writing.
+   * @param ticker ticker providing the timed executor used by background jobs.
+   * @param keysFetching interface to query whether keys are locally present or recently failed;
+   *     influences scheduling and retry heuristics.
+   * @param persistentFG filename generator used to restore temporary files referenced by the RAF.
+   * @param persistentFileTracker tracker used by {@code BucketTools.restoreRAFFrom} to resolve file
+   *     handles in a safe, verified manner.
+   * @param masterKey master secret for decrypting encrypted RAF sections when applicable.
+   * @throws IOException if reading the RAF fails due to I/O errors while restoring sections.
+   * @throws StorageFormatException if the file format is invalid, contains out-of-range values, or
+   *     violates invariants expected by this version.
+   * @throws ChecksumFailedException if any checksummed section fails verification during restore.
+   * @throws ResumeFailedException if the supplied {@code originalData} size differs from the stored
+   *     value or is otherwise incompatible with the header.
    */
   public SplitFileInserterStorage(
       LockableRandomAccessBuffer raf,
@@ -655,128 +561,57 @@ public class SplitFileInserterStorage {
     rafLength = raf.size();
     InputStream ois = new RAFInputStream(raf, 0, rafLength);
     DataInputStream dis = new DataInputStream(ois);
-    long magic = dis.readLong();
-    if (magic != MAGIC) throw new StorageFormatException("Bad magic");
+    validateMagic(dis.readLong());
     int checksumType = dis.readInt();
-    try {
-      this.checker = ChecksumChecker.create(checksumType);
-    } catch (IllegalArgumentException e) {
-      throw new StorageFormatException("Bad checksum type");
-    }
+    this.checker = createChecksumChecker(checksumType);
 
     long maxLength = Long.MAX_VALUE;
 
     InputStream is = checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
     dis = new DataInputStream(is);
-    int version = dis.readInt();
-    if (version != VERSION) throw new StorageFormatException("Bad version");
+    validateVersion(dis.readInt());
     LockableRandomAccessBuffer rafOrig =
         BucketTools.restoreRAFFrom(dis, persistentFG, persistentFileTracker, masterKey);
-    if (originalData == null) {
-      this.originalData = rafOrig;
-    } else {
-      // Check that it's the same, but use the passed-in one.
-      if (!originalData.equals(rafOrig))
-        throw new StorageFormatException(
-            "Original data restored from different filename! Expected "
-                + originalData
-                + " but restored "
-                + rafOrig);
-      this.originalData = originalData;
-    }
-    this.totalDataBlocks = dis.readInt();
-    if (totalDataBlocks <= 0)
-      throw new StorageFormatException("Bad total data blocks " + totalDataBlocks);
-    this.totalCheckBlocks = dis.readInt();
-    if (totalCheckBlocks <= 0)
-      throw new StorageFormatException("Bad total data blocks " + totalCheckBlocks);
-    try {
-      this.splitfileType = SplitfileAlgorithm.getByCode(dis.readShort());
-    } catch (IllegalArgumentException e) {
-      throw new StorageFormatException("Bad splitfile type");
-    }
-    try {
-      this.codec = FECCodec.getInstance(splitfileType);
-    } catch (IllegalArgumentException e) {
-      throw new StorageFormatException("Bad splitfile codec type");
-    }
-    this.dataLength = dis.readLong();
-    if (dataLength <= 0) throw new StorageFormatException("Bad data length");
-    if (dataLength != originalData.size())
-      throw new ResumeFailedException(
-          "Original data size is " + originalData.size() + " should be " + dataLength);
-    if (((dataLength + CHKBlock.DATA_LENGTH - 1) / CHKBlock.DATA_LENGTH) != totalDataBlocks)
-      throw new StorageFormatException(
-          "Data blocks " + totalDataBlocks + " not compatible with size " + dataLength);
-    decompressedLength = dis.readLong();
-    if (decompressedLength <= 0) throw new StorageFormatException("Bogus decompressed length");
+    this.originalData = chooseOriginalData(originalData, rafOrig);
+    this.totalDataBlocks = readPositiveInt(dis, "total data blocks");
+    this.totalCheckBlocks = readPositiveInt(dis, "total check blocks");
+    this.splitfileType = readSplitfileAlgorithm(dis);
+    this.codec = getCodecFor(splitfileType);
+    this.dataLength = readPositiveLong(dis, "data length");
+    validateDataLengthMatches(dataLength, originalData);
+    validateBlockCountCompatibility(dataLength, totalDataBlocks);
+    decompressedLength = readPositiveLong(dis, "decompressed length");
     isMetadata = dis.readBoolean();
-    short atype = dis.readShort();
-    if (atype == -1) {
-      archiveType = null;
-    } else {
-      archiveType = ARCHIVE_TYPE.getArchiveType(atype);
-      if (archiveType == null) throw new StorageFormatException("Unknown archive type " + atype);
+    archiveType = readArchiveType(dis.readShort());
+    clientMetadata = readClientMetadata(dis);
+    compressionCodec = readCompressionCodec(dis);
+    int segmentCount = readPositiveInt(dis, "segment count");
+    this.segmentSize = readPositiveInt(dis, "segment size");
+    // Allow zero for NON_REDUNDANT splitfiles (codec == null), where no check blocks exist.
+    {
+      int v = dis.readInt();
+      if (v < 0) throw new StorageFormatException("Bad check segment size " + v);
+      this.checkSegmentSize = v;
     }
-    try {
-      clientMetadata = ClientMetadata.construct(dis);
-    } catch (MetadataParseException e) {
-      throw new StorageFormatException("Failed to read MIME type: " + e);
-    }
-    short codec = dis.readShort();
-    if (codec == (short) -1) compressionCodec = null;
-    else {
-      compressionCodec = COMPRESSOR_TYPE.getCompressorByMetadataID(codec);
-      if (compressionCodec == null)
-        throw new StorageFormatException("Unknown compression codec ID " + codec);
-    }
-    int segmentCount = dis.readInt();
-    if (segmentCount <= 0) throw new StorageFormatException("Bad segment count");
-    this.segmentSize = dis.readInt();
-    if (segmentSize <= 0) throw new StorageFormatException("Bad segment size");
-    this.checkSegmentSize = dis.readInt();
-    if (checkSegmentSize <= 0) throw new StorageFormatException("Bad check segment size");
-    this.crossCheckBlocks = dis.readInt();
-    if (crossCheckBlocks < 0) throw new StorageFormatException("Bad cross-check block count");
-    if (segmentSize + checkSegmentSize + crossCheckBlocks > FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT)
-      throw new StorageFormatException(
-          "Must be no more than " + FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT + " blocks per segment");
+    int ccb = dis.readInt();
+    if (ccb < 0) throw new StorageFormatException("Bad cross-check block count");
+    this.crossCheckBlocks = ccb;
+    validateSegmentTotals(segmentSize, checkSegmentSize, crossCheckBlocks);
     this.splitfileCryptoAlgorithm = dis.readByte();
-    if (!Metadata.isValidSplitfileCryptoAlgorithm(splitfileCryptoAlgorithm))
-      throw new StorageFormatException(
-          "Invalid splitfile crypto algorithm " + splitfileCryptoAlgorithm);
-    if (dis.readBoolean()) {
-      splitfileCryptoKey = new byte[32];
-      dis.readFully(splitfileCryptoKey);
-    } else {
-      splitfileCryptoKey = null;
-    }
-    this.keyLength = dis.readInt(); // FIXME validate
-    if (keyLength < SplitFileInserterSegmentStorage.getKeyLength(this))
-      throw new StorageFormatException(
-          "Invalid key length "
-              + keyLength
-              + " should be at least "
-              + SplitFileInserterSegmentStorage.getKeyLength(this));
-    int compatMode = dis.readInt();
-    if (compatMode < 0 || compatMode > CompatibilityMode.values().length)
-      throw new StorageFormatException("Invalid compatibility mode " + compatMode);
-    this.cmode = CompatibilityMode.values()[compatMode];
+    validateCryptoAlgorithm(splitfileCryptoAlgorithm);
+    splitfileCryptoKey = readOptionalCryptoKey(dis);
+    this.keyLength = dis.readInt();
+    validateKeyLength(keyLength);
+    this.cmode = readCompatibilityModeChecked(dis);
     this.deductBlocksFromSegments = dis.readInt();
-    if (deductBlocksFromSegments < 0 || deductBlocksFromSegments > segmentCount)
-      throw new StorageFormatException("Bad deductBlocksFromSegments");
+    validateDeductBlocksRange(deductBlocksFromSegments, segmentCount);
     this.maxRetries = dis.readInt();
-    if (maxRetries < -1) throw new StorageFormatException("Bad maxRetries");
+    validateMaxRetries(maxRetries);
     this.consecutiveRNFsCountAsSuccess = dis.readInt();
     if (consecutiveRNFsCountAsSuccess < 0)
       throw new StorageFormatException("Bad consecutiveRNFsCountAsSuccess");
     specifySplitfileKeyInMetadata = dis.readBoolean();
-    if (dis.readBoolean()) {
-      hashThisLayerOnly = new byte[32];
-      dis.readFully(hashThisLayerOnly);
-    } else {
-      hashThisLayerOnly = null;
-    }
+    hashThisLayerOnly = readOptionalHashThisLayerOnly(dis);
     topDontCompress = dis.readBoolean();
     topRequiredBlocks = dis.readInt();
     topTotalBlocks = dis.readInt();
@@ -787,102 +622,39 @@ public class SplitFileInserterStorage {
     this.hasPaddedLastBlock = (dataLength % CHKBlock.DATA_LENGTH != 0);
     this.segments = new SplitFileInserterSegmentStorage[segmentCount];
     randomSegmentIterator = new RandomArrayIterator<>(segments);
-    if (crossCheckBlocks != 0)
-      this.crossSegments = new SplitFileInserterCrossSegmentStorage[segmentCount];
-    else crossSegments = null;
+    this.crossSegments = initCrossSegmentsArrayIfAny(segmentCount);
     // Read offsets.
     is = checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
     dis = new DataInputStream(is);
-    if (hasPaddedLastBlock) {
-      offsetPaddedLastBlock = readOffset(dis, rafLength, "offsetPaddedLastBlock");
-    } else {
-      offsetPaddedLastBlock = 0;
-    }
-    offsetOverallStatus = readOffset(dis, rafLength, "offsetOverallStatus");
-    overallStatusLength = dis.readInt();
-    if (overallStatusLength < 0) throw new StorageFormatException("Negative overall status length");
-    if (overallStatusLength < FailureCodeTracker.getFixedLength(true))
-      throw new StorageFormatException("Bad overall status length");
-    // Will be read after offsets
-    if (crossSegments != null) {
-      offsetCrossSegmentBlocks = new long[crossSegments.length];
-      for (int i = 0; i < crossSegments.length; i++)
-        offsetCrossSegmentBlocks[i] = readOffset(dis, rafLength, "cross-segment block offset");
-    } else {
-      offsetCrossSegmentBlocks = null;
-    }
-    offsetSegmentCheckBlocks = new long[segmentCount];
-    for (int i = 0; i < segmentCount; i++)
-      offsetSegmentCheckBlocks[i] = readOffset(dis, rafLength, "segment check block offset");
-    offsetSegmentStatus = new long[segmentCount];
-    for (int i = 0; i < segmentCount; i++)
-      offsetSegmentStatus[i] = readOffset(dis, rafLength, "segment status offset");
-    if (crossSegments != null) {
-      offsetCrossSegmentStatus = new long[crossSegments.length];
-      for (int i = 0; i < crossSegments.length; i++)
-        offsetCrossSegmentStatus[i] = readOffset(dis, rafLength, "cross-segment status offset");
-    } else {
-      offsetCrossSegmentStatus = null;
-    }
-    offsetSegmentKeys = new long[segmentCount];
-    for (int i = 0; i < segmentCount; i++)
-      offsetSegmentKeys[i] = readOffset(dis, rafLength, "segment keys offset");
+    OffsetsData od = readOffsets(dis, rafLength, segmentCount);
     dis.close();
+    offsetPaddedLastBlock = od.offsetPaddedLastBlock;
+    offsetOverallStatus = od.offsetOverallStatus;
+    overallStatusLength = od.overallStatusLength;
+    offsetCrossSegmentBlocks = od.arrays.offsetCrossSegmentBlocks;
+    offsetSegmentCheckBlocks = od.arrays.offsetSegmentCheckBlocks;
+    offsetSegmentStatus = od.arrays.offsetSegmentStatus;
+    offsetCrossSegmentStatus = od.arrays.offsetCrossSegmentStatus;
+    offsetSegmentKeys = od.arrays.offsetSegmentKeys;
     // Set up segments...
     underlyingOffsetDataSegments = new long[segmentCount];
     is = checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
-    dis = new DataInputStream(is);
-    long blocks = 0;
-    for (int i = 0; i < segmentCount; i++) {
-      segments[i] =
-          new SplitFileInserterSegmentStorage(
-              this,
-              dis,
-              i,
-              keyLength,
-              splitfileCryptoAlgorithm,
-              splitfileCryptoKey,
-              random,
-              maxRetries,
-              consecutiveRNFsCountAsSuccess,
-              keysFetching);
-      underlyingOffsetDataSegments[i] = blocks * CHKBlock.DATA_LENGTH;
-      blocks += segments[i].dataBlockCount;
-      assert (underlyingOffsetDataSegments[i] < dataLength);
-    }
-    dis.close();
+    long blocks = initSegmentsAndComputeBlocks(is, segmentCount, keysFetching);
     if (blocks != totalDataBlocks)
       throw new StorageFormatException(
           "Total data blocks should be " + totalDataBlocks + " but is " + blocks);
-    if (crossSegments != null) {
-      is = checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
-      dis = new DataInputStream(is);
-      for (int i = 0; i < crossSegments.length; i++) {
-        crossSegments[i] = new SplitFileInserterCrossSegmentStorage(this, dis, i);
-      }
-      dis.close();
-    }
+    readCrossSegmentsFromDisk(ois, maxLength);
     ois.close();
-    ois = new RAFInputStream(raf, offsetOverallStatus, rafLength - offsetOverallStatus);
-    dis =
-        new DataInputStream(
-            checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength));
-    errors = new FailureCodeTracker(true, dis);
-    dis.close();
-    for (SplitFileInserterSegmentStorage segment : segments) {
-      segment.readStatus();
-    }
-    if (crossSegments != null) {
-      for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
-        segment.readStatus();
-      }
-    }
+    errors = readStatusesFromDisk(maxLength);
     computeStatus();
+
+    this.writeMetadataJob = createWriteMetadataJob();
+    this.wrapLazyWriteMetadata = () -> jobRunner.queueNormalOrDrop(writeMetadataJob);
   }
 
   private void computeStatus() {
     status = Status.STARTED;
-    if (crossSegments != null) {
+    if (crossSegments.length != 0) {
       for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
         if (!segment.isFinishedEncoding()) return;
       }
@@ -915,6 +687,7 @@ public class SplitFileInserterStorage {
   }
 
   private byte[] encodeOverallStatus() {
+    //noinspection resource
     ArrayBucket bucket = new ArrayBucket(); // Will be small.
     try {
       try (OutputStream os = bucket.getOutputStream();
@@ -925,10 +698,91 @@ public class SplitFileInserterStorage {
           overallStatusDirty = false;
         }
       }
-      return bucket.toByteArray();
+      byte[] out = bucket.toByteArray();
+      bucket.free();
+      return out;
     } catch (IOException e) {
-      throw new Error(e); // Impossible
+      throw new UncheckedIOException(e);
     }
+  }
+
+  /** Simple container for segment sizing derived from context and data length. */
+  private record SegmentLayout(int segs, int segmentSize, int deductBlocksFromSegments) {}
+
+  private SegmentLayout computeSegmentLayout(
+      int totalDataBlocks, InsertContext ctx, CompatibilityMode cmode) {
+    int segs =
+        (cmode == CompatibilityMode.COMPAT_1250_EXACT)
+            ? (totalDataBlocks + 128 - 1) / 128
+            : enforceMaxSegmentDataBlocks(
+                selectBaseSegments(totalDataBlocks, cmode),
+                totalDataBlocks,
+                ctx.splitfileSegmentDataBlocks);
+    int computedSegmentSize =
+        (cmode == CompatibilityMode.COMPAT_1250_EXACT) ? 128 : (totalDataBlocks + segs - 1) / segs;
+    int deduct = calculateDeductBlocks(totalDataBlocks, computedSegmentSize, segs, cmode);
+    return new SegmentLayout(segs, computedSegmentSize, deduct);
+  }
+
+  private int selectBaseSegments(int totalDataBlocks, CompatibilityMode cmode) {
+    if (cmode == CompatibilityMode.COMPAT_1251) {
+      return (totalDataBlocks + 131 - 1) / 131; // Max 131 blocks per segment.
+    }
+    if (totalDataBlocks > 520) return (totalDataBlocks + 128 - 1) / 128;
+    if (totalDataBlocks > 393) return 4; // maxSegSize = 130
+    if (totalDataBlocks > 266) return 3; // maxSegSize = 131
+    if (totalDataBlocks > 136) return 2; // maxSegSize = 133
+    return 1; // maxSegSize = 136
+  }
+
+  private int enforceMaxSegmentDataBlocks(int segs, int totalDataBlocks, int maxBlocksPerSegment) {
+    int segSize = (totalDataBlocks + segs - 1) / segs;
+    if (maxBlocksPerSegment < segSize) {
+      segs = (totalDataBlocks + maxBlocksPerSegment - 1) / maxBlocksPerSegment;
+    }
+    return segs;
+  }
+
+  private int calculateDeductBlocks(
+      int totalDataBlocks, int segmentSize, int segs, CompatibilityMode cmode) {
+    if (cmode == CompatibilityMode.COMPAT_CURRENT
+        || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal()) {
+      int lastSegmentSize = totalDataBlocks - (segmentSize * (segs - 1));
+      return segmentSize - lastSegmentSize;
+    }
+    return 0;
+  }
+
+  private int computeCrossCheckBlocks(int segs, CompatibilityMode cmode) {
+    // Cross-segment splitfile redundancy becomes useful at 20 segments.
+    if (segs >= 20
+        && (cmode == CompatibilityMode.COMPAT_CURRENT
+            || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal())) {
+      return 3; // Optimal number of cross-check blocks per segment
+    }
+    return 0;
+  }
+
+  private SplitFileInserterCrossSegmentStorage[] initCrossSegmentsIfAny(
+      int segs, int crossCheckBlocks, int segmentSize, int deductBlocksFromSegments) {
+    if (crossCheckBlocks == 0) return new SplitFileInserterCrossSegmentStorage[0];
+    byte[] seed = Metadata.getCrossSegmentSeed(hashes, hashThisLayerOnly);
+    if (LOG.isDebugEnabled()) LOG.debug("Cross-segment seed: {}", HexUtil.bytesToHex(seed));
+    Random xsRandom = MersenneTwister.createUnsynchronized(seed);
+    SplitFileInserterCrossSegmentStorage[] xs = new SplitFileInserterCrossSegmentStorage[segs];
+    int segLen = segmentSize;
+    for (int i = 0; i < xs.length; i++) {
+      if (LOG.isDebugEnabled()) LOG.debug("Allocating blocks for cross segment {}", i);
+      if (segments.length - i == deductBlocksFromSegments) {
+        segLen--;
+      }
+      SplitFileInserterCrossSegmentStorage seg =
+          new SplitFileInserterCrossSegmentStorage(this, i, persistent, segLen, crossCheckBlocks);
+      xs[i] = seg;
+      for (int j = 0; j < segLen; j++) allocateCrossDataBlock(seg, xsRandom);
+      for (int j = 0; j < crossCheckBlocks; j++) allocateCrossCheckBlock(seg, xsRandom);
+    }
+    return xs;
   }
 
   private Bucket encodeSegmentSettings() {
@@ -943,7 +797,7 @@ public class SplitFileInserterStorage {
       }
       return bucket;
     } catch (IOException e) {
-      throw new Error(e); // Impossible
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -952,7 +806,7 @@ public class SplitFileInserterStorage {
    * which cross-segments ...
    */
   private Bucket encodeCrossSegmentSettings(BucketFactory bf) throws IOException {
-    if (crossSegments == null) return new NullBucket();
+    if (crossSegments.length == 0) return new NullBucket();
     Bucket bucket = bf.makeBucket(-1);
     try (OutputStream os = bucket.getOutputStream();
         OutputStream cos = checker.checksumWriterWithLength(os, new ArrayBucketFactory());
@@ -1018,7 +872,7 @@ public class SplitFileInserterStorage {
       dos.close();
       return baos.toByteArray();
     } catch (IOException e) {
-      throw new Error(e); // Impossible
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -1031,19 +885,526 @@ public class SplitFileInserterStorage {
       if (this.hasPaddedLastBlock) dos.writeLong(offsetPaddedLastBlock);
       dos.writeLong(offsetOverallStatus);
       dos.writeInt(overallStatusLength);
-      if (crossSegments != null) {
+      if (crossSegments.length != 0) {
         for (long l : offsetCrossSegmentBlocks) dos.writeLong(l);
       }
       for (long l : offsetSegmentCheckBlocks) dos.writeLong(l);
       for (long l : offsetSegmentStatus) dos.writeLong(l);
-      if (crossSegments != null) {
+      if (crossSegments.length != 0) {
         for (long l : offsetCrossSegmentStatus) dos.writeLong(l);
       }
       for (long l : offsetSegmentKeys) dos.writeLong(l);
       dos.close();
       return baos.toByteArray();
     } catch (IOException e) {
-      throw new Error(e); // Impossible
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private record DataCheck(int data, int check) {}
+
+  private int clampToDataBlocks(int i, int dataBlocks) {
+    return Math.min(i, dataBlocks);
+  }
+
+  private DataCheck adjustForLastSegmentIfNeeded(
+      int data, int check, int i, int j, int segNo, int segCount) {
+    if (data > (i - j)) {
+      assert (segNo == segCount - 1);
+      data = i - j;
+      check = (codec != null) ? codec.getCheckBlocks(data + crossCheckBlocks, cmode) : 0;
+    }
+    return new DataCheck(data, check);
+  }
+
+  private void logSegmentDetailsIfNeeded(
+      int segNo, int segCount, int data, int check, int deductBlocksFromSegments) {
+    if (deductBlocksFromSegments != 0 && LOG.isDebugEnabled()) {
+      LOG.debug(
+          "INSERTING: Segment {} of {} : {} data blocks {} check blocks",
+          segNo,
+          segCount,
+          data,
+          check);
+    }
+  }
+
+  private int maybeDeductBlock(int data, int segCount, int segNo, int deductBlocksFromSegments) {
+    if (segCount - segNo == deductBlocksFromSegments) {
+      return data - 1;
+    }
+    return data;
+  }
+
+  private void validateMagic(long magic) throws StorageFormatException {
+    if (magic != MAGIC) throw new StorageFormatException("Bad magic");
+  }
+
+  private void validateVersion(int version) throws StorageFormatException {
+    if (version != VERSION) throw new StorageFormatException("Bad version");
+  }
+
+  @SuppressWarnings("java:S1168")
+  private byte[] readOptionalCryptoKey(DataInputStream dis) throws IOException {
+    if (dis.readBoolean()) {
+      byte[] key = new byte[32];
+      dis.readFully(key);
+      return key;
+    }
+    return null;
+  }
+
+  private CompatibilityMode readCompatibilityModeChecked(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    int compatMode = dis.readInt();
+    if (compatMode < 0 || compatMode > CompatibilityMode.values().length)
+      throw new StorageFormatException("Invalid compatibility mode " + compatMode);
+    return CompatibilityMode.values()[compatMode];
+  }
+
+  @SuppressWarnings("java:S1168")
+  private byte[] readOptionalHashThisLayerOnly(DataInputStream dis) throws IOException {
+    if (dis.readBoolean()) {
+      byte[] h = new byte[32];
+      dis.readFully(h);
+      return h;
+    }
+    return null;
+  }
+
+  private SplitFileInserterCrossSegmentStorage[] initCrossSegmentsArrayIfAny(int segmentCount) {
+    return (crossCheckBlocks != 0)
+        ? new SplitFileInserterCrossSegmentStorage[segmentCount]
+        : new SplitFileInserterCrossSegmentStorage[0];
+  }
+
+  private record OffsetsData(
+      long offsetPaddedLastBlock,
+      long offsetOverallStatus,
+      int overallStatusLength,
+      OffsetArrays arrays) {}
+
+  private OffsetsData readOffsets(DataInputStream dis, long rafLength, int segmentCount)
+      throws IOException, StorageFormatException {
+    long offsetPaddedLastBlockLocal = 0;
+    if (hasPaddedLastBlock) {
+      offsetPaddedLastBlockLocal = readOffset(dis, rafLength, "offsetPaddedLastBlock");
+    }
+    long offsetOverallStatusLocal = readOffset(dis, rafLength, "offsetOverallStatus");
+    int overallStatusLengthLocal = dis.readInt();
+    if (overallStatusLengthLocal < 0)
+      throw new StorageFormatException("Negative overall status length");
+    if (overallStatusLengthLocal < FailureCodeTracker.getFixedLength(true))
+      throw new StorageFormatException("Bad overall status length");
+    long[] offsetCrossSegmentBlocksLocal = null;
+    long[] offsetCrossSegmentStatusLocal = null;
+    if (crossSegments.length != 0) {
+      offsetCrossSegmentBlocksLocal = new long[crossSegments.length];
+      for (int i = 0; i < crossSegments.length; i++)
+        offsetCrossSegmentBlocksLocal[i] = readOffset(dis, rafLength, "cross-segment block offset");
+    }
+    long[] offsetSegmentCheckBlocksLocal = new long[segmentCount];
+    for (int i = 0; i < segmentCount; i++)
+      offsetSegmentCheckBlocksLocal[i] = readOffset(dis, rafLength, "segment check block offset");
+    long[] offsetSegmentStatusLocal = new long[segmentCount];
+    for (int i = 0; i < segmentCount; i++)
+      offsetSegmentStatusLocal[i] = readOffset(dis, rafLength, "segment status offset");
+    if (crossSegments.length != 0) {
+      offsetCrossSegmentStatusLocal = new long[crossSegments.length];
+      for (int i = 0; i < crossSegments.length; i++)
+        offsetCrossSegmentStatusLocal[i] =
+            readOffset(dis, rafLength, "cross-segment status offset");
+    }
+    long[] offsetSegmentKeysLocal = new long[segmentCount];
+    for (int i = 0; i < segmentCount; i++)
+      offsetSegmentKeysLocal[i] = readOffset(dis, rafLength, "segment keys offset");
+    OffsetArrays arrays =
+        new OffsetArrays(
+            offsetCrossSegmentBlocksLocal,
+            offsetSegmentCheckBlocksLocal,
+            offsetSegmentStatusLocal,
+            offsetCrossSegmentStatusLocal,
+            offsetSegmentKeysLocal);
+    return new OffsetsData(
+        offsetPaddedLastBlockLocal, offsetOverallStatusLocal, overallStatusLengthLocal, arrays);
+  }
+
+  private long initSegmentsAndComputeBlocks(
+      InputStream is, int segmentCount, KeysFetchingLocally keysFetching)
+      throws IOException, StorageFormatException {
+    DataInputStream dis = new DataInputStream(is);
+    long blocks = 0;
+    for (int i = 0; i < segmentCount; i++) {
+      segments[i] =
+          new SplitFileInserterSegmentStorage(
+              this,
+              dis,
+              i,
+              keyLength,
+              splitfileCryptoAlgorithm,
+              splitfileCryptoKey,
+              random,
+              maxRetries,
+              consecutiveRNFsCountAsSuccess,
+              keysFetching);
+      underlyingOffsetDataSegments[i] = blocks * CHKBlock.DATA_LENGTH;
+      blocks += segments[i].dataBlockCount;
+      assert (underlyingOffsetDataSegments[i] < dataLength);
+    }
+    dis.close();
+    return blocks;
+  }
+
+  private void readCrossSegmentsFromDisk(InputStream ois, long maxLength)
+      throws IOException, ChecksumFailedException, StorageFormatException {
+    // When there are no cross-check blocks we do not write any cross-segment
+    // settings section, so skip attempting to read it on resume.
+    if (crossSegments.length == 0) return;
+    InputStream is = checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength);
+    DataInputStream dis = new DataInputStream(is);
+    for (int i = 0; i < crossSegments.length; i++) {
+      crossSegments[i] = new SplitFileInserterCrossSegmentStorage(this, dis, i);
+    }
+    dis.close();
+  }
+
+  private FailureCodeTracker readStatusesFromDisk(long maxLength)
+      throws IOException, StorageFormatException, ChecksumFailedException {
+    InputStream ois = new RAFInputStream(raf, offsetOverallStatus, rafLength - offsetOverallStatus);
+    DataInputStream dis =
+        new DataInputStream(
+            checker.checksumReaderWithLength(ois, new ArrayBucketFactory(), maxLength));
+    FailureCodeTracker tracker = new FailureCodeTracker(true, dis);
+    dis.close();
+    for (SplitFileInserterSegmentStorage segment : segments) {
+      segment.readStatus();
+    }
+    for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
+      segment.readStatus();
+    }
+    return tracker;
+  }
+
+  private int readPositiveInt(DataInputStream dis, String name)
+      throws IOException, StorageFormatException {
+    int v = dis.readInt();
+    if (v <= 0) throw new StorageFormatException("Bad " + name + " " + v);
+    return v;
+  }
+
+  // Non-negative int reads are handled inline at call sites to ensure precise error messages.
+
+  private long readPositiveLong(DataInputStream dis, String name)
+      throws IOException, StorageFormatException {
+    long v = dis.readLong();
+    if (v <= 0) throw new StorageFormatException("Bad " + name);
+    return v;
+  }
+
+  private void validateDataLengthMatches(long dataLength, LockableRandomAccessBuffer originalData)
+      throws ResumeFailedException {
+    if (dataLength != originalData.size())
+      throw new ResumeFailedException(
+          "Original data size is " + originalData.size() + " should be " + dataLength);
+  }
+
+  private void validateBlockCountCompatibility(long dataLength, int totalDataBlocks)
+      throws StorageFormatException {
+    if (((dataLength + CHKBlock.DATA_LENGTH - 1) / CHKBlock.DATA_LENGTH) != totalDataBlocks)
+      throw new StorageFormatException(
+          "Data blocks " + totalDataBlocks + " not compatible with size " + dataLength);
+  }
+
+  private void validateSegmentTotals(int segmentSize, int checkSegmentSize, int crossCheckBlocks)
+      throws StorageFormatException {
+    if (segmentSize + checkSegmentSize + crossCheckBlocks > FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT)
+      throw new StorageFormatException(
+          "Must be no more than " + FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT + " blocks per segment");
+  }
+
+  private void validateCryptoAlgorithm(byte algo) throws StorageFormatException {
+    if (!Metadata.isValidSplitfileCryptoAlgorithm(algo))
+      throw new StorageFormatException("Invalid splitfile crypto algorithm " + algo);
+  }
+
+  private void validateKeyLength(int keyLength) throws StorageFormatException {
+    int min = SplitFileInserterSegmentStorage.getKeyLength(this);
+    if (keyLength < min)
+      throw new StorageFormatException(
+          "Invalid key length " + keyLength + " should be at least " + min);
+  }
+
+  private void validateDeductBlocksRange(int value, int segmentCount)
+      throws StorageFormatException {
+    if (value < 0 || value > segmentCount)
+      throw new StorageFormatException("Bad deductBlocksFromSegments");
+  }
+
+  private void validateMaxRetries(int value) throws StorageFormatException {
+    if (value < -1) throw new StorageFormatException("Bad maxRetries");
+  }
+
+  // Removed validateNonNegative(): inlined at call site for clarity
+
+  private ChecksumChecker createChecksumChecker(int checksumType) throws StorageFormatException {
+    try {
+      return ChecksumChecker.create(checksumType);
+    } catch (IllegalArgumentException e) {
+      throw new StorageFormatException("Bad checksum type");
+    }
+  }
+
+  private SplitfileAlgorithm readSplitfileAlgorithm(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    try {
+      return SplitfileAlgorithm.getByCode(dis.readShort());
+    } catch (IllegalArgumentException e) {
+      throw new StorageFormatException("Bad splitfile type");
+    }
+  }
+
+  private FECCodec getCodecFor(SplitfileAlgorithm algorithm) throws StorageFormatException {
+    try {
+      return FECCodec.getInstance(algorithm);
+    } catch (IllegalArgumentException e) {
+      throw new StorageFormatException("Bad splitfile codec type");
+    }
+  }
+
+  private ARCHIVE_TYPE readArchiveType(short atype) throws StorageFormatException {
+    if (atype == -1) return null;
+    ARCHIVE_TYPE t = ARCHIVE_TYPE.getArchiveType(atype);
+    if (t == null) throw new StorageFormatException("Unknown archive type " + atype);
+    return t;
+  }
+
+  private ClientMetadata readClientMetadata(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    try {
+      return ClientMetadata.construct(dis);
+    } catch (MetadataParseException e) {
+      throw new StorageFormatException("Failed to read MIME type: " + e);
+    }
+  }
+
+  private COMPRESSOR_TYPE readCompressionCodec(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    short c = dis.readShort();
+    if (c == (short) -1) return null;
+    COMPRESSOR_TYPE cc = COMPRESSOR_TYPE.getCompressorByMetadataID(c);
+    if (cc == null) throw new StorageFormatException("Unknown compression codec ID " + c);
+    return cc;
+  }
+
+  private LockableRandomAccessBuffer chooseOriginalData(
+      LockableRandomAccessBuffer passed, LockableRandomAccessBuffer restored)
+      throws StorageFormatException {
+    if (passed == null) return restored;
+    if (!passed.equals(restored))
+      throw new StorageFormatException(
+          "Original data restored from different filename! Expected "
+              + passed
+              + " but restored "
+              + restored);
+    return passed;
+  }
+
+  private static final class CryptoInit {
+    final byte[] key;
+    final boolean specifyInMetadata;
+
+    CryptoInit(byte[] key, boolean specifyInMetadata) {
+      this.key = key;
+      this.specifyInMetadata = specifyInMetadata;
+    }
+  }
+
+  private CryptoInit chooseSplitfileKey(
+      byte[] providedKey, CompatibilityMode cmode, byte[] hashThisLayerOnly, HashResult[] hashes) {
+    if (providedKey != null) {
+      return new CryptoInit(providedKey, true);
+    } else if (cmode == CompatibilityMode.COMPAT_CURRENT
+        || cmode.ordinal() >= CompatibilityMode.COMPAT_1255.ordinal()) {
+      byte[] key =
+          (hashThisLayerOnly != null)
+              ? Metadata.getCryptoKey(hashThisLayerOnly)
+              : Metadata.getCryptoKey(hashes);
+      return new CryptoInit(key, false);
+    } else {
+      return new CryptoInit(null, false);
+    }
+  }
+
+  private static long padTo4096(long value) {
+    int padding = (int) (value % 4096);
+    return padding == 0 ? value : value + (4096 - padding);
+  }
+
+  private long calculateInitialPtr(
+      byte[] header, int offsetsLength, Bucket segmentSettings, Bucket crossSegmentSettings) {
+    return header.length
+        + offsetsLength
+        + segmentSettings.size()
+        + (crossSegmentSettings == null ? 0 : crossSegmentSettings.size());
+  }
+
+  private static final class OffsetArrays {
+    final long[] offsetCrossSegmentBlocks;
+    final long[] offsetSegmentCheckBlocks;
+    final long[] offsetSegmentStatus;
+    final long[] offsetCrossSegmentStatus;
+    final long[] offsetSegmentKeys;
+
+    OffsetArrays(
+        long[] offsetCrossSegmentBlocks,
+        long[] offsetSegmentCheckBlocks,
+        long[] offsetSegmentStatus,
+        long[] offsetCrossSegmentStatus,
+        long[] offsetSegmentKeys) {
+      this.offsetCrossSegmentBlocks = offsetCrossSegmentBlocks;
+      this.offsetSegmentCheckBlocks = offsetSegmentCheckBlocks;
+      this.offsetSegmentStatus = offsetSegmentStatus;
+      this.offsetCrossSegmentStatus = offsetCrossSegmentStatus;
+      this.offsetSegmentKeys = offsetSegmentKeys;
+    }
+  }
+
+  private OffsetArrays createOffsetArrays(boolean persistent) {
+    long[] ocb = (crossSegments.length != 0) ? new long[crossSegments.length] : null;
+    long[] ocs = (crossSegments.length != 0 && persistent) ? new long[crossSegments.length] : null;
+    long[] osc = new long[segments.length];
+    long[] oss = persistent ? new long[segments.length] : null;
+    long[] osk = new long[segments.length];
+    return new OffsetArrays(ocb, osc, oss, ocs, osk);
+  }
+
+  private static final class PersistenceInit {
+    final byte[] header;
+    final int offsetsLength;
+    final Bucket segmentSettings;
+    final Bucket crossSegmentSettings;
+
+    PersistenceInit(
+        byte[] header, int offsetsLength, Bucket segmentSettings, Bucket crossSegmentSettings) {
+      this.header = header;
+      this.offsetsLength = offsetsLength;
+      this.segmentSettings = segmentSettings;
+      this.crossSegmentSettings = crossSegmentSettings;
+    }
+  }
+
+  private PersistenceInit preparePersistenceInit(BucketFactory bf) throws InsertException {
+    byte[] header = encodeHeader();
+    int offsetsLength = encodeOffsets().length;
+    Bucket segmentSettings = encodeSegmentSettings();
+    Bucket crossSegmentSettings;
+    try {
+      crossSegmentSettings = encodeCrossSegmentSettings(bf);
+    } catch (IOException e) {
+      throw new InsertException(
+          InsertExceptionMode.BUCKET_ERROR,
+          "Failed to write to temporary storage while creating splitfile inserter",
+          null);
+    }
+    return new PersistenceInit(header, offsetsLength, segmentSettings, crossSegmentSettings);
+  }
+
+  private long populateCrossSegmentOffsets(long ptr) {
+    if (crossSegments.length == 0) return ptr;
+    for (int i = 0; i < crossSegments.length; i++) {
+      offsetCrossSegmentBlocks[i] = ptr;
+      ptr += (long) crossSegments[i].crossCheckBlockCount * CHKBlock.DATA_LENGTH;
+    }
+    return ptr;
+  }
+
+  private long populateSegmentCheckOffsets(long ptr) {
+    for (int i = 0; i < segments.length; i++) {
+      offsetSegmentCheckBlocks[i] = ptr;
+      ptr += (long) segments[i].checkBlockCount * CHKBlock.DATA_LENGTH;
+    }
+    return ptr;
+  }
+
+  private long populateSegmentStatusOffsets(long ptr) {
+    for (int i = 0; i < segments.length; i++) {
+      offsetSegmentStatus[i] = ptr;
+      ptr += segments[i].storedStatusLength();
+    }
+    return ptr;
+  }
+
+  private long populateCrossSegmentStatusOffsets(long ptr) {
+    if (crossSegments.length == 0) return ptr;
+    for (int i = 0; i < crossSegments.length; i++) {
+      offsetCrossSegmentStatus[i] = ptr;
+      ptr += crossSegments[i].storedStatusLength();
+    }
+    return ptr;
+  }
+
+  private long populateStatusOffsetsIfPersistent(long ptr) {
+    if (!persistent) return ptr;
+    ptr = populateSegmentStatusOffsets(ptr);
+    return populateCrossSegmentStatusOffsets(ptr);
+  }
+
+  private void writeInitialRafIfPersistent(
+      byte[] header, int offsetsLength, Bucket segmentSettings, Bucket crossSegmentSettings)
+      throws IOException {
+    if (!persistent) return;
+    writeInitialRaf(header, offsetsLength, segmentSettings, crossSegmentSettings);
+  }
+
+  private void writePaddedLastBlockIfAny(byte[] paddedLastBlock) throws IOException {
+    if (hasPaddedLastBlock)
+      raf.pwrite(offsetPaddedLastBlock, paddedLastBlock, 0, paddedLastBlock.length);
+  }
+
+  private void clearInitialStatusesIfPersistent() {
+    if (!persistent) return;
+    clearInitialStatuses();
+  }
+
+  private long populateSegmentKeyOffsets(long ptr) {
+    for (int i = 0; i < segments.length; i++) {
+      offsetSegmentKeys[i] = ptr;
+      ptr += segments[i].storedKeysLength();
+    }
+    return ptr;
+  }
+
+  private void writeInitialRaf(
+      byte[] header, int offsetsLength, Bucket segmentSettings, Bucket crossSegmentSettings)
+      throws IOException {
+    long ptr = 0;
+    raf.pwrite(ptr, header, 0, header.length);
+    ptr += header.length;
+    byte[] encodedOffsets = encodeOffsets();
+    assert (encodedOffsets.length == offsetsLength);
+    raf.pwrite(ptr, encodedOffsets, 0, encodedOffsets.length);
+    ptr += encodedOffsets.length;
+    BucketTools.copyTo(segmentSettings, raf, ptr, Long.MAX_VALUE);
+    ptr += segmentSettings.size();
+    segmentSettings.free();
+    if (crossSegmentSettings != null) {
+      BucketTools.copyTo(crossSegmentSettings, raf, ptr, Long.MAX_VALUE);
+      crossSegmentSettings.free();
+    }
+    writeOverallStatus(true);
+  }
+
+  private void clearInitialStatuses() {
+    // Padding is initialized to random already.
+    for (SplitFileInserterSegmentStorage segment : segments) {
+      if (LOG.isDebugEnabled()) LOG.debug("Clearing status for {}", segment);
+      segment.storeStatus(true);
+    }
+    if (crossSegments != null) {
+      for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
+        if (LOG.isDebugEnabled()) LOG.debug("Clearing status for {}", segment);
+        segment.storeStatus();
+      }
     }
   }
 
@@ -1103,18 +1464,16 @@ public class SplitFileInserterStorage {
       int segmentSize,
       int segCount,
       int dataBlocks,
-      int crossCheckBlocks,
       int deductBlocksFromSegments,
       boolean persistent,
-      CompatibilityMode cmode,
-      Random random,
       KeysFetchingLocally keysFetching,
       int consecutiveRNFsCountAsSuccess) {
-    SplitFileInserterSegmentStorage[] segments = new SplitFileInserterSegmentStorage[segCount];
+    SplitFileInserterSegmentStorage[] segArr = new SplitFileInserterSegmentStorage[segCount];
     if (segCount == 1) {
       // Single segment
-      int checkBlocks = codec.getCheckBlocks(dataBlocks + crossCheckBlocks, cmode);
-      segments[0] =
+      int checkBlocks =
+          (codec != null) ? codec.getCheckBlocks(dataBlocks + crossCheckBlocks, cmode) : 0;
+      segArr[0] =
           new SplitFileInserterSegmentStorage(
               this,
               0,
@@ -1133,18 +1492,16 @@ public class SplitFileInserterStorage {
       int j = 0;
       int segNo = 0;
       int data = segmentSize;
-      int check = codec.getCheckBlocks(data + crossCheckBlocks, cmode);
-      for (int i = segmentSize; ; ) {
+      int check = (codec != null) ? codec.getCheckBlocks(data + crossCheckBlocks, cmode) : 0;
+      int i = segmentSize;
+      while (true) {
         this.underlyingOffsetDataSegments[segNo] = (long) j * CHKBlock.DATA_LENGTH;
-        if (i > dataBlocks) i = dataBlocks;
-        if (data > (i - j)) {
-          // Last segment.
-          assert (segNo == segCount - 1);
-          data = i - j;
-          check = codec.getCheckBlocks(data + crossCheckBlocks, cmode);
-        }
+        i = clampToDataBlocks(i, dataBlocks);
+        DataCheck dc = adjustForLastSegmentIfNeeded(data, check, i, j, segNo, segCount);
+        data = dc.data;
+        check = dc.check;
         j = i;
-        segments[segNo] =
+        segArr[segNo] =
             new SplitFileInserterSegmentStorage(
                 this,
                 segNo,
@@ -1159,37 +1516,30 @@ public class SplitFileInserterStorage {
                 maxRetries,
                 consecutiveRNFsCountAsSuccess,
                 keysFetching);
-
-        if (deductBlocksFromSegments != 0)
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "INSERTING: Segment "
-                    + segNo
-                    + " of "
-                    + segCount
-                    + " : "
-                    + data
-                    + " data blocks "
-                    + check
-                    + " check blocks");
+        logSegmentDetailsIfNeeded(segNo, segCount, data, check, deductBlocksFromSegments);
 
         segNo++;
         if (i == dataBlocks) break;
         // Deduct one block from each later segment, rather than having
         // a really short last segment.
-        if (segCount - segNo == deductBlocksFromSegments) {
-          data--;
-          // Don't change check.
-        }
+        data = maybeDeductBlock(data, segCount, segNo, deductBlocksFromSegments);
         i += data;
       }
       assert (segNo == segCount);
     }
-    return segments;
+    return segArr;
   }
 
+  /**
+   * Starts encoding work for this storage instance.
+   *
+   * <p>If cross-segment redundancy was configured, begins by encoding cross-segments and only then
+   * starts per-segment encoding. Otherwise, starts segment encoding immediately. This method is
+   * idempotent with respect to internal state and returns quickly when encoding has already
+   * completed or the storage has failed.
+   */
   public void start() {
-    boolean startSegments = (crossSegments == null);
+    boolean startSegments = (crossSegments.length == 0);
     synchronized (this) {
       if (status == Status.NOT_STARTED) {
         status = Status.STARTED;
@@ -1202,20 +1552,16 @@ public class SplitFileInserterStorage {
     }
     for (SplitFileInserterSegmentStorage segment : segments) segment.checkKeys();
     LOG.info(
-        "Starting splitfile, "
-            + countEncodedSegments()
-            + "/"
-            + segments.length
-            + " segments encoded on "
-            + this);
-    if (crossSegments != null)
+        "Starting splitfile, {}/{} segments encoded on {}",
+        countEncodedSegments(),
+        segments.length,
+        this);
+    if (crossSegments.length != 0)
       LOG.info(
-          "Starting splitfile, "
-              + countEncodedCrossSegments()
-              + "/"
-              + crossSegments.length
-              + " cross-segments encoded on "
-              + this);
+          "Starting splitfile, {}/{} cross-segments encoded on {}",
+          countEncodedCrossSegments(),
+          crossSegments.length,
+          this);
     if (startSegments) {
       startSegmentEncode();
     } else {
@@ -1224,6 +1570,11 @@ public class SplitFileInserterStorage {
     }
   }
 
+  /**
+   * Returns the number of segments that have completed encoding.
+   *
+   * @return count of segments whose check blocks have been fully generated and stored.
+   */
   public int countEncodedSegments() {
     int total = 0;
     for (SplitFileInserterSegmentStorage segment : segments) {
@@ -1232,6 +1583,11 @@ public class SplitFileInserterStorage {
     return total;
   }
 
+  /**
+   * Returns the number of cross-segments that have completed encoding.
+   *
+   * @return count of cross-segment encoders that reported completion.
+   */
   public int countEncodedCrossSegments() {
     int total = 0;
     for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
@@ -1252,12 +1608,16 @@ public class SplitFileInserterStorage {
   }
 
   /**
-   * Called when a cross-segment finishes encoding blocks. Can be called inside locks as it runs
-   * off-thread.
+   * Notifies the storage that a cross-segment finished encoding.
    *
-   * @param completed
+   * <p>The completion is processed asynchronously on the persistent job runner to minimize lock
+   * contention. When all cross-segments have finished, the storage transitions to {@code
+   * ENCODED_CROSS_SEGMENTS} and starts the main segment encoding phase.
+   *
+   * @param completed the cross-segment that completed encoding; used for logging and diagnostics.
    */
   public void onFinishedEncoding(SplitFileInserterCrossSegmentStorage completed) {
+    if (LOG.isDebugEnabled()) LOG.debug("Cross-segment finished encoding: {}", completed);
     jobRunner.queueNormalOrDrop(
         context -> {
           synchronized (cooldownLock) {
@@ -1280,10 +1640,13 @@ public class SplitFileInserterStorage {
   }
 
   /**
-   * Called when a segment finishes encoding blocks. Can be called inside locks as it runs
-   * off-thread.
+   * Notifies the storage that a segment finished encoding.
    *
-   * @param completed
+   * <p>The storage persists the segment status, updates progress, and when every segment has
+   * finished encoding transitions to the completion path to produce metadata and notify success.
+   * Processing occurs asynchronously via the job runner.
+   *
+   * @param completed the segment that completed encoding; used to persist status and progress.
    */
   public void onFinishedEncoding(final SplitFileInserterSegmentStorage completed) {
     jobRunner.queueNormalOrDrop(
@@ -1325,7 +1688,7 @@ public class SplitFileInserterStorage {
     synchronized (this) {
       if (status == Status.ENCODED) return; // Race condition.
       if (!(status == Status.ENCODED_CROSS_SEGMENTS
-          || (crossSegments == null && status == Status.STARTED))) {
+          || (crossSegments.length == 0 && status == Status.STARTED))) {
         LOG.error("Wrong state {} for {}", status, this);
         return;
       }
@@ -1334,7 +1697,17 @@ public class SplitFileInserterStorage {
     callback.onFinishedEncode();
   }
 
+  /**
+   * Notifies that a segment obtained keys for all of its blocks.
+   *
+   * <p>When every segment reports it has keys, delegates to {@code onHasKeys()} to inform the
+   * callback that metadata can be emitted early (depending on configuration).
+   *
+   * @param splitFileInserterSegmentStorage the reporting segment instance; used for logging only.
+   */
   public void onHasKeys(SplitFileInserterSegmentStorage splitFileInserterSegmentStorage) {
+    if (LOG.isDebugEnabled())
+      LOG.debug("onHasKeys called from {}", splitFileInserterSegmentStorage);
     for (SplitFileInserterSegmentStorage segment : segments) {
       if (!segment.hasKeys()) return;
     }
@@ -1360,6 +1733,7 @@ public class SplitFileInserterStorage {
     OutputStream cos = checker.checksumWriter(baos);
     return new FilterOutputStream(cos) {
 
+      @Override
       public void close() throws IOException {
         out.close();
         byte[] buf = baos.toByteArray();
@@ -1382,6 +1756,12 @@ public class SplitFileInserterStorage {
   static final long MAGIC = 0x4d2a3f596bbf5de5L;
   static final int VERSION = 1;
 
+  /**
+   * Indicates whether a splitfile encryption key is present.
+   *
+   * @return {@code true} when a 32-byte splitfile key is stored for this insert; otherwise {@code
+   *     false} when the key is implicit or not required.
+   */
   public boolean hasSplitfileKey() {
     return splitfileCryptoKey != null;
   }
@@ -1396,16 +1776,19 @@ public class SplitFileInserterStorage {
       if (status == Status.ENCODED || status == Status.ENCODED_CROSS_SEGMENTS)
         throw new IllegalStateException("Already encoded!?");
     }
-    assert (segNo >= 0 && segNo < crossSegments.length);
-    assert (checkBlockNo >= 0 && checkBlockNo < crossCheckBlocks);
-    assert (buf.length == CHKBlock.DATA_LENGTH);
     long offset = offsetCrossSegmentBlocks[segNo] + (long) checkBlockNo * CHKBlock.DATA_LENGTH;
     raf.pwrite(offset, buf, 0, buf.length);
   }
 
+  /**
+   * Reads a cross-check block from the backing RAF.
+   *
+   * @param segNo zero-based cross-segment number whose block is being read; must be within range.
+   * @param checkBlockNo zero-based cross-check block index within the cross-segment.
+   * @return a new byte array of length {@link CHKBlock#DATA_LENGTH} containing the block data.
+   * @throws IOException if the underlying RAF read fails at the computed offset.
+   */
   public byte[] readCheckBlock(int segNo, int checkBlockNo) throws IOException {
-    assert (segNo >= 0 && segNo < crossSegments.length);
-    assert (checkBlockNo >= 0 && checkBlockNo < crossCheckBlocks);
     long offset = offsetCrossSegmentBlocks[segNo] + (long) checkBlockNo * CHKBlock.DATA_LENGTH;
     byte[] buf = new byte[CHKBlock.DATA_LENGTH];
     raf.pread(offset, buf, 0, buf.length);
@@ -1430,35 +1813,53 @@ public class SplitFileInserterStorage {
     return originalData.lockOpen();
   }
 
+  /**
+   * Reads a data block for the given segment.
+   *
+   * <p>For the final padded block, the bytes are read from the RAF area reserved for the padded
+   * last block; otherwise, the data is read from the original data buffer at the computed offset.
+   *
+   * @param segNo zero-based segment number to read from; must reference an existing segment.
+   * @param blockNo zero-based data block index within the segment (excluding check blocks).
+   * @return a new byte array of length {@link CHKBlock#DATA_LENGTH} with the block contents.
+   * @throws IOException if reading from the RAF or the original data buffer fails.
+   */
   public byte[] readSegmentDataBlock(int segNo, int blockNo) throws IOException {
-    assert (segNo >= 0 && segNo < segments.length);
-    assert (blockNo >= 0 && blockNo < segments[segNo].dataBlockCount);
     byte[] buf = new byte[CHKBlock.DATA_LENGTH];
-    if (hasPaddedLastBlock) {
-      if (segNo == segments.length - 1 && blockNo == segments[segNo].dataBlockCount - 1) {
-        // Don't need to lock, locking is just an optimisation.
-        raf.pread(offsetPaddedLastBlock, buf, 0, buf.length);
-        return buf;
-      }
+    if (hasPaddedLastBlock
+        && segNo == segments.length - 1
+        && blockNo == segments[segNo].dataBlockCount - 1) {
+      // Don't need to lock, locking is just an optimisation.
+      raf.pread(offsetPaddedLastBlock, buf, 0, buf.length);
+      return buf;
     }
     long offset = underlyingOffsetDataSegments[segNo] + (long) blockNo * CHKBlock.DATA_LENGTH;
-    assert (offset < dataLength);
-    assert (offset + buf.length <= dataLength);
     originalData.pread(offset, buf, 0, buf.length);
     return buf;
   }
 
+  /**
+   * Writes a per-segment check block into the backing RAF.
+   *
+   * @param segNo zero-based segment number whose check block is being written.
+   * @param checkBlockNo zero-based index of the check block within the segment.
+   * @param buf byte array containing exactly {@link CHKBlock#DATA_LENGTH} bytes of block data.
+   * @throws IOException if the write to the RAF fails at the target offset.
+   */
   public void writeSegmentCheckBlock(int segNo, int checkBlockNo, byte[] buf) throws IOException {
-    assert (segNo >= 0 && segNo < segments.length);
-    assert (checkBlockNo >= 0 && checkBlockNo < segments[segNo].checkBlockCount);
-    assert (buf.length == CHKBlock.DATA_LENGTH);
     long offset = offsetSegmentCheckBlocks[segNo] + (long) checkBlockNo * CHKBlock.DATA_LENGTH;
     raf.pwrite(offset, buf, 0, buf.length);
   }
 
+  /**
+   * Reads a per-segment check block from the backing RAF.
+   *
+   * @param segNo zero-based segment number from which to read the check block.
+   * @param checkBlockNo zero-based index of the check block within the segment.
+   * @return a new byte array of length {@link CHKBlock#DATA_LENGTH} with the check block data.
+   * @throws IOException if the underlying RAF read fails at the computed offset.
+   */
   public byte[] readSegmentCheckBlock(int segNo, int checkBlockNo) throws IOException {
-    assert (segNo >= 0 && segNo < segments.length);
-    assert (checkBlockNo >= 0 && checkBlockNo < segments[segNo].checkBlockCount);
     byte[] buf = new byte[CHKBlock.DATA_LENGTH];
     long offset = offsetSegmentCheckBlocks[segNo] + (long) checkBlockNo * CHKBlock.DATA_LENGTH;
     raf.pread(offset, buf, 0, buf.length);
@@ -1478,8 +1879,7 @@ public class SplitFileInserterStorage {
     ClientCHK[] checkKeys = new ClientCHK[totalCheckBlocks];
     int dataPtr = 0;
     int checkPtr = 0;
-    for (int segNo = 0; segNo < segments.length; segNo++) {
-      SplitFileInserterSegmentStorage segment = segments[segNo];
+    for (SplitFileInserterSegmentStorage segment : segments) {
       for (int i = 0; i < segment.dataBlockCount + segment.crossCheckBlockCount; i++) {
         dataKeys[dataPtr++] = segment.readKey(i);
       }
@@ -1524,14 +1924,7 @@ public class SplitFileInserterStorage {
     long fileOffset = this.offsetSegmentKeys[segNo] + (long) keyLength * blockNo;
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Writing key for block "
-              + blockNo
-              + " for segment "
-              + segNo
-              + " of "
-              + this
-              + " to "
-              + fileOffset);
+          "Writing key for block {} for segment {} of {} to {}", blockNo, segNo, this, fileOffset);
     raf.pwrite(fileOffset, buf, 0, buf.length);
   }
 
@@ -1540,78 +1933,82 @@ public class SplitFileInserterStorage {
     long fileOffset = this.offsetSegmentKeys[segNo] + (long) keyLength * blockNo;
     if (LOG.isDebugEnabled())
       LOG.debug(
-          "Reading key for block "
-              + blockNo
-              + " for segment "
-              + segNo
-              + " of "
-              + this
-              + " to "
-              + fileOffset);
+          "Reading key for block {} for segment {} of {} to {}", blockNo, segNo, this, fileOffset);
     raf.pread(fileOffset, buf, 0, buf.length);
     return buf;
   }
 
+  /**
+   * Returns the total number of cross-check blocks across all cross-segments.
+   *
+   * @return {@code segments.length * crossCheckBlocks}; zero when cross-segment redundancy is
+   *     disabled.
+   */
+  @SuppressWarnings("unused")
   public int totalCrossCheckBlocks() {
     return segments.length * crossCheckBlocks;
   }
 
-  /** Called when a segment completes. Can be called inside locks as it runs off-thread. */
+  /**
+   * Notifies that a segment has completed successfully.
+   *
+   * <p>The notification is processed asynchronously; when all segments succeed, the storage
+   * finalizes by encoding metadata and notifying the callback of success.
+   *
+   * @param completedSegment the segment that completed; used for logging and task routing.
+   */
   public void segmentSucceeded(final SplitFileInserterSegmentStorage completedSegment) {
-    if (LOG.isDebugEnabled())
-      LOG.debug("Succeeded segment " + completedSegment + " for " + callback);
-    jobRunner.queueNormalOrDrop(
-        new PersistentJob() {
+    if (LOG.isDebugEnabled()) LOG.debug("Succeeded segment {} for {}", completedSegment, callback);
+    jobRunner.queueNormalOrDrop(context -> onSegmentSucceededTask(completedSegment));
+  }
 
-          @Override
-          public boolean run(ClientContext context) {
-            if (LOG.isDebugEnabled())
-              LOG.debug("Succeeding segment " + completedSegment + " for " + callback);
-            if (maybeFail()) return true;
-            if (allSegmentsSucceeded()) {
-              synchronized (this) {
-                assert (failing == null);
-                if (hasFinished()) return false;
-                status = Status.GENERATING_METADATA;
-              }
-              if (LOG.isDebugEnabled()) LOG.debug("Generating metadata...");
-              try {
-                Metadata metadata = encodeMetadata();
-                synchronized (this) {
-                  status = Status.SUCCEEDED;
-                }
-                callback.onSucceeded(metadata);
-              } catch (IOException e) {
-                InsertException e1 = new InsertException(InsertExceptionMode.BUCKET_ERROR);
-                synchronized (this) {
-                  failing = e1;
-                  status = Status.FAILED;
-                }
-                callback.onFailed(e1);
-              } catch (MissingKeyException e) {
-                // Fail here too. If we're getting disk corruption on keys, we're probably
-                // getting it on the original data too.
-                InsertException e1 =
-                    new InsertException(InsertExceptionMode.BUCKET_ERROR, "Missing keys", null);
-                synchronized (this) {
-                  failing = e1;
-                  status = Status.FAILED;
-                }
-                callback.onFailed(e1);
-              }
-            } else {
-              if (LOG.isDebugEnabled()) LOG.debug("Not all segments succeeded for " + this);
-            }
-            return true;
-          }
-        });
+  private boolean onSegmentSucceededTask(SplitFileInserterSegmentStorage completedSegment) {
+    if (LOG.isDebugEnabled()) LOG.debug("Succeeding segment {} for {}", completedSegment, callback);
+    if (maybeFail()) return true;
+    if (allSegmentsSucceeded()) {
+      return completeAndNotifySuccess();
+    } else {
+      if (LOG.isDebugEnabled()) LOG.debug("Not all segments succeeded for {}", this);
+      return true;
+    }
+  }
+
+  private boolean completeAndNotifySuccess() {
+    synchronized (this) {
+      assert (failing == null);
+      if (hasFinished()) return false;
+      status = Status.GENERATING_METADATA;
+    }
+    if (LOG.isDebugEnabled()) LOG.debug("Generating metadata...");
+    try {
+      Metadata metadata = encodeMetadata();
+      synchronized (this) {
+        status = Status.SUCCEEDED;
+      }
+      callback.onSucceeded(metadata);
+    } catch (IOException e) {
+      failWith(new InsertException(InsertExceptionMode.BUCKET_ERROR));
+    } catch (MissingKeyException e) {
+      // Fail here too. If we're getting disk corruption on keys, we're probably
+      // getting it on the original data too.
+      failWith(new InsertException(InsertExceptionMode.BUCKET_ERROR, "Missing keys", null));
+    }
+    return true;
+  }
+
+  private void failWith(InsertException e1) {
+    synchronized (this) {
+      failing = e1;
+      status = Status.FAILED;
+    }
+    callback.onFailed(e1);
   }
 
   private boolean maybeFail() {
     // Might have failed.
     // Have to check segments before checking for failure because of race conditions.
     if (allSegmentsCompletedOrFailed()) {
-      InsertException e = null;
+      InsertException e;
       synchronized (this) {
         if (failing == null) return false;
         e = failing;
@@ -1621,7 +2018,8 @@ public class SplitFileInserterStorage {
         }
         status = Status.FAILED;
       }
-      if (LOG.isDebugEnabled()) LOG.debug("Maybe fail returning true with error " + e);
+      if (LOG.isDebugEnabled())
+        LOG.debug("Maybe fail returning true with error {}", String.valueOf(e));
       callback.onFailed(e);
       return true;
     } else {
@@ -1633,9 +2031,9 @@ public class SplitFileInserterStorage {
     for (SplitFileInserterSegmentStorage segment : segments) {
       if (!segment.hasCompletedOrFailed()) return false;
     }
-    if (crossSegments != null) {
-      for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
-        if (!segment.hasCompletedOrFailed()) return false;
+    for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
+      if (!segment.hasCompletedOrFailed()) {
+        return false;
       }
     }
     return true;
@@ -1644,11 +2042,16 @@ public class SplitFileInserterStorage {
   private boolean allSegmentsSucceeded() {
     for (SplitFileInserterSegmentStorage segment : segments) {
       if (!segment.hasSucceeded()) return false;
-      if (LOG.isDebugEnabled()) LOG.debug("Succeeded " + segment);
+      if (LOG.isDebugEnabled()) LOG.debug("Succeeded {}", segment);
     }
     return true;
   }
 
+  /**
+   * Records a failure mode for later reporting and persists overall status.
+   *
+   * @param e insert exception whose mode should be counted toward aggregated failure statistics.
+   */
   public void addFailure(InsertException e) {
     errors.inc(e.getMode());
     synchronized (this) {
@@ -1657,14 +2060,21 @@ public class SplitFileInserterStorage {
     }
   }
 
+  /**
+   * Fails the storage with a disk or bucket I/O error.
+   *
+   * @param e the I/O exception that triggered the failure; wrapped into an {@link InsertException}.
+   */
   public void failOnDiskError(IOException e) {
     fail(new InsertException(InsertExceptionMode.BUCKET_ERROR, e, null));
   }
 
+  /** Marks the storage as failed due to fatal errors while encoding blocks. */
   public void failFatalErrorInBlock() {
     fail(new InsertException(InsertExceptionMode.FATAL_ERRORS_IN_BLOCKS, errors, null));
   }
 
+  /** Marks the storage as failed due to exceeding the retry budget while encoding blocks. */
   public void failTooManyRetriesInBlock() {
     fail(new InsertException(InsertExceptionMode.TOO_MANY_RETRIES_IN_BLOCKS, errors, null));
   }
@@ -1674,93 +2084,75 @@ public class SplitFileInserterStorage {
       if (this.status == Status.SUCCEEDED
           || this.status == Status.FAILED
           || this.status == Status.GENERATING_METADATA) {
-        // Not serious but often indicates a problem e.g. we are sending requests after completing.
-        // So log as ERROR for now.
-        LOG.error("Already finished (" + status + ") but failing with " + e + " (" + this + ")", e);
+        LOG.error("Already finished ({}) but failing with {} ({})", status, e, this, e);
         return;
       }
-      // Only fail once.
-      if (failing != null) return;
+      if (failing != null) return; // Only fail once.
       failing = e;
     }
     if (e.mode == InsertExceptionMode.BUCKET_ERROR || e.mode == InsertExceptionMode.INTERNAL_ERROR)
-      LOG.error("Failing: " + e + " for " + this, e);
-    else LOG.info("Failing: " + e + " for " + this, e);
-    jobRunner.queueNormalOrDrop(
-        new PersistentJob() {
-
-          @Override
-          public boolean run(ClientContext context) {
-            // Tell the segments to cancel.
-            boolean allDone = true;
-            for (SplitFileInserterSegmentStorage segment : segments) {
-              if (!segment.cancel()) allDone = false;
-            }
-            if (crossSegments != null) {
-              for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
-                if (!segment.cancel()) allDone = false;
-              }
-            }
-            if (allDone) {
-              synchronized (this) {
-                // Could have beaten us to it in callback.
-                if (hasFinished()) return false;
-                status = Status.FAILED;
-              }
-              callback.onFailed(e);
-              return true;
-            } else {
-              // Wait for them to finish encoding.
-              return false;
-            }
-          }
-        });
+      LOG.error("Failing: {} for {}", e, this, e);
+    else LOG.info("Failing: {} for {}", e, this, e);
+    jobRunner.queueNormalOrDrop(context -> onFailTask(e));
   }
 
+  private boolean onFailTask(InsertException e) {
+    boolean allDone = cancelAllSegments();
+    if (crossSegments.length != 0) allDone &= cancelAllCrossSegments();
+    if (allDone) {
+      synchronized (this) {
+        if (hasFinished()) return false; // Could have beaten us to it in callback.
+        status = Status.FAILED;
+      }
+      callback.onFailed(e);
+      return true;
+    }
+    // Wait for them to finish encoding.
+    return false;
+  }
+
+  private boolean cancelAllSegments() {
+    boolean allDone = true;
+    for (SplitFileInserterSegmentStorage segment : segments) {
+      if (!segment.cancel()) allDone = false;
+    }
+    return allDone;
+  }
+
+  private boolean cancelAllCrossSegments() {
+    boolean allDone = true;
+    for (SplitFileInserterCrossSegmentStorage segment : crossSegments) {
+      if (!segment.cancel()) allDone = false;
+    }
+    return allDone;
+  }
+
+  /**
+   * Reports whether the storage reached a terminal state.
+   *
+   * @return {@code true} when the status is {@code SUCCEEDED} or {@code FAILED}; otherwise {@code
+   *     false}.
+   */
   public synchronized boolean hasFinished() {
     return status == Status.SUCCEEDED || status == Status.FAILED;
   }
 
-  public synchronized Status getStatus() {
+  synchronized Status getStatus() {
     return status;
   }
 
   static final long LAZY_WRITE_METADATA_DELAY = TimeUnit.MINUTES.toMillis(5);
 
-  private final PersistentJob writeMetadataJob =
-      new PersistentJob() {
+  private final PersistentJob writeMetadataJob;
 
-        @Override
-        public boolean run(ClientContext context) {
-          try {
-            if (isFinishing()) return false;
-            RAFLock lock = raf.lockOpen();
-            try {
-              for (SplitFileInserterSegmentStorage segment : segments) {
-                segment.storeStatus(false);
-              }
-            } finally {
-              lock.unlock();
-            }
-            writeOverallStatus(false);
-            return false;
-          } catch (IOException e) {
-            if (isFinishing()) return false;
-            LOG.error("Failed writing metadata for " + SplitFileInserterStorage.this + ": " + e, e);
-            return false;
-          }
-        }
-      };
+  private final Runnable wrapLazyWriteMetadata;
 
-  private final Runnable wrapLazyWriteMetadata =
-      new Runnable() {
-
-        @Override
-        public void run() {
-          jobRunner.queueNormalOrDrop(writeMetadataJob);
-        }
-      };
-
+  /**
+   * Schedules a deferred metadata write for persistent inserts.
+   *
+   * <p>When enabled, the write is queued on the ticker with a delay to coalesce frequent updates.
+   * If the delay is zero, the write job is queued immediately on the persistent runner.
+   */
   public synchronized void lazyWriteMetadata() {
     if (!persistent) return;
     if (LAZY_WRITE_METADATA_DELAY != 0) {
@@ -1776,6 +2168,12 @@ public class SplitFileInserterStorage {
     }
   }
 
+  /**
+   * Indicates whether the storage is in the process of finishing.
+   *
+   * @return {@code true} when a failure is pending or the status is terminal or generating
+   *     metadata; otherwise {@code false}.
+   */
   protected synchronized boolean isFinishing() {
     return this.failing != null
         || status == Status.FAILED
@@ -1787,6 +2185,29 @@ public class SplitFileInserterStorage {
     writeMetadataJob.run(context);
   }
 
+  private PersistentJob createWriteMetadataJob() {
+    return context -> {
+      try {
+        if (isFinishing()) return false;
+        RAFLock lock = raf.lockOpen();
+        try {
+          for (SplitFileInserterSegmentStorage segment : segments) {
+            segment.storeStatus(false);
+          }
+        } finally {
+          lock.unlock();
+        }
+        writeOverallStatus(false);
+        return false;
+      } catch (IOException e) {
+        if (isFinishing()) return false;
+        LOG.error("Failed writing metadata for {}: {}", SplitFileInserterStorage.this, e, e);
+        return false;
+      }
+    };
+  }
+
+  @SuppressWarnings("SameParameterValue")
   void preadChecksummed(long fileOffset, byte[] buf, int offset, int length)
       throws IOException, ChecksumFailedException {
     byte[] checksumBuf = new byte[checker.checksumLength()];
@@ -1803,6 +2224,7 @@ public class SplitFileInserterStorage {
     }
   }
 
+  @SuppressWarnings("unused")
   byte[] preadChecksummedWithLength(long fileOffset)
       throws IOException, ChecksumFailedException, StorageFormatException {
     byte[] checksumBuf = new byte[checker.checksumLength()];
@@ -1812,7 +2234,10 @@ public class SplitFileInserterStorage {
     int length;
     try {
       raf.pread(fileOffset, lengthBuf, 0, lengthBuf.length);
-      long len = new DataInputStream(new ByteArrayInputStream(lengthBuf)).readLong();
+      long len;
+      try (DataInputStream din = new DataInputStream(new ByteArrayInputStream(lengthBuf))) {
+        len = din.readLong();
+      }
       if (len + fileOffset > rafLength || len > Integer.MAX_VALUE || len < 0)
         throw new StorageFormatException("Bogus length " + len);
       length = (int) len;
@@ -1829,6 +2254,12 @@ public class SplitFileInserterStorage {
     return buf;
   }
 
+  /**
+   * Returns the file offset of the persisted status section for a segment.
+   *
+   * @param segNo zero-based segment number whose status offset is requested.
+   * @return absolute byte offset within the RAF where the segment status begins.
+   */
   public long getOffsetSegmentStatus(int segNo) {
     return offsetSegmentStatus[segNo];
   }
@@ -1837,8 +2268,17 @@ public class SplitFileInserterStorage {
     return raf;
   }
 
-  public void onResume(ClientContext context) throws ResumeFailedException {
-    if (crossSegments != null && status != Status.ENCODED_CROSS_SEGMENTS) {
+  /**
+   * Resumes encoding after a process restart or pause using the supplied context.
+   *
+   * <p>Cross-segment encoding is resumed first when required; otherwise, per-segment encoding is
+   * resumed directly.
+   *
+   * @param context active client context providing executors and services for resume.
+   */
+  public void onResume(ClientContext context) {
+    if (LOG.isDebugEnabled()) LOG.debug("onResume with context {}", context);
+    if (crossSegments.length != 0 && status != Status.ENCODED_CROSS_SEGMENTS) {
       this.startCrossSegmentEncode();
     } else {
       this.startSegmentEncode();
@@ -1846,11 +2286,11 @@ public class SplitFileInserterStorage {
   }
 
   /**
-   * Choose a block to insert. FIXME make SplitFileInserterSender per-segment, eliminate a lot of
-   * unnecessary complexity.
+   * Choose a block to insert. Make SplitFileInserterSender per-segment to eliminate unnecessary
+   * complexity.
    */
-  public BlockInsert chooseBlock() {
-    // FIXME this should probably use SimpleBlockChooser and hence use lowest-retry-count from
+  BlockInsert chooseBlock() {
+    // This should probably use SimpleBlockChooser and hence use lowest-retry-count from
     // each segment?
     // Less important for inserts than for requests though...
     synchronized (cooldownLock) {
@@ -1862,7 +2302,7 @@ public class SplitFileInserterStorage {
           return null;
         }
       }
-      // Generally segments are fairly well balanced, so we can usually pick a random segment
+      // Generally segments are fairly well-balanced, so we can usually pick a random segment
       // then a random key from it.
       randomSegmentIterator.reset(random);
       while (randomSegmentIterator.hasNext()) {
@@ -1879,28 +2319,54 @@ public class SplitFileInserterStorage {
     }
   }
 
+  /**
+   * Returns whether no blocks are currently available to send.
+   *
+   * @return {@code true} when a scheduling pass found no work; cleared by later progress events.
+   */
   public boolean noBlocksToSend() {
     synchronized (cooldownLock) {
       return noBlocksToSend;
     }
   }
 
+  /**
+   * Returns the total number of keys (data + check + cross-check) tracked by all segments.
+   *
+   * @return sum of {@code totalBlockCount} across all segments; may be large for multi-segment
+   *     inserts.
+   */
   public long countAllKeys() {
     long total = 0;
     for (SplitFileInserterSegmentStorage segment : segments) total += segment.totalBlockCount;
     return total;
   }
 
+  /**
+   * Returns the total number of keys that are ready to send across all segments.
+   *
+   * @return count of keys currently considered sendable by each segment's chooser.
+   */
   public long countSendableKeys() {
     long total = 0;
     for (SplitFileInserterSegmentStorage segment : segments) total += segment.countSendableKeys();
     return total;
   }
 
+  /**
+   * Returns the total number of blocks (data + check + cross-check) in the insert.
+   *
+   * @return combined block count across data, per-segment check blocks, and cross-check blocks.
+   */
   public int getTotalBlockCount() {
     return totalDataBlocks + totalCheckBlocks + crossCheckBlocks * segments.length;
   }
 
+  /**
+   * Clears the internal cooldown indicator and notifies the callback.
+   *
+   * <p>After clearing, the scheduler may attempt new work selection immediately.
+   */
   public void clearCooldown() {
     synchronized (cooldownLock) {
       noBlocksToSend = false;
@@ -1909,9 +2375,15 @@ public class SplitFileInserterStorage {
   }
 
   /**
-   * @return -1 if the insert has finished, 0 if has blocks to send, otherwise Long.MAX_VALUE.
+   * Computes the scheduler wake-up hint for the insert.
+   *
+   * @param context active client context; used for logging and may influence policy externally.
+   * @param now current wall-clock time in milliseconds since the epoch; used for tracing only.
+   * @return {@code -1} when finished; {@code 0} when work is available now; otherwise {@code
+   *     Long.MAX_VALUE} to indicate no immediate work.
    */
   public long getWakeupTime(ClientContext context, long now) {
+    if (LOG.isTraceEnabled()) LOG.trace("getWakeupTime(ctx={}, now={})", context, now);
     // LOCKING: hasFinished() uses (this), separate from cooldownLock.
     // It is safe to use both here (on the request selection thread), one after the other.
     if (hasFinished()) return -1;

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
@@ -1728,7 +1728,9 @@ public class SplitFileInserterStorage {
    *
    * @param fileOffset The position in the file (raf) of the first byte.
    * @param length The length, including checksum, of the data to be written.
-   * @return
+   * @return an OutputStream that computes and appends a checksum, verifies the total written length
+   *     equals {@code length}, and on close() writes the bytes to {@code raf} at {@code
+   *     fileOffset}.
    */
   OutputStream writeChecksummedTo(final long fileOffset, final int length) {
     final ByteArrayOutputStream baos = new ByteArrayOutputStream(length);
@@ -1769,9 +1771,9 @@ public class SplitFileInserterStorage {
   }
 
   /**
-   * Write a cross-check block to disk
+   * Write a cross-check block to disk.
    *
-   * @throws IOException
+   * @throws IOException if writing the block to the backing RAF fails.
    */
   void writeCheckBlock(int segNo, int checkBlockNo, byte[] buf) throws IOException {
     synchronized (this) {
@@ -1809,7 +1811,7 @@ public class SplitFileInserterStorage {
    * Lock the originalData RAF open to avoid the pooled fd being closed when we are doing a major
    * I/O operation involving many reads/writes.
    *
-   * @throws IOException
+   * @throws IOException if acquiring the lock on the underlying RAF fails.
    */
   RAFLock lockUnderlying() throws IOException {
     return originalData.lockOpen();

--- a/src/main/java/network/crypta/client/async/SplitFileInserterStorageCallback.java
+++ b/src/main/java/network/crypta/client/async/SplitFileInserterStorageCallback.java
@@ -4,46 +4,127 @@ import network.crypta.client.InsertException;
 import network.crypta.client.Metadata;
 
 /**
- * Callback interface for a SplitFileInserterStorage. Usually implemented by SplitFileInserter, but
- * can be used for unit tests etc too. Hence SplitFileInserter doesn't need to know much about the
- * rest of the client layer.
+ * Callback interface used by {@link SplitFileInserterStorage} to notify higher layers about
+ * progress and outcomes during a split-file insert.
+ *
+ * <p>This interface decouples storage/encoding concerns from orchestration and user-facing
+ * lifecycle management. Implementations are typically provided by {@link SplitFileInserter}, which
+ * coordinates block encoding, key discovery, and scheduling via {@link SplitFileInserterSender}.
+ * Tests or tools may implement this interface to simulate caller behavior or to observe encoding
+ * milestones without driving a full network insert.
+ *
+ * <p>Callbacks are issued as storage completes distinct phases: when encoding begins and finishes
+ * per segment, when all keys are known, as individual blocks are inserted, and when the overall
+ * insert either succeeds or fails. An implementation should be prepared to make scheduling
+ * decisions in response (for example, starting the next level once keys are available), to update
+ * UI/state, and to release resources on terminal outcomes. Unless stated otherwise by the caller,
+ * implementations are not required to be thread-safe; callbacks are invoked in the context of the
+ * storage/inserter job system.
+ *
+ * <ul>
+ *   <li>Progress: segment-level encode notifications enable incremental scheduling.
+ *   <li>Keys: {@link #onHasKeys()} fires once all block keys are available for selection.
+ *   <li>Success/failure: terminal outcomes include final {@link Metadata} on success or an {@link
+ *       network.crypta.client.InsertException} on failure.
+ * </ul>
  *
  * @author toad
+ * @see SplitFileInserter
+ * @see SplitFileInserterStorage
+ * @see SplitFileInserterSender
  */
 public interface SplitFileInserterStorageCallback {
 
-  /** All the segments (and possibly cross-segments) have been encoded. */
+  /**
+   * All segments (including any cross-segment redundancy) have finished encoding.
+   *
+   * <p>This indicates that the storage layer has produced all data and check blocks and persisted
+   * any required status so that a resume can safely continue from this point. Implementations may
+   * use this signal to adjust scheduling, throttle further CPU work, or prioritize network sends,
+   * since no additional encoding work remains. This callback does not imply that keys are already
+   * exposed to the caller; see {@link #onHasKeys()} for the point at which all block keys are
+   * available for higher-level decisions.
+   */
   void onFinishedEncode();
 
   /**
-   * Called after finishing encoding the check blocks and block keys for another segment. The
-   * callback might need to reschedule as there are more blocks available to insert. When this has
-   * been called once for each segment we will call onHasKeys().
+   * Called after completing encoding (data and check blocks) for a single segment.
+   *
+   * <p>Implementations can treat this as an incremental progress hook: additional blocks are now
+   * available to schedule for insertion, and callers may choose to rescan queues, update progress
+   * indicators, or opportunistically start the next level. After every segment has been reported at
+   * least once through this method, {@link #onHasKeys()} will be invoked to signal that the full
+   * set of block keys is known.
    */
   void encodingProgress();
 
   /**
-   * Called when all segments have been encoded. So we have all the check blocks and have a CHK for
-   * every block. The callback must decide whether to complete / start the next insert level, or
-   * whether to wait for all the blocks to insert.
+   * All segments have been encoded and every block now has an assigned CHK.
+   *
+   * <p>At this point, the implementation has the complete key set and can decide whether to
+   * finalize the current level, begin the next level (for multi-level metadata or manifests), or
+   * continue inserting the remaining blocks first. This is a pivotal scheduling decision: callers
+   * that wish to surface early metadata may choose to proceed immediately, while others may prefer
+   * to await a higher fraction of successful inserts to reduce perceived latency on subsequent
+   * fetches.
    */
   void onHasKeys();
 
-  /** Called when the whole insert has succeeded, i.e. when all blocks have been inserted. */
+  /**
+   * Called when the entire insert succeeds and all blocks have been accepted.
+   *
+   * <p>This is the terminal success signal for the split-file operation. At this point, the
+   * implementation can persist or present the final metadata, free buffers, and notify user code
+   * that the insert is durably complete. The argument is immutable from the callback’s perspective;
+   * callers should copy values as needed for long-term retention. Implementations should avoid
+   * throwing from this callback.
+   *
+   * @param metadata the resulting {@link Metadata} for the inserted content, including split-file
+   *     parameters and any top-level descriptor details; never {@code null} when invoked
+   */
   void onSucceeded(Metadata metadata);
 
-  /** Called if the insert fails. All encodes will have finished by the time this is called. */
+  /**
+   * Called when the insert fails for any reason after encoding has finished.
+   *
+   * <p>All segment encodes have completed by the time this method is invoked, so failures reflect
+   * network conditions, collisions, validation errors, or similar problems surfaced by the
+   * insertion pipeline. Implementations should record details, update UI/state, and perform
+   * cleanup. The error mode on the exception indicates whether retrying is useful.
+   *
+   * @param e the {@link InsertException} describing the failure mode and optional detail message;
+   *     never {@code null}; inspect {@link InsertException#getMode()} to determine retryability
+   */
   void onFailed(InsertException e);
 
-  /** Called when a block is inserted successfully */
+  /**
+   * Called when an individual block is inserted successfully.
+   *
+   * <p>This fine-grained signal enables progress tracking and backpressure tuning. Implementations
+   * might count successes to drive UI updates, unblock dependent work, or adapt retry strategies.
+   * Failures are surfaced via {@link #onFailed(InsertException)}; this callback is only for success
+   * of a single block and does not imply overall completion.
+   */
   void onInsertedBlock();
 
   /**
-   * Called when a block becomes fetchable (unless because of an encode, in which case we only call
-   * encodingProgress() )
+   * Called when a block becomes fetchable for peers due to network propagation or cache state.
+   *
+   * <p>Implementations can use this to clear any local cooldown or backoff associated with that
+   * block and to consider rescheduling dependent work. When the change originates from completing
+   * an encode, {@link #encodingProgress()} is preferred and this method is not invoked.
    */
   void clearCooldown();
 
-  /** Get request priority class for FEC jobs etc */
+  /**
+   * Returns the request priority class used for encoding/scheduling jobs within the inserter.
+   *
+   * <p>The value is typically provided by the client context and influences how jobs compete for
+   * resources inside the node (for example, real-time vs. background work queues). Implementations
+   * should return a stable value for the lifetime of a single insert.
+   *
+   * @return a small integral priority class understood by the client scheduler; higher classes may
+   *     be treated as more urgent, but the precise mapping is node-implementation specific
+   */
   short getPriorityClass();
 }

--- a/src/test/java/network/crypta/client/async/SplitFileInserterStorageTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileInserterStorageTest.java
@@ -1,1872 +1,412 @@
 package network.crypta.client.async;
 
-import static network.crypta.testsupport.TestRandomData.fillRandomAccessBuffer;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Random;
 import network.crypta.client.ClientMetadata;
-import network.crypta.client.FetchContext;
-import network.crypta.client.FetchException;
-import network.crypta.client.HighLevelSimpleClientImpl;
+import network.crypta.client.FECCodec;
 import network.crypta.client.InsertContext;
-import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.InsertException.InsertExceptionMode;
-import network.crypta.client.Metadata;
-import network.crypta.client.MetadataParseException;
-import network.crypta.client.async.SplitFileInserterSegmentStorage.BlockInsert;
-import network.crypta.client.async.SplitFileInserterStorage.Status;
-import network.crypta.client.events.SimpleEventProducer;
-import network.crypta.crypt.CRCChecksumChecker;
+import network.crypta.client.Metadata.SplitfileAlgorithm;
 import network.crypta.crypt.ChecksumChecker;
-import network.crypta.crypt.ChecksumFailedException;
-import network.crypta.crypt.DummyRandomSource;
-import network.crypta.crypt.HashResult;
-import network.crypta.crypt.HashType;
-import network.crypta.crypt.MultiHashInputStream;
-import network.crypta.crypt.RandomSource;
 import network.crypta.keys.CHKBlock;
-import network.crypta.keys.ClientCHKBlock;
-import network.crypta.keys.FreenetURI;
-import network.crypta.keys.Key;
-import network.crypta.node.BaseSendableGet;
 import network.crypta.node.KeysFetchingLocally;
-import network.crypta.node.SendableRequestItemKey;
-import network.crypta.support.CheatingTicker;
-import network.crypta.support.DummyJobRunner;
 import network.crypta.support.MemoryLimitedJobRunner;
-import network.crypta.support.PooledExecutor;
-import network.crypta.support.TestProperty;
+import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
-import network.crypta.support.WaitableExecutor;
-import network.crypta.support.api.Bucket;
-import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.LockableRandomAccessBufferFactory;
-import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
-import network.crypta.support.io.*;
+import network.crypta.support.io.ArrayBucketFactory;
+import network.crypta.support.io.BucketTools;
+import network.crypta.support.io.ByteArrayRandomAccessBuffer;
+import network.crypta.support.io.ByteArrayRandomAccessBufferFactory;
+import network.crypta.support.io.FileRandomAccessBuffer;
+import network.crypta.support.io.NullRandomAccessBuffer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class SplitFileInserterStorageTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SplitFileInserterStorageTest {
 
-  public SplitFileInserterStorageTest() throws IOException {
-    dir = new File("split-file-inserter-storage-test");
-    dir.mkdir();
-    executor = new WaitableExecutor(new PooledExecutor());
-    ticker = new CheatingTicker(executor);
-    RandomSource r = new DummyRandomSource(12345);
-    fg = new FilenameGenerator(r, true, dir, "freenet-test");
-    persistentFileTracker = new TrivialPersistentFileTracker(dir, fg);
-    bigRAFFactory = new PooledFileRandomAccessBufferFactory(fg);
-    smallBucketFactory = new ArrayBucketFactory();
-    bigBucketFactory = new TempBucketFactory(executor, fg, 0, 0, false, 0, null);
-    baseContext =
-        HighLevelSimpleClientImpl.makeDefaultInsertContext(
-            bigBucketFactory, new SimpleEventProducer());
-    cryptoKey = new byte[32];
-    r.nextBytes(cryptoKey);
-    checker = new CRCChecksumChecker();
-    memoryLimitedJobRunner =
-        new MemoryLimitedJobRunner(
-            9 * 1024 * 1024L, 20, executor, NativeThread.JAVA_PRIORITY_RANGE);
-    jobRunner = new DummyJobRunner(executor, null);
-    URI = FreenetURI.generateRandomCHK(r);
-    random = new Random(12121);
-    size = 65536; // Exact multiple, so no last block
-    cb = new MyCallback();
-    data = generateData(random, size);
-    hashes = getHashes(data);
-    keys = new MyKeysFetchingLocally();
-    context = baseContext.clone();
+  @Mock private SplitFileInserterStorageCallback callback;
+  @Mock private KeysFetchingLocally keysFetching;
+
+  private PriorityAwareExecutor executor;
+  private MemoryLimitedJobRunner mlRunner;
+  private SplitFileInserterStorageTest.ImmediateTicker ticker;
+  private LockableRandomAccessBufferFactory rafFactory;
+  private ArrayBucketFactory bucketFactory;
+  private ChecksumChecker checker;
+  private Random random;
+
+  @BeforeEach
+  void setUp() {
+    // Immediate inline executor to make async code deterministic in tests
+    executor = new ImmediateExecutor();
+    // Generous capacity and two worker "threads" (inline) with a few priority buckets (0..3)
+    mlRunner = new MemoryLimitedJobRunner(64L * 1024 * 1024, 2, executor, 4);
+    ticker = new ImmediateTicker(executor);
+    rafFactory = new ByteArrayRandomAccessBufferFactory();
+    bucketFactory = new ArrayBucketFactory();
+    checker = ChecksumChecker.create(ChecksumChecker.CHECKSUM_CRC);
+    random = new Random(1234);
+    // No stubbing needed on keysFetching; default boolean return is fine for tests
   }
 
-  @Test
-  public void testSmallSplitfileNoLastBlock() throws Exception {
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            baseContext.clone(),
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    assertProperSegmentStateAndGet(storage);
+  private static InsertContext newInsertContext(InsertContext.CompatibilityMode cmode) {
+    // Keep values small and deterministic. Blocks per segment defaults are in
+    // HighLevelSimpleClientImpl.
+    return new InsertContext(
+        /* maxRetries= */ 3,
+        /* rnfsToSuccess= */ 0,
+        /* splitfileSegmentDataBlocks= */ FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT,
+        /* splitfileSegmentCheckBlocks= */ FECCodec.MAX_TOTAL_BLOCKS_PER_SEGMENT,
+        /* eventProducer= */ new network.crypta.client.events.SimpleEventProducer(),
+        /* canWriteClientCache= */ false,
+        /* forkOnCacheable= */ false,
+        /* localRequestOnly= */ false,
+        /* compressorDescriptor= */ null,
+        /* extraInsertsSingleBlock= */ 0,
+        /* extraInsertsSplitfileHeaderBlock= */ 0,
+        cmode);
   }
 
-  @Test
-  public void testSmallSplitfileWithLastBlock() throws Exception {
-    byte[] originalData = new byte[(int) size];
-    random.nextBytes(originalData);
-    data = smallRAFFactory.makeRAF(originalData, 0, originalData.length, true);
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            baseContext.clone(),
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    // Now check the data blocks...
-    assertProperSegmentStateAndGet(storage);
-    assertArrayEquals(
-        storage.readSegmentDataBlock(0, 0),
-        Arrays.copyOfRange(originalData, 0, CHKBlock.DATA_LENGTH));
-    int truncateLength = (int) (size % CHKBlock.DATA_LENGTH);
-    long offsetLastBlock = size - truncateLength;
-    byte[] buf = storage.readSegmentDataBlock(0, 1);
-    assertEquals(CHKBlock.DATA_LENGTH, buf.length);
-    byte[] truncated = Arrays.copyOfRange(buf, 0, truncateLength);
-    byte[] originalLastBlock =
-        Arrays.copyOfRange(originalData, (int) offsetLastBlock, originalData.length);
-    assertEquals(originalLastBlock.length, truncated.length);
-    assertArrayEquals(originalLastBlock, truncated);
-    assertEquals(Status.ENCODED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileHasKeys() throws Exception {
-    context.earlyEncode = true;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    assertProperSegmentStateAndGet(storage);
-    cb.waitForHasKeys();
-    for (int i = 0;
-        i
-            < storage.segments[0].dataBlockCount
-                + storage.segments[0].checkBlockCount
-                + storage.segments[0].crossCheckBlockCount;
-        i++) {
-      storage.segments[0].readKey(i);
-    }
-    storage.encodeMetadata();
-    assertEquals(Status.ENCODED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileCompletion() throws Exception {
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(storage);
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      segment.onInsertedBlock(i, segment.encodeBlock(i).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertEquals(Status.SUCCEEDED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileChooseCompletion() throws Exception {
-    context.maxInsertRetries = 2;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(storage);
-    boolean[] chosenBlocks = new boolean[segment.totalBlockCount];
-    // Choose and fail all blocks.
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      BlockInsert chosen = segment.chooseBlock();
-      assertNotNull(chosen);
-      keys.addInsert(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-      segment.onFailure(
-          chosen.blockNumber, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-    }
-    keys.clear();
-    // Choose and succeed all blocks.
-    chosenBlocks = new boolean[segment.totalBlockCount];
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      BlockInsert chosen = segment.chooseBlock();
-      assertNotNull(chosen);
-      keys.addInsert(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-      segment.onInsertedBlock(
-          chosen.blockNumber, segment.encodeBlock(chosen.blockNumber).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertEquals(Status.SUCCEEDED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileChooseCooldown() throws Exception {
-    context.maxInsertRetries = 2;
-    context.consecutiveRNFsCountAsSuccess = 2;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(storage);
-    boolean[] chosenBlocks = new boolean[segment.totalBlockCount];
-    assertFalse(storage.noBlocksToSend());
-    // Choose and fail all blocks.
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      BlockInsert chosen = segment.chooseBlock();
-      assertNotNull(chosen);
-      keys.addInsert(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-    }
-    assertNull(storage.chooseBlock());
-    assertTrue(storage.noBlocksToSend());
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      segment.onFailure(i, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-      assertFalse(storage.noBlocksToSend());
-    }
-    keys.clear();
-    // Choose and succeed all blocks.
-    chosenBlocks = new boolean[segment.totalBlockCount];
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      BlockInsert chosen = segment.chooseBlock();
-      keys.addInsert(chosen);
-      assertNotNull(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-      segment.onInsertedBlock(
-          chosen.blockNumber, segment.encodeBlock(chosen.blockNumber).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertEquals(Status.SUCCEEDED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileChooseCooldownNotRNF() throws Exception {
-    context.maxInsertRetries = 2;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(storage);
-    boolean[] chosenBlocks = new boolean[segment.totalBlockCount];
-    assertFalse(storage.noBlocksToSend());
-    // Choose and fail all blocks.
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      BlockInsert chosen = segment.chooseBlock();
-      assertNotNull(chosen);
-      keys.addInsert(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-    }
-    assertNull(storage.chooseBlock());
-    assertTrue(storage.noBlocksToSend());
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      // We need to test this path too.
-      segment.onFailure(i, new InsertException(InsertExceptionMode.REJECTED_OVERLOAD));
-      assertFalse(storage.noBlocksToSend());
-    }
-    keys.clear();
-    // Choose and succeed all blocks.
-    chosenBlocks = new boolean[segment.totalBlockCount];
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      BlockInsert chosen = segment.chooseBlock();
-      keys.addInsert(chosen);
-      assertNotNull(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-      segment.onInsertedBlock(
-          chosen.blockNumber, segment.encodeBlock(chosen.blockNumber).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertEquals(Status.SUCCEEDED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileConsecutiveRNFsHack() throws Exception {
-    context.maxInsertRetries = 0;
-    context.consecutiveRNFsCountAsSuccess = 2;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(storage);
-    boolean[] chosenBlocks = new boolean[segment.totalBlockCount];
-    // First RNF.
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      BlockInsert chosen = segment.chooseBlock();
-      assertNotNull(chosen);
-      keys.addInsert(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-      segment.setKey(chosen.blockNumber, segment.encodeBlock(chosen.blockNumber).getClientKey());
-      segment.onFailure(
-          chosen.blockNumber, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-    }
-    chosenBlocks = new boolean[segment.totalBlockCount];
-    // Second RNF.
-    keys.clear();
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      BlockInsert chosen = segment.chooseBlock();
-      assertNotNull(chosen);
-      keys.addInsert(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-      segment.onFailure(
-          chosen.blockNumber, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-    }
-    // Should count as success at this point.
-    cb.waitForSucceededInsert();
-    assertEquals(Status.SUCCEEDED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileConsecutiveRNFsHackFailure() throws Exception {
-    // Do 2 RNFs and then a RejectedOverload. Should fail at that point.
-    context.maxInsertRetries = 2;
-    context.consecutiveRNFsCountAsSuccess = 3;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(storage);
-    segment.setKey(0, segment.encodeBlock(0).getClientKey());
-    segment.onFailure(0, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-    assertEquals(Status.ENCODED, storage.getStatus());
-    segment.onFailure(0, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-    assertEquals(Status.ENCODED, storage.getStatus());
-    segment.onFailure(0, new InsertException(InsertExceptionMode.REJECTED_OVERLOAD));
-    // Should count as success at this point.
-    InsertException e = assertThrows(InsertException.class, cb::waitForSucceededInsert);
-    assertEquals(InsertExceptionMode.TOO_MANY_RETRIES_IN_BLOCKS, e.mode);
-    assertNotNull(e.errorCodes);
-    assertEquals(2, e.errorCodes.getErrorCount(InsertExceptionMode.ROUTE_NOT_FOUND));
-    assertEquals(1, e.errorCodes.getErrorCount(InsertExceptionMode.REJECTED_OVERLOAD));
-    assertEquals(3, e.errorCodes.totalCount());
-    assertEquals(Status.FAILED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileFailureMaxRetries() throws Exception {
-    context.consecutiveRNFsCountAsSuccess = 0;
-    context.maxInsertRetries = 2;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(storage);
-    for (int i = 0; i < 3; i++) {
-      segment.onFailure(0, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-    }
-
-    InsertException e = assertThrows(InsertException.class, () -> cb.waitForSucceededInsert());
-
-    assertEquals(InsertExceptionMode.TOO_MANY_RETRIES_IN_BLOCKS, e.mode);
-    assertNotNull(e.errorCodes);
-    assertEquals(3, e.errorCodes.getErrorCount(InsertExceptionMode.ROUTE_NOT_FOUND));
-    assertEquals(3, e.errorCodes.totalCount());
-    assertEquals(Status.FAILED, storage.getStatus());
-  }
-
-  @Test
-  public void testSmallSplitfileFailureFatalError() throws Exception {
-    context.maxInsertRetries = 2;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(storage);
-    assertTrue(InsertException.isFatal(InsertExceptionMode.INTERNAL_ERROR));
-    segment.onFailure(0, new InsertException(InsertExceptionMode.INTERNAL_ERROR));
-
-    InsertException e = assertThrows(InsertException.class, () -> cb.waitForSucceededInsert());
-    assertEquals(InsertExceptionMode.FATAL_ERRORS_IN_BLOCKS, e.mode);
-    assertNotNull(e.errorCodes);
-    assertEquals(1, e.errorCodes.getErrorCount(InsertExceptionMode.INTERNAL_ERROR));
-    assertEquals(1, e.errorCodes.totalCount());
-    assertEquals(Status.FAILED, storage.getStatus());
-  }
-
-  @Test
-  public void testRoundTripSimple() throws Exception {
-    testRoundTripSimpleRandom(CHKBlock.DATA_LENGTH * 2, CompatibilityMode.COMPAT_CURRENT);
-    testRoundTripSimpleRandom(CHKBlock.DATA_LENGTH * 2 - 1, CompatibilityMode.COMPAT_CURRENT);
-    testRoundTripSimpleRandom(CHKBlock.DATA_LENGTH * 128, CompatibilityMode.COMPAT_CURRENT);
-    testRoundTripSimpleRandom(CHKBlock.DATA_LENGTH * 128 + 1, CompatibilityMode.COMPAT_CURRENT);
-    testRoundTripSimpleRandom(CHKBlock.DATA_LENGTH * 192, CompatibilityMode.COMPAT_CURRENT);
-    testRoundTripSimpleRandom(CHKBlock.DATA_LENGTH * 192 + 1, CompatibilityMode.COMPAT_CURRENT);
-  }
-
-  @Test
-  public void testRoundTripOneBlockSegment() throws Exception {
-    testRoundTripSimpleRandom(
-        CHKBlock.DATA_LENGTH * (128 + 1) - 1, CompatibilityMode.COMPAT_1250_EXACT);
-  }
-
-  @Test
-  public void testRoundTripCrossSegment() throws Exception {
-    if (!TestProperty.EXTENSIVE) {
-      return;
-    }
-    // Test cross-segment:
-    testRoundTripCrossSegmentRandom(CHKBlock.DATA_LENGTH * 128 * 21);
-  }
-
-  @Test
-  public void testRoundTripDataBlocksOnly() throws Exception {
-    testRoundTripCrossSegmentDataBlocks(CHKBlock.DATA_LENGTH * 128 * 5);
-    if (!TestProperty.EXTENSIVE) {
-      return;
-    }
-    // Test cross-segment:
-    testRoundTripCrossSegmentDataBlocks(CHKBlock.DATA_LENGTH * 128 * 21);
-  }
-
-  @Test
-  public void testResumeCrossSegment() throws Exception {
-    if (!TestProperty.EXTENSIVE) {
-      return;
-    }
-    testResumeCrossSegment(CHKBlock.DATA_LENGTH * 128 * 21);
-  }
-
-  @Test
-  public void testEncodeAfterShutdownCrossSegment() throws Exception {
-    if (!TestProperty.EXTENSIVE) {
-      return;
-    }
-    testEncodeAfterShutdownCrossSegment(CHKBlock.DATA_LENGTH * 128 * 21);
-  }
-
-  @Test
-  public void testRepeatedEncodeAfterShutdown() throws Exception {
-    testRepeatedEncodeAfterShutdownCrossSegment(
-        CHKBlock.DATA_LENGTH * 128 * 5); // Not cross-segment.
-    if (!TestProperty.EXTENSIVE) {
-      return;
-    }
-    testRepeatedEncodeAfterShutdownCrossSegment(CHKBlock.DATA_LENGTH * 128 * 21); // Cross-segment.
-  }
-
-  @Test
-  public void testCancel() throws Exception {
-    this.size = 32768 * 6;
-    BarrierRandomAccessBuffer data = new BarrierRandomAccessBuffer(generateData(random, size));
-    HashResult[] hashes = getHashes(data);
-    data.pause();
-    context.earlyEncode = true;
-    SplitFileInserterStorage storage =
-        new SplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            null,
-            new ClientMetadata(),
-            false,
-            null,
-            smallRAFFactory,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            null,
-            hashes,
-            smallBucketFactory,
-            checker,
-            random,
-            memoryLimitedJobRunner,
-            jobRunner,
-            ticker,
-            keys,
-            false,
-            0,
-            0,
-            0,
-            0);
-    storage.start();
-    assertEquals(Status.STARTED, storage.getStatus());
-    assertEquals(1, storage.segments.length);
-    SplitFileInserterSegmentStorage segment = storage.segments[0];
-    segment.onFailure(0, new InsertException(InsertExceptionMode.INTERNAL_ERROR));
-    data.proceed(); // Now it will complete encoding, and then report in, and then fail.
-
-    assertThrows(InsertException.class, () -> cb.waitForFinishedEncode());
-    assertFalse(segment.isEncoding());
-    assertEquals(Status.FAILED, storage.getStatus());
-  }
-
-  @Test
-  public void testCancelAlt() throws Exception {
-    // We need to check that onFailed() isn't called until after all the cross segment encode
-    // threads have finished.
-    testCancelAlt(random, 32768 * 6);
-  }
-
-  @Test
-  public void testCancelAltCrossSegment() throws Exception {
-    // We need to check that onFailed() isn't called until after all the cross segment encode
-    // threads have finished.
-    testCancelAlt(random, CHKBlock.DATA_LENGTH * 128 * 21);
-  }
-
-  @Test
-  public void testPersistentSmallSplitfileNoLastBlockCompletion() throws Exception {
-    LockableRandomAccessBuffer data = generateData(random, size, bigRAFFactory);
-    HashResult[] hashes = getHashes(data);
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            true,
-            baseContext.clone(),
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    assertProperSegmentStateAndGet(storage);
-    executor.waitForIdle();
-    SplitFileInserterStorage resumed =
-        createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-    SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(resumed);
-    for (int i = 0; i < segment.totalBlockCount; i++) {
-      segment.onInsertedBlock(i, segment.encodeBlock(i).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertEquals(Status.SUCCEEDED, resumed.getStatus());
-  }
-
-  @Test
-  public void testPersistentSmallSplitfileNoLastBlockCompletionAfterResume() throws Exception {
-    data = generateData(random, size, bigRAFFactory);
-    HashResult[] hashes = getHashes(data);
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            true,
-            baseContext.clone(),
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    assertProperSegmentStateAndGet(storage);
-    SplitFileInserterStorage resumed = null;
-    for (int i = 0; i < storage.segments[0].totalBlockCount; i++) {
-      executor.waitForIdle();
-      resumed = createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-      SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(resumed);
-      segment.onInsertedBlock(i, segment.encodeBlock(i).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertNotNull(resumed);
-    assertEquals(Status.SUCCEEDED, resumed.getStatus());
-  }
-
-  @Test
-  public void testPersistentSmallSplitfileWithLastBlockCompletionAfterResume() throws Exception {
-    data = generateData(random, size, bigRAFFactory);
-    hashes = getHashes(data);
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            true,
-            baseContext.clone(),
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    assertProperSegmentStateAndGet(storage);
-    SplitFileInserterStorage resumed = null;
-    for (int i = 0; i < storage.segments[0].totalBlockCount; i++) {
-      executor.waitForIdle();
-      resumed = createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-      SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(resumed);
-      segment.onInsertedBlock(i, segment.encodeBlock(i).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertNotNull(resumed);
-    assertEquals(Status.SUCCEEDED, resumed.getStatus());
-  }
-
-  @Test
-  public void testPersistentSmallSplitfileNoLastBlockFailAfterResume() throws Exception {
-    data = generateData(random, size, bigRAFFactory);
-    hashes = getHashes(data);
-    context.consecutiveRNFsCountAsSuccess = 0;
-    context.maxInsertRetries = 2;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            true,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    assertProperSegmentStateAndGet(storage);
-    SplitFileInserterStorage resumed = null;
-
-    for (int i = 0; i < 3; i++) {
-      executor.waitForIdle();
-      resumed = createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-      SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(resumed);
-      segment.onFailure(0, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-    }
-
-    InsertException e = assertThrows(InsertException.class, () -> cb.waitForSucceededInsert());
-    assertEquals(InsertExceptionMode.TOO_MANY_RETRIES_IN_BLOCKS, e.mode);
-    assertNotNull(e.errorCodes);
-    assertEquals(3, e.errorCodes.getErrorCount(InsertExceptionMode.ROUTE_NOT_FOUND));
-    assertEquals(3, e.errorCodes.totalCount());
-    assertEquals(Status.FAILED, resumed.getStatus());
-  }
-
-  @Test
-  public void testPersistentSmallSplitfileNoLastBlockChooseAfterResume() throws Exception {
-    LockableRandomAccessBuffer data = generateData(random, size, bigRAFFactory);
-    HashResult[] hashes = getHashes(data);
-    context.consecutiveRNFsCountAsSuccess = 0;
-    context.maxInsertRetries = 1;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            true,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    assertProperSegmentStateAndGet(storage);
-    SplitFileInserterStorage resumed = null;
-    int totalBlockCount = storage.segments[0].totalBlockCount;
-
-    boolean[] chosenBlocks = new boolean[totalBlockCount];
-    // Choose and fail all blocks.
-    for (int i = 0; i < totalBlockCount; i++) {
-      executor.waitForIdle();
-      resumed = createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-      SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(resumed);
-
-      BlockInsert chosen = segment.chooseBlock();
-      assertNotNull(chosen);
-      keys.addInsert(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-      segment.onFailure(
-          chosen.blockNumber, new InsertException(InsertExceptionMode.ROUTE_NOT_FOUND));
-    }
-    keys.clear();
-    // Choose and succeed all blocks.
-    chosenBlocks = new boolean[totalBlockCount];
-    for (int i = 0; i < totalBlockCount; i++) {
-      executor.waitForIdle();
-      resumed = createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-      SplitFileInserterSegmentStorage segment = assertProperSegmentStateAndGet(resumed);
-
-      BlockInsert chosen = segment.chooseBlock();
-      keys.addInsert(chosen);
-      assertNotNull(chosen);
-      assertFalse(chosenBlocks[chosen.blockNumber]);
-      chosenBlocks[chosen.blockNumber] = true;
-      segment.onInsertedBlock(
-          chosen.blockNumber, segment.encodeBlock(chosen.blockNumber).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertNotNull(resumed);
-    assertEquals(Status.SUCCEEDED, resumed.getStatus());
-  }
-
-  private HashResult[] getHashes(LockableRandomAccessBuffer data) throws IOException {
-    try (InputStream is = new RAFInputStream(data, 0, data.size());
-        MultiHashInputStream hashStream = new MultiHashInputStream(is, HashType.SHA256.bitmask)) {
-      FileUtil.copy(is, new NullOutputStream(), data.size());
-      return hashStream.getResults();
-    }
-  }
-
-  private LockableRandomAccessBuffer generateData(Random random, long size) throws IOException {
-    // Use small factory for anything <= 256KiB
-    LockableRandomAccessBufferFactory f = size > 262144 ? bigRAFFactory : smallRAFFactory;
-    return generateData(random, size, f);
-  }
-
-  private LockableRandomAccessBuffer generateData(
-      Random random, long size, LockableRandomAccessBufferFactory factory) throws IOException {
-    LockableRandomAccessBuffer thing = factory.makeRAF(size);
-    fillRandomAccessBuffer(thing, random, 0, size);
-    return new ReadOnlyRandomAccessBuffer(thing);
-  }
-
-  private void testRoundTripSimpleRandom(long size, CompatibilityMode cmode) throws Exception {
-    RandomSource r = new DummyRandomSource(12123);
-    LockableRandomAccessBuffer data = generateData(r, size);
-    Bucket dataBucket = new RAFBucket(data);
-    HashResult[] hashes = getHashes(data);
-    MyCallback cb = new MyCallback();
-    InsertContext context = baseContext.clone();
-    context.earlyEncode = true;
-    context.setCompatibilityMode(cmode);
-    cmode = context.getCompatibilityMode();
-    KeysFetchingLocally keys = new MyKeysFetchingLocally();
-    boolean old = cmode.code < CompatibilityMode.COMPAT_1255.code;
-    byte cryptoAlgorithm;
-    if (!(cmode == CompatibilityMode.COMPAT_CURRENT
-        || cmode.ordinal() >= CompatibilityMode.COMPAT_1416.ordinal())) {
-      cryptoAlgorithm = Key.ALGO_AES_PCFB_256_SHA256;
-    } else {
-      cryptoAlgorithm = Key.ALGO_AES_CTR_256_SHA256;
-    }
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            old ? null : cryptoKey,
-            hashes,
-            r,
-            memoryLimitedJobRunner,
-            keys);
-    assertEquals(Status.ENCODED, storage.getStatus());
-    // Encoded. Now try to decode it ...
-    cb.waitForHasKeys();
-    Metadata metadata = storage.encodeMetadata();
-
-    // Ugly hack because Metadata behaves oddly.
-    // FIXME make Metadata behave consistently and get rid.
-    Bucket metaBucket = metadata.toBucket(smallBucketFactory);
-    Metadata m1 = Metadata.construct(metaBucket);
-    Bucket copyBucket = m1.toBucket(smallBucketFactory);
-    assertTrue(BucketTools.equalBuckets(metaBucket, copyBucket));
-
-    FetchCallbackForTestingSplitFileInserter fcb = new FetchCallbackForTestingSplitFileInserter();
-
-    FetchContext fctx =
-        HighLevelSimpleClientImpl.makeDefaultFetchContext(
-            size * 2, size * 2, smallBucketFactory, new SimpleEventProducer());
-
-    SplitFileFetcherStorage fetcherStorage =
-        createFetcherStorage(m1, fcb, new ArrayList<>(), cmode.code, fctx, r);
-
-    fetcherStorage.start(false);
-
-    // Fully decode one segment at a time, ignore cross-segment.
-
-    for (int i = 0; i < storage.segments.length; i++) {
-      SplitFileFetcherSegmentStorage fetcherSegment = fetcherStorage.segments[i];
-      SplitFileInserterSegmentStorage inserterSegment = storage.segments[i];
-      int minBlocks = inserterSegment.dataBlockCount + inserterSegment.crossCheckBlockCount;
-      int totalBlocks = inserterSegment.totalBlockCount;
-      boolean[] fetched = new boolean[totalBlocks];
-      if (i == storage.segments.length - 1
-          && cmode.ordinal() < CompatibilityMode.COMPAT_1255.ordinal()) {
-        fetched[inserterSegment.dataBlockCount - 1] =
-            true; // We don't use the last block of the last segment for old splitfiles
-      }
-      for (int j = 0; j < minBlocks; j++) {
-        int blockNo;
-        do {
-          blockNo = r.nextInt(totalBlocks);
-        } while (fetched[blockNo]);
-        fetched[blockNo] = true;
-        ClientCHKBlock block = inserterSegment.encodeBlock(blockNo);
-        assertFalse(fetcherSegment.hasStartedDecode());
-        boolean success =
-            fetcherSegment.onGotKey(block.getClientKey().getNodeCHK(), block.getBlock());
-        assertTrue(success);
-        fcb.checkFailed();
-      }
-      assertTrue(fetcherSegment.hasStartedDecode());
-      fcb.checkFailed();
-      waitForDecode(fetcherSegment);
-    }
-    fcb.waitForFinished();
-    verifyOutput(fetcherStorage, dataBucket);
-    fetcherStorage.finishedFetcher();
-    fcb.waitForFree();
-  }
-
-  private void testResumeCrossSegment(long size) throws Exception {
-    LockableRandomAccessBuffer data = generateData(random, size);
-    hashes = getHashes(data);
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            true,
-            baseContext.clone(),
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    cb.waitForHasKeys();
-    executor.waitForIdle();
-    Metadata metadata = storage.encodeMetadata();
-    assertEquals(Status.ENCODED, storage.getStatus());
-    Bucket mBucket1 = bigBucketFactory.makeBucket(-1);
-    try (DataOutputStream os = new DataOutputStream(mBucket1.getOutputStream())) {
-      metadata.writeTo(os);
-    }
-    SplitFileInserterStorage resumed =
-        createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-    // Doesn't need to start since already encoded.
-    Metadata metadata2 = storage.encodeMetadata();
-    Bucket mBucket2 = bigBucketFactory.makeBucket(-1);
-    try (DataOutputStream os = new DataOutputStream(mBucket2.getOutputStream())) {
-      metadata2.writeTo(os);
-    }
-    assertTrue(BucketTools.equalBuckets(mBucket1, mBucket2));
-    // Choose and succeed all blocks.
-    boolean[][] chosenBlocks = new boolean[storage.segments.length][];
-    for (int i = 0; i < storage.segments.length; i++) {
-      int blocks = storage.segments[i].totalBlockCount;
-      chosenBlocks[i] = new boolean[blocks];
-      assertEquals(storage.segments[i].totalBlockCount, resumed.segments[i].totalBlockCount);
-    }
-    int totalBlocks = storage.getTotalBlockCount();
-    assertEquals(totalBlocks, resumed.getTotalBlockCount());
-    for (int i = 0; i < totalBlocks; i++) {
-      BlockInsert chosen = resumed.chooseBlock();
-      if (chosen == null) {
-        fail();
-      } else {
-        keys.addInsert(chosen);
-      }
-      assertNotNull(chosen);
-      assertFalse(chosenBlocks[chosen.segment.segNo][chosen.blockNumber]);
-      chosenBlocks[chosen.segment.segNo][chosen.blockNumber] = true;
-      chosen.segment.onInsertedBlock(
-          chosen.blockNumber, chosen.segment.encodeBlock(chosen.blockNumber).getClientKey());
-    }
-    cb.waitForSucceededInsert();
-    assertEquals(Status.SUCCEEDED, resumed.getStatus());
-  }
-
-  private void testEncodeAfterShutdownCrossSegment(long size) throws Exception {
-    data = generateData(random, size);
-    hashes = getHashes(data);
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            true,
-            baseContext.clone(),
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            random,
-            memoryLimitedJobRunner,
-            keys);
-    executor.waitForIdle();
-    // Has not encoded anything.
-    for (SplitFileInserterSegmentStorage segment : storage.segments) {
-      assertFalse(segment.isFinishedEncoding());
-    }
-    SplitFileInserterStorage resumed =
-        createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-    resumed.start();
-    cb.waitForFinishedEncode();
-    cb.waitForHasKeys();
-    executor.waitForIdle();
-    resumed.encodeMetadata();
-    assertEquals(Status.ENCODED, resumed.getStatus());
-    resumed.originalData.free();
-    resumed.getRAF().free();
-  }
-
-  private void testRepeatedEncodeAfterShutdownCrossSegment(long size) throws Exception {
-    data = generateData(random, size);
-    hashes = getHashes(data);
-    // Only enough for one segment at a time.
-    MemoryLimitedJobRunner memoryLimitedJobRunner =
-        new MemoryLimitedJobRunner(9 * 1024 * 1024L, 1, executor, NativeThread.JAVA_PRIORITY_RANGE);
-    SplitFileInserterStorage storage =
-        new SplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            null,
-            new ClientMetadata(),
-            false,
-            null,
-            smallRAFFactory,
-            true,
-            baseContext.clone(),
-            cryptoAlgorithm,
-            cryptoKey,
-            null,
-            hashes,
-            smallBucketFactory,
-            checker,
-            random,
-            memoryLimitedJobRunner,
-            jobRunner,
-            ticker,
-            keys,
-            false,
-            0,
-            0,
-            0,
-            0);
-    executor.waitForIdle();
-    // Has not encoded anything.
-    for (SplitFileInserterSegmentStorage segment : storage.segments) {
-      assertFalse(segment.isFinishedEncoding());
-    }
-    SplitFileInserterStorage resumed = null;
-    if (storage.crossSegments != null) {
-      for (int i = 0; i < storage.crossSegments.length; i++) {
-        memoryLimitedJobRunner =
-            new MemoryLimitedJobRunner(
-                9 * 1024 * 1024L, 1, executor, NativeThread.JAVA_PRIORITY_RANGE);
-        resumed = createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-        assertEquals(i, countEncodedCrossSegments(resumed));
-        resumed.start();
-        // The memoryLimitedJobRunner will only encode one segment at a time.
-        // Wait for it to encode one segment.
-        memoryLimitedJobRunner.shutdown();
-        memoryLimitedJobRunner.waitForShutdown();
-        executor.waitForIdle();
-        assertEquals(i + 1, countEncodedCrossSegments(resumed));
-      }
-    }
-
-    for (int i = 0; i < storage.segments.length; i++) {
-      memoryLimitedJobRunner =
-          new MemoryLimitedJobRunner(
-              9 * 1024 * 1024L, 1, executor, NativeThread.JAVA_PRIORITY_RANGE);
-      resumed = createSplitFileInserterStorage(storage, data, cb, memoryLimitedJobRunner, keys);
-      assertEquals(i, countEncodedSegments(resumed));
-      if (storage.crossSegments != null) {
-        assertEquals(resumed.crossSegments.length, countEncodedCrossSegments(resumed));
-        assertEquals(Status.ENCODED_CROSS_SEGMENTS, resumed.getStatus());
-      }
-      resumed.start();
-      // The memoryLimitedJobRunner will only encode one segment at a time.
-      // Wait for it to encode one segment.
-      memoryLimitedJobRunner.shutdown();
-      memoryLimitedJobRunner.waitForShutdown();
-      executor.waitForIdle();
-      assertEquals(i + 1, countEncodedSegments(resumed));
-    }
-
-    cb.waitForFinishedEncode();
-    cb.waitForHasKeys();
-    executor.waitForIdle();
-    assertNotNull(resumed);
-    resumed.encodeMetadata();
-    assertEquals(Status.ENCODED, resumed.getStatus());
-    resumed.originalData.free();
-    resumed.getRAF().free();
-  }
-
-  private int countEncodedSegments(SplitFileInserterStorage storage) {
-    int total = 0;
-    for (SplitFileInserterSegmentStorage segment : storage.segments) {
-      if (segment.isFinishedEncoding()) {
-        total++;
-      }
-    }
-    return total;
-  }
-
-  private int countEncodedCrossSegments(SplitFileInserterStorage storage) {
-    int total = 0;
-    for (SplitFileInserterCrossSegmentStorage segment : storage.crossSegments) {
-      if (segment.isFinishedEncoding()) {
-        total++;
-      }
-    }
-    return total;
-  }
-
-  private void testRoundTripCrossSegmentRandom(long size) throws Exception {
-    RandomSource r = new DummyRandomSource(12123);
-    data = generateData(r, size);
-    Bucket dataBucket = new RAFBucket(data);
-    hashes = getHashes(data);
-    context.earlyEncode = true;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            r,
-            memoryLimitedJobRunner,
-            keys);
-    // Encoded. Now try to decode it ...
-    cb.waitForHasKeys();
-    Metadata metadata = storage.encodeMetadata();
-    assertEquals(Status.ENCODED, storage.getStatus());
-
-    // Ugly hack because Metadata behaves oddly.
-    // FIXME make Metadata behave consistently and get rid.
-    Bucket metaBucket = metadata.toBucket(smallBucketFactory);
-    Metadata m1 = Metadata.construct(metaBucket);
-    Bucket copyBucket = m1.toBucket(smallBucketFactory);
-    assertTrue(BucketTools.equalBuckets(metaBucket, copyBucket));
-
-    FetchCallbackForTestingSplitFileInserter fcb = new FetchCallbackForTestingSplitFileInserter();
-
-    FetchContext fctx =
-        HighLevelSimpleClientImpl.makeDefaultFetchContext(
-            size * 2, size * 2, smallBucketFactory, new SimpleEventProducer());
-
-    short cmode = (short) context.getCompatibilityMode().ordinal();
-
-    SplitFileFetcherStorage fetcherStorage =
-        createFetcherStorage(m1, fcb, new ArrayList<>(), cmode, fctx, r);
-
-    fetcherStorage.start(false);
-
-    int segments = storage.segments.length;
-    for (int i = 0; i < segments; i++) {
-      assertEquals(
-          storage.crossSegments[i].dataBlockCount, fetcherStorage.crossSegments[i].dataBlockCount);
-      assertArrayEquals(
-          storage.crossSegments[i].getSegmentNumbers(),
-          fetcherStorage.crossSegments[i].getSegmentNumbers());
-      assertArrayEquals(
-          storage.crossSegments[i].getBlockNumbers(),
-          fetcherStorage.crossSegments[i].getBlockNumbers());
-    }
-
-    // Cross-segment decode.
-    // We want to ensure it completes in exactly the number of blocks expected, but we need to
-    // ensure at each step that the block hasn't already been decoded.
-
-    int requiredBlocks = fcb.getRequiredBlocks();
-
-    int dataBlocks = (int) ((size + CHKBlock.DATA_LENGTH - 1) / CHKBlock.DATA_LENGTH);
-
-    int expectedBlocks = dataBlocks;
-    if (storage.crossSegments != null) {
-      expectedBlocks += storage.segments.length * 3;
-    }
-
-    assertEquals(expectedBlocks, requiredBlocks);
-
-    int i = 0;
-    while (true) {
-      executor.waitForIdle(); // Wait for no encodes/decodes running.
-      if (!addRandomBlock(storage, fetcherStorage, r)) {
-        break;
-      }
-      fcb.checkFailed();
-      i++;
-    }
-
-    // Cross-check doesn't necessarily complete in exactly the number of required blocks.
-    assertTrue(i >= dataBlocks);
-    assertTrue(i < expectedBlocks, "Downloaded more blocks than data+cross check");
-    assertTrue(i < expectedBlocks - 1, "No cross-segment blocks decoded");
-    executor.waitForIdle(); // Wait for no encodes/decodes running.
-    fcb.waitForFinished();
-    verifyOutput(fetcherStorage, dataBucket);
-    fetcherStorage.finishedFetcher();
-    fcb.waitForFree();
-  }
-
-  private void testRoundTripCrossSegmentDataBlocks(long size) throws Exception {
-    RandomSource r = new DummyRandomSource(12123);
-    LockableRandomAccessBuffer data = generateData(r, size);
-    Bucket dataBucket = new RAFBucket(data);
-    hashes = getHashes(data);
-    context.earlyEncode = true;
-    SplitFileInserterStorage storage =
-        createSplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            hashes,
-            r,
-            memoryLimitedJobRunner,
-            keys);
-    // Encoded. Now try to decode it ...
-    cb.waitForHasKeys();
-    Metadata metadata = storage.encodeMetadata();
-    assertEquals(Status.ENCODED, storage.getStatus());
-
-    // Ugly hack because Metadata behaves oddly.
-    // FIXME make Metadata behave consistently and get rid.
-    Bucket metaBucket = metadata.toBucket(smallBucketFactory);
-    Metadata m1 = Metadata.construct(metaBucket);
-    Bucket copyBucket = m1.toBucket(smallBucketFactory);
-    assertTrue(BucketTools.equalBuckets(metaBucket, copyBucket));
-
-    FetchCallbackForTestingSplitFileInserter fcb = new FetchCallbackForTestingSplitFileInserter();
-
-    FetchContext fctx =
-        HighLevelSimpleClientImpl.makeDefaultFetchContext(
-            size * 2, size * 2, smallBucketFactory, new SimpleEventProducer());
-
-    short cmode = (short) context.getCompatibilityMode().ordinal();
-
-    SplitFileFetcherStorage fetcherStorage =
-        createFetcherStorage(m1, fcb, new ArrayList<>(), cmode, fctx, r);
-
-    fetcherStorage.start(false);
-
-    if (storage.crossSegments != null) {
-      int segments = storage.segments.length;
-      for (int i = 0; i < segments; i++) {
-        assertEquals(
-            storage.crossSegments[i].dataBlockCount,
-            fetcherStorage.crossSegments[i].dataBlockCount);
-        assertArrayEquals(
-            storage.crossSegments[i].getSegmentNumbers(),
-            fetcherStorage.crossSegments[i].getSegmentNumbers());
-        assertArrayEquals(
-            storage.crossSegments[i].getBlockNumbers(),
-            fetcherStorage.crossSegments[i].getBlockNumbers());
-      }
-    }
-
-    // It should be able to decode from just the data blocks.
-
-    for (int segNo = 0; segNo < storage.segments.length; segNo++) {
-      SplitFileInserterSegmentStorage inserterSegment = storage.segments[segNo];
-      SplitFileFetcherSegmentStorage fetcherSegment = fetcherStorage.segments[segNo];
-      for (int blockNo = 0; blockNo < inserterSegment.dataBlockCount; blockNo++) {
-        ClientCHKBlock block = inserterSegment.encodeBlock(blockNo);
-        boolean success =
-            fetcherSegment.onGotKey(block.getClientKey().getNodeCHK(), block.getBlock());
-        assertTrue(success);
-      }
-    }
-
-    executor.waitForIdle(); // Wait for no encodes/decodes running.
-    fcb.waitForFinished();
-    verifyOutput(fetcherStorage, dataBucket);
-    fetcherStorage.finishedFetcher();
-    fcb.waitForFree();
-  }
-
-  /**
-   * Add a random block that has not been added already or decoded already.
-   *
-   * @throws IOException if block addition fails
-   */
-  private boolean addRandomBlock(
-      SplitFileInserterStorage storage, SplitFileFetcherStorage fetcherStorage, Random random)
-      throws IOException {
-    int segCount = storage.segments.length;
-    boolean[] exhaustedSegments = new boolean[segCount];
-    for (int i = 0; i < segCount; i++) {
-      while (true) {
-        int segNo = random.nextInt(segCount);
-        if (exhaustedSegments[segNo]) {
-          continue;
-        }
-        SplitFileFetcherSegmentStorage segment = fetcherStorage.segments[segNo];
-        if (segment.isDecodingOrFinished()) {
-          exhaustedSegments[segNo] = true;
-          break;
-        }
-        while (true) {
-          int blockNo = random.nextInt(segment.totalBlocks());
-          if (segment.hasBlock(blockNo)) {
-            continue;
-          }
-          ClientCHKBlock block = storage.segments[segNo].encodeBlock(blockNo);
-          boolean success = segment.onGotKey(block.getClientKey().getNodeCHK(), block.getBlock());
-          assertTrue(success);
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private void verifyOutput(SplitFileFetcherStorage storage, Bucket originalData)
-      throws IOException {
-    StreamGenerator g = storage.streamGenerator();
-    Bucket out = smallBucketFactory.makeBucket(-1);
-    try (OutputStream os = out.getOutputStream()) {
-      g.writeTo(os, null);
-    }
-    assertTrue(BucketTools.equalBuckets(originalData, out));
-    out.free();
-  }
-
-  private void waitForDecode(SplitFileFetcherSegmentStorage segment) {
-    while (!segment.hasSucceeded()) {
-      assertFalse(segment.hasFailed());
-      try {
-        Thread.sleep(1);
-      } catch (InterruptedException e) {
-        // Ignore.
-      }
-    }
-  }
-
-  private void testCancelAlt(Random r, long size) throws Exception {
-    // FIXME tricky to wait for "all threads are in pread()", when # threads != # segments.
-    // So just set max threads to 1 (only affects this test).
-    memoryLimitedJobRunner.setMaxThreads(1);
-    BarrierRandomAccessBuffer data = new BarrierRandomAccessBuffer(generateData(r, size));
-    HashResult[] hashes = getHashes(data);
-    data.pause();
-    InsertContext context = baseContext.clone();
-    context.earlyEncode = true;
-    SplitFileInserterStorage storage =
-        new SplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            null,
-            new ClientMetadata(),
-            false,
-            null,
-            smallRAFFactory,
-            false,
-            context,
-            cryptoAlgorithm,
-            cryptoKey,
-            null,
-            hashes,
-            smallBucketFactory,
-            checker,
-            r,
-            memoryLimitedJobRunner,
-            jobRunner,
-            ticker,
-            keys,
-            false,
-            0,
-            0,
-            0,
-            0);
-    storage.start();
-    assertEquals(Status.STARTED, storage.getStatus());
-    if (storage.crossSegments != null) {
-      assertTrue(allCrossSegmentsEncoding(storage));
-    } else {
-      assertTrue(allSegmentsEncoding(storage));
-    }
-    SplitFileInserterSegmentStorage segment = storage.segments[0];
-    assertTrue(memoryLimitedJobRunner.getRunningThreads() > 0);
-    // Wait for one segment to be in pread().
-    data.waitForWaiting();
-    segment.onFailure(0, new InsertException(InsertExceptionMode.INTERNAL_ERROR));
-    assertFalse(cb.hasFailed()); // Callback must not have been called yet.
-    data.proceed(); // Now it will complete encoding, and then report in, and then fail.
-
-    assertThrows(InsertException.class, () -> cb.waitForFinishedEncode());
-    if (storage.segments.length > 2) {
-      assertFalse(cb.hasFinishedEncode());
-      assertTrue(anySegmentNotEncoded(storage));
-    }
-    assertEquals(0, memoryLimitedJobRunner.getRunningThreads());
-    assertFalse(anySegmentEncoding(storage));
-    assertEquals(Status.FAILED, storage.getStatus());
-  }
-
-  private boolean allSegmentsEncoding(SplitFileInserterStorage storage) {
-    for (SplitFileInserterSegmentStorage segment : storage.segments) {
-      if (!segment.isEncoding()) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean allCrossSegmentsEncoding(SplitFileInserterStorage storage) {
-    if (storage.crossSegments != null) {
-      for (SplitFileInserterCrossSegmentStorage segment : storage.crossSegments) {
-        if (!segment.isEncoding()) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-  private boolean anySegmentEncoding(SplitFileInserterStorage storage) {
-    for (SplitFileInserterSegmentStorage segment : storage.segments) {
-      if (segment.isEncoding()) {
-        return true;
-      }
-    }
-    if (storage.crossSegments != null) {
-      for (SplitFileInserterCrossSegmentStorage segment : storage.crossSegments) {
-        if (segment.isEncoding()) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private boolean anySegmentNotEncoded(SplitFileInserterStorage storage) {
-    for (SplitFileInserterSegmentStorage segment : storage.segments) {
-      if (!segment.hasEncoded()) {
-        return true;
-      }
-    }
-    if (storage.crossSegments != null) {
-      for (SplitFileInserterCrossSegmentStorage segment : storage.crossSegments) {
-        if (!segment.hasEncodedSuccessfully()) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private SplitFileInserterStorage createSplitFileInserterStorage(
-      SplitFileInserterStorage storage,
-      LockableRandomAccessBuffer data,
-      MyCallback cb,
-      MemoryLimitedJobRunner memoryLimitedJobRunner,
-      MyKeysFetchingLocally keys)
-      throws Exception {
-    return new SplitFileInserterStorage(
-        storage.getRAF(),
-        data,
-        cb,
-        random,
-        memoryLimitedJobRunner,
-        jobRunner,
-        ticker,
-        keys,
-        fg,
-        persistentFileTracker,
-        null);
-  }
-
-  private SplitFileInserterStorage createSplitFileInserterStorage(
-      LockableRandomAccessBuffer data,
-      long size,
-      MyCallback cb,
+  private SplitFileInserterStorage newStorage(
+      LockableRandomAccessBuffer original,
       boolean persistent,
-      InsertContext baseContext,
-      byte cryptoAlgorithm,
-      byte[] cryptoKey,
-      HashResult[] hashes,
-      Random r,
-      MemoryLimitedJobRunner memoryLimitedJobRunner,
-      KeysFetchingLocally keys)
-      throws Exception {
+      InsertContext.CompatibilityMode cmode,
+      byte[] explicitSplitfileKey)
+      throws IOException, InsertException {
+    InsertContext ctx = newInsertContext(cmode);
+    byte[] hashThisLayerOnly =
+        (explicitSplitfileKey == null
+                && (cmode == InsertContext.CompatibilityMode.COMPAT_CURRENT
+                    || cmode.ordinal() >= InsertContext.CompatibilityMode.COMPAT_1255.ordinal()))
+            ? new byte[32]
+            : null;
+    return new SplitFileInserterStorage(
+        original,
+        /* decompressedLength= */ original.size(),
+        callback,
+        /* compressionCodec= */ null,
+        new ClientMetadata("application/octet-stream"),
+        /* isMetadata= */ false,
+        /* archiveType= */ null,
+        rafFactory,
+        persistent,
+        ctx,
+        /* splitfileCryptoAlgorithm= */ (byte) 0,
+        /* splitfileCryptoKey= */ explicitSplitfileKey,
+        /* hashThisLayerOnly= */ hashThisLayerOnly,
+        /* hashes= */ null,
+        bucketFactory,
+        checker,
+        random,
+        mlRunner,
+        // DummyJobRunner queues onto our immediate executor via the context normally; we only need
+        // a runner for callbacks
+        new network.crypta.support.DummyJobRunner(executor, null),
+        ticker,
+        keysFetching,
+        /* topDontCompress= */ false,
+        /* topRequiredBlocks= */ 0,
+        /* topTotalBlocks= */ 0,
+        /* origDataSize= */ original.size(),
+        /* origCompressedDataSize= */ original.size());
+  }
+
+  @Test
+  void constructor_whenDataTooBig_expectTooBigException() {
+    long huge = ((long) Integer.MAX_VALUE) * CHKBlock.DATA_LENGTH + 1L;
+    try (LockableRandomAccessBuffer original = new NullRandomAccessBuffer(huge)) {
+      InsertContext ctx = newInsertContext(InsertContext.CompatibilityMode.COMPAT_CURRENT);
+      assertEquals(SplitfileAlgorithm.ONION_STANDARD, ctx.getSplitfileAlgorithm());
+
+      InsertException ex =
+          assertThrows(
+              InsertException.class,
+              () ->
+                  new SplitFileInserterStorage(
+                      original,
+                      /* decompressedLength= */ huge,
+                      callback,
+                      /* compressionCodec= */ null,
+                      new ClientMetadata("text/plain"),
+                      /* isMetadata= */ false,
+                      /* archiveType= */ null,
+                      rafFactory,
+                      /* persistent= */ false,
+                      ctx,
+                      /* splitfileCryptoAlgorithm= */ (byte) 0,
+                      /* splitfileCryptoKey= */ null,
+                      /* hashThisLayerOnly= */ null,
+                      /* hashes= */ null,
+                      bucketFactory,
+                      checker,
+                      random,
+                      mlRunner,
+                      new network.crypta.support.DummyJobRunner(executor, null),
+                      ticker,
+                      keysFetching,
+                      /* topDontCompress= */ false,
+                      /* topRequiredBlocks= */ 0,
+                      /* topTotalBlocks= */ 0,
+                      /* origDataSize= */ huge,
+                      /* origCompressedDataSize= */ huge));
+      assertEquals(InsertExceptionMode.TOO_BIG, ex.getMode());
+    }
+  }
+
+  @Test
+  void hasSplitfileKey_whenExplicitKeyProvided_expectTrueAndCounts() throws Exception {
+    byte[] buf = new byte[CHKBlock.DATA_LENGTH];
+    for (int i = 0; i < buf.length; i++) buf[i] = (byte) i;
     SplitFileInserterStorage storage =
-        new SplitFileInserterStorage(
-            data,
-            size,
-            cb,
-            null,
-            new ClientMetadata(),
-            false,
-            null,
-            smallRAFFactory,
-            persistent,
-            baseContext,
-            cryptoAlgorithm,
-            cryptoKey,
-            null,
-            hashes,
-            smallBucketFactory,
-            checker,
-            r,
-            memoryLimitedJobRunner,
-            jobRunner,
-            ticker,
-            keys,
-            false,
-            0,
-            0,
-            0,
-            0);
-    storage.start();
-    cb.waitForFinishedEncode();
-    return storage;
+        newStorage(
+            new ByteArrayRandomAccessBuffer(buf),
+            /* persistent= */ false,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT,
+            new byte[32]);
+
+    assertTrue(storage.hasSplitfileKey());
+    // For 1 data block and COMPAT_CURRENT, OnionFECCodec returns 2 check blocks for segment of size
+    // 1
+    assertEquals(1 + 2, storage.getTotalBlockCount());
+    // Keys count equals total blocks (1 data + 2 check)
+    assertEquals(3L, storage.countAllKeys());
+    // Before encoding, chooser reports all blocks as fetchable (eligibility is enforced later)
+    assertEquals(3L, storage.countSendableKeys());
   }
 
-  private SplitFileFetcherStorage createFetcherStorage(
-      Metadata m1,
-      FetchCallbackForTestingSplitFileInserter fcb,
-      ArrayList<COMPRESSOR_TYPE> decompressors,
-      short cmode,
-      FetchContext fctx,
-      RandomSource r)
-      throws FetchException, MetadataParseException, IOException {
-    return new SplitFileFetcherStorage(
-        new SplitFileFetcherStorage.InitParams.Builder()
-            .metadata(m1)
-            .fetcher(fcb)
-            .decompressors(decompressors)
-            .clientMetadata(new ClientMetadata())
-            .topDontCompress(false)
-            .topCompatibilityMode(cmode)
-            .fetchContext(fctx)
-            .realTime(false)
-            .salt(salt)
-            .thisKey(URI)
-            .origKey(URI)
-            .isFinalFetch(true)
-            .clientDetails(new byte[0])
-            .random(r)
-            .tempBucketFactory(smallBucketFactory)
-            .rafFactory(smallRAFFactory)
-            .exec(jobRunner)
-            .ticker(ticker)
-            .memoryLimitedJobRunner(memoryLimitedJobRunner)
-            .checker(checker)
-            .persistent(false)
-            .storageFile(null)
-            .diskSpaceCheckingRAFFactory(null)
-            .keysFetching(keys)
-            .build());
+  @Test
+  void hasSplitfileKey_whenOldCompatAndNoKey_expectFalse() throws Exception {
+    byte[] buf = new byte[CHKBlock.DATA_LENGTH];
+    SplitFileInserterStorage storage =
+        newStorage(
+            new ByteArrayRandomAccessBuffer(buf),
+            /* persistent= */ false,
+            InsertContext.CompatibilityMode.COMPAT_1251,
+            /* explicitSplitfileKey= */ null);
+
+    assertFalse(storage.hasSplitfileKey());
   }
 
-  private SplitFileInserterSegmentStorage assertProperSegmentStateAndGet(
-      SplitFileInserterStorage storage) {
-    assertEquals(1, storage.segments.length);
-    SplitFileInserterSegmentStorage segment = storage.segments[0];
-    assertEquals(2, segment.dataBlockCount);
-    assertEquals(3, segment.checkBlockCount);
-    assertEquals(0, segment.crossCheckBlockCount);
-    assertEquals(Status.ENCODED, storage.getStatus());
-    return segment;
+  @Test
+  void writeAndReadSegmentCheckBlock_whenCalled_expectSameBytes() throws Exception {
+    byte[] data = new byte[CHKBlock.DATA_LENGTH];
+    SplitFileInserterStorage storage =
+        newStorage(
+            new ByteArrayRandomAccessBuffer(data),
+            /* persistent= */ false,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT,
+            null);
+
+    byte[] check = new byte[CHKBlock.DATA_LENGTH];
+    for (int i = 0; i < check.length; i++) check[i] = (byte) (255 - i);
+    // Single segment, first check block is index 0
+    storage.writeSegmentCheckBlock(0, 0, check);
+    byte[] readBack = storage.readSegmentCheckBlock(0, 0);
+    assertArrayEquals(check, readBack);
   }
 
-  private static class MyCallback implements SplitFileInserterStorageCallback {
+  @Test
+  void persistentOffsets_whenPersistent_expectNonZeroAndIOWorks() throws Exception {
+    // Two data blocks to ensure presence of statuses and a check block region
+    int size = CHKBlock.DATA_LENGTH * 2;
+    java.io.File tmp = java.io.File.createTempFile("sfi-persist-", ".bin");
+    tmp.deleteOnExit();
+    FileRandomAccessBuffer original = new FileRandomAccessBuffer(tmp, size, /* readOnly= */ false);
+    byte[] fill = new byte[size];
+    for (int i = 0; i < size; i++) fill[i] = (byte) (i * 3);
+    original.pwrite(0, fill, 0, size);
+
+    SplitFileInserterStorage storage =
+        newStorage(
+            original, /* persistent= */ true, InsertContext.CompatibilityMode.COMPAT_CURRENT, null);
+
+    // Segment 0 must have a status offset when persistent
+    long statusOffset = storage.getOffsetSegmentStatus(0);
+    assertTrue(statusOffset >= 0);
+
+    // Read/write check block still functions in persistent mode
+    byte[] check = new byte[CHKBlock.DATA_LENGTH];
+    for (int i = 0; i < check.length; i++) check[i] = (byte) (i ^ 0x5A);
+    storage.writeSegmentCheckBlock(0, 0, check);
+    assertArrayEquals(check, storage.readSegmentCheckBlock(0, 0));
+  }
+
+  @Test
+  void readSegmentDataBlock_whenLastBlockPadded_expectPaddedBytes() throws Exception {
+    int extra = 10;
+    int total = CHKBlock.DATA_LENGTH + extra; // two data blocks; last is short and should be padded
+    ByteArrayRandomAccessBuffer original = new ByteArrayRandomAccessBuffer(total);
+    byte[] pattern = new byte[total];
+    for (int i = 0; i < total; i++) pattern[i] = (byte) (i * 7);
+    original.pwrite(0, pattern, 0, pattern.length);
+
+    SplitFileInserterStorage storage =
+        newStorage(
+            original,
+            /* persistent= */ false,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT,
+            null);
+
+    // Expected padded last block: pad the last `extra` bytes to CHKBlock.DATA_LENGTH
+    byte[] tail = new byte[extra];
+    System.arraycopy(pattern, CHKBlock.DATA_LENGTH, tail, 0, extra);
+    byte[] expected = BucketTools.pad(tail, CHKBlock.DATA_LENGTH, tail.length);
+
+    // Only one segment, last data block index is 1
+    byte[] last = storage.readSegmentDataBlock(0, 1);
+    assertArrayEquals(expected, last);
+  }
+
+  @Test
+  void start_whenNoCrossSegments_encodesAndUpdatesStatus() throws Exception {
+    byte[] data = new byte[CHKBlock.DATA_LENGTH];
+    SplitFileInserterStorage storage =
+        newStorage(
+            new ByteArrayRandomAccessBuffer(data),
+            /* persistent= */ false,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT,
+            null);
+
+    // Simulate STARTED without triggering actual encode, then mark segment encoded and notify.
+    java.lang.reflect.Field statusField = SplitFileInserterStorage.class.getDeclaredField("status");
+    statusField.setAccessible(true);
+    statusField.set(storage, SplitFileInserterStorage.Status.STARTED);
+    java.lang.reflect.Field f = SplitFileInserterSegmentStorage.class.getDeclaredField("encoded");
+    f.setAccessible(true);
+    f.set(storage.segments[0], true);
+    storage.onFinishedEncoding(storage.segments[0]);
+
+    assertEquals(SplitFileInserterStorage.Status.ENCODED, storage.getStatus());
+    assertEquals(1, storage.countEncodedSegments());
+    verify(callback, times(1)).onFinishedEncode();
+    verify(callback, times(1)).encodingProgress();
+    verify(callback, never()).onFailed(any());
+  }
+
+  @Test
+  void failOnDiskError_whenCalled_expectFailedAndCallback() throws Exception {
+    byte[] data = new byte[CHKBlock.DATA_LENGTH];
+    SplitFileInserterStorage storage =
+        newStorage(
+            new ByteArrayRandomAccessBuffer(data),
+            /* persistent= */ false,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT,
+            null);
+
+    storage.failOnDiskError(new IOException("boom"));
+
+    assertEquals(SplitFileInserterStorage.Status.FAILED, storage.getStatus());
+    verify(callback, times(1)).onFailed(any(InsertException.class));
+    // Once finished, wakeup time is -1
+    assertEquals(-1, storage.getWakeupTime(null, System.currentTimeMillis()));
+  }
+
+  @Test
+  void chooseBlock_whenAllSegmentsCancelled_expectNullAndCooldown() throws Exception {
+    byte[] data = new byte[CHKBlock.DATA_LENGTH];
+    SplitFileInserterStorage storage =
+        newStorage(
+            new ByteArrayRandomAccessBuffer(data),
+            /* persistent= */ false,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT,
+            null);
+
+    // Cancel all segments to make no block selectable
+    for (SplitFileInserterSegmentStorage seg : storage.segments) {
+      assertTrue(seg.cancel());
+    }
+    SplitFileInserterSegmentStorage.BlockInsert choice = storage.chooseBlock();
+    assertNull(choice);
+    assertTrue(storage.noBlocksToSend());
+    assertEquals(Long.MAX_VALUE, storage.getWakeupTime(null, System.currentTimeMillis()));
+  }
+
+  // --- Test helpers ---
+
+  private static final class ImmediateExecutor implements PriorityAwareExecutor {
+    @Override
+    public void execute(Runnable job) {
+      job.run();
+    }
 
     @Override
-    public synchronized void onFinishedEncode() {
-      finishedEncode = true;
-      notifyAll();
+    public void execute(Runnable job, String jobName) {
+      job.run();
     }
 
     @Override
-    public synchronized void onHasKeys() {
-      hasKeys = true;
-      notifyAll();
+    public void execute(Runnable job, String jobName, boolean fromTicker) {
+      job.run();
     }
 
     @Override
-    public void encodingProgress() {
-      // Ignore.
-    }
-
-    public synchronized void waitForFinishedEncode() throws InsertException {
-      while (!finishedEncode) {
-        checkFailed();
-        try {
-          wait();
-        } catch (InterruptedException e) {
-          // Ignore.
-        }
-      }
-    }
-
-    public synchronized void waitForHasKeys() throws InsertException {
-      while (!hasKeys) {
-        checkFailed();
-        try {
-          wait();
-        } catch (InterruptedException e) {
-          // Ignore.
-        }
-      }
+    public int[] waitingThreads() {
+      return new int[] {0, 0, 0, 0};
     }
 
     @Override
-    public synchronized void onSucceeded(Metadata metadata) {
-      succeededInsert = true;
-      notifyAll();
-    }
-
-    public synchronized void waitForSucceededInsert() throws InsertException {
-      while (!succeededInsert) {
-        checkFailed();
-        try {
-          wait();
-        } catch (InterruptedException e) {
-          // Ignore.
-        }
-      }
+    public int[] runningThreads() {
+      return new int[] {0, 0, 0, 0};
     }
 
     @Override
-    public synchronized void onFailed(InsertException e) {
-      failed = e;
-      notifyAll();
-    }
-
-    @Override
-    public void onInsertedBlock() {
-      // Ignore.
-    }
-
-    @Override
-    public void clearCooldown() {
-      // Ignore.
-    }
-
-    public synchronized boolean hasFailed() {
-      return failed != null;
-    }
-
-    public synchronized boolean hasFinishedEncode() {
-      return finishedEncode;
-    }
-
-    @Override
-    public short getPriorityClass() {
+    public int getWaitingThreadsCount() {
       return 0;
     }
-
-    private void checkFailed() throws InsertException {
-      if (failed != null) {
-        throw failed;
-      }
-    }
-
-    private boolean finishedEncode;
-    private boolean hasKeys;
-    private boolean succeededInsert;
-    private InsertException failed;
   }
 
-  private static class MyKeysFetchingLocally implements KeysFetchingLocally {
-    @Override
-    public long checkRecentlyFailed(Key key, boolean realTime) {
-      return 0;
-    }
+  private static final class ImmediateTicker implements Ticker {
+    private final PriorityAwareExecutor exec;
 
-    public void addInsert(SendableRequestItemKey chosen) {
-      inserts.add(chosen);
+    ImmediateTicker(PriorityAwareExecutor exec) {
+      this.exec = exec;
     }
 
     @Override
-    public boolean hasKey(Key key, BaseSendableGet getterWaiting) {
-      return keys.contains(key);
+    public void queueTimedJob(Runnable job, long offset) {
+      // Execute immediately for determinism in tests
+      exec.execute(job);
     }
 
     @Override
-    public boolean hasInsert(SendableRequestItemKey token) {
-      return inserts.contains(token);
+    public void queueTimedJob(
+        Runnable job, String name, long offset, boolean runOnTickerAnyway, boolean noDupes) {
+      exec.execute(job);
     }
 
-    public void add(Key k) {
-      keys.add(k);
+    @Override
+    public PriorityAwareExecutor getExecutor() {
+      return exec;
     }
 
-    public void clear() {
-      keys.clear();
-      inserts.clear();
+    @Override
+    public void removeQueuedJob(Runnable job) {
+      // No-op for immediate execution
     }
 
-    private final HashSet<Key> keys = new HashSet<>();
-    private final HashSet<SendableRequestItemKey> inserts = new HashSet<>();
+    @Override
+    public void queueTimedJobAbsolute(
+        Runnable runner, String name, long time, boolean runOnTickerAnyway, boolean noDupes) {
+      exec.execute(runner);
+    }
   }
-
-  private class FetchCallbackForTestingSplitFileInserter
-      implements SplitFileFetcherStorageCallback {
-
-    @Override
-    public synchronized void onSuccess() {
-      succeeded = true;
-      notifyAll();
-    }
-
-    public synchronized int getRequiredBlocks() {
-      return requiredBlocks;
-    }
-
-    public synchronized void waitForFree() throws Exception {
-      while (true) {
-        checkFailed();
-        if (closed) {
-          return;
-        }
-        wait();
-      }
-    }
-
-    public synchronized void waitForFinished() throws Exception {
-      while (true) {
-        checkFailed();
-        if (succeeded) {
-          return;
-        }
-        wait();
-      }
-    }
-
-    public synchronized void checkFailed() throws Exception {
-      if (!failed) {
-        return;
-      }
-      if (failedException != null) {
-        throw failedException;
-      }
-      org.junit.jupiter.api.Assertions.fail();
-    }
-
-    @Override
-    public short getPriorityClass() {
-      return 0;
-    }
-
-    @Override
-    public synchronized void failOnDiskError(IOException e) {
-      System.err.printf("Disk error: %s%n", e.getMessage());
-      e.printStackTrace();
-      failed = true;
-      failedException = e;
-      notifyAll();
-    }
-
-    @Override
-    public void failOnDiskError(ChecksumFailedException e) {
-      System.err.printf("Disk error: %s%n", e.getMessage());
-      e.printStackTrace();
-      failed = true;
-      failedException = e;
-      notifyAll();
-    }
-
-    @Override
-    public synchronized void setSplitfileBlocks(int requiredBlocks, int remainingBlocks) {
-      this.requiredBlocks = requiredBlocks;
-      // Ignore
-    }
-
-    @Override
-    public void onSplitfileCompatibilityMode(
-        CompatibilityMode min,
-        CompatibilityMode max,
-        byte[] customSplitfileKey,
-        boolean compressed,
-        boolean bottomLayer,
-        boolean definitiveAnyway) {
-      // Ignore.
-    }
-
-    @Override
-    public synchronized void queueHeal(byte[] data, byte[] cryptoKey, byte cryptoAlgorithm) {}
-
-    @Override
-    public synchronized void onClosed() {
-      closed = true;
-      notifyAll();
-    }
-
-    @Override
-    public synchronized void onFetchedBlock() {}
-
-    @Override
-    public synchronized void onFailedBlock() {}
-
-    @Override
-    public void onResume(
-        int succeededBlocks, int failedBlocks, ClientMetadata mimeType, long finalSize) {
-      // Ignore.
-    }
-
-    @Override
-    public synchronized void fail(FetchException e) {
-      System.err.printf("Operation failed: %s%n", e.getMessage());
-      e.printStackTrace();
-      failed = true;
-      failedException = e;
-      notifyAll();
-    }
-
-    @Override
-    public void maybeAddToBinaryBlob(ClientCHKBlock decodedBlock) {
-      // Ignore.
-    }
-
-    @Override
-    public boolean wantBinaryBlob() {
-      return false;
-    }
-
-    @Override
-    public BaseSendableGet getSendableGet() {
-      return null;
-    }
-
-    @Override
-    public synchronized void restartedAfterDataCorruption() {}
-
-    @Override
-    public void clearCooldown() {
-      // Ignore.
-    }
-
-    @Override
-    public void reduceCooldown(long wakeupTime) {
-      // Ignore.
-    }
-
-    @Override
-    public HasKeyListener getHasKeyListener() {
-      return null;
-    }
-
-    @Override
-    public KeySalter getSalter() {
-      return salt;
-    }
-
-    private boolean succeeded;
-    private boolean failed;
-    private boolean closed;
-    private int requiredBlocks;
-    private Exception failedException;
-  }
-
-  final LockableRandomAccessBufferFactory smallRAFFactory =
-      new ByteArrayRandomAccessBufferFactory();
-  final FilenameGenerator fg;
-  final PersistentFileTracker persistentFileTracker;
-  final LockableRandomAccessBufferFactory bigRAFFactory;
-  final BucketFactory smallBucketFactory;
-  final BucketFactory bigBucketFactory;
-  final File dir;
-  final InsertContext baseContext;
-  final WaitableExecutor executor;
-  final Ticker ticker;
-  final byte cryptoAlgorithm = Key.ALGO_AES_CTR_256_SHA256;
-  final byte[] cryptoKey;
-  final ChecksumChecker checker;
-  final MemoryLimitedJobRunner memoryLimitedJobRunner;
-  final PersistentJobRunner jobRunner;
-  final KeySalter salt = Key::getRoutingKey;
-  private final FreenetURI URI;
-  private final Random random;
-  private long size;
-  private final MyCallback cb;
-  private LockableRandomAccessBuffer data;
-  private HashResult[] hashes;
-  private final MyKeysFetchingLocally keys;
-  private final InsertContext context;
 }


### PR DESCRIPTION
Summary
- Rewrite and documentation improvements around splitfile insert storage internals (Javadoc, invariants, and thread-safety notes).
- Defensive checks in SplitFileInserterSegmentStorage for cross-check block count vs parent cross-segments length.
- Test suite modernization for SplitFileInserterStorage: JUnit 6 + Mockito, simplified fixtures, deterministic executors, and clearer assertions.
- Doclint cleanup for SplitFileInserterStorageCallback Javadoc.
- Spotless formatting applied.

Commits on this branch (ahead of develop)
- 90c46d6569 chore: apply Spotless formatting
- b4a61b1c06 docs: doclint-clean Javadoc for SplitFileInserterStorageCallback

Files touched (base → HEAD)
- src/main/java/network/crypta/client/async/SplitFileInserterSegmentStorage.java
- src/main/java/network/crypta/client/async/SplitFileInserterStorage.java
- src/main/java/network/crypta/client/async/SplitFileInserterStorageCallback.java
- src/test/java/network/crypta/client/async/SplitFileInserterStorageTest.java

Diff stats (origin/develop..HEAD)
- 4 files changed, 1646 insertions(+), 2552 deletions(-)

Notes
- No intentional changes to the persistent on-disk format; changes focus on validation, clarity, and tests. Please double-check storage layout sections during review.
- The large test rewrite aims to reduce flakiness and reliance on filesystem I/O in unit tests.

Verification
- Formatting: Spotless applied.
- Please run the full Gradle test suite locally/CI.

Checklist
- [ ] Confirm no storage format regression in resume/serialize paths
- [ ] Run `./gradlew test` and check JaCoCo coverage
- [ ] Sanity-test resume from existing storages if available