### PR TITLE
fix(client/htmlfilter): guard empty attribute tokens to avoid StringIndexOutOfBounds; add regression test

### DIFF
--- a/src/main/java/network/crypta/client/filter/HTMLFilter.java
+++ b/src/main/java/network/crypta/client/filter/HTMLFilter.java
@@ -1341,6 +1341,15 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
       boolean waitingForValue = false;
       String previousKey = "";
       for (String rawAttribute : unparsedAttrs) {
+        // Skip empty or whitespace-only fragments that can appear due to trailing spaces
+        // before '>' or multiple consecutive spaces between attributes.
+        if (rawAttribute == null) {
+          continue;
+        }
+        rawAttribute = rawAttribute.trim();
+        if (rawAttribute.isEmpty()) {
+          continue;
+        }
         if (waitingForValue) {
           waitingForValue = false;
           previousKey = applyDeferredValue(attributes, previousKey, rawAttribute);
@@ -1361,7 +1370,9 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
     private AttributeToken parseAttributeToken(String rawAttribute, String previousKey) {
       AttributeToken token = new AttributeToken();
       int separatorIndex = rawAttribute.indexOf('=');
-      if (separatorIndex == rawAttribute.length() - 1) {
+      // Handle the special case where the attribute ends with '=' (value in next token),
+      // but guard against empty strings where indexOf returns -1 and length() - 1 is also -1.
+      if (separatorIndex >= 0 && separatorIndex == rawAttribute.length() - 1) {
         token.expectingValue = true;
         token.key = separatorIndex == 0 ? previousKey : rawAttribute.substring(0, separatorIndex);
         token.key = token.key.toLowerCase();

--- a/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
@@ -214,7 +214,7 @@ class HTMLFilterTest {
   }
 
   @Test
-  void readFilter_handlesTrailingWhitespaceAttributeWithoutCrash() throws Exception {
+  void readFilter_handlesTrailingWhitespaceAttributeWithoutCrash() {
     // This input previously produced an empty attribute token before '>' causing a crash
     String html = "<!DOCTYPE html><html><body><a href=\"/x\" >Hello</a></body></html>";
     ByteArrayInputStream in = new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/HTMLFilterTest.java
@@ -1,6 +1,7 @@
 package network.crypta.client.filter;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -210,5 +211,24 @@ class HTMLFilterTest {
     // Assert: sanitizeURI uses the 4-arg variant (uri, overrideType, noRelative=false,
     // inline=false)
     verify(callback).processURI("/path", null, false, false);
+  }
+
+  @Test
+  void readFilter_handlesTrailingWhitespaceAttributeWithoutCrash() throws Exception {
+    // This input previously produced an empty attribute token before '>' causing a crash
+    String html = "<!DOCTYPE html><html><body><a href=\"/x\" >Hello</a></body></html>";
+    ByteArrayInputStream in = new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    assertDoesNotThrow(
+        () ->
+            ContentFilter.filter(
+                in,
+                out,
+                "text/html; charset=UTF-8",
+                new java.net.URI("http://example.com/"),
+                "http://example.com",
+                null,
+                null,
+                "UTF-8"));
   }
 }


### PR DESCRIPTION
Summary
- Fix a crash in HTMLFilter when sanitizing tags that contain a trailing whitespace before the closing '>' (e.g., `<a href="/x" >`).
- Root cause: an empty attribute fragment was parsed, causing `separatorIndex == -1` to match `rawAttribute.length() - 1` on an empty string, leading to `substring(0, -1)` and `StringIndexOutOfBoundsException`.

User-visible impact
- Prevents `FetchException: Internal error` thrown from `ClientGetter` during HTML sanitization when encountering tags with a dangling space before '>'.

Changes
- ParsedTag.toAttributeMap(): skip null/whitespace-only attribute fragments so empty tokens are not parsed.
- ParsedTag.parseAttributeToken(): treat the "value-deferred" case only when the '=' actually exists (`separatorIndex >= 0 && separatorIndex == rawAttribute.length() - 1`).
- Tests: add regression test in `HTMLFilterTest.readFilter_handlesTrailingWhitespaceAttributeWithoutCrash` verifying no exception for `<a href="/x" >`.

Risk and compatibility
- Behavior only changes for empty/whitespace attribute tokens, which are not semantically meaningful. Legitimate `key=` followed by a separate token value remains supported.
- No policy surfaces changed; only crash avoidance and defensive parsing.

Reproduction log (before this fix)
```
Caught java.lang.StringIndexOutOfBoundsException: Range [0, -1) out of bounds for length 0
 at ... String.substring(String.java:2834)
 at network.crypta.client.filter.HTMLFilter$ParsedTag.parseAttributeToken(HTMLFilter.java:1366)
 ...
```

Implementation notes
- Kept the change localized to parsing/sanitization path; did not touch tokenizer emission behavior or higher-level sanitizers.

Validation
- New unit test passes locally.
- Existing `HTMLFilterTest` suite passes locally.

Please review focusing on:
- Defensive handling of empty tokens in `toAttributeMap()` and '=' guard in `parseAttributeToken()`.
- Test coverage sufficiency and naming.
