### PR TITLE
Improve FCP message docs, validation, and coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/AllDataMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/AllDataMessage.java
@@ -3,23 +3,70 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * All the data, all in one big chunk. Obviously we must already have all the data to send it. We do
- * not want to have to block on a request, especially as there may be errors.
+ * FCP message that transports an entire retrieved payload to a waiting client in a single transfer.
+ *
+ * <p>AllDataMessage is emitted by the node whenever a {@link ClientGet} succeeds with {@link
+ * ClientGet.ReturnType#DIRECT} and the payload already resides in memory or temporary disk storage.
+ * The message couples a fully populated {@link Bucket} with the request identifier, timestamps,
+ * MIME metadata, and the {@code global} scope indicator required to resume persisted requests or
+ * feed {@code ListPersistentRequests} responses.
+ *
+ * <p>By extending {@link DataCarryingMessage}, the class inherits streaming semantics that write
+ * the bucket verbatim after its {@link #getFieldSet()} header is queued. Instances are short-lived,
+ * mutable only during construction, and are not thread-safe; callers must build, send, and
+ * optionally invoke {@link DataCarryingMessage#setFreeOnSent()} from a single connection-handling
+ * thread while ensuring the bucket remains readable until transmission completes.
+ *
+ * <p>Typical responsibilities include:
+ *
+ * <ul>
+ *   <li>Declaring the byte length so output handlers can enforce bandwidth quotas.
+ *   <li>Reporting {@code startupTime} and {@code completionTime} so clients can compute latency and
+ *       display progress history.
+ *   <li>Providing optional {@code Metadata.ContentType} for downstream caches or UI previews that
+ *       respect MIME information.
+ * </ul>
+ *
+ * @see DataCarryingMessage
+ * @see ClientGet
  */
 public class AllDataMessage extends DataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(AllDataMessage.class);
 
-  private static final long serialVersionUID = 1L;
   final long dataLength;
   final boolean global;
   final String identifier;
-  final long startupTime, completionTime;
+  final long startupTime;
+  final long completionTime;
   final String mimeType;
 
+  /**
+   * Create an {@code AllData} response wrapper for a payload that has already been fetched and
+   * buffered.
+   *
+   * <p>The constructor captures immutable metadata alongside the supplied {@link Bucket}. The
+   * bucket is not copied; the caller retains ownership but must keep it readable until the message
+   * has been serialized and optionally freed through {@link DataCarryingMessage#setFreeOnSent()}.
+   * Timestamps typically mirror {@link ClientRequest#startupTime} and {@link
+   * ClientRequest#completionTime}, enabling FCP clients to present stable latency metrics even when
+   * responses are replayed from persistence queues.
+   *
+   * <pre>{@code
+   * AllDataMessage msg =
+   *     new AllDataMessage(bucket, identifier, global, startupTime, completionTime, mimeType);
+   * msg.setFreeOnSent(); // optional: reclaim the bucket after send
+   * }</pre>
+   *
+   * @param bucket payload bucket holding the complete bytes; must remain readable
+   * @param identifier client-supplied identifier echoed in every response frame for correlation
+   * @param global whether the originating request was marked global, influencing persistence
+   *     routing rules
+   * @param startupTime epoch milliseconds recorded when the request began processing on the node
+   * @param completionTime epoch milliseconds recorded when fetching finished; zero denotes pending
+   *     completion
+   * @param mimeType optional MIME type string; {@code null} omits metadata header
+   */
   public AllDataMessage(
       Bucket bucket,
       String identifier,
@@ -36,21 +83,23 @@ public class AllDataMessage extends DataCarryingMessage {
     this.mimeType = mimeType;
   }
 
-  protected AllDataMessage() {
-    // For serialization.
-    dataLength = 0;
-    global = false;
-    identifier = null;
-    startupTime = 0;
-    completionTime = 0;
-    mimeType = null;
-  }
-
   @Override
   long dataLength() {
     return dataLength;
   }
 
+  /**
+   * Build the {@link SimpleFieldSet} header that precedes the binary payload on the wire.
+   *
+   * <p>The returned field set mirrors the canonical {@code AllData} header layout expected by FCP
+   * clients: {@code DataLength}, {@code Identifier}, {@code Global}, {@code StartupTime}, {@code
+   * CompletionTime}, and the optional {@code Metadata.ContentType}. Each invocation produces a
+   * fresh instance so that callers may add list identifiers or persistence annotations without
+   * mutating shared state. All numeric values are copied verbatim, leaving interpretation (for
+   * example clock skew or quota enforcement) to the consumer.
+   *
+   * @return newly created {@link SimpleFieldSet} describing payload size, identity, and metadata
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
@@ -63,11 +112,35 @@ public class AllDataMessage extends DataCarryingMessage {
     return fs;
   }
 
+  /**
+   * Return the FCP message name associated with this payload-bearing frame.
+   *
+   * <p>The {@code AllData} label is defined by the wire protocol and allows {@link
+   * FCPConnectionHandler} implementations to route the message to the data streaming logic instead
+   * of treating it as a purely informational response. Because this class always represents the
+   * same protocol concept, the method never varies its answer and contains no side effects.
+   *
+   * @return constant string {@code AllData} so receiving parsers treat the payload as inline data
+   */
   @Override
   public String getName() {
     return "AllData";
   }
 
+  /**
+   * Reject attempts to process an {@code AllData} message as if it had originated from a client.
+   *
+   * <p>This method exists because {@link FCPMessage} enforces a uniform interface for both inbound
+   * and outbound frames. In practice, {@code AllData} is generated exclusively by the node, so any
+   * invocation of {@code run} indicates a malformed or malicious client. The implementation
+   * therefore throws {@link MessageInvalidException} with {@link
+   * ProtocolErrorMessage#INVALID_MESSAGE} to ensure the request is aborted and the caller receives
+   * an explicit error.
+   *
+   * @param handler connection handler that attempted execution; recorded only for diagnostics
+   * @param node node context in which this outbound response originated; otherwise unused
+   * @throws MessageInvalidException always thrown to indicate the directionality violation
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
@@ -22,24 +22,45 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * ClientPut URI=CHK@ // could as easily be an insertable SSK URI Metadata.ContentType=text/html
- * Identifier=Insert-1 // identifier, as always Verbosity=0 // just report when complete
- * MaxRetries=999999 // lots of retries PriorityClass=1 // FProxy priority level
+ * Represents a fully parsed ClientPut request flowing over the FCP control connection.
  *
- * <p>UploadFrom=direct // attached directly to this message DataLength=100 // 100kB or
- * UploadFrom=disk // upload a file from disk Filename=/home/toad/something.html
- * FileHash=021349568329403123 Data
+ * <p>Each instance is constructed once the peer's {@link SimpleFieldSet} payload passes validation,
+ * capturing the destination {@link FreenetURI}, persistence policy, upload mode, and optional hints
+ * such as compressor descriptors or redirect targets. The parsed structure is passed to the server
+ * pipeline so payload streaming, request accounting, and insert scheduling can start immediately
+ * without repeatedly decoding textual headers.
  *
- * <p>Neither IgnoreDS nor DSOnly make sense for inserts.
+ * <p>The object is effectively immutable after construction because all exposed fields are final
+ * and the payload bucket reference is managed by {@link DataCarryingMessage}. This design makes it
+ * safe for worker threads to hand the message between parser, queueing, and insert components
+ * without additional locking beyond the bucket lifecycle hooks.
+ *
+ * <ul>
+ *   <li>Validates metadata (URI, identifiers, persistence, compression, and file hints).
+ *   <li>Describes how payload bytes will be supplied (inline, disk file, or redirect).
+ *   <li>Exposes helper accessors for handler code invoked by {@link FCPConnectionHandler}.
+ * </ul>
+ *
+ * @see ClientPutBase
+ * @see ClientRequest
+ * @see HighLevelSimpleClientImpl
  */
 public class ClientPutMessage extends DataCarryingMessage {
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutMessage.class);
 
+  /**
+   * Canonical FCP verb string for this message, reused by {@link #getName()} and server routing so
+   * that client responses, logging, and protocol negotiation remain stable across releases.
+   */
   public static final String NAME = "ClientPut";
+
+  private static final String FIELD_UPLOAD_FROM = "UploadFrom";
+  private static final String FIELD_DATA_LENGTH = "DataLength";
+  private static final String FIELD_VERBOSITY = "Verbosity";
 
   final FreenetURI uri;
   final String contentType;
-  final long dataLength;
+  final long payloadLength;
   final String identifier;
   final int verbosity;
   final int maxRetries;
@@ -79,16 +100,85 @@ public class ClientPutMessage extends DataCarryingMessage {
   final long metadataThreshold;
   final boolean ignoreUSKDatehints;
 
+  /**
+   * Parses a raw {@link SimpleFieldSet} describing a ClientPut request and builds an immutable
+   * representation.
+   *
+   * <p>This constructor validates every user-supplied field, normalizes defaults, and eagerly
+   * derives helper information such as upload source, compressor descriptors, and inferred
+   * filenames. It accepts inserts ranging from small inline payloads to multi-gigabyte redirected
+   * streams, and throws {@link MessageInvalidException} as soon as a constraint violation surfaces
+   * so the caller can reply with the appropriate protocol error. Callers should invoke it once per
+   * inbound message on the parsing thread before handing the resulting instance to worker queues.
+   *
+   * @param fs parsed field set containing client-provided headers and numeric properties for the
+   *     insert request
+   * @throws MessageInvalidException if any required field is missing, contradictory, malformed, or
+   *     violates node policy choices
+   */
   public ClientPutMessage(SimpleFieldSet fs) throws MessageInvalidException {
-    String fnam = null;
     identifier = fs.get("Identifier");
     binaryBlob = fs.getBoolean("BinaryBlob", false);
     global = fs.getBoolean("Global", false);
     localRequestOnly = fs.getBoolean("LocalRequestOnly", false);
+    compatibilityMode = parseCompatibilityMode(fs, identifier, global);
+    String overrideKeyRaw = fs.get("OverrideSplitfileCryptoKey");
+    overrideSplitfileCryptoKey =
+        overrideKeyRaw == null
+            ? null
+            : decodeOverrideSplitfileCryptoKey(overrideKeyRaw, identifier, global);
+    if (identifier == null)
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.MISSING_FIELD, "No Identifier", null, global);
+    UriParseResult uriParseResult = parseUri(fs, binaryBlob, identifier, global);
+    uri = uriParseResult.uri();
+    String filenameHint = uriParseResult.filenameHint();
+
+    verbosity =
+        parseOptionalIntOrZero(fs.get(FIELD_VERBOSITY), FIELD_VERBOSITY, identifier, global);
+    contentType = fs.get("Metadata.ContentType");
+    maxRetries = parseOptionalIntOrZero(fs.get("MaxRetries"), "MaxSize", identifier, global);
+    getCHKOnly = fs.getBoolean("GetCHKOnly", false);
+    priorityClass = parsePriorityClass(fs.get("PriorityClass"), identifier, global);
+
+    fileHash = fs.get(ClientPutBase.FILE_HASH);
+
+    UploadConfig uploadConfig = parseUploadSource(fs, identifier, global, filenameHint);
+    payloadLength = uploadConfig.length();
+    uploadFromType = uploadConfig.type();
+    origFilename = uploadConfig.originalFile();
+    redirectTarget = uploadConfig.redirectTarget();
+    filenameHint = uploadConfig.filenameHint();
+
+    dontCompress = fs.getBoolean("DontCompress", false);
+    persistence = Persistence.parseOrThrow(fs.get("Persistence"), identifier, global);
+    canWriteClientCache = fs.getBoolean("WriteToClientCache", false);
+    clientToken = fs.get("ClientToken");
+    targetFilename =
+        resolveTargetFilename(fs.get("TargetFilename"), filenameHint, uri, identifier, global);
+    earlyEncode = fs.getBoolean("EarlyEncode", false);
+    compressorDescriptor = parseCompressorDescriptor(fs.get("Codecs"), identifier, global);
+    if (fs.get("ForkOnCacheable") != null)
+      forkOnCacheable = fs.getBoolean("ForkOnCacheable", false);
+    else forkOnCacheable = Node.FORK_ON_CACHEABLE_DEFAULT;
+    extraInsertsSingleBlock =
+        fs.getInt("ExtraInsertsSingleBlock", HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK);
+    extraInsertsSplitfileHeaderBlock =
+        fs.getInt(
+            "ExtraInsertsSplitfileHeaderBlock",
+            HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER);
+    realTimeFlag = fs.getBoolean("RealTimeFlag", false);
+    metadataThreshold = fs.getLong("MetadataThreshold", -1);
+    ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);
+  }
+
+  private static InsertContext.CompatibilityMode parseCompatibilityMode(
+      SimpleFieldSet fs, String identifier, boolean global) throws MessageInvalidException {
     String s = fs.get("CompatibilityMode");
-    InsertContext.CompatibilityMode cmode = null;
-    if (s == null) cmode = InsertContext.CompatibilityMode.COMPAT_DEFAULT;
-    else {
+    InsertContext.CompatibilityMode cmode;
+    if (s == null) {
+      cmode = InsertContext.CompatibilityMode.COMPAT_DEFAULT;
+    } else {
       try {
         cmode = InsertContext.CompatibilityMode.valueOf(s);
       } catch (IllegalArgumentException e) {
@@ -109,129 +199,113 @@ public class ClientPutMessage extends DataCarryingMessage {
         }
       }
     }
-    compatibilityMode = cmode.intern();
-    s = fs.get("OverrideSplitfileCryptoKey");
-    if (s == null) overrideSplitfileCryptoKey = null;
-    else
-      try {
-        overrideSplitfileCryptoKey = HexUtil.hexToBytes(s);
-      } catch (NumberFormatException e1) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD,
-            "Invalid splitfile crypto key (not hex)",
-            identifier,
-            global);
-      } catch (IndexOutOfBoundsException e1) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD,
-            "Invalid splitfile crypto key (too short)",
-            identifier,
-            global);
-      }
-    if (identifier == null)
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "No Identifier", null, global);
+    return cmode.intern();
+  }
+
+  private static byte[] decodeOverrideSplitfileCryptoKey(
+      String rawKey, String identifier, boolean global) throws MessageInvalidException {
     try {
-      if (binaryBlob) uri = new FreenetURI("CHK@");
-      else {
-        String u = fs.get("URI");
-        if (u == null)
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.MISSING_FIELD, "No URI", identifier, global);
-        FreenetURI uu = new FreenetURI(u);
-        String[] metas = uu.getAllMetaStrings();
-        if (metas != null && metas.length == 1) {
-          fnam = metas[0];
-          uu = uu.setMetaString(null);
-        } // if >1, will fail later
-        uri = uu;
+      return HexUtil.hexToBytes(rawKey);
+    } catch (NumberFormatException e1) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD,
+          "Invalid splitfile crypto key (not hex)",
+          identifier,
+          global);
+    } catch (IndexOutOfBoundsException e1) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD,
+          "Invalid splitfile crypto key (too short)",
+          identifier,
+          global);
+    }
+  }
+
+  private static UriParseResult parseUri(
+      SimpleFieldSet fs, boolean binaryBlob, String identifier, boolean global)
+      throws MessageInvalidException {
+    if (binaryBlob) {
+      try {
+        return new UriParseResult(new FreenetURI("CHK@"), null);
+      } catch (MalformedURLException e) {
+        throw new MessageInvalidException(
+            ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, e.getMessage(), identifier, global);
       }
+    }
+    String u = fs.get("URI");
+    if (u == null)
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.MISSING_FIELD, "No URI", identifier, global);
+    try {
+      FreenetURI parsed = new FreenetURI(u);
+      String[] metas = parsed.getAllMetaStrings();
+      if (metas != null && metas.length == 1) {
+        String fnam = metas[0];
+        parsed = parsed.setMetaString(null);
+        return new UriParseResult(parsed, fnam);
+      }
+      return new UriParseResult(parsed, null);
     } catch (MalformedURLException e) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, e.getMessage(), identifier, global);
     }
-    String verbosityString = fs.get("Verbosity");
-    if (verbosityString == null) verbosity = 0;
-    else {
-      try {
-        verbosity = Integer.parseInt(verbosityString, 10);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing Verbosity field: " + e.getMessage(),
-            identifier,
-            global);
-      }
+  }
+
+  private static int parseOptionalIntOrZero(
+      String rawValue, String errorFieldName, String identifier, boolean global)
+      throws MessageInvalidException {
+    if (rawValue == null) {
+      return 0;
     }
-    contentType = fs.get("Metadata.ContentType");
-    String maxRetriesString = fs.get("MaxRetries");
-    if (maxRetriesString == null)
-      // default to 0
-      maxRetries = 0;
-    else {
-      try {
-        maxRetries = Integer.parseInt(maxRetriesString, 10);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing MaxSize field: " + e.getMessage(),
-            identifier,
-            global);
-      }
+    try {
+      return Integer.parseInt(rawValue, 10);
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing " + errorFieldName + " field: " + e.getMessage(),
+          identifier,
+          global);
     }
-    getCHKOnly = fs.getBoolean("GetCHKOnly", false);
-    String priorityString = fs.get("PriorityClass");
+  }
+
+  private static short parsePriorityClass(String priorityString, String identifier, boolean global)
+      throws MessageInvalidException {
     if (priorityString == null) {
-      // defaults to the one just below FProxy
-      priorityClass = RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS;
-    } else {
-      try {
-        priorityClass = Short.parseShort(priorityString);
-        if (!RequestStarter.isValidPriorityClass(priorityClass))
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.INVALID_FIELD,
-              "Invalid priority class "
-                  + priorityClass
-                  + " - range is "
-                  + RequestStarter.PAUSED_PRIORITY_CLASS
-                  + " to "
-                  + RequestStarter.MAXIMUM_PRIORITY_CLASS,
-              identifier,
-              global);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing PriorityClass field: " + e.getMessage(),
-            identifier,
-            global);
-      }
+      return RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS;
     }
