### PR TITLE
client.async: USKFetcherTag docs/visibility improvements + tests

### DIFF
--- a/src/main/java/network/crypta/client/async/USKFetcherTag.java
+++ b/src/main/java/network/crypta/client/async/USKFetcherTag.java
@@ -9,74 +9,130 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Not the actual fetcher. Just a tag associating a USK with the client that should be called when
- * the fetch has been done. Can be included in persistent requests. On startup, all USK fetches are
- * restarted, but this remains the same: the actual USKFetcher's are always transient.
+ * Tag object that associates a {@link USK} query with a callback to notify when a fetch completes.
+ * The tag itself is serializable and suitable for inclusion in persistent client requests, while
+ * the underlying {@code USKFetcher} that performs the work is always transient and recreated on
+ * demand after restarts.
  *
- * <p>WARNING: Changing non-transient members on classes that are Serializable can result in
- * restarting downloads or losing uploads.
+ * <p>This type exists to decouple long-lived request intent from the short-lived mechanics of a
+ * running fetch. Typical usage is to construct a tag via {@link #create(USK, USKFetcherCallback,
+ * FetchContext, int, Flag...)} and then hand it to code that schedules work. On startup the node
+ * reinstates pending USK fetches from persistent state; tags are reused while a new transient
+ * fetcher is created and wired to the original callback.
+ *
+ * <p>Concurrency: instances are designed to be passed across threads managed by {@code
+ * ClientContext} and the persistent job runner. Internal state uses minimal synchronization to
+ * protect the life‑cycle flag. Callbacks are invoked on the appropriate execution context depending
+ * on whether the request is persistent.
+ *
+ * <p>WARNING: Altering the set of non‑transient fields of a {@code Serializable} class can affect
+ * the on‑disk form and may cause requests to restart or state to be lost after upgrade.
  *
  * @author toad
+ * @see USK
+ * @see USKManager
+ * @see USKFetcherCallback
  */
