### PR TITLE
EnterFiniteCooldownEvent: add unit tests and improve Javadoc

### DIFF
--- a/src/main/java/network/crypta/client/events/EnterFiniteCooldownEvent.java
+++ b/src/main/java/network/crypta/client/events/EnterFiniteCooldownEvent.java
@@ -2,21 +2,88 @@ package network.crypta.client.events;
 
 import network.crypta.support.TimeUtil;
 
+/**
+ * Event indicating the client has entered a finite cooldown until a specific time.
+ *
+ * <p>This event represents a scheduled pause in client activity that is expected to end at a
+ * concrete, known instant. It differs from indefinite backoff or paused states by providing an
+ * absolute wake-up time, enabling UIs and monitoring components to present an accurate remaining
+ * duration and plan subsequent work. Typical usage is to emit an instance on an event bus or to a
+ * listener set when the client transitions into cooldown due to backoff policies, rate limiting, or
+ * temporary resource constraints.
+ *
+ * <p>The type is immutable and therefore thread-safe: its sole public field is final and set at
+ * construction. The textual description returned by {@link #getDescription()} is computed on each
+ * call using the current system clock and {@link TimeUtil#formatTime(long, int, boolean)}, so the
+ * formatted remaining time naturally decreases over time. If the configured wake-up time is in the
+ * past, the formatted interval may be negative, signaling that the cooldown has already elapsed.
+ *
+ * <ul>
+ *   <li><strong>Responsibility:</strong> carry the absolute wake-up time and expose a concise,
+ *       human-friendly description of the remaining delay.
+ *   <li><strong>Mutability:</strong> immutable after construction; safe to share across threads.
+ *   <li><strong>Identification:</strong> {@link #getCode()} returns a stable, small integer code
+ *       for routing and filtering.
+ * </ul>
+ *
+ * @see ClientEvent
+ * @see TimeUtil#formatTime(long, int, boolean)
+ */
 public class EnterFiniteCooldownEvent implements ClientEvent {
 
+  /**
+   * Absolute instant when the cooldown ends, in milliseconds since the Unix epoch (UTC).
+   *
+   * <p>This value is read-only and stable for the lifetime of the object. Consumers typically use
+   * it to compute remaining delay as {@code wakeupTime - System.currentTimeMillis()} and display a
+   * countdown or schedule work to resume at or after this moment. Values in the past indicate that
+   * the cooldown has already expired.
+   */
   public final long wakeupTime;
 
   static final int CODE = 0x10;
 
+  /**
+   * Creates an event describing entry into a finite cooldown that ends at the given time.
+   *
+   * <p>The provided time is stored verbatim as an absolute epoch millisecond value. Callers are
+   * responsible for selecting a sensible value; no bounds are enforced here. Passing a value
+   * earlier than the current system time is allowed and will result in negative remaining duration
+   * in {@link #getDescription()}.
+   *
+   * @param wakeupTime absolute wake-up time in milliseconds since the Unix epoch (UTC); may be in
+   *     the past, present, or future depending on the caller's scheduling needs
+   */
   public EnterFiniteCooldownEvent(long wakeupTime) {
     this.wakeupTime = wakeupTime;
   }
 
+  /**
+   * Returns a human-friendly description of the remaining time until wake-up.
+   *
+   * <p>The string is computed relative to the current system clock by formatting {@code (wakeupTime
+   * - System.currentTimeMillis())} with two terms and fractional seconds via {@link
+   * TimeUtil#formatTime(long, int, boolean)}. As time passes, repeated calls produce updated
+   * values. If {@code wakeupTime} is in the past, the formatted interval may include a leading
+   * minus sign to indicate that the cooldown has already elapsed.
+   *
+   * @return a concise English description such as {@code "Wake up in 1m30.000s"}; never {@code
+   *     null}
+   */
   @Override
   public String getDescription() {
     return "Wake up in " + TimeUtil.formatTime(wakeupTime - System.currentTimeMillis(), 2, true);
   }
 
+  /**
+   * Returns a stable, small integer identifying this event type.
+   *
+   * <p>The value is suitable for lightweight routing, filtering, or serialization schemes that use
+   * compact numeric discriminators. It currently returns {@link #CODE} ({@code 0x10}).
+   *
+   * @return the event code for {@code EnterFiniteCooldownEvent}; the value is constant across
+   *     instances
+   */
   @Override
   public int getCode() {
     return CODE;

--- a/src/test/java/network/crypta/client/events/EnterFiniteCooldownEventTest.java
+++ b/src/test/java/network/crypta/client/events/EnterFiniteCooldownEventTest.java
@@ -1,0 +1,105 @@
+package network.crypta.client.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class EnterFiniteCooldownEventTest {
+
+  private static final String PREFIX = "Wake up in ";
+
+  @Test
+  void getCode_whenInvoked_expectConstantCode() {
+    // Arrange
+    long wakeup = System.currentTimeMillis() + 1000L;
+    EnterFiniteCooldownEvent event = new EnterFiniteCooldownEvent(wakeup);
+
+    // Act
+    int code = event.getCode();
+
+    // Assert
+    assertEquals(0x10, code, "Event code should match the defined constant");
+  }
+
+  @Test
+  void getDescription_whenFutureWithinSeconds_expectFractionalSeconds() {
+    // Arrange
+    long targetDeltaMs = 1500L; // ~1.5s in the future
+    long wakeup = System.currentTimeMillis() + targetDeltaMs;
+    EnterFiniteCooldownEvent event = new EnterFiniteCooldownEvent(wakeup);
+
+    String desc = event.getDescription();
+
+    // Assert
+    assertNotNull(desc);
+    assertTrue(desc.startsWith(PREFIX), "Description should start with the fixed prefix");
+
+    double seconds = extractTrailingSeconds(desc);
+    // Allow a generous range to avoid flakiness due to scheduling/CPU variance.
+    assertTrue(
+        seconds > 0.9 && seconds <= 1.6,
+        () -> "Expected seconds within (0.9, 1.6], got: " + seconds + " for: " + desc);
+  }
+
+  @Test
+  void getDescription_whenInPast_expectNegativeFractionalSeconds() {
+    // Arrange
+    long wakeup = System.currentTimeMillis() - 250L; // 0.25s in the past
+    EnterFiniteCooldownEvent event = new EnterFiniteCooldownEvent(wakeup);
+
+    // Act
+    String desc = event.getDescription();
+
+    // Assert
+    assertNotNull(desc);
+    assertTrue(desc.startsWith(PREFIX), "Description should start with the fixed prefix");
+
+    double seconds = extractTrailingSeconds(desc);
+    assertTrue(
+        seconds < 0.0 && seconds >= -1.0,
+        () -> "Expected a small negative seconds value, got: " + seconds + " for: " + desc);
+  }
+
+  @Test
+  void getDescription_whenMinutePlusSeconds_expectMinuteAndFractionalSeconds() {
+    // Arrange
+    long targetDeltaMs = 60_000L + 2_500L; // ~1m 2.5s in the future
+    long wakeup = System.currentTimeMillis() + targetDeltaMs;
+    EnterFiniteCooldownEvent event = new EnterFiniteCooldownEvent(wakeup);
+
+    // Act
+    String desc = event.getDescription();
+
+    // Assert
+    assertNotNull(desc);
+    assertTrue(
+        desc.startsWith(PREFIX + "1m"),
+        () -> "Expected description to include '1m' prefix, got: " + desc);
+
+    double seconds = extractTrailingSeconds(desc);
+    assertTrue(
+        seconds > 1.5 && seconds <= 3.0,
+        () -> "Expected roughly 2.5s remaining after minutes, got: " + seconds + " for: " + desc);
+  }
+
+  // Extracts the trailing seconds component (with optional leading minus sign) from the
+  // description string. The format is guaranteed by TimeUtil to use a dot as the decimal
+  // separator with exactly three fractional digits when fractions are present.
+  private static double extractTrailingSeconds(String description) {
+    String tail = description.substring(PREFIX.length());
+    Pattern p = Pattern.compile("(-?\\d+(?:\\.\\d{3})?)s$");
+    Matcher m = p.matcher(tail);
+    if (!m.find()) {
+      throw new AssertionError("Could not parse seconds from description: " + description);
+    }
+    return Double.parseDouble(m.group(1));
+  }
+}


### PR DESCRIPTION
Summary
- Add unit test for EnterFiniteCooldownEvent covering code constant and description formatting for future, past, and minute+seconds cases
- Improve Javadoc on EnterFiniteCooldownEvent to clarify semantics, immutability, and description behavior
- Apply Spotless formatting to keep style consistent

Changes
- src/main/java/network/crypta/client/events/EnterFiniteCooldownEvent.java:1 — Enriched class- and method-level Javadoc; no behavior changes
- src/test/java/network/crypta/client/events/EnterFiniteCooldownEventTest.java:1 — New tests validating description output and event code

Rationale
- Provide guardrails for description formatting (uses TimeUtil.formatTime(wakeupTime - System.currentTimeMillis(), 2, true)) and ensure the event code remains stable
- Document intended usage and thread-safety of the event type

Testing
- Ran tests locally where applicable (unit tests compile and run under Gradle)
- Spotless formatting applied via ./gradlew spotlessApply

Notes
- Base: develop
- Branch: feature/fix-EnterFiniteCooldownEvent
