### PR TITLE
client-events: Add EventDumper tests and Javadoc

### DIFF
--- a/src/main/java/network/crypta/client/events/EventDumper.java
+++ b/src/main/java/network/crypta/client/events/EventDumper.java
@@ -4,16 +4,78 @@ import java.io.IOException;
 import java.io.Writer;
 import network.crypta.client.async.ClientContext;
 
+/**
+ * A {@link ClientEventListener} that writes a one-line textual description of each received event
+ * to a provided {@link Writer}.
+ *
+ * <p>This utility is useful in diagnostics, tests, or lightweight logging pipelines where a
+ * compact, append-only representation of client events is desired. For every delivered {@code
+ * ClientEvent}, the listener calls {@code getDescription()} and writes the resulting line followed
+ * by a newline. The supplied writer is never flushed or closed by this class; lifecycle and
+ * buffering are the responsibility of the caller.
+ *
+ * <p>Error handling is intentionally minimal: {@link IOException} from the writer is swallowed to
+ * avoid interfering with the surrounding event dispatch. As a result, failures to write do not
+ * propagate to callers, and events will continue to be processed.
+ *
+ * <p>Thread-safety depends on the provided writer. This class performs no synchronization; if the
+ * writer may be accessed concurrently, callers should coordinate access or supply a thread-safe
+ * wrapper. For higher throughput, consider wrapping the writer in a {@code BufferedWriter}.
+ *
+ * <ul>
+ *   <li>Writes exactly one line per event (description plus {@code '\n'}).
+ *   <li>Never closes the writer; ownership remains with the caller.
+ *   <li>Ignores I/O failures to keep event delivery non-intrusive.
+ * </ul>
+ *
+ * @see ClientEventListener
+ * @see network.crypta.client.events.ClientEvent
+ */
 public class EventDumper implements ClientEventListener {
 
   final Writer w;
   final boolean removeWithProducer;
 
+  /**
+   * Creates a new dumper that appends one descriptive line per received event to the given writer.
+   *
+   * <p>The writer is used as-is and is not closed or flushed by this instance; callers control its
+   * lifecycle and buffering strategy. The {@code removeWithProducer} flag is recorded and may be
+   * consulted by the surrounding event subsystem to decide whether this listener should be removed
+   * together with the producer that owns it.
+   *
+   * @param writer the destination to which event descriptions are written; must not be {@code
+   *     null}; caller retains ownership and is responsible for flushing and closing
+   * @param removeWithProducer whether the listener should be considered removable together with its
+   *     producer by frameworks that support such semantics; this class does not act on the flag
+   */
   public EventDumper(Writer writer, boolean removeWithProducer) {
     this.w = writer;
     this.removeWithProducer = removeWithProducer;
   }
 
+  /**
+   * Receives an event and writes its description as a single line to the configured writer.
+   *
+   * <p>The implementation calls {@code ce.getDescription()}, appends a newline, and attempts to
+   * write the result. Any {@link IOException} thrown by the writer is caught and ignored to avoid
+   * disrupting event dispatch. No synchronization is performed; callers should ensure safe access
+   * when multiple threads may deliver events concurrently.
+   *
+   * <p>Preconditions: {@code ce} must be non-{@code null}. The {@code context} parameter may be
+   * provided by the dispatching framework but is not consulted by this implementation.
+   *
+   * <pre>{@code
+   * // Example: direct invocation
+   * var dumper = new EventDumper(writer, false);
+   * dumper.receive(event, context);
+   * }</pre>
+   *
+   * @param ce the event being delivered; must be non-{@code null}; its {@code getDescription()}
+   *     text is written verbatim followed by a newline
+   * @param context framework-supplied context for the event dispatch; accepted but ignored by this
+   *     implementation
+   */
   @Override
   public void receive(ClientEvent ce, ClientContext context) {
     try {

--- a/src/test/java/network/crypta/client/events/EventDumperTest.java
+++ b/src/test/java/network/crypta/client/events/EventDumperTest.java
@@ -1,0 +1,87 @@
+package network.crypta.client.events;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import network.crypta.client.async.ClientContext;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class EventDumperTest {
+
+  @Mock private ClientEvent clientEvent;
+  @Mock private ClientContext clientContext;
+
+  @Test
+  void constructor_whenGivenArgs_setsFields() {
+    StringWriter writer = new StringWriter();
+    EventDumper dumper = new EventDumper(writer, true);
+
+    // Verify constructor wired fields as given (package-visible in the same package)
+    assertEquals(writer, dumper.w, "Writer should be the same instance");
+    assertTrue(dumper.removeWithProducer, "Flag removeWithProducer should be stored");
+  }
+
+  @Test
+  void receive_whenDescriptionProvided_writesDescriptionWithNewline() {
+    StringWriter writer = new StringWriter();
+    EventDumper dumper = new EventDumper(writer, false);
+    when(clientEvent.getDescription()).thenReturn("hello");
+
+    dumper.receive(clientEvent, clientContext);
+
+    assertEquals("hello\n", writer.toString(), "Should write description followed by newline");
+  }
+
+  @Test
+  void receive_whenDescriptionIsNull_writesLiteralNullWithNewline() {
+    StringWriter writer = new StringWriter();
+    EventDumper dumper = new EventDumper(writer, false);
+    when(clientEvent.getDescription()).thenReturn(null);
+
+    dumper.receive(clientEvent, clientContext);
+
+    // String concatenation with null yields the literal "null"
+    assertEquals("null\n", writer.toString(), "Should write literal null followed by newline");
+  }
+
+  @Test
+  void receive_whenWriterThrows_ignoresIOException() {
+    Writer throwingWriter =
+        new Writer() {
+          @Override
+          public void write(char @NotNull [] cbuf, int off, int len) throws IOException {
+            throw new IOException("fail");
+          }
+
+          @Override
+          public void flush() {
+            // Intentionally a no-op: this test double only needs to throw from write()
+            // flush() is irrelevant for exercising EventDumper's error handling.
+          }
+
+          @Override
+          public void close() {
+            // Intentionally a no-op for the same reason as flush(): no resource management is
+            // required in this minimal test double.
+          }
+        };
+
+    EventDumper dumper = new EventDumper(throwingWriter, false);
+    when(clientEvent.getDescription()).thenReturn("anything");
+
+    assertDoesNotThrow(
+        () -> dumper.receive(clientEvent, clientContext),
+        "IOException from underlying writer must be ignored");
+  }
+}


### PR DESCRIPTION
Summary
- Add unit tests for EventDumper
- Add comprehensive Javadoc to EventDumper
- Apply Spotless formatting

Details
- Tests cover:
  - Writes description + newline when provided
  - Writes literal "null\n" when description is null
  - Swallows IOException from underlying Writer and continues
- No behavior changes in production logic; only documentation added to EventDumper and style formatting applied.

Notes
- JUnit 6 (Jupiter) tests; no new dependencies beyond existing catalog.
- Verified formatting via `./gradlew spotlessApply` locally prior to commit.

Branch
- Head: feature/fix-EventDumper
- Base: develop

Please let me know if you prefer the tests under a different package or any additional scenarios to be covered.