### PR TITLE
docs(client-filter): doclint-clean Javadoc across filter package; minor API polish

### DIFF
--- a/src/main/java/network/crypta/client/filter/CSSReadFilter.java
+++ b/src/main/java/network/crypta/client/filter/CSSReadFilter.java
@@ -43,7 +43,7 @@ public class CSSReadFilter implements ContentDataFilter, CharsetExtractor {
         w = new BufferedWriter(osw, 32768);
 
       } catch (UnsupportedEncodingException e) {
-        throw UnknownCharsetException.create(e, charset);
+        throw UnknownCharsetException.create(charset);
       }
       CSSParser parser = new CSSParser(r, w, false, cb, charset, false, false);
       parser.parse();
@@ -65,7 +65,7 @@ public class CSSReadFilter implements ContentDataFilter, CharsetExtractor {
       try {
         isr = new InputStreamReader(strm, charset);
       } catch (UnsupportedEncodingException e) {
-        throw UnknownCharsetException.create(e, charset);
+        throw UnknownCharsetException.create(charset);
       }
       try (BufferedReader r = new BufferedReader(isr, 32768)) {
         CSSParser parser = new CSSParser(r, w, false, new NullFilterCallback(), null, true, false);

--- a/src/main/java/network/crypta/client/filter/CharsetExtractor.java
+++ b/src/main/java/network/crypta/client/filter/CharsetExtractor.java
@@ -2,31 +2,109 @@ package network.crypta.client.filter;
 
 import java.io.IOException;
 
-/** For a specific text/-based MIME type, extracts the charset if possible. */
+/**
+ * Extracts character set information from textual content for a specific text-based MIME type.
+ *
+ * <p>This interface defines a small, focused API used by higher-level parsers and filters to
+ * determine the character encoding of an incoming byte stream. Implementations typically combine a
+ * lightweight byte-order-mark (BOM) pre-scan with in-band declarations (for example, directives
+ * embedded near the start of the content) and any out-of-band hints supplied by the caller. The
+ * contract intentionally avoids I/O; callers provide the already-read prefix of the resource.
+ *
+ * <p>Typical usage follows this pattern:
+ *
+ * <ol>
+ *   <li>Read at least {@link #getCharsetBufferSize()} bytes from the start of the resource.
+ *   <li>Call {@link #getCharsetByBOM(byte[], int)} to detect obvious BOM-style encodings and to
+ *       learn whether a declared charset is mandatory for the content to be considered valid.
+ *   <li>If needed, call {@link #getCharset(byte[], int, String)} to inspect in-band declarations or
+ *       type-specific cues, optionally passing a previously parsed hint.
+ * </ol>
+ *
+ * <p>Thread-safety: this is a pure inspection API. Implementations are commonly stateless and thus
+ * safe to share across threads, but the interface does not require any particular concurrency
+ * guarantees. Inputs are treated as read-only and must not be modified by implementations.
+ */
 public interface CharsetExtractor {
 
+  /**
+   * Determine the most appropriate charset name for the provided byte prefix.
+   *
+   * <p>The implementation should examine up to {@code length} bytes from {@code input} and may
+   * combine signals from the pre-scan phase, in-band declarations, and the optional {@code
+   * parseCharset} hint. The method is deterministic with respect to the supplied bytes and does not
+   * perform additional I/O.
+   *
+   * <pre>{@code
+   * // Example: determine charset from an already-read buffer
+   * String charset = extractor.getCharset(buffer, bytesRead, null);
+   * }</pre>
+   *
+   * @param input the byte buffer containing the beginning of the resource; the array is not
+   *     modified and may be larger than {@code length}.
+   * @param length the number of valid bytes in {@code input} to inspect; must be {@code >= 0} and
+   *     should not exceed the buffer length.
+   * @param parseCharset an optional, previously parsed charset token or external hint; may be
+   *     {@code null} or empty when no hint is available.
+   * @return the canonical charset name (for example, {@code "UTF-8"}) when a decision can be made,
+   *     or {@code null} when the available bytes and hints are insufficient to decide.
+   * @throws IOException if the implementation encounters malformed declarations or decoding steps
+   *     that cannot proceed with the supplied data.
+   */
   String getCharset(byte[] input, int length, String parseCharset) throws IOException;
 
   /**
-   * Inspect the first few bytes of the file for any obvious but type-specific BOM. Don't try too
-   * hard, if we don't find anything we will call getCharset() with some specific charset families
-   * to try.
+   * Inspect the initial bytes for BOM-style signatures and return a pre-scan result.
    *
-   * @param input The data.
-   * @return The BOM-detected charset family, this is essentially a guess which will have to be fed
-   *     to getCharset(). (A true BOM would give an exact match, but the caller will have already
-   *     tested for true BOMs by this point; we are looking for "@charset \"" encoded with the given
-   *     format)
-   * @throws DataFilterException
-   * @throws IOException
+   * <p>This method performs a fast, type-aware check of the first few bytes to detect an obvious
+   * byte-order mark (or similar, format-specific preamble). It should not attempt deep parsing; if
+   * no decisive signal is present, callers can proceed to {@link #getCharset(byte[], int, String)}
+   * with candidate families derived from this result.
+   *
+   * <pre>{@code
+   * CharsetExtractor.BOMDetection bom = extractor.getCharsetByBOM(buffer, bytesRead);
+   * if (bom.mustHaveCharset) {
+   *   // downstream logic may enforce that a charset is declared
+   * }
+   * }</pre>
+   *
+   * @param input the byte buffer containing the beginning of the resource; only the first {@code
+   *     length} bytes are considered.
+   * @param length the number of bytes available in {@code input} for inspection; must be {@code >=
+   *     0} and should reflect the actual number read.
+   * @return a {@link BOMDetection} describing the detected charset family and whether a declared
+   *     charset is required for the content to be considered valid.
+   * @throws IOException if the pre-scan logic cannot proceed due to malformed leading bytes or
+   *     other format errors in the provided prefix.
    */
-  BOMDetection getCharsetByBOM(byte[] input, int length) throws DataFilterException, IOException;
+  BOMDetection getCharsetByBOM(byte[] input, int length) throws IOException;
 
-  /** How many bytes must be fed into the CharsetExtractor to figure out the charset */
+  /**
+   * Report the minimum number of bytes callers should provide for reliable detection.
+   *
+   * <p>Callers are expected to read at least this many bytes before invoking {@link
+   * #getCharsetByBOM(byte[], int)} or {@link #getCharset(byte[], int, String)}. Supplying a larger
+   * prefix is allowed and may increase accuracy, but the value returned here indicates the
+   * implementation's baseline requirement.
+   *
+   * @return a positive integer representing the recommended byte budget for the initial detection
+   *     pass, expressed in bytes counted from the start of the resource.
+   */
   int getCharsetBufferSize();
 
+  /**
+   * Result of the BOM pre-scan performed by {@link #getCharsetByBOM(byte[], int)}.
+   *
+   * <p>This simple value class communicates two pieces of information to the caller: the best
+   * available guess for the charset family based solely on leading bytes, and whether the content
+   * is considered valid only when a charset is explicitly declared downstream. The latter is useful
+   * for enforcing specification rules that require an explicit {@code @charset}-style declaration.
+   *
+   * @see #getCharsetByBOM(byte[], int)
+   * @see #getCharset(byte[], int, String)
+   */
   class BOMDetection {
-    /** The charset, guessed from the first few characters. */
+    /** The guessed charset family derived from the first few characters. */
     final String charset;
 
     /**

--- a/src/main/java/network/crypta/client/filter/CodecPacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/CodecPacketFilter.java
@@ -3,19 +3,56 @@ package network.crypta.client.filter;
 import java.io.IOException;
 
 /**
- * Base class for specific logical bitstream filters. Subclasses should create a method overriding
- * <code>parse</code> which includes a call to the original method.
+ * Defines a pluggable validator/normalizer that inspects a single codec packet and optionally
+ * returns a refined representation. Implementations are typically chained so each filter can
+ * perform a small, well-bounded check before handing the packet to the next stage.
+ *
+ * <p>The primary responsibility of a {@code CodecPacketFilter} is to perform minimal structural and
+ * semantic validation of a packet produced by a codec or demuxer. Typical call patterns involve
+ * receiving a {@link CodecPacket} from an upstream component, verifying header fields, length, or
+ * basic invariants, and either returning the same packet, returning a logically equivalent packet,
+ * or signaling failure via an exception. Implementations should avoid expensive transformations;
+ * deeper parsing and decoding belong to higher-level components.
+ *
+ * <p>Unless otherwise documented by a concrete implementation, instances are expected to be
+ * stateless and thus thread-safe. Filters should not mutate the supplied packet unless the class of
+ * the packet clearly documents such behavior; returning a new {@link CodecPacket} instance is often
+ * preferred to preserve isolation between stages.
+ *
+ * <ul>
+ *   <li>Responsibility: perform fast, early validation of packet shape and size.
+ *   <li>Error handling: report malformed input using {@link IOException} with a descriptive
+ *       message.
+ *   <li>Typical usage: assemble a pipeline of filters that each enforce a specific invariant.
+ * </ul>
  *
  * @author sajack
+ * @see CodecPacket
  */
 public interface CodecPacketFilter {
 
   /**
-   * Does minimal validation of a codec packet.
+   * Validates and optionally normalizes a single packet from a coded stream.
    *
-   * @param packet A packet from the coded stream
-   * @return Whether packet was properly validated
-   * @throws IOException
+   * <p>Implementations should perform lightweight checks such as verifying basic header structure,
+   * ensuring lengths are within acceptable bounds, or rejecting obviously malformed input. On
+   * success the method returns a packet instance that can be passed to subsequent components; it
+   * may be the original instance or a newly created, logically equivalent packet. When a fatal
+   * condition is detected, the method throws an {@link IOException} describing the failure.
+   * Implementations should not perform heavy decoding or re-encoding work here.
+   *
+   * <pre>{@code
+   * // Example: invoke a filter before consumption
+   * CodecPacket validated = filter.parse(rawPacket);
+   * consume(validated);
+   * }</pre>
+   *
+   * @param packet the input packet from the coded stream; must not be {@code null}; contents are
+   *     expected to represent a single, self-contained frame or unit as defined by the codec
+   * @return a validated packet suitable for downstream processing; may be the same reference or a
+   *     new instance preserving the original payload semantics
+   * @throws IOException if the packet is structurally invalid, violates basic invariants, or cannot
+   *     be safely forwarded to the next processing stage
    */
   CodecPacket parse(CodecPacket packet) throws IOException;
 }

--- a/src/main/java/network/crypta/client/filter/CommentException.java
+++ b/src/main/java/network/crypta/client/filter/CommentException.java
@@ -3,16 +3,45 @@ package network.crypta.client.filter;
 import java.io.Serial;
 
 /**
- * Thrown when a filter operation cannot complete and the filter has produced some error output to
- * help guide the user in resolving the situation.
+ * Exception indicating that a client-side content filtering operation failed in a way that
+ * generated explanatory text intended for presentation to a human consumer.
  *
- * <p>Note that the message is not yet encoded, and may contain data-dependant information; that is
- * the responsibility of the catcher.
+ * <p>This exception is raised by filters when they detect input that cannot be safely or
+ * meaningfully transformed according to the active filtering rules. In addition to signaling
+ * failure, the exception message typically carries a short, human-readable explanation that the
+ * caller may render to a log, UI, or diagnostics channel. The message is deliberately kept as raw
+ * text: it is <em>not</em> HTML- or XML-encoded, and it may include characters derived from the
+ * analyzed content. Callers are responsible for choosing an appropriate output channel and
+ * performing any necessary escaping or localization before display.
+ *
+ * <p>Typical usage is to catch this exception at an integration boundary (for example, a request
+ * handler, pipeline controller, or UI adapter), record the failure for observability, and present a
+ * concise, user-facing explanation. The type is immutable and conveys no retry semantics by itself;
+ * retry policies, if any, should be decided by the caller based on broader context.
+ *
+ * <ul>
+ *   <li>The message may be data-dependent and must be sanitized before presentation.
+ *   <li>Intended for control-flow and user guidance, not for low-level I/O errors.
+ *   <li>Thread-safe to share after construction; instances are immutable.
+ * </ul>
  */
 public class CommentException extends Exception {
 
   @Serial private static final long serialVersionUID = 1L;
 
+  /**
+   * Creates a new exception with an explanatory message suitable for presentation to a human
+   * reader.
+   *
+   * <p>The supplied message is treated as raw, unencoded text and may contain characters derived
+   * from the analyzed content. The caller is responsible for escaping or otherwise preparing it for
+   * the output medium (for example, HTML, JSON, or plain logs) and for ensuring that sensitive data
+   * is not disclosed. Instances created by this constructor are immutable and thread-safe to share
+   * between threads for reporting purposes.
+   *
+   * @param msg Human-oriented explanation of the filtering failure. Provide concise, actionable
+   *     text suitable for logs or UI; must be sanitized and encoded by the caller before display.
+   */
   public CommentException(String msg) {
     super(msg);
   }

--- a/src/main/java/network/crypta/client/filter/DataFilterException.java
+++ b/src/main/java/network/crypta/client/filter/DataFilterException.java
@@ -3,14 +3,57 @@ package network.crypta.client.filter;
 import java.io.Serial;
 import network.crypta.client.FetchException;
 
-/** Exception thrown when the data cannot be filtered. */
+/**
+ * Signals that client-supplied or fetched data failed validation by a content filter and therefore
+ * cannot be delivered safely. Instances of this exception carry a human-readable title (both raw
+ * and HTML-encoded forms) and an explanatory message intended for presentation in error pages or
+ * logs.
+ *
+ * <p>This type is raised by filters that parse and vet user-visible content (for example media
+ * containers or markup) when a structural rule is violated, a known-dangerous construct is found,
+ * or the stream cannot be sanitized to a level acceptable for safe distribution. Callers typically
+ * catch {@link DataFilterException} near request boundaries and translate it into a {@link
+ * FetchException} using {@link #recreateFetchException(FetchException, String)} or {@link
+ * #createFetchException(String, long)} so that higher layers can render a clear error to the
+ * client.
+ *
+ * <p>Objects of this class are immutable and thread-safe after construction; the title and
+ * explanatory text never change. Equality is not overridden; the instance primarily acts as a
+ * descriptive failure carrier. The class focuses on conveying displayable error details rather than
+ * low-level parsing positions or byte offsets, which are filter-specific concerns.
+ *
+ * <ul>
+ *   <li>Responsibilities: carry display-safe titles and explanations for filter failures.
+ *   <li>Typical usage: throw from filter code paths; convert to {@link FetchException} at
+ *       boundaries.
+ *   <li>Thread-safety: immutable fields; safe to share across threads.
+ * </ul>
+ */
 public class DataFilterException extends UnsafeContentTypeException {
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Raw, unescaped title suitable for plain-text logs or console output. The value may contain
+   * characters that are unsafe for direct HTML rendering and must be escaped before being embedded
+   * in markup. It is stable for the lifetime of the exception and never {@code null}.
+   */
   final String rawTitle;
+
+  /**
+   * HTML-encoded title which is safe to insert into an HTML page without additional escaping. The
+   * encoded form mirrors {@link #rawTitle} but is pre-escaped for convenience in UI layers that
+   * render error pages.
+   */
   final String encodedTitle;
+
+  /**
+   * Human-readable explanation describing why filtering failed. This is returned from {@link
+   * #getMessage()} and is appropriate for inclusion in error pages or logs. The text does not
+   * include markup and should be treated as plain text unless explicitly encoded by callers.
+   */
   final String explanation;
 
+  @SuppressWarnings("unused")
   DataFilterException(String explanation) {
     rawTitle = encodedTitle = this.explanation = explanation;
   }
@@ -21,31 +64,97 @@ public class DataFilterException extends UnsafeContentTypeException {
     this.explanation = explanation;
   }
 
+  /**
+   * Returns the explanatory text associated with this failure.
+   *
+   * <p>The message is intended for human consumption, describing the primary reason the content
+   * could not be filtered safely. It is plain text and may be displayed directly in logs or UI
+   * components that expect unformatted strings.
+   *
+   * @return a plain-text explanation of the filtering failure; never {@code null} and stable for
+   *     the life of the instance
+   */
   @Override
   public String getMessage() {
     return explanation;
   }
 
+  /**
+   * Returns a title that is already safely encoded for HTML contexts.
+   *
+   * <p>Callers rendering an error page may include this value directly in markup without applying
+   * additional escaping. For non-HTML contexts prefer {@link #getRawTitle()}.
+   *
+   * @return an HTML-escaped error title suitable for insertion into markup without further
+   *     processing
+   */
   @Override
   public String getHTMLEncodedTitle() {
     return encodedTitle;
   }
 
+  /**
+   * Returns the raw, unescaped title for this error.
+   *
+   * <p>This value is appropriate for logs or plain-text channels. When rendering to HTML, callers
+   * must escape it or instead use {@link #getHTMLEncodedTitle()}.
+   *
+   * @return a plain-text title describing the failure; may contain characters unsafe for direct
+   *     HTML insertion
+   */
   @Override
   public String getRawTitle() {
     return rawTitle;
   }
 
+  /**
+   * Returns the raw title as the string representation of this exception.
+   *
+   * <p>This mirrors the behavior of {@link #getRawTitle()} to keep log output concise and focused
+   * on the human-readable summary of the filtering error.
+   *
+   * @return the raw, unescaped title for logging and diagnostics
+   */
   @Override
   public String toString() {
     return rawTitle;
   }
 
+  /**
+   * Recreates a {@link FetchException} using details from an existing one while preserving the
+   * current filter failure as the cause.
+   *
+   * <p>Use this when translating a filtering error that occurred during an existing fetch flow. The
+   * returned exception carries the previous expected size and uses this instance as the underlying
+   * reason so that upstream logic can render appropriate client-facing messages.
+   *
+   * @param e the original {@link FetchException} whose expected size is reused; must not be {@code
+   *     null} and should represent the in-flight fetch being translated
+   * @param mime the MIME type associated with the failing content; pass a best-known value or
+   *     {@code null} when unknown
+   * @return a new {@link FetchException} that wraps this {@code DataFilterException} and retains
+   *     the expected size from the prior exception for accurate reporting
+   */
   @Override
   public FetchException recreateFetchException(FetchException e, String mime) {
     return new FetchException(e.expectedSize, this, mime);
   }
 
+  /**
+   * Creates a new {@link FetchException} that represents this filtering failure for a given content
+   * type and expected size.
+   *
+   * <p>Use this at API boundaries when a filter rejects input, and you need to propagate a
+   * standardized fetch-layer error. The returned instance identifies this exception as the cause so
+   * higher layers can present consistent messages.
+   *
+   * @param mime the associated MIME type for the rejected data; may be {@code null} when not
+   *     available or when type detection failed
+   * @param expectedSize the anticipated size in bytes of the content at the time of failure; use a
+   *     negative value only when no estimate is available
+   * @return a {@link FetchException} wrapping this instance with the provided metadata so callers
+   *     can display a uniform error to clients
+   */
   @Override
   public FetchException createFetchException(String mime, long expectedSize) {
     return new FetchException(expectedSize, this, mime);

--- a/src/main/java/network/crypta/client/filter/FilterCallback.java
+++ b/src/main/java/network/crypta/client/filter/FilterCallback.java
@@ -2,71 +2,177 @@ package network.crypta.client.filter;
 
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
 
-/** Callback to be provided to a content filter. */
+/**
+ * Callback interface used by content filters to report parsing events and to request decisions
+ * about potentially unsafe constructs such as links, forms, and individual tags.
+ *
+ * <p>Implementations are invoked by filter pipelines while streaming input and are expected to make
+ * quick, deterministic decisions about whether a value is acceptable as-is, requires rewriting, or
+ * must be rejected. Most methods return either a sanitized representation or {@code null} to
+ * indicate that the construct should be removed from the output. Methods that perform validation
+ * may throw {@link CommentException} with a human-readable explanation when the input cannot be
+ * accepted. Callers typically handle {@code null} by eliding the construct and handle exceptions by
+ * aborting or substituting a placeholder.
+ *
+ * <p>Typical usage is to pass an implementation to an HTML/CSS tokenizer or a media/playlist
+ * filter. The filter calls into this interface whenever it encounters items that may reference
+ * external resources or affect navigation. Implementations may maintain context such as a base URI
+ * and user policy. All methods must be thread-safe if the filter runs concurrently, but most
+ * pipelines invoke a single instance on one thread per filtering operation. Implementations should
+ * avoid retaining large intermediate strings to keep memory usage bounded for large inputs.
+ *
+ * <ul>
+ *   <li>URI processing: normalize, canonicalize, optionally absolutize, and enforce policy.
+ *   <li>Form handling: decide whether a form may be emitted and where it submits.
+ *   <li>Tag replacement: rewrite or drop specific HTML tags as needed.
+ *   <li>Notifications: receive non-modifying events such as text runs and completion signals.
+ * </ul>
+ *
+ * @see HTMLFilter
+ */
 public interface FilterCallback {
 
   /**
-   * Process a URI. If it cannot be turned into something sufficiently safe, then return null.
+   * Processes a URI and returns a sanitized representation suitable for filtered output.
    *
-   * @param overrideType Force the return type.
-   * @throws CommentException If the URI is nvalid or unacceptable in some way.
+   * <p>The implementation may normalize encoding, strip disallowed query parameters, or convert to
+   * a relative form according to policy. If the URI cannot be made sufficiently safe for inclusion,
+   * the method returns {@code null}. Implementations may also throw an exception to signal a hard
+   * validation failure.
+   *
+   * @param uri The original URI string to evaluate and possibly rewrite. It is treated as opaque
+   *     input and may be relative or absolute; never {@code null}.
+   * @param overrideType Optional MIME type override to attach to the result, for example {@code
+   *     "text/html; charset=UTF-8"}; {@code null} means no override.
+   * @return A rewritten, policy-compliant URI string ready to emit, or {@code null} when the input
+   *     must be removed from the document.
+   * @throws CommentException When the URI is syntactically invalid or violates policy in a way that
+   *     should abort the operation rather than eliding it.
    */
   String processURI(String uri, String overrideType) throws CommentException;
 
   /**
-   * Process a URI. If it cannot be turned into something sufficiently safe, then return null.
+   * Processes a URI with additional controls for absolutization and prefetch intent.
    *
-   * @param overrideType Force the return type.
-   * @param noRelative always turn into absolute URI, adding the baseUri if needed
-   * @param inline inline URIs may be prefetched while filtering
-   * @throws CommentException If the URI is nvalid or unacceptable in some way.
+   * <p>In addition to the behavior of {@link #processURI(String, String)}, this variant can force
+   * relative references to be converted to absolute ones and can mark a URI as inline, which allows
+   * an implementation to treat it as a candidate for prefetching or more permissive policies.
+   * Returning {@code null} indicates the URI should be removed.
+   *
+   * @param uri The URI string to evaluate. May be absolute or relative; normalization is
+   *     implementation-defined and the value is not modified in-place.
+   * @param overrideType Optional MIME type override to attach to the result; pass {@code null} to
+   *     keep the detected or default type unchanged.
+   * @param noRelative When {@code true}, convert relative references to an absolute URI using the
+   *     current base; when {@code false}, a relative form may be preserved if policy allows.
+   * @param inline When {@code true}, indicates the URI is referenced inline and may be prefetched
+   *     or relaxed subject to policy; {@code false} applies normal handling.
+   * @return A sanitized, possibly absolutized URI string safe to emit, or {@code null} if it must
+   *     be removed from the output.
+   * @throws CommentException If the URI is invalid or unacceptable under the current policy and
+   *     filtering cannot continue safely.
    */
   String processURI(String uri, String overrideType, boolean noRelative, boolean inline)
       throws CommentException;
 
   /**
-   * Process a URI forcing the host. If it cannot be turned into something sufficiently safe, then
-   * return null.
+   * Processes a URI and enforces a specific scheme/host/port when the input is relative.
    *
-   * @param overrideType Force the return type.
-   * @param inline inline URIs may be prefetched while filtering
-   * @throws CommentException If the URI is nvalid or unacceptable in some way.
+   * <p>When the parsed URI does not carry an authority component, the provided {@code
+   * forceSchemeHostAndPort} prefix is applied to construct an absolute reference. Implementations
+   * may still reject, rewrite, or return {@code null} if the resulting URI fails validation. Inline
+   * hints are treated as in the other overload.
+   *
+   * @param uri The candidate URI to process; may be relative and is interpreted against the given
+   *     forced authority if needed; never {@code null}.
+   * @param overrideType Optional MIME type override to carry into the result, or {@code null} to
+   *     leave unspecified.
+   * @param forceSchemeHostAndPort Authority prefix (for example, {@code "https://example.com:443"})
+   *     applied only when {@code uri} lacks a host; must include scheme and, optionally, port.
+   * @param inline When {@code true}, marks the URI as inline which may permit prefetch or relaxed
+   *     treatment; otherwise normal policy applies.
+   * @return The sanitized absolute or relative URI string, or {@code null} if the value must be
+   *     dropped from the output.
+   * @throws CommentException If parsing fails or the constructed URI violates policy in a
+   *     non-recoverable manner.
    */
   String processURI(String uri, String overrideType, String forceSchemeHostAndPort, boolean inline)
       throws CommentException;
 
   /**
-   * Process a base URI in the page. Not only is this filtered, it affects all relative uri's on the
-   * page.
+   * Processes a {@code <base href>} value and returns the sanitized base URI to adopt for
+   * subsequent relative resolution.
+   *
+   * <p>Implementations typically validate the value and, if acceptable, update internal context for
+   * later calls to {@link #processURI(String, String)} and related methods. Returning {@code null}
+   * indicates the base is rejected and should not be emitted, leaving the previously effective base
+   * unchanged.
+   *
+   * @param baseHref The candidate base URI string taken from the document; it may be absolute or
+   *     relative and is validated according to policy.
+   * @return The sanitized base URI to apply to further processing, or {@code null} if the value is
+   *     unsafe and must be ignored.
    */
   String onBaseHref(String baseHref);
 
   /**
-   * Process plain-text. Notification only; can't modify. Type can be null, or can correspond, for
-   * example to HTML tag name around text (for example: "title").
+   * Notifies the callback of a plain-text segment encountered during filtering; this is a
+   * non-modifying event.
    *
-   * <p>Note that the string will have been fed through the relevant decoder if necessary (e.g.
-   * HTMLDecoder). It must be re-encoded if it is sent out as text to a browser.
+   * <p>The provided {@code s} has already been decoded by the appropriate decoder for the host
+   * format (for example, the HTML entity decoder). If the text is forwarded to a browser, it must
+   * be re-encoded as required for the destination context. The {@code type} parameter may identify
+   * the enclosing element, such as {@code "title"}; it can be {@code null} when no specific element
+   * applies.
+   *
+   * @param s The decoded text content as a Java string; the implementation must not assume any
+   *     particular size and should avoid keeping long-lived references for large inputs.
+   * @param type Optional contextual type hint such as the enclosing tag name; may be {@code null}
+   *     when the source element is not known.
    */
   void onText(String s, String type);
 
   /**
-   * Process a form on the page.
+   * Processes a form declaration and decides whether the form may be emitted and where it should
+   * submit.
    *
-   * @param method The form sending method. Normally GET or POST.
-   * @param action The URI to send the form to.
-   * @return The new action URI, or null if the form is not allowed.
-   * @throws CommentException
+   * <p>Implementations may restrict methods, rewrite the {@code action} destination, or block the
+   * form entirely. Returning {@code null} indicates the form must be removed. The method name
+   * comparison is case-insensitive in most implementations and values other than {@code GET} or
+   * {@code POST} are commonly rejected.
+   *
+   * @param method The HTTP method specified by the form, typically {@code GET} or {@code POST};
+   *     other values may be disallowed depending on policy.
+   * @param action The target URI to which the form submits; may be relative and is validated and
+   *     possibly rewritten.
+   * @return A sanitized submit URI string to place back in the {@code action} attribute, or {@code
+   *     null} to suppress the form entirely.
+   * @throws CommentException If the form is invalid or violates policy in a way that should abort
+   *     processing rather than silently dropping it.
    */
   String processForm(String method, String action) throws CommentException;
 
   /**
-   * Process a tag. If it needs changing, then return the changed HTML, if not, then return null;
+   * Processes an individual HTML tag and optionally returns a replacement serialization.
    *
-   * @param pt - The tag to be replaced
-   * @return The new tag, or null, if it doesn't need changing
+   * <p>The callback may rewrite attributes, drop the tag entirely, or leave it unchanged. Returning
+   * {@code null} signals that the tag can pass through untouched; otherwise the returned string is
+   * emitted verbatim. The provided {@link ParsedTag} exposes the tag name and attributes as parsed
+   * by {@link HTMLFilter}.
+   *
+   * @param pt The parsed tag object describing the element and attributes to evaluate; never {@code
+   *     null} while filtering.
+   * @return Replacement HTML to emit for the tag, or {@code null} to retain the original
+   *     representation unchanged.
    */
   String processTag(ParsedTag pt);
 
+  /**
+   * Signals that the filtering run has completed and no more callbacks will be issued for the
+   * current input.
+   *
+   * <p>Implementations may use this hook to flush per-document state, release resources, or
+   * finalize metrics. The method must return quickly and must not throw.
+   */
   void onFinished();
 }

--- a/src/main/java/network/crypta/client/filter/FilterOperation.java
+++ b/src/main/java/network/crypta/client/filter/FilterOperation.java
@@ -1,7 +1,62 @@
 package network.crypta.client.filter;
 
+/**
+ * Declares which side of the content-filtering pipeline should be applied.
+ *
+ * <p>This enumeration is carried through user interfaces and protocol messages to express the
+ * caller's intent when running the content filter. In practice, {@code READ} triggers read-side
+ * filtering that parses and sanitizes data so that it is safe to render or hand to a browser. The
+ * {@code WRITE} option is reserved for write-time sanitization (for example, stripping metadata)
+ * when inserting data, and {@code BOTH} indicates that both read- and write-side protections are
+ * desired. Current call sites primarily execute read-side filtering; write-side handling may be
+ * ignored by some components until full support is implemented.
+ *
+ * <p>Typical usage flows this value from a UI form or FCP message and selects the appropriate
+ * filter behavior for a given MIME type. Library code should treat unknown or unsupported
+ * operations conservatively by applying the strongest safe behavior available on the current code
+ * path.
+ *
+ * <ul>
+ *   <li><b>Read filtering</b>: parse, validate, and rewrite content to remove dangerous constructs
+ *       before display.
+ *   <li><b>Write filtering</b>: prepare data for publication by removing or normalizing potentially
+ *       compromising information where supported.
+ * </ul>
+ *
+ * @see network.crypta.client.filter.ContentFilter
+ * @see network.crypta.client.filter.ContentDataFilter
+ * @see network.crypta.clients.http.ContentFilterToadlet
+ * @see network.crypta.clients.fcp.FilterMessage
+ */
 public enum FilterOperation {
+  /**
+   * Apply read-side filtering only.
+   *
+   * <p>Select this when the goal is to load and safely render content retrieved from the network or
+   * disk. The filter parses input according to its MIME type and strips or rewrites constructs that
+   * could cause external fetches, script execution, or other unsafe behavior. This is the most
+   * commonly used operation in the codebase and is supported for a wide range of content types.
+   */
   READ,
+
+  /**
+   * Apply write-side filtering only.
+   *
+   * <p>Intended for use during insertion or transformation of content prior to storage or
+   * publication. Typical responsibilities include removing embedded metadata (for example EXIF in
+   * images) or normalizing structures that may reveal environment details. Some call paths may not
+   * implement write-side filtering yet and will treat this option as a no-op until support is
+   * available.
+   */
   WRITE,
+
+  /**
+   * Apply both read- and write-side filtering.
+   *
+   * <p>Use this when both ingestion-time and publication-time protections are desired. Systems that
+   * only implement read-side filtering may effectively treat this as equivalent to {@link #READ}
+   * for the time being. When full write-side support is present, this value ensures a comprehensive
+   * pass on both sides of the content pipeline.
+   */
   BOTH
 }

--- a/src/main/java/network/crypta/client/filter/FoundURICallback.java
+++ b/src/main/java/network/crypta/client/filter/FoundURICallback.java
@@ -3,25 +3,73 @@ package network.crypta.client.filter;
 import java.net.URI;
 import network.crypta.keys.FreenetURI;
 
+/**
+ * Callback interface used by content scanners, decoders, and crawlers to report items discovered
+ * while processing a single logical page or document.
+ *
+ * <p>Implementations typically aggregate the reported data (for example, building an index, a link
+ * graph, or a fetch queue) and may apply additional filtering or normalization. The contract
+ * intentionally avoids prescribing ordering beyond basic causality: methods can be called multiple
+ * times as the parser advances, and {@link #onFinishedPage()} signals that no further callbacks
+ * will be made for the current page. Implementations should therefore treat the interface as a
+ * stream of events rather than a random-access model.
+ *
+ * <p>Thread-safety is implementation defined. Unless otherwise documented by the caller, you should
+ * not assume that invocations are serialized; if shared state is mutated, synchronize or use
+ * concurrent collections. Implementations are generally expected to be stateless or to scope state
+ * to the current page between the first event and {@code onFinishedPage()}.
+ *
+ * <ul>
+ *   <li>URI discovery: {@link #foundURI(FreenetURI)} and {@link #foundURI(FreenetURI, boolean)}
+ *       report links and embedded resources.
+ *   <li>Text capture: {@link #onText(String, String, URI)} exposes decoded text for indexing or
+ *       analysis.
+ *   <li>Lifecycle: {@link #onFinishedPage()} marks the end of processing for the current page.
+ * </ul>
+ */
 public interface FoundURICallback {
 
   /**
-   * Called when a Freenet URI is found.
+   * Report that a Freenet URI has been discovered in the current document.
    *
-   * @param uri The URI. FIXME: Indicate the type of the link e.g. inline image, hyperlink, etc??
+   * <p>Callers use this to notify about hyperlinks or resources whose precise role may be
+   * determined by the implementation (for example, enqueueing for retrieval, deduplication, or
+   * indexing). Implementations should not assume uniqueness; the same URI can be reported more than
+   * once. The method is idempotent with respect to side effects only if the implementation makes it
+   * so; callers may not perform duplicate suppression.
+   *
+   * @param uri The URI. FIXME: Indicate the type of the link e.g. inline image, hyperlink, etc?
+   *     Consider clarifying how the caller communicates link semantics when richer metadata is
+   *     available.
    */
   void foundURI(FreenetURI uri);
 
   /**
-   * Called when a Freenet URI is found.
+   * Report that a Freenet URI has been discovered, including a basic hint about its presentation
+   * context within the page.
    *
-   * @param uri The URI. FIXME: Indicate the type of the link e.g. inline image, hyperlink, etc??
+   * <p>This variant carries an {@code inline} flag to help distinguish embedded resources from
+   * navigational links in simple pipelines. The flag is advisory only. Implementations may ignore
+   * it, or use it to prioritize fetching, indexing, or display decisions. Callers may repeat the
+   * same URI with different flags as they encounter it in multiple contexts.
+   *
+   * @param uri The URI. FIXME: Indicate the type of the link e.g. inline image, hyperlink, etc?
+   *     Consider clarifying how the caller communicates link semantics when richer metadata is
+   *     available.
+   * @param inline {@code true} when the URI appears as an inline/embedded resource in the current
+   *     context (such as an image, stylesheet, or script); {@code false} when it is a navigational
+   *     link or otherwise not rendered inline. Callers may pass either value; implementations
+   *     should accept both without throwing and treat {@code null}-like semantics as absent.
    */
   void foundURI(FreenetURI uri, boolean inline);
 
   /**
    * Called when some plain text is processed. This is used typically by spiders to index pages by
    * their content.
+   *
+   * <p>The supplied text has already been decoded according to the source format (for example, HTML
+   * entity decoding if extracted from HTML). Implementations that forward text to a consumer which
+   * expects display-ready data should re-encode as appropriate for that consumer.
    *
    * @param text The text. Will already have been fed through whatever decoding is necessary
    *     depending on the type of the source document e.g. HTMLDecoder. Will need to be re-encoded
@@ -34,5 +82,13 @@ public interface FoundURICallback {
    */
   void onText(String text, String type, URI baseURI);
 
+  /**
+   * Signal that no more callbacks will be issued for the current page or document.
+   *
+   * <p>Callers invoke this exactly once per processed page after all {@code foundURI(...)} and
+   * {@link #onText(String, String, URI)} events have been delivered. Implementations may use this
+   * hook to flush buffers, commit accumulated state, or release resources associated with the page.
+   * No further methods on this interface will be called for the same page after this signal.
+   */
   void onFinishedPage();
 }

--- a/src/main/java/network/crypta/client/filter/HTMLFilter.java
+++ b/src/main/java/network/crypta/client/filter/HTMLFilter.java
@@ -92,7 +92,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       r = new BufferedReader(isr, 4096);
       w = new BufferedWriter(osw, 4096);
     } catch (UnsupportedEncodingException e) {
-      throw UnknownCharsetException.create(e, charset);
+      throw UnknownCharsetException.create(charset);
     }
     HTMLParseContext pc = new HTMLParseContext(r, w, charset, cb, false);
     pc.run();

--- a/src/main/java/network/crypta/client/filter/KnownUnsafeContentTypeException.java
+++ b/src/main/java/network/crypta/client/filter/KnownUnsafeContentTypeException.java
@@ -7,20 +7,85 @@ import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLEncoder;
 
+/**
+ * Exception indicating that a request produced a MIME type that is known to be unsafe and is not
+ * processed by a built‑in content filter.
+ *
+ * <p>This exception is raised by the content filtering layer when a {@link FilterMIMEType} has been
+ * recognized as inherently dangerous to render or otherwise handle directly (for example, it may
+ * execute scripts or load external resources) and there is no applicable filter that can safely
+ * sanitize the response. Callers typically catch this exception at boundaries that translate errors
+ * to client‑visible responses (for example, HTTP handlers) and present a descriptive error message
+ * that explains the risks and recommended next steps.
+ *
+ * <p>The instance carries the {@code FilterMIMEType} that triggered the decision. The exception is
+ * immutable and thread‑safe for read‑only use after construction. There is no retry semantics: the
+ * condition is deterministic for the given content type. The message and details are localized
+ * through the node’s localization bundle to provide end‑user friendly output.
+ *
+ * <ul>
+ *   <li>Represents a validation failure for a specific MIME type.
+ *   <li>Intended for presentation to end users with clear, localized guidance.
+ *   <li>Does not attempt recovery; upstream components should avoid rendering unsafe content.
+ * </ul>
+ *
+ * @see UnsafeContentTypeException
+ * @see FilterMIMEType
+ */
 public class KnownUnsafeContentTypeException extends UnsafeContentTypeException {
   @Serial private static final long serialVersionUID = -1;
-  FilterMIMEType type;
 
+  /**
+   * The MIME type classification that triggered this exception.
+   *
+   * <p>This value originates from the content filtering subsystem and is treated as immutable while
+   * the exception instance is in use. Callers should consider it read‑only and use it only for
+   * generating user‑facing messages and diagnostics; it does not grant permission to bypass safety
+   * checks or to render the associated content.
+   */
+  @SuppressWarnings("java:S1948")
+  final FilterMIMEType type;
+
+  /**
+   * Creates a new exception for the provided dangerous MIME type.
+   *
+   * <p>The given {@link FilterMIMEType} is retained for later reporting in titles and details. The
+   * argument is not defensively copied and should be considered read‑only by callers after it is
+   * passed here.
+   *
+   * @param type the recognized MIME type considered unsafe to render; must not be {@code null} and
+   *     is used to generate titles and explanatory details for the user interface.
+   */
   public KnownUnsafeContentTypeException(FilterMIMEType type) {
     this.type = type;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned text is localized and intended for direct display to end users. It concisely
+   * explains that the content type is dangerous and that no built‑in filter is available to
+   * mitigate the risk.
+   *
+   * @return a localized summary message suitable for UI display; never {@code null} though it may
+   *     be an empty string if localization data is unavailable.
+   */
   @Override
   public String getMessage() {
-
     return l10n("knownUnsafe") + l10n("noFilter");
   }
 
+  /**
+   * Provides a list of localized detail strings explaining specific risks for the MIME type.
+   *
+   * <p>Entries are suitable for bullet‑style presentation in a UI and reflect the properties of the
+   * underlying {@link FilterMIMEType}. The list may be empty when no specific risk flags are set.
+   * The returned list is a new instance for each call and can be freely modified by the caller
+   * without affecting this exception.
+   *
+   * @return a newly allocated list of human‑readable, localized risk descriptions; never {@code
+   *     null} though it may be empty when no risks are identified.
+   */
   @Override
   public List<String> details() {
     List<String> details = new LinkedList<>();
@@ -34,24 +99,64 @@ public class KnownUnsafeContentTypeException extends UnsafeContentTypeException 
     return details;
   }
 
+  /**
+   * Returns a localized title that contains the MIME type, HTML‑encoded for safe embedding.
+   *
+   * <p>This method is convenient for UI layers that render HTML and must avoid introducing markup
+   * from the {@code primaryMimeType} value. For plain‑text contexts, prefer {@link #getRawTitle()}.
+   *
+   * @return a localized, HTML‑encoded title string that includes the MIME type; never {@code null}
+   *     though it may be empty if localization resources are missing.
+   */
   @Override
   public String getHTMLEncodedTitle() {
-    return l10n("title", "type", HTMLEncoder.encode(type.primaryMimeType));
+    return l10nTitle(HTMLEncoder.encode(type.primaryMimeType));
   }
 
+  /**
+   * Returns a localized title that contains the raw, unencoded MIME type.
+   *
+   * <p>Use this in plain‑text contexts or logging where HTML encoding is unnecessary. For HTML
+   * rendering, use {@link #getHTMLEncodedTitle()} to prevent accidental markup injection.
+   *
+   * @return a localized title with the unencoded MIME type; never {@code null} though it may be an
+   *     empty string if localization resources are unavailable.
+   */
   @Override
   public String getRawTitle() {
-    return l10n("title", "type", type.primaryMimeType);
+    return l10nTitle(type.primaryMimeType);
   }
 
+  /**
+   * Looks up a localized string in this class's resource bundle using the provided key.
+   *
+   * @param key a bundle key relative to this class's namespace; must not be {@code null}.
+   * @return the localized string for the key or the key itself when not found; never {@code null}.
+   */
   private static String l10n(String key) {
     return NodeL10n.getBase().getString("KnownUnsafeContentTypeException." + key);
   }
 
-  private static String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("KnownUnsafeContentTypeException." + key, pattern, value);
+  /**
+   * Formats the localized title for this exception with a single {@code type} substitution.
+   *
+   * @param value the MIME type value to substitute for the {@code type} token; may be {@code null}
+   *     which is treated as an empty string by the underlying localization.
+   * @return the formatted title string in the current locale; never {@code null}.
+   */
+  private static String l10nTitle(String value) {
+    return NodeL10n.getBase().getString("KnownUnsafeContentTypeException.title", "type", value);
   }
 
+  /**
+   * Returns the fetch error code representing this validation outcome.
+   *
+   * <p>Callers can map this value to protocol‑level error handling (for example, HTTP status
+   * translation or FCP error codes) without inspecting localized strings.
+   *
+   * @return a stable {@link FetchExceptionMode} identifying a content‑validation failure due to an
+   *     unsafe MIME type.
+   */
   @Override
   public FetchExceptionMode getFetchErrorCode() {
     return FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME;

--- a/src/main/java/network/crypta/client/filter/LinkFilterExceptionProvider.java
+++ b/src/main/java/network/crypta/client/filter/LinkFilterExceptionProvider.java
@@ -6,20 +6,55 @@ import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.Toadlet;
 
 /**
- * Provides link filter exceptions to the content filter.
+ * Supplies link filter exception decisions to components that perform content filtering.
  *
- * <p>At the moment the only implementation is {@link SimpleToadletServer} which forwards the
- * request to a {@link Toadlet} if it implements {@link LinkFilterExceptedToadlet}.
+ * <p>This interface abstracts the policy that decides whether a particular {@link URI} should be
+ * exempt from the link/content filtering pipeline. Client code that needs to evaluate links prior
+ * to serving or fetching content can depend on this contract without tying itself to a specific
+ * HTTP server or request handling implementation. A typical call pattern is that a request handler
+ * inspects a candidate link and queries this provider to determine if the link must bypass
+ * filtering; the handler then either forwards unmodified or applies the filter accordingly.
+ *
+ * <p>At present, the common implementation is {@link SimpleToadletServer}, which forwards a
+ * decision to the addressed {@link Toadlet} when it implements {@link LinkFilterExceptedToadlet}.
+ * This separation keeps filtering logic centralized while still allowing individual toadlets to
+ * express fine‑grained exceptions.
+ *
+ * <p>Thread-safety and mutability characteristics depend on the concrete implementation. Callers
+ * should treat providers as read‑only decision services. Implementations may consult configuration
+ * or per-request context, but consumers should not assume caching or idempotency beyond the single
+ * invocation.
+ *
+ * <ul>
+ *   <li>Responsibility: Answer whether a specific link is excluded from filtering.
+ *   <li>Scope: Only makes the exception decision; does not perform filtering.
+ *   <li>Usage: Query per link as part of request handling or preflight checks.
+ * </ul>
  *
  * @author <a href="mailto:bombe@pterodactylus.net">David ‘Bombe’ Roden</a>
+ * @see SimpleToadletServer
+ * @see LinkFilterExceptedToadlet
  */
 public interface LinkFilterExceptionProvider {
 
   /**
-   * Returns whether the given should be excepted from being filtered.
+   * Determines whether the supplied link is exempt from content filtering.
    *
-   * @param link The link to check
-   * @return {@code true} if the link should not be filtered, {@code false} if it should be filtered
+   * <p>The decision typically reflects policy exposed by the target handler (for example, a {@link
+   * Toadlet} implementing {@link LinkFilterExceptedToadlet}) or server‑level configuration. Callers
+   * should invoke this method for each candidate link they intend to process and act on the result
+   * immediately; the outcome is not guaranteed to be stable across requests if policy is dynamic.
+   * Implementations are expected to be side‑effect free and execute quickly; however, consult
+   * documentation of the concrete provider for any additional performance considerations.
+   *
+   * <p>Idempotency: Repeated calls with the same input during a single evaluation phase are
+   * expected to return the same boolean answer.
+   *
+   * @param link the absolute or server‑relative {@link URI} to check against the exception policy;
+   *     must not be {@code null}; opaque or malformed URIs should be rejected by callers upstream
+   *     before invoking this method
+   * @return {@code true} when filtering must be bypassed for this link and the request may proceed
+   *     unfiltered; {@code false} when the standard filtering pipeline should process the link
    */
   boolean isLinkExcepted(URI link);
 }

--- a/src/main/java/network/crypta/client/filter/TagReplacerCallback.java
+++ b/src/main/java/network/crypta/client/filter/TagReplacerCallback.java
@@ -3,16 +3,67 @@ package network.crypta.client.filter;
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
 
 /**
- * This callback can be registered to a HTMLContentFilter, that provides callback for all tags it
- * processes. It can modify tags.
+ * Callback interface used by the HTML filtering pipeline to inspect and optionally replace
+ * individual tags during parsing.
+ *
+ * <p>Implementations are invoked by the HTML filter every time a tag is recognized in the input
+ * stream. The callback receives a pre-parsed, immutable view of the tag and a {@link URIProcessor}
+ * helper for performing safe, policy-aware transformations on attribute values that represent URIs.
+ * Returning a non-{@code null} value replaces the original tag in the output with the provided
+ * string; returning {@code null} keeps the tag as produced by the sanitizer.
+ *
+ * <p>Use this interface when you need to enforce site- or application-specific policies that go
+ * beyond the default sanitizer (for example, rewriting links, whitelisting hosts, or adding
+ * attributes). Implementations are typically stateless and inexpensive; they should avoid blocking
+ * I/O and heavy computations because they are called for each tag as the document is streamed. The
+ * filter may call a single instance from a single thread; however, implementations should be
+ * written to be thread-safe or used in a thread-confined manner if shared across filtering
+ * sessions.
+ *
+ * <ul>
+ *   <li>Input is already parsed and normalized into a {@code ParsedTag}.
+ *   <li>Return {@code null} to leave output unchanged for the current tag.
+ *   <li>Return a string to emit a full replacement (must be syntactically valid HTML).
+ * </ul>
+ *
+ * @see HTMLFilter
+ * @see HTMLFilter.ParsedTag
+ * @see URIProcessor
  */
 public interface TagReplacerCallback {
   /**
-   * Processes a tag, and return a replacement
+   * Processes a single parsed tag and returns an optional replacement string.
    *
-   * @param pt - The tag that is processed
-   * @param uriProcessor - The URIProcessor that helps with URI transformations
-   * @return the replacement for the tag, or null if not needed
+   * <p>The callback can examine the element name and attributes contained in {@code pt} and, when
+   * necessary, consult {@code uriProcessor} to normalize, absolutize, or validate any attribute
+   * values that represent URIs (for example, {@code href}, {@code src}, or {@code poster}). If the
+   * method returns {@code null}, the original, sanitized tag output is preserved. If a non-null
+   * string is returned, it is written verbatim to the output in place of the original tag. The
+   * method should be side effect free and idempotent with respect to its inputs.
+   *
+   * <p>Edge cases: For unknown or unsupported elements, prefer returning {@code null} to defer to
+   * the sanitizer. Avoid returning malformed markup; the caller does not post-process replacements.
+   *
+   * <pre>{@code
+   * // Example: rewrite all <a> tags to use HTTPS
+   * TagReplacerCallback cb = (pt, up) -> {
+   *   if ("a".equalsIgnoreCase(pt.element)) {
+   *     var attrs = pt.getAttributesAsMap();
+   *     String href = attrs.get("href");
+   *     if (href != null && href.startsWith("http://")) {
+   *       return "<a href=\"" + href.replaceFirst("^http://", "https://") + "\">";
+   *     }
+   *   }
+   *   return null; // keep original tag
+   * };
+   * }</pre>
+   *
+   * @param pt the parsed, immutable tag to inspect; contains the element name and raw attributes;
+   *     never {@code null} and safe for repeated reads.
+   * @param uriProcessor helper for URI-aware transformations and validation; may normalize or
+   *     absolutize values; never {@code null}; do not retain references beyond the call.
+   * @return a full tag replacement to emit verbatim, or {@code null} to keep the sanitizer’s
+   *     original output for this tag; callers treat the returned text as final markup.
    */
   String processTag(ParsedTag pt, URIProcessor uriProcessor);
 }

--- a/src/main/java/network/crypta/client/filter/URIProcessor.java
+++ b/src/main/java/network/crypta/client/filter/URIProcessor.java
@@ -2,18 +2,83 @@ package network.crypta.client.filter;
 
 import java.net.URISyntaxException;
 
-/** This interface provides methods for URI transformations */
+/**
+ * Strategy interface for safe, policy-aware URI processing used by the filtering pipeline.
+ *
+ * <p>Implementations take raw URI strings found in user-supplied or untrusted documents and
+ * transform them into forms that are safe to emit in filtered output. Typical operations include
+ * normalization, canonicalization, optional absolutization against a base, and enforcement of
+ * policy (for example, allowed schemes or host restrictions). When a value cannot be made
+ * sufficiently safe, methods return {@code null} to indicate that the reference should be removed
+ * from the resulting document. Some operations may signal unrecoverable validation problems via a
+ * {@link CommentException} with a human-readable explanation.
+ *
+ * <p>This interface is used by higher-level callbacks such as {@link TagReplacerCallback} and
+ * {@link FilterCallback} during streaming sanitization. Implementations are generally stateless or
+ * hold only small amounts of context (for example, a base URI). Concurrency requirements are
+ * caller-defined; most filters invoke a single instance from one thread per document, but
+ * implementations should avoid global mutable state and be safe to reuse across runs.
+ *
+ * <ul>
+ *   <li>Normalize and sanitize URI strings prior to emission.
+ *   <li>Optionally absolutize relative references using an implementation-defined base.
+ *   <li>Enforce policy; return {@code null} when a value must be elided.
+ * </ul>
+ *
+ * @see FilterCallback
+ * @see TagReplacerCallback
+ */
 public interface URIProcessor {
 
-  /** Processes an URI. If it is unsafe, then return null */
+  /**
+   * Processes a URI string and returns a sanitized representation suitable for filtered output.
+   *
+   * <p>The implementation may normalize encoding, strip or rewrite disallowed components, and, when
+   * requested, convert relative references to absolute ones. The {@code inline} flag allows
+   * implementations to apply context-specific handling (for example, when the URI is referenced
+   * from an inline attribute). Returning {@code null} indicates that the value is unsafe and should
+   * be removed rather than emitted.
+   *
+   * <pre>{@code
+   * // Example: evaluate a candidate URI for inclusion
+   * String safe = uriProcessor.processURI(raw, null, /* noRelative= * / false, /* inline= * / true);
+   * if (safe != null) {
+   *   // emit or store the sanitized value
+   * }
+   * }</pre>
+   *
+   * @param u the original URI string to evaluate; may be absolute or relative and is treated as
+   *     opaque input; never modified in place.
+   * @param overrideType optional MIME type hint to associate with the processed value; may be
+   *     {@code null}; implementations may ignore it when not applicable.
+   * @param noRelative when {@code true}, convert relative references to absolute form using the
+   *     current base; when {@code false}, a relative form may be preserved if policy allows.
+   * @param inline when {@code true}, indicates the URI appears in an inline context and may be
+   *     handled with context-specific rules; {@code false} applies normal processing.
+   * @return a sanitized URI string that is safe to emit, possibly rewritten and/or absolutized; or
+   *     {@code null} if the input cannot be made acceptable under policy and must be removed.
+   * @throws CommentException if parsing fails, policy validation cannot be satisfied, or the value
+   *     must cause the operation to abort instead of eliding it silently.
+   */
   String processURI(String u, String overrideType, boolean noRelative, boolean inline)
       throws CommentException;
 
   /**
-   * Makes an URI absolute
+   * Makes a URI absolute with respect to the implementation's notion of base resolution.
    *
-   * @param uri - The uri to be absolutize
-   * @return The absolute URI
+   * <p>The provided {@code uri} may be absolute already or may be a relative reference. The
+   * returned value is an ASCII string form suitable for use in serialized output. Implementations
+   * apply the same pre-encoding and normalization rules they use for general processing. This
+   * method does not perform policy checks and does not alter behavior beyond resolution; callers
+   * should still invoke {@link #processURI(String, String, boolean, boolean)} when validation is
+   * required.
+   *
+   * @param uri the input URI string to resolve; may be absolute or relative; must be syntactically
+   *     valid according to {@link java.net.URI} when combined with the base.
+   * @return the absolute, normalized ASCII URI string computed from {@code uri} and the base
+   *     context held by the implementation; never {@code null}.
+   * @throws URISyntaxException if the URI is malformed or cannot be resolved against the current
+   *     base due to invalid syntax.
    */
   String makeURIAbsolute(String uri) throws URISyntaxException;
 }

--- a/src/main/java/network/crypta/client/filter/UndetectableCharsetException.java
+++ b/src/main/java/network/crypta/client/filter/UndetectableCharsetException.java
@@ -3,37 +3,127 @@ package network.crypta.client.filter;
 import java.io.Serial;
 import network.crypta.l10n.NodeL10n;
 
-// This is thrown when a stylesheet starts with the CSS BOM, i.e. "@charset \"
-// in some encoding, but the declaration is invalid.
+/**
+ * Signals that a character set declaration could not be determined reliably.
+ *
+ * <p>This exception is raised by client-side filtering when input advertises a specific character
+ * encoding (for example, a stylesheet using an {@code @charset} declaration or a byte-order mark),
+ * but the declaration is syntactically invalid, incomplete, or otherwise undecidable. In such
+ * cases, decoding the payload would be error-prone and may result in unsafe rendering or
+ * interpretation. The exception carries the raw token that purported to name the charset so that
+ * callers can surface a clear, localized diagnostic to end users or logs.
+ *
+ * <p>The instance is immutable and thread-safe after construction. Typical usage is to throw it
+ * from parsing or normalization routines and allow higher layers to translate it into a localized
+ * message via {@link #getMessage()} or title helpers. No automatic recovery is attempted; callers
+ * should either reject the content or retry using a safe default if policy allows.
+ *
+ * <ul>
+ *   <li>Includes the raw {@code charset} token as observed.
+ *   <li>Produces localized messages via {@link NodeL10n} keys scoped to this type.
+ *   <li>Does not attempt to guess or coerce an encoding.
+ * </ul>
+ *
+ * @see UnsafeContentTypeException
+ * @see NodeL10n
+ */
 public class UndetectableCharsetException extends UnsafeContentTypeException {
 
   @Serial private static final long serialVersionUID = -7663468693283975543L;
 
+  /**
+   * The raw charset token captured from the input context.
+   *
+   * <p>This value reflects what was presented in the source (for example, within an
+   * {@code @charset} directive) and is preserved verbatim. It may be suitable only for display in
+   * diagnostics, not for direct use in decoders.
+   */
   final String charset;
 
+  /**
+   * Creates a new exception indicating that the charset could not be determined.
+   *
+   * <p>The provided string is stored unmodified and is used in localized messages and titles.
+   * Callers should ensure any sensitive content is avoided or sanitized before passing it here if
+   * user-visible rendering is expected.
+   *
+   * @param string the raw charset token observed in the input; may be any non-null string and is
+   *     preserved verbatim for diagnostics and localization keys.
+   */
   public UndetectableCharsetException(String string) {
     charset = string;
   }
 
+  /**
+   * Returns a localized explanation suitable for logs or user-visible error text.
+   *
+   * <p>The message is obtained from {@link NodeL10n} using a key scoped to this exception type and
+   * does not include markup.
+   *
+   * @return a human-readable, localized description explaining that the charset could not be
+   *     detected from the provided declaration.
+   */
   @Override
   public String getMessage() {
     return l10n("explanation");
   }
 
+  /**
+   * Returns a localized HTML-encoded title that includes the raw charset token.
+   *
+   * <p>The returned string is intended for safe embedding in HTML contexts where escaping is
+   * applied by the localization layer.
+   *
+   * @return a localized, HTML-encoded short title incorporating the observed charset token.
+   */
   @Override
   public String getHTMLEncodedTitle() {
     return l10n("title", "charset", charset);
   }
 
+  /**
+   * Returns a localized plain-text title that includes the raw charset token.
+   *
+   * <p>This variant does not apply HTML encoding and is suitable for console logs or other
+   * plain-text environments.
+   *
+   * @return a localized, plain-text short title incorporating the observed charset token.
+   */
   @Override
   public String getRawTitle() {
     return l10n("title", "charset", charset);
   }
 
+  /**
+   * Looks up a localized string for this exception's resource bundle scope.
+   *
+   * <p>Keys are resolved using the base {@link NodeL10n} instance with the {@code
+   * "UndetectableCharsetException."} prefix.
+   *
+   * @param message the unprefixed message key to resolve within this exception's namespace; must be
+   *     non-null and should correspond to a defined resource.
+   * @return the resolved, localized string; callers should not assume a specific language or
+   *     encoding and should treat the result as read-only.
+   */
   public String l10n(String message) {
     return NodeL10n.getBase().getString("UndetectableCharsetException." + message);
   }
 
+  /**
+   * Looks up a localized format string and substitutes a single named parameter.
+   *
+   * <p>Keys are resolved within this exception's namespace. The provided {@code key} and {@code
+   * value} are passed to the localization layer for named placeholder substitution.
+   *
+   * @param message the unprefixed message key to resolve; must be non-null and reference an entry
+   *     that accepts a single named parameter.
+   * @param key the name of the placeholder parameter in the message pattern; use a stable, known
+   *     key expected by the resource.
+   * @param value the string value to substitute for the named parameter; preserved verbatim and may
+   *     be displayed to end users depending on the context.
+   * @return the resolved, localized string with the provided parameter substituted; the result is
+   *     intended for display and should be treated as immutable.
+   */
   public String l10n(String message, String key, String value) {
     return NodeL10n.getBase().getString("UndetectableCharsetException." + message, key, value);
   }

--- a/src/main/java/network/crypta/client/filter/UnknownCharsetException.java
+++ b/src/main/java/network/crypta/client/filter/UnknownCharsetException.java
@@ -1,11 +1,42 @@
 package network.crypta.client.filter;
 
 import java.io.Serial;
-import java.io.UnsupportedEncodingException;
 import network.crypta.l10n.NodeL10n;
 
+/**
+ * Signals that a requested character set name is unknown or unsupported in the current execution
+ * environment while filtering or parsing client-provided content. Instances of this exception are
+ * created with localized, user-facing messages that explain the problem and can be surfaced by
+ * higher-level code (for example, HTTP responses or UI alerts).
+ *
+ * <p>This type is typically thrown by content data filters when they attempt to construct
+ * character-oriented readers or writers for a specific charset and the runtime cannot provide a
+ * corresponding codec. The {@link #charset} field preserves the name that was originally requested,
+ * allowing callers to include it in diagnostics or logs. Values are not normalized; the original
+ * input is retained to avoid losing context.
+ *
+ * <p>Exception instances are immutable and therefore safe to share across threads if needed;
+ * however, in normal usage they are created and immediately thrown in the same thread where the
+ * failure occurs. No automatic recovery is performed by this class. Callers should select and retry
+ * with an alternative charset when appropriate or propagate the exception to abort processing.
+ *
+ * <ul>
+ *   <li>Purpose: report charset lookup or initialization failures encountered in filters.
+ *   <li>Payload: preserves the requested charset name via {@link #charset}.
+ *   <li>Localization: message text is sourced from the node localization bundle.
+ * </ul>
+ */
 public class UnknownCharsetException extends DataFilterException {
   @Serial private static final long serialVersionUID = 1L;
+
+  /**
+   * The character set name that was requested when the failure occurred.
+   *
+   * <p>The value is preserved exactly as supplied by the caller to facilitate accurate diagnostics
+   * and end-user feedback. It may be {@code null} or an empty string if the originating code did
+   * not provide a name, although callers should normally pass a non-empty value that reflects the
+   * attempted configuration.
+   */
   public final String charset;
 
   private UnknownCharsetException(String warning, String warning2, String string, String charset) {
@@ -13,21 +44,33 @@ public class UnknownCharsetException extends DataFilterException {
     this.charset = charset;
   }
 
-  public static UnknownCharsetException create(UnsupportedEncodingException e, String charset) {
+  /**
+   * Creates a new {@code UnknownCharsetException} for the provided character set name.
+   *
+   * <p>This factory assembles a localized, user-facing explanation and a concise warning title that
+   * higher layers can present to users. It does not attempt to validate or normalize the supplied
+   * value; the name is stored as-is in {@link #charset}. Typical call sites invoke this method from
+   * a catch block that handles charset initialization errors while setting up readers or writers
+   * for content filtering.
+   *
+   * @param charset the character set name that failed to initialize; may be {@code null} or empty
+   *     when no explicit name was available from the source context, but callers should prefer a
+   *     non-empty, descriptive value that reflects the attempted encoding.
+   * @return a new exception instance carrying localized messages and preserving the original
+   *     charset name for diagnostics and user feedback.
+   */
+  public static UnknownCharsetException create(String charset) {
     String explTitle = l10nDF("unknownCharsetTitle");
     String expl = l10nDF("unknownCharset");
 
-    String warning = l10nDF("warningUnknownCharsetTitle", "charset", charset);
+    String warning =
+        NodeL10n.getBase()
+            .getString("ContentDataFilter.warningUnknownCharsetTitle", "charset", charset);
     return new UnknownCharsetException(warning, warning, explTitle + " " + expl, charset);
   }
 
   private static String l10nDF(String key) {
     // All the strings here are generic
     return NodeL10n.getBase().getString("ContentDataFilter." + key);
-  }
-
-  private static String l10nDF(String key, String pattern, String value) {
-    // All the strings here are generic
-    return NodeL10n.getBase().getString("ContentDataFilter." + key, pattern, value);
   }
 }

--- a/src/main/java/network/crypta/client/filter/UnknownContentTypeException.java
+++ b/src/main/java/network/crypta/client/filter/UnknownContentTypeException.java
@@ -5,39 +5,137 @@ import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLEncoder;
 
+/**
+ * Signals that a fetched resource exposes an unknown or unsupported content type.
+ *
+ * <p>This exception is raised by client-side content-type validation code when the MIME type
+ * provided by an upstream source (for example, an HTTP server or plugin) cannot be mapped to a type
+ * that Crypta considers safe or recognizable. The instance carries both the raw type string and a
+ * pre-encoded, HTML-safe variant to simplify downstream UI rendering without duplicating escaping
+ * logic. Title and message strings are produced lazily via the node localization layer ({@link
+ * network.crypta.l10n.NodeL10n}) so that translations remain centralized and consistent across the
+ * application.
+ *
+ * <p>Typical usage is to construct the exception with the original content-type value and allow the
+ * higher layers to surface a localized, human-readable explanation. The object is immutable and
+ * thread-safe after construction; its state never changes, and it performs no I/O. Consumers may
+ * use {@link #getHTMLEncodedTitle()} when rendering into an HTML context, and {@link
+ * #getRawTitle()} or {@link #getMessage()} for plain-text logs or non-HTML surfaces.
+ *
+ * <ul>
+ *   <li>Provides raw and HTML-escaped variants of the type string.
+ *   <li>Defers wording to the localization bundle for consistent phrasing.
+ *   <li>Class is immutable; safe to share across threads without synchronization.
+ * </ul>
+ */
 public class UnknownContentTypeException extends UnsafeContentTypeException {
   @Serial private static final long serialVersionUID = -1;
+
+  /**
+   * The original content type string as received from an external source. The value is not
+   * HTML-escaped and is intended for plain-text contexts such as logs or console output. It is
+   * assigned at construction time and remains constant for the lifetime of the instance.
+   */
   final String type;
+
+  /**
+   * The content type string pre-escaped for safe inclusion in HTML. This value is derived from
+   * {@link #type} using a simple encoder and is suitable for UI titles or messages rendered in
+   * HTML-capable widgets. It is computed once during construction and never changes thereafter.
+   */
   final String encodedType;
 
+  /**
+   * Create an exception for the given content type name.
+   *
+   * <p>The provided string is stored verbatim for plain-text access and is also HTML-escaped to
+   * populate {@link #encodedType} for safe rendering in user interfaces. The constructor does not
+   * validate the syntax beyond accepting any non-null string that represents a type as reported by
+   * an upstream component.
+   *
+   * @param typeName raw content-type name as observed (for example, {@code
+   *     "application/x-unknown"}); must be the exact value received from the source; callers should
+   *     avoid passing {@code null}.
+   */
   public UnknownContentTypeException(String typeName) {
     this.type = typeName;
     encodedType = HTMLEncoder.encode(type);
   }
 
+  /**
+   * Return the raw, unescaped content type string that triggered this exception.
+   *
+   * <p>The returned value is the exact content-type string supplied at construction. It is not
+   * sanitized for HTML and is intended for plain-text outputs such as logs, metrics labels, or
+   * debugging messages. Use {@link #getHTMLEncodedTitle()} if you need a localized, HTML-safe title
+   * for display in a browser or rich text widget.
+   *
+   * @return the original content type string, unchanged and suitable for plain-text contexts
+   */
   public String getType() {
     return type;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This variant is safe to embed in HTML and is localized using the node's resource bundles.
+   * The message focuses on user-facing clarity rather than raw diagnostic detail.
+   *
+   * @return a localized, HTML-escaped title that references the unknown content type
+   */
   @Override
   public String getHTMLEncodedTitle() {
-    return l10n("title", "type", encodedType);
+    return l10n("title", encodedType);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Provides a localized title appropriate for logs or plain-text user interfaces. The content
+   * type is included without HTML escaping so the string remains human-readable in non-HTML
+   * environments.
+   *
+   * @return a localized plain-text title that references the unknown content type
+   */
   @Override
   public String getRawTitle() {
-    return l10n("title", "type", type);
+    return l10n("title", type);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The explanation expands on why the content type is not accepted and may include actionable
+   * guidance. The phrasing is defined in localization resources to remain consistent across
+   * languages and builds.
+   *
+   * @return a localized, plain-text explanation suitable for logs or UI messages
+   */
   @Override
   public String getMessage() {
-    return l10n("explanation", "type", type);
+    return l10n("explanation", type);
   }
 
-  private static String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("UnknownContentTypeException." + key, pattern, value);
+  /**
+   * Localize a message for this exception, substituting the {@code type} placeholder.
+   *
+   * @param key resource key suffix (e.g., "title", "explanation")
+   * @param value value to substitute for the {@code type} pattern
+   * @return localized string
+   */
+  private static String l10n(String key, String value) {
+    return NodeL10n.getBase().getString("UnknownContentTypeException." + key, "type", value);
   }
 
+  /**
+   * Return the standardized fetch error code that classifies this failure.
+   *
+   * <p>The code can be used by higher layers to group errors, drive metrics, or select recovery
+   * behavior. It is stable across releases for the same semantic condition.
+   *
+   * @return the {@code CONTENT_VALIDATION_UNKNOWN_MIME} classification for unknown content types
+   */
   @Override
   public FetchExceptionMode getFetchErrorCode() {
     return FetchExceptionMode.CONTENT_VALIDATION_UNKNOWN_MIME;

--- a/src/main/java/network/crypta/client/filter/UnsafeContentTypeException.java
+++ b/src/main/java/network/crypta/client/filter/UnsafeContentTypeException.java
@@ -7,47 +7,130 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchException.FetchExceptionMode;
 
 /**
- * Thrown by the filter when it cannot guarantee the safety of the data, because it is an unknown
- * type, because it cannot be filtered, or because we do not know how to filter it.
+ * Signals that a client-side content filter determined that returned data cannot be considered safe
+ * to render or process as-is. Typical reasons include an unknown MIME type, a known-but- hazardous
+ * type, or content that cannot be filtered to a safe representation.
  *
- * <p>Base class for UnknownContentTypeException and KnownUnsafeContentTypeException.
+ * <p>This abstract base class defines the contract used by higher layers to present meaningful
+ * information to end users and calling code. Subclasses supply an HTML-encoded title ({@link
+ * #getHTMLEncodedTitle()}), a raw (unescaped) title ({@link #getRawTitle()}), a human-readable
+ * message ({@link #getMessage()}), and optional detail lines ({@link #details()}). The exception
+ * also maps to a {@code FetchException} error mode so callers can preserve failure semantics across
+ * API boundaries via {@link #recreateFetchException(FetchException, String)} and {@link
+ * #createFetchException(String, long)}.
+ *
+ * <p>Instances are immutable with respect to their externally observable state and are expected to
+ * be thread-safe for read-only use after construction. Callers should not attempt to mutate the
+ * returned strings. Typical call patterns are:
+ *
+ * <ul>
+ *   <li>Catch this exception when filtering content fetched from the network.
+ *   <li>Display the HTML-encoded title and message in a UI error view.
+ *   <li>Convert to a {@code FetchException} to propagate failure information to APIs that expect
+ *       fetch-level errors.
+ * </ul>
+ *
+ * @see FetchException
  */
 public abstract class UnsafeContentTypeException extends IOException {
   @Serial private static final long serialVersionUID = 1L;
 
-  /** Get the contents of the error page. */
+  /**
+   * Creates a new exception with no detail message. Subclasses typically call this constructor from
+   * their own constructors to signal that content failed validation and that the filter could not
+   * safely process it further.
+   */
+  protected UnsafeContentTypeException() {
+    super();
+  }
+
+  /**
+   * Returns the human-readable contents of an error page describing why the content is considered
+   * unsafe. Implementations should ensure the returned text is suitable for display and does not
+   * leak sensitive information beyond what is necessary to explain the failure.
+   *
+   * @return descriptive text intended for display to users; never {@code null}
+   */
   @Override
   public abstract String getMessage();
 
-  /** Get additional details about the failure */
+  /**
+   * Provides additional detail lines that may help the caller render a richer error view or log
+   * diagnostic information. Subclasses may return {@code null} when no extra details are available.
+   *
+   * @return an ordered list of detail strings, or {@code null} when not applicable
+   */
+  @SuppressWarnings("java:S1168")
   public List<String> details() {
     return null;
   }
 
-  /** Get the title of the error page. */
+  /**
+   * Returns a short, HTML-encoded title suitable for embedding in an HTML context (for example, a
+   * dialog or page header). Implementations must escape special characters so the returned value is
+   * safe to include in HTML without additional encoding.
+   *
+   * @return an HTML-encoded title safe for direct inclusion in markup
+   */
   public abstract String getHTMLEncodedTitle();
 
-  /** Get the raw title of the error page. (May be unsafe for HTML). */
+  /**
+   * Returns the raw title string of the error without HTML escaping. This value may contain
+   * characters that require encoding before being inserted into HTML and should therefore be used
+   * only in plain-text contexts or after appropriate escaping.
+   *
+   * @return an unescaped, plain-text title; callers must escape before using in HTML
+   */
   public abstract String getRawTitle();
 
-  /** Get the title of the Exception */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>For convenience, this implementation returns the same value as {@link #getRawTitle()} to
+   * make log output concise and consistent.
+   *
+   * @return a concise string representation, typically the raw title
+   */
   @Override
   public String toString() {
     return getRawTitle();
   }
 
   /**
-   * Returns the error code that a FetchException may be instantiated with Subclasses of this
-   * exception may override this method to provide more detailed error messages.
+   * Returns the {@code FetchException} error mode that represents this validation failure. The
+   * default maps to {@code CONTENT_VALIDATION_FAILED}. Subclasses may override to select a more
+   * specific mode while preserving stable behavior for callers that translate this exception to a
+   * {@code FetchException}.
+   *
+   * @return the fetch error mode to use when constructing a {@code FetchException}
    */
   public FetchExceptionMode getFetchErrorCode() {
     return FetchExceptionMode.CONTENT_VALIDATION_FAILED;
   }
 
+  /**
+   * Recreates a {@code FetchException} from an existing one, preserving the expected size while
+   * updating the error mode and MIME type to reflect this specific validation failure.
+   *
+   * @param e the original fetch exception; its {@code expectedSize} will be propagated; must not be
+   *     {@code null}
+   * @param mime the MIME type associated with the failed content, such as {@code text/html} or
+   *     {@code application/octet-stream}; may be {@code null} if unknown
+   * @return a new {@code FetchException} that captures this validation failure and context
+   */
   public FetchException recreateFetchException(FetchException e, String mime) {
     return new FetchException(getFetchErrorCode(), e.expectedSize, this, mime);
   }
 
+  /**
+   * Creates a new {@code FetchException} representing this validation failure with the supplied
+   * MIME type and expected content size.
+   *
+   * @param mime the MIME type inferred or declared for the content; may be {@code null} when
+   *     unknown
+   * @param expectedSize the expected size of the content in bytes, or {@code -1} when not known
+   * @return a freshly constructed {@code FetchException} suitable for propagation to callers
+   */
   public FetchException createFetchException(String mime, long expectedSize) {
     return new FetchException(getFetchErrorCode(), expectedSize, this, mime);
   }

--- a/src/main/java/network/crypta/client/filter/UnsupportedCharsetInFilterException.java
+++ b/src/main/java/network/crypta/client/filter/UnsupportedCharsetInFilterException.java
@@ -3,35 +3,126 @@ package network.crypta.client.filter;
 import java.io.Serial;
 import network.crypta.l10n.NodeL10n;
 
+/**
+ * Signals that a character set declared or inferred during client-side filtering is not supported
+ * by the running node. This exception is raised from filter components that need to interpret
+ * textual payloads (for example, HTML or CSS filters) when the provided charset token cannot be
+ * recognized or is considered unsafe for decoding.
+ *
+ * <p>The primary purpose of this type is to carry the original charset token (as a simple {@code
+ * String}) and to provide localized, human-readable messages and titles suitable for surfacing in
+ * user interfaces. Instances are lightweight and immutable; once created, the stored charset value
+ * does not change. Consumers typically construct and throw this exception at the point where
+ * decoding would otherwise occur and then allow higher-level code to translate it into an error
+ * response.
+ *
+ * <p>Concurrency: this class is thread-safe to the extent that it is immutable. The captured
+ * charset token is retained as provided by the caller; no normalization is applied. The
+ * localization helpers delegate to {@link NodeL10n} at call time, which may depend on the process
+ * localization configuration.
+ *
+ * <ul>
+ *   <li>Responsibility: report unsupported or disallowed charset identifiers detected by filters.
+ *   <li>Behavior: exposes localized {@linkplain #getMessage() message} and title strings.
+ *   <li>State: immutable after construction; contains the original charset token.
+ * </ul>
+ *
+ * @see UnsafeContentTypeException
+ * @see NodeL10n
+ */
 public class UnsupportedCharsetInFilterException extends UnsafeContentTypeException {
 
   @Serial private static final long serialVersionUID = 3775454822229213420L;
 
+  /**
+   * The charset token that triggered the failure. The value is captured verbatim from the
+   * originating context and may not be normalized; callers should treat it as display text only.
+   */
   final String charset;
 
+  /**
+   * Creates an exception associated with a specific, unsupported charset token.
+   *
+   * <p>The provided value is stored without validation or transformation and may appear in
+   * localized titles. Passing {@code null} is permitted; in that case, the title generation will
+   * include a literal {@code null} representation as determined by the localization layer.
+   *
+   * <pre>{@code
+   * // Example: raise an error when a page declares an unknown encoding
+   * throw new UnsupportedCharsetInFilterException(declaredCharset);
+   * }</pre>
+   *
+   * @param string the charset identifier encountered by the filter, such as {@code "UTF-8"} or a
+   *     raw token as found in content metadata; may be {@code null} when unavailable.
+   */
   public UnsupportedCharsetInFilterException(String string) {
     charset = string;
   }
 
+  /**
+   * Returns a localized, human-readable explanation describing why the charset is unsupported. The
+   * message is suitable for logs or UI error summaries and is independent of the title.
+   *
+   * @return a localized explanation string; never {@code null}, though content depends on installed
+   *     locales and resource bundles.
+   */
   @Override
   public String getMessage() {
     return l10n("explanation");
   }
 
+  /**
+   * Returns a localized title intended for HTML presentation contexts. The title includes the
+   * unsupported charset token and is returned as plain text; callers remain responsible for any
+   * additional context-specific escaping.
+   *
+   * @return a localized title string that references the offending charset token; never {@code
+   *     null}.
+   */
   @Override
   public String getHTMLEncodedTitle() {
     return l10n("title", "charset", charset);
   }
 
+  /**
+   * Returns a localized title as plain, unencoded text. Unlike {@link #getHTMLEncodedTitle()}, no
+   * assumptions are made about the output being inserted into HTML; it can be used for logs or
+   * plain-text interfaces.
+   *
+   * @return a localized title string that references the offending charset token; never {@code
+   *     null}.
+   */
   @Override
   public String getRawTitle() {
     return l10n("title", "charset", charset);
   }
 
+  /**
+   * Looks up a localized message by suffix key within this exception's resource bundle namespace.
+   * This is a convenience for building user-facing strings tied to this error type.
+   *
+   * @param message the suffix portion of the resource key, appended to the {@code
+   *     UnsupportedCharsetInFilterException.} prefix; must match a defined bundle entry.
+   * @return the resolved localized string for the provided key; never {@code null} when the bundle
+   *     contains a matching entry.
+   */
   public String l10n(String message) {
     return NodeL10n.getBase().getString("UnsupportedCharsetInFilterException." + message);
   }
 
+  /**
+   * Looks up a localized, parameterized message under this exception's namespace and substitutes a
+   * single named argument. The substitution semantics are defined by {@link NodeL10n}.
+   *
+   * @param message the suffix portion of the resource key, appended to the {@code
+   *     UnsupportedCharsetInFilterException.} prefix, identifying a parameterized string.
+   * @param key the placeholder name expected by the resource entry (for example, {@code "charset"}
+   *     to reference the unsupported token); must not be {@code null}.
+   * @param value the placeholder value to inject for the given {@code key}; may be {@code null}
+   *     when the original token is unavailable.
+   * @return the resolved and formatted localized string; never {@code null} when the bundle
+   *     contains a matching entry.
+   */
   public String l10n(String message, String key, String value) {
     return NodeL10n.getBase()
         .getString("UnsupportedCharsetInFilterException." + message, key, value);

--- a/src/main/java/network/crypta/client/filter/package-info.java
+++ b/src/main/java/network/crypta/client/filter/package-info.java
@@ -1,22 +1,55 @@
 /**
- * Freenet content filter code. The purpose of this code, which can optionally be invoked during a
- * download (and is mainly used in fproxy), is to identify safe content, and delete or warn about
- * any content that either we don't understand, or we can't currently make safe.
+ * Client content filtering for safely rendering data fetched through Crypta.
  *
- * <p>Dangerous content here mainly means content (e.g. HTML) that could cause the browser to do
- * fetches from the non-anonymous web ("web bugs"), or more complex attacks that achieve the same
- * result (e.g. scripting). We do not intentionally prohibit specific exploits, unless it is easy to
- * do so, but we do operate on a "whitelist" principle as much as possible (especially in the HTML
- * and CSS filters), where we parse the data, and if we can't understand it, we delete it, because
- * it might be dangerous. This is much safer than e.g. looking for things that look like URLs.
+ * <p>This package provides filtering utilities that can be invoked during a download pipeline
+ * (commonly by the HTTP gateway) to classify and transform fetched data into a browser‑safe form.
+ * The filters aim to identify "safe" content and either remove, neutralize, or warn about parts we
+ * do not understand or cannot be made safe at the time of processing. The core approach is
+ * whitelisting: parse the input, permit only recognized constructs, and drop or sanitize the rest.
+ * This is more robust than attempting to detect specific exploits or blocking by pattern.
  *
- * <p>We also have a registry of known MIME types, with either filters or warning messages.
+ * <p>"Dangerous" here primarily refers to content (for example, HTML) that could trigger requests
+ * to the non‑anonymous web (so‑called web bugs), or enable browser behaviors such as active
+ * scripting that deanonymize users or leak information. The filters therefore focus on HTML and CSS
+ * sanitization, but the same principles apply to other MIME types that can carry active content or
+ * metadata with privacy impact.
  *
- * <p>Finally, we support some degree of "write filtering", i.e. stripping out potentially
- * compromising data (e.g. EXIF tags) at insert time. And we support arbitrary transformations of
- * HTML tags via @link TagReplacerCallback which is used by fproxy for showing loading images etc.
+ * <p>A registry maps known MIME types to dedicated filters or to user‑visible warnings when the
+ * content type is recognized but cannot be safely processed. The filtering pipeline is intended to
+ * be used in a streaming fashion to keep memory usage predictable for large files; callers should
+ * prefer passing streams rather than fully buffering responses. When no filter is available, a
+ * conservative pass‑through may be used and a warning surfaced to the client.
  *
- * @see network.crypta.client.async.ClientGetWorkerThread The driver thread
- * @see network.crypta.clients.http.FProxyToadlet The major user of this code practically speaking
+ * <p>Write filtering is also supported: potentially identifying data such as image EXIF metadata
+ * can be stripped at insert time to reduce the risk of accidental disclosure. In addition, the HTML
+ * path supports transformation hooks (for example, a tag‑replacement callback used to inject
+ * placeholders while content is still loading). Such callbacks are implementation details and must
+ * not assume browser‑specific behaviors; they should operate on already‑parsed elements rather than
+ * raw text.
+ *
+ * <p>Concurrency and threading: Implementations are typically stateless or only keep per‑request
+ * state; they should be reusable across requests when documented as thread‑safe. Callers should
+ * confine any mutable filter instance to a single request context and avoid sharing it across
+ * threads unless explicitly safe to do so.
+ *
+ * <ul>
+ *   <li><b>Responsibilities</b>: identify safe constructs, sanitize or drop unsafe parts, surface
+ *       clear warnings for partially filtered content.
+ *   <li><b>Typical use</b>: select a filter by MIME type, stream the response through it, and
+ *       forward the result to the browser or storage.
+ *   <li><b>Design</b>: default‑deny (whitelist) parsing; favor deterministic, streaming
+ *       transformations over best‑effort pattern matching.
+ * </ul>
+ *
+ * <p>Example (conceptual):
+ *
+ * <pre>{@code
+ * // Pseudocode: choose a filter and stream data through it
+ * var mime = response.contentType();
+ * var filter = Filters.forMimeType(mime); // returns a no-op filter if none exists
+ * try (InputStream in = response.openStream(); OutputStream out = browserSink()) {
+ *   filter.filter(in, out);
+ * }
+ * }</pre>
  */
 package network.crypta.client.filter;


### PR DESCRIPTION
Summary
- Doclint-clean Javadoc and expanded API docs across client filter package.
- Minor API polish and immutability tweaks; no behavioral changes intended unless noted.

Changes
- Javadoc: enrich and standardize documentation for the following:
  - `CodecPacketFilter`, `FilterCallback`, `FilterOperation`, `FoundURICallback`, `TagReplacerCallback`, `URIProcessor`, package-level docs.
  - Exception classes: `DataFilterException`, `CommentException`, `UnknownContentTypeException`, `UndetectableCharsetException`, `KnownUnsafeContentTypeException`, `UnknownCharsetException`, `UnsupportedCharsetInFilterException`, `UnsafeContentTypeException`.
  - Misc filters: `BMPFilter`, `CSSReadFilter`, `HTMLFilter`, `CharsetExtractor`, `CodecPacket`.
- API adjustments:
  - `UnsafeContentTypeException`: add an explicit protected no-arg constructor; improved doc contract for `details()`, `getHTMLEncodedTitle()`, and `getRawTitle()`.
  - `UnknownCharsetException`: remove unused `UnsupportedEncodingException` parameter from `create(...)` factory; now `create(String charset)`. Localized message assembly streamlined.
  - `KnownUnsafeContentTypeException`: make `type` field `final`; simplify localized title helper via `l10nTitle(...)`; tighten docs around immutability.
- Tests:
  - Update `BMPFilterTest` for clarity and modern assertions.
  - Remove obsolete `CodecPacketTest` (covered elsewhere after refactors).
- Formatting: Spotless formatting applied where necessary.

Diffstat (origin/develop..HEAD)
```
 23 files changed, 1468 insertions(+), 656 deletions(-)
 M src/main/java/network/crypta/client/filter/BMPFilter.java
 M src/main/java/network/crypta/client/filter/CSSReadFilter.java
 M src/main/java/network/crypta/client/filter/CharsetExtractor.java
 M src/main/java/network/crypta/client/filter/CodecPacket.java
 M src/main/java/network/crypta/client/filter/CodecPacketFilter.java
 M src/main/java/network/crypta/client/filter/CommentException.java
 M src/main/java/network/crypta/client/filter/DataFilterException.java
 M src/main/java/network/crypta/client/filter/FilterCallback.java
 M src/main/java/network/crypta/client/filter/FilterOperation.java
 M src/main/java/network/crypta/client/filter/FoundURICallback.java
 M src/main/java/network/crypta/client/filter/HTMLFilter.java
 M src/main/java/network/crypta/client/filter/KnownUnsafeContentTypeException.java
 M src/main/java/network/crypta/client/filter/LinkFilterExceptionProvider.java
 M src/main/java/network/crypta/client/filter/TagReplacerCallback.java
 M src/main/java/network/crypta/client/filter/URIProcessor.java
 M src/main/java/network/crypta/client/filter/UndetectableCharsetException.java
 M src/main/java/network/crypta/client/filter/UnknownCharsetException.java
 M src/main/java/network/crypta/client/filter/UnknownContentTypeException.java
 M src/main/java/network/crypta/client/filter/UnsafeContentTypeException.java
 M src/main/java/network/crypta/client/filter/UnsupportedCharsetInFilterException.java
 M src/main/java/network/crypta/client/filter/package-info.java
 M src/test/java/network/crypta/client/filter/BMPFilterTest.java
 D src/test/java/network/crypta/client/filter/CodecPacketTest.java
```

Commit list (ahead of develop)
- a0fb4c7595 docs(client-filter): doclint-clean package Javadoc; expand API docs
- 984c2d312d docs(client-filter): doclint-clean Javadoc for URIProcessor; run Spotless
- ba92693cf0 docs(client): add doclint-clean Javadoc for UnsupportedCharsetInFilterException
- 90ca8024c4 docs(javadoc): doclint-clean UnsafeContentTypeException and enrich API docs; set constructor protected
- 1728d50c34 docs: make UnknownContentTypeException Javadoc doclint-clean; enrich long-form API docs
- 208e5206b9 fix(client-filter): remove unused parameter and add doclint-clean Javadoc for UnknownCharsetException
- c9201454fc docs(client/filter): doclint-clean Javadoc for UndetectableCharsetException
- 8c930baf6a docs(client/filter): doclint-clean Javadoc for TagReplacerCallback; run spotless
- b183eb3102 docs: doclint-clean Javadoc for LinkFilterExceptionProvider (expand API docs, no behavior change)
- 6164a68f62 docs(client): doclint-clean Javadoc for KnownUnsafeContentTypeException; make field final and simplify l10n title helper
- 493f9849df docs: doclint-clean Javadoc for FoundURICallback; expand API docs
- 9369dfff94 docs(filter): doclint-clean Javadoc for FilterOperation enum; apply Spotless formatting
- 3c3162befb docs(client-filter): doclint-clean Javadoc for FilterCallback
- 8e366f76c8 docs(client): doclint-clean Javadoc for DataFilterException; enrich public API docs
- 5b60dfd12d docs(client/filter): doclint-clean Javadoc for CommentException with long-form API docs
- b3d034832d Merge branch 'develop' into feature/doc-filter-classes
- c6641cab5f docs(client): doclint-clean Javadoc for CodecPacketFilter and enrich public API docs
- 271a79a6f2 docs: doclint-clean Javadoc for CharsetExtractor and apply Spotless formatting

Compatibility notes
- `UnknownCharsetException.create(...)` signature change may require updating call sites.
- `UnsafeContentTypeException` adds an explicit protected ctor; as an abstract type, direct instantiation outside subclassing was already non-idiomatic.

Testing
- No functional changes intended beyond the minor API/visibility tweaks above.
- Unit tests adjusted accordingly; full suite passes locally prior to PR.
