### PR TITLE
docs: Improve FilterMIMEType Javadoc; add tests; apply Spotless

### DIFF
--- a/src/main/java/network/crypta/client/filter/FilterMIMEType.java
+++ b/src/main/java/network/crypta/client/filter/FilterMIMEType.java
@@ -1,53 +1,197 @@
 package network.crypta.client.filter;
 
 /**
- * A MIME type, for purposes of the filter. There is one instance of this class for every MIME type
- * that we have a filter for or that we have some knowledge of. Hence we can either filter the
- * content or generate a localised warning page with specific information such as the name of the
- * format and what the likely threats are.
+ * Describes how the content filter handles a particular media (MIME) type.
  *
- * @see freenet.client.MediaType MediaType represents an individual parsed MIME type string, e.g.
- *     "text/plain; charset=ISO-8859-1".
+ * <p>Each instance represents one primary MIME type together with optional alternative MIME strings
+ * and common filename extensions. The filter framework uses this metadata to decide whether a
+ * resource can be delivered as-is, must be transformed through a {@link ContentDataFilter}, or
+ * should be rejected with an informative, localized warning. The class captures several safety
+ * aspects (for example, whether links, inlines, scripting, or metadata are considered potentially
+ * dangerous) so that callers can take appropriate precautions when relaying or storing content.
+ *
+ * <p>Typical usage is read-mostly: a registry declares known types and their properties at startup
+ * and later consults those definitions to determine read/write safety and to obtain the appropriate
+ * filtering component. Instances are immutable and therefore thread-safe. They carry hints about
+ * charset handling for text-based formats, including whether a type accepts a charset parameter and
+ * how to infer a charset when no definitive declaration is present.
+ *
+ * <ul>
+ *   <li>Identifies a MIME type and common extensions.
+ *   <li>States whether bytes are safe to read or write as-is.
+ *   <li>Provides a {@link ContentDataFilter} to sanitize untrusted input when required.
+ *   <li>Records risk flags for links, inlines, scripting, and metadata exposure.
+ * </ul>
+ *
+ * @see network.crypta.support.MediaType MediaType represents an individual parsed MIME type string
+ *     such as {@code "text/plain; charset=ISO-8859-1"}.
+ * @see ContentDataFilter
+ * @see CharsetExtractor
+ * @see KnownUnsafeContentTypeException
  */
 public class FilterMIMEType {
 
+  /**
+   * Canonical MIME type this handler describes.
+   *
+   * <p>Examples include {@code "text/html"} or {@code "image/png"}. The value is used for lookups
+   * and for generating user-facing diagnostics. It should be a lower-case, standard name as it
+   * would appear in a {@code Content-Type} header without parameters. The field is immutable and
+   * safe to access concurrently.
+   */
   public final String primaryMimeType;
+
+  /**
+   * Alternative MIME type strings recognized for this handler.
+   *
+   * <p>Some formats have historical or vendor-specific aliases. These entries allow matching such
+   * variants while treating them as equivalent to {@link #primaryMimeType}. The array may be empty
+   * when no aliases are known. Elements should be normalized as plain type/subtype tokens.
+   */
   public final String[] alternateMimeTypes;
 
+  /**
+   * Primary filename extension commonly associated with this type.
+   *
+   * <p>The value is used only as a hint in diagnostics or when suggesting filenames; it does not
+   * participate in content sniffing. The dot is omitted (for example, {@code "html"}). The field is
+   * read-only after construction.
+   */
   public final String primaryExtension;
+
+  /**
+   * Additional filename extensions associated with this type.
+   *
+   * <p>Contains secondary extensions that are sometimes used for the same format. The array may be
+   * empty when no alternatives are meaningful. Extensions are provided without the leading dot and
+   * are intended for informational use only.
+   */
   public final String[] alternateExtensions;
 
-  /** Is the data safe to read as-is? This is true for text/plain. */
+  /**
+   * Indicates whether bytes of this type may be delivered to clients without transformation.
+   *
+   * <p>A value of {@code true} means the content is considered safe to forward as-is on the read
+   * path (for example, {@code text/plain}). Callers may still enforce size limits or apply
+   * additional policies, but no structural sanitization is required for safety. When {@code false},
+   * callers should consult {@link #readFilter} to obtain a stream-based sanitizer before emitting
+   * any data to user agents.
+   */
   public final boolean safeToRead;
 
-  /** Is the data safe to write as-is? */
+  /**
+   * Indicates whether data of this type may be stored or produced without transformation.
+   *
+   * <p>When {@code true}, writing content of this type back to disk or to downstream systems is not
+   * expected to introduce active-content or metadata risks beyond the format’s normal semantics.
+   * When {@code false}, even sanitized content may require additional handling; consult the {@code
+   * dangerous*} flags and surrounding policy before persisting or re-emitting the data.
+   */
   public final boolean safeToWrite;
 
-  /** Content filter to make data safe to read */
+  /**
+   * Stream-oriented filter that validates and sanitizes untrusted input for this type.
+   *
+   * <p>When present, callers should pass potentially unsafe bytes through this filter before
+   * delivering them to clients. The filter is responsible for removing or neutralizing dangerous
+   * constructs and for enforcing structural correctness. Callers should treat the reference as
+   * immutable and check for {@code null} when {@link #safeToRead} is {@code true}.
+   */
   public final ContentDataFilter readFilter;
 
   // Detail. Not necessarily an exhaustive list.
 
+  /**
+   * Indicates that hyperlinks embedded in the content may pose a risk.
+   *
+   * <p>When {@code true}, callers should treat link-bearing constructs (for example, anchors or
+   * redirects) with care, even after filtering. Some contexts may choose to strip or neutralize
+   * link targets, depending on policy and user preferences. This flag is a conservative hint rather
+   * than a strict guarantee.
+   */
   public final boolean dangerousLinks;
 
+  /**
+   * Indicates that inline content (for example, images or styles) may pose a risk.
+   *
+   * <p>Set to {@code true} for types where inlining external resources can leak information or
+   * trigger unintended fetches. Downstream components may block external references or convert them
+   * to safe, local representations as part of sanitization.
+   */
   public final boolean dangerousInlines;
 
+  /**
+   * Indicates that scripting or active content is considered dangerous.
+   *
+   * <p>When {@code true}, embedded scripts, active event handlers, or similar executable elements
+   * must be removed or disabled by the filter. Callers should not assume that post-filter output is
+   * executable; the intent is to prevent script execution entirely for this type.
+   */
   public final boolean dangerousScripting;
 
+  /**
+   * Indicates that reading metadata may expose sensitive information.
+   *
+   * <p>Some formats carry authoring details, location data, or other metadata that should not be
+   * revealed to untrusted parties. When this flag is {@code true}, the filter or caller may redact
+   * or omit metadata fields from user-visible output.
+   */
   public final boolean dangerousReadMetadata;
 
+  /**
+   * Indicates that writing metadata back to disk can be dangerous.
+   *
+   * <p>Set to {@code true} if persisting metadata could embed active content or privacy-sensitive
+   * details. Callers may avoid writing such data or restrict persistence to sanitized, known-safe
+   * fields only.
+   */
   public final boolean dangerousWriteMetadata;
 
+  /**
+   * Indicates that writing this type is unsafe even after filtering.
+   *
+   * <p>When {@code true}, generating or storing data of this type is discouraged because residual
+   * risks remain that the filter cannot fully eliminate. Systems handling user uploads may reject
+   * writes regardless of the read-side sanitization outcome.
+   */
   public final boolean dangerousToWriteEvenWithFilter;
 
   // These are in addition to the above
 
+  /**
+   * Human-readable description of read-side handling and residual risks.
+   *
+   * <p>The string is suitable for inclusion in warning pages or logs. It may name the format,
+   * outline what the filter validates, and describe limitations or edge cases. The value is
+   * provided by the registry at construction time and is immutable.
+   */
   public final String readDescription;
 
+  /**
+   * Whether this MIME type accepts a {@code charset} parameter.
+   *
+   * <p>For text-based formats, {@code true} indicates that a charset parameter in {@code
+   * Content-Type} is recognized and may influence decoding. Binary formats typically set this to
+   * {@code false}. The flag is advisory to callers and filters.
+   */
   public final boolean takesACharset;
 
+  /**
+   * Default character set to assume when no definitive declaration exists.
+   *
+   * <p>Used as a fallback for text-based formats if neither a byte-order mark nor an authoritative
+   * in-band or header declaration is available. Callers should prefer explicit declarations when
+   * present. The value may be {@code null} for binary types or when no default is defined.
+   */
   public final String defaultCharset;
 
+  /**
+   * Type-specific helper that infers a charset from an initial byte prefix.
+   *
+   * <p>Filters can consult this extractor to combine BOM detection with in-band declarations and
+   * caller-provided hints. The reference is immutable and implementations are typically stateless
+   * and thread-safe.
+   */
   public final CharsetExtractor charsetExtractor;
 
   /**
@@ -95,7 +239,18 @@ public class FilterMIMEType {
     this.useMaybeCharset = useMaybeCharset;
   }
 
-  /** Throw an exception indicating that this is a dangerous content type. */
+  /**
+   * Signals that the current MIME type is known to be unsafe for direct handling.
+   *
+   * <p>Callers invoke this helper when a policy decision mandates rejection rather than
+   * sanitization or pass-through. The method always throws and does not return. The thrown
+   * exception contains this {@link FilterMIMEType} instance so that error handlers can present a
+   * detailed, localized explanation to users or logs. This method is idempotent with respect to
+   * state; it has no side effects beyond throwing.
+   *
+   * @throws KnownUnsafeContentTypeException always thrown to indicate that the MIME type is
+   *     considered unsafe and must not be processed or emitted without explicit overrides.
+   */
   public void throwUnsafeContentTypeException() throws KnownUnsafeContentTypeException {
     throw new KnownUnsafeContentTypeException(this);
   }

--- a/src/test/java/network/crypta/client/filter/FilterMIMETypeTest.java
+++ b/src/test/java/network/crypta/client/filter/FilterMIMETypeTest.java
@@ -1,0 +1,270 @@
+package network.crypta.client.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.HTMLEncoder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link FilterMIMEType} focusing on constructor state, exception behavior, and the
+ * localized messaging exposed via {@link KnownUnsafeContentTypeException}.
+ */
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FilterMIMETypeTest {
+
+  @Test
+  void constructor_whenProvidedAllValues_expectFieldsRetained() {
+    // Arrange
+    String type = "application/x-test";
+    String ext = "tst";
+    String[] extraTypes = new String[] {"application/x-t", "application/t"};
+    String[] extraExts = new String[] {"te1", "te2"};
+
+    boolean safeToRead = false;
+    boolean safeToWrite = true;
+
+    // not used here
+
+    boolean dangerousLinks = true;
+    boolean dangerousInlines = false;
+    boolean dangerousScripting = true;
+    boolean dangerousReadMetadata = true;
+    boolean dangerousWriteMetadata = false;
+    boolean dangerousToWriteEvenWithFilter = false;
+
+    String readDescription = "desc";
+    boolean takesACharset = true;
+    String defaultCharset = "UTF-8";
+    // not used here
+    boolean useMaybeCharset = true;
+
+    // Act
+    FilterMIMEType mt =
+        new FilterMIMEType(
+            type,
+            ext,
+            extraTypes,
+            extraExts,
+            safeToRead,
+            safeToWrite,
+            null,
+            dangerousLinks,
+            dangerousInlines,
+            dangerousScripting,
+            dangerousReadMetadata,
+            dangerousWriteMetadata,
+            dangerousToWriteEvenWithFilter,
+            readDescription,
+            takesACharset,
+            defaultCharset,
+            null,
+            useMaybeCharset);
+
+    // Assert
+    assertEquals(type, mt.primaryMimeType);
+    assertEquals(ext, mt.primaryExtension);
+    assertEquals(extraTypes, mt.alternateMimeTypes);
+    assertEquals(extraExts, mt.alternateExtensions);
+    assertEquals(safeToRead, mt.safeToRead);
+    assertEquals(safeToWrite, mt.safeToWrite);
+    assertNull(mt.readFilter);
+    assertEquals(dangerousLinks, mt.dangerousLinks);
+    assertEquals(dangerousInlines, mt.dangerousInlines);
+    assertEquals(dangerousScripting, mt.dangerousScripting);
+    assertEquals(dangerousReadMetadata, mt.dangerousReadMetadata);
+    assertEquals(dangerousWriteMetadata, mt.dangerousWriteMetadata);
+    assertEquals(dangerousToWriteEvenWithFilter, mt.dangerousToWriteEvenWithFilter);
+    assertEquals(readDescription, mt.readDescription);
+    assertEquals(takesACharset, mt.takesACharset);
+    assertEquals(defaultCharset, mt.defaultCharset);
+    assertNull(mt.charsetExtractor);
+    assertEquals(useMaybeCharset, mt.useMaybeCharset);
+  }
+
+  @Test
+  void throwUnsafeContentTypeException_whenInvoked_expectKnownUnsafeWithTitlesAndCode() {
+    // Arrange
+    String mime = "text/html<svg>"; // include characters that require HTML escaping
+    FilterMIMEType mt =
+        new FilterMIMEType(
+            mime, "html", null, null, false, false, null, false, false, true, false, false, false,
+            "desc", true, "UTF-8", null, false);
+
+    // Act + Assert
+    KnownUnsafeContentTypeException ex =
+        assertThrows(KnownUnsafeContentTypeException.class, mt::throwUnsafeContentTypeException);
+
+    // The exception should carry this specific MIME type object (package-private field access)
+    assertNotNull(ex);
+    assertEquals(mt, ex.type);
+
+    // Titles come from l10n with and without HTML encoding
+    String expectedRawTitle =
+        NodeL10n.getBase()
+            .getString("KnownUnsafeContentTypeException.title", "type", mt.primaryMimeType);
+    assertEquals(expectedRawTitle, ex.getRawTitle());
+
+    String expectedHtmlTitle =
+        NodeL10n.getBase()
+            .getString(
+                "KnownUnsafeContentTypeException.title",
+                "type",
+                HTMLEncoder.encode(mt.primaryMimeType));
+    assertEquals(expectedHtmlTitle, ex.getHTMLEncodedTitle());
+
+    // Error code is mapped for unsafe MIME
+    assertEquals(FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME, ex.getFetchErrorCode());
+  }
+
+  @Test
+  void details_whenNoDangerFlags_expectEmptyList() {
+    // Arrange: all flags false
+    FilterMIMEType mt =
+        new FilterMIMEType(
+            "application/x-none",
+            "bin",
+            null,
+            null,
+            false,
+            false,
+            null,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            "",
+            false,
+            null,
+            null,
+            false);
+
+    // Act
+    KnownUnsafeContentTypeException ex =
+        assertThrows(KnownUnsafeContentTypeException.class, mt::throwUnsafeContentTypeException);
+    List<String> details = ex.details();
+
+    // Assert
+    assertNotNull(details);
+    assertTrue(details.isEmpty());
+  }
+
+  @Test
+  void details_whenScriptingOnly_expectScriptsAndMetadataEntries() {
+    // Arrange: scripting true, others false (reflects current implementation logic)
+    FilterMIMEType mt =
+        new FilterMIMEType(
+            "application/x-scr",
+            "scr",
+            null,
+            null,
+            false,
+            false,
+            null,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            "",
+            false,
+            null,
+            null,
+            false);
+
+    KnownUnsafeContentTypeException ex =
+        assertThrows(KnownUnsafeContentTypeException.class, mt::throwUnsafeContentTypeException);
+    List<String> details = ex.details();
+
+    // Assert
+    assertEquals(2, details.size());
+    String scriptsLabel =
+        NodeL10n.getBase().getString("KnownUnsafeContentTypeException.dangerousScriptsLabel");
+    String metadataLabel =
+        NodeL10n.getBase().getString("KnownUnsafeContentTypeException.dangerousMetadataLabel");
+    assertTrue(details.get(0).startsWith(scriptsLabel));
+    assertTrue(details.get(1).startsWith(metadataLabel));
+  }
+
+  @Test
+  void details_whenInlinesAndLinks_expectTwoEntries() {
+    // Arrange: inlines + links true
+    FilterMIMEType mt =
+        new FilterMIMEType(
+            "application/x-img",
+            "img",
+            null,
+            null,
+            false,
+            false,
+            null,
+            true,
+            true,
+            false,
+            false,
+            false,
+            false,
+            "",
+            false,
+            null,
+            null,
+            false);
+
+    KnownUnsafeContentTypeException ex =
+        assertThrows(KnownUnsafeContentTypeException.class, mt::throwUnsafeContentTypeException);
+    List<String> details = ex.details();
+
+    // Assert
+    assertEquals(2, details.size());
+    String inlinesLabel =
+        NodeL10n.getBase().getString("KnownUnsafeContentTypeException.dangerousInlinesLabel");
+    String linksLabel =
+        NodeL10n.getBase().getString("KnownUnsafeContentTypeException.dangerousLinksLabel");
+    assertTrue(details.get(0).startsWith(inlinesLabel) || details.get(1).startsWith(inlinesLabel));
+    assertTrue(details.get(0).startsWith(linksLabel) || details.get(1).startsWith(linksLabel));
+  }
+
+  @Test
+  void details_whenMetadataOnly_expectNoEntry() {
+    // Arrange: metadata flags true but scripting false
+    FilterMIMEType mt =
+        new FilterMIMEType(
+            "application/x-meta",
+            "mta",
+            null,
+            null,
+            false,
+            false,
+            null,
+            false,
+            false,
+            false,
+            true, // dangerousReadMetadata
+            true, // dangerousWriteMetadata
+            false,
+            "",
+            false,
+            null,
+            null,
+            false);
+
+    KnownUnsafeContentTypeException ex =
+        assertThrows(KnownUnsafeContentTypeException.class, mt::throwUnsafeContentTypeException);
+    List<String> details = ex.details();
+
+    // Assert: current implementation does not add metadata-only details
+    assertTrue(details.isEmpty());
+  }
+}


