### PR TITLE
feat(fcp): harden ClientGetMessage parsing

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -269,7 +269,7 @@ public class ClientGet extends ClientRequest
     // Has already been checked
     fctx.setMaxOutputLength(message.maxSize);
     fctx.setMaxTempLength(message.maxTempSize);
-    fctx.setCanWriteClientCache(message.writeToClientCache);
+    fctx.setCanWriteClientCache(message.shouldWriteToClientCache());
     fctx.setFilterData(message.filterData);
     fctx.setIgnoreUSKDatehints(message.ignoreUSKDatehints);
     compatMode = new CompatibilityAnalyser();

--- a/src/main/java/network/crypta/clients/fcp/ClientGetMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetMessage.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -19,24 +20,49 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * ClientGet message.
+ * Represents the on-wire {@code ClientGet} message exchanged between FCP clients and the node.
  *
- * <p>Example:
+ * <p>The message aggregates every option a requester can provide, including routing hints, return
+ * channels, persistence, local caching policies, bandwidth priorities, and optional checksum or
+ * metadata payloads. Construction eagerly validates each field, so invalid identifiers, URIs, retry
+ * counts, or disk targets trigger a {@link MessageInvalidException} before the network stack
+ * attempts to start work. That early failure path protects downstream components from dealing with
+ * partially initialized state.
  *