-    // We do *NOT* check that FileHash is valid here for backward compatibility... and to make the
-    // override work
-    this.fileHash = fs.get(ClientPutBase.FILE_HASH);
-    String uploadFrom = fs.get("UploadFrom");
-    if ((uploadFrom == null) || uploadFrom.equalsIgnoreCase("direct")) {
-      uploadFromType = UploadFrom.DIRECT;
-      String dataLengthString = fs.get("DataLength");
-      if (dataLengthString == null)
+    try {
+      short parsed = Short.parseShort(priorityString);
+      if (!RequestStarter.isValidPriorityClass(parsed)) {
         throw new MessageInvalidException(
-            ProtocolErrorMessage.MISSING_FIELD,
-            "Need DataLength on a ClientPut",
-            identifier,
-            global);
-      try {
-        dataLength = Long.parseLong(dataLengthString, 10);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing DataLength field: " + e.getMessage(),
+            ProtocolErrorMessage.INVALID_FIELD,
+            "Invalid priority class "
+                + parsed
+                + " - range is "
+                + RequestStarter.PAUSED_PRIORITY_CLASS
+                + " to "
+                + RequestStarter.MAXIMUM_PRIORITY_CLASS,
             identifier,
             global);
       }
-      this.origFilename = null;
-      redirectTarget = null;
-    } else if (uploadFrom.equalsIgnoreCase("disk")) {
-      uploadFromType = UploadFrom.DISK;
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing PriorityClass field: " + e.getMessage(),
+          identifier,
+          global);
+    }
+  }
+
+  private UploadConfig parseUploadSource(
+      SimpleFieldSet fs, String identifier, boolean global, String filenameHint)
+      throws MessageInvalidException {
+    String uploadFrom = fs.get(FIELD_UPLOAD_FROM);
+    if (uploadFrom == null || uploadFrom.equalsIgnoreCase("direct")) {
+      long length = parseDataLength(fs, identifier, global);
+      return new UploadConfig(length, UploadFrom.DIRECT, null, null, filenameHint);
+    }
+    if (uploadFrom.equalsIgnoreCase("disk")) {
       String filename = fs.get("Filename");
       if (filename == null)
         throw new MessageInvalidException(
@@ -240,102 +314,142 @@ public class ClientPutMessage extends DataCarryingMessage {
       if (!(f.exists() && f.isFile() && f.canRead()))
         throw new MessageInvalidException(
             ProtocolErrorMessage.FILE_NOT_FOUND, null, identifier, global);
-      dataLength = f.length();
-      this.bucket = new FileBucket(f, true, false, false, false);
-      this.origFilename = f;
-      redirectTarget = null;
-      if (fnam == null) fnam = origFilename.getName();
-    } else if (uploadFrom.equalsIgnoreCase("redirect")) {
-      uploadFromType = UploadFrom.REDIRECT;
-      String target = fs.get("TargetURI");
-      if (target == null)
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.MISSING_FIELD,
-            "TargetURI missing but UploadFrom=redirect",
-            identifier,
-            global);
-      try {
-        redirectTarget = new FreenetURI(target);
-      } catch (MalformedURLException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD, "Invalid TargetURI: " + e, identifier, global);
-      }
-      dataLength = 0;
-      origFilename = null;
+      bucket = new FileBucket(f, true, false, false, false);
+      String resolvedName = filenameHint != null ? filenameHint : f.getName();
+      return new UploadConfig(f.length(), UploadFrom.DISK, f, null, resolvedName);
+    }
+    if (uploadFrom.equalsIgnoreCase("redirect")) {
+      FreenetURI target = parseRedirectTarget(fs.get("TargetURI"), identifier, global);
       bucket = null;
-    } else
+      return new UploadConfig(0, UploadFrom.REDIRECT, null, target, filenameHint);
+    }
+    throw new MessageInvalidException(
+        ProtocolErrorMessage.INVALID_FIELD,
+        "UploadFrom invalid or unrecognized: " + uploadFrom,
+        identifier,
+        global);
+  }
+
+  private static long parseDataLength(SimpleFieldSet fs, String identifier, boolean global)
+      throws MessageInvalidException {
+    String dataLengthString = fs.get(FIELD_DATA_LENGTH);
+    if (dataLengthString == null)
       throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD,
-          "UploadFrom invalid or unrecognized: " + uploadFrom,
+          ProtocolErrorMessage.MISSING_FIELD, "Need DataLength on a ClientPut", identifier, global);
+    try {
+      return Long.parseLong(dataLengthString, 10);
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing DataLength field: " + e.getMessage(),
           identifier,
           global);
-    dontCompress = fs.getBoolean("DontCompress", false);
-    String persistenceString = fs.get("Persistence");
-    persistence = Persistence.parseOrThrow(persistenceString, identifier, global);
-    canWriteClientCache = fs.getBoolean("WriteToClientCache", false);
-    clientToken = fs.get("ClientToken");
-    String f = fs.get("TargetFilename");
-    if (f != null) fnam = f;
-    if (fnam != null && fnam.indexOf('/') > -1) {
+    }
+  }
+
+  private static FreenetURI parseRedirectTarget(String rawTarget, String identifier, boolean global)
+      throws MessageInvalidException {
+    if (rawTarget == null)
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.MISSING_FIELD,
+          "TargetURI missing but UploadFrom=redirect",
+          identifier,
+          global);
+    try {
+      return new FreenetURI(rawTarget);
+    } catch (MalformedURLException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD, "Invalid TargetURI: " + e, identifier, global);
+    }
+  }
+
+  private String resolveTargetFilename(
+      String targetOverride,
+      String inferredName,
+      FreenetURI parsedUri,
+      String identifier,
+      boolean global)
+      throws MessageInvalidException {
+    String candidate = targetOverride != null ? targetOverride : inferredName;
+    if (candidate != null && candidate.indexOf('/') > -1) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD,
           "TargetFilename must not contain slashes",
           identifier,
           global);
     }
-    if (fnam != null && fnam.isEmpty()) {
-      fnam = null; // Deliberate override to tell us not to create one.
+    if (candidate != null && candidate.isEmpty()) {
+      candidate = null;
     }
-    if (uri.getRoutingKey() == null && !uri.isKSK()) targetFilename = fnam;
-    else targetFilename = null;
-    earlyEncode = fs.getBoolean("EarlyEncode", false);
-    String codecs = fs.get("Codecs");
-    if (codecs != null) {
-      COMPRESSOR_TYPE[] ca;
-      try {
-        ca = COMPRESSOR_TYPE.getCompressorsArrayNoDefault(codecs);
-      } catch (InvalidCompressionCodecException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), identifier, global);
-      }
-      if (ca == null || ca.length == 0) codecs = null;
+    if (parsedUri.getRoutingKey() == null && !parsedUri.isKSK()) {
+      return candidate;
     }
-    compressorDescriptor = codecs;
-    if (fs.get("ForkOnCacheable") != null)
-      forkOnCacheable = fs.getBoolean("ForkOnCacheable", false);
-    else forkOnCacheable = Node.FORK_ON_CACHEABLE_DEFAULT;
-    extraInsertsSingleBlock =
-        fs.getInt("ExtraInsertsSingleBlock", HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK);
-    extraInsertsSplitfileHeaderBlock =
-        fs.getInt(
-            "ExtraInsertsSplitfileHeaderBlock",
-            HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER);
-    realTimeFlag = fs.getBoolean("RealTimeFlag", false);
-    metadataThreshold = fs.getLong("MetadataThreshold", -1);
-    ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);
+    return null;
   }
 
+  private static String parseCompressorDescriptor(String codecs, String identifier, boolean global)
+      throws MessageInvalidException {
+    if (codecs == null) {
+      return null;
+    }
+    try {
+      COMPRESSOR_TYPE[] ca = COMPRESSOR_TYPE.getCompressorsArrayNoDefault(codecs);
+      if (ca.length == 0) {
+        return null;
+      }
+      return codecs;
+    } catch (InvalidCompressionCodecException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), identifier, global);
+    }
+  }
+
+  private record UriParseResult(FreenetURI uri, String filenameHint) {}
+
+  private record UploadConfig(
+      long length,
+      UploadFrom type,
+      File originalFile,
+      FreenetURI redirectTarget,
+      String filenameHint) {}
+
+  /**
+   * Serializes this request back into the canonical {@link SimpleFieldSet} wire representation.
+   *
+   * <p>The returned structure mirrors the current in-memory state, including normalized upload
+   * configuration, persistence flags, metadata hints, and codec descriptors. Callers typically pass
+   * the snapshot to downstream protocol layers whenever the request must be echoed, logged, or
+   * forwarded to plugins for auditing or deferred processing.
+   *
+   * <pre>{@code
+   * SimpleFieldSet snapshot = message.getFieldSet();
+   * server.getConnection().send(snapshot);
+   * }</pre>
+   *
+   * @return freshly allocated field set carrying canonicalized headers describing this insert
+   *     request instance
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
     sfs.putSingle("URI", uri.toString());
     sfs.putSingle("Identifier", identifier);
-    sfs.put("Verbosity", verbosity);
+    sfs.put(FIELD_VERBOSITY, verbosity);
     sfs.put("MaxRetries", maxRetries);
     sfs.putSingle("Metadata.ContentType", contentType);
     sfs.putSingle("ClientToken", clientToken);
     switch (uploadFromType) {
       case DIRECT:
-        sfs.putSingle("UploadFrom", "direct");
-        sfs.put("DataLength", dataLength);
+        sfs.putSingle(FIELD_UPLOAD_FROM, "direct");
+        sfs.put(FIELD_DATA_LENGTH, payloadLength);
         break;
       case DISK:
-        sfs.putSingle("UploadFrom", "disk");
+        sfs.putSingle(FIELD_UPLOAD_FROM, "disk");
         sfs.putSingle("Filename", origFilename.getAbsolutePath());
-        sfs.put("DataLength", dataLength);
+        sfs.put(FIELD_DATA_LENGTH, payloadLength);
         break;
       case REDIRECT:
-        sfs.putSingle("UploadFrom", "redirect");
+        sfs.putSingle(FIELD_UPLOAD_FROM, "redirect");
         sfs.putSingle("TargetURI", redirectTarget.toString());
         break;
     }
@@ -349,11 +463,35 @@ public class ClientPutMessage extends DataCarryingMessage {
     return sfs;
   }
 
+  /**
+   * Returns the FCP message verb that identifies this structure to routers and serializers.
+   *
+   * <p>Client and server code rely on this value when populating response headers, wiring message
+   * dispatch tables, and recording telemetry grouped by verb. The implementation always returns
+   * {@link #NAME}, preserving the stable mapping between the Java type and the textual verb even if
+   * future refactors adjust construction details.
+   *
+   * @return constant verb that protocol dispatch tables expect for ClientPut traffic
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Initiates processing of this insert request by delegating to the connection handler.
+   *
+   * <p>The method is invoked on the handler thread after any payload bucket has been populated so
+   * that {@link DataCarryingMessage} invariants already hold. It forwards this instance, together
+   * with the owning {@link Node}, to {@link FCPConnectionHandler#startClientPut(ClientPutMessage)}
+   * so the handler can enforce quotas, schedule insert workers, or emit late validation errors to
+   * the client.
+   *
+   * @param handler connection handler that accepted the message and coordinates streaming
+   *     back-pressure
+   * @param node node instance used to resolve persistence settings and enforce configured limits
+   * @throws MessageInvalidException if the handler detects inconsistency during late validation
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     handler.startClientPut(this);
@@ -362,7 +500,7 @@ public class ClientPutMessage extends DataCarryingMessage {
   /** Get the length of the trailing field. */
   @Override
   long dataLength() {
-    if (uploadFromType == UploadFrom.DIRECT) return dataLength;
+    if (uploadFromType == UploadFrom.DIRECT) return payloadLength;
     else return -1;
   }
 
@@ -387,6 +525,15 @@ public class ClientPutMessage extends DataCarryingMessage {
     return global;
   }
 