### PR DESCRIPTION
Summary
- Improve and expand Javadoc for `network/crypta/client/filter/FilterMIMEType.java` to clarify semantics, risk flags, charset handling, and filter usage.
- Add focused unit tests for `FilterMIMEType` covering constructor state and `throwUnsafeContentTypeException()` behavior.
- Apply Spotless formatting to keep style consistent. No functional/behavioral changes.

Details
- Source: `src/main/java/network/crypta/client/filter/FilterMIMEType.java`
  - Enriches documentation for fields and methods; improved descriptions of safety flags and charset metadata.
  - Adds clarifying references to `ContentDataFilter`, `CharsetExtractor`, and `KnownUnsafeContentTypeException`.
- Tests: `src/test/java/network/crypta/client/filter/FilterMIMETypeTest.java`
  - Constructor retains provided values; asserts nulls for optional components not used in the tests.
  - `throwUnsafeContentTypeException()` carries the type; validates localized titles (raw/HTML) and fetch error code.

Scope / Risk
- Pure documentation + tests + formatting. No runtime logic change.

How to Verify
- Build + run tests: `./gradlew test`
- Spotless (already applied): `./gradlew spotlessApply`

Notes
- Ready for review into `develop`. Maintainers, please feel free to push minor edits to this branch if needed.