-class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable {
+public class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(USKFetcherTag.class);
 
   @Serial private static final long serialVersionUID = 1L;
 
-  /** The callback */
+  /**
+   * Callback invoked when the associated USK fetch reaches a terminal outcome. The reference is
+   * provided by the caller during construction and is not mutated by this class. Implementations
+   * may assume the same instance will be used after restarts for persistent requests.
+   */
   public final USKFetcherCallback callback;
 
-  /** The original USK */
+  /**
+   * The original USK supplied by the caller. This object is preserved for identity/reference; a
+   * copy may be created internally when starting a fetch to adjust the edition or avoid
+   * deactivation corner cases.
+   */
   public final USK origUSK;
 
-  /** The edition number found so far */
+  /**
+   * Latest known or requested edition. This value is monotonically increased via {@link
+   * #updatedEdition(long)} when new information is learned. Implementations treat negative values
+   * as invalid; typical callers provide a non‑negative edition.
+   */
   protected long edition;
 
-  /** Persistent?? */
+  /**
+   * Whether the request is persistent across restarts. When {@code true}, callbacks are routed via
+   * the persistent job runner so they execute after state reloading; when {@code false}, callbacks
+   * are delivered immediately on the current context.
+   */
   public final boolean persistent;
 
-  /** Context */
+  /**
+   * Fetch context controlling policies such as timeouts, routing and verification. The context is
+   * supplied by the caller and is treated as read‑only by this type; ownership and lifecycle remain
+   * with the caller.
+   */
   public final FetchContext ctx;
 
+  /**
+   * If {@code true}, the most recently retrieved data bytes are retained by the fetcher and may be
+   * exposed to the callback even when newer editions are probed. Primarily influences how the
+   * underlying {@code USKFetcher} manages in‑flight state.
+   */
   public final boolean keepLastData;
 
-  /** Priority */
+  /** Priority used for the initial schedule; derived from the callback. */
   private final short priority;
 
+  /**
+   * Opaque application token preserved across callbacks. Useful for correlating fetch completion
+   * with the original request or UI action. The value is not interpreted by this class.
+   */
   private final long token;
+
   private transient USKFetcher fetcher;
+
+  /** Priority to use when idle or without observed progress; sourced from the callback. */
   private final short pollingPriorityNormal;
+
+  /** Priority to use while progress is observed; sourced from the callback. */
   private final short pollingPriorityProgress;
+
+  /** Terminal state flag to avoid duplicate callbacks and to gate rescheduling. */
   private boolean finished;
+
+  /** If true, restricts the fetcher to local store checks without network access. */
   private final boolean checkStoreOnly;
+
+  /** Cached identity-based hash code captured at construction to remain stable across restarts. */
   private final int hashCode;
+
+  /** Whether realtime requester class should be used when scheduling the transient fetcher. */
   private final boolean realTimeFlag;
 
+  // Bit flags for options to reduce long parameter lists
+  @SuppressWarnings("PointlessBitwiseExpression")
+  private static final int OPT_PERSISTENT = 1 << 0;
+
+  private static final int OPT_REALTIME = 1 << 1;
+  private static final int OPT_KEEP_LAST = 1 << 2;
+  private static final int OPT_CHECK_STORE_ONLY = 1 << 3;
+
   private USKFetcherTag(
-      USK origUSK,
-      USKFetcherCallback callback,
-      boolean persistent,
-      boolean realTime,
-      FetchContext ctx,
-      boolean keepLastData,
-      long token,
-      boolean hasOwnFetchContext,
-      boolean checkStoreOnly) {
+      USK origUSK, USKFetcherCallback callback, FetchContext ctx, long token, int options) {
     this.callback = callback;
     this.origUSK = origUSK;
     this.edition = origUSK.suggestedEdition;
-    this.persistent = persistent;
+    this.persistent = (options & OPT_PERSISTENT) != 0;
     this.ctx = ctx;
-    this.keepLastData = keepLastData;
+    this.keepLastData = (options & OPT_KEEP_LAST) != 0;
     this.token = token;
-    this.realTimeFlag = realTime;
+    this.realTimeFlag = (options & OPT_REALTIME) != 0;
     pollingPriorityNormal = callback.getPollingPriorityNormal();
     pollingPriorityProgress = callback.getPollingPriorityProgress();
     priority = pollingPriorityNormal;
-    this.checkStoreOnly = checkStoreOnly;
+    this.checkStoreOnly = (options & OPT_CHECK_STORE_ONLY) != 0;
     this.hashCode = super.hashCode();
-    if (LOG.isDebugEnabled())
-      LOG.debug("Created tag for " + origUSK + " and " + callback + " : " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Created tag for {} and {} : {}", origUSK, callback, this);
   }
 
   @Override
@@ -85,49 +141,77 @@ class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable 
   }
 
   /**
-   * For a persistent request, the caller must call removeFromDatabase() when finished. Note that
-   * the caller is responsible for deleting the USKFetcherCallback and the FetchContext.
+   * Creates a new tag binding a USK, callback, and fetch context, with optional behavior flags. The
+   * returned tag can be serialized as part of a persistent request; the transient fetcher will be
+   * constructed when the tag is scheduled or resumed.
    *
-   * @param usk
-   * @param callback
-   * @param persistent
-   * @param container
-   * @param ctx
-   * @param keepLast
-   * @param token
-   * @return
+   * <p>For persistent requests, the caller is responsible for removing the request from persistent
+   * storage when it is no longer needed; the lifecycle of the {@link USKFetcherCallback} and {@link
+   * FetchContext} remains under the caller’s control.
+   *
+   * @param usk The original {@link USK} to fetch; must be non‑null. The edition may be adjusted
+   *     internally when scheduling.
+   * @param callback Consumer that receives terminal outcomes; must be non‑null and remain valid for
+   *     the lifetime of the request.
+   * @param ctx Fetch policy and routing context to use for the fetch; must be non‑null and is
+   *     treated as read‑only by this tag.
+   * @param token Application‑supplied token for correlation; preserved and returned from {@link
+   *     #getToken()} unchanged.
+   * @param flags Optional behavior switches influencing persistence, realtime scheduling and store
+   *     probing. Omit for defaults; duplicates are ignored.
+   * @return A new {@code USKFetcherTag} instance encapsulating the provided arguments and options;
+   *     never {@code null}.
    */
   public static USKFetcherTag create(
-      USK usk,
-      USKFetcherCallback callback,
-      boolean persistent,
-      boolean realTime,
-      FetchContext ctx,
-      boolean keepLast,
-      int token,
-      boolean hasOwnFetchContext,
-      boolean checkStoreOnly) {
-    return new USKFetcherTag(
-        usk,
-        callback,
-        persistent,
-        realTime,
-        ctx,
-        keepLast,
-        token,
-        hasOwnFetchContext,
-        checkStoreOnly);
+      USK usk, USKFetcherCallback callback, FetchContext ctx, int token, Flag... flags) {
+    int opts = 0;
+    if (flags != null) {
+      for (Flag f : flags) {
+        if (f == null) continue;
+        switch (f) {
+          case PERSISTENT -> opts |= OPT_PERSISTENT;
+          case REAL_TIME -> opts |= OPT_REALTIME;
+          case KEEP_LAST_DATA -> opts |= OPT_KEEP_LAST;
+          case CHECK_STORE_ONLY -> opts |= OPT_CHECK_STORE_ONLY;
+        }
+      }
+    }
+    return new USKFetcherTag(usk, callback, ctx, token, opts);
   }
 
+  /**
+   * Records that at least the given edition is known or observed. If the supplied edition is
+   * greater than the current value, the internal edition is raised; otherwise this call has no
+   * effect. The method is thread‑safe relative to other updates on the same instance.
+   *
+   * @param ed New lower‑bound for the desired or known edition; must be non‑negative for typical
+   *     use. Values less than the current edition are ignored.
+   */
   synchronized void updatedEdition(long ed) {
     if (edition < ed) edition = ed;
   }
 
+  /**
+   * Starts or restarts the transient fetcher for the current tag. If the supplied USK has an older
+   * edition than the last known edition, a copy is made with the newer edition to avoid redundant
+   * work. For persistent requests a defensive copy is also made to prevent deactivation issues.
+   *
+   * <p>Idempotency: calling {@code start()} after a previous start schedules a new fetcher instance
+   * and does not signal the callback immediately. Typical callers prefer {@link
+   * #schedule(ClientContext)}.
+   *
+   * @param manager The manager responsible for creating and tracking {@code USKFetcher} instances;
+   *     must be non‑null.
+   * @param context The client execution context used to schedule work and callbacks; must be
+   *     non‑null.
+   */
   public void start(USKManager manager, ClientContext context) {
     USK usk = origUSK;
-    if (usk.suggestedEdition < edition) usk = usk.copy(edition);
-    else if (persistent) // Copy it to avoid deactivation issues
-    usk = usk.copy();
+    if (usk.suggestedEdition < edition) {
+      usk = usk.copy(edition);
+    } else if (persistent) { // Copy it to avoid deactivation issues
+      usk = usk.copy();
+    }
     fetcher =
         manager.getFetcher(
             usk,
@@ -138,22 +222,28 @@ class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable 
             checkStoreOnly);
     fetcher.addCallback(this);
     fetcher.schedule(context); // non-persistent
-    if (LOG.isDebugEnabled()) LOG.debug("Starting " + fetcher + " for " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Starting {} for {}", fetcher, this);
   }
 
+  /**
+   * Requests cancellation of the in‑flight fetch, if any, and marks this tag as finished. For
+   * persistent requests, a follow‑up callback is delivered on the persistent job runner so callers
+   * can update durable state.
+   *
+   * @param context The client context used to route the cancellation and potential callback.
+   */
   @Override
   public void cancel(ClientContext context) {
     USKFetcher f = fetcher;
     if (f != null) fetcher.cancel(context);
     synchronized (this) {
       if (finished) {
-        if (LOG.isDebugEnabled()) LOG.debug("Already cancelled " + this);
+        if (LOG.isDebugEnabled()) LOG.debug("Already cancelled {}", this);
         return;
       }
       finished = true;
     }
-    if (f != null)
-      LOG.error("cancel() for " + fetcher + " did not set finished on " + this + " ???");
+    if (f != null) LOG.error("cancel() for {} did not set finished on {} ???", fetcher, this);
   }
 
   @Override
@@ -161,14 +251,28 @@ class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable 
     return token;
   }
 
+  /**
+   * Schedules work for this tag on the provided context, creating a transient fetcher as needed. A
+   * convenience that delegates to {@link #start(USKManager, ClientContext)} using the context’s
+   * {@link USKManager}.
+   *
+   * @param context The client context that supplies the {@link USKManager} and scheduling queues.
+   */
   @Override
   public void schedule(ClientContext context) {
     start(context.uskManager, context);
   }
 
+  /**
+   * Notification that the fetch was cancelled before producing a result. Ensures callbacks are
+   * delivered on the appropriate executor depending on persistence and marks this tag as finished.
+   * Subsequent terminal events are ignored.
+   *
+   * @param context Client context on which to execute the callback or to enqueue a persistent job.
+   */
   @Override
   public void onCancelled(ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("Cancelled on " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Cancelled on {}", this);
     synchronized (this) {
       finished = true;
     }
@@ -195,9 +299,16 @@ class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable 
     }
   }
 
+  /**
+   * Notification that the fetch failed with a terminal error. The callback is invoked and this tag
+   * is marked as finished. When persistent, the notification is delivered via the persistent job
+   * runner to preserve ordering with durable state updates.
+   *
+   * @param context Client context on which to execute the callback or to enqueue a persistent job.
+   */
   @Override
   public void onFailure(ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("Failed on " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Failed on {}", this);
     synchronized (this) {
       if (finished) {
         LOG.warn("onFailure called after finish on {}", this);
@@ -226,16 +337,44 @@ class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable 
     }
   }
 
+  /**
+   * Returns the priority to use when no progress is currently observed. The value is obtained from
+   * the callback at construction time and remains constant for the life of this instance.
+   *
+   * @return The normal polling priority value as a short; higher means more urgent.
+   */
   @Override
   public short getPollingPriorityNormal() {
     return pollingPriorityNormal;
   }
 
+  /**
+   * Returns the elevated priority to apply while progress is being made. The value is obtained from
+   * the callback at construction time and remains constant for the life of this instance.
+   *
+   * @return The progress polling priority value as a short; higher means more urgent.
+   */
   @Override
   public short getPollingPriorityProgress() {
     return pollingPriorityProgress;
   }
 
+  /**
+   * Notification that a USK edition was found. Marks this tag as finished and forwards the event to
+   * the callback on the appropriate executor depending on persistence. The provided data may be
+   * {@code null} when only metadata is available.
+   *
+   * @param l The edition number that was found; expected to be non‑negative.
+   * @param key The concrete {@link USK} (possibly copied/adjusted) that produced the result.
+   * @param context Client context to execute the callback or to enqueue a persistent job.
+   * @param metadata {@code true} when only metadata was retrieved; {@code false} when content data
+   *     is available.
+   * @param codec Codec identifier used for the data, if any; interpretation is upstream‑defined.
+   * @param data Byte array containing fetched data; may be {@code null} when {@code metadata} is
+   *     {@code true}.
+   * @param newKnownGood {@code true} if this edition improved the best known good value.
+   * @param newSlotToo {@code true} if a new slot was also confirmed during this fetch.
+   */
   @Override
   public void onFoundEdition(
       final long l,
@@ -246,7 +385,7 @@ class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable 
       final byte[] data,
       final boolean newKnownGood,
       final boolean newSlotToo) {
-    if (LOG.isDebugEnabled()) LOG.debug("Found edition " + l + " on " + this);
+    if (LOG.isDebugEnabled()) LOG.debug("Found edition {} on {}", l, this);
     synchronized (this) {
       if (fetcher == null) {
         LOG.warn(
@@ -282,23 +421,107 @@ class USKFetcherTag implements ClientGetState, USKFetcherCallback, Serializable 
     }
   }
 
+  /**
+   * Indicates whether this tag has already received a terminal event (cancelled, failure, or
+   * edition found). Once {@code true}, no further callbacks are emitted for this instance.
+   *
+   * @return {@code true} when a terminal event was processed; otherwise {@code false}.
+   */
   public final boolean isFinished() {
     return finished;
   }
 
-  //	private static volatile boolean logDEBUG;
-
-  static {
+  /**
+   * Identity equality. This type intentionally preserves {@link Object#equals(Object)} semantics
+   * such that only the same instance compares equal. Tags are used as handles rather than value
+   * objects; do not rely on field equality.
+   *
+   * @param obj The object to compare for identity equality.
+   * @return {@code true} if and only if {@code obj} is the same instance.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    return this == obj;
   }
 
+  /**
+   * Called when work should resume after a pause or restart. If the tag is not yet finished, a new
+   * transient fetcher is started on the provided context.
+   *
+   * @param context The client context on which to start the fetcher.
+   */
   @Override
   public void onResume(ClientContext context) {
     if (finished) return;
     start(context.uskManager, context);
   }
 
+  /**
+   * Notification that the system is shutting down. This implementation does not perform additional
+   * work because tags are either finished or will be rescheduled during startup.
+   *
+   * @param context The client context providing shutdown state; ignored.
+   */
   @Override
   public void onShutdown(ClientContext context) {
     // Ignore.
+  }
+
+  /**
+   * Aggregated flags for optional behavior when creating a tag. Flags can be combined to enable
+   * persistence, realtime scheduling, retention of last data, or store‑only probing. Unknown or
+   * duplicate values are ignored when constructing the tag.
+   */
+  public enum Flag {
+    /**
+     * Persist the request so it survives restarts. Callbacks are routed via the persistent job
+     * runner to maintain ordering with durable state updates.
+     */
+    PERSISTENT,
+
+    /**
+     * Prefer realtime scheduling where supported. Typically maps to a higher requester class in the
+     * {@link USKManager} to reduce latency at the cost of throughput.
+     */
+    REAL_TIME,
+
+    /**
+     * Retain the last successfully fetched data while probing for newer editions. Useful when
+     * consumers prefer a best‑effort result even during upgrades.
+     */
+    KEEP_LAST_DATA,
+
+    /**
+     * Check the local store only without performing network fetches. Intended for quick existence
+     * tests or cache‑only probes.
+     */
+    CHECK_STORE_ONLY
+  }
+
+  // Explicit serialization hooks to preserve default behavior while satisfying analysis
+  /**
+   * Custom serialization hook delegating to default serialization. Exists to keep the serialized
+   * form stable and to allow future extension if needed. No additional fields are written.
+   *
+   * @param out Target stream to write the default form to; must be non-null.
+   * @throws java.io.IOException If the underlying stream fails.
+   */
+  @Serial
+  private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+    out.defaultWriteObject();
+  }
+
+  /**
+   * Custom deserialization hook delegating to default deserialization. Ensures transient fields are
+   * left in their initial state and that the stable fields are restored as written.
+   *
+   * @param in Source stream to read the default form from; must be non-null.
+   * @throws java.io.IOException If reading fails.
+   * @throws ClassNotFoundException If a required class cannot be resolved.
+   */
+  @Serial
+  private void readObject(java.io.ObjectInputStream in)
+      throws java.io.IOException, ClassNotFoundException {
+    in.defaultReadObject();
   }
 }

--- a/src/main/java/network/crypta/client/async/USKFetcherTagCallback.java
+++ b/src/main/java/network/crypta/client/async/USKFetcherTagCallback.java
@@ -1,6 +1,51 @@
 package network.crypta.client.async;
 
+/**
+ * Callback extension that receives the concrete {@link USKFetcherTag} instance associated with a
+ * USK fetch. Implementations typically store the tag for later correlation, transitions, or UI
+ * updates and then handle terminal events via the inherited {@link USKFetcherCallback} methods.
+ *
+ * <p>The framework calls {@link #setTag(USKFetcherTag, ClientContext)} before delivering terminal
+ * events such as {@code onFoundEdition}, {@code onFailure}, or {@code onCancelled}. For persistent
+ * requests, this method may be invoked after a restart when callbacks are replayed on the
+ * persistent job runner. Implementations should therefore treat it as idempotent and thread‑safe.
+ * The provided {@link ClientContext} reflects the execution environment where subsequent callback
+ * methods will run.
+ *
+ * <p>Typical responsibilities include:
+ *
+ * <ul>
+ *   <li>Capturing the tag to enable handoff or transition to another state machine.
+ *   <li>Associating the tag with UI elements or request tracking structures.
+ *   <li>Reading immutable properties (token, persistence) needed to process results.
+ * </ul>
+ *
+ * @see USKFetcherTag
+ * @see USKFetcherCallback
+ * @see ClientContext
+ */
 public interface USKFetcherTagCallback extends USKFetcherCallback {
 
+  /**
+   * Supplies the runtime tag instance and execution context prior to delivering terminal events.
+   * Implementations usually cache the tag for later correlation or transitions. The call may occur
+   * more than once across the lifecycle (e.g., after restart), and should be written to be
+   * thread‑safe and idempotent. Avoid blocking; heavy work should be deferred to subsequent event
+   * handlers running on the provided context.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * class MyCb implements USKFetcherTagCallback {
+   *   private USKFetcherTag tag;
+   *   public void setTag(USKFetcherTag t, ClientContext ctx) { this.tag = t; }
+   * }
+   * }</pre>
+   *
+   * @param tag The concrete {@link USKFetcherTag} associated with this callback; expected non‑null
+   *     and stable for the duration of the current fetch attempt.
+   * @param context The client execution context where callbacks execute; use only for lightweight
+   *     coordination and do not retain beyond the immediate callback unless documented.
+   */
   void setTag(USKFetcherTag tag, ClientContext context);
 }

--- a/src/main/java/network/crypta/client/async/USKManager.java
+++ b/src/main/java/network/crypta/client/async/USKManager.java
@@ -147,13 +147,12 @@ public class USKManager {
     return USKFetcherTag.create(
         usk,
         callback,
-        persistent,
-        realTime,
         ctx,
-        keepLast,
         0,
-        ownFetchContext,
-        checkStoreOnly || ctx.localRequestOnly);
+        persistent ? USKFetcherTag.Flag.PERSISTENT : null,
+        realTime ? USKFetcherTag.Flag.REAL_TIME : null,
+        keepLast ? USKFetcherTag.Flag.KEEP_LAST_DATA : null,
+        (checkStoreOnly || ctx.localRequestOnly) ? USKFetcherTag.Flag.CHECK_STORE_ONLY : null);
   }
 
   USKFetcher getFetcher(

--- a/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
+++ b/src/test/java/network/crypta/client/async/USKFetcherTagTest.java
@@ -1,0 +1,590 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.config.Config;
+import network.crypta.crypt.DSAPublicKey;
+import network.crypta.crypt.Global;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.crypt.SHA256;
+import network.crypta.keys.ClientSSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.NodeSSK;
+import network.crypta.keys.USK;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.ArrayBucket;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class USKFetcherTagTest {
+
+  // -------------- Minimal direct helpers (copied from existing tests) --------------
+
+  private static final class DirectExecutor implements PriorityAwareExecutor {
+    @Override
+    public void execute(Runnable job) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName, boolean fromTicker) {
+      job.run();
+    }
+
+    @Override
+    public int[] waitingThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int[] runningThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int getWaitingThreadsCount() {
+      return 0;
+    }
+  }
+
+  private static final class DirectTicker implements Ticker {
+    private final PriorityAwareExecutor executor = new DirectExecutor();
+
+    @Override
+    public void queueTimedJob(Runnable job, long offset) {
+      job.run();
+    }
+
+    @Override
+    public void queueTimedJob(
+        Runnable job, String name, long offset, boolean runOnTickerAnyway, boolean noDupes) {
+      job.run();
+    }
+
+    @Override
+    public PriorityAwareExecutor getExecutor() {
+      return executor;
+    }
+
+    @Override
+    public void removeQueuedJob(Runnable job) {
+      // no-op
+    }
+
+    @Override
+    public void queueTimedJobAbsolute(
+        Runnable runner, String name, long time, boolean runOnTickerAnyway, boolean noDupes) {
+      runner.run();
+    }
+  }
+
+  private static FetchContext newFetchContext() {
+    // Small, deterministic limits; context is forwarded only.
+    return new FetchContext(
+        16L * 1024, // maxOutputLength
+        16L * 1024, // maxTempLength
+        4096, // maxMetadataSize
+        4, // maxRecursionLevel
+        0, // maxArchiveRestarts
+        2, // maxArchiveLevels
+        false, // dontEnterImplicitArchives
+        1, // maxSplitfileBlockRetries
+        1, // maxNonSplitfileRetries
+        1, // maxUSKRetries
+        true, // allowSplitfiles
+        true, // followRedirects
+        false, // localRequestOnly
+        false, // filterData
+        0, // maxDataBlocksPerSegment
+        0, // maxCheckBlocksPerSegment
+        size -> new ArrayBucket(), // BucketFactory
+        new SimpleEventProducer(),
+        true, // ignoreTooManyPathComponents
+        true, // canWriteClientCache
+        null, // charset
+        null, // overrideMIME
+        null // schemeHostAndPort
+        );
+  }
+
+  private static InsertContext newInsertContext() {
+    return new InsertContext(
+        0, // maxRetries
+        0, // rnfsToSuccess
+        0, // splitfileSegmentDataBlocks
+        0, // splitfileSegmentCheckBlocks
+        new SimpleEventProducer(),
+        true, // canWriteClientCache
+        false, // forkOnCacheable
+        false, // localRequestOnly
+        null, // compressorDescriptor
+        0, // extraInsertsSingleBlock
+        0, // extraInsertsSplitfileHeaderBlock
+        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+  }
+
+  private static ClientContext minimalContext(
+      ClientLayerPersister jobRunner,
+      LinkFilterExceptionProvider linkFilterExceptionProvider,
+      FetchContext defaultPF,
+      InsertContext defaultPI,
+      USKManager uskManager,
+      PersistentTempBucketFactory ptbf,
+      TempBucketFactory tbf) {
+    return new ClientContext(
+        1L,
+        jobRunner,
+        new DirectExecutor(),
+        Mockito.mock(ArchiveManager.class),
+        ptbf,
+        tbf,
+        Mockito.mock(PersistentFileTracker.class),
+        Mockito.mock(HealingQueue.class),
+        uskManager,
+        Mockito.mock(RandomSource.class),
+        new java.util.Random(123),
+        new DirectTicker(),
+        Mockito.mock(MemoryLimitedJobRunner.class),
+        Mockito.mock(FilenameGenerator.class),
+        Mockito.mock(FilenameGenerator.class),
+        Mockito.mock(LockableRandomAccessBufferFactory.class),
+        Mockito.mock(LockableRandomAccessBufferFactory.class),
+        Mockito.mock(FileRandomAccessBufferFactory.class),
+        Mockito.mock(FileRandomAccessBufferFactory.class),
+        Mockito.mock(RealCompressor.class),
+        Mockito.mock(DatastoreChecker.class),
+        Mockito.mock(PersistentRequestRoot.class),
+        Mockito.mock(MasterSecret.class),
+        linkFilterExceptionProvider,
+        defaultPF,
+        defaultPI,
+        Mockito.mock(Config.class));
+  }
+
+  // ---------------- Test fixture ----------------
+
+  private USK usk;
+  private FetchContext fetchContext;
+
+  @Mock private USKManager uskManager;
+  @Mock private USKFetcher fetcher;
+  @Mock private ClientContext mockContext;
+
+  @BeforeEach
+  void setup() throws MalformedURLException {
+    // Deterministic key material for USK
+    DSAPublicKey pubKey = new DSAPublicKey(Global.DSAgroupBigA, BigInteger.valueOf(2));
+    byte[] pubKeyHash = SHA256.digest(pubKey.asBytes());
+    byte[] cryptoKey = new byte[ClientSSK.CRYPTO_KEY_LENGTH];
+    Arrays.fill(cryptoKey, (byte) 0x2A);
+    byte cryptoAlgorithm = Key.ALGO_AES_PCFB_256_SHA256;
+    byte[] extras =
+        new byte[] {NodeSSK.SSK_VERSION, 0, cryptoAlgorithm, 0, (byte) KeyBlock.HASH_SHA256};
+
+    usk = new USK(pubKeyHash, cryptoKey, extras, "testsite", 5L);
+    fetchContext = newFetchContext();
+  }
+
+  private USKFetcherTag newTag(
+      USKFetcherCallback callback,
+      boolean persistent,
+      boolean realTime,
+      boolean keepLast,
+      boolean checkStoreOnly,
+      int token) {
+    return USKFetcherTag.create(
+        usk,
+        callback,
+        fetchContext,
+        token,
+        persistent ? USKFetcherTag.Flag.PERSISTENT : null,
+        realTime ? USKFetcherTag.Flag.REAL_TIME : null,
+        keepLast ? USKFetcherTag.Flag.KEEP_LAST_DATA : null,
+        checkStoreOnly ? USKFetcherTag.Flag.CHECK_STORE_ONLY : null);
+  }
+
+  @Test
+  @DisplayName("start_nonPersistent_usesOrigUSK_addsCallback_andSchedules")
+  void start_nonPersistent_usesOrigUSK_addsCallback_andSchedules() {
+    // Arrange
+    USKFetcherCallback cb = Mockito.mock(USKFetcherCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 11);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 22);
+    USKFetcherTag tag = newTag(cb, false, false, false, false, 42);
+
+    ArgumentCaptor<USK> uskCap = ArgumentCaptor.forClass(USK.class);
+    ArgumentCaptor<ClientRequester> reqCap = ArgumentCaptor.forClass(ClientRequester.class);
+    when(uskManager.getFetcher(
+            uskCap.capture(), eq(fetchContext), reqCap.capture(), eq(false), eq(false)))
+        .thenReturn(fetcher);
+
+    // Act
+    tag.start(uskManager, mockContext);
+
+    // Assert
+    assertSame(
+        usk, uskCap.getValue(), "Non-persistent start should pass the original USK instance");
+    ClientRequester wrapper = reqCap.getValue();
+    assertEquals(
+        11, wrapper.getPriorityClass(), "Wrapper priority should match normal polling priority");
+    assertFalse(wrapper.realTimeFlag, "Wrapper should not be real-time for realTime=false");
+    verify(fetcher, times(1)).addCallback(tag);
+    verify(fetcher, times(1)).schedule(mockContext);
+  }
+
+  @Test
+  @DisplayName("start_persistent_copiesUSK_and_usesRTClient_whenRealTime")
+  void start_persistent_copiesUSK_and_usesRTClient_whenRealTime() {
+    // Arrange
+    USKFetcherCallback cb = Mockito.mock(USKFetcherCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 7);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 9);
+    USKFetcherTag tag = newTag(cb, true, true, true, true, 77);
+
+    ArgumentCaptor<USK> uskCap = ArgumentCaptor.forClass(USK.class);
+    ArgumentCaptor<ClientRequester> reqCap = ArgumentCaptor.forClass(ClientRequester.class);
+    ArgumentCaptor<Boolean> keepLastCap = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> checkStoreOnlyCap = ArgumentCaptor.forClass(Boolean.class);
+    when(uskManager.getFetcher(
+            uskCap.capture(),
+            eq(fetchContext),
+            reqCap.capture(),
+            keepLastCap.capture(),
+            checkStoreOnlyCap.capture()))
+        .thenReturn(fetcher);
+
+    // Act
+    tag.start(uskManager, mockContext);
+
+    // Assert
+    USK used = uskCap.getValue();
+    // For persistent=true, USK is copied even if edition is unchanged
+    assertNotSame(used, usk, "Persistent start should pass a copy of the USK");
+    assertEquals(used, usk, "Copied USK should be equal to the original");
+    ClientRequester wrapper = reqCap.getValue();
+    assertTrue(wrapper.realTimeFlag, "Wrapper should be real-time when realTime=true");
+    assertEquals(Short.valueOf((short) 7), Short.valueOf(wrapper.getPriorityClass()));
+    assertTrue(keepLastCap.getValue(), "keepLastData flag should pass through");
+    assertTrue(checkStoreOnlyCap.getValue(), "checkStoreOnly flag should pass through");
+    verify(fetcher).addCallback(tag);
+    verify(fetcher).schedule(mockContext);
+  }
+
+  @Test
+  @DisplayName("updatedEdition_higherEdition_passesCopyWithUpdatedEdition")
+  void updatedEdition_higherEdition_passesCopyWithUpdatedEdition() {
+    // Arrange
+    USKFetcherCallback cb = Mockito.mock(USKFetcherCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 5);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 6);
+    USKFetcherTag tag = newTag(cb, false, false, false, false, 1);
+
+    long newer = usk.suggestedEdition + 10;
+    tag.updatedEdition(newer);
+
+    ArgumentCaptor<USK> uskCap = ArgumentCaptor.forClass(USK.class);
+    when(uskManager.getFetcher(
+            uskCap.capture(),
+            eq(fetchContext),
+            any(ClientRequester.class),
+            anyBoolean(),
+            anyBoolean()))
+        .thenReturn(fetcher);
+
+    // Act
+    tag.start(uskManager, mockContext);
+
+    // Assert
+    USK used = uskCap.getValue();
+    assertEquals(
+        newer, used.suggestedEdition, "Start must pass a USK copy with the updated edition");
+    assertNotSame(used, usk, "USK instance should be a copy when edition increases");
+  }
+
+  @Test
+  @DisplayName("cancel_invokesFetcherCancel_and_setsFinished")
+  void cancel_invokesFetcherCancel_and_setsFinished() {
+    // Arrange
+    USKFetcherCallback cb = Mockito.mock(USKFetcherCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 1);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 2);
+    USKFetcherTag tag = newTag(cb, false, false, false, false, 99);
+    when(uskManager.getFetcher(
+            any(USK.class),
+            any(FetchContext.class),
+            any(ClientRequester.class),
+            anyBoolean(),
+            anyBoolean()))
+        .thenReturn(fetcher);
+    tag.start(uskManager, mockContext);
+
+    // Act
+    tag.cancel(mockContext);
+
+    // Assert
+    verify(fetcher, times(1)).cancel(mockContext);
+    assertTrue(tag.isFinished(), "Tag should be marked finished after cancel");
+  }
+
+  @Test
+  @DisplayName("onCancelled_nonPersistent_callsCallbackDirectly_and_setsTagWhenSupported")
+  void onCancelled_nonPersistent_callsCallbackDirectly_and_setsTagWhenSupported() {
+    // Arrange
+    USKFetcherTagCallback cb = Mockito.mock(USKFetcherTagCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 3);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 4);
+    USKFetcherTag tag = newTag(cb, false, false, false, false, 10);
+
+    // Act
+    tag.onCancelled(mockContext);
+
+    // Assert
+    verify(cb, times(1)).setTag(tag, mockContext);
+    verify(cb, times(1)).onCancelled(mockContext);
+    assertTrue(tag.isFinished(), "Tag should be finished after onCancelled");
+  }
+
+  @Test
+  @DisplayName("onCancelled_persistent_queuesJobRunner_and_invokesCallbackInsideJob")
+  void onCancelled_persistent_queuesJobRunner_and_invokesCallbackInsideJob()
+      throws PersistenceDisabledException {
+    // Arrange: build a real context with a mocked job runner and manager
+    ClientLayerPersister jobRunner = Mockito.mock(ClientLayerPersister.class);
+    USKManager manager = Mockito.mock(USKManager.class);
+    ClientContext ctx =
+        minimalContext(
+            jobRunner,
+            Mockito.mock(LinkFilterExceptionProvider.class),
+            newFetchContext(),
+            newInsertContext(),
+            manager,
+            Mockito.mock(PersistentTempBucketFactory.class),
+            Mockito.mock(TempBucketFactory.class));
+
+    USKFetcherTagCallback cb = Mockito.mock(USKFetcherTagCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 8);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 9);
+    USKFetcherTag tag = newTag(cb, true, false, false, false, 2);
+
+    // jobRunner.queue should immediately run the job with provided context
+    doAnswer(
+            inv -> {
+              PersistentJob job = inv.getArgument(0);
+              job.run(ctx);
+              return null;
+            })
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+
+    // Act
+    tag.onCancelled(ctx);
+
+    // Assert: setTag and onCancelled called via queued job
+    verify(cb, times(1)).setTag(tag, ctx);
+    verify(cb, times(1)).onCancelled(ctx);
+    assertTrue(tag.isFinished(), "Tag should be finished after persistent onCancelled");
+  }
+
+  @Test
+  @DisplayName("onFailure_afterFinished_doesNotInvokeCallback")
+  void onFailure_afterFinished_doesNotInvokeCallback() {
+    // Arrange
+    USKFetcherCallback cb = Mockito.mock(USKFetcherCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 1);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 2);
+    USKFetcherTag tag = newTag(cb, false, false, false, false, 0);
+    tag.onCancelled(mockContext); // sets finished
+
+    // Act
+    tag.onFailure(mockContext);
+
+    // Assert: no callback, still finished
+    verify(cb, times(0)).onFailure(any());
+    assertTrue(tag.isFinished());
+  }
+
+  @Test
+  @DisplayName("onFoundEdition_nonPersistent_invokesCallback_and_setsFinished")
+  void onFoundEdition_nonPersistent_invokesCallback_and_setsFinished() {
+    // Arrange
+    USKFetcherTagCallback cb = Mockito.mock(USKFetcherTagCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 1);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 2);
+    USKFetcherTag tag = newTag(cb, false, false, false, false, 123);
+
+    long edition = 42L;
+    short codec = 7;
+    byte[] data = new byte[] {1, 2, 3};
+
+    // Act
+    tag.onFoundEdition(edition, usk.copy(edition), mockContext, false, codec, data, true, true);
+
+    // Assert
+    verify(cb, times(1)).setTag(tag, mockContext);
+    // Capture and assert arguments instead of eq(...)
+    ArgumentCaptor<Long> lCap = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<USK> uCap = ArgumentCaptor.forClass(USK.class);
+    ArgumentCaptor<ClientContext> cCap = ArgumentCaptor.forClass(ClientContext.class);
+    ArgumentCaptor<Boolean> mCap = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Short> codecCap = ArgumentCaptor.forClass(Short.class);
+    ArgumentCaptor<byte[]> dataCap = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Boolean> kCap = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Boolean> sCap = ArgumentCaptor.forClass(Boolean.class);
+    verify(cb, times(1))
+        .onFoundEdition(
+            lCap.capture(),
+            uCap.capture(),
+            cCap.capture(),
+            mCap.capture(),
+            codecCap.capture(),
+            dataCap.capture(),
+            kCap.capture(),
+            sCap.capture());
+    assertEquals(edition, lCap.getValue());
+    assertEquals(mockContext, cCap.getValue());
+    assertFalse(mCap.getValue());
+    assertEquals(codec, codecCap.getValue());
+    assertArrayEquals(data, dataCap.getValue());
+    assertTrue(kCap.getValue());
+    assertTrue(sCap.getValue());
+    assertTrue(tag.isFinished());
+
+    // Calling again should be ignored because finished
+    tag.onFoundEdition(
+        edition + 1, usk.copy(edition + 1), mockContext, false, codec, data, true, true);
+    verify(cb, times(1))
+        .onFoundEdition(
+            anyLong(),
+            any(USK.class),
+            any(ClientContext.class),
+            anyBoolean(),
+            anyShort(),
+            any(),
+            anyBoolean(),
+            anyBoolean());
+  }
+
+  @Test
+  @DisplayName("getters_token_and_priorities")
+  void getters_token_and_priorities() {
+    USKFetcherCallback cb = Mockito.mock(USKFetcherCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 15);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 25);
+    USKFetcherTag tag = newTag(cb, false, false, false, true, 31415);
+
+    assertEquals(31415L, tag.getToken());
+    assertEquals(15, tag.getPollingPriorityNormal());
+    assertEquals(25, tag.getPollingPriorityProgress());
+    assertFalse(tag.isFinished());
+  }
+
+  @Test
+  @DisplayName("schedule_usesContextUSKManager")
+  void schedule_usesContextUSKManager() {
+    // Arrange a real-ish context carrying our mocked manager
+    ClientLayerPersister jobRunner = Mockito.mock(ClientLayerPersister.class);
+    ClientContext ctx =
+        minimalContext(
+            jobRunner,
+            Mockito.mock(LinkFilterExceptionProvider.class),
+            newFetchContext(),
+            newInsertContext(),
+            uskManager,
+            Mockito.mock(PersistentTempBucketFactory.class),
+            Mockito.mock(TempBucketFactory.class));
+
+    USKFetcherCallback cb = Mockito.mock(USKFetcherCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 5);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 6);
+    USKFetcherTag tag = newTag(cb, false, false, false, false, 100);
+
+    when(uskManager.getFetcher(
+            any(USK.class),
+            eq(fetchContext),
+            any(ClientRequester.class),
+            anyBoolean(),
+            anyBoolean()))
+        .thenReturn(fetcher);
+
+    // Act
+    tag.schedule(ctx);
+
+    // Assert: start() should have delegated to manager.getFetcher and scheduled the fetcher
+    verify(uskManager, times(1))
+        .getFetcher(
+            any(USK.class),
+            eq(fetchContext),
+            any(ClientRequester.class),
+            anyBoolean(),
+            anyBoolean());
+    verify(fetcher, times(1)).addCallback(tag);
+    verify(fetcher, times(1)).schedule(ctx);
+  }
+
+  @Test
+  @DisplayName("onResume_whenFinished_doesNothing")
+  void onResume_whenFinished_doesNothing() {
+    USKFetcherCallback cb = Mockito.mock(USKFetcherCallback.class);
+    when(cb.getPollingPriorityNormal()).thenReturn((short) 1);
+    when(cb.getPollingPriorityProgress()).thenReturn((short) 2);
+    USKFetcherTag tag = newTag(cb, false, false, false, false, 0);
+    tag.onCancelled(mockContext); // mark finished
+
+    tag.onResume(mockContext);
+    // No interactions expected since finished prevents restart
+    verify(uskManager, times(0))
+        .getFetcher(
+            any(USK.class),
+            any(FetchContext.class),
+            any(ClientRequester.class),
+            anyBoolean(),
+            anyBoolean());
+  }
+}


