### PR TITLE
client: replace FailureCodeTracker.clone() with copy factory; update exception copy paths

### DIFF
--- a/src/main/java/network/crypta/client/FailureCodeTracker.java
+++ b/src/main/java/network/crypta/client/FailureCodeTracker.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * <p>WARNING: Changing non-transient members on classes that are Serializable can result in
  * restarting downloads or losing uploads.
  */
-public class FailureCodeTracker implements Cloneable, Serializable {
+public class FailureCodeTracker implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(FailureCodeTracker.class);
 
   @Serial private static final long serialVersionUID = 1L;
@@ -235,13 +235,19 @@ public class FailureCodeTracker implements Cloneable, Serializable {
   }
 
   /**
-   * Copy the FailureCodeTracker. We implement Cloneable to shut up findbugs, but Object.clone()
-   * won't work because it's a shallow copy, so we implement it with merge().
+   * Create a defensive copy of the supplied tracker.
+   *
+   * <p>The returned instance preserves the {@code insert} mode and all accumulated counts at the
+   * time of copying. Passing {@code null} returns {@code null} to ease optional flows.
+   *
+   * @param source the tracker to copy; may be {@code null}
+   * @return a new tracker with equivalent state, or {@code null} when {@code source} is {@code
+   *     null}
    */
-  @Override
-  public FailureCodeTracker clone() {
-    FailureCodeTracker tracker = new FailureCodeTracker(insert);
-    tracker.merge(this);
+  public static FailureCodeTracker copyOf(FailureCodeTracker source) {
+    if (source == null) return null;
+    FailureCodeTracker tracker = new FailureCodeTracker(source.insert);
+    tracker.merge(source);
     return tracker;
   }
 

--- a/src/main/java/network/crypta/client/FetchException.java
+++ b/src/main/java/network/crypta/client/FetchException.java
@@ -547,7 +547,7 @@ public class FetchException extends Exception {
     initCause(e);
     this.mode = e.mode;
     this.newURI = e.newURI;
-    this.errorCodes = e.errorCodes == null ? null : e.errorCodes.clone();
+    this.errorCodes = FailureCodeTracker.copyOf(e.errorCodes);
     this.expectedMimeType = e.expectedMimeType;
     this.expectedSize = e.getExpectedSize();
     this.extraMessage = e.extraMessage;
@@ -1015,7 +1015,7 @@ public class FetchException extends Exception {
     if (cause != null) initCause(cause);
     this.mode = base.mode;
     this.newURI = base.newURI;
-    this.errorCodes = base.errorCodes == null ? null : base.errorCodes.clone();
+    this.errorCodes = FailureCodeTracker.copyOf(base.errorCodes);
     this.expectedMimeType = expectedMimeType;
     this.expectedSize = expectedSize;
     this.extraMessage = base.extraMessage;

--- a/src/main/java/network/crypta/client/InsertException.java
+++ b/src/main/java/network/crypta/client/InsertException.java
@@ -230,7 +230,7 @@ public class InsertException extends Exception {
     super(e.getMessage());
     extra = e.extra;
     mode = e.mode;
-    errorCodes = e.errorCodes == null ? null : e.errorCodes.clone();
+    errorCodes = FailureCodeTracker.copyOf(e.errorCodes);
     uri = e.uri;
   }
 
@@ -249,7 +249,7 @@ public class InsertException extends Exception {
     super(e.getMessage(), e.getCause(), /*enableSuppression*/ true, /*writableStackTrace*/ true);
     extra = e.extra;
     mode = e.mode;
-    errorCodes = e.errorCodes == null ? null : e.errorCodes.clone();
+    errorCodes = FailureCodeTracker.copyOf(e.errorCodes);
     uri = expectedURI;
     // Copy suppressed exceptions and the original stack trace frames.
     for (Throwable s : e.getSuppressed()) addSuppressed(s);

--- a/src/main/java/network/crypta/client/async/SingleBlockInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleBlockInserter.java
@@ -442,7 +442,9 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
     if (LOG.isDebugEnabled()) LOG.debug("Failed: {}", String.valueOf(e));
     retries++;
     if ((retries > ctx.maxInsertRetries) && (ctx.maxInsertRetries != -1)) {
-      fail(InsertException.construct(persistent ? errors.clone() : errors), context);
+      fail(
+          InsertException.construct(persistent ? FailureCodeTracker.copyOf(errors) : errors),
+          context);
       return;
     }
     clearWakeupTime(context);


### PR DESCRIPTION
Summary
- Remove Object.clone/Cloneable from FailureCodeTracker and replace with an explicit copy factory `FailureCodeTracker.copyOf(...)`.
- Update exception copy paths and a caller to use the explicit copy:
  - FetchException: copy constructors now duplicate the tracker via `FailureCodeTracker.copyOf(...)` where previously `clone()` was used.
  - InsertException: copy constructors now duplicate the tracker via `FailureCodeTracker.copyOf(...)` where previously `clone()` was used.
  - SingleBlockInserter: when persisting, use `FailureCodeTracker.copyOf(errors)` instead of `errors.clone()`.

Rationale
`Cloneable` is error‑prone and bypasses constructors; shallow semantics are often surprising. `FailureCodeTracker` already has a `merge(...)` helper; `copyOf(...)` simply constructs a new tracker and merges, preserving counts and `insert` mode.

Implementation Notes
- `FailureCodeTracker.copyOf` returns `null` when the input is `null` for convenience in conditional flows.
- No functional behavior change intended beyond removing the use of `clone()`.
- Compiles against Java 21; Spotless applied.

Testing
- Existing unit tests compile and pass locally for targeted classes.
- Ran focused tests:
  - `./gradlew -x spotlessKotlinGradle -x spotlessJava -x spotlessKotlin test --tests 'network.crypta.client.FailureCodeTrackerTest' --tests 'network.crypta.client.FetchExceptionTest' --tests 'network.crypta.client.InsertExceptionTest'`

Risk
- Low: changes are mechanical and localized to copying semantics that previously used `clone()`.

Files Touched
- src/main/java/network/crypta/client/FailureCodeTracker.java
- src/main/java/network/crypta/client/FetchException.java
- src/main/java/network/crypta/client/InsertException.java
- src/main/java/network/crypta/client/async/SingleBlockInserter.java

If maintainers prefer a copy constructor over `copyOf`, I can swap to `new FailureCodeTracker(src)` with identical semantics, but opted for the factory for parity with `ClientMetadata.copyOf` added in #469.