### PR TITLE
test(events): add SplitfileCompatibilityModeEvent tests and improve Javadoc

### DIFF
--- a/src/main/java/network/crypta/client/events/SplitfileCompatibilityModeEvent.java
+++ b/src/main/java/network/crypta/client/events/SplitfileCompatibilityModeEvent.java
@@ -2,26 +2,139 @@ package network.crypta.client.events;
 
 import network.crypta.client.InsertContext.CompatibilityMode;
 
+/**
+ * Event describing the compatibility window and encoding flags chosen for a splitfile operation.
+ *
+ * <p>This value object is emitted by higher-level insert/fetch logic to announce the selected
+ * {@link CompatibilityMode} range a splitfile should honor as it is encoded or interpreted, along
+ * with auxiliary properties that influence the on-disk representation. The event is useful for
+ * operators and UIs that want to display why a particular splitfile layout was picked, and for
+ * programmatic consumers that gate behavior based on a stable event code exposed via {@link
+ * #getCode()}.
+ *
+ * <p>Instances carry a lower and upper bound for compatibility, an optional cryptographic key
+ * associated with the splitfile, and two booleans that indicate compression and layer context. The
+ * fields are final; however, the {@code byte[]} reference is exposed directly and is not copied. Do
+ * not modify its contents after construction. Treat instances as read-mostly; mutating the array
+ * would be visible to other threads and consumers.
+ *
+ * <ul>
+ *   <li>Responsibilities: convey the selected compatibility window and related flags.
+ *   <li>Immutability: fields are final; the key array must be treated as read-only.
+ *   <li>Thread-safety: safe for concurrent reads when the array is not mutated by callers.
+ * </ul>
+ *
+ * @see ClientEvent
+ * @see CompatibilityMode
+ */
 public class SplitfileCompatibilityModeEvent implements ClientEvent {
 
+  /**
+   * The minimum {@link CompatibilityMode} that the operation must satisfy.
+   *
+   * <p>This lower bound constrains how data is laid out so previously deployed readers can still
+   * process the splitfile. It is typically determined by configuration or the environment’s
+   * defaults. The value is inclusive; producers choose parameters at or above this level depending
+   * on the {@link #maxCompatibilityMode} bound.
+   */
   public final CompatibilityMode minCompatibilityMode;
+
+  /**
+   * The maximum {@link CompatibilityMode} that the operation may target.
+   *
+   * <p>This upper bound allows newer, more efficient layouts to be used when available while still
+   * honoring {@link #minCompatibilityMode}. It is inclusive and represents the highest mode that a
+   * consumer of the resulting data is expected to understand.
+   */
   public final CompatibilityMode maxCompatibilityMode;
+
+  /**
+   * Opaque cryptographic key material associated with the splitfile, if any.
+   *
+   * <p>The contents and length are defined by upstream components. The reference is stored as is
+   * and not defensively copied; callers must not modify the array after passing it to the
+   * constructor. The field may be {@code null} when no key is applicable for the current context.
+   */
   public final byte[] splitfileCryptoKey;
+
+  /**
+   * Whether compression should be disabled for the relevant splitfile layer.
+   *
+   * <p>When {@code true}, producers skip applying compression for the associated portion of the
+   * splitfile, preserving exact bytes at the cost of larger size. When {@code false}, compression
+   * policy is left to the producer’s defaults.
+   */
   public final boolean dontCompress;
+
+  /**
+   * Whether the event pertains specifically to the bottom layer of the splitfile.
+   *
+   * <p>This flag allows consumers to distinguish configuration for the lowest layer (data blocks)
+   * from higher metadata or header layers, which may be treated differently by encoders.
+   */
   public final boolean bottomLayer;
 
+  /**
+   * Stable integer identifier for this event kind.
+   *
+   * <p>The code can be used for programmatic routing, counters, or filtering policies in logs and
+   * UIs. The value is stable within the producing component and equals {@code 0x0D}.
+   */
   public static final int CODE = 0x0D;
 
+  /**
+   * Returns the stable integer identifier for this event type.
+   *
+   * <p>Clients may switch on this code to aggregate metrics or to route the event to specialized
+   * handlers. The value is constant for all instances of this class and does not depend on field
+   * contents.
+   *
+   * @return a stable integer code identifying the compatibility-mode event; suitable for
+   *     comparisons and counters across instances.
+   */
   @Override
   public int getCode() {
     return CODE;
   }
 
+  /**
+   * Returns a concise, human-readable summary of the compatibility range.
+   *
+   * <p>The description lists the lower and upper {@link CompatibilityMode} bounds selected for the
+   * splitfile. It is intended for logs, progress displays, and diagnostics and should not be parsed
+   * programmatically. Use {@link #getCode()} for machine handling when needed.
+   *
+   * <pre>{@code
+   * // Example: record the chosen window
+   * LOG.info("Selected: {}", event.getDescription());
+   * }</pre>
+   *
+   * @return a non-null summary describing the minimum and maximum compatibility modes in plain
+   *     text; callers must treat the returned string as read-only.
+   */
   @Override
   public String getDescription() {
     return "CompatibilityMode between " + minCompatibilityMode + " and " + maxCompatibilityMode;
   }
 
+  /**
+   * Creates a new event with the provided compatibility window and flags.
+   *
+   * <p>The array reference for {@code splitfileCryptoKey} is stored directly and is not copied.
+   * Pass a fresh or immutable instance if later modification is a concern. Booleans control
+   * compression policy and layer context used by producers or UIs.
+   *
+   * @param min the lower, inclusive {@link CompatibilityMode} bound to honor; must not be {@code
+   *     null} when a concrete mode is required by the producer.
+   * @param max the upper, inclusive {@link CompatibilityMode} bound allowed for encoding; must not
+   *     be {@code null} when a concrete mode is required by the producer.
+   * @param splitfileCryptoKey optional key bytes associated with the splitfile; reference is stored
+   *     as-is and must not be mutated after construction; may be {@code null}.
+   * @param dontCompress {@code true} to disable compression for the relevant layer; {@code false}
+   *     to allow default compression behavior.
+   * @param bottomLayer {@code true} when the configuration applies to the bottom layer; otherwise
+   *     refers to a higher layer or global context.
+   */
   public SplitfileCompatibilityModeEvent(
       CompatibilityMode min,
       CompatibilityMode max,

--- a/src/test/java/network/crypta/client/events/SplitfileCompatibilityModeEventTest.java
+++ b/src/test/java/network/crypta/client/events/SplitfileCompatibilityModeEventTest.java
@@ -1,0 +1,98 @@
+package network.crypta.client.events;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.client.InsertContext.CompatibilityMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SplitfileCompatibilityModeEventTest {
+
+  @Test
+  void getCode_whenCalled_returnsDefinedConstant() {
+    // Arrange
+    byte[] key = new byte[] {1, 2, 3, 4};
+    SplitfileCompatibilityModeEvent evt =
+        new SplitfileCompatibilityModeEvent(
+            CompatibilityMode.COMPAT_1250, CompatibilityMode.COMPAT_1468, key, false, true);
+
+    // Act
+    int code = evt.getCode();
+
+    // Assert
+    assertEquals(SplitfileCompatibilityModeEvent.CODE, code);
+    assertEquals(0x0D, code);
+  }
+
+  @Test
+  void getDescription_whenEnumsProvided_formatsExpectedString() {
+    // Arrange
+    byte[] key = new byte[] {9};
+    SplitfileCompatibilityModeEvent evt =
+        new SplitfileCompatibilityModeEvent(
+            CompatibilityMode.COMPAT_1250_EXACT, CompatibilityMode.COMPAT_1468, key, true, false);
+
+    // Act
+    String description = evt.getDescription();
+
+    // Assert
+    assertEquals("CompatibilityMode between COMPAT_1250_EXACT and COMPAT_1468", description);
+  }
+
+  @Test
+  void constructor_whenValuesProvided_setsAllFields() {
+    // Arrange
+    CompatibilityMode min = CompatibilityMode.COMPAT_1251;
+    CompatibilityMode max = CompatibilityMode.COMPAT_1416;
+    byte[] key = new byte[] {10, 11, 12};
+    boolean dontCompress = true;
+    boolean bottomLayer = true;
+
+    // Act
+    SplitfileCompatibilityModeEvent evt =
+        new SplitfileCompatibilityModeEvent(min, max, key, dontCompress, bottomLayer);
+
+    // Assert
+    assertSame(min, evt.minCompatibilityMode);
+    assertSame(max, evt.maxCompatibilityMode);
+    assertSame(key, evt.splitfileCryptoKey);
+    assertArrayEquals(new byte[] {10, 11, 12}, evt.splitfileCryptoKey);
+    assertTrue(evt.dontCompress);
+    assertTrue(evt.bottomLayer);
+  }
+
+  @Test
+  void getDescription_whenNullEnums_returnsLiteralNullText() {
+    // Arrange
+    SplitfileCompatibilityModeEvent evt =
+        new SplitfileCompatibilityModeEvent(null, null, null, false, false);
+
+    // Act
+    String description = evt.getDescription();
+
+    // Assert
+    assertEquals("CompatibilityMode between null and null", description);
+    assertNull(evt.splitfileCryptoKey);
+  }
+
+  @Test
+  void getDescription_whenMinNullMaxPresent_formatsMixedString() {
+    // Arrange
+    SplitfileCompatibilityModeEvent evt =
+        new SplitfileCompatibilityModeEvent(
+            null, CompatibilityMode.COMPAT_1250, new byte[] {1}, false, false);
+
+    // Act
+    String description = evt.getDescription();
+
+    // Assert
+    assertEquals("CompatibilityMode between null and COMPAT_1250", description);
+  }
+}


### PR DESCRIPTION
Summary
- Add unit tests for SplitfileCompatibilityModeEvent and improve Javadoc.
- Apply Spotless formatting on touched files.

Changes
- src/main/java/network/crypta/client/events/SplitfileCompatibilityModeEvent.java
  - Add comprehensive Javadoc for fields, constructor, getCode(), and getDescription().
  - No functional behavior changes.
- src/test/java/network/crypta/client/events/SplitfileCompatibilityModeEventTest.java
  - New JUnit 6 tests covering:
    - getCode() returns the defined constant (0x0D) and equals CODE
    - getDescription() formatting for typical enums and nulls
    - Constructor assigns all fields; array reference is preserved

Rationale
- Clarifies the purpose and guarantees of the event (compatibility window, flags, key handling).
- Establishes tests around the stable event code and human-readable description.

Risk/Impact
- Low. Purely documentation and tests; no runtime behavior changes.

Testing
- Compiles and ran Spotless locally. Tests included; CI should run them under JUnit 6 config.

Notes
- Branch: feature/fix-SplitfileCompatibilityModeEvent
- Base: develop
- Ready for review.