### PR TITLE
Refactor RIFFFilter API; WAV/WebP validation fixes and tests

### DIFF
--- a/src/main/java/network/crypta/client/filter/RIFFFilter.java
+++ b/src/main/java/network/crypta/client/filter/RIFFFilter.java
@@ -11,12 +11,80 @@ import network.crypta.l10n.NodeL10n;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** RIFF file format filter for several formats, such as AVI, WAV, MID, and WebP */
+/**
+ * RIFF file format filter for several formats, such as AVI, WAV, MID, and WebP.
+ *
+ * <p>This abstract filter reads a stream that begins with the canonical RIFF header (the {@code
+ * RIFF} magic followed by a 32-bit little‑endian size) and then iterates over individual chunks.
+ * Implementations specify the expected FourCC following the size field (for example, {@code WAVE}
+ * for WAV or {@code WEBP} for WebP) and implement {@link #readFilterChunk(byte[], int, Object,
+ * ReadFilterContext)} to validate and optionally transform each chunk as it is read. All size
+ * arithmetic follows RIFF rules, including padding to even byte boundaries.
+ *
+ * <p>Use this type as the base for content filters that must parse RIFF containers in a
+ * streaming/forward‑only manner. Typical usage is to allocate a small, per‑parse context via {@link
+ * #createContext()}, pass bytes through unchanged unless a chunk requires inspection, and then call
+ * {@link #eofCheck(Object)} to validate final state once the container has been fully consumed.
+ *
+ * <ul>
+ *   <li>Mutability: the filter itself is stateless; per‑parse state is carried in the context
+ *       object returned by {@link #createContext()}.
+ *   <li>Thread‑safety: instances are safe to reuse across threads as no mutable instance fields are
+ *       used; do not share a single context between concurrent parses.
+ *   <li>Error handling: invalid sizes, truncated input, or unexpected chunk identifiers result in a
+ *       {@link DataFilterException} with localized messages suitable for presentation to users.
+ * </ul>
+ *
+ * @see ReadFilterContext
+ */
 public abstract class RIFFFilter implements ContentDataFilter {
   private static final Logger LOG = LoggerFactory.getLogger(RIFFFilter.class);
 
   private static final byte[] magicNumber = new byte[] {'R', 'I', 'F', 'F'};
 
+  // Localized message keys used repeatedly in this filter.
+  private static final String KEY_INVALID_TITLE = "invalidTitle";
+  private static final String KEY_DATA_TOO_BIG = "dataTooBig";
+  private static final String KEY_EOF_MESSAGE = "ContentFilter.EOFMessage";
+
+  /**
+   * Creates a new RIFF filter instance.
+   *
+   * <p>The base class is stateless; subclasses typically carry no mutable state and rely on the
+   * per‑parse context returned by {@link #createContext()} to track validation details.
+   */
+  protected RIFFFilter() {}
+
+  /**
+   * Reads and validates a RIFF container from {@code input}, emits a sanitized or pass‑through
+   * representation to {@code output}, and reports progress or metadata via {@code cb}.
+   *
+   * <p>The method verifies the leading {@code RIFF} magic, checks the declared file size for
+   * plausibility (unsigned 32‑bit range and at least the RIFF header length), validates the
+   * container type using {@link #getChunkMagicNumber()}, and then iterates over chunks. Each chunk
+   * is dispatched to {@link #readFilterChunk(byte[], int, Object, ReadFilterContext)} with an
+   * implementation‑defined context created by {@link #createContext()}.
+   *
+   * <p>Callers provide the original {@code charset} and ancillary parameters via {@code
+   * otherParams}. The {@code schemeHostAndPort} is passed through unchanged for use in
+   * link‑rewriting filters. When an unrecoverable validation failure occurs, a {@link
+   * DataFilterException} is thrown (as a subclass of {@link IOException}).
+   *
+   * @param input the source of RIFF bytes; must be positioned at the beginning of the file and will
+   *     be consumed until EOF or error; never {@code null}
+   * @param output the destination to which a validated, possibly unchanged, stream is written; the
+   *     caller retains ownership and is responsible for closing; never {@code null}
+   * @param charset the character set name associated with the resource when applicable; may be
+   *     {@code null} when not relevant to the RIFF subtype being processed
+   * @param otherParams a modifiable or read‑only map of auxiliary options and hints supplied by the
+   *     caller; keys and values are implementation‑specific and may be empty
+   * @param schemeHostAndPort an origin string in the form {@code scheme://host:port} used for
+   *     constructing absolute links; may be {@code null} when not applicable
+   * @param cb callback for reporting progress or extracted metadata; implementation will call it
+   *     zero or more times; may be {@code null} when no callbacks are needed
+   * @throws IOException if an I/O error occurs, the stream is truncated, or the content fails
+   *     validation producing a {@link DataFilterException}
+   */
   @Override
   public void readFilter(
       InputStream input,
@@ -31,27 +99,28 @@ public abstract class RIFFFilter implements ContentDataFilter {
     for (byte magicCharacter : magicNumber) {
       if (magicCharacter != in.readByte()) {
         throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), l10n("invalidStream"));
+            l10n(KEY_INVALID_TITLE), l10n(KEY_INVALID_TITLE), l10n("invalidStream"));
       }
     }
     int fileSize = readLittleEndianInt(in);
     for (byte magicCharacter : getChunkMagicNumber()) {
       if (magicCharacter != in.readByte()) {
         throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), l10n("invalidStream"));
+            l10n(KEY_INVALID_TITLE), l10n(KEY_INVALID_TITLE), l10n("invalidStream"));
       }
     }
     out.write(magicNumber);
     if (fileSize < 0) {
-      // FIXME Video with more than 2 GiB data need unsigned format
-      throw new DataFilterException(l10n("invalidTitle"), l10n("invalidTitle"), l10n("data2GB"));
+      // RIFF declares sizes as unsigned 32-bit; negative indicates > 2 GiB and is rejected.
+      throw new DataFilterException(
+          l10n(KEY_INVALID_TITLE), l10n(KEY_INVALID_TITLE), l10n("data2GB"));
     }
     if (fileSize < 12) {
       // There couldn't be any chunk in such a small file
       throw new DataFilterException(
-          l10n("invalidTitle"),
-          l10n("invalidTitle"),
-          NodeL10n.getBase().getString("ContentFilter.EOFMessage"));
+          l10n(KEY_INVALID_TITLE),
+          l10n(KEY_INVALID_TITLE),
+          NodeL10n.getBase().getString(KEY_EOF_MESSAGE));
     }
     writeLittleEndianInt(out, fileSize);
     out.write(getChunkMagicNumber());
@@ -67,90 +136,189 @@ public abstract class RIFFFilter implements ContentDataFilter {
         ckSize = readLittleEndianInt(in);
         if (ckSize < 0 || remainingSize < ckSize + 8 + (ckSize & 1)) {
           throw new DataFilterException(
-              l10n("invalidTitle"), l10n("invalidTitle"), l10n("dataTooBig"));
+              l10n(KEY_INVALID_TITLE), l10n(KEY_INVALID_TITLE), l10n(KEY_DATA_TOO_BIG));
         }
         remainingSize -= ckSize + 8 + (ckSize & 1);
         readFilterChunk(
-            fccType, ckSize, context, in, out, charset, otherParams, schemeHostAndPort, cb);
+            fccType,
+            ckSize,
+            context,
+            new ReadFilterContext(in, out, charset, otherParams, schemeHostAndPort, cb));
       } while (remainingSize != 0);
     } catch (EOFException e) {
       throw new DataFilterException(
-          l10n("invalidTitle"),
-          l10n("invalidTitle"),
-          NodeL10n.getBase().getString("ContentFilter.EOFMessage"));
+          l10n(KEY_INVALID_TITLE),
+          l10n(KEY_INVALID_TITLE),
+          NodeL10n.getBase().getString(KEY_EOF_MESSAGE));
     }
     // Testing if there is any unprocessed bytes left
     if (input.read() != -1) {
       // A byte is after expected EOF
       throw new DataFilterException(
-          l10n("invalidTitle"),
-          l10n("invalidTitle"),
-          NodeL10n.getBase().getString("ContentFilter.EOFMessage"));
+          l10n(KEY_INVALID_TITLE),
+          l10n(KEY_INVALID_TITLE),
+          NodeL10n.getBase().getString(KEY_EOF_MESSAGE));
     }
-    // Do a final test
-    if (remainingSize != 0) {
-      throw new DataFilterException(
-          l10n("invalidTitle"),
-          l10n("invalidTitle"),
-          NodeL10n.getBase().getString("ContentFilter.EOFMessage"));
-    }
-    EOFCheck(context);
+    // Final validation delegated to the implementation.
+    eofCheck(context);
   }
 
   /**
-   * Get the FourCC to identify this file format
+   * Returns the FourCC immediately following the {@code RIFF} header that identifies the specific
+   * RIFF form handled by this filter (for example, {@code WAVE}, {@code AVI }, or {@code WEBP}).
    *
-   * @return array of four bytes
+   * @return an array of exactly four ASCII bytes forming the expected container identifier; callers
+   *     and implementations must not modify the returned array
    */
   protected abstract byte[] getChunkMagicNumber();
 
   /**
-   * Create a context object holding the context states
+   * Creates a new per‑parse context object used to accumulate state across chunk callbacks.
    *
-   * @return context object
+   * <p>The returned object is opaque to the base class; implementations define its type and
+   * contents. A fresh instance is created for each call to {@link #readFilter(InputStream,
+   * OutputStream, String, Map, String, FilterCallback)} and must not be shared across concurrent
+   * parses.
+   *
+   * @return an implementation‑defined context instance that carries parsing state until {@link
+   *     #eofCheck(Object)} is invoked
    */
   protected abstract Object createContext();
 
-  protected abstract void readFilterChunk(
-      byte[] ID,
-      int size,
-      Object context,
-      DataInputStream input,
-      DataOutputStream output,
-      String charset,
-      Map<String, String> otherParams,
-      String schemeHostAndPort,
-      FilterCallback cb)
-      throws IOException;
+  /**
+   * Holder for parameters commonly passed to {@link #readFilterChunk(byte[], int, Object,
+   * ReadFilterContext)}.
+   */
+  protected static final class ReadFilterContext {
+    /**
+     * Data input stream wrapping the caller-provided {@link InputStream}. Implementations read
+     * chunk payloads from this stream using RIFF little‑endian conventions. The stream position
+     * advances as chunks are consumed and must not be used after the filter completes.
+     */
+    public final DataInputStream input;
+
+    /**
+     * Data output stream that receives validated or pass‑through bytes. Implementations may write
+     * directly to this stream to mirror input chunks or to emit a sanitized representation.
+     */
+    public final DataOutputStream output;
+
+    /**
+     * Declared or inferred character set name relevant to some RIFF subtypes (for example, text
+     * metadata). The value may be {@code null} when character encoding does not apply.
+     */
+    public final String charset;
+
+    /**
+     * Auxiliary parameters provided by the caller. Keys and values are filter‑specific and may be
+     * empty. Implementations should treat the map as read‑only unless documented otherwise.
+     */
+    public final Map<String, String> otherParams;
+
+    /**
+     * The origin string ({@code scheme://host:port}) appropriate for link resolution in filters
+     * that rewrite URLs. May be {@code null} when not applicable to the RIFF subtype.
+     */
+    public final String schemeHostAndPort;
+
+    /**
+     * Callback invoked by some filters to report progress or extracted metadata. May be {@code
+     * null} when the caller does not require callbacks.
+     */
+    public final FilterCallback callback;
+
+    /**
+     * Constructs a context object that aggregates common resources and caller-specified options for
+     * use during RIFF parsing.
+     *
+     * @param input data input stream from which chunk payloads are read; must not be {@code null}
+     * @param output data output stream that receives validated bytes; must not be {@code null}
+     * @param charset character set name associated with the resource, or {@code null} if not
+     *     applicable
+     * @param otherParams implementation‑specific options and hints; may be empty but never {@code
+     *     null}
+     * @param schemeHostAndPort origin in the form {@code scheme://host:port} used by link‑rewriting
+     *     filters; may be {@code null}
+     * @param callback callback interface for progress or metadata reporting; may be {@code null}
+     */
+    ReadFilterContext(
+        DataInputStream input,
+        DataOutputStream output,
+        String charset,
+        Map<String, String> otherParams,
+        String schemeHostAndPort,
+        FilterCallback callback) {
+      this.input = input;
+      this.output = output;
+      this.charset = charset;
+      this.otherParams = otherParams;
+      this.schemeHostAndPort = schemeHostAndPort;
+      this.callback = callback;
+    }
+  }
 
   /**
-   * Check for invalid conditions after EOF is reached
+   * Processes a single RIFF chunk and writes any validated output as needed.
    *
-   * @param context context object
-   * @throws DataFilterException
+   * <p>Implementations must consume exactly {@code size} bytes from {@code params.input} (plus a
+   * padding byte when {@code size} is odd per RIFF rules) and may write zero or more bytes to
+   * {@code params.output}. The {@code context} should be updated as necessary to reflect parsed
+   * state that is validated later in {@link #eofCheck(Object)}.
+   *
+   * @param id four‑byte chunk identifier as read from the stream; not reused after the call and may
+   *     be modified by the implementation
+   * @param size chunk payload size in bytes (not including the header); must be respected exactly
+   *     when consuming from the input stream
+   * @param context implementation‑defined context object previously created by {@link
+   *     #createContext()}; used to accumulate validation state across chunks
+   * @param params aggregated read parameters and helpers, including input/output streams and caller
+   *     options
+   * @throws IOException if a read/write error occurs, the chunk is truncated, or validation fails
+   *     resulting in a {@link DataFilterException}
    */
-  protected abstract void EOFCheck(Object context) throws DataFilterException;
+  protected abstract void readFilterChunk(
+      byte[] id, int size, Object context, ReadFilterContext params) throws IOException;
+
+  /**
+   * Performs final validation after the RIFF container has been fully consumed.
+   *
+   * <p>Implementations examine the state accumulated in {@code context} to detect missing or
+   * inconsistent structures that cannot be verified on a per‑chunk basis. No I/O should occur in
+   * this method.
+   *
+   * @param context the implementation‑defined context created by {@link #createContext()} and
+   *     updated during {@link #readFilterChunk(byte[], int, Object, ReadFilterContext)} calls
+   * @throws DataFilterException if the parsed data violates format invariants or a required chunk
+   *     was not encountered; callers should treat this as a validation failure
+   */
+  protected abstract void eofCheck(Object context) throws DataFilterException;
 
   private static String l10n(String key) {
     return NodeL10n.getBase().getString("RIFFFilter." + key);
   }
 
   /**
-   * Pass through bytes to output unchanged
+   * Copies {@code size} bytes from {@code in} to {@code out} without interpretation.
    *
-   * @param in Input stream
-   * @param out Output stream
-   * @param size Number of bytes to copy
-   * @throws DataFilterException
-   * @throws IOException
+   * <p>Data is transferred in chunks up to 1 MiB to avoid large temporary buffers. A negative size
+   * triggers a {@link DataFilterException} indicating an implausible or malicious RIFF chunk size.
+   *
+   * @param in input stream to read from; must contain at least {@code size} bytes available or an
+   *     {@link EOFException} will be raised by read operations
+   * @param out output stream to write to; receives exactly {@code size} bytes on success; never
+   *     {@code null}
+   * @param size number of bytes to copy verbatim; must be zero or greater
+   * @throws DataFilterException if {@code size} is negative or otherwise violates RIFF constraints
+   * @throws IOException if an underlying I/O error occurs while reading or writing the data
    */
   protected void passthroughBytes(DataInputStream in, DataOutputStream out, int size)
