### PR TITLE
Improve ClientPutDir documentation and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -17,31 +17,39 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Handles the {@code ClientPutComplexDir} FCP command, enabling a client to stage and upload a
+ * directory tree composed of files, nested folders, and redirect targets from multiple sources.
  *
+ * <p>The message aggregates {@link DirPutFile} entries keyed by their hierarchical name, tracks
+ * data that must still be read from the network connection, and ultimately produces the manifest
+ * expected by {@link ClientPutDirMessage}. A single instance encapsulates one client request and is
+ * therefore not thread-safe; callers construct it, stream any pending data in lexical order, and
+ * hand it to {@link FCPConnectionHandler} for execution on the node.
  *
- * <pre>
+ * <p>Larger directory puts benefit from this class because it keeps metadata, MIME hints, and
+ * {@link ManifestElement ManifestElements} adjacent to their payloads while enforcing sequential
+ * numbering and ordering rules. Error reporting distinguishes between malformed hierarchies, access
+ * restrictions, and I/O problems so the client can retry selectively.
+ *
+ * <ul>
+ *   <li>Builds a nested {@code Map} structure that mirrors directory layout before dispatch.
+ *   <li>Streams {@code UploadFrom=direct} payloads in alphabetical order to avoid buffering.
+ *   <li>Validates disk-sourced files against {@link Node#getClientCore()} upload policy.
+ * </ul>
+ *
+ * <p>Example payload:
+ *
+ * <pre>{@code
  * ClientPutComplexDir
- * &lt; ... standard ClientPutDir headers ... &gt;
  * Files.0.Name=hello.txt
  * Files.0.UploadFrom=direct
- * Files.0.Metadata.ContentType=text/plain
  * Files.0.DataLength=6
- *  ( upload the 6 bytes following this message as hello.txt, type plain text)
- * Files.1.Name=something.pdf
- * Files.1.UploadFrom=disk
- * Files.1.Filename=something.pdf
- *  ( upload something.pdf, guess the mime type from the filename )
- * Files.2.Name=toad.jpeg
- * Files.2.UploadFrom=redirect
- * Files.2.TargetURI=CHK@...,...,...
- * Files.2.Metadata.ContentType=image/jpeg
- *  ( not yet supported, but would be really useful! FIXME ! )
- * (note that the Files.x must always be a decimal integer. We use these for sort
- *  order for UploadFrom=direct. they must be sequential and start at 0).
- * ...
  * End
- * &lt;data from above direct uploads, ***in alphabetical order***&gt;
- * </pre>
+ * <binary payload here>
+ * }</pre>
+ *
+ * @see ClientPutDirMessage
+ * @see DirPutFile
  */
 public class ClientPutComplexDirMessage extends ClientPutDirMessage {
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutComplexDirMessage.class);
@@ -55,6 +63,26 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
   /** Total number of bytes of attached data */
   private final long attachedBytes;
 
+  /**
+   * Creates a new message by parsing the supplied {@link SimpleFieldSet} and provisioning bucket
+   * storage for any pending direct uploads.
+   *
+   * <p>The constructor performs all structural validation eagerly: it enforces sequential {@code
+   * Files.x} numbering, builds the hierarchical lookup map used later by {@link #run}, and queues
+   * {@link DirectDirPutFile} instances whose payload bytes are expected to follow the message body.
+   * Bucket factories are selected according to persistence so that temporary uploads stay in fast
+   * scratch storage while forever requests use disk-backed buckets.
+   *
+   * <pre>{@code
+   * ClientPutComplexDirMessage msg =
+   *     new ClientPutComplexDirMessage(fields, tempFactory, persistentFactory);
+   * }</pre>
+   *
+   * @param fs structured field set describing {@code Files.*} entries plus metadata
+   * @param bfTemp transient bucket factory for non-forever uploads and streaming buffers
+   * @param bfPersistent persistent bucket factory keeping FOREVER payloads durably available
+   * @throws MessageInvalidException if mandatory headers are missing or hierarchy rules break
+   */
   public ClientPutComplexDirMessage(
       SimpleFieldSet fs, BucketFactory bfTemp, PersistentTempBucketFactory bfPersistent)
       throws MessageInvalidException {
@@ -69,7 +97,6 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
     if (files == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "Missing Files section", identifier, global);
-    boolean logMINOR = LOG.isDebugEnabled();
     for (int i = 0; ; i++) {
       SimpleFieldSet subset = files.subset(Integer.toString(i));
       if (subset == null) break;
@@ -80,11 +107,11 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
               global,
               (persistence == Persistence.FOREVER) ? bfPersistent : bfTemp);
       addFile(f);
-      if (LOG.isDebugEnabled()) LOG.debug("Adding " + f);
+      if (LOG.isDebugEnabled()) LOG.debug("Adding {}", f);
       if (f instanceof DirectDirPutFile file) {
         totalBytes += file.bytesToRead();
         filesToRead.addLast(f);
-        if (LOG.isDebugEnabled()) LOG.debug("totalBytes now " + totalBytes);
+        if (LOG.isDebugEnabled()) LOG.debug("totalBytes now {}", totalBytes);
       }
     }
     attachedBytes = totalBytes;
@@ -93,7 +120,7 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
   /**
    * Add a file to the filesByName.
    *
-   * @throws MessageInvalidException
+   * @throws MessageInvalidException if the provided path collides with an existing directory entry
    */
   private void addFile(DirPutFile f) throws MessageInvalidException {
     addFile(filesByName, f.getName(), f);
@@ -128,6 +155,15 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
 
   static final String NAME = "ClientPutComplexDir";
 
+  /**
+   * Returns the canonical command name advertised to the FCP layer and logging facilities.
+   *
+   * <p>The identifier is a constant shared by every instance so routers can compare it cheaply
+   * against incoming tokens and dispatch without additional allocations. It is also used by unit
+   * tests to assert protocol compatibility when future versions add optional fields.
+   *
+   * @return constant name string that downstream {@link ClientRequest} classifiers understand
+   */
   @Override
   public String getName() {
     return NAME;
@@ -138,10 +174,27 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
     return attachedBytes;
   }
 
+  @SuppressWarnings("unused")
   String getIdentifier() {
     return identifier;
   }
 
+  /**
+   * Reads any {@code UploadFrom=direct} payloads from the provided stream and persists them through
+   * the chosen bucket factory.
+   *
+   * <p>The order of reads must remain alphabetical by filename so that the streamlined sender can
+   * write a single concatenated blob. Each {@link DirectDirPutFile} tracks its expected byte count,
+   * and {@link MessageInvalidException} is raised if the stream ends prematurely or provides excess
+   * data. The {@link FCPServer} parameter allows policy hooks to be triggered if future versions
+   * need to enforce throttling or audit logging.
+   *
+   * @param is decoded message continuation stream containing the concatenated direct payload bytes
+   * @param bf bucket factory already selected for this request, reused for direct attachments
+   * @param server FCP server orchestrating the client session, never {@code null}
+   * @throws IOException if the socket or bucket write fails while copying payload bytes
+   * @throws MessageInvalidException if read sizes mismatch declarations or validation rejects input
+   */
   @Override
   public void readFrom(InputStream is, BucketFactory bf, FCPServer server)
       throws IOException, MessageInvalidException {
@@ -150,6 +203,19 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
     }
   }
 
+  /**
+   * Writes pending {@code UploadFrom=direct} payloads to the supplied output stream in strict
+   * lexical order.
+   *
+   * <p>This method mirrors {@link #readFrom(InputStream, BucketFactory, FCPServer)} but targets a
+   * caller-supplied stream, such as a socket or bucket. It assumes that each {@link DirPutFile} has
+   * already staged its data and therefore only delegates to {@link DirectDirPutFile#write} without
+   * buffering. Implementations must ensure the stream honors blocking semantics because large
+   * directories may emit megabytes of data per invocation.
+   *
+   * @param os destination stream that receives previously buffered direct-upload payloads
+   * @throws IOException if writing any buffered payload fails or the stream closes unexpectedly
+   */
   @Override
   protected void writeData(OutputStream os) throws IOException {
     for (DirPutFile f : filesToRead) {
@@ -157,6 +223,21 @@ public class ClientPutComplexDirMessage extends ClientPutDirMessage {
     }
   }
 
+  /**
+   * Converts parsed files into {@link ManifestElement} trees and instructs the handler to start the
+   * directory insert.
+   *
+   * <p>During execution the method validates disk-backed files through {@link Node#getClientCore()}
+   * before constructing the manifest, thereby ensuring policy compliance without touching the
+   * network. The resulting map mirrors the original hierarchy so downstream components can process
+   * nested directories without recomputing paths. The insert begins immediately afterward, and any
+   * {@link MessageInvalidException} bubbles up to the caller so the FCP client receives actionable
+   * feedback.
+   *
+   * @param handler active connection handler responsible for initiating the put job
+   * @param node node instance that supplies policy checks and storage context for the request
+   * @throws MessageInvalidException if conversion detects disallowed files or inconsistent input
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     // Convert the hierarchical hashmap's of DirPutFile's to hierarchical hashmap's

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDirMessage.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.net.MalformedURLException;
+import java.util.Optional;
 import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
@@ -11,22 +12,34 @@ import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
 import network.crypta.support.compress.InvalidCompressionCodecException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Put a directory, rather than a file. Base class.
+ * Base message for inserting directory hierarchies through the Freenet Client Protocol (FCP).
  *
- * <p>Two forms: ClientPutDiskDir and ClientPutComplexDir
+ * <p>This abstract container centralizes the parsing and validation shared by {@link
+ * ClientPutDiskDirMessage} and {@link ClientPutComplexDirMessage}. A node controller builds an
+ * instance from an inbound {@link SimpleFieldSet} and hands it to {@link RequestStarter}, which
+ * turns the embedded metadata into the actual insert pipeline. The message spells out the target
+ * {@link FreenetURI}, retry envelope, splitfile compatibility mode, compression hints, and
+ * persistence knobs expected by the storage layer so that both directory flavours remain
+ * interoperable.
  *
- * <p>Both share: Identifier=<identifier> Verbosity=<verbosity as ClientPut> MaxRetries=<max retries
- * as ClientPut> PriorityClass=<priority class> URI=<target URI> GetCHKOnly=<GetCHKOnly as
- * ClientPut> DontCompress=<DontCompress as ClientPut> ClientToken=<ClientToken as ClientPut>
- * Persistence=<Persistence as ClientPut> Global=<Global as ClientPut>
+ * <p>All fields are populated during construction and the type is effectively immutable afterward,
+ * which lets callers hand references across worker threads without additional synchronization. The
+ * class enforces conservative defaults—such as the immediate priority class and cache-writing
+ * guardrails—so that omitted wire fields cannot accidentally degrade node health. Subclasses add
+ * payload handling (disk vs. complex manifests) while reusing the contract defined here.
+ *
+ * <ul>
+ *   <li>Validates every user-supplied numeric or binary option and reports protocol errors.
+ *   <li>Exposes computed defaults through getters so monitoring code can serialize them back.
+ *   <li>Coordinates cache controls, compressor descriptors, and URI post-processing.
+ * </ul>
+ *
+ * @see ClientPutDiskDirMessage
+ * @see ClientPutComplexDirMessage
  */
 public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ClientPutDirMessage.class);
-
   // Some subtypes of this (ClientPutComplexDirMessage) may carry a payload.
 
   final String identifier;
@@ -43,7 +56,15 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
   final boolean earlyEncode;
   final boolean canWriteClientCache;
   final String compressorDescriptor;
-  public boolean forkOnCacheable;
+
+  /**
+   * Signals whether cacheable blocks should be forked into independent inserts while obeying the
+   * node's {@link Node#FORK_ON_CACHEABLE_DEFAULT} policy. Callers read this flag to decide if a
+   * cache hit should spawn separate background persistence work or remain in-band with the parent
+   * request, allowing UI clients to trade extra bandwidth for faster convergence on popular data.
+   */
+  public final boolean forkOnCacheable;
+
   final int extraInsertsSingleBlock;
   final int extraInsertsSplitfileHeaderBlock;
   final InsertContext.CompatibilityMode compatibilityMode;
@@ -53,126 +74,39 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
   final String targetFilename;
   final boolean ignoreUSKDatehints;
 
-  public ClientPutDirMessage(SimpleFieldSet fs) throws MessageInvalidException {
+  /**
+   * Creates the message by parsing the wire-level {@link SimpleFieldSet} submitted through FCP.
+   *
+   * <p>The constructor inspects every optional and required field, applies defaults that mirror the
+   * standalone {@code ClientPut} flow, and converts invalid input into descriptive {@link
+   * ProtocolErrorMessage} instances. Validation happens eagerly so that subclasses can rely on
+   * strongly typed values (priority classes, URIs, retry counts, compressor descriptors, and
+   * splitfile toggles) without repeating boilerplate. The {@code fs} argument is not retained
+   * beyond construction, allowing the resulting object to be shared freely. Because parsing may
+   * reject malformed tokens at several points, callers should be prepared to propagate the thrown
+   * exception back to the remote client.
+   *
+   * @param fs parsed field set received from the client; must include URI, identifier, and related
+   *     directory insert options, and may omit unspecified optional controls.
+   * @throws MessageInvalidException if any value is missing, outside allowed ranges, or
+   *     inconsistent with the expected encoding, including malformed URIs or crypto keys.
+   */
+  protected ClientPutDirMessage(SimpleFieldSet fs) throws MessageInvalidException {
     identifier = fs.get("Identifier");
     global = fs.getBoolean("Global", false);
     defaultName = fs.get("DefaultName");
-    String s = fs.get("CompatibilityMode");
-    InsertContext.CompatibilityMode cmode = null;
-    if (s == null) cmode = InsertContext.CompatibilityMode.COMPAT_DEFAULT;
-    else {
-      try {
-        cmode = InsertContext.CompatibilityMode.valueOf(s);
-      } catch (IllegalArgumentException e) {
-        try {
-          cmode = InsertContext.CompatibilityMode.values()[Integer.parseInt(s)];
-        } catch (NumberFormatException e1) {
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.INVALID_FIELD,
-              "Invalid CompatibilityMode (not a name and not a number)",
-              identifier,
-              global);
-        } catch (ArrayIndexOutOfBoundsException e1) {
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.INVALID_FIELD,
-              "Invalid CompatibilityMode (not a valid number)",
-              identifier,
-              global);
-        }
-      }
-    }
-    compatibilityMode = cmode.intern();
-    s = fs.get("OverrideSplitfileCryptoKey");
-    if (s == null) overrideSplitfileCryptoKey = null;
-    else
-      try {
-        overrideSplitfileCryptoKey = HexUtil.hexToBytes(s);
-      } catch (NumberFormatException e1) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD,
-            "Invalid splitfile crypto key (not hex)",
-            identifier,
-            global);
-      } catch (IndexOutOfBoundsException e1) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD,
-            "Invalid splitfile crypto key (too short)",
-            identifier,
-            global);
-      }
+    compatibilityMode = parseCompatibilityMode(fs, identifier, global);
+    overrideSplitfileCryptoKey =
+        parseOverrideSplitfileCryptoKey(fs, identifier, global).orElse(null);
     localRequestOnly = fs.getBoolean("LocalRequestOnly", false);
     if (identifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "No Identifier", null, global);
