### PR TITLE
Document NullFilterCallback semantics and add focused unit tests

### DIFF
--- a/src/main/java/network/crypta/client/filter/NullFilterCallback.java
+++ b/src/main/java/network/crypta/client/filter/NullFilterCallback.java
@@ -2,34 +2,130 @@ package network.crypta.client.filter;
 
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
 
+/**
+ * A no-op implementation of {@link FilterCallback} used when a filter pipeline needs a callback but
+ * the caller does not wish to perform any URI rewriting, form handling, or tag replacement.
+ *
+ * <p>This class follows the <em>Null Object</em> pattern. All processing methods return {@code
+ * null} to indicate that the corresponding construct should be omitted from filtered output, and
+ * notification methods perform no action. It is useful for tests, for bulk parsing where link
+ * extraction is disabled, or as a safe default when policy decisions must be deferred to a higher
+ * layer.
+ *
+ * <p>Instances are stateless and thread-safe. Multiple filter runs may reuse the same instance
+ * concurrently without external synchronization. Because this implementation never allocates or
+ * mutates per-call state, it has negligible overhead and predictable behavior across all inputs.
+ *
+ * <ul>
+ *   <li>All {@code process*} methods return {@code null}.
+ *   <li>{@link #onText(String, String)} and {@link #onFinished()} are no-ops.
+ *   <li>No method throws unless required by the interface; checked exceptions are never raised
+ *       here.
+ * </ul>
+ *
+ * @see FilterCallback
+ * @see HTMLFilter
+ */
 public class NullFilterCallback implements FilterCallback {
 
+  /**
+   * Creates a new stateless callback. Instances are reusable across filter runs and safe for
+   * concurrent use by multiple threads because this implementation keeps no per-invocation state.
+   */
+  public NullFilterCallback() {
+    // Intentionally empty: this callback is stateless and requires no initialization.
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation always returns {@code null}, effectively removing the URI from the
+   * output. It does not validate, normalize, or rewrite the input and never throws.
+   *
+   * @param uri the candidate URI string to evaluate; the value is ignored and may be any string
+   * @param overrideType optional MIME type override; ignored by this implementation
+   * @return always {@code null} to signal the caller to elide the reference from output
+   */
   @Override
   public String processURI(String uri, String overrideType) {
     return null;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation accepts no base URI and therefore returns {@code null} for any input. It
+   * maintains no internal document base and performs no validation.
+   *
+   * @param baseHref raw {@code <base href>} value encountered in the source; ignored here
+   * @return always {@code null}, indicating that the base should not be adopted or emitted
+   */
   @Override
   public String onBaseHref(String baseHref) {
     return null;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This method performs no action. The text and contextual type are ignored.
+   *
+   * @param s decoded text content; ignored by this implementation and may be empty
+   * @param type optional context such as an element name; ignored and may be {@code null}
+   */
   @Override
   public void onText(String s, String type) {
     // Do nothing
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation returns {@code null} for any method and action, suppressing the form in
+   * the filtered output. It does not validate the HTTP method or rewrite the {@code action}
+   * attribute and never throws.
+   *
+   * @param method HTTP method name from the form declaration; any value is accepted and ignored
+   * @param action target submit URI as declared in the form; ignored by this implementation
+   * @return always {@code null}, indicating the form should be dropped entirely
+   */
   @Override
   public String processForm(String method, String action) {
     return null;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Always returns {@code null}. The flags {@code noRelative} and {@code inline} are ignored; no
+   * absolutization, normalization, or policy enforcement is performed.
+   *
+   * @param uri the URI string to consider; any value is accepted and ignored
+   * @param overrideType optional MIME type override to associate; ignored here
+   * @param noRelative when {@code true}, callers would typically absolutize; ignored by this class
+   * @param inline when {@code true}, callers may treat the reference as inline; ignored here
+   * @return always {@code null}, directing the caller to omit the reference from output
+   * @throws CommentException never thrown by this implementation
+   */
   @Override
   public String processURI(String uri, String overrideType, boolean noRelative, boolean inline)
       throws CommentException {
     return null;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Always returns {@code null}. The {@code forceSchemeHostAndPort} hint is ignored and no
+   * transformation is attempted. No exceptions are thrown.
+   *
+   * @param uri the candidate URI string; accepted as-is and ignored
+   * @param overrideType optional MIME type override; ignored by this implementation
+   * @param forceSchemeHostAndPort authority to apply to relative URIs; ignored here
+   * @param inline whether the reference is inline; ignored and has no effect
+   * @return always {@code null} so the caller removes the reference from serialized output
+   * @throws CommentException never thrown by this implementation
+   */
   @Override
   public String processURI(
       String uri, String overrideType, String forceSchemeHostAndPort, boolean inline)
@@ -37,11 +133,25 @@ public class NullFilterCallback implements FilterCallback {
     return null;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Always returns {@code null}, signaling that the original tag should be preserved unchanged
+   * by the caller. No attribute inspection or rewriting is performed.
+   *
+   * @param pt the parsed tag object describing an element and its attributes; ignored here
+   * @return always {@code null} so the caller emits the original representation
+   */
   @Override
   public String processTag(ParsedTag pt) {
     return null;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>No operation. Provided for symmetry with other implementations that might flush state.
+   */
   @Override
   public void onFinished() {
     // Ignore.

--- a/src/test/java/network/crypta/client/filter/NullFilterCallbackTest.java
+++ b/src/test/java/network/crypta/client/filter/NullFilterCallbackTest.java
@@ -1,0 +1,98 @@
+package network.crypta.client.filter;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import network.crypta.client.filter.HTMLFilter.ParsedTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class NullFilterCallbackTest {
+
+  @Test
+  void processURI_whenSimpleCall_expectNull() {
+    NullFilterCallback cb = new NullFilterCallback();
+
+    String result1 = cb.processURI("http://example.com", "text/html");
+    String result2 = cb.processURI("/relative/path", null);
+
+    assertNull(result1);
+    assertNull(result2);
+  }
+
+  @ParameterizedTest(name = "noRelative={1}, inline={2}")
+  @CsvSource({
+    "http://example.com,false,false",
+    "/relative,true,false",
+    "'data:image/png;base64,abcd',false,true",
+    "//schemeless.example,false,true"
+  })
+  void processURI_withFlags_whenAnyCombination_expectNull(
+      String uri, boolean noRelative, boolean inline) throws CommentException {
+    NullFilterCallback cb = new NullFilterCallback();
+    String result = cb.processURI(uri, null, noRelative, inline);
+    assertNull(result);
+  }
+
+  @ParameterizedTest(name = "uri={0}, inline={2}")
+  @CsvSource({
+    "/img.png, https://host.tld:443, false",
+    "favicon.ico, https://example.org, true",
+    "http://already.absolute, https://ignored.example, false"
+  })
+  void processURI_withForcedAuthority_whenRelativeOrAbsolute_expectNull(
+      String uri, String force, boolean inline) throws CommentException {
+    NullFilterCallback cb = new NullFilterCallback();
+    String result = cb.processURI(uri, null, force, inline);
+    assertNull(result);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"https://base.example/", "/relative/base", "", "about:blank"})
+  void onBaseHref_whenAnyString_expectNull(String base) {
+    NullFilterCallback cb = new NullFilterCallback();
+    String result = cb.onBaseHref(base);
+    assertNull(result);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"GET, /submit", "POST, http://example.com/form", "PUT, /ignored", "DELETE, /ignored"})
+  void processForm_whenAnyMethodAndAction_expectNull(String method, String action) {
+    NullFilterCallback cb = new NullFilterCallback();
+    String result = cb.processForm(method, action);
+    assertNull(result);
+  }
+
+  @Test
+  void processTag_whenParsedTagProvided_expectNull() {
+    NullFilterCallback cb = new NullFilterCallback();
+    Map<String, String> attrs = new HashMap<>();
+    attrs.put("id", "x");
+    attrs.put("class", "c");
+    ParsedTag tag = new ParsedTag("div", attrs);
+
+    String result = cb.processTag(tag);
+    assertNull(result);
+  }
+
+  @Test
+  void onText_whenAnyInput_expectNoException() {
+    NullFilterCallback cb = new NullFilterCallback();
+    assertDoesNotThrow(() -> cb.onText("hello", "title"));
+    assertDoesNotThrow(() -> cb.onText("", null));
+  }
+
+  @Test
+  void onFinished_whenInvoked_expectNoException() {
+    NullFilterCallback cb = new NullFilterCallback();
+    assertDoesNotThrow(cb::onFinished);
+  }
+}


### PR DESCRIPTION
Summary
- Add comprehensive Javadoc to NullFilterCallback describing null-object semantics, behavior, and thread-safety.
- Add unit test class NullFilterCallbackTest covering URI processing, base href, form handling, tag processing, and text/finish callbacks.

Details
- The implementation remains a safe no-op; all process* methods return null and notifications are no-ops.
- No functional behavior changes; this is documentation and tests only.

Why
- Clarifies intended behavior for consumers and future maintainers.
- Prevents regressions and documents expectations via tests.

Testing
- Compiles and tests locally; new tests validate expected null-object behaviors across methods.

Risk
- Low; no production behavior changes.

Notes
- Target base: develop.
- Conventional commit style observed in history.
