### PR TITLE
Fix USKSparseProxyCallback and add tests; Javadoc cleanup for async client

### DIFF
--- a/src/main/java/network/crypta/client/async/USKSparseProxyCallback.java
+++ b/src/main/java/network/crypta/client/async/USKSparseProxyCallback.java
@@ -5,10 +5,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Proxy class to only pass through latest-slot updates after an onRoundFinished(). Note that it
- * completely ignores last-known-good updates.
+ * A filtering {@link USKProgressCallback} that forwards only sparse, significant updates from an
+ * underlying USK subscription.
+ *
+ * <p>This proxy coalesces noisy progress into a compact signal suitable for user interfaces or
+ * higher-level coordination. During an active polling round it records the latest observed edition
+ * and associated metadata but suppresses intermediate callbacks. Once the round transitions between
+ * phases, it emits at most one consolidated update reflecting the current best knowledge of the
+ * latest slot. Older or regressive signals are ignored unless they contribute new "known-good"
+ * information. This reduces redundant work and log volume while preserving the key state
+ * transitions library clients typically care about.
+ *
+ * <p>Thread-safety: instances synchronize internally to track the last observed/sent edition and to
+ * ensure that at most one coalesced update is forwarded per phase. The wrapped callback is invoked
+ * outside the monitor. Callers may reuse a single instance across polling lifecycles, but should
+ * avoid sharing a single instance across different subscriptions.
+ *
+ * <ul>
+ *   <li>Coalesces updates within a round; forwards on phase boundaries.
+ *   <li>Prefers the newest observed edition; remembers "known-good" advancement.
+ *   <li>Falls back to the latest recorded slot when no in-round update exists.
+ * </ul>
  *
  * @author toad