-    try {
-      String u = fs.get("URI");
-      if (u == null)
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.MISSING_FIELD, "No URI", identifier, global);
-      FreenetURI uu = new FreenetURI(u);
-      // Client is allowed to put a slash at the end if it wants to, but this is discouraged.
-      String[] meta = uu.getAllMetaStrings();
-      if (meta != null && meta.length == 1 && meta[0].isEmpty()) uu = uu.setMetaString(null);
-      uri = uu;
-    } catch (MalformedURLException e) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, e.getMessage(), identifier, global);
-    }
-    String verbosityString = fs.get("Verbosity");
-    if (verbosityString == null) verbosity = 0;
-    else {
-      try {
-        verbosity = Integer.parseInt(verbosityString, 10);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing Verbosity field: " + e.getMessage(),
-            identifier,
-            global);
-      }
-    }
-    String maxRetriesString = fs.get("MaxRetries");
-    if (maxRetriesString == null)
-      // default to 0
-      maxRetries = 0;
-    else {
-      try {
-        maxRetries = Integer.parseInt(maxRetriesString, 10);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing MaxSize field: " + e.getMessage(),
-            identifier,
-            global);
-      }
-    }
+    uri = parseUri(fs, identifier, global);
+    verbosity = parseOptionalInt(fs, "Verbosity", "Verbosity field", identifier, global);
+    maxRetries = parseOptionalInt(fs, "MaxRetries", "MaxSize field", identifier, global);
     getCHKOnly = fs.getBoolean("GetCHKOnly", false);