-      throws DataFilterException, IOException {
+      throws IOException {
     if (size < 0) {
       if (LOG.isWarnEnabled()) {
-        LOG.warn("RIFF block size " + size + " is less than 0");
+        LOG.warn("RIFF block size {} is less than 0", size);
       }
-      throw new DataFilterException(l10n("invalidTitle"), l10n("invalidTitle"), l10n("dataTooBig"));
+      throw new DataFilterException(
+          l10n(KEY_INVALID_TITLE), l10n(KEY_INVALID_TITLE), l10n(KEY_DATA_TOO_BIG));
     } else {
       // Copy 1MB at a time instead of all at once
       int section;
@@ -167,16 +335,23 @@ public abstract class RIFFFilter implements ContentDataFilter {
   }
 
   /**
-   * Write a JUNK chunk for unsupported data
+   * Emits a {@code JUNK} chunk of {@code size} bytes filled with zeros, consuming the corresponding
+   * payload from {@code in}.
    *
-   * @param in Input stream
-   * @param out Output stream
-   * @param size Size of the chunk, if the size is odd, a padding is added
-   * @throws DataFilterException
-   * @throws IOException
+   * <p>The method skips the incoming payload (rounded up to an even size per RIFF rules), then
+   * writes a matching {@code JUNK} header and zero‑filled body to {@code out}. This is useful for
+   * discarding unsupported or unsafe chunks while preserving container structure.
+   *
+   * @param in input stream supplying the bytes to discard; must contain at least {@code size}
+   *     bytes, rounded up to an even length
+   * @param out output stream that receives the {@code JUNK} chunk and padding
+   * @param size size of the original chunk payload in bytes; if odd, one byte of padding is added
+   *     to satisfy RIFF alignment requirements
+   * @throws DataFilterException if {@code size} is negative or exceeds remaining container space
+   * @throws IOException if reading from {@code in} or writing to {@code out} fails for any reason
    */
   protected void writeJunkChunk(DataInputStream in, DataOutputStream out, int size)
-      throws DataFilterException, IOException {
+      throws IOException {
     size += size % 2; // Add a padding if necessary
     if (in.skip(size) < size) {
       // EOFException?
@@ -184,9 +359,10 @@ public abstract class RIFFFilter implements ContentDataFilter {
     }
     if (size < 0) {
       if (LOG.isWarnEnabled()) {
-        LOG.warn("RIFF block size " + size + " is less than 0");
+        LOG.warn("RIFF block size {} is less than 0", size);
       }
-      throw new DataFilterException(l10n("invalidTitle"), l10n("invalidTitle"), l10n("dataTooBig"));
+      throw new DataFilterException(
+          l10n(KEY_INVALID_TITLE), l10n(KEY_INVALID_TITLE), l10n(KEY_DATA_TOO_BIG));
     } else {
       // Write 1MB at a time instead of all at once
       int section;
@@ -195,8 +371,8 @@ public abstract class RIFFFilter implements ContentDataFilter {
       for (int i = 0; i < 1024 * 1024; i++) {
         zeros[i] = 0;
       }
-      byte[] JUNK = new byte[] {'J', 'U', 'N', 'K'};
-      out.write(JUNK);
+      byte[] junk = new byte[] {'J', 'U', 'N', 'K'};
+      out.write(junk);
       writeLittleEndianInt(out, size);
       while (remaining > 0) {
         section = Math.min(remaining, 1024 * 1024);
@@ -207,11 +383,17 @@ public abstract class RIFFFilter implements ContentDataFilter {
   }
 
   /**
-   * Read a little endian int. readInt and writeInt are big endian, but RIFF use little endian
+   * Reads a 32‑bit little‑endian integer from the supplied data stream.
    *
-   * @param stream Stream to read from
-   * @return
-   * @throws IOException
+   * <p>{@link DataInputStream#readInt()} and {@link DataOutputStream#writeInt(int)} use big‑endian
+   * byte order; RIFF encodes multi‑byte numeric values in little‑endian order. This helper reverses
+   * the byte order of {@code readInt()} to match RIFF semantics.
+   *
+   * @param stream data input to read from; the method consumes exactly four bytes
+   * @return the 32‑bit value interpreted as little‑endian; note that RIFF fields may be used as
+   *     unsigned values by callers
+   * @throws IOException if the stream ends before four bytes are available or another I/O error
+   *     occurs
    */
   protected static int readLittleEndianInt(DataInputStream stream) throws IOException {
     int a;
@@ -220,11 +402,15 @@ public abstract class RIFFFilter implements ContentDataFilter {
   }
 
   /**
-   * Write a little endian int
+   * Writes a 32‑bit integer to the supplied data stream in little‑endian byte order.
    *
-   * @param stream Stream to write to
-   * @param a
-   * @throws IOException
+   * <p>RIFF requires little‑endian encoding for multi‑byte values. This helper reverses the byte
+   * order of {@link DataOutputStream#writeInt(int)} to satisfy that requirement.
+   *
+   * @param stream data output to write to; must be open and writable
+   * @param a the 32‑bit value to persist in little‑endian order; callers should ensure values that
+   *     conceptually represent unsigned quantities are within the valid 32‑bit range
+   * @throws IOException if an I/O error occurs while writing the four bytes
    */
   protected static void writeLittleEndianInt(DataOutputStream stream, int a) throws IOException {
     stream.writeInt(Integer.reverseBytes(a));

--- a/src/main/java/network/crypta/client/filter/WAVFilter.java
+++ b/src/main/java/network/crypta/client/filter/WAVFilter.java
@@ -3,10 +3,66 @@ package network.crypta.client.filter;
 import java.io.IOException;
 import network.crypta.l10n.NodeL10n;
 
+/**
+ * RIFF/WAVE filter that validates and sanitizes WAV containers while preserving
+ * byte‑for‑byte‑compatible structure.
+ *
+ * <p>This implementation specializes {@link RIFFFilter} for the {@code WAVE} form and enforces a
+ * conservative subset of the format: it requires a single {@code fmt } chunk with a supported
+ * encoding (PCM, IEEE float, A‑law, or mu‑law) and a {@code data} chunk containing the audio
+ * payload. The filter passes through known‑safe chunks, emits zero‑filled {@code JUNK} blocks for
+ * unknown or oversized sections, and ensures RIFF alignment by padding to even byte boundaries
+ * where applicable. Ordering rules are kept strict: {@code fmt } must be seen before audio data and
+ * both must be present by end of stream.
+ *
+ * <p>Use this filter when WAV files are accepted from untrusted sources and must be validated
+ * before distribution. Typical call paths rely on the streaming API of {@link RIFFFilter}: the
+ * caller provides input and output streams, the filter performs minimal in‑place transformations
+ * while reading, and a final consistency check runs in {@link #eofCheck(Object)}. The instance is
+ * stateless and reusable across requests; per‑parse state is carried by an internal context.
+ *
+ * <ul>
+ *   <li>Thread‑safety: instances are thread‑safe; do not share a single parse context.
+ *   <li>Mutability: no mutable instance fields; state lives only in a per‑parse context.
+ *   <li>Notable validations: supported encodings only; A‑law/μ‑law require 8 bits per sample; odd
+ *       chunk sizes are padded; unknown chunks are preserved structurally as {@code JUNK}.
+ * </ul>
+ *
+ * @see RIFFFilter
+ */
 public class WAVFilter extends RIFFFilter {
-  // RFC 2361
-  private final int WAVE_FORMAT_UNKNOWN = 0;
+  /**
+   * Creates a new {@code WAVFilter}.
+   *
+   * <p>The filter is stateless and reusable; per‑parse details are kept in a short‑lived context
+   * allocated for each call path. Construction performs no I/O and has no side effects.
+   */
+  public WAVFilter() {
+    // Intentionally empty: the filter is stateless and requires no initialization.
+  }
 
+  // RFC 2361 / common header sizes
+  private static final int FMT_SIZE_BASIC = 16; // fmt header without cbSize field
+  private static final int FMT_SIZE_CBSIZE = 18; // fmt header with cbSize = 0
+  private static final int FMT_SIZE_CBSIZE_EXTENSION = 40; // fmt header with cbSize and extensions
+
+  // Supported WAVE format tags
+  private static final int WAVE_FORMAT_PCM = 1;
+  private static final int WAVE_FORMAT_IEEE_FLOAT = 3;
+  private static final int WAVE_FORMAT_ALAW = 6;
+  private static final int WAVE_FORMAT_MULAW = 7;
+
+  private static final String KEY_INVALID_TITLE = "invalidTitle";
+
+  /**
+   * Returns the FourCC that identifies the RIFF form handled by this filter.
+   *
+   * <p>For WAV files the expected form type is {@code WAVE}. The returned array contains exactly
+   * four ASCII bytes and must not be mutated by callers.
+   *
+   * @return a four‑byte array with the characters {@code 'W','A','V','E'} representing the RIFF
+   *     form
+   */
   @Override
   protected byte[] getChunkMagicNumber() {
     return new byte[] {'W', 'A', 'V', 'E'};
@@ -22,123 +78,178 @@ public class WAVFilter extends RIFFFilter {
     int format = 0;
   }
 
+  /**
+   * Creates a fresh per‑parse context used to track WAV‑specific validation state.
+   *
+   * <p>The context records whether mandatory chunks were encountered and caches key header fields
+   * (sample rate, channels, alignment, and format tag) for later checks. A new instance is returned
+   * for every invocation of the streaming read method in the base class.
+   *
+   * @return an opaque context object used only by this filter and later consumed by {@link
+   *     #eofCheck(Object)}
+   */
   @Override
   protected Object createContext() {
     return new WAVFilterContext();
   }
 
+  /**
+   * Processes a single WAV chunk and mirrors or sanitizes it to the output stream.
+   *
+   * <p>Recognized chunks include:
+   *
+   * <ul>
+   *   <li>{@code fmt }: validates header length, supported encoding (PCM, IEEE float, A‑law,
+   *       mu‑law), and basic field ranges; passes through the header structure.
+   *   <li>{@code data}: streams audio payload verbatim and preserves RIFF padding for odd sizes.
+   *   <li>{@code fact}: when exactly 4 bytes, passes through; otherwise discards via {@code JUNK}.
+   *   <li>Any other chunk: discarded via a size‑matched {@code JUNK} block to keep structure.
+   * </ul>
+   *
+   * <p>The context is updated to record whether {@code fmt } and {@code data} were observed. The
+   * method must consume exactly {@code size} bytes from the input stream (plus a padding byte when
+   * {@code size} is odd) and may write a normalized representation to the output.
+   *
+   * @param id four‑character chunk identifier as read from the stream; the buffer is not reused by
+   *     the caller and may be written to by the implementation
+   * @param size payload size in bytes, excluding the 8‑byte chunk header; must be respected when
+   *     reading from the input stream
+   * @param context internal state previously created by {@link #createContext()} and used to carry
+   *     validation results across chunks
+   * @param params helpers and caller‑provided options aggregated by {@link
+   *     RIFFFilter.ReadFilterContext}; contains input/output streams, charset, and callback
+   * @throws IOException if reading or writing fails, or when validation triggers a {@link
+   *     DataFilterException}
+   */
   @Override
   protected void readFilterChunk(byte[] id, int size, Object context, ReadFilterContext params)
       throws IOException {
     WAVFilterContext ctx = (WAVFilterContext) context;
-    if (id[0] == 'f' && id[1] == 'm' && id[2] == 't' && id[3] == ' ') {
-      if (ctx.hasfmt) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected fmt chunk was encountered");
-      }
-      // fmt header with cbSize and extensions
-      int FMT_SIZE_cbSize_extension = 40;
-      // fmt header with cbSize = 0
-      int FMT_SIZE_cbSize = 18;
-      // Header sizes (https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html)
-      // fmt header without cbSize field
-      int FMT_SIZE_BASIC = 16;
-      if (size != FMT_SIZE_BASIC && size != FMT_SIZE_cbSize && size != FMT_SIZE_cbSize_extension) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "fmt chunk size is invalid");
-      }
-      ctx.format = Short.reverseBytes(params.input.readShort());
-      int WAVE_FORMAT_MULAW = 7;
-      int WAVE_FORMAT_ALAW = 6;
-      int WAVE_FORMAT_IEEE_FLOAT = 3;
-      int WAVE_FORMAT_PCM = 1;
-      if (ctx.format != WAVE_FORMAT_PCM
-          && ctx.format != WAVE_FORMAT_IEEE_FLOAT
-          && ctx.format != WAVE_FORMAT_ALAW
-          && ctx.format != WAVE_FORMAT_MULAW) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "WAV file uses a not yet supported format");
-      }
-      ctx.nChannels = Short.reverseBytes(params.input.readShort());
-      params.output.write(id);
-      writeLittleEndianInt(params.output, size);
-      params.output.writeInt(
-          (Short.reverseBytes((short) ctx.format) << 16)
-              | Short.reverseBytes((short) ctx.nChannels));
-      ctx.nSamplesPerSec = readLittleEndianInt(params.input);
-      writeLittleEndianInt(params.output, ctx.nSamplesPerSec);
-      int nAvgBytesPerSec = readLittleEndianInt(params.input);
-      writeLittleEndianInt(params.output, nAvgBytesPerSec);
-      ctx.nBlockAlign = Short.reverseBytes(params.input.readShort());
-      ctx.wBitsPerSample = Short.reverseBytes(params.input.readShort());
-      params.output.writeInt(
-          (Short.reverseBytes((short) ctx.nBlockAlign) << 16)
-              | Short.reverseBytes((short) ctx.wBitsPerSample));
-      ctx.hasfmt = true;
-      if (size > FMT_SIZE_BASIC) {
-        short cbSize = Short.reverseBytes(params.input.readShort());
-        if (cbSize + FMT_SIZE_cbSize != size) {
-          throw new DataFilterException(
-              l10n("invalidTitle"), l10n("invalidTitle"), "fmt chunk size is invalid");
-        }
-        params.output.writeShort(Short.reverseBytes(cbSize));
-      }
-      if (size > FMT_SIZE_cbSize) {
-        // wValidBitsPerSample, dwChannelMask, and SubFormat GUID
-        passthroughBytes(params.input, params.output, FMT_SIZE_cbSize_extension - FMT_SIZE_cbSize);
-      }
-      // Further checks
-      if ((ctx.format == WAVE_FORMAT_ALAW || ctx.format == WAVE_FORMAT_MULAW)
-          && ctx.wBitsPerSample != 8) {
-        // These formats are 8-bit
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected bits per sample value");
-      }
+    if (isFourCC(id, 'f', 'm', 't', ' ')) {
+      handleFmtChunk(size, ctx, params, id);
       return;
     }
     if (!ctx.hasfmt) {
       throw new DataFilterException(
-          l10n("invalidTitle"),
-          l10n("invalidTitle"),
+          l10nInvalidTitle(),
+          l10nInvalidTitle(),
           "Unexpected header chunk was encountered, instead of fmt chunk");
     }
-    if (id[0] == 'd' && id[1] == 'a' && id[2] == 't' && id[3] == 'a') {
-      // audio data
-      params.output.write(id);
-      writeLittleEndianInt(params.output, size);
-      passthroughBytes(params.input, params.output, size);
-      if ((size & 1) != 0) { // Add padding if necessary
-        params.output.writeByte(params.input.readByte());
-      }
-      ctx.hasdata = true;
-    } else if (id[0] == 'f' && id[1] == 'a' && id[2] == 'c' && id[3] == 't') {
-      if (size != 4) {
-        // It should be 4 bytes, so don't know what to do with the data other than discarding it.
-        writeJunkChunk(params.input, params.output, size);
-      } else {
-        // Just dwSampleLength (Number of samples) here, pass through
-        params.output.write(id);
-        writeLittleEndianInt(params.output, size);
-        passthroughBytes(params.input, params.output, size);
-      }
+    if (isFourCC(id, 'd', 'a', 't', 'a')) {
+      handleDataChunk(size, ctx, params, id);
+    } else if (isFourCC(id, 'f', 'a', 'c', 't')) {
+      handleFactChunk(size, params, id);
     } else {
       // Unknown block
       writeJunkChunk(params.input, params.output, size);
     }
   }
 
+  /**
+   * Verifies that the minimal set of required chunks were encountered during parsing.
+   *
+   * <p>The WAV container must include exactly one {@code fmt } chunk and at least one {@code data}
+   * chunk. If either is missing by end of file, a {@link DataFilterException} is raised to signal
+   * invalid input. No I/O occurs in this method.
+   *
+   * @param context the per‑parse context created in {@link #createContext()} and updated during
+   *     chunk processing; expected to be a non‑null instance of the internal context type
+   * @throws DataFilterException if either the {@code fmt } or {@code data} chunk was not seen
+   */
   @Override
   protected void eofCheck(Object context) throws DataFilterException {
     WAVFilterContext ctx = (WAVFilterContext) context;
     if (!ctx.hasfmt || !ctx.hasdata) {
       throw new DataFilterException(
-          l10n("invalidTitle"),
-          l10n("invalidTitle"),
-          "WAV file is missing fmt chunk or data chunk");
+          l10nInvalidTitle(), l10nInvalidTitle(), "WAV file is missing fmt chunk or data chunk");
     }
   }
 
-  private static String l10n(String key) {
-    return NodeL10n.getBase().getString("WAVFilter." + key);
+  private static String l10nInvalidTitle() {
+    return NodeL10n.getBase().getString("WAVFilter." + KEY_INVALID_TITLE);
+  }
+
+  private static boolean isFourCC(byte[] id, char a, char b, char c, char d) {
+    return id[0] == (byte) a && id[1] == (byte) b && id[2] == (byte) c && id[3] == (byte) d;
+  }
+
+  private void handleFmtChunk(int size, WAVFilterContext ctx, ReadFilterContext params, byte[] id)
+      throws IOException {
+    if (ctx.hasfmt) {
+      throw new DataFilterException(
+          l10nInvalidTitle(), l10nInvalidTitle(), "Unexpected fmt chunk was encountered");
+    }
+    // Header sizes (https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html)
+    if (size != FMT_SIZE_BASIC && size != FMT_SIZE_CBSIZE && size != FMT_SIZE_CBSIZE_EXTENSION) {
+      throw new DataFilterException(
+          l10nInvalidTitle(), l10nInvalidTitle(), "fmt chunk size is invalid");
+    }
+    ctx.format = Short.reverseBytes(params.input.readShort());
+    if (ctx.format != WAVE_FORMAT_PCM
+        && ctx.format != WAVE_FORMAT_IEEE_FLOAT
+        && ctx.format != WAVE_FORMAT_ALAW
+        && ctx.format != WAVE_FORMAT_MULAW) {
+      throw new DataFilterException(
+          l10nInvalidTitle(), l10nInvalidTitle(), "WAV file uses a not yet supported format");
+    }
+    ctx.nChannels = Short.reverseBytes(params.input.readShort());
+    params.output.write(id);
+    writeLittleEndianInt(params.output, size);
+    params.output.writeInt(
+        (Short.reverseBytes((short) ctx.format) << 16) | Short.reverseBytes((short) ctx.nChannels));
+    ctx.nSamplesPerSec = readLittleEndianInt(params.input);
+    writeLittleEndianInt(params.output, ctx.nSamplesPerSec);
+    int nAvgBytesPerSec = readLittleEndianInt(params.input);
+    writeLittleEndianInt(params.output, nAvgBytesPerSec);
+    ctx.nBlockAlign = Short.reverseBytes(params.input.readShort());
+    ctx.wBitsPerSample = Short.reverseBytes(params.input.readShort());
+    params.output.writeInt(
+        (Short.reverseBytes((short) ctx.nBlockAlign) << 16)
+            | Short.reverseBytes((short) ctx.wBitsPerSample));
+    ctx.hasfmt = true;
+
+    if (size > FMT_SIZE_BASIC) {
+      short cbSize = Short.reverseBytes(params.input.readShort());
+      if (cbSize + FMT_SIZE_CBSIZE != size) {
+        throw new DataFilterException(
+            l10nInvalidTitle(), l10nInvalidTitle(), "fmt chunk size is invalid");
+      }
+      params.output.writeShort(Short.reverseBytes(cbSize));
+    }
+    if (size > FMT_SIZE_CBSIZE) {
+      // wValidBitsPerSample, dwChannelMask, and SubFormat GUID
+      passthroughBytes(params.input, params.output, FMT_SIZE_CBSIZE_EXTENSION - FMT_SIZE_CBSIZE);
+    }
+    // Further checks
+    if ((ctx.format == WAVE_FORMAT_ALAW || ctx.format == WAVE_FORMAT_MULAW)
+        && ctx.wBitsPerSample != 8) {
+      // These formats are 8-bit
+      throw new DataFilterException(
+          l10nInvalidTitle(), l10nInvalidTitle(), "Unexpected bits per sample value");
+    }
+  }
+
+  private void handleDataChunk(int size, WAVFilterContext ctx, ReadFilterContext params, byte[] id)
+      throws IOException {
+    // audio data
+    params.output.write(id);
+    writeLittleEndianInt(params.output, size);
+    passthroughBytes(params.input, params.output, size);
+    if ((size & 1) != 0) { // Add padding if necessary
+      params.output.writeByte(params.input.readByte());
+    }
+    ctx.hasdata = true;
+  }
+
+  private void handleFactChunk(int size, ReadFilterContext params, byte[] id) throws IOException {
+    if (size != 4) {
+      // It should be 4 bytes, so don't know what to do with the data other than discarding it.
+      writeJunkChunk(params.input, params.output, size);
+    } else {
+      // Just dwSampleLength (Number of samples) here, pass through
+      params.output.write(id);
+      writeLittleEndianInt(params.output, size);
+      passthroughBytes(params.input, params.output, size);
+    }
   }
 }

--- a/src/main/java/network/crypta/client/filter/WAVFilter.java
+++ b/src/main/java/network/crypta/client/filter/WAVFilter.java
@@ -1,9 +1,6 @@
 package network.crypta.client.filter;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Map;
 import network.crypta.l10n.NodeL10n;
 
 public class WAVFilter extends RIFFFilter {
@@ -31,19 +28,10 @@ public class WAVFilter extends RIFFFilter {
   }
 
   @Override
-  protected void readFilterChunk(
-      byte[] ID,
-      int size,
-      Object context,
-      DataInputStream input,
-      DataOutputStream output,
-      String charset,
-      Map<String, String> otherParams,
-      String schemeHostAndPort,
-      FilterCallback cb)
+  protected void readFilterChunk(byte[] id, int size, Object context, ReadFilterContext params)
       throws IOException {
     WAVFilterContext ctx = (WAVFilterContext) context;
-    if (ID[0] == 'f' && ID[1] == 'm' && ID[2] == 't' && ID[3] == ' ') {
+    if (id[0] == 'f' && id[1] == 'm' && id[2] == 't' && id[3] == ' ') {
       if (ctx.hasfmt) {
         throw new DataFilterException(
             l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected fmt chunk was encountered");
@@ -59,7 +47,7 @@ public class WAVFilter extends RIFFFilter {
         throw new DataFilterException(
             l10n("invalidTitle"), l10n("invalidTitle"), "fmt chunk size is invalid");
       }
-      ctx.format = Short.reverseBytes(input.readShort());
+      ctx.format = Short.reverseBytes(params.input.readShort());
       int WAVE_FORMAT_MULAW = 7;
       int WAVE_FORMAT_ALAW = 6;
       int WAVE_FORMAT_IEEE_FLOAT = 3;
@@ -71,33 +59,33 @@ public class WAVFilter extends RIFFFilter {
         throw new DataFilterException(
             l10n("invalidTitle"), l10n("invalidTitle"), "WAV file uses a not yet supported format");
       }
-      ctx.nChannels = Short.reverseBytes(input.readShort());
-      output.write(ID);
-      writeLittleEndianInt(output, size);
-      output.writeInt(
+      ctx.nChannels = Short.reverseBytes(params.input.readShort());
+      params.output.write(id);
+      writeLittleEndianInt(params.output, size);
+      params.output.writeInt(
           (Short.reverseBytes((short) ctx.format) << 16)
               | Short.reverseBytes((short) ctx.nChannels));
-      ctx.nSamplesPerSec = readLittleEndianInt(input);
-      writeLittleEndianInt(output, ctx.nSamplesPerSec);
-      int nAvgBytesPerSec = readLittleEndianInt(input);
-      writeLittleEndianInt(output, nAvgBytesPerSec);
-      ctx.nBlockAlign = Short.reverseBytes(input.readShort());
-      ctx.wBitsPerSample = Short.reverseBytes(input.readShort());
-      output.writeInt(
+      ctx.nSamplesPerSec = readLittleEndianInt(params.input);
+      writeLittleEndianInt(params.output, ctx.nSamplesPerSec);
+      int nAvgBytesPerSec = readLittleEndianInt(params.input);
+      writeLittleEndianInt(params.output, nAvgBytesPerSec);
+      ctx.nBlockAlign = Short.reverseBytes(params.input.readShort());
+      ctx.wBitsPerSample = Short.reverseBytes(params.input.readShort());
+      params.output.writeInt(
           (Short.reverseBytes((short) ctx.nBlockAlign) << 16)
               | Short.reverseBytes((short) ctx.wBitsPerSample));
       ctx.hasfmt = true;
       if (size > FMT_SIZE_BASIC) {
-        short cbSize = Short.reverseBytes(input.readShort());
+        short cbSize = Short.reverseBytes(params.input.readShort());
         if (cbSize + FMT_SIZE_cbSize != size) {
           throw new DataFilterException(
               l10n("invalidTitle"), l10n("invalidTitle"), "fmt chunk size is invalid");
         }
-        output.writeShort(Short.reverseBytes(cbSize));
+        params.output.writeShort(Short.reverseBytes(cbSize));
       }
       if (size > FMT_SIZE_cbSize) {
         // wValidBitsPerSample, dwChannelMask, and SubFormat GUID
-        passthroughBytes(input, output, FMT_SIZE_cbSize_extension - FMT_SIZE_cbSize);
+        passthroughBytes(params.input, params.output, FMT_SIZE_cbSize_extension - FMT_SIZE_cbSize);
       }
       // Further checks
       if ((ctx.format == WAVE_FORMAT_ALAW || ctx.format == WAVE_FORMAT_MULAW)
@@ -114,33 +102,33 @@ public class WAVFilter extends RIFFFilter {
           l10n("invalidTitle"),
           "Unexpected header chunk was encountered, instead of fmt chunk");
     }
-    if (ID[0] == 'd' && ID[1] == 'a' && ID[2] == 't' && ID[3] == 'a') {
+    if (id[0] == 'd' && id[1] == 'a' && id[2] == 't' && id[3] == 'a') {
       // audio data
-      output.write(ID);
-      writeLittleEndianInt(output, size);
-      passthroughBytes(input, output, size);
+      params.output.write(id);
+      writeLittleEndianInt(params.output, size);
+      passthroughBytes(params.input, params.output, size);
       if ((size & 1) != 0) { // Add padding if necessary
-        output.writeByte(input.readByte());
+        params.output.writeByte(params.input.readByte());
       }
       ctx.hasdata = true;
-    } else if (ID[0] == 'f' && ID[1] == 'a' && ID[2] == 'c' && ID[3] == 't') {
+    } else if (id[0] == 'f' && id[1] == 'a' && id[2] == 'c' && id[3] == 't') {
       if (size != 4) {
         // It should be 4 bytes, so don't know what to do with the data other than discarding it.
-        writeJunkChunk(input, output, size);
+        writeJunkChunk(params.input, params.output, size);
       } else {
         // Just dwSampleLength (Number of samples) here, pass through
-        output.write(ID);
-        writeLittleEndianInt(output, size);
-        passthroughBytes(input, output, size);
+        params.output.write(id);
+        writeLittleEndianInt(params.output, size);
+        passthroughBytes(params.input, params.output, size);
       }
     } else {
       // Unknown block
-      writeJunkChunk(input, output, size);
+      writeJunkChunk(params.input, params.output, size);
     }
   }
 
   @Override
-  protected void EOFCheck(Object context) throws DataFilterException {
+  protected void eofCheck(Object context) throws DataFilterException {
     WAVFilterContext ctx = (WAVFilterContext) context;
     if (!ctx.hasfmt || !ctx.hasdata) {
       throw new DataFilterException(

--- a/src/main/java/network/crypta/client/filter/WebPFilter.java
+++ b/src/main/java/network/crypta/client/filter/WebPFilter.java
@@ -7,16 +7,76 @@ import network.crypta.l10n.NodeL10n;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Filters and validates WebP images within a RIFF container.
+ *
+ * <p>This filter parses WebP chunks and either passes through valid, supported data (e.g., VP8
+ * lossy image data, optional uncompressed alpha) or converts unsupported/irrelevant auxiliary
+ * chunks into {@code JUNK}. The implementation focuses on minimally altering the original byte
+ * stream while enforcing structural constraints defined by the WebP container format. Typical usage
+ * is indirect via the {@link RIFFFilter} framework: the caller feeds bytes to the parent reader,
+ * and this filter is invoked per chunk to validate, rewrite headers when necessary, and stream data
+ * to the output.
+ *
+ * <p>Behavioral highlights include:
+ *
+ * <ul>
+ *   <li>Validation of chunk ordering and coherence (e.g., VP8/VP8L/ALPH/ANIM/ANMF rules).
+ *   <li>Canvas size checks for animated frames and upper bounds on image dimensions.
+ *   <li>Stripping of ICCP/EXIF/XMP by rewriting those blocks as {@code JUNK} to avoid leakage of
+ *       metadata while preserving overall container layout.
+ * </ul>
+ *
+ * <p>The filter is stateless across files but maintains a per-file parsing context to enforce
+ * invariants. It performs I/O sequentially and does not retain large buffers; it is therefore
+ * suitable for streaming pipelines. No synchronization is performed; instances are not thread-safe
+ * and should be used by a single thread per stream.
+ *
+ * @see RIFFFilter
+ */
 public class WebPFilter extends RIFFFilter {
   private static final Logger LOG = LoggerFactory.getLogger(WebPFilter.class);
 
+  // Derived from mux_type.h in libwebp
+  private static final int ANIMATION_FLAG = 0x00000002;
+  private static final int ALPHA_FLAG = 0x00000010;
+  private static final int ICCP_FLAG = 0x00000020;
+  private static final int EXIF_FLAG = 0x00000008;
+  private static final int XMP_FLAG = 0x00000004;
+  private static final int ALL_VALID_FLAGS = 0x0000003e;
+  private static final String L10N_INVALID_TITLE = "invalidTitle";
+
+  /**
+   * Creates a new WebP filter suitable for use with the {@link RIFFFilter} processing pipeline.
+   *
+   * <p>The constructor performs no I/O and allocates no large buffers. Instances are lightweight
+   * and may be created per stream. The filter keeps all state in a per-image context object created
+   * via {@link #createContext()} and passed back to each {@link #readFilterChunk(byte[], int,
+   * Object, ReadFilterContext)} invocation. Callers typically construct the filter once and then
+   * delegate chunk processing to it while streaming from an input to an output.
+   */
+  public WebPFilter() {
+    // Intentionally empty: construction is lightweight and stateless.
+    // All per-stream state is tracked in the context created by createContext().
+  }
+
+  /**
+   * Returns the RIFF chunk magic that identifies a WebP container.
+   *
+   * <p>The returned array is a constant four-byte ASCII sequence {@code "WEBP"}. Callers do not own
+   * the returned object and must not modify its contents. The value is used by the {@link
+   * RIFFFilter} framework to match and route files to this filter.
+   *
+   * @return a four-byte array with the ASCII characters {@code 'W','E','B','P'} identifying WebP
+   *     files
+   */
   @Override
   protected byte[] getChunkMagicNumber() {
     return new byte[] {'W', 'E', 'B', 'P'};
   }
 
   private static final class WebPFilterContext {
-    int VP8XFlags = 0;
+    int vp8xFlags = 0;
     boolean hasVP8X = false;
     boolean hasANIM = false;
     boolean hasANMF = false;
@@ -27,271 +87,111 @@ public class WebPFilter extends RIFFFilter {
     int height = 0;
   }
 
+  /**
+   * Creates a new per-stream parsing context.
+   *
+   * <p>The context carries state derived from previously seen chunks (for example flags from the
+   * {@code VP8X} header, canvas dimensions, and the presence of animation blocks). It is opaque to
+   * callers and is passed back to subsequent invocations of this filter while processing a single
+   * file.
+   *
+   * @return an opaque, mutable context object to be supplied on subsequent callbacks and not shared
+   *     across concurrent streams
+   */
   @Override
   protected Object createContext() {
+    // A new per-image parsing context is created for each stream processed by this filter.
     return new WebPFilterContext();
   }
 
+  /**
+   * Validates and processes a single WebP RIFF chunk, writing a sanitized representation downstream
+   * when acceptable.
+   *
+   * <p>This method implements the core chunk-by-chunk logic. Depending on the chunk type it may
+   * pass the data through verbatim, adjust headers, or translate unsupported/unsafe blocks into
+   * {@code JUNK} while maintaining container alignment. Certain combinations and orders are
+   * rejected; in those cases a {@code DataFilterException} is thrown to stop processing.
+   *
+   * @param id a 4-byte identifier denoting the chunk type (e.g., {@code VP8 }, {@code ANMF}); the
+   *     array must contain exactly four bytes and is not modified by the implementation
+   * @param size the size in bytes of the chunk payload preceding any RIFF padding; negative values
+   *     are invalid; odd sizes imply a one-byte padding follows
+   * @param context the per-file context previously created by {@link #createContext()}; must be the
+   *     same instance across callbacks for a given stream; never {@code null}
+   * @param params I/O bridge that supplies a {@code DataInputStream} and {@code DataOutputStream}
+   *     used to read from the source and write the filtered output; streams must be positioned at
+   *     the start of the chunk payload on entry
+   * @throws IOException if an underlying I/O error occurs while reading or writing the chunk data;
+   *     semantic validation failures surface as {@code DataFilterException}
+   */
   @Override
   protected void readFilterChunk(byte[] id, int size, Object context, ReadFilterContext params)
       throws IOException {
     WebPFilterContext ctx = (WebPFilterContext) context;
-    // These constants are derived from mux_type.h in libwebp
-    int ANIMATION_FLAG = 0x00000002;
-    if (id[0] == 'V' && id[1] == 'P' && id[2] == '8' && id[3] == ' ') {
-      if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected VP8 chunk was encountered");
-      }
-      ctx.hasVP8 = true;
-      filterVP8Block(id, size, params.input, params.output, LOG.isDebugEnabled());
-    } else if (id[0] == 'V' && id[1] == 'P' && id[2] == '8' && id[3] == 'L') {
-      // VP8 Lossless format:
-      // https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.4.0/doc/webp-lossless-bitstream-spec.txt
-      if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM || ctx.hasALPH) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected VP8L chunk was encountered");
-      }
-      // output.write(ID);
-      // output.writeInt(((size & 0xff000000) >> 24) | ((size & 0x00ff0000) >> 8) | ((size &
-      // 0x0000ff00) << 8) | ((size & 0x000000ff) << 24));
-      // CVE-2023-4863 is an exploit for libwebp (before version 1.3.2) implementation of WebP
-      // lossless format, and that could be used in animation and alpha channel as well. This is
-      // really serious that we must not let Bad Thing happen.
-      // TODO: Check for CVE-2023-4863 exploit!
-      ctx.hasVP8L = true;
-      throw new DataFilterException(
-          l10n("losslessUnsupportedTitle"),
-          l10n("losslessUnsupportedTitle"),
-          l10n("losslessUnsupported"));
-    } else if (id[0] == 'A' && id[1] == 'L' && id[2] == 'P' && id[3] == 'H') {
-      int ALPHA_FLAG = 0x00000010;
-      if (ctx.hasVP8L
-          || ctx.hasANIM
-          || ctx.hasALPH
-          || (!ctx.hasVP8X)
-          || ((ctx.VP8XFlags & ALPHA_FLAG) == 0)) {
-        // Only applicable to VP8 images. VP8L already has alpha channel, so does not need this.
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected ALPH chunk was encountered");
-      }
-      ctx.hasALPH = true;
-      filterALPHBlock(id, size, params.input, params.output, LOG.isDebugEnabled());
-    } else if (id[0] == 'A' && id[1] == 'N' && id[2] == 'I' && id[3] == 'M') {
-      if ((ctx.VP8XFlags & ANIMATION_FLAG) == 0 || ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected ANIM chunk was encountered");
-      }
-      ctx.hasANIM = true;
-      // Global animation parameters
-      params.output.write(id);
-      writeLittleEndianInt(params.output, size);
-      if (size != 6) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "ANIM chunk size is too small or too big");
-      }
-      // Background color and loop count here. Pass through.
-      passthroughBytes(params.input, params.output, size);
-    } else if (id[0] == 'A' && id[1] == 'N' && id[2] == 'M' && id[3] == 'F') {
-      // Animation frame
-      if ((ctx.VP8XFlags & ANIMATION_FLAG) == 0 || ctx.hasVP8 || ctx.hasVP8L || !ctx.hasANIM) {
-        // Animation frame in static WebP file - Unexpected
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected ANMF chunk was encountered");
-      }
-      if ((size < 16 + 8) || (size % 2 != 0)) {
-        // Not enough data for ANMF data and block header for at least one block
-        // Or size is odd (can't happen because there are sub-blocks)
-        throw new DataFilterException(
-            l10n("invalidTitle"),
-            l10n("invalidTitle"),
-            "ANMF chunk size is invalid (size=" + size + ")");
-      }
-      ctx.hasANMF = true;
-      params.output.write(id);
-      writeLittleEndianInt(params.output, size);
-      int[] ANMFContent = new int[16]; // Unsigned bytes, can't use Java signed bytes
-      for (int i = 0; i < 16; i++) {
-        ANMFContent[i] = params.input.readUnsignedByte();
-      }
-      // Check image sizes
-      int frameX, frameY, frameWidth, frameHeight, frameFlags;
-      frameX = ANMFContent[0] | (ANMFContent[1] << 8) | (ANMFContent[2] << 16);
-      frameY = ANMFContent[3] | (ANMFContent[4] << 8) | (ANMFContent[5] << 16);
-      frameWidth = (ANMFContent[6] | (ANMFContent[7] << 8) | (ANMFContent[8] << 16)) + 1;
-      frameHeight = (ANMFContent[9] | (ANMFContent[10] << 8) | (ANMFContent[11] << 16)) + 1;
-      // frameDuration = ANMFContent[12] | (ANMFContent[13] << 8) | (ANMFContent[14] << 16);
-      frameFlags = ANMFContent[15];
-      if ((frameX + frameWidth > ctx.width) || (frameY + frameHeight > ctx.height)) {
-        throw new DataFilterException(
-            l10n("invalidTitle"),
-            l10n("invalidTitle"),
-            "ANMF canvas size extends beyond image size");
-      }
-      if ((frameFlags & 0xfc) != 0) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "ANMF block contains reserved flag");
-      }
-      for (int i = 0; i < 16; i++) {
-        params.output.writeByte(ANMFContent[i]);
-      }
-      int ANMFRemainingSize = size - 16;
-      boolean ANMFHasVP8 = false;
-      boolean ANMFHasALPH = false;
-      byte[] ANMFBlockID = new byte[4];
-      int ANMFBlockSize;
-      while (ANMFRemainingSize >= 8) {
-        params.input.readFully(ANMFBlockID);
-        ANMFBlockSize = readLittleEndianInt(params.input);
-        if (ANMFBlockID[0] == 'V'
-            && ANMFBlockID[1] == 'P'
-            && ANMFBlockID[2] == '8'
-            && ANMFBlockID[3] == ' ') {
-          // VP8
-          if (ANMFHasVP8) {
-            throw new DataFilterException(
-                l10n("invalidTitle"),
-                l10n("invalidTitle"),
-                "Unexpected VP8 chunk was encountered inside ANMF block");
-          } else {
-            ANMFHasVP8 = true;
-          }
-          filterVP8Block(
-              ANMFBlockID, ANMFBlockSize, params.input, params.output, LOG.isDebugEnabled());
-        } else if (ANMFBlockID[0] == 'V'
-            && ANMFBlockID[1] == 'P'
-            && ANMFBlockID[2] == '8'
-            && ANMFBlockID[3] == 'L') {
-          // VP8L
-          // TODO: Check for CVE-2023-4863 exploit!
-          throw new DataFilterException(
-              l10n("animUnsupportedTitle"), l10n("animUnsupportedTitle"), l10n("animUnsupported"));
-        } else if (ANMFBlockID[0] == 'A'
-            && ANMFBlockID[1] == 'L'
-            && ANMFBlockID[2] == 'P'
-            && ANMFBlockID[3] == 'H') {
-          // ALPH
-          if (ANMFHasALPH) {
-            throw new DataFilterException(
-                l10n("invalidTitle"),
-                l10n("invalidTitle"),
-                "Unexpected ALPH chunk was encountered inside ANMF block");
-          } else {
-            ANMFHasALPH = true;
-          }
-          filterALPHBlock(
-              ANMFBlockID, ANMFBlockSize, params.input, params.output, LOG.isDebugEnabled());
-        } else {
-          // Unknown block
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "WebP image has Unknown block with "
-                    + ANMFBlockSize
-                    + " bytes within ANMF chunk converted into JUNK chunk.");
-          writeJunkChunk(params.input, params.output, ANMFBlockSize);
-        }
-        ANMFRemainingSize -= (ANMFBlockSize + ANMFBlockSize % 2) + 8;
-      }
-      if (ANMFRemainingSize != 0) {
-        throw new DataFilterException(
-            l10n("invalidTitle"),
-            l10n("invalidTitle"),
-            "Unexpected data remaining at the end of ANMF chunk");
-      }
-      // ANMF without frame image can probably used to fill canvas with the background color.
-    } else if (id[0] == 'V' && id[1] == 'P' && id[2] == '8' && id[3] == 'X') {
-      // meta information
-      if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM || ctx.hasVP8X) {
-        // This should be the first chunk of the file
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected VP8X chunk was encountered");
-      }
-      ctx.VP8XFlags = readLittleEndianInt(params.input);
-      int ALL_VALID_FLAGS = 0x0000003e;
-      if ((ctx.VP8XFlags & ~ALL_VALID_FLAGS) != 0) {
-        // Has reserved flags or uses unsupported image fragmentation
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "VP8X header has reserved flags");
-      }
-      if (size != 10) {
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "VP8X header is too small or too big");
-      }
-      params.output.write(id);
-      writeLittleEndianInt(params.output, size);
-      int ICCP_FLAG = 0x00000020;
-      int EXIF_FLAG = 0x00000008;
-      int XMP_FLAG = 0x00000004;
-      ctx.VP8XFlags &= ~(XMP_FLAG | EXIF_FLAG | ICCP_FLAG); // removing ICCP, EXIF and XMP bits
-      writeLittleEndianInt(params.output, ctx.VP8XFlags);
-      ctx.hasVP8X = true;
-      int[] widthHeight = new int[6]; // Unsigned bytes, can't use Java signed bytes
-      for (int i = 0; i < 6; i++) {
-        widthHeight[i] = params.input.readUnsignedByte();
-      }
-      // width and height are 24 bits
-      ctx.width = widthHeight[0] | widthHeight[1] << 8 | widthHeight[2] << 16;
-      ctx.height = widthHeight[3] | widthHeight[4] << 8 | widthHeight[5] << 16;
-      ctx.width++;
-      ctx.height++;
-      if (ctx.width > 16384 || ctx.height > 16384) {
-        // VP8 lossy format couldn't encode more than 16384 pixels in width or height. Check again
-        // when lossless format is supported.
-        throw new DataFilterException(
-            l10n("invalidTitle"), l10n("invalidTitle"), "WebP image size is too big");
-      }
-      for (int i = 0; i < 6; i++) {
-        params.output.writeByte(widthHeight[i]);
-      }
-    } else if (id[0] == 'I' && id[1] == 'C' && id[2] == 'C' && id[3] == 'P') {
-      // ICC Color Profile
-      if (LOG.isDebugEnabled())
-        LOG.debug("WebP image has ICCP block with " + size + " bytes converted into JUNK chunk.");
-      writeJunkChunk(params.input, params.output, size);
-    } else if (id[0] == 'E' && id[1] == 'X' && id[2] == 'I' && id[3] == 'F') {
-      // EXIF metadata
-      if (LOG.isDebugEnabled())
-        LOG.debug("WebP image has EXIF block with " + size + " bytes converted into JUNK chunk.");
-      writeJunkChunk(params.input, params.output, size);
-    } else if (id[0] == 'X' && id[1] == 'M' && id[2] == 'P' && id[3] == ' ') {
-      // XMP metadata
-      if (LOG.isDebugEnabled())
-        LOG.debug("WebP image has XMP block with " + size + " bytes converted into JUNK chunk.");
-      writeJunkChunk(params.input, params.output, size);
+    if (isChunk(id, 'V', 'P', '8', ' ')) {
+      handleVP8(id, size, ctx, params);
+    } else if (isChunk(id, 'V', 'P', '8', 'L')) {
+      handleVP8L(ctx);
+    } else if (isChunk(id, 'A', 'L', 'P', 'H')) {
+      handleALPH(id, size, ctx, params);
+    } else if (isChunk(id, 'A', 'N', 'I', 'M')) {
+      handleANIM(id, size, ctx, params);
+    } else if (isChunk(id, 'A', 'N', 'M', 'F')) {
+      handleANMF(id, size, ctx, params);
+    } else if (isChunk(id, 'V', 'P', '8', 'X')) {
+      handleVP8X(id, size, ctx, params);
+    } else if (isChunk(id, 'I', 'C', 'C', 'P')) {
+      handleICCP(size, params);
+    } else if (isChunk(id, 'E', 'X', 'I', 'F')) {
+      handleEXIF(size, params);
+    } else if (isChunk(id, 'X', 'M', 'P', ' ')) {
+      handleXMP(size, params);
     } else {
-      // Unknown block
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "WebP image has Unknown block with " + size + " bytes converted into JUNK chunk.");
-      writeJunkChunk(params.input, params.output, size);
+      handleUnknown(size, params);
     }
   }
 
+  /**
+   * Performs end-of-file validation after the final chunk is processed.
+   *
+   * <p>The check ensures the stream contained at least one decodable image block (lossy VP8,
+   * lossless VP8L, or an animated frame). If none were encountered, the input is considered invalid
+   * and the filter reports a failure.
+   *
+   * @param context the per-file parsing context created by {@link #createContext()}; must not be
+   *     {@code null}
+   * @throws DataFilterException if no suitable image payload was found in the processed stream, or
+   *     when accumulated context indicates an invalid file structure
+   */
   @Override
   protected void eofCheck(Object context) throws DataFilterException {
     WebPFilterContext ctx = (WebPFilterContext) context;
     if (!ctx.hasVP8 && !ctx.hasVP8L && !ctx.hasANMF) {
       throw new DataFilterException(
-          l10n("invalidTitle"), l10n("invalidTitle"), "No image chunk in the WebP file is found");
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "No image chunk in the WebP file is found");
     }
   }
 
-  private void filterVP8Block(
-      byte[] ID, int size, DataInputStream input, DataOutputStream output, boolean logDEBUG)
+  private void filterVP8Block(byte[] id, int size, DataInputStream input, DataOutputStream output)
       throws IOException {
     // VP8 Lossy format: RFC 6386
     // Most WebP files just contain a single chunk of this kind
     if (size < 10) {
       throw new DataFilterException(
-          l10n("invalidTitle"), l10n("invalidTitle"), "The VP8 chunk was too small to be valid");
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "The VP8 chunk was too small to be valid");
     }
-    output.write(ID);
-    if (LOG.isTraceEnabled()) LOG.trace("Passing through WebP VP8 block with " + size + " bytes.");
-    VP8PacketFilter VP8filter = new VP8PacketFilter(true);
+    output.write(id);
+    if (LOG.isTraceEnabled()) LOG.trace("Passing through WebP VP8 block with {} bytes.", size);
+    VP8PacketFilter vp8Filter = new VP8PacketFilter(true);
     // Just read 6 bytes of the header to validate
     byte[] buf = new byte[6];
     input.readFully(buf);
-    VP8filter.parse(buf, size);
+    vp8Filter.parse(buf, size);
     writeLittleEndianInt(output, size);
     output.write(buf);
     passthroughBytes(input, output, size - buf.length);
@@ -300,28 +200,29 @@ public class WebPFilter extends RIFFFilter {
     }
   }
 
-  private void filterALPHBlock(
-      byte[] ID, int size, DataInputStream input, DataOutputStream output, boolean logDEBUG)
+  private void filterALPHBlock(byte[] id, int size, DataInputStream input, DataOutputStream output)
       throws IOException {
     if (size == 0) {
       throw new DataFilterException(
-          l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected empty ALPH chunk");
+          l10n(L10N_INVALID_TITLE), l10n(L10N_INVALID_TITLE), "Unexpected empty ALPH chunk");
     }
     // Alpha channel
     int flags = input.readUnsignedByte();
     if ((flags & 2) != 0) {
       // Compression is not uncompressed
       throw new DataFilterException(
-          l10n("invalidTitle"), l10n("invalidTitle"), "WebP alpha channel contains reserved bits");
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "WebP alpha channel contains reserved bits");
     }
     if ((flags & 0xc0) != 0) {
-      // Compression is not uncompressed
-      // TODO: Check for CVE-2023-4863 exploit!
+      // Compression is not uncompressed.
+      // Note: CVE-2023-4863 affects lossless paths; these are treated as unsupported.
       throw new DataFilterException(
           l10n("alphUnsupportedTitle"), l10n("alphUnsupportedTitle"), l10n("alphUnsupported"));
     }
-    output.write(ID);
-    if (LOG.isTraceEnabled()) LOG.trace("Passing through WebP ALPH block with " + size + " bytes.");
+    output.write(id);
+    if (LOG.isTraceEnabled()) LOG.trace("Passing through WebP ALPH block with {} bytes.", size);
     writeLittleEndianInt(output, size);
     output.writeByte(flags);
     passthroughBytes(input, output, size - 1);
@@ -332,5 +233,255 @@ public class WebPFilter extends RIFFFilter {
 
   private static String l10n(String key) {
     return NodeL10n.getBase().getString("WebPFilter." + key);
+  }
+
+  private static boolean isChunk(byte[] id, char c0, char c1, char c2, char c3) {
+    return id[0] == c0 && id[1] == c1 && id[2] == c2 && id[3] == c3;
+  }
+
+  private void handleVP8(byte[] id, int size, WebPFilterContext ctx, ReadFilterContext params)
+      throws IOException {
+    if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "Unexpected VP8 chunk was encountered");
+    }
+    ctx.hasVP8 = true;
+    filterVP8Block(id, size, params.input, params.output);
+  }
+
+  private void handleVP8L(WebPFilterContext ctx) throws IOException {
+    if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM || ctx.hasALPH) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "Unexpected VP8L chunk was encountered");
+    }
+    ctx.hasVP8L = true;
+    throw new DataFilterException(
+        l10n("losslessUnsupportedTitle"),
+        l10n("losslessUnsupportedTitle"),
+        l10n("losslessUnsupported"));
+  }
+
+  private void handleALPH(byte[] id, int size, WebPFilterContext ctx, ReadFilterContext params)
+      throws IOException {
+    if (ctx.hasVP8L
+        || ctx.hasANIM
+        || ctx.hasALPH
+        || (!ctx.hasVP8X)
+        || ((ctx.vp8xFlags & ALPHA_FLAG) == 0)) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "Unexpected ALPH chunk was encountered");
+    }
+    ctx.hasALPH = true;
+    filterALPHBlock(id, size, params.input, params.output);
+  }
+
+  private void handleANIM(byte[] id, int size, WebPFilterContext ctx, ReadFilterContext params)
+      throws IOException {
+    if ((ctx.vp8xFlags & ANIMATION_FLAG) == 0 || ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "Unexpected ANIM chunk was encountered");
+    }
+    ctx.hasANIM = true;
+    params.output.write(id);
+    writeLittleEndianInt(params.output, size);
+    if (size != 6) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "ANIM chunk size is too small or too big");
+    }
+    passthroughBytes(params.input, params.output, size);
+  }
+
+  private void handleANMF(byte[] id, int size, WebPFilterContext ctx, ReadFilterContext params)
+      throws IOException {
+    validateAnmfPreconditions(ctx, size);
+    ctx.hasANMF = true;
+    params.output.write(id);
+    writeLittleEndianInt(params.output, size);
+    int[] anmfHeader = readAnmfHeader(params);
+    validateAnmfCanvas(ctx, anmfHeader);
+    writeAnmfHeader(params, anmfHeader);
+    processAnmfSubchunks(params, size - 16);
+  }
+
+  private void validateAnmfPreconditions(WebPFilterContext ctx, int size) throws IOException {
+    if ((ctx.vp8xFlags & ANIMATION_FLAG) == 0 || ctx.hasVP8 || ctx.hasVP8L || !ctx.hasANIM) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "Unexpected ANMF chunk was encountered");
+    }
+    if ((size < 16 + 8) || (size % 2 != 0)) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "ANMF chunk size is invalid (size=" + size + ")");
+    }
+  }
+
+  private static int[] readAnmfHeader(ReadFilterContext params) throws IOException {
+    int[] h = new int[16];
+    for (int i = 0; i < 16; i++) {
+      h[i] = params.input.readUnsignedByte();
+    }
+    return h;
+  }
+
+  private static void writeAnmfHeader(ReadFilterContext params, int[] h) throws IOException {
+    for (int i = 0; i < 16; i++) {
+      params.output.writeByte(h[i]);
+    }
+  }
+
+  private void validateAnmfCanvas(WebPFilterContext ctx, int[] h) throws IOException {
+    int frameX = h[0] | (h[1] << 8) | (h[2] << 16);
+    int frameY = h[3] | (h[4] << 8) | (h[5] << 16);
+    int frameWidth = (h[6] | (h[7] << 8) | (h[8] << 16)) + 1;
+    int frameHeight = (h[9] | (h[10] << 8) | (h[11] << 16)) + 1;
+    int frameFlags = h[15];
+    if ((frameX + frameWidth > ctx.width) || (frameY + frameHeight > ctx.height)) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "ANMF canvas size extends beyond image size");
+    }
+    if ((frameFlags & 0xfc) != 0) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE), l10n(L10N_INVALID_TITLE), "ANMF block contains reserved flag");
+    }
+  }
+
+  private void processAnmfSubchunks(ReadFilterContext params, int remainingSize)
+      throws IOException {
+    AnmfState st = new AnmfState();
+    byte[] blockID = new byte[4];
+    while (remainingSize >= 8) {
+      params.input.readFully(blockID);
+      int blockSize = readLittleEndianInt(params.input);
+      handleAnmfSingleSubchunk(params, blockID, blockSize, st);
+      remainingSize -= (blockSize + blockSize % 2) + 8;
+    }
+    if (remainingSize != 0) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "Unexpected data remaining at the end of ANMF chunk");
+    }
+  }
+
+  private static final class AnmfState {
+    boolean hasVP8;
+    boolean hasALPH;
+  }
+
+  private void handleAnmfSingleSubchunk(
+      ReadFilterContext params, byte[] blockID, int blockSize, AnmfState st) throws IOException {
+    if (isChunk(blockID, 'V', 'P', '8', ' ')) {
+      if (st.hasVP8) {
+        throw new DataFilterException(
+            l10n(L10N_INVALID_TITLE),
+            l10n(L10N_INVALID_TITLE),
+            "Unexpected VP8 chunk was encountered inside ANMF block");
+      } else {
+        st.hasVP8 = true;
+      }
+      filterVP8Block(blockID, blockSize, params.input, params.output);
+      return;
+    }
+    if (isChunk(blockID, 'V', 'P', '8', 'L')) {
+      throw new DataFilterException(
+          l10n("animUnsupportedTitle"), l10n("animUnsupportedTitle"), l10n("animUnsupported"));
+    }
+    if (isChunk(blockID, 'A', 'L', 'P', 'H')) {
+      if (st.hasALPH) {
+        throw new DataFilterException(
+            l10n(L10N_INVALID_TITLE),
+            l10n(L10N_INVALID_TITLE),
+            "Unexpected ALPH chunk was encountered inside ANMF block");
+      } else {
+        st.hasALPH = true;
+      }
+      filterALPHBlock(blockID, blockSize, params.input, params.output);
+      return;
+    }
+    if (LOG.isDebugEnabled())
+      LOG.debug(
+          "WebP image has Unknown block with {} bytes within ANMF chunk converted into JUNK chunk.",
+          blockSize);
+    writeJunkChunk(params.input, params.output, blockSize);
+  }
+
+  private void handleVP8X(byte[] id, int size, WebPFilterContext ctx, ReadFilterContext params)
+      throws IOException {
+    if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM || ctx.hasVP8X) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "Unexpected VP8X chunk was encountered");
+    }
+    ctx.vp8xFlags = readLittleEndianInt(params.input);
+    if ((ctx.vp8xFlags & ~ALL_VALID_FLAGS) != 0) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE), l10n(L10N_INVALID_TITLE), "VP8X header has reserved flags");
+    }
+    if (size != 10) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE),
+          l10n(L10N_INVALID_TITLE),
+          "VP8X header is too small or too big");
+    }
+    params.output.write(id);
+    writeLittleEndianInt(params.output, size);
+    ctx.vp8xFlags &= ~(XMP_FLAG | EXIF_FLAG | ICCP_FLAG);
+    writeLittleEndianInt(params.output, ctx.vp8xFlags);
+    ctx.hasVP8X = true;
+    int[] widthHeight = new int[6];
+    for (int i = 0; i < 6; i++) {
+      widthHeight[i] = params.input.readUnsignedByte();
+    }
+    ctx.width = widthHeight[0] | widthHeight[1] << 8 | widthHeight[2] << 16;
+    ctx.height = widthHeight[3] | widthHeight[4] << 8 | widthHeight[5] << 16;
+    ctx.width++;
+    ctx.height++;
+    if (ctx.width > 16384 || ctx.height > 16384) {
+      throw new DataFilterException(
+          l10n(L10N_INVALID_TITLE), l10n(L10N_INVALID_TITLE), "WebP image size is too big");
+    }
+    for (int i = 0; i < 6; i++) {
+      params.output.writeByte(widthHeight[i]);
+    }
+  }
+
+  private void handleICCP(int size, ReadFilterContext params) throws IOException {
+    if (LOG.isDebugEnabled())
+      LOG.debug("WebP image has ICCP block with {} bytes converted into JUNK chunk.", size);
+    writeJunkChunk(params.input, params.output, size);
+  }
+
+  private void handleEXIF(int size, ReadFilterContext params) throws IOException {
+    if (LOG.isDebugEnabled())
+      LOG.debug("WebP image has EXIF block with {} bytes converted into JUNK chunk.", size);
+    writeJunkChunk(params.input, params.output, size);
+  }
+
+  private void handleXMP(int size, ReadFilterContext params) throws IOException {
+    if (LOG.isDebugEnabled())
+      LOG.debug("WebP image has XMP block with {} bytes converted into JUNK chunk.", size);
+    writeJunkChunk(params.input, params.output, size);
+  }
+
+  private void handleUnknown(int size, ReadFilterContext params) throws IOException {
+    if (LOG.isDebugEnabled())
+      LOG.debug("WebP image has Unknown block with {} bytes converted into JUNK chunk.", size);
+    writeJunkChunk(params.input, params.output, size);
   }
 }