### PR DESCRIPTION
Summary
- Improve and expand Javadoc for USKFetcherTag, clarifying purpose, lifecycle, concurrency, and persistence semantics.
- Make USKFetcherTag public for clearer API usage and to align with other client async types.
- Update USKFetcherTagCallback Javadoc (doclint‑clean), minor tidy in USKManager.
- Add comprehensive unit test USKFetcherTagTest.
- Apply Spotless formatting across touched files.

Changes
- src/main/java/network/crypta/client/async/USKFetcherTag.java: docs overhaul; visibility -> public; minor comments and structure tidy (no behavior changes intended).
- src/main/java/network/crypta/client/async/USKFetcherTagCallback.java: expanded Javadoc.
- src/main/java/network/crypta/client/async/USKManager.java: minor adjustments consistent with USKFetcherTag changes.
- src/test/java/network/crypta/client/async/USKFetcherTagTest.java: new tests.

Rationale
- Aligns with ongoing documentation/doclint cleanup efforts across client async components.
- Public visibility for USKFetcherTag helps clarify intended external use as a serializable, persistent tag.

Testing
- New tests added for USKFetcherTag behavior.
- Build formatting enforced via Spotless: `./gradlew spotlessApply`.

Notes
- No functional changes expected beyond visibility; serialization remains stable (serialVersionUID unchanged).
- Please review API surface change (class visibility) for downstream expectations.
