### PR TITLE
Clarify ConfigData export behavior

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ConfigData.java
+++ b/src/main/java/network/crypta/clients/fcp/ConfigData.java
@@ -1,15 +1,36 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.config.Config;
+import network.crypta.config.PersistentConfig;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Server-to-client FCP message that transports slices of the node configuration.
+ *
+ * <p>This type assembles a {@link SimpleFieldSet} containing whichever option categories a caller
+ * requests (current values, defaults, metadata flags, descriptions, and data types). The resulting
+ * tree mirrors the structure returned by {@link PersistentConfig#exportFieldSet(Config.RequestType,
+ * boolean)} for each category, letting remote tooling reconstruct the node's configuration dialog
+ * without needing multiple round trips.
+ *
+ * <p>Each instance is immutable once constructed. Callers decide at construction time which
+ * sections should be included and whether an identifier should be attached so that asynchronous
+ * responses can be correlated. The exporter queries the {@link Node} configuration only if at least
+ * one section is requested, preventing unnecessary work when the message would otherwise be empty.
+ *
+ * <ul>
+ *   <li>Intended consumers are FCP clients that need a snapshot of configuration state.
+ *   <li>Messages are constructed on the server and never accepted from clients.
+ *   <li>The produced field set omits empty subsections so payloads stay compact.
+ * </ul>
+ *
+ * <p>Thread-safety: instances rely on the underlying {@link PersistentConfig}; only construct them
+ * in threads that can safely read configuration state, and avoid sharing mutable {@link Node}
+ * references across threads without external coordination.
+ */
 public class ConfigData extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ConfigData.class);
-
-  static final String name = "ConfigData";
+  static final String NAME = "ConfigData";
 
   final Node node;
   final boolean withCurrent;
