### PR TITLE
fix(fcp): refactor AddPeer handling and tests

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -28,58 +28,155 @@ import network.crypta.node.PeerTooOldException;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.MediaType;
 import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * FCP message that adds a new peer reference to the running node.
+ *
+ * <p>Instances of this class are constructed from a {@link SimpleFieldSet} received over an FCP
+ * connection. The constructor parses common metadata such as {@code Identifier}, {@code Trust}, and
+ * {@code Visibility}, and, when present, the peer reference itself or an indirection to it using a
+ * {@code URL} or {@code File} field. During {@link #run(FCPConnectionHandler, Node)} the message
+ * resolves the reference, validates that it is well-formed and not a self reference, and finally
+ * installs the new peer in the node's darknet or opennet peer table.
+ *
+ * <p>The implementation enforces full-access permissions, rejects duplicate peers, and translates
+ * low-level parsing or network errors into {@link MessageInvalidException} instances that are
+ * reported back to the client as protocol errors. AddPeer instances are not thread-safe and are
+ * intended to be used only within the {@link FCPConnectionHandler} that is currently processing the
+ * corresponding FCP connection.
+ *
+ * <p>Typical callers do not construct this class directly; instead they delegate to {@link
+ * FCPMessage#create(String, SimpleFieldSet)} after decoding the message name and fields from the
+ * wire.
+ *
+ * @see PeerMessage
+ * @see Node#addPeerConnection(PeerNode)
+ */
 public class AddPeer extends FCPMessage {
   private static final Logger LOG = LoggerFactory.getLogger(AddPeer.class);
 
+  /**
+   * Protocol message name constant for {@code AddPeer}.
+   *
+   * <p>FCP clients send this value as the textual message name when requesting that the node add a
+   * new peer reference, and the server uses it when selecting {@link AddPeer} from {@link
+   * FCPMessage#create(String, SimpleFieldSet)} while decoding inbound messages.
+   */
   public static final String NAME = "AddPeer";
 
   SimpleFieldSet fs;
-  final String identifier;
+  final String messageIdentifier;
   final FRIEND_TRUST trust;
   final FRIEND_VISIBILITY visibility;
 
+  /**
+   * Creates a new {@link AddPeer} instance from the supplied field set.
+   *
+   * <p>The constructor extracts the {@code Identifier}, {@code Trust}, and {@code Visibility}
+   * fields from {@code fs}, storing the identifier for later replies and converting the trust and
+   * visibility strings to the corresponding {@link FRIEND_TRUST} and {@link FRIEND_VISIBILITY}
+   * enumeration values. The extracted keys are removed from the field set so that the remaining
+   * data describes only the peer reference itself or indirections to it such as {@code URL} and
+   * {@code File} fields.
+   *
+   * <p>No I/O is performed at construction time. Any issues with missing or invalid fields are
+   * reported immediately via {@link MessageInvalidException}, allowing callers to send a clear
+   * protocol error back to the client before attempting to interact with the node.
+   *
+   * @param fs client-supplied field set containing the decoded AddPeer request fields, including
+   *     identifier, trust, visibility, and peer reference information; must not be {@code null}
+   * @throws MessageInvalidException if required fields are missing, empty, or cannot be converted
+   *     into valid {@link FRIEND_TRUST} or {@link FRIEND_VISIBILITY} values
+   */
   public AddPeer(SimpleFieldSet fs) throws MessageInvalidException {
     this.fs = fs;
-    this.identifier = fs.get("Identifier");
+    this.messageIdentifier = fs.get("Identifier");
     fs.removeValue("Identifier");
     try {
       this.trust = FRIEND_TRUST.valueOf(fs.get("Trust"));
       fs.removeValue("Trust");
     } catch (NullPointerException e) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "AddPeer requires Trust", identifier, false);
+          ProtocolErrorMessage.MISSING_FIELD, "AddPeer requires Trust", messageIdentifier, false);
     } catch (IllegalArgumentException e) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD, "Invalid Trust value on AddPeer", identifier, false);
+          ProtocolErrorMessage.INVALID_FIELD,
+          "Invalid Trust value on AddPeer",
+          messageIdentifier,
+          false);
     }
     try {
       this.visibility = FRIEND_VISIBILITY.valueOf(fs.get("Visibility"));
       fs.removeValue("Visibility");
     } catch (NullPointerException e) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "AddPeer requires Visibility", identifier, false);