- * <p>ClientGet IgnoreDS=false // true = ignore the datastore DSOnly=false // true = only check the
- * datastore, don't route (~= htl 0) URI=KSK@sample.txt Identifier=Request Number One Verbosity=0 //
- * no status, just tell us when it's done ReturnType=direct // return all at once over the FCP
- * connection MaxSize=100 // maximum size of returned data MaxTempSize=1000 // maximum size of
- * intermediary data MaxRetries=100 // automatic retry supported as an option PriorityClass=1 //
- * priority class 1 = interactive Persistence=reboot // continue until node is restarted; report
- * progress while client is connected, including if it reconnects after losing connection
- * ClientToken=hello // returned in PersistentGet, a hint to the client, so the client doesn't need
- * to maintain its own state IgnoreUSKDatehints=false // true = don't use USK datehints EndMessage
+ * <p>Instances are effectively immutable after parsing, making them safe to reuse across handler
+ * callbacks even when multiple threads deliver status updates. The class also centralizes
+ * serialization logic so that only a curated subset of the original fields is echoed back to the
+ * client, preventing accidental leakage of local-only attributes such as disk paths.
+ *
+ * <ul>
+ *   <li>Parses and validates user-supplied {@link SimpleFieldSet} parameters.
+ *   <li>Tracks how the requested data should be returned (direct, disk, or none).
+ *   <li>Holds derived metadata such as cache policy and allowable MIME types.
+ * </ul>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * SimpleFieldSet fields = ...; // obtained from the FCP socket
+ * ClientGetMessage message = new ClientGetMessage(fields);
+ * handler.startClientGet(message);
+ * }</pre>
+ *
+ * @see ClientGet
+ * @see FCPConnectionHandler
  */
 public class ClientGetMessage extends BaseDataCarryingMessage {
   private static final Logger LOG = LoggerFactory.getLogger(ClientGetMessage.class);
 
+  /**
+   * Constant message name advertised to the FCP dispatcher so that inbound field sets are routed to
+   * this type; the value never changes because the wire protocol expects {@code ClientGet}
+   * literally.
+   */
   public static final String NAME = "ClientGet";
+
+  private static final String FIELD_MAX_SIZE = "MaxSize";
+  private static final String FIELD_MAX_TEMP_SIZE = "MaxTempSize";
   final boolean ignoreDS;
   final boolean dsOnly;
   final FreenetURI uri;
@@ -53,7 +79,7 @@ public class ClientGetMessage extends BaseDataCarryingMessage {
   final boolean global;
   final boolean binaryBlob;
   final String[] allowedMIMETypes;
-  public boolean writeToClientCache;
+  private final boolean writeToClientCache;
   final String charset;
   final boolean filterData;
   final boolean realTimeFlag;
@@ -63,181 +89,238 @@ public class ClientGetMessage extends BaseDataCarryingMessage {
 
   // Legacy threshold callback removed.
 
+  /**
+   * Creates a message by parsing and validating the user-supplied field set.
+   *
+   * <p>The constructor inspects every supported parameter, applies sensible defaults, and ensures
+   * that file paths, URIs, numeric bounds, and persistence modes meet protocol rules. The resulting
+   * instance carries both raw and derived fields (such as {@link #returnType}) so routing and
+   * handler code can react without re-reading the original {@link SimpleFieldSet}. Because parsing
+   * is strict, callers should be prepared to relay validation errors back to the remote client.
+   *
+   * @param fs field set from the remote peer containing ClientGet parameters and defaults.
+   * @throws MessageInvalidException if identifiers, numeric ranges, return type, or disk targets
+   *     are invalid.
+   */
   public ClientGetMessage(SimpleFieldSet fs) throws MessageInvalidException {
-    short defaultPriority;
     clientToken = fs.get("ClientToken");
     global = fs.getBoolean("Global", false);
     ignoreDS = fs.getBoolean("IgnoreDS", false);
     dsOnly = fs.getBoolean("DSOnly", false);
-    identifier = fs.get("Identifier");
+    identifier = requireIdentifier(fs);
     allowedMIMETypes = fs.getAll("AllowedMIMETypes");
     filterData = fs.getBoolean("FilterData", false);
     charset = fs.get("Charset");
-    if (identifier == null)
+    uri = parseUri(fs);
+    verbosity = parseVerbosity(fs);
+    ReturnTypeConfig returnTypeConfig = resolveReturnType(fs);
+    returnType = returnTypeConfig.type();
+    diskFile = returnTypeConfig.diskFile();
+    maxSize =
+        parsePositiveLong(fs.get(FIELD_MAX_SIZE), FIELD_MAX_SIZE, "Maximum size must be positive");
+    maxTempSize =
+        parsePositiveLong(
+            fs.get(FIELD_MAX_TEMP_SIZE), FIELD_MAX_TEMP_SIZE, "Maximum temp size must be positive");
+    maxRetries = parseMaxRetries(fs.get("MaxRetries"));
+    priorityClass = parsePriorityClass(fs.get("PriorityClass"), returnTypeConfig.defaultPriority());
+    persistence = parsePersistence(fs);
+    writeToClientCache = fs.getBoolean("WriteToClientCache", persistence == Persistence.CONNECTION);
+    binaryBlob = fs.getBoolean("BinaryBlob", false);
+    realTimeFlag = fs.getBoolean("RealTimeFlag", false);
+    initialMetadataLength =
+        validateInitialMetadataLength(fs.getLong("InitialMetadata.DataLength", 0));
+    ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);
+  }
+
+  private String requireIdentifier(SimpleFieldSet fs) throws MessageInvalidException {
+    String value = fs.get("Identifier");
+    if (value == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "No Identifier", null, global);
+    }
+    return value;
+  }
+
+  private FreenetURI parseUri(SimpleFieldSet fs) throws MessageInvalidException {
     try {
-      uri = new FreenetURI(fs.get("URI"));
+      return new FreenetURI(fs.get("URI"));
     } catch (MalformedURLException e) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, e.getMessage(), identifier, global);
     }