-    String priorityString = fs.get("PriorityClass");
-    if (priorityString == null) {
-      // defaults to the one just below FProxy
-      priorityClass = RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS;
-    } else {
-      try {
-        priorityClass = Short.parseShort(priorityString);
-        if (!RequestStarter.isValidPriorityClass(priorityClass))
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.INVALID_FIELD,
-              "Invalid priority class "
-                  + priorityClass
-                  + " - range is "
-                  + RequestStarter.PAUSED_PRIORITY_CLASS
-                  + " to "
-                  + RequestStarter.MAXIMUM_PRIORITY_CLASS,
-              identifier,
-              global);
-      } catch (NumberFormatException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.ERROR_PARSING_NUMBER,
-            "Error parsing PriorityClass field: " + e.getMessage(),
-            identifier,
-            global);
-      }
-    }
+    priorityClass = parsePriorityClass(fs, identifier, global);
     dontCompress = fs.getBoolean("DontCompress", false);
     String persistenceString = fs.get("Persistence");
     persistence = Persistence.parseOrThrow(persistenceString, identifier, global);
@@ -180,18 +114,7 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
     clientToken = fs.get("ClientToken");
     targetFilename = fs.get("TargetFilename");
     earlyEncode = fs.getBoolean("EarlyEncode", false);