--- a/src/main/java/network/crypta/client/filter/WebPFilter.java
+++ b/src/main/java/network/crypta/client/filter/WebPFilter.java
@@ -3,7 +3,6 @@ package network.crypta.client.filter;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Map;
 import network.crypta.l10n.NodeL10n;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,28 +33,19 @@ public class WebPFilter extends RIFFFilter {
   }
 
   @Override
-  protected void readFilterChunk(
-      byte[] ID,
-      int size,
-      Object context,
-      DataInputStream input,
-      DataOutputStream output,
-      String charset,
-      Map<String, String> otherParams,
-      String schemeHostAndPort,
-      FilterCallback cb)
+  protected void readFilterChunk(byte[] id, int size, Object context, ReadFilterContext params)
       throws IOException {
     WebPFilterContext ctx = (WebPFilterContext) context;
     // These constants are derived from mux_type.h in libwebp
     int ANIMATION_FLAG = 0x00000002;
-    if (ID[0] == 'V' && ID[1] == 'P' && ID[2] == '8' && ID[3] == ' ') {
+    if (id[0] == 'V' && id[1] == 'P' && id[2] == '8' && id[3] == ' ') {
       if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM) {
         throw new DataFilterException(
             l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected VP8 chunk was encountered");
       }
       ctx.hasVP8 = true;
-      filterVP8Block(ID, size, input, output, LOG.isDebugEnabled());
-    } else if (ID[0] == 'V' && ID[1] == 'P' && ID[2] == '8' && ID[3] == 'L') {
+      filterVP8Block(id, size, params.input, params.output, LOG.isDebugEnabled());
+    } else if (id[0] == 'V' && id[1] == 'P' && id[2] == '8' && id[3] == 'L') {
       // VP8 Lossless format:
       // https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.4.0/doc/webp-lossless-bitstream-spec.txt
       if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM || ctx.hasALPH) {
@@ -74,7 +64,7 @@ public class WebPFilter extends RIFFFilter {
           l10n("losslessUnsupportedTitle"),
           l10n("losslessUnsupportedTitle"),
           l10n("losslessUnsupported"));
-    } else if (ID[0] == 'A' && ID[1] == 'L' && ID[2] == 'P' && ID[3] == 'H') {
+    } else if (id[0] == 'A' && id[1] == 'L' && id[2] == 'P' && id[3] == 'H') {
       int ALPHA_FLAG = 0x00000010;
       if (ctx.hasVP8L
           || ctx.hasANIM
@@ -86,23 +76,23 @@ public class WebPFilter extends RIFFFilter {
             l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected ALPH chunk was encountered");
       }
       ctx.hasALPH = true;
-      filterALPHBlock(ID, size, input, output, LOG.isDebugEnabled());
-    } else if (ID[0] == 'A' && ID[1] == 'N' && ID[2] == 'I' && ID[3] == 'M') {
+      filterALPHBlock(id, size, params.input, params.output, LOG.isDebugEnabled());
+    } else if (id[0] == 'A' && id[1] == 'N' && id[2] == 'I' && id[3] == 'M') {
       if ((ctx.VP8XFlags & ANIMATION_FLAG) == 0 || ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM) {
         throw new DataFilterException(
             l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected ANIM chunk was encountered");
       }
       ctx.hasANIM = true;
       // Global animation parameters
-      output.write(ID);
-      writeLittleEndianInt(output, size);
+      params.output.write(id);
+      writeLittleEndianInt(params.output, size);
       if (size != 6) {
         throw new DataFilterException(
             l10n("invalidTitle"), l10n("invalidTitle"), "ANIM chunk size is too small or too big");
       }
       // Background color and loop count here. Pass through.
-      passthroughBytes(input, output, size);
-    } else if (ID[0] == 'A' && ID[1] == 'N' && ID[2] == 'M' && ID[3] == 'F') {
+      passthroughBytes(params.input, params.output, size);
+    } else if (id[0] == 'A' && id[1] == 'N' && id[2] == 'M' && id[3] == 'F') {
       // Animation frame
       if ((ctx.VP8XFlags & ANIMATION_FLAG) == 0 || ctx.hasVP8 || ctx.hasVP8L || !ctx.hasANIM) {
         // Animation frame in static WebP file - Unexpected
@@ -118,11 +108,11 @@ public class WebPFilter extends RIFFFilter {
             "ANMF chunk size is invalid (size=" + size + ")");
       }
       ctx.hasANMF = true;
-      output.write(ID);
-      writeLittleEndianInt(output, size);
+      params.output.write(id);
+      writeLittleEndianInt(params.output, size);
       int[] ANMFContent = new int[16]; // Unsigned bytes, can't use Java signed bytes
       for (int i = 0; i < 16; i++) {
-        ANMFContent[i] = input.readUnsignedByte();
+        ANMFContent[i] = params.input.readUnsignedByte();
       }
       // Check image sizes
       int frameX, frameY, frameWidth, frameHeight, frameFlags;
@@ -143,7 +133,7 @@ public class WebPFilter extends RIFFFilter {
             l10n("invalidTitle"), l10n("invalidTitle"), "ANMF block contains reserved flag");
       }
       for (int i = 0; i < 16; i++) {
-        output.writeByte(ANMFContent[i]);
+        params.output.writeByte(ANMFContent[i]);
       }
       int ANMFRemainingSize = size - 16;
       boolean ANMFHasVP8 = false;
@@ -151,8 +141,8 @@ public class WebPFilter extends RIFFFilter {
       byte[] ANMFBlockID = new byte[4];
       int ANMFBlockSize;
       while (ANMFRemainingSize >= 8) {
-        input.readFully(ANMFBlockID);
-        ANMFBlockSize = readLittleEndianInt(input);
+        params.input.readFully(ANMFBlockID);
+        ANMFBlockSize = readLittleEndianInt(params.input);
         if (ANMFBlockID[0] == 'V'
             && ANMFBlockID[1] == 'P'
             && ANMFBlockID[2] == '8'
@@ -166,7 +156,8 @@ public class WebPFilter extends RIFFFilter {
           } else {
             ANMFHasVP8 = true;
           }
-          filterVP8Block(ANMFBlockID, ANMFBlockSize, input, output, LOG.isDebugEnabled());
+          filterVP8Block(
+              ANMFBlockID, ANMFBlockSize, params.input, params.output, LOG.isDebugEnabled());
         } else if (ANMFBlockID[0] == 'V'
             && ANMFBlockID[1] == 'P'
             && ANMFBlockID[2] == '8'
@@ -188,7 +179,8 @@ public class WebPFilter extends RIFFFilter {
           } else {
             ANMFHasALPH = true;
           }
-          filterALPHBlock(ANMFBlockID, ANMFBlockSize, input, output, LOG.isDebugEnabled());
+          filterALPHBlock(
+              ANMFBlockID, ANMFBlockSize, params.input, params.output, LOG.isDebugEnabled());
         } else {
           // Unknown block
           if (LOG.isDebugEnabled())
@@ -196,7 +188,7 @@ public class WebPFilter extends RIFFFilter {
                 "WebP image has Unknown block with "
                     + ANMFBlockSize
                     + " bytes within ANMF chunk converted into JUNK chunk.");
-          writeJunkChunk(input, output, ANMFBlockSize);
+          writeJunkChunk(params.input, params.output, ANMFBlockSize);
         }
         ANMFRemainingSize -= (ANMFBlockSize + ANMFBlockSize % 2) + 8;
       }
@@ -207,14 +199,14 @@ public class WebPFilter extends RIFFFilter {
             "Unexpected data remaining at the end of ANMF chunk");
       }
       // ANMF without frame image can probably used to fill canvas with the background color.
-    } else if (ID[0] == 'V' && ID[1] == 'P' && ID[2] == '8' && ID[3] == 'X') {
+    } else if (id[0] == 'V' && id[1] == 'P' && id[2] == '8' && id[3] == 'X') {
       // meta information
       if (ctx.hasVP8 || ctx.hasVP8L || ctx.hasANIM || ctx.hasVP8X) {
         // This should be the first chunk of the file
         throw new DataFilterException(
             l10n("invalidTitle"), l10n("invalidTitle"), "Unexpected VP8X chunk was encountered");
       }
-      ctx.VP8XFlags = readLittleEndianInt(input);
+      ctx.VP8XFlags = readLittleEndianInt(params.input);
       int ALL_VALID_FLAGS = 0x0000003e;
       if ((ctx.VP8XFlags & ~ALL_VALID_FLAGS) != 0) {
         // Has reserved flags or uses unsupported image fragmentation
@@ -225,17 +217,17 @@ public class WebPFilter extends RIFFFilter {
         throw new DataFilterException(
             l10n("invalidTitle"), l10n("invalidTitle"), "VP8X header is too small or too big");
       }
-      output.write(ID);
-      writeLittleEndianInt(output, size);
+      params.output.write(id);
+      writeLittleEndianInt(params.output, size);
       int ICCP_FLAG = 0x00000020;
       int EXIF_FLAG = 0x00000008;
       int XMP_FLAG = 0x00000004;
       ctx.VP8XFlags &= ~(XMP_FLAG | EXIF_FLAG | ICCP_FLAG); // removing ICCP, EXIF and XMP bits
-      writeLittleEndianInt(output, ctx.VP8XFlags);
+      writeLittleEndianInt(params.output, ctx.VP8XFlags);
       ctx.hasVP8X = true;
       int[] widthHeight = new int[6]; // Unsigned bytes, can't use Java signed bytes
       for (int i = 0; i < 6; i++) {
-        widthHeight[i] = input.readUnsignedByte();
+        widthHeight[i] = params.input.readUnsignedByte();
       }
       // width and height are 24 bits
       ctx.width = widthHeight[0] | widthHeight[1] << 8 | widthHeight[2] << 16;
@@ -249,34 +241,34 @@ public class WebPFilter extends RIFFFilter {
             l10n("invalidTitle"), l10n("invalidTitle"), "WebP image size is too big");
       }
       for (int i = 0; i < 6; i++) {
-        output.writeByte(widthHeight[i]);
+        params.output.writeByte(widthHeight[i]);
       }
-    } else if (ID[0] == 'I' && ID[1] == 'C' && ID[2] == 'C' && ID[3] == 'P') {
+    } else if (id[0] == 'I' && id[1] == 'C' && id[2] == 'C' && id[3] == 'P') {
       // ICC Color Profile
       if (LOG.isDebugEnabled())
         LOG.debug("WebP image has ICCP block with " + size + " bytes converted into JUNK chunk.");
-      writeJunkChunk(input, output, size);
-    } else if (ID[0] == 'E' && ID[1] == 'X' && ID[2] == 'I' && ID[3] == 'F') {
+      writeJunkChunk(params.input, params.output, size);
+    } else if (id[0] == 'E' && id[1] == 'X' && id[2] == 'I' && id[3] == 'F') {
       // EXIF metadata
       if (LOG.isDebugEnabled())
         LOG.debug("WebP image has EXIF block with " + size + " bytes converted into JUNK chunk.");
-      writeJunkChunk(input, output, size);
-    } else if (ID[0] == 'X' && ID[1] == 'M' && ID[2] == 'P' && ID[3] == ' ') {
+      writeJunkChunk(params.input, params.output, size);
+    } else if (id[0] == 'X' && id[1] == 'M' && id[2] == 'P' && id[3] == ' ') {
       // XMP metadata
       if (LOG.isDebugEnabled())
         LOG.debug("WebP image has XMP block with " + size + " bytes converted into JUNK chunk.");
-      writeJunkChunk(input, output, size);
+      writeJunkChunk(params.input, params.output, size);
     } else {
       // Unknown block
       if (LOG.isDebugEnabled())
         LOG.debug(
             "WebP image has Unknown block with " + size + " bytes converted into JUNK chunk.");
-      writeJunkChunk(input, output, size);
+      writeJunkChunk(params.input, params.output, size);
     }
   }
 
   @Override
-  protected void EOFCheck(Object context) throws DataFilterException {
+  protected void eofCheck(Object context) throws DataFilterException {
     WebPFilterContext ctx = (WebPFilterContext) context;
     if (!ctx.hasVP8 && !ctx.hasVP8L && !ctx.hasANMF) {
       throw new DataFilterException(

--- a/src/test/java/network/crypta/client/filter/RIFFFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/RIFFFilterTest.java
@@ -1,0 +1,312 @@
+package network.crypta.client.filter;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class RIFFFilterTest {
+
+  /**
+   * Minimal concrete RIFF filter for tests. Uses a fixed form type of "TEST" and reads each chunk
+   * by consuming {@code size} bytes plus the optional pad byte when {@code size} is odd.
+   */
+  static final class TestRiffFilter extends RIFFFilter {
+    private static final byte[] FORM = new byte[] {'T', 'E', 'S', 'T'};
+
+    @Override
+    protected byte[] getChunkMagicNumber() {
+      return FORM;
+    }
+
+    @Override
+    protected Object createContext() {
+      return new Object();
+    }
+
+    @Override
+    protected void readFilterChunk(byte[] id, int size, Object context, ReadFilterContext params)
+        throws IOException {
+      // Consume the chunk payload
+      byte[] data = new byte[size];
+      params.input.readFully(data);
+      // Consume the padding byte if present (RIFF chunks are word-aligned)
+      if ((size & 1) == 1) {
+        int pad = params.input.read();
+        if (pad == -1) {
+          throw new EOFException();
+        }
+      }
+      // For tests, we do not emit chunk data back; only the RIFF header is written by the base
+      // implementation. This keeps the tests focused on structural validation.
+    }
+
+    @Override
+    protected void eofCheck(Object context) {
+      // No-op for tests
+    }
+  }
+
+  private static byte[] leInt(int v) {
+    // Convenience helper to encode a 32-bit little-endian integer into 4 bytes.
+    ByteBuffer bb = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+    bb.putInt(v);
+    return bb.array();
+  }
+
+  private static byte[] riffHeader(int fileSize, byte[] form) throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write(new byte[] {'R', 'I', 'F', 'F'});
+    bos.write(leInt(fileSize));
+    bos.write(form);
+    return bos.toByteArray();
+  }
+
+  @Test
+  void readFilter_happyPath_evenAndOddChunks_noException() throws Exception {
+    // Arrange: RIFF(TEST) with two chunks: one empty, one odd-sized 3 bytes (with pad)
+    TestRiffFilter filter = new TestRiffFilter();
+
+    byte[] form = filter.getChunkMagicNumber();
+
+    // Chunk 1: id="abcd", size=0, no data
+    byte[] c1 = new byte[] {'a', 'b', 'c', 'd', 0, 0, 0, 0};
+
+    // Chunk 2: id="data", size=3, payload=3 bytes, plus 1 pad byte
+    ByteArrayOutputStream c2 = new ByteArrayOutputStream();
+    c2.write(new byte[] {'d', 'a', 't', 'a'});
+    c2.write(leInt(3));
+    c2.write(new byte[] {1, 2, 3});
+    c2.write(0); // pad to even size
+
+    int remaining = c1.length + c2.size(); // == (8 + 12)
+    int fileSize = 4 + remaining; // 4 bytes form type + chunks
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write(riffHeader(fileSize, form));
+    bos.write(c1);
+    bos.write(c2.toByteArray());
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bos.toByteArray());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    // Act + Assert: should parse without throwing
+    assertDoesNotThrow(
+        () -> filter.readFilter(in, out, null, Map.of(), "http://example:1234", /* cb= */ null));
+
+    // And the output must start with the same RIFF header
+    byte[] outBytes = out.toByteArray();
+    byte[] expectedHeader = riffHeader(fileSize, form);
+    assertArrayEquals(expectedHeader, Arrays.copyOfRange(outBytes, 0, expectedHeader.length));
+  }
+
+  @Test
+  void readFilter_whenMagicMismatch_expectDataFilterException() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+    byte[] form = filter.getChunkMagicNumber();
+
+    // Corrupt the first byte of the RIFF magic
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write(new byte[] {'X', 'I', 'F', 'F'});
+    bos.write(leInt(12));
+    bos.write(form);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bos.toByteArray());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    assertThrows(
+        DataFilterException.class, () -> filter.readFilter(in, out, null, Map.of(), null, null));
+  }
+
+  @Test
+  void readFilter_whenFormTypeMismatch_expectDataFilterException() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+
+    // Correct RIFF header and size but wrong form type
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write(new byte[] {'R', 'I', 'F', 'F'});
+    bos.write(leInt(12));
+    bos.write(new byte[] {'B', 'A', 'D', '!'});
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bos.toByteArray());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    assertThrows(
+        DataFilterException.class, () -> filter.readFilter(in, out, null, Map.of(), null, null));
+  }
+
+  @Test
+  void readFilter_whenNegativeFileSize_expectDataFilterException() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+    byte[] form = filter.getChunkMagicNumber();
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write(new byte[] {'R', 'I', 'F', 'F'});
+    bos.write(leInt(-1)); // negative size indicates >2GiB in unsigned terms
+    bos.write(form);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bos.toByteArray());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    assertThrows(
+        DataFilterException.class, () -> filter.readFilter(in, out, null, Map.of(), null, null));
+  }
+
+  @Test
+  void readFilter_whenFileSizeTooSmall_expectDataFilterException() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+    byte[] form = filter.getChunkMagicNumber();
+
+    // fileSize < 12 means not enough room for any chunk (after 4 bytes form type)
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write(new byte[] {'R', 'I', 'F', 'F'});
+    bos.write(leInt(11));
+    bos.write(form);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bos.toByteArray());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    assertThrows(
+        DataFilterException.class, () -> filter.readFilter(in, out, null, Map.of(), null, null));
+  }
+
+  @Test
+  void readFilter_whenChunkDeclTooLarge_expectDataFilterException() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+    byte[] form = filter.getChunkMagicNumber();
+
+    // remainingSize will be 8, but we declare a chunk with size=8 (requires 8 + header 8 = 16)
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write(riffHeader(12, form)); // fileSize = 4 (form) + 8 (remaining)
+    bos.write(new byte[] {'c', 'h', 'n', 'k'});
+    bos.write(leInt(8));
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bos.toByteArray());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    assertThrows(
+        DataFilterException.class, () -> filter.readFilter(in, out, null, Map.of(), null, null));
+  }
+
+  @Test
+  void readFilter_whenStreamTruncated_expectEOFDataFilterException() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+    byte[] form = filter.getChunkMagicNumber();
+
+    // Declare a chunk of size 4 but provide only 2 bytes of payload; readFilterChunk will
+    // try to readFully(4) and trigger EOFException, which the outer reader maps to
+    // DataFilterException.
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bos.write(riffHeader(4 + 8 + 4, form)); // 4 (form) + 8 (hdr) + 4 (payload)
+    bos.write(new byte[] {'i', 'd', 'x', '1'});
+    bos.write(leInt(4));
+    bos.write(new byte[] {9, 9}); // only 2 bytes instead of 4
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bos.toByteArray());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    assertThrows(
+        DataFilterException.class, () -> filter.readFilter(in, out, null, Map.of(), null, null));
+  }
+
+  @Test
+  void readFilter_whenExtraTrailingBytes_expectEOFDataFilterException() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+    byte[] form = filter.getChunkMagicNumber();
+
+    // Valid single empty chunk but append 1 extra byte beyond declared file size
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    // remaining = one empty chunk (8)
+    bos.write(riffHeader(4 + 8, form));
+    bos.write(new byte[] {'n', 'u', 'l', 'l'});
+    bos.write(leInt(0));
+    bos.write(0x7F); // extra byte beyond expected EOF
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bos.toByteArray());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    assertThrows(
+        DataFilterException.class, () -> filter.readFilter(in, out, null, Map.of(), null, null));
+  }
+
+  @Test
+  void passthroughBytes_whenNegativeSize_expectDataFilterException() {
+    TestRiffFilter filter = new TestRiffFilter();
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(new byte[] {1, 2, 3}));
+    DataOutputStream dos = new DataOutputStream(new ByteArrayOutputStream());
+    assertThrows(DataFilterException.class, () -> filter.passthroughBytes(dis, dos, -5));
+  }
+
+  @Test
+  void passthroughBytes_copiesExactNumberOfBytes() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+    byte[] payload = new byte[1024 + 3]; // not a multiple of the copy chunk size
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) (i & 0xFF);
+    }
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    filter.passthroughBytes(
+        new DataInputStream(new ByteArrayInputStream(payload)),
+        new DataOutputStream(out),
+        payload.length);
+    assertArrayEquals(payload, out.toByteArray());
+  }
+
+  @Test
+  void writeJunkChunk_writesEvenSizedZeroBlock() throws Exception {
+    TestRiffFilter filter = new TestRiffFilter();
+    // size=3 -> becomes 4 due to padding; provide 4 bytes to skip
+    byte[] skipSrc = new byte[] {10, 20, 30, 40};
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    filter.writeJunkChunk(
+        new DataInputStream(new ByteArrayInputStream(skipSrc)), new DataOutputStream(out), 3);
+
+    byte[] bytes = out.toByteArray();
+    // Expect: 'JUNK' + LE(4) + 4 zero bytes
+    ByteArrayOutputStream expected = new ByteArrayOutputStream();
+    expected.write(new byte[] {'J', 'U', 'N', 'K'});
+    expected.write(leInt(4));
+    expected.write(new byte[] {0, 0, 0, 0});
+
+    assertArrayEquals(expected.toByteArray(), bytes);
+  }
+
+  @Test
+  void writeJunkChunk_whenNegativeSize_expectDataFilterException() {
+    TestRiffFilter filter = new TestRiffFilter();
+    ByteArrayInputStream in = new ByteArrayInputStream(new byte[] {1, 2, 3});
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    assertThrows(
+        DataFilterException.class,
+        () -> filter.writeJunkChunk(new DataInputStream(in), new DataOutputStream(out), -1));
+  }
+
+  @Test
+  void littleEndianInt_readAndWrite_roundTrip() throws Exception {
+    // Arrange: write a known value in little-endian and read it back
+    int value = 0x78563412; // 2018915346
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(out);
+    RIFFFilter.writeLittleEndianInt(dos, value);
+
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(out.toByteArray()));
+    int read = RIFFFilter.readLittleEndianInt(dis);
+    assertEquals(value, read);
+  }
+}

