### PR TITLE
Improve FCP feed docs/tests and keep N2N hierarchy

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/BaseDataCarryingMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/BaseDataCarryingMessage.java
@@ -4,22 +4,117 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import network.crypta.support.api.BucketFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Base class for FCP messages that carry an additional binary payload alongside their structured
+ * header fields.
+ *
+ * <p>While {@link FCPMessage} deals only with the textual part of a Freenet Client Protocol (FCP)
+ * message, implementations of this type define how the trailing byte stream is read from and
+ * written to a connection. Typical subclasses use {@link BucketFactory} and related abstractions to
+ * buffer or stream large objects such as file data, directory structures, or metadata blocks
+ * without loading them entirely into memory.
+ *
+ * <p>Instances are usually short-lived and owned by a single connection handler; they are not
+ * inherently thread-safe and should not be shared across threads without external coordination. The
+ * life cycle of a message normally follows this pattern:
+ *
+ * <ul>
+ *   <li>the header is decoded into a {@link network.crypta.support.SimpleFieldSet} and mapped to a
+ *       concrete {@code BaseDataCarryingMessage} subclass;
+ *   <li>{@link #readFrom(InputStream, BucketFactory, FCPServer)} is invoked to consume the payload
+ *       bytes from the input stream; and
+ *   <li>later, {@link #send(OutputStream)} (which in turn calls {@link #writeData(OutputStream)})
+ *       is used to write the message back to a client or peer.
+ * </ul>
+ *
+ * <p>Subclasses must ensure that {@link #dataLength()} accurately reflects the number of bytes
+ * consumed and produced so that higher-level framing on the connection remains consistent and
+ * subsequent messages are parsed correctly.
+ */
 public abstract class BaseDataCarryingMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(BaseDataCarryingMessage.class);
 
+  /**
+   * Returns the length in bytes of the binary payload associated with this message.
+   *
+   * <p>The value is typically derived from header fields that have already been parsed before the
+   * payload is read or written. A non-negative value indicates the exact number of bytes that
+   * {@link #readFrom(InputStream, BucketFactory, FCPServer)} expects to consume from the incoming
+   * stream and that {@link #writeData(OutputStream)} will attempt to produce when the message is
+   * sent. Implementations may return a negative value to signal that no additional payload needs to
+   * be transferred for this particular message instance.
+   *
+   * @return payload length in bytes, or a negative value if the message does not have a separate
+   *     binary payload to transfer
+   */
   abstract long dataLength();
 
+  /**
+   * Reads the binary payload for this message from the supplied input stream.
+   *
+   * <p>This method is invoked after the textual header has been parsed and an instance of the
+   * concrete message type has been created. Implementations are expected to consume exactly {@code
+   * dataLength()} bytes from {@code is} (when the length is non-negative), using {@code bf} to
+   * allocate any temporary or persistent storage that backs the payload. The {@code server}
+   * parameter provides access to connection-local configuration or services that may influence how
+   * the data is stored. The input stream is not closed by this method; callers remain responsible
+   * for connection-level resource management.
+   *
+   * <p>Subclasses should validate that the payload matches the expectations derived from the
+   * header, and they should throw {@link MessageInvalidException} if inconsistencies, premature end
+   * of stream, or other protocol violations are detected.
+   *
+   * @param is input stream positioned at the start of the payload; must provide at least {@link
+   *     #dataLength()} readable bytes unless the implementation accepts a shorter payload
+   * @param bf bucket factory that implementations may use to allocate storage for the decoded
+   *     payload; typically non-{@code null} for messages that carry large or persistent data
+   * @param server FCP server instance associated with the current connection, which may be
+   *     consulted for configuration, logging, or helper services during decoding
+   * @throws IOException if an I/O error occurs while reading from {@code is} or interacting with
+   *     bucket storage
+   * @throws MessageInvalidException if the payload is malformed, violates protocol constraints, or
+   *     cannot be represented by this message implementation
+   */
   public abstract void readFrom(InputStream is, BucketFactory bf, FCPServer server)
       throws IOException, MessageInvalidException;
 
+  /**
+   * Sends this message, including its binary payload, to the supplied output stream.
+   *
+   * <p>This implementation first delegates to {@link FCPMessage#send(OutputStream)} to emit the
+   * textual header and field set, and then invokes {@link #writeData(OutputStream)} to stream the
+   * payload bytes. The method does not close or flush the stream; callers are responsible for
+   * framing, buffering, and lifecycle management at the connection level.
+   *
+   * <p>Subclasses should ensure that {@link #writeData(OutputStream)} writes exactly {@link
+   * #dataLength()} bytes when the length is non-negative so that subsequent messages are aligned
+   * correctly on the wire.
+   *
+   * @param os output stream that receives the serialized message header and payload; must remain
+   *     open and writable for the duration of the call
+   * @throws IOException if writing either the header or payload to {@code os} fails for any reason
+   */
   @Override
   public void send(OutputStream os) throws IOException {
     super.send(os);
     writeData(os);
   }
 
+  /**
+   * Writes the binary payload for this message to the given output stream.
+   *
+   * <p>This method is called exactly once by {@link #send(OutputStream)} after the textual header
+   * has been written. Implementations should stream the payload directly to {@code os}, avoiding
+   * unnecessary buffering for large objects when possible. They must not close or flush the stream,
+   * as those responsibilities belong to the caller managing the underlying connection.
+   *
+   * <p>Implementations should honor the contract implied by {@link #dataLength()} and write a
+   * number of bytes consistent with the value returned by that method so that the receiving side
+   * can safely parse the next message on the connection.
+   *
+   * @param os output stream to receive the payload bytes; must be non-{@code null} and writable for
+   *     the duration of the method call
+   * @throws IOException if an error occurs while retrieving or streaming the payload to {@code os}
+   */
   protected abstract void writeData(OutputStream os) throws IOException;
 }

--- a/src/main/java/network/crypta/clients/fcp/BookmarkFeed.java
+++ b/src/main/java/network/crypta/clients/fcp/BookmarkFeed.java
@@ -6,17 +6,91 @@ import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
 import network.crypta.support.io.NullBucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class BookmarkFeed extends N2NFeedMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(BookmarkFeed.class);
+/**
+ * Node-to-node feed message that advertises a bookmark recommendation to external FCP clients.
+ *
+ * <p>Instances encapsulate the full textual body exposed through {@link FeedMessage} alongside the
+ * originating peer metadata and a structured bookmark payload. Typical producers are darknet peers
+ * forwarding bookmark suggestions and UI alerts that render them; consumers are FCP clients that
+ * monitor feed streams to mirror remote peers' bookmarks. Each object is immutable after
+ * construction—the constructor computes all derived fields and the backing {@link Bucket} instances
+ * remain read-only, so callers may safely hand the instance to serialization routines without
+ * defensive copying.
+ *
+ * <p>The class focuses on accurately reporting provenance information. It stores the sending node
+ * name and the timestamps describing when the recommendation was composed, sent, and received.
+ * Downstream processing can therefore sort or filter entries based on message latency or recency
+ * before presenting them to users. Because {@code BookmarkFeed} extends {@link FeedMessage}, it
+ * participates in the same multipart payload semantics and inherits guarantees such as stable
+ * bucket iteration order and deterministic data lengths.
+ *
+ * <ul>
+ *   <li>Encapsulates bookmark metadata and peer timing data for FCP serialization.
+ *   <li>Stores optional free-form descriptions as dedicated multipart buckets.
+ *   <li>Produces {@link SimpleFieldSet} headers compatible with existing feed consumers.
+ * </ul>
+ *
+ * <p>Thread-safety: construction and population are single-threaded, but the resulting object is
+ * effectively immutable and may be shared between threads as long as no thread mutates the
+ * inherited bucket map. All fields are final except the map inherited from {@link FeedMessage},
+ * which is populated once in the constructor and then treated as read-only.
+ */
+public class BookmarkFeed extends FeedMessage {
 
+  /**
+   * Public FCP message identifier for bookmark notifications, emitted by {@link #getName()} and
+   * used by consumers to filter feed entries originating from this class. Clients monitoring {@code
+   * Feed} traffic compare against this constant to decide whether to render bookmark decoration, so
+   * the literal value must remain stable across protocol revisions.
+   */
   public static final String NAME = "BookmarkFeed";
-  private final String name;
-  private final FreenetURI URI;
-  private final boolean hasAnActivelink;
 
+  private final String bookmarkTitle;
+  private final FreenetURI bookmarkUri;
+  private final boolean hasAnActivelink;
+  private final String sourceNodeName;
+  private final long composed;
+  private final long sent;
+  private final long received;
+
+  /**
+   * Create a bookmark feed entry populated with peer metadata, descriptive text, and bookmark
+   * details ready to serialize over FCP.
+   *
+   * <p>The textual arguments describe what the peer recommends, while the timing parameters record
+   * when the peer composed, transmitted, and delivered the message. {@code description} becomes a
+   * dedicated {@link Bucket} named {@code "Description"}; if {@code null}, the bucket is replaced
+   * with a {@link NullBucket} placeholder to keep payload structure stable. All supplied strings
+   * are treated as display text, so callers should pre-sanitize any user-provided content.
+   *
+   * @param header single-line headline shown most prominently in feed readers; may be {@code null}
+   *     when the short text already summarizes the recommendation.
+   * @param shortText concise secondary summary that elaborates on {@code header}; {@code null}
+   *     values omit the field from the serialized header.
+   * @param text long-form body of the recommendation encoded in UTF-8 and stored as payload bytes;
+   *     must be non-{@code null}, and callers keep ownership of the original string.
+   * @param priorityClass numeric priority hint (higher values are sent sooner) mirrored into the
+   *     {@link SimpleFieldSet}; typical ranges align with other feed messages.
+   * @param updatedTime timestamp in milliseconds representing the producer's notion of freshness;
+   *     readers can use it to deduplicate edits.
+   * @param sourceNodeName human-readable identifier of the peer that originated the bookmark; may
+   *     be {@code null} or empty when anonymity is preferred.
+   * @param composed epoch milliseconds when the peer composed the message; pass {@code -1} if
+   *     unknown so the field is omitted from the serialized header.
+   * @param sent epoch milliseconds describing when the peer transmitted the entry; negative values
+   *     indicate the timestamp is not available.
+   * @param received milliseconds since epoch recording when this node ingested the message;
+   *     negative values omit the field, mirroring the other timestamps' conventions.
+   * @param bookmarkTitle short label for the bookmark being recommended; appears as {@code "Name"}
+   *     in the outgoing field set and should not contain newlines.
+   * @param bookmarkUri parsed Freenet URI pointing to the recommended resource; the constructor
+   *     stores the reference and later serializes it with {@link FreenetURI#toString()}.
+   * @param description optional textual description of the bookmark; when non-{@code null} it is
+   *     encoded as UTF-8 bytes and shipped as the {@code "Description"} bucket.
+   * @param hasAnActivelink flag signaling whether the recommendation includes a clickable link or
+   *     merely informational content.
+   */
   public BookmarkFeed(
       String header,
       String shortText,
@@ -27,23 +101,18 @@ public class BookmarkFeed extends N2NFeedMessage {
       long composed,
       long sent,
       long received,
-      String name,
-      FreenetURI URI,
+      String bookmarkTitle,
+      FreenetURI bookmarkUri,
       String description,
       boolean hasAnActivelink) {
-    super(
-        header,
-        shortText,
-        text,
-        priorityClass,
-        updatedTime,
-        sourceNodeName,
-        composed,
-        sent,
-        received);
-    this.name = name;
-    this.URI = URI;
+    super(header, shortText, text, priorityClass, updatedTime);
+    this.bookmarkTitle = bookmarkTitle;
+    this.bookmarkUri = bookmarkUri;
     this.hasAnActivelink = hasAnActivelink;
+    this.sourceNodeName = sourceNodeName;
+    this.composed = composed;
+    this.sent = sent;
+    this.received = received;
     final Bucket descriptionBucket;
     if (description != null) {
       descriptionBucket = new ArrayBucket(description.getBytes(StandardCharsets.UTF_8));
@@ -53,15 +122,39 @@ public class BookmarkFeed extends N2NFeedMessage {
     buckets.put("Description", descriptionBucket);
   }
 
+  /**
+   * Build the structured representation of this bookmark entry, combining inherited feed metadata
+   * with node provenance and bookmark-specific fields.
+   *
+   * <p>The returned {@link SimpleFieldSet} is a fresh copy per invocation. It always contains the
+   * base feed keys from {@link FeedMessage#getFieldSet()} plus {@code SourceNodeName}. The
+   * timestamp trio is included only when their corresponding fields are non-negative, preserving
+   * backward compatibility with peers that never supplied such data. Finally, the bookmark title,
+   * URI, and active-link flag are appended for client consumption.
+   *
+   * @return mutable field set describing the entire message; callers may modify it without
+   *     affecting this instance, and bucket payloads remain owned by the message.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = super.getFieldSet();
-    fs.putSingle("Name", name);
-    fs.putSingle("URI", URI.toString());
+    fs.putSingle("SourceNodeName", sourceNodeName);
+    if (composed >= 0) fs.put("TimeComposed", composed);
+    if (sent >= 0) fs.put("TimeSent", sent);
+    if (received >= 0) fs.put("TimeReceived", received);
+    fs.putSingle("Name", bookmarkTitle);
+    fs.putSingle("URI", bookmarkUri.toString());
     fs.put("HasAnActivelink", hasAnActivelink);
     return fs;
   }
 
+  /**
+   * Return the wire-level identifier for this message type, enabling FCP code to route the entry or
+   * label serialized output.
+   *
+   * @return the constant {@link #NAME} string {@code "BookmarkFeed"}; callers must not modify the
+   *     returned reference.
+   */
   @Override
   public String getName() {
     return NAME;

--- a/src/main/java/network/crypta/clients/fcp/BookmarkFeed.java
+++ b/src/main/java/network/crypta/clients/fcp/BookmarkFeed.java
@@ -36,7 +36,7 @@ import network.crypta.support.io.NullBucket;
  * inherited bucket map. All fields are final except the map inherited from {@link FeedMessage},
  * which is populated once in the constructor and then treated as read-only.
  */
-public class BookmarkFeed extends FeedMessage {
+public class BookmarkFeed extends N2NFeedMessage {
 
   /**
    * Public FCP message identifier for bookmark notifications, emitted by {@link #getName()} and
@@ -49,10 +49,6 @@ public class BookmarkFeed extends FeedMessage {
   private final String bookmarkTitle;
   private final FreenetURI bookmarkUri;
   private final boolean hasAnActivelink;
-  private final String sourceNodeName;
-  private final long composed;
-  private final long sent;
-  private final long received;
 
   /**
    * Create a bookmark feed entry populated with peer metadata, descriptive text, and bookmark
@@ -105,14 +101,19 @@ public class BookmarkFeed extends FeedMessage {
       FreenetURI bookmarkUri,
       String description,
       boolean hasAnActivelink) {
-    super(header, shortText, text, priorityClass, updatedTime);
+    super(
+        header,
+        shortText,
+        text,
+        priorityClass,
+        updatedTime,
+        sourceNodeName,
+        composed,
+        sent,
+        received);
     this.bookmarkTitle = bookmarkTitle;
     this.bookmarkUri = bookmarkUri;
     this.hasAnActivelink = hasAnActivelink;
-    this.sourceNodeName = sourceNodeName;
-    this.composed = composed;
-    this.sent = sent;
-    this.received = received;
     final Bucket descriptionBucket;
     if (description != null) {
       descriptionBucket = new ArrayBucket(description.getBytes(StandardCharsets.UTF_8));
@@ -138,10 +139,6 @@ public class BookmarkFeed extends FeedMessage {
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = super.getFieldSet();
-    fs.putSingle("SourceNodeName", sourceNodeName);
-    if (composed >= 0) fs.put("TimeComposed", composed);
-    if (sent >= 0) fs.put("TimeSent", sent);
-    if (received >= 0) fs.put("TimeReceived", received);
     fs.putSingle("Name", bookmarkTitle);
     fs.putSingle("URI", bookmarkUri.toString());
     fs.put("HasAnActivelink", hasAnActivelink);

--- a/src/main/java/network/crypta/clients/fcp/FeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FeedMessage.java
@@ -5,13 +5,43 @@ import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Freenet Client Protocol (FCP) message that represents a single feed entry sent from the node to
+ * an external client.
+ *
+ * <p>Instances of this class carry two short textual descriptors ({@code header} and {@code
+ * shortText}) and a potentially larger UTF&#8209;8 encoded body, which is stored as a {@link
+ * Bucket} entry named {@code "Text"}. The binary body is handled through the multipart payload
+ * support of {@link MultipleDataCarryingMessage}, so the message appears on the wire as a regular
+ * FCP header followed by a sequence of payload bytes whose size is derived from the bucket
+ * contents.
+ *
+ * <p>The feed mechanism is typically used to surface human‑readable notifications to clients, such
+ * as status information or user alerts, while keeping the protocol framing consistent with other
+ * data‑carrying messages. A {@code FeedMessage} is constructed on the server side shortly before it
+ * is written to an output stream and is not intended to be instantiated or executed in response to
+ * client input.
+ *
+ * <p>Thread‑safety: instances are mutable only during construction. After the constructor has
+ * populated the internal bucket map the object is effectively read‑only and should be confined to a
+ * single thread, typically the FCP connection handler that sends the message.
+ *
+ * @see MultipleDataCarryingMessage
+ * @see TextFeedMessage
+ * @see URIFeedMessage
+ */
 public class FeedMessage extends MultipleDataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(FeedMessage.class);
-
+  /**
+   * Protocol message name used on the FCP wire for feed notifications.
+   *
+   * <p>This constant is returned by {@link #getName()} and is used by the {@link FCPMessage}
+   * factory logic when routing decoded messages. The value is stable across releases so that
+   * existing clients can register interest in feed messages by comparing against the literal {@code
+   * "Feed"} string.
+   */
   public static final String NAME = "Feed";
+
   // We assume that the header and shortText doesn't contain any newlines
   private final String header;
   private final String shortText;
@@ -19,6 +49,26 @@ public class FeedMessage extends MultipleDataCarryingMessage {
   private final short priorityClass;
   private final long updatedTime;
 
+  /**
+   * Create a new feed message with the given metadata and body text.
+   *
+   * <p>The {@code text} argument is converted to UTF&#8209;8 bytes and stored in an {@link
+   * ArrayBucket} under the key {@code "Text"}, which participates in the multipart payload managed
+   * by the superclass. The {@code header} and {@code shortText} values are copied verbatim and are
+   * expected not to contain newline characters so that they can be embedded safely into the textual
+   * {@link SimpleFieldSet} header.
+   *
+   * @param header short one‑line summary displayed most prominently to the user; should not contain
+   *     newline characters and may be {@code null} when no header is required.
+   * @param shortText secondary summary that provides brief context; like {@code header}, this is
+   *     expected to be a single line of text without embedded newlines and may be {@code null}.
+   * @param text full body of the feed entry that will be sent as binary payload bytes; must be
+   *     non‑{@code null} and may contain arbitrary characters, including newlines.
+   * @param priorityClass numeric priority hint used by the surrounding FCP infrastructure; higher
+   *     values typically indicate messages that should be delivered before lower priority entries.
+   * @param updatedTime timestamp in milliseconds since the epoch indicating when the feed entry was
+   *     last updated; the semantics of this value are defined by the producer of the message.
+   */
   public FeedMessage(
       String header, String shortText, String text, short priorityClass, long updatedTime) {
     this.header = header;
@@ -31,6 +81,20 @@ public class FeedMessage extends MultipleDataCarryingMessage {
     buckets.put("Text", textBucket);
   }
 
+  /**
+   * Build the {@link SimpleFieldSet} header that describes this feed message and its payload.
+   *
+   * <p>This implementation starts with the multipart payload metadata provided by {@link
+   * MultipleDataCarryingMessage#getFieldSet()}, which includes individual length fields for each
+   * bucket and the aggregated {@code DataLength}. It then appends feed‑specific fields such as
+   * {@code Header}, {@code ShortText}, {@code PriorityClass}, and {@code UpdatedTime}. If either
+   * {@code header} or {@code shortText} is {@code null}, the corresponding key is omitted from the
+   * returned structure.
+   *
+   * @return a newly created field set describing both the multipart payload lengths and the
+   *     feed‑specific metadata; callers are free to modify this instance without affecting the
+   *     internal state of the message.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = super.getFieldSet();
@@ -41,6 +105,22 @@ public class FeedMessage extends MultipleDataCarryingMessage {
     return fs;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>For {@code FeedMessage} this method always signals a protocol error. Feed messages are
+   * designed to flow from server to client only, so receiving such a message from a client is
+   * treated as invalid input. The implementation therefore throws a {@link MessageInvalidException}
+   * with the {@link ProtocolErrorMessage#INVALID_MESSAGE} code and does not inspect its arguments.
+   *
+   * @param handler connection handler associated with the FCP session; ignored by this
+   *     implementation because feed messages are not processed on the server side when received
+   *     from clients.
+   * @param node node instance that would normally provide access to core services; ignored here
+   *     because the method always fails fast with a protocol error.
+   * @throws MessageInvalidException always thrown to indicate that {@code FeedMessage} instances
+   *     must not be sent from client to server in this direction.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
@@ -50,6 +130,16 @@ public class FeedMessage extends MultipleDataCarryingMessage {
         false);
   }
 
+  /**
+   * Return the FCP wire name of this message type.
+   *
+   * <p>The implementation simply returns the constant {@link #NAME}, allowing callers that only
+   * depend on the {@link FCPMessage} abstraction to discover the concrete message identifier used
+   * when serializing this instance. This value is typically written as the first line of the FCP
+   * message on the connection.
+   *
+   * @return the literal string {@code "Feed"}, identifying this message type in FCP exchanges.
+   */
   @Override
   public String getName() {
     return NAME;

--- a/src/main/java/network/crypta/clients/fcp/MultipleDataCarryingMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/MultipleDataCarryingMessage.java
@@ -9,29 +9,115 @@ import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.BucketTools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Base class for FCP messages that send multiple binary payload segments in a single message
+ * instance.
+ *
+ * <p>Where {@link DataCarryingMessage} implementations typically stream a single {@link Bucket}
+ * payload, this type manages a small ordered collection of buckets identified by field-name
+ * prefixes. Each entry in {@link #buckets} contributes both a length field (for example {@code
+ * SomePartLength}) in the {@link SimpleFieldSet} header and a corresponding sequence of bytes in
+ * the trailing payload region. The overall data length reported to the protocol layer is the sum of
+ * all bucket sizes.
+ *
+ * <p>Instances of this class are generally constructed and populated on the server side shortly
+ * before being written to an {@link OutputStream}. The API is intentionally one-way: {@link
+ * #readFrom(InputStream, BucketFactory, FCPServer)} is not supported and will always throw, because
+ * decoding arbitrary multipart payloads depends on message-specific conventions. Subclasses provide
+ * higher-level methods for inserting buckets in the correct order and with appropriate field names.
+ *
+ * <p>Thread-safety: instances are mutable and not inherently thread-safe. Callers should confine
+ * each message to a single thread (typically the connection handler) between construction and
+ * sending. The {@link #buckets} map preserves insertion order so that both header fields and
+ * payload segments appear deterministically on the wire.
+ *
+ * @see BaseDataCarryingMessage
+ * @see DataCarryingMessage
+ * @see Bucket
+ */
 public abstract class MultipleDataCarryingMessage extends BaseDataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(MultipleDataCarryingMessage.class);
 
   // The iteration order matters, hence a LinkedHashMap
+  /**
+   * Collection of payload segments that will be serialized as part of this message.
+   *
+   * <p>Keys represent the logical field name prefix for each segment (for example {@code
+   * "Metadata."} or {@code "Data."}), while values are {@link Bucket} instances that provide the
+   * actual bytes. The concrete subclass is responsible for populating this map before sending the
+   * message, typically by creating buckets through a {@link BucketFactory} and inserting them in
+   * the desired order. The {@link LinkedHashMap} preserves insertion order so that header fields
+   * and payload segments are emitted in a predictable sequence.
+   */
   protected Map<String, Bucket> buckets = new LinkedHashMap<>();
 
+  /**
+   * Flag indicating whether buckets should be freed immediately after the message is sent.
+   *
+   * <p>When set to {@code true}, {@link #writeData(OutputStream)} calls {@link Bucket#free()} on
+   * each bucket as soon as its contents have been written to the output stream. This is useful for
+   * large, transient payloads that are not reused after transmission and allows backing resources
+   * (such as temporary files or off-heap buffers) to be reclaimed promptly. Subclasses typically
+   * toggle this flag through {@link #setFreeOnSent()} once they have finished constructing the
+   * payload.
+   */
   protected boolean freeOnSent;
 
+  /**
+   * Marks this message so that its buckets are freed once the payload has been written.
+   *
+   * <p>Calling this method is idempotent and only affects the behavior of the subsequent {@link
+   * #writeData(OutputStream)} invocation. It does not free any buckets immediately; instead, each
+   * bucket is released after its bytes have been copied to the output stream. This is typically
+   * used for messages whose payload is generated on demand and does not need to be retained after
+   * the client has received it.
+   */
+  @SuppressWarnings("unused")
   void setFreeOnSent() {
     freeOnSent = true;
   }
 
   // We can't read an arbitrary multiple data carrying message from an InputStream
   // This class is only used to send such messages to the client
+  /**
+   * Unsupported operation for {@code MultipleDataCarryingMessage}.
+   *
+   * <p>This implementation always throws {@link UnsupportedOperationException}. The class is
+   * intended exclusively for constructing outgoing messages that aggregate multiple payload
+   * segments; the corresponding on-wire representations are parsed by message-specific logic
+   * elsewhere in the FCP stack. As a result, there is no generic format that would allow an
+   * arbitrary instance of this type to be reconstructed from an {@link InputStream}.
+   *
+   * @param is input stream that would otherwise carry the binary payload; ignored by this
+   *     implementation
+   * @param bf bucket factory that would normally create storage for the decoded data; ignored here
+   * @param server server instance associated with the connection; ignored by this implementation
+   * @throws IOException never thrown by this implementation, declared to satisfy the superclass
+   *     contract
+   * @throws MessageInvalidException never thrown by this implementation, declared to satisfy the
+   *     superclass contract
+   * @throws UnsupportedOperationException always thrown to signal that reading into this message
+   *     type is not supported
+   */
   @Override
   public void readFrom(InputStream is, BucketFactory bf, FCPServer server)
       throws IOException, MessageInvalidException {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Writes all buckets contained in this message to the supplied output stream.
+   *
+   * <p>The method iterates over {@link #buckets} in insertion order and delegates to {@link
+   * BucketTools#copyTo(Bucket, OutputStream, long)} to stream each bucket's content. If {@link
+   * #freeOnSent} is {@code true}, each bucket is freed immediately after its data has been written.
+   * The output stream is not closed or flushed by this method; callers are responsible for
+   * connection-level lifecycle management.
+   *
+   * @param os output stream that receives the concatenated payload segments; must remain open and
+   *     writable for the duration of the call
+   * @throws IOException if an I/O error occurs while reading from a bucket or writing to {@code os}
+   */
   @Override
   protected void writeData(OutputStream os) throws IOException {
     for (Map.Entry<String, Bucket> entry : buckets.entrySet()) {
@@ -41,9 +127,24 @@ public abstract class MultipleDataCarryingMessage extends BaseDataCarryingMessag
     }
   }
 
+  /**
+   * Builds the structured field set describing this message's payload.
+   *
+   * <p>For each entry in {@link #buckets}, this method adds a length field whose name is
+   * constructed by appending {@code "Length"} to the bucket key. It also accumulates the total
+   * payload size in bytes and publishes it under the {@code "DataLength"} field. This information
+   * enables FCP clients to allocate buffers or progress indicators before the payload bytes
+   * themselves are streamed over the connection.
+   *
+   * <p>The returned {@link SimpleFieldSet} is newly created on each invocation and may be freely
+   * modified by the caller without affecting the internal state of the message.
+   *
+   * @return a field set that includes per-part length fields and the aggregated {@code DataLength}
+   *     value describing the binary payload of this message
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
-    int dataLength = 0;
+    long dataLength = 0;
     SimpleFieldSet fs = new SimpleFieldSet(true);
     for (Map.Entry<String, Bucket> entry : buckets.entrySet()) {
       String field = entry.getKey();
@@ -55,13 +156,35 @@ public abstract class MultipleDataCarryingMessage extends BaseDataCarryingMessag
     return fs;
   }
 
+  /**
+   * Returns the sum of the sizes of all buckets that make up this message's payload.
+   *
+   * <p>This value matches the {@code DataLength} field produced by {@link #getFieldSet()} and
+   * represents the exact number of bytes that {@link #writeData(OutputStream)} will attempt to
+   * stream to the client. If the bucket collection is empty, the method returns {@code 0}. The
+   * value is recomputed on each call by iterating over {@link #buckets}, so callers that need it
+   * repeatedly should cache the result if performance is critical.
+   *
+   * @return total payload length in bytes across all buckets currently stored in {@link #buckets}
+   */
   @Override
   public long dataLength() {
-    int dataLength = 0;
+    long dataLength = 0;
     for (Bucket bucket : buckets.values()) dataLength += bucket.size();
     return dataLength;
   }
 
+  /**
+   * Returns the marker string that separates the header from the binary payload in the on-wire
+   * representation of this message.
+   *
+   * <p>For multipart payload messages the literal string {@code "Data"} is used, matching the
+   * semantics of other data-carrying FCP messages. The surrounding infrastructure uses this value
+   * when composing or parsing the textual header and when deciding whether additional payload bytes
+   * follow.
+   *
+   * @return the header terminator token {@code "Data"}, indicating that payload bytes follow
+   */
   @Override
   String getEndString() {
     return "Data";

--- a/src/main/java/network/crypta/clients/fcp/N2NFeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/N2NFeedMessage.java
@@ -1,16 +1,105 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Abstract base class for feed messages that carry node&#8209;to&#8209;node metadata in addition to
+ * the textual payload defined by {@link FeedMessage}.
+ *
+ * <p>The core feed infrastructure represents each entry as a {@link FeedMessage}, which provides
+ * the human‑readable header, short summary, and body text transported over the Freenet Client
+ * Protocol (FCP). {@code N2NFeedMessage} extends this model for notifications that originate from
+ * another node in the network, attaching details about the sending peer and timestamps describing
+ * how the message moved through the system.
+ *
+ * <p>Subclasses such as {@link TextFeedMessage}, {@link URIFeedMessage}, and {@link BookmarkFeed}
+ * specialize the payload while relying on this class to keep track of when the message was
+ * composed, transmitted, and received. All metadata is supplied at construction time and exposed
+ * indirectly through {@link #getFieldSet()}, which encodes the node information into the outgoing
+ * FCP header. Instances are effectively immutable after construction and are typically created on a
+ * single thread that prepares messages for delivery to FCP clients.
+ *
+ * @see FeedMessage
+ * @see TextFeedMessage
+ * @see URIFeedMessage
+ * @see BookmarkFeed
+ */
 public abstract class N2NFeedMessage extends FeedMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(N2NFeedMessage.class);
 
+  /**
+   * Descriptive name of the node that sent the underlying message.
+   *
+   * <p>The value is written to the FCP header field {@code "SourceNodeName"} and is usually a
+   * human‑readable label chosen by the remote peer. It is treated purely as display text; callers
+   * should not assume uniqueness or attempt to parse structured identifiers from it.
+   */
   protected final String sourceNodeName;
-  protected final long composed, sent, received;
 
-  public N2NFeedMessage(
+  /**
+   * Time at which the sender composed the message, expressed in epoch milliseconds.
+   *
+   * <p>When this value is non‑negative it is exported in the {@code "TimeComposed"} field of the
+   * {@link SimpleFieldSet} returned by {@link #getFieldSet()}. A value of {@code -1} indicates that
+   * the composition time is unknown or was not supplied by the originating node.
+   */
+  protected final long composed;
+
+  /**
+   * Time at which the sender transmitted the message towards this node, in epoch milliseconds.
+   *
+   * <p>If this value is non‑negative it is written to the FCP header under the key {@code
+   * "TimeSent"}. A value of {@code -1} signals that no explicit send time is available, either
+   * because the sender did not provide one or because the transport layer does not expose it.
+   */
+  protected final long sent;
+
+  /**
+   * Time at which this node received the message, in epoch milliseconds.
+   *
+   * <p>When non‑negative this timestamp is exported in the {@code "TimeReceived"} field of the
+   * header built by {@link #getFieldSet()}. A value of {@code -1} means that the receipt time is
+   * not known, for example when older data is reconstructed without precise timing information.
+   */
+  protected final long received;
+
+  /**
+   * Create a new node‑to‑node feed message with timing metadata and textual content.
+   *
+   * <p>The textual arguments mirror those of {@link FeedMessage}: a short {@code header}, a
+   * secondary {@code shortText}, and a full {@code text} body that is stored as a binary payload.
+   * The {@code priorityClass} and {@code updatedTime} parameters are passed through to the
+   * superclass unchanged, while {@code sourceNodeName} and the three timestamp values are retained
+   * to describe the origin and life‑cycle of the message as it flows between nodes.
+   *
+   * @param header short one‑line summary describing the message; callers should avoid embedding
+   *     newline characters because the value is placed directly into the textual FCP header and may
+   *     be {@code null} when no separate title is required.
+   * @param shortText secondary summary that gives additional context beyond {@code header}; like
+   *     the header it is expected to be a single logical line of text and may be {@code null} if
+   *     there is no distinct short description.
+   * @param text full body of the feed entry that will be sent as payload bytes; this string is
+   *     converted to UTF‑8 and may contain arbitrary characters, including newlines, but must not
+   *     be {@code null} when constructing an instance.
+   * @param priorityClass numeric priority hint used by the surrounding FCP infrastructure to order
+   *     outgoing messages; higher values typically indicate entries that should be delivered before
+   *     lower‑priority ones on the same connection.
+   * @param updatedTime timestamp representing the last update time of the feed entry from the
+   *     perspective of the sender or alerting subsystem; the concrete semantics are defined by the
+   *     code that constructs the message and are not interpreted further here.
+   * @param sourceNodeName human‑readable name of the node that originated the message; this value
+   *     is exported in the {@code "SourceNodeName"} header field and may be {@code null} or empty
+   *     when no friendly identifier is available for the peer.
+   * @param composed time at which the sender composed the message content, expressed in
+   *     milliseconds since the Unix epoch; use {@code -1} when the composition time is unknown or
+   *     not tracked by the upstream component.
+   * @param sent time at which the sender transmitted the message towards this node, also in epoch
+   *     milliseconds; use {@code -1} if the transport does not expose a precise send time or if it
+   *     is otherwise unavailable.
+   * @param received time at which this node received the message from the network, in epoch
+   *     milliseconds; a value of {@code -1} indicates that the receipt time could not be recorded
+   *     or is intentionally left unspecified.
+   */
+  protected N2NFeedMessage(
       String header,
       String shortText,
       String text,
@@ -27,6 +116,18 @@ public abstract class N2NFeedMessage extends FeedMessage {
     this.received = received;
   }
 
+  /**
+   * Build a {@link SimpleFieldSet} that describes this feed entry, including node metadata.
+   *
+   * <p>This implementation starts with the header produced by {@link FeedMessage#getFieldSet()},
+   * which contains the textual fields and multipart payload information, then adds node‑specific
+   * keys. The {@code "SourceNodeName"} entry is always included, while the {@code "TimeComposed"},
+   * {@code "TimeSent"}, and {@code "TimeReceived"} fields are present only when their corresponding
+   * timestamps are non‑negative.
+   *
+   * @return a newly created field set combining the base feed metadata with node‑to‑node timing
+   *     information ready to be serialized onto the FCP connection.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = super.getFieldSet();

--- a/src/main/java/network/crypta/clients/fcp/TextFeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TextFeedMessage.java
@@ -4,14 +4,78 @@ import java.nio.charset.StandardCharsets;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
 import network.crypta.support.io.NullBucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Feed message that carries a textual node‑to‑node notification with an optional extra body.
+ *
+ * <p>This class extends {@link N2NFeedMessage} and therefore behaves like a regular {@link
+ * FeedMessage} enriched with information about the originating node and transmission timestamps. In
+ * addition to the standard {@code "Text"} payload created by the superclass, it attaches a second
+ * payload bucket named {@code "MessageText"}, which can be used to transport an auxiliary textual
+ * fragment such as a detailed description, log excerpt, or peer‑specific note.
+ *
+ * <p>The primary constructor accepts all fields at once, so instances are fully initialized and
+ * effectively immutable after construction. Callers typically create a {@code TextFeedMessage} on a
+ * single thread shortly before sending it over an FCP connection. The bucket map is populated
+ * eagerly using either an {@link ArrayBucket} containing UTF‑8 encoded bytes of the supplied
+ * message text, or a {@link NullBucket} when no additional text is provided, so read‑only methods
+ * such as {@link #getFieldSet()} and {@link #dataLength()} can be called without further I/O.
+ *
+ * <p>Thread‑safety: instances are not designed for concurrent mutation but are safe for read‑only
+ * access from a single thread once constructed.
+ *
+ * @see N2NFeedMessage
+ * @see FeedMessage
+ * @see network.crypta.support.SimpleFieldSet
+ */
 public class TextFeedMessage extends N2NFeedMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(TextFeedMessage.class);
 
+  /**
+   * Protocol name of this message type used on the FCP wire.
+   *
+   * <p>The value of this constant is returned by {@link #getName()} and is written as the leading
+   * line of the serialized message when the FCP connection sends a {@code TextFeedMessage}. Client
+   * implementations can compare incoming message names against this literal to detect node‑to‑node
+   * text feed entries with the extra {@code "MessageText"} payload segment attached.
+   */
   public static final String NAME = "TextFeed";
 
+  /**
+   * Create a new node‑to‑node feed message that carries textual content and an optional extra body.
+   *
+   * <p>The parameters that describe the header, short summary, and main body are forwarded
+   * unchanged to the {@link N2NFeedMessage} constructor, which in turn populates the {@code "Text"}
+   * bucket and base header fields. This constructor additionally creates a {@link Bucket} for the
+   * {@code messageText} argument and stores it under the key {@code "MessageText"} in the internal
+   * bucket map. When {@code messageText} is {@code null}, a {@link NullBucket} of zero length is
+   * used so that the field set still exposes a {@code MessageTextLength} entry consistent with the
+   * data‑carrying contract.
+   *
+   * <p>The resulting instance is ready to be serialized and sent to an FCP client. No further
+   * mutation of bucket contents is expected once construction completes.
+   *
+   * @param header short human‑readable title for the feed entry; may be {@code null} when no
+   *     dedicated header line is required by the caller.
+   * @param shortText secondary summary line providing compact context beyond {@code header}; may be
+   *     {@code null} if the feed entry does not use a short description.
+   * @param text full body text for the main feed payload; converted to UTF‑8 bytes and stored in a
+   *     {@code "Text"} bucket, and therefore must not be {@code null}.
+   * @param priorityClass numeric priority hint used by the surrounding FCP infrastructure when
+   *     ordering outgoing messages; higher values generally indicate more urgent notifications.
+   * @param updatedTime timestamp in milliseconds since the Unix epoch indicating when the feed
+   *     entry was last updated from the perspective of the producer.
+   * @param sourceNodeName descriptive name of the remote node that originated this message; written
+   *     to the {@code "SourceNodeName"} header field and may be {@code null} or empty.
+   * @param composed time at which the sender composed the message body, expressed in epoch
+   *     milliseconds; use {@code -1} when the composition time is unknown or not tracked.
+   * @param sent time at which the message was transmitted towards this node, in epoch milliseconds;
+   *     use {@code -1} when a precise send time is unavailable or intentionally omitted.
+   * @param received time at which this node received the message, in epoch milliseconds; use {@code
+   *     -1} when the receipt time could not be recorded or is not meaningful.
+   * @param messageText optional additional textual payload carried in the {@code "MessageText"}
+   *     bucket; when {@code null}, an empty {@link NullBucket} is used instead of an {@link
+   *     ArrayBucket}.
+   */
   public TextFeedMessage(
       String header,
       String shortText,
@@ -42,6 +106,16 @@ public class TextFeedMessage extends N2NFeedMessage {
     buckets.put("MessageText", messageTextBucket);
   }
 
+  /**
+   * Return the symbolic protocol name identifying this message type.
+   *
+   * <p>The value is the constant {@link #NAME}, which is used by the FCP layer when serializing the
+   * message and by clients that need to distinguish {@code TextFeedMessage} instances from other
+   * feed or control messages. The returned string is immutable and may be compared directly against
+   * the literal {@code "TextFeed"} in client code.
+   *
+   * @return the literal protocol name {@code "TextFeed"} associated with this class.
+   */
   @Override
   public String getName() {
     return NAME;

--- a/src/main/java/network/crypta/clients/fcp/URIFeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/URIFeedMessage.java
@@ -1,20 +1,97 @@
 package network.crypta.clients.fcp;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
 import network.crypta.support.io.NullBucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class URIFeedMessage extends N2NFeedMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(URIFeedMessage.class);
-
+/**
+ * Freenet Client Protocol (FCP) feed message that advertises a resource identified by a {@link
+ * FreenetURI}.
+ *
+ * <p>Instances of this class are created on the server side when a peer announces content on the
+ * node-to-node download feed. The message combines the generic header, short text, and body text
+ * handled by {@link FeedMessage} with additional metadata describing the origin node, timestamps
+ * for when the announcement was composed, sent, and received, and an optional human-readable
+ * description stored as a separate payload bucket named {@code "Description"}.
+ *
+ * <p>The resulting feed entry is serialized as a multipart FCP message. Timing and node metadata
+ * are exported through {@link #getFieldSet()}, while the URI and description are exposed as
+ * standard header and payload fields that downstream FCP clients can display or process further.
+ * Instances are effectively immutable after construction and are typically used on a single thread
+ * responsible for writing messages to an FCP connection.
+ *
+ * <ul>
+ *   <li>Wire name is {@link #NAME} and is returned by {@link #getName()}.
+ *   <li>The {@link FreenetURI} is sent as the {@code "URI"} header value.
+ *   <li>The optional description contributes to the overall {@code DataLength} alongside the main
+ *       text body.
+ * </ul>
+ *
+ * @see FeedMessage
+ * @see FreenetURI
+ * @see network.crypta.node.useralerts.DownloadFeedUserAlert
+ */
+public class URIFeedMessage extends FeedMessage {
+  /**
+   * Protocol message name used on the FCP wire for URI feed notifications.
+   *
+   * <p>This literal appears as the first line of the serialized FCP message and allows clients to
+   * recognize URI feed entries without depending on the concrete Java type. It is also returned by
+   * {@link #getName()} so components that work with the generic {@link FCPMessage} abstraction can
+   * still distinguish {@code URIFeedMessage} instances by their protocol name.
+   */
   public static final String NAME = "URIFeed";
-  private final FreenetURI URI;
 
+  private final FreenetURI uri;
+  private final String sourceNodeName;
+  private final long composed;
+  private final long sent;
+  private final long received;
+
+  /**
+   * Create a new URI-based feed message with node metadata and optional description text.
+   *
+   * <p>The textual parameters mirror those of {@link FeedMessage}. The URI is stored verbatim and
+   * must be non-{@code null}; a {@link NullPointerException} is thrown if it is missing. A
+   * non-{@code null} description is converted to UTF-8 bytes and stored in an {@link ArrayBucket}
+   * under the key {@code "Description"}, while a {@code null} description results in a {@link
+   * NullBucket} that contributes zero bytes to the overall data length.
+   *
+   * <p>Timestamps and source node name are exported into the {@link SimpleFieldSet} built by {@link
+   * #getFieldSet()}. A value of {@code -1} for any timestamp suppresses the corresponding {@code
+   * "TimeComposed"}, {@code "TimeSent"}, or {@code "TimeReceived"} field so callers can signal
+   * unknown times without inventing placeholder values.
+   *
+   * @param header short, user-visible title shown most prominently; may be {@code null} and should
+   *     not contain embedded newlines because it is copied into the textual FCP header.
+   * @param shortText secondary summary providing additional context; may be {@code null} and is
+   *     likewise expected to be a single logical line of text without newlines.
+   * @param text full body of the feed entry to be delivered as the primary payload; must be
+   *     non-{@code null} and may contain arbitrary characters, including Unicode and line breaks.
+   * @param priorityClass numeric priority hint used by the FCP infrastructure when ordering
+   *     outgoing messages; higher values typically indicate more urgent notifications.
+   * @param updatedTime timestamp in milliseconds since the Unix epoch representing when the entry
+   *     was last updated from the server's perspective; the value is forwarded unchanged.
+   * @param sourceNodeName human-readable name of the peer that announced the URI; may be {@code
+   *     null} or empty when no friendly identifier is available, and is exported as the {@code
+   *     "SourceNodeName"} header field.
+   * @param composed time at which the remote peer composed the announcement, expressed in epoch
+   *     milliseconds; use {@code -1} to indicate that this information is not known.
+   * @param sent time when the remote peer sent the announcement towards this node, in epoch
+   *     milliseconds; {@code -1} again indicates an unknown or unavailable value.
+   * @param received time when this node received the announcement from the network, in epoch
+   *     milliseconds; {@code -1} suppresses the corresponding header field in {@link
+   *     #getFieldSet()}.
+   * @param uri target {@link FreenetURI} that identifies the advertised content; must not be {@code
+   *     null} and is neither normalized nor modified by this constructor.
+   * @param description optional textual description associated with the URI; when non-{@code null}
+   *     it is encoded as UTF-8 bytes into a {@link Bucket} named {@code "Description"}, otherwise a
+   *     {@link NullBucket} is used to represent the absence of description data.
+   */
   public URIFeedMessage(
       String header,
       String shortText,
@@ -25,19 +102,14 @@ public class URIFeedMessage extends N2NFeedMessage {
       long composed,
       long sent,
       long received,
-      FreenetURI URI,
+      FreenetURI uri,
       String description) {
-    super(
-        header,
-        shortText,
-        text,
-        priorityClass,
-        updatedTime,
-        sourceNodeName,
-        composed,
-        sent,
-        received);
-    this.URI = URI;
+    super(header, shortText, text, priorityClass, updatedTime);
+    this.sourceNodeName = sourceNodeName;
+    this.composed = composed;
+    this.sent = sent;
+    this.received = received;
+    this.uri = Objects.requireNonNull(uri, "uri");
     final Bucket descriptionBucket;
     if (description != null) {
       descriptionBucket = new ArrayBucket(description.getBytes(StandardCharsets.UTF_8));
@@ -47,13 +119,47 @@ public class URIFeedMessage extends N2NFeedMessage {
     buckets.put("Description", descriptionBucket);
   }
 
+  /**
+   * Build the FCP header for this URI feed entry.
+   *
+   * <p>This implementation starts with the base header produced by {@link FeedMessage#getFieldSet}
+   * and then appends node and URI-specific fields. The {@code "SourceNodeName"} entry is always
+   * present. The {@code "TimeComposed"}, {@code "TimeSent"}, and {@code "TimeReceived"} keys are
+   * only included when their corresponding timestamps are non-negative, allowing callers to
+   * distinguish between known and unknown timing information. Finally, the target URI is exported
+   * as a string in the {@code "URI"} field so clients can display or follow it.
+   *
+   * @return a new {@link SimpleFieldSet} combining generic feed metadata, any available timing
+   *     information, and the URI; callers may freely modify the returned instance without affecting
+   *     the internal state of this message.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = super.getFieldSet();
-    fs.putSingle("URI", URI.toString());
+    fs.putSingle("SourceNodeName", sourceNodeName);
+    if (composed != -1) {
+      fs.put("TimeComposed", composed);
+    }
+    if (sent != -1) {
+      fs.put("TimeSent", sent);
+    }
+    if (received != -1) {
+      fs.put("TimeReceived", received);
+    }
+    fs.putSingle("URI", uri.toString());
     return fs;
   }
 
+  /**
+   * Return the protocol name for this message type.
+   *
+   * <p>The value matches {@link #NAME} and is used on the FCP wire as the identifier on the first
+   * line of the serialized message. Keeping the name constant allows clients to reliably recognize
+   * URI feed notifications even when they interact only with the abstract {@link FCPMessage}
+   * hierarchy instead of this concrete class.
+   *
+   * @return the literal {@link #NAME} value, currently {@code "URIFeed"}.
+   */
   @Override
   public String getName() {
     return NAME;

--- a/src/main/java/network/crypta/clients/fcp/URIFeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/URIFeedMessage.java
@@ -35,7 +35,7 @@ import network.crypta.support.io.NullBucket;
  * @see FreenetURI
  * @see network.crypta.node.useralerts.DownloadFeedUserAlert
  */
-public class URIFeedMessage extends FeedMessage {
+public class URIFeedMessage extends N2NFeedMessage {
   /**
    * Protocol message name used on the FCP wire for URI feed notifications.
    *
@@ -47,10 +47,6 @@ public class URIFeedMessage extends FeedMessage {
   public static final String NAME = "URIFeed";
 
   private final FreenetURI uri;
-  private final String sourceNodeName;
-  private final long composed;
-  private final long sent;
-  private final long received;
 
   /**
    * Create a new URI-based feed message with node metadata and optional description text.
@@ -104,11 +100,16 @@ public class URIFeedMessage extends FeedMessage {
       long received,
       FreenetURI uri,
       String description) {
-    super(header, shortText, text, priorityClass, updatedTime);
-    this.sourceNodeName = sourceNodeName;
-    this.composed = composed;
-    this.sent = sent;
-    this.received = received;
+    super(
+        header,
+        shortText,
+        text,
+        priorityClass,
+        updatedTime,
+        sourceNodeName,
+        composed,
+        sent,
+        received);
     this.uri = Objects.requireNonNull(uri, "uri");
     final Bucket descriptionBucket;
     if (description != null) {
@@ -136,16 +137,6 @@ public class URIFeedMessage extends FeedMessage {
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = super.getFieldSet();
-    fs.putSingle("SourceNodeName", sourceNodeName);
-    if (composed != -1) {
-      fs.put("TimeComposed", composed);
-    }
-    if (sent != -1) {
-      fs.put("TimeSent", sent);
-    }
-    if (received != -1) {
-      fs.put("TimeReceived", received);
-    }
     fs.putSingle("URI", uri.toString());
     return fs;
   }

--- a/src/test/java/network/crypta/clients/fcp/BookmarkFeedTest.java
+++ b/src/test/java/network/crypta/clients/fcp/BookmarkFeedTest.java
@@ -1,0 +1,121 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import network.crypta.support.io.NullBucket;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class BookmarkFeedTest {
+
+  private static final String HEADER = "Bookmark header";
+  private static final String SHORT_TEXT = "Short summary";
+  private static final String BODY_TEXT = "Long body of the bookmark notification";
+  private static final short PRIORITY_CLASS = 3;
+  private static final long UPDATED_TIME = 42L;
+  private static final String SOURCE_NODE_NAME = "RemoteNode";
+  private static final long COMPOSED = 100L;
+  private static final long SENT = 200L;
+  private static final long RECEIVED = 300L;
+  private static final String BOOKMARK_NAME = "Favorite link";
+
+  @Test
+  void getFieldSet_whenBookmarkHasMetadata_exportsNameUriAndFlags() throws Exception {
+    FreenetURI uri = sampleUri();
+    BookmarkFeed feed =
+        new BookmarkFeed(
+            HEADER,
+            SHORT_TEXT,
+            BODY_TEXT,
+            PRIORITY_CLASS,
+            UPDATED_TIME,
+            SOURCE_NODE_NAME,
+            COMPOSED,
+            SENT,
+            RECEIVED,
+            BOOKMARK_NAME,
+            uri,
+            "A bookmark description",
+            true);
+
+    SimpleFieldSet fieldSet = feed.getFieldSet();
+
+    assertEquals(HEADER, fieldSet.getString("Header"));
+    assertEquals(SHORT_TEXT, fieldSet.getString("ShortText"));
+    assertEquals(PRIORITY_CLASS, fieldSet.getLong("PriorityClass"));
+    assertEquals(UPDATED_TIME, fieldSet.getLong("UpdatedTime"));
+    assertEquals(SOURCE_NODE_NAME, fieldSet.getString("SourceNodeName"));
+    assertEquals(COMPOSED, fieldSet.getLong("TimeComposed"));
+    assertEquals(SENT, fieldSet.getLong("TimeSent"));
+    assertEquals(RECEIVED, fieldSet.getLong("TimeReceived"));
+    assertEquals(BOOKMARK_NAME, fieldSet.getString("Name"));
+    assertEquals(uri.toString(), fieldSet.getString("URI"));
+    assertEquals("true", fieldSet.getString("HasAnActivelink"));
+  }
+
+  @Test
+  void constructor_whenDescriptionProvided_storesDescriptionAsArrayBucket() throws Exception {
+    String description = "UTF-8: café";
+    BookmarkFeed feed = createFeedWithDescription(description);
+
+    Bucket descriptionBucket = feed.buckets.get("Description");
+
+    assertNotNull(descriptionBucket);
+    assertInstanceOf(ArrayBucket.class, descriptionBucket);
+    assertEquals(description, bucketToString(descriptionBucket));
+  }
+
+  @Test
+  void constructor_whenDescriptionMissing_usesNullBucketPlaceholder() {
+    BookmarkFeed feed = createFeedWithDescription(null);
+
+    Bucket descriptionBucket = feed.buckets.get("Description");
+
+    assertNotNull(descriptionBucket);
+    assertInstanceOf(NullBucket.class, descriptionBucket);
+    assertEquals(0, descriptionBucket.size());
+  }
+
+  @Test
+  void getName_alwaysReturnsBookmarkFeedConstant() {
+    BookmarkFeed feed = createFeedWithDescription("desc");
+
+    assertEquals(BookmarkFeed.NAME, feed.getName());
+  }
+
+  private static BookmarkFeed createFeedWithDescription(String description) {
+    return new BookmarkFeed(
+        HEADER,
+        SHORT_TEXT,
+        BODY_TEXT,
+        PRIORITY_CLASS,
+        UPDATED_TIME,
+        SOURCE_NODE_NAME,
+        COMPOSED,
+        SENT,
+        RECEIVED,
+        BOOKMARK_NAME,
+        sampleUri(),
+        description,
+        false);
+  }
+
+  private static FreenetURI sampleUri() {
+    return new FreenetURI("KSK", "bookmark");
+  }
+
+  private static String bucketToString(Bucket bucket) throws IOException {
+    try (InputStream inputStream = bucket.getInputStream()) {
+      return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FeedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FeedMessageTest.java
@@ -1,0 +1,117 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FeedMessageTest {
+
+  @Test
+  void getFieldSet_whenConstructedWithStandardParameters_expectHeaderShortTextAndLengthFields() {
+    // Arrange
+    String header = "Test header";
+    String shortText = "Short summary";
+    String text = "Body text with UTF-8 ☃ and newlines\nsecond line";
+    short priorityClass = 5;
+    long updatedTime = 1_694_000_000L;
+
+    FeedMessage message = new FeedMessage(header, shortText, text, priorityClass, updatedTime);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    // Assert
+    assertEquals(header, fieldSet.get("Header"));
+    assertEquals(shortText, fieldSet.get("ShortText"));
+    assertEquals(priorityClass, fieldSet.getShort("PriorityClass", (short) -1));
+    assertEquals(updatedTime, fieldSet.getLong("UpdatedTime", -1L));
+
+    int expectedBytes = text.getBytes(StandardCharsets.UTF_8).length;
+    assertEquals(expectedBytes, fieldSet.getLong("TextLength", -1L));
+    assertEquals(expectedBytes, fieldSet.getLong("DataLength", -1L));
+  }
+
+  @Test
+  void getFieldSet_whenHeaderAndShortTextAreNull_expectFieldsOmitted() {
+    // Arrange
+    String text = "Only body text";
+    short priorityClass = 1;
+    long updatedTime = 42L;
+
+    FeedMessage message = new FeedMessage(null, null, text, priorityClass, updatedTime);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    // Assert
+    assertNull(fieldSet.get("Header"));
+    assertNull(fieldSet.get("ShortText"));
+
+    int expectedBytes = text.getBytes(StandardCharsets.UTF_8).length;
+    assertEquals(expectedBytes, fieldSet.getLong("TextLength", -1L));
+    assertEquals(expectedBytes, fieldSet.getLong("DataLength", -1L));
+  }
+
+  @Test
+  void dataLength_whenTextContainsMultiByteCharacters_expectUtf8ByteLengthUsed() {
+    // Arrange
+    String text = "ASCII and üñîçødê ☃";
+    FeedMessage message = new FeedMessage("header", "short", text, (short) 3, 100L);
+
+    long expectedBytes = text.getBytes(StandardCharsets.UTF_8).length;
+
+    // Act
+    long dataLength = message.dataLength();
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    // Assert
+    assertEquals(expectedBytes, dataLength);
+    assertEquals(expectedBytes, fieldSet.getLong("DataLength", -1L));
+  }
+
+  @Test
+  void run_whenInvoked_expectMessageInvalidExceptionWithInvalidMessageCode() {
+    // Arrange
+    FeedMessage message = new FeedMessage("header", "short", "text", (short) 2, 123_456_789L);
+    Node node = org.mockito.Mockito.mock(Node.class);
+
+    // Act
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(null, node));
+
+    // Assert
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "Feed goes from server to client not the other way around", exception.getMessage());
+    assertNull(exception.ident);
+    assertFalse(exception.global);
+  }
+
+  @Test
+  void getName_whenCalled_expectFeedConstantReturned() {
+    // Arrange
+    FeedMessage message = new FeedMessage("header", "short", "text", (short) 1, 987_654_321L);
+
+    // Act & Assert
+    assertEquals(FeedMessage.NAME, message.getName());
+  }
+
+  @Test
+  void getEndString_whenCalled_expectDataMarkerReturned() {
+    // Arrange
+    FeedMessage message = new FeedMessage("header", "short", "text", (short) 1, 0L);
+
+    // Act & Assert
+    assertEquals("Data", message.getEndString());
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/TextFeedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/TextFeedMessageTest.java
@@ -1,0 +1,163 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import network.crypta.support.io.NullBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class TextFeedMessageTest {
+
+  @Test
+  void getFieldSet_whenMessageTextProvided_expectMessageTextBucketContributesToLengths() {
+    // Arrange
+    String header = "Test header";
+    String shortText = "Short summary";
+    String text = "Body text with UTF-8 ☃ and newlines\nsecond line";
+    short priorityClass = 5;
+    long updatedTime = 1_694_000_000L;
+    String sourceNodeName = "PeerNode-A";
+    long composed = 100L;
+    long sent = 200L;
+    long received = 300L;
+    String messageText = "Additional message text";
+
+    TextFeedMessage message =
+        new TextFeedMessage(
+            header,
+            shortText,
+            text,
+            priorityClass,
+            updatedTime,
+            sourceNodeName,
+            composed,
+            sent,
+            received,
+            messageText);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
+    int messageTextBytes = messageText.getBytes(StandardCharsets.UTF_8).length;
+    long expectedTotalBytes = (long) textBytes + messageTextBytes;
+
+    // Assert: base feed fields
+    assertEquals(header, fieldSet.get("Header"));
+    assertEquals(shortText, fieldSet.get("ShortText"));
+    assertEquals(priorityClass, fieldSet.getShort("PriorityClass", (short) -1));
+    assertEquals(updatedTime, fieldSet.getLong("UpdatedTime", -1L));
+
+    // Assert: node-to-node metadata
+    assertEquals(sourceNodeName, fieldSet.get("SourceNodeName"));
+    assertEquals(composed, fieldSet.getLong("TimeComposed", -1L));
+    assertEquals(sent, fieldSet.getLong("TimeSent", -1L));
+    assertEquals(received, fieldSet.getLong("TimeReceived", -1L));
+
+    // Assert: bucket lengths and aggregated DataLength
+    assertEquals(textBytes, fieldSet.getLong("TextLength", -1L));
+    assertEquals(messageTextBytes, fieldSet.getLong("MessageTextLength", -1L));
+    assertEquals(expectedTotalBytes, fieldSet.getLong("DataLength", -1L));
+    assertEquals(expectedTotalBytes, message.dataLength());
+
+    // Assert: implementation detail – non-null message text uses ArrayBucket
+    Bucket messageBucket = getBuckets(message).get("MessageText");
+    assertEquals(ArrayBucket.class, messageBucket.getClass());
+  }
+
+  @Test
+  void getFieldSet_whenTimestampsUnknown_expectTimeFieldsOmitted() {
+    // Arrange
+    String header = "Header";
+    String shortText = "Short";
+    String text = "Body";
+    short priorityClass = 1;
+    long updatedTime = 42L;
+    String sourceNodeName = "UnknownNode";
+    String messageText = "Message payload";
+
+    TextFeedMessage message =
+        new TextFeedMessage(
+            header,
+            shortText,
+            text,
+            priorityClass,
+            updatedTime,
+            sourceNodeName,
+            -1L,
+            -1L,
+            -1L,
+            messageText);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    // Assert
+    assertEquals(sourceNodeName, fieldSet.get("SourceNodeName"));
+    assertNull(fieldSet.get("TimeComposed"));
+    assertNull(fieldSet.get("TimeSent"));
+    assertNull(fieldSet.get("TimeReceived"));
+
+    int messageTextBytes = messageText.getBytes(StandardCharsets.UTF_8).length;
+    assertEquals(messageTextBytes, fieldSet.getLong("MessageTextLength", -1L));
+  }
+
+  @Test
+  void getFieldSet_whenMessageTextNull_expectZeroLengthNullBucketAndBodyOnlyDataLength() {
+    // Arrange
+    String text = "Body only";
+    short priorityClass = 3;
+    long updatedTime = 1234L;
+
+    TextFeedMessage message =
+        new TextFeedMessage(
+            "Header", "Short", text, priorityClass, updatedTime, "SomeNode", 10L, 20L, 30L, null);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
+
+    // Assert: the MessageText bucket exists but contributes zero bytes
+    assertEquals(textBytes, fieldSet.getLong("TextLength", -1L));
+    assertEquals(0L, fieldSet.getLong("MessageTextLength", -1L));
+    assertEquals(textBytes, fieldSet.getLong("DataLength", -1L));
+    assertEquals(textBytes, message.dataLength());
+
+    Bucket messageBucket = getBuckets(message).get("MessageText");
+    assertEquals(NullBucket.class, messageBucket.getClass());
+  }
+
+  @Test
+  void getName_whenCalled_expectTextFeedConstantReturned() {
+    // Arrange
+    TextFeedMessage message =
+        new TextFeedMessage(
+            "Header", "Short", "Body", (short) 1, 0L, "Node", -1L, -1L, -1L, "message");
+
+    // Act & Assert
+    assertEquals(TextFeedMessage.NAME, message.getName());
+  }
+
+  private Map<String, Bucket> getBuckets(TextFeedMessage message) {
+    try {
+      Field bucketsField = MultipleDataCarryingMessage.class.getDeclaredField("buckets");
+      bucketsField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Map<String, Bucket> buckets = (Map<String, Bucket>) bucketsField.get(message);
+      return buckets;
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to access buckets for TextFeedMessage", e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/URIFeedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/URIFeedMessageTest.java
@@ -1,0 +1,290 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import network.crypta.support.io.NullBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // Test method naming: method_whenCondition_expectOutcome
+@ExtendWith(MockitoExtension.class)
+class URIFeedMessageTest {
+
+  @Mock private FreenetURI uriMock;
+
+  @Test
+  void constructor_whenDescriptionNonNull_expectArrayBucketWithUtf8Bytes() throws IOException {
+    // Arrange
+    String header = "Test header";
+    String shortText = "Short summary";
+    String text = "Body text with UTF-8 ☃ and newlines\nsecond line";
+    short priorityClass = 5;
+    long updatedTime = 1_694_000_000L;
+    String sourceNodeName = "PeerNode-A";
+    long composed = 100L;
+    long sent = 200L;
+    long received = 300L;
+    String description = "Description with UTF-8 ✓";
+
+    URIFeedMessage message =
+        new URIFeedMessage(
+            header,
+            shortText,
+            text,
+            priorityClass,
+            updatedTime,
+            sourceNodeName,
+            composed,
+            sent,
+            received,
+            uriMock,
+            description);
+
+    int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
+    int descriptionBytes = description.getBytes(StandardCharsets.UTF_8).length;
+    long expectedTotalBytes = (long) textBytes + descriptionBytes;
+
+    // Act
+    Map<String, Bucket> buckets = getBuckets(message);
+    Bucket textBucket = buckets.get("Text");
+    Bucket descriptionBucket = buckets.get("Description");
+
+    // Assert: text bucket from FeedMessage
+    assertEquals(ArrayBucket.class, textBucket.getClass());
+    assertEquals(textBytes, textBucket.size());
+
+    // Assert: description bucket populated with UTF-8 bytes
+    assertEquals(ArrayBucket.class, descriptionBucket.getClass());
+    assertEquals(descriptionBytes, descriptionBucket.size());
+    assertEquals(expectedTotalBytes, message.dataLength());
+
+    // Verify bucket contents decode back to the original description
+    try (InputStream in = descriptionBucket.getInputStream()) {
+      byte[] buffer = in.readAllBytes();
+      String decoded = new String(buffer, StandardCharsets.UTF_8);
+      assertEquals(description, decoded);
+    }
+  }
+
+  @Test
+  void constructor_whenDescriptionNull_expectNullBucketWithZeroLength() {
+    // Arrange
+    String text = "Body only";
+    short priorityClass = 3;
+    long updatedTime = 1234L;
+
+    URIFeedMessage message =
+        new URIFeedMessage(
+            "Header",
+            "Short",
+            text,
+            priorityClass,
+            updatedTime,
+            "SomeNode",
+            10L,
+            20L,
+            30L,
+            uriMock,
+            null);
+
+    int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
+
+    // Act
+    Map<String, Bucket> buckets = getBuckets(message);
+    Bucket textBucket = buckets.get("Text");
+    Bucket descriptionBucket = buckets.get("Description");
+
+    // Assert: text bucket still populated from FeedMessage
+    assertEquals(ArrayBucket.class, textBucket.getClass());
+    assertEquals(textBytes, textBucket.size());
+
+    // Assert: null description leads to a NullBucket with zero size
+    assertEquals(NullBucket.class, descriptionBucket.getClass());
+    assertEquals(0L, descriptionBucket.size());
+
+    // Overall DataLength should reflect only the text bucket
+    assertEquals(textBytes, message.dataLength());
+  }
+
+  @Test
+  void constructor_whenDescriptionEmpty_expectArrayBucketWithZeroLength() {
+    // Arrange
+    String text = "Body";
+    String description = "";
+    short priorityClass = 2;
+    long updatedTime = 99L;
+
+    URIFeedMessage message =
+        new URIFeedMessage(
+            "Header",
+            "Short",
+            text,
+            priorityClass,
+            updatedTime,
+            "Node",
+            1L,
+            2L,
+            3L,
+            uriMock,
+            description);
+
+    int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
+
+    // Act
+    Map<String, Bucket> buckets = getBuckets(message);
+    Bucket textBucket = buckets.get("Text");
+    Bucket descriptionBucket = buckets.get("Description");
+
+    // Assert
+    assertEquals(ArrayBucket.class, descriptionBucket.getClass());
+    assertEquals(0L, descriptionBucket.size());
+    assertEquals(ArrayBucket.class, textBucket.getClass());
+    assertEquals(textBytes, textBucket.size());
+    assertEquals(textBytes, message.dataLength());
+  }
+
+  @Test
+  void getFieldSet_whenStandardValuesProvided_expectBaseFieldsAndUriPresent() {
+    // Arrange
+    String header = "URI Feed Header";
+    String shortText = "Short URI summary";
+    String text = "Body text";
+    short priorityClass = 7;
+    long updatedTime = 1_700_000_000L;
+    String sourceNodeName = "OriginNode";
+    long composed = 1234L;
+    long sent = 5678L;
+    long received = 9012L;
+    String description = "Descriptive text";
+
+    String uriString = "KSK@some-doc";
+    org.mockito.Mockito.when(uriMock.toString()).thenReturn(uriString);
+
+    URIFeedMessage message =
+        new URIFeedMessage(
+            header,
+            shortText,
+            text,
+            priorityClass,
+            updatedTime,
+            sourceNodeName,
+            composed,
+            sent,
+            received,
+            uriMock,
+            description);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    int textBytes = text.getBytes(StandardCharsets.UTF_8).length;
+    int descriptionBytes = description.getBytes(StandardCharsets.UTF_8).length;
+    long expectedTotalBytes = (long) textBytes + descriptionBytes;
+
+    // Assert: base feed metadata
+    assertEquals(header, fieldSet.get("Header"));
+    assertEquals(shortText, fieldSet.get("ShortText"));
+    assertEquals(priorityClass, fieldSet.getShort("PriorityClass", (short) -1));
+    assertEquals(updatedTime, fieldSet.getLong("UpdatedTime", -1L));
+
+    // Assert: node-to-node metadata
+    assertEquals(sourceNodeName, fieldSet.get("SourceNodeName"));
+    assertEquals(composed, fieldSet.getLong("TimeComposed", -1L));
+    assertEquals(sent, fieldSet.getLong("TimeSent", -1L));
+    assertEquals(received, fieldSet.getLong("TimeReceived", -1L));
+
+    // Assert: URI is included
+    assertEquals(uriString, fieldSet.get("URI"));
+
+    // Assert: bucket lengths and aggregated DataLength
+    assertEquals(textBytes, fieldSet.getLong("TextLength", -1L));
+    assertEquals(descriptionBytes, fieldSet.getLong("DescriptionLength", -1L));
+    assertEquals(expectedTotalBytes, fieldSet.getLong("DataLength", -1L));
+    assertEquals(expectedTotalBytes, message.dataLength());
+  }
+
+  @Test
+  void getFieldSet_whenTimestampsUnknown_expectTimeFieldsOmittedButUriPresent() {
+    // Arrange
+    String text = "Body";
+    String description = "Desc";
+    short priorityClass = 4;
+    long updatedTime = 42L;
+    String sourceNodeName = "UnknownNode";
+    String uriString = "KSK@editionless";
+
+    org.mockito.Mockito.when(uriMock.toString()).thenReturn(uriString);
+
+    URIFeedMessage message =
+        new URIFeedMessage(
+            "Header",
+            "Short",
+            text,
+            priorityClass,
+            updatedTime,
+            sourceNodeName,
+            -1L,
+            -1L,
+            -1L,
+            uriMock,
+            description);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    // Assert: source node name is present but time fields are omitted
+    assertEquals(sourceNodeName, fieldSet.get("SourceNodeName"));
+    assertNull(fieldSet.get("TimeComposed"));
+    assertNull(fieldSet.get("TimeSent"));
+    assertNull(fieldSet.get("TimeReceived"));
+
+    // URI remains present regardless of timestamps
+    assertEquals(uriString, fieldSet.get("URI"));
+  }
+
+  @Test
+  void getName_whenCalled_expectUriFeedConstantReturned() {
+    // Arrange
+    URIFeedMessage message =
+        new URIFeedMessage(
+            "Header",
+            "Short",
+            "Text",
+            (short) 1,
+            0L,
+            "Node",
+            -1L,
+            -1L,
+            -1L,
+            uriMock,
+            "Description");
+
+    // Act & Assert
+    assertEquals(URIFeedMessage.NAME, message.getName());
+    assertEquals("URIFeed", message.getName());
+  }
+
+  private static Map<String, Bucket> getBuckets(MultipleDataCarryingMessage message) {
+    try {
+      java.lang.reflect.Field bucketsField =
+          MultipleDataCarryingMessage.class.getDeclaredField("buckets");
+      bucketsField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Map<String, Bucket> buckets = (Map<String, Bucket>) bucketsField.get(message);
+      return buckets;
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to access buckets for URIFeedMessage", e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add doclint-compliant Javadoc that explains how BaseDataCarryingMessage, MultipleDataCarryingMessage, FeedMessage, TextFeedMessage, URIFeedMessage, BookmarkFeed, and N2NFeedMessage work together
- add focused JUnit 6 suites for FeedMessage, TextFeedMessage, URIFeedMessage, and BookmarkFeed to lock down field-set output, payload buckets, and run() behaviour
- refactor BookmarkFeed and URIFeedMessage so they continue to extend N2NFeedMessage, centralizing source/timestamp metadata handling instead of duplicating it

## Testing
- Not run (not requested)
