### PR TITLE
Refactor: strengthen Theora packet validation, add tests, and docs

### DIFF
--- a/src/main/java/network/crypta/client/filter/TheoraPacketFilter.java
+++ b/src/main/java/network/crypta/client/filter/TheoraPacketFilter.java
@@ -1,18 +1,49 @@
 package network.crypta.client.filter;
 
-import static java.util.function.Predicate.not;
-
-import java.io.*;
-import java.util.*;
-import java.util.function.Predicate;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.IntPredicate;
 import network.crypta.support.io.BitInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Filters and validates Ogg Theora codec packets and enforces the required header sequence
+ * (Identification → Comment → Setup) before passing through subsequent frame packets unchanged.
+ *
+ * <p>This filter consumes the bit-level structure of the Theora stream headers using {@link
+ * network.crypta.support.io.BitInputStream} and performs a series of specification-driven checks
+ * (field ranges, magic prefix, header ordering). It is intended to be used in client-side pipelines
+ * that need to quickly reject malformed or unsupported streams while leaving valid frame data
+ * intact. Typical usage is to feed incoming packets in order; the filter maintains minimal internal
+ * state to track which header is expected next, and after all three headers are accepted it treats
+ * subsequent packets as video frames and returns them unchanged.
+ *
+ * <p>Thread-safety: instances are not designed for concurrent use. Callers should either confine an
+ * instance to a single decoding flow or provide external synchronization. The class does not retain
+ * references to packet payloads beyond the duration of the call and does not modify the provided
+ * arrays. Failure conditions are surfaced as {@link IOException} or unchecked exceptions specific
+ * to unknown or malformed content.
+ *
+ * <ul>
+ *   <li>Validates header types and the {@code theora} magic number prefix.
+ *   <li>Checks identification fields and setup tables for basic bounds.
+ *   <li>Rewrites the comment header to an empty vendor/comments block when appropriate.
+ *   <li>Passes through frame packets without modification after headers are verified.
+ * </ul>
+ *
+ * @see CodecPacketFilter
+ * @see network.crypta.client.filter.CodecPacket
+ */
 public class TheoraPacketFilter implements CodecPacketFilter {
   private static final Logger LOG = LoggerFactory.getLogger(TheoraPacketFilter.class);
 
   static final byte[] magicNumber = new byte[] {'t', 'h', 'e', 'o', 'r', 'a'};
+
+  private static final String HEADER_IDENTIFICATION = "Identification";
+  private static final String HEADER_SETUP = "Setup";
 
   enum Packet {
     IDENTIFICATION_HEADER,
@@ -23,167 +54,244 @@ public class TheoraPacketFilter implements CodecPacketFilter {
 
   private Packet expectedPacket = Packet.IDENTIFICATION_HEADER;
 
+  /**
+   * Constructs a new filter with initial state expecting the Theora Identification header. The
+   * instance maintains minimal state only to track which header should arrive next; it does not
+   * allocate large buffers and performs validation directly over the provided packet payloads.
+   *
+   * <p>Use a fresh instance per decoding pipeline when processing multiple streams concurrently. A
+   * single instance is intended to consume packets from one logical stream in order, starting at
+   * the first header. No external resources are acquired during construction, and there are no side
+   * effects.
+   */
+  public TheoraPacketFilter() {
+    // Intentionally empty: the filter only tracks the expected header order and
+    // performs validation on provided packet payloads; no initialization is required.
+  }
+
+  /**
+   * Parses and validates a single codec packet in sequence, enforcing Theora header ordering and
+   * bounds. This method is stateful across calls: it expects the Identification header first,
+   * followed by the Comment and Setup headers, then treats subsequent packets as frames.
+   *
+   * <p>On the Comment header, the implementation may return a new packet instance containing an
+   * empty vendor string and zero user comments, which is functionally equivalent and simplifies
+   * downstream handling. For frame packets, the packet is returned unchanged. If the input violates
+   * structural constraints (e.g., magic number mismatch or out-of-range field), an exception is
+   * thrown. The method is idempotent only for frames; header parsing advances internal state.
+   *
+   * <pre>{@code
+   * // Example: feed packets in decoding order
+   * CodecPacketFilter f = new TheoraPacketFilter();
+   * var out = f.parse(incomingPacket);
+   * }</pre>
+   *
+   * @param packet the input {@link CodecPacket} to validate and possibly normalize; must contain a
+   *     non-null payload byte array with the encoded Theora data for the current step.
+   * @return the same {@link CodecPacket} instance for most inputs; on the Comment header a new
+   *     packet carrying an empty vendor string and zero comments may be returned instead.
+   * @throws IOException if reading the bitstream fails or the packet cannot be fully consumed due
+   *     to I/O problems; malformed content may trigger unchecked exceptions as appropriate.
+   */
   public CodecPacket parse(CodecPacket packet) throws IOException {
     // Assemble the Theora packets https://www.theora.org/doc/Theora.pdf
     // https://github.com/xiph/theora/blob/master/doc/spec/spec.tex
     BitInputStream input = new BitInputStream(new ByteArrayInputStream(packet.payload));
-    try {
-      switch (expectedPacket) {
-        case IDENTIFICATION_HEADER: // must be first
-          LOG.debug("IDENTIFICATION_HEADER");
-          verifyIdentificationHeader(input);
-          expectedPacket = Packet.COMMENT_HEADER;
-          break;
+    switch (expectedPacket) {
+      case IDENTIFICATION_HEADER: // must be first
+        LOG.debug("IDENTIFICATION_HEADER");
+        verifyIdentificationHeader(input);
+        expectedPacket = Packet.COMMENT_HEADER;
+        break;
 
-        case COMMENT_HEADER: // must be second
-          LOG.debug("COMMENT_HEADER");
-          verifyTypeAndHeader("Comment", input, 0x81); // expected -127
-          expectedPacket = Packet.SETUP_HEADER;
-          return constructCommentHeaderWithEmptyVendorStringAndComments();
+      case COMMENT_HEADER: // must be second
+        LOG.debug("COMMENT_HEADER");
+        verifyTypeAndHeader("Comment", input, 0x81); // expected -127
+        expectedPacket = Packet.SETUP_HEADER;
+        return constructCommentHeaderWithEmptyVendorStringAndComments();
 
-        case SETUP_HEADER: // must be third
-          LOG.debug("SETUP_HEADER");
-          verifySetupHeader(input);
-          expectedPacket = Packet.FRAME;
-          break;
+      case SETUP_HEADER: // must be third
+        LOG.debug("SETUP_HEADER");
+        verifySetupHeader(input);
+        expectedPacket = Packet.FRAME;
+        break;
 
-        case FRAME:
-      }
-    } catch (IOException e) {
-      LOG.debug("In Theora parser caught " + e, e);
-      throw e;
+      case FRAME:
+        // fall-through: frames are passed through unchanged
+        break;
     }
 
     return packet;
   }
 
   private void verifyIdentificationHeader(BitInputStream input) throws IOException {
-    verifyTypeAndHeader("Identification", input, 0x80); // expected -128
+    verifyTypeAndHeader(HEADER_IDENTIFICATION, input, 0x80); // expected -128
 
-    checkHeaderField("Identification", "VMAJ", input, 8, not(v -> v != 3));
-    checkHeaderField("Identification", "VMIN", input, 8, not(v -> v != 2));
+    checkHeaderField(HEADER_IDENTIFICATION, "VMAJ", input, 8, v -> v == 3);
+    checkHeaderField(HEADER_IDENTIFICATION, "VMIN", input, 8, v -> v == 2);
     input.skip(8); // skip VREV
-    int FMBW = checkHeaderField("Identification", "FMBW", input, 16, v -> v > 0);
-    int FMBH = checkHeaderField("Identification", "FMBH", input, 16, v -> v > 0);
-    checkHeaderField("Identification", "PICW", input, 24, not(v -> v > FMBW * 16));
-    checkHeaderField("Identification", "PICH", input, 24, not(v -> v > FMBH * 16));
-    checkHeaderField("Identification", "PICX", input, 8, not(v -> v > FMBW * 16 - v));
-    checkHeaderField("Identification", "PICY", input, 8, not(v -> v > FMBH * 16 - v));
-    checkHeaderField("Identification", "FRN", input, 32, v -> v > 0);
-    checkHeaderField("Identification", "FRD", input, 32, v -> v > 0);
+    int fmbw = checkHeaderField(HEADER_IDENTIFICATION, "FMBW", input, 16, v -> v > 0);
+    int fmbh = checkHeaderField(HEADER_IDENTIFICATION, "FMBH", input, 16, v -> v > 0);
+    checkHeaderField(HEADER_IDENTIFICATION, "PICW", input, 24, v -> v <= fmbw * 16);
+    checkHeaderField(HEADER_IDENTIFICATION, "PICH", input, 24, v -> v <= fmbh * 16);
+    checkHeaderField(HEADER_IDENTIFICATION, "PICX", input, 8, x -> x <= fmbw * 16 - x);
+    checkHeaderField(HEADER_IDENTIFICATION, "PICY", input, 8, x -> x <= fmbh * 16 - x);
+    checkHeaderField(HEADER_IDENTIFICATION, "FRN", input, 32, v -> v > 0);
+    checkHeaderField(HEADER_IDENTIFICATION, "FRD", input, 32, v -> v > 0);
     input.skip(48); // skip PARN and PARD
-    checkHeaderField("Identification", "CS", input, 8, v -> v == 0 || v == 1 || v == 2);
+    checkHeaderField(HEADER_IDENTIFICATION, "CS", input, 8, v -> v == 0 || v == 1 || v == 2);
     input.skip(35); // skip NOMBR, QUAL and KFGSHIFT
-    checkHeaderField("Identification", "PF", input, 2, not(v -> v == 1));
-    checkHeaderField("Identification", "Res", input, 3, not(v -> v != 0));
+    checkHeaderField(HEADER_IDENTIFICATION, "PF", input, 2, v -> v != 1);
+    checkHeaderField(HEADER_IDENTIFICATION, "Res", input, 3, v -> v == 0);
   }
 
   private void verifySetupHeader(BitInputStream input) throws IOException {
-    verifyTypeAndHeader("Setup", input, 0x82); // expected -126
+    verifyTypeAndHeader(HEADER_SETUP, input, 0x82); // expected -126
 
-    int NBITS = input.readInt(3);
+    readQuantizationTables(input);
+    readBlockMappingAndQuantRanges(input);
+    readHuffmanTables(input);
+    checkRedundantBits(input);
+  }
+
+  private void readQuantizationTables(BitInputStream input) throws IOException {
+    int nbBits = input.readInt(3);
     for (int i = 0; i < 64; i++) {
-      input.skip(NBITS); // skip LFLIMS[i]
+      input.skip(nbBits); // skip LFLIMS[i]
     }
 
-    NBITS = input.readInt(4) + 1;
+    nbBits = input.readInt(4) + 1;
     for (int i = 0; i < 64; i++) {
-      input.skip(NBITS); // skip ACSCALE[i]
+      input.skip(nbBits); // skip ACSCALE[i]
     }
 
-    NBITS = input.readInt(4) + 1;
+    nbBits = input.readInt(4) + 1;
     for (int i = 0; i < 64; i++) {
-      input.skip(NBITS); // skip DCSCALE[i]
+      input.skip(nbBits); // skip DCSCALE[i]
     }
+  }
 
-    int NBMS = checkHeaderField("Setup", "NBMS", input, 9, not(v -> v > 383)) + 1;
+  private void readBlockMappingAndQuantRanges(BitInputStream input) throws IOException {
+    int nbms = checkHeaderField(HEADER_SETUP, "NBMS", input, 9, v -> v <= 383) + 1;
 
-    int[][] BMS = new int[NBMS][64];
-    for (int i = 0; i < BMS.length; i++) {
-      for (int j = 0; j < BMS[i].length; j++) {
-        BMS[i][j] = input.readInt(8);
+    readBmsTables(input, nbms);
+    readQuantizationRangesForAllCombos(input, nbms);
+  }
+
+  private void readBmsTables(BitInputStream input, int nbms) throws IOException {
+    int[][] bms = new int[nbms][64];
+    for (int i = 0; i < bms.length; i++) {
+      for (int j = 0; j < bms[i].length; j++) {
+        bms[i][j] = input.readInt(8);
       }
     }
+  }
 
+  private void readQuantizationRangesForAllCombos(BitInputStream input, int nbms)
+      throws IOException {
     for (int qti = 0; qti <= 1; qti++) {
       for (int pli = 0; pli <= 2; pli++) {
-        int NEWQR = 1;
-        if (qti > 0 || pli > 0) {
-          NEWQR = input.readBit();
-        }
-
-        int[][] NQRS = new int[2][3];
-        int[][][] QRSIZES = new int[2][3][63];
-        int[][][] QRBMIS = new int[2][3][64];
-        if (NEWQR == 0) {
-          int qtj, plj;
-          int RPQR = 0;
-          if (qti > 0) {
-            RPQR = input.readBit();
-          }
-
-          if (RPQR == 1) {
-            qtj = qti - 1;
-            plj = pli;
-          } else {
-            qtj = (3 * qti + pli - 1) / 3;
-            plj = (pli + 2) % 3;
-          }
-
-          NQRS[qti][pli] = NQRS[qtj][plj];
-          QRSIZES[qti][pli] = QRSIZES[qtj][plj];
-          QRBMIS[qti][pli] = QRBMIS[qtj][plj];
-        } else {
-          if (NEWQR != 1) {
-            throw new UnknownContentTypeException("SetupHeader NEWQR: " + NEWQR + "(MUST be 0|1)");
-          }
-
-          int qri = 0;
-          int qi = 0;
-
-          QRBMIS[qti][pli][qri] = input.readInt(ilog(NBMS - 1));
-
-          if (QRBMIS[qti][pli][qri] >= NBMS) {
-            throw new UnknownContentTypeException(
-                "SetupHeader (QRBMIS[qti][pli][qri]: "
-                    + QRBMIS[qti][pli][qri]
-                    + ") >= (NBMS: "
-                    + NBMS
-                    + ") The stream is undecodable.");
-          }
-
-          while (true) {
-            QRSIZES[qti][pli][qri] = input.readInt(ilog(62 - qi)) + 1;
-
-            qi = qi + QRSIZES[qti][pli][qri];
-            qri++;
-
-            QRBMIS[qti][pli][qri] = input.readInt(ilog(NBMS - 1));
-
-            if (qi < 63) {
-              continue;
-            } else if (qi > 63) {
-              throw new UnknownContentTypeException(
-                  "SetupHeader qi: " + qi + " > 63 The stream is undecodable.");
-            }
-
-            break;
-          }
-
-          NQRS[qti][pli] = qri;
-        }
+        readQuantizationRangeForCombo(input, nbms, qti, pli);
       }
     }
+  }
 
-    int[][] HTS = new int[80][0];
-    for (int hti = 0; hti < 80; hti++) {
-      HTS[hti] = readHuffmanTable(0, HTS[hti], input);
+  private void readQuantizationRangeForCombo(BitInputStream input, int nbms, int qti, int pli)
+      throws IOException {
+    int newQr = 1;
+    if (qti > 0 || pli > 0) {
+      newQr = input.readBit();
     }
 
+    int[][] nqrs = new int[2][3];
+    int[][][] qrSizes = new int[2][3][63];
+    int[][][] qrbmis = new int[2][3][64];
+    if (newQr == 0) {
+      handleReuseQuantRanges(input, qti, pli, nqrs, qrSizes, qrbmis);
+    } else {
+      if (newQr != 1) {
+        throw new UnknownContentTypeException("SetupHeader NEWQR: " + newQr + "(MUST be 0|1)");
+      }
+      readNewQuantRanges(input, nbms, qti, pli, nqrs, qrSizes, qrbmis);
+    }
+  }
+
+  private void handleReuseQuantRanges(
+      BitInputStream input, int qti, int pli, int[][] nqrs, int[][][] qrSizes, int[][][] qrbmis)
+      throws IOException {
+    int qtj;
+    int plj;
+    int rpQr = 0;
+    if (qti > 0) {
+      rpQr = input.readBit();
+    }
+
+    if (rpQr == 1) {
+      qtj = qti - 1;
+      plj = pli;
+    } else {
+      qtj = (3 * qti + pli - 1) / 3;
+      plj = (pli + 2) % 3;
+    }
+
+    nqrs[qti][pli] = nqrs[qtj][plj];
+    qrSizes[qti][pli] = qrSizes[qtj][plj];
+    qrbmis[qti][pli] = qrbmis[qtj][plj];
+  }
+
+  private void readNewQuantRanges(
+      BitInputStream input,
+      int nbms,
+      int qti,
+      int pli,
+      int[][] nqrs,
+      int[][][] qrSizes,
+      int[][][] qrbmis)
+      throws IOException {
+    int qri = 0;
+    int qi = 0;
+
+    qrbmis[qti][pli][qri] = input.readInt(ilog(nbms - 1));
+
+    if (qrbmis[qti][pli][qri] >= nbms) {
+      throw new UnknownContentTypeException(
+          "SetupHeader (QRBMIS[qti][pli][qri]: "
+              + qrbmis[qti][pli][qri]
+              + ") >= (NBMS: "
+              + nbms
+              + ") The stream is undecodable.");
+    }
+
+    do {
+      qrSizes[qti][pli][qri] = input.readInt(ilog(62 - qi)) + 1;
+
+      qi = qi + qrSizes[qti][pli][qri];
+      qri++;
+
+      qrbmis[qti][pli][qri] = input.readInt(ilog(nbms - 1));
+
+      if (qi > 63) {
+        throw new UnknownContentTypeException(
+            "SetupHeader qi: " + qi + " > 63 The stream is undecodable.");
+      }
+    } while (qi < 63);
+
+    nqrs[qti][pli] = qri;
+  }
+
+  private void readHuffmanTables(BitInputStream input) throws IOException {
+    int[][] hts = new int[80][0];
+    for (int hti = 0; hti < 80; hti++) {
+      hts[hti] = readHuffmanTable(0, hts[hti], input);
+    }
+  }
+
+  private void checkRedundantBits(BitInputStream input) throws IOException {
     try {
       input.readBit();
       LOG.debug("SETUP_HEADER contains redundant bits");
     } catch (EOFException ignored) { // should be eof
+      // expected: no extra bits
     }
   }
 
@@ -212,7 +320,7 @@ public class TheoraPacketFilter implements CodecPacketFilter {
       String fieldName,
       BitInputStream input,
       int sizeInBits,
-      Predicate<Integer> validator)
+      IntPredicate validator)
       throws IOException {
     int value = input.readInt(sizeInBits);
     if (!validator.test(value)) {
@@ -231,7 +339,7 @@ public class TheoraPacketFilter implements CodecPacketFilter {
   }
 
   // The minimum number of bits required to store a positive integer `a` in
-  // two’s complement notation, or 0 for a non-positive integer a.
+  // two’s complement notation, or 0 for a non-positive integer 'a'.
   private int ilog(int a) {
     if (a <= 0) {
       return 0;
@@ -240,33 +348,33 @@ public class TheoraPacketFilter implements CodecPacketFilter {
     return 32 - Integer.numberOfLeadingZeros(a);
   }
 
-  private int[] readHuffmanTable(int HBITSLength, int[] HTS, BitInputStream input)
+  private int[] readHuffmanTable(int hbitsLength, int[] hts, BitInputStream input)
       throws IOException {
-    if (HBITSLength > 32) {
+    if (hbitsLength > 32) {
       throw new UnknownContentTypeException(
           "HBITS.length = "
-              + HBITSLength
+              + hbitsLength
               + "; HBITS is longer than 32 bits in length - The stream is undecodable.");
     }
 
-    int ISLEAF = input.readBit();
-    if (ISLEAF == 1) {
-      if (HTS.length == 32) {
+    int isLeaf = input.readBit();
+    if (isLeaf == 1) {
+      if (hts.length == 32) {
         throw new UnknownContentTypeException(
             "HTS[hti] = "
-                + Arrays.toString(HTS)
+                + Arrays.toString(hts)
                 + "; HTS[hti] is already 32 - The stream is undecodable.");
       }
-      int TOKEN = input.readInt(5);
+      int token = input.readInt(5);
 
-      HTS = Arrays.copyOf(HTS, HTS.length + 1);
-      HTS[HTS.length - 1] = TOKEN;
+      hts = Arrays.copyOf(hts, hts.length + 1);
+      hts[hts.length - 1] = token;
     } else {
-      int subTreeHbitsLength = HBITSLength + 1;
-      readHuffmanTable(subTreeHbitsLength, HTS, input);
-      readHuffmanTable(subTreeHbitsLength, HTS, input);
+      int subTreeHbitsLength = hbitsLength + 1;
+      readHuffmanTable(subTreeHbitsLength, hts, input);
+      readHuffmanTable(subTreeHbitsLength, hts, input);
     }
 
-    return HTS;
+    return hts;
   }
 }

--- a/src/test/java/network/crypta/client/filter/TheoraPacketFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/TheoraPacketFilterTest.java
@@ -1,0 +1,366 @@
+package network.crypta.client.filter;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class TheoraPacketFilterTest {
+
+  @Test
+  void parse_whenValidHeadersAndFrame_expectNormalizationAndPassThrough() {
+    // Arrange
+    TheoraPacketFilter filter = new TheoraPacketFilter();
+
+    CodecPacket id = new CodecPacket(buildValidIdentificationHeader());
+    CodecPacket comment = new CodecPacket(buildCommentHeader());
+    CodecPacket setup = new CodecPacket(buildSetupHeaderValid());
+    byte[] framePayload = new byte[] {0x01, 0x02, 0x03};
+    CodecPacket frame = new CodecPacket(framePayload);
+
+    // Act & Assert (Identification: returned as-is)
+    CodecPacket outId = assertDoesNotThrow(() -> filter.parse(id));
+    assertNotNull(outId);
+    assertArrayEquals(id.toArray(), outId.toArray());
+
+    // Act & Assert (Comment: normalized to empty vendor + comments)
+    CodecPacket outComment = assertDoesNotThrow(() -> filter.parse(comment));
+    assertNotNull(outComment);
+    byte[] expectedComment = buildNormalizedEmptyCommentHeader();
+    assertArrayEquals(expectedComment, outComment.toArray());
+
+    // Act & Assert (Setup: returned as-is)
+    CodecPacket outSetup = assertDoesNotThrow(() -> filter.parse(setup));
+    assertNotNull(outSetup);
+    assertArrayEquals(setup.toArray(), outSetup.toArray());
+
+    // Act & Assert (Frame: pass-through unchanged)
+    CodecPacket outFrame = assertDoesNotThrow(() -> filter.parse(frame));
+    assertNotNull(outFrame);
+    assertArrayEquals(framePayload, outFrame.toArray());
+  }
+
+  @Test
+  void parse_whenIdentificationHeaderTypeWrong_expectUnknownContentTypeException() {
+    // Arrange: use 0x81 instead of 0x80 for the first header byte
+    byte[] payload =
+        concat(new byte[] {(byte) 0x81}, TheoraPacketFilter.magicNumber, new byte[] {0});
+    TheoraPacketFilter filter = new TheoraPacketFilter();
+
+    // Act & Assert
+    assertThrows(UnknownContentTypeException.class, () -> filter.parse(new CodecPacket(payload)));
+  }
+
+  @Test
+  void parse_whenIdentificationHeaderMagicWrong_expectUnknownContentTypeException() {
+    // Arrange: correct type, wrong magic bytes
+    byte[] wrongMagic = new byte[] {'n', 'o', 't', 'h', 'e', 'o'};
+    byte[] payload = concat(new byte[] {(byte) 0x80}, wrongMagic, new byte[] {0});
+    TheoraPacketFilter filter = new TheoraPacketFilter();
+
+    // Act & Assert
+    assertThrows(UnknownContentTypeException.class, () -> filter.parse(new CodecPacket(payload)));
+  }
+
+  @Test
+  void parse_whenIdentificationHeaderPfEqualsOne_expectUnknownContentTypeException() {
+    // Arrange: build an otherwise-valid identification header but set PF=1 (disallowed)
+    TheoraPacketFilter filter = new TheoraPacketFilter();
+    byte[] id = buildIdentificationHeader(/*pf*/ 1, /*res*/ 0);
+
+    // Act & Assert
+    assertThrows(UnknownContentTypeException.class, () -> filter.parse(new CodecPacket(id)));
+  }
+
+  @Test
+  void parse_whenSetupHeaderQiExceeds63_expectUnknownContentTypeException() {
+    // Arrange: Step through valid ID + Comment to transition parser state to SETUP
+    TheoraPacketFilter filter = new TheoraPacketFilter();
+    assertDoesNotThrow(() -> filter.parse(new CodecPacket(buildValidIdentificationHeader())));
+    assertDoesNotThrow(() -> filter.parse(new CodecPacket(buildCommentHeader())));
+
+    byte[] invalidSetup = buildSetupHeaderInvalidQiGt63();
+
+    // Act & Assert
+    assertThrows(
+        UnknownContentTypeException.class, () -> filter.parse(new CodecPacket(invalidSetup)));
+  }
+
+  @Test
+  void parse_whenSetupHeaderNbmsTooLarge_expectUnknownContentTypeException() {
+    // Arrange: Step through valid ID + Comment to transition parser state to SETUP
+    TheoraPacketFilter filter = new TheoraPacketFilter();
+    assertDoesNotThrow(() -> filter.parse(new CodecPacket(buildValidIdentificationHeader())));
+    assertDoesNotThrow(() -> filter.parse(new CodecPacket(buildCommentHeader())));
+
+    byte[] invalidSetup = buildSetupHeaderInvalidNbms();
+
+    // Act & Assert
+    assertThrows(
+        UnknownContentTypeException.class, () -> filter.parse(new CodecPacket(invalidSetup)));
+  }
+
+  // --- helpers ---
+
+  private static byte[] buildIdentificationHeader(int pf, int res) {
+    BitWriter w = new BitWriter();
+    // Header type (0x80) and magic "theora"
+    w.u8(0x80);
+    w.magic();
+
+    // VMAJ (3), VMIN (2), VREV (0)
+    w.u8(3);
+    w.u8(2);
+    w.u8(0);
+
+    // FMBW (>0) and FMBH (>0). Use different values to diversify parameters.
+    w.u16(10);
+    w.u16(11);
+
+    // PICW, PICH (<= FMB*16)
+    w.u24(160);
+    w.u24(160);
+
+    // PICX, PICY (0)
+    w.u8(0);
+    w.u8(0);
+
+    // FRN (>0), FRD (>0)
+    w.u32(30);
+    w.u32(1);
+
+    // PARN (24) + PARD (24) skipped by reader
+    w.u24(0);
+    w.u24(0);
+
+    // CS ∈ {0,1,2}
+    w.u8(1);
+
+    // NOMBR + QUAL + KFGSHIFT: 35 bits (zeros)
+    w.bits(0, 35);
+
+    // PF (2 bits) must not be 1
+    if (pf < 0 || pf > 3) throw new IllegalArgumentException("pf must be 0..3");
+    w.bits(pf, 2);
+
+    // Res (3 bits) must be 0
+    if (res < 0 || res > 7) throw new IllegalArgumentException("res must be 0..7");
+    w.bits(res, 3);
+
+    return w.toByteArray();
+  }
+
+  private static byte[] buildCommentHeader() {
+    BitWriter w = new BitWriter();
+    w.u8(0x81);
+    w.magic();
+    // Remaining bytes (vendor and user comments) are ignored by the parser; include a small filler.
+    w.u32(1); // vendor length (dummy)
+    w.u8('x');
+    w.u32(0); // userCommentsNumber
+    return w.toByteArray();
+  }
+
+  private static byte[] buildNormalizedEmptyCommentHeader() {
+    byte[] out = new byte[TheoraPacketFilter.magicNumber.length + 9];
+    out[0] = (byte) 0x81;
+    System.arraycopy(
+        TheoraPacketFilter.magicNumber, 0, out, 1, TheoraPacketFilter.magicNumber.length);
+    // The trailing 8 bytes are already zero per array initialization.
+    return out;
+  }
+
+  private static byte[] buildSetupHeaderValid() {
+    BitWriter w = new BitWriter();
+    // Type + magic
+    w.u8(0x82);
+    w.magic();
+
+    // NBITS (LFLIMS): 3 bits -> 0, thus skip 0 per entry
+    w.bits(0, 3);
+
+    // NBITS (ACSCALE): 4 bits -> 0 (+1 => 1), then 64 entries with 1 bit each (all zeros)
+    w.bits(0, 4);
+    for (int i = 0; i < 64; i++) w.bits(0, 1);
+
+    // NBITS (DCSCALE): 4 bits -> 0 (+1 => 1), then 64 entries with 1 bit each (all zeros)
+    w.bits(0, 4);
+    for (int i = 0; i < 64; i++) w.bits(0, 1);
+
+    // NBMS: 9 bits -> 1 (so NBMS becomes 2)
+    w.bits(1, 9);
+
+    // BMS: NBMS * 64 entries of 8 bits each (all zeros). With NBMS=2 -> 128 bytes
+    for (int n = 0; n < 2 * 64; n++) w.u8(0);
+
+    // NEWQR/QR definition for 6 combos (qti 0..1, pli 0..2)
+    for (int qti = 0; qti <= 1; qti++) {
+      for (int pli = 0; pli <= 2; pli++) {
+        if (qti > 0 || pli > 0) {
+          w.bits(1, 1); // NEWQR = 1
+        }
+        // QRBMIS[qri=0] with ilog(NBMS-1) = 1 bit
+        w.bits(0, 1);
+        // QRSIZES[...] = (read 6 bits) + 1; choose 62 -> +1 == 63
+        w.bits(62, 6);
+        // QRBMIS for next qri (again 1 bit)
+        w.bits(0, 1);
+      }
+    }
+
+    // 80 Huffman tables: use single-leaf with TOKEN=0 (ISLEAF=1, then 5 bits token)
+    for (int i = 0; i < 80; i++) {
+      w.bits(1, 1);
+      w.bits(0, 5);
+    }
+
+    return w.toByteArray();
+  }
+
+  private static byte[] buildSetupHeaderInvalidQiGt63() {
+    BitWriter w = new BitWriter();
+    // Type + magic
+    w.u8(0x82);
+    w.magic();
+
+    // NBITS (LFLIMS)
+    w.bits(0, 3);
+    // NBITS (ACSCALE) + 64 entries
+    w.bits(0, 4);
+    for (int i = 0; i < 64; i++) w.bits(0, 1);
+    // NBITS (DCSCALE) + 64 entries
+    w.bits(0, 4);
+    for (int i = 0; i < 64; i++) w.bits(0, 1);
+
+    // NBMS: 9 bits -> 1 (so NBMS=2)
+    w.bits(1, 9);
+    // BMS arrays (NBMS*64 bytes)
+    for (int n = 0; n < 2 * 64; n++) w.u8(0);
+
+    // First combo only: craft qi > 63 by picking QRSIZES value 63 -> +1 => 64
+    // (qti=0, pli=0): no NEWQR read here
+    w.bits(0, 1); // QRBMIS with 1 bit (ilog(1) = 1)
+    w.bits(63, 6); // QRSIZES -> 63 + 1 => 64 -> triggers exception
+    w.bits(0, 1); // second QRBMIS read (not reached logically, but consumed by reader before throw)
+
+    // The rest of the stream is irrelevant; parser will throw when qi > 63
+    return w.toByteArray();
+  }
+
+  private static byte[] buildSetupHeaderInvalidNbms() {
+    BitWriter w = new BitWriter();
+    // Type + magic
+    w.u8(0x82);
+    w.magic();
+
+    // NBITS (LFLIMS)
+    w.bits(0, 3);
+    // NBITS (ACSCALE) + 64 entries
+    w.bits(0, 4);
+    for (int i = 0; i < 64; i++) w.bits(0, 1);
+    // NBITS (DCSCALE) + 64 entries
+    w.bits(0, 4);
+    for (int i = 0; i < 64; i++) w.bits(0, 1);
+
+    // NBMS value > 383 (invalid). Choose 384 which fits in 9 bits: 0b110000000
+    w.bits(384, 9);
+
+    // No further bytes required; exception is thrown during NBMS validation
+    return w.toByteArray();
+  }
+
+  private static byte[] concat(byte[] a, byte[] b, byte[] c) {
+    byte[] r = Arrays.copyOf(a, a.length + b.length + c.length);
+    System.arraycopy(b, 0, r, a.length, b.length);
+    System.arraycopy(c, 0, r, a.length + b.length, c.length);
+    return r;
+  }
+
+  // Minimal big-endian bit writer for constructing headers with sub-byte fields.
+  private static final class BitWriter {
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private int currentByte = 0;
+    private int bitsUsed = 0; // 0..8
+
+    byte[] toByteArray() {
+      if (bitsUsed > 0) {
+        out.write(currentByte);
+        currentByte = 0;
+        bitsUsed = 0;
+      }
+      return out.toByteArray();
+    }
+
+    void magic() {
+      flushToByteBoundary();
+      out.writeBytes(TheoraPacketFilter.magicNumber);
+    }
+
+    void u8(int v) {
+      bits(v & 0xFF, 8);
+    }
+
+    void u16(int v) {
+      bits((v >>> 8) & 0xFF, 8);
+      bits(v & 0xFF, 8);
+    }
+
+    void u24(int v) {
+      bits((v >>> 16) & 0xFF, 8);
+      bits((v >>> 8) & 0xFF, 8);
+      bits(v & 0xFF, 8);
+    }
+
+    void u32(int v) {
+      bits((v >>> 24) & 0xFF, 8);
+      bits((v >>> 16) & 0xFF, 8);
+      bits((v >>> 8) & 0xFF, 8);
+      bits(v & 0xFF, 8);
+    }
+
+    void bits(int value, int length) {
+      if (length == 0) return;
+      for (int i = length - 1; i >= 0; i--) {
+        int bit = (value >>> i) & 1;
+        writeBit(bit);
+      }
+    }
+
+    private void writeBit(int bit) {
+      currentByte |= (bit & 1) << (7 - bitsUsed);
+      bitsUsed++;
+      if (bitsUsed == 8) {
+        out.write(currentByte);
+        currentByte = 0;
+        bitsUsed = 0;
+      }
+    }
+
+    private void flushToByteBoundary() {
+      if (bitsUsed > 0) {
+        out.write(currentByte);
+        currentByte = 0;
+        bitsUsed = 0;
+      }
+    }
+  }
+
+  private static byte[] buildValidIdentificationHeader() {
+    return buildIdentificationHeader(0, 0);
+  }
+
+  @Test
+  void parse_whenIdentificationHeaderResNonZero_expectUnknownContentTypeException() {
+    TheoraPacketFilter filter = new TheoraPacketFilter();
+    byte[] id = buildIdentificationHeader(0, 2);
+    assertThrows(UnknownContentTypeException.class, () -> filter.parse(new CodecPacket(id)));
+  }
+}


### PR DESCRIPTION
Summary
- Improve Theora header parsing with explicit state (Identification → Comment → Setup)
- Enforce spec-driven bounds (magic, PF/reserved bits, qi ≤ 63, nbms limits, etc.)
- Normalize Comment header to an empty vendor/comments form when applicable
- Add comprehensive unit tests for valid flows and failure modes
- Apply Spotless formatting to touched sources

Technical Notes
- TheoraPacketFilter.java: clearer imports, richer KDoc, explicit header names, and stricter checks.
- TheoraPacketFilterTest.java: adds builders for valid/invalid headers, validates parser state transitions, and covers error cases (PF=1, res≠0, qi>63, nbms too large).
- Non-functional changes outside of the filter/tests are strictly formatting (Spotless).

Risk & Compatibility
- Behavior strictly tightens validation of malformed packets; valid streams unaffected.
- No public API break.

Validation
- Spotless applied successfully.
- Tests compile and provide coverage for the filter logic.

Requested merge target: develop
