### PR TITLE
docs(async): doclint-clean Javadoc for USK callbacks

### DIFF
--- a/src/main/java/network/crypta/client/async/USKProgressCallback.java
+++ b/src/main/java/network/crypta/client/async/USKProgressCallback.java
@@ -1,17 +1,58 @@
 package network.crypta.client.async;
 
+/**
+ * Callback interface used by asynchronous USK fetchers to report progress around the transition
+ * from local datastore checks to network activity, and to signal the end of a polling round.
+ *
+ * <p>Implementations receive notifications at key points in the USK polling lifecycle so that user
+ * interfaces, logging systems, or orchestration code can provide feedback without participating in
+ * the protocol itself. Typical call patterns are: the client checks the datastore; when it decides
+ * to contact peers, {@link #onSendingToNetwork(ClientContext)} is invoked; once all polling
+ * requests cool down and probe attempts complete, {@link #onRoundFinished(ClientContext)} is
+ * called. Implementations should return quickly and avoid blocking network or scheduler threads.
+ *
+ * <p>Concurrency: callbacks may be invoked on internal worker threads. No ordering beyond what is
+ * stated here is guaranteed, and a callback can be invoked multiple times over the lifetime of a
+ * long-running request. Implementations should be thread-safe if shared across requests and must
+ * tolerate long gaps between notifications.
+ *
+ * <ul>
+ *   <li>Never perform blocking I/O inside a callback.
+ *   <li>Prefer idempotent updates; the same notification might occur more than once.
+ *   <li>Assume {@code ClientContext} is non-null and scoped to the current request.
+ * </ul>
+ *
+ * @see USKCallback
+ */
 public interface USKProgressCallback extends USKCallback {
 
   /**
-   * Called when the datastore has been checked and we are now going to send requests. There might
-   * be a long gap between this callback and the time at which we actually start a network level
-   * request.
+   * Notifies that the client has finished the local datastore phase and intends to send network
+   * requests for the current USK polling cycle. There may be a noticeable delay before the first
+   * packet actually leaves the node, for example while scheduling aligns or rate limits apply.
+   *
+   * <p>Use this signal to update progress indicators or logs that distinguish between local lookup
+   * and network activity. Implementations should return promptly; heavy work here can delay the
+   * beginning of the network phase and negatively impact latency.
+   *
+   * @param context execution context for the request; never {@code null}; provides access to
+   *     request-scoped services and identifiers suitable for logging and lightweight progress
+   *     updates
    */
   void onSendingToNetwork(ClientContext context);
 
   /**
-   * Called when we have checked the datastore, and all our polling requests have gone into
-   * cooldown, and all our random future edition probes have completed.
+   * Notifies that a polling round concluded after the datastore checks, cooldown of active polling
+   * requests, and completion of any random future-edition probes. At this point the scheduler may
+   * decide to begin a new round or stop depending on policy and observed results.
+   *
+   * <p>Use this signal to finalize per-round metrics, refresh UI state, or emit summary logs. The
+   * method should perform only quick bookkeeping; avoid long-running operations that could stall
+   * subsequent scheduling decisions.
+   *
+   * @param context execution context for the request; never {@code null}; holds stable identifiers
+   *     and lightweight helpers intended for diagnostics and progress reporting within the current
+   *     polling round
    */
   void onRoundFinished(ClientContext context);
 }

--- a/src/main/java/network/crypta/client/async/USKRetrieverCallback.java
+++ b/src/main/java/network/crypta/client/async/USKRetrieverCallback.java
@@ -4,26 +4,78 @@ import network.crypta.client.FetchResult;
 import network.crypta.keys.USK;
 import network.crypta.node.RequestStarter;
 
