### PR TITLE
docs(events): doclint-clean Javadoc for ClientEvent* and package docs

### DIFF
--- a/src/main/java/network/crypta/client/events/ClientEvent.java
+++ b/src/main/java/network/crypta/client/events/ClientEvent.java
@@ -1,15 +1,64 @@
 package network.crypta.client.events;
 
 /**
- * Event handling for clients.
+ * Describes a client-facing event emitted by higher-level operations.
+ *
+ * <p>This interface models a lightweight, immutable signal that conveys what happened during a
+ * client request or background activity. Implementations typically wrap a concise, human-readable
+ * description together with a stable integer code that can be used for programmatic routing,
+ * filtering, or correlation in logs. Events are produced by components that implement
+ * ClientEventProducer implementations produce these events and ClientEventListener implementations
+ * consume them; listeners may log, persist, aggregate, or display them to users.
+ *
+ * <p>Use this type when you need to surface progress, state changes, or non-fatal conditions to the
+ * client layer without throwing exceptions. A common pattern is to define small value objects for
+ * concrete event kinds (for example, progress updates or expected content metadata) that implement
+ * this interface and are dispatched to interested listeners. Implementations are generally
+ * thread-safe by virtue of being immutable; consumers should treat instances as read-only. The
+ * integer code is intended to remain stable across versions of a component, while the textual
+ * description is optimized for operators and end users.
+ *
+ * <ul>
+ *   <li>Responsibilities: identify the event, summarize it for humans, and allow filtering.
+ *   <li>Scope: communicates information; it is not an error/exception transport mechanism.
+ *   <li>Usage: emit from producers, subscribe via listeners, and log or render as needed.
+ * </ul>
  *
  * @author oskar
  */
 public interface ClientEvent {
 
-  /** Returns a string describing the event. */
+  /**
+   * Returns a human-readable description of the event.
+   *
+   * <p>The description should be concise, suitable for logs or status panels, and should avoid
+   * embedding sensitive information. Implementations are encouraged to keep the text stable enough
+   * for operators to recognize recurring conditions, while remaining clear to end users. The string
+   * is informational only and must not be parsed programmatically; use {@link #getCode()} for
+   * machine handling.
+   *
+   * <pre>{@code
+   * // Example: log the description at INFO level
+   * listener.receive(event, context); // typical dispatch path
+   * String summary = event.getDescription();
+   * }</pre>
+   *
+   * @return a non-null, human-oriented summary; callers do not take ownership and must not modify
+   *     the returned string instance if it happens to be shared.
+   */
   String getDescription();
 
-  /** Returns a unique code for this event. */
+  /**
+   * Returns a stable integer that identifies the event kind.
+   *
+   * <p>The code is suitable for programmatic routing, de-duplication, or metric labeling. Its
+   * uniqueness scope is defined by the producing component; consumers should not assume global
+   * uniqueness across the entire application unless documented by a specific producer. The value is
+   * intended to be stable across releases of the emitting component to support filtering policies
+   * and dashboards.
+   *
+   * @return an integer identifier for the event type; stable within the producing component and
+   *     suitable for comparisons, switches, or counters.
+   */
   int getCode();
 }