+  }
+
+  private int parseVerbosity(SimpleFieldSet fs) throws MessageInvalidException {
     String verbosityString = fs.get("Verbosity");
-    if (verbosityString == null) verbosity = 0;
-    else {
-      try {
-        verbosity = Integer.parseInt(verbosityString, 10);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing Verbosity field: " + e.getMessage(),
-            identifier,
-            global);
-      }
+    if (verbosityString == null) {
+      return 0;
     }
-    String returnTypeString = fs.get("ReturnType");
-    returnType = parseReturnTypeFCP(returnTypeString);
-    if (returnType == ReturnType.DIRECT) {
-      diskFile = null;
-      // default just below FProxy
-      defaultPriority = RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS;
-    } else if (returnType == ReturnType.NONE) {
-      diskFile = null;
-      defaultPriority = RequestStarter.PREFETCH_PRIORITY_CLASS;
-    } else if (returnType == ReturnType.DISK) {
-      defaultPriority = RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS;
-      String filename = fs.get("Filename");
-      if (filename == null)
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.MISSING_FIELD, "Missing Filename", identifier, global);
-      diskFile = new File(filename);
-      if (diskFile.exists())
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.DISK_TARGET_EXISTS, null, identifier, global);
-      try {
-        // Check whether we can create a temp file in the target directory.
-        File temp =
-            FileUtil.createTempFile(diskFile.getName(), ".freenet-tmp", diskFile.getParentFile());
-        temp.delete();
-      } catch (IOException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.COULD_NOT_CREATE_FILE, e.getMessage(), identifier, global);
-      }
-    } else
+    try {
+      return Integer.parseInt(verbosityString, 10);
+    } catch (NumberFormatException e) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.MESSAGE_PARSE_ERROR, "Unknown return-type", identifier, global);
-    String maxSizeString = fs.get("MaxSize");
-    if (maxSizeString == null)
-      // default to unlimited
-      maxSize = Long.MAX_VALUE;
-    else {
-      try {
-        maxSize = Long.parseLong(maxSizeString, 10);
-        if (maxSize < 0)
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing Verbosity field: " + e.getMessage(),
+          identifier,
+          global);
+    }
+  }
+
+  private ReturnTypeConfig resolveReturnType(SimpleFieldSet fs) throws MessageInvalidException {
+    ReturnType parsedType = parseReturnTypeFCP(fs.get("ReturnType"));
+    return switch (parsedType) {
+      case DIRECT ->
+          new ReturnTypeConfig(parsedType, null, RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS);
+      case NONE -> new ReturnTypeConfig(parsedType, null, RequestStarter.PREFETCH_PRIORITY_CLASS);
+      case DISK ->
+          new ReturnTypeConfig(
+              parsedType, initDiskFile(fs), RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS);
+      default ->
           throw new MessageInvalidException(
-              ProtocolErrorMessage.INVALID_FIELD,
-              "Maximum size must be positive",
-              identifier,
-              global);
-      } catch (NumberFormatException e) {
+              ProtocolErrorMessage.MESSAGE_PARSE_ERROR, "Unknown return-type", identifier, global);
+    };
+  }
+
+  private File initDiskFile(SimpleFieldSet fs) throws MessageInvalidException {
+    String filename = fs.get("Filename");
+    if (filename == null) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.MISSING_FIELD, "Missing Filename", identifier, global);
+    }
+    File target = new File(filename);
+    if (target.exists()) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.DISK_TARGET_EXISTS, null, identifier, global);
+    }
+    try {
+      File temp = FileUtil.createTempFile(target.getName(), ".freenet-tmp", target.getParentFile());
+      Files.delete(temp.toPath());
+    } catch (IOException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.COULD_NOT_CREATE_FILE, e.getMessage(), identifier, global);
+    }
+    return target;
+  }
+
+  private long parsePositiveLong(String value, String fieldName, String invalidValueMessage)
+      throws MessageInvalidException {
+    if (value == null) {
+      return Long.MAX_VALUE;
+    }
+    try {
+      long parsed = Long.parseLong(value, 10);
+      if (parsed < 0) {
         throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing MaxSize field: " + e.getMessage(),
+            ProtocolErrorMessage.INVALID_FIELD, invalidValueMessage, identifier, global);
+      }
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing " + fieldName + " field: " + e.getMessage(),
+          identifier,
+          global);
+    }
+  }
+
+  private int parseMaxRetries(String value) throws MessageInvalidException {
+    if (value == null) {
+      logMaxRetries(0);
+      return 0;
+    }
+    try {
+      int parsed = Integer.parseInt(value, 10);
+      if (parsed < -1) {
+        throw new MessageInvalidException(
+            ProtocolErrorMessage.INVALID_FIELD,
+            "Max retries must be -1 or larger",
             identifier,
             global);
       }
+      logMaxRetries(parsed);
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing MaxRetries field: " + e.getMessage(),
+          identifier,
+          global);
     }
