### PR TITLE
client/events: Document FinishedCompressionEvent, expose stable CODE constant, and add tests

### DIFF
--- a/src/main/java/network/crypta/client/events/FinishedCompressionEvent.java
+++ b/src/main/java/network/crypta/client/events/FinishedCompressionEvent.java
@@ -1,24 +1,98 @@
 package network.crypta.client.events;
 
+/**
+ * Event published when an attempted compression step has finished and the final sizes are known.
+ *
+ * <p>This value object is part of the client-facing event stream and captures the outcome of a
+ * single compression attempt performed by a higher-level operation (for example, a splitfile
+ * insert). It records which codec identifier was used as well as the original, uncompressed size
+ * and the resulting compressed size. Consumers typically use this to produce progress logs, surface
+ * metrics, or decide whether the compressed form should be retained. The class is immutable and
+ * thread-safe for concurrent read access once constructed.
+ *
+ * <p>Typical usage is to create an instance after a compressor finishes and dispatch it to any
+ * registered listeners alongside other progress events. When {@link #codec} is {@code -1}, the
+ * payload is uncompressed and {@link #compressedSize} is expected to equal {@link #originalSize}.
+ * No I/O or computation happens inside this type; it merely conveys already-computed values.
+ *
+ * <ul>
+ *   <li>Responsibilities: carry the codec identifier and size figures after compression.
+ *   <li>Mutability: immutable; all fields are {@code final} and exposed for read-only use.
+ *   <li>Thread-safety: safe for concurrent reads without external synchronization.
+ * </ul>
+ *
+ * @see ClientEvent
+ * @see StartedCompressionEvent
+ */
 public class FinishedCompressionEvent implements ClientEvent {
 
-  static final int code = 0x09;
+  /**
+   * Stable code identifying this event kind within the client event set.
+   *
+   * <p>The numeric value remains constant across releases to support programmatic routing,
+   * filtering, and metrics. It is returned by {@link #getCode()} and may be compared directly
+   * against other event codes for equality.
+   */
+  static final int CODE = 0x09;
 
-  /** Codec, -1 = uncompressed */
+  /**
+   * Compression codec identifier used for the attempt; {@code -1} denotes no compression.
+   *
+   * <p>The concrete mapping of integers to codec implementations is defined by higher-level
+   * components. A value of {@code -1} indicates an uncompressed payload. The field is immutable and
+   * safe to read concurrently.
+   */
   public final int codec;
 
-  /** Original size */
+  /**
+   * Size of the original, uncompressed data in bytes.
+   *
+   * <p>This value reflects the exact byte length of the input presented to the compressor. It is
+   * non-negative and does not change after construction. Consumers may use it to compute
+   * compression ratios or to validate that {@link #compressedSize} is sensible for the chosen
+   * {@link #codec}.
+   */
   public final long originalSize;
 
-  /** Compressed size */
+  /**
+   * Size of the compressed output in bytes (or original size when uncompressed).
+   *
+   * <p>When {@link #codec} equals {@code -1}, this value typically matches {@link #originalSize}.
+   * For successful compression attempts, it is less than or equal to the original size. The field
+   * is immutable and suitable for use in logs, metrics, or UI summaries.
+   */
   public final long compressedSize;
 
+  /**
+   * Creates a new event instance describing the outcome of a compression attempt.
+   *
+   * <p>The constructor accepts the codec identifier and the measured sizes in bytes. It does not
+   * perform validation or I/O; callers are expected to supply consistent values. Instances are
+   * immutable and safe to share across threads without further synchronization.
+   *
+   * @param codec integer identifier of the compression codec; use {@code -1} to indicate that the
+   *     data remained uncompressed and that {@code compressedSize} should equal {@code origSize}.
+   * @param origSize original uncompressed size in bytes; must be non-negative and represent the
+   *     exact byte length of the input provided to the compressor.
+   * @param compressedSize resulting size in bytes after applying the codec; for uncompressed data
+   *     it should equal the original size; otherwise it is typically less than or equal to it.
+   */
   public FinishedCompressionEvent(int codec, long origSize, long compressedSize) {
     this.codec = codec;
     this.originalSize = origSize;
     this.compressedSize = compressedSize;
   }
 
+  /**
+   * Returns a concise, human-readable summary of the compression outcome.
+   *
+   * <p>The description includes the codec identifier and both the original and compressed sizes in
+   * bytes. It is intended for logs, user interfaces, or diagnostic output and is not guaranteed to
+   * be stable for machine parsing.
+   *
+   * @return a short summary string describing the codec, original size, and compressed size in
+   *     bytes; callers must treat the returned instance as read-only.
+   */
   @Override
   public String getDescription() {
     return "Compressed data: codec="
@@ -29,8 +103,16 @@ public class FinishedCompressionEvent implements ClientEvent {
         + compressedSize;
   }
 
+  /**
+   * Returns the stable numeric code that identifies this event type.
+   *
+   * <p>The value is suitable for programmatic routing, filtering, and metric labeling and is
+   * guaranteed to match {@link #CODE}.
+   *
+   * @return the event identifier code that remains stable across releases; equal to {@link #CODE}.
+   */
   @Override
   public int getCode() {
-    return code;
+    return CODE;
   }
 }

--- a/src/test/java/network/crypta/client/events/FinishedCompressionEventTest.java
+++ b/src/test/java/network/crypta/client/events/FinishedCompressionEventTest.java
@@ -1,0 +1,71 @@
+package network.crypta.client.events;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100") // test method naming with underscores
+class FinishedCompressionEventTest {
+
+  @Test
+  @DisplayName("constructor sets fields as provided")
+  void constructor_whenGivenValues_setsFields() {
+    // Arrange
+    int codec = 7;
+    long orig = 1_234_567L;
+    long comp = 987_654L;
+
+    // Act
+    FinishedCompressionEvent event = new FinishedCompressionEvent(codec, orig, comp);
+
+    // Assert
+    assertAll(
+        () -> assertEquals(codec, event.codec, "codec should match constructor arg"),
+        () -> assertEquals(orig, event.originalSize, "originalSize should match constructor arg"),
+        () ->
+            assertEquals(
+                comp, event.compressedSize, "compressedSize should match constructor arg"));
+  }
+
+  @ParameterizedTest(name = "codec={0}, orig={1}, comp={2}")
+  @MethodSource("descriptionCases")
+  void getDescription_whenVariousValues_formatsCorrectly(int codec, long orig, long comp) {
+    // Arrange
+    FinishedCompressionEvent event = new FinishedCompressionEvent(codec, orig, comp);
+
+    // Act
+    String description = event.getDescription();
+
+    // Assert
+    String expected =
+        "Compressed data: codec=" + codec + ", origSize=" + orig + ", compressedSize=" + comp;
+    assertEquals(expected, description);
+  }
+
+  static Stream<Arguments> descriptionCases() {
+    return Stream.of(
+        Arguments.of(1, 1000L, 500L), // typical compression
+        Arguments.of(-1, 123L, 123L), // uncompressed marker
+        Arguments.of(0, 0L, 0L), // zeros
+        Arguments.of(Integer.MAX_VALUE, Long.MAX_VALUE, Long.MIN_VALUE) // extremes
+        );
+  }
+
+  @Test
+  void getCode_returnsStableConstant() {
+    // Arrange
+    FinishedCompressionEvent event = new FinishedCompressionEvent(3, 10L, 8L);
+
+    // Act
+    int actualCode = event.getCode();
+
+    // Assert
+    assertEquals(0x09, actualCode, "event code must remain stable (0x09)");
+  }
+}


### PR DESCRIPTION
Summary
- Add comprehensive JavaDoc for FinishedCompressionEvent and clarify semantics.
- Promote static event code field to stable constant `CODE` and update `getCode()` to return it.
- Introduce unit test `FinishedCompressionEventTest` (JUnit 6) and tidy assertion formatting.
- Apply Spotless formatting across touched sources.

Technical Notes
- The public field previously named `code` is now `CODE` (uppercase). Behavior of `getCode()` remains identical, returning the same numeric value (0x09).
- JavaDoc documents immutability, thread-safety, and expected relationships between fields for greater clarity in client code.

Changes
- src/main/java/network/crypta/client/events/FinishedCompressionEvent.java
  - JavaDoc added; static `code` -> `CODE`; minor formatting.
- src/test/java/network/crypta/client/events/FinishedCompressionEventTest.java
  - New test with constructor and description coverage; formatting improved for readability.

Formatting
- Ran `./gradlew spotlessApply` prior to commit to align with project style.

Testing
- Project uses JUnit 6; tests run on the JUnit Platform. To run locally: `./gradlew --parallel test --tests *FinishedCompressionEventTest`.

Risk/Compatibility
- Low risk overall. The rename from `code` to `CODE` is a source-level symbol change; downstream code directly referencing the constant should update to `FinishedCompressionEvent.CODE`. The event code value remains unchanged (`0x09`), and `getCode()` behavior is unaffected.

Request
- Please review and merge into `develop`. If preferred, we can adjust naming or split the JavaDoc and constant rename into separate commits.
