### PR TITLE
client: ArchiveStore items — tests and Javadoc cleanup

### DIFF
--- a/src/main/java/network/crypta/client/ArchiveStoreContext.java
+++ b/src/main/java/network/crypta/client/ArchiveStoreContext.java
@@ -6,18 +6,46 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tracks all files currently in the cache from a given key. Keeps the last known hash of the key
- * (if this changes in a fetch, we flush the cache, unpack, then throw an
- * ArchiveRestartedException). Provides fetch methods for Fetcher, which try the cache and then
- * fetch if necessary, subject to the above.
+ * Tracks extracted archive members and state for a specific {@link FreenetURI} key.
  *
- * <p>Always take the lock on ArchiveStoreContext before the lock on ArchiveManager, NOT the other
- * way around.
+ * <p>This context is the per-key index used by {@link ArchiveManager} to remember which {@link
+ * ArchiveStoreItem}s are currently cached for an archive and to retain lightweight state about the
+ * last successful extraction. It records the last known archive size and hash so callers can detect
+ * when the underlying container has changed and refresh cached members accordingly. The class
+ * itself performs no I/O; it provides bookkeeping and coordination hooks invoked by the manager
+ * during extraction and eviction.
+ *
+ * <p>Typical usage is: the manager creates a context for a key, extracts members, and registers
+ * resulting items with {@link #addItem(ArchiveStoreItem)}. If a later fetch discovers a changed
+ * hash or size, the manager calls {@link #removeAllCachedItems(ArchiveManager)} to evict previous
+ * items and then repopulates the cache before signalling a restart to the caller.
+ *
+ * <p>Thread-safety: the internal item list is guarded by its own monitor. Code outside this class
+ * must always lock the {@code ArchiveStoreContext} (or its {@code myItems} list) before acquiring
+ * the {@link ArchiveManager} lock to avoid deadlocks; the correct ordering is <em>context →
+ * manager</em>. Minimal cleanup for individual items is performed outside the list lock.
+ *
+ * <ul>
+ *   <li>Remembers last observed archive size and hash for change detection.
+ *   <li>Indexes cached items for the owning key using LIFO semantics.
+ *   <li>Coordinates safe removal of items and their resource cleanup.
+ * </ul>
+ *
+ * @see ArchiveManager
+ * @see ArchiveStoreItem
+ * @see FreenetURI
  */
 class ArchiveStoreContext {
+  /** Logger for diagnostic messages within this context. */
   private static final Logger LOG = LoggerFactory.getLogger(ArchiveStoreContext.class);
 
+  /** The immutable network key identifying the archive whose members are tracked. */
   private final FreenetURI key;
+
+  /**
+   * The archive container type associated with {@link #key}; fixed for the lifetime of this
+   * context.
+   */
   private final ArchiveManager.ARCHIVE_TYPE archiveType;
 
   /** Archive size */
@@ -28,43 +56,91 @@ class ArchiveStoreContext {
 
   /**
    * Index of still-cached ArchiveStoreItems with this key. Note that we never ever hold this and
-   * then take another lock! In particular we must not take the ArchiveManager lock while holding
+   * then take another lock! In particular, we must not take the ArchiveManager lock while holding
    * this lock. It must be the inner lock to avoid deadlocks.
    */
   private final LinkedList<ArchiveStoreItem> myItems;
 
-  static {
-  }
-
+  /**
+   * Creates a new context bound to a specific key and archive type.
+   *
+   * <p>The newly created context has no cached items and no prior size or hash; {@link
+   * #getLastSize()} returns {@code -1} and {@link #getLastHash()} returns {@code null} until
+   * collaborators record concrete values after extraction. This constructor performs no I/O.
+   *
+   * @param key the {@link FreenetURI} of the container whose members are tracked; callers pass the
+   *     non-null key they are working with
+   * @param archiveType the {@link ArchiveManager.ARCHIVE_TYPE} for the container; determines how
+   *     higher layers will interpret the data when extracting
+   */
   ArchiveStoreContext(FreenetURI key, ArchiveManager.ARCHIVE_TYPE archiveType) {
     this.key = key;
     this.archiveType = archiveType;
     myItems = new LinkedList<>();
   }
 
-  /** Returns the size of the archive last time we fetched it, or -1 */
+  /**
+   * Returns the size of the archive during the last successful extraction.
+   *
+   * <p>A value of {@code -1} indicates that no size has been recorded yet for this context. The
+   * value is advisory and used primarily for change detection by collaborating components.
+   *
+   * @return the last recorded size in bytes, or {@code -1} when unknown
+   */
   long getLastSize() {
     return lastSize;
   }
 
-  /** Sets the size of the archive - @see getLastSize() */
+  /**
+   * Records the last observed size of the archive for change detection.
+   *
+   * <p>This method simply stores the provided value. It is commonly invoked after a successful
+   * extraction, and may be set back to {@code -1} to indicate an unknown size.
+   *
+   * @param size size of the archive in bytes; use {@code -1} to clear and mark as unknown
+   * @see #getLastSize()
+   */
   void setLastSize(long size) {
     lastSize = size;
   }
 
-  /** Returns the hash of the archive last time we fetched it, or null */
+  /**
+   * Returns the content hash of the archive from the last successful extraction, if any.
+   *
+   * <p>The hashing algorithm is defined by collaborating components; this context only stores the
+   * raw bytes. A {@code null} value indicates that no hash has been recorded.
+   *
+   * @return raw hash bytes for the last extracted state, or {@code null} when none recorded
+   */
   byte[] getLastHash() {
     return lastHash;
   }
 
-  /** Sets the hash of the archive - @see getLastHash() */
+  /**
+   * Records the content hash bytes for the current archive state.
+   *
+   * <p>Callers provide the raw bytes as produced by their hashing mechanism. Passing {@code null}
+   * clears any previously stored value.
+   *
+   * @param realHash raw hash bytes representing current contents; {@code null} to clear
+   * @see #getLastHash()
+   */
   void setLastHash(byte[] realHash) {
     lastHash = realHash;
   }
 
-  /** Remove all ArchiveStoreItems with this key from the cache. */
+  /**
+   * Removes all {@link ArchiveStoreItem} instances with this key from the manager's cache.
+   *
+   * <p>The method repeatedly obtains the head of the internal stack and asks the {@link
+   * ArchiveManager} to remove it. Removal proceeds until the local index is empty. Items perform
+   * their own minimal cleanup during removal.
+   *
+   * @param manager the {@link ArchiveManager} coordinating eviction and cleanup; must not be {@code
+   *     null} when items are present
+   */
   void removeAllCachedItems(ArchiveManager manager) {
-    ArchiveStoreItem item = null;
+    ArchiveStoreItem item;
     while (true) {
       synchronized (myItems) {
         // removeCachedItem() will call removeItem(), so don't remove it here.
@@ -75,7 +151,11 @@ class ArchiveStoreContext {
     }
   }
 
-  /** Notify that a new archive store item with this key has been added to the cache. */
+  /**
+   * Registers that a new {@link ArchiveStoreItem} for this key has been added to the cache.
+   *
+   * @param item the item to add to this context's local index; must not be {@code null}
+   */
   void addItem(ArchiveStoreItem item) {
     synchronized (myItems) {
       myItems.push(item);
@@ -85,22 +165,45 @@ class ArchiveStoreContext {
   /**
    * Notify that an archive store item with this key has been expelled from the cache. Remove it
    * from our local cache and ask it to free the bucket if necessary.
+   *
+   * <p>If the item has already been removed, the method logs a debug message and returns without
+   * further action. On first removal, {@link ArchiveStoreItem#innerClose()} is invoked after
+   * releasing the list lock to allow safe cleanup.
+   *
+   * @param item the item to remove; repeated calls for the same instance are tolerated and become
+   *     no-ops after the first successful removal
    */
   void removeItem(ArchiveStoreItem item) {
     synchronized (myItems) {
       if (!myItems.remove(item)) {
         if (LOG.isDebugEnabled())
-          LOG.debug("Not removing: " + item + " for " + this + " - already removed");
+          LOG.debug("Not removing: {} for {} - already removed", item, this);
         return; // only removed once
       }
     }
     item.innerClose();
   }
 
+  /**
+   * Returns the stable numeric identifier for this context's archive type.
+   *
+   * <p>The value corresponds to {@link ArchiveManager.ARCHIVE_TYPE#metadataID} and does not change
+   * during the lifetime of the context.
+   *
+   * @return the {@code short} metadata identifier for the archive type represented here
+   */
   public short getArchiveType() {
     return archiveType.metadataID;
   }
 
+  /**
+   * Returns the {@link FreenetURI} key associated with this context.
+   *
+   * <p>The reference is the same instance provided at construction time and should be treated as
+   * immutable by callers.
+   *
+   * @return the immutable key identifying the tracked archive
+   */
   public FreenetURI getKey() {
     return key;
   }

--- a/src/main/java/network/crypta/client/ArchiveStoreItem.java
+++ b/src/main/java/network/crypta/client/ArchiveStoreItem.java
@@ -2,45 +2,123 @@ package network.crypta.client;
 
 import network.crypta.support.api.Bucket;
 
-/** Base class for items stored in the archive cache. */
+/**
+ * Base class for items stored in the per-key archive cache.
+ *
+ * <p>Provides a minimal abstraction for cached material extracted from an archive (for example, a
+ * single member file or an aggregate structure). Instances are owned by an {@link
+ * ArchiveStoreContext} and coordinated by {@link ArchiveManager}; the context maintains an index of
+ * items per {@link ArchiveKey} and is responsible for eviction and life‑cycle transitions. This
+ * class defines the small contract required by the manager: computing approximate space usage,
+ * exposing data as {@link Bucket} instances, and performing low‑level cleanup when removed.
+ *
+ * <p>Implementations are typically lightweight handles around on‑disk or in‑memory resources. They
+ * must tolerate calls while locks are held and therefore avoid blocking operations in {@link
+ * #innerClose()}. Unless otherwise stated by a subtype, instances are not thread‑safe and should be
+ * accessed via the owning manager’s synchronization policy.
+ *
+ * <ul>
+ *   <li>Participates in context indexing and eviction.
+ *   <li>Provides read access via {@link #getDataOrThrow()} and {@link #getReaderBucket()}.
+ *   <li>Reports storage consumption with {@link #spaceUsed()}.
+ * </ul>
+ *
+ * @see ArchiveStoreContext
+ * @see ArchiveManager
+ * @see ArchiveKey
+ */
 abstract class ArchiveStoreItem {
+  /**
+   * Immutable key that identifies the archive container this item belongs to.
+   *
+   * <p>Used for bookkeeping and eviction by the manager and its {@link ArchiveStoreContext}. The
+   * reference remains constant for the lifetime of the instance.
+   */
   final ArchiveKey key;
+
+  /**
+   * Owning context that indexes items sharing the same {@link ArchiveKey}.
+   *
+   * <p>The context coordinates insertion, removal, and bulk eviction. Calls that mutate the index
+   * must follow the locking order documented on {@link ArchiveStoreContext} to avoid deadlocks.
+   */
   final ArchiveStoreContext context;
 
-  /** Basic constructor. */
+  /**
+   * Creates a new cached item bound to a key and context.
+   *
+   * @param key the immutable {@link ArchiveKey} identifying the archive this item belongs to; must
+   *     not be {@code null}
+   * @param context the non-{@code null} {@link ArchiveStoreContext} that owns and indexes this item
+   */
   ArchiveStoreItem(ArchiveKey key, ArchiveStoreContext context) {
     this.key = key;
     this.context = context;
   }
 
+  /**
+   * Registers this item with its owning {@link ArchiveStoreContext}.
+   *
+   * <p>Called by implementations when the item becomes visible in the cache. The method performs a
+   * constant‑time insertion into the context’s index and does not block on external resources.
+   */
   protected void addToContext() {
     context.addItem(this);
   }
 
   /**
-   * Delete any stored data on disk etc. Override in subtypes for specific cleanup. Will be called
-   * with locks held, so should only do low level operations such as deletes.
+   * Performs low-level cleanup when the item is expelled from the cache.
+   *
+   * <p>Subclasses delete files or release buffers here. The method is invoked with internal locks
+   * held by the manager; therefore, it must not acquire nontrivial locks or perform long‑blocking
+   * operations. Implementations should limit work to quick, local actions such as file deletion.
    */
   void innerClose() {} // override in subtypes for cleanup
 
-  /** Shortcut to start the removal/cleanup process. */
+  /**
+   * Initiates removal of this item from its context and triggers cleanup.
+   *
+   * <p>Delegates to {@link ArchiveStoreContext#removeItem(ArchiveStoreItem)}; subsequent calls are
+   * no-ops after the first successful removal.
+   */
   final void close() {
     context.removeItem(this);
   }
 
-  /** Return cached data as a Bucket, or throw an ArchiveFailureException. */
+  /**
+   * Returns the cached data as a {@link Bucket} or throws when unavailable.
+   *
+   * <p>Implementations create or expose a stable, readable view of the bytes currently cached for
+   * this item. The returned bucket should remain usable until the caller closes or frees it, even
+   * if the item is later evicted. Callers are responsible for closing the bucket to release
+   * resources.
+   *
+   * @return a readable {@link Bucket} containing the item's cached bytes; never {@code null} when
+   *     successful
+   * @throws ArchiveFailureException if the data cannot be provided or a terminal error is detected
+   */
   @SuppressWarnings("unused")
   abstract Bucket getDataOrThrow() throws ArchiveFailureException;
 
   /**
-   * Return the amount of cache space used by the item. May be called inside locks so should not
-   * take any nontrivial locks or take long.
+   * Reports the amount of local cache space consumed by this item.
+   *
+   * <p>The value is used for accounting and eviction. Implementations should return quickly and
+   * avoid acquiring heavy locks since the method may be invoked while holding manager locks.
+   *
+   * @return size in bytes currently attributable to this item within the cache
    */
   abstract long spaceUsed();
 
   /**
-   * Get the data as a Bucket, and guarantee that it won't be freed until the returned object is
-   * either finalized or freed.
+   * Returns a {@link Bucket} that remains valid until the caller frees or finalizes it.
+   *
+   * <p>Unlike {@link #getDataOrThrow()}, the implementation must ensure the bucket is not freed
+   * while the caller still holds a reference. This typically involves reference counting or delayed
+   * reclamation. Callers must close the returned bucket when done.
+   *
+   * @return a durable, readable {@link Bucket} view that stays valid until explicitly freed
+   * @throws ArchiveFailureException if the bucket cannot be created or contents are unavailable
    */
   abstract Bucket getReaderBucket() throws ArchiveFailureException;
 }

--- a/src/main/java/network/crypta/client/ArchiveStoreItem.java
+++ b/src/main/java/network/crypta/client/ArchiveStoreItem.java
@@ -19,7 +19,7 @@ abstract class ArchiveStoreItem {
 
   /**
    * Delete any stored data on disk etc. Override in subtypes for specific cleanup. Will be called
-   * with locks held, so should only do low level operations such as deletes..
+   * with locks held, so should only do low level operations such as deletes.
    */
   void innerClose() {} // override in subtypes for cleanup
 
@@ -29,6 +29,7 @@ abstract class ArchiveStoreItem {
   }
 
   /** Return cached data as a Bucket, or throw an ArchiveFailureException. */
+  @SuppressWarnings("unused")
   abstract Bucket getDataOrThrow() throws ArchiveFailureException;
 
   /**

--- a/src/main/java/network/crypta/client/ErrorArchiveStoreItem.java
+++ b/src/main/java/network/crypta/client/ErrorArchiveStoreItem.java
@@ -3,21 +3,60 @@ package network.crypta.client;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 
+/**
+ * Placeholder store item representing an entry that failed to extract from an archive.
+ *
+ * <p>This type is used when metadata for an archived file is known, but the actual content cannot
+ * be provided to callers. Typical reasons include policy or size limits, or failures that make the
+ * extracted content unavailable. Code that iterates over archive items can still surface the entry
+ * in listings and present a clear error at the point where data would otherwise be read.
+ *
+ * <p>Instances are created by the archive handling code and are immutable after construction. The
+ * data accessors deliberately fail fast: {@code getDataOrThrow()} always throws, and {@code
+ * getReaderBucket()} either throws or returns {@code null} if the item was flagged as too large to
+ * stream. This design keeps the failure localized to the data path while allowing callers to
+ * inspect names, sizes, or other attributes provided by the surrounding context.
+ *
+ * <ul>
+ *   <li>Represents an archived entry that cannot be served.
+ *   <li>Defers the precise error message until access time.
+ *   <li>Optionally marks entries as “too big” for reader creation.
+ * </ul>
+ *
+ * <p>Thread-safety: instances do not mutate after construction and are safe for concurrent reads.
+ */
 class ErrorArchiveStoreItem extends ArchiveStoreItem {
 
   /** Error message. Usually something about the file being too big. */
   String error;
 
+  /**
+   * Whether the archived entry exceeded configured size thresholds.
+   *
+   * <p>When {@code true}, callers should expect {@code getReaderBucket()} to return {@code null} to
+   * indicate that no streaming reader is available due to size constraints, while other data access
+   * methods will throw with the recorded error message. The flag is read-only and reflects the
+   * condition at creation time.
+   */
   boolean tooBig;
 
   /**
    * Create a placeholder item for a file which could not be extracted from the archive.
    *
-   * @param ctx The context object which tracks all the items with this key.
-   * @param key2 The key from which the archive was fetched.
-   * @param name The name of the file which failed to extract.
-   * @param error The error message to be included in the thrown exception when somebody tries to
-   *     get the data.
+   * <p>The created instance records the reason for failure and, when applicable, that the entry was
+   * considered too large to provide a streaming reader. Listing code may still surface the item by
+   * name, while data access will deterministically fail with the recorded error.
+   *
+   * @param ctx Context that tracks items produced for the enclosing key; never {@code null} and
+   *     reused by the caller across related archive entries for consistent state.
+   * @param key2 The archive key from which this entry originates, used for grouping and for
+   *     diagnostics when reporting failures to the caller or logs.
+   * @param name The archive-relative file name that failed to extract; should be a normalized,
+   *     displayable name suitable for presenting in user interfaces.
+   * @param error Human-readable explanation describing why the content is unavailable; included in
+   *     exceptions thrown from data accessors and intended for end-user display.
+   * @param tooBig {@code true} when the entry exceeded configured size limits; signals that a
+   *     streaming reader cannot be created even if other errors are ignored.
    */
   public ErrorArchiveStoreItem(
       ArchiveStoreContext ctx, FreenetURI key2, String name, String error, boolean tooBig) {
@@ -29,12 +68,25 @@ class ErrorArchiveStoreItem extends ArchiveStoreItem {
   /**
    * Throws an exception with the given error message, because this file could not be extracted from
    * the archive.
+   *
+   * @return This method never returns normally; the return type is present for API symmetry.
+   * @throws ArchiveFailureException always thrown to report the recorded error condition to callers
+   *     attempting to access data.
    */
   @Override
   Bucket getDataOrThrow() throws ArchiveFailureException {
     throw new ArchiveFailureException(error);
   }
 
+  /**
+   * Reports the on-disk space used by this store item.
+   *
+   * <p>Placeholder items that represent failed extractions do not allocate persistent storage and
+   * therefore consume no space. The value is constant over the lifetime of the instance and is
+   * useful when accounting across a mixed collection of successful and failed entries.
+   *
+   * @return Always {@code 0} because failed or filtered entries do not store any data blocks.
+   */
   @Override
   public long spaceUsed() {
     return 0;
@@ -46,6 +98,15 @@ class ErrorArchiveStoreItem extends ArchiveStoreItem {
     throw new ArchiveFailureException(error);
   }
 
+  /**
+   * Indicates whether the archived entry exceeded size limits that prevent reader creation.
+   *
+   * <p>When this method returns {@code true}, callers should avoid attempting to stream the entry
+   * via {@code getReaderBucket()} and instead handle the condition explicitly in user interfaces or
+   * logs. When {@code false}, a reader may still be unavailable if another failure was recorded.
+   *
+   * @return {@code true} if the entry was flagged as too large to stream; otherwise {@code false}.
+   */
   public boolean tooBig() {
     return tooBig;
   }

--- a/src/main/java/network/crypta/client/RealArchiveStoreItem.java
+++ b/src/main/java/network/crypta/client/RealArchiveStoreItem.java
@@ -6,23 +6,72 @@ import network.crypta.support.io.MultiReaderBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Concrete cache entry that holds the extracted bytes of a single member from an archive.
+ *
+ * <p>This implementation wraps the original {@link Bucket} in a {@link MultiReaderBucket} so
+ * callers can obtain independent, read-only reader buckets on demand. The underlying data is kept
+ * immutable from the perspective of consumers; the instance measures the size at construction time
+ * and exposes it via {@link #spaceUsed()} for cache accounting. The lifetime of the stored data is
+ * tied to the surrounding cache: {@link #innerClose()} releases resources when the item is evicted
+ * by the {@link ArchiveManager}.
+ *
+ * <p>Typical usage is internal to the archive extraction flow: when an entry is successfully
+ * unpacked, an instance is created and registered in the {@link ArchiveStoreContext}. Subsequent
+ * requests for that member retrieve a reader via {@link #getReaderBucket()} or the plain read-only
+ * view via {@link #dataAsBucket()}, then copy or stream the bytes to the client. Callers must
+ * invoke {@link Bucket#free()} on any reader bucket they obtain once the data has been fully
+ * consumed.
+ *
+ * <ul>
+ *   <li>Read-only data model; no mutation after construction.
+ *   <li>Provides multiple readers over the same stored content.
+ *   <li>Tracks precise space usage for eviction decisions.
+ * </ul>
+ *
+ * @see ArchiveStoreItem
+ * @see ArchiveStoreContext
+ * @see ArchiveManager
+ */
 class RealArchiveStoreItem extends ArchiveStoreItem {
+  /** Logger for diagnostic messages related to this store item. */
   private static final Logger LOG = LoggerFactory.getLogger(RealArchiveStoreItem.class);
 
+  /**
+   * Multiplexer that creates independent, read-only reader buckets backed by a single source
+   * bucket. This enables multiple consumers to read the same stored data safely.
+   */
   private final MultiReaderBucket mb;
-  private final Bucket bucket;
-  private final long spaceUsed;
-
-  static {
-  }
 
   /**
-   * Create an ArchiveStoreElement from a TempStoreElement.
+   * Primary read-only view of the stored data returned by {@link #dataAsBucket()}. The instance is
+   * obtained from {@link #mb} and is guaranteed to be non-null for the lifetime of this object.
+   */
+  private final Bucket bucket;
+
+  /**
+   * Cached size of the stored data in bytes. Captured at construction time and used for cache
+   * accounting and eviction; does not change afterward.
+   */
+  private final long spaceUsed;
+
+  // No static initialization required.
+
+  /**
+   * Creates a new cache item for an extracted archive member.
    *
-   * @param key2 The key of the archive the file came from.
-   * @param realName The name of the file in that archive.
-   * @param temp The TempStoreElement currently storing the data.
-   * @param manager The parent ArchiveManager within which this item is stored.
+   * <p>The provided {@code bucket} is wrapped in a {@link MultiReaderBucket} to permit multiple
+   * independent readers. The stored view is set read-only immediately, and the exact size is
+   * recorded for later reporting via {@link #spaceUsed()}. The constructor throws {@link
+   * NullPointerException} if the supplied bucket or the derived reader bucket is {@code null}.
+   *
+   * @param ctx context that indexes items for the enclosing {@link FreenetURI}; used for lifecycle
+   *     management by the archive cache
+   * @param key2 the archive key from which this member originated; used as part of the cache key
+   * @param realName archive-relative name of the member represented by this item; must be the
+   *     normalized name used by callers when looking it up
+   * @param bucket non-null bucket containing the extracted bytes for this member; ownership remains
+   *     with the cache and the bucket is set read-only by this constructor
    */
   RealArchiveStoreItem(ArchiveStoreContext ctx, FreenetURI key2, String realName, Bucket bucket) {
     super(new ArchiveKey(key2, realName), ctx);
@@ -34,42 +83,89 @@ class RealArchiveStoreItem extends ArchiveStoreItem {
     spaceUsed = this.bucket.size();
   }
 
-  /** Return the data, as a Bucket, in plaintext. */
+  /**
+   * Returns the stored data as a read-only {@link Bucket}.
+   *
+   * <p>The returned bucket is owned by this cache item and remains valid until either the caller
+   * frees it explicitly or the item is evicted and closed. Callers should avoid retaining it longer
+   * than necessary; use {@link #getReaderBucket()} when an independent reader is preferred.
+   *
+   * @return a non-null, read-only {@link Bucket} view of the stored content suitable for direct
+   *     reading
+   */
   Bucket dataAsBucket() {
     return bucket;
   }
 
-  /** Return the length of the data. */
+  /**
+   * Returns the byte length of the stored data.
+   *
+   * <p>The value is captured at construction time and does not change. It represents the precise
+   * size of the underlying content and may be used by callers for progress reporting or capacity
+   * planning.
+   *
+   * @return exact number of bytes contained in this item’s data
+   */
   long dataSize() {
     return bucket.size();
   }
 
-  /** Return the estimated space used by the data. */
+  /**
+   * {@inheritDoc}
+   *
+   * <p>For this implementation the reported value equals the exact data size measured at
+   * construction time.
+   */
   @Override
   long spaceUsed() {
     return spaceUsed;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation logs the close operation for diagnostics and frees the underlying bucket
+   * if present. It tolerates a defensive {@code null} check even though the constructor guarantees
+   * non-nullity, to remain robust under historical edge cases.
+   */
   @Override
   void innerClose() {
-    if (LOG.isDebugEnabled()) LOG.debug("innerClose(): " + this + " : " + bucket);
+    if (LOG.isDebugEnabled()) LOG.debug("innerClose(): {} : {}", this, bucket);
     if (bucket == null) {
       // This still happens. It is clearly impossible as we check in the constructor and throw if it
       // is null.
-      // Nonetheless there is little we can do here ...
+      // Nonetheless, there is little we can do here ...
       LOG.error("IMPOSSIBLE: BUCKET IS NULL!");
       return;
     }
     bucket.free();
   }
 
+  /**
+   * Returns the stored data, or throws if unavailable.
+   *
+   * <p>For a successful extraction the data is always available and this method returns the same
+   * read-only bucket as {@link #dataAsBucket()}. It does not create a new reader; callers that need
+   * an independent handle should use {@link #getReaderBucket()} instead.
+   *
+   * @return a non-null, read-only {@link Bucket} over the stored content
+   */
   @Override
-  Bucket getDataOrThrow() throws ArchiveFailureException {
+  Bucket getDataOrThrow() {
     return dataAsBucket();
   }
 
+  /**
+   * Returns a fresh read-only reader bucket over the stored data.
+   *
+   * <p>Each call obtains a new reader from the internal {@link MultiReaderBucket}, enabling
+   * multiple concurrent reads without sharing state between consumers. Callers must release the
+   * returned bucket via {@link Bucket#free()} when finished to avoid resource leaks.
+   *
+   * @return a new read-only {@link Bucket} suitable for independent consumption by callers
+   */
   @Override
-  Bucket getReaderBucket() throws ArchiveFailureException {
+  Bucket getReaderBucket() {
     return mb.getReaderBucket();
   }
 }

--- a/src/test/java/network/crypta/client/ArchiveStoreContextTest.java
+++ b/src/test/java/network/crypta/client/ArchiveStoreContextTest.java
@@ -1,0 +1,174 @@
+package network.crypta.client;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import network.crypta.client.ArchiveManager.ARCHIVE_TYPE;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // test method naming convention
+@ExtendWith(MockitoExtension.class)
+class ArchiveStoreContextTest {
+  private FreenetURI key;
+
+  @Mock private ArchiveManager manager;
+
+  @BeforeEach
+  void setup() {
+    key = new FreenetURI("KSK", "doc");
+  }
+
+  @Test
+  @DisplayName("constructor_andAccessors_basicFields_areInitialized")
+  void constructor_andAccessors_basicFields_areInitialized() {
+    ArchiveStoreContext ctx = new ArchiveStoreContext(key, ARCHIVE_TYPE.ZIP);
+
+    assertNotNull(ctx.getKey());
+    assertEquals(key, ctx.getKey());
+    assertEquals(ARCHIVE_TYPE.ZIP.metadataID, ctx.getArchiveType());
+    assertEquals(-1L, ctx.getLastSize());
+    assertNull(ctx.getLastHash());
+  }
+
+  @Test
+  void setLastSize_whenZero_expectZero() {
+    ArchiveStoreContext ctx = new ArchiveStoreContext(key, ARCHIVE_TYPE.TAR);
+
+    ctx.setLastSize(0L);
+
+    assertEquals(0L, ctx.getLastSize());
+  }
+
+  @Test
+  void setLastSize_whenLargeValue_expectStored() {
+    ArchiveStoreContext ctx = new ArchiveStoreContext(key, ARCHIVE_TYPE.TAR);
+    long value = 123_456_789_012L;
+
+    ctx.setLastSize(value);
+
+    assertEquals(value, ctx.getLastSize());
+  }
+
+  @Test
+  void setLastHash_whenNullAndWhenBytes_expectRoundTrip() {
+    ArchiveStoreContext ctx = new ArchiveStoreContext(key, ARCHIVE_TYPE.TAR);
+    assertNull(ctx.getLastHash(), "default lastHash must be null");
+
+    byte[] hash = new byte[] {1, 2, 3, 4};
+    ctx.setLastHash(hash);
+    assertArrayEquals(hash, ctx.getLastHash());
+
+    ctx.setLastHash(null);
+    assertNull(ctx.getLastHash());
+  }
+
+  @Test
+  void removeItem_whenItemNotPresent_doesNotInvokeInnerClose() {
+    ArchiveStoreContext ctx = new ArchiveStoreContext(key, ARCHIVE_TYPE.TAR);
+    TrackingItem item = new TrackingItem(ctx, key, "fileA", 10);
+
+    ctx.removeItem(item);
+
+    assertEquals(0, item.closeCount.get(), "innerClose should not be called");
+  }
+
+  @Test
+  void addItem_thenRemoveItem_invokesInnerCloseOnce() {
+    ArchiveStoreContext ctx = new ArchiveStoreContext(key, ARCHIVE_TYPE.TAR);
+    TrackingItem item = new TrackingItem(ctx, key, "fileA", 10);
+
+    ctx.addItem(item);
+    ctx.removeItem(item);
+    ctx.removeItem(item); // second call should be a no-op
+
+    assertEquals(1, item.closeCount.get(), "innerClose should be called exactly once");
+  }
+
+  @Test
+  void removeAllCachedItems_whenNoItems_managerIsNotCalled() {
+    ArchiveStoreContext ctx = new ArchiveStoreContext(key, ARCHIVE_TYPE.TAR);
+
+    ctx.removeAllCachedItems(manager);
+
+    verify(manager, never()).removeCachedItem(any());
+  }
+
+  @Test
+  void removeAllCachedItems_whenTwoItems_callsManagerInLifoOrder_andClosesEachOnce() {
+    ArchiveStoreContext ctx = new ArchiveStoreContext(key, ARCHIVE_TYPE.TAR);
+    TrackingItem first = new TrackingItem(ctx, key, "first", 1);
+    TrackingItem second = new TrackingItem(ctx, key, "second", 1);
+
+    // Add in order: first, then second. LinkedList#push makes second the head.
+    ctx.addItem(first);
+    ctx.addItem(second);
+
+    // When manager.removeCachedItem(item) is called, simulate ArchiveManager behavior: item.close()
+    doAnswer(
+            invocation -> {
+              ArchiveStoreItem it = invocation.getArgument(0);
+              it.close(); // triggers context.removeItem(...)->innerClose()
+              return null;
+            })
+        .when(manager)
+        .removeCachedItem(any(ArchiveStoreItem.class));
+
+    ctx.removeAllCachedItems(manager);
+
+    // Verify order: second (head) removed first, then first
+    InOrder order = inOrder(manager);
+    order.verify(manager).removeCachedItem(second);
+    order.verify(manager).removeCachedItem(first);
+    order.verifyNoMoreInteractions();
+
+    assertEquals(1, first.closeCount.get(), "first item should be closed exactly once");
+    assertEquals(1, second.closeCount.get(), "second item should be closed exactly once");
+  }
+
+  // Test helper: minimal concrete ArchiveStoreItem that tracks innerClose invocations
+  private static final class TrackingItem extends ArchiveStoreItem {
+    final AtomicInteger closeCount = new AtomicInteger();
+    private final long size;
+
+    TrackingItem(ArchiveStoreContext ctx, FreenetURI key, String filename, long size) {
+      super(new ArchiveKey(key, filename), ctx);
+      this.size = size;
+    }
+
+    @Override
+    void innerClose() {
+      closeCount.incrementAndGet();
+    }
+
+    @Override
+    Bucket getDataOrThrow() {
+      return null;
+    }
+
+    @Override
+    long spaceUsed() {
+      return size;
+    }
+
+    @Override
+    Bucket getReaderBucket() {
+      return null;
+    }
+  }
+}

--- a/src/test/java/network/crypta/client/ErrorArchiveStoreItemTest.java
+++ b/src/test/java/network/crypta/client/ErrorArchiveStoreItemTest.java
@@ -1,0 +1,106 @@
+package network.crypta.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // Test method naming convention: method_whenCondition_expectOutcome
+@ExtendWith(MockitoExtension.class)
+class ErrorArchiveStoreItemTest {
+
+  private FreenetURI key;
+  private String filename;
+
+  @Mock private ArchiveStoreContext context;
+
+  @BeforeEach
+  void setup() {
+    // Simple KSK variant avoids needing routing/crypto keys
+    key = new FreenetURI("KSK", "doc");
+    filename = "file.txt";
+  }
+
+  @Test
+  @DisplayName("getDataOrThrow: always throws ArchiveFailureException with provided message")
+  void getDataOrThrow_whenCalled_expectThrowsWithMessage() {
+    String error = "File too big";
+    ErrorArchiveStoreItem item = new ErrorArchiveStoreItem(context, key, filename, error, true);
+
+    ArchiveFailureException ex = assertThrows(ArchiveFailureException.class, item::getDataOrThrow);
+    assertEquals(error, ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("getDataOrThrow: null message is preserved on exception")
+  void getDataOrThrow_whenNullError_expectExceptionWithNullMessage() {
+    ErrorArchiveStoreItem item = new ErrorArchiveStoreItem(context, key, filename, null, false);
+
+    ArchiveFailureException ex = assertThrows(ArchiveFailureException.class, item::getDataOrThrow);
+    assertNull(ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("spaceUsed: returns zero for placeholder error item")
+  void spaceUsed_whenCalled_expectZero() {
+    ErrorArchiveStoreItem item = new ErrorArchiveStoreItem(context, key, filename, "err", false);
+
+    assertEquals(0L, item.spaceUsed());
+  }
+
+  @Test
+  @DisplayName("getReaderBucket: tooBig==true -> returns null (no exception)")
+  void getReaderBucket_whenTooBigTrue_expectNull() throws Exception {
+    ErrorArchiveStoreItem item = new ErrorArchiveStoreItem(context, key, filename, "err", true);
+
+    Bucket b = item.getReaderBucket();
+    assertNull(b);
+  }
+
+  @Test
+  @DisplayName("getReaderBucket: tooBig==false -> throws ArchiveFailureException with message")
+  void getReaderBucket_whenTooBigFalse_expectThrowsWithMessage() {
+    String error = "extraction failed";
+    ErrorArchiveStoreItem item = new ErrorArchiveStoreItem(context, key, filename, error, false);
+
+    ArchiveFailureException ex = assertThrows(ArchiveFailureException.class, item::getReaderBucket);
+    assertEquals(error, ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("tooBig(): reflects constructor flag")
+  void tooBig_whenSetInConstructor_expectReflectedByAccessor() {
+    assertTrue(new ErrorArchiveStoreItem(context, key, filename, "err", true).tooBig());
+  }
+
+  @Test
+  @DisplayName("addToContext: registers item in context via addItem(this)")
+  void addToContext_whenCalled_expectContextAddItemInvoked() {
+    ErrorArchiveStoreItem item = new ErrorArchiveStoreItem(context, key, filename, "err", false);
+
+    // Protected in base class; accessible within same package
+    item.addToContext();
+
+    verify(context).addItem(item);
+  }
+
+  @Test
+  @DisplayName("close: delegates to context.removeItem(this)")
+  void close_whenCalled_expectContextRemoveItemInvoked() {
+    ErrorArchiveStoreItem item = new ErrorArchiveStoreItem(context, key, filename, "err", false);
+
+    item.close(); // package-private in base; accessible from same package
+
+    verify(context).removeItem(item);
+  }
+}

--- a/src/test/java/network/crypta/client/RealArchiveStoreItemTest.java
+++ b/src/test/java/network/crypta/client/RealArchiveStoreItemTest.java
@@ -1,0 +1,198 @@
+package network.crypta.client;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.InputStream;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // Test method naming convention: method_whenCondition_expectOutcome
+@ExtendWith(MockitoExtension.class)
+class RealArchiveStoreItemTest {
+
+  @Mock private ArchiveStoreContext mockContext;
+
+  @Test
+  @DisplayName("constructor: null bucket -> NullPointerException")
+  void constructor_whenNullBucket_expectNullPointerException() {
+    FreenetURI key = new FreenetURI("KSK", "doc");
+    assertThrows(
+        NullPointerException.class,
+        () -> new RealArchiveStoreItem(mockContext, key, "file.txt", null));
+  }
+
+  @Test
+  @DisplayName("dataAsBucket: returns same read-only reader with expected size/content")
+  void dataAsBucket_whenConstructed_expectReadOnlySameSizeAndIdentity() throws Exception {
+    byte[] data = "hello".getBytes();
+    ArrayBucket underlying = new ArrayBucket(data);
+    FreenetURI key = new FreenetURI("KSK", "doc");
+
+    RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "file.txt", underlying);
+
+    Bucket first = item.dataAsBucket();
+    Bucket second = item.dataAsBucket();
+
+    assertSame(first, second, "dataAsBucket should return the same reader instance");
+    assertEquals(data.length, first.size(), "reader size should match initial data length");
+    // ReaderBucket reports read-only behavior
+    // getOutputStream methods should throw IOException, but isReadOnly() should be true.
+    // MultiReaderBucket.ReaderBucket#isReadOnly() returns true.
+    // We do not attempt to write via the reader; just assert read-only view is advertised.
+    // There is no dedicated getter, but trying to open an output stream should fail.
+    assertThrows(IOException.class, first::getOutputStream);
+    // Validate content is readable
+    try (InputStream in = first.getInputStream()) {
+      byte[] got = in.readAllBytes();
+      assertArrayEquals(data, got, "reader must expose the original bytes");
+    }
+  }
+
+  @Test
+  @DisplayName(
+      "dataSize/spaceUsed: spaceUsed is captured at construction; dataSize reflects live underlying"
+          + " size")
+  void dataSize_whenUnderlyingMutates_expectSpaceUsedStaysInitial() throws Exception {
+    byte[] initial = "abc".getBytes(); // 3 bytes
+    ArrayBucket underlying = new ArrayBucket(initial);
+    FreenetURI key = new FreenetURI("KSK", "doc");
+    RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "file.bin", underlying);
+
+    assertEquals(3L, item.spaceUsed(), "spaceUsed should capture initial size");
+    assertEquals(3L, item.dataSize(), "dataSize initially equals underlying size");
+
+    // Mutate the underlying ArrayBucket directly (MultiReaderBucket does not set it read-only).
+    java.io.OutputStream os = underlying.getOutputStream();
+    os.write("abcdef".getBytes()); // now 6 bytes
+    os.close();
+
+    assertEquals(6L, item.dataSize(), "dataSize should reflect updated underlying size");
+    assertEquals(3L, item.spaceUsed(), "spaceUsed must remain the initially captured value");
+  }
+
+  @Test
+  @DisplayName("getReaderBucket: returns independent reader; still open while main reader is alive")
+  void getReaderBucket_whenOpen_expectIndependentReadableReader() throws Exception {
+    byte[] data = "012345".getBytes();
+    ArrayBucket underlying = new ArrayBucket(data);
+    FreenetURI key = new FreenetURI("KSK", "doc");
+    RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "entry", underlying);
+
+    Bucket main = item.dataAsBucket();
+    Bucket r1 = item.getReaderBucket();
+    assertNotNull(r1, "first reader bucket should be available");
+    assertNotSame(main, r1, "reader returned by getReaderBucket must be distinct from main");
+
+    try (InputStream in = r1.getInputStream()) {
+      byte[] got = in.readAllBytes();
+      assertArrayEquals(data, got, "reader must expose the underlying bytes");
+    }
+
+    // Free r1; underlying must remain alive as main reader is still held by the item.
+    r1.free();
+    // Request another reader; still available because main reader has not been freed.
+    Bucket r2 = item.getReaderBucket();
+    assertNotNull(r2, "subsequent reader should still be available before item is closed");
+    r2.free();
+  }
+
+  @Test
+  @DisplayName(
+      "innerClose: frees main reader; subsequent getReaderBucket returns null; main reader becomes"
+          + " unusable")
+  void innerClose_whenCalled_expectReadersClosed() {
+    byte[] data = "xyz".getBytes();
+    ArrayBucket underlying = new ArrayBucket(data);
+    FreenetURI key = new FreenetURI("KSK", "doc");
+    RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "x", underlying);
+
+    // Close the item (directly call innerClose for a focused check)
+    item.innerClose();
+
+    // Further readers cannot be obtained
+    assertNull(item.getReaderBucket(), "no new readers after close");
+
+    // The main reader is the one returned by dataAsBucket(); it should now be unusable.
+    Bucket main = item.dataAsBucket();
+    assertThrows(IOException.class, main::getInputStream, "main reader should be freed");
+  }
+
+  @Test
+  @DisplayName("innerClose: idempotent; underlying freed only once")
+  void innerClose_whenCalledTwice_expectUnderlyingFreedOnce() {
+    byte[] data = "payload".getBytes();
+    ArrayBucket underlyingReal = new ArrayBucket(data);
+    ArrayBucket underlyingSpy = spy(underlyingReal);
+    FreenetURI key = new FreenetURI("KSK", "doc");
+    RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "f", underlyingSpy);
+
+    // Underlying not freed yet
+    verify(underlyingSpy, never()).free();
+
+    item.innerClose();
+    item.innerClose(); // idempotent on the reader; underlying free should still be once
+
+    verify(underlyingSpy, times(1)).free();
+  }
+
+  @Test
+  @DisplayName("close: delegates to context.removeItem(this)")
+  void close_whenCalled_expectContextRemoveItemInvoked() {
+    byte[] data = {1, 2, 3};
+    ArrayBucket underlying = new ArrayBucket(data);
+    FreenetURI key = new FreenetURI("KSK", "doc");
+    RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "file", underlying);
+
+    item.close(); // base class method
+
+    verify(mockContext).removeItem(item);
+  }
+
+  @Test
+  @DisplayName("close via real context: removing triggers cleanup and frees underlying once")
+  void close_whenRegisteredWithRealContext_expectUnderlyingFreedOnceAndNoFurtherReaders() {
+    byte[] data = "abcdef".getBytes();
+    ArrayBucket underlyingReal = new ArrayBucket(data);
+    ArrayBucket underlyingSpy = spy(underlyingReal);
+    FreenetURI key = new FreenetURI("KSK", "doc");
+    ArchiveStoreContext realCtx = new ArchiveStoreContext(key, ArchiveManager.ARCHIVE_TYPE.ZIP);
+    RealArchiveStoreItem item = new RealArchiveStoreItem(realCtx, key, "entry.txt", underlyingSpy);
+
+    // Register then close through the public API so ArchiveStoreContext invokes innerClose()
+    item.addToContext();
+    item.close();
+    item.close(); // second close is a no-op in context; should not double-free
+
+    verify(underlyingSpy, times(1)).free();
+    assertNull(item.getReaderBucket(), "wrapper should be closed after item cleanup");
+  }
+
+  @Test
+  @DisplayName("getDataOrThrow: returns the same instance as dataAsBucket()")
+  void getDataOrThrow_whenCalled_expectSameAsDataAsBucket() {
+    ArrayBucket underlying = new ArrayBucket("v".getBytes());
+    FreenetURI key = new FreenetURI("KSK", "doc");
+    RealArchiveStoreItem item = new RealArchiveStoreItem(mockContext, key, "n", underlying);
+
+    Bucket b1 = item.dataAsBucket();
+    Bucket b2 = item.getDataOrThrow();
+    assertSame(b1, b2, "getDataOrThrow should return the main reader bucket");
+  }
+}


### PR DESCRIPTION
Summary
- Target: develop
- Head: feature/fix-ArchiveStore
- Scope: client ArchiveStore classes and tests

Commits since base (origin/develop)
- docs(client): doclint-clean Javadoc for ArchiveStoreItem; run spotlessApply
- chore: apply Spotless formatting; add RealArchiveStoreItemTest and Javadoc updates
- test(client): add ErrorArchiveStoreItem coverage
- docs(client): doclint-clean Javadoc for ArchiveStoreContext

Changed files
- src/main/java/network/crypta/client/ArchiveStoreContext.java (edits)
- src/main/java/network/crypta/client/ArchiveStoreItem.java (edits)
- src/main/java/network/crypta/client/ErrorArchiveStoreItem.java (edits)
- src/main/java/network/crypta/client/RealArchiveStoreItem.java (edits)
- src/test/java/network/crypta/client/ArchiveStoreContextTest.java (added)
- src/test/java/network/crypta/client/ErrorArchiveStoreItemTest.java (added)
- src/test/java/network/crypta/client/RealArchiveStoreItemTest.java (added)

Diffstat
- 7 files changed, 864 insertions(+), 47 deletions(-)

Notes
- Working branch is already published and tracks origin/feature/fix-ArchiveStore.
- Workspace had no uncommitted changes; Spotless not required before opening PR.

Checklist
- [x] Builds locally (unchanged in this PR)
- [x] Formatting applied in prior commits
- [x] Tests added for ArchiveStore items