-    String maxTempSizeString = fs.get("MaxTempSize");
-    if (maxTempSizeString == null)
-      // default to unlimited
-      maxTempSize = Long.MAX_VALUE;
-    else {
-      try {
-        maxTempSize = Long.parseLong(maxTempSizeString, 10);
-        if (maxTempSize < 0)
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.INVALID_FIELD,
-              "Maximum temp size must be positive",
-              identifier,
-              global);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing MaxSize field: " + e.getMessage(),
-            identifier,
-            global);
-      }
+  }
+
+  private void logMaxRetries(int value) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("max retries={}", value);
     }
-    String maxRetriesString = fs.get("MaxRetries");
-    if (maxRetriesString == null)
-      // default to 0
-      maxRetries = 0;
-    else {
-      try {
-        maxRetries = Integer.parseInt(maxRetriesString, 10);
-        if (maxRetries < -1)
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.INVALID_FIELD,
-              "Max retries must be -1 or larger",
-              identifier,
-              global);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing MaxSize field: " + e.getMessage(),
-            identifier,
-            global);
-      }
-    }
-    if (LOG.isDebugEnabled()) LOG.debug("max retries=" + maxRetries);
-    String priorityString = fs.get("PriorityClass");
+  }
+
+  private short parsePriorityClass(String priorityString, short defaultPriority)
+      throws MessageInvalidException {
     if (priorityString == null) {
-      // defaults to the one just below FProxy
-      priorityClass = defaultPriority;
-    } else {
-      try {
-        priorityClass = Short.parseShort(priorityString);
-        if (!RequestStarter.isValidPriorityClass(priorityClass))
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.INVALID_FIELD,
-              "Invalid priority class "
-                  + priorityClass
-                  + " - range is "
-                  + RequestStarter.PAUSED_PRIORITY_CLASS
-                  + " to "
-                  + RequestStarter.MAXIMUM_PRIORITY_CLASS,
-              identifier,
-              global);
-      } catch (NumberFormatException e) {
+      return defaultPriority;
+    }
+    try {
+      short parsed = Short.parseShort(priorityString);
+      if (!RequestStarter.isValidPriorityClass(parsed)) {
         throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing PriorityClass field: " + e.getMessage(),
+            ProtocolErrorMessage.INVALID_FIELD,
+            "Invalid priority class "
+                + parsed
+                + " - range is "
+                + RequestStarter.PAUSED_PRIORITY_CLASS
+                + " to "
+                + RequestStarter.MAXIMUM_PRIORITY_CLASS,
             identifier,
             global);
       }
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing PriorityClass field: " + e.getMessage(),
+          identifier,
+          global);
     }
+  }
+
+  private Persistence parsePersistence(SimpleFieldSet fs) throws MessageInvalidException {
     String persistenceString = fs.get("Persistence");
-    persistence = Persistence.parseOrThrow(persistenceString, identifier, global);
-    if (global && (persistence == Persistence.CONNECTION)) {
+    Persistence parsed = Persistence.parseOrThrow(persistenceString, identifier, global);
+    if (global && (parsed == Persistence.CONNECTION)) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.NOT_SUPPORTED,
           "Global requests must be persistent",
           identifier,
-          global);
+          true);
     }
-    writeToClientCache = fs.getBoolean("WriteToClientCache", persistence == Persistence.CONNECTION);
-    binaryBlob = fs.getBoolean("BinaryBlob", false);
-    realTimeFlag = fs.getBoolean("RealTimeFlag", false);
-    initialMetadataLength = fs.getLong("InitialMetadata.DataLength", 0);
-    if (initialMetadataLength < 0)
+    return parsed;
+  }
+
+  private long validateInitialMetadataLength(long length) throws MessageInvalidException {
+    if (length < 0) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD,
           "Invalid data length for initial metadata",
           identifier,
           global);
-    ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);
+    }
+    return length;
   }
 