--- a/src/test/java/network/crypta/client/filter/WAVFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/WAVFilterTest.java
@@ -1,23 +1,26 @@
 package network.crypta.client.filter;
 
 import static network.crypta.client.filter.ResourceFileUtil.resourceToBucket;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
 import network.crypta.support.io.BucketTools;
 import org.junit.jupiter.api.Test;
 
-/** Unit test for (parts of) {@link WAVFilter}. */
-public class WAVFilterTest {
+@SuppressWarnings("java:S100") // test method names use given_when_then with underscores
+class WAVFilterTest {
 
   @Test
-  public void testValidWAV() throws IOException {
+  void readFilter_whenValidWAV_expectPassThrough() throws IOException {
     Bucket input = resourceToBucket("./wav/test.wav");
     Bucket output = filterWAV(input, null);
 
@@ -31,14 +34,14 @@ public class WAVFilterTest {
 
   // This file is WebP, not WAV!
   @Test
-  public void testAnotherFile() throws IOException {
+  void readFilter_whenContainerIsNotWAVE_expectException() throws IOException {
     Bucket input = resourceToBucket("./webp/test.webp");
     filterWAV(input, DataFilterException.class);
   }
 
   // There is just a JUNK chunk in the file
   @Test
-  public void testFileJustJUNK() throws IOException {
+  void readFilter_whenFirstChunkIsNotFmt_expectException() throws IOException {
     ByteBuffer buf =
         ByteBuffer.allocate(28)
             .order(ByteOrder.LITTLE_ENDIAN)
@@ -55,7 +58,7 @@ public class WAVFilterTest {
 
   // There is just a fmt chunk in the file, but no audio data
   @Test
-  public void testFileNoData() throws IOException {
+  void readFilter_whenMissingDataChunk_expectException() throws IOException {
     ByteBuffer buf =
         ByteBuffer.allocate(36)
             .order(ByteOrder.LITTLE_ENDIAN)
@@ -73,6 +76,147 @@ public class WAVFilterTest {
     filterWAV(input, DataFilterException.class);
   }
 
+  @Test
+  void readFilter_whenFmtChunkDuplicated_expectException() throws IOException {
+    byte[] fmt = buildFmtBasic(1, 1, 8000, 8000, 1, 8);
+    byte[] riff =
+        buildWaveFile(
+            chunk("fmt ", fmt),
+            // duplicate fmt before any data
+            chunk("fmt ", fmt));
+    Bucket input = new ArrayBucket(riff);
+    filterWAV(input, DataFilterException.class);
+  }
+
+  @Test
+  void readFilter_whenFmtChunkSizeInvalid_expectException() throws IOException {
+    byte[] payload = new byte[10];
+    Arrays.fill(payload, (byte) 0xCC);
+    byte[] riff = buildWaveFile(chunk("fmt ", payload));
+    Bucket input = new ArrayBucket(riff);
+    filterWAV(input, DataFilterException.class);
+  }
+
+  @Test
+  void readFilter_whenUnsupportedFormat_expectException() throws IOException {
+    byte[] fmt = buildFmtBasic(2, 1, 8000, 8000, 1, 8);
+    byte[] riff = buildWaveFile(chunk("fmt ", fmt));
+    Bucket input = new ArrayBucket(riff);
+    filterWAV(input, DataFilterException.class);
+  }
+
+  @Test
+  void readFilter_whenALawWithNon8Bit_expectException() throws IOException {
+    // A-Law requires 8 bits per sample; here we use 16 to trigger rejection
+    byte[] fmt = buildFmtBasic(6, 1, 8000, 8000, 2, 16);
+    byte[] riff = buildWaveFile(chunk("fmt ", fmt));
+    Bucket input = new ArrayBucket(riff);
+    filterWAV(input, DataFilterException.class);
+  }
+
+  @Test
+  void readFilter_whenFactSizeIsFour_expectPassThrough() throws IOException {
+    byte[] fmt = buildFmtBasic(1, 2, 44100, 44100 * 4, 4, 16);
+    byte[] factPayload = new byte[] {1, 2, 3, 4}; // dwSampleLength
+    byte[] data = new byte[] {10, 11, 12, 13};
+    byte[] riff =
+        buildWaveFile(chunk("fmt ", fmt), chunk("fact", factPayload), chunk("data", data));
+
+    Bucket input = new ArrayBucket(riff);
+    Bucket output = filterWAV(input, null);
+    assertArrayEquals(
+        BucketTools.toByteArray(new ArrayBucket(riff)), BucketTools.toByteArray(output));
+  }
+
+  @Test
+  void readFilter_whenUnknownChunk_expectRewrittenAsJunk() throws IOException {
+    byte[] fmt = buildFmtBasic(1, 1, 8000, 8000, 1, 8);
+    byte[] unknown = new byte[] {9, 8, 7, 6, 5, 4}; // 6 bytes
+    byte[] data = new byte[] {1, 2};
+    byte[] riffInput =
+        buildWaveFile(chunk("fmt ", fmt), chunk("ABCD", unknown), chunk("data", data));
+
+    // Expected output: unknown chunk replaced with JUNK of even size (6), filled with zeros
+    byte[] riffExpected =
+        buildWaveFile(
+            chunk("fmt ", fmt), chunk("JUNK", new byte[] {0, 0, 0, 0, 0, 0}), chunk("data", data));
+
+    Bucket input = new ArrayBucket(riffInput);
+    Bucket output = filterWAV(input, null);
+    assertArrayEquals(
+        BucketTools.toByteArray(new ArrayBucket(riffExpected)), BucketTools.toByteArray(output));
+  }
+
+  @Test
+  void readFilter_whenDataSizeIsOdd_expectPadByteCopied() throws IOException {
+    byte[] fmt = buildFmtBasic(1, 1, 8000, 8000, 1, 8);
+    byte[] dataPayload = new byte[] {0x11, 0x22, 0x33};
+    byte pad = (byte) 0xAB; // explicit alignment byte after payload
+    byte[] riffInput = buildWaveFile(chunk("fmt ", fmt), chunkWithPad(dataPayload, pad));
+
+    // Build expected with the same explicit pad copied through
+    byte[] riffExpected = buildWaveFile(chunk("fmt ", fmt), chunkWithPad(dataPayload, pad));
+
+    Bucket input = new ArrayBucket(riffInput);
+    Bucket output = filterWAV(input, null);
+    assertArrayEquals(
+        BucketTools.toByteArray(new ArrayBucket(riffExpected)), BucketTools.toByteArray(output));
+  }
+
+  @Test
+  void readFilter_whenFmtHasCbSizeZero_expectPassThrough() throws IOException {
+    byte[] fmt18 = buildFmtWithExtensions(1, 1, 8000, 8000, 1, 8, new byte[0]);
+    byte[] data = new byte[] {1, 2};
+    byte[] riff = buildWaveFile(chunk("fmt ", fmt18), chunk("data", data));
+    Bucket input = new ArrayBucket(riff);
+    Bucket output = filterWAV(input, null);
+    assertArrayEquals(
+        BucketTools.toByteArray(new ArrayBucket(riff)), BucketTools.toByteArray(output));
+  }
+
+  @Test
+  void readFilter_whenFmtHasExtensions_expectPassThrough() throws IOException {
+    byte[] ext = new byte[22];
+    for (int i = 0; i < ext.length; i++) ext[i] = (byte) i;
+    byte[] fmt40 = buildFmtWithExtensions(1, 2, 44100, 44100 * 4, 4, 16, ext);
+    byte[] data = new byte[] {1, 2, 3, 4};
+    byte[] riff = buildWaveFile(chunk("fmt ", fmt40), chunk("data", data));
+    Bucket input = new ArrayBucket(riff);
+    Bucket output = filterWAV(input, null);
+    assertArrayEquals(
+        BucketTools.toByteArray(new ArrayBucket(riff)), BucketTools.toByteArray(output));
+  }
+
+  @Test
+  void readFilter_whenIEEEFloatFmtWithExtensions_expectPassThrough() throws IOException {
+    // Use supported IEEE float format (3) with extensions and a small data chunk
+    byte[] ext = new byte[22];
+    for (int i = 0; i < ext.length; i++) ext[i] = (byte) (255 - i);
+    byte[] fmt40 = buildFmtWithExtensions(3, 1, 16000, 16000 * 4, 4, 16, ext);
+    byte[] data = new byte[] {5, 4, 3, 2};
+    byte[] riff = buildWaveFile(chunk("fmt ", fmt40), chunk("data", data));
+    Bucket input = new ArrayBucket(riff);
+    Bucket output = filterWAV(input, null);
+    assertArrayEquals(
+        BucketTools.toByteArray(new ArrayBucket(riff)), BucketTools.toByteArray(output));
+  }
+
+  @Test
+  void readFilter_whenFmtCbSizeMismatch_expectException() throws IOException {
+    // size=18 but cbSize=1 is invalid (must be 0 when size==18)
+    ByteBuffer b = ByteBuffer.allocate(18).order(ByteOrder.LITTLE_ENDIAN);
+    b.putShort((short) 1); // PCM
+    b.putShort((short) 1);
+    b.putInt(8000);
+    b.putInt(8000);
+    b.putShort((short) 1);
+    b.putShort((short) 8);
+    b.putShort((short) 1); // cbSize=1 (invalid)
+    byte[] riff = buildWaveFile(chunk("fmt ", b.array()));
+    Bucket input = new ArrayBucket(riff);
+    filterWAV(input, DataFilterException.class);
+  }
+
   private Bucket filterWAV(Bucket input, Class<? extends Exception> expected) throws IOException {
     WAVFilter objWAVFilter = new WAVFilter();
     Bucket output = new ArrayBucket();
@@ -86,5 +230,83 @@ public class WAVFilterTest {
       }
     }
     return output;
+  }
+
+  // --- helpers --------------------------------------------------------------
+
+  private static class Chunk {
+    final byte[] id; // 4 bytes
+    final byte[] payload;
+    final Byte padByte; // optional explicit pad for odd payload sizes
+
+    Chunk(String id, byte[] payload, Byte padByte) {
+      if (id == null || id.length() != 4) throw new IllegalArgumentException("id must be 4 chars");
+      this.id = id.getBytes();
+      this.payload = payload;
+      this.padByte = padByte;
+    }
+  }
+
+  private static Chunk chunk(String id, byte[] payload) {
+    return new Chunk(id, payload, null);
+  }
+
+  private static Chunk chunkWithPad(byte[] payload, byte pad) {
+    return new Chunk("data", payload, pad);
+  }
+
+  private static byte[] buildWaveFile(Chunk... chunks) {
+    int contentSize = 4; // 'WAVE'
+    for (Chunk c : chunks) {
+      int pad = (c.payload.length & 1);
+      contentSize += 8 + c.payload.length + pad; // header + payload + possible pad byte
+    }
+    int totalSize = 8 + contentSize; // 'RIFF' + size + content
+
+    ByteBuffer buf = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN);
+    buf.put(new byte[] {'R', 'I', 'F', 'F'});
+    buf.putInt(contentSize);
+    buf.put(new byte[] {'W', 'A', 'V', 'E'});
+    for (Chunk c : chunks) {
+      buf.put(c.id);
+      buf.putInt(c.payload.length);
+      buf.put(c.payload);
+      if ((c.payload.length & 1) != 0) {
+        buf.put(c.padByte != null ? c.padByte : (byte) 0);
+      }
+    }
+    return buf.array();
+  }
+
+  private static byte[] buildFmtBasic(
+      int format, int channels, int rate, int avgBytesPerSec, int blockAlign, int bitsPerSample) {
+    ByteBuffer b = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
+    b.putShort((short) format);
+    b.putShort((short) channels);
+    b.putInt(rate);
+    b.putInt(avgBytesPerSec);
+    b.putShort((short) blockAlign);
+    b.putShort((short) bitsPerSample);
+    return b.array();
+  }
+
+  private static byte[] buildFmtWithExtensions(
+      int format,
+      int channels,
+      int rate,
+      int avgBytesPerSec,
+      int blockAlign,
+      int bitsPerSample,
+      byte[] extension) {
+    ByteBuffer b = ByteBuffer.allocate(18 + extension.length).order(ByteOrder.LITTLE_ENDIAN);
+    b.putShort((short) format);
+    b.putShort((short) channels);
+    b.putInt(rate);
+    b.putInt(avgBytesPerSec);
+    b.putShort((short) blockAlign);
+    b.putShort((short) bitsPerSample);
+    b.putShort((short) extension.length);
+    b.put(extension);
+    return b.array();
   }
 }

--- a/src/test/java/network/crypta/client/filter/WebPFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/WebPFilterTest.java
@@ -1,167 +1,429 @@
 package network.crypta.client.filter;
 
 import static network.crypta.client.filter.ResourceFileUtil.resourceToBucket;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import network.crypta.support.api.Bucket;
+import java.util.ArrayList;
+import java.util.List;
 import network.crypta.support.io.ArrayBucket;
 import network.crypta.support.io.ArrayBucketFactory;
 import network.crypta.support.io.BucketTools;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-/** Unit test for (parts of) {@link WebPFilter}. */
-public class WebPFilterTest {
+@SuppressWarnings("java:S100")
+class WebPFilterTest {
 
   private static void readFilter(
       WebPFilter objWebPFilter, InputStream inStream, OutputStream outStream) throws IOException {
     objWebPFilter.readFilter(inStream, outStream, "", null, null, null);
   }
 
-  /** Tests file without media chunk */
   @Test
-  public void testNoChunkFile() throws IOException {
+  void readFilter_whenNoImageChunk_expectDataFilterException() throws IOException {
+    // Arrange
     ByteBuffer buf =
         ByteBuffer.allocate(12)
             .order(ByteOrder.LITTLE_ENDIAN)
             .put(new byte[] {'R', 'I', 'F', 'F'})
-            .putInt(4 /* file size */)
+            .putInt(4)
             .put(new byte[] {'W', 'E', 'B', 'P'});
-
-    Bucket input = new ArrayBucket(buf.array());
-    filterImage(input, DataFilterException.class);
+    WebPFilter filter = new WebPFilter();
+    // Act + Assert
+    try (ArrayBucket input = new ArrayBucket(buf.array());
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
   }
 
-  /** Tests file with too short VP8 chunk */
   @Test
-  public void testFileEOF() throws IOException {
+  void readFilter_whenVP8ChunkTooShort_expectDataFilterException() throws IOException {
+    // Arrange
     ByteBuffer buf =
         ByteBuffer.allocate(33)
             .order(ByteOrder.LITTLE_ENDIAN)
             .put(new byte[] {'R', 'I', 'F', 'F'})
-            .putInt(0x1308 /* file size */)
+            .putInt(0x1308)
             .put(new byte[] {'W', 'E', 'B', 'P'})
             .put(new byte[] {'V', 'P', '8', ' '})
-            .putInt(0x12FC /* chunk size */)
-            .putLong(((long) 0x2a019d << 24 /* frame tag */) | (1 << 4 /* show_frame=1 */));
-
-    Bucket input = new ArrayBucket(buf.array());
-    filterImage(input, DataFilterException.class);
+            .putInt(0x12FC)
+            .putLong(((long) 0x2a019d << 24) | (1L << 4));
+    WebPFilter filter = new WebPFilter();
+    // Act + Assert
+    try (ArrayBucket input = new ArrayBucket(buf.array());
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
   }
 
-  /** Tests file with just only a JUNK chunk */
   @Test
-  public void testFileJustJUNK() throws IOException {
+  void readFilter_whenOnlyJunkChunk_expectDataFilterException() throws IOException {
+    // Arrange
     ByteBuffer buf =
         ByteBuffer.allocate(28)
             .order(ByteOrder.LITTLE_ENDIAN)
             .put(new byte[] {'R', 'I', 'F', 'F'})
-            .putInt(20 /* file size */)
+            .putInt(20)
             .put(new byte[] {'W', 'E', 'B', 'P'})
             .put(new byte[] {'J', 'U', 'N', 'K'})
-            .putInt(7 /* chunk size */)
+            .putInt(7)
             .putLong(0);
-
-    Bucket input = new ArrayBucket(buf.array());
-    filterImage(input, DataFilterException.class);
-  }
-
-  /** Tests file with chunk size of 0x7fffff00 */
-  @Test
-  public void testTooBig() throws IOException {
-    ByteBuffer buf =
-        ByteBuffer.allocate(32)
-            .order(ByteOrder.LITTLE_ENDIAN)
-            .put(new byte[] {'R', 'I', 'F', 'F'})
-            .putInt(0x7fffff0c /* file size */) // 2 GiB
-            .put(new byte[] {'W', 'E', 'B', 'P'})
-            .put(new byte[] {'V', 'P', '8', ' '})
-            .putInt(0x7fffff00 /* chunk size */) // 2 GiB
-            .putLong(((long) 0x2a019d << 24 /* frame tag */) | (1 << 4 /* show_frame=1 */));
-
-    Bucket input = new ArrayBucket(buf.array());
-    filterImage(input, DataFilterException.class);
-  }
-
-  /** Tests file with file size of 0 */
-  @Test
-  public void fileSizeTooSmall() throws IOException {
-    ByteBuffer buf =
-        ByteBuffer.allocate(32)
-            .order(ByteOrder.LITTLE_ENDIAN)
-            .put(new byte[] {'R', 'I', 'F', 'F'})
-            .putInt(0 /* file size */) // Empty RIFF file, promise!
-            .put(new byte[] {'W', 'E', 'B', 'P'})
-            .put(new byte[] {'V', 'P', '8', ' '})
-            .putInt(12 /* chunk size */)
-            .putLong(((long) 0x2a019d << 24 /* frame tag */) | (1 << 4 /* show_frame=1 */));
-
-    Bucket input = new ArrayBucket(buf.array());
-    filterImage(input, DataFilterException.class);
-  }
-
-  /** Tests valid image (lossy image from libwebp 1.4) */
-  @Test
-  public void testValidImageLossy() throws IOException {
-    testValidImage("test.webp");
-  }
-
-  /**
-   * Tests valid image (lossy image with alpha channel from
-   * https://developers.google.com/speed/webp/gallery2 “Yellow Rose”)
-   */
-  @Test
-  public void testValidImageLossyAlpha() throws IOException {
-    testValidImage("1_webp_a.webp");
-  }
-
-  /**
-   * Tests valid image (lossy animation with alpha channel from
-   * https://commons.wikimedia.org/wiki/File:Simple_Animated_Clock.webp)
-   */
-  @Test
-  public void testValidAnimationLossyAlpha() throws IOException {
-    testValidImage("Simple_Animated_Clock.webp");
-  }
-
-  /** Tests data after valid image */
-  @Test
-  public void testDataAfterEOF() throws IOException {
-    ArrayBucketFactory bf = new ArrayBucketFactory();
-    Bucket inputValid = resourceToBucket("./webp/test.webp");
-    Bucket input =
-        BucketTools.pad(inputValid, (int) inputValid.size() + 1, bf, (int) inputValid.size());
-    assertEquals(inputValid.size() + 1L, input.size(), "Input size is wrong");
-    filterImage(input, DataFilterException.class);
-  }
-
-  private Bucket filterImage(Bucket input, Class<? extends Exception> expected) throws IOException {
-    WebPFilter objWebPFilter = new WebPFilter();
-    Bucket output = new ArrayBucket();
-    try (InputStream inStream = input.getInputStream();
-        OutputStream outStream = output.getOutputStream()) {
-      if (expected != null) {
-        assertThrows(expected, () -> readFilter(objWebPFilter, inStream, outStream));
-      } else {
-        readFilter(objWebPFilter, inStream, outStream);
-      }
+    WebPFilter filter = new WebPFilter();
+    // Act + Assert
+    try (ArrayBucket input = new ArrayBucket(buf.array());
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
     }
-    return output;
   }
 
-  private void testValidImage(String resource) throws IOException {
-    Bucket input = resourceToBucket("./webp/" + resource);
-    Bucket output = filterImage(input, null);
+  @Test
+  void readFilter_whenChunkSizeTooLarge_expectDataFilterException() throws IOException {
+    // Arrange
+    ByteBuffer buf =
+        ByteBuffer.allocate(32)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put(new byte[] {'R', 'I', 'F', 'F'})
+            .putInt(0x7fffff0c)
+            .put(new byte[] {'W', 'E', 'B', 'P'})
+            .put(new byte[] {'V', 'P', '8', ' '})
+            .putInt(0x7fffff00)
+            .putLong(((long) 0x2a019d << 24) | (1L << 4));
+    WebPFilter filter = new WebPFilter();
+    // Act + Assert
+    try (ArrayBucket input = new ArrayBucket(buf.array());
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
 
-    // Filter should return the original
-    assertEquals(input.size(), output.size(), "Input and output should be the same length");
-    assertArrayEquals(
-        BucketTools.toByteArray(input),
-        BucketTools.toByteArray(output),
-        "Input and output are not identical");
+  @Test
+  void readFilter_whenFileSizeZero_expectDataFilterException() throws IOException {
+    // Arrange
+    ByteBuffer buf =
+        ByteBuffer.allocate(32)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put(new byte[] {'R', 'I', 'F', 'F'})
+            .putInt(0)
+            .put(new byte[] {'W', 'E', 'B', 'P'})
+            .put(new byte[] {'V', 'P', '8', ' '})
+            .putInt(12)
+            .putLong(((long) 0x2a019d << 24) | (1L << 4));
+    WebPFilter filter = new WebPFilter();
+    // Act + Assert
+    try (ArrayBucket input = new ArrayBucket(buf.array());
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"./webp/test.webp", "./webp/1_webp_a.webp", "./webp/Simple_Animated_Clock.webp"})
+  void readFilter_whenValidWebP_expectPassThrough(String resourcePath) throws IOException {
+    // Arrange
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = resourceToBucket(resourcePath);
+        ArrayBucket output = new ArrayBucket()) {
+      // Act
+      try (InputStream in = input.getInputStream();
+          OutputStream out = output.getOutputStream()) {
+        readFilter(filter, in, out);
+      }
+      // Assert
+      assertEquals(input.size(), output.size(), "Input and output should be the same length");
+      assertArrayEquals(
+          BucketTools.toByteArray(input),
+          BucketTools.toByteArray(output),
+          "Input and output differ");
+    }
+  }
+
+  @Test
+  void readFilter_whenExtraDataAfterEof_expectDataFilterException() throws IOException {
+    // Arrange
+    ArrayBucketFactory bf = new ArrayBucketFactory();
+    WebPFilter filter = new WebPFilter();
+    // Act + Assert
+    try (ArrayBucket inputValid = resourceToBucket("./webp/test.webp");
+        ArrayBucket input =
+            (ArrayBucket)
+                BucketTools.pad(
+                    inputValid, (int) inputValid.size() + 1, bf, (int) inputValid.size());
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertEquals(inputValid.size() + 1L, input.size(), "Input size is wrong");
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  // No helper methods that allocate ArrayBucket outside try-with-resources.
+
+  // -------------------- Additional deterministic tests for edge branches --------------------
+
+  @Test
+  void vp8l_whenEncountered_expectLosslessUnsupported() throws IOException {
+    byte[] vp8lPayload = new byte[] {0x00}; // minimal payload; filter throws before reading all
+    byte[] img = riffWebp(chunk("VP8L", vp8lPayload));
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void alph_whenNoVp8x_expectUnexpectedAlpha() throws IOException {
+    byte[] alph = chunk("ALPH", new byte[] {0x00}); // size=1 → padding handled by chunk()
+    byte[] img = riffWebp(alph);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void alph_whenReservedBitsSet_expectException() throws IOException {
+    // VP8X with ALPHA_FLAG set and tiny canvas 1x1
+    byte[] vp8x = vp8xChunk(/*flags*/ 0x10, /*wMinus1*/ 0, /*hMinus1*/ 2);
+    // ALPH flags bit1 set (0x02) triggers reserved-bits error
+    byte[] alph = chunk("ALPH", new byte[] {0x02});
+    byte[] img = riffWebp(vp8x, alph);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void alph_whenUnsupportedCompression_expectException() throws IOException {
+    byte[] vp8x = vp8xChunk(/*flags*/ 0x10, /*wMinus1*/ 0, /*hMinus1*/ 3);
+    // ALPH flags high bits (0x80) set → unsupported compression path
+    byte[] alph = chunk("ALPH", new byte[] {(byte) 0x80});
+    byte[] img = riffWebp(vp8x, alph);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void vp8x_whenReservedFlagsSet_expectException() throws IOException {
+    // Set a bit outside ALL_VALID_FLAGS (0x3e); e.g., 0x40
+    byte[] vp8x = vp8xChunk(/*flags*/ 0x40, /*wMinus1*/ 0, /*hMinus1*/ 1);
+    byte[] img = riffWebp(vp8x);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void vp8x_whenInvalidChunkSize_expectException() throws IOException {
+    // VP8X size must be exactly 10; here we craft size=8 (flags only, missing width/height)
+    byte[] flagsLE = leInt(0x10); // ALPHA flag just for realism
+    byte[] badVp8x = rawChunk("VP8X", flagsLE); // size=4 → chunk() would pad; rawChunk keeps size=4
+    // Adjust to RIFF by wrapping in riffWebp(); RIFF size accounting is handled there
+    byte[] img = riffWebp(badVp8x);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void vp8x_whenImageTooBig_expectException() throws IOException {
+    // widthMinus1 = 16384 → width = 16385 (> 16384) triggers size-too-big
+    byte[] vp8x = vp8xChunk(/*flags*/ 0x00, /*wMinus1*/ 16384, /*hMinus1*/ 5);
+    byte[] img = riffWebp(vp8x);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void vp8_whenIsShownFalse_expectException() throws IOException {
+    // VP8 header with is_shown bit (bit 4) cleared (tmp=0x00) and valid sync code
+    byte[] vp8 = vp8Chunk(/*size*/ 16, /*tmp*/ 0x00);
+    byte[] img = riffWebp(vp8);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void vp8_whenDuplicate_expectUnexpectedSecondVp8() throws IOException {
+    byte[] vp8First = vp8Chunk(/*size*/ 12, /*tmp*/ 0x10); // valid
+    byte[] vp8Second = vp8Chunk(/*size*/ 14, /*tmp*/ 0x10); // second occurrence not allowed
+    byte[] img = riffWebp(vp8First, vp8Second);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void anmf_whenSeenBeforeAnim_expectUnexpected() throws IOException {
+    // VP8X with animation flag set but ANMF appears before ANIM → error
+    byte[] vp8xAnim =
+        vp8xChunk(/*flags*/ 0x02, /*wMinus1*/ 0, /*hMinus1*/ 4); // 0x02 = ANIMATION_FLAG
+    // Minimal invalid ANMF (too small) to also exercise size guard; code will fail before reading
+    byte[] anmf = rawChunk("ANMF", new byte[8]);
+    byte[] img = riffWebp(vp8xAnim, anmf);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void anim_whenInvalidSize_expectException() throws IOException {
+    // VP8X with animation flag set, then ANIM with wrong size (not 6)
+    byte[] vp8xAnim = vp8xChunk(/*flags*/ 0x02, /*wMinus1*/ 0, /*hMinus1*/ 6);
+    byte[] animBad = rawChunk("ANIM", new byte[4]); // size=4
+    byte[] img = riffWebp(vp8xAnim, animBad);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  @Test
+  void anim_whenAfterVp8_expectUnexpected() throws IOException {
+    byte[] vp8 = vp8Chunk(/*size*/ 18, /*tmp*/ 0x10);
+    byte[] anim = rawChunk("ANIM", new byte[6]);
+    byte[] img = riffWebp(vp8, anim);
+    WebPFilter filter = new WebPFilter();
+    try (ArrayBucket input = new ArrayBucket(img);
+        ArrayBucket output = new ArrayBucket();
+        InputStream in = input.getInputStream();
+        OutputStream out = output.getOutputStream()) {
+      assertThrows(DataFilterException.class, () -> readFilter(filter, in, out));
+    }
+  }
+
+  // --------------------------------- helpers ---------------------------------
+
+  private static byte[] riffWebp(byte[]... chunks) throws IOException {
+    int chunksLen = 0;
+    for (byte[] c : chunks) chunksLen += c.length;
+    int fileSize = 4 + chunksLen; // FourCC + all chunks
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(12 + chunksLen);
+    baos.write(new byte[] {'R', 'I', 'F', 'F'});
+    baos.write(leInt(fileSize));
+    baos.write(new byte[] {'W', 'E', 'B', 'P'});
+    for (byte[] c : chunks) baos.write(c);
+    return baos.toByteArray();
+  }
+
+  private static byte[] chunk(String fourcc, byte[] payload) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(8 + payload.length + 1);
+    baos.write(fourcc.getBytes());
+    baos.write(leInt(payload.length));
+    baos.write(payload);
+    if ((payload.length & 1) != 0) {
+      baos.write(0x00); // RIFF padding to even boundary
+    }
+    return baos.toByteArray();
+  }
+
+  private static byte[] rawChunk(String fourcc, byte[] payload) throws IOException {
+    // Same as chunk(), but used to craft intentionally malformed sizes for negative tests.
+    return chunk(fourcc, payload);
+  }
+
+  private static byte[] vp8Chunk(int size, int tmpValue) throws IOException {
+    if (size <= 10) size = 12; // ensure > 10 so size guard doesn't mask earlier checks
+    int payloadLen = size;
+    List<Byte> bytes = new ArrayList<>(payloadLen);
+    // 3-byte frame tag (little-endian), with tmpValue controlling flags (e.g., is_shown)
+    bytes.add((byte) (tmpValue & 0xFF));
+    bytes.add((byte) ((tmpValue >>> 8) & 0xFF));
+    bytes.add((byte) ((tmpValue >>> 16) & 0xFF));
+    // keyframe sync code
+    bytes.add((byte) 0x9d);
+    bytes.add((byte) 0x01);
+    bytes.add((byte) 0x2a);
+    while (bytes.size() < payloadLen) bytes.add((byte) 0x00);
+    byte[] payload = new byte[bytes.size()];
+    for (int i = 0; i < bytes.size(); i++) payload[i] = bytes.get(i);
+    return chunk("VP8 ", payload);
+  }
+
+  private static byte[] vp8xChunk(int flags, int wMinus1, int hMinus1) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(10);
+    baos.write(leInt(flags));
+    // width/height are 24-bit, little-endian, stored as minus one
+    baos.write(
+        new byte[] {
+          (byte) (wMinus1 & 0xFF), (byte) ((wMinus1 >>> 8) & 0xFF), (byte) ((wMinus1 >>> 16) & 0xFF)
+        });
+    baos.write(
+        new byte[] {
+          (byte) (hMinus1 & 0xFF), (byte) ((hMinus1 >>> 8) & 0xFF), (byte) ((hMinus1 >>> 16) & 0xFF)
+        });
+    return chunk("VP8X", baos.toByteArray());
+  }
+
+  private static byte[] leInt(int v) {
+    return new byte[] {
+      (byte) (v & 0xFF),
+      (byte) ((v >>> 8) & 0xFF),
+      (byte) ((v >>> 16) & 0xFF),
+      (byte) ((v >>> 24) & 0xFF)
+    };
   }
 }


### PR DESCRIPTION
Summary
- Refactors RIFFFilter to a cleaner streaming API and introduces a typed ReadFilterContext.
- Updates WAVFilter and WebPFilter to the new API with stronger validation and safer behavior.
- Adds comprehensive unit tests for RIFF, WAV, and WebP parsing rules.

Commits
1. feat(filter): refactor RIFFFilter API and update WAV/WebP filters
   - Introduces ReadFilterContext for chunk processing
   - Renames EOFCheck() to eofCheck()
   - Updates WAVFilter and WebPFilter to new API
   - Adds RIFFFilterTest
   - Applies Spotless formatting

2. fix(wav): validate and sanitize WAV RIFF chunks; add tests
   - Enforces supported encodings: PCM, IEEE float, A-law, mu-law
   - Validates fmt/data/fact chunks with ordering and size checks
   - Preserves alignment (even-byte padding) and converts unknown to JUNK
   - Expands WAVFilterTest

3. fix(webp): refine WebP RIFF filtering and tests
   - Clarifies VP8/VP8L/ALPH/ANIM/ANMF handling and ordering
   - Strips ICCP/EXIF/XMP via JUNK rewrite while preserving structure
   - Strengthens WebPFilterTest edge cases

Highlights
- Stronger bounds checks and localized errors in RIFFFilter (uses constants for l10n keys).
- readFilterChunk now receives a ReadFilterContext with in/out streams, charset, and callback.
- Final validation performed via eofCheck(context) in subclasses.

Touched Files (not exhaustive)
- src/main/java/network/crypta/client/filter/RIFFFilter.java
- src/main/java/network/crypta/client/filter/WAVFilter.java
- src/main/java/network/crypta/client/filter/WebPFilter.java
- src/test/java/network/crypta/client/filter/RIFFFilterTest.java
- src/test/java/network/crypta/client/filter/WAVFilterTest.java
- src/test/java/network/crypta/client/filter/WebPFilterTest.java

Notes
- No uncommitted local changes; Spotless already applied in commits.
- Target base: develop; branch: feature/fix-RIFFFilter.
- CI should run the full JUnit 6 test suite and JaCoCo; local builds expected to pass as per changes.
