### PR TITLE
feat(filter): harden GenericReadFilterCallback and add unit tests

### DIFF
--- a/src/main/java/network/crypta/client/filter/GenericReadFilterCallback.java
+++ b/src/main/java/network/crypta/client/filter/GenericReadFilterCallback.java
@@ -6,7 +6,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
 import network.crypta.clients.http.ExternalLinkToadlet;
@@ -15,27 +15,87 @@ import network.crypta.clients.http.StaticToadlet;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.support.*;
+import network.crypta.support.URIPreEncoder;
+import network.crypta.support.URLDecoder;
+import network.crypta.support.URLEncodedFormatException;
 import network.crypta.support.api.HTTPRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Filters and normalizes URIs discovered while reading user-provided HTML content.
+ *
+ * <p>This callback is used by the HTML read filter to validate links, rewrite references into
+ * Crypta-safe forms, and decide whether a particular URI should be allowed to pass through. It is
+ * designed for untrusted input: the implementation prefers safety and determinism over permissive
+ * behavior. Typical usage is as an instance passed to the HTML filter; the filter invokes the
+ * methods defined by {@link FilterCallback} and {@link URIProcessor} whenever it encounters text,
+ * tags, or attributes that may embed an address.
+ *
+ * <p>Key behaviors include:
+ *
+ * <ul>
+ *   <li>Resolution of relative references against a base URI provided at construction time.
+ *   <li>Protocol allow‑listing for external links and strict validation of Freenet-style keys.
+ *   <li>Normalization and sanitization of fragments, queries, and character encodings.
+ * </ul>
+ *
+ * <p>The class is mutable only with respect to the current base URI (it is updated when a valid
+ * {@code <base href>} is encountered). All other operations are stateless and thread-safe with
+ * regard to shared constants, but instances are not intended for concurrent reuse during a single
+ * parse because they track base-URI state per document.
+ *
+ * @see FilterCallback
+ * @see URIProcessor
+ */
 public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
   private static final Logger LOG = LoggerFactory.getLogger(GenericReadFilterCallback.class);
 
-  public static final HashSet<String> allowedProtocols;
+  private static final Set<String> allowedProtocols;
+
   // RFC3986
   //  unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
-  protected static final String UNRESERVED = "[a-zA-Z0-9\\-\\._~]";
+  /**
+   * Pattern for an RFC 3986 "unreserved" character. The value matches ASCII letters, digits and the
+   * characters {@code - . _ ~}. It is used as a building block for more complete expressions that
+   * validate or sanitize user-supplied URI components. The constant is exposed as {@code protected}
+   * for reuse in specialized filters.
+   */
+  protected static final String UNRESERVED = "[a-zA-Z0-9\\-._~]";
+
   //  pct-encoded   = "%" HEXDIG HEXDIG
-  protected static final String PCT_ENCODED = "(?:%[0-9A-Fa-f][0-9A-Fa-f])";
+  /**
+   * Pattern for an RFC 3986 percent-encoded octet. It matches a percent sign followed by two
+   * hexadecimal digits. Callers typically combine this with {@link #UNRESERVED} and other tokens to
+   * recognize valid path/query fragments without decoding first.
+   */
+  protected static final String PCT_ENCODED = "%[0-9A-Fa-f][0-9A-Fa-f]";
+
   //  sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
   //                / "*" / "+" / "," / ";" / "="
-  protected static final String SUB_DELIMS = "[\\!\\$&'\\(\\)\\*\\+,;=]";
+  /**
+   * Pattern for RFC 3986 sub-delimiters. These symbols are allowed in various URI components and
+   * are treated as literals when percent-encoding is not required. Exposing the value enables
+   * consistent validation across related filters.
+   */
+  protected static final String SUB_DELIMS = "[!$&'()*+,;=]";
+
   //  pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+  /**
+   * Pattern for the RFC 3986 {@code pchar} production, combining unreserved characters,
+   * percent-encoded octets, sub-delimiters, and the literal characters {@code :} and {@code @}.
+   * Used to validate path segments and similar components without performing decoding.
+   */
   protected static final String PCHAR =
       "(?>" + UNRESERVED + "|" + PCT_ENCODED + "|" + SUB_DELIMS + "|[:@])";
-  protected static final String FRAGMENT = "(?>" + PCHAR + "|\\/|\\?)*";
+
+  /**
+   * Pattern for RFC 3986 fragment content. It accepts a sequence of {@link #PCHAR} along with
+   * forward slashes and question marks. This is intentionally permissive within the standard’s
+   * constraints to allow safe passthrough of anchors.
+   */
+  protected static final String FRAGMENT = "(?>" + PCHAR + "|/|\\?)*";
+
   //  fragment      = *( pchar / "/" / "?" )
   static final String PLUGINS_PREFIX = "/plugins/";
   private static final Pattern anchorRegex;