-    String codecs = fs.get("Codecs");
-    if (codecs != null) {
-      COMPRESSOR_TYPE[] ca;
-      try {
-        ca = COMPRESSOR_TYPE.getCompressorsArrayNoDefault(codecs);
-      } catch (InvalidCompressionCodecException e) {
-        throw new MessageInvalidException(
-            ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), identifier, global);
-      }
-      if (ca == null || ca.length == 0) codecs = null;
-    }
-    compressorDescriptor = codecs;
+    compressorDescriptor = parseCompressorDescriptor(fs, identifier, global);
     if (fs.get("ForkOnCacheable") != null)
       forkOnCacheable = fs.getBoolean("ForkOnCacheable", false);
     else forkOnCacheable = Node.FORK_ON_CACHEABLE_DEFAULT;
@@ -205,6 +128,20 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
     ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);
   }
 
+  /**
+   * Serializes the message back into a {@link SimpleFieldSet} that mirrors the original request.
+   *
+   * <p>The resulting structure contains the normalized URI, identifier, verbosity and retry budget,
+   * and flags such as {@code GetCHKOnly} or compression preferences so downstream logging or
+   * round-tripping code can faithfully represent the mutation task. Optional fields—including
+   * compressor descriptors and default file names—are included only when specified to keep the wire
+   * format compact. The returned field set is newly allocated on every call, so callers may mutate
+   * it without affecting the message, and the method is safe to invoke from concurrent inspection
+   * routines. No payload data is exposed because subclasses handle directory blobs separately.
+   *
+   * @return mutable field set containing the canonicalized header values ready for transmission or
+   *     auditing, excluding any directory payload bytes handled by subclasses.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
@@ -221,5 +158,144 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
     sfs.put("Global", global);
     sfs.putSingle("DefaultName", defaultName);
     return sfs;
+  }
+
+  private static InsertContext.CompatibilityMode parseCompatibilityMode(
+      SimpleFieldSet fs, String identifier, boolean global) throws MessageInvalidException {
+    String modeValue = fs.get("CompatibilityMode");
+    if (modeValue == null) {
+      return InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern();
+    }
+    try {
+      return InsertContext.CompatibilityMode.valueOf(modeValue).intern();
+    } catch (IllegalArgumentException e) {
+      try {
+        int ordinal = Integer.parseInt(modeValue);
+        return InsertContext.CompatibilityMode.values()[ordinal].intern();
+      } catch (NumberFormatException e1) {
+        throw new MessageInvalidException(
+            ProtocolErrorMessage.INVALID_FIELD,
+            "Invalid CompatibilityMode (not a name and not a number)",
+            identifier,
+            global);
+      } catch (ArrayIndexOutOfBoundsException e1) {
+        throw new MessageInvalidException(
+            ProtocolErrorMessage.INVALID_FIELD,
+            "Invalid CompatibilityMode (not a valid number)",
+            identifier,
+            global);
+      }
+    }
+  }
+
+  private static Optional<byte[]> parseOverrideSplitfileCryptoKey(
+      SimpleFieldSet fs, String identifier, boolean global) throws MessageInvalidException {
+    String key = fs.get("OverrideSplitfileCryptoKey");
+    if (key == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(HexUtil.hexToBytes(key));
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD,
+          "Invalid splitfile crypto key (not hex)",
+          identifier,
+          global);
+    } catch (IndexOutOfBoundsException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD,
+          "Invalid splitfile crypto key (too short)",
+          identifier,
+          global);
+    }
+  }
+
+  private static FreenetURI parseUri(SimpleFieldSet fs, String identifier, boolean global)
+      throws MessageInvalidException {
+    try {
+      String uriValue = fs.get("URI");
+      if (uriValue == null)
+        throw new MessageInvalidException(
+            ProtocolErrorMessage.MISSING_FIELD, "No URI", identifier, global);
+      FreenetURI parsed = new FreenetURI(uriValue);
+      String[] meta = parsed.getAllMetaStrings();
+      if (meta != null && meta.length == 1 && meta[0].isEmpty()) {
+        parsed = parsed.setMetaString(null);
+      }
+      return parsed;
+    } catch (MalformedURLException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, e.getMessage(), identifier, global);
+    }
+  }
+
+  private static int parseOptionalInt(
+      SimpleFieldSet fs,
+      String fieldName,
+      String errorFieldLabel,
+      String identifier,
+      boolean global)
+      throws MessageInvalidException {
+    String value = fs.get(fieldName);
+    if (value == null) {
+      return 0;
+    }
+    try {
+      return Integer.parseInt(value, 10);
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing " + errorFieldLabel + ": " + e.getMessage(),
+          identifier,
+          global);
+    }
+  }
+
+  private static short parsePriorityClass(SimpleFieldSet fs, String identifier, boolean global)
+      throws MessageInvalidException {
+    String priorityString = fs.get("PriorityClass");
+    if (priorityString == null) {
+      return RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS;
+    }
+    try {
+      short parsed = Short.parseShort(priorityString);
+      if (!RequestStarter.isValidPriorityClass(parsed))
+        throw new MessageInvalidException(
+            ProtocolErrorMessage.INVALID_FIELD,
+            "Invalid priority class "
+                + parsed
+                + " - range is "
+                + RequestStarter.PAUSED_PRIORITY_CLASS
+                + " to "
+                + RequestStarter.MAXIMUM_PRIORITY_CLASS,
+            identifier,
+            global);
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.ERROR_PARSING_NUMBER,
+          "Error parsing PriorityClass field: " + e.getMessage(),
+          identifier,
+          global);
+    }
+  }
+
+  private static String parseCompressorDescriptor(
+      SimpleFieldSet fs, String identifier, boolean global) throws MessageInvalidException {
+    String codecs = fs.get("Codecs");
+    if (codecs == null) {
+      return null;
+    }
+    try {
+      COMPRESSOR_TYPE[] compressors = COMPRESSOR_TYPE.getCompressorsArrayNoDefault(codecs);
+      if (compressors.length == 0) {
+        return null;
+      }
+      return codecs;
+    } catch (InvalidCompressionCodecException e) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), identifier, global);
+    }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
@@ -15,17 +15,37 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Insert a directory from disk as a manifest.
+ * Inserts a directory tree from local storage as an FCP manifest upload request.
  *
- * <p>ClientPutDiskDirMessage < generic fields from ClientPutDirMessage > Filename=<filename>
- * AllowUnreadableFiles=<unless true, any unreadable files cause the whole request to fail> End
+ * <p>The message is queued by {@link FCPConnectionHandler} when a user submits a {@code
+ * ClientPutDiskDir} command, meaning the node must serialize the current on-disk layout into a
+ * manifest structure. The implementation mirrors the wizard-style internal directory upload flow so
+ * that automated tooling and GUI clients observe consistent MIME detection rules, hidden-file
+ * handling, and recursive traversal semantics. Every directory level is unfolded eagerly to size
+ * files, attach {@link DefaultMIMETypes}, and guard against unreadable paths before the actual
+ * network transfer begins. Callers typically instantiate this message during request construction,
+ * then rely on {@link #run(FCPConnectionHandler, Node)} to build the manifest map and hand it to
+ * the node core. The class is thread-confined: each instance is used by a single connection
+ * handler, but the generated bucket map may be consumed by asynchronous upload workers. Error
+ * reporting is immediate, so missing directories or unreadable files fail fast instead of producing
+ * partial manifests.
  *
- * <p>FIXME this should use the same code as makeDiskDirManifest does for internal directory
- * inserts.
+ * <p><strong>Responsibilities</strong>
+ *
+ * <ul>
+ *   <li>Validate source directories against node upload policies.
+ *   <li>Create {@link ManifestElement} entries for every file and subdirectory.
+ *   <li>Respect client flags governing hidden and unreadable files while preserving legacy
+ *       behavior.
+ * </ul>
  */
 public class ClientPutDiskDirMessage extends ClientPutDirMessage {
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutDiskDirMessage.class);
 
