### PR TITLE
docs,test: ArchiveKey Javadoc and comprehensive unit tests

### DIFF
--- a/src/main/java/network/crypta/client/ArchiveKey.java
+++ b/src/main/java/network/crypta/client/ArchiveKey.java
@@ -2,16 +2,67 @@ package network.crypta.client;
 
 import network.crypta.keys.FreenetURI;
 
+/**
+ * Immutable pair of a Freenet {@link FreenetURI} and a filename inside an archive/manifest.
+ *
+ * <p>This value object is commonly used by fetchers and manifest handlers to identify a specific
+ * member within a container that is addressed by a single network key. The {@code key} refers to
+ * the manifest or top-level object on the network (e.g., a CHK/SSK/USK/KSK), and {@code filename}
+ * provides the intra-archive path of the desired member. Instances are immutable after construction
+ * and can safely be used as map keys or elements in sets, provided that callers do not pass {@code
+ * null} fields.
+ *
+ * <p>Equality and hashing are defined in terms of both components: two {@code ArchiveKey} values
+ * are equal only when the {@link #key} values are equal and the {@link #filename} strings are
+ * equal. The {@link #hashCode()} is derived from both in a way that is stable for the lifetime of
+ * the instance. The class performs no normalization of filenames; callers should provide canonical
+ * names if that is significant for their use case.
+ *
+ * <ul>
+ *   <li>Thread-safety: instances are thread-safe due to immutability.
+ *   <li>Nullability: the constructor does not defensively reject {@code null} values; invoking
+ *       {@link #equals(Object)} or {@link #hashCode()} on objects containing {@code null} fields
+ *       may raise {@link NullPointerException}. Prefer passing non-null values.
+ * </ul>
+ */
 public class ArchiveKey {
 
   final FreenetURI key;
   final String filename;
 
+  /**
+   * Create a new {@code ArchiveKey} from a network {@link FreenetURI} and an archive member name.
+   *
+   * <p>No validation or normalization is performed. In particular, {@code filename2} is used as-is
+   * (including path separators, case, or leading {@code ./}). For deterministic behavior across
+   * components, callers should supply canonicalized values where appropriate.
+   *
+   * @param key2 The network key that identifies the archive or manifest holding the member. May be
+   *     {@code null}, but subsequent calls to {@link #equals(Object)} or {@link #hashCode()} may
+   *     then throw {@link NullPointerException}.
+   * @param filename2 The filename or entry name inside the addressed archive or manifest. May be
+   *     {@code null}, with the same caveats regarding {@link NullPointerException} as for {@code
+   *     key2}.
+   */
   public ArchiveKey(FreenetURI key2, String filename2) {
     key = key2;
     filename = filename2;
   }
 
+  /**
+   * Compare for equality with another object.
+   *
+   * <p>Returns {@code true} only if the argument is an {@code ArchiveKey} and both the network key
+   * and the filename are equal to this instance's corresponding values. The comparison is
+   * reference-safe (it first checks for identity), but it does not guard against {@code null}
+   * components that may have been supplied at construction time.
+   *
+   * @param o The object to compare with this instance; may be {@code null} or of another type.
+   * @return {@code true} when both {@link #key} and {@link #filename} are equal; {@code false} for
+   *     {@code null} or incompatible types.
+   * @throws NullPointerException If either this instance or the compared instance was constructed
+   *     with {@code null} fields, equality may dereference a {@code null} and raise this exception.
+   */
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof ArchiveKey cmp)) return false;
@@ -20,11 +71,31 @@ public class ArchiveKey {
     return (cmp.key.equals(key) && cmp.filename.equals(filename));
   }
 
+  /**
+   * Compute a hash code suitable for hash-based collections.
+   *
+   * <p>The hash is derived from both components and is consistent with {@link #equals(Object)}. As
+   * the instance is immutable, the returned value is stable for the lifetime of the object.
+   *
+   * @return A hash composed of the network key and filename; identical objects produce identical
+   *     values.
+   * @throws NullPointerException If either component is {@code null}, hashing will dereference it
+   *     and raise this exception.
+   */
   @Override
   public int hashCode() {
     return key.hashCode() ^ filename.hashCode();
   }
 