@@ -43,20 +103,9 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
   private static BaseL10n l10n = NodeL10n.getBase();
 
   static {
-    allowedProtocols = new HashSet<>();
-    allowedProtocols.add("http");
-    allowedProtocols.add("https");
-    allowedProtocols.add("ftp");
-    allowedProtocols.add("mailto");
-    allowedProtocols.add("nntp");
-    allowedProtocols.add("news");
-    allowedProtocols.add("snews");
-    allowedProtocols.add("about");
-    allowedProtocols.add("irc");
+    allowedProtocols =
+        Set.of("http", "https", "ftp", "mailto", "nntp", "news", "snews", "about", "irc");
     // file:// ?
-  }
-
-  static {
   }
 
   static {
@@ -72,6 +121,26 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
   private URI baseURI;
   private URI strippedBaseURI;
 
+  private static final String ERROR_KEY = "error";
+
+  /**
+   * Creates a new callback bound to a specific base {@link URI}. The base is used to resolve
+   * relative references and may be updated later via a valid {@code <base href>} discovered during
+   * processing.
+   *
+   * <p>The supplied callbacks are optional: when present, {@code cb} receives notifications about
+   * URIs that were recognized, and {@code trc} can replace or rewrite parsed tags during filtering.
+   * The exception provider allows explicit per-URI exemptions from strict filtering rules.
+   *
+   * @param uri Base URI used to resolve relative links and to compute stripped variants. Must be an
+   *     absolute URI suitable for HTML resolution; {@code null} is not permitted.
+   * @param cb Callback notified when URIs are found. May be {@code null} if the caller does not
+   *     need notifications.
+   * @param trc Tag replacement callback invoked for each parsed tag. May be {@code null} to disable
+   *     tag-level rewrites.
+   * @param linkFilterExceptionProvider Provider consulted to decide whether a given link should be
+   *     excepted from standard filtering. May be {@code null} for default behavior.
+   */
   public GenericReadFilterCallback(
       URI uri,
       FoundURICallback cb,
@@ -84,6 +153,21 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
     setStrippedURI(uri.toString());
   }
 
+  /**
+   * Creates a new callback from a {@code FreenetURI}. The URI is converted to a relative {@link
+   * URI} suitable for use as a base for resolution.
+   *
+   * @param uri Base key represented as a {@code FreenetURI}. Must parse into a valid relative
+   *     {@code URI} for subsequent resolution operations.
+   * @param cb Callback notified when URIs are found. May be {@code null} if notifications are not
+   *     required by the caller.
+   * @param trc Tag replacement callback invoked for each parsed tag. May be {@code null} to disable
+   *     tag-level rewrites.
+   * @param linkFilterExceptionProvider Provider consulted to decide whether a given link should be
+   *     excepted from standard filtering. May be {@code null} for default behavior.
+   * @throws IllegalArgumentException if the {@code FreenetURI} cannot be converted to a relative
+   *     {@code URI} due to a syntax error.
+   */
   public GenericReadFilterCallback(
       FreenetURI uri,
       FoundURICallback cb,
@@ -96,7 +180,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       this.trc = trc;
       this.linkFilterExceptionProvider = linkFilterExceptionProvider;
     } catch (URISyntaxException e) {
-      throw new Error(e);
+      throw new IllegalArgumentException(e);
     }
   }
 
@@ -120,11 +204,44 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
     return l10n.getString("GenericReadFilterCallback." + key);
   }
 
+  /**
+   * Processes a single URI reference using default options.
+   *
+   * <p>The input is parsed, normalized, and either rewritten into a safe form or rejected based on
+   * protocol and path rules. Relative references are resolved against the current base URI. Use the
+   * multi-argument overloads to control base-href handling or inline context.
+   *
+   * @param u Raw URI string taken from markup or attribute content. May be absolute or relative,
+   *     and may contain percent-encoded sequences.
+   * @param overrideType Optional media-type override used when building internal links. When {@code
+   *     null}, no override is applied.
+   * @return A sanitized, ASCII-safe URI string suitable for emission back into the filtered
+   *     document.
+   * @throws CommentException if the input cannot be parsed, uses a disallowed protocol, or violates
+   *     filter safety constraints.
+   */
   @Override
   public String processURI(String u, String overrideType) throws CommentException {
     return processURI(u, overrideType, false, false);
   }
 
+  /**
+   * Processes a URI reference with explicit control over base-href semantics and inline context.
+   *
+   * <p>When {@code forBaseHref} is {@code true}, the input is treated as a candidate for {@code
+   * <base href>} and must not be relative. The {@code inline} flag allows callers to annotate that
+   * the URI was found in inline content; this only affects callbacks, not the rewriting logic.
+   *
+   * @param u Raw URI string as encountered. Must be syntactically valid after preprocessing.
+   * @param overrideType Optional media-type override appended to internal links. {@code null} to
+   *     omit.
+   * @param forBaseHref Whether the value originates from a {@code <base href>} attribute; relative
+   *     input is rejected in this mode.
+   * @param inline Hints that the reference was found in inline content. Used for notifications.
+   * @return The sanitized, resolved URI string appropriate for reinsertion into the document.
+   * @throws CommentException if the value is malformed, forbidden by policy, or not acceptable in
+   *     the requested mode.
+   */
   @Override
   public String processURI(String u, String overrideType, boolean forBaseHref, boolean inline)
       throws CommentException {
@@ -133,150 +250,46 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       return u;
     }
 
-    boolean noRelative = forBaseHref;
     // evil hack, see #2451 and r24565,r24566
-    u = u.replaceAll(" #", " %23");
+    u = u.replace(" #", " %23");
 
-    URI uri;
-    URI resolved;
-    try {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Processing " + u);
-      }
-      uri = URIPreEncoder.encodeURI(u).normalize();
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Processing " + uri);
-      }
-      if (u.startsWith("/") || u.startsWith("%2f"))
-      // Don't bother with relative URIs if it's obviously absolute.
-      // Don't allow encoded /'s, they're just too confusing (here they would get decoded
-      // and then coalesced with other slashes).
-      {
-        noRelative = true;
-      }
-      if (!noRelative) {
-        resolved = baseURI.resolve(uri);
-      } else {
-        resolved = uri;
-      }
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Resolved: " + resolved);
-      }
-    } catch (URISyntaxException e1) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Failed to parse URI: " + e1);
-      }
-      throw new CommentException(l10n("couldNotParseURIWithError", "error", e1.getMessage()));
-    }
+    ParsedUris parsed = parseAndResolve(u, forBaseHref);
+    URI uri = parsed.uri;
+    URI resolved = parsed.resolved;
+
     String path = uri.getPath();
 
