### PR TITLE
fix(client): polish PushingTagReplacerCallback and add tests

### DIFF
--- a/src/main/java/network/crypta/client/filter/PushingTagReplacerCallback.java
+++ b/src/main/java/network/crypta/client/filter/PushingTagReplacerCallback.java
@@ -2,6 +2,8 @@ package network.crypta.client.filter;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Map;
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.ToadletContext;
@@ -11,8 +13,36 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLEncoder;
 
 /**
- * This TagReplcaerCallback adds pushing support for freesites, and replaces their img's to pushed
- * ones
+ * Tag replacer that injects client‑side pushing support and rewrites image tags.
+ *
+ * <p>This callback is used by the HTML filtering pipeline to augment fetched pages with
+ * FProxy-specific behaviors when web pushing is enabled. It performs two main tasks:
+ *
+ * <ul>
+ *   <li>Rewrites {@code <img>} elements to client-side updatable placeholders backed by {@link
+ *       network.crypta.clients.http.updateableelements.ImageElement}, enabling progressive fetching
+ *       and display while honoring size limits.
+ *   <li>Injects required script and localization snippets into the document {@code <head>} and
+ *       before the closing {@code </body>} to initialize the push runtime and UI strings.
+ * </ul>
+ *
+ * <p>Instances are immutable after construction and hold references to the tracker, the maximum
+ * response size, and the current {@link network.crypta.clients.http.ToadletContext}. They do not
+ * maintain additional internal state. Concurrency: the class is safe for concurrent use provided
+ * that the supplied tracker and context are themselves safe to use from the calling threads. The
+ * callback returns {@code null} for tags it does not handle, allowing the caller to leave the
+ * original content unchanged.
+ *
+ * <p>Typical usage is to construct the callback once per request and pass it to the surrounding
+ * HTML filter, which calls {@link #processTag(HTMLFilter.ParsedTag, URIProcessor)} for each parsed
+ * token. The behavior is a no-op unless both JavaScript and web pushing are enabled in the
+ * container.
+ *
+ * @see TagReplacerCallback
+ * @see HTMLFilter
+ * @see network.crypta.clients.http.updateableelements.ImageElement
+ * @see network.crypta.clients.http.FProxyFetchTracker
+ * @see network.crypta.clients.http.ToadletContext
  */
 public class PushingTagReplacerCallback implements TagReplacerCallback {
 
@@ -26,11 +56,18 @@ public class PushingTagReplacerCallback implements TagReplacerCallback {
   private final ToadletContext ctx;
 
   /**
-   * Constructor
+   * Creates a new callback configured for the current request lifecycle.
    *
-   * @param tracker - The FProxyFetchTracker
-   * @param maxSize - The maxSize used for fetching
-   * @param ctx - The current ToadletContext
+   * <p>The instance holds the provided tracker, size limit, and context for later use while
+   * processing HTML tags. It does not start any network operations by itself; work happens lazily
+   * when {@link #processTag(HTMLFilter.ParsedTag, URIProcessor)} is invoked by the filter.
+   *
+   * @param tracker The fetch tracker used to account, correlate, and observe pushed sub‑requests;
+   *     must be the tracker associated with the enclosing page request.
+   * @param maxSize Maximum number of bytes permitted for rewritten image fetches; values at or
+   *     below zero are treated as non-positive limits by downstream components.
+   * @param ctx The active {@link ToadletContext} providing configuration and unique request id;
+   *     must not be {@code null} for push injection to be effective.
    */
   public PushingTagReplacerCallback(FProxyFetchTracker tracker, long maxSize, ToadletContext ctx) {
     this.tracker = tracker;
@@ -39,10 +76,16 @@ public class PushingTagReplacerCallback implements TagReplacerCallback {
   }
 
   /**
-   * Returns the javascript code that initializes the l10n on the client side. It must be inserted
-   * to the page.
+   * Builds the JavaScript snippet that initializes client‑side localization keys.
    *
-   * @return The javascript code that needs to be inserted in order to l10n work
+   * <p>The generated code defines a global {@code l10n} object containing key/value pairs derived
+   * from the node’s translation bundle under the {@code fproxy.push.*} prefix. The snippet is
+   * intended to be injected into the document so subsequent scripts can reference translated UI
+   * strings without additional network round‑trips. Keys are HTML‑encoded for safety, and the
+   * builder elides the trailing comma when no entries are present.
+   *
+   * @return A non‑{@code null} JavaScript string that declares {@code var l10n = {...};}; empty
+   *     objects are possible when no matching translation keys exist.
    */
   public static String getClientSideLocalizationScript() {
     StringBuilder l10nBuilder = new StringBuilder("var l10n={\n");
@@ -63,61 +106,105 @@ public class PushingTagReplacerCallback implements TagReplacerCallback {
     return l10n;
   }
 
+  /**
+   * Processes a single parsed tag and returns an optional replacement fragment.
+   *
+   * <p>When pushing is enabled, the method:
+   *
+   * <ul>
+   *   <li>Rewrites {@code <img>} elements to an updatable client‑side representation tied to the
+   *       current request and {@link #maxSize}.
+   *   <li>Injects the push/runtime script into an opening {@code <head>} tag.
+   *   <li>Appends localization and a hidden {@code requestId} input before the closing {@code
+   *       </body>} tag.
+   * </ul>
+   *
+   * For all other tags or when pushing is disabled, the method returns {@code null} to indicate no
+   * change.
+   *
+   * <p>Idempotency: the method computes output solely from the supplied tag, the request context,
+   * and current configuration, and does not mutate the instance. Invalid or malformed tags are
+   * safely ignored.
+   *
+   * <pre>{@code
+   * // Example: use inside an HTML filter loop
+   * var cb = new PushingTagReplacerCallback(tracker, maxSize, ctx);
+   * var replacement = cb.processTag(pt, uriProcessor);
+   * }</pre>
+   *
+   * @param pt The parsed tag including name, attributes, and position; passes through unchanged
+   *     when the element is not handled or pushing is disabled.
+   * @param uriProcessor Helper used to normalize and absolutize {@code src} attributes; must be
+   *     capable of resolving relative paths in the page’s base context.
+   * @return Either a replacement HTML fragment to splice into the output, or {@code null} to leave
+   *     the original tag untouched by this callback.
+   */
   @Override
   public String processTag(ParsedTag pt, URIProcessor uriProcessor) {
-    // If javascript or pushing is disabled, then it won't need pushing
-    if (ctx.getContainer().isFProxyJavascriptEnabled()
-        && ctx.getContainer().isFProxyWebPushingEnabled()) {
-      if (pt.element.toLowerCase().compareTo("img") == 0) {
-        // Img's needs to be replaced with pushed ImageElement's
-        for (String attr : pt.unparsedAttrs) {
-          String name = attr.substring(0, attr.indexOf('='));
-          String value = attr.substring(attr.indexOf('=') + 2, attr.length() - 1);
-          if (name.compareTo("src") == 0) {
-            String src;
-            try {
-              // We need absolute URI
-              src =
-                  uriProcessor.makeURIAbsolute(uriProcessor.processURI(value, null, false, false));
-            } catch (CommentException ce) {
-              return null;
-            } catch (URISyntaxException use) {
-              return null;
-            }
-            if (src.startsWith("/")) {
-              src = src.substring(1);
-            }
-            try {
-              // Create the ImageElement
-              return new ImageElement(tracker, new FreenetURI(src), maxSize, ctx, pt, true)
-                  .generate();
-            } catch (MalformedURLException mue) {
-              return null;
-            }
-          }
-        }
-      } else if (pt.element.toLowerCase().compareTo("body") == 0 && pt.startSlash) {
-        // After the <body>, we need to insert the requestId and the l10n script
-        return ""
-            .concat(
-                /*new XmlAlertElement(ctx).generate()*/ ""
-                    .concat(
-                        "<input id=\"requestId\" type=\"hidden\" value=\""
-                            + ctx.getUniqueId()
-                            + "\" name=\"requestId\"/>"))
-            .concat(
-                "<script type=\"text/javascript\" language=\"javascript\">"
-                    .concat(getClientSideLocalizationScript())
-                    .concat("</script>"))
-            .concat("</body>");
-      } else if (pt.element.toLowerCase().compareTo("head") == 0) {
-        // After the <head>, we need to add GWT support
-        return "<head><script type=\"text/javascript\" language=\"javascript\""
-            + " src=\"/static/freenetjs/freenetjs.nocache.js\"></script><noscript><style>"
-            + " .jsonly {display:none;}</style></noscript><link href=\"/static/reset.css\""
-            + " rel=\"stylesheet\" type=\"text/css\" />";
-      }
+    if (!isPushingEnabled()) {
+      return null;
+    }
+
+    // pt.element can be null for malformed or empty tokens; guard to avoid NPE
+    String element = pt.element != null ? pt.element.toLowerCase(Locale.ROOT) : null;
+    if ("img".equals(element)) {
+      return handleImgTag(pt, uriProcessor);
+    }
+    if ("body".equals(element) && pt.startSlash) {
+      return generateBodyCloseInjection();
+    }
+    if ("head".equals(element)) {
+      return generateHeadInjection();
     }
     return null;
+  }
+
+  private boolean isPushingEnabled() {
+    return ctx.getContainer().isFProxyJavascriptEnabled()
+        && ctx.getContainer().isFProxyWebPushingEnabled();
+  }
+
+  private String handleImgTag(ParsedTag pt, URIProcessor uriProcessor) {
+    Map<String, String> attrs = pt.getAttributesAsMap();
+    String value = attrs.get("src");
+    if (value == null) {
+      return null;
+    }
+    String src;
+    try {
+      src = uriProcessor.makeURIAbsolute(uriProcessor.processURI(value, null, false, false));
+    } catch (CommentException | URISyntaxException e) {
+      return null;
+    }
+    if (src.startsWith("/")) {
+      src = src.substring(1);
+    }
+    try {
+      return new ImageElement(tracker, new FreenetURI(src), maxSize, ctx, pt, true).generate();
+    } catch (MalformedURLException mue) {
+      return null;
+    }
+  }
+
+  private String generateBodyCloseInjection() {
+    return ""
+        .concat(
+            /*new XmlAlertElement(ctx).generate()*/ ""
+                .concat(
+                    "<input id=\"requestId\" type=\"hidden\" value=\""
+                        + ctx.getUniqueId()
+                        + "\" name=\"requestId\"/>"))
+        .concat(
+            "<script type=\"text/javascript\" language=\"javascript\">"
+                .concat(getClientSideLocalizationScript())
+                .concat("</script>"))
+        .concat("</body>");
+  }
+
+  private String generateHeadInjection() {
+    return "<head><script type=\"text/javascript\" language=\"javascript\""
+        + " src=\"/static/freenetjs/freenetjs.nocache.js\"></script><noscript><style>"
+        + " .jsonly {display:none;}</style></noscript><link href=\"/static/reset.css\""
+        + " rel=\"stylesheet\" type=\"text/css\" />";
   }
 }

--- a/src/test/java/network/crypta/client/filter/PushingTagReplacerCallbackTest.java
+++ b/src/test/java/network/crypta/client/filter/PushingTagReplacerCallbackTest.java
@@ -1,0 +1,258 @@
+package network.crypta.client.filter;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import network.crypta.client.filter.HTMLFilter.ParsedTag;
+import network.crypta.clients.http.SimpleToadletServer;
+import network.crypta.clients.http.ToadletContext;
+import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class PushingTagReplacerCallbackTest {
+
+  @Mock private network.crypta.clients.http.FProxyFetchTracker tracker;
+  @Mock private ToadletContext ctx;
+  @Mock private URIProcessor uriProcessor;
+
+  private SimpleToadletServer container;
+
+  /** No-op ticker to avoid executing queued jobs during tests (deterministic). */
+  private static final class NoopTicker implements Ticker {
+    @Override
+    public void queueTimedJob(Runnable job, long offset) {
+      // no-op
+    }
+
+    @Override
+    public void queueTimedJob(
+        Runnable job, String name, long offset, boolean runOnTickerAnyway, boolean noDupes) {
+      // no-op
+    }
+
+    @Override
+    public PriorityAwareExecutor getExecutor() {
+      return null;
+    }
+
+    @Override
+    public void removeQueuedJob(Runnable job) {
+      // no-op
+    }
+
+    @Override
+    public void queueTimedJobAbsolute(
+        Runnable runner, String name, long time, boolean runOnTickerAnyway, boolean noDupes) {
+      // no-op
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    // Mock SimpleToadletServer (final class; inline mock-maker enabled in test resources)
+    container = mock(SimpleToadletServer.class);
+    when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(container.isFProxyWebPushingEnabled()).thenReturn(true);
+    // Avoid background activity
+    when(container.getTicker()).thenReturn(new NoopTicker());
+    // Provide a PushDataManager (mock is fine; BaseUpdateableElement.init will call
+    // elementRendered)
+    PushDataManager pdm = mock(PushDataManager.class);
+    when(container.getPushDataManager()).thenReturn(pdm);
+
+    when(ctx.getContainer()).thenReturn(container);
+    when(ctx.getUniqueId()).thenReturn("req-123");
+
+    // Deterministic element id inside ImageElement
+    when(tracker.makeRandomElementID()).thenReturn(42);
+  }
+
+  @Test
+  void getClientSideLocalizationScript_returnsVarWithExpectedKeys() {
+    // Arrange
+    // Ensure fallback (default language) is loaded so prefix scan is populated
+    NodeL10n.getBase().getDefaultLanguageTranslation();
+
+    // Act
+    String script = PushingTagReplacerCallback.getClientSideLocalizationScript();
+
+    // Assert
+    assertNotNull(script);
+    assertTrue(script.startsWith("var l10n={"));
+    assertTrue(script.endsWith("};"));
+    // Must include known fproxy.push keys with values from en.properties
+    assertTrue(script.contains("hide:"), "contains hide key");
+    assertTrue(script.contains("show:"), "contains show key");
+    assertTrue(script.contains("imageprogress:"), "contains imageprogress key");
+    assertTrue(script.contains("pushingCancelled:"), "contains pushingCancelled key");
+  }
+
+  @Test
+  void processTag_whenJsOrPushDisabled_returnsNull() {
+    // Arrange
+    // Disable either flag → gate should return null regardless of tag
+    when(container.isFProxyJavascriptEnabled()).thenReturn(false);
+    when(container.isFProxyWebPushingEnabled()).thenReturn(false);
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 1234L, ctx);
+    ParsedTag head = new ParsedTag("head", Map.of());
+
+    // Act
+    String out = cb.processTag(head, uriProcessor);
+
+    // Assert
+    assertNull(out);
+  }
+
+  @Test
+  void processTag_img_withValidKskSrc_returnsImageElementHtml() throws Exception {
+    // Arrange
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 4096L, ctx);
+    Map<String, String> attrs = new HashMap<>();
+    attrs.put("src", "KSK@foo"); // Valid KSK URI (no keys required)
+    ParsedTag img = new ParsedTag("IMG", attrs); // case-insensitive element name
+
+    when(uriProcessor.processURI("KSK@foo", null, false, false)).thenReturn("KSK@foo");
+    when(uriProcessor.makeURIAbsolute("KSK@foo")).thenReturn("KSK@foo");
+
+    // Act
+    String out = cb.processTag(img, uriProcessor);
+
+    // Assert
+    assertNotNull(out, "Expected generated ImageElement HTML");
+    assertTrue(out.contains("<span"));
+    assertTrue(out.contains("jsonly ImageElement"), "includes JS-enabled placeholder");
+    assertTrue(out.contains("<noscript>"), "includes noscript fallback");
+    assertTrue(out.contains("<img"), "renders original <img> in noscript");
+  }
+
+  @Test
+  void processTag_img_whenNoSrcAttribute_returnsNull() {
+    // Arrange
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 1L, ctx);
+    ParsedTag img = new ParsedTag("img", Map.of("alt", "x"));
+
+    // Act
+    String out = cb.processTag(img, uriProcessor);
+
+    // Assert
+    assertNull(out);
+  }
+
+  @Test
+  void processTag_img_whenProcessUriThrowsCommentException_returnsNull() throws Exception {
+    // Arrange
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 1L, ctx);
+    ParsedTag img = new ParsedTag("img", Map.of("src", "KSK@foo"));
+    when(uriProcessor.processURI("KSK@foo", null, false, false))
+        .thenThrow(new CommentException("bad"));
+
+    // Act
+    String out = cb.processTag(img, uriProcessor);
+
+    // Assert
+    assertNull(out);
+  }
+
+  @Test
+  void processTag_img_whenMakeUriAbsoluteThrowsURISyntaxException_returnsNull() throws Exception {
+    // Arrange
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 1L, ctx);
+    ParsedTag img = new ParsedTag("img", Map.of("src", "KSK@foo"));
+    when(uriProcessor.processURI("KSK@foo", null, false, false)).thenReturn("KSK@foo");
+    when(uriProcessor.makeURIAbsolute("KSK@foo")).thenThrow(new URISyntaxException("x", "y"));
+
+    // Act
+    String out = cb.processTag(img, uriProcessor);
+
+    // Assert
+    assertNull(out);
+  }
+
+  @Test
+  void processTag_img_whenLeadingSlashIsPresent_trimsAndParsesSuccessfully() throws Exception {
+    // Arrange
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 1L, ctx);
+    ParsedTag img = new ParsedTag("img", Map.of("src", "/KSK@foo"));
+    when(uriProcessor.processURI("/KSK@foo", null, false, false)).thenReturn("/KSK@foo");
+    when(uriProcessor.makeURIAbsolute("/KSK@foo")).thenReturn("/KSK@foo");
+
+    // Act
+    String out = cb.processTag(img, uriProcessor);
+
+    // Assert
+    assertNotNull(out);
+    assertTrue(out.contains("jsonly ImageElement"));
+  }
+
+  @Test
+  void processTag_img_whenFreenetUriIsMalformed_returnsNull() throws Exception {
+    // Arrange
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 1L, ctx);
+    // Value missing '@' → FreenetURI throws MalformedURLException which is caught
+    ParsedTag img = new ParsedTag("img", Map.of("src", "NOT_A_URI"));
+    when(uriProcessor.processURI("NOT_A_URI", null, false, false)).thenReturn("NOT_A_URI");
+    when(uriProcessor.makeURIAbsolute("NOT_A_URI")).thenReturn("NOT_A_URI");
+
+    // Act
+    String out = cb.processTag(img, uriProcessor);
+
+    // Assert
+    assertNull(out);
+  }
+
+  @Test
+  void processTag_bodyClosing_injectsRequestIdAndL10nScript() {
+    // Arrange
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 1L, ctx);
+    List<String> tokens = new ArrayList<>();
+    tokens.add("/BODY"); // produces startSlash=true with element name "BODY"
+    ParsedTag bodyClose = new ParsedTag(tokens);
+
+    // Act
+    String out = cb.processTag(bodyClose, uriProcessor);
+
+    // Assert
+    assertNotNull(out);
+    assertTrue(out.startsWith("<input id=\"requestId\""), "hidden requestId is injected first");
+    assertTrue(out.contains("value=\"req-123\""), "request id value is present");
+    assertTrue(out.contains("<script type=\"text/javascript\""), "l10n script injected");
+    assertTrue(out.endsWith("</body>"));
+  }
+
+  @Test
+  void processTag_head_injectsGwtSupport() {
+    // Arrange
+    PushingTagReplacerCallback cb = new PushingTagReplacerCallback(tracker, 1L, ctx);
+    ParsedTag head = new ParsedTag("head", Map.of());
+
+    // Act
+    String out = cb.processTag(head, uriProcessor);
+
+    // Assert
+    assertNotNull(out);
+    assertTrue(out.startsWith("<head><script"));
+    assertTrue(out.contains("/static/freenetjs/freenetjs.nocache.js"));
+    assertTrue(out.contains("<noscript><style>"));
+    assertTrue(out.contains("/static/reset.css"));
+  }
+}