+          ProtocolErrorMessage.MISSING_FIELD,
+          "AddPeer requires Visibility",
+          messageIdentifier,
+          false);
     } catch (IllegalArgumentException e) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD,
           "Invalid Visibility value on AddPeer",
-          identifier,
+          messageIdentifier,
           false);
     }
   }
 
+  /**
+   * Returns the field set used when serializing this message to the wire.
+   *
+   * <p>This implementation returns a new, initially empty {@link SimpleFieldSet} instance with the
+   * appropriate structural flags. As a consequence, outbound AddPeer messages contain only the
+   * protocol message name without additional fields. Server-side processing instead relies on the
+   * constructor-supplied field set stored in the {@link #fs} field when handling incoming messages.
+   *
+   * @return a new, empty {@link SimpleFieldSet} that results in a minimal on-the-wire
+   *     representation when {@link #send(java.io.OutputStream)} is invoked
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Returns the FCP message name for this type.
+   *
+   * <p>The returned value is always {@link #NAME}. It is written as the first line of the
+   * serialized message output and is also consulted by {@link FCPMessage#create(String,
+   * SimpleFieldSet)} when mapping inbound messages to concrete implementations such as {@link
+   * AddPeer}.
+   *
+   * @return non-{@code null} message name token identifying the AddPeer request type on the wire
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Fetches a peer reference document from the given URL.
+   *
+   * <p>This helper opens a {@link URLConnection}, selects an appropriate character set using {@link
+   * MediaType#getCharsetRobustOrUTF(String)} based on the {@code Content-Type} header, and reads
+   * the entire response as text. Lines are appended to a {@link StringBuilder} in order with single
+   * {@code '\n'} separators, producing a form that can later be parsed into a {@link
+   * SimpleFieldSet} representation of the peer reference.
+   *
+   * <p>The connection's input stream is closed automatically when the method returns, but the
+   * {@link URLConnection} itself is not further configured (for example, no timeouts are changed).
+   * Callers are expected to provide a URL that yields a small text document containing the desired
+   * reference.
+   *
+   * @param url absolute URL pointing to a textual peer reference document; must not be {@code null}
+   * @return mutable buffer containing the full textual contents of the response, including trailing
+   *     newline characters if present
+   * @throws IOException if establishing the connection or reading the response body fails for any
+   *     reason, including network errors or unexpected end-of-stream conditions
+   */
   public static StringBuilder getReferenceFromURL(URL url) throws IOException {
     StringBuilder ref = new StringBuilder(1024);
 
@@ -97,16 +194,38 @@ public class AddPeer extends FCPMessage {
     }
   }
 