-    HTTPRequest req = new HTTPRequestImpl(uri, "GET");
-    if (path != null) {
-      if (path.equals("/") && req.isParameterSet("newbookmark") && !forBaseHref) {
-        return processBookmark(req);
-      } else if (path.startsWith(StaticToadlet.ROOT_URL)) {
-        // @see bug #2297
-        return path;
-      } else if (linkFilterExceptionProvider != null) {
-        if (linkFilterExceptionProvider.isLinkExcepted(uri)) {
-          return path + ((uri.getQuery() != null) ? ("?" + uri.getQuery()) : "");
-        }
-      }
+    String special = handlePathSpecialCases(uri, path, forBaseHref);
+    if (special != null) {
+      return special;
     }
 
     String reason = l10n("deletedURI");
 
-    // Try as an absolute URI
-
     URI origURI = uri;
 
     // Convert localhost uri's to relative internal ones.
+    uri = normalizeLocalhost(uri);
 
     String host = uri.getHost();
-    if (host != null
-        && (host.equals("localhost") || host.equals("127.0.0.1"))
-        && uri.getPort() == 8888) {
-      try {
-        uri = new URI(null, null, null, -1, uri.getPath(), uri.getQuery(), uri.getFragment());
-      } catch (URISyntaxException e) {
-        LOG.error("URI " + uri + " looked like localhost but could not parse", e);
-        throw new CommentException("URI looked like localhost but could not parse: " + e);
-      }
-      host = null;
-    }
-
     String rpath = uri.getPath();
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Path: \"" + path + "\" rpath: \"" + rpath + "\"");
+      LOG.debug("Path: \"{}\" rpath: \"{}\"", path, rpath);
     }
 
     if (host == null) {
-
-      boolean isAbsolute = false;
-
-      if (rpath != null) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Resolved URI (rpath absolute): \"" + rpath + "\"");
-        }
-
-        // Valid FreenetURI?
-        try {
-          String p = rpath;
-          while (p.startsWith("/")) {
-            p = p.substring(1);
-          }
-          FreenetURI furi = new FreenetURI(p, true);
-          isAbsolute = true;
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Parsed: " + furi);
-          }
-          return processURI(furi, uri, overrideType, true, inline);
-        } catch (MalformedURLException e) {
-          // Not a FreenetURI
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Malformed URL (a): " + e, e);
-          }
-          if (e.getMessage() != null) {
-            reason = l10n("malformedAbsoluteURL", "error", e.getMessage());
-          } else {
-            reason = l10n("couldNotParseAbsoluteCryptaURI");
-          }
-        }
+      String absoluteProcessed = tryProcessAbsolutePath(rpath, uri, overrideType, inline);
+      if (absoluteProcessed != null) {
+        return absoluteProcessed;
       }
+      reason = updateReasonIfAbsoluteMalformed(rpath, reason);
 
-      if ((!isAbsolute) && (!forBaseHref)) {
-
-        // Relative URI
-
-        rpath = resolved.getPath();
-        if (rpath == null) {
-          throw new CommentException("No URI");
+      if (!forBaseHref) {
+        String relativeProcessed = tryProcessRelativePath(resolved, uri, overrideType, inline);
+        if (relativeProcessed != null) {
+          return relativeProcessed;
         }
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Resolved URI (rpath relative): " + rpath);
-        }
-
-        // Valid FreenetURI?
-        try {
-          String p = rpath;
-          while (p.startsWith("/")) {
-            p = p.substring(1);
-          }
-          FreenetURI furi = new FreenetURI(p, true);
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Parsed: " + furi);
-          }
-          return processURI(furi, uri, overrideType, forBaseHref, inline);
-        } catch (MalformedURLException e) {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Malformed URL (b): " + e, e);
-          }
-          if (e.getMessage() != null) {
-            reason = l10n("malformedRelativeURL", "error", e.getMessage());
-          } else {
-            reason = l10n("couldNotParseRelativeCryptaURI");
-          }
-        }
+        reason = updateReasonIfRelativeMalformed(reason);
       }
     }
 
@@ -285,16 +298,32 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
     if (forBaseHref) {
       throw new CommentException(l10n("bogusBaseHref"));
     }
-    if (GenericReadFilterCallback.allowedProtocols.contains(uri.getScheme())) {
-      return ExternalLinkToadlet.escape(uri.toString());
-    } else {
-      if (uri.getScheme() == null) {
-        throw new CommentException(reason);
-      }
-      throw new CommentException(l10n("protocolNotEscaped", "protocol", uri.getScheme()));
+    if (uri.getScheme() == null) {
+      throw new CommentException(reason);
     }
+    if (allowedProtocols.contains(uri.getScheme())) {
+      return ExternalLinkToadlet.escape(uri.toString());
+    }
+    throw new CommentException(l10n("protocolNotEscaped", "protocol", uri.getScheme()));
   }
 
+  /**
+   * Processes a URI and, when the host is absent, prefixes it with a forced scheme/authority.
+   *
+   * <p>This overload is useful when filtering content that must resolve to an absolute address even
+   * when the source provided a relative form. If the processed URI already contains a host, the
+   * value is returned unchanged.
+   *
+   * @param u Raw URI string as encountered in the document.
+   * @param overrideType Optional media-type override appended for internal links; may be {@code
+   *     null}.
+   * @param forceSchemeHostAndPort A literal prefix such as {@code http://localhost:8888} to be
+   *     prepended when the processed URI does not specify a host.
+   * @param inline Hints that the reference was found in inline content. Used for notifications.
+   * @return A sanitized, absolute URI string, prefixed when necessary to include the given
+   *     scheme/host/port.
+   * @throws CommentException if the value is malformed or forbidden by policy.
+   */
   @Override
   public String processURI(
       String u, String overrideType, String forceSchemeHostAndPort, boolean inline)
