### PR TITLE
test: add StartedCompressionEvent tests; expand JavaDoc

### DIFF
--- a/src/main/java/network/crypta/client/events/StartedCompressionEvent.java
+++ b/src/main/java/network/crypta/client/events/StartedCompressionEvent.java
@@ -2,24 +2,91 @@ package network.crypta.client.events;
 
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
 
-/** Event indicating that we are attempting to compress the file. */
+/**
+ * Event published when the client begins compressing content prior to storage or upload.
+ *
+ * <p>This event marks the moment the insertion pipeline switches from raw input to a compressed
+ * representation. It carries the chosen compressor type so UIs and diagnostics can surface what
+ * algorithm is being used. Instances of this class are immutable and thread-safe to read after
+ * construction: a producer creates the event once and passes it to interested listeners without
+ * further mutation. The event does not start or manage compression; it is strictly a notification
+ * describing that compression is about to be attempted for the current item.
+ *
+ * <p>Typical flows emit this event shortly before bytes are fed to the compressor and will later
+ * publish a corresponding completion/failure event. Consumers generally log the transition,
+ * annotate progress, or update user-facing status. If {@code codec} is {@code null}, callers must
+ * avoid dereferencing it; in particular, {@link #getDescription()} requires a non-{@code null}
+ * codec. No delivery guarantees are provided by this type; ordering and fan-out are determined by
+ * the surrounding event system.
+ *
+ * <ul>
+ *   <li>Immutable snapshot of the selected compressor type
+ *   <li>Emitted when compression is about to begin
+ *   <li>Safe to share across threads after construction
+ * </ul>
+ *
+ * @see network.crypta.client.events.FinishedCompressionEvent
+ * @see network.crypta.client.events.ClientEventProducer
+ * @see COMPRESSOR_TYPE
+ */
 public class StartedCompressionEvent implements ClientEvent {
 
+  /**
+   * The compressor algorithm selected for this operation.
+   *
+   * <p>This value reflects the upstream choice at the time the event is created. It is immutable
+   * and may be {@code null} when the selection is deferred; callers that need a human-friendly
+   * label should verify non-null before dereferencing.
+   */
   public final COMPRESSOR_TYPE codec;
 
+  /**
+   * Creates a new event describing the start of a compression attempt.
+   *
+   * <p>The constructor records the compressor type that upstream code selected for the current
+   * item. The instance is intended to be passed to an event producer immediately after creation.
+   * Passing {@code null} is permitted, but note that some consumers, including {@link
+   * #getDescription()}, assume a non-{@code null} codec and will throw a {@link
+   * NullPointerException} if it is missing.
+   *
+   * @param codec the compressor algorithm that will be used for this operation; may be {@code null}
+   *     if unknown at emit time, but consumers that render a description require a non-{@code null}
+   *     value.
+   */
   public StartedCompressionEvent(COMPRESSOR_TYPE codec) {
     this.codec = codec;
   }
 
-  static final int code = 0x08;
+  // Stable identifier for this event type
+  static final int CODE = 0x08;
 
+  /**
+   * Returns a human-readable description of the event and selected codec.
+   *
+   * <p>The string is suitable for logs, progress panels, or diagnostics and includes the
+   * human-friendly name exposed by the {@code codec}. The result does not contain sensitive file
+   * details and is stable for a given codec value.
+   *
+   * @return a concise message indicating that compression started with the specified codec; the
+   *     returned string is owned by the caller and may be cached.
+   * @throws NullPointerException if {@link #codec} is {@code null} and its name is dereferenced
+   */
   @Override
   public String getDescription() {
     return "Started compression attempt with " + codec.codecName;
   }
 
+  /**
+   * Returns the stable integer code that identifies this event type.
+   *
+   * <p>The code is intended for compact transport or storage and remains constant across releases
+   * where compatibility is maintained. Consumers should not infer ordering or severity from the
+   * numeric value.
+   *
+   * @return the constant {@code 0x08}, the identifier for {@code StartedCompressionEvent}
+   */
   @Override
   public int getCode() {
-    return code;
+    return CODE;
   }
 }

--- a/src/test/java/network/crypta/client/events/StartedCompressionEventTest.java
+++ b/src/test/java/network/crypta/client/events/StartedCompressionEventTest.java
@@ -1,0 +1,67 @@
+package network.crypta.client.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class StartedCompressionEventTest {
+
+  @ParameterizedTest
+  @EnumSource(COMPRESSOR_TYPE.class)
+  void getDescription_whenCodecProvided_matchesCodecName(COMPRESSOR_TYPE codec) {
+    // Arrange
+    StartedCompressionEvent event = new StartedCompressionEvent(codec);
+
+    // Act
+    String description = event.getDescription();
+
+    // Assert
+    assertEquals(
+        "Started compression attempt with " + codec.codecName,
+        description,
+        "Description should include the codec's human-readable name");
+  }
+
+  @Test
+  void getDescription_whenCodecIsNull_throwsNullPointerException() {
+    // Arrange
+    StartedCompressionEvent event = new StartedCompressionEvent(null);
+
+    // Act + Assert
+    assertThrows(NullPointerException.class, event::getDescription);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = COMPRESSOR_TYPE.class)
+  void getCode_whenCalled_returnsExpectedConstant(COMPRESSOR_TYPE codec) {
+    // Arrange
+    StartedCompressionEvent event = new StartedCompressionEvent(codec);
+
+    // Act
+    int code = event.getCode();
+
+    // Assert
+    assertEquals(0x08, code, "Event code must be the stable constant 0x08");
+  }
+
+  @Test
+  void codecField_whenConstructed_isSameInstance() {
+    // Arrange
+    COMPRESSOR_TYPE codec = COMPRESSOR_TYPE.BZIP2;
+
+    // Act
+    StartedCompressionEvent event = new StartedCompressionEvent(codec);
+
+    // Assert
+    assertSame(codec, event.codec, "Codec field must reference the constructor argument");
+  }
+}


### PR DESCRIPTION
Summary
- Add JUnit 6 parameterized tests for StartedCompressionEvent
- Expand JavaDoc with clearer semantics and thread-safety notes
- Rename constant field from `code` to `CODE` for clarity; keep numeric value 0x08

Details
- Tests validate:
  - `getDescription()` includes the human-readable codec name
  - `getDescription()` throws NPE when codec is null (as currently implemented)
  - `getCode()` returns stable constant 0x08
  - Field `codec` retains constructor instance identity
- JavaDoc clarifies lifecycle, immutability, and usage; added references to related events

Compatibility
- No runtime behavior changes; only constant name changed from `code` → `CODE` (same value 0x08). If any code references the field directly as `StartedCompressionEvent.code`, it must be updated to `StartedCompressionEvent.CODE`.

Files
- src/main/java/network/crypta/client/events/StartedCompressionEvent.java
- src/test/java/network/crypta/client/events/StartedCompressionEventTest.java

Notes
- Codebase formatted with Spotless.
- Built on branch `feature/started-compression-event-tests` based off `develop`.
