### PR TITLE
Document DirPutFile variants and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/DirPutFile.java
+++ b/src/main/java/network/crypta/clients/fcp/DirPutFile.java
@@ -9,26 +9,103 @@ import network.crypta.support.api.RandomAccessBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A request to upload a file to a manifest. A ClientPutComplexDir will contain many of these. */
+/**
+ * Represents a single file entry contributed to a multi-file FCP directory upload.
+ *
+ * <p>The class captures the manifest-relative file name together with the negotiated {@link
+ * ClientMetadata} carried through various upload phases. Subclasses decide how the actual bytes are
+ * sourced (direct socket streaming, disk references, or redirect instructions), while the base type
+ * guarantees that metadata remains available for manifest assembly and size accounting. Callers
+ * typically instantiate concrete implementations through {@link #create(SimpleFieldSet, String,
+ * boolean, BucketFactory)} after parsing a {@link SimpleFieldSet} received via FCP, then keep the
+ * resulting instance attached to a {@code ClientPutComplexDir} manifest builder.
+ *
+ * <p>Instances behave as request-scoped transfer objects: the file name is immutable, but the
+ * {@code ClientMetadata} payload may be enriched by subclasses before manifest serialization. No
+ * internal synchronization is provided, so callers should confine each instance to the thread that
+ * manages the surrounding request context.
+ *
+ * <ul>
+ *   <li>Provides shared MIME-type inference helpers.
+ *   <li>Builds {@link ManifestElement} objects for manifest serialization.
+ *   <li>Acts as the polymorphic contract for storage-backed {@link RandomAccessBucket} data.
+ * </ul>
+ *
+ * @see DirectDirPutFile
+ */
 abstract class DirPutFile {
   private static final Logger LOG = LoggerFactory.getLogger(DirPutFile.class);
 
+  /**
+   * Manifest-relative path for the file entry, preserved exactly as supplied by the client request
+   * so downstream code can maintain folder structures and friendly names.
+   */
   final String name;
+
+  /**
+   * Mutable metadata associated with the file, including MIME type and additional header-like
+   * attributes that will be serialized alongside the manifest entry.
+   */
   ClientMetadata meta;
 
   // Legacy threshold callback removed.
 
+  /**
+   * Creates a new directory entry descriptor with a fixed name and initial MIME declaration.
+   *
+   * <p>The constructor performs no validation beyond storing the supplied values because subclasses
+   * already validated their inputs while parsing the surrounding {@link SimpleFieldSet}. Callers
+   * therefore pass canonical manifest paths and MIME tokens that will remain stable for the
+   * lifetime of the request. Subclasses may later tweak {@link #meta} to add metadata extensions.
+   *
+   * @param name canonical manifest-relative identifier, including optional forward-slash segments.
+   * @param mimeType initial MIME type string that may be overridden by explicit metadata blocks.
+   */
   protected DirPutFile(String name, String mimeType) {
     this.name = name;
     meta = new ClientMetadata(mimeType);
   }
 
+  /**
+   * Infers a MIME type from the provided file name when the client does not supply one explicitly.
+   *
+   * <p>The helper delegates to {@link DefaultMIMETypes#guessMIMEType(String, boolean)} so the
+   * returned MIME reflects the same heuristics used elsewhere in the FCP stack. The result is only
+   * a best effort guess based on the filename extension and should be overridden when the client or
+   * upper layers know more precise content descriptors.
+   *
+   * @param name file name containing an optional extension that influences MIME guessing logic.
+   * @return detected MIME type string; defaults to {@code application/octet-stream} when unknown.
+   */
   protected static String guessMIME(String name) {
     // Guess it just from the name
     return DefaultMIMETypes.guessMIMEType(name, true);
   }
 
-  /** Create a DirPutFile from a SimpleFieldSet. */
+  /**
+   * Creates a {@code DirPutFile} by interpreting the supplied FCP field set and upload options.
+   *
+   * <p>This factory understands the {@code UploadFrom} specifier and instantiates concrete
+   * implementations that either stream data directly, read from disk, or proxy an external redirect
+   * URL. It validates declared MIME overrides using {@link DefaultMIMETypes} and preserves the
+   * user-provided identifier for precise error reporting. The returned instance is ready to attach
+   * to a directory upload builder and will defer expensive resource acquisition until {@link
+   * #getData()} is invoked.
+   *
+   * <pre>{@code
+   * DirPutFile entry = DirPutFile.create(fields, requestId, false, bucketFactory);
+   * manifest.add(entry.getElement());
+   * }</pre>
+   *
+   * @param subset parsed message fields containing {@code Name}, {@code UploadFrom}, and metadata.
+   * @param identifier request identifier echoed in thrown {@link ProtocolErrorMessage} instances.
+   * @param global whether the client connection expects globally broadcast error signaling flags.
+   * @param bf bucket factory available to direct uploads for staging in-memory or temp-file data.
+   * @return concrete {@code DirPutFile} aligned with the requested upload mechanism, never {@code
+   *     null}.
+   * @throws MessageInvalidException if required fields are missing or options are syntactically
+   *     invalid for the declared upload mode.
+   */
   public static DirPutFile create(
       SimpleFieldSet subset, String identifier, boolean global, BucketFactory bf)
       throws MessageInvalidException {
@@ -62,21 +139,62 @@ abstract class DirPutFile {
     }
   }
 
+  /**
+   * Returns the manifest-relative name originally provided for this file entry.
+   *
+   * <p>The value may contain forward slashes to express synthetic folders, and is never normalized
+   * by this class so downstream callers can preserve user intent. Because the field is final, the
+   * result remains stable for the entire request lifecycle and can safely be cached in manifest
+   * builders without additional synchronization.
+   *
+   * @return exact manifest-relative name string describing where the element will appear.
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Reports the MIME type currently attached to this entry's metadata bundle.
+   *
+   * <p>The MIME value starts with either the constructor argument or the best-effort guess returned
+   * by {@link #guessMIME(String)}, and may later be replaced when a {@code Metadata.ContentType}
+   * override is parsed. The returned string is owned by {@link ClientMetadata} and should be
+   * treated as immutable by callers.
+   *
+   * @return MIME type describing the payload, such as {@code text/html} or {@code image/png}.
+   */
   public String getMIMEType() {
     return meta.getMIMEType();
   }
 
+  /**
+   * Provides random-access byte storage backing the upload entry.
+   *
+   * <p>Subclasses decide when the underlying bucket is materialized; some defer creation until the
+   * first read to avoid unnecessary disk I/O. Callers must therefore be prepared for the method to
+   * block while allocating buckets or reading from disk. The returned bucket remains owned by the
+   * caller, who is responsible for closing it when manifest serialization completes.
+   *
+   * @return random-access bucket carrying file contents ready for hashing and encryption.
+   */
   public abstract RandomAccessBucket getData();
 
+  /**
+   * Builds a {@link ManifestElement} snapshot representing this file for inclusion in a manifest.
+   *
+   * <p>The method ensures the manifest entry name matches the final path component (so directories
+   * are flattened per manifest rules), logs the transformation when debug logging is enabled, and
+   * pairs the resolved {@link RandomAccessBucket} with MIME and size metadata. Callers typically
+   * use the returned element immediately and then release the bucket via the enclosing manifest
+   * writer.
+   *
+   * @return manifest element populated with sanitized name, data bucket, MIME, and byte length.
+   */
   public ManifestElement getElement() {
     String n = name;
     int idx = n.lastIndexOf('/');
     if (idx != -1) n = n.substring(idx + 1);
-    if (LOG.isDebugEnabled()) LOG.debug("Element name: " + name + " -> " + n);
+    if (LOG.isDebugEnabled()) LOG.debug("Element name: {} -> {}", name, n);
     return new ManifestElement(n, getData(), getMIMEType(), getData().size());
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/DirectDirPutFile.java
+++ b/src/main/java/network/crypta/clients/fcp/DirectDirPutFile.java
@@ -8,16 +8,72 @@ import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.BucketTools;
 import network.crypta.support.io.NullBucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/** Specialized DirPutFile for direct uploads. */
+/**
+ * DirectDirPutFile represents a manifest entry whose bytes arrive inline with the FCP command
+ * stream.
+ *
+ * <p>The class is instantiated during request parsing whenever a client selects {@code
+ * UploadFrom=direct}. It captures the required {@code DataLength}, eagerly sizes a {@link
+ * RandomAccessBucket}, and exposes streaming helpers so manifest builders can read directly from
+ * the client connection without temporarily constructing disk manifests. Callers typically place
+ * the resulting instance into a {@code ClientPutComplexDir} workflow to assemble directories that
+ * mix streamed and disk-backed files.
+ *
+ * <p>The instance owns its bucket for the lifetime of the upload, guaranteeing that read lengths
+ * stay immutable and that the stored data can be replayed multiple times (for hashing, retries, or
+ * manifest serialization) by calling {@link #getData()} as needed. No synchronization is provided;
+ * callers should confine each object to the thread coordinating the associated FCP request to avoid
+ * concurrent reads against the same bucket handles.
+ *
+ * <p>Because the implementation deals with user-controlled input sizes, it assumes that the
+ * surrounding {@link BucketFactory} enforces quota or spilling policies appropriate for the node's
+ * resource limits. Large uploads therefore stream directly into the staging bucket, while tiny ones
+ * may remain purely in-memory, giving operators predictable behavior regardless of payload size.
+ *
+ * <ul>
+ *   <li>Validates that {@code DataLength} exists and parses cleanly.
+ *   <li>Allocates a bucket sized for the declared payload before bytes are received.
+ *   <li>Provides directional copy helpers for sockets and manifest serialization stages.
+ * </ul>
+ *
+ * @see DirPutFile
+ * @see DiskDirPutFile
+ */
 public class DirectDirPutFile extends DirPutFile {
-  private static final Logger LOG = LoggerFactory.getLogger(DirectDirPutFile.class);
 
   private final RandomAccessBucket data;
   private final long length;
 
+  /**
+   * Builds a {@link DirectDirPutFile} for a {@code UploadFrom=direct} manifest element.
+   *
+   * <p>The factory extracts the {@code DataLength} from the provided {@link SimpleFieldSet},
+   * verifies that it is numeric, and immediately obtains a {@link RandomAccessBucket} of matching
+   * size from the supplied {@link BucketFactory}. The MIME type is inherited either from the
+   * explicit {@code Metadata.ContentType} that the caller resolved earlier or from the default
+   * guessing heuristics exposed by {@link DirPutFile#guessMIME(String)}. Any allocation or parsing
+   * problem translates into a {@link MessageInvalidException} whose error code mirrors the exact
+   * fault so the requesting client receives actionable diagnostics.
+   *
+   * <pre>{@code
+   * DirectDirPutFile file = DirectDirPutFile.create(
+   *     "docs/readme.txt", null, fields, requestId, false, bucketFactory);
+   * file.read(clientInputStream);
+   * }</pre>
+   *
+   * @param name manifest-relative entry name chosen by the client; must be non-null and stable.
+   * @param contentTypeOverride optional MIME token supplied earlier; {@code null} triggers
+   *     guessing.
+   * @param subset parsed FCP message subset containing at least {@code DataLength} metadata.
+   * @param identifier unique request identifier echoed in error messages sent back to the user.
+   * @param global whether protocol errors should be flagged as globally broadcast messages.
+   * @param bf bucket factory responsible for providing appropriately sized staging buckets.
+   * @return fully initialized {@code DirectDirPutFile} ready to receive {@link #read(InputStream)}
+   *     bytes.
+   * @throws MessageInvalidException if {@code DataLength} is missing, malformed, or the bucket
+   *     allocation fails for the requested size.
+   */
   public static DirectDirPutFile create(
       String name,
       String contentTypeOverride,
@@ -66,18 +122,72 @@ public class DirectDirPutFile extends DirPutFile {
     this.data = data;
   }
 
+  /**
+   * Reports the exact byte count that must still be copied from the client connection.
+   *
+   * <p>The value equals the {@code DataLength} parsed during creation and never changes afterward,
+   * making it safe to use for progress reporting, rate limiting, or pre-sizing manifest builders.
+   * Because {@link BucketFactory} allocated storage to match this number, exceeding it would
+   * indicate a client protocol error, whereas providing fewer bytes would leave the bucket
+   * partially empty and eventually cause downstream integrity checks to fail.
+   *
+   * @return immutable byte length declaration for the staged upload payload.
+   */
   public long bytesToRead() {
     return length;
   }
 
+  /**
+   * Streams {@link InputStream} data into the staging bucket until the declared length is reached.
+   *
+   * <p>The method consumes exactly {@link #bytesToRead()} bytes, delegating to {@link
+   * BucketTools#copyFrom(network.crypta.support.api.Bucket, java.io.InputStream, long)} so short
+   * reads, premature EOF, or transport errors surface as {@link IOException}s. Callers are
+   * responsible for providing a blocking stream that delivers at least the advertised length; extra
+   * bytes will be left unread and should remain buffered by the transport layer for subsequent
+   * protocol messages. The bucket contents can be revisited multiple times after this call
+   * completes, allowing retryable hashing or manifest serialization without contacting the client
+   * again.
+   *
+   * @param is input stream sourced from the client socket; must remain open for the entire copy.
+   * @throws IOException if the underlying stream cannot supply the required bytes or on bucket
+   *     write failures.
+   */
   public void read(InputStream is) throws IOException {
     BucketTools.copyFrom(data, is, length);
   }
 
+  /**
+   * Writes the staged payload into the supplied {@link OutputStream} for manifest assembly.
+   *
+   * <p>The copy size equals {@link #bytesToRead()}, ensuring downstream consumers receive the same
+   * bytes previously accepted via {@link #read(InputStream)}. Because the content lives inside a
+   * {@link RandomAccessBucket}, multiple invocations remain safe and deterministic, which is useful
+   * for hashing, network retransmissions, or persisting the directory to disk caches. The delegate
+   * {@link BucketTools#copyTo(network.crypta.support.api.Bucket, OutputStream, long)} propagates
+   * {@link IOException}s whenever the output stream backpressure prevents timely writes.
+   *
+   * @param os destination stream, typically a manifest serializer or archive builder output.
+   * @throws IOException if the destination rejects bytes, closes prematurely, or experiences I/O
+   *     errors during transfer.
+   */
   public void write(OutputStream os) throws IOException {
     BucketTools.copyTo(data, os, length);
   }
 
+  /**
+   * Returns the {@link RandomAccessBucket} that backs this direct upload entry.
+   *
+   * <p>The bucket owns the entire payload exactly as supplied by the client and offers random
+   * access semantics so higher layers can seek, read, or even duplicate ranges without restreaming
+   * over the network. Callers should treat the reference as mutable state confined to the owning
+   * request context; concurrently reading and writing from multiple threads risks violating
+   * invariants maintained by the bucket implementation. The caller remains responsible for closing
+   * or freeing the bucket when the directory upload completes, typically via the surrounding
+   * manifest builder.
+   *
+   * @return non-null bucket handle storing the uploaded bytes until the request lifecycle ends.
+   */
   @Override
   public RandomAccessBucket getData() {
     return data;

--- a/src/main/java/network/crypta/clients/fcp/DiskDirPutFile.java
+++ b/src/main/java/network/crypta/clients/fcp/DiskDirPutFile.java
@@ -5,14 +5,63 @@ import network.crypta.client.DefaultMIMETypes;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.FileBucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * DiskDirPutFile models a directory upload element whose bytes live on the local filesystem rather
+ * than streaming over the FCP connection.
+ *
+ * <p>Instances are typically constructed while parsing {@code UploadFrom=disk} manifests. They
+ * store the canonical manifest-relative name inherited from {@link DirPutFile} along with a {@link
+ * File} reference that points to the caller-specified source path. No bytes are copied during
+ * construction; instead, the {@link #getData()} method opens a {@link FileBucket} on demand, which
+ * keeps memory usage low even for very large files. The caller is responsible for ensuring that the
+ * referenced file remains accessible for the lifetime of the enclosing request and that concurrent
+ * modifications do not violate integrity expectations.
+ *
+ * <p>Because the file contents reside on disk, the class excels when directories include
+ * preexisting artifacts that should be re-used verbatim, such as site assets or archival exports.
+ * It avoids the latency of restreaming those bytes through the FCP socket and allows directories to
+ * mix disk-based and direct uploads seamlessly. Thread safety mirrors {@link FileBucket}: each
+ * instance should be confined to the request thread orchestrating the manifest build to prevent
+ * parallel access to the same {@link File} handle.
+ *
+ * <ul>
+ *   <li>Defers I/O until manifest serialization needs the bytes.
+ *   <li>Provides MIME inference that honors both manifest hints and actual file extensions.
+ *   <li>Surfaces missing file declarations as {@link MessageInvalidException} for client clarity.
+ * </ul>
+ *
+ * @see DirectDirPutFile
+ * @see FileBucket
+ */
 public class DiskDirPutFile extends DirPutFile {
-  private static final Logger LOG = LoggerFactory.getLogger(DiskDirPutFile.class);
 
   final File file;
 
+  /**
+   * Builds a {@link DiskDirPutFile} representing a manifest entry sourced from disk.
+   *
+   * <p>The factory verifies that the {@code Filename} field exists in the {@link SimpleFieldSet},
+   * then captures both the {@link File} reference and the effective MIME type. MIME determination
+   * prefers an explicit {@code Metadata.ContentType} supplied earlier, falling back to {@link
+   * #guessMIME(String, File)} when unspecified. Any missing required field triggers a {@link
+   * MessageInvalidException} carrying the caller-provided identifier so protocol clients receive
+   * actionable error responses.
+   *
+   * <pre>{@code
+   * DiskDirPutFile entry = DiskDirPutFile.create(
+   *     "images/logo.png", null, subset, requestId, false);
+   * FileBucket bucket = (FileBucket) entry.getData();
+   * }</pre>
+   *
+   * @param name manifest-relative identifier for the entry, including optional subdirectories.
+   * @param contentTypeOverride explicit MIME token or {@code null} to enable automatic detection.
+   * @param subset parsed message subset containing {@code Filename} and metadata from the client.
+   * @param identifier caller-supplied token echoed in failure messages for correlation.
+   * @param global whether errors should be flagged as global broadcast messages on the connection.
+   * @return immutable {@code DiskDirPutFile} bound to the referenced file path.
+   * @throws MessageInvalidException if the {@code Filename} field is missing or unusable.
+   */
   public static DiskDirPutFile create(
       String name,
       String contentTypeOverride,
@@ -34,25 +83,73 @@ public class DiskDirPutFile extends DirPutFile {
     return new DiskDirPutFile(name, mimeType, file);
   }
 
-  // FIXME implement FileHash support
+  /**
+   * Creates a disk-backed directory entry with a fixed name, MIME type, and source file.
+   *
+   * <p>The constructor merely stores references; it does not validate whether the file exists or is
+   * readable, leaving that responsibility to the caller and later {@link #getData()} invocations.
+   * Supplying an absolute or manifest-relative path is acceptable, but the chosen location must
+   * remain stable until the upload finalizes so retries see identical bytes. Use {@link
+   * #guessMIME(String, File)} to align MIME selection with the factory when creating instances
+   * manually. TODO: implement FileHash support.
+   *
+   * @param name manifest-relative entry name recorded inside the directory manifest.
+   * @param mimeType MIME declaration already validated by callers, never {@code null}.
+   * @param f source file on disk whose contents will be streamed into the manifest output.
+   */
   public DiskDirPutFile(String name, String mimeType, File f) {
     super(name, mimeType);
     this.file = f;
   }
 
+  /**
+   * Derives a MIME type for disk uploads by consulting both manifest metadata and file extensions.
+   *
+   * <p>The method starts with {@link DirPutFile#guessMIME(String)} to honor manifest naming, then
+   * falls back to {@link DefaultMIMETypes#guessMIMEType(String, boolean)} using the actual file
+   * system name if the manifest guess was inconclusive. This two-step approach keeps directory
+   * manifests consistent with direct uploads while still respecting cases where the manifest name
+   * omits an extension but the underlying file retains one.
+   *
+   * @param name manifest-relative path supplied by the client; may omit extensions.
+   * @param file filesystem {@link File} whose name may expose a more accurate MIME hint.
+   * @return non-null MIME type string best matching the available hints.
+   */
   protected static String guessMIME(String name, File file) {
     String mime = DirPutFile.guessMIME(name);
     if (mime == null) {
-      mime = DefaultMIMETypes.guessMIMEType(file.getName(), false /* fixme? */);
+      mime = DefaultMIMETypes.guessMIMEType(file.getName(), false);
     }
     return mime;
   }
 
+  /**
+   * Opens a {@link FileBucket} over the referenced disk file so callers can stream the contents.
+   *
+   * <p>Each invocation returns a fresh bucket that reads lazily from disk, honoring the {@code
+   * random-access} contract required by {@link DirPutFile}. The bucket is configured to keep the
+   * backing file available ({@code deleteOnFree=false}) so retries or multiple manifest passes can
+   * reuse the same bytes. Callers must ensure that the file remains stable and readable until the
+   * returned bucket is freed.
+   *
+   * @return newly allocated {@code FileBucket} exposing the on-disk payload.
+   */
   @Override
   public RandomAccessBucket getData() {
     return new FileBucket(file, true, false, false, false);
   }
 
+  /**
+   * Returns the underlying {@link File} referenced by this manifest entry for inspection or
+   * verification.
+   *
+   * <p>The file object is the same instance provided at construction time and may be absolute or
+   * relative. Callers may inspect it to check size, timestamps, or permissions before initiating
+   * uploads, but any mutations should occur before {@link #getData()} is called to avoid race
+   * conditions with readers.
+   *
+   * @return immutable {@link File} reference representing the upload source path.
+   */
   public File getFile() {
     return file;
   }

--- a/src/main/java/network/crypta/clients/fcp/RedirectDirPutFile.java
+++ b/src/main/java/network/crypta/clients/fcp/RedirectDirPutFile.java
@@ -8,6 +8,29 @@ import network.crypta.support.api.RandomAccessBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Represents a directory entry that redirects to a {@link FreenetURI} instead of embedding data.
+ *
+ * <p>This implementation is selected when an FCP client issues a multi-file insert with {@code
+ * UploadFrom=redirect}. Rather than staging bytes inside a {@link RandomAccessBucket}, the class
+ * retains the manifest-relative file name, negotiates a MIME type, and carries the target URI so
+ * that manifest serialization can produce a redirect element. Instances are immutable except for
+ * the inherited {@link DirPutFile#meta} metadata bundle, which is still scoped to the request that
+ * owns the directory builder.
+ *
+ * <p>Callers typically obtain instances through {@link #create(String, String, SimpleFieldSet,
+ * String, boolean)} while parsing an incoming {@link SimpleFieldSet}. Once constructed, the object
+ * can be attached to a manifest builder and later queried for {@link #getElement()} when the
+ * directory is serialized onto the network. Because no payload buckets exist, the type has trivial
+ * memory usage and can safely be shared across threads provided the surrounding manifest builder
+ * enforces its own synchronization rules.
+ *
+ * <ul>
+ *   <li>Does not allocate disk or memory buckets, relying solely on redirect metadata.
+ *   <li>Guarantees that {@link #getData()} always returns {@code null} to signal redirect entries.
+ *   <li>Ensures MIME inference mirrors the behavior of other {@link DirPutFile} subclasses.
+ * </ul>
+ */
 public class RedirectDirPutFile extends DirPutFile {
   private static final Logger LOG = LoggerFactory.getLogger(RedirectDirPutFile.class);
 
@@ -15,6 +38,28 @@ public class RedirectDirPutFile extends DirPutFile {
 
   // Legacy threshold callback removed.
 
+  /**
+   * Creates a {@code RedirectDirPutFile} from the provided FCP field subset.
+   *
+   * <p>The factory validates that {@code TargetURI} is present, parses it into a {@link FreenetURI}
+   * instance, and determines the MIME type either from {@code Metadata.ContentType} or from the
+   * manifest-relative name. Errors are surfaced via {@link MessageInvalidException} so the caller
+   * can relay precise {@link ProtocolErrorMessage} details back to the client. The returned
+   * instance is ready for manifest assembly and contains no buffered payload data.
+   *
+   * @param name manifest-relative entry name whose extension may influence MIME inference; must not
+   *     be {@code null}.
+   * @param contentTypeOverride MIME override supplied by the client; {@code null} to trigger the
+   *     standard {@link #guessMIME(String)} heuristic.
+   * @param subset parsed request fields that include {@code TargetURI}; the object is not mutated
+   *     by this method.
+   * @param identifier textual identifier echoed in generated protocol errors for traceability.
+   * @param global whether the caller expects the error to be flagged as global when thrown back to
+   *     the client connection.
+   * @return redirect entry that can be added directly to a manifest builder without further setup.
+   * @throws MessageInvalidException if {@code TargetURI} is missing, syntactically invalid, or the
+   *     MIME override fails validation against {@link ProtocolErrorMessage} rules.
+   */
   public static RedirectDirPutFile create(
       String name,
       String contentTypeOverride,
@@ -36,23 +81,49 @@ public class RedirectDirPutFile extends DirPutFile {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD, "Invalid TargetURI: " + e, identifier, global);
     }
-    if (LOG.isDebugEnabled()) LOG.debug("targetURI = " + targetURI);
+    if (LOG.isDebugEnabled()) LOG.debug("targetURI = {}", targetURI);
     String mimeType;
     if (contentTypeOverride != null) mimeType = contentTypeOverride;
     else mimeType = guessMIME(name);
     return new RedirectDirPutFile(name, mimeType, targetURI);
   }
 
+  /**
+   * Builds a redirect entry with a fixed manifest path, MIME declaration, and target URI.
+   *
+   * <p>This constructor is primarily used by {@link #create(String, String, SimpleFieldSet, String,
+   * boolean)} but can also serve tests that want to assemble redirect elements manually. All
+   * arguments are stored verbatim and the resulting instance contains no payload data or side
+   * effects.
+   *
+   * @param name manifest-relative entry name; callers should pass the exact value that will appear
+   *     in the directory manifest.
+   * @param mimeType MIME string associated with the redirect; typically a client override or the
+   *     result of {@link #guessMIME(String)}.
+   * @param targetURI destination URI to embed in the manifest; must refer to a valid {@link
+   *     FreenetURI} instance expected by fetchers.
+   */
   public RedirectDirPutFile(String name, String mimeType, FreenetURI targetURI) {
     super(name, mimeType);
     this.targetURI = targetURI;
   }
 
+  /** {@inheritDoc} */
   @Override
   public RandomAccessBucket getData() {
     return null;
   }
 
+  /**
+   * Returns a {@link ManifestElement} describing this redirect for manifest serialization.
+   *
+   * <p>The element contains no backing data bucket and reports a size of {@code -1} per manifest
+   * conventions. The {@link ManifestElement#getName()} matches the original manifest-relative path,
+   * which is important for directory builders that preserve folder hierarchies.
+   *
+   * @return manifest element that references {@link #targetURI} and retains the negotiated MIME
+   *     type, never {@code null}.
+   */
   @Override
   public ManifestElement getElement() {
     return new ManifestElement(name, targetURI, getMIMEType());

--- a/src/test/java/network/crypta/clients/fcp/DirectDirPutFileTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DirectDirPutFileTest.java
@@ -1,0 +1,165 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.BucketTools;
+import network.crypta.support.io.NullBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"java:S100", "resource"})
+class DirectDirPutFileTest {
+
+  private static final String NAME = "index.html";
+  private static final String IDENTIFIER = "req-1";
+  private static final boolean GLOBAL = true;
+
+  @Mock private BucketFactory bucketFactory;
+  @Mock private RandomAccessBucket bucket;
+
+  @Test
+  void create_whenDataLengthMissing_expectMessageInvalidException() {
+    SimpleFieldSet subset = new SimpleFieldSet(true);
+
+    MessageInvalidException ex =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> DirectDirPutFile.create(NAME, null, subset, IDENTIFIER, GLOBAL, bucketFactory));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    assertTrue(ex.global);
+    assertTrue(ex.getMessage().contains("DataLength"));
+    verifyNoInteractions(bucketFactory);
+  }
+
+  @Test
+  void create_whenDataLengthNotNumeric_expectMessageInvalidException() {
+    SimpleFieldSet subset = subsetWithLength("not-a-number");
+
+    MessageInvalidException ex =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> DirectDirPutFile.create(NAME, null, subset, IDENTIFIER, GLOBAL, bucketFactory));
+
+    assertEquals(ProtocolErrorMessage.ERROR_PARSING_NUMBER, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    assertTrue(ex.global);
+    verifyNoInteractions(bucketFactory);
+  }
+
+  @Test
+  void create_whenBucketFactoryFails_expectMessageInvalidException() throws IOException {
+    SimpleFieldSet subset = subsetWithLength("10");
+    IOException failure = new IOException("disk full");
+    when(bucketFactory.makeBucket(10L)).thenThrow(failure);
+
+    MessageInvalidException ex =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> DirectDirPutFile.create(NAME, null, subset, IDENTIFIER, GLOBAL, bucketFactory));
+
+    assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, ex.protocolCode);
+    assertTrue(ex.getMessage().contains("could not allocate temp bucket"));
+  }
+
+  @Test
+  void create_whenLengthZero_expectNullBucketAndZeroBytesToRead() throws MessageInvalidException {
+    SimpleFieldSet subset = subsetWithLength("0");
+
+    DirectDirPutFile file =
+        DirectDirPutFile.create(NAME, null, subset, IDENTIFIER, GLOBAL, bucketFactory);
+
+    assertEquals(0, file.bytesToRead());
+    assertInstanceOf(NullBucket.class, file.getData());
+    verifyNoInteractions(bucketFactory);
+  }
+
+  @Test
+  void create_whenLengthPositive_usesFactoryBucketAndMimeOverride()
+      throws IOException, MessageInvalidException {
+    SimpleFieldSet subset = subsetWithLength("42");
+    when(bucketFactory.makeBucket(42L)).thenReturn(bucket);
+    String overrideMime = "text/plain";
+
+    DirectDirPutFile file =
+        DirectDirPutFile.create(NAME, overrideMime, subset, IDENTIFIER, GLOBAL, bucketFactory);
+
+    assertSame(bucket, file.getData());
+    assertEquals(42, file.bytesToRead());
+    assertEquals(overrideMime, file.getMIMEType());
+    verify(bucketFactory).makeBucket(42L);
+  }
+
+  @Test
+  void read_whenCalled_invokesBucketToolsCopyFrom() throws Exception {
+    long length = 8L;
+    DirectDirPutFile file = newFileWithBucket(length);
+    InputStream input = new ByteArrayInputStream(new byte[0]);
+
+    try (MockedStatic<BucketTools> mocked = Mockito.mockStatic(BucketTools.class)) {
+      file.read(input);
+      mocked.verify(() -> BucketTools.copyFrom(bucket, input, length));
+    }
+  }
+
+  @Test
+  void write_whenCalled_invokesBucketToolsCopyTo() throws Exception {
+    long length = 12L;
+    DirectDirPutFile file = newFileWithBucket(length);
+    OutputStream output = new ByteArrayOutputStream();
+
+    try (MockedStatic<BucketTools> mocked = Mockito.mockStatic(BucketTools.class)) {
+      mocked.when(() -> BucketTools.copyTo(bucket, output, length)).thenReturn(length);
+      file.write(output);
+      mocked.verify(() -> BucketTools.copyTo(bucket, output, length));
+    }
+  }
+
+  @Test
+  void read_whenBucketToolsThrowsIOException_propagates() throws Exception {
+    long length = 5L;
+    DirectDirPutFile file = newFileWithBucket(length);
+    InputStream input = new ByteArrayInputStream(new byte[0]);
+
+    try (MockedStatic<BucketTools> mocked = Mockito.mockStatic(BucketTools.class)) {
+      IOException failure = new IOException("copy failure");
+      mocked.when(() -> BucketTools.copyFrom(bucket, input, length)).thenThrow(failure);
+
+      IOException thrown = assertThrows(IOException.class, () -> file.read(input));
+      assertSame(failure, thrown);
+    }
+  }
+
+  private DirectDirPutFile newFileWithBucket(long length) throws Exception {
+    SimpleFieldSet subset = subsetWithLength(Long.toString(length));
+    when(bucketFactory.makeBucket(length)).thenReturn(bucket);
+    return DirectDirPutFile.create(NAME, null, subset, IDENTIFIER, GLOBAL, bucketFactory);
+  }
+
+  private static SimpleFieldSet subsetWithLength(String length) {
+    SimpleFieldSet subset = new SimpleFieldSet(true);
+    subset.putSingle("DataLength", length);
+    return subset;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/DiskDirPutFileTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DiskDirPutFileTest.java
@@ -1,0 +1,100 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.client.DefaultMIMETypes;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.FileBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class DiskDirPutFileTest {
+
+  private static final String IDENTIFIER = "req-42";
+  private static final boolean GLOBAL = true;
+
+  @TempDir Path tempDir;
+
+  @Test
+  void create_whenFilenameMissing_expectMessageInvalidException() {
+    SimpleFieldSet subset = new SimpleFieldSet(true);
+
+    MessageInvalidException ex =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> DiskDirPutFile.create("index.html", null, subset, IDENTIFIER, GLOBAL));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    assertTrue(ex.global);
+    assertTrue(ex.getMessage().contains("Missing field: Filename"));
+  }
+
+  @Test
+  void create_whenOverrideProvided_expectMimeTypeMatchesOverride() throws Exception {
+    File source = createTempFile("override.txt");
+    SimpleFieldSet subset = subsetWithFilename(source);
+    String overrideMime = "application/json";
+
+    DiskDirPutFile file =
+        DiskDirPutFile.create("folder/data.txt", overrideMime, subset, IDENTIFIER, GLOBAL);
+
+    assertEquals(overrideMime, file.getMIMEType());
+    assertEquals(source.getAbsolutePath(), file.getFile().getAbsolutePath());
+  }
+
+  @Test
+  void create_whenOverrideMissing_expectMimeDerivedFromName() throws Exception {
+    String name = "docs/index.html";
+    File source = createTempFile("nameDerived.bin");
+    SimpleFieldSet subset = subsetWithFilename(source);
+
+    DiskDirPutFile file = DiskDirPutFile.create(name, null, subset, IDENTIFIER, GLOBAL);
+
+    assertEquals(DefaultMIMETypes.guessMIMEType(name, true), file.getMIMEType());
+  }
+
+  @Test
+  void guessMIME_whenNameHasNoExtension_expectGuessFromFileName() throws IOException {
+    File pngFile = createTempFile("photo.png");
+
+    String mime = DiskDirPutFile.guessMIME("folder/readme", pngFile);
+
+    assertEquals(DefaultMIMETypes.guessMIMEType(pngFile.getName(), false), mime);
+  }
+
+  @Test
+  void getData_whenInvoked_returnsFileBucketBoundToResolvedFile() throws IOException {
+    File file = createTempFile("bucket.dat");
+    DiskDirPutFile diskDirPutFile =
+        new DiskDirPutFile("file.bin", "application/octet-stream", file);
+
+    RandomAccessBucket data = diskDirPutFile.getData();
+
+    assertInstanceOf(FileBucket.class, data);
+    FileBucket bucket = (FileBucket) data;
+    assertEquals(file.getAbsolutePath(), bucket.getFile().getAbsolutePath());
+  }
+
+  private File createTempFile(String name) throws IOException {
+    Path path = tempDir.resolve(name);
+    Files.createDirectories(path.getParent());
+    Files.deleteIfExists(path);
+    return Files.createFile(path).toFile();
+  }
+
+  private static SimpleFieldSet subsetWithFilename(File file) {
+    SimpleFieldSet subset = new SimpleFieldSet(true);
+    subset.putSingle("Filename", file.getAbsolutePath());
+    return subset;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/RedirectDirPutFileTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RedirectDirPutFileTest.java
@@ -1,0 +1,92 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.client.DefaultMIMETypes;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.ManifestElement;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class RedirectDirPutFileTest {
+
+  private static final String IDENTIFIER = "redirect-test";
+  private static final boolean GLOBAL = true;
+  private static final String VALID_TARGET = "KSK@redirect-target";
+
+  @Test
+  void create_whenTargetUriMissing_expectMessageInvalidException() {
+    SimpleFieldSet subset = new SimpleFieldSet(true);
+
+    MessageInvalidException ex =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> RedirectDirPutFile.create("file.txt", "text/plain", subset, IDENTIFIER, GLOBAL));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    assertTrue(ex.global);
+    assertTrue(ex.getMessage().contains("TargetURI missing"));
+  }
+
+  @Test
+  void create_whenTargetUriInvalid_expectMessageInvalidException() {
+    SimpleFieldSet subset = subsetWithTarget("not-a-valid-uri");
+
+    MessageInvalidException ex =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> RedirectDirPutFile.create("file.txt", null, subset, IDENTIFIER, GLOBAL));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    assertTrue(ex.global);
+    assertTrue(ex.getMessage().startsWith("Invalid TargetURI"));
+  }
+
+  @Test
+  void create_whenContentTypeOverrideProvided_buildsRedirectManifestElement() throws Exception {
+    String name = "docs/index.html";
+    String overrideMime = "text/html";
+    SimpleFieldSet subset = subsetWithTarget(VALID_TARGET);
+
+    RedirectDirPutFile file =
+        RedirectDirPutFile.create(name, overrideMime, subset, IDENTIFIER, false);
+
+    assertEquals(name, file.getName());
+    assertEquals(overrideMime, file.getMIMEType());
+    assertNull(file.getData());
+
+    ManifestElement element = file.getElement();
+    assertEquals(name, element.getName());
+    assertEquals(overrideMime, element.getMimeTypeOverride());
+    assertNull(element.getData());
+    assertEquals(-1L, element.getSize());
+    assertEquals(new FreenetURI(VALID_TARGET), element.getTargetURI());
+  }
+
+  @Test
+  void create_whenContentTypeMissing_guessesMimeFromName() throws Exception {
+    String name = "images/photo.png";
+    SimpleFieldSet subset = subsetWithTarget(VALID_TARGET);
+
+    RedirectDirPutFile file = RedirectDirPutFile.create(name, null, subset, IDENTIFIER, false);
+
+    String expectedMime = DefaultMIMETypes.guessMIMEType(name, true);
+    assertEquals(expectedMime, file.getMIMEType());
+
+    ManifestElement element = file.getElement();
+    assertEquals(expectedMime, element.getMimeTypeOverride());
+    assertEquals(new FreenetURI(VALID_TARGET), element.getTargetURI());
+  }
+
+  private static SimpleFieldSet subsetWithTarget(String target) {
+    SimpleFieldSet subset = new SimpleFieldSet(true);
+    subset.putSingle("TargetURI", target);
+    return subset;
+  }
+}


### PR DESCRIPTION
## Summary
- expand the DirPutFile contract docs so callers know how manifest names, metadata, and factories behave
- document the direct and disk implementations, clean up their logging, and add tests that prove length validation, MIME inference, and bucket wiring
- document RedirectDirPutFile, switch its debug logging to parameterized placeholders, and add tests that cover both error paths and manifest element construction

## Testing
- Not run (not requested)