@@ -306,9 +335,9 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       uri = URIPreEncoder.encodeURI(filtered).normalize();
     } catch (URISyntaxException e1) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Failed to parse URI: " + e1);
+        LOG.debug("Failed to parse URI: {}", String.valueOf(e1));
       }
-      throw new CommentException(l10n("couldNotParseURIWithError", "error", e1.getMessage()));
+      throw new CommentException(l10n("couldNotParseURIWithError", ERROR_KEY, e1.getMessage()));
     }
     if (uri.getHost() == null) {
       return forceSchemeHostAndPort + filtered;
@@ -316,34 +345,67 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
     return filtered;
   }
 
+  /**
+   * Resolves a possibly relative URI string against the current base and returns its ASCII form.
+   *
+   * <p>The input is first normalized using the project’s pre-encoder to ensure that reserved
+   * characters are percent-encoded as required for safe transport.
+   *
+   * @param uri A possibly relative URI string found in content; {@code null} is not permitted.
+   * @return An ASCII-only absolute URI string produced by resolution against the current base.
+   * @throws URISyntaxException if the input cannot be parsed or normalized into a syntactically
+   *     valid {@code URI}.
+   */
   @Override
   public String makeURIAbsolute(String uri) throws URISyntaxException {
     return baseURI.resolve(URIPreEncoder.encodeURI(uri).normalize()).toASCIIString();
   }
 
+  /**
+   * Handles a {@code <base href>} declaration and updates the current base URI when valid.
+   *
+   * <p>The supplied value is sanitized through the general URI processing routine in {@code
+   * forBaseHref} mode. When accepted, the internal base used for subsequent relative resolution is
+   * updated and the ASCII representation of the new base is returned.
+   *
+   * @param baseHref The candidate base-href value from markup.
+   * @return The ASCII form of the updated base URI when accepted, or {@code null} when the value is
+   *     rejected and the base remains unchanged.
+   */
   @Override
   public String onBaseHref(String baseHref) {
     String ret;
     try {
       ret = processURI(baseHref, null, true, false);
     } catch (CommentException e1) {
-      LOG.error("Failed to parse base href: " + baseHref + " -> " + e1.getMessage());
+      LOG.error("Failed to parse base href: {} -> {}", baseHref, e1.getMessage());
       ret = null;
     }
     if (ret == null) {
-      LOG.error("onBaseHref() failed: cannot sanitize " + baseHref);
+      LOG.error("onBaseHref() failed: cannot sanitize {}", baseHref);
       return null;
     } else {
       try {
         baseURI = new URI(ret);
         setStrippedURI(ret);
       } catch (URISyntaxException e) {
-        throw new Error(e); // Impossible
+        throw new IllegalStateException(e); // Impossible
       }
       return baseURI.toASCIIString();
     }
   }
 
+  /**
+   * Reports a text node encountered during filtering.
+   *
+   * <p>When a {@code FoundURICallback} is configured, this method forwards the text and its type
+   * together with the current base URI so callers can perform additional analysis or analytics. The
+   * method does not modify state and performs no rewriting.
+   *
+   * @param s The text content as extracted from the document. May be empty.
+   * @param type A short classifier supplied by the caller describing the context of the text (for
+   *     example, attribute kind or element name). May be {@code null} if unspecified.
+   */
   @Override
   public void onText(String s, String type) {
     if (cb != null) {
@@ -352,10 +414,19 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
   }
 
   /**
-   * Process a form. Current strategy: - Both POST and GET forms are allowed to / Anything that is
-   * hazardous should be protected through formPassword.
+   * Processes a form action and method discovered in the document and determines whether it is
+   * permitted. Only {@code GET} and {@code POST} methods are considered, and only actions targeting
+   * safe internal endpoints are allowed. When invalid, {@code null} is returned to indicate the
+   * element should be removed or left unchanged.
    *
-   * @throws CommentException If the form element could not be parsed and the user should be told.
+   * @param method The HTTP method as found in markup. Case-insensitive; when {@code null}, defaults
+   *     to {@code GET}. Values other than {@code GET} or {@code POST} are rejected.
+   * @param action The raw action attribute to be validated. Must be a relative path targeting a
+   *     permitted internal endpoint; absolute URIs and attempts to escape are disallowed.
+   * @return A sanitized, ASCII-safe action string if the form is allowed; otherwise {@code null}
+   *     when the action should be removed or ignored by the caller.
+   * @throws CommentException if the action cannot be parsed into a valid URI or violates the
+   *     filter’s safety rules.
    */
   @Override
   public String processForm(String method, String action) throws CommentException {
@@ -369,7 +440,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
     if (!(method.equals("POST") || method.equals("GET"))) {
       return null; // no irregular form sending methods
     }
-    // FIXME what about /downloads/ /friends/ etc?
+    // Note: Access to other internal paths (e.g., /downloads/, /friends/) is not permitted here.
     // Allow access to Library for searching, form passwords are used for actions such as adding
     // bookmarks
     if (action.equals("/library/")) {
@@ -389,23 +460,29 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
         if (after.contains("../")) {
           throw new CommentException(l10n("invalidFormURIAttemptToEscape"));
         }
-        if (after.matches("[A-Za-z0-9\\.]+")) {
+        if (after.matches("[A-Za-z0-9.]+")) {
           return uri.toASCIIString();
         }
       }
     } catch (URISyntaxException e) {
       throw new CommentException(
-          l10n("couldNotParseFormURIWithError", "error", e.getLocalizedMessage()));
+          l10n("couldNotParseFormURIWithError", ERROR_KEY, e.getLocalizedMessage()));
     }
     // Otherwise disallow.
     return null;
   }
 
   /**
-   * Processes a tag. It calls the TagReplacerCallback if present.
+   * Processes a single parsed tag and optionally replaces it using the configured {@code
+   * TagReplacerCallback}.
    *
-   * @param pt - The tag, that needs to be processed
-   * @return The replacement for the tag, or null, if no replacement needed
+   * <p>When a replacer was supplied at construction, the tag is delegated to it together with this
+   * callback for context. If no replacer is present, the method returns {@code null} to indicate
+   * that the original tag should be left untouched by the caller.
+   *
+   * @param pt The parsed tag instance to consider for replacement. Must not be {@code null}; tag
+   *     names and attributes are expected to be normalized by the caller’s parser.
+   * @return The replacement text for the tag or {@code null} when no replacement is required.
    */
   @Override
   public String processTag(ParsedTag pt) {
@@ -416,6 +493,12 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
     }
   }
 
