### PR TITLE
style(java): Add Javadoc for ExpectedMIMEEvent and apply Spotless

### DIFF
--- a/src/main/java/network/crypta/client/events/ExpectedMIMEEvent.java
+++ b/src/main/java/network/crypta/client/events/ExpectedMIMEEvent.java
@@ -1,20 +1,81 @@
 package network.crypta.client.events;
 
+/**
+ * Event indicating the producer's currently expected MIME type for a payload or response.
+ *
+ * <p>This lightweight, immutable value object communicates content-type expectations to listeners
+ * and user interfaces. Producers emit the event when they can infer or determine a MIME type ahead
+ * of actually producing or receiving the bytes (for example, after parsing headers, reading a
+ * manifest, or inspecting metadata). Downstream components can use this information to prime
+ * renderers, select decoders, validate responses, or simply display a helpful hint to operators.
+ * The class carries a stable {@linkplain #getCode() numeric code} for programmatic routing and a
+ * concise {@linkplain #getDescription() description} suitable for logs and status panels.
+ *
+ * <p>Instances are thread-safe and read-only by construction: all fields are {@code final}, and no
+ * mutation is provided. The {@link #expectedMIMEType} value is stored verbatim as supplied by the
+ * producer; consumers should therefore tolerate variants such as parameters (e.g., {@code
+ * "text/html; charset=UTF-8"}) or case differences. When the type is unknown, producers may supply
+ * {@code null} and listeners should handle that case conservatively (for example, by falling back
+ * to generic handling).
+ *
+ * <ul>
+ *   <li><b>Responsibility:</b> surface the MIME type that the client currently expects.
+ *   <li><b>Typical usage:</b> create an instance, then dispatch through a {@link ClientEvent}
+ *       pipeline to interested listeners.
+ *   <li><b>Scope:</b> conveys metadata only; it does not enforce validation or decoding.
+ * </ul>
+ *
+ * @see ClientEvent
+ */
 public class ExpectedMIMEEvent implements ClientEvent {
 
+  /**
+   * Stable identifier for this event kind.
+   *
+   * <p>The value supports programmatic routing, filtering, and metrics. It remains constant across
+   * releases for compatibility with downstream consumers that key on event codes.
+   */
   static final int CODE = 0x0B;
 
+  /**
+   * The MIME type string that the producer expects for the associated content.
+   *
+   * <p>The value is stored as provided by the emitter and may be {@code null} when the type is not
+   * yet known. It may include optional parameters (for example, a {@code charset}) and should be
+   * treated as read-only by consumers. No normalization or validation is performed here.
+   */
   public final String expectedMIMEType;
 
+  /**
+   * Creates a new event with the given expected MIME type string.
+   *
+   * <p>The constructor performs no validation or canonicalization. Callers may pass a parameterized
+   * MIME value (such as {@code "application/json; charset=UTF-8"}) or {@code null} when the type is
+   * unknown. Instances created via this constructor are immutable and safe to share across threads.
+   *
+   * @param type the expected MIME type string as reported by the producer; may be {@code null} when
+   *     unknown and may include parameters; callers should avoid mutating referenced data after
+   *     publishing the event.
+   */
   public ExpectedMIMEEvent(String type) {
     this.expectedMIMEType = type;
   }
 
+  /** {@inheritDoc} */
   @Override
   public int getCode() {
     return CODE;
   }
 
+  /**
+   * Returns a concise human-readable description including the expected MIME type.
+   *
+   * <p>The string is intended for logs and status displays and is not meant for machine parsing.
+   * Use {@link #getCode()} and {@link #expectedMIMEType} for programmatic handling.
+   *
+   * @return a non-{@code null} sentence summarizing the expected MIME type; callers do not take
+   *     ownership of the returned instance.
+   */
   @Override
   public String getDescription() {
     return "Expected MIME type: " + expectedMIMEType;

--- a/src/test/java/network/crypta/client/events/ExpectedMIMEEventTest.java
+++ b/src/test/java/network/crypta/client/events/ExpectedMIMEEventTest.java
@@ -1,0 +1,81 @@
+package network.crypta.client.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@SuppressWarnings("java:S100")
+class ExpectedMIMEEventTest {
+
+  @Test
+  void constructor_andAccessors_whenNormalType_expectValues() {
+    // Arrange
+    String mime = "text/html";
+
+    // Act
+    ExpectedMIMEEvent event = new ExpectedMIMEEvent(mime);
+
+    // Assert
+    assertEquals(mime, event.expectedMIMEType, "Field should reflect constructor argument");
+    assertEquals(0x0B, event.getCode(), "Event code should match constant");
+    assertEquals(
+        "Expected MIME type: text/html",
+        event.getDescription(),
+        "Description should prefix with label");
+  }
+
+  @Test
+  void getDescription_whenNullType_expectNullLiteralInDescription() {
+    // Arrange & Act
+    ExpectedMIMEEvent event = new ExpectedMIMEEvent(null);
+
+    // Assert
+    assertNull(event.expectedMIMEType, "Field should be null when constructed with null");
+    assertEquals(0x0B, event.getCode(), "Event code remains constant for all instances");
+    String description = event.getDescription();
+    assertNotNull(description, "Description must be non-null even if MIME type is null");
+    assertEquals(
+        "Expected MIME type: null",
+        description,
+        "String concatenation should render null as literal 'null'");
+  }
+
+  @Test
+  void getDescription_whenEmptyType_expectTrailingSpaceOnly() {
+    // Arrange
+    String mime = "";
+
+    // Act
+    ExpectedMIMEEvent event = new ExpectedMIMEEvent(mime);
+
+    // Assert
+    assertEquals("", event.expectedMIMEType, "Field should allow empty strings");
+    assertEquals(
+        "Expected MIME type: ",
+        event.getDescription(),
+        "Description should handle empty MIME without extra punctuation");
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "application/json; charset=UTF-8",
+    "image/png",
+    "application/octet-stream",
+    "text/plain; charset=US-ASCII"
+  })
+  void getDescription_whenVariousTypes_expectFormattedPrefix(String mime) {
+    // Arrange & Act
+    ExpectedMIMEEvent event = new ExpectedMIMEEvent(mime);
+
+    // Assert
+    assertEquals(mime, event.expectedMIMEType, "Field preserves exact MIME value");
+    assertEquals(
+        "Expected MIME type: " + mime,
+        event.getDescription(),
+        "Description must include exact MIME value with standard prefix");
+  }
+}


### PR DESCRIPTION
Summary
- Add comprehensive Javadoc to ExpectedMIMEEvent to clarify purpose, usage, and guarantees.
- Apply Spotless/google-java-format to changed files and tidy test assertions for readability.
- Add unit tests for ExpectedMIMEEvent description/formatting edge cases.

Motivation
- Improve code documentation coverage and clarity for client event types without changing behavior.
- Keep formatting consistent with the project’s Spotless configuration.

Changes
- src/main/java/network/crypta/client/events/ExpectedMIMEEvent.java
  - Add Javadoc on class, fields, constructor, and methods. No functional changes.
- src/test/java/network/crypta/client/events/ExpectedMIMEEventTest.java
  - New tests for description formatting across null/empty/parameterized MIME values and general behavior.

Behavioral impact
- None. This is documentation and formatting only; public API unchanged, event code remains 0x0B.

Validation
- Spotless applied locally via `./gradlew spotlessApply`.
- Working tree is clean; no additional changes pending.

Commit(s)
- 7a8882a5c4 style(java): apply Spotless and add Javadoc for ExpectedMIMEEvent

Notes
- Target branch: develop
- Please let me know if you’d like a separate commit split for tests vs Javadoc or any rewording in Javadoc.