--- a/src/main/java/network/crypta/client/events/ClientEventListener.java
+++ b/src/main/java/network/crypta/client/events/ClientEventListener.java
@@ -3,19 +3,55 @@ package network.crypta.client.events;
 import network.crypta.client.async.ClientContext;
 
 /**
- * Event handling for clients.
+ * Receives and acts upon client-layer events emitted by producers.
+ *
+ * <p>Implementations of this interface subscribe to events created by components such as request
+ * starters, schedulers, and storage pipelines. A listener typically logs, aggregates, forwards, or
+ * renders event information to users without altering the underlying control flow. The contract is
+ * intentionally lightweight: a listener is invoked for each event and may perform side effects
+ * appropriate to its role (e.g., append to a log, update a progress bar, or enqueue follow-up
+ * work).
+ *
+ * <p>Invocation can be synchronous or asynchronous depending on the producer. Implementations must
+ * return promptly and avoid long blocking operations in the callback. When database access or other
+ * persistence-affecting work is required, schedule it through the provided {@code ClientContext}
+ * rather than performing it inline. Treat event objects as immutable and thread-safe; listeners
+ * should not retain references for mutation or cross-thread modification.
+ *
+ * <ul>
+ *   <li>Responsibilities: observe events, perform minimal processing, delegate heavier work.
+ *   <li>Concurrency: may be called from internal worker threads; keep handlers fast.
+ *   <li>Failure model: listeners should be defensive and avoid throwing unchecked exceptions.
+ * </ul>
  *
  * @author oskar
+ * @see ClientEvent
+ * @see ClientEventProducer
  */
 public interface ClientEventListener {
 
   /**
-   * Hears an event.
+   * Receives a single event raised by a producer, with contextual services for follow-up work.
    *
-   * @param ce ClientEvent
-   * @param context The database context the event was generated in. NOTE THAT IT MAY NOT HAVE BEEN
-   *     GENERATED IN A DATABASE CONTEXT AT ALL: In this case, container will be null, and you
-   *     should use context to schedule a DBJob.
+   * <p>Producers call this method zero or more times during a request or background operation.
+   * Implementations should keep processing quick and non-blocking; if additional I/O or persistence
+   * is required, use the {@code ClientContext} to offload the work to the appropriate executors or
+   * job runners. The event object is intended for read-only inspection. Implementations may choose
+   * to ignore specific event kinds or to coalesce repeated signals.
+   *
+   * <pre>{@code
+   * // Example: log significant events and schedule DB work when needed
+   * public void receive(ClientEvent e, ClientContext ctx) {
+   *   LOG.info("{}", e.getDescription());
+   *   // Use ctx to enqueue persistence tasks instead of blocking here.
+   * }
+   * }</pre>
+   *
+   * @param ce the event instance being delivered; non-null; consumers must not modify or retain it
+   *     for mutation and should treat it as immutable data.
+   * @param context execution and persistence context associated with the event; may not carry an
+   *     active database transaction; use it to schedule database work instead of performing it
+   *     inline in the callback.
    */
   void receive(ClientEvent ce, ClientContext context);
 }

--- a/src/main/java/network/crypta/client/events/ClientEventProducer.java
+++ b/src/main/java/network/crypta/client/events/ClientEventProducer.java
@@ -3,32 +3,77 @@ package network.crypta.client.events;
 import network.crypta.client.async.ClientContext;
 
 /**
- * Event handling for clients.
+ * Produces and dispatches client-layer events to registered listeners.
  *
+ * <p>Implementations of this interface act as the source of truth for events that describe progress
+ * and notable occurrences during client operations. A producer maintains a set of {@code
+ * ClientEventListener} instances and, when appropriate, delivers {@code ClientEvent} instances to
+ * each listener. Typical use is within request pipelines, where producers surface human-readable
+ * updates (e.g., expected sizes, MIME types, or compression status) and allow external components
+ * to observe behavior without coupling to internal control flow.
+ *
+ * <p>Dispatch strategy (synchronous vs. asynchronous) is implementation-dependent; callers must not
+ * assume a particular threading model. To avoid re-entrancy surprises and UI stalls, producers
+ * should strive to dispatch quickly, and listeners should avoid blocking. A common pattern is to
+ * pass a {@code ClientContext} alongside each event so listeners can schedule heavier work on
+ * background executors rather than executing it inline.
+ *
+ * <ul>
+ *   <li>Responsibilities: track listeners, emit events reliably, document ordering guarantees.
+ *   <li>Threading: may call listeners from worker or IO threads; keep handlers fast.
+ *   <li>Failure: producers should isolate listener failures to prevent cascading errors.
+ * </ul>
+ *
+ * @see ClientEvent
+ * @see ClientEventListener
  * @author oskar
  */
 public interface ClientEventProducer {
 
   /**
-   * Sends the event to all registered EventListeners.
+   * Sends the event to all currently registered listeners with contextual services.
    *
-   * @param ce the ClientEvent to raise
+   * <p>Each registered listener is invoked once for the given event. Implementations may choose to
+   * deliver callbacks synchronously on the caller's thread or asynchronously on internal executors.
+   * Listeners should treat the delivered event as immutable and must avoid long blocking work in
+   * the callback. When persistence or I/O is necessary, prefer using the provided {@code
+   * ClientContext} to enqueue the work rather than performing it inline.
+   *
+   * <pre>{@code
+   * // Example: producer dispatch
+   * producer.produceEvent(new StartedCompressionEvent(), context);
+   * }</pre>
+   *
+   * @param ce the event instance to raise; non-null; conveys a human-friendly description and a
+   *     stable event code suitable for filtering or correlation.
+   * @param context execution and persistence context associated with the event; non-null; use it to
+   *     schedule follow-up work and avoid blocking inside listener callbacks.
    */
   void produceEvent(ClientEvent ce, ClientContext context);
 
   /**
-   * Adds an EventListener that will receive all events produced by the implementing object.
+   * Adds a listener that will receive all subsequent events produced by this instance.
    *
-   * @param cel The ClientEventListener to add.
+   * <p>Implementations may disallow duplicate registrations or coalesce them; callers should not
+   * rely on a listener being invoked more than once per event. Registration and removal need to be
+   * thread-safe if performed concurrently with event dispatch.
+   *
+   * @param cel the listener to register; non-null; should return quickly and avoid blocking the
+   *     dispatch thread; may be called from arbitrary worker threads.
    */
   void addEventListener(ClientEventListener cel);
 
   /**
-   * Removes an EventListener that will no longer receive events produced by the implementing
-   * object.
+   * Removes a listener so it no longer receives events from this instance.
    *
-   * @param cel The ClientEventListener to remove.
-   * @return true if a Listener was removed, false otherwise.
+   * <p>After successful removal, the listener will not be invoked for any future events. If the
+   * listener was not previously registered, the method has no effect. Implementations should ensure
+   * removal is safe to call concurrently with dispatch and does not invalidate internal iteration.
+   *
+   * @param cel the listener to remove; non-null; the exact matching semantics are implementation
+   *     dependent (reference equality is common).
+   * @return {@code true} if a previously registered listener was removed; {@code false} when no
+   *     matching listener was found or removal did not change the registration set.
    */
   boolean removeEventListener(ClientEventListener cel);
 }

