### PR TITLE
docs(client): doclint-clean Javadoc for ArchiveExtractCallback

### DIFF
--- a/src/main/java/network/crypta/client/ArchiveExtractCallback.java
+++ b/src/main/java/network/crypta/client/ArchiveExtractCallback.java
@@ -4,21 +4,96 @@ import java.io.Serializable;
 import network.crypta.client.async.ClientContext;
 import network.crypta.support.api.Bucket;
 
-/** Called when we have extracted an archive, and a specified file either is or isn't in it. */
+/**
+ * Callback interface that reports the outcome of extracting a single entry from an archive.
+ *
+ * <p>Implementations receive one of the methods defined here once an archive extraction attempt
+ * completes. Typical call patterns are:
+ *
+ * <ul>
+ *   <li>{@link #gotBucket(Bucket, ClientContext)} when the requested entry is found and its
+ *       contents are materialized into a {@link Bucket}.
+ *   <li>{@link #notInArchive(ClientContext)} when the requested entry does not exist within the
+ *       archive.
+ *   <li>{@link #onFailed(ArchiveRestartException, ClientContext)} or {@link
+ *       #onFailed(ArchiveFailureException, ClientContext)} when extraction fails.
+ * </ul>
+ *
+ * <p>Unless otherwise documented by the component invoking this callback, methods may be invoked on
+ * a worker thread. Implementations should therefore avoid long blocking operations on the callback
+ * thread and delegate heavier work as needed. When off-thread extraction is requested by the
+ * caller, the provided {@link Bucket} is typically persistent, allowing the recipient to read the
+ * data after the method returns. Callers are responsible for obeying the {@link Bucket} lifetime
+ * semantics defined elsewhere.
+ *
+ * <p>This interface is designed to be stateless and reusable across multiple extraction attempts;
+ * implementations may capture state if desired, but should document any concurrency limitations.
+ *
+ * @see Bucket
+ * @see ClientContext
+ * @see ArchiveRestartException
+ * @see ArchiveFailureException
+ */
 public interface ArchiveExtractCallback extends Serializable {
 
   /**
-   * Got the data. Note that the bucket will be persistent if the caller asked for an off-thread
-   * extraction.
+   * Called when the requested archive entry is found and its data are available.
+   *
+   * <p>The supplied {@code Bucket} contains the extracted content of the target entry. If the
+   * extraction was performed off-thread (as requested by the caller), the {@code Bucket} is
+   * typically persistent so its contents remain accessible beyond the scope of this call. The
+   * implementation should consume or hand off the bucket according to the {@link Bucket} contract
+   * and avoid performing long-running operations on the callback thread.
+   *
+   * <pre>{@code
+   * // Example: record that the entry was obtained
+   * callback.gotBucket(dataBucket, context);
+   * }</pre>
+   *
+   * @param data the extracted entry content; usually persistent for off-thread extraction; never
+   *     {@code null} when this method is invoked
+   * @param context the client execution context associated with the extraction; can be used to
+   *     access shared state or services; never {@code null}
    */
   void gotBucket(Bucket data, ClientContext context);
 
-  /** Not in the archive */
+  /**
+   * Called when the requested entry is not present in the archive.
+   *
+   * <p>Use this signal to update caller-visible state or to try alternative sources if applicable.
+   * No {@link Bucket} is provided because there is no content to deliver.
+   *
+   * @param context the client execution context associated with the extraction attempt; useful for
+   *     logging, metrics, or follow-up actions; never {@code null}
+   */
   void notInArchive(ClientContext context);
 
-  /** Failed: restart */
+  /**
+   * Called when extraction fails in a way that may be resolved by restarting the operation.
+   *
+   * <p>This variant conveys a recoverable condition. Callers commonly respond by scheduling a
+   * retry, potentially after backoff or once prerequisites are satisfied. Implementations should
+   * avoid throwing from this method; surface errors through the provided context if necessary.
+   *
+   * @param e the failure describing why a restart is advisable; includes details for diagnostics;
+   *     never {@code null}
+   * @param context the client execution context associated with the extraction; may be used to log
+   *     the failure, update state, or enqueue a retry; never {@code null}
+   */
   void onFailed(ArchiveRestartException e, ClientContext context);
 
-  /** Failed for some other reason */
+  /**
+   * Called when extraction fails for a non-restartable reason.
+   *
+   * <p>Use this to report a terminal failure where a simple retry is not expected to succeed
+   * without external intervention (for example, an unsupported format or a permanent integrity
+   * error). Implementations should record relevant diagnostics and notify upstream components as
+   * appropriate.
+   *
+   * @param e the non-restartable failure explaining why extraction could not complete; includes
+   *     diagnostic details; never {@code null}
+   * @param context the client execution context associated with the failed extraction; use for
+   *     logging, metrics, or cleanup; never {@code null}
+   */
   void onFailed(ArchiveFailureException e, ClientContext context);
 }


### PR DESCRIPTION
Summary
- Make ArchiveExtractCallback Javadoc fully doclint-clean (Xdoclint:all), and enrich API docs with long-form guidance for large files.

Context & Motivation
- The interface previously triggered javadoc doclint warnings (missing @param tags) and had minimal documentation.
- This update removes doclint warnings and provides substantive documentation for public APIs, improving discoverability and consistency.

Changes
- Interface Javadoc: Added a detailed overview including responsibilities, call patterns, threading notes, and related types.
- Methods:
  - gotBucket(Bucket, ClientContext): Expanded description, clarified Bucket persistence semantics, added usage snippet, and complete @param tags.
  - notInArchive(ClientContext): Clarified semantics and added @param.
  - onFailed(ArchiveRestartException, ClientContext): Documented recoverable failures, retry guidance, and @param tags.
  - onFailed(ArchiveFailureException, ClientContext): Documented terminal failures and @param tags.
- All edits are comments only; no behavioral or signature changes.

Validation
- Built classes: ./gradlew -q classes
- Doclint check (file-scoped):
  javadoc -quiet -Xdoclint:all -classpath "build/classes/java/main:build/resources/main" -sourcepath . -d /tmp/doclint-out "src/main/java/network/crypta/client/ArchiveExtractCallback.java"
- Result: 0 warnings.
- Formatting: ./gradlew spotlessApply

Diff Summary (vs develop)
- 1 file changed: 81 insertions, 6 deletions.
  src/main/java/network/crypta/client/ArchiveExtractCallback.java

Commit(s) on this branch
- docs(client): doclint-clean Javadoc for ArchiveExtractCallback with long-form API docs

Scope & Risk
- Comments-only change; no production behavior modified; low risk.

Notes
- If preferred, I can apply the same doclint pass to adjacent client callbacks in a follow-up.