+  /**
+   * Return a diagnostic string of the form {@code <key>:<filename>}.
+   *
+   * <p>The method delegates to {@link FreenetURI#toString()} for the key and performs simple
+   * concatenation with a colon separator. No quoting or escaping is applied. If either component is
+   * {@code null}, the literal string {@code "null"} will appear in the output.
+   *
+   * @return A concise {@code key:filename} rendering intended for logs and diagnostics.
+   */
   @Override
   public String toString() {
     return key + ":" + filename;

--- a/src/test/java/network/crypta/client/ArchiveKeyTest.java
+++ b/src/test/java/network/crypta/client/ArchiveKeyTest.java
@@ -1,0 +1,144 @@
+package network.crypta.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100") // Test method naming convention: method_whenCondition_expectOutcome
+class ArchiveKeyTest {
+
+  private static FreenetURI ksk(String name) {
+    // Simple KSK (no routing/crypto keys) is sufficient for ArchiveKey tests
+    return new FreenetURI("KSK", name);
+  }
+
+  @Test
+  @DisplayName("equals: same instance -> true")
+  void equals_whenSameInstance_expectTrue() {
+    ArchiveKey a = new ArchiveKey(ksk("doc"), "file.txt");
+
+    //noinspection EqualsWithItself
+    assertEquals(a, a);
+  }
+
+  @Test
+  @DisplayName("equals: null -> false")
+  @SuppressWarnings("java:S5785")
+  void equals_whenNull_expectFalse() {
+    ArchiveKey a = new ArchiveKey(ksk("doc"), "file.txt");
+
+    //noinspection SimplifiableAssertion,ConstantValue
+    assertFalse(a.equals(null));
+  }
+
+  @Test
+  @DisplayName("equals: different type -> false")
+  @SuppressWarnings("java:S5785")
+  void equals_whenDifferentClass_expectFalse() {
+    ArchiveKey a = new ArchiveKey(ksk("doc"), "file.txt");
+
+    //noinspection SimplifiableAssertion,EqualsBetweenInconvertibleTypes
+    assertFalse(a.equals("not-an-archive-key"));
+  }
+
+  @Test
+  @DisplayName("equals: same key and filename -> true (symmetry)")
+  void equals_whenSameFields_expectTrueAndSymmetric() {
+    FreenetURI key = ksk("doc");
+    ArchiveKey a1 = new ArchiveKey(key, "file.txt");
+    ArchiveKey a2 = new ArchiveKey(new FreenetURI(key), "file.txt");
+
+    assertEquals(a1, a2);
+    assertEquals(a2, a1);
+  }
+
+  @Test
+  @DisplayName("equals: different key -> false")
+  void equals_whenDifferentKey_expectFalse() {
+    ArchiveKey a1 = new ArchiveKey(ksk("doc1"), "file.txt");
+    ArchiveKey a2 = new ArchiveKey(ksk("doc2"), "file.txt");
+
+    assertNotEquals(a1, a2);
+  }
+
+  @Test
+  @DisplayName("equals: different filename -> false")
+  void equals_whenDifferentFilename_expectFalse() {
+    FreenetURI key = ksk("doc");
+    ArchiveKey a1 = new ArchiveKey(key, "file1.txt");
+    ArchiveKey a2 = new ArchiveKey(new FreenetURI(key), "file2.txt");
+
+    assertNotEquals(a1, a2);
+  }
+
+  @Test
+  @DisplayName("hashCode: equal objects -> same hash")
+  void hashCode_whenEqualObjects_expectSameHash() {
+    FreenetURI key = ksk("doc");
+    ArchiveKey a1 = new ArchiveKey(key, "file.txt");
+    ArchiveKey a2 = new ArchiveKey(new FreenetURI(key), "file.txt");
+
+    assertEquals(a1.hashCode(), a2.hashCode());
+  }
+
+  @Test
+  @DisplayName("hashCode: null key -> throws NPE")
+  void hashCode_whenNullKey_expectThrowsNPE() {
+    ArchiveKey a = new ArchiveKey(null, "file.txt");
+
+    assertThrows(NullPointerException.class, a::hashCode);
+  }
+
+  @Test
+  @DisplayName("hashCode: null filename -> throws NPE")
+  void hashCode_whenNullFilename_expectThrowsNPE() {
+    ArchiveKey a = new ArchiveKey(ksk("doc"), null);
+
+    assertThrows(NullPointerException.class, a::hashCode);
+  }
+
+  @Test
+  @DisplayName("equals: other has null key -> throws NPE (asymmetric null handling)")
+  void equals_whenOtherHasNullKey_expectThrowsNPE() {
+    ArchiveKey lhs = new ArchiveKey(ksk("doc"), "file.txt");
+    ArchiveKey rhs = new ArchiveKey(null, "file.txt");
+
+    assertThrows(NullPointerException.class, () -> lhs.equals(rhs));
+  }
+
+  @Test
+  @DisplayName("equals: other has null filename -> throws NPE (asymmetric null handling)")
+  void equals_whenOtherHasNullFilename_expectThrowsNPE() {
+    ArchiveKey lhs = new ArchiveKey(ksk("doc"), "file.txt");
+    ArchiveKey rhs = new ArchiveKey(ksk("doc"), null);
+
+    assertThrows(NullPointerException.class, () -> lhs.equals(rhs));
+  }
+
+  @Test
+  @DisplayName("toString: key + ':' + filename")
+  void toString_whenValid_expectKeyColonFilename() {
+    FreenetURI key = ksk("doc");
+    String filename = "file.txt";
+    ArchiveKey a = new ArchiveKey(key, filename);
+
+    String expected = key + ":" + filename;
+    assertEquals(expected, a.toString());
+  }
+
+  @Test
+  @DisplayName("toString: null parts -> contains 'null'")
+  void toString_whenNullParts_expectContainsNullLiteral() {
+    ArchiveKey a1 = new ArchiveKey(null, "file.txt");
+    ArchiveKey a2 = new ArchiveKey(ksk("doc"), null);
+
+    assertTrue(a1.toString().startsWith("null:"));
+    assertTrue(a2.toString().endsWith(":null"));
+  }
+}


### PR DESCRIPTION
Summary
- Add detailed Javadoc to ArchiveKey describing immutability, equals/hashCode contract, null-handling caveats, and toString semantics (diagnostic output).
- Add comprehensive JUnit 6 tests for ArchiveKey covering: equality (identity, null, different type, symmetry), differing fields, hashCode consistency, explicit NPE behavior for null components, and toString rendering (including nulls).

Changes
- src/main/java/network/crypta/client/ArchiveKey.java (docs only; no behavior changes)
- src/test/java/network/crypta/client/ArchiveKeyTest.java (new)

Rationale
- Clarifies expected behavior and edge cases for a commonly used value object so callers can reason about null-safety and usage as map/set keys.
- Locks in behavior via tests to prevent accidental regressions.

Testing
- New tests validate equals/hashCode/toString behavior and NPE cases.
- Formatting applied with Spotless prior to commit.

Compatibility / Risk
- No functional changes: only documentation and tests were added.
- ArchiveKey continues to allow null fields; this is now explicitly tested and documented to ensure any future semantic change is intentional.

Meta
- Branch: feature/archivekey-javadoc-tests
- Base: develop
- Conventional commits used for clarity.