+  /**
+   * Signals that the current page/document has been fully processed.
+   *
+   * <p>If a {@code FoundURICallback} was provided at construction, its {@code onFinishedPage}
+   * method is invoked to allow the caller to finalize any per-document bookkeeping.
+   */
   @Override
   public void onFinished() {
     if (cb != null) {
@@ -430,7 +513,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       try {
         strippedBaseURI = new URI(u);
       } catch (URISyntaxException e) {
-        LOG.error("Can't strip base URI: " + e + " parsing " + u);
+        LOG.error("Can't strip base URI: {} parsing {}", e, u);
         strippedBaseURI = baseURI;
       }
     } else {
@@ -440,20 +523,20 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
 
   private String processBookmark(HTTPRequest req) throws CommentException {
     // allow links to the root to add bookmarks
-    String bookmark_key = req.getParam("newbookmark");
-    String bookmark_desc = req.getParam("desc");
-    String bookmark_activelink = req.getParam("hasAnActivelink", "");
+    String bookmarkKey = req.getParam("newbookmark");
+    String bookmarkDesc = req.getParam("desc");
+    String bookmarkActivelink = req.getParam("hasAnActivelink", "");
 
     try {
-      FreenetURI furi = new FreenetURI(bookmark_key);
-      bookmark_key = furi.toString();
-      bookmark_desc = URLEncoder.encode(bookmark_desc, StandardCharsets.UTF_8);
+      FreenetURI furi = new FreenetURI(bookmarkKey);
+      bookmarkKey = furi.toString();
+      bookmarkDesc = URLEncoder.encode(bookmarkDesc, StandardCharsets.UTF_8);
     } catch (MalformedURLException e) {
       throw new CommentException("Invalid Crypta URI: " + e);
     }
 
-    String url = "/?newbookmark=" + bookmark_key + "&desc=" + bookmark_desc;
-    if (bookmark_activelink.equals("true")) {
+    String url = "/?newbookmark=" + bookmarkKey + "&desc=" + bookmarkDesc;
+    if (bookmarkActivelink.equals("true")) {
       url = url + "&hasAnActivelink=true";
     }
     return url;
@@ -461,102 +544,38 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
 
   private String finishProcess(
       HTTPRequest req, String overrideType, String path, URI u, boolean noRelative) {
-    String typeOverride = req.getParam("type", null);
-    if (overrideType != null) {
-      typeOverride = overrideType;
-    }
+    String typeOverride = computeTypeOverride(req, overrideType);
 
-    if (typeOverride != null) {
-      String[] split = HTMLFilter.splitType(typeOverride);
-      if (split[1] != null) {
-        String charset = split[1];
-        if (charset != null) {
-          try {
-            charset = URLDecoder.decode(charset, false);
-          } catch (URLEncodedFormatException e) {
-            charset = null;
-          }
-        }
-        if (charset != null && charset.indexOf('&') != -1) {
-          charset = null;
-        }
-        if (charset != null && !Charset.isSupported(charset)) {
-          charset = null;
-        }
-        if (charset != null) {
-          typeOverride = split[0] + "; charset=" + charset;
-        } else {
-          typeOverride = split[0];
-        }
-      }
-    }
-
-    // REDFLAG any other options we should support?
-    // Obviously we don't want to support ?force= !!
-    // At the moment, ?type= and ?force= are the only options supported by FProxy anyway.
-
+    // Other options are not supported here; only ?type= is considered.
     try {
-      // URI encoding issues: FreenetURI.toString() does URLEncode'ing of critical components.
-      // So if we just pass it in to the component-wise constructor, we end up encoding twice,
-      // so get %2520 for a space.
-
-      // However, we want to support encoded slashes or @'s in the path, so we don't want to
-      // just decode before feeding it to the constructor. It looks like the best option is
-      // to construct it ourselves and then re-parse it. This is doing unnecessary work, it
-      // would be much easier if we had a component-wise constructor for URI that didn't
-      // re-encode, but at least it works...
-
-      StringBuilder sb = new StringBuilder();
-      if (strippedBaseURI.getScheme() != null && !noRelative) {
-        sb.append(strippedBaseURI.getScheme());
-        sb.append("://");
-        sb.append(strippedBaseURI.getAuthority());
-        assert (path.startsWith("/"));
-      }
-      sb.append(path);
-      if (typeOverride != null) {
-        sb.append("?type=");
-        sb.append(network.crypta.support.URLEncoder.encode(typeOverride, "", false, "="));
-      }
-      if (u.getFragment() != null) {
-        sb.append('#');
-        sb.append(u.getRawFragment());
-      }
-
-      URI uri = new URI(sb.toString());
+      URI uri = buildUri(path, typeOverride, u, noRelative);
 
       if (!noRelative) {
         uri = strippedBaseURI.relativize(uri);
       }
       if (LOG.isDebugEnabled()) {
         LOG.debug(
-            "Returning "
-                + uri.toASCIIString()
-                + " from "
-                + path
-                + " from baseURI="
-                + baseURI
-                + " stripped base uri="
-                + strippedBaseURI.toString());
+            "Returning {} from {} from baseURI={} stripped base uri={}",
+            uri.toASCIIString(),
+            path,
+            baseURI,
+            strippedBaseURI);
       }
       return uri.toASCIIString();
     } catch (URISyntaxException e) {
       LOG.error(
-          "Could not parse own URI: path="
-              + path
-              + ", typeOverride="
-              + typeOverride
-              + ", frag="
-              + u.getFragment()
-              + " : "
-              + e,
+          "Could not parse own URI: path={}, typeOverride={}, frag={} : {}",
+          path,
+          typeOverride,
+          u.getFragment(),
+          e,
           e);
       String p = path;
       if (typeOverride != null) {
         p += "?type=" + typeOverride;
       }
       if (u.getFragment() != null) {
-        // FIXME encode it properly
+        // Encode fragment for fallback safely
         p += URLEncoder.encode(u.getFragment(), StandardCharsets.UTF_8);
       }
       return p;
@@ -575,5 +594,185 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
       cb.foundURI(furi, inline);
     }
     return finishProcess(req, overrideType, '/' + furi.toString(false, false), uri, noRelative);
+  }
+
+  private record ParsedUris(URI uri, URI resolved, boolean noRelative) {}
+
+  private ParsedUris parseAndResolve(String u, boolean noRelative) throws CommentException {
+    try {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Processing {}", u);
+      }
+      URI uri = URIPreEncoder.encodeURI(u).normalize();
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Processing {}", uri);
+      }
+      if (u.startsWith("/") || u.startsWith("%2f")) {
+        // Don't bother with relative URIs if it's obviously absolute.
+        // Don't allow encoded /'s, they're just too confusing (here they would get decoded
+        // and then coalesced with other slashes).
+        noRelative = true;
+      }
+      URI resolved = noRelative ? uri : baseURI.resolve(uri);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Resolved: {}", resolved);
+      }
+      return new ParsedUris(uri, resolved, noRelative);
+    } catch (URISyntaxException e1) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Failed to parse URI: {}", String.valueOf(e1));
+      }
+      throw new CommentException(l10n("couldNotParseURIWithError", ERROR_KEY, e1.getMessage()));
+    }
+  }
+
+  private String handlePathSpecialCases(URI uri, String path, boolean forBaseHref)
+      throws CommentException {
+    HTTPRequest req = new HTTPRequestImpl(uri, "GET");
+    if (path != null) {
+      if (path.equals("/") && req.isParameterSet("newbookmark") && !forBaseHref) {
+        return processBookmark(req);
+      } else if (path.startsWith(StaticToadlet.ROOT_URL)) {
+        // @see bug #2297
+        return path;
+      } else if (linkFilterExceptionProvider != null
+          && linkFilterExceptionProvider.isLinkExcepted(uri)) {
+        return path + ((uri.getQuery() != null) ? ("?" + uri.getQuery()) : "");
+      }
+    }
+    return null;
+  }
+
+  private URI normalizeLocalhost(URI uri) throws CommentException {
+    String host = uri.getHost();
+    if (host != null
+        && (host.equals("localhost") || host.equals("127.0.0.1"))
+        && uri.getPort() == 8888) {
+      try {
+        return new URI(null, null, null, -1, uri.getPath(), uri.getQuery(), uri.getFragment());
+      } catch (URISyntaxException e) {
+        // Avoid double-logging; rethrow with context only
+        throw new CommentException("URI looked like localhost but could not parse: " + e);
+      }
+    }
+    return uri;
+  }
+
+  private String tryProcessAbsolutePath(
+      String rpath, URI uri, String overrideType, boolean inline) {
+    if (rpath == null) return null;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Resolved URI (rpath absolute): \"{}\"", rpath);
+    }
+    try {
+      String p = stripLeadingSlashes(rpath);
+      FreenetURI furi = new FreenetURI(p, true);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Parsed: {}", furi);
+      }
+      return processURI(furi, uri, overrideType, true, inline);
+    } catch (MalformedURLException e) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Malformed URL (a): {}", e, e);
+      }
+      return null;
+    }
+  }
+
+  private String updateReasonIfAbsoluteMalformed(String rpath, String currentReason) {
+    if (rpath == null) return currentReason;
+    // Not a FreenetURI
+    return l10n("malformedAbsoluteURL", ERROR_KEY, "");
+  }
+
+  private String tryProcessRelativePath(URI resolved, URI uri, String overrideType, boolean inline)
+      throws CommentException {
+    String rpath = resolved.getPath();
+    if (rpath == null) {
+      throw new CommentException("No URI");
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Resolved URI (rpath relative): {}", rpath);
+    }
+    try {
+      String p = stripLeadingSlashes(rpath);
+      FreenetURI furi = new FreenetURI(p, true);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Parsed: {}", furi);
+      }
+      return processURI(furi, uri, overrideType, false, inline);
+    } catch (MalformedURLException e) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Malformed URL (b): {}", e, e);
+      }
+      return null;
+    }
+  }
+
+  private String updateReasonIfRelativeMalformed(String currentReason) {
+    String msg = l10n("malformedRelativeURL", ERROR_KEY, "");
+    return (msg != null) ? msg : currentReason;
+  }
+
+  private static String stripLeadingSlashes(String p) {
+    String s = p;
+    while (s.startsWith("/")) {
+      s = s.substring(1);
+    }
+    return s;
+  }
+
+  private String computeTypeOverride(HTTPRequest req, String overrideType) {
+    String typeOverride = req.getParam("type", null);
+    if (overrideType != null) {
+      typeOverride = overrideType;
+    }
+    if (typeOverride == null) return null;
+
+    String[] split = HTMLFilter.splitType(typeOverride);
+    if (split[1] != null) {
+      String normalized = normalizeCharset(split[1]);
+      return (normalized != null) ? (split[0] + "; charset=" + normalized) : split[0];
+    }
+    return typeOverride;
+  }
+
+  private String normalizeCharset(String charset) {
+    String cs = charset;
+    if (cs != null) {
+      try {
+        cs = URLDecoder.decode(cs, false);
+      } catch (URLEncodedFormatException e) {
+        cs = null;
+      }
+    }
+    if (cs != null && cs.indexOf('&') != -1) {
+      cs = null;
+    }
+    if (cs != null && !Charset.isSupported(cs)) {
+      cs = null;
+    }
+    return cs;
+  }
+
+  private URI buildUri(String path, String typeOverride, URI u, boolean noRelative)
+      throws URISyntaxException {
+    StringBuilder sb = new StringBuilder();
+    if (strippedBaseURI.getScheme() != null && !noRelative) {
+      sb.append(strippedBaseURI.getScheme());
+      sb.append("://");
+      sb.append(strippedBaseURI.getAuthority());
+      assert (path.startsWith("/"));
+    }
+    sb.append(path);
+    if (typeOverride != null) {
+      sb.append("?type=");
+      sb.append(network.crypta.support.URLEncoder.encode(typeOverride, "", false, "="));
+    }
+    if (u.getFragment() != null) {
+      sb.append('#');
+      sb.append(u.getRawFragment());
+    }
+    return new URI(sb.toString());
   }
 }