+  private record ReturnTypeConfig(ReturnType type, File diskFile, short defaultPriority) {}
+
+  /**
+   * Returns a sanitized {@link SimpleFieldSet} snapshot suitable for forwarding to peer nodes or
+   * echoing back to the requesting client.
+   *
+   * <p>The returned structure includes only the commonly shared ClientGet arguments (identifiers,
+   * URI, verbosity, return type, and size limits). Sensitive local-only values such as filenames or
+   * cached metadata are intentionally omitted to avoid revealing operator information. The snapshot
+   * is rebuilt on every invocation so that downstream consumers cannot mutate the internal state of
+   * this message instance.
+   *
+   * @return field set containing ClientGet options safe for serialization without leakage.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
@@ -248,8 +331,8 @@ public class ClientGetMessage extends BaseDataCarryingMessage {
     fs.putSingle("Identifier", identifier);
     fs.put("Verbosity", verbosity);
     fs.putSingle("ReturnType", getReturnTypeString());
-    fs.put("MaxSize", maxSize);
-    fs.put("MaxTempSize", maxTempSize);
+    fs.put(FIELD_MAX_SIZE, maxSize);
+    fs.put(FIELD_MAX_TEMP_SIZE, maxTempSize);
     fs.put("MaxRetries", maxRetries);
     fs.put("BinaryBlob", binaryBlob);
     return fs;
@@ -259,14 +342,51 @@ public class ClientGetMessage extends BaseDataCarryingMessage {
     return returnType.toString();
   }
 
+  /**
+   * Supplies the canonical name advertised to the FCP dispatch layer.
+   *
+   * <p>Even though the value is always {@link #NAME}, this indirection keeps the {@link
+   * BaseDataCarryingMessage} contract satisfied and enables instrumentation hooks that inspect
+   * names before executing a handler. The method is pure and side effect free, allowing it to be
+   * invoked repeatedly when tracing or metrics systems need to tag outgoing responses.
+   *
+   * @return literal {@code ClientGet} so dispatchers map field sets consistently.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Delegates processing to the provided connection handler for execution on the node.
+   *
+   * <p>The handler typically schedules the request with {@link RequestStarter}, causing the node to
+   * retrieve or stream data according to the persistence and return type captured inside this
+   * message. Callers should only invoke this method once per instance; repeated calls would enqueue
+   * redundant work and potentially exceed resource quotas because the message carries immutable
+   * identifiers and client tokens.
+   *
+   * @param handler active connection handler orchestrating ClientGet lifecycle and status relays.
+   * @param node node instance whose datastore, routing, and scheduler components execute the
+   *     request.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) {
     handler.startClientGet(this);
+  }
+
+  /**
+   * Indicates whether fetched data should be written to the client cache when returned.
+   *
+   * <p>The flag is derived from the requested persistence: ephemeral {@code CONNECTION} requests
+   * write by default so reconnections resume quickly, whereas reboot- or forever-persistent ones
+   * rely on datastore durability instead. External callers can consult this helper when determining
+   * whether to materialize temporary buckets or bypass caching for highly transient transfers.
+   *
+   * @return true to mirror into client cache, false to stream directly.
+   */
+  public boolean shouldWriteToClientCache() {
+    return writeToClientCache;
   }
 
   ReturnType parseReturnTypeFCP(String string) throws MessageInvalidException {
@@ -287,6 +407,22 @@ public class ClientGetMessage extends BaseDataCarryingMessage {
     return initialMetadataLength;
   }
 
+  /**
+   * Reads optional initial metadata that may accompany the literal message body.
+   *
+   * <p>The implementation allocates a {@link Bucket} sized exactly to {@link
+   * #initialMetadataLength} and streams bytes from the provided {@link InputStream}. Because the
+   * metadata block is small compared to the requested payload, the entire block is buffered before
+   * processing continues. Callers should provide a {@link BucketFactory} capable of producing
+   * in-memory or temporary-disk buckets appropriate for the configured node environment.
+   *
+   * @param is input stream positioned at the pending metadata payload.
+   * @param bf factory allocating metadata buckets that honor memory or disk caps.
+   * @param server owning FCP server reference retained for interface symmetry and logging.
+   * @throws IOException if streaming bytes or writing into the bucket triggers I/O failures.
+   * @throws MessageInvalidException if metadata length bookkeeping contradicts earlier validation
+   *     expectations.
+   */
   @Override
   public void readFrom(InputStream is, BucketFactory bf, FCPServer server)
       throws IOException, MessageInvalidException {
@@ -298,11 +434,37 @@ public class ClientGetMessage extends BaseDataCarryingMessage {
     initialMetadata = data;
   }
 
+  /**
+   * ClientGet never writes auxiliary data back to the wire through this hook and therefore always
+   * signals unsupported behavior.
+   *
+   * <p>The FCP control channel expects responses to be produced by {@link FCPConnectionHandler}
+   * callbacks instead of this streaming method; keeping the implementation as a hard failure avoids
+   * subtle bugs where large payloads might be double-buffered. Subclasses of {@link
+   * BaseDataCarryingMessage} that do emit data override this method, but ClientGet acts only as a
+   * request envelope.
+   *
+   * @param os ignored output stream placeholder satisfying the superclass signature contract.
+   * @throws IOException never thrown because the method raises {@link
+   *     UnsupportedOperationException} first.
+   */
   @Override
   protected void writeData(OutputStream os) throws IOException {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Returns the metadata bucket captured during {@link #readFrom(InputStream, BucketFactory,
+   * FCPServer)}.
+   *
+   * <p>The bucket may be {@code null} when no metadata was supplied or zero-length when the client
+   * specified a size but streamed no data. Callers should treat the bucket as read-only and release
+   * or recycle it via the owning {@link BucketFactory} once the node has interpreted the contained
+   * hints. The bucket remains identical between invocations; the method simply exposes the stored
+   * reference without copying.
+   *
+   * @return metadata bucket supplied by the client, or {@code null} when absent.
+   */
   public Bucket getInitialMetadata() {
     return initialMetadata;
   }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetMessageTest.java
@@ -1,0 +1,213 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.clients.fcp.ClientGet.ReturnType;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientGetMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
+
+  @Test
+  void parseReturnTypeFCP_whenStringIsNull_returnsDirect() throws MessageInvalidException {
+    ClientGetMessage message = new ClientGetMessage(baseFieldSet());
+
+    ReturnType result = message.parseReturnTypeFCP(null);
+
+    assertEquals(ReturnType.DIRECT, result);
+  }
+
+  @Test
+  void parseReturnTypeFCP_whenLowerCaseValue_parsesEnum() throws MessageInvalidException {
+    ClientGetMessage message = new ClientGetMessage(baseFieldSet());
+
+    ReturnType result = message.parseReturnTypeFCP("disk");
+
+    assertEquals(ReturnType.DISK, result);
+  }
+
+  @Test
+  void parseReturnTypeFCP_whenInvalid_throwsMessageInvalidException()
+      throws MessageInvalidException {
+    ClientGetMessage message = new ClientGetMessage(baseFieldSet());
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.parseReturnTypeFCP("bogus"));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals(message.identifier, exception.ident);
+  }
+
+  @Test
+  void constructor_whenGlobalAndConnectionPersistence_throwsNotSupported() {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("Global", true);
+    fs.putOverwrite("Persistence", Persistence.CONNECTION.name());
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientGetMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.NOT_SUPPORTED, exception.protocolCode);
+    assertEquals(fs.get("Identifier"), exception.ident);
+  }
+
+  @Test
+  void constructor_whenDiskReturnTypeWithoutFilename_throwsMissingField() {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putOverwrite("ReturnType", ReturnType.DISK.name());
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientGetMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("Missing Filename", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenDiskReturnTargetExists_throwsDiskTargetExists(@TempDir Path tempDir)
+      throws IOException {
+    Path existing = tempDir.resolve("existing.bin");
+    Files.createFile(existing);
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putOverwrite("ReturnType", ReturnType.DISK.name());
+    fs.putSingle("Filename", existing.toString());
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientGetMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.DISK_TARGET_EXISTS, exception.protocolCode);
+    assertEquals(fs.get("Identifier"), exception.ident);
+  }
+
+  @Test
+  void constructor_whenMaxSizeIsNegative_throwsInvalidField() {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putOverwrite("MaxSize", "-5");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientGetMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertTrue(exception.getMessage().contains("Maximum size"));
+  }
+
+  @Test
+  void constructor_whenInitialMetadataLengthNegative_throwsInvalidField() {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("InitialMetadata.DataLength", -1);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientGetMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals("Invalid data length for initial metadata", exception.getMessage());
+  }
+
+  @Test
+  void getFieldSet_whenCalled_containsCoreValues() throws MessageInvalidException {
+    ClientGetMessage message = new ClientGetMessage(baseFieldSet());
+
+    SimpleFieldSet fields = message.getFieldSet();
+
+    assertTrue(fields.getBoolean("IgnoreDS", false));
+    assertEquals(message.uri.toString(false, false), fields.get("URI"));
+    assertTrue(fields.getBoolean("FilterData", false));
+    assertEquals("UTF-8", fields.get("Charset"));
+    assertEquals(message.identifier, fields.get("Identifier"));
+    assertEquals(message.verbosity, fields.getInt("Verbosity", -1));
+    assertEquals(message.returnType.toString(), fields.get("ReturnType"));
+    assertEquals(message.maxSize, fields.getLong("MaxSize", -1));
+    assertEquals(message.maxTempSize, fields.getLong("MaxTempSize", -1));
+    assertEquals(message.maxRetries, fields.getInt("MaxRetries", -1));
+    assertTrue(fields.getBoolean("BinaryBlob", false));
+  }
+
+  @Test
+  void run_whenInvoked_delegatesToConnectionHandler() throws MessageInvalidException {
+    ClientGetMessage message = new ClientGetMessage(baseFieldSet());
+
+    message.run(handler, node);
+
+    verify(handler).startClientGet(message);
+  }
+
+  @Test
+  void readFrom_whenMetadataPresent_storesBucketWithPayload() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("InitialMetadata.DataLength", 5);
+    ClientGetMessage message = new ClientGetMessage(fs);
+    byte[] payload = "HELLO".getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream input = new ByteArrayInputStream(payload);
+
+    message.readFrom(input, new ArrayBucketFactory(), null);
+
+    Bucket metadata = message.getInitialMetadata();
+    assertNotNull(metadata);
+    assertEquals(payload.length, metadata.size());
+    try (InputStream stored = metadata.getInputStream()) {
+      assertArrayEquals(payload, stored.readAllBytes());
+    }
+  }
+
+  @Test
+  void readFrom_whenMetadataLengthZero_keepsMetadataNull() throws Exception {
+    ClientGetMessage message = new ClientGetMessage(baseFieldSet());
+
+    message.readFrom(new ByteArrayInputStream(new byte[0]), new ArrayBucketFactory(), null);
+
+    assertNull(message.getInitialMetadata());
+  }
+
+  @Test
+  void dataLength_whenMetadataLengthProvided_returnsSameValue() throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("InitialMetadata.DataLength", 42);
+    ClientGetMessage message = new ClientGetMessage(fs);
+
+    long length = message.dataLength();
+
+    assertEquals(42, length);
+  }
+
+  private SimpleFieldSet baseFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "request-1");
+    fs.putSingle("URI", "KSK@sample.txt");
+    fs.put("IgnoreDS", true);
+    fs.put("FilterData", true);
+    fs.putSingle("Charset", "UTF-8");
+    fs.put("Verbosity", 1);
+    fs.putSingle("ReturnType", ReturnType.DIRECT.name());
+    fs.put("MaxSize", 4096);
+    fs.put("MaxTempSize", 8192);
+    fs.put("MaxRetries", 2);
+    fs.put("BinaryBlob", true);
+    fs.putSingle("Persistence", Persistence.REBOOT.name());
+    return fs;
+  }
+}


### PR DESCRIPTION
## Summary
- tighten ClientGetMessage validation and richly describe its responsibilities
- expose helper accessors for cache writes and field-set serialization
- add unit tests covering parsing paths, metadata ingestion, and handler delegation

## Testing
- not run (not requested)