### PR DESCRIPTION
Summary
- Improve Javadoc and behavior guards in `PushingTagReplacerCallback`
- Add `PushingTagReplacerCallbackTest` covering l10n script generation, <img> rewrite flow, and head/body injections
- Apply Spotless formatting

Motivation
- Clarify responsibilities and concurrency assumptions in the tag replacer used by the HTML filter
- Strengthen safety guards (only operate when JS and web pushing are enabled)
- Increase test coverage for client-side pushing integration points

Technical Notes
- `PushingTagReplacerCallback.java`:
  - Expanded class and constructor documentation, clarified parameter roles
  - Minor refactors for readability; no functional changes to public API
  - Keeps behavior as no-op when pushing or JS are disabled
- Tests (`PushingTagReplacerCallbackTest.java`):
  - Uses Mockito to simulate `SimpleToadletServer` container and `ToadletContext`
  - Validates l10n snippet contains expected fproxy.push keys
  - Exercises IMG rewrite path, including leading slash handling and error conditions
  - Verifies head/body injections (GWT support and requestId + l10n script)

Commit(s)
- f7dc6bc479 fix(client): polish PushingTagReplacerCallback and add tests

Files Changed
- src/main/java/network/crypta/client/filter/PushingTagReplacerCallback.java
- src/test/java/network/crypta/client/filter/PushingTagReplacerCallbackTest.java

Formatting
- Ran `./gradlew spotlessApply` before committing.

Notes
- Base branch for PR: develop
- Branch: feature/fix-PushingTagReplacerCallback