--- a/src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java
+++ b/src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java
@@ -1,0 +1,222 @@
+package network.crypta.client.filter;
+
+import static network.crypta.l10n.BaseL10n.LANGUAGE.ENGLISH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.stream.Stream;
+import network.crypta.client.filter.HTMLFilter.ParsedTag;
+import network.crypta.clients.http.ExternalLinkToadlet;
+import network.crypta.keys.FreenetURI;
+import network.crypta.l10n.BaseL10nTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class GenericReadFilterCallbackTest {
+
+  @Mock private FoundURICallback foundURICallback;
+  @Mock private TagReplacerCallback tagReplacerCallback;
+  @Mock private LinkFilterExceptionProvider linkFilterExceptionProvider;
+
+  @BeforeAll
+  static void setupL10n() {
+    // Ensure deterministic error messages during testing
+    GenericReadFilterCallback.setBaseL10n(BaseL10nTest.createTestL10n(ENGLISH));
+  }
+
+  private GenericReadFilterCallback newCallback(String base) throws URISyntaxException {
+    return new GenericReadFilterCallback(
+        new URI(base), foundURICallback, tagReplacerCallback, linkFilterExceptionProvider);
+  }
+
+  @Test
+  void processURI_whenAnchor_expectReturnedAsIs() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    String anchor = "#section_1-~ok?allowed";
+    String result = cb.processURI(anchor, null);
+
+    assertEquals(anchor, result);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("processURI_simpleCases")
+  void processURI_whenSimpleCases_expectSanitized(
+      String name, String base, String input, String expected, boolean excepted) throws Exception {
+    if (excepted) {
+      when(linkFilterExceptionProvider.isLinkExcepted(any(URI.class))).thenReturn(true);
+    }
+    GenericReadFilterCallback cb = newCallback(base);
+    String result = cb.processURI(input, null);
+    assertEquals(expected, result);
+  }
+
+  static Stream<Arguments> processURI_simpleCases() {
+    String base = "http://localhost:8888/";
+    return Stream.of(
+        Arguments.of(
+            "bookmark simple",
+            base,
+            "/?newbookmark=KSK@mykey&desc=My Bookmark",
+            "/?newbookmark=KSK@mykey&desc=My+Bookmark",
+            false),
+        Arguments.of(
+            "bookmark active",
+            base,
+            "/?newbookmark=KSK@mykey&desc=Title&hasAnActivelink=true",
+            "/?newbookmark=KSK@mykey&desc=Title&hasAnActivelink=true",
+            false),
+        Arguments.of("static path", base, "/static/js/app.js?foo=bar", "/static/js/app.js", false),
+        Arguments.of(
+            "excepted provider", base, "/private/secret?x=1&y=2", "/private/secret?x=1&y=2", true));
+  }
+
+  @Test
+  void processURI_whenValidFreenetUriInline_expectCallbacksAndRelativePath() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/base/page");
+
+    String input = "KSK@hello";
+    String result = cb.processURI(input, null, false, true);
+
+    assertEquals("/KSK@hello", result);
+
+    ArgumentCaptor<FreenetURI> cap = ArgumentCaptor.forClass(FreenetURI.class);
+    verify(foundURICallback, times(1)).foundURI(cap.capture());
+    assertEquals("KSK@hello", cap.getValue().toString());
+    verify(foundURICallback, times(1)).foundURI(cap.getValue(), true);
+  }
+
+  @Test
+  void processURI_whenOverrideTypeWithCharset_expectTypeParameterEncoded() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    String input = "KSK@doc";
+    String result = cb.processURI(input, "text/html; charset=UTF-8");
+
+    assertEquals("/KSK@doc?type=text/html%3b%20charset=UTF-8", result);
+  }
+
+  @Test
+  void processURI_whenExternalHttp_expectEscapedToExternalLinkToadlet() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    String input = "http://example.com/path?q=a b";
+    String result = cb.processURI(input, null);
+
+    assertEquals(
+        ExternalLinkToadlet.PATH + "?_CHECKED_HTTP_=http://example.com/path?q=a%20b", result);
+  }
+
+  @Test
+  void processURI_whenDisallowedProtocol_expectException() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    assertThrows(CommentException.class, () -> cb.processURI("javascript:alert(1)", null));
+  }
+
+  @Test
+  void processURI_whenInvalidRelative_expectExceptionWithReason() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    CommentException ex =
+        assertThrows(CommentException.class, () -> cb.processURI("not/a/freenet/uri", null));
+    assertNotNull(ex.getMessage());
+  }
+
+  @Test
+  void processURI_withForcedAuthority_whenHostMissing_expectPrefixed() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/base/page");
+
+    String result =
+        cb.processURI("/KSK@hello", null, "http://forced.example:1234", /* inline= */ false);
+
+    assertEquals("http://forced.example:1234/KSK@hello", result);
+  }
+
+  @Test
+  void makeURIAbsolute_whenRelative_expectResolvedAgainstBase() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://example.org/dir/page");
+
+    String absolute = cb.makeURIAbsolute("sub/asset.css");
+    assertEquals("http://example.org/dir/sub/asset.css", absolute);
+  }
+
+  @Test
+  void onBaseHref_whenValidFreenetBase_expectUpdatedAndReturned() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    String result = cb.onBaseHref("KSK@site/");
+    assertEquals("/KSK@site/", result);
+
+    // subsequent onText should carry the updated base
+    cb.onText("text", "p");
+    verify(foundURICallback, times(1)).onText("text", "p", new URI("/KSK@site/"));
+  }
+
+  @Test
+  void onBaseHref_whenExternalAbsolute_expectNull() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    String result = cb.onBaseHref("http://example.com/");
+    assertNull(result);
+  }
+
+  @Test
+  void processForm_whenVariousInputs_expectPolicyApplied() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    // null action -> remove
+    assertNull(cb.processForm("GET", null));
+
+    // unsupported method -> remove
+    assertNull(cb.processForm("PUT", "/any"));
+
+    // allow /library/
+    assertEquals("/library/", cb.processForm("POST", "/library/"));
+
+    // absolute form action -> rejected
+    assertThrows(CommentException.class, () -> cb.processForm("GET", "http://example.com/"));
+
+    // plugin action accepted
+    assertEquals("/plugins/My.Plugin", cb.processForm("GET", "/plugins/My.Plugin"));
+
+    // traversal attempt rejected
+    assertThrows(CommentException.class, () -> cb.processForm("GET", "/plugins/../evil"));
+  }
+
+  @Test
+  void processTag_whenCallbackPresent_expectDelegated() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    ParsedTag tag = new HTMLFilter.ParsedTag("a", java.util.Collections.emptyMap());
+    when(tagReplacerCallback.processTag(tag, cb)).thenReturn("<a>replaced</a>");
+
+    String replacement = cb.processTag(tag);
+    assertEquals("<a>replaced</a>", replacement);
+  }
+
+  @Test
+  void onFinished_whenCallbackPresent_expectEndOfPageNotified() throws Exception {
+    GenericReadFilterCallback cb = newCallback("http://localhost:8888/");
+
+    cb.onFinished();
+    verify(foundURICallback, times(1)).onFinishedPage();
+  }
+}


