### PR TITLE
docs(client): clarify Javadoc for metadata exceptions and client package overview

### DIFF
--- a/src/main/java/network/crypta/client/MetadataParseException.java
+++ b/src/main/java/network/crypta/client/MetadataParseException.java
@@ -2,11 +2,52 @@ package network.crypta.client;
 
 import java.io.Serial;
 
-/** Thrown when Metadata parse fails. */
+/**
+ * Exception indicating that client metadata could not be parsed.
+ *
+ * <p>This checked exception is raised by client-side parsing code when an input that is expected to
+ * represent metadata is malformed, incomplete, or otherwise violates the format understood by the
+ * caller. It intentionally conveys a semantic parsing failure rather than transport or I/O errors.
+ * Typical usage is to throw this exception from a parser or decoder and allow higher layers to
+ * decide whether to surface a user-facing message, log diagnostics, or retry with a different
+ * source.
+ *
+ * <p>The instance is immutable and safe to share between threads once constructed. The message
+ * supplied at construction time should be concise and suitable for logs; callers may include
+ * contextual details such as an identifier, schema version, or a short excerpt of the offending
+ * input as appropriate. This type does not track a cause in its current form; if you need to attach
+ * a root cause, consider wrapping that exception when you create the message.
+ *
+ * <ul>
+ *   <li>Represents a parsing/validation failure of metadata content.
+ *   <li>Intended for client-side code paths, not network transport issues.
+ *   <li>Does not record an offset/location; callers should include such context in the message.
+ * </ul>
+ *
+ * @see java.text.ParseException
+ */
 public class MetadataParseException extends Exception {
 
   @Serial private static final long serialVersionUID = 4910650977022715220L;
 
+  /**
+   * Creates a new exception describing why parsing failed.
+   *
+   * <p>Use a clear, actionable message that helps operators or calling code understand the nature
+   * of the problem (e.g., unknown field, invalid value range, or truncated input). The message is
+   * preserved verbatim for logs and error propagation. This constructor does not accept a cause; if
+   * a lower-level exception exists, include its salient details in the message text.
+   *
+   * <pre>{@code
+   * // Example: surface a metadata decoding error
+   * if (!isValid(meta)) {
+   *   throw new MetadataParseException("Unsupported metadata version: " + meta.getVersion());
+   * }
+   * }</pre>
+   *
+   * @param string human-readable description of the parsing failure; must be non-null and should
+   *     explain what was invalid or unexpected in the input so callers can act on it.
+   */
   public MetadataParseException(String string) {
     super(string);
   }

--- a/src/main/java/network/crypta/client/MetadataUnresolvedException.java
+++ b/src/main/java/network/crypta/client/MetadataUnresolvedException.java
@@ -2,11 +2,62 @@ package network.crypta.client;
 
 import java.io.Serial;
 
+/**
+ * Exception indicating that required metadata references could not be resolved.
+ *
+ * <p>Parsers may successfully read a metadata structure while still leaving some referenced items
+ * unresolved (for example, external keys, manifests, or chunks that are not yet available). This
+ * checked exception communicates that follow-up work is needed before the requested operation can
+ * complete. Callers typically catch this exception, inspect {@link #mustResolve}, and decide
+ * whether to initiate additional fetches, defer the operation, or report a recoverable status to
+ * the user.
+ *
+ * <p>Instances are immutable and safe to share between threads. The message should concisely
+ * summarize the reason resolution failed or was deferred and may include contextual details such as
+ * a high-level identifier. The design intentionally separates parse errors from resolution failures
+ * to help distinguish malformed input ({@link MetadataParseException}) from missing dependencies.
+ *
+ * <ul>
+ *   <li>Represents a recoverable, dependency-related failure during metadata handling.
+ *   <li>Encourages callers to resolve listed prerequisites and retry the operation.
+ *   <li>Does not include byte offsets or counts; include such context in the message if useful.
+ * </ul>
+ *
+ * @see Metadata
+ * @see MetadataParseException
+ */
 public class MetadataUnresolvedException extends Exception {
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Array of metadata prerequisites that require resolution before continuing.
+   *
+   * <p>The array reference is final; callers should treat its contents as read-only for the
+   * duration of error handling. Implementations may pass an empty or {@code null} array when no
+   * specific items are known, in which case the message provides the best available context.
+   */
   public final Metadata[] mustResolve;
 
+  /**
+   * Creates a new exception describing which metadata items must be resolved.
+   *
+   * <p>Construct this exception when resolution cannot proceed because one or more prerequisites
+   * are missing or unavailable. The {@code mustResolve} array identifies items that, once retrieved
+   * or computed, should allow the caller to retry. The message should remain concise and suitable
+   * for logs or user-facing diagnostics.
+   *
+   * <pre>{@code
+   * // Example: indicate unresolved dependencies prior to insertion
+   * if (!dependenciesAvailable(meta)) {
+   *   throw new MetadataUnresolvedException(meta.getMissing(), "Metadata dependencies unresolved");
+   * }
+   * }</pre>
+   *
+   * @param mustResolve array of metadata dependencies that require resolution; may be {@code null}
+   *     or empty when specific items are unknown, and should be treated as read-only by callers.
+   * @param message human-readable description summarizing why resolution failed or was deferred;
+   *     must be non-null and concise enough for logs and error propagation.
+   */
   public MetadataUnresolvedException(Metadata[] mustResolve, String message) {
     super(message);
     this.mustResolve = mustResolve;

--- a/src/main/java/network/crypta/client/package-info.java
+++ b/src/main/java/network/crypta/client/package-info.java
@@ -1,14 +1,30 @@
 /**
- * Client layer (support code: metadata, MIME types, container unpacking etc).
+ * Client layer utilities and types for handling high-level operations such as metadata parsing,
+ * MIME type handling, and unpacking of container formats.
  *
- * @see freenet.client#async for most of the actual implementation.
- *     <h1>Overview of the client layer</h1>
- *     <p>The client layer implements high-level requests, i.e. download a whole file from a key,
- *     upload a whole file, etc. Metadata, FEC encoding and decoding, classes to parse the metadata
- *     and decide how to fetch the file, support for files bigger than a single key, support for
- *     fetching files within zip/tar containers, etc. Uses the key implementations, the node itself,
- *     and all the support code. Used by FCP, fproxy, clients, etc.
- *     <p>Requests can be either persistent or transient. For details on persistence, see the
- *     comments at the top of @see freenet.client.async.ClientLayerPersister .
+ * <p>This package groups the components used by higher-level client flows to describe and interpret
+ * stored content. Typical call patterns include parsing metadata to learn how a resource is laid
+ * out, selecting an appropriate strategy (single block, split-file, or container traversal), and
+ * coordinating follow-up actions in collaboration with node and transport layers. While these types
+ * provide the structure and decisions necessary to fetch or insert complex resources, the actual
+ * network I/O and scheduling are handled elsewhere in the system.
+ *
+ * <p>Many classes here favor immutability for clarity when passing parsed descriptions across
+ * threads. Where mutation is necessary, implementations document their thread-safety guarantees and
+ * expected usage. Errors are surfaced using precise, purpose-specific exceptions that distinguish
+ * malformed inputs from inputs that are well-formed but incomplete, enabling callers to react with
+ * either immediate failure or a resolve-and-retry workflow as appropriate.
+ *
+ * <p>Common responsibilities include:
+ *
+ * <ul>
+ *   <li>Parsing and validating content metadata and associated descriptors.
+ *   <li>Mapping metadata to retrieval or insertion plans for complex resources.
+ *   <li>Identifying and unpacking supported container formats when requested.
+ *   <li>Describing prerequisites that must be resolved before an operation can proceed.
+ * </ul>
+ *
+ * @see java.net.URI
+ * @see java.nio.file.Path
  */
 package network.crypta.client;


### PR DESCRIPTION
Summary
- Expand and clarify Javadoc in the client layer to satisfy doclint and improve developer-facing documentation.

Changes
- src/main/java/network/crypta/client/MetadataParseException.java: Replace terse comment with a detailed class-level Javadoc describing intent, usage, immutability, and relationship to parse errors; add constructor Javadoc with guidance and example snippet.
- src/main/java/network/crypta/client/MetadataUnresolvedException.java: Add comprehensive class-level Javadoc distinguishing resolution failures from parse errors, thread-safety notes, and @see links; document the semantics of the mustResolve array and the constructor parameters with an example.
- src/main/java/network/crypta/client/package-info.java: Rewrite package overview to describe responsibilities (metadata parsing/validation, retrieval planning, container handling) and the error model; include references to standard types for context.

Rationale
- Aligns with recent efforts to clean up Javadoc with doclint enabled across the client module.
- Improves clarity around error semantics between malformed metadata (parse) and unresolved dependencies (resolve-and-retry paths).

Scope and Risk
- Documentation-only changes; no functional code paths modified.
- Builds should be unaffected beyond doc generation. Spotless has been applied.

Commits
- a2544f74eb docs(client): clarify Javadoc for metadata exceptions and package overview

Checks
- Ran `./gradlew spotlessApply` locally to ensure formatting.

Please let me know if you'd like additional cross-links or examples added.