### PR TITLE
Document NullClientCallback and add tests

### DIFF
--- a/src/main/java/network/crypta/client/NullClientCallback.java
+++ b/src/main/java/network/crypta/client/NullClientCallback.java
@@ -11,65 +11,209 @@ import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** */
+/**
+ * Null-object implementation of {@link ClientGetCallback} and {@link ClientPutCallback} that
+ * performs minimal logging and resource cleanup.
+ *
+ * <p>This callback is intended for callers that must satisfy the client callback contracts but do
+ * not need application-specific behavior for each event. It logs every callback at trace level when
+ * tracing is enabled and frees the {@link Bucket} instances that carry fetched payloads or
+ * generated metadata, helping to avoid resource leaks while keeping outcome handling effectively
+ * neutral. The implementation does not attempt retries, scheduling changes, or UI notifications.
+ *
+ * <p>The instance holds a single immutable {@link RequestClient} reference that identifies the
+ * logical owner of the associated requests. The class itself maintains no additional mutable state;
+ * thread-safety therefore depends primarily on the thread-safety of the provided {@link
+ * RequestClient} and the surrounding components that invoke the callbacks.
+ *
+ * <ul>
+ *   <li>Implements both fetch and put callback interfaces with neutral default behavior.
+ *   <li>Logs all events at trace level only when trace logging is enabled.
+ *   <li>Frees data and metadata buckets on success paths to avoid leaking resources.
+ * </ul>
+ *
+ * @see ClientGetCallback
+ * @see ClientPutCallback
+ * @see RequestClient
+ */
 public class NullClientCallback implements ClientGetCallback, ClientPutCallback {
   private static final Logger LOG = LoggerFactory.getLogger(NullClientCallback.class);
 
-  static {
-  }
-
   private final RequestClient cb;
 
+  /**
+   * Creates a new callback instance bound to the given {@link RequestClient}.
+   *
+   * <p>The supplied client identifies the logical owner of requests associated with this callback
+   * and is returned unchanged from {@link #getRequestClient()}. Typical usage constructs one
+   * instance per logical client and reuses it across multiple requests that do not require
+   * specialized per-request callback behavior. The reference is stored as provided; this class does
+   * not validate or wrap it.
+   *
+   * @param cb the scheduling identity for this callback instance; callers should normally supply a
+   *     non-{@code null} client and ensure that the reference remains valid for the lifetime of
+   *     in-flight requests.
+   */
   public NullClientCallback(RequestClient cb) {
     this.cb = cb;
   }
 
+  /**
+   * Handles a fetch failure without performing application-level recovery.
+   *
+   * <p>This implementation logs the supplied {@link FetchException} together with the associated
+   * {@link ClientGetter} at trace level when tracing is enabled and otherwise does nothing. It does
+   * not attempt retries, modify the {@code state}, or rethrow the exception. The method is safe to
+   * use in scenarios where failures should be recorded for diagnostics but silently ignored at the
+   * caller boundary.
+   *
+   * @param e the failure description produced by the fetch logic; passed through to logging and
+   *     never modified by this implementation.
+   * @param state the originating getter that reported the failure; used only for logging and may be
+   *     {@code null} when no concrete state object is available.
+   */
   @Override
   public void onFailure(FetchException e, ClientGetter state) {
-    if (LOG.isTraceEnabled())
-      LOG.trace("NullClientCallback#onFailure e=" + e + ", state=" + state, e);
+    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onFailure e={}, state={}", e, state, e);
   }
 
+  /**
+   * Handles an insert failure by logging but performing no further action.
+   *
+   * <p>This implementation records the {@link InsertException} and the associated {@link
+   * BaseClientPutter} at trace level when tracing is enabled and otherwise takes no steps to
+   * recover from the failure. It does not modify the putter state or rethrow the exception. This
+   * makes it suitable as a default for insert flows that only require diagnostic logging.
+   *
+   * @param e the exception describing why the insert failed or was cancelled; used solely for
+   *     logging and never altered.
+   * @param state the putter instance associated with the failed insert; may be {@code null} and is
+   *     used only for log context.
+   */
   @Override
   public void onFailure(InsertException e, BaseClientPutter state) {
-    if (LOG.isTraceEnabled())
-      LOG.trace("NullClientCallback#onFailure e=" + e + ", state=" + state, e);
+    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onFailure e={}, state={}", e, state, e);
   }
 
+  /**
+   * Receives a hint that inserted content may now be fetchable.
+   *
+   * <p>This implementation writes a trace-level log entry containing the given {@link
+   * BaseClientPutter} when tracing is enabled and otherwise does nothing. It does not attempt to
+   * trigger follow-up fetch operations or alter the internal state of the putter. Callers that
+   * require richer behavior can override this method in a custom callback while still delegating to
+   * this implementation for logging.
+   *
+   * @param state the putter associated with the insert operation that became fetchable; may be
+   *     {@code null} and is used only for logging purposes.
+   */
   @Override
   public void onFetchable(BaseClientPutter state) {
-    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onFetchable state=" + state);
+    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onFetchable state={}", state);
   }
 
+  /**
+   * Notifies that a final {@link FreenetURI} has been generated for an insert operation.
+   *
+   * <p>This implementation logs the generated URI and the associated {@link BaseClientPutter} at
+   * trace level when tracing is enabled and otherwise ignores the event. It does not store the URI
+   * or pass it to other components, making it safe to use when the application does not need to
+   * expose the URI but still wants visibility into the callback sequence for debugging.
+   *
+   * @param uri the URI produced by the insert pipeline; passed directly to the logger and not
+   *     validated or retained.
+   * @param state the putter that produced the URI; used only for logging and allowed to be {@code
+   *     null}.
+   */
   @Override
   public void onGeneratedURI(FreenetURI uri, BaseClientPutter state) {
     if (LOG.isTraceEnabled())
-      LOG.trace("NullClientCallback#onGeneratedURI uri=" + uri + ", state=" + state);
+      LOG.trace("NullClientCallback#onGeneratedURI uri={}, state={}", uri, state);
   }
 
+  /**
+   * Handles a successful fetch by logging and freeing the payload bucket.
+   *
+   * <p>This implementation logs the given {@link FetchResult} and {@link ClientGetter} at trace
+   * level when tracing is enabled and then calls {@code free()} on the underlying {@link Bucket}
+   * referenced by the result. After this method returns the bucket is considered released and
+   * callers must not attempt to read from it again. The method does not transform the payload or
+   * notify other components.
+   *
+   * @param result the successful fetch result whose payload bucket will be freed; expected to be
+   *     non-{@code null}.
+   * @param state the getter associated with the fetch operation; used only for logging and may be
+   *     {@code null}.
+   */
   @Override
   public void onSuccess(FetchResult result, ClientGetter state) {
     if (LOG.isTraceEnabled())
-      LOG.trace("NullClientCallback#onSuccess result=" + result + ", state=" + state);
+      LOG.trace("NullClientCallback#onSuccess result={}, state={}", result, state);
     result.data.free();
   }
 
+  /**
+   * Handles successful completion of an insert without additional processing.
+   *
+   * <p>This implementation logs the provided {@link BaseClientPutter} at trace level when tracing
+   * is enabled and otherwise does nothing. It does not inspect or free any buckets associated with
+   * the insert; higher-level code remains responsible for releasing resources that are not managed
+   * automatically by the insert pipeline.
+   *
+   * @param state the putter that has reached a terminal success state; may be {@code null} and is
+   *     used exclusively for logging.
+   */
   @Override
   public void onSuccess(BaseClientPutter state) {
-    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onSuccess state=" + state);
+    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onSuccess state={}", state);
   }
 
+  /**
+   * Handles generated metadata by logging and freeing the associated {@link Bucket}.
+   *
+   * <p>This implementation logs the {@link BaseClientPutter} at trace level when tracing is enabled
+   * and then invokes {@link Bucket#free()} on the supplied metadata bucket. After this method
+   * returns the bucket is considered released; callers must not read from it or free it again. The
+   * metadata is not persisted or passed to other components.
+   *
+   * @param metadata the metadata bucket returned instead of a URI; this implementation always frees
+   *     the bucket and treats it as consumed.
+   * @param state the putter associated with the metadata; used only for logging and may be {@code
+   *     null}.
+   */
   @Override
   public void onGeneratedMetadata(Bucket metadata, BaseClientPutter state) {
-    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onGeneratedMetadata state=" + state);
+    if (LOG.isTraceEnabled()) LOG.trace("NullClientCallback#onGeneratedMetadata state={}", state);
     metadata.free();
   }
 
+  /**
+   * Resumes this callback instance after a node restart.
+   *
+   * <p>This implementation intentionally performs no work because the callback does not track any
+   * persistent client-side state. It is still invoked by the surrounding persistence framework to
+   * satisfy the {@link network.crypta.client.async.ClientBaseCallback} contract. The method is
+   * idempotent and inexpensive to call.
+   *
+   * @param context the execution context used by other callbacks to reattach persistent resources;
+   *     ignored by this implementation but expected to be non-{@code null}.
+   */
   @Override
   public void onResume(ClientContext context) {
     // Do nothing.
   }
 
+  /**
+   * Returns the scheduling identity associated with this callback.
+   *
+   * <p>The returned {@link RequestClient} is exactly the instance supplied to the constructor; it
+   * is never wrapped, cloned, or lazily initialized. Callers typically expose this identity to the
+   * scheduler so that multiple requests sharing the same client can be grouped for accounting and
+   * prioritization.
+   *
+   * @return the {@link RequestClient} originally provided at construction time; may be {@code null}
+   *     if a {@code null} reference was supplied to the constructor.
+   */
   @Override
   public RequestClient getRequestClient() {
     return cb;

--- a/src/test/java/network/crypta/client/NullClientCallbackTest.java
+++ b/src/test/java/network/crypta/client/NullClientCallbackTest.java
@@ -1,0 +1,162 @@
+package network.crypta.client;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.async.BaseClientPutter;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class NullClientCallbackTest {
+
+  @Mock private RequestClient requestClient;
+
+  @Mock private Bucket bucket;
+
+  @Mock private Bucket metadataBucket;
+
+  @Mock private ClientGetter clientGetter;
+
+  @Mock private BaseClientPutter baseClientPutter;
+
+  @Mock private ClientContext clientContext;
+
+  @Test
+  void getRequestClient_whenConstructed_expectSameInstanceReturned() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+
+    // Act
+    RequestClient result = callback.getRequestClient();
+
+    // Assert
+    assertSame(requestClient, result);
+  }
+
+  @Test
+  void onSuccess_whenFetchResultProvided_expectBucketFreed() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    FetchResult fetchResult = new FetchResult(metadata, bucket);
+
+    // Act
+    callback.onSuccess(fetchResult, clientGetter);
+
+    // Assert
+    verify(bucket).free();
+  }
+
+  @Test
+  void onSuccess_whenBucketFreeThrowsRuntimeException_expectExceptionPropagated() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    FetchResult fetchResult = new FetchResult(metadata, bucket);
+    RuntimeException failure = new RuntimeException("free failed");
+    doThrow(failure).when(bucket).free();
+
+    // Act & Assert
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> callback.onSuccess(fetchResult, clientGetter));
+    assertSame(failure, thrown);
+  }
+
+  @Test
+  void onGeneratedMetadata_whenBucketProvided_expectMetadataBucketFreed() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+
+    // Act
+    callback.onGeneratedMetadata(metadataBucket, baseClientPutter);
+
+    // Assert
+    verify(metadataBucket).free();
+  }
+
+  @Test
+  void onGeneratedMetadata_whenFreeThrowsRuntimeException_expectExceptionPropagated() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+    RuntimeException failure = new RuntimeException("free failed");
+    doThrow(failure).when(metadataBucket).free();
+
+    // Act & Assert
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class,
+            () -> callback.onGeneratedMetadata(metadataBucket, baseClientPutter));
+    assertSame(failure, thrown);
+  }
+
+  @Test
+  void onFailureFetch_whenCalled_expectNoException() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+    FetchException exception = new FetchException(FetchExceptionMode.INTERNAL_ERROR);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> callback.onFailure(exception, clientGetter));
+  }
+
+  @Test
+  void onFailureInsert_whenCalled_expectNoException() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+    InsertException exception = new InsertException(InsertExceptionMode.INTERNAL_ERROR);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> callback.onFailure(exception, baseClientPutter));
+  }
+
+  @Test
+  void onFetchable_whenCalled_expectNoException() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> callback.onFetchable(baseClientPutter));
+  }
+
+  @Test
+  void onGeneratedURI_whenCalled_expectNoException() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+    FreenetURI uri = new FreenetURI("CHK", null);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> callback.onGeneratedURI(uri, baseClientPutter));
+  }
+
+  @Test
+  void onSuccessPutter_whenCalled_expectNoException() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> callback.onSuccess(baseClientPutter));
+  }
+
+  @Test
+  void onResume_whenCalled_expectNoException() {
+    // Arrange
+    NullClientCallback callback = new NullClientCallback(requestClient);
+
+    // Act & Assert
+    assertDoesNotThrow(() -> callback.onResume(clientContext));
+  }
+}