+  /**
+   * Canonical message name emitted to peers and logs so that protocol consumers can match the
+   * {@code ClientPutDiskDir} verb without inspecting implementation details.
+   */
   public static final String NAME = "ClientPutDiskDir";
 
   final File dirname;
@@ -34,6 +54,18 @@ public class ClientPutDiskDirMessage extends ClientPutDirMessage {
 
   // Legacy threshold callback removed.
 
+  /**
+   * Creates a message from the raw {@link SimpleFieldSet} received over FCP.
+   *
+   * <p>The constructor extracts required flags immediately so that later validation has fixed
+   * semantics even if the caller mutates the field set. The {@code Filename} field must resolve to
+   * a directory on the local filesystem; the path is not normalized here because upload policy
+   * checks may rely on the original representation.
+   *
+   * @param fs parsed field set containing {@code Filename}, {@code AllowUnreadableFiles}, and
+   *     optional {@code includeHiddenFiles} entries; must not be {@code null}.
+   * @throws MessageInvalidException if the {@code Filename} field is absent.
+   */
   public ClientPutDiskDirMessage(SimpleFieldSet fs) throws MessageInvalidException {
     super(fs);
     allowUnreadableFiles = fs.getBoolean("AllowUnreadableFiles", false);
@@ -45,11 +77,32 @@ public class ClientPutDiskDirMessage extends ClientPutDirMessage {
     dirname = new File(fnam);
   }
 
+  /**
+   * Returns the wire-level name {@code ClientPutDiskDir} so protocol handlers can identify the
+   * request type.
+   *
+   * @return constant message identifier understood by the node core.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Validates the requested directory and starts the manifest-building upload sequence.
+   *
+   * <p>The method checks whether the node configuration allows reading from the requested path,
+   * performs a full recursive traversal via {@link #makeBucketsByName(File, String)}, and hands the
+   * resulting manifest tree to {@link FCPConnectionHandler#startClientPutDir}. Errors are raised
+   * immediately if the directory is blocked or if the traversal encounters unreadable entries when
+   * such failures are not allowed by the client flag. This call is synchronous for traversal but
+   * the returned buckets may be consumed asynchronously by upload workers.
+   *
+   * @param handler connection handler owning this message; must be non-null and connected.
+   * @param node node instance that enforces upload policy and owns the datastore.
+   * @throws MessageInvalidException if the directory is not permitted or traversal fails under the
+   *     configured validation rules.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.getServer().getCore().allowUploadFrom(dirname))
@@ -65,14 +118,23 @@ public class ClientPutDiskDirMessage extends ClientPutDirMessage {
   }
 
   /**
-   * Create a map of String -> Bucket for every file in a directory and its subdirs.
+   * Recursively converts the provided directory into a tree of manifest entries keyed by local
+   * filenames.
    *
-   * @throws MessageInvalidException
+   * @param thisdir directory whose immediate children are inspected; must already exist on disk.
+   * @param prefix logical path prefix appended to every discovered file or directory name for the
+   *     manifest.
+   * @return mutable map where keys are child names and values are {@link ManifestElement} instances
+   *     or nested maps representing subdirectories.
+   * @throws MessageInvalidException if a directory does not exist or a child violates the
+   *     configured readability rules.
    */
   private HashMap<String, Object> makeBucketsByName(File thisdir, String prefix)
       throws MessageInvalidException {
 
-    if (LOG.isDebugEnabled()) LOG.debug("Listing directory: " + thisdir);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Listing directory: {}", thisdir);
+    }
 
     HashMap<String, Object> ret = new HashMap<>();
 
@@ -80,46 +142,72 @@ public class ClientPutDiskDirMessage extends ClientPutDirMessage {
     if (filelist == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.FILE_NOT_FOUND, "No such directory!", identifier, global);
-    for (int i = 0; i < filelist.length; i++) {
-      if (filelist[i].isHidden() && !includeHiddenFiles) continue;
-      //   Skip unreadable files and dirs
-      //   Skip files nonexistent (dangling symlinks) - check last
-      if (filelist[i].canRead() && filelist[i].exists()) {
-        if (filelist[i].isFile()) {
-          File f = filelist[i];
-
-          FileBucket bucket = new FileBucket(f, true, false, false, false);
-
-          ret.put(
-              f.getName(),
-              new ManifestElement(
-                  f.getName(),
-                  prefix + f.getName(),
-                  bucket,
-                  DefaultMIMETypes.guessMIMEType(f.getName(), true),
-                  f.length()));
-        } else if (filelist[i].isDirectory()) {
-          HashMap<String, Object> subdir =
-              makeBucketsByName(
-                  new File(thisdir, filelist[i].getName()), prefix + filelist[i].getName() + '/');
-          ret.put(filelist[i].getName(), subdir);
-        } else if (!allowUnreadableFiles) {
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.FILE_NOT_FOUND,
-              "Not directory and not file: " + filelist[i],
-              identifier,
-              global);
-        }
-      } else {
-        if (!allowUnreadableFiles)
-          throw new MessageInvalidException(
-              ProtocolErrorMessage.FILE_NOT_FOUND,
-              "Not readable or doesn't exist: " + filelist[i],
-              identifier,
-              global);
+    for (File child : filelist) {
+      if (shouldSkipEntry(child)) {
+        continue;
       }
+      addEntry(ret, prefix, child);
     }
     return ret;
+  }
+
+  private boolean shouldSkipHidden(File child) {
+    return child.isHidden() && !includeHiddenFiles;
+  }
+
+  private boolean shouldSkipEntry(File child) throws MessageInvalidException {
+    if (shouldSkipHidden(child)) {
+      return true;
+    }
+    return skipUnreadableEntry(child);
+  }
+
+  private boolean skipUnreadableEntry(File child) throws MessageInvalidException {
+    if (child.canRead() && child.exists()) {
+      return false;
+    }
+    if (!allowUnreadableFiles) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.FILE_NOT_FOUND,
+          "Not readable or doesn't exist: " + child,
+          identifier,
+          global);
+    }
+    return true;
+  }
+
+  private void addEntry(HashMap<String, Object> ret, String prefix, File child)
+      throws MessageInvalidException {
+    if (child.isFile()) {
+      addFileEntry(ret, prefix, child);
+    } else if (child.isDirectory()) {
+      HashMap<String, Object> subdir = makeBucketsByName(child, prefix + child.getName() + '/');
+      ret.put(child.getName(), subdir);
+    } else {
+      handleUnknownEntry(child);
+    }
+  }
+
+  private void addFileEntry(HashMap<String, Object> ret, String prefix, File file) {
+    FileBucket bucket = new FileBucket(file, true, false, false, false);
+    ret.put(
+        file.getName(),
+        new ManifestElement(
+            file.getName(),
+            prefix + file.getName(),
+            bucket,
+            DefaultMIMETypes.guessMIMEType(file.getName(), true),
+            file.length()));
+  }
+
+  private void handleUnknownEntry(File child) throws MessageInvalidException {
+    if (!allowUnreadableFiles) {
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.FILE_NOT_FOUND,
+          "Not directory and not file: " + child,
+          identifier,
+          global);
+    }
   }
 
   @Override
