### PR TITLE
Client: add ArchiveContext tests and clarify Javadoc

### DIFF
--- a/src/main/java/network/crypta/client/ArchiveContext.java
+++ b/src/main/java/network/crypta/client/ArchiveContext.java
@@ -6,24 +6,93 @@ import java.util.HashSet;
 import network.crypta.keys.FreenetURI;
 
 /**
+ * Tracks archive traversal state during recursive fetch operations.
+ *
+ * <p>This context object accompanies a fetch that may descend into container formats (for example,
+ * manifests or archives that reference other items). It records the set of archives that have been
+ * visited so far and applies a simple upper bound on the allowed nesting depth. The main purpose is
+ * to prevent accidental or malicious cycles such as an archive that indirectly references itself or
+ * a pair of archives that reference each other.
+ *
+ * <p>Instances are lightweight and are intended to be created per logical fetch. The class is
+ * mutable but synchronizes its public methods; callers may share a single instance across threads
+ * in a pipeline without additional locking. Loop detection is based on the {@link FreenetURI}
+ * values provided by the caller; equality and hash semantics are those of {@code FreenetURI}. A
+ * {@code null} key is a valid set element and therefore can detect a repeated {@code null} input as
+ * a loop as well.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities</strong>:
+ *       <ul>
+ *         <li>Remember previously seen archive identifiers for the current traversal.
+ *         <li>Enforce a maximum number of distinct archive levels.
+ *         <li>Provide a reset hook to clear accumulated state between independent traversals.
+ *       </ul>
+ * </ul>
+ *
+ * <p><strong>Serialization notice:</strong> this class implements {@link Serializable}. Changing
+ * non-transient fields affects the serialized form and can cause existing downloads to restart or
+ * uploads to be lost when upgrading persisted state.
+ *
  * @author amphibian (Matthew Toseland)
- *     <p>Object passed down a full fetch, including all the recursion. Used, at present, for
- *     detecting archive fetch loops, hence the name.
- *     <p>WARNING: Changing non-transient members on classes that are Serializable can result in
- *     restarting downloads or losing uploads.
  */
 public class ArchiveContext implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
+
+  /**
+   * Set of archive identifiers already observed in the current traversal.
+   *
+   * <p>The set is lazily allocated on the first call to {@link #doLoopDetection(FreenetURI)} and is
+   * cleared by {@link #clear()}. Elements are compared using {@link FreenetURI} equality; a {@code
+   * null} key is also a valid element and can therefore detect repeated {@code null} inputs as a
+   * loop. The collection is used only from synchronized methods.
+   */
   private HashSet<FreenetURI> soFar;
+
+  /**
+   * Maximum number of distinct archives permitted during a traversal.
+   *
+   * <p>The value is treated as a strict bound on the cardinality of {@link #soFar}: when the number
+   * of distinct elements already stored exceeds this value, additional attempts to add a new
+   * archive are rejected. Typical values are small (for example, 1–10) to protect against cycles.
+   */
   final int maxArchiveLevels;
+
+  /**
+   * Upper bound on archive size in bytes as supplied by the caller.
+   *
+   * <p>The context stores this limit to keep related settings together; it does not itself enforce
+   * the size bound. Higher layers in the client fetch pipeline use the value to reject overlarge
+   * archives before or during processing.
+   */
   final long maxArchiveSize;
 
+  /**
+   * Create a new context with explicit limits.
+   *
+   * <p>The context maintains a set of distinct archive identifiers seen so far. A size check is
+   * performed before adding a new identifier; if the set already contains more than {@code max}
+   * elements, loop detection fails even before the new key is added. This means a context with
+   * {@code max=0} still accepts the first unique key and rejects the second.
+   *
+   * @param maxArchiveSize maximum archive size in bytes used by higher-level components to bound
+   *     processing; this class stores the value but does not enforce it directly.
+   * @param max maximum number of distinct archive levels allowed in a traversal before detection
+   *     fails; non-negative values are expected and typical callers use small integers.
+   */
   public ArchiveContext(long maxArchiveSize, int max) {
     this.maxArchiveLevels = max;
     this.maxArchiveSize = maxArchiveSize;
   }
 
