### PR TITLE
USKInserter: parameterized logging, expanded Javadoc, and new unit tests

### DIFF
--- a/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/src/main/java/network/crypta/client/async/USKInserter.java
@@ -21,9 +21,37 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Insert a USK. The algorithm is simply to do a thorough search for the latest edition, and insert
- * at the following slot. Thereafter, if we get a collision, increment our slot; if we get more than
- * 5 consecutive collisions, search for the latest slot again.
+ * Inserts content into an {@link network.crypta.keys.USK} (Updatable Subspace Key).
+ *
+ * <p>The inserter performs a search for the latest known edition of the USK and attempts to insert
+ * the provided block at the immediately following slot. If a collision is reported (the slot is
+ * already taken), the inserter advances to the next slot and retries. After a bounded number of
+ * consecutive collisions, it re-enters discovery to refresh the latest known good edition before
+ * continuing.
+ *
+ * <p>Typical usage is to construct an instance with the desired data, compression settings, and
+ * insert context, then call {@link #schedule(ClientContext)} to begin the asynchronous workflow.
+ * Progress and completion are reported through the supplied {@link PutCompletionCallback}. This
+ * class coordinates a {@link USKFetcherTag} to discover the current edition and a {@link
+ * SingleBlockInserter} to perform the actual SSK block insert for a given edition of the USK.
+ *
+ * <p>Concurrency: instances are stateful and not intended for reuse across multiple inserts.
+ * Internal state transitions occur on callbacks driven by the client framework; externally visible
+ * methods guard state via synchronization where necessary. Callers should treat an instance as
+ * single-use and avoid concurrent calls other than lifecycle hooks invoked by the framework.
+ *
+ * <ul>
+ *   <li>Search: discovers the latest known edition before first insert.
+ *   <li>Insert: writes the SSK block to {@code edition + 1} and advances on collisions.
+ *   <li>Hints: optionally emits USK date hints after a successful insert when configured.
+ *   <li>Lifecycle: supports cancel, resume after persistence, and shutdown notifications.
+ * </ul>
+ *
+ * @see USKFetcherTag
+ * @see SingleBlockInserter
+ * @see network.crypta.keys.USK
+ * @see network.crypta.client.InsertContext
+ * @see PutCompletionCallback
  */
 public class USKInserter
     implements ClientPutState, USKFetcherCallback, PutCompletionCallback, Serializable {
@@ -31,47 +59,99 @@ public class USKInserter
 
   @Serial private static final long serialVersionUID = 1L;
 
-  static {
-  }
-
-  // Stuff to be passed on to the SingleBlockInserter
+  /** Stuff forwarded to the {@link SingleBlockInserter} when creating an insert. */
   final BaseClientPutter parent;
+
+  /**
+   * Source payload to insert. Implementations provide byte access, length, and free semantics; this
+   * reference may be freed when the insert completes if {@code freeData} is enabled.
+   */
+  @SuppressWarnings("java:S1948")
   Bucket data;
+
+  /** Compression codec identifier to apply to the payload prior to insertion. */
   final short compressionCodec;
+
+  /** Per-insert configuration including retry policy, priorities, and flags. */
   final InsertContext ctx;
+
+  /** Callback notified of encode, success, failure, and state transitions. */
+  @SuppressWarnings("java:S1948")
   final PutCompletionCallback cb;
+
+  /** True if the payload represents metadata rather than primary content. */
   final boolean isMetadata;
+
+  /** Original content length in bytes, when known, used for progress reporting. */
   final int sourceLength;
+
+  /** Numeric token used by the parent for correlation and progress reporting. */
   final int token;
+
+  /**
+   * Opaque token supplied by the caller and returned in callbacks. It is not interpreted by the
+   * inserter and may be {@code null}. Ownership and mutability follow caller conventions.
+   */
+  @SuppressWarnings("java:S1948")
   public final Object tokenObject;
+
+  /** Whether this inserter participates in a persistent (resumable) operation. */
   final boolean persistent;
+
+  /** Real-time request flag used to influence scheduler/priorities downstream. */
   final boolean realTimeFlag;
 
+  /** Private insertable USK containing material needed to derive per-edition insert URIs. */
   final InsertableUSK privUSK;
+
+  /** Corresponding public USK used to resolve and report editions to consumers. */
   final USK pubUSK;
 
-  /** Scanning for latest slot */
+  /** Fetcher used to discover the latest inserted edition (scanning for latest slot). */
   private USKFetcherTag fetcher;
 
-  /** Insert the actual SSK */
+  /** Helper that inserts the actual SSK block for a given edition. */
   private SingleBlockInserter sbi;
 
+  /** Candidate edition being attempted for insertion; advances on collision. */
   private long edition;
 
-  /** Number of collisions while trying to insert so far */
+  /** Number of consecutive collisions encountered while attempting to insert. */
   private int consecutiveCollisions;
 
+  /** True once the inserter has reached a terminal state (success, failure, or cancel). */
   private boolean finished;
 
-  /** After attempting inserts on this many slots, go back to the Fetcher */
+  /** After this many attempted slots without success, fall back to re-fetch the latest. */
   private static final long MAX_TRIED_SLOTS = 10;
 
+  /** If true, frees {@link #data} after completion or terminal failure. */
   private final boolean freeData;
+
+  /** Precomputed identity-based hash code; used to keep stable identity semantics. */
   final int hashCode;
+
+  /** Additional insert attempts or related behavior delegated to lower levels. */
   private final int extraInserts;
+
+  /** Crypto algorithm identifier to use for underlying SSK insert, if applicable. */
   final byte cryptoAlgorithm;
+
+  /** Optional override for the crypto key material; {@code null} to auto-generate. */
   final byte[] forceCryptoKey;
 
+  /**
+   * Starts the asynchronous USK insert process.
+   *
+   * <p>Schedules a discovery pass to find the latest known edition and then attempts to insert the
+   * provided data at the next edition. Progress and completion are delivered to the configured
+   * {@link PutCompletionCallback}. Idempotent with respect to repeated calls before completion;
+   * subsequent calls after a terminal state have no effect.
+   *
+   * @param context the client context providing executors, managers, and factories; must be
+   *     non-{@code null} and valid for the lifetime of the operation
+   * @throws InsertException if scheduling the initial discovery or insert fails immediately
+   */
   @Override
   public void schedule(ClientContext context) throws InsertException {
     // Caller calls schedule()
@@ -94,7 +174,7 @@ public class USKInserter
    */
   private void scheduleFetcher(ClientContext context) {
     synchronized (this) {
-      if (LOG.isDebugEnabled()) LOG.debug("scheduling fetcher for " + pubUSK.getURI());
+      if (LOG.isDebugEnabled()) LOG.debug("scheduling fetcher for {}", pubUSK.getURI());
       if (finished) return;
       fetcher =
           context.uskManager.getFetcherForInsertDontSchedule(
@@ -105,11 +185,27 @@ public class USKInserter
               context,
               persistent,
               ctx.ignoreUSKDatehints);
-      if (LOG.isDebugEnabled()) LOG.debug("scheduled: " + fetcher);
+      if (LOG.isDebugEnabled()) LOG.debug("scheduled: {}", fetcher);
     }
     fetcher.schedule(context);
   }
 
+  /**
+   * Callback from the USK fetcher indicating the latest known edition.
+   *
+   * <p>Updates the candidate edition and, when possible, determines whether the content is already
+   * present by comparing data and codec. If the payload is already inserted at the reported
+   * edition, completes successfully. Otherwise, schedules an insert attempt at the next edition.
+   *
+   * @param l the discovered latest edition number (non-negative)
+   * @param key the USK associated with the discovery callback; same logical USK as this inserter
+   * @param context the client context used to schedule subsequent work
+   * @param lastContentWasMetadata whether the discovered edition contains metadata content
+   * @param codec the compression codec detected on the discovered edition
+   * @param hisData the discovered edition bytes when available; may be {@code null}
+   * @param newKnownGood true if this discovery advanced the known-good edition state
+   * @param newSlotToo true if the next slot is now known to exist or be reserved
+   */
   @Override
   public void onFoundEdition(
       long l,
@@ -136,7 +232,7 @@ public class USKInserter
             sbi = null;
           }
         } catch (IOException e) {
-          LOG.error("Could not decode: " + e, e);
+          LOG.error("Could not decode: {}", e, e);
         }
       }
       if (persistent) {
@@ -157,13 +253,14 @@ public class USKInserter
   }
 
   private void insertSucceeded(ClientContext context, long edition) {
+    // Inserts optional USK date hints after a successful content insert when configured.
     if (ctx.ignoreUSKDatehints) {
-      if (LOG.isDebugEnabled()) LOG.debug("Inserted to edition " + edition);
+      if (LOG.isDebugEnabled()) LOG.debug("Inserted to edition {}", edition);
       cb.onSuccess(this, context);
       return;
     }
     if (LOG.isDebugEnabled())
-      LOG.debug("Inserted to edition " + edition + " - inserting USK date hints...");
+      LOG.debug("Inserted to edition {} - inserting USK date hints...", edition);
     USKDateHint hint = USKDateHint.now();
     MultiPutCompletionCallback m =
         new MultiPutCompletionCallback(cb, parent, tokenObject, persistent, true);
@@ -195,12 +292,12 @@ public class USKInserter
                 extraInserts,
                 cryptoAlgorithm,
                 forceCryptoKey);
-        LOG.info("Inserting " + uri + " with " + sb + " for insert of " + pubUSK);
+        LOG.info("Inserting {} with {} for insert of {}", uri, sb, pubUSK);
         m.add(sb);
         sb.schedule(context);
         added = true;
       } catch (IOException e) {
-        LOG.error("Unable to insert USK date hints due to disk I/O error: " + e, e);
+        LOG.error("Unable to insert USK date hints due to disk I/O error: {}", e, e);
         if (!added) {
           cb.onFailure(
               new InsertException(
@@ -210,7 +307,7 @@ public class USKInserter
           return;
         } // Else try to insert the other hints.
       } catch (InsertException e) {
-        LOG.error("Unable to insert USK date hints due to error: " + e, e);
+        LOG.error("Unable to insert USK date hints due to error: {}", e, e);
         if (!added) {
           cb.onFailure(e, this, context);
           return;
@@ -222,12 +319,12 @@ public class USKInserter
   }
 
   private void scheduleInsert(ClientContext context) {
+    // Schedules a single-block insert for the current candidate edition.
     long edNo = Math.max(edition, context.uskManager.lookupLatestSlot(pubUSK) + 1);
     synchronized (this) {
       if (finished) return;
       edition = edNo;
-      if (LOG.isDebugEnabled())
-        LOG.debug("scheduling insert for " + pubUSK.getURI() + ' ' + edition);
+      if (LOG.isDebugEnabled()) LOG.debug("scheduling insert for {} {}", pubUSK.getURI(), edition);
       sbi =
           new SingleBlockInserter(
               parent,
@@ -266,6 +363,16 @@ public class USKInserter
     }
   }
 
+  /**
+   * Notifies that the single-block insert succeeded.
+   *
+   * <p>Updates the USK manager with the confirmed edition, frees data if configured, and reports
+   * the encoded USK (with concrete edition) to the completion callback. Also triggers optional USK
+   * date hint insertion when enabled by the insert context.
+   *
+   * @param state the originating state that completed, expected to be a {@link SingleBlockInserter}
+   * @param context the client context for follow-up work and bookkeeping
+   */
   @Override
   public synchronized void onSuccess(ClientPutState state, ClientContext context) {
     USK newEdition = pubUSK.copy(edition);
@@ -274,9 +381,9 @@ public class USKInserter
     FreenetURI targetURI = pubUSK.getSSK(edition).getURI();
     FreenetURI realURI = ((SingleBlockInserter) state).getURI(context);
     if (!targetURI.equals(realURI))
-      LOG.error("URI should be " + targetURI + " actually is " + realURI);
+      LOG.error("URI should be {} actually is {}", targetURI, realURI);
     else {
-      if (LOG.isDebugEnabled()) LOG.debug("URI should be " + targetURI + " actually is " + realURI);
+      if (LOG.isDebugEnabled()) LOG.debug("URI should be {} actually is {}", targetURI, realURI);
       context.uskManager.updateKnownGood(pubUSK, edition, context);
     }
     if (freeData) {
@@ -288,6 +395,17 @@ public class USKInserter
     // FINISHED!!!! Yay!!!
   }
 
+  /**
+   * Handles insert failure from the single-block inserter.
+   *
+   * <p>On collision, advances the edition and retries until a bound is reached, after which it
+   * reschedules discovery. For other failures, transitions to a terminal state, frees data if
+   * configured, and propagates the failure to the completion callback.
+   *
+   * @param e the cause of the failure, including mode information such as collisions
+   * @param state the state reporting the failure, typically a {@link SingleBlockInserter}
+   * @param context the client context used to schedule retries or propagate the failure
+   */
   @Override
   public void onFailure(InsertException e, ClientPutState state, ClientContext context) {
     synchronized (this) {
@@ -315,11 +433,58 @@ public class USKInserter
     }
   }
 
+  /**
+   * Returns a stable identity-based hash code for this inserter instance.
+   *
+   * @return the precomputed hash code suitable for identity maps and sets
+   */
   @Override
   public int hashCode() {
     return hashCode;
   }
 
+  /**
+   * Uses reference equality. Inserter instances are not value objects and equality is not defined
+   * over state.
+   *
+   * @param obj the object to compare with this instance
+   * @return {@code true} if and only if {@code obj} is the same instance as this
+   */
+  @Override
+  public boolean equals(Object obj) {
+    return this == obj;
+  }
+
+  /**
+   * Creates a new inserter for the given USK and payload.
+   *
+   * <p>The constructor captures all parameters needed to discover the target edition and perform an
+   * SSK block insert. No I/O or scheduling occurs until {@link #schedule(ClientContext)} is called.
+   * Callers may choose to have the payload freed automatically upon terminal completion.
+   *
+   * @param parent parent putter coordinating progress, priority, and client identity; non-null
+   * @param data source bucket providing the bytes to insert; may be freed on completion when
+   *     enabled
+   * @param compressionCodec compression codec identifier to apply to {@code data} prior to insert
+   * @param uri base USK URI that will be used to derive concrete per-edition insert URIs
+   * @param ctx insert context controlling behavior such as priorities, retries, and date hints
+   * @param cb completion callback receiving success, failure, and encode notifications
+   * @param isMetadata whether {@code data} represents metadata rather than primary content
+   * @param sourceLength original content length in bytes, when known; used for progress reporting
+   * @param token numeric token associated with this insert for correlation and logging
+   * @param addToParent if {@code true}, increments parent accounting and notifies clients
+   *     immediately
+   * @param tokenObject opaque token to return in callbacks; may be {@code null}
+   * @param context client context used for immediate parent notifications performed by the
+   *     constructor
+   * @param freeData if {@code true}, frees {@code data} on terminal completion (success/failure)
+   * @param persistent whether this inserter is persistent and can be resumed after restart
+   * @param realTimeFlag real-time scheduling hint that may influence downstream prioritization
+   * @param extraInserts additional insert attempts or related tuning delegated to lower layers
+   * @param cryptoAlgorithm crypto algorithm identifier for the underlying SSK insert
+   * @param forceCryptoKey optional crypto key override; {@code null} to auto-select
+   * @throws MalformedURLException if {@code uri} does not form a valid insertable USK
+   */
   public USKInserter(
       BaseClientPutter parent,
       Bucket data,
@@ -365,6 +530,13 @@ public class USKInserter
     this.realTimeFlag = realTimeFlag;
   }
 
+  /**
+   * No-arg constructor for serialization frameworks.
+   *
+   * <p>Not intended for direct use by application code. Fields are initialized to defaults only to
+   * satisfy deserialization requirements.
+   */
+  @SuppressWarnings("unused")
   protected USKInserter() {
     // For serialization.
     this.hashCode = 0;
@@ -388,11 +560,25 @@ public class USKInserter
     this.realTimeFlag = false;
   }
 
+  /**
+   * Returns the parent putter that owns this inserter.
+   *
+   * @return the non-null parent used for coordination, progress, and prioritization
+   */
   @Override
   public BaseClientPutter getParent() {
     return parent;
   }
 
+  /**
+   * Cancels the ongoing insert if it has not yet reached a terminal state.
+   *
+   * <p>Cancels any outstanding discovery and insert tasks, frees data when configured, and reports
+   * a {@link InsertExceptionMode#CANCELLED} failure to the completion callback. Safe to call more
+   * than once; subsequent calls after completion have no effect.
+   *
+   * @param context the client context used to propagate cancellation downstream
+   */
   @Override
   public void cancel(ClientContext context) {
     USKFetcherTag tag;
@@ -421,13 +607,28 @@ public class USKInserter
     cb.onFailure(new InsertException(InsertExceptionMode.CANCELLED), this, context);
   }
 
+  /**
+   * Callback from the USK fetcher when discovery did not find a suitable edition.
+   *
+   * <p>Proceeds to schedule an insert at the next candidate edition based on current knowledge.
+   *
+   * @param context the client context used to schedule the insert attempt
+   */
   @Override
   public void onFailure(ClientContext context) {
     if (LOG.isDebugEnabled())
-      LOG.debug("Fetcher failed to find the given edition or any later edition on " + this);
+      LOG.debug("Fetcher failed to find the given edition or any later edition on {}", this);
     scheduleInsert(context);
   }
 
+  /**
+   * Indicates that the fetcher was cancelled unexpectedly.
+   *
+   * <p>Treats this as an error and cancels the overall operation, reporting a cancellation failure
+   * to the completion callback.
+   *
+   * @param context the client context used while propagating cancellation
+   */
   @Override
   public void onCancelled(ClientContext context) {
     synchronized (this) {
@@ -438,49 +639,107 @@ public class USKInserter
     cancel(context);
   }
 
+  /**
+   * Notifies that an encode event occurred during the insert pipeline. This implementation does not
+   * take action for encode events; the final success path reports the encoded USK separately.
+   *
+   * @param key the key associated with the encode event
+   * @param state the state reporting the event
+   * @param context the client context at the time of the event
+   */
   @Override
   public void onEncode(BaseClientKey key, ClientPutState state, ClientContext context) {
     // Ignore
   }
 
+  /**
+   * Notifies that the inserter transitioned between internal states. This implementation does not
+   * expect transitions outside the insert lifecycle; unexpected transitions are logged.
+   *
+   * @param oldState previous state instance
+   * @param newState new state instance
+   * @param context client context during the transition
+   */
   @Override
   public void onTransition(
       ClientPutState oldState, ClientPutState newState, ClientContext context) {
     // Shouldn't happen
-    LOG.error("Got onTransition(" + oldState + ',' + newState + ')');
+    LOG.error("Got onTransition({},{})", oldState, newState);
   }
 
+  /**
+   * Reports metadata produced during the insert pipeline. This inserter does not expect metadata
+   * callbacks for USK inserts; unexpected events are logged.
+   *
+   * @param m metadata instance
+   * @param state the state reporting the metadata
+   * @param context the client context at the time of the callback
+   */
   @Override
   public void onMetadata(Metadata m, ClientPutState state, ClientContext context) {
     // Shouldn't happen
-    LOG.error("Got onMetadata(" + m + ',' + state + ')');
+    LOG.error("Got onMetadata({},{})", m, state);
   }
 
+  /**
+   * Indicates that a set of blocks has finished processing. Not used by this inserter.
+   *
+   * @param state reporting state
+   * @param context client context
+   */
   @Override
   public void onBlockSetFinished(ClientPutState state, ClientContext context) {
     // Ignore
   }
 
+  /**
+   * Returns the opaque token associated with this operation.
+   *
+   * @return the token object provided at construction time; may be {@code null}
+   */
   @Override
   public Object getToken() {
     return tokenObject;
   }
 
+  /**
+   * Indicates that content is fetchable for verification or reporting. Not used by this inserter.
+   *
+   * @param state reporting state
+   */
   @Override
   public void onFetchable(ClientPutState state) {
     // Ignore
   }
 
+  /**
+   * Returns the normal polling priority used by the scheduler for this operation.
+   *
+   * @return the priority class delegated from the parent
+   */
   @Override
   public short getPollingPriorityNormal() {
     return parent.getPriorityClass();
   }
 
+  /**
+   * Returns the progress polling priority used by the scheduler for this operation.
+   *
+   * @return the priority class delegated from the parent
+   */
   @Override
   public short getPollingPriorityProgress() {
     return parent.getPriorityClass();
   }
 
+  /**
+   * Receives metadata as a bucket during the insert pipeline. This inserter does not retain such
+   * metadata and frees the provided bucket immediately.
+   *
+   * @param meta metadata as a bucket; will be freed by this method
+   * @param state reporting state
+   * @param context client context
+   */
   @Override
   public void onMetadata(Bucket meta, ClientPutState state, ClientContext context) {
     LOG.error("onMetadata on {} from {}", this, state);
@@ -489,6 +748,16 @@ public class USKInserter
 
   private transient boolean resumed = false;
 
+  /**
+   * Resumes the inserter after persistence or a paused state.
+   *
+   * <p>Propagates resume events to owned resources exactly once and re-arms any outstanding fetch
+   * or insert operations.
+   *
+   * @param context the client context used to resume subordinate components
+   * @throws InsertException if resuming the insert pipeline fails
+   * @throws ResumeFailedException if any component cannot resume cleanly
+   */
   @Override
   public void onResume(ClientContext context) throws InsertException, ResumeFailedException {
     if (resumed) return;
@@ -499,12 +768,17 @@ public class USKInserter
     if (sbi != null) sbi.onResume(context);
   }
 
+  /**
+   * Notifies the inserter of an imminent shutdown so it can release resources eagerly.
+   *
+   * @param context the client context at shutdown time
+   */
   @Override
   public void onShutdown(ClientContext context) {
-    SingleBlockInserter sbi;
+    SingleBlockInserter localSbi;
     synchronized (this) {
-      sbi = this.sbi;
+      localSbi = this.sbi;
     }
-    if (sbi != null) sbi.onShutdown(context);
+    if (localSbi != null) localSbi.onShutdown(context);
   }
 }

--- a/src/test/java/network/crypta/client/async/USKInserterTest.java
+++ b/src/test/java/network/crypta/client/async/USKInserterTest.java
@@ -1,0 +1,764 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serial;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertException;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.InsertableClientSSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.USK;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class USKInserterTest {
+
+  @Mock private PutCompletionCallback cb;
+
+  @Mock private BaseClientPutter parent;
+
+  @Mock private USKManager uskManager;
+
+  @Mock private USKFetcherTag fetcherTag;
+
+  @Mock private Bucket metaBucket;
+
+  private ClientContext context;
+
+  private static class InlineExecutor implements PriorityAwareExecutor {
+    @Override
+    public void execute(Runnable job) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName, boolean fromTicker) {
+      job.run();
+    }
+
+    @Override
+    public int[] waitingThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int[] runningThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int getWaitingThreadsCount() {
+      return 0;
+    }
+  }
+
+  private record InserterCfg(
+      boolean isMetadata,
+      boolean addToParent,
+      boolean freeData,
+      boolean persistent,
+      boolean realTimeFlag) {}
+
+  private static final class DummyRandomSource extends RandomSource {
+    @Serial private static final long serialVersionUID = 1L;
+
+    @Override
+    public int acceptEntropy(
+        network.crypta.crypt.EntropySource source, long data, int entropyGuess) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(network.crypta.crypt.EntropySource timer) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(network.crypta.crypt.EntropySource fnpTimingSource, double bias) {
+      return 0;
+    }
+
+    @Override
+    public int acceptEntropyBytes(
+        network.crypta.crypt.EntropySource myPacketDataSource,
+        byte[] buf,
+        int offset,
+        int length,
+        double bias) {
+      return 0;
+    }
+
+    @Override
+    public void close() {
+      // No external resources to release in this test stub.
+    }
+  }
+
+  @BeforeEach
+  void setup() {
+    // Minimal ClientContext: only fields touched by these tests are used.
+    // Many collaborators are irrelevant here and can be passed as null or simple stubs.
+    context =
+        new ClientContext(
+            1L,
+            Mockito.mock(ClientLayerPersister.class),
+            new InlineExecutor(),
+            null, // ArchiveManager
+            null, // PersistentTempBucketFactory
+            null, // TempBucketFactory
+            null, // PersistentFileTracker
+            null, // HealingQueue
+            uskManager,
+            new DummyRandomSource(),
+            new SecureRandom(),
+            null, // Ticker
+            null, // MemoryLimitedJobRunner
+            null, // FilenameGenerator fg
+            null, // FilenameGenerator persistentFG
+            null, // LockableRandomAccessBufferFactory rafFactory
+            null, // LockableRandomAccessBufferFactory persistentRAFFactory
+            null, // FileRandomAccessBufferFactory transient
+            null, // FileRandomAccessBufferFactory persistent
+            null, // RealCompressor
+            null, // DatastoreChecker
+            null, // PersistentRequestRoot
+            null, // MasterSecret transient
+            null, // LinkFilterExceptionProvider
+            // Default persistent contexts used only when building fetchers internally; not
+            // exercised
+            // in these tests.
+            new FetchContext(
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                true,
+                0,
+                0,
+                0,
+                false,
+                false,
+                false,
+                false,
+                0,
+                0,
+                null,
+                new SimpleEventProducer(),
+                false,
+                false,
+                null,
+                null,
+                null),
+            new InsertContext(
+                0,
+                0,
+                0,
+                0,
+                new SimpleEventProducer(),
+                false,
+                false,
+                false,
+                null,
+                0,
+                0,
+                InsertContext.CompatibilityMode.COMPAT_CURRENT),
+            null // Config
+            );
+  }
+
+  // Helpers in tests create per-test SSKs to build consistent public/insertable USK URIs.
+
+  private static Bucket makeBucket(byte[] data) {
+    // Minimal bucket backed by provided bytes; supports read and free().
+    return new Bucket() {
+      private boolean freed = false;
+
+      @Override
+      public java.io.OutputStream getOutputStream() throws IOException {
+        throw new IOException("read-only");
+      }
+
+      @Override
+      public java.io.OutputStream getOutputStreamUnbuffered() throws IOException {
+        throw new IOException("read-only");
+      }
+
+      @Override
+      public InputStream getInputStream() {
+        return new ByteArrayInputStream(data);
+      }
+
+      @Override
+      public InputStream getInputStreamUnbuffered() {
+        return new ByteArrayInputStream(data);
+      }
+
+      @Override
+      public String getName() {
+        return "test-bucket";
+      }
+
+      @Override
+      public long size() {
+        return data.length;
+      }
+
+      @Override
+      public boolean isReadOnly() {
+        return true;
+      }
+
+      @Override
+      public void setReadOnly() {
+        // Bucket is a read-only stub; nothing to change.
+      }
+
+      @Override
+      public void free() {
+        freed = true;
+      }
+
+      @Override
+      public Bucket createShadow() {
+        return null;
+      }
+
+      @Override
+      public void onResume(ClientContext context) {
+        // Not persistent in tests; nothing to resume.
+      }
+
+      @Override
+      public void storeTo(DataOutputStream dos) {
+        // Not persistent in tests; no-op.
+      }
+
+      @Override
+      public String toString() {
+        return "Bucket[freed=" + freed + "]";
+      }
+    };
+  }
+
+  private USKInserter newInserter(
+      Bucket data,
+      short compressionCodec,
+      FreenetURI uskUri,
+      InsertContext insertCtx,
+      InserterCfg cfg)
+      throws Exception {
+    // Parent getClient() is consulted when scheduling a fetcher; we provide a minimal mock.
+    var rc = Mockito.mock(network.crypta.node.RequestClient.class);
+    Mockito.lenient().when(parent.getClient()).thenReturn(rc);
+    Mockito.lenient().when(rc.persistent()).thenReturn(cfg.persistent);
+    Mockito.lenient().when(rc.realTimeFlag()).thenReturn(cfg.realTimeFlag);
+
+    return new USKInserter(
+        parent,
+        data,
+        compressionCodec,
+        uskUri,
+        insertCtx,
+        cb,
+        cfg.isMetadata,
+        (int) data.size(),
+        123,
+        cfg.addToParent,
+        "token",
+        context,
+        cfg.freeData,
+        cfg.persistent,
+        cfg.realTimeFlag,
+        0,
+        Key.ALGO_AES_PCFB_256_SHA256,
+        null);
+  }
+
+  @Test
+  void schedule_whenCalled_schedulesFetcher() throws Exception {
+    // Arrange
+    String site = "mysite";
+    long edition = 10L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    byte[] bytes = "data".getBytes(StandardCharsets.UTF_8);
+    Bucket bucket = makeBucket(bytes);
+
+    InsertContext ic =
+        new InsertContext(
+            0,
+            0,
+            0,
+            0,
+            new SimpleEventProducer(),
+            false,
+            false,
+            false,
+            null,
+            0,
+            0,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    ic.ignoreUSKDatehints = false;
+
+    when(uskManager.getFetcherForInsertDontSchedule(
+            any(USK.class),
+            any(short.class),
+            any(USKFetcherCallback.class),
+            any(),
+            any(ClientContext.class),
+            any(Boolean.class),
+            any(Boolean.class)))
+        .thenReturn(fetcherTag);
+
+    USKInserter inserter =
+        newInserter(
+            bucket, (short) 1, insertUri, ic, new InserterCfg(false, false, false, false, false));
+
+    // Act
+    inserter.schedule(context);
+
+    // Assert
+    verify(fetcherTag, times(1)).schedule(context);
+  }
+
+  @Test
+  void onFoundEdition_whenDataAndCodecMatch_expectAlreadyInsertedAndSuccessCallbacks()
+      throws Exception {
+    // Arrange: prepare data and matching hisData/codec/metadata
+    byte[] bytes = "hello".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "mysite";
+    long edition = 5L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    USK publicUSK =
+        USK.create(
+            new FreenetURI(
+                "USK",
+                site,
+                null,
+                ssk.pubKeyHash,
+                ssk.cryptoKey,
+                ssk.getURI().getExtra(),
+                edition));
+
+    InsertContext ic =
+        new InsertContext(
+            0,
+            0,
+            0,
+            0,
+            new SimpleEventProducer(),
+            false,
+            false,
+            false,
+            null,
+            0,
+            0,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    ic.ignoreUSKDatehints = true; // skip USK date hints path for determinism
+
+    USKInserter inserter =
+        newInserter(
+            data, (short) 3, insertUri, ic, new InserterCfg(false, false, true, false, false));
+
+    // Act: Found matching edition with identical data
+    long foundEdition = 7L;
+    inserter.onFoundEdition(foundEdition, publicUSK, context, false, (short) 3, bytes, true, true);
+
+    // Assert: parent and callback methods invoked; success path without date hints
+    verify(parent, times(1)).completedBlock(true, context);
+
+    ArgumentCaptor<USK> uskCaptor = ArgumentCaptor.forClass(USK.class);
+    verify(cb, times(1)).onEncode(uskCaptor.capture(), any(), any());
+    assertEquals(foundEdition, uskCaptor.getValue().suggestedEdition);
+
+    verify(cb, times(1)).onSuccess(any(), any());
+  }
+
+  @Test
+  void onSuccess_whenURIsMatch_updatesKnownGood_andEncodesAndSucceeds() throws Exception {
+    // Arrange
+    byte[] bytes = "payload".getBytes(StandardCharsets.UTF_8);
+    Bucket data = makeBucket(bytes);
+    String site = "site";
+    long edition = 12;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+
+    InsertContext ic =
+        new InsertContext(
+            0,
+            0,
+            0,
+            0,
+            new SimpleEventProducer(),
+            false,
+            false,
+            false,
+            null,
+            0,
+            0,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    ic.ignoreUSKDatehints = true; // deterministic: avoid date hints branch
+
+    USKInserter inserter =
+        newInserter(
+            data, (short) 1, insertUri, ic, new InserterCfg(false, false, true, false, false));
+
+    // The inserter computes targetURI from pubUSK + current edition (initial suggested edition).
+    USK pub =
+        USK.create(
+            new FreenetURI(
+                "USK",
+                site,
+                null,
+                ssk.pubKeyHash,
+                ssk.cryptoKey,
+                ssk.getURI().getExtra(),
+                edition));
+    FreenetURI targetURI = pub.getSSK(edition).getURI();
+
+    // Mock SingleBlockInserter state to report the expected URI
+    SingleBlockInserter state = Mockito.mock(SingleBlockInserter.class);
+    when(state.getURI(context)).thenReturn(targetURI);
+
+    // Act
+    inserter.onSuccess(state, context);
+
+    // Assert: Update known good, encode callback and success invoked
+    verify(uskManager, times(1)).updateKnownGood(pub, edition, context);
+    verify(cb, times(1)).onEncode(any(), any(), any());
+    verify(cb, times(1)).onSuccess(any(), any());
+  }
+
+  @Test
+  void cancel_whenActive_cancelsFetcher_freesData_andEmitsCancelledFailure() throws Exception {
+    // Arrange
+    byte[] bytes = "cancel-me".getBytes(StandardCharsets.UTF_8);
+    Bucket data = Mockito.spy(makeBucket(bytes));
+    String site = "abc";
+    long edition = 1L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+
+    InsertContext ic =
+        new InsertContext(
+            0,
+            0,
+            0,
+            0,
+            new SimpleEventProducer(),
+            false,
+            false,
+            false,
+            null,
+            0,
+            0,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+
+    USKInserter inserter =
+        newInserter(
+            data, (short) 0, insertUri, ic, new InserterCfg(false, false, true, false, false));
+
+    // Ensure a fetcher exists by scheduling once so cancel() can cancel it.
+    when(uskManager.getFetcherForInsertDontSchedule(
+            any(USK.class),
+            any(short.class),
+            any(USKFetcherCallback.class),
+            any(),
+            any(ClientContext.class),
+            any(Boolean.class),
+            any(Boolean.class)))
+        .thenReturn(fetcherTag);
+    inserter.schedule(context);
+
+    // Act
+    inserter.cancel(context);
+
+    // Assert
+    verify(fetcherTag, times(1)).cancel(context);
+    verify(data, times(1)).free();
+
+    ArgumentCaptor<InsertException> ex = ArgumentCaptor.forClass(InsertException.class);
+    verify(cb, times(1)).onFailure(ex.capture(), any(), any());
+    assertEquals(InsertExceptionMode.CANCELLED, ex.getValue().getMode());
+  }
+
+  @Test
+  void onMetadataBucket_whenCalled_freesBucket() {
+    // Arrange
+    String site = "x";
+    long edition = 1L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic =
+        new InsertContext(
+            0,
+            0,
+            0,
+            0,
+            new SimpleEventProducer(),
+            false,
+            false,
+            false,
+            null,
+            0,
+            0,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    USKInserter inserter;
+    try {
+      inserter =
+          newInserter(
+              Mockito.mock(Bucket.class),
+              (short) 0,
+              insertUri,
+              ic,
+              new InserterCfg(false, false, false, false, false));
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+
+    // Act
+    inserter.onMetadata(metaBucket, inserter, context);
+
+    // Assert
+    verify(metaBucket, times(1)).free();
+  }
+
+  @Test
+  void getTokenAndPollingPriority_returnProvidedValues() throws Exception {
+    // Arrange
+    String site = "p";
+    long edition = 2L;
+    InsertableClientSSK ssk = InsertableClientSSK.createRandom(new DummyRandomSource(), site);
+    FreenetURI insertUri =
+        new FreenetURI(
+            "USK",
+            site,
+            null,
+            ssk.getInsertURI().getRoutingKey(),
+            ssk.getInsertURI().getCryptoKey(),
+            ssk.getInsertURI().getExtra(),
+            edition);
+    InsertContext ic =
+        new InsertContext(
+            0,
+            0,
+            0,
+            0,
+            new SimpleEventProducer(),
+            false,
+            false,
+            false,
+            null,
+            0,
+            0,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    Bucket data = makeBucket("t".getBytes(StandardCharsets.UTF_8));
+    doReturn((short) 42).when(parent).getPriorityClass();
+
+    USKInserter inserter =
+        new USKInserter(
+            parent,
+            data,
+            (short) 0,
+            insertUri,
+            ic,
+            cb,
+            false,
+            1,
+            7,
+            false,
+            "tok",
+            context,
+            false,
+            false,
+            false,
+            0,
+            Key.ALGO_AES_PCFB_256_SHA256,
+            null);
+
+    // Assert
+    assertSame("tok", inserter.getToken());
+    assertEquals(42, inserter.getPollingPriorityNormal());
+    assertEquals(42, inserter.getPollingPriorityProgress());
+  }
+
+  @Test
+  void onResume_callsAllCollaboratorsOnce() throws Exception {
+    // Arrange
+    Bucket data = Mockito.mock(Bucket.class);
+    String site2 = "z";
+    long edition2 = 3L;
+    InsertableClientSSK ssk2 = InsertableClientSSK.createRandom(new DummyRandomSource(), site2);
+    FreenetURI insertUri2 =
+        new FreenetURI(
+            "USK",
+            site2,
+            null,
+            ssk2.getInsertURI().getRoutingKey(),
+            ssk2.getInsertURI().getCryptoKey(),
+            ssk2.getInsertURI().getExtra(),
+            edition2);
+    InsertContext ic =
+        new InsertContext(
+            0,
+            0,
+            0,
+            0,
+            new SimpleEventProducer(),
+            false,
+            false,
+            false,
+            null,
+            0,
+            0,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+
+    USKInserter inserter =
+        newInserter(
+            data, (short) 1, insertUri2, ic, new InserterCfg(false, false, false, false, false));
+
+    // Create a fetcher via schedule so onResume delegates to it.
+    when(uskManager.getFetcherForInsertDontSchedule(
+            any(USK.class),
+            any(short.class),
+            any(USKFetcherCallback.class),
+            any(),
+            any(ClientContext.class),
+            any(Boolean.class),
+            any(Boolean.class)))
+        .thenReturn(fetcherTag);
+    inserter.schedule(context);
+
+    // Act: first call should notify; second call should be ignored
+    inserter.onResume(context);
+    inserter.onResume(context);
+
+    // Assert
+    verify(data, times(1)).onResume(context);
+    verify(cb, times(1)).onResume(context);
+    verify(fetcherTag, times(1)).onResume(context);
+  }
+
+  @Test
+  void onFailure_whenNonCollision_callsCallbackAndFreesData() throws Exception {
+    // Arrange
+    byte[] bytes2 = "err".getBytes(StandardCharsets.UTF_8);
+    Bucket data2 = Mockito.spy(makeBucket(bytes2));
+    String site3 = "errsite";
+    long edition3 = 4L;
+    InsertableClientSSK ssk3 = InsertableClientSSK.createRandom(new DummyRandomSource(), site3);
+    FreenetURI insertUri3 =
+        new FreenetURI(
+            "USK",
+            site3,
+            null,
+            ssk3.getInsertURI().getRoutingKey(),
+            ssk3.getInsertURI().getCryptoKey(),
+            ssk3.getInsertURI().getExtra(),
+            edition3);
+    InsertContext ic =
+        new InsertContext(
+            0,
+            0,
+            0,
+            0,
+            new SimpleEventProducer(),
+            false,
+            false,
+            false,
+            null,
+            0,
+            0,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+
+    USKInserter inserter =
+        newInserter(
+            data2, (short) 1, insertUri3, ic, new InserterCfg(false, false, true, false, false));
+
+    // Act
+    InsertException ex2 = new InsertException(InsertExceptionMode.BUCKET_ERROR);
+    inserter.onFailure(ex2, Mockito.mock(ClientPutState.class), context);
+
+    // Assert
+    verify(cb, times(1)).onFailure(Mockito.eq(ex2), any(), any());
+    verify(data2, times(1)).free();
+  }
+
+  // Reflection helpers are intentionally omitted; tests use public APIs to prime state.
+}


### PR DESCRIPTION
Summary
- Expand Javadoc and internal field documentation for USKInserter to clarify behavior, lifecycle, and collaboration with USKFetcherTag and SingleBlockInserter.
- Convert string-concatenated SLF4J debug/error logs to parameterized form ("{}") to avoid unnecessary string building when disabled.
- Add a new JUnit 6 test suite for USKInserter covering scheduling, discovery, success path, cancel, resume, and failure handling.
- Tests avoid reflection for state setup; they use public APIs (e.g., schedule()) and Mockito stubs for collaborators instead.

Files
- src/main/java/network/crypta/client/async/USKInserter.java
  - Javadoc additions, parameterized logging, and clarifying comments/annotations
- src/test/java/network/crypta/client/async/USKInserterTest.java (new)
  - Comprehensive unit tests using Mockito and inline Bucket stubs

Implementation Notes
- No intentional functional changes in USKInserter; the main code changes are documentation and logging style.
- Tests model minimal ClientContext and collaborators; they use SecureRandom for compatibility with the JUnit 6 setup and dummy RandomSource for deterministic inserts where needed.
- Reflection helpers previously used in tests are removed; tests now rely on public lifecycle to initialize internal collaborators.

Why
- Improves clarity and maintainability of USK insertion flow.
- Adds coverage for key behaviors and reduces reliance on private fields in tests.

Risks
- Low; changes to main code are non-functional (docs/log formatting). Tests are isolated to the test scope.

Validation
- Spotless applied prior to commit.
- Local compile/tasks were executed by CI on push (if configured). No additional runtime changes expected.

Checklist
- [x] Code formatted (Spotless)
- [x] New tests added
- [x] No functional behavior change intended in main sources