+ * @see USKCallback
+ * @see USKProgressCallback
+ * @see USKManager
+ * @see USK
  */
 public class USKSparseProxyCallback implements USKProgressCallback {
   private static final Logger LOG = LoggerFactory.getLogger(USKSparseProxyCallback.class);
@@ -24,18 +47,58 @@ public class USKSparseProxyCallback implements USKProgressCallback {
   private boolean lastWasKnownGoodToo;
   private boolean roundFinished;
 
-  static {
-  }
-
+  /**
+   * Creates a new sparse proxy around a target {@link USKCallback} for the given key.
+   *
+   * <p>The proxy captures detailed progress during a polling round and forwards at most one
+   * coalesced update per phase transition to the wrapped callback. Use this when consumers prefer a
+   * compact signal of the latest edition over a high-frequency stream of intermediate updates.
+   *
+   * <pre>{@code
+   * // Example: wrap a verbose callback to reduce update volume
+   * USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
+   * }</pre>
+   *
+   * @param cb The non-null callback to receive coalesced, phase-aligned notifications. It is
+   *     invoked on internal threads; callers must ensure it is thread-safe.
+   * @param key The non-null USK whose editions are being tracked by this proxy. Used for fallback
+   *     lookups when no in-round update has been observed yet.
+   */
   public USKSparseProxyCallback(USKCallback cb, USK key) {
     target = cb;
     lastEdition = -1; // So we see the first one even if it's 0
     lastSent = -1;
     this.key = key;
     if (LOG.isDebugEnabled())
-      LOG.debug("Creating sparse proxy callback " + this + " for " + cb + " for " + key);
+      LOG.debug("Creating sparse proxy callback {} for {} for {}", this, cb, key);
   }
 
+  /**
+   * Receives an update about a discovered or advanced USK edition and applies sparse-forwarding
+   * rules.
+   *
+   * <p>Within a polling round the proxy remembers only the newest observed edition and whether it
+   * also advanced the highest known-good value. Updates for older editions are dropped unless they
+   * contribute a known-good advance. The wrapped callback is invoked immediately only after a phase
+   * boundary has been signalled; otherwise the information is retained and may be forwarded later
+   * from {@link #onSendingToNetwork(ClientContext)} or {@link #onRoundFinished(ClientContext)}.
+   *
+   * @param l The logical edition discovered by the fetcher; higher values denote newer editions and
+   *     should be non-negative where available.
+   * @param key A copy of the USK associated with this discovery; typically carries {@code l} as its
+   *     edition component.
+   * @param context Execution context for the request; non-null and scoped to the current
+   *     subscription lifecycle.
+   * @param metadata True when {@code data} represents metadata for the edition rather than full
+   *     content; consumers may use this to defer expensive processing.
+   * @param codec Short identifier of the content codec for {@code data}; a negative value indicates
+   *     that no codec applies to the current payload.
+   * @param data Raw bytes for the discovered edition or its metadata; may be {@code null} when only
+   *     structural advancement is being reported.
+   * @param newKnownGood True when the highest successfully fetched (known-good) edition increased
+   *     as a result of this discovery.
+   * @param newSlotToo True when the highest examined SSK slot also advanced alongside known-good.
+   */
   @Override
   public void onFoundEdition(
       long l,
@@ -64,21 +127,51 @@ public class USKSparseProxyCallback implements USKProgressCallback {
     target.onFoundEdition(l, key, context, metadata, codec, data, newKnownGood, newSlotToo);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation delegates directly to the wrapped target callback.
+   */
   @Override
   public short getPollingPriorityNormal() {
     return target.getPollingPriorityNormal();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation delegates directly to the wrapped target callback.
+   */
   @Override
   public short getPollingPriorityProgress() {
     return target.getPollingPriorityProgress();
   }
 
+  /**
+   * Signals that the subscription is transitioning from local checks to network activity.
+   *
+   * <p>If no edition was forwarded during the current round, the proxy attempts a best-effort
+   * fallback to the latest recorded slot for the configured key and emits a single consolidated
+   * update to the wrapped callback. If an edition was already sent for the round, no further
+   * forwarding occurs here.
+   *
+   * @param context Execution context for the current request; non-null and suitable for lightweight
+   *     diagnostics associated with this transition.
+   */
   @Override
   public void onSendingToNetwork(ClientContext context) {
     innerRoundFinished(context, false);
   }
 
+  /**
+   * Signals that a polling round has finished and forwards at most one coalesced update.
+   *
+   * <p>When the round completes, any retained "newest edition" observation is forwarded once to the
+   * wrapped callback. Subsequent invocations within the same round are suppressed. This keeps the
+   * consumer view aligned with natural scheduler milestones while avoiding redundant notifications.
+   *
+   * @param context Execution context for the current request; non-null and scoped to this round.
+   */
   @Override
   public void onRoundFinished(ClientContext context) {
     innerRoundFinished(context, true);
@@ -107,7 +200,7 @@ public class USKSparseProxyCallback implements USKProgressCallback {
       data = null;
       wasKnownGood = false;
     }
-    if (ed == -1) return;
+    // At this point, either we returned above or ed is guaranteed != -1
     target.onFoundEdition(ed, key, context, meta, codec, data, wasKnownGood, wasKnownGood);
   }
 }

--- a/src/main/java/network/crypta/client/async/package-info.java
+++ b/src/main/java/network/crypta/client/async/package-info.java
@@ -1,48 +1,52 @@
 /**
- * Client layer core classes (implementation of actually fetching files etc).
+ * Asynchronous client layer for high‑level fetch and insert workflows.
  *
- * @see freenet.client for a description of the overall architecture of the client layer.
- *     <p>This package is mainly for classes that actually run high-level requests, inserts, site
- *     inserts, etc. The major components here:
- *     <ul>
- *       <li>@see ClientRequester The top level requests: A site insert, a fetch for a key on
- *           Freenet (which may involve following redirects, unpacking containers, splitfiles, etc),
- *           an insert of a file etc. E.g. @see ClientGetter
- *       <li>@see ClientGetState The current stage in a request. E.g. fetch a block and follow the
- *           metadata and redirects if necessary (@see SingleFileFetcher), or download a splitfile
- *           (@see SplitFileFetcher).
- *       <li>@see ClientPutState The current stage in an insert. E.g. insert a single block (@see
- *           SingleBlockInserter), or a splitfile (@see SplitFileInserter).
- *       <li>Code for actually choosing which request to start. ClientRequestScheduler is an
- *           interface class, the actual request selection tree is on ClientRequestSelector. We keep
- *           a separate structure (mostly Bloom filters) using KeyListeners to identify which block
- *           belongs to which client, as we will often be offered blocks, or fetch them on behalf of
- *           other nodes. This is kept by ClientRequestSchedulerCore for persistent requests and
- *           ClientRequestSchedulerNonPersistent for transient requests.
- *       <li>The cooldown queue: @see CooldownTracker. This is used to ensure that we don't keep on
- *           selecting the same request repeatedly, while choosing requests efficiently.
- * @see network.crypta.node.FailureTable for a closely related mechanism at the node level.
- *     <li>USK-related code
- *     <li>The healing queue
- *     <li>Misc persistence-related code, @see ClientLayerPersister for the persistence
- *         architecture.
- *     </ul>
- *     <p>The main connections to other layers: Code which uses the client layer:
- *     <ul>
- *       <li>@see freenet.client.HighLevelSimpleClient (a lightweight API used both internally and
- *           by some plugins)
- *       <li>@see freenet.clients.fcp The interface to external FCP clients
- *       <li>Some code and plugins use the classes here directly.
- *     </ul>
- *     <p>Code which the client layer uses:
- *     <ul>
- *       <li>@see freenet.client Support classes for MIME type handling, container handling, etc
- *       <li>@see freenet.node.SendableRequest The actual implementation of sending requests
- *       <li>@see freenet.support Especially @see freenet.support.RandomGrabArray and related
- *           classes
- *       <li>@see freenet.client.events Events are sent to other layers (especially FCP)
- *       <li>@see freenet.client.filter Content filtering code. Content filtering is implemented in
- *           the client layer for various reasons.
- *     </ul>
+ * <p>This package contains the engines that execute user‑visible requests: fetching data by key,
+ * inserting files or whole sites, tracking progress, and coordinating retries. A single logical
+ * request often expands into many low‑level operations such as following redirects, verifying
+ * checksums, fetching splitfile segments, or assembling container formats. Implementations model
+ * these steps as state machines and collaborate with schedulers to make progress without blocking
+ * callers. Requests can be persistent (restored across restarts) or transient (memory‑only).
+ *
+ * <p>The scheduler selects which unit of work to start next based on priority classes, fairness
+ * across clients, and back‑off/cooldown policies. Key listeners map blocks offered by the network
+ * back to active requests. USK utilities provide polling and insertion for updatable keys. Healing
+ * utilities re‑queue incomplete segments so long‑running downloads recover from transient failures.
+ * Persistence focuses on durability for complex requests while rebuilding global indexes on
+ * startup.
+ *
+ * <p><strong>Notable components</strong>
+ *
+ * <ul>
+ *   <li>High‑level request orchestration via {@link network.crypta.client.async.ClientRequester}
+ *       and concrete getters such as {@link network.crypta.client.async.ClientGetter}.
+ *   <li>State machines for gets ({@link network.crypta.client.async.ClientGetState}) and puts
+ *       ({@link network.crypta.client.async.ClientPutState}). Fetchers include {@link
+ *       network.crypta.client.async.SingleFileFetcher} and {@link
+ *       network.crypta.client.async.SplitFileFetcher}; inserters include {@link
+ *       network.crypta.client.async.SingleBlockInserter} and {@link
+ *       network.crypta.client.async.SplitFileInserter}.
+ *   <li>Scheduling primitives: {@link network.crypta.client.async.ClientRequestScheduler} and the
+ *       selection tree in {@link network.crypta.client.async.ClientRequestSelector}. Block
+ *       selection/back‑off helpers include {@link network.crypta.client.async.CooldownBlockChooser}
+ *       and key mapping via {@link network.crypta.client.async.KeyListener} and {@link
+ *       network.crypta.client.async.KeyListenerTracker}.
+ *   <li>USK support: {@link network.crypta.client.async.USKManager}, {@link
+ *       network.crypta.client.async.USKFetcher}, and {@link
+ *       network.crypta.client.async.USKInserter}.
+ *   <li>Healing and housekeeping: {@link network.crypta.client.async.HealingQueue} and related
+ *       helpers keep long downloads moving by revisiting incomplete segments.
+ *   <li>Durable request persistence: {@link network.crypta.client.async.ClientLayerPersister}
+ *       checkpoints active work and resumes it after restarts.
+ * </ul>
+ *
+ * <p><strong>Interactions</strong>
+ *
+ * <ul>
+ *   <li>Uses node‑level request senders and failure tracking; see {@link
+ *       network.crypta.node.FailureTable} for related back‑off decisions.
+ *   <li>Exposes progress and lifecycle to client interfaces, including the FCP layer (for example,
+ *       {@link network.crypta.clients.fcp.PersistentRequestClient}).
+ * </ul>
  */
 package network.crypta.client.async;

--- a/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
+++ b/src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java
@@ -1,0 +1,378 @@
+package network.crypta.client.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.MalformedURLException;
+import java.util.Random;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.config.Config;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.ClientSSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.NodeSSK;
+import network.crypta.keys.USK;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class USKSparseProxyCallbackTest {
+
+  // ---------------- Minimal helpers to construct deterministic inputs ----------------
+
+  private static byte[] bytes(int len, int start) {
+    byte[] b = new byte[len];
+    for (int i = 0; i < len; i++) b[i] = (byte) (start + i);
+    return b;
+  }
+
+  private static USK newUsk() throws MalformedURLException {
+    byte[] pubKeyHash = bytes(NodeSSK.PUBKEY_HASH_SIZE, 0);
+    byte[] cryptoKey = bytes(ClientSSK.CRYPTO_KEY_LENGTH, 32);
+    byte[] extras =
+        new byte[] {
+          NodeSSK.SSK_VERSION, 0, Key.ALGO_AES_PCFB_256_SHA256, 0, (byte) KeyBlock.HASH_SHA256
+        };
+    return new USK(pubKeyHash, cryptoKey, extras, "site", 0L);
+  }
+
+  private static final class DirectExecutor implements PriorityAwareExecutor {
+    @Override
+    public void execute(Runnable job) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName) {
+      job.run();
+    }
+
+    @Override
+    public void execute(Runnable job, String jobName, boolean fromTicker) {
+      job.run();
+    }
+
+    @Override
+    public int[] waitingThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int[] runningThreads() {
+      return new int[0];
+    }
+
+    @Override
+    public int getWaitingThreadsCount() {
+      return 0;
+    }
+  }
+
+  private static final class DirectTicker implements Ticker {
+    private final PriorityAwareExecutor executor = new DirectExecutor();
+
+    @Override
+    public void queueTimedJob(Runnable job, long offset) {
+      job.run();
+    }
+
+    @Override
+    public void queueTimedJob(
+        Runnable job, String name, long offset, boolean runOnTickerAnyway, boolean noDupes) {
+      job.run();
+    }
+
+    @Override
+    public PriorityAwareExecutor getExecutor() {
+      return executor;
+    }
+
+    @Override
+    public void removeQueuedJob(Runnable job) {
+      // no-op
+    }
+
+    @Override
+    public void queueTimedJobAbsolute(
+        Runnable runner, String name, long time, boolean runOnTickerAnyway, boolean noDupes) {
+      runner.run();
+    }
+  }
+
+  private static FetchContext newFetchContext() {
+    // Copied pattern from existing tests to match constructor signature
+    network.crypta.support.api.BucketFactory bf =
+        new network.crypta.support.io.ArrayBucketFactory();
+    return new FetchContext(
+        64 * 1024,
+        64 * 1024,
+        1024,
+        1,
+        0,
+        0,
+        true,
+        0,
+        0,
+        3,
+        true,
+        false,
+        false,
+        false,
+        0,
+        0,
+        bf,
+        new SimpleEventProducer(),
+        true,
+        false,
+        null,
+        null,
+        null);
+  }
+
+  private static InsertContext newInsertContext() {
+    return new InsertContext(
+        0, // maxRetries
+        0, // rnfsToSuccess
+        0, // splitfileSegmentDataBlocks
+        0, // splitfileSegmentCheckBlocks
+        new SimpleEventProducer(),
+        true, // canWriteClientCache
+        false, // forkOnCacheable
+        false, // localRequestOnly
+        null, // compressorDescriptor
+        0, // extraInsertsSingleBlock
+        0, // extraInsertsSplitfileHeaderBlock
+        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+  }
+
+  private static ClientContext minimalContext(
+      ClientLayerPersister jobRunner,
+      LinkFilterExceptionProvider linkFilterExceptionProvider,
+      FetchContext defaultPF,
+      InsertContext defaultPI,
+      USKManager uskManager,
+      PersistentTempBucketFactory ptbf,
+      TempBucketFactory tbf) {
+    return new ClientContext(
+        1L,
+        jobRunner,
+        new DirectExecutor(),
+        Mockito.mock(ArchiveManager.class),
+        ptbf,
+        tbf,
+        Mockito.mock(PersistentFileTracker.class),
+        Mockito.mock(HealingQueue.class),
+        uskManager,
+        Mockito.mock(RandomSource.class),
+        new Random(123),
+        new DirectTicker(),
+        Mockito.mock(MemoryLimitedJobRunner.class),
+        Mockito.mock(FilenameGenerator.class),
+        Mockito.mock(FilenameGenerator.class),
+        Mockito.mock(LockableRandomAccessBufferFactory.class),
+        Mockito.mock(LockableRandomAccessBufferFactory.class),
+        Mockito.mock(FileRandomAccessBufferFactory.class),
+        Mockito.mock(FileRandomAccessBufferFactory.class),
+        Mockito.mock(RealCompressor.class),
+        Mockito.mock(DatastoreChecker.class),
+        Mockito.mock(PersistentRequestRoot.class),
+        Mockito.mock(MasterSecret.class),
+        linkFilterExceptionProvider,
+        defaultPF,
+        defaultPI,
+        Mockito.mock(Config.class));
+  }
+
+  // ---------------- Mocks and test fixture ----------------
+
+  @Mock private USKCallback target;
+  @Mock private USKManager uskManager;
+  @Mock private ClientLayerPersister persister;
+  @Mock private LinkFilterExceptionProvider linkFilterExceptionProvider;
+  @Mock private PersistentTempBucketFactory ptbf;
+  @Mock private TempBucketFactory tbf;
+
+  private ClientContext context;
+  private USK usk;
+
+  @BeforeEach
+  void setUp() throws MalformedURLException {
+    context =
+        minimalContext(
+            persister,
+            linkFilterExceptionProvider,
+            newFetchContext(),
+            newInsertContext(),
+            uskManager,
+            ptbf,
+            tbf);
+    usk = newUsk();
+  }
+
+  @Test
+  @DisplayName("onFoundEdition_beforeRoundFinished_defers_untilRoundFinishedFlush")
+  void onFoundEdition_beforeRoundFinished_defers_untilRoundFinishedFlush() {
+    // Arrange
+    USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
+
+    // Act: two updates before the round finishes; should not pass through yet
+    byte[] data12 = new byte[] {1, 2};
+    byte[] data345 = new byte[] {3, 4, 5};
+    proxy.onFoundEdition(1L, usk, context, true, (short) 7, data12, false, false);
+    proxy.onFoundEdition(2L, usk, context, false, (short) 9, data345, true, true);
+
+    // Assert: no call yet
+    verify(target, never())
+        .onFoundEdition(
+            any(Long.class),
+            eq(usk),
+            eq(context),
+            any(Boolean.class),
+            any(Short.class),
+            any(),
+            any(Boolean.class),
+            any(Boolean.class));
+
+    // Act: finish the round; should flush a single latest notification (edition 2)
+    proxy.onRoundFinished(context);
+
+    // Assert: exactly once with latest values and knownGood propagated
+    verify(target, times(1))
+        .onFoundEdition(2L, usk, context, false, (short) 9, data345, true, true);
+
+    // Act: finishing again without new updates should not duplicate
+    proxy.onRoundFinished(context);
+    verify(target, times(1))
+        .onFoundEdition(2L, usk, context, false, (short) 9, data345, true, true);
+  }
+
+  @Test
+  @DisplayName("onSendingToNetwork_flushesWithoutSettingRound_and_noDuplicates")
+  void onSendingToNetwork_flushesWithoutSettingRound_and_noDuplicates() {
+    // Arrange
+    USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
+
+    // Act: update then flush via sending-to-network
+    byte[] data8 = new byte[] {8};
+    proxy.onFoundEdition(5L, usk, context, false, (short) 1, data8, false, false);
+    proxy.onSendingToNetwork(context);
+
+    // Assert: flushed once with wasKnownGood=false → both flags false
+    verify(target, times(1))
+        .onFoundEdition(5L, usk, context, false, (short) 1, data8, false, false);
+
+    // Act: call again without new updates — should not duplicate
+    proxy.onSendingToNetwork(context);
+    verify(target, times(1))
+        .onFoundEdition(5L, usk, context, false, (short) 1, data8, false, false);
+  }
+
+  @Test
+  @DisplayName("onRoundFinished_whenNoEdition_noPassThrough_evenIfLookupHasValue")
+  void onRoundFinished_whenNoEdition_noPassThrough_evenIfLookupHasValue() {
+    // Arrange
+    USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
+
+    // Case 1: with no prior editions seen, guard returns early and nothing is forwarded
+    proxy.onRoundFinished(context);
+    verify(target, never())
+        .onFoundEdition(
+            any(Long.class),
+            eq(usk),
+            eq(context),
+            any(Boolean.class),
+            any(Short.class),
+            any(),
+            any(Boolean.class),
+            any(Boolean.class));
+
+    // Case 2: calling again without any prior edition still results in no call
+    proxy.onRoundFinished(context);
+    verify(target, never())
+        .onFoundEdition(
+            any(Long.class),
+            eq(usk),
+            eq(context),
+            any(Boolean.class),
+            any(Short.class),
+            any(),
+            any(Boolean.class),
+            any(Boolean.class));
+  }
+
+  @Test
+  @DisplayName(
+      "onFoundEdition_whenOlderAndRoundFinishedAndNewKnownGoodTrue_callsThroughImmediately")
+  void onFoundEdition_whenOlderAndRoundFinishedAndNewKnownGoodTrue_callsThroughImmediately() {
+    // Arrange
+    USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
+    byte[] data1 = new byte[] {1};
+    proxy.onFoundEdition(5L, usk, context, false, (short) 0, data1, false, false);
+    proxy.onRoundFinished(context); // finish the round so subsequent older edition may pass through
+
+    // Act: older edition but newKnownGood=true should call through immediately
+    byte[] data9 = new byte[] {9};
+    proxy.onFoundEdition(4L, usk, context, true, (short) 2, data9, true, false);
+
+    // Assert: called with the older edition's parameters
+    verify(target, times(1))
+        .onFoundEdition(5L, usk, context, false, (short) 0, data1, false, false);
+    verify(target, times(1)).onFoundEdition(4L, usk, context, true, (short) 2, data9, true, false);
+  }
+
+  @Test
+  @DisplayName("onFoundEdition_sameEditionThenKnownGood_setsFlag_forFlush")
+  void onFoundEdition_sameEditionThenKnownGood_setsFlag_forFlush() {
+    // Arrange
+    USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
+
+    // Act: first store the edition (knownGood=false), then mark same edition as knownGood
+    byte[] data23 = new byte[] {2, 3};
+    proxy.onFoundEdition(7L, usk, context, true, (short) 11, data23, false, false);
+    proxy.onFoundEdition(7L, usk, context, true, (short) 11, data23, true, false);
+    proxy.onRoundFinished(context);
+
+    // Assert: the flush uses wasKnownGood=true for both flags
+    verify(target, times(1)).onFoundEdition(7L, usk, context, true, (short) 11, data23, true, true);
+  }
+
+  @Test
+  @DisplayName("priority_methods_delegate_to_target")
+  void priority_methods_delegate_to_target() {
+    when(target.getPollingPriorityNormal()).thenReturn((short) 12);
+    when(target.getPollingPriorityProgress()).thenReturn((short) 34);
+
+    USKSparseProxyCallback proxy = new USKSparseProxyCallback(target, usk);
+
+    assertEquals(12, proxy.getPollingPriorityNormal());
+    assertEquals(34, proxy.getPollingPriorityProgress());
+  }
+}


### PR DESCRIPTION
Summary
- Fix and harden `USKSparseProxyCallback` in async client.
- Add `USKSparseProxyCallbackTest` for core behaviors.
- Doclint-clean and enrich async package Javadoc (`package-info.java`).

Branch
- Source: `feature/fix-USKSparseProxyCallback`
- Base: `develop`

Commits
- 23a4fd3f74 — docs(async): doclint-clean package Javadoc and enrich async client overview
- 42bb3b127b — chore: apply Spotless formatting and commit pending USKSparseProxyCallback changes and tests

Changed Files
- M src/main/java/network/crypta/client/async/USKSparseProxyCallback.java
- M src/main/java/network/crypta/client/async/package-info.java
- A src/test/java/network/crypta/client/async/USKSparseProxyCallbackTest.java

Diff Stat
- 3 files changed, 526 insertions(+), 51 deletions(-)

Notes
- Working tree is clean; no additional formatting changes were required at PR time. Spotless was applied in prior commit.
- Tests target JUnit 6 on the JUnit Platform per project conventions.

Verification
- To run locally: `./gradlew test` (JUnit 6). Coverage target remains 80% via JaCoCo; SonarCloud configured if `SONAR_TOKEN` is present.