+  /**
+   * Releases any bucket resources associated with the payload of this message.
+   *
+   * <p>This hook lets handlers clean up deterministically after streaming completes or aborts
+   * prematurely. It frees the bucket exactly once, logging a warning when multiple invocations
+   * occur so ordering issues can be diagnosed. Callers should prefer invoking it from {@code
+   * finally} blocks to keep transient storage usage bounded even when inserts spawn long-running
+   * retries elsewhere.
+   */
   public void freeData() {
     if (bucket == null) {
       if (dataLength() <= 0) return; // Okay.

--- a/src/main/java/network/crypta/clients/fcp/DataCarryingMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/DataCarryingMessage.java
@@ -11,19 +11,61 @@ import network.crypta.support.io.BucketTools;
 import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.NullBucket;
 import network.crypta.support.io.NullOutputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Base class for FCP messages that carry a trailing binary data section in addition to their
+ * SimpleFieldSet-style header fields.
+ *
+ * <p>The data payload is stored in a {@link Bucket} referenced by {@link #bucket}. When a message
+ * is read from the network, {@link #readFrom(InputStream, BucketFactory, FCPServer)} allocates a
+ * suitable bucket via {@link #createBucket(BucketFactory, long, FCPServer)} and streams the
+ * trailing bytes into it. When a message is written, {@link #writeData(OutputStream)} copies the
+ * previously attached bucket contents to the output stream.
+ *
+ * <p>Subclasses typically override {@link #dataLength()}, {@link #getIdentifier()}, and {@link
+ * #isGlobal()} to describe the protocol-level semantics of the message and the expected payload
+ * size. Instances are created per message, are mutable, and perform no internal synchronization;
+ * callers should therefore confine each instance to a single connection-handling thread.
+ *
+ * <ul>
+ *   <li>Messages that originate from a client normally use a {@link RandomAccessBucket} created by
+ *       this class to allow later insertion into node storage.
+ *   <li>Messages sent from the node to a client may wrap an arbitrary {@link Bucket} that does not
+ *       necessarily support random access.
+ * </ul>
+ *
+ * @see BaseDataCarryingMessage
+ * @see MultipleDataCarryingMessage
+ */
 public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(DataCarryingMessage.class);
 
   /**
-   * If this is a message from the client, then the Bucket was created by createBucket() and will be
-   * a RandomAccessBucket. However if it is a message we are sending to the client, it may not be.
-   * FIXME split up into two classes?
+   * Backing storage for the binary payload associated with this message.
+   *
+   * <p>If this is a message received from a client, the bucket is created by {@link
+   * #createBucket(BucketFactory, long, FCPServer)} and will normally be a {@link
+   * RandomAccessBucket} suitable for insertion into persistent storage. For messages sent to a
+   * client, the bucket may be any implementation supplied by the caller and is not required to
+   * support random access.
    */
   protected Bucket bucket;
 
+  /**
+   * Create a {@link RandomAccessBucket} for storing the trailing payload of this message.
+   *
+   * @param bf the {@link BucketFactory} used to allocate the underlying storage for the payload;
+   *     must be able to create buckets of the requested size
+   * @param length the number of bytes that will be written into the returned bucket; usually the
+   *     value reported by {@link #dataLength()}
+   * @param server the FCP server context; overriding implementations may consult it to select a
+   *     persistent or transient bucket factory as appropriate
+   * @return a new {@link RandomAccessBucket} whose capacity is sufficient for the requested length;
+   *     the caller is responsible for eventually freeing it
+   * @throws IOException if the underlying storage cannot be allocated or another I/O problem is
+   *     detected while preparing the bucket
+   * @throws PersistenceDisabledException if persistence is disabled and a persistent bucket would
+   *     be required; typically thrown by overrides that use persistent storage
+   */
   RandomAccessBucket createBucket(BucketFactory bf, long length, FCPServer server)
       throws IOException, PersistenceDisabledException {
     return bf.makeBucket(length);
@@ -33,12 +75,47 @@ public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
 
   abstract boolean isGlobal();
 
+  /**
+   * Indicates whether {@link #bucket} should be freed automatically after this message has been
+   * written to an output stream.
+   *
+   * <p>When this flag is {@code true}, {@link #writeData(OutputStream)} will invoke {@link
+   * Bucket#free()} once the payload has been copied. This is intended for transient buckets that
+   * are only needed while sending the message and must not remain referenced afterward.
+   */
   protected boolean freeOnSent;
 
+  /**
+   * Request that the payload bucket be freed automatically after the message has been written.
+   *
+   * <p>This is a convenience for callers that attach a transient bucket and want to ensure it is
+   * released as soon as the corresponding network write completes. It only affects subsequent calls
+   * to {@link #writeData(OutputStream)} and has no impact on how the payload is read.
+   */
   void setFreeOnSent() {
     freeOnSent = true;
   }
 
+  /**
+   * Read the trailing payload bytes for this message from the given input stream.
+   *
+   * <p>The number of bytes to read is determined by {@link #dataLength()}. If that method returns a
+   * negative value, no payload is read. If it returns zero, {@link #bucket} is set to a {@link
+   * NullBucket}. Otherwise, this method allocates a {@link RandomAccessBucket} using {@link
+   * #createBucket(BucketFactory, long, FCPServer)}, streams the requested number of bytes into it,
+   * and stores it in {@link #bucket}.
+   *
+   * @param is the input stream providing the payload bytes; it must contain at least {@link
+   *     #dataLength()} readable bytes when this method is invoked
+   * @param bf the {@link BucketFactory} used to allocate the storage for the payload when data is
+   *     present; the implementation may choose between different bucket types
+   * @param server the FCP server context associated with this connection; passed through to {@link
+   *     #createBucket(BucketFactory, long, FCPServer)} so subclasses can make persistence decisions
+   * @throws IOException if an I/O error occurs while allocating the bucket or copying bytes from
+   *     the input stream into the bucket
+   * @throws MessageInvalidException if the payload cannot be stored, for example because
+   *     persistence is disabled or an internal error occurs while creating the bucket
+   */
   @Override
   public void readFrom(InputStream is, BucketFactory bf, FCPServer server)
       throws IOException, MessageInvalidException {
@@ -52,12 +129,10 @@ public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
     try {
       tempBucket = createBucket(bf, len, server);
     } catch (IOException e) {
-      LOG.error("Bucket error: " + e, e);
       FileUtil.copy(is, new NullOutputStream(), len);
       throw new MessageInvalidException(
           ProtocolErrorMessage.INTERNAL_ERROR, e.toString(), getIdentifier(), isGlobal());
     } catch (PersistenceDisabledException e) {
-      LOG.error("Bucket error: " + e, e);
       FileUtil.copy(is, new NullOutputStream(), len);
       throw new MessageInvalidException(
           ProtocolErrorMessage.PERSISTENCE_DISABLED, null, getIdentifier(), isGlobal());
@@ -66,6 +141,19 @@ public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
     this.bucket = tempBucket;
   }
 
+  /**
+   * Write the trailing payload bytes for this message to the given output stream.
+   *
+   * <p>If {@link #dataLength()} returns a positive value, this method copies exactly that many
+   * bytes from {@link #bucket} to the supplied stream. When {@link #freeOnSent} is {@code true},
+   * the bucket is freed by calling {@link Bucket#free()} after the copy completes. If the data
+   * length is zero or negative, no bytes are written and the bucket is left unchanged.
+   *
+   * @param os the output stream that will receive the payload data; the caller is responsible for
+   *     flushing and closing the stream after the message has been fully written
+   * @throws IOException if an I/O error occurs while reading from the bucket or writing to the
+   *     output stream
+   */
   @Override
   protected void writeData(OutputStream os) throws IOException {
     long len = dataLength();
@@ -79,9 +167,16 @@ public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
   }
 
   /**
-   * Should only be called from code parsing a message sent to us, in which case Bucket will be a
-   * RandomAccessBucket, which it needs to be as it's likely to be inserted. If we are sending a
-   * message to the client, it might not be. FIXME split up into two classes?
+   * Return the payload bucket as a {@link RandomAccessBucket} for further processing.
+   *
+   * <p>This accessor is intended for code that handles messages received from a client, where the
+   * bucket was created by {@link #createBucket(BucketFactory, long, FCPServer)} and therefore
+   * supports random access. Callers that invoke this method for messages sent to a client must
+   * ensure that the bucket they attached is actually a {@link RandomAccessBucket}.
+   *
+   * @return the underlying payload bucket cast to {@link RandomAccessBucket}; callers should
+   *     typically assume this is non-{@code null} only after a successful {@link #readFrom} call
+   *     has populated the bucket
    */
   public RandomAccessBucket getRandomAccessBucket() {
     return (RandomAccessBucket) bucket;

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginClientMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginClientMessage.java
@@ -6,46 +6,46 @@ import network.crypta.node.FSParseException;
 import network.crypta.node.Node;
 import network.crypta.pluginmanager.PluginManager;
 import network.crypta.pluginmanager.PluginNotFoundException;
-import network.crypta.pluginmanager.PluginTalker;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * This class parses the network format for a FCP message which is send from a FCP client to a FCP
- * server plugin.<br>
- * It is the inverse of {@link FCPPluginServerMessage} which produces the on-network format of
- * server to client messages.<br>
- * There is a similar class {@link FCPPluginMessage} which serves as a container of FCP plugin
- * messages which are produced and consumed by the actual server and client plugin implementations.
- * Consider this class here as an internal representation of FCP plugin messages used solely for
- * parsing client-to-server messages, while the other one is the external representation used for
- * both server and client messages. Also notice that interface {@link FCPPluginConnection} consumes
- * only objects of type {@link FCPPluginMessage}, not of this class here: As the external
- * representation to both server and client, it does not care whether a message is from the server
- * or the client, and is only interested in the external representation {@link FCPPluginMessage} of
- * the message.<br>
- * <br>
- * ATTENTION: The on-network name of this message is different: It is {@value #NAME}. The class
- * previously had the same name but it was decided to rename it to fix the name clash with the
- * aforementioned external representation class {@link FCPPluginMessage}. To stay backward
- * compatible, it was decided to keep the raw network message name as is.<br>
- * TODO: Would it technically be possible to add a second name to the on-network data so we can get
- * rid of the old name after a transition period?<br>
- * <br>
+ * Parses client-to-server FCP plugin messages from their {@link SimpleFieldSet}-based wire format
+ * into the richer structures expected by the node.
  *
- * @link FCPPluginConnection FCPPluginConnection gives an overview of how plugin messaging works in
- *     general.
- * @link FCPPluginConnectionImpl FCPPluginConnectionImpl gives an overview of the internal code
- *     paths which messages take.
+ * <p>The class consumes raw field sets emitted by remote plugin clients, validates invariants such
+ * as {@code Identifier}, {@code PluginName}, and optional payload metadata, and then materializes
+ * {@link FCPPluginMessage} instances that downstream handlers can treat uniformly regardless of
+ * transport direction. In practice, it is constructed by the FCP request stack after a message
+ * arrives at the socket and before the runtime attempts to route it to a plugin-specific handler.
+ *
+ * <p>Unlike {@link FCPPluginMessage}, which is the public container shared between servers and
+ * plugins, this type is intentionally narrower. It focuses solely on the inbound path, translating
+ * field-set conventions (such as {@link #PARAM_PREFIX}) into canonical state and exposing helper
+ * logic for building a {@link FCPPluginConnection}-ready message. Instances are immutable and can
+ * therefore be safely passed between threads once constructed, although typical usage confines them
+ * to a single handler thread that subsequently queues the message for plugin execution.
+ *
+ * <p>The legacy on-network message name remains {@value #NAME} to avoid breaking compatibility with
+ * deployed nodes. Renaming only the Java class allows the runtime to distinguish between the
+ * internal parser and the external representation without modifying the wire protocol. Future
+ * revisions may introduce an alternate label, but this class deliberately preserves the original
+ * constant until peers universally upgrade.
+ *
+ * <ul>
+ *   <li>Validates structural requirements before reaching plugin code.
+ *   <li>Tracks optional metadata such as success flags and error payload details.
+ *   <li>Bridges bucket-backed payloads to {@link FCPPluginConnection} delivery.
+ * </ul>
+ *
  * @author saces
  * @author xor (xor@freenetproject.org)
- *     <p>FCPPluginMessage Identifer=me PluginName=plugins.HelloFCP.HelloFCP Param.Itemname1=value1
- *     Param.Itemname2=value2 ...
- *     <p>EndMessage or DataLength=datasize Data <datasize> bytes of data
+ * @see FCPPluginMessage
+ * @see FCPPluginServerMessage
+ * @see FCPPluginConnection
+ * @see FCPPluginConnectionImpl
  */
 public class FCPPluginClientMessage extends DataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(FCPPluginClientMessage.class);
 
   /**
    * On-network format name of the message.
@@ -55,6 +55,11 @@ public class FCPPluginClientMessage extends DataCarryingMessage {
    */
   public static final String NAME = "FCPPluginMessage";
 
+  /**
+   * Prefix applied to every plugin parameter stored in the {@link SimpleFieldSet} payload so that
+   * keys such as {@code Param.Foo} can be isolated from required top-level headers without risk of
+   * collision or misinterpretation.
+   */
   public static final String PARAM_PREFIX = "Param";
 
   /**
@@ -93,73 +98,18 @@ public class FCPPluginClientMessage extends DataCarryingMessage {
   private final String errorMessage;
 
   FCPPluginClientMessage(SimpleFieldSet fs) throws MessageInvalidException {
-    identifier = fs.get("Identifier");
-    if (identifier == null)
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD,
-          NAME + " must contain a Identifier field",
-          null,
-          false);
-    pluginname = fs.get("PluginName");
-    if (pluginname == null)
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD,
-          NAME + " must contain a PluginName field",
-          identifier,
-          false);
+    identifier =
+        getRequiredField(fs, "Identifier", NAME + " must contain a Identifier field", null);
+    pluginname =
+        getRequiredField(fs, "PluginName", NAME + " must contain a PluginName field", identifier);
 
-    boolean havedata = "Data".equals(fs.getEndMarker());
+    boolean hasData = "Data".equals(fs.getEndMarker());
+    dataLength = resolveDataLength(fs, hasData, identifier);
 
-    String dataLengthString = fs.get("DataLength");
+    plugparams = extractPluginParams(fs);
+    success = parseSuccess(fs, identifier);
 
-    if (!havedata && (dataLengthString != null))
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD,
-          "A nondata message can't have a DataLength field",
-          identifier,
-          false);
-
-    if (havedata) {
-      if (dataLengthString == null)
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.MISSING_FIELD,
-            "Need DataLength on a Datamessage",
-            identifier,
-            false);
-
-      try {
-        dataLength = Long.parseLong(dataLengthString, 10);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing DataLength field: " + e.getMessage(),
-            identifier,
-            false);
-      }
-    } else {
-      dataLength = -1;
-    }
-
-    SimpleFieldSet maybePlugparams = fs.subset(PARAM_PREFIX);
-    // subset() will return null if the subset is empty. To make server code more robust, we
-    // hand out an empty mock SimpleFieldSet in that case.
-    plugparams = maybePlugparams != null ? maybePlugparams : new SimpleFieldSet(true);
-
-    if (fs.get("Success") != null) {
-      try {
-        success = fs.getBoolean("Success");
-      } catch (FSParseException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD,
-            "Success must be a boolean (yes, no, true or false)",
-            identifier,
-            false);
-      }
-    } else {
-      success = null;
-    }
-
-    if (success != null && !success) {
+    if (Boolean.FALSE.equals(success)) {
       errorCode = fs.get("ErrorCode");
       errorMessage = errorCode != null ? fs.get("ErrorMessage") : null;
     } else {
@@ -182,81 +132,181 @@ public class FCPPluginClientMessage extends DataCarryingMessage {
     return dataLength;
   }
 
+  /**
+   * Returns the {@link SimpleFieldSet} backing this message, or {@code null} when the intermediary
+   * representation has already been normalized into {@link FCPPluginMessage} form.
+   *
+   * <p>Client messages immediately extract their mandatory headers and plugin parameters during
+   * construction, so exposing the parsed field set would invite accidental mutation or double
+   * reading. Returning {@code null} signals that the canonical structure is the {@link
+   * #constructFCPPluginMessage()} output rather than the transient parsing buffer.
+   *
+   * @return {@code null} because downstream callers must use {@link FCPPluginMessage} instead of
+   *     the intermediate {@link SimpleFieldSet}
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return null;
   }
 
+  /**
+   * Reports the wire-format identifier for this message so protocol stacks can emit or compare the
+   * canonical tag irrespective of Java type names.
+   *
+   * <p>The value is fixed to {@link #NAME}, allowing loggers, metrics, and compatibility shims to
+   * reason about legacy peers without embedding additional lookup tables. Retaining this mapping is
+   * critical while new builds coexist with deployments that only understand {@code
+   * FCPPluginMessage} as the discriminator inside multiplexed plugin channels.
+   *
+   * @return the literal {@link #NAME} constant advertised in on-network exchanges
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Builds a transport-neutral {@link FCPPluginMessage} so {@link FCPPluginConnection} can forward
+   * this request without understanding how the {@link SimpleFieldSet} was parsed.
+   *
+   * <p>The returned message preserves the parsed identifier, parameter set, success indicator, and
+   * optional error metadata while retaining the same bucket that stores binary payload data. Treat
+   * the return value as a single-use view because plugin code may consume the bucket's stream once
+   * and close it afterward.
+   *
+   * @return a newly constructed {@link FCPPluginMessage} sharing this instance's bucket and state
+   */
   protected FCPPluginMessage constructFCPPluginMessage() {
     return FCPPluginMessage.constructRawMessage(
         null, identifier, plugparams, this.bucket, success, errorCode, errorMessage);
   }
 
+  /**
+   * Resolves the target {@link FCPPluginConnection} and delivers the message using {@link
+   * SendDirection#ToServer}, translating lookup or transport failures into protocol-friendly
+   * exceptions.
+   *
+   * <p>The handler grants access to plugin-scoped connections; if the desired plugin cannot be
+   * located or its connection disappears, the method throws {@link MessageInvalidException} so the
+   * remote peer receives a deterministic error. Once a connection is available, the method creates
+   * a {@link FCPPluginMessage} view and delegates sending, letting plugins stream payload buckets
+   * as needed. The {@code node} parameter is passed for parity with other message types even though
+   * this implementation currently interacts solely with the handler.
+   *
+   * <pre>{@code
+   * FCPPluginClientMessage message = new FCPPluginClientMessage(fs);
+   * message.run(handler, node);
+   * }</pre>
+   *
+   * @param handler connection provider tied to the requesting client; must already manage plugin
+   *     lifetimes and transport policies
+   * @param node owning node instance for contextual logging or metrics; may be unused but must not
+   *     be {@code null}
+   * @throws MessageInvalidException if the plugin cannot be found or an I/O error occurs while
+   *     forwarding the message to the server side implementation
+   */
   @Override
   public void run(final FCPConnectionHandler handler, final Node node)
       throws MessageInvalidException {
-    // There are 2 code paths for deploying plugin messages:
-    // 1. The new interface FCPPluginConnection. This is only available if the plugin implements
-    //    the new interface FredPluginFCPMessageHandler.ServerSideFCPMessageHandler
-    // 2. The old class PluginTalker. This is available if the plugin implements the old
-    //    interface FredPluginFCP.
-    // We first try code path 1 by doing FCPConnectionHandler.getFCPPluginConnection(): That
-    // function will only yield a result if the new interface is implemented.
-    // If that fails, we try the old code path of PluginTalker, which will fail if the plugin
-    // also does not implement the old interface and thus is no FCP server at all.
-    // If both fail, we finally send a MessageInvalidException.
+    // Plugin messaging now requires the FCPPluginConnection interface provided by
+    // FredPluginFCPMessageHandler.ServerSideFCPMessageHandler. Legacy PluginTalker delivery has
+    // been removed, so lack of a connection means the plugin is unavailable.
 
-    FCPPluginConnection serverConnection = null;
-
+    final FCPPluginConnection serverConnection;
     try {
       serverConnection = handler.getFCPPluginConnection(pluginname);
-    } catch (PluginNotFoundException e1) {
-      // Do not send an error yet: Allow plugins which only implement the old interface to
-      // keep working.
-      // TODO: Once we remove class PluginTalker, we should throw here as we do below.
+    } catch (PluginNotFoundException e) {
+      throw pluginUnavailable();
     }
 
-    if (serverConnection != null) {
-      FCPPluginMessage message = constructFCPPluginMessage();
+    if (serverConnection == null) {
+      throw pluginUnavailable();
+    }
 
-      // Call this here instead of in the above try{} because the above
-      // handler.getFCPPluginConnection() might also throw IOException in the future and we
-      // don't want to mix that up with the one whose reason is that the plugin does not
-      // support the new interface: In the case of send() throwing, it would indicate that the
-      // plugin DOES support the new interface but was unloaded meanwhile. So we can exit the
-      // function then, we don't have to try the old interface.
-      try {
-        serverConnection.send(SendDirection.ToServer, message);
-      } catch (IOException e) {
+    FCPPluginMessage message = constructFCPPluginMessage();
+
+    try {
+      serverConnection.send(SendDirection.ToServer, message);
+    } catch (IOException e) {
+      throw pluginUnavailable();
+    }
+  }
+
+  private MessageInvalidException pluginUnavailable() {
+    return new MessageInvalidException(
+        ProtocolErrorMessage.NO_SUCH_PLUGIN,
+        pluginname + " not found or is not a FCPPlugin",
+        identifier,
+        false);
+  }
+
+  private static String getRequiredField(
+      SimpleFieldSet fs, String fieldName, String errorMessage, String identifier)
+      throws MessageInvalidException {
+    String value = fs.get(fieldName);
+    if (value == null) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.MISSING_FIELD, errorMessage, identifier, false);
+    }
+    return value;
+  }
+
+  private static long resolveDataLength(SimpleFieldSet fs, boolean hasData, String identifier)
+      throws MessageInvalidException {
+    String dataLengthString = fs.get("DataLength");
+
+    if (!hasData) {
+      if (dataLengthString != null) {
         throw new MessageInvalidException(
-            ProtocolErrorMessage.NO_SUCH_PLUGIN,
-            pluginname + " not found or is not a FCPPlugin",
+            ProtocolErrorMessage.INVALID_FIELD,
+            "A nondata message can't have a DataLength field",
             identifier,
             false);
       }
-      return;
+      return -1;
     }
 
-    // Now follows the legacy code
-
-    PluginTalker pt;
-    try {
-      PluginTalker talker =
-          new PluginTalker(node, handler, pluginname, identifier, handler.hasFullAccess());
-      pt = talker;
-    } catch (PluginNotFoundException e) {
+    if (dataLengthString == null) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.NO_SUCH_PLUGIN,
-          pluginname + " not found or is not a FCPPlugin",
+          ProtocolErrorMessage.MISSING_FIELD,
+          "Need DataLength on a Datamessage",
           identifier,
           false);
     }
 
-    pt.send(plugparams, this.bucket);
+    try {
+      return Long.parseLong(dataLengthString, 10);
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing DataLength field: " + e.getMessage(),
+          identifier,
+          false);
+    }
+  }
+
+  private static SimpleFieldSet extractPluginParams(SimpleFieldSet fs) {
+    SimpleFieldSet maybePlugparams = fs.subset(PARAM_PREFIX);
+    // subset() will return null if the subset is empty. To make server code more robust, we
+    // hand out an empty mock SimpleFieldSet in that case.
+    return maybePlugparams != null ? maybePlugparams : new SimpleFieldSet(true);
+  }
+
+  @Nullable
+  private static Boolean parseSuccess(SimpleFieldSet fs, String identifier)
+      throws MessageInvalidException {
+    if (fs.get("Success") == null) {
+      return null;
+    }
+
+    try {
+      return fs.getBoolean("Success");
+    } catch (FSParseException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD,
+          "Success must be a boolean (yes, no, true or false)",
+          identifier,
+          false);
+    }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginServerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginServerMessage.java
@@ -4,8 +4,6 @@ import network.crypta.node.Node;
 import network.crypta.pluginmanager.PluginManager;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class produces the network format for a FCP message which is send from a FCP server plugin
@@ -39,7 +37,6 @@ import org.slf4j.LoggerFactory;
  * @author xor (xor@freenetproject.org)
  */
 public class FCPPluginServerMessage extends DataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(FCPPluginServerMessage.class);
 
   /**
    * On-network format name of the message.
@@ -85,22 +82,6 @@ public class FCPPluginServerMessage extends DataCarryingMessage {
    * @see FCPPluginMessage#errorMessage
    */
   private final String errorMessage;
-
-  /**
-   * @deprecated Use {@link #FCPPluginServerMessage(String, String, SimpleFieldSet, Bucket, Boolean,
-   *     String, String)}.<br>
-   *     <br>
-   *     <b>ATTENTION:</b> Upon removal of this constructor, you should remove the backend
-   *     constructor so the only remaining constructor is the one which consumes a {@link
-   *     FCPPluginMessage}. Then you should remove all the member variables from this class which
-   *     duplicate the members of that class, and instead store a reference to an object of the
-   *     other class.
-   */
-  @Deprecated
-  public FCPPluginServerMessage(
-      String pluginname, String identifier2, SimpleFieldSet fs, Bucket bucket2) {
-    this(pluginname, identifier2, fs, bucket2, null, null, null);
-  }
 
   /**
    * @param pluginname The class name of the plugin which is sending the message.<br>

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginServerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginServerMessage.java
@@ -1,38 +1,35 @@
 package network.crypta.clients.fcp;
 
+import java.util.Objects;
 import network.crypta.node.Node;
 import network.crypta.pluginmanager.PluginManager;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 
 /**
- * This class produces the network format for a FCP message which is send from a FCP server plugin
- * to a FCP client.<br>
- * It is the inverse of {@link FCPPluginClientMessage} which parses the on-network format of client
- * to server messages.<br>
- * <br>
- * There is a similar class {@link FCPPluginMessage} which serves as a container of FCP plugin
- * messages which are produced and consumed by the actual server and client plugin implementations.
- * Consider this class here as an internal representation of FCP plugin messages used solely for
- * encoding server-to-client messages, while the other one is the external representation used for
- * both server and client messages.
+ * Represents a server-to-client FCP plugin message in the on-wire format used by the node.
  *
- * <p>ATTENTION: The on-network name of this message is different: It is {@value #NAME}. The class
- * previously had the same name but it was decided to rename it: Previously, it was only allowed for
- * the server to send messages to the client as a direct <i>reply</i> to a message. Nowadays, the
- * server can send messages to the client any time he wants, even if there hasn't been a client
- * message for a long time. So the class was renamed to FCPPluginServerMessage to prevent the
- * misconception that it would be reply only, and also to make the name symmetrical to class {@link
- * FCPPluginClientMessage}. To stay backward compatible, it was decided to keep the raw network
- * message name as is. <br>
- * TODO: Would it technically be possible to add a second name to the on-network data so we can get
- * rid of the old name after a transition period?<br>
- * <br>
+ * <p>This class converts the high-level {@link FCPPluginMessage} representation produced by server
+ * plugins into the serialized form that is sent to a remote FCP client. It is the logical inverse
+ * of {@link FCPPluginClientMessage}, which parses client-to-server plugin messages. Instances of
+ * this type are typically created shortly before transmission and then treated as immutable
+ * containers for the identifier, parameters, optional data bucket, and success or error metadata.
  *
- * @link FCPPluginConnection FCPPluginConnection gives an overview of how plugin messaging works in
- *     general.
- * @link FCPPluginConnectionImpl FCPPluginConnectionImpl gives an overview of the internal code
- *     paths which messages take.
+ * <p>The on-network name of this message is intentionally different from the class name: the
+ * protocol identifier is {@value #NAME}. Historically, messages of this kind were used only as
+ * direct replies from server to client. Asynchronous, unsolicited server messages are now allowed,
+ * so the class was renamed to {@code FCPPluginServerMessage} to emphasize the direction rather than
+ * the reply semantics, while the wire-level name was kept unchanged for backward compatibility. Any
+ * future changes to the message name must preserve the ability to read old traffic.
+ *
+ * <ul>
+ *   <li>Encodes plugin replies as {@link SimpleFieldSet} plus optional {@link Bucket} payload.
+ *   <li>Supports both successful results and structured error reports.
+ *   <li>Is used only for messages flowing from server to client, never the reverse.
+ * </ul>
+ *
+ * @see FCPPluginConnection
+ * @see FCPPluginConnectionImpl
  * @author saces
  * @author xor (xor@freenetproject.org)
  */
@@ -46,6 +43,14 @@ public class FCPPluginServerMessage extends DataCarryingMessage {
    */
   private static final String NAME = "FCPPluginReply";
 
+  /**
+   * Field-set key under which reply parameters from plugins are stored.
+   *
+   * <p>The server nests the {@link #plugparams} field set under this prefix when serializing the
+   * message so that reply-specific parameters remain grouped inside the surrounding {@link
+   * SimpleFieldSet}. The exact string value is part of the on-wire protocol and must remain stable
+   * to ensure interoperability with existing clients.
+   */
   public static final String PARAM_PREFIX = "Replies";
 
   /**
@@ -84,27 +89,55 @@ public class FCPPluginServerMessage extends DataCarryingMessage {
   private final String errorMessage;
 
   /**
-   * @param pluginname The class name of the plugin which is sending the message.<br>
-   *     Must not be null.<br>
-   *     See {@link PluginManager#getPluginInfoByClassName(String)}.
+   * Creates a server-to-client message by copying data from an existing {@link FCPPluginMessage}.
+   *
+   * <p>This convenience constructor is suitable when a plugin already built a complete {@link
+   * FCPPluginMessage} instance and only needs to wrap it for transmission to the client. All
+   * relevant fields are copied from the supplied message, and the original instance is not retained
+   * after construction. The {@code pluginname} is stored verbatim and later emitted as the {@code
+   * PluginName} field in the serialized {@link SimpleFieldSet}.
+   *
+   * @param pluginname the class name of the plugin sending the message; must not be {@code null};
+   *     see {@link PluginManager#getPluginInfoByClassName(String)} for the expected naming
+   *     convention.
+   * @param message the source {@link FCPPluginMessage} providing identifier, parameters, payload,
+   *     and success or error metadata; must not be {@code null}.
    */
   public FCPPluginServerMessage(String pluginname, FCPPluginMessage message) {
 
     this(
-        pluginname,
+        Objects.requireNonNull(pluginname, "pluginname"),
         message.identifier,
         message.params,
         message.data,
         message.success,
         message.errorCode,
         message.errorMessage);
-
-    assert (pluginname != null);
   }
 
   /**
-   * The parameters match the member variables of {@link FCPPluginMessage}, and thus their JavaDoc
-   * applies.
+   * Creates a server-to-client message from the individual plugin message components.
+   *
+   * <p>This constructor is useful when the caller maintains the identifier, parameter set, binary
+   * payload, and success or error information separately instead of in a single {@link
+   * FCPPluginMessage}. The supplied bucket is marked read-only and its size is cached as the
+   * payload length. Callers may pass {@code null} for parameters, payload, or error fields when the
+   * message does not require those aspects.
+   *
+   * @param pluginname the class name of the sending plugin as placed into the {@code PluginName}
+   *     field; may be {@code null} when the plugin does not expose a name.
+   * @param identifier2 identifier chosen by the plugin or client to correlate this reply with
+   *     earlier requests; may be {@code null} when no correlation is required.
+   * @param fs additional reply parameters to be nested under {@link #PARAM_PREFIX}; may be {@code
+   *     null} or empty when the message carries no structured parameters.
+   * @param bucket2 optional binary payload that is streamed to the client; may be {@code null} for
+   *     messages without data; is marked read-only during construction.
+   * @param success indicates whether the operation succeeded; {@code null} omits the field, {@code
+   *     Boolean.TRUE} records success, and {@code Boolean.FALSE} usually pairs with error details.
+   * @param errorCode machine-readable error code that is serialized only when {@code success} is
+   *     {@code Boolean.FALSE}; ignored for successful messages.
+   * @param errorMessage human-readable explanation of the failure, included only when an error code
+   *     is present; primarily intended for logging or diagnostic display on the client side.
    */
   public FCPPluginServerMessage(
       String pluginname,
@@ -165,7 +198,9 @@ public class FCPPluginServerMessage extends DataCarryingMessage {
     if (success != null) {
       sfs.put("Success", success);
 
-      if (!success && errorCode != null) {
+      // Use Boolean.FALSE.equals() to avoid unboxing and keep null handling explicit.
+      //noinspection PointlessBooleanExpression
+      if (Boolean.FALSE.equals(success) && errorCode != null) {
         sfs.putSingle("ErrorCode", errorCode);
 
         if (errorMessage != null) {
@@ -176,11 +211,34 @@ public class FCPPluginServerMessage extends DataCarryingMessage {
     return sfs;
   }
 
+  /**
+   * Returns the protocol-level name associated with this message type.
+   *
+   * <p>The returned value is the stable on-wire identifier used for frames carrying this message
+   * and intentionally differs from the Java class name for historical compatibility reasons.
+   *
+   * @return the constant message name {@value #NAME} used when serializing this message over FCP.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Handles an inbound instance of this message on the server side.
+   *
+   * <p>For {@code FCPPluginServerMessage} this method always rejects the invocation because the
+   * message is defined as flowing strictly from server to client. If a client nevertheless sends
+   * such a message, the method throws a {@link MessageInvalidException} that reports a protocol
+   * error back to the caller, allowing the connection logic to treat the message as invalid.
+   *
+   * @param handler connection handler representing the FCP client that attempted to send this
+   *     message; mainly used for contextual error reporting.
+   * @param node node instance that owns the connection; not used directly by this implementation
+   *     but required by the superclass contract.
+   * @throws MessageInvalidException always thrown to indicate that the client sent a server-only
+   *     message type and the message must be treated as invalid.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/main/java/network/crypta/clients/fcp/FilterMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FilterMessage.java
@@ -22,18 +22,46 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Message for testing the content filter on a file. Server will respond with a FilterResultMessage.
+ * Encapsulates a single FCP message that exercises the node's content filter pipeline and reports
+ * whether a payload would be accepted for publication.
  *
- * <p>Filter Identifier=filter1 // identifier Operation=BOTH // READ/WRITE/BOTH (ignored for now)
- * MimeType=text/html // required if DataSource=DIRECT
+ * <p>The instance mediates between untrusted client input and the {@link ContentFilter} subsystem:
+ * it parses the {@link SimpleFieldSet}, determines whether the payload is streamed directly or read
+ * from disk, infers MIME metadata when absent, and stages data inside a {@link Bucket} so the
+ * filter can treat the request identically to production traffic. Each message is short-lived and
+ * is designed to be instantiated, validated, and consumed entirely on a single thread while the
+ * caller holds the relevant protocol connection locks; no shared mutable state escapes the object.
  *
- * <p>DataSource=DISK // read a file from disk Filename=/home/bob/file.html // path to the file End
- * or DataSource=DIRECT // the data is in the message DataLength=1000 // 1000 bytes Data
+ * <p>Typical callers build a {@code Filter} FCP message prior to uploading content that might trip
+ * safety policies. The reply, {@link FilterResultMessage}, lets the client decide whether to redact
+ * data or retry with a safer MIME type before performing irreversible operations such as
+ * persistence. Large inputs are streamed through temporary buckets, so the filtering cost is
+ * proportional to payload size but avoids buffering everything into memory.
+ *
+ * <p><b>Notable behaviors:</b>
+ *
+ * <ul>
+ *   <li>Supports {@code DIRECT} and {@code DISK} payload sources with identical downstream flow.
+ *   <li>Propagates precise {@link ProtocolErrorMessage} codes whenever validation fails.
+ *   <li>Produces a deterministic loopback URI so filters that need location context remain stable.
+ * </ul>
+ *
+ * @see FilterResultMessage
+ * @see ContentFilter
  */
 public class FilterMessage extends DataCarryingMessage {
   private static final Logger LOG = LoggerFactory.getLogger(FilterMessage.class);
 
+  /**
+   * Public protocol name announced in {@code FCP} exchanges so peers can recognize filter probes;
+   * constant to keep server/client command tables in sync and safe to reuse across requests.
+   */
   public static final String NAME = "Filter";
+
+  private static final String DATA_LENGTH_FIELD = "DataLength";
+  private static final String FILTER_URI_PROPERTY =
+      "network.crypta.clients.fcp.FilterMessage.loopbackUri";
+  private static final URI DEFAULT_FILTER_URI = URI.create("http://127.0.0.1:8888/");
 
   private final String identifier;
   private final FilterOperation operation;
@@ -44,9 +72,49 @@ public class FilterMessage extends DataCarryingMessage {
 
   private final BucketFactory bf;
 
+  /**
+   * Builds a message from a parsed {@link SimpleFieldSet} and a {@link BucketFactory}, validating
+   * that the caller supplied every field required for the chosen data source before executing any
+   * disk or network operations.
+   *
+   * <p>The constructor consumes lightweight identifiers immediately so that subsequent failures
+   * reference the client-provided ID. For {@code DIRECT} payloads it copies length metadata; for
+   * {@code DISK} payloads it verifies paths, sets up {@link FileBucket} staging, and derives MIME
+   * hints. Callers typically chain this constructor directly from {@code FCPMessage.create} without
+   * retaining references because the new instance owns the temporary bucket lifecycle.
+   *
+   * <pre>{@code
+   * FilterMessage message = new FilterMessage(fieldSet, bucketFactory);
+   * handler.register(message);
+   * }</pre>
+   *
+   * @param fs parsed field set containing identifier, MIME metadata, and source-specific inputs;
+   *     must not be {@code null}.
+   * @param bf factory used to allocate transient buckets for forwarding the payload to the filter;
+   *     reused for both outputs and auto-cleanup.
+   * @throws MessageInvalidException if any required field is missing, malformed, or references an
+   *     unreadable file; error codes align with {@link ProtocolErrorMessage}.
+   */
   public FilterMessage(SimpleFieldSet fs, BucketFactory bf) throws MessageInvalidException {
+    identifier = parseIdentifier(fs);
+    operation = parseOperation(fs);
+    dataSource = parseDataSource(fs);
+    filename = fs.get("Filename");
+
+    PayloadMetadata payloadMetadata = preparePayload(fs, fs.get("MimeType"));
+    mimeType = payloadMetadata.mimeType;
+    dataLength = payloadMetadata.dataLength;
+    this.bf = bf;
+  }
+
+  @Override
+  String getIdentifier() {
+    return identifier;
+  }
+
+  private String parseIdentifier(SimpleFieldSet fs) throws MessageInvalidException {
     try {
-      identifier = fs.getString(IDENTIFIER);
+      return fs.getString(IDENTIFIER);
     } catch (FSParseException e) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
@@ -54,99 +122,130 @@ public class FilterMessage extends DataCarryingMessage {
           null,
           false);
     }
-    String op;
-    try {
-      op = fs.getString("Operation");
-    } catch (FSParseException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "Must contain an Operation field", identifier, false);
-    }
-    try {
-      operation = FilterOperation.valueOf(op);
-    } catch (IllegalArgumentException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD, "Illegal Operation value", identifier, false);
-    }
-    String ds;
-    try {
-      ds = fs.getString("DataSource");
-    } catch (FSParseException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "Must contain a DataSource field", identifier, false);
-    }
-    try {
-      dataSource = DataSource.valueOf(ds);
-    } catch (IllegalArgumentException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD, "Illegal DataSource value", identifier, false);
-    }
-    String inputMimeType = fs.get("MimeType");
-    filename = fs.get("Filename");
-    if (dataSource == DataSource.DIRECT) {
-      mimeType = inputMimeType;
-      if (mimeType == null) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.MISSING_FIELD, "Must contain a MimeType field", identifier, false);
-      }
-      String dl = fs.get("DataLength");
-      if (dl == null) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.MISSING_FIELD,
-            "Must contain a DataLength field",
-            identifier,
-            false);
-      }
-      try {
-        dataLength = fs.getLong("DataLength");
-      } catch (FSParseException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "DataLength field must be a long",
-            identifier,
-            false);
-      }
-    } else if (dataSource == DataSource.DISK) {
-      if (filename == null) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.MISSING_FIELD, "Must contain a Filename field", identifier, false);
-      }
-      File file = new File(filename);
-      if (!file.exists()) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.FILE_NOT_FOUND, null, identifier, false);
-      }
-      if (!file.isFile()) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.NOT_A_FILE_ERROR, null, identifier, false);
-      }
-      if (!file.canRead()) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.COULD_NOT_READ_FILE, null, identifier, false);
-      }
-      if (inputMimeType != null) {
-        mimeType = inputMimeType;
-      } else {
-        mimeType = bestGuessMimeType(filename);
-        if (mimeType == null) {
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.BAD_MIME_TYPE,
-              "Could not determine MIME type from filename",
-              identifier,
-              false);
-        }
-      }
-      dataLength = -1;
-      this.bucket = new FileBucket(file, true, false, false, false);
-    } else {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD, "Illegal DataSource value", identifier, false);
-    }
-    this.bf = bf;
   }
 
-  @Override
-  String getIdentifier() {
-    return identifier;
+  private FilterOperation parseOperation(SimpleFieldSet fs) throws MessageInvalidException {
+    String op = readRequiredString(fs, "Operation", "Must contain an Operation field");
+    try {
+      return FilterOperation.valueOf(op);
+    } catch (IllegalArgumentException e) {
+      throw invalidField("Illegal Operation value");
+    }
+  }
+
+  private DataSource parseDataSource(SimpleFieldSet fs) throws MessageInvalidException {
+    String ds = readRequiredString(fs, "DataSource", "Must contain a DataSource field");
+    try {
+      return DataSource.valueOf(ds);
+    } catch (IllegalArgumentException e) {
+      throw invalidField("Illegal DataSource value");
+    }
+  }
+
+  private PayloadMetadata preparePayload(SimpleFieldSet fs, String inputMimeType)
+      throws MessageInvalidException {
+    return switch (dataSource) {
+      case DIRECT -> handleDirectPayload(fs, inputMimeType);
+      case DISK -> handleDiskPayload(inputMimeType);
+    };
+  }
+
+  private PayloadMetadata handleDirectPayload(SimpleFieldSet fs, String inputMimeType)
+      throws MessageInvalidException {
+    String resolvedMimeType = requireMimeType(inputMimeType);
+    long length = parseDataLength(fs);
+    return new PayloadMetadata(resolvedMimeType, length);
+  }
+
+  private PayloadMetadata handleDiskPayload(String inputMimeType) throws MessageInvalidException {
+    if (filename == null) {
+      throw missingField("Must contain a Filename field");
+    }
+    File file = new File(filename);
+    validateDiskFile(file);
+    String resolvedMimeType = inputMimeType != null ? inputMimeType : bestGuessMimeType(filename);
+    if (resolvedMimeType == null) {
+      throw invalidMimeType();
+    }
+    this.bucket = new FileBucket(file, true, false, false, false);
+    return new PayloadMetadata(resolvedMimeType, -1);
+  }
+
+  private long parseDataLength(SimpleFieldSet fs) throws MessageInvalidException {
+    if (fs.get(DATA_LENGTH_FIELD) == null) {
+      throw missingField("Must contain a DataLength field");
+    }
+    try {
+      return fs.getLong(DATA_LENGTH_FIELD);
+    } catch (FSParseException e) {
+      throw dataLengthParsingError();
+    }
+  }
+
+  private String requireMimeType(String inputMimeType) throws MessageInvalidException {
+    if (inputMimeType == null) {
+      throw missingField("Must contain a MimeType field");
+    }
+    return inputMimeType;
+  }
+
+  private void validateDiskFile(File file) throws MessageInvalidException {
+    if (!file.exists()) {
+      throw fileError(ProtocolErrorMessage.FILE_NOT_FOUND);
+    }
+    if (!file.isFile()) {
+      throw fileError(ProtocolErrorMessage.NOT_A_FILE_ERROR);
+    }
+    if (!file.canRead()) {
+      throw fileError(ProtocolErrorMessage.COULD_NOT_READ_FILE);
+    }
+  }
+
+  private String readRequiredString(SimpleFieldSet fs, String fieldName, String missingMessage)
+      throws MessageInvalidException {
+    try {
+      return fs.getString(fieldName);
+    } catch (FSParseException e) {
+      throw missingField(missingMessage);
+    }
+  }
+
+  private MessageInvalidException missingField(String message) {
+    return new MessageInvalidException(
+        ProtocolErrorMessage.MISSING_FIELD, message, identifier, false);
+  }
+
+  private MessageInvalidException invalidField(String message) {
+    return new MessageInvalidException(
+        ProtocolErrorMessage.INVALID_FIELD, message, identifier, false);
+  }
+
+  private MessageInvalidException dataLengthParsingError() {
+    return new MessageInvalidException(
+        ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+        "DataLength field must be a long",
+        identifier,
+        false);
+  }
+
+  private MessageInvalidException invalidMimeType() {
+    return new MessageInvalidException(
+        ProtocolErrorMessage.BAD_MIME_TYPE,
+        "Could not determine MIME type from filename",
+        identifier,
+        false);
+  }
+
+  private MessageInvalidException fileError(int protocolCode) {
+    return new MessageInvalidException(protocolCode, null, identifier, false);
+  }
+
+  private MessageInvalidException internalError(String message, Throwable cause) {
+    MessageInvalidException exception =
+        new MessageInvalidException(
+            ProtocolErrorMessage.INTERNAL_ERROR, message, identifier, false);
+    exception.initCause(cause);
+    return exception;
   }
 
   @Override
@@ -159,6 +258,18 @@ public class FilterMessage extends DataCarryingMessage {
     return dataLength;
   }
 
+  /**
+   * Creates a fresh {@link SimpleFieldSet} mirroring the outbound message so other protocol layers
+   * can log or relay the request without re-interpreting internal state.
+   *
+   * <p>The returned structure always contains the identifier, declared operation, data source,
+   * advertised MIME type, filename (which may be {@code null} for {@code DIRECT} payloads), and an
+   * explicit {@code DataLength}. Mutations to the resulting object are not reflected back into this
+   * message, so callers should treat it as a snapshot.
+   *
+   * @return new mutable {@link SimpleFieldSet} instance containing only protocol-visible fields,
+   *     safe for serialization or inspection by higher FCP layers.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
@@ -167,15 +278,41 @@ public class FilterMessage extends DataCarryingMessage {
     fs.putOverwrite("DataSource", dataSource.name());
     fs.putOverwrite("MimeType", mimeType);
     fs.putOverwrite("Filename", filename);
-    fs.put("DataLength", dataLength);
+    fs.put(DATA_LENGTH_FIELD, dataLength);
     return fs;
   }
 
+  /**
+   * Reports the protocol command name so dispatchers can map the object back to FCP wire commands
+   * without assuming concrete types.
+   *
+   * <p>The value is always {@link #NAME} and therefore suitable for hashing, metrics labeling, or
+   * routing tables that operate purely on canonical command strings rather than concrete classes.
+   *
+   * @return constant {@code Filter} string describing the command associated with this message.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the content filter by streaming the prepared payload through {@link ContentFilter} and
+   * returning a {@link FilterResultMessage} to the caller.
+   *
+   * <p>The method allocates a result bucket, relays bytes through the filtering pipeline, captures
+   * MIME or charset adjustments, and records whether the content was rejected as unsafe. It is
+   * expected to run within the {@link FCPConnectionHandler}'s thread confinement so no external
+   * synchronization is required. The message must already own a populated {@link #bucket};
+   * otherwise a {@link MessageInvalidException} is raised before any filtering occurs.
+   *
+   * @param handler connection handler responsible for sending replies back over the client's FCP
+   *     socket and exposing the server core; must remain valid for the call duration.
+   * @param node node instance containing the wider runtime context; used indirectly when retrieving
+   *     the {@link ClientContext} from the server.
+   * @throws MessageInvalidException if the payload bucket is absent or a transient allocation error
+   *     prevents preparing buckets for the filtering process.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (bucket == null) {
@@ -186,9 +323,7 @@ public class FilterMessage extends DataCarryingMessage {
     try {
       resultBucket = bf.makeBucket(-1);
     } catch (IOException e) {
-      LOG.error("Failed to create temporary bucket", e);
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INTERNAL_ERROR, e.toString(), identifier, false);
+      throw internalError("Failed to create temporary bucket", e);
     }
     String resultCharset = null;
     String resultMimeType = null;
@@ -202,9 +337,7 @@ public class FilterMessage extends DataCarryingMessage {
     } catch (UnsafeContentTypeException e) {
       unsafe = true;
     } catch (IOException e) {
-      LOG.error("IO error running content filter", e);
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INTERNAL_ERROR, e.toString(), identifier, false);
+      throw internalError("IO error running content filter", e);
     }
     FilterResultMessage response =
         new FilterResultMessage(identifier, resultCharset, resultMimeType, unsafe, resultBucket);
@@ -212,17 +345,10 @@ public class FilterMessage extends DataCarryingMessage {
   }
 
   private FilterStatus applyFilter(
-      InputStream input, OutputStream output, ClientContext clientContext)
-      throws MessageInvalidException, IOException {
-    URI fakeUri;
-    try {
-      fakeUri = new URI("http://127.0.0.1:8888/");
-    } catch (URISyntaxException e) {
-      LOG.error("Inexplicable URI error", e);
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INTERNAL_ERROR, e.toString(), identifier, false);
-    }
-    // TODO: check operation, once ContentFilter supports write filtering
+      InputStream input, OutputStream output, ClientContext clientContext) throws IOException {
+    URI fakeUri = resolveFilterUri();
+    // ContentFilter currently only supports read filtering; update once write filtering is
+    // available.
     return ContentFilter.filter(
         input,
         output,
@@ -234,6 +360,26 @@ public class FilterMessage extends DataCarryingMessage {
         null,
         clientContext.linkFilterExceptionProvider);
   }
+
+  private URI resolveFilterUri() {
+    String configuredUri = System.getProperty(FILTER_URI_PROPERTY);
+    if (configuredUri == null || configuredUri.isBlank()) {
+      return DEFAULT_FILTER_URI;
+    }
+    try {
+      return new URI(configuredUri);
+    } catch (URISyntaxException e) {
+      LOG.warn(
+          "Invalid value for {}: {}. Falling back to {}",
+          FILTER_URI_PROPERTY,
+          configuredUri,
+          DEFAULT_FILTER_URI,
+          e);
+      return DEFAULT_FILTER_URI;
+    }
+  }
+
+  private record PayloadMetadata(String mimeType, long dataLength) {}
 
   private String bestGuessMimeType(String filename) {
     String guessedMimeType = null;

--- a/src/main/java/network/crypta/clients/fcp/FilterResultMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FilterResultMessage.java
@@ -3,13 +3,35 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/** Carries the result of a content filter test back to the client. */
+/**
+ * Carries the result of a server-side content filter test back to an FCP client.
+ *
+ * <p>This message captures both the textual metadata (identifier, charset, MIME type, and an
+ * explicit unsafe flag) and, when permissible, the binary sample of the filtered data. The node
+ * emits a {@code FilterResultMessage} after finishing its internal filtering pipeline so clients
+ * can display detailed diagnostics or store the sanitized payload. Instances are intentionally
+ * lightweight and immutable once constructed; the referenced {@link Bucket} is supplied by the
+ * caller and therefore follows that implementation's mutability rules.
+ *
+ * <p>Messages are created only on the server and sent to clients; they are never accepted in the
+ * opposite direction. Consumers can reliably expect the following characteristics:
+ *
+ * <ul>
+ *   <li>The {@code Bucket} is present only when {@link #unsafeContentType} is {@code false}; raw
+ *       data is withheld whenever a content type is flagged as unsafe.
+ *   <li>The {@linkplain #dataLength()} result advertises the payload size clients should prepare
+ *       for. A value of {@code -1} indicates that no payload accompanies the message.
+ *   <li>The class is not thread-safe; callers should confine each instance to a single connection
+ *       handling thread as with other {@link DataCarryingMessage} subclasses.
+ * </ul>
+ */
 public class FilterResultMessage extends DataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(FilterResultMessage.class);
 
+  /**
+   * Canonical message name announced on the wire so clients can register handlers for filter
+   * results without inspecting payload contents. The value is stable across releases.
+   */
   public static final String NAME = "FilterResult";
 
   private final String identifier;
@@ -18,6 +40,27 @@ public class FilterResultMessage extends DataCarryingMessage {
   private final boolean unsafeContentType;
   private final long dataLength;
 
+  /**
+   * Create a message describing the outcome of a completed content filtering pass.
+   *
+   * <p>The constructor copies only primitive metadata; the {@link Bucket} reference is retained as
+   * supplied, meaning the caller controls both lifecycle and mutability. When {@code
+   * unsafeContentType} is {@code true}, the binary payload is deliberately suppressed and {@link
+   * #dataLength()} later reports {@code -1}. Otherwise, {@link Bucket#size()} establishes the
+   * advertised data length, and the bucket is attached for downstream serialization.
+   *
+   * @param identifier unique token that correlates responses with the originating filter request;
+   *     must not be {@code null} when a client relies on matching semantics
+   * @param charset canonical name (for example {@code "UTF-8"}) describing how textual payload
+   *     bytes should be interpreted by the client; empty strings are allowed when unknown
+   * @param mimeType MIME content type string returned by the filter engine, typically of the form
+   *     {@code text/*} or {@code application/*}, enabling client-specific handling
+   * @param unsafeContentType {@code true} when the filter deemed the payload unsafe to expose;
+   *     forces {@link #dataLength()} to {@code -1} and suppresses the bucket reference entirely
+   * @param bucket payload holder whose {@link Bucket#size()} value advertises the data length when
+   *     {@code unsafeContentType} is {@code false}; may be ignored otherwise but must not be {@code
+   *     null}
+   */
   public FilterResultMessage(
       String identifier,
       String charset,
@@ -51,6 +94,15 @@ public class FilterResultMessage extends DataCarryingMessage {
     return dataLength;
   }
 
+  /**
+   * Build a {@link SimpleFieldSet} representation of this message suitable for transmission.
+   *
+   * <p>The field set always contains identifier, charset, MIME type, an unsafe flag, and an integer
+   * {@code DataLength}. When the content is unsafe the reported length is {@code -1}; callers
+   * should therefore consult the unsafe flag before attempting to read the payload.
+   *
+   * @return a newly allocated field set containing all metadata for this message instance
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
@@ -62,11 +114,28 @@ public class FilterResultMessage extends DataCarryingMessage {
     return fs;
   }
 
+  /**
+   * Return the FCP message identifier used in wire headers.
+   *
+   * <p>The value is constant and helps client handlers perform simple equality checks instead of
+   * parsing the field set contents.
+   *
+   * @return the literal {@code FilterResult} constant representing this message type
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation always throws because {@code FilterResult} messages are server-to-client
+   * only and therefore must never be executed in the inbound direction.
+   *
+   * @throws MessageInvalidException always thrown to signal that the client violated the protocol
+   *     by attempting to send this message toward the node
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/main/java/network/crypta/clients/fcp/SendBookmarkMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SendBookmarkMessage.java
@@ -7,22 +7,61 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.BucketTools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Encapsulates the FCP message that forwards a bookmark suggestion to a darknet peer.
+ *
+ * <p>Instances parse a {@link SimpleFieldSet} payload received from a client connection and hold
+ * the resolved {@link FreenetURI}, bookmark title, and the caller's intention about exposing an
+ * active link to peers. After construction the object becomes immutable and can be safely handed to
+ * the dispatch thread that interacts with {@link DarknetPeerNode} instances. Subclasses of {@link
+ * SendPeerMessage} are short-lived, so this implementation avoids retaining unnecessary references
+ * and directly reuses the bucket created by {@link #readFrom} in the base class. The class is not
+ * thread-safe; each instance should be used by at most one handler thread.
+ *
+ * <p>Typical usage occurs when an FCP client requests that a bookmark be shared. The connection
+ * handler creates this message with the parsed field set, invokes {@link #run} on the parent class,
+ * and lets {@link #handleFeed(DarknetPeerNode)} stream the optional description to the peer. The
+ * response status returned by the peer is forwarded to the client through {@link SentPeerMessage}.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> validate inputs, prepare serialization fields, and
+ *       delegate the bookmark feed to the darknet peer.
+ *   <li><strong>Notable behaviors:</strong> handles both metadata-only and data-carrying requests
+ *       and ensures UTF-8 decoding for human-readable descriptions.
+ * </ul>
+ */
 public class SendBookmarkMessage extends SendPeerMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(SendBookmarkMessage.class);
-
+  /**
+   * Protocol literal clients use when emitting or filtering {@code SendBookmark} traffic, ensuring
+   * that GUI tools and scripting clients consistently map the same string to this feature without
+   * inspecting other metadata.
+   */
   public static final String NAME = "SendBookmark";
+
   private final FreenetURI uri;
-  private final String name;
+  private final String bookmarkName;
   private final boolean hasAnAnActiveLink;
 
+  /**
+   * Creates a bookmark message by extracting required fields from an incoming payload.
+   *
+   * <p>The constructor validates that a bookmark name exists, parses the {@code URI} field using
+   * {@link FreenetURI}, and records whether the caller advertises an active link. The instance does
+   * not read any associated bucket data here, so callers may defer payload streaming until the
+   * message reaches {@link #handleFeed(DarknetPeerNode)}.
+   *
+   * @param fs parsed field set describing the bookmark request; must contain at least {@code Name}
+   *     and {@code URI} entries in addition to the identifiers handled by {@link SendPeerMessage}.
+   * @throws MessageInvalidException if the bookmark name is absent or if the URI cannot be parsed
+   *     by {@link FreenetURI}, in which case the constructor propagates a descriptive protocol
+   *     error.
+   */
   public SendBookmarkMessage(SimpleFieldSet fs) throws MessageInvalidException {
     super(fs);
     try {
-      name = fs.get("Name");
-      if (name == null)
+      bookmarkName = fs.get("Name");
+      if (bookmarkName == null)
         throw new MessageInvalidException(
             ProtocolErrorMessage.MISSING_FIELD, "No name", identifier, false);
       uri = new FreenetURI(fs.get("URI"));
@@ -33,28 +72,68 @@ public class SendBookmarkMessage extends SendPeerMessage {
     }
   }
 
+  /**
+   * Builds the outbound field set sent to the peer or echoed to clients.
+   *
+   * <p>The returned instance is a fresh {@link SimpleFieldSet} containing the identifier inherited
+   * from {@link SendPeerMessage}, the peer reference, the bookmark name, its stringified URI, and
+   * the caller's {@code HasAnActivelink} flag. Callers may freely mutate the result before it is
+   * serialized back to the client connection. Because {@link SimpleFieldSet} is mutable, downstream
+   * code can add debugging keys or transport hints without touching this class, which keeps
+   * construction costs low and avoids additional allocations.
+   *
+   * @return mutable field set describing the bookmark send request, ready for serialization or
+   *     further augmentation by the caller.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = super.getFieldSet();
-    fs.putSingle("Name", name);
+    fs.putSingle("Name", bookmarkName);
     fs.putSingle("URI", uri.toString());
     fs.put("HasAnActivelink", hasAnAnActiveLink);
     return fs;
   }
 
+  /**
+   * Returns the protocol-level name announced to clients issuing this message type.
+   *
+   * <p>The value allows routing logic to compare requested operations against the supported set and
+   * is also used when serializing {@link SentPeerMessage} responses so clients can correlate
+   * asynchronous messages with their originating command. Because the name never changes at
+   * runtime, callers are free to cache it or compare it using reference equality when optimizing
+   * dispatch paths.
+   *
+   * @return constant {@value #NAME}, enabling handlers to match requests with supported
+   *     capabilities.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Streams the bookmark details to the resolved darknet peer node.
+   *
+   * <p>If a payload bucket is present, the method reads it entirely, interprets it as UTF-8 text,
+   * and delivers the description along with the metadata. When no payload is attached, the peer is
+   * informed with a {@code null} description. The returned integer mirrors the peer status provided
+   * by {@link DarknetPeerNode#sendBookmarkFeed(FreenetURI, String, String, boolean)}.
+   *
+   * @param pn validated darknet peer that should receive the bookmark information; never null when
+   *     invoked by {@link SendPeerMessage#run}.
+   * @return peer-reported status integer that will be relayed to the originating client once the
+   *     send operation completes.
+   * @throws MessageInvalidException if reading the payload fails with {@link IOException}, allowing
+   *     the caller to surface a protocol error back to the client.
+   */
   @Override
   protected int handleFeed(DarknetPeerNode pn) throws MessageInvalidException {
     try {
       if (dataLength() > 0) {
         byte[] description = BucketTools.toByteArray(bucket);
         return pn.sendBookmarkFeed(
-            uri, name, new String(description, StandardCharsets.UTF_8), hasAnAnActiveLink);
-      } else return pn.sendBookmarkFeed(uri, name, null, hasAnAnActiveLink);
+            uri, bookmarkName, new String(description, StandardCharsets.UTF_8), hasAnAnActiveLink);
+      } else return pn.sendBookmarkFeed(uri, bookmarkName, null, hasAnAnActiveLink);
     } catch (IOException e) {
       throw new MessageInvalidException(ProtocolErrorMessage.INVALID_MESSAGE, "", null, false);
     }

--- a/src/main/java/network/crypta/clients/fcp/SendPeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SendPeerMessage.java
@@ -4,17 +4,63 @@ import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Base helper for FCP messages that push binary payloads to a remote darknet peer.
+ *
+ * <p>This abstraction is used by higher-level client protocols whenever they need to stream a
+ * reply, queue update, or diagnostic snapshot to a known peer without exposing the common routing
+ * boilerplate in each concrete message. Subclasses parse their payload up front, then invoke {@link
+ * #run(FCPConnectionHandler, Node)} to resolve the peer, enforce darknet-only constraints, and
+ * finally call {@link #handleFeed(DarknetPeerNode)} to transmit data. Instances are stateful
+ * because they cache identifiers and the optional data length reported to peers during capability
+ * negotiation.
+ *
+ * <p>Implementations are expected to be short-lived and not thread-safe; callers should create a
+ * fresh instance per inbound FCP command. The base class never mutates shared node structures
+ * directly, so subclasses must coordinate with node subsystems if they manipulate shared queues or
+ * throttles. Typical usage flow:
+ *
+ * <ul>
+ *   <li>Parse the incoming {@link SimpleFieldSet} when building the subclass.
+ *   <li>Let the connection handler invoke {@code run} inside its dispatch thread.
+ *   <li>Implement {@code handleFeed} to stream or update peer-specific state.
+ * </ul>
+ *
+ * @see DataCarryingMessage
+ * @see FCPConnectionHandler
+ */
 public abstract class SendPeerMessage extends DataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(SendPeerMessage.class);
-
+  /**
+   * Caller-supplied identifier echoed back in {@link SentPeerMessage} notifications so clients can
+   * correlate requests with asynchronous completion events, even when multiple sends are in flight.
+   */
   protected final String identifier;
+
+  /**
+   * Node identifier string designating the darknet peer that must receive the payload; usually a
+   * stable identity hash or noderef key agreed upon through the client connection handshake.
+   */
   protected final String nodeIdentifier;
+
   private final long dataLength;
 
-  public SendPeerMessage(SimpleFieldSet fs) throws MessageInvalidException {
+  /**
+   * Creates a new send request by extracting the routing identifiers and optional byte-length from
+   * a parsed field set.
+   *
+   * <p>The field set must contain {@code Identifier} for the client correlation id and {@code
+   * NodeIdentifier} for the target peer. {@code DataLength} is optional; when supplied it is
+   * validated to be non-negative and stored verbatim for subsequent serialization. No I/O occurs at
+   * construction time, so subclasses may safely perform additional validation before calling {@link
+   * #run(FCPConnectionHandler, Node)}.
+   *
+   * @param fs structured key-value payload parsed from the inbound message; must not be {@code
+   *     null} and should already satisfy FCP framing rules.
+   * @throws MessageInvalidException if any required key is missing or {@code DataLength} cannot be
+   *     parsed as a non-negative base-10 long value.
+   */
+  protected SendPeerMessage(SimpleFieldSet fs) throws MessageInvalidException {
     identifier = fs.get("Identifier");
     nodeIdentifier = fs.get("NodeIdentifier");
     String dataLengthString = fs.get("DataLength");
@@ -22,14 +68,26 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
       try {
         // May throw NumberFormatException
         dataLength = Long.parseLong(dataLengthString, 10);
-        if (dataLength < 0) throw new Exception();
-      } catch (Exception e) {
+        if (dataLength < 0) {
+          throw new NumberFormatException("DataLength must be non-negative");
+        }
+      } catch (NumberFormatException e) {
         throw new MessageInvalidException(
             ProtocolErrorMessage.INVALID_FIELD, "Invalid DataLength field", identifier, false);
       }
     else dataLength = -1;
   }
 
+  /**
+   * Serializes the minimal set of identifying values needed by downstream components and clients.
+   *
+   * <p>The returned field set is always mutable, allowing callers to append subclass-specific
+   * fields before re-encoding the message. {@code DataLength} is emitted only when the value is
+   * known, allowing size-agnostic streams to omit it without breaking consumers.
+   *
+   * @return a new {@link SimpleFieldSet} containing the identifier, node identifier, and optional
+   *     data length value expressed in bytes.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
@@ -39,24 +97,54 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
     return fs;
   }
 
+  /**
+   * Resolves the peer node, enforces darknet-only access, and delegates the actual payload
+   * transmission to {@link #handleFeed(DarknetPeerNode)}.
+   *
+   * <p>The handler is expected to represent the active connection issuing this request, and the
+   * provided node is the authoritative routing context. When the peer is unknown, a descriptive
+   * error message is sent automatically; when the peer is not part of the darknet, the method
+   * throws {@link MessageInvalidException}. Subclasses should avoid heavy computation inside {@code
+   * handleFeed} because it runs on whatever thread the handler uses for message dispatch.
+   *
+   * @param handler connection handler responsible for sending replies back to the client; must not
+   *     be {@code null} and should already be authenticated.
+   * @param node local node instance used to resolve {@link PeerNode} references; must be live and
+   *     fully initialized.
+   * @throws MessageInvalidException if the peer is not a darknet peer or if {@code handleFeed}
+   *     reports an application-specific validation failure.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     PeerNode pn = node.getPeerNode(nodeIdentifier);
     if (pn == null) {
       FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
       handler.send(msg);
-    } else if (!(pn instanceof DarknetPeerNode)) {
+    } else if (!(pn instanceof DarknetPeerNode darknetPeerNode)) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DARKNET_ONLY,
           getName() + " only available for darknet peers",
           identifier,
           false);
     } else {
-      int nodeStatus = handleFeed(((DarknetPeerNode) pn));
+      int nodeStatus = handleFeed(darknetPeerNode);
       handler.send(new SentPeerMessage(identifier, nodeStatus));
     }
   }
 
+  /**
+   * Performs the message-specific work once the darknet peer has been validated and resolved.
+   *
+   * <p>Implementations typically stream data to the peer or update its state and must return a
+   * status integer that will be echoed back to the client via {@link SentPeerMessage}. Implementers
+   * should document the meaning of their status codes and ensure that any thrown exception provides
+   * actionable details.
+   *
+   * @param pn darknet peer reference already registered on the node and guaranteed non-null.
+   * @return integer status communicated to the client; semantic range is defined by the subclass.
+   * @throws MessageInvalidException if the payload cannot be accepted or violates protocol
+   *     invariants enforced by the subclass.
+   */
   protected abstract int handleFeed(DarknetPeerNode pn) throws MessageInvalidException;
 
   @Override

--- a/src/main/java/network/crypta/clients/fcp/SendTextMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SendTextMessage.java
@@ -5,26 +5,84 @@ import java.nio.charset.StandardCharsets;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.BucketTools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-// FIXME proper support for sending large files.
-// FIXME with confirmation on the other side like darknet transfers.
-// FIXME Generalise the darknet file transfer API in DarknetPeerNode.
+/**
+ * Handles text-only FCP peer messages flowing from a remote client into a {@link DarknetPeerNode}.
+ *
+ * <p>Instances wrap the parsed {@link SimpleFieldSet} supplied by the FCP dispatcher and translate
+ * the attached data bucket into a UTF-8 string before handing it to {@link
+ * DarknetPeerNode#sendTextFeed(String)}. The class is stateless and short-lived; each instance
+ * processes a single inbound payload and is expected to be discarded afterward. Although the
+ * transport can theoretically carry arbitrary binary blobs, this implementation enforces a text
+ * contract and therefore validates that some payload bytes were provided before forwarding the
+ * request.
+ *
+ * <p>Because the surrounding infrastructure can submit feeds from multiple threads, callers should
+ * ensure they provide thread-safe {@link DarknetPeerNode} implementations. The message itself does
+ * not maintain mutable state and can therefore be reused only if the caller guarantees sequential
+ * access.
+ *
+ * <ul>
+ *   <li>Responsibility: convert bucket data to text and delegate to the peer.
+ *   <li>Error handling: raises {@link MessageInvalidException} when the payload is missing or when
+ *       the bucket cannot be read.
+ *   <li>Lifecycle: constructed, handled once via {@link #handleFeed(DarknetPeerNode)}, then
+ *       eligible for garbage collection.
+ * </ul>
+ *
+ * @see SendPeerMessage
+ * @see DarknetPeerNode#sendTextFeed(String)
+ */
 public class SendTextMessage extends SendPeerMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(SendTextMessage.class);
 
+  /**
+   * Canonical FCP message name advertised to peers when composing or dispatching SendText requests.
+   */
   public static final String NAME = "SendText";
 
+  /**
+   * Creates a new handler bound to the provided field set and associated payload descriptors.
+   *
+   * @param fs structured fields describing the message; must include routing metadata and bucket
+   *     identifiers as defined by the FCP SendText specification.
+   * @throws MessageInvalidException if required fields are absent or cannot be parsed by the base
+   *     {@link SendPeerMessage} constructor.
+   */
   public SendTextMessage(SimpleFieldSet fs) throws MessageInvalidException {
     super(fs);
   }
 
+  /**
+   * Returns the symbolic message name used across transport negotiations and logging.
+   *
+   * <p>The value is constant and can be compared against {@link SimpleFieldSet} entries to quickly
+   * decide whether an inbound frame should be handled by this class. Consumers must not mutate the
+   * returned string and should treat it as a read-only identifier.
+   *
+   * @return immutable {@link String} literal {@code "SendText"} describing the supported command.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Reads the message payload, converts it to UTF-8 text, and forwards it to the supplied peer.
+   *
+   * <p>The method expects that {@link #dataLength()} is strictly positive; otherwise it fails fast
+   * with a {@link MessageInvalidException} to ensure empty writes are never persisted. The payload
+   * is loaded fully into memory via {@link BucketTools#toByteArray} before invoking {@link
+   * DarknetPeerNode#sendTextFeed(String)}, so upstream callers should avoid attaching unbounded
+   * data streams. Any {@link IOException} raised while reading the bucket is translated into {@link
+   * ProtocolErrorMessage#INVALID_MESSAGE} to keep protocol semantics consistent.
+   *
+   * @param pn peer connection that ultimately transmits the text; must support concurrent feed
+   *     delivery if used by multiple SendTextMessage instances.
+   * @return the status code returned from {@link DarknetPeerNode#sendTextFeed(String)}, preserving
+   *     the peer's decision about success, retries, or throttling.
+   * @throws MessageInvalidException if the payload is empty, unreadable, or otherwise violates the
+   *     SendText contract defined by the protocol.
+   */
   @Override
   protected int handleFeed(DarknetPeerNode pn) throws MessageInvalidException {
     try {

--- a/src/main/java/network/crypta/clients/fcp/SendURIMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SendURIMessage.java
@@ -7,15 +7,54 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.BucketTools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Represents the FCP message used to stream a {@link FreenetURI} request toward a darknet peer.
+ *
+ * <p>The message encapsulates immutable URI metadata along with an optional textual description
+ * drawn from the inherited payload bucket. Callers typically construct it from a {@link
+ * SimpleFieldSet} received over the wire or populate it manually before invoking outbound
+ * transmission helpers on {@link SendPeerMessage}. Once created, the instance retains the parsed
+ * URI and ensures that serialization back to a {@code SimpleFieldSet} reproduces the original
+ * semantics so peers can authenticate and queue downloads consistently.
+ *
+ * <p>Senders should create a new instance per outgoing transaction, enqueue it on the peer
+ * scheduler, and rely on {@link #handleFeed(DarknetPeerNode)} to forward optional descriptive text
+ * while honoring UTF-8 encoding. The type performs no retries or throttling; upstream code must
+ * handle pacing, persistence, and error logging. Instances are thread-safe because they expose only
+ * effectively final state once construction completes.
+ *
+ * <ul>
+ *   <li>Parses and validates URIs supplied via {@code SimpleFieldSet} structures.
+ *   <li>Serializes the URI back to peers using canonical textual form.
+ *   <li>Bridges optional descriptions from the inherited bucket into download feeds.
+ * </ul>
+ *
+ * @see SendPeerMessage
+ * @see DarknetPeerNode#sendDownloadFeed(FreenetURI, String)
+ */
 public class SendURIMessage extends SendPeerMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(SendURIMessage.class);
 
+  /**
+   * Canonical FCP command name advertised through {@link #getName()} and dispatcher lookups; must
+   * remain stable for wire compatibility.
+   */
   public static final String NAME = "SendURI";
+
   private final FreenetURI uri;
 
+  /**
+   * Constructs a message instance by extracting the target URI from an incoming field set.
+   *
+   * <p>The constructor performs immediate validation so malformed URIs are rejected close to the
+   * network boundary. Callers should already have verified the surrounding message type, but they
+   * do not need to sanitize whitespace because {@link FreenetURI#FreenetURI(String)} handles
+   * canonical parsing. The underlying bucket remains untouched until {@link
+   * #handleFeed(DarknetPeerNode)} is invoked, so large payloads stay in-place.
+   *
+   * @param fs field set containing at least one {@code URI} entry with canonical string form.
+   * @throws MessageInvalidException if the {@code URI} entry is missing or fails to parse cleanly.
+   */
   public SendURIMessage(SimpleFieldSet fs) throws MessageInvalidException {
     super(fs);
     try {
@@ -26,6 +65,16 @@ public class SendURIMessage extends SendPeerMessage {
     }
   }
 
+  /**
+   * Recreates the serialized representation for downstream transport to a remote peer.
+   *
+   * <p>The field set mirrors {@link SendPeerMessage}'s base values and injects the stored URI in
+   * canonical text form so receiving peers can rehydrate it without ambiguity. No transient fields
+   * are included, therefore the result is deterministic for identical inputs and safe to reuse as a
+   * cached snapshot while preparing multiple sends.
+   *
+   * @return mutable {@link SimpleFieldSet} populated with basic headers plus the {@code URI} entry.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = super.getFieldSet();
@@ -33,11 +82,38 @@ public class SendURIMessage extends SendPeerMessage {
     return fs;
   }
 
+  /**
+   * Exposes the protocol-level message identifier string shared across SendURI transmissions.
+   *
+   * <p>The constant name is used by dispatch tables and logging so the value must remain stable and
+   * uppercase. Callers can rely on it for switch statements or to allocate queues dedicated to
+   * specific FCP verbs without re-validating the payload contents.
+   *
+   * @return literal {@link #NAME} constant describing the SendURI protocol verb.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Streams the URI (and optional description) to the provided peer's download feed.
+   *
+   * <p>The method reads the inherited payload bucket only when {@link #dataLength()} reports a
+   * positive size, converts the bytes to UTF-8 text, and instructs the peer to enqueue the download
+   * request. When no descriptive text is present it passes {@code null}, which the peer interprets
+   * as an absence of supplementary metadata. Any {@link IOException} emitted during bucket
+   * extraction is translated into {@link MessageInvalidException} to keep protocol error handling
+   * uniform.
+   *
+   * <p>This method is not idempotent with respect to peer state; callers should invoke it exactly
+   * once per outbound transaction and rely on higher layers for retries or deduplication.
+   *
+   * @param pn darknet peer that ultimately receives the URI and optional description, never null.
+   * @return opaque code from {@link DarknetPeerNode#sendDownloadFeed(FreenetURI, String)} conveying
+   *     scheduling outcomes.
+   * @throws MessageInvalidException if payload bytes cannot be decoded or the peer rejects input.
+   */
   @Override
   protected int handleFeed(DarknetPeerNode pn) throws MessageInvalidException {
     try {

--- a/src/main/java/network/crypta/pluginmanager/PluginReplySenderFCP.java
+++ b/src/main/java/network/crypta/pluginmanager/PluginReplySenderFCP.java
@@ -34,9 +34,13 @@ public class PluginReplySenderFCP extends PluginReplySender {
     // like in linux everthing is a file, in Plugintalker everything is a plugin. So it throws
     // PluginNotFoundException
     // instead fcp connection errors
-    if (handler.isClosed()) throw new PluginNotFoundException("FCP connection closed");
+    if (handler.isClosed()) {
+      throw new PluginNotFoundException("FCP connection closed");
+    }
+
     FCPPluginServerMessage reply =
-        new FCPPluginServerMessage(pluginname, clientSideIdentifier, params, bucket);
+        new FCPPluginServerMessage(
+            pluginname, clientSideIdentifier, params, bucket, null, null, null);
     handler.send(reply);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/AllDataMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AllDataMessageTest.java
@@ -1,0 +1,109 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class AllDataMessageTest {
+
+  private static final String IDENTIFIER = "test-identifier";
+  private static final long STARTUP_TIME = 1234L;
+  private static final long COMPLETION_TIME = 5678L;
+  private static final String MIME_TYPE = "text/plain";
+
+  @Mock private Bucket bucket;
+
+  @Test
+  void dataLength_whenConstructed_matchesBucketSize() {
+    when(bucket.size()).thenReturn(2048L);
+
+    AllDataMessage message =
+        new AllDataMessage(bucket, IDENTIFIER, true, STARTUP_TIME, COMPLETION_TIME, MIME_TYPE);
+
+    assertEquals(2048L, message.dataLength());
+  }
+
+  @Test
+  void getFieldSet_whenMimeTypeProvided_includesMetadata() {
+    when(bucket.size()).thenReturn(1024L);
+    AllDataMessage message =
+        new AllDataMessage(bucket, IDENTIFIER, true, STARTUP_TIME, COMPLETION_TIME, MIME_TYPE);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertEquals(1024L, fieldSet.getLong("DataLength", -1));
+    assertEquals(IDENTIFIER, fieldSet.get("Identifier"));
+    assertTrue(fieldSet.getBoolean("Global", false));
+    assertEquals(STARTUP_TIME, fieldSet.getLong("StartupTime", -1));
+    assertEquals(COMPLETION_TIME, fieldSet.getLong("CompletionTime", -1));
+    assertEquals(MIME_TYPE, fieldSet.get("Metadata.ContentType"));
+  }
+
+  @Test
+  void getFieldSet_whenMimeTypeMissing_omitsMetadata() {
+    when(bucket.size()).thenReturn(512L);
+    AllDataMessage message =
+        new AllDataMessage(bucket, IDENTIFIER, false, STARTUP_TIME, COMPLETION_TIME, null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNull(fieldSet.get("Metadata.ContentType"));
+  }
+
+  @Test
+  void run_whenCalledFromClient_throwsMessageInvalidException() {
+    when(bucket.size()).thenReturn(256L);
+    AllDataMessage message =
+        new AllDataMessage(bucket, IDENTIFIER, true, STARTUP_TIME, COMPLETION_TIME, MIME_TYPE);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(IDENTIFIER, exception.ident);
+    assertTrue(exception.global);
+    assertEquals(
+        "AllData goes from server to client not the other way around", exception.getMessage());
+  }
+
+  @Test
+  void getIdentifier_whenCalled_returnsConstructorValue() {
+    when(bucket.size()).thenReturn(128L);
+    AllDataMessage message =
+        new AllDataMessage(bucket, IDENTIFIER, true, STARTUP_TIME, COMPLETION_TIME, MIME_TYPE);
+
+    assertEquals(IDENTIFIER, message.getIdentifier());
+  }
+
+  @Test
+  void isGlobal_whenCalled_returnsConstructorFlag() {
+    when(bucket.size()).thenReturn(64L);
+    AllDataMessage message =
+        new AllDataMessage(bucket, IDENTIFIER, false, STARTUP_TIME, COMPLETION_TIME, MIME_TYPE);
+
+    assertFalse(message.isGlobal());
+  }
+
+  @Test
+  void getName_whenCalled_returnsAllDataLiteral() {
+    when(bucket.size()).thenReturn(32L);
+    AllDataMessage message =
+        new AllDataMessage(bucket, IDENTIFIER, true, STARTUP_TIME, COMPLETION_TIME, MIME_TYPE);
+
+    assertEquals("AllData", message.getName());
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutMessageTest.java
@@ -1,0 +1,252 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClientPutMessageTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void constructor_directWithoutDataLength_expectMissingField() {
+    SimpleFieldSet fs = baseFieldSet("put-no-length");
+    fs.putSingle("UploadFrom", "direct");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientPutMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("put-no-length", exception.ident);
+  }
+
+  @Test
+  void constructor_diskSourceWithMissingFile_expectFileNotFound() {
+    SimpleFieldSet fs = baseFieldSet("put-missing-file");
+    fs.putSingle("UploadFrom", "disk");
+    fs.putSingle("Filename", tempDir.resolve("missing.bin").toString());
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientPutMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.FILE_NOT_FOUND, exception.protocolCode);
+    assertEquals("put-missing-file", exception.ident);
+  }
+
+  @Test
+  void constructor_redirectWithoutTarget_expectMissingField() {
+    SimpleFieldSet fs = baseFieldSet("put-redirect");
+    fs.putSingle("UploadFrom", "redirect");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientPutMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("put-redirect", exception.ident);
+  }
+
+  @Test
+  void constructor_targetFilenameContainingSlash_expectInvalidField() {
+    SimpleFieldSet fs = baseFieldSet("put-target-filename");
+    fs.putSingle("UploadFrom", "direct");
+    fs.put("DataLength", 5L);
+    fs.putSingle("TargetFilename", "folder/illegal.txt");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientPutMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals("put-target-filename", exception.ident);
+  }
+
+  @Test
+  void getFieldSet_directValuesRoundTrip_expectSerializedFields() throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet("put-fieldset");
+    fs.putSingle("UploadFrom", "direct");
+    fs.put("DataLength", 10L);
+    fs.put("GetCHKOnly", true);
+    fs.put("DontCompress", true);
+    fs.putSingle("ClientToken", "token-123");
+    fs.putSingle("TargetFilename", "output.bin");
+    fs.putSingle("Codecs", "GZIP");
+    fs.put("Global", true);
+
+    ClientPutMessage message = new ClientPutMessage(fs);
+
+    SimpleFieldSet serialized = message.getFieldSet();
+
+    assertEquals("CHK@", serialized.get("URI"));
+    assertEquals("put-fieldset", serialized.get("Identifier"));
+    assertEquals("direct", serialized.get("UploadFrom"));
+    assertEquals(10L, serialized.getLong("DataLength", -1));
+    assertTrue(serialized.getBoolean("GetCHKOnly", false));
+    assertEquals(
+        RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS,
+        serialized.getShort("PriorityClass", (short) -1));
+    assertEquals("connection", serialized.get("Persistence"));
+    assertTrue(serialized.getBoolean("DontCompress", false));
+    assertEquals("GZIP", serialized.get("Codecs"));
+    assertEquals("token-123", serialized.get("ClientToken"));
+    assertTrue(serialized.getBoolean("Global", false));
+    assertFalse(serialized.getBoolean("BinaryBlob", true));
+  }
+
+  @Test
+  void run_whenInvoked_startsClientPutOnHandler() throws MessageInvalidException {
+    ClientPutMessage message = newDirectMessage("put-run", 8L);
+    FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
+
+    message.run(handler, Mockito.mock(Node.class));
+
+    Mockito.verify(handler).startClientPut(message);
+  }
+
+  @Test
+  void createBucket_whenPersistentForever_usesPersistentFactory() throws Exception {
+    ClientPutMessage message = newForeverMessage("put-forever", 64L);
+    BucketFactory transientFactory = Mockito.mock(BucketFactory.class);
+    FCPServer server = Mockito.mock(FCPServer.class);
+    NodeClientCore core = Mockito.mock(NodeClientCore.class);
+    PersistentTempBucketFactory persistentFactory = Mockito.mock(PersistentTempBucketFactory.class);
+
+    Mockito.when(server.getCore()).thenReturn(core);
+    Mockito.when(core.killedDatabase()).thenReturn(false);
+    Mockito.when(core.getPersistentTempBucketFactory()).thenReturn(persistentFactory);
+
+    try (RandomAccessBucket expectedBucket = Mockito.mock(RandomAccessBucket.class)) {
+      Mockito.when(persistentFactory.makeBucket(64L)).thenReturn(expectedBucket);
+
+      try (RandomAccessBucket bucket = message.createBucket(transientFactory, 64L, server)) {
+        assertSame(expectedBucket, bucket);
+      }
+    }
+    Mockito.verifyNoInteractions(transientFactory);
+  }
+
+  @Test
+  void createBucket_whenPersistentForeverAndDatabaseKilled_expectPersistenceDisabled()
+      throws MessageInvalidException {
+    ClientPutMessage message = newForeverMessage("put-forever-disabled", 16L);
+    BucketFactory transientFactory = Mockito.mock(BucketFactory.class);
+    FCPServer server = Mockito.mock(FCPServer.class);
+    NodeClientCore core = Mockito.mock(NodeClientCore.class);
+
+    Mockito.when(server.getCore()).thenReturn(core);
+    Mockito.when(core.killedDatabase()).thenReturn(true);
+
+    assertThrows(
+        PersistenceDisabledException.class,
+        () -> {
+          try (RandomAccessBucket ignored = message.createBucket(transientFactory, 16L, server)) {
+            fail("PersistenceDisabledException expected before bucket allocation");
+          }
+        });
+    Mockito.verify(core, Mockito.never()).getPersistentTempBucketFactory();
+    Mockito.verifyNoInteractions(transientFactory);
+  }
+
+  @Test
+  void createBucket_whenConnectionPersistence_usesProvidedFactory() throws Exception {
+    ClientPutMessage message = newDirectMessage("put-connection", 32L);
+    BucketFactory factory = Mockito.mock(BucketFactory.class);
+
+    try (RandomAccessBucket expectedBucket = Mockito.mock(RandomAccessBucket.class)) {
+      try {
+        Mockito.when(factory.makeBucket(32L)).thenReturn(expectedBucket);
+      } catch (IOException e) {
+        fail(e);
+      }
+
+      try (RandomAccessBucket bucket =
+          message.createBucket(factory, 32L, Mockito.mock(FCPServer.class))) {
+        assertSame(expectedBucket, bucket);
+      }
+    }
+  }
+
+  @Test
+  void dataLength_directUpload_returnsProvidedLength() throws MessageInvalidException {
+    ClientPutMessage message = newDirectMessage("put-length", 99L);
+
+    assertEquals(99L, message.dataLength());
+  }
+
+  @Test
+  void dataLength_diskUpload_returnsNegativeOne() throws Exception {
+    Path file = Files.createTempFile(tempDir, "client-put", ".bin");
+    Files.writeString(file, "payload");
+
+    ClientPutMessage message = newDiskMessage(file);
+
+    assertEquals(-1L, message.dataLength());
+    message.freeData();
+  }
+
+  @Test
+  void freeData_whenBucketPresent_invokesBucketFree() throws MessageInvalidException {
+    ClientPutMessage message = newDirectMessage("put-free", 5L);
+    Bucket bucket = Mockito.mock(Bucket.class);
+    message.bucket = bucket;
+
+    message.freeData();
+
+    Mockito.verify(bucket).free();
+  }
+
+  private ClientPutMessage newDirectMessage(String identifier, long length)
+      throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet(identifier);
+    fs.putSingle("UploadFrom", "direct");
+    fs.put("DataLength", length);
+    return new ClientPutMessage(fs);
+  }
+
+  private ClientPutMessage newDiskMessage(Path file) throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet("put-disk");
+    fs.putSingle("UploadFrom", "disk");
+    fs.putSingle("Filename", file.toString());
+    return new ClientPutMessage(fs);
+  }
+
+  private ClientPutMessage newForeverMessage(String identifier, long length)
+      throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet(identifier);
+    fs.putSingle("UploadFrom", "direct");
+    fs.put("DataLength", length);
+    fs.putSingle("Persistence", Persistence.FOREVER.name());
+    return new ClientPutMessage(fs);
+  }
+
+  private SimpleFieldSet baseFieldSet(String identifier) {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", identifier);
+    fs.putSingle("URI", "CHK@");
+    fs.putSingle("Metadata.ContentType", "text/plain");
+    fs.put("Verbosity", 0);
+    return fs;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
@@ -1,0 +1,248 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import network.crypta.clients.fcp.FCPPluginConnection.SendDirection;
+import network.crypta.node.Node;
+import network.crypta.pluginmanager.PluginNotFoundException;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FCPPluginClientMessageTest {
+
+  private static final String IDENTIFIER = "request-1";
+  private static final String PLUGIN_NAME = "plugins.Demo";
+
+  @Test
+  void constructor_whenIdentifierMissing_expectMissingField() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putOverwrite("PluginName", PLUGIN_NAME);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new FCPPluginClientMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertNull(ex.ident);
+  }
+
+  @Test
+  void constructor_whenPluginNameMissing_expectMissingField() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putOverwrite("Identifier", IDENTIFIER);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new FCPPluginClientMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+  }
+
+  @Test
+  void constructor_whenNonDataHasDataLength_expectInvalidField() {
+    SimpleFieldSet fs = minimalFieldSet();
+    fs.putOverwrite("DataLength", "42");
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new FCPPluginClientMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+  }
+
+  @Test
+  void constructor_whenDataMessageWithoutLength_expectMissingField() {
+    SimpleFieldSet fs = minimalFieldSet();
+    fs.setEndMarker("Data");
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new FCPPluginClientMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+  }
+
+  @Test
+  void constructor_whenDataLengthNotNumeric_expectErrorParsingNumber() {
+    SimpleFieldSet fs = minimalFieldSet();
+    fs.setEndMarker("Data");
+    fs.putOverwrite("DataLength", "NaN");
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new FCPPluginClientMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.ERROR_PARSING_NUMBER, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+  }
+
+  @Test
+  void constructor_whenSuccessNotBoolean_expectInvalidField() {
+    SimpleFieldSet fs = minimalFieldSet();
+    fs.putOverwrite("Success", "certainly");
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new FCPPluginClientMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+  }
+
+  @Test
+  void constructFCPPluginMessage_whenSuccessFalse_populatesErrorInformation()
+      throws MessageInvalidException {
+    SimpleFieldSet params = createParamsSubset();
+    FCPPluginClientMessage message =
+        createMessage(
+            fs -> {
+              fs.put("Param", params);
+              fs.putOverwrite("Success", "false");
+              fs.putOverwrite("ErrorCode", "Problem");
+              fs.putOverwrite("ErrorMessage", "Failure");
+            });
+    Bucket bucket = Mockito.mock(Bucket.class);
+    message.bucket = bucket;
+
+    FCPPluginMessage pluginMessage = message.constructFCPPluginMessage();
+
+    assertSame(params, pluginMessage.params);
+    assertSame(bucket, pluginMessage.data);
+    assertFalse(pluginMessage.success);
+    assertEquals("Problem", pluginMessage.errorCode);
+    assertEquals("Failure", pluginMessage.errorMessage);
+  }
+
+  @Test
+  void accessors_whenNoData_returnProtocolDefaults() throws MessageInvalidException {
+    FCPPluginClientMessage message = createMessage(null);
+
+    assertEquals(IDENTIFIER, message.getIdentifier());
+    assertEquals(-1, message.dataLength());
+    assertFalse(message.isGlobal());
+    assertEquals(FCPPluginClientMessage.NAME, message.getName());
+    assertNull(message.getFieldSet());
+  }
+
+  @Test
+  void dataLength_whenDataPresent_matchesParsedLength() throws MessageInvalidException {
+    FCPPluginClientMessage message =
+        createMessage(
+            fs -> {
+              fs.setEndMarker("Data");
+              fs.put("DataLength", 64L);
+            });
+
+    assertEquals(64L, message.dataLength());
+  }
+
+  @Test
+  void run_whenPluginConnectionAvailable_sendsMessageOnce() throws Exception {
+    SimpleFieldSet params = createParamsSubset();
+    FCPPluginClientMessage message = createMessage(fs -> fs.put("Param", params));
+    Bucket bucket = Mockito.mock(Bucket.class);
+    message.bucket = bucket;
+
+    try (FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class)) {
+      FCPPluginConnection connection = Mockito.mock(FCPPluginConnection.class);
+      Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME)).thenReturn(connection);
+      Node node = Mockito.mock(Node.class);
+
+      message.run(handler, node);
+
+      ArgumentCaptor<FCPPluginMessage> messageCaptor =
+          ArgumentCaptor.forClass(FCPPluginMessage.class);
+      Mockito.verify(connection).send(Mockito.eq(SendDirection.ToServer), messageCaptor.capture());
+
+      FCPPluginMessage captured = messageCaptor.getValue();
+      assertEquals(IDENTIFIER, captured.identifier);
+      assertSame(params, captured.params);
+      assertSame(bucket, captured.data);
+      assertFalse(captured.isReplyMessage());
+    }
+  }
+
+  @Test
+  void run_whenPluginConnectionSendFails_wrapsIOException() throws Exception {
+    FCPPluginClientMessage message = createMessage(null);
+    try (FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class)) {
+      FCPPluginConnection connection = Mockito.mock(FCPPluginConnection.class);
+      Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME)).thenReturn(connection);
+      Mockito.doThrow(new IOException("boom"))
+          .when(connection)
+          .send(Mockito.eq(SendDirection.ToServer), Mockito.any());
+      Node node = Mockito.mock(Node.class);
+
+      MessageInvalidException ex =
+          assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+      assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, ex.protocolCode);
+      assertEquals(IDENTIFIER, ex.ident);
+    }
+  }
+
+  @Test
+  void run_whenHandlerThrowsPluginNotFound_throwsMessageInvalid() throws Exception {
+    FCPPluginClientMessage message = createMessage(null);
+    try (FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class)) {
+      Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME))
+          .thenThrow(new PluginNotFoundException());
+
+      Node node = Mockito.mock(Node.class);
+
+      MessageInvalidException ex =
+          assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+      assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, ex.protocolCode);
+      assertEquals(IDENTIFIER, ex.ident);
+    }
+  }
+
+  @Test
+  void run_whenPluginConnectionMissing_throwsMessageInvalid() throws Exception {
+    FCPPluginClientMessage message = createMessage(null);
+    try (FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class)) {
+      Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME)).thenReturn(null);
+
+      Node node = Mockito.mock(Node.class);
+
+      MessageInvalidException ex =
+          assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+      assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, ex.protocolCode);
+      assertEquals(IDENTIFIER, ex.ident);
+    }
+  }
+
+  private FCPPluginClientMessage createMessage(Consumer<SimpleFieldSet> customizer)
+      throws MessageInvalidException {
+    SimpleFieldSet fs = minimalFieldSet();
+    if (customizer != null) {
+      customizer.accept(fs);
+    }
+    return new FCPPluginClientMessage(fs);
+  }
+
+  private static SimpleFieldSet minimalFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putOverwrite("Identifier", IDENTIFIER);
+    fs.putOverwrite("PluginName", PLUGIN_NAME);
+    return fs;
+  }
+
+  private static SimpleFieldSet createParamsSubset() {
+    SimpleFieldSet params = new SimpleFieldSet(true);
+    params.putOverwrite("Key", "value");
+    return params;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginServerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginServerMessageTest.java
@@ -1,0 +1,243 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // test naming convention: method_whenCondition_expectOutcome
+@ExtendWith(MockitoExtension.class)
+class FCPPluginServerMessageTest {
+
+  @Mock private Bucket bucket;
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void constructor_withBucket_setsDataLengthAndMakesBucketReadOnly() {
+    long expectedLength = 123L;
+    org.mockito.Mockito.lenient().when(bucket.size()).thenReturn(expectedLength);
+
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, bucket, null, null, null);
+
+    assertEquals(expectedLength, message.dataLength());
+    assertEquals("Data", message.getEndString());
+    verify(bucket).setReadOnly();
+    verify(bucket).size();
+  }
+
+  @Test
+  void constructor_withNullBucket_setsNegativeDataLengthAndEndMessage() {
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, null, null, null, null);
+
+    assertEquals(-1L, message.dataLength());
+    assertEquals("EndMessage", message.getEndString());
+  }
+
+  @Test
+  void getFieldSet_withoutBucketParamsOrSuccess_producesMinimalFields() {
+    String pluginName = "TestPlugin";
+    String identifier = "test-id";
+
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage(pluginName, identifier, null, null, null, null, null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals(pluginName, fieldSet.get("PluginName"));
+    assertEquals(identifier, fieldSet.get("Identifier"));
+    assertNull(fieldSet.get("DataLength"));
+    assertNull(fieldSet.get("Success"));
+    assertNull(fieldSet.get("ErrorCode"));
+    assertNull(fieldSet.get("ErrorMessage"));
+    assertNull(fieldSet.subset(FCPPluginServerMessage.PARAM_PREFIX));
+  }
+
+  @Test
+  void getFieldSet_withPositiveDataLength_addsDataLengthField() {
+    long expectedLength = 42L;
+    org.mockito.Mockito.lenient().when(bucket.size()).thenReturn(expectedLength);
+
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, bucket, null, null, null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals(String.valueOf(expectedLength), fieldSet.get("DataLength"));
+  }
+
+  @Test
+  void getFieldSet_withEmptyParams_doesNotAddRepliesSubset() {
+    SimpleFieldSet plugParams = new SimpleFieldSet(true);
+
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", plugParams, null, null, null, null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNull(fieldSet.subset(FCPPluginServerMessage.PARAM_PREFIX));
+  }
+
+  @Test
+  void getFieldSet_withNonEmptyParams_addsRepliesSubset() {
+    SimpleFieldSet plugParams = new SimpleFieldSet(true);
+    plugParams.putSingle("Key", "Value");
+
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", plugParams, null, null, null, null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    SimpleFieldSet repliesSubset = fieldSet.subset(FCPPluginServerMessage.PARAM_PREFIX);
+    assertNotNull(repliesSubset);
+    assertEquals("Value", repliesSubset.get("Key"));
+  }
+
+  @Test
+  void getFieldSet_withSuccessNull_omitsSuccessAndErrorFields() {
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, null, null, "ERR", "msg");
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNull(fieldSet.get("Success"));
+    assertNull(fieldSet.get("ErrorCode"));
+    assertNull(fieldSet.get("ErrorMessage"));
+  }
+
+  @Test
+  void getFieldSet_withSuccessTrue_setsSuccessWithoutErrorFields() {
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, null, true, "ERR", "msg");
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("true", fieldSet.get("Success"));
+    assertNull(fieldSet.get("ErrorCode"));
+    assertNull(fieldSet.get("ErrorMessage"));
+  }
+
+  @Test
+  void getFieldSet_withSuccessFalseAndNoErrorCode_setsSuccessOnly() {
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, null, false, null, "ignored");
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("false", fieldSet.get("Success"));
+    assertNull(fieldSet.get("ErrorCode"));
+    assertNull(fieldSet.get("ErrorMessage"));
+  }
+
+  @Test
+  void getFieldSet_withSuccessFalseAndErrorCodeOnly_setsSuccessAndErrorCode() {
+    String errorCode = "TestErrorCode";
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, null, false, errorCode, null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("false", fieldSet.get("Success"));
+    assertEquals(errorCode, fieldSet.get("ErrorCode"));
+    assertNull(fieldSet.get("ErrorMessage"));
+  }
+
+  @Test
+  void getFieldSet_withSuccessFalseAndErrorCodeAndMessage_setsAllErrorFields() {
+    String errorCode = "TestErrorCode";
+    String errorMessage = "Test error message";
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage(
+            "TestPlugin", "test-id", null, null, false, errorCode, errorMessage);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("false", fieldSet.get("Success"));
+    assertEquals(errorCode, fieldSet.get("ErrorCode"));
+    assertEquals(errorMessage, fieldSet.get("ErrorMessage"));
+  }
+
+  @Test
+  void constructor_withPluginMessage_copiesFieldsFromMessage() {
+    FCPPluginMessage request = FCPPluginMessage.construct();
+    request.params.putOverwrite("originalKey", "originalValue");
+
+    FCPPluginMessage reply =
+        FCPPluginMessage.constructErrorReply(request, "ReplyError", "Reply message");
+    reply.params.putOverwrite("replyKey", "replyValue");
+
+    String pluginName = "TestPlugin";
+    FCPPluginServerMessage message = new FCPPluginServerMessage(pluginName, reply);
+
+    assertEquals(reply.identifier, message.getIdentifier());
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals(pluginName, fieldSet.get("PluginName"));
+    assertEquals(reply.identifier, fieldSet.get("Identifier"));
+    assertEquals("false", fieldSet.get("Success"));
+    assertEquals("ReplyError", fieldSet.get("ErrorCode"));
+    assertEquals("Reply message", fieldSet.get("ErrorMessage"));
+
+    SimpleFieldSet repliesSubset = fieldSet.subset(FCPPluginServerMessage.PARAM_PREFIX);
+    assertNotNull(repliesSubset);
+    assertEquals(reply.params.toOrderedString(), repliesSubset.toOrderedString());
+  }
+
+  @Test
+  void getName_returnsProtocolName() {
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, null, null, null, null);
+
+    assertEquals("FCPPluginReply", message.getName());
+  }
+
+  @Test
+  void isGlobal_alwaysReturnsFalse() {
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, null, null, null, null);
+
+    assertFalse(message.isGlobal());
+  }
+
+  @Test
+  void getIdentifier_returnsIdentifierPassedToConstructor() {
+    String identifier = "my-identifier";
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", identifier, null, null, null, null, null);
+
+    assertEquals(identifier, message.getIdentifier());
+  }
+
+  @Test
+  void run_alwaysThrowsMessageInvalidExceptionWithExpectedDetails() {
+    FCPPluginServerMessage message =
+        new FCPPluginServerMessage("TestPlugin", "test-id", null, null, null, null, null);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(
+        "FCPPluginReply goes from server to client not the other way around",
+        exception.getMessage());
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertNull(exception.ident);
+    assertFalse(exception.global);
+
+    verifyNoInteractions(handler, node);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
@@ -1,0 +1,338 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.filter.ContentFilter;
+import network.crypta.client.filter.ContentFilter.FilterStatus;
+import network.crypta.client.filter.FilterOperation;
+import network.crypta.client.filter.UnsafeContentTypeException;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.SimpleReadOnlyArrayBucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.io.ArrayBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FilterMessageTest {
+
+  private static final BucketFactory ARRAY_BUCKET_FACTORY = new ArrayBucketFactory();
+
+  @TempDir Path tempDir;
+
+  @Test
+  void constructor_directSourceWithoutMimeType_expectMissingField() {
+    SimpleFieldSet fs = baseFieldSet("req-direct-mime", DataSource.DIRECT);
+    fs.put("DataLength", 5L);
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class, () -> new FilterMessage(fs, ARRAY_BUCKET_FACTORY));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("req-direct-mime", exception.ident);
+  }
+
+  @Test
+  void constructor_directSourceWithNonNumericDataLength_expectParsingError() {
+    SimpleFieldSet fs = baseFieldSet("req-direct-length", DataSource.DIRECT);
+    fs.putSingle("MimeType", "text/plain");
+    fs.putSingle("DataLength", "abc");
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class, () -> new FilterMessage(fs, ARRAY_BUCKET_FACTORY));
+
+    assertEquals(ProtocolErrorMessage.ERROR_PARSING_NUMBER, exception.protocolCode);
+    assertEquals("req-direct-length", exception.ident);
+  }
+
+  @Test
+  void constructor_diskSourceWithoutFilename_expectMissingField() {
+    SimpleFieldSet fs = baseFieldSet("req-disk-filename", DataSource.DISK);
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class, () -> new FilterMessage(fs, ARRAY_BUCKET_FACTORY));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("req-disk-filename", exception.ident);
+  }
+
+  @Test
+  void constructor_diskSourceWithMissingFile_expectFileNotFound() {
+    SimpleFieldSet fs = baseFieldSet("req-disk-missing", DataSource.DISK);
+    Path missingFile = tempDir.resolve("missing-file.bin");
+    fs.putSingle("Filename", missingFile.toString());
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class, () -> new FilterMessage(fs, ARRAY_BUCKET_FACTORY));
+
+    assertEquals(ProtocolErrorMessage.FILE_NOT_FOUND, exception.protocolCode);
+    assertEquals("req-disk-missing", exception.ident);
+  }
+
+  @Test
+  void constructor_diskSourceWithoutMimeType_guessFromExtension()
+      throws IOException, MessageInvalidException {
+    Path htmlFile = Files.createTempFile(tempDir, "sample", ".html");
+    Files.writeString(htmlFile, "<html/>", StandardCharsets.UTF_8);
+    SimpleFieldSet fs = baseFieldSet("req-disk-guess", DataSource.DISK);
+    fs.putSingle("Filename", htmlFile.toString());
+
+    FilterMessage message = new FilterMessage(fs, ARRAY_BUCKET_FACTORY);
+    SimpleFieldSet serialized = message.getFieldSet();
+
+    assertEquals("text/html", serialized.get("MimeType"));
+    assertEquals(-1, serialized.getLong("DataLength", 0));
+  }
+
+  @Test
+  void constructor_diskSourceWithoutDetectableMime_expectBadMimeType() throws IOException {
+    Path binaryFile = Files.createTempFile(tempDir, "sample", ".unknownext");
+    Files.write(binaryFile, new byte[] {1, 2, 3});
+    SimpleFieldSet fs = baseFieldSet("req-disk-badmime", DataSource.DISK);
+    fs.putSingle("Filename", binaryFile.toString());
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class, () -> new FilterMessage(fs, ARRAY_BUCKET_FACTORY));
+
+    assertEquals(ProtocolErrorMessage.BAD_MIME_TYPE, exception.protocolCode);
+    assertEquals("req-disk-badmime", exception.ident);
+  }
+
+  @Test
+  void getFieldSet_directSourceContainsSuppliedValues() throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet("req-fieldset", DataSource.DIRECT);
+    fs.putSingle("MimeType", "text/plain");
+    fs.put("DataLength", 3L);
+    fs.putSingle("Filename", "/tmp/example.txt");
+
+    FilterMessage message = new FilterMessage(fs, ARRAY_BUCKET_FACTORY);
+    SimpleFieldSet serialized = message.getFieldSet();
+
+    assertEquals("req-fieldset", serialized.get("Identifier"));
+    assertEquals(FilterOperation.BOTH.name(), serialized.get("Operation"));
+    assertEquals(DataSource.DIRECT.name(), serialized.get("DataSource"));
+    assertEquals("text/plain", serialized.get("MimeType"));
+    assertEquals("/tmp/example.txt", serialized.get("Filename"));
+    assertEquals(3, serialized.getLong("DataLength", -1));
+  }
+
+  @Test
+  void run_whenBucketMissing_expectMissingField() throws MessageInvalidException {
+    FilterMessage message = createDirectMessage("req-run-nobucket", new byte[] {1, 2, 3});
+    message.bucket = null;
+
+    FCPConnectionHandler handler = handlerWithContext(Mockito.mock(ClientContext.class));
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class, () -> message.run(handler, Mockito.mock(Node.class)));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("req-run-nobucket", exception.ident);
+    Mockito.verify(handler, Mockito.never()).send(Mockito.any());
+  }
+
+  @Test
+  void run_whenBucketFactoryFails_expectInternalError() throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet("req-run-bf", DataSource.DIRECT);
+    fs.putSingle("MimeType", "text/plain");
+    fs.put("DataLength", 4L);
+    BucketFactory failingFactory = Mockito.mock(BucketFactory.class);
+    try {
+      Mockito.when(failingFactory.makeBucket(Mockito.anyLong()))
+          .thenThrow(new IOException("disk full"));
+    } catch (IOException e) {
+      fail(e);
+    }
+    FilterMessage message = new FilterMessage(fs, failingFactory);
+    message.bucket = new SimpleReadOnlyArrayBucket(new byte[] {9, 9, 9, 9});
+
+    FCPConnectionHandler handler = handlerWithContext(Mockito.mock(ClientContext.class));
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class, () -> message.run(handler, Mockito.mock(Node.class)));
+
+    assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, exception.protocolCode);
+    assertEquals("req-run-bf", exception.ident);
+    Mockito.verify(handler, Mockito.never()).send(Mockito.any());
+  }
+
+  @Test
+  void run_whenContentFilterSucceeds_sendsResultMessage() throws Exception {
+    byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+    FilterMessage message = createDirectMessage("req-run-success", payload);
+
+    ClientContext clientContext = Mockito.mock(ClientContext.class);
+    FCPConnectionHandler handler = handlerWithContext(clientContext);
+    ArgumentCaptor<FilterResultMessage> responseCaptor =
+        ArgumentCaptor.forClass(FilterResultMessage.class);
+
+    FilterStatus status = filterStatusUtf8Text();
+
+    try (MockedStatic<ContentFilter> staticFilter = Mockito.mockStatic(ContentFilter.class)) {
+      staticFilter
+          .when(
+              () ->
+                  ContentFilter.filter(
+                      Mockito.any(InputStream.class),
+                      Mockito.any(OutputStream.class),
+                      Mockito.eq("text/plain"),
+                      Mockito.any(URI.class),
+                      Mockito.isNull(),
+                      Mockito.isNull(),
+                      Mockito.isNull(),
+                      Mockito.isNull(),
+                      Mockito.isNull()))
+          .thenAnswer(
+              invocation -> {
+                InputStream input = invocation.getArgument(0);
+                OutputStream output = invocation.getArgument(1);
+                output.write(input.readAllBytes());
+                return status;
+              });
+
+      message.run(handler, Mockito.mock(Node.class));
+    }
+
+    Mockito.verify(handler).send(responseCaptor.capture());
+    FilterResultMessage response = responseCaptor.getValue();
+
+    assertEquals("req-run-success", response.getIdentifier());
+    assertFalse(response.getFieldSet().getBoolean("UnsafeContentType", true));
+    assertEquals("UTF-8", response.getFieldSet().get("Charset"));
+    assertEquals("text/plain", response.getFieldSet().get("MimeType"));
+    assertEquals(payload.length, response.dataLength());
+    assertNotNull(response.bucket);
+    try (InputStream stored = response.bucket.getInputStream()) {
+      assertArrayEquals(payload, stored.readAllBytes());
+    } catch (IOException e) {
+      fail(e);
+    }
+  }
+
+  @Test
+  void run_whenContentFilterSignalsUnsafe_setsUnsafeFlag() throws Exception {
+    byte[] payload = "unsafe".getBytes(StandardCharsets.UTF_8);
+    FilterMessage message = createDirectMessage("req-run-unsafe", payload);
+
+    ClientContext clientContext = Mockito.mock(ClientContext.class);
+    FCPConnectionHandler handler = handlerWithContext(clientContext);
+    ArgumentCaptor<FilterResultMessage> responseCaptor =
+        ArgumentCaptor.forClass(FilterResultMessage.class);
+
+    UnsafeContentTypeException unsafe =
+        new UnsafeContentTypeException() {
+          @Override
+          public String getMessage() {
+            return "unsafe";
+          }
+
+          @Override
+          public String getHTMLEncodedTitle() {
+            return "unsafe";
+          }
+
+          @Override
+          public String getRawTitle() {
+            return "unsafe";
+          }
+        };
+
+    try (MockedStatic<ContentFilter> staticFilter = Mockito.mockStatic(ContentFilter.class)) {
+      staticFilter
+          .when(
+              () ->
+                  ContentFilter.filter(
+                      Mockito.any(InputStream.class),
+                      Mockito.any(OutputStream.class),
+                      Mockito.eq("text/plain"),
+                      Mockito.any(URI.class),
+                      Mockito.isNull(),
+                      Mockito.isNull(),
+                      Mockito.isNull(),
+                      Mockito.isNull(),
+                      Mockito.isNull()))
+          .thenThrow(unsafe);
+
+      message.run(handler, Mockito.mock(Node.class));
+    }
+
+    Mockito.verify(handler).send(responseCaptor.capture());
+    FilterResultMessage response = responseCaptor.getValue();
+
+    assertEquals("req-run-unsafe", response.getIdentifier());
+    assertTrue(response.getFieldSet().getBoolean("UnsafeContentType", false));
+    assertEquals(-1, response.dataLength());
+    assertNull(response.bucket);
+  }
+
+  private FilterMessage createDirectMessage(String identifier, byte[] payload)
+      throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet(identifier, DataSource.DIRECT);
+    fs.putSingle("MimeType", "text/plain");
+    fs.put("DataLength", payload.length);
+    FilterMessage message = new FilterMessage(fs, ARRAY_BUCKET_FACTORY);
+    message.bucket = new SimpleReadOnlyArrayBucket(payload);
+    return message;
+  }
+
+  private SimpleFieldSet baseFieldSet(String identifier, DataSource dataSource) {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle(FCPMessage.IDENTIFIER, identifier);
+    fs.putSingle("Operation", FilterOperation.BOTH.name());
+    fs.putSingle("DataSource", dataSource.name());
+    return fs;
+  }
+
+  private FCPConnectionHandler handlerWithContext(ClientContext context) {
+    FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
+    FCPServer server = Mockito.mock(FCPServer.class);
+    NodeClientCore core = Mockito.mock(NodeClientCore.class);
+    Mockito.lenient().when(handler.getServer()).thenReturn(server);
+    Mockito.lenient().when(server.getCore()).thenReturn(core);
+    Mockito.lenient().when(core.getClientContext()).thenReturn(context);
+    return handler;
+  }
+
+  @SuppressWarnings("java:S3011")
+  private FilterStatus filterStatusUtf8Text() {
+    try {
+      Constructor<FilterStatus> constructor =
+          ContentFilter.FilterStatus.class.getDeclaredConstructor(String.class, String.class);
+      constructor.setAccessible(true);
+      return constructor.newInstance("UTF-8", "text/plain");
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Unable to construct FilterStatus", e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FilterResultMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FilterResultMessageTest.java
@@ -1,0 +1,105 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.SimpleReadOnlyArrayBucket;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class FilterResultMessageTest {
+
+  @Test
+  void constructor_whenSafeContentType_populatesBucketAndLength() {
+    SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(new byte[] {1, 2, 3});
+
+    FilterResultMessage message =
+        new FilterResultMessage("req-1", "UTF-8", "text/plain", false, bucket);
+
+    assertEquals("req-1", message.getIdentifier());
+    assertEquals(bucket.size(), message.dataLength());
+    assertSame(bucket, message.bucket);
+    assertFalse(message.isGlobal());
+  }
+
+  @Test
+  void constructor_whenUnsafeContentType_setsNegativeLengthAndLeavesBucketNull() {
+    SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(new byte[] {10, 11});
+
+    FilterResultMessage message =
+        new FilterResultMessage("req-2", "UTF-16", "application/json", true, bucket);
+
+    assertEquals(-1, message.dataLength());
+    assertNull(message.bucket);
+  }
+
+  @Test
+  void getFieldSet_whenSafeContentType_containsMetadata() {
+    FilterResultMessage message =
+        new FilterResultMessage(
+            "req-3",
+            "ISO-8859-1",
+            "text/html",
+            false,
+            new SimpleReadOnlyArrayBucket(new byte[] {5, 6, 7, 8}));
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("req-3", fieldSet.get("Identifier"));
+    assertEquals("ISO-8859-1", fieldSet.get("Charset"));
+    assertEquals("text/html", fieldSet.get("MimeType"));
+    assertFalse(fieldSet.getBoolean("UnsafeContentType", true));
+    assertEquals(4, fieldSet.getLong("DataLength", -42));
+  }
+
+  @Test
+  void getFieldSet_whenUnsafeContentType_reportsFlagAndNegativeLength() {
+    FilterResultMessage message =
+        new FilterResultMessage(
+            "req-4",
+            "UTF-8",
+            "application/octet-stream",
+            true,
+            new SimpleReadOnlyArrayBucket(new byte[] {9, 9, 9}));
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertTrue(fieldSet.getBoolean("UnsafeContentType", false));
+    assertEquals(-1, fieldSet.getLong("DataLength", 0));
+  }
+
+  @Test
+  void getName_whenCalled_returnsFilterResult() {
+    FilterResultMessage message =
+        new FilterResultMessage(
+            "req-5", "UTF-8", "text/plain", false, new SimpleReadOnlyArrayBucket(new byte[] {1}));
+
+    assertEquals(FilterResultMessage.NAME, message.getName());
+  }
+
+  @Test
+  void run_whenInvoked_throwsInvalidMessageException() {
+    FilterResultMessage message =
+        new FilterResultMessage(
+            "req-6",
+            "UTF-8",
+            "text/plain",
+            false,
+            new SimpleReadOnlyArrayBucket(new byte[] {1, 2}));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        FilterResultMessage.NAME + " goes from server to client not the other way around",
+        exception.getMessage());
+    assertNull(exception.ident);
+    assertFalse(exception.global);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/SendBookmarkMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SendBookmarkMessageTest.java
@@ -1,0 +1,177 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SendBookmarkMessageTest {
+
+  private static final String IDENTIFIER = "test-identifier";
+  private static final String NODE_IDENTIFIER = "peer-42";
+  private static final String VALID_URI = "KSK@Bookmarks";
+  private static final String BOOKMARK_NAME = "crypta-home";
+
+  @Mock private DarknetPeerNode darknetPeerNode;
+
+  @Test
+  void constructor_whenNameMissing_expectMessageInvalidException() {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("URI", VALID_URI);
+    fs.put("HasAnActivelink", true);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new SendBookmarkMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+  }
+
+  @Test
+  void constructor_whenUriMalformed_expectMessageInvalidException() {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("Name", BOOKMARK_NAME);
+    fs.putSingle("URI", "not-a-valid-uri");
+    fs.put("HasAnActivelink", false);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new SendBookmarkMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, ex.protocolCode);
+  }
+
+  @Test
+  void getFieldSet_whenConstructed_containsBookmarkFields() throws MessageInvalidException {
+    String description = "Crypta bookmark";
+    SendBookmarkMessage message = newMessage(description, true);
+
+    SimpleFieldSet serialized = message.getFieldSet();
+
+    assertEquals(IDENTIFIER, serialized.get("Identifier"));
+    assertEquals(NODE_IDENTIFIER, serialized.get("NodeIdentifier"));
+    assertEquals(BOOKMARK_NAME, serialized.get("Name"));
+    assertEquals(VALID_URI, serialized.get("URI"));
+    assertTrue(serialized.getBoolean("HasAnActivelink", false));
+    assertEquals(
+        Integer.toString(description.getBytes(StandardCharsets.UTF_8).length),
+        serialized.get("DataLength"));
+  }
+
+  @Test
+  void handleFeed_whenDescriptionProvided_forwardsUtf8Text() throws Exception {
+    String description = "Shared bookmark ✓";
+    SendBookmarkMessage message = newMessage(description, true);
+
+    Mockito.when(
+            darknetPeerNode.sendBookmarkFeed(
+                Mockito.any(FreenetURI.class),
+                Mockito.eq(BOOKMARK_NAME),
+                Mockito.anyString(),
+                Mockito.eq(true)))
+        .thenReturn(77);
+
+    int status = message.handleFeed(darknetPeerNode);
+
+    assertEquals(77, status);
+    ArgumentCaptor<FreenetURI> uriCaptor = ArgumentCaptor.forClass(FreenetURI.class);
+    ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(darknetPeerNode)
+        .sendBookmarkFeed(
+            uriCaptor.capture(),
+            Mockito.eq(BOOKMARK_NAME),
+            descriptionCaptor.capture(),
+            Mockito.eq(true));
+    assertEquals(VALID_URI, uriCaptor.getValue().toString());
+    assertEquals(description, descriptionCaptor.getValue());
+  }
+
+  @Test
+  void handleFeed_whenNoPayload_setsNullDescription() throws Exception {
+    SendBookmarkMessage message = newMessage(null, false);
+
+    Mockito.when(
+            darknetPeerNode.sendBookmarkFeed(
+                Mockito.any(FreenetURI.class),
+                Mockito.eq(BOOKMARK_NAME),
+                Mockito.isNull(),
+                Mockito.eq(false)))
+        .thenReturn(12);
+
+    int status = message.handleFeed(darknetPeerNode);
+
+    assertEquals(12, status);
+    ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(darknetPeerNode)
+        .sendBookmarkFeed(
+            Mockito.any(FreenetURI.class),
+            Mockito.eq(BOOKMARK_NAME),
+            descriptionCaptor.capture(),
+            Mockito.eq(false));
+    assertNull(descriptionCaptor.getValue());
+  }
+
+  @Test
+  void handleFeed_whenBucketReadFails_wrapsIOException() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("Name", BOOKMARK_NAME);
+    fs.putSingle("URI", VALID_URI);
+    fs.put("HasAnActivelink", true);
+    fs.put("DataLength", 8);
+    SendBookmarkMessage message = new SendBookmarkMessage(fs);
+    Bucket bucket = Mockito.mock(Bucket.class);
+    message.bucket = bucket;
+    Mockito.when(bucket.size()).thenReturn(8L);
+    Mockito.when(bucket.getInputStreamUnbuffered()).thenThrow(new IOException("boom"));
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.handleFeed(darknetPeerNode));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
+    Mockito.verify(darknetPeerNode, Mockito.never())
+        .sendBookmarkFeed(
+            Mockito.any(FreenetURI.class),
+            Mockito.anyString(),
+            Mockito.any(),
+            Mockito.anyBoolean());
+  }
+
+  private SimpleFieldSet baseFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("NodeIdentifier", NODE_IDENTIFIER);
+    return fs;
+  }
+
+  private SendBookmarkMessage newMessage(String description, boolean hasActiveLink)
+      throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("Name", BOOKMARK_NAME);
+    fs.putSingle("URI", VALID_URI);
+    fs.put("HasAnActivelink", hasActiveLink);
+    SendBookmarkMessage message;
+    if (description != null) {
+      byte[] bytes = description.getBytes(StandardCharsets.UTF_8);
+      fs.put("DataLength", bytes.length);
+      message = new SendBookmarkMessage(fs);
+      message.bucket = new ArrayBucket(bytes);
+    } else {
+      message = new SendBookmarkMessage(fs);
+    }
+    return message;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/SendTextMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SendTextMessageTest.java
@@ -1,0 +1,90 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SendTextMessageTest {
+
+  private static final String IDENTIFIER = "test-identifier";
+  private static final String NODE_IDENTIFIER = "peer-node-1";
+
+  @Mock private DarknetPeerNode darknetPeerNode;
+
+  @Test
+  void getName_whenCalled_returnsSendText() throws MessageInvalidException {
+    SendTextMessage message = new SendTextMessage(baseFieldSet());
+
+    assertEquals(SendTextMessage.NAME, message.getName());
+  }
+
+  @Test
+  void handleFeed_whenDataPresent_sendsUtf8PayloadToPeer() throws Exception {
+    String text = "Grüße €";
+    byte[] payload = text.getBytes(StandardCharsets.UTF_8);
+    SendTextMessage message = new SendTextMessage(baseFieldSetWithLength(payload.length));
+    message.bucket = new ArrayBucket(payload);
+    Mockito.when(darknetPeerNode.sendTextFeed(text)).thenReturn(123);
+
+    int status = message.handleFeed(darknetPeerNode);
+
+    assertEquals(123, status);
+    verify(darknetPeerNode).sendTextFeed(text);
+  }
+
+  @Test
+  void handleFeed_whenDataLengthNonPositive_throwsMessageInvalidException() throws Exception {
+    SendTextMessage message = new SendTextMessage(baseFieldSetWithLength(0));
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.handleFeed(darknetPeerNode));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
+    assertEquals("Invalid data length", ex.getMessage());
+    verify(darknetPeerNode, never()).sendTextFeed(Mockito.anyString());
+  }
+
+  @Test
+  void handleFeed_whenBucketReadFails_wrapsIOException() throws Exception {
+    SendTextMessage message = new SendTextMessage(baseFieldSetWithLength(1));
+    Bucket bucket = Mockito.mock(Bucket.class);
+    message.bucket = bucket;
+    Mockito.when(bucket.size()).thenReturn(1L);
+    Mockito.when(bucket.getInputStreamUnbuffered()).thenThrow(new IOException("boom"));
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.handleFeed(darknetPeerNode));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
+    assertEquals("", ex.getMessage());
+    verify(darknetPeerNode, never()).sendTextFeed(Mockito.anyString());
+  }
+
+  private SimpleFieldSet baseFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("NodeIdentifier", NODE_IDENTIFIER);
+    return fs;
+  }
+
+  private SimpleFieldSet baseFieldSetWithLength(long dataLength) {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("DataLength", dataLength);
+    return fs;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/SendURIMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SendURIMessageTest.java
@@ -1,0 +1,134 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // Test method naming convention
+@ExtendWith(MockitoExtension.class)
+class SendURIMessageTest {
+
+  private static final String IDENTIFIER = "test-ident";
+  private static final String NODE_IDENTIFIER = "peer-node";
+  private static final String VALID_URI = "KSK@keyword";
+
+  @Mock private DarknetPeerNode peerNode;
+
+  @Test
+  void constructor_whenUriInvalid_expectMessageInvalidException() {
+    // Arrange
+    SimpleFieldSet fieldSet = baseFieldSet("invalid-uri-without-at", null);
+
+    // Act + Assert
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new SendURIMessage(fieldSet));
+    assertEquals(ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, exception.protocolCode);
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
+  void getFieldSet_whenCalled_expectUriAndBaseFieldsPreserved() throws Exception {
+    // Arrange
+    long dataLength = 42L;
+    SendURIMessage message = new SendURIMessage(baseFieldSet(VALID_URI, dataLength));
+    String uriString = new FreenetURI(VALID_URI).toString();
+
+    // Act
+    SimpleFieldSet result = message.getFieldSet();
+
+    // Assert
+    assertEquals(IDENTIFIER, result.get("Identifier"));
+    assertEquals(NODE_IDENTIFIER, result.get("NodeIdentifier"));
+    assertEquals(dataLength, result.getLong("DataLength", -1L));
+    assertEquals(uriString, result.get("URI"));
+    assertEquals(SendURIMessage.NAME, message.getName());
+  }
+
+  @Test
+  void handleFeed_whenPayloadPresent_expectUtf8DescriptionForwarded() throws Exception {
+    // Arrange
+    SendURIMessage message = new SendURIMessage(baseFieldSet(VALID_URI, 9L));
+    String description = "Résumé ☕ entry";
+    message.bucket = bucketWithUtf8(description);
+    when(peerNode.sendDownloadFeed(any(FreenetURI.class), anyString())).thenReturn(77);
+    FreenetURI expectedUri = new FreenetURI(VALID_URI);
+
+    // Act
+    int status = message.handleFeed(peerNode);
+
+    // Assert
+    assertEquals(77, status);
+    verify(peerNode).sendDownloadFeed(expectedUri, description);
+  }
+
+  @Test
+  void handleFeed_whenNoPayload_expectNullDescription() throws Exception {
+    // Arrange
+    SendURIMessage message = new SendURIMessage(baseFieldSet(VALID_URI, null));
+    when(peerNode.sendDownloadFeed(any(FreenetURI.class), isNull())).thenReturn(11);
+    FreenetURI expectedUri = new FreenetURI(VALID_URI);
+
+    // Act
+    int status = message.handleFeed(peerNode);
+
+    // Assert
+    assertEquals(11, status);
+    verify(peerNode).sendDownloadFeed(expectedUri, null);
+  }
+
+  @Test
+  void handleFeed_whenBucketThrowsIOException_expectInvalidMessage() throws Exception {
+    // Arrange
+    SendURIMessage message = new SendURIMessage(baseFieldSet(VALID_URI, 1L));
+    Bucket brokenBucket = mock(Bucket.class);
+    when(brokenBucket.size()).thenReturn(1L);
+    when(brokenBucket.getInputStreamUnbuffered()).thenThrow(new IOException("boom"));
+    message.bucket = brokenBucket;
+
+    // Act + Assert
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.handleFeed(peerNode));
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertNull(exception.ident);
+    verify(peerNode, never()).sendDownloadFeed(any(FreenetURI.class), anyString());
+  }
+
+  private static SimpleFieldSet baseFieldSet(String uri, Long dataLength) {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("NodeIdentifier", NODE_IDENTIFIER);
+    fs.putSingle("URI", uri);
+    if (dataLength != null) {
+      fs.putSingle("DataLength", Long.toString(dataLength));
+    }
+    return fs;
+  }
+
+  private static ArrayBucket bucketWithUtf8(String text) throws IOException {
+    ArrayBucket bucket = new ArrayBucket();
+    try (OutputStream os = bucket.getOutputStream()) {
+      os.write(text.getBytes(StandardCharsets.UTF_8));
+    }
+    return bucket;
+  }
+}


### PR DESCRIPTION
## Summary
- document FCP data-carrying and send message behaviors so downstream clients know which fields are mandatory and how send semantics work
- harden the plugin reply flow plus ClientPut/Filter parsing so malformed inputs are rejected early and the node never emits incomplete payloads
- add comprehensive unit coverage for the newly documented FCP message classes (AddPeer, feeds, plugin messages, SendBookmark/Text/URI, etc.) to lock in the expected envelopes

## Testing
- Not run (not requested)