-/** Interface implemented by USKRetriever clients. */
+/**
+ * Callback contract for clients that consume results from a USK retriever.
+ *
+ * <p>Implementations receive notifications when the retriever discovers and downloads a newer
+ * edition for a given {@link USK}. This interface is intentionally small and synchronous so it can
+ * be implemented by UI controllers, logging/reporting components, or higher-level coordinators.
+ * Typical usage is to register an instance with a retriever or subscription manager, update the
+ * application state on {@link #onFound(USK, long, FetchResult)}, and influence background polling
+ * aggressiveness by returning priorities through {@link #getPollingPriorityNormal()} and {@link
+ * #getPollingPriorityProgress()}.
+ *
+ * <p>Concurrency and ordering: callbacks may be invoked on internal worker threads. Implementations
+ * should be thread-safe if shared and must avoid blocking operations; heavy work should be
+ * dispatched to application executors. Notifications can repeat over time as newer editions become
+ * available. The interface does not guarantee delivery for every intermediate edition if multiple
+ * updates occur quickly.
+ *
+ * <ul>
+ *   <li>Keep implementations fast and idempotent to avoid head-of-line blocking.
+ *   <li>Persist only data the application actually needs; payloads may be large.
+ *   <li>Use {@link RequestStarter} constants when returning polling priorities.
+ * </ul>
+ *
+ * @see USKCallback
+ * @see RequestStarter
+ */
 public interface USKRetrieverCallback {
 
   /**
-   * Called when a new edition is found and downloaded.
+   * Notifies that a new USK edition has been found and its content retrieved.
    *
-   * @param edition The USK edition number.
-   * @param data The retrieved data.
+   * <p>The retriever supplies the original key used to subscribe, the discovered logical edition
+   * number, and the corresponding fetch result. Implementations commonly persist the payload,
+   * update a cache, or trigger downstream processing. This method should return quickly; lengthy
+   * work should be scheduled elsewhere to keep polling responsive. The same method may be invoked
+   * multiple times over the lifetime of a subscription as newer editions are published.
+   *
+   * @param origUSK The original key for the subscription or request; never {@code null}. It may be
+   *     reused across callbacks and identifies the logical update stream rather than a specific
+   *     edition.
+   * @param edition The discovered edition number associated with this callback. Higher values
+   *     represent newer content; callers must handle out-of-order delivery when processing quickly
+   *     advancing streams.
+   * @param data The retrieved content wrapper for the edition, including any metadata provided by
+   *     the client layer. Callers should treat the contained buffers as owned by the callee after
+   *     this method returns.
    */
   void onFound(USK origUSK, long edition, FetchResult data);
 
   /**
-   * Priority at which the polling should run normally. You have to return one of the constants from
-   * {@link RequestStarter}.
+   * Returns the scheduler priority used for steady-state background polling.
+   *
+   * <p>This value applies when no immediate progress is expected. It should reflect the desired
+   * background importance relative to other client activity and be one of the documented constants
+   * in {@link RequestStarter}. Returning a lower urgency may reduce bandwidth usage at the cost of
+   * update latency.
+   *
+   * @return A {@link RequestStarter} priority constant representing normal background polling
+   *     urgency; callers must not return arbitrary values outside the supported constant set.
    */
   short getPollingPriorityNormal();
 
   /**
-   * Priority at which the polling should run when starting, or immediately after making some
-   * progress. You have to return one of the constants from {@link RequestStarter}.
+   * Returns the scheduler priority to use at startup or immediately after progress.
+   *
+   * <p>This value is typically higher than the normal background level and is applied to reduce
+   * end-to-end latency around initial subscription and recent discoveries. It must match a constant
+   * from {@link RequestStarter}. Implementations may return the same value as normal when no boost
+   * is desired.
+   *
+   * @return A {@link RequestStarter} priority constant indicating boosted urgency during startup or
+   *     right after progress; must correspond to a supported scheduler priority level.
    */
   short getPollingPriorityProgress();
 }


### PR DESCRIPTION
Summary
- Add long-form, doclint-clean Javadoc for async USK callback interfaces.
- No code behavior changes; comments only. Formatted with Spotless.

Changes
- src/main/java/network/crypta/client/async/USKProgressCallback.java
  - Comprehensive class-level docs describing lifecycle, call timing, and concurrency expectations.
  - Enriched method docs for onSendingToNetwork(...) and onRoundFinished(...), with param tags and guidance.
  - Links to related interface USKCallback.

- src/main/java/network/crypta/client/async/USKRetrieverCallback.java
  - Expanded top-level docs with usage patterns and threading guidance.
  - Detailed onFound(...) param semantics (origUSK, edition, data) and performance/ownership notes.
  - Added @return details for getPollingPriorityNormal()/getPollingPriorityProgress() and link to RequestStarter.

Validation
- Doclint: zero warnings for both files.
  Repro:
  ./gradlew -q classes
  javadoc -quiet -Xdoclint:all -classpath "build/classes/java/main:build/resources/main" -sourcepath . -d /tmp/doclint-out "src/main/java/network/crypta/client/async/USKProgressCallback.java"
  javadoc -quiet -Xdoclint:all -classpath "build/classes/java/main:build/resources/main" -sourcepath . -d /tmp/doclint-out "src/main/java/network/crypta/client/async/USKRetrieverCallback.java"

- Formatting: ./gradlew spotlessApply (before commit).

Notes
- Comments-only change; no imports, signatures, or logic altered.
- Keeps links resolvable to remain doclint-clean.

Please let me know if you’d like the same treatment applied to additional async client interfaces.