### PR DESCRIPTION
## Summary

This PR documents `NullClientCallback` with doclint-clean Javadoc and adds a focused unit test that verifies its null-object semantics and resource handling.

## Changes

- **NullClientCallback Javadoc** (`src/main/java/network/crypta/client/NullClientCallback.java`)
  - Replaces the empty class-level Javadoc with a detailed description of its role as a null-object implementation of `ClientGetCallback` and `ClientPutCallback`.
  - Documents constructor semantics and the relationship between the callback and its `RequestClient`.
  - Adds method-level Javadoc for all public callbacks, including:
    - `onFailure(FetchException, ClientGetter)` and `onFailure(InsertException, BaseClientPutter)`
    - `onFetchable(BaseClientPutter)` and `onGeneratedURI(FreenetURI, BaseClientPutter)`
    - `onSuccess(FetchResult, ClientGetter)` and `onSuccess(BaseClientPutter)`
    - `onGeneratedMetadata(Bucket, BaseClientPutter)`
    - `onResume(ClientContext)` and `getRequestClient()`
  - Clarifies that the implementation logs at trace level only, does not perform retries or higher-level recovery, and is responsible for freeing data/metadata buckets on success paths.

- **New tests for NullClientCallback** (`src/test/java/network/crypta/client/NullClientCallbackTest.java`)
  - Verifies that `getRequestClient()` returns the same `RequestClient` instance passed into the constructor.
  - Asserts that `onSuccess(FetchResult, ClientGetter)` frees the underlying data bucket and propagates runtime exceptions from `Bucket.free()`.
  - Asserts that `onGeneratedMetadata(Bucket, BaseClientPutter)` frees the metadata bucket and propagates runtime exceptions from `Bucket.free()`.
  - Confirms that the remaining callbacks (`onFailure` variants, `onFetchable`, `onGeneratedURI`, `onSuccess(BaseClientPutter)`, `onResume`) are safe no-ops beyond trace logging and do not throw.

## Rationale

`NullClientCallback` is used when callers must provide a callback but do not need custom behavior. The previous implementation had minimal or missing documentation and no direct tests. This PR makes the class easier to understand and maintain, and it encodes its resource-management behavior (freeing buckets) in a deterministic test.

## Testing

- `./gradlew test --tests 'network.crypta.client.NullClientCallbackTest'`
- `./gradlew test`

Both targeted and full test suites pass locally.