+  /**
+   * Fetches a peer reference document from a {@link FreenetURI}.
+   *
+   * <p>The supplied {@link HighLevelSimpleClient} is used to request up to approximately
+   * 31&nbsp;000 bytes of data from the given URI. The response is exposed as a {@link Bucket}, from
+   * which this method opens an input stream and reads the contents as text using {@link
+   * MediaType#getCharsetRobustOrUTF(String)} with a {@code text/plain} content type hint. Each line
+   * of text is appended to a {@link StringBuilder} with a single {@code '\n'} separator, producing
+   * a buffer suitable for later parsing into a {@link SimpleFieldSet}.
+   *
+   * <p>The client instance is not closed or modified by this method; callers remain responsible for
+   * its lifecycle and any broader request management. This helper focuses purely on efficiently
+   * retrieving small textual reference documents.
+   *
+   * @param url Freenet URI locating the remotely stored peer reference document; must not be {@code
+   *     null}
+   * @param client high-level client instance used to perform the fetch within the appropriate
+   *     request priority class and security context; must be configured for the target node
+   * @return mutable buffer containing the full textual contents of the fetched document, including
+   *     any trailing newline characters
+   * @throws IOException if reading the fetched data from the node fails due to I/O errors in the
+   *     underlying stream
+   * @throws FetchException if the URI cannot be fetched successfully, for example due to routing
+   *     failures, timeouts, or protocol-level error responses
+   */
   public static StringBuilder getReferenceFromFreenetURI(
       FreenetURI url, HighLevelSimpleClient client) throws IOException, FetchException {
     StringBuilder ref = new StringBuilder(1024); // the 1024 is the initial capacity
 
-    try (InputStream is =
-            client
-                .fetch(url, 31000)
-                .asBucket()
-                .getInputStream(); // limit to 31k, which should suffice even if we add many more
-        // ipv6 addresses
+    try (Bucket bucket = client.fetch(url, 31000).asBucket();
+        // limit to 31k, which should suffice even if we add many more ipv6 addresses
+        InputStream is = bucket.getInputStream();
         BufferedReader in =
             new BufferedReader(
                 new InputStreamReader(is, MediaType.getCharsetRobustOrUTF("text/plain")))) {
@@ -119,206 +238,254 @@ public class AddPeer extends FCPMessage {
     }
   }
 
+  /**
+   * Executes the AddPeer request against the supplied node.
+   *
+   * <p>The method first enforces that the originating FCP connection has full-access permissions,
+   * rejecting the request with {@link ProtocolErrorMessage#ACCESS_DENIED} when the handler lacks
+   * the required capabilities. It then resolves the peer reference from the constructor-supplied
+   * field set, optionally dereferencing a {@code URL} or {@code File} indirection, and parses the
+   * resulting text into a structured {@link SimpleFieldSet}.
+   *
+   * <p>Depending on whether the {@code opennet} flag is present, the implementation creates either
+   * an opennet or darknet {@link PeerNode}, validates that the reference does not describe the node
+   * itself, and attempts to register the new peer with the node's peer manager. Any parse errors,
+   * signature problems, duplicate identities, or configuration constraints are reported via {@link
+   * MessageInvalidException} with an appropriate {@link ProtocolErrorMessage} code, which the
+   * handler will translate into a protocol error response.
+   *
+   * @param handler connection handler representing the client session that issued the AddPeer
+   *     request; used to send back the resulting {@link PeerMessage} or error messages
+   * @param node running node instance to which the new peer should be added and from which client
+   *     fetches and peer database operations are performed
+   * @throws MessageInvalidException if access is denied, the peer reference cannot be parsed or
+   *     verified, the reference describes the node itself, or a peer with the same identity already
+   *     exists on the node
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+    ensureFullAccess(handler);
+    fs = resolveFieldSetForReference(node);
+    fs.setEndMarker("End");
+    PeerNode peerNode = createPeer(node);
+    handler.send(new PeerMessage(peerNode, true, true, messageIdentifier));
+  }
+
+  private void ensureFullAccess(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "AddPeer requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "AddPeer requires full access",
+          messageIdentifier,
+          false);
     }
+  }
+
+  private SimpleFieldSet resolveFieldSetForReference(Node node) throws MessageInvalidException {
     String urlString = fs.get("URL");
-    String fileString = fs.get("File");
-    StringBuilder ref = null;
     if (urlString != null) {
-      try {
-        try {
-          FreenetURI refUri = new FreenetURI(urlString);
-          HighLevelSimpleClient client =
-              node.getClientCore()
-                  .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
-          ref = AddPeer.getReferenceFromFreenetURI(refUri, client);
-        } catch (MalformedURLException | FetchException e) {
-          LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: " + urlString);
-          URL url;
-          try {
-            url = URI.create(urlString).toURL();
-          } catch (IllegalArgumentException uriException) {
-            throw new MalformedURLException(uriException.getMessage());
-          }
-          ref = AddPeer.getReferenceFromURL(url);
-        }
-      } catch (MalformedURLException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.URL_PARSE_ERROR,
-            "Error parsing ref URL <" + urlString + ">: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (IOException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.URL_PARSE_ERROR,
-            "IO error while retrieving ref URL <" + urlString + ">: " + e.getMessage(),
-            identifier,
-            false);
-      }
-      ref = new StringBuilder(ref.toString().trim());
-      if (ref.toString().isEmpty()) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref from URL <" + urlString + '>',
-            identifier,
-            false);
-      }
-      try {
-        fs = new SimpleFieldSet(ref.toString(), false, true, true);
-      } catch (IOException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref from URL <" + urlString + ">: " + e.getMessage(),
-            identifier,
-            false);
-      }
-    } else if (fileString != null) {
-      File f = new File(fileString);
-      if (!f.isFile()) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.NOT_A_FILE_ERROR,
-            "The given ref file path <" + fileString + "> is not a file",
-            identifier,
-            false);
-      }
-      try (BufferedReader in =
-          new BufferedReader(
-              new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8))) {
-        ref = new StringBuilder(1024);
-        String line;
-        while ((line = in.readLine()) != null) {
-          line = line.trim();
-          ref.append(line).append('\n');
-        }
-      } catch (FileNotFoundException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.FILE_NOT_FOUND,
-            "File not found when retrieving ref file <" + fileString + ">: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (IOException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.FILE_PARSE_ERROR,
-            "IO error while retrieving ref file <" + fileString + ">: " + e.getMessage(),
-            identifier,
-            false);
-      }
-      ref = new StringBuilder(ref.toString().trim());
-      if (ref.toString().isEmpty()) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref from file <" + fileString + '>',
-            identifier,
-            false);
-      }
-      try {
-        fs = new SimpleFieldSet(ref.toString(), false, true, true);
-      } catch (IOException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref from file <" + fileString + ">: " + e.getMessage(),
-            identifier,
-            false);
-      }
+      return buildFieldSetFromUrl(urlString, node);
     }
-    fs.setEndMarker("End");
-    PeerNode pn;
+    String fileString = fs.get("File");
+    if (fileString != null) {
+      return buildFieldSetFromFile(fileString);
+    }
+    return fs;
+  }
+
+  private SimpleFieldSet buildFieldSetFromUrl(String urlString, Node node)
+      throws MessageInvalidException {
+    StringBuilder ref = fetchReferenceFromUrl(urlString, node);
+    String refString = ref.toString().trim();
+    if (refString.isEmpty()) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.REF_PARSE_ERROR,
+          "Error parsing ref from URL <" + urlString + '>',
+          messageIdentifier,
+          false);
+    }
+    try {
+      return new SimpleFieldSet(refString, false, true, true);
+    } catch (IOException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.REF_PARSE_ERROR,
+          "Error parsing ref from URL <" + urlString + ">: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    }
+  }
+
+  private StringBuilder fetchReferenceFromUrl(String urlString, Node node)
+      throws MessageInvalidException {
+    try {
+      return tryFetchFromCryptaUriOrUrl(urlString, node);
+    } catch (MalformedURLException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.URL_PARSE_ERROR,
+          "Error parsing ref URL <" + urlString + ">: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    } catch (IOException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.URL_PARSE_ERROR,
+          "IO error while retrieving ref URL <" + urlString + ">: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    }
+  }
+
+  private StringBuilder tryFetchFromCryptaUriOrUrl(String urlString, Node node) throws IOException {
+    try {
+      FreenetURI refUri = new FreenetURI(urlString);
+      HighLevelSimpleClient client =
+          node.getClientCore()
+              .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+      return AddPeer.getReferenceFromFreenetURI(refUri, client);
+    } catch (MalformedURLException | FetchException e) {
+      LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: {}", urlString);
+      URL url = createUrlFromString(urlString);
+      return AddPeer.getReferenceFromURL(url);
+    }
+  }
+
+  private URL createUrlFromString(String urlString) throws MalformedURLException {
+    try {
+      return URI.create(urlString).toURL();
+    } catch (IllegalArgumentException uriException) {
+      throw new MalformedURLException(uriException.getMessage());
+    }
+  }
+
+  private SimpleFieldSet buildFieldSetFromFile(String fileString) throws MessageInvalidException {
+    StringBuilder ref = readReferenceFromFile(fileString);
+    String refString = ref.toString().trim();
+    if (refString.isEmpty()) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.REF_PARSE_ERROR,
+          "Error parsing ref from file <" + fileString + '>',
+          messageIdentifier,
+          false);
+    }
+    try {
+      return new SimpleFieldSet(refString, false, true, true);
+    } catch (IOException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.REF_PARSE_ERROR,
+          "Error parsing ref from file <" + fileString + ">: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    }
+  }
+
+  private StringBuilder readReferenceFromFile(String fileString) throws MessageInvalidException {
+    File file = new File(fileString);
+    if (!file.isFile()) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.NOT_A_FILE_ERROR,
+          "The given ref file path <" + fileString + "> is not a file",
+          messageIdentifier,
+          false);
+    }
+    StringBuilder ref = new StringBuilder(1024);
+    try (BufferedReader in =
+        new BufferedReader(
+            new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = in.readLine()) != null) {
+        ref.append(line.trim()).append('\n');
+      }
+      return ref;
+    } catch (FileNotFoundException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.FILE_NOT_FOUND,
+          "File not found when retrieving ref file <" + fileString + ">: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    } catch (IOException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.FILE_PARSE_ERROR,
+          "IO error while retrieving ref file <" + fileString + ">: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    }
+  }
+
+  private PeerNode createPeer(Node node) throws MessageInvalidException {
     boolean isOpennetRef = fs.getBoolean("opennet", false);
-    if (isOpennetRef) {
-      try {
-        pn = node.createNewOpennetNode(fs);
-      } catch (FSParseException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (OpennetDisabledException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.OPENNET_DISABLED,
-            "Error adding ref: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (PeerParseException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (ReferenceSignatureVerificationException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_SIGNATURE_INVALID,
-            "Error adding ref: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (PeerTooOldException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref: " + e.getMessage(),
-            identifier,
-            false);
-      }
-      if (Arrays.equals(pn.peerECDSAPubKeyHash, node.getOpennetPubKeyHash()))
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.CANNOT_PEER_WITH_SELF,
-            "Node cannot peer with itself",
-            identifier,
-            false);
-      if (!node.addPeerConnection(pn)) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.DUPLICATE_PEER_REF,
-            "Node already has a peer with that identity",
-            identifier,
-            false);
-      }
-      System.out.println("Added opennet peer: " + pn);
-    } else {
-      try {
-        pn = node.createNewDarknetNode(fs, trust, visibility);
-      } catch (FSParseException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (PeerParseException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (ReferenceSignatureVerificationException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_SIGNATURE_INVALID,
-            "Error adding ref: " + e.getMessage(),
-            identifier,
-            false);
-      } catch (PeerTooOldException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.REF_PARSE_ERROR,
-            "Error parsing ref: " + e.getMessage(),
-            identifier,
-            false);
-      }
-      if (Arrays.equals(pn.peerECDSAPubKeyHash, node.getDarknetPubKeyHash()))
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.CANNOT_PEER_WITH_SELF,
-            "Node cannot peer with itself",
-            identifier,
-            false);
-      if (!node.addPeerConnection(pn)) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.DUPLICATE_PEER_REF,
-            "Node already has a peer with that identity",
-            identifier,
-            false);
-      }
-      System.out.println("Added darknet peer: " + pn);
+    PeerNode peerNode = isOpennetRef ? createOpennetPeer(node) : createDarknetPeer(node);
+    ensureNotSelfPeer(node, isOpennetRef, peerNode);
+    addPeerConnection(node, isOpennetRef, peerNode);
+    return peerNode;
+  }
+
+  private PeerNode createOpennetPeer(Node node) throws MessageInvalidException {
+    try {
+      return node.createNewOpennetNode(fs);
+    } catch (FSParseException | PeerParseException | PeerTooOldException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.REF_PARSE_ERROR,
+          "Error parsing ref: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    } catch (OpennetDisabledException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.OPENNET_DISABLED,
+          "Error adding ref: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    } catch (ReferenceSignatureVerificationException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.REF_SIGNATURE_INVALID,
+          "Error adding ref: " + e.getMessage(),
+          messageIdentifier,
+          false);
     }
-    handler.send(new PeerMessage(pn, true, true, identifier));
+  }
+
+  private PeerNode createDarknetPeer(Node node) throws MessageInvalidException {
+    try {
+      return node.createNewDarknetNode(fs, trust, visibility);
+    } catch (FSParseException | PeerParseException | PeerTooOldException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.REF_PARSE_ERROR,
+          "Error parsing ref: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    } catch (ReferenceSignatureVerificationException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.REF_SIGNATURE_INVALID,
+          "Error adding ref: " + e.getMessage(),
+          messageIdentifier,
+          false);
+    }
+  }
+
+  private void ensureNotSelfPeer(Node node, boolean isOpennetRef, PeerNode peerNode)
+      throws MessageInvalidException {
+    byte[] nodePubKeyHash =
+        isOpennetRef ? node.getOpennetPubKeyHash() : node.getDarknetPubKeyHash();
+    if (Arrays.equals(peerNode.peerECDSAPubKeyHash, nodePubKeyHash)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.CANNOT_PEER_WITH_SELF,
+          "Node cannot peer with itself",
+          messageIdentifier,
+          false);
+    }
+  }
+
+  private void addPeerConnection(Node node, boolean isOpennetRef, PeerNode peerNode)
+      throws MessageInvalidException {
+    if (!node.addPeerConnection(peerNode)) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.DUPLICATE_PEER_REF,
+          "Node already has a peer with that identity",
+          messageIdentifier,
+          false);
+    }
+    if (isOpennetRef) {
+      LOG.info("Added opennet peer: {}", peerNode);
+    } else {
+      LOG.info("Added darknet peer: {}", peerNode);
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
@@ -1,0 +1,406 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchResult;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.io.comm.ReferenceSignatureVerificationException;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.node.FSParseException;
+import network.crypta.node.Node;
+import network.crypta.node.OpennetDisabledException;
+import network.crypta.node.OpennetPeerNode;
+import network.crypta.node.PeerNode;
+import network.crypta.node.PeerTooOldException;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings({"java:S100", "java:S2095", "resource"})
+@ExtendWith(MockitoExtension.class)
+class AddPeerTest {
+
+  private static final String IDENTIFIER = "test-ident";
+
+  @Test
+  void constructor_whenTrustMissing_throwsMessageInvalidExceptionWithMissingFieldCode() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    // No Trust field
+    fs.putSingle("Visibility", FRIEND_VISIBILITY.YES.name());
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new AddPeer(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("AddPeer requires Trust", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
+  void constructor_whenTrustInvalid_throwsMessageInvalidExceptionWithInvalidFieldCode() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("Trust", "NOT_A_VALID_VALUE");
+    fs.putSingle("Visibility", FRIEND_VISIBILITY.YES.name());
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new AddPeer(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals("Invalid Trust value on AddPeer", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
+  void constructor_whenVisibilityMissing_throwsMessageInvalidExceptionWithMissingFieldCode() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("Trust", FRIEND_TRUST.NORMAL.name());
+    // No Visibility field
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new AddPeer(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("AddPeer requires Visibility", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
+  void constructor_whenVisibilityInvalid_throwsMessageInvalidExceptionWithInvalidFieldCode() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("Trust", FRIEND_TRUST.NORMAL.name());
+    fs.putSingle("Visibility", "NOT_A_VALID_VALUE");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new AddPeer(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals("Invalid Visibility value on AddPeer", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
+  void getName_whenCalled_returnsAddPeerConstant() throws MessageInvalidException {
+    SimpleFieldSet fs = minimalValidFieldSet();
+
+    AddPeer addPeer = new AddPeer(fs);
+
+    assertEquals(AddPeer.NAME, addPeer.getName());
+  }
+
+  @Test
+  void getFieldSet_whenCalled_returnsNonNullEmptyFieldSet() throws MessageInvalidException {
+    SimpleFieldSet fs = minimalValidFieldSet();
+
+    AddPeer addPeer = new AddPeer(fs);
+
+    SimpleFieldSet result = addPeer.getFieldSet();
+    assertNotNull(result);
+    // A freshly created SimpleFieldSet should not contain user data yet.
+    assertNull(result.get("Identifier"));
+  }
+
+  @Test
+  void getReferenceFromURL_whenFileHasTwoLines_readsBothLinesWithTrailingNewlines(
+      @TempDir Path tempDir) throws IOException {
+    Path file = tempDir.resolve("peer-ref.txt");
+    Files.writeString(file, "line1\nline2\n", StandardCharsets.UTF_8);
+
+    URL url = file.toUri().toURL();
+
+    StringBuilder result = AddPeer.getReferenceFromURL(url);
+
+    assertEquals("line1\nline2\n", result.toString());
+  }
+
+  @Test
+  void getReferenceFromFreenetURI_whenClientReturnsBucket_readsBucketContent() throws Exception {
+    Bucket bucket = new ArrayBucket();
+    try (OutputStream out = bucket.getOutputStream()) {
+      out.write("ref-line-1\nref-line-2\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    FetchResult fetchResult = new FetchResult(new ClientMetadata("text/plain"), bucket);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    when(client.fetch(any(FreenetURI.class), eq(31000L))).thenReturn(fetchResult);
+
+    FreenetURI uri = mock(FreenetURI.class);
+
+    StringBuilder result = AddPeer.getReferenceFromFreenetURI(uri, client);
+
+    assertEquals("ref-line-1\nref-line-2\n", result.toString());
+  }
+
+  @Test
+  void run_whenHandlerHasNoFullAccess_throwsAccessDenied() throws MessageInvalidException {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(false);
+    Node node = mock(Node.class);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
+    assertEquals("AddPeer requires full access", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+    verifyNoMoreInteractions(node);
+  }
+
+  @Test
+  void run_whenOpennetRefCreatesPeer_addsPeerAndSendsPeerMessage() throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.put("opennet", true);
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    OpennetPeerNode peerNode = mock(OpennetPeerNode.class);
+    when(node.createNewOpennetNode(any(SimpleFieldSet.class))).thenReturn(peerNode);
+    when(node.getOpennetPubKeyHash()).thenReturn(new byte[] {1});
+    when(node.addPeerConnection(peerNode)).thenReturn(true);
+
+    addPeer.run(handler, node);
+
+    verify(node).createNewOpennetNode(any(SimpleFieldSet.class));
+    verify(node).addPeerConnection(peerNode);
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(messageCaptor.capture());
+    FCPMessage sent = messageCaptor.getValue();
+    assertNotNull(sent);
+    assertEquals(PeerMessage.class, sent.getClass());
+    PeerMessage peerMessage = (PeerMessage) sent;
+    assertEquals(IDENTIFIER, peerMessage.identifier);
+  }
+
+  @Test
+  void run_whenDarknetRefCreatesPeer_addsPeerWithConfiguredTrustAndVisibility() throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    // No opennet flag -> darknet
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    DarknetPeerNode peerNode = mock(DarknetPeerNode.class);
+    when(node.getDarknetPubKeyHash()).thenReturn(new byte[] {1});
+    when(node.addPeerConnection(peerNode)).thenReturn(true);
+
+    when(node.createNewDarknetNode(
+            any(SimpleFieldSet.class), any(FRIEND_TRUST.class), any(FRIEND_VISIBILITY.class)))
+        .thenReturn(peerNode);
+
+    addPeer.run(handler, node);
+
+    ArgumentCaptor<FRIEND_TRUST> trustCaptor = ArgumentCaptor.forClass(FRIEND_TRUST.class);
+    ArgumentCaptor<FRIEND_VISIBILITY> visibilityCaptor =
+        ArgumentCaptor.forClass(FRIEND_VISIBILITY.class);
+
+    verify(node)
+        .createNewDarknetNode(
+            any(SimpleFieldSet.class), trustCaptor.capture(), visibilityCaptor.capture());
+    verify(node).addPeerConnection(peerNode);
+
+    assertEquals(FRIEND_TRUST.NORMAL, trustCaptor.getValue());
+    assertEquals(FRIEND_VISIBILITY.YES, visibilityCaptor.getValue());
+  }
+
+  @Test
+  void run_whenOpennetRefIsSelf_throwsCannotPeerWithSelf() throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.put("opennet", true);
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    OpennetPeerNode peerNode = mock(OpennetPeerNode.class);
+    when(node.createNewOpennetNode(any(SimpleFieldSet.class))).thenReturn(peerNode);
+    when(node.getOpennetPubKeyHash()).thenReturn(null);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.CANNOT_PEER_WITH_SELF, exception.protocolCode);
+    verify(node, never()).addPeerConnection(any(PeerNode.class));
+  }
+
+  @Test
+  void run_whenOpennetRefDuplicatePeer_throwsDuplicatePeerRef() throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.put("opennet", true);
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    OpennetPeerNode peerNode = mock(OpennetPeerNode.class);
+    when(node.createNewOpennetNode(any(SimpleFieldSet.class))).thenReturn(peerNode);
+    when(node.getOpennetPubKeyHash()).thenReturn(new byte[] {1});
+    when(node.addPeerConnection(peerNode)).thenReturn(false);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.DUPLICATE_PEER_REF, exception.protocolCode);
+  }
+
+  @Test
+  void run_whenOpennetCreationFailsWithFSParseException_throwsRefParseError() throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.put("opennet", true);
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    when(node.createNewOpennetNode(any(SimpleFieldSet.class)))
+        .thenThrow(new FSParseException("parse-error"));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.REF_PARSE_ERROR, exception.protocolCode);
+  }
+
+  @Test
+  void run_whenOpennetCreationFailsWithOpennetDisabled_throwsOpennetDisabledError()
+      throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.put("opennet", true);
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    when(node.createNewOpennetNode(any(SimpleFieldSet.class)))
+        .thenThrow(new OpennetDisabledException("disabled"));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.OPENNET_DISABLED, exception.protocolCode);
+  }
+
+  @Test
+  void run_whenOpennetCreationFailsWithInvalidSignature_throwsRefSignatureInvalid()
+      throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.put("opennet", true);
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    when(node.createNewOpennetNode(any(SimpleFieldSet.class)))
+        .thenThrow(new ReferenceSignatureVerificationException("bad-sig"));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.REF_SIGNATURE_INVALID, exception.protocolCode);
+  }
+
+  @Test
+  void run_whenOpennetCreationFailsWithPeerTooOld_throwsRefParseError() throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.put("opennet", true);
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    when(node.createNewOpennetNode(any(SimpleFieldSet.class)))
+        .thenThrow(new PeerTooOldException("too-old", 1, null));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.REF_PARSE_ERROR, exception.protocolCode);
+  }
+
+  @Test
+  void run_whenDarknetCreationFailsWithInvalidSignature_throwsRefSignatureInvalid()
+      throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    Node node = mock(Node.class);
+    when(node.createNewDarknetNode(
+            any(SimpleFieldSet.class), any(FRIEND_TRUST.class), any(FRIEND_VISIBILITY.class)))
+        .thenThrow(new ReferenceSignatureVerificationException("bad-sig"));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.REF_SIGNATURE_INVALID, exception.protocolCode);
+  }
+
+  @Test
+  void run_whenFilePathIsDirectory_throwsNotAFileError(@TempDir Path tempDir)
+      throws MessageInvalidException {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.putSingle("File", tempDir.toString());
+
+    AddPeer addPeer = new AddPeer(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+    Node node = mock(Node.class);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.NOT_A_FILE_ERROR, exception.protocolCode);
+  }
+
+  private SimpleFieldSet minimalValidFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("Trust", FRIEND_TRUST.NORMAL.name());
+    fs.putSingle("Visibility", FRIEND_VISIBILITY.YES.name());
+    return fs;
+  }
+}


### PR DESCRIPTION
Summary
- Refactor `AddPeer` FCP message handling for clarity and robustness.
- Improve resource handling for FreenetURI fetches by using `Bucket` in try-with-resources.
- Strengthen error mapping from parsing/fetch failures to `ProtocolErrorMessage` codes.
- Add comprehensive unit tests for `AddPeer` covering constructor validation, URL/URI/file handling, and opennet/darknet peer creation flows.

Details
- Replace `identifier` field with clearer `messageIdentifier` and use it consistently when constructing `MessageInvalidException` instances.
- Factor `run()` logic into focused helpers:
  - `ensureFullAccess()` to enforce full-access FCP permissions.
  - `resolveFieldSetForReference()` to handle inline, URL, and file-based peer reference resolution.
  - `createPeer()`, `createOpennetPeer()`, `createDarknetPeer()` for opennet/darknet node creation with clear exception mapping.
  - `ensureNotSelfPeer()` and `addPeerConnection()` to guard against self-peering and duplicate peer refs.
- For FreenetURI-based references, use `Bucket` from `HighLevelSimpleClient.fetch()` and wrap both the bucket and its InputStream in try-with-resources, ensuring all resources are closed even on error.
- For URL and file-based references, centralize parsing and error handling into helpers that trim and validate the reference text before constructing a `SimpleFieldSet`.
- Introduce `AddPeerTest` with Mockito-based tests to verify:
  - Missing/invalid `Trust` and `Visibility` fields map to `MISSING_FIELD` / `INVALID_FIELD` codes.
  - `getName()` and `getFieldSet()` behavior.
  - `getReferenceFromURL()` and `getReferenceFromFreenetURI()` read content correctly.
  - `run()` behavior for opennet/darknet peers, self-peering detection, duplicate peers, and exception-to-protocol-code mapping.

Testing
- `./gradlew spotlessApply` (already run) to ensure formatting.
- Please run `./gradlew --parallel test` or the project’s preferred test command in your environment to validate the full test suite.