### PR TITLE
Add CodecPacket unit tests and enhance Javadoc; apply Spotless

### DIFF
--- a/src/main/java/network/crypta/client/filter/CodecPacket.java
+++ b/src/main/java/network/crypta/client/filter/CodecPacket.java
@@ -2,17 +2,79 @@ package network.crypta.client.filter;
 
 import java.util.Arrays;
 
+/**
+ * Light-weight container for a codec packet's raw payload bytes.
+ *
+ * <p>This type is a light-weight container used by the client-side filtering and codec layer to
+ * represent a single packet as a contiguous byte array. It does not perform decoding or validation;
+ * it simply carries the payload between stages that expect a concrete {@code byte[]}
+ * representation. Typical usage constructs an instance with a byte array, passes it across
+ * boundaries where parsing or transformation occurs, and finally extracts the array via {@link
+ * #toArray()} for downstream I/O or protocol handling.
+ *
+ * <p>The instance stores the provided array reference without copying. As a consequence, the
+ * content of the array defines both equality and the hash code. If the array content is modified
+ * after construction, the results of {@link #equals(Object)} and {@link #hashCode()} may change.
+ * Callers should therefore avoid mutating the payload when instances are used as map keys or are
+ * shared across components that assume stable identity.
+ *
+ * <ul>
+ *   <li>Equality is content-based via {@link Arrays#equals(byte[], byte[])}, not by reference.
+ *   <li>Hash code follows {@link Arrays#hashCode(byte[])}, enabling use in hashed collections.
+ *   <li>The payload array may be {@code null}; methods document behavior for this case.
+ * </ul>
+ *
+ * @see Arrays#equals(byte[], byte[])
+ * @see Arrays#hashCode(byte[])
+ */
 public class CodecPacket {
-  protected byte[] payload = null;
+  /**
+   * Raw packet payload bytes held by this container.
+   *
+   * <p>The reference is stored as provided by the creator and may be {@code null}. The contents of
+   * this array define both equality and hashing for the enclosing instance. Because arrays are
+   * mutable, changes to the contents after construction will be reflected in later equality and
+   * hash-code computations. Prefer treating the data as effectively immutable once published.
+   */
+  protected byte[] payload;
 
   CodecPacket(byte[] payload) {
     this.payload = payload;
   }
 
+  /**
+   * Returns the underlying payload array without copying.
+   *
+   * <p>The returned reference is the same array that was supplied at construction time. No deep or
+   * defensive copy is created, so subsequent modifications to its contents will be visible to any
+   * holders of this instance and may affect the results of {@link #equals(Object)} and {@link
+   * #hashCode()} for collections that already contain this object.
+   *
+   * <pre>{@code
+   * // Example: extracting bytes for downstream processing
+   * CodecPacket packet = new CodecPacket(bytes);
+   * byte[] raw = packet.toArray();
+   * // Pass raw to an encoder/decoder as needed
+   * }</pre>
+   *
+   * @return the same {@code byte[]} reference supplied to the constructor; may be {@code null} when
+   *     the payload is intentionally absent or unknown.
+   */
   public byte[] toArray() {
     return payload;
   }
 
+  /**
+   * Computes a hash code derived from the payload contents.
+   *
+   * <p>The calculation delegates to {@link Arrays#hashCode(byte[])}. If the payload is {@code
+   * null}, the returned value follows {@code Arrays.hashCode(null)} semantics (zero). When the
+   * array content changes after construction, the hash code changes correspondingly, which can
+   * disrupt hashed collections; avoid mutating payloads used as keys.
+   *
+   * @return an integer hash code consistent with {@link #equals(Object)} for the current payload
+   *     contents; returns {@code 0} when the payload is {@code null}.
+   */
   @Override
   public int hashCode() {
     final int prime = 31;
@@ -21,6 +83,19 @@ public class CodecPacket {
     return result;
   }
 
+  /**
+   * Compares this packet to another for content equality.
+   *
+   * <p>Two instances are considered equal when their payload arrays are equal according to {@link
+   * Arrays#equals(byte[], byte[])}. This comparison is null-safe; a {@code null} payload is only
+   * equal to another {@code null} payload. Reference identity is short-circuited for efficiency
+   * when the same object is compared to itself.
+   *
+   * @param obj another object to compare against; equality is defined only for other {@code
+   *     CodecPacket} instances based on the byte array contents and nullness.
+   * @return {@code true} when {@code obj} is a {@code CodecPacket} whose payload equals this
+   *     instance's payload by content; {@code false} otherwise.
+   */
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;

--- a/src/test/java/network/crypta/client/filter/CodecPacketTest.java
+++ b/src/test/java/network/crypta/client/filter/CodecPacketTest.java
@@ -1,0 +1,127 @@
+package network.crypta.client.filter;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({"java:S100", "java:S1764", "java:S2159"})
+class CodecPacketTest {
+
+  @Test
+  void toArray_whenPayloadProvided_returnsSameReference() {
+    // Arrange
+    byte[] payload = new byte[] {1, 2, 3};
+    CodecPacket packet = new CodecPacket(payload);
+
+    // Act
+    byte[] result = packet.toArray();
+
+    // Assert
+    assertSame(payload, result, "toArray() should return the same array reference");
+    assertArrayEquals(new byte[] {1, 2, 3}, result);
+  }
+
+  @Test
+  void toArray_whenPayloadIsNull_returnsNull() {
+    // Arrange
+    CodecPacket packet = new CodecPacket(null);
+
+    // Act
+    byte[] result = packet.toArray();
+
+    // Assert
+    assertNull(result, "toArray() should return null when payload is null");
+  }
+
+  @Test
+  void equals_whenSameInstance_returnsTrue() {
+    // Arrange
+    CodecPacket packet = new CodecPacket(new byte[] {10});
+
+    // Act & Assert
+    //noinspection EqualsWithItself
+    assertEquals(packet, packet);
+  }
+
+  @Test
+  void equals_whenOtherIsNull_returnsFalse() {
+    // Arrange
+    CodecPacket packet = new CodecPacket(new byte[] {1});
+
+    // Act & Assert
+    assertNotEquals(null, packet);
+  }
+
+  @Test
+  void equals_whenDifferentType_returnsFalse() {
+    // Arrange
+    CodecPacket packet = new CodecPacket(new byte[] {1, 2});
+
+    // Act & Assert
+    assertNotEquals(new Object(), packet);
+  }
+
+  @Test
+  void equals_and_hashCode_whenSameContentDifferentArrays_areEqualAndHashMatch() {
+    // Arrange
+    byte[] a1 = new byte[] {5, 6, 7};
+    byte[] a2 = new byte[] {5, 6, 7}; // distinct instance, same content
+    CodecPacket p1 = new CodecPacket(a1);
+    CodecPacket p2 = new CodecPacket(a2);
+
+    // Sanity check the arrays are different references
+    assertNotSame(a1, a2);
+
+    // Act & Assert
+    assertEquals(p1, p2, "Packets with same content should be equal");
+    assertEquals(p1.hashCode(), p2.hashCode(), "Equal packets must have same hashCode");
+  }
+
+  @Test
+  void equals_whenBothPayloadsNull_returnsTrue() {
+    // Arrange
+    CodecPacket p1 = new CodecPacket(null);
+    CodecPacket p2 = new CodecPacket(null);
+
+    // Act & Assert
+    assertEquals(p1, p2);
+    assertEquals(p1.hashCode(), p2.hashCode());
+  }
+
+  @Test
+  void equals_whenOnePayloadNull_returnsFalse() {
+    // Arrange
+    CodecPacket p1 = new CodecPacket(null);
+    CodecPacket p2 = new CodecPacket(new byte[] {});
+
+    // Act & Assert
+    assertNotEquals(p1, p2);
+    assertNotEquals(p2, p1);
+  }
+
+  @Test
+  void equals_whenDifferentContent_returnsFalse() {
+    // Arrange
+    CodecPacket p1 = new CodecPacket(new byte[] {1, 2, 3});
+    CodecPacket p2 = new CodecPacket(new byte[] {1, 2, 4});
+
+    // Act & Assert
+    assertNotEquals(p1, p2);
+  }
+
+  @Test
+  void equals_whenEmptyArrays_areEqual() {
+    // Arrange
+    CodecPacket p1 = new CodecPacket(new byte[] {});
+    CodecPacket p2 = new CodecPacket(new byte[] {});
+
+    // Act & Assert
+    assertEquals(p1, p2);
+    assertEquals(p1.hashCode(), p2.hashCode());
+  }
+}


### PR DESCRIPTION
Summary
- Add focused unit tests for `network.crypta.client.filter.CodecPacket` covering:
  - `toArray()` reference semantics (same array returned) and null payload
  - Equality/`hashCode` for same content vs different content, null handling, and non-packet comparisons
- Enhance Javadoc in `CodecPacket` to clearly describe payload semantics, equality, and hashing behavior.
- Run Spotless to keep formatting consistent with project style.

Motivation
`CodecPacket` is a small but frequently used container. This change documents its reference and equality semantics explicitly, and adds tests to lock those behaviors in. Clearer docs reduce misuse (e.g., mutating payloads while using instances as map keys) and tests guard future regressions.

Changes
- src/main/java/network/crypta/client/filter/CodecPacket.java
  - Add comprehensive class and method Javadoc
  - Clarify field documentation for `payload`
- src/test/java/network/crypta/client/filter/CodecPacketTest.java (new)
  - New tests validating `toArray()`, `equals`, and `hashCode` behavior
- Formatting: Spotless applied (no functional changes)

Diff Stat
- 2 files changed, 203 insertions(+), 1 deletion(-)

Compatibility
- No runtime behavior changes; documentation and tests only. Equality and hashing still delegate to `Arrays.equals/hashCode` as before.

Testing
- Tests pass locally (JUnit 6). The new test class is part of `src/test/java` and runs on the JUnit Platform per project setup.

Notes
- Target branch: `develop`
- Head branch: `feature/fix-CodecPacket`
- Single commit: `7f82478c2e6a43d736f972e39e954dcffa3d5f24` ("chore: apply Spotless and update CodecPacket docs/tests").