@@ -131,12 +219,34 @@ public class ClientPutDiskDirMessage extends ClientPutDirMessage {
     return identifier;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This message derives all payload information from the supplied {@link SimpleFieldSet}, so no
+   * additional data is streamed from the request body.
+   *
+   * @param is ignored because {@code ClientPutDiskDir} has no binary payload.
+   * @param bf ignored; manifests are built directly from the filesystem.
+   * @param server ignored; included for API symmetry with other messages.
+   * @throws IOException never thrown because no I/O occurs here.
+   * @throws MessageInvalidException never thrown because parsing already completed in the
+   *     constructor.
+   */
   @Override
   public void readFrom(InputStream is, BucketFactory bf, FCPServer server)
       throws IOException, MessageInvalidException {
     // Do nothing
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>No additional data is written because the entire manifest content is produced from the local
+   * filesystem instead of a pre-serialized buffer.
+   *
+   * @param os ignored output stream provided by the protocol framework.
+   * @throws IOException never thrown because the method writes nothing.
+   */
   @Override
   protected void writeData(OutputStream os) throws IOException {
     // Do nothing

--- a/src/test/java/network/crypta/clients/fcp/ClientPutComplexDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutComplexDirMessageTest.java
@@ -1,0 +1,209 @@
+package network.crypta.clients.fcp;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.ManifestElement;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.ArrayBucket;
+import network.crypta.support.io.ArrayBucketFactory;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientPutComplexDirMessageTest {
+
+  private final BucketFactory tempBucketFactory = new ArrayBucketFactory();
+
+  @Mock private PersistentTempBucketFactory persistentBucketFactory;
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
+  @Mock private Node node;
+  @Mock private NodeClientCore core;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    lenient().when(node.getClientCore()).thenReturn(core);
+    lenient().when(core.allowUploadFrom(any(File.class))).thenReturn(true);
+    lenient()
+        .when(persistentBucketFactory.makeBucket(anyLong()))
+        .thenAnswer(invocation -> new ArrayBucket());
+  }
+
+  @Test
+  void constructor_whenFilesSectionMissing_expectMessageInvalidException() {
+    SimpleFieldSet fs = baseFieldSet();
+
+    MessageInvalidException ex =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> new ClientPutComplexDirMessage(fs, tempBucketFactory, persistentBucketFactory));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+  }
+
+  @Test
+  void dataLength_whenMultipleDirectFiles_expectSumOfBytes() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    addDirectFile(fs, 0, "alpha.txt", 5);
+    addDirectFile(fs, 1, "bravo.txt", 3);
+
+    ClientPutComplexDirMessage message =
+        new ClientPutComplexDirMessage(fs, tempBucketFactory, persistentBucketFactory);
+
+    assertEquals(8, message.dataLength());
+  }
+
+  @Test
+  void constructor_whenPersistenceForever_expectPersistentBucketsUsed() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putOverwrite("Persistence", "forever");
+    addDirectFile(fs, 0, "payload.bin", 9);
+
+    BucketFactory tempFactory = mock(BucketFactory.class);
+    PersistentTempBucketFactory persistentFactory = mock(PersistentTempBucketFactory.class);
+    when(persistentFactory.makeBucket(9L)).thenReturn(new ArrayBucket());
+
+    new ClientPutComplexDirMessage(fs, tempFactory, persistentFactory);
+
+    //noinspection EmptyTryBlock
+    try (RandomAccessBucket ignored = verify(persistentFactory).makeBucket(9L)) {
+      // release the bucket immediately; only the side effect of verify() is needed
+    }
+    verifyNoInteractions(tempFactory);
+  }
+
+  @Test
+  void readFrom_whenDirectFilesPresent_expectWriteDataOutputsSameBytes() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    addDirectFile(fs, 0, "alpha.txt", 4);
+    addDirectFile(fs, 1, "bravo.txt", 6);
+    ClientPutComplexDirMessage message =
+        new ClientPutComplexDirMessage(fs, tempBucketFactory, persistentBucketFactory);
+
+    byte[] payload = "abcdEFGHIJ".getBytes(UTF_8);
+    message.readFrom(new ByteArrayInputStream(payload), tempBucketFactory, server);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    message.writeData(output);
+
+    assertArrayEquals(payload, output.toByteArray());
+  }
+
+  @Test
+  void run_whenDiskFileNotAllowed_expectAccessDenied() throws Exception {
+    Path diskFile = Files.writeString(tempDir.resolve("disk.txt"), "denied");
+    when(core.allowUploadFrom(diskFile.toFile())).thenReturn(false);
+    SimpleFieldSet fs = baseFieldSet();
+    addDiskFile(fs, 0, "disk.txt", diskFile);
+    ClientPutComplexDirMessage message =
+        new ClientPutComplexDirMessage(fs, tempBucketFactory, persistentBucketFactory);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
+    verify(handler, never()).startClientPutDir(any(), any(), anyBoolean());
+  }
+
+  @Test
+  void run_whenFilesInSubdirectories_expectManifestTreeAndData() throws Exception {
+    Path diskFile = Files.writeString(tempDir.resolve("disk.txt"), "disk-data");
+    when(core.allowUploadFrom(diskFile.toFile())).thenReturn(true);
+    byte[] directBytes = "hello".getBytes(UTF_8);
+    SimpleFieldSet fs = baseFieldSet();
+    addDirectFile(fs, 0, "docs/direct.txt", directBytes.length);
+    addDiskFile(fs, 1, "docs/disk.txt", diskFile);
+    ClientPutComplexDirMessage message =
+        new ClientPutComplexDirMessage(fs, tempBucketFactory, persistentBucketFactory);
+
+    message.readFrom(new ByteArrayInputStream(directBytes), tempBucketFactory, server);
+    message.run(handler, node);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<HashMap<String, Object>> manifestCaptor = ArgumentCaptor.forClass(HashMap.class);
+    verify(handler).startClientPutDir(eq(message), manifestCaptor.capture(), eq(false));
+
+    HashMap<String, Object> manifest = manifestCaptor.getValue();
+    @SuppressWarnings("unchecked")
+    HashMap<String, Object> docs = (HashMap<String, Object>) manifest.get("docs");
+    assertNotNull(docs);
+
+    ManifestElement directElement = (ManifestElement) docs.get("direct.txt");
+    assertNotNull(directElement);
+    assertEquals(directBytes.length, directElement.getSize());
+    assertArrayEquals(directBytes, readAllBytes(directElement.getData()));
+
+    ManifestElement diskElement = (ManifestElement) docs.get("disk.txt");
+    assertNotNull(diskElement);
+    assertEquals(Files.size(diskFile), diskElement.getSize());
+    assertEquals("disk-data", new String(readAllBytes(diskElement.getData()), UTF_8));
+  }
+
+  private static SimpleFieldSet baseFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "test-id");
+    fs.putSingle("URI", "KSK@site");
+    fs.putSingle("Persistence", "connection");
+    return fs;
+  }
+
+  private static void addDirectFile(SimpleFieldSet fs, int index, String name, long length) {
+    String prefix = "Files." + index;
+    fs.putSingle(prefix + ".Name", name);
+    fs.putSingle(prefix + ".UploadFrom", "direct");
+    fs.put(prefix + ".DataLength", length);
+  }
+
+  private static void addDiskFile(SimpleFieldSet fs, int index, String name, Path path) {
+    String prefix = "Files." + index;
+    fs.putSingle(prefix + ".Name", name);
+    fs.putSingle(prefix + ".UploadFrom", "disk");
+    fs.putSingle(prefix + ".Filename", path.toAbsolutePath().toString());
+  }
+
+  private static byte[] readAllBytes(RandomAccessBucket bucket) throws IOException {
+    InputStream input = bucket.getInputStream();
+    if (input == null) {
+      return new byte[0];
+    }
+    try (input;
+        ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+      input.transferTo(output);
+      return output.toByteArray();
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
@@ -1,0 +1,223 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.ManifestElement;
+import network.crypta.support.io.FileBucket;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientPutDiskDirMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
+  @Mock private NodeClientCore core;
+  @Mock private Node node;
+  @Mock private InputStream inputStream;
+  @Mock private BucketFactory bucketFactory;
+  @Mock private FCPServer otherServer;
+  @Mock private OutputStream outputStream;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(handler.getServer()).thenReturn(server);
+    lenient().when(server.getCore()).thenReturn(core);
+    lenient().when(core.allowUploadFrom(any())).thenReturn(true);
+  }
+
+  @Test
+  void constructor_whenFilenameMissing_expectException() {
+    SimpleFieldSet fs = baseFieldSet();
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new ClientPutDiskDirMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+  }
+
+  @Test
+  void getName_whenCalled_returnsConstant() throws MessageInvalidException {
+    ClientPutDiskDirMessage message = newMessage(tempDir);
+
+    assertEquals(ClientPutDiskDirMessage.NAME, message.getName());
+  }
+
+  @Test
+  void run_whenUploadNotAllowed_expectAccessDenied() throws Exception {
+    when(core.allowUploadFrom(any())).thenReturn(false);
+    ClientPutDiskDirMessage message = newMessage(tempDir);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
+    verify(handler, never()).startClientPutDir(any(), any(), anyBoolean());
+  }
+
+  @Test
+  void run_whenDirectoryContainsFiles_passesManifestToHandler() throws Exception {
+    Path file = Files.writeString(tempDir.resolve("index.html"), "<html>");
+    Path nestedDir = Files.createDirectory(tempDir.resolve("assets"));
+    Path nestedFile = Files.writeString(nestedDir.resolve("style.css"), "body");
+    Files.writeString(tempDir.resolve(".secret"), "hidden");
+
+    ClientPutDiskDirMessage message = newMessage(tempDir);
+
+    message.run(handler, node);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<HashMap<String, Object>> bucketsCaptor = ArgumentCaptor.forClass(HashMap.class);
+    verify(handler).startClientPutDir(eq(message), bucketsCaptor.capture(), eq(true));
+    HashMap<String, Object> buckets = bucketsCaptor.getValue();
+
+    assertFalse(buckets.containsKey(".secret"));
+
+    ManifestElement rootElement = (ManifestElement) buckets.get("index.html");
+    assertEquals("index.html", rootElement.fullName);
+    assertEquals(Files.size(file), rootElement.getSize());
+    FileBucket bucket = (FileBucket) rootElement.getData();
+    assertEquals(file.toFile().getAbsolutePath(), bucket.getFile().getAbsolutePath());
+
+    @SuppressWarnings("unchecked")
+    HashMap<String, Object> nested = (HashMap<String, Object>) buckets.get("assets");
+    assertNotNull(nested);
+    ManifestElement nestedElement = (ManifestElement) nested.get("style.css");
+    assertEquals("assets/style.css", nestedElement.fullName);
+    assertEquals(Files.size(nestedFile), nestedElement.getSize());
+  }
+
+  @Test
+  void run_whenUnreadableFileAndNotAllowed_expectFileNotFound() throws Exception {
+    Path unreadable = Files.createFile(tempDir.resolve("secret.txt"));
+    File unreadableFile = unreadable.toFile();
+    Assumptions.assumeTrue(unreadableFile.setReadable(false));
+    Assumptions.assumeFalse(unreadableFile.canRead());
+    try {
+      ClientPutDiskDirMessage message = newMessage(tempDir);
+
+      MessageInvalidException ex =
+          assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+      assertEquals(ProtocolErrorMessage.FILE_NOT_FOUND, ex.protocolCode);
+    } finally {
+      boolean restored = unreadableFile.setReadable(true);
+      assertTrue(restored || unreadableFile.canRead(), "Failed to restore readability");
+    }
+  }
+
+  @Test
+  void run_whenUnreadableFileAllowed_skipsUnreadableEntry() throws Exception {
+    Path unreadable = Files.createFile(tempDir.resolve("secret.txt"));
+    File unreadableFile = unreadable.toFile();
+    Assumptions.assumeTrue(unreadableFile.setReadable(false));
+    Assumptions.assumeFalse(unreadableFile.canRead());
+    try {
+      ClientPutDiskDirMessage message = newMessage(tempDir, true, false);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<HashMap<String, Object>> bucketsCaptor =
+          ArgumentCaptor.forClass(HashMap.class);
+
+      assertDoesNotThrow(() -> message.run(handler, node));
+      verify(handler).startClientPutDir(eq(message), bucketsCaptor.capture(), eq(true));
+
+      HashMap<String, Object> buckets = bucketsCaptor.getValue();
+      assertFalse(buckets.containsKey("secret.txt"));
+    } finally {
+      boolean restored = unreadableFile.setReadable(true);
+      assertTrue(restored || unreadableFile.canRead(), "Failed to restore readability");
+    }
+  }
+
+  @Test
+  void run_whenIncludeHiddenFilesTrue_includesHiddenEntries() throws Exception {
+    Path hiddenFile = Files.writeString(tempDir.resolve(".secret.txt"), "hidden");
+
+    ClientPutDiskDirMessage message = newMessage(tempDir, false, true);
+
+    message.run(handler, node);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<HashMap<String, Object>> bucketsCaptor = ArgumentCaptor.forClass(HashMap.class);
+    verify(handler).startClientPutDir(eq(message), bucketsCaptor.capture(), eq(true));
+    HashMap<String, Object> buckets = bucketsCaptor.getValue();
+
+    ManifestElement hiddenElement = (ManifestElement) buckets.get(".secret.txt");
+    assertNotNull(hiddenElement);
+    assertEquals(".secret.txt", hiddenElement.fullName);
+    assertEquals(Files.size(hiddenFile), hiddenElement.getSize());
+  }
+
+  @Test
+  void readFrom_whenInvoked_doesNothing() throws Exception {
+    ClientPutDiskDirMessage message = newMessage(tempDir);
+
+    assertDoesNotThrow(() -> message.readFrom(inputStream, bucketFactory, otherServer));
+    assertEquals("test-id", message.getIdentifier());
+  }
+
+  @Test
+  void writeData_whenInvoked_doesNothing() throws Exception {
+    ClientPutDiskDirMessage message = newMessage(tempDir);
+
+    assertDoesNotThrow(() -> message.writeData(outputStream));
+    assertEquals("test-id", message.getIdentifier());
+  }
+
+  private SimpleFieldSet baseFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "test-id");
+    fs.putSingle("URI", "KSK@site");
+    fs.putSingle("Persistence", "connection");
+    return fs;
+  }
+
+  private ClientPutDiskDirMessage newMessage(Path dir) throws MessageInvalidException {
+    return newMessage(dir, false, false);
+  }
+
+  private ClientPutDiskDirMessage newMessage(
+      Path dir, boolean allowUnreadable, boolean includeHidden) throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("Filename", dir.toAbsolutePath().toString());
+    if (allowUnreadable) {
+      fs.put("AllowUnreadableFiles", true);
+    }
+    if (includeHidden) {
+      fs.put("includeHiddenFiles", true);
+    }
+    return new ClientPutDiskDirMessage(fs);
+  }
+}


### PR DESCRIPTION
## Summary
- expand the ClientPutDir message hierarchy documentation so FCP clients know the execution contract and defaults
- refactor ClientPutDiskDir traversal to make hidden/unreadable handling clearer and add targeted helpers
- add focused unit tests for ClientPutComplexDirMessage and ClientPutDiskDirMessage covering manifests, payload flow, and validation branches

## Testing
- Not Run (not requested)