### PR DESCRIPTION
Summary
- Refactors and documents `GenericReadFilterCallback` to improve safety, determinism, and readability while preserving intended behaviors.
- Adds comprehensive unit tests in `GenericReadFilterCallbackTest` covering sanitization, link policy decisions, base-href handling, external link escaping, and form rules.

Key Changes
- Replace `HashSet` with immutable `Set.of(...)` for `allowedProtocols`.
- Tighten RFC 3986 pattern constants and add detailed Javadoc for `UNRESERVED`, `PCT_ENCODED`, `SUB_DELIMS`, `PCHAR`, and `FRAGMENT`.
- Reduce regex overhead: simplify `PCT_ENCODED` and escape classes; prefer direct `String.replace` over `replaceAll` where regex is not required.
- Parameterize SLF4J logging messages and guard with `isDebugEnabled()` where appropriate.
- Introduce small, focused helpers to clarify control flow:
  - `parseAndResolve(...)` (internal) to pre-encode, parse, and resolve URIs once.
  - `handlePathSpecialCases(...)` to centralize bookmark/static/exception-provider logic.
  - `normalizeLocalhost(...)` to convert `http://localhost:8888/...` into internal relative URIs.
  - `tryProcessAbsolutePath(...)` / `tryProcessRelativePath(...)` with dedicated reason updates for malformed cases.
  - `computeTypeOverride(...)` and `normalizeCharset(...)` for predictable media-type handling.
- Strengthen error messaging (`ERROR_KEY`) and avoid double logging; throw `CommentException` with localized messages consistently.
- Make the FreenetURI constructor failure map to `IllegalArgumentException` (instead of `Error`) when building from a `FreenetURI`.

Tests
- `src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java`:
  - Parameterized coverage for bookmark/static/exception-provider cases.
  - External HTTP escaping to `ExternalLinkToadlet`.
  - Disallowed protocol (e.g., `javascript:`) rejection.
  - Inline Freenet URI processing with callback verification.
  - `type` override encoding in query string.
  - `makeURIAbsolute` resolution logic.
  - `<base href>` handling and propagation to subsequent events.
  - Form processing (null/unsupported/allowed paths, traversal rejection).
  - Tag replacement callback delegation and end-of-page callback.

Why
- The previous implementation mixed parsing, resolution, and dispatch logic, which made it harder to reason about corner cases and error reasons. This refactor separates concerns, adds explicit Javadoc, and improves log clarity.
- Unit tests provide guardrails for link policy and sanitization behavior.

Compatibility and Risk
- Behavior aligns with existing policy: protocol allow‑list unchanged; external links still routed through `ExternalLinkToadlet`.
- Error wording may be slightly more consistent due to centralized localization keys.
- Constructing from `FreenetURI` now throws `IllegalArgumentException` instead of `Error` for invalid input; this is safer and easier to handle.

Notes
- Spotless was run prior to commit.
- One commit in this branch not present in `develop`: 983ee7c9ef.
- If desired, I can run `./gradlew test` and share the report and coverage summary, or wire this PR to CI guidance.