+  /**
+   * No-arg constructor for serialization frameworks.
+   *
+   * <p>The constructed instance has both {@code maxArchiveLevels} and {@code maxArchiveSize} set to
+   * {@code 0}. With these defaults, the context allows exactly one unique archive before reporting
+   * too many levels on the next distinct input.
+   */
   protected ArchiveContext() {
     // For serialization.
     maxArchiveLevels = 0;
@@ -31,9 +100,19 @@ public class ArchiveContext implements Serializable {
   }
 
   /**
-   * Check for a loop.
+   * Check whether adding the given key would introduce a loop and record it if allowed.
    *
-   * <p>The URI provided is expected to be a reasonably unique identifier for the archive.
+   * <p>The method lazily initializes the internal set on first use, verifies the current depth
+   * limit, and then attempts to add the key. If the set already contains more than {@code
+   * maxArchiveLevels} elements, an exception is thrown without modifying the set. If the key was
+   * already present, the operation fails with a loop-detected exception. Otherwise, the key is
+   * recorded and the method returns normally.
+   *
+   * @param key archive identifier used for loop detection; may be {@code null}. Equality and hash
+   *     semantics follow {@link FreenetURI} (or {@code null}) and determine whether two inputs are
+   *     considered the same archive.
+   * @throws ArchiveFailureException when the number of distinct archives exceeds the configured
+   *     limit, or when the same key is observed again within the current traversal.
    */
   public synchronized void doLoopDetection(FreenetURI key) throws ArchiveFailureException {
     if (soFar == null) {
@@ -46,6 +125,13 @@ public class ArchiveContext implements Serializable {
     }
   }
 
+  /**
+   * Clear all accumulated state so a new traversal can start fresh.
+   *
+   * <p>After calling this method the context forgets all previously seen archives. A subsequent
+   * call to {@link #doLoopDetection(FreenetURI)} with a key that was seen before clearing will be
+   * treated as a first encounter.
+   */
   public synchronized void clear() {
     soFar = null;
   }

--- a/src/test/java/network/crypta/client/ArchiveContextTest.java
+++ b/src/test/java/network/crypta/client/ArchiveContextTest.java
@@ -1,0 +1,117 @@
+package network.crypta.client;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class ArchiveContextTest {
+
+  @Test
+  @DisplayName("doLoopDetection: accepts up to max+1 unique keys, then throws TOO_MANY_LEVELS")
+  void doLoopDetection_whenWithinLimit_acceptsUpToMaxPlusOneUnique_thenTooManyOnNext() {
+    // Arrange
+    int maxLevels = 2;
+    ArchiveContext ctx = new ArchiveContext(1_000_000L, maxLevels);
+    FreenetURI k1 = new FreenetURI("KSK", "a");
+    FreenetURI k2 = new FreenetURI("KSK", "b");
+    FreenetURI k3 = new FreenetURI("KSK", "c");
+    FreenetURI k4 = new FreenetURI("KSK", "d");
+
+    // Act + Assert (no exception for first max+1 unique keys)
+    assertDoesNotThrow(() -> ctx.doLoopDetection(k1));
+    assertDoesNotThrow(() -> ctx.doLoopDetection(k2));
+    assertDoesNotThrow(() -> ctx.doLoopDetection(k3));
+
+    // Next unique should exceed the limit and throw
+    ArchiveFailureException ex =
+        assertThrows(ArchiveFailureException.class, () -> ctx.doLoopDetection(k4));
+    assertEquals(
+        ArchiveFailureException.TOO_MANY_LEVELS,
+        ex.getMessage(),
+        "Expected TOO_MANY_LEVELS message");
+  }
+
+  @Test
+  @DisplayName("doLoopDetection: same key twice throws ARCHIVE_LOOP_DETECTED")
+  void doLoopDetection_whenSameKeyRepeated_expectArchiveLoopDetected() throws Exception {
+    // Arrange
+    ArchiveContext ctx = new ArchiveContext(1_000_000L, 10);
+    FreenetURI key1 = new FreenetURI("KSK", "dup");
+    FreenetURI key1Again = new FreenetURI("KSK", "dup"); // equal to key1
+
+    // Act
+    ctx.doLoopDetection(key1);
+
+    // Assert
+    ArchiveFailureException ex =
+        assertThrows(ArchiveFailureException.class, () -> ctx.doLoopDetection(key1Again));
+    assertEquals(
+        ArchiveFailureException.ARCHIVE_LOOP_DETECTED,
+        ex.getMessage(),
+        "Expected ARCHIVE_LOOP_DETECTED message");
+  }
+
+  @Test
+  @DisplayName("doLoopDetection: null twice is treated as a loop")
+  void doLoopDetection_whenNullTwice_expectArchiveLoopDetected() throws Exception {
+    // Arrange
+    ArchiveContext ctx = new ArchiveContext(1_000_000L, 10);
+
+    // Act
+    ctx.doLoopDetection(null);
+
+    // Assert
+    ArchiveFailureException ex =
+        assertThrows(ArchiveFailureException.class, () -> ctx.doLoopDetection(null));
+    assertEquals(
+        ArchiveFailureException.ARCHIVE_LOOP_DETECTED,
+        ex.getMessage(),
+        "Expected ARCHIVE_LOOP_DETECTED message for null re-use");
+  }
+
+  @Test
+  @DisplayName("clear: resets seen set so re-adding previous key is allowed")
+  void clear_whenCalled_resetsStateAllowingReadd() throws Exception {
+    // Arrange
+    ArchiveContext ctx = new ArchiveContext(1_000_000L, 10);
+    FreenetURI key = new FreenetURI("KSK", "x");
+
+    // Act
+    ctx.doLoopDetection(key);
+    ctx.clear();
+
+    // Assert: after clear the same key should be accepted again once
+    assertDoesNotThrow(() -> ctx.doLoopDetection(key));
+    // And a consecutive duplicate should now be detected again
+    ArchiveFailureException ex =
+        assertThrows(ArchiveFailureException.class, () -> ctx.doLoopDetection(key));
+    assertEquals(
+        ArchiveFailureException.ARCHIVE_LOOP_DETECTED,
+        ex.getMessage(),
+        "Expected ARCHIVE_LOOP_DETECTED after re-adding same key post-clear");
+  }
+
+  @Test
+  @DisplayName(
+      "default ctor: zero max levels allows one unique, then throws TOO_MANY_LEVELS before add")
+  void defaultConstructor_withZeroMaxLevels_allowsOneUniqueThenTooMany() {
+    // Arrange: use package-visible protected constructor
+    ArchiveContext ctx = new ArchiveContext();
+    FreenetURI k1 = new FreenetURI("KSK", "one");
+    FreenetURI k2 = new FreenetURI("KSK", "two");
+
+    // Act + Assert
+    assertDoesNotThrow(() -> ctx.doLoopDetection(k1));
+    ArchiveFailureException ex =
+        assertThrows(ArchiveFailureException.class, () -> ctx.doLoopDetection(k2));
+    assertEquals(
+        ArchiveFailureException.TOO_MANY_LEVELS,
+        ex.getMessage(),
+        "Expected TOO_MANY_LEVELS with default (0) max levels");
+  }
+}


### PR DESCRIPTION
Summary
- Add focused JUnit 6 tests for ArchiveContext loop detection and depth limit behavior.
- Clarify ArchiveContext Javadoc: responsibilities, thread-safety, depth semantics, and serialization notes.
- No functional changes to production code; comments and docs only. Tests assert the current behavior.

Changes
- src/main/java/network/crypta/client/ArchiveContext.java
  - Expanded class/method field-level Javadoc and parameter/throws documentation.
  - Documented synchronization and semantics of null keys and maxArchiveLevels.
- src/test/java/network/crypta/client/ArchiveContextTest.java (new)
  - doLoopDetection accepts up to max+1 unique keys then throws TOO_MANY_LEVELS.
  - Repeated key triggers ARCHIVE_LOOP_DETECTED.
  - null twice is treated as a loop.
  - clear() resets state and then detects duplicate again.

Branch & CI
- Branch: feature/fix-ArchiveContext.
- Base: develop.
- Formatting: ran ./gradlew spotlessApply before committing.

Rationale
ArchiveContext is used during recursive archive traversal; having explicit tests around loop detection and nesting limits makes future changes safer. Adding comprehensive Javadoc improves maintainability and clarifies intended behavior.

Validation
- Builds locally with Java 21+.
- Spotless passes.

Notes
- Only docs and tests changed; no behavior modification.