@@ -20,8 +41,37 @@ public class ConfigData extends FCPMessage {
   final boolean withShortDescription;
   final boolean withLongDescription;
   final boolean withDataTypes;
-  final String identifier;
+  final String requestIdentifier;
 
+  /**
+   * Creates a configuration snapshot request with a precisely scoped payload budget.
+   *
+   * <p>The supplied boolean switches determine which sections are exported, allowing callers to
+   * tailor the trade-off between completeness and serialization cost. All flags default to {@code
+   * false}, so a caller must explicitly opt in to each exported view. The identifier is optional
+   * but recommended for clients that expect multiple outstanding responses.
+   *
+   * @param node node instance providing the backing {@link PersistentConfig}; must be non-null and
+   *     ready for read-only queries.
+   * @param withCurrent exports {@link Config.RequestType#CURRENT_SETTINGS} when {@code true}; set
+   *     to {@code false} to omit effective values entirely.
+   * @param withDefaults exports {@link Config.RequestType#DEFAULT_SETTINGS} when {@code true}; best
+   *     used when clients offer reset-to-default UX controls.
+   * @param withSortOrder includes {@link Config.RequestType#SORT_ORDER} entries to help UIs order
+   *     options consistently; unused interfaces can set this to {@code false}.
+   * @param withExpertFlag includes {@link Config.RequestType#EXPERT_FLAG} metadata to annotate
+   *     advanced options in downstream tooling when {@code true}.
+   * @param withForceWriteFlag exports {@link Config.RequestType#FORCE_WRITE_FLAG} information so
+   *     clients know which settings require explicit confirmation.
+   * @param withShortDescription exports {@link Config.RequestType#SHORT_DESCRIPTION} strings for
+   *     concise UI labels; disable to reduce payload size in automated workflows.
+   * @param withLongDescription exports {@link Config.RequestType#LONG_DESCRIPTION} prose for
+   *     help-text rich interfaces that surface detailed guidance.
+   * @param withDataTypes includes {@link Config.RequestType#DATA_TYPE} tokens describing how values
+   *     should be parsed or rendered on the client.
+   * @param identifier identifier echoed into the payload via {@link FCPMessage#IDENTIFIER}; may be
+   *     {@code null} when the caller does not need correlation.
+   */
   public ConfigData(
       Node node,
       boolean withCurrent,
@@ -42,76 +92,113 @@ public class ConfigData extends FCPMessage {
     this.withShortDescription = withShortDescription;
     this.withLongDescription = withLongDescription;
     this.withDataTypes = withDataTypes;
-    this.identifier = identifier;
+    this.requestIdentifier = identifier;
   }
 
+  /**
+   * Builds the {@link SimpleFieldSet} payload that will be serialized into the outgoing FCP
+   * message.
+   *
+   * <p>The exporter requests each enabled subsection from {@link PersistentConfig} exactly once and
+   * attaches it under a stable key (for example {@code current}, {@code default}, or {@code
+   * shortDescription}). Empty subsections are suppressed to avoid emitting redundant braces. When
+   * no sections are enabled the returned field set is empty unless an identifier is present.
+   *
+   * <pre>{@code
+   * ConfigData data = new ConfigData(node, true, false, false, false,
+   *     false, true, false, false, "cfg-1");
+   * SimpleFieldSet payload = data.getFieldSet();
+   * }</pre>
+   *
+   * @return a short-lived field set containing the requested subsections and optional identifier;
+   *     callers must not mutate subsets that are also owned by {@link PersistentConfig}.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    if (withCurrent) {
-      SimpleFieldSet current =
-          node.getConfig().exportFieldSet(Config.RequestType.CURRENT_SETTINGS, true);
-      if (!current.isEmpty()) {
-        fs.put("current", current);
-      }
-    }
-    if (withDefaults) {
-      SimpleFieldSet defaultSettings =
-          node.getConfig().exportFieldSet(Config.RequestType.DEFAULT_SETTINGS, false);
-      if (!defaultSettings.isEmpty()) {
-        fs.put("default", defaultSettings);
-      }
-    }
-    if (withSortOrder) {
-      SimpleFieldSet sortOrder =
-          node.getConfig().exportFieldSet(Config.RequestType.SORT_ORDER, false);
-      if (!sortOrder.isEmpty()) {
-        fs.put("sortOrder", sortOrder);
-      }
-    }
-    if (withExpertFlag) {
-      SimpleFieldSet expertFlag =
-          node.getConfig().exportFieldSet(Config.RequestType.EXPERT_FLAG, false);
-      if (!expertFlag.isEmpty()) {
-        fs.put("expertFlag", expertFlag);
-      }
-    }
-    if (withForceWriteFlag) {
-      SimpleFieldSet forceWriteFlag =
-          node.getConfig().exportFieldSet(Config.RequestType.FORCE_WRITE_FLAG, false);
-      if (!forceWriteFlag.isEmpty()) {
-        fs.put("forceWriteFlag", forceWriteFlag);
-      }
-    }
-    if (withShortDescription) {
-      SimpleFieldSet shortDescription =
-          node.getConfig().exportFieldSet(Config.RequestType.SHORT_DESCRIPTION, false);
-      if (!shortDescription.isEmpty()) {
-        fs.put("shortDescription", shortDescription);
-      }
-    }
-    if (withLongDescription) {
-      SimpleFieldSet longDescription =
-          node.getConfig().exportFieldSet(Config.RequestType.LONG_DESCRIPTION, false);
-      if (!longDescription.isEmpty()) {
-        fs.put("longDescription", longDescription);
-      }
-    }
-    if (withDataTypes) {
-      SimpleFieldSet type = node.getConfig().exportFieldSet(Config.RequestType.DATA_TYPE, false);
-      if (!type.isEmpty()) {
-        fs.put("dataType", type);
-      }
-    }
-    if (identifier != null) fs.putSingle("Identifier", identifier);
+    PersistentConfig config = needsConfigLookup() ? node.getConfig() : null;
+    addSection(fs, config, withCurrent, Config.RequestType.CURRENT_SETTINGS, true, "current");
+    addSection(fs, config, withDefaults, Config.RequestType.DEFAULT_SETTINGS, false, "default");
+    addSection(fs, config, withSortOrder, Config.RequestType.SORT_ORDER, false, "sortOrder");
+    addSection(fs, config, withExpertFlag, Config.RequestType.EXPERT_FLAG, false, "expertFlag");
+    addSection(
+        fs,
+        config,
+        withForceWriteFlag,
+        Config.RequestType.FORCE_WRITE_FLAG,
+        false,
+        "forceWriteFlag");
+    addSection(
+        fs,
+        config,
+        withShortDescription,
+        Config.RequestType.SHORT_DESCRIPTION,
+        false,
+        "shortDescription");
+    addSection(
+        fs,
+        config,
+        withLongDescription,
+        Config.RequestType.LONG_DESCRIPTION,
+        false,
+        "longDescription");
+    addSection(fs, config, withDataTypes, Config.RequestType.DATA_TYPE, false, "dataType");
+    if (requestIdentifier != null) fs.putSingle("Identifier", requestIdentifier);
     return fs;
   }
 
-  @Override
-  public String getName() {
-    return name;
+  /** Returns {@code true} if any section flag is enabled and a configuration lookup is required. */
+  private boolean needsConfigLookup() {
+    return withCurrent
+        || withDefaults
+        || withSortOrder
+        || withExpertFlag
+        || withForceWriteFlag
+        || withShortDescription
+        || withLongDescription
+        || withDataTypes;
   }
 
+  /** Adds a subsection when the flag is enabled and the exported data is non-empty. */
+  private static void addSection(
+      SimpleFieldSet target,
+      PersistentConfig config,
+      boolean includeSection,
+      Config.RequestType type,
+      boolean defaults,
+      String subsetKey) {
+    if (!includeSection || config == null) {
+      return;
+    }
+    SimpleFieldSet section = config.exportFieldSet(type, defaults);
+    if (!section.isEmpty()) {
+      target.put(subsetKey, section);
+    }
+  }
+
+  /**
+   * Returns the protocol-level name for this message.
+   *
+   * @return the literal {@link #NAME} constant used in the serialized header.
+   */
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  /**
+   * Rejects inbound attempts to invoke this message from clients.
+   *
+   * <p>{@code ConfigData} is defined as a server-to-client response. If a client emits one, the
+   * node reports {@link ProtocolErrorMessage#INVALID_MESSAGE} so the caller can correct its
+   * protocol flow. The exception is non-global and does not close the connection automatically.
+   *
+   * @param handler connection that attempted to process the message; ignored because validation
+   *     always fails earlier.
+   * @param node node that received the invalid message; provided for interface completeness but not
+   *     consulted.
+   * @throws MessageInvalidException always thrown to signal the unsupported direction.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/test/java/network/crypta/clients/fcp/ConfigDataTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ConfigDataTest.java
@@ -1,0 +1,125 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import network.crypta.config.Config.RequestType;
+import network.crypta.config.PersistentConfig;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ConfigDataTest {
+
+  @Mock private Node node;
+  @Mock private PersistentConfig config;
+  @Mock private FCPConnectionHandler connectionHandler;
+
+  @Test
+  void getFieldSet_whenAllSectionsRequested_expectCorrespondingSubsets() {
+    when(node.getConfig()).thenReturn(config);
+    SimpleFieldSet current = nonEmptyFieldSet("Current", "true");
+    SimpleFieldSet defaults = nonEmptyFieldSet("Default", "42");
+    SimpleFieldSet sort = nonEmptyFieldSet("Sort", "10");
+    SimpleFieldSet expert = nonEmptyFieldSet("Expert", "yes");
+    SimpleFieldSet forceWrite = nonEmptyFieldSet("Force", "confirm");
+    SimpleFieldSet shortDesc = nonEmptyFieldSet("Short", "sh");
+    SimpleFieldSet longDesc = nonEmptyFieldSet("Long", "loooooong");
+    SimpleFieldSet dataTypes = nonEmptyFieldSet("Type", "string");
+
+    when(config.exportFieldSet(RequestType.CURRENT_SETTINGS, true)).thenReturn(current);
+    when(config.exportFieldSet(RequestType.DEFAULT_SETTINGS, false)).thenReturn(defaults);
+    when(config.exportFieldSet(RequestType.SORT_ORDER, false)).thenReturn(sort);
+    when(config.exportFieldSet(RequestType.EXPERT_FLAG, false)).thenReturn(expert);
+    when(config.exportFieldSet(RequestType.FORCE_WRITE_FLAG, false)).thenReturn(forceWrite);
+    when(config.exportFieldSet(RequestType.SHORT_DESCRIPTION, false)).thenReturn(shortDesc);
+    when(config.exportFieldSet(RequestType.LONG_DESCRIPTION, false)).thenReturn(longDesc);
+    when(config.exportFieldSet(RequestType.DATA_TYPE, false)).thenReturn(dataTypes);
+
+    ConfigData configData =
+        new ConfigData(node, true, true, true, true, true, true, true, true, "request-42");
+
+    SimpleFieldSet result = configData.getFieldSet();
+
+    Map<String, SimpleFieldSet> subsets = result.directSubsets();
+    assertEquals(8, subsets.size());
+    assertSame(current, subsets.get("current"));
+    assertSame(defaults, subsets.get("default"));
+    assertSame(sort, subsets.get("sortOrder"));
+    assertSame(expert, subsets.get("expertFlag"));
+    assertSame(forceWrite, subsets.get("forceWriteFlag"));
+    assertSame(shortDesc, subsets.get("shortDescription"));
+    assertSame(longDesc, subsets.get("longDescription"));
+    assertSame(dataTypes, subsets.get("dataType"));
+    assertEquals("request-42", result.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenNoFlagsEnabled_expectEmptyResultAndNoConfigAccess() {
+    ConfigData configData =
+        new ConfigData(node, false, false, false, false, false, false, false, false, null);
+
+    SimpleFieldSet result = configData.getFieldSet();
+
+    assertTrue(result.directSubsets().isEmpty());
+    assertNull(result.get("Identifier"));
+    verify(node, never()).getConfig();
+    verifyNoInteractions(config);
+  }
+
+  @Test
+  void getFieldSet_whenExportReturnsEmptySubset_expectSubsetOmitted() {
+    when(node.getConfig()).thenReturn(config);
+    when(config.exportFieldSet(RequestType.SHORT_DESCRIPTION, false))
+        .thenReturn(new SimpleFieldSet(true));
+
+    ConfigData configData =
+        new ConfigData(node, false, false, false, false, false, true, false, false, "id");
+
+    SimpleFieldSet result = configData.getFieldSet();
+
+    assertTrue(result.directSubsets().isEmpty());
+    assertEquals("id", result.get("Identifier"));
+    verify(config).exportFieldSet(RequestType.SHORT_DESCRIPTION, false);
+  }
+
+  @Test
+  void getName_whenCalled_returnsStaticName() {
+    ConfigData configData =
+        new ConfigData(node, false, false, false, false, false, false, false, false, null);
+
+    assertEquals("ConfigData", configData.getName());
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidException() {
+    ConfigData configData =
+        new ConfigData(node, false, false, false, false, false, false, false, false, null);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> configData.run(connectionHandler, node));
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "ConfigData goes from server to client not the other way around", exception.getMessage());
+    assertNull(exception.ident);
+  }
+
+  private static SimpleFieldSet nonEmptyFieldSet(String key, String value) {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle(key, value);
+    return fs;
+  }
+}


### PR DESCRIPTION
## Summary
- document the ConfigData FCP message and rename the protocol constant for clarity
- centralize section exports with helpers so we avoid unnecessary PersistentConfig reads
- add Mockito-based tests that cover all section combinations and the server-only guard

## Testing
- not run (not requested)
