### PR TITLE
test(theora): expand TheoraBitstreamFilter coverage and add Javadoc

### DIFF
--- a/src/main/java/network/crypta/client/filter/TheoraBitstreamFilter.java
+++ b/src/main/java/network/crypta/client/filter/TheoraBitstreamFilter.java
@@ -6,16 +6,73 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Filters and normalizes Theora packets carried inside Ogg pages.
+ *
+ * <p>This filter wraps an {@link OggBitstreamFilter} and uses a {@link TheoraPacketFilter} to
+ * inspect each packet on an input {@link OggPage}. Packets that parse successfully are preserved,
+ * while packets that cannot be parsed as Theora are skipped silently for the caller (a debug log is
+ * emitted), and a new {@link OggPage} is produced that contains only the accepted packets. If the
+ * underlying bitstream is found to be invalid by the superclass, parsing is aborted and {@code
+ * null} is returned from {@link #parse(OggPage)}.
+ *
+ * <p>Typical usage is to construct one instance per logical Ogg/Theora stream and invoke {@link
+ * #parse(OggPage)} for each page in order. The class holds minimal per-stream state and is intended
+ * to be used in a single-threaded decoding/ingestion pipeline; instances are not designed to be
+ * shared across threads without external synchronization.
+ *
+ * <ul>
+ *   <li>Responsibility: accept well-formed Theora packets and drop malformed ones.
+ *   <li>Scope: operates at the packet level within an Ogg page; does not transcode.
+ *   <li>Failure model: invalid packets are ignored; invalid streams stop further processing.
+ * </ul>
+ *
+ * @see OggBitstreamFilter
+ * @see TheoraPacketFilter
+ * @see OggPage
+ * @see CodecPacket
+ */
 public class TheoraBitstreamFilter extends OggBitstreamFilter {
   private static final Logger LOG = LoggerFactory.getLogger(TheoraBitstreamFilter.class);
 
   private final TheoraPacketFilter parser;
 
+  /**
+   * Creates a new Theora bitstream filter initialized from the supplied page.
+   *
+   * <p>The provided {@code page} is forwarded to the superclass to initialize common Ogg stream
+   * validation and state. Callers typically construct the filter with the first page of a Theora
+   * logical stream and then feed subsequent pages via {@link #parse(OggPage)}.
+   *
+   * <pre>{@code
+   * // Example: construct per-stream filter and feed pages
+   * var filter = new TheoraBitstreamFilter(firstPage);
+   * var processed = filter.parse(nextPage);
+   * }</pre>
+   *
+   * @param page initial {@link OggPage} used to initialize superclass state; must represent the
+   *     same logical stream as subsequent pages; not {@code null}.
+   */
   protected TheoraBitstreamFilter(OggPage page) {
     super(page);
     parser = new TheoraPacketFilter();
   }
 
+  /**
+   * Parses and filters a single Ogg page, returning a page that retains only packets accepted by
+   * the Theora packet parser.
+   *
+   * <p>The method first delegates to the superclass for generic Ogg processing. If the stream has
+   * been marked invalid, it returns {@code null}. Otherwise, each packet from the input page is
+   * parsed; packets that raise a {@code DataFilterException} are skipped, and all other packets are
+   * kept. A new {@link OggPage} instance is returned that references the filtered packet list.
+   *
+   * @param page input {@link OggPage} belonging to the same logical stream used at construction;
+   *     must not be {@code null}.
+   * @return a new {@link OggPage} containing only packets successfully parsed as Theora; returns
+   *     {@code null} when the stream is not valid per superclass checks.
+   * @throws IOException if an I/O error occurs during superclass parsing or page materialization.
+   */
   @Override
   OggPage parse(OggPage page) throws IOException {
     page = super.parse(page);

--- a/src/test/java/network/crypta/client/filter/TheoraBitstreamFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/TheoraBitstreamFilterTest.java
@@ -2,35 +2,56 @@ package network.crypta.client.filter;
 
 import static network.crypta.client.filter.ResourceFileUtil.resourceToDataInputStream;
 import static network.crypta.client.filter.ResourceFileUtil.resourceToOggPage;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class TheoraBitstreamFilterTest {
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class TheoraBitstreamFilterTest {
 
   @Test
-  public void parseIdentificationHeaderTest() throws IOException {
+  void parse_whenIdentificationHeader_expectSamePackets() throws IOException {
+    // Arrange
     OggPage page = resourceToOggPage("./ogg/theora_header.ogg");
-    TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
-    assertEquals(page.asPackets(), theoraBitstreamFilter.parse(page).asPackets());
+    TheoraBitstreamFilter filter = new TheoraBitstreamFilter(page);
+
+    // Act
+    var resultPackets = filter.parse(page).asPackets();
+
+    // Assert
+    assertEquals(page.asPackets(), resultPackets);
   }
 
   @Test
-  public void parseTest() throws IOException {
+  void parse_whenParsingRealTheoraStream_expectNoExceptions() throws IOException {
+    // Arrange
+    int processed = 0;
+
     try (DataInputStream input =
         resourceToDataInputStream("./ogg/Infinite_Hands-2008-Thusnelda-2009-09-18.ogv")) {
       OggPage page = OggPage.readPage(input);
       int pageSerial = page.getSerial();
-      TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
+      TheoraBitstreamFilter filter = new TheoraBitstreamFilter(page);
 
+      // Act
       while (true) {
         try {
           if (page.getSerial() == pageSerial) {
-            theoraBitstreamFilter.parse(page);
+            filter.parse(page);
+            processed++;
           }
 
           page = OggPage.readPage(input);
@@ -39,12 +60,114 @@ public class TheoraBitstreamFilterTest {
         }
       }
     }
+
+    // Assert
+    // At least one page of the target serial should be processed without exceptions.
+    assertTrue(processed > 0);
   }
 
   @Test
-  public void parseInvalidHeaderTest() throws IOException {
+  void parse_whenInvalidHeader_expectUnknownContentTypeException() throws IOException {
+    // Arrange
     OggPage page = resourceToOggPage("./ogg/invalid_header.ogg");
-    TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
-    assertThrows(UnknownContentTypeException.class, () -> theoraBitstreamFilter.parse(page));
+    TheoraBitstreamFilter filter = new TheoraBitstreamFilter(page);
+
+    // Act & Assert
+    assertThrows(UnknownContentTypeException.class, () -> filter.parse(page));
+  }
+
+  @Test
+  void parse_whenParserThrowsDataFilterException_skipsPacket() throws Exception {
+    OggPage page = buildSyntheticPage(1234, 1, new byte[] {1, 2}, new byte[] {3, 4, 5});
+    TheoraBitstreamFilter filter = new TheoraBitstreamFilter(page);
+
+    // Replace internal parser with a stub that throws for the first packet and returns a custom
+    // packet for the second.
+    TheoraPacketFilter stub =
+        new TheoraPacketFilter() {
+          int idx = 0;
+
+          @Override
+          public CodecPacket parse(CodecPacket packet) throws IOException {
+            if (idx++ == 0) {
+              throw new DataFilterException("skip this packet");
+            }
+            return new CodecPacket(new byte[] {9, 9});
+          }
+        };
+    setParserViaReflection(filter, stub);
+
+    OggPage out = filter.parse(page);
+    Collection<CodecPacket> packets = out.asPackets();
+    assertEquals(1, packets.size());
+    assertArrayEquals(new byte[] {9, 9}, packets.iterator().next().toArray());
+  }
+
+  @Test
+  void parse_whenParserThrowsUnknownContentTypeException_propagates() throws Exception {
+    OggPage page = buildSyntheticPage(2222, 1, new byte[] {10, 11, 12});
+    TheoraBitstreamFilter filter = new TheoraBitstreamFilter(page);
+
+    TheoraPacketFilter stub =
+        new TheoraPacketFilter() {
+          @Override
+          public CodecPacket parse(CodecPacket packet) throws IOException {
+            throw new UnknownContentTypeException("theora/test");
+          }
+        };
+    setParserViaReflection(filter, stub);
+
+    assertThrows(UnknownContentTypeException.class, () -> filter.parse(page));
+  }
+
+  @Test
+  void parse_whenPageSequenceOutOfOrder_throwsDataFilterException() throws Exception {
+    OggPage first = buildSyntheticPage(777, 1, new byte[] {1});
+    TheoraBitstreamFilter filter = new TheoraBitstreamFilter(first);
+
+    // Same serial number, but jump sequence number by +2 to violate ordering rules
+    OggPage outOfOrder = buildSyntheticPage(777, 3, new byte[] {2});
+    assertThrows(DataFilterException.class, () -> filter.parse(outOfOrder));
+  }
+
+  // Helpers
+  private static OggPage buildSyntheticPage(int serial, int pageNumber, byte[]... packets)
+      throws IOException {
+    // Build a minimal Ogg page with provided packets (each fits in a single segment <255 bytes).
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(new byte[] {0x4f, 0x67, 0x67, 0x53}); // "OggS"
+    out.write(0); // version
+    out.write(0); // headerType
+    out.write(new byte[8]); // granule position
+    out.write(intToBytes(serial)); // bitstream serial
+    out.write(intToBytes(pageNumber)); // page sequence number
+    out.write(new byte[4]); // checksum (ignored by parser here)
+
+    int segmentCount = packets.length;
+    out.write((byte) segmentCount);
+    for (byte[] p : packets) {
+      if (p.length == 0 || p.length >= 255) {
+        throw new IllegalArgumentException("packet must be 1..254 bytes for this helper");
+      }
+      out.write((byte) p.length);
+    }
+    for (byte[] p : packets) {
+      out.write(p);
+    }
+
+    try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+      return OggPage.readPage(in);
+    }
+  }
+
+  private static byte[] intToBytes(int value) {
+    return ByteBuffer.allocate(4).putInt(value).array();
+  }
+
+  private static void setParserViaReflection(TheoraBitstreamFilter filter, TheoraPacketFilter stub)
+      throws Exception {
+    var field = TheoraBitstreamFilter.class.getDeclaredField("parser");
+    field.setAccessible(true);
+    field.set(filter, stub);
   }
 }


### PR DESCRIPTION
Summary
- Add comprehensive Javadoc to TheoraBitstreamFilter describing purpose, usage, and behavior.
- Expand and refactor tests in TheoraBitstreamFilterTest:
  - Identification header round‑trip now clearer and behavior‑named.
  - Real‑stream parsing assertion that at least one page is processed without exceptions.
  - New tests covering:
    - Skipping malformed packets when TheoraPacketFilter throws DataFilterException.
    - Propagation of UnknownContentTypeException.
    - Out‑of‑order page sequence handling (throws DataFilterException).
  - Helpers to synthesize minimal Ogg pages for precise, deterministic scenarios.
- Apply Spotless formatting across modified sources.

Notes
- No functional production code changes beyond non‑behavioral Javadoc additions.
- Formatting performed via Spotless (spotlessApply). Build files under build-logic/build/… reported style issues during spotlessCheck but are generated artifacts and are not tracked.

Change scope
- 2 files changed:
  - src/main/java/network/crypta/client/filter/TheoraBitstreamFilter.java (Javadoc only)
  - src/test/java/network/crypta/client/filter/TheoraBitstreamFilterTest.java (tests)

Motivation
- Improve test coverage and clarify the responsibilities and failure model of the Theora bitstream filter. The added tests guard current behavior and provide a baseline for future refactors.

Risk
- Low: test-only changes and documentation. Parsing behavior is unchanged.

CI
- Please run the standard Gradle test workflow in CI. Locally, Spotless was applied.