--- a/src/main/java/network/crypta/client/events/package-info.java
+++ b/src/main/java/network/crypta/client/events/package-info.java
@@ -1,6 +1,27 @@
 /**
- * Client events layer. This layer provides a series of notifications (@see ClientEvent ) of the
- * progress of a high-level request to higher layers (e.g. FCP, fproxy) so they can e.g. render
- * progress bars.
+ * Client events layer that reports progress, state changes, and informational notifications emitted
+ * by client operations.
+ *
+ * <p>This package defines a small, decoupled event model used by higher layers to observe what is
+ * happening inside client requests without binding to internal control flow. Producers emit
+ * lightweight event objects that carry a human-readable description and a stable integer code,
+ * while listeners subscribe to those events to log, render UI feedback, or trigger follow-up work.
+ * Typical call paths originate in request starters or schedulers, which raise events as milestones
+ * are reached; UI or service components consume the stream to communicate status to users or other
+ * systems.
+ *
+ * <p>Events are designed to be read-only and safe to share across threads. Producers should
+ * dispatch quickly and avoid invoking listener code that blocks for long periods. When persistence
+ * or heavy I/O is required in response to an event, listeners should defer work to background
+ * executors provided by the surrounding client context rather than performing it inline. Textual
+ * descriptions are intended for operators and end users, whereas integer codes enable programmatic
+ * filtering and correlation.
+ *
+ * <ul>
+ *   <li>Responsibilities: surface client progress and state transitions to observers.
+ *   <li>Key types: event producers, event listeners, and immutable event values.
+ *   <li>Dispatch: synchronous or asynchronous depending on producer; keep handlers fast.
+ *   <li>Typical categories: progress updates, expected metadata, warnings, and completion.
+ * </ul>
  */
 package network.crypta.client.events;


### PR DESCRIPTION
Summary
- Add long-form, doclint-clean Javadoc for the client event APIs:
  - src/main/java/network/crypta/client/events/ClientEvent.java
  - src/main/java/network/crypta/client/events/ClientEventListener.java
  - src/main/java/network/crypta/client/events/ClientEventProducer.java
  - src/main/java/network/crypta/client/events/package-info.java
- Enriched top-level docs and method tags with concrete guidance (immutability, threading, dispatch patterns, and usage), while keeping behavior unchanged.
- Ensured valid HTML, first-sentence summaries, and complete @param/@return tags to satisfy doclint.

Rationale
These files are part of the public client events surface. Doclint previously flagged missing @return/@param tags and unresolved links during single-file runs. This PR brings the package and interfaces to a doclint-clean state with substantive, longer-form API documentation.

Implementation Notes
- Comments only; no code, signatures, or behavior changed.
- Removed unresolved links that fail when running javadoc in isolation; kept narrative descriptive and neutral.
- Ran Spotless before committing (spotlessApply).

Validation
- Single-file doclint runs for each updated file report zero warnings.
- Gradle Spotless completed successfully.

Scope
- Focused, documentation-only change scoped to the client events package.
