### PR TITLE
docs(client): doclint‑clean Javadoc for ExpectedHashesEvent + comprehensive tests

### DIFF
--- a/src/main/java/network/crypta/client/events/ExpectedHashesEvent.java
+++ b/src/main/java/network/crypta/client/events/ExpectedHashesEvent.java
@@ -2,21 +2,76 @@ package network.crypta.client.events;
 
 import network.crypta.crypt.HashResult;
 
+/**
+ * Event that conveys the set of content hashes a client expects to observe.
+ *
+ * <p>This value object is emitted by higher-level client operations when they can determine one or
+ * more reference digests for the item being fetched, inserted, or verified. Listeners may log this
+ * information, compare it with actual results, or surface the data to user interfaces. The event
+ * carries only metadata; it does not perform any computation and has no side effects. Instances are
+ * immutable with respect to the reference they expose, although the referenced array itself is not
+ * defensively copied. Callers should therefore treat the {@link #hashes} field as read-only and
+ * avoid mutating it after constructing the event.
+ *
+ * <p>Typical usages include:
+ *
+ * <ul>
+ *   <li>Reporting digests calculated by a preparatory step so downstream components can validate
+ *       retrieved data.
+ *   <li>Attaching expected digests to progress logs to aid troubleshooting and correlation.
+ *   <li>Providing a compact, serializable summary for audit or testing utilities.
+ * </ul>
+ *
+ * <p>Thread-safety note: The class itself is effectively immutable once constructed, but because
+ * the {@code hashes} array reference is stored as provided, external mutation of that array would
+ * be observable by listeners. Prefer supplying a dedicated array instance that is not modified
+ * after publication.
+ *
+ * @see ClientEvent
+ * @see HashResult
+ */
 public class ExpectedHashesEvent implements ClientEvent {
 
+  /**
+   * The expected content digests associated with this event.
+   *
+   * <p>The array groups zero or more {@link HashResult} entries, typically one per algorithm. The
+   * reference is stored as provided by the caller; no defensive copy is performed. The reference
+   * may be {@code null} to indicate the absence of expected hashes. Consumers should treat the
+   * array as read-only.
+   */
   public final HashResult[] hashes;
 
+  /**
+   * Stable identifier for this event type.
+   *
+   * <p>The value is suitable for programmatic routing, filtering, or metric labeling. It remains
+   * constant across releases for compatibility with downstream consumers.
+   */
   public static final int CODE = 0x0E;
 
+  /**
+   * Creates a new event containing the provided expected digests.
+   *
+   * <p>No validation or de-duplication is performed here; producers should construct the array in
+   * the desired order and with the desired uniqueness guarantees. The array reference is stored as
+   * is and not copied.
+   *
+   * @param h array of expected {@link HashResult} values; may be {@code null} when no digests are
+   *     available or applicable. The array is not defensively copied and should not be mutated
+   *     after construction.
+   */
   public ExpectedHashesEvent(HashResult[] h) {
     hashes = h;
   }
 
+  /** {@inheritDoc} */
   @Override
   public int getCode() {
     return CODE;
   }
 
+  /** {@inheritDoc} */
   @Override
   public String getDescription() {
     return "Expected hashes";

--- a/src/test/java/network/crypta/client/events/ExpectedHashesEventTest.java
+++ b/src/test/java/network/crypta/client/events/ExpectedHashesEventTest.java
@@ -1,0 +1,75 @@
+package network.crypta.client.events;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import network.crypta.crypt.HashResult;
+import network.crypta.crypt.HashType;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class ExpectedHashesEventTest {
+
+  @Test
+  void constructor_whenNullArray_expectNullReferenceStored() {
+    // Arrange
+    HashResult[] input = null;
+
+    // Act
+    //noinspection ConstantValue
+    ExpectedHashesEvent event = new ExpectedHashesEvent(input);
+
+    // Assert
+    assertNull(event.hashes, "Expected null to be stored when input is null");
+  }
+
+  @Test
+  void constructor_whenEmptyArray_expectSameReferenceStored() {
+    // Arrange
+    HashResult[] input = new HashResult[0];
+
+    // Act
+    ExpectedHashesEvent event = new ExpectedHashesEvent(input);
+
+    // Assert
+    assertSame(input, event.hashes, "Constructor should not defensively copy the array");
+    assertEquals(0, event.hashes.length, "Empty input array should remain empty");
+  }
+
+  @Test
+  void constructor_whenArrayProvided_expectSameReferenceAndElementsPreserved() {
+    // Arrange
+    byte[] sha1 = new byte[HashType.SHA1.hashLength];
+    for (int i = 0; i < sha1.length; i++) sha1[i] = (byte) i;
+    byte[] md5 = new byte[HashType.MD5.hashLength];
+    for (int i = 0; i < md5.length; i++) md5[i] = (byte) (i + 1);
+
+    HashResult h1 = new HashResult(HashType.SHA1, sha1);
+    HashResult h2 = new HashResult(HashType.MD5, md5);
+    HashResult[] input = new HashResult[] {h1, h2};
+
+    // Act
+    ExpectedHashesEvent event = new ExpectedHashesEvent(input);
+
+    // Assert
+    assertSame(input, event.hashes, "Array reference should be stored as-is");
+    assertArrayEquals(input, event.hashes, "Element order and values should be preserved");
+  }
+
+  @Test
+  void api_whenQueried_expectStableCodeAndDescription() {
+    // Arrange
+    ExpectedHashesEvent event = new ExpectedHashesEvent(new HashResult[0]);
+
+    // Act & Assert
+    assertInstanceOf(ClientEvent.class, event, "Event must implement ClientEvent");
+    assertEquals(ExpectedHashesEvent.CODE, event.getCode(), "getCode should return CODE constant");
+    assertEquals(0x0E, event.getCode(), "CODE must be the expected numeric value");
+    assertNotNull(event.getDescription(), "Description must be non-null");
+    assertEquals("Expected hashes", event.getDescription(), "Description text must match");
+  }
+}


### PR DESCRIPTION
Summary
- Add doclint-clean, long-form Javadoc to ExpectedHashesEvent (class, field, constructor), including usage notes and thread-safety considerations.
- Add focused JUnit 6 test ExpectedHashesEventTest covering constructor behavior (null/empty/preserved reference), code/description contract, and API shape.
- No production behavior changes; documentation only plus new tests.

Motivation
- Ensure the public API has substantive, accurate documentation that passes javadoc doclint.
- Provide deterministic unit tests to lock in current semantics and guard against regressions.

Changes
- src/main/java/network/crypta/client/events/ExpectedHashesEvent.java
  - Added long-form Javadoc (summary + extended description + field and constructor docs) with {@inheritDoc} for interface methods.
- src/test/java/network/crypta/client/events/ExpectedHashesEventTest.java
  - New tests asserting constructor semantics and ClientEvent contract.

Implementation Notes
- The event stores the provided hashes array by reference; tests and docs call this out so consumers avoid mutating it post-publication.
- Ran Spotless to keep formatting consistent.

Verification
- Targeted test: ./gradlew test --tests 'network.crypta.client.events.ExpectedHashesEventTest' (passes locally).
- Full suite: Unrelated failure observed in ModuloTimeTriggeringPolicyTest on this environment; not impacted by these changes.

Scope
- No refactors or behavior changes in production code; documentation and tests only.

