### PR TITLE
Document request status objects and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/DownloadRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadRequestStatus.java
@@ -12,7 +12,34 @@ import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Cached status of a download of a file i.e. a ClientGet */
+/**
+ * Represents the mutable life cycle of a single ClientGet request once it has been accepted by the
+ * FCP layer. Instances collect success/failure metadata, inferred MIME information, and progressive
+ * hints about how the client should treat the retrieved data. The class is designed as a
+ * thread-safe hand-off object: request executors update it under synchronization while callers poll
+ * immutable snapshots via {@link #copy()} or the exposed read methods.
+ *
+ * <p>Consumers typically construct an instance when a request enters the queue, pass it through
+ * dispatch/execution code, and periodically query it to populate status messages, UI widgets, or
+ * persistence payloads. The object keeps track of byte counts, priority, and dynamically discovered
+ * insert compatibility modes so that retry logic can make informed decisions about compression and
+ * storage layout.
+ *
+ * <p>Thread-safety is deliberately coarse grained: most mutators are {@code synchronized} to
+ * simplify reasoning over state transitions, while getters expose the most recent consistent view
+ * without additional locking. Callers should prefer cloning via {@link #copy()} when they need to
+ * hold a reference beyond a single read, because inner arrays (such as split-file keys) are copied
+ * defensively.
+ *
+ * <ul>
+ *   <li>Tracks byte size, MIME type, and compression hints for downstream consumers.
+ *   <li>Captures both short and long failure reasons for human-readable diagnostics.
+ *   <li>Stores redirection targets and split-file metadata so resumed downloads can skip work.
+ * </ul>
+ *
+ * @see RequestStatus
+ * @see network.crypta.clients.fcp.ClientGetMessage
+ */
 public class DownloadRequestStatus extends RequestStatus {
   private static final Logger LOG = LoggerFactory.getLogger(DownloadRequestStatus.class);
 
@@ -29,7 +56,14 @@ public class DownloadRequestStatus extends RequestStatus {
   private FreenetURI uri;
   boolean filterData;
   Bucket dataShadow;
+
+  /**
+   * Indicates whether the caller explicitly requested a MIME override on the returned file. A true
+   * value means downstream logic must preserve the supplied MIME type, even when validators report
+   * conflicts, whereas false allows detected content types to replace guesses.
+   */
   public final boolean overriddenDataType;
+
   private boolean detectedDontCompress;
 
   synchronized void setFinished(
@@ -45,14 +79,7 @@ public class DownloadRequestStatus extends RequestStatus {
     if (mimeType == null
         && (failureCode == FetchExceptionMode.CONTENT_VALIDATION_UNKNOWN_MIME
             || failureCode == FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME)) {
-      LOG.error(
-          "MIME type is null but failure code is "
-              + FetchException.getMessage(failureCode)
-              + " for "
-              + getIdentifier()
-              + " : "
-              + uri,
-          new Exception("error"));
+      logMimeTypeMismatch(failureCode, getIdentifier(), uri);
     }
     this.dataSize = dataSize;
     this.mimeType = mimeType;
@@ -110,14 +137,7 @@ public class DownloadRequestStatus extends RequestStatus {
     if (mime == null
         && (failureCode == FetchExceptionMode.CONTENT_VALIDATION_UNKNOWN_MIME
             || failureCode == FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME)) {
-      LOG.error(
-          "MIME type is null but failure code is "
-              + FetchException.getMessage(failureCode)
-              + " for "
-              + identifier
-              + " : "
-              + uri,
-          new Exception("error"));
+      logMimeTypeMismatch(failureCode, identifier, uri);
     }
     this.overriddenDataType = overriddenDataType;
     this.failureCode = failureCode;
@@ -153,40 +173,127 @@ public class DownloadRequestStatus extends RequestStatus {
     this.detectedDontCompress = source.detectedDontCompress;
   }
 
+  /**
+   * Reports whether the retrieved entity currently targets anonymous temporary storage.
+   *
+   * <p>When {@code true} the request has no preselected on-disk path; callers should keep the data
+   * inside the client area or prompt the user to choose a location. Requests backed by a concrete
+   * destination return {@code false} once the destination is known.
+   *
+   * @return {@code true} when {@link #getDestFilename()} is {@code null}, implying temporary space
+   *     usage.
+   */
   public final boolean toTempSpace() {
     return destFilename == null;
   }
 
+  /**
+   * Provides the most recent fetch failure category reported by the worker thread.
+   *
+   * <p>The mode helps external logic choose between retries, user-visible explanations, or aborting
+   * the transfer entirely. A return value of {@code null} indicates either that the request still
+   * runs or that it finished successfully.
+   *
+   * @return the {@link FetchExceptionMode} describing the last terminal error, or {@code null} when
+   *     none has been recorded.
+   */
   public FetchExceptionMode getFailureCode() {
     return failureCode;
   }
 
+  /**
+   * Returns the MIME type inferred or overridden for the downloaded payload.
+   *
+   * <p>The method favors explicitly supplied overrides, otherwise falls back to validator-detected
+   * values, and may be {@code null} while inference is still pending. Downstream consumers should
+   * therefore treat the result as advisory until the request transitions to a finished state and
+   * validators confirm whether the MIME was acceptable.
+   *
+   * @return the MIME type string, or {@code null} when undetermined or still being validated.
+   */
   public String getMIMEType() {
     return mimeType;
   }
 
+  /**
+   * Reports the best-known size in bytes for the requested payload.
+   *
+   * <p>The value reflects either the byte count streamed by the network layer, an estimate supplied
+   * with the original request, or the length retrieved from metadata. Because status updates are
+   * synchronized, callers can treat the number as a consistent snapshot even while the download
+   * progresses.
+   *
+   * @return the byte length advertised so far, or zero when the size has not yet been learned.
+   */
   @Override
   public long getDataSize() {
     return dataSize;
   }
 
+  /**
+   * Exposes the final destination file requested by the client, when any.
+   *
+   * <p>This path is only valid on the originating node, must not be shared across trust boundaries,
+   * and can be {@code null} while the request is destined for temporary storage or before the user
+   * picks a path.
+   *
+   * @return the destination {@link File}, or {@code null} while targeting temp space.
+   */
   public File getDestFilename() {
     return destFilename;
   }
 
+  /**
+   * Returns the compatibility modes guessed while parsing the split-file metadata.
+   *
+   * <p>The returned array may be shared across readers, so callers should copy it if they intend to
+   * mutate the contents. The value is {@code null} until compatibility detection runs.
+   *
+   * @return an array describing the effective {@link CompatibilityMode}s, or {@code null} when
+   *     undetected.
+   */
   public CompatibilityMode[] getCompatibilityMode() {
     return detectedCompatModes;
   }
 
+  /**
+   * Provides the override key used to decrypt split-file blocks when the client supplied one.
+   *
+   * <p>The array is a snapshot in time; callers should defensively copy it to avoid leaking mutable
+   * internals. {@code null} indicates that the request uses the key embedded in the URI itself.
+   *
+   * @return a byte array holding the override key, or {@code null} when defaulting to the URI key.
+   */
   public byte[] getOverriddenSplitfileCryptoKey() {
     return detectedSplitfileKey;
   }
 
+  /**
+   * Supplies the URI that is currently associated with the request, including redirects.
+   *
+   * <p>The value initially reflects the URI provided by the caller, but the worker may swap in a
+   * redirection target once detected via {@link #redirect(FreenetURI)}. Consumers should therefore
+   * consult this method each time they need to display or persist linkage data instead of caching
+   * an early reference.
+   *
+   * @return the active {@link FreenetURI} for this download, or {@code null} before initialization.
+   */
   @Override
   public FreenetURI getURI() {
     return uri;
   }
 
+  /**
+   * Explains why the request failed or was rejected by validation layers.
+   *
+   * <p>When {@code longDescription} is {@code true}, the method returns the verbose explanation
+   * suitable for UI tooltips or logs; otherwise it emits a condensed human-readable summary. Either
+   * may be {@code null} if the request has not yet encountered an error or the worker has not
+   * filled in the relevant field.
+   *
+   * @param longDescription {@code true} for the verbose reason, {@code false} for the short label.
+   * @return the requested failure reason flavor, or {@code null} when the information is missing.
+   */
   @Override
   public String getFailureReason(boolean longDescription) {
     if (longDescription) return failureReasonLong;
@@ -211,6 +318,15 @@ public class DownloadRequestStatus extends RequestStatus {
     this.dataSize = dataLength;
   }
 
+  /**
+   * Exposes the optional bucket that mirrors the download's payload for post-processing.
+   *
+   * <p>The returned {@link Bucket} is typically a transient shadow used for filtering or checksum
+   * verification when the output stream is not directly available to the caller. Because the
+   * pointer can change while the download progresses, access is synchronized.
+   *
+   * @return the current shadow bucket, or {@code null} when no auxiliary copy exists.
+   */
   public synchronized Bucket getDataShadow() {
     return dataShadow;
   }
@@ -219,10 +335,29 @@ public class DownloadRequestStatus extends RequestStatus {
     this.uri = redirect;
   }
 
+  /**
+   * Signals whether the worker discovered that compression should be bypassed for reinsertion.
+   *
+   * <p>Downloads that carry already compressed or encrypted blocks set this flag so reinsertion
+   * logic skips redundant compression attempts. Because the answer can only flip from {@code false}
+   * to {@code true}, callers may safely treat a {@code true} value as sticky for the remainder of
+   * the job.
+   *
+   * @return {@code true} when compression should be avoided, {@code false} otherwise.
+   */
   public synchronized boolean detectedDontCompress() {
     return detectedDontCompress;
   }
 
+  /**
+   * Provides the filename clients should display when offering a save dialog or progress entry.
+   *
+   * <p>The destination filename takes precedence when explicitly provided. Otherwise, the method
+   * derives a name from {@link FreenetURI#getPreferredFilename()} provided the URI supplies meta
+   * strings or a document name. {@code null} is returned when no reasonable candidate exists.
+   *
+   * @return a display-ready filename suggestion, or {@code null} when unavailable.
+   */
   @Override
   public String getPreferredFilename() {
     if (destFilename != null) return destFilename.getName();
@@ -231,8 +366,30 @@ public class DownloadRequestStatus extends RequestStatus {
     return null;
   }
 
+  /**
+   * Creates a defensive snapshot of this status object, including copies of mutable arrays.
+   *
+   * <p>The returned instance is detached from future updates, making it safe to cache or publish
+   * beyond the owning thread. Use this when serializing status responses or when UI components need
+   * to observe a stable view while the background task keeps running.
+   *
+   * @return an immutable snapshot of the current status fields.
+   */
   @Override
   public DownloadRequestStatus copy() {
     return new DownloadRequestStatus(this);
+  }
+
+  private static void logMimeTypeMismatch(
+      FetchExceptionMode failureCode, String identifier, FreenetURI uri) {
+    if (!LOG.isErrorEnabled()) {
+      return;
+    }
+    LOG.error(
+        "MIME type is null but failure code is {} for {} : {}",
+        FetchException.getMessage(failureCode),
+        identifier,
+        uri,
+        new Exception("error"));
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/DownloadRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/DownloadRequestStatus.java
@@ -134,6 +134,25 @@ public class DownloadRequestStatus extends RequestStatus {
     this.detectedDontCompress = dontCompress;
   }
 
+  private DownloadRequestStatus(DownloadRequestStatus source) {
+    super(source);
+    this.failureCode = source.failureCode;
+    this.failureReasonShort = source.failureReasonShort;
+    this.failureReasonLong = source.failureReasonLong;
+    this.mimeType = source.mimeType;
+    this.dataSize = source.dataSize;
+    this.destFilename = source.destFilename;
+    this.detectedCompatModes =
+        source.detectedCompatModes != null ? source.detectedCompatModes.clone() : null;
+    this.detectedSplitfileKey =
+        source.detectedSplitfileKey != null ? source.detectedSplitfileKey.clone() : null;
+    this.uri = source.uri;
+    this.filterData = source.filterData;
+    this.dataShadow = source.dataShadow;
+    this.overriddenDataType = source.overriddenDataType;
+    this.detectedDontCompress = source.detectedDontCompress;
+  }
+
   public final boolean toTempSpace() {
     return destFilename == null;
   }
@@ -210,5 +229,10 @@ public class DownloadRequestStatus extends RequestStatus {
     if (uri != null && (uri.hasMetaStrings() || uri.getDocName() != null))
       return uri.getPreferredFilename();
     return null;
+  }
+
+  @Override
+  public DownloadRequestStatus copy() {
+    return new DownloadRequestStatus(this);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/RequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatus.java
@@ -1,21 +1,37 @@
 package network.crypta.clients.fcp;
 
 import java.util.Date;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 
 /**
- * The status of a request. Cached copy i.e. can be accessed outside the database thread even for a
- * persistent request.
+ * Captures the life-cycle snapshot of a single Freenet Client Protocol request.
  *
- * <p>Methods that change the status should be package-local, and called either within
- * freenet.clients.fcp, or via RequestStatusCache. Hence we should be able to lock the
- * RequestStatusCache and be confident that nothing is going to change under us.
+ * <p>A {@code RequestStatus} combines high-level state (started, finished, success) with granular
+ * counters, timestamps, and persistence policies so higher layers can render progress without
+ * blocking the database thread. Instances arise when users schedule fetches/inserts or when
+ * persisted jobs are reloaded at startup, and they are subsequently mutated only by the owning
+ * request code paths.
+ *
+ * <p>The class is deliberately abstract: subclasses specify transport-specific details such as the
+ * originating {@link FreenetURI}, failure descriptions, and data sizing. Implementations are
+ * expected to snapshot themselves via {@link #copy()} so callers can access status objects outside
+ * synchronization blocks without risking torn reads. Unless noted otherwise, getters may be safely
+ * invoked from any thread that already coordinates with {@code RequestStatusCache}.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> expose immutable identifiers, mutable priority, and
+ *       completion metadata.
+ *   <li><strong>Concurrency:</strong> mutation methods synchronize on {@code this}; readers mirror
+ *       that discipline for the guarded fields.
+ *   <li><strong>Persistence:</strong> {@link #isPersistentForever()} and {@link #isPersistent()}
+ *       describe whether the request survives client restarts.
+ * </ul>
  *
  * @author toad
+ * @see RequestStatusCache
  */
 public abstract class RequestStatus {
 
@@ -28,9 +44,7 @@ public abstract class RequestStatus {
   private int minBlocks;
   private int fetchedBlocks;
 
-  /**
-   * @see ClientRequester#latestSuccess
-   */
+  /** Timestamp of the most recent successful block or completion event. */
   private Date latestSuccess;
 
   private int fatallyFailedBlocks;
@@ -53,6 +67,7 @@ public abstract class RequestStatus {
     this.isTotalFinalized = true;
   }
 
+  @SuppressWarnings("SameParameterValue")
   synchronized void restart(boolean started) {
     // See ClientRequester.getLatestSuccess() for why this defaults to current time.
     this.latestSuccess = new Date();
@@ -63,8 +78,35 @@ public abstract class RequestStatus {
   }
 
   /**
-   * Constructor for creating a status from a request that has already started, e.g. on startup. We
-   * will also create status when a request is created.
+   * Creates a mutable status holder for a request that may already be in flight or persisted on
+   * disk.
+   *
+   * <p>Callers typically invoke this constructor while wiring {@code ClientRequest} instances at
+   * submission time or when replaying stored jobs on startup. Each supplied metric is immediately
+   * copied into a guarded field, and mutable timestamps are cloned to prevent accidental sharing.
+   * The constructor does not perform validation beyond storing the snapshots, so upstream code must
+   * ensure that block counts and flags reflect the latest durable state.
+   *
+   * @param identifier stable token used to match external protocol events and cache lookups; must
+   *     be unique per running node.
+   * @param persistence persistence policy describing whether the request outlives disconnections or
+   *     restarts.
+   * @param started whether the request has already begun transferring data at creation time.
+   * @param finished indicates that the request reached a terminal outcome, successful or otherwise.
+   * @param success marks that the requested data was fetched or inserted successfully when finished
+   *     is true.
+   * @param total total number of blocks known for the operation; 0 means not yet discovered.
+   * @param min minimum number of successful blocks required before treating the request as complete
+   *     (e.g., redundancy threshold).
+   * @param fetched number of blocks already downloaded or uploaded according to the splitter.
+   * @param latestSuccess timestamp of the most recent successful block or completion, may be null
+   *     when never succeeded.
+   * @param fatal number of blocks that failed permanently and will not be retried.
+   * @param failed number of blocks that have failed transiently but may be retried.
+   * @param latestFailure timestamp of the last observed failure, may be null when nothing failed
+   *     yet.
+   * @param totalFinalized whether {@code total} is definitive (no more blocks will be discovered).
+   * @param prio scheduler priority used to arbitrate bandwidth between competing client requests.
    */
   RequestStatus(
       String identifier,
@@ -99,7 +141,17 @@ public abstract class RequestStatus {
     this.persistence = persistence;
   }
 
-  /** Copy constructor used by subclasses to provide defensive snapshots. */
+  /**
+   * Builds a defensive copy of another status instance so subclasses can expose snapshots.
+   *
+   * <p>The constructor copies every scalar, clones mutable timestamps, and intentionally omits any
+   * shared references so callers can retain the resulting object beyond internal synchronization
+   * windows. Subclasses typically delegate to this constructor within their own {@link #copy()}
+   * implementation before adding subclass-specific state.
+   *
+   * @param source reference status whose fields should be mirrored without sharing mutable
+   *     structures or synchronization guards.
+   */
   protected RequestStatus(RequestStatus source) {
     this.identifier = source.identifier;
     this.persistence = source.persistence;
@@ -117,83 +169,269 @@ public abstract class RequestStatus {
     this.isTotalFinalized = source.isTotalFinalized;
   }
 
+  /**
+   * Reports whether the associated client request already completed successfully.
+   *
+   * <p>The flag flips to {@code true} only once {@link #setFinished(boolean)} commits a successful
+   * terminal state, and it remains true for the lifetime of this instance even if the client
+   * restarts. Because UI layers poll this method frequently, it simply returns the cached boolean
+   * without synchronization, relying on callers to coordinate through {@code RequestStatusCache}
+   * when stricter happens-before guarantees are required.
+   *
+   * @return {@code true} when the request reached a successful terminal state; {@code false} while
+   *     pending or failed.
+   */
   public boolean hasSucceeded() {
     return hasSucceeded;
   }
 
+  /**
+   * Indicates whether the request finished, regardless of outcome.
+   *
+   * <p>The value turns {@code true} as soon as {@link #setFinished(boolean)} executes, even before
+   * listeners observe the final result, and remains latched until {@link #restart(boolean)} runs.
+   * Poll this method to decide when to stop rendering progress indicators or when it is safe to
+   * emit final notifications to remote clients.
+   *
+   * @return {@code true} when the tracked operation is no longer running; {@code false} otherwise.
+   */
   public boolean hasFinished() {
     return hasFinished;
   }
 
-  public short getPriority() {
+  /**
+   * Returns the current scheduler priority associated with the request.
+   *
+   * <p>The value is read under synchronization because {@link #setPriority(short)} may be invoked
+   * concurrently by operators manually reprioritizing downloads. Higher numbers generally represent
+   * higher priority within the queue, but the exact semantics depend on the upstream scheduler.
+   * Consumers can compare this number against policy thresholds to categorize requests.
+   *
+   * @return priority level currently assigned to the request, typically within the user-configured
+   *     bounds.
+   */
+  public synchronized short getPriority() {
     return priority;
   }
 
+  /**
+   * Retrieves the stable external identifier backing this status entry.
+   *
+   * <p>The identifier is the token exchanged over FCP and stored inside caches so UI components or
+   * remote clients can match asynchronous events to the originating submission. Identifiers are
+   * opaque, case-sensitive strings; treat them as stable handles rather than deriving semantics
+   * from their contents.
+   *
+   * @return immutable identifier string chosen at request creation time.
+   */
   public String getIdentifier() {
     return identifier;
   }
 
+  /**
+   * Provides the latest known total block count for the request.
+   *
+   * <p>The total may increase as splitfile metadata becomes available. Once {@link
+   * #isTotalFinalized()} is true the figure matches the final number of transfers, enabling
+   * accurate percentage calculations and disk predictions. Until then, treat the number as a moving
+   * target and update progress displays dynamically.
+   *
+   * @return number of blocks anticipated for the operation; may be zero while unknown.
+   */
   public int getTotalBlocks() {
     return totalBlocks;
   }
 
+  /**
+   * States whether {@link #getTotalBlocks()} is final or still provisional.
+   *
+   * <p>Splitfile fetches often discover additional segments after the first metadata blocks arrive.
+   * When this method returns {@code true}, consumers can rely on {@code totalBlocks} staying
+   * constant for the remainder of the request and may safely cache derived estimates without
+   * recomputing denominators every tick.
+   *
+   * @return {@code true} when the total block count will no longer change.
+   */
   public boolean isTotalFinalized() {
     return isTotalFinalized;
   }
 
+  /**
+   * Returns the minimum number of blocks that must succeed for completion.
+   *
+   * <p>Some insert/fetch operations use redundancy; they may finish once a threshold is met even if
+   * {@link #getTotalBlocks()} is larger. This target originates from the splitter metadata and
+   * usually remains fixed, so comparing it with {@link #getFetchedBlocks()} reveals how close the
+   * request is to meeting its redundancy goals.
+   *
+   * @return required minimum of successful blocks before declaring overall success.
+   */
   public int getMinBlocks() {
     return minBlocks;
   }
 
+  /**
+   * Reports how many blocks already succeeded.
+   *
+   * <p>This counter increments as {@link SplitfileProgressEvent} notifications arrive and is the
+   * primary input for user-facing progress indicators. It monotonically increases until completion
+   * or cancellation and easily represents very large splitfiles because it is stored as a 32-bit
+   * integer.
+   *
+   * @return number of blocks reported as successfully fetched or inserted thus far.
+   */
   public int getFetchedBlocks() {
     return fetchedBlocks;
   }
 
   /**
-   * @deprecated Use {@link #getLastSuccess()} instead.
+   * Returns a defensive copy of the last success timestamp.
+   *
+   * <p>The timestamp records the moment when the most recent block, or the whole request,
+   * succeeded. A {@code null} value indicates that no successes have occurred yet. Callers receive
+   * a clone to avoid mutating internal state and may safely retain the returned {@link Date} for
+   * formatting or auditing purposes.
+   *
+   * @return cloned {@link Date} of the last success, or {@code null} if none occurred.
    */
-  @Deprecated
-  public long getLastActivity() {
-    return latestSuccess != null ? latestSuccess.getTime() : 0;
-  }
-
   public Date getLastSuccess() {
     // clone() because Date is mutable.
     return latestSuccess != null ? (Date) latestSuccess.clone() : null;
   }
 
+  /**
+   * Returns a defensive copy of the most recent failure timestamp.
+   *
+   * <p>The value is updated whenever {@link #updateStatus(SplitfileProgressEvent)} records a fatal
+   * or transient failure. A {@code null} timestamp indicates a failure-free run so far. The clone
+   * is safe to retain beyond the lifespan of the status object and is suitable for logging or
+   * alerting without additional synchronization.
+   *
+   * @return cloned {@link Date} representing the last failure, or {@code null} if nothing failed.
+   */
   public Date getLastFailure() {
     // clone() because Date is mutable.
     return latestFailure != null ? (Date) latestFailure.clone() : null;
   }
 
-  /** Get the original URI for a fetch or the final URI for an insert. */
+  /**
+   * Returns the canonical {@link FreenetURI} related to this request.
+   *
+   * <p>Fetch requests report their original key while insert requests typically report the final
+   * key assigned by the network once the data becomes addressable. Implementations must guarantee
+   * that the returned URI accurately identifies the user-visible resource because UI and logging
+   * layers surface it directly to end users.
+   *
+   * @return immutable Freenet URI representing the resource being transferred.
+   */
   public abstract FreenetURI getURI();
 
+  /**
+   * Provides the expected payload size expressed in bytes.
+   *
+   * <p>Depending on the request type this value may come from manifest metadata or from a known
+   * insert source. Subclasses should return {@code -1} when the size is unknown. Callers use the
+   * information to preallocate disk space, enforce quotas, and display human-readable progress
+   * indicators with estimated time remaining.
+   *
+   * @return non-negative number of bytes when known, or {@code -1} if indeterminate.
+   */
   public abstract long getDataSize();
 
+  /**
+   * Indicates whether the request is configured to persist indefinitely across restarts.
+   *
+   * <p>Requests marked {@link Persistence#FOREVER} remain queued until they succeed or are manually
+   * cancelled. Use this helper to distinguish between opportunistic and durable queue entries, and
+   * to surface warnings when users attempt to delete persistent jobs.
+   *
+   * @return {@code true} if the persistence policy equals {@link Persistence#FOREVER}.
+   */
   public boolean isPersistentForever() {
     return persistence == Persistence.FOREVER;
   }
 
+  /**
+   * States whether the request survives beyond the current FCP connection.
+   *
+   * <p>Persistent requests may be resumed after reconnecting, while {@link Persistence#CONNECTION}
+   * requests are automatically cleaned up when the client disconnects. UI layers use this flag to
+   * filter short-lived jobs and to warn users that connection-bound requests will disappear when
+   * the session closes.
+   *
+   * @return {@code true} if the underlying persistence policy is not {@link
+   *     Persistence#CONNECTION}.
+   */
   public boolean isPersistent() {
     return persistence != Persistence.CONNECTION;
   }
 
+  /**
+   * Returns how many blocks have failed irrecoverably.
+   *
+   * <p>Fatal failures usually indicate data corruption or exceeding retry limits. Once recorded,
+   * they count against {@link #getMinBlocks()} and are never retried. Monitoring tools can use the
+   * value to escalate user prompts when recovery appears impossible and to recommend cancelling the
+   * job if redundancy has been exhausted.
+   *
+   * @return count of permanently failed blocks for the request.
+   */
   public int getFatalyFailedBlocks() {
     return fatallyFailedBlocks;
   }
 
+  /**
+   * Returns the number of blocks that failed but may still succeed on retry.
+   *
+   * <p>Splitfile processing often experiences transient failures due to routing issues. These are
+   * captured here until a retry resolves them, or they transition into fatal failures. Operators
+   * can compare this counter with the number of running retries to gauge whether additional
+   * bandwidth is required.
+   *
+   * @return count of retryable failed blocks currently tracked.
+   */
   public int getFailedBlocks() {
     return failedBlocks;
   }
 
-  public boolean isStarted() {
+  /**
+   * Indicates whether the request lifecycle has already started transferring data.
+   *
+   * <p>The value is synchronized because {@link #setStarted(boolean)} may toggle it under lock
+   * while state transitions occur. Callers can use the flag to distinguish between queued and
+   * actively running jobs for display or scheduling purposes.
+   *
+   * @return {@code true} when the request progressed beyond submission; {@code false} otherwise.
+   */
+  public synchronized boolean isStarted() {
     return hasStarted;
   }
 
+  /**
+   * Returns a human-readable explanation for the latest failure.
+   *
+   * <p>Implementations should provide concise summaries when {@code longDescription} is {@code
+   * false} and more verbose diagnostics otherwise. The text is typically surfaced in user-visible
+   * logs or protocol replies and should therefore avoid leaking sensitive information. Where
+   * possible, include actionable hints such as retry advice or error tokens that map to help pages.
+   *
+   * @param longDescription {@code true} to request detailed diagnostics; {@code false} for concise
+   *     summaries.
+   * @return explanatory text describing the failure state, or {@code null} when unknown.
+   */
   public abstract String getFailureReason(boolean longDescription);
 
+  /**
+   * Applies a {@link SplitfileProgressEvent} snapshot to this status while holding the monitor.
+   *
+   * <p>The method copies counters and timestamp clones from the event, ensuring that listeners see
+   * up-to-date block statistics and lifecycle information. Callers must already ensure that events
+   * arrive in order for a given request because this method assumes monotonic progress when
+   * updating fields such as {@link #minBlocks} and {@link #totalBlocks}.
+   *
+   * @param event event emitted by the splitter describing current block, failure, and success
+   *     counts; must not be {@code null}.
+   */
   public synchronized void updateStatus(SplitfileProgressEvent event) {
     this.failedBlocks = event.failedBlocks;
     this.fatallyFailedBlocks = event.fatallyFailedBlocks;
@@ -207,25 +445,56 @@ public abstract class RequestStatus {
     this.totalBlocks = event.totalBlocks;
   }
 
+  /**
+   * Updates the scheduler priority while holding the intrinsic lock.
+   *
+   * <p>Invocations originate from user commands or automatic QoS adjustments. The value takes
+   * effect immediately for subsequent queue decisions, so callers should avoid oscillating the
+   * priority rapidly. No validation is performed beyond storing the primitive; schedulers interpret
+   * the numeric range according to their own policy documents.
+   *
+   * @param newPriority priority value to commit verbatim; callers must keep it within configured
+   *     bounds.
+   */
   public synchronized void setPriority(short newPriority) {
     this.priority = newPriority;
   }
 
+  /**
+   * Marks whether the request has begun execution.
+   *
+   * <p>The flag usually transitions to {@code true} when the worker thread picks up the job and may
+   * be reset via {@link #restart(boolean)}. Because external observers may poll {@link
+   * #isStarted()}, the change occurs under synchronization, ensuring that readers never observe
+   * half-applied transitions.
+   *
+   * @param started {@code true} when work has begun; {@code false} when queued.
+   */
   public synchronized void setStarted(boolean started) {
     this.hasStarted = started;
   }
 
   /**
-   * Get the preferred filename, from the URI, the filename, etc.
+   * Resolves the best-effort filename associated with the request.
    *
-   * @return A filename or null if not enough information to give one.
+   * <p>Implementations may derive the value from URI metadata, client-provided hints, or bundle
+   * manifests. Return {@code null} when no meaningful filename is available, and avoid embedding
+   * directory separators so callers can use the value directly for display or export prompts.
+   * Implementations may also normalize whitespace to keep UI layout predictable across locales.
+   *
+   * @return preferred filename or {@code null} when insufficient information exists.
    */
   public abstract String getPreferredFilename();
 
   /**
-   * Get the preferred filename, from the URI or the filename etc.
+   * Returns a non-null filename suitable for UI display or local storage prompts.
    *
-   * @return A filename, including the localised version of "unknown" if we don't know enough.
+   * <p>This helper delegates to {@link #getPreferredFilename()} and substitutes a localized
+   * placeholder when the request lacks naming metadata. It never throws and therefore simplifies UI
+   * code that merely needs some label while the transfer is pending, even for requests that never
+   * revealed a meaningful name.
+   *
+   * @return filename from {@link #getPreferredFilename()} or a localized "unknown" placeholder.
    */
   public String getPreferredFilenameSafe() {
     String ret = getPreferredFilename();
@@ -234,8 +503,14 @@ public abstract class RequestStatus {
   }
 
   /**
-   * Create an immutable snapshot of this request status. Subclasses must return a new instance so
-   * callers can safely access the snapshot outside of internal locks.
+   * Creates an immutable snapshot of this request status.
+   *
+   * <p>Subclasses must return a brand-new instance populated through the copy constructor so
+   * callers can safely retain the snapshot outside internal locks. Implementations typically add
+   * their own subclass-specific cloning semantics before returning the result, often copying URI
+   * and payload metadata alongside the core fields stored here.
+   *
+   * @return fresh snapshot reflecting the state at invocation time.
    */
   public abstract RequestStatus copy();
 }

--- a/src/main/java/network/crypta/clients/fcp/RequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatus.java
@@ -17,7 +17,7 @@ import network.crypta.l10n.NodeL10n;
  *
  * @author toad
  */
-public abstract class RequestStatus implements Cloneable {
+public abstract class RequestStatus {
 
   private final String identifier;
   private boolean hasStarted;
@@ -97,6 +97,24 @@ public abstract class RequestStatus implements Cloneable {
     this.latestFailure = latestFailure != null ? (Date) latestFailure.clone() : null;
     this.isTotalFinalized = totalFinalized;
     this.persistence = persistence;
+  }
+
+  /** Copy constructor used by subclasses to provide defensive snapshots. */
+  protected RequestStatus(RequestStatus source) {
+    this.identifier = source.identifier;
+    this.persistence = source.persistence;
+    this.hasStarted = source.hasStarted;
+    this.hasFinished = source.hasFinished;
+    this.hasSucceeded = source.hasSucceeded;
+    this.priority = source.priority;
+    this.totalBlocks = source.totalBlocks;
+    this.minBlocks = source.minBlocks;
+    this.fetchedBlocks = source.fetchedBlocks;
+    this.latestSuccess = source.latestSuccess != null ? (Date) source.latestSuccess.clone() : null;
+    this.fatallyFailedBlocks = source.fatallyFailedBlocks;
+    this.failedBlocks = source.failedBlocks;
+    this.latestFailure = source.latestFailure != null ? (Date) source.latestFailure.clone() : null;
+    this.isTotalFinalized = source.isTotalFinalized;
   }
 
   public boolean hasSucceeded() {
@@ -215,11 +233,9 @@ public abstract class RequestStatus implements Cloneable {
     else return ret;
   }
 
-  public RequestStatus clone() {
-    try {
-      return (RequestStatus) super.clone();
-    } catch (CloneNotSupportedException e) {
-      throw new Error(e);
-    }
-  }
+  /**
+   * Create an immutable snapshot of this request status. Subclasses must return a new instance so
+   * callers can safely access the snapshot outside of internal locks.
+   */
+  public abstract RequestStatus copy();
 }

--- a/src/main/java/network/crypta/clients/fcp/RequestStatusCache.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatusCache.java
@@ -154,7 +154,7 @@ public class RequestStatusCache {
   public synchronized void addTo(List<RequestStatus> status) {
     // FIXME is it better to just synchronize on the RequestStatusCache when
     // rendering the downloads page, and when updating? Ugly though ...
-    for (RequestStatus req : requestsByIdentifier.values()) status.add(req.clone());
+    for (RequestStatus req : requestsByIdentifier.values()) status.add(req.copy());
   }
 
   public synchronized void updateExpectedMIME(String identifier, String foundDataMimeType) {

--- a/src/main/java/network/crypta/clients/fcp/UploadDirRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadDirRequestStatus.java
@@ -54,6 +54,12 @@ public class UploadDirRequestStatus extends UploadRequestStatus {
     this.totalFiles = files;
   }
 
+  private UploadDirRequestStatus(UploadDirRequestStatus source) {
+    super(source);
+    this.totalDataSize = source.totalDataSize;
+    this.totalFiles = source.totalFiles;
+  }
+
   private final long totalDataSize;
   private final int totalFiles;
 
@@ -68,5 +74,10 @@ public class UploadDirRequestStatus extends UploadRequestStatus {
   @Override
   public long getDataSize() {
     return totalDataSize;
+  }
+
+  @Override
+  public UploadDirRequestStatus copy() {
+    return new UploadDirRequestStatus(this);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/UploadDirRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadDirRequestStatus.java
@@ -5,8 +5,90 @@ import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 
+/**
+ * Captures the evolving status of a site or directory upload handled through the FCP layer.
+ *
+ * <p>This status object tracks both the aggregate byte count and the number of files remaining so
+ * operators can surface long-running progress bars and quota indicators for large manifests.
+ * Callers typically obtain instances from {@link RequestStatusCache} or the various {@code
+ * ClientPutDir} flows, inspect the counters, and optionally snapshot the instance via {@link
+ * #copy()} before handing it to background reporters. All mutable state is inherited from {@link
+ * UploadRequestStatus}; this subclass simply adds directory-centric metadata such as the overall
+ * file tally. The instance relies on the superclass synchronization, so external callers should
+ * treat it as a snapshot or invoke {@link #copy()} when sharing across threads.
+ *
+ * <p>Typical lifecycle:
+ *
+ * <ul>
+ *   <li>Constructed when a directory insert is scheduled or restored from persistence.
+ *   <li>Polled repeatedly by monitoring endpoints to retrieve byte counts and failure reasons.
+ *   <li>Copied and published once the upload finishes or when UI code needs an immutable view.
+ * </ul>
+ *
+ * <p>The {@link #getTotalDataSize()} and {@link #getNumberOfFiles()} metrics represent best-known
+ * estimates for the pending upload. They may change as manifests expand, but once {@link
+ * RequestStatus#isTotalFinalized()} is true the values stabilize and can be archived alongside
+ * audit logs. Use {@link #getDataSize()} when the caller does not care whether the data originated
+ * from a directory or a single file.
+ */
 public class UploadDirRequestStatus extends UploadRequestStatus {
 
+  /**
+   * Creates a new mutable directory upload status populated with the supplied counters and
+   * metadata.
+   *
+   * <p>Callers should pass the latest known values when resuming persisted work or creating a fresh
+   * request so user interfaces immediately display accurate estimates. All timestamps are
+   * defensively copied by the superclass. The {@code size} and {@code files} arguments represent
+   * the aggregate payload of the directory tree and may be zero for empty manifests.
+   *
+   * <pre>{@code
+   * UploadDirRequestStatus status = new UploadDirRequestStatus(...);
+   * cache.put(status.getIdentifier(), status);
+   * }</pre>
+   *
+   * @param identifier unique string used to correlate request updates across the FCP layer; must
+   *     remain stable for the lifetime of the upload.
+   * @param persistence persistence mode describing whether the upload survives disconnections or
+   *     restarts; see {@link ClientRequest.Persistence} for the allowed values.
+   * @param started {@code true} when the underlying splitter already began transferring data;
+   *     otherwise {@code false} so new listeners know the request is dormant.
+   * @param finished flag indicating whether the upload is already in a terminal state at the moment
+   *     this status object is created.
+   * @param success outcome marker that is meaningful only when {@code finished} is {@code true}; it
+   *     reports whether the insert succeeded without fatal errors.
+   * @param total number of blocks currently known for the insert, typically the splitfile total or
+   *     an estimated upper bound.
+   * @param min minimum block count needed before the request can be considered complete even if the
+   *     total grows later.
+   * @param fetched number of blocks that have been successfully inserted so far; used for progress
+   *     ratios and ETA calculations.
+   * @param latestSuccess timestamp of the most recent successful block or finalization event; may
+   *     be {@code null} if nothing has succeeded yet.
+   * @param fatal number of blocks that permanently failed and will not be retried any further.
+   * @param failed number of retryable blocks that have failed so far but could still succeed on the
+   *     next attempt.
+   * @param latestFailure timestamp of the most recent failure notification; {@code null} when no
+   *     failures have occurred.
+   * @param totalFinalized {@code true} when {@code total} is final and additional blocks will not
+   *     be discovered by the splitter.
+   * @param prio scheduler priority controlling how the request competes for bandwidth relative to
+   *     other uploads.
+   * @param finalURI published {@link FreenetURI} when the upload already committed; may be {@code
+   *     null} until completion.
+   * @param targetURI desired {@link FreenetURI} originally requested by the client; usually
+   *     non-null even before the final URI exists.
+   * @param failureCode machine-readable failure classification explaining why the last attempt
+   *     failed; can be {@code null} when no error occurred.
+   * @param failureReasonShort concise failure description suitable for tables or notifications;
+   *     {@code null} when no failure is known.
+   * @param failureReasonLong long-form failure explanation for logs, REST responses, or verbose
+   *     status pages.
+   * @param size aggregate payload size of the directory in bytes; callers may pass zero to indicate
+   *     an empty manifest or unknown size.
+   * @param files total number of files scheduled for insertion at this time; may be zero for
+   *     metadata-only structures.
+   */
   public UploadDirRequestStatus(
       String identifier,
       Persistence persistence,
@@ -63,19 +145,48 @@ public class UploadDirRequestStatus extends UploadRequestStatus {
   private final long totalDataSize;
   private final int totalFiles;
 
+  /**
+   * Reports the best-known aggregate byte size for the directory upload.
+   *
+   * <p>The value mirrors {@link #getDataSize()} but remains available under a dedicated accessor so
+   * UI code can distinguish directory uploads from single-file inserts. It is not recomputed on the
+   * fly; callers should treat it as a cached estimate and refresh from a newer status when
+   * manifests change.
+   *
+   * @return number of bytes that the directory is expected to consume, or zero for empty uploads.
+   */
   public long getTotalDataSize() {
-    return totalDataSize;
+    return getDataSize();
   }
 
+  /**
+   * Returns how many files are currently expected to be inserted within this directory request.
+   *
+   * <p>The count includes every file discovered by the manifest so far, including nested paths.
+   * Zero indicates either an empty directory or an as-yet unknown file list. The value is a
+   * snapshot that may change when the underlying client discovers more files.
+   *
+   * @return total number of files scheduled for upload, or zero when unknown/empty.
+   */
   public int getNumberOfFiles() {
     return totalFiles;
   }
 
+  /** {@inheritDoc} */
   @Override
   public long getDataSize() {
     return totalDataSize;
   }
 
+  /**
+   * Produces a detached snapshot of this status, including directory-specific metadata.
+   *
+   * <p>Use this when publishing state to other threads or remote clients to avoid exposing the
+   * mutable instance managed by worker code. The resulting copy never shares mutable references, so
+   * future calls to mutators on the original do not affect the snapshot.
+   *
+   * @return new status instance mirroring the current values while remaining immutable thereafter.
+   */
   @Override
   public UploadDirRequestStatus copy() {
     return new UploadDirRequestStatus(this);

--- a/src/main/java/network/crypta/clients/fcp/UploadFileRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadFileRequestStatus.java
@@ -69,6 +69,14 @@ public class UploadFileRequestStatus extends UploadRequestStatus {
     this.compressing = compressing;
   }
 
+  private UploadFileRequestStatus(UploadFileRequestStatus source) {
+    super(source);
+    this.dataSize = source.dataSize;
+    this.mimeType = source.mimeType;
+    this.origFilename = source.origFilename;
+    this.compressing = source.compressing;
+  }
+
   @Override
   public long getDataSize() {
     return dataSize;
@@ -95,5 +103,10 @@ public class UploadFileRequestStatus extends UploadRequestStatus {
     String s = super.getPreferredFilename();
     if (s == null && origFilename != null) return origFilename.getName();
     return s;
+  }
+
+  @Override
+  public UploadFileRequestStatus copy() {
+    return new UploadFileRequestStatus(this);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/UploadFileRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadFileRequestStatus.java
@@ -7,7 +7,31 @@ import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 
-/** Cached status of a file upload */
+/**
+ * Captures the evolving status of a single file upload handled through the FCP client API.
+ *
+ * <p>This specialization of {@link UploadRequestStatus} preserves metadata that only exists for
+ * file-based inserts, including byte size estimates, MIME typing hints, and the originating
+ * filename if one was provided by the submitting client. Instances are created by the request cache
+ * to mirror the lifecycle of {@code ClientPut} operations and remain mutable while the upload runs.
+ * Consumer code typically reads these objects via the status cache to drive web UIs, command-line
+ * monitors, or plugin notifications without keeping strong references to the live request.
+ *
+ * <p>The class is intentionally lightweight and thread-safe for concurrent readers: the mutable
+ * compression state is guarded by {@link #updateCompressionStatus(ClientPut.COMPRESS_STATE)}, while
+ * other fields are immutable snapshots taken when the cache entry was constructed. Callers should
+ * therefore re-query periodically rather than holding on to references that may become stale after
+ * a restart or when a worker thread commits the final URI.
+ *
+ * <ul>
+ *   <li>Tracks MIME type and human-friendly filename hints so download dialogs can present sane
+ *       defaults.
+ *   <li>Spans the entire compression pipeline by reflecting whether the request waits, compresses,
+ *       or already streams encrypted blocks.
+ *   <li>Offers deterministic {@link #copy()} snapshots, allowing callers to hand status objects to
+ *       other components without additional synchronization.
+ * </ul>
+ */
 public class UploadFileRequestStatus extends UploadRequestStatus {
 
   private final long dataSize;
@@ -77,27 +101,95 @@ public class UploadFileRequestStatus extends UploadRequestStatus {
     this.compressing = source.compressing;
   }
 
+  /**
+   * Reports the number of bytes queued for insertion as captured when the status was created.
+   *
+   * <p>The size originates from the {@code ClientPut} metadata and therefore reflects the entire
+   * payload, including any directories that were flattened prior to compression. The value does not
+   * change after construction because the upload scheduler treats the request as immutable once
+   * block enumeration finishes. Callers should treat the number as advisory for progress bars and
+   * be aware that certain streaming uploads may not know their final size upfront.
+   *
+   * @return positive byte count representing the payload, or {@code 0} when no estimate was
+   *     available at scheduling time.
+   */
   @Override
   public long getDataSize() {
     return dataSize;
   }
 
+  /**
+   * Exposes the MIME type hint that accompanied the upload request.
+   *
+   * <p>The MIME value helps downstream components choose appropriate content handlers and inform
+   * GUI clients whether a file likely contains text, images, or opaque binary data. The type is not
+   * revalidated; it simply mirrors the user-supplied value (or the detector result) captured in the
+   * {@code ClientPut}. Implementations retain the raw string so callers may apply their own parsing
+   * or subtype matching logic.
+   *
+   * @return textual MIME identifier such as {@code "text/plain"}, or {@code null} when the client
+   *     submitted no type information.
+   */
   public String getMIMEType() {
     return mimeType;
   }
 
+  /**
+   * Returns the on-disk filename that originated the upload when such a file existed.
+   *
+   * <p>The value is particularly helpful when the preferred filename cannot be inferred from URIs;
+   * in that case callers fall back to {@link File#getName()} to pre-populate save dialogs. When the
+   * upload came from a temporary bucket rather than user storage this method returns {@code null},
+   * signaling that no stable human-friendly name is available.
+   *
+   * @return {@link File} pointing at the source path, or {@code null} when the data originates from
+   *     an anonymous or transient bucket.
+   */
   public File getOrigFilename() {
     return origFilename;
   }
 
+  /**
+   * Reveals the current compression stage as observed by the request cache.
+   *
+   * <p>The compression state helps UIs distinguish whether the request waits for CPU resources,
+   * actively compresses, or already streams encrypted blocks into the network. The value is updated
+   * by {@link ClientPut} whenever significant transitions occur and therefore reflects a
+   * best-effort view that may lag behind the most recent worker thread change. Consumers should use
+   * the enumeration primarily for user feedback instead of implementing scheduling logic.
+   *
+   * @return {@link COMPRESS_STATE} describing waiting, compressing, or working behavior; never
+   *     {@code null} after the status was initialized.
+   */
   public COMPRESS_STATE isCompressing() {
     return compressing;
   }
 
+  /**
+   * Updates the cached compression state in a thread-safe manner.
+   *
+   * <p>This method is invoked exclusively by {@code RequestStatusCache} wiring or worker threads to
+   * publish stage transitions. It intentionally performs no validation because the caller already
+   * determines the canonical state.
+   *
+   * @param status the most recent {@link COMPRESS_STATE} reported by the upload pipeline.
+   */
   synchronized void updateCompressionStatus(COMPRESS_STATE status) {
     compressing = status;
   }
 
+  /**
+   * Suggests the most appropriate filename for user interfaces that expose downloads or logs.
+   *
+   * <p>The method first delegates to {@link UploadRequestStatus#getPreferredFilename()} so URI
+   * metadata (document names or meta strings) wins whenever the insert explicitly advertised a
+   * label. If no URI-derived hint exists, the method falls back to {@link #getOrigFilename()} and
+   * returns the basename of the originating file. This guarantees deterministic filenames even when
+   * the upload stemmed from a directory flattening stage with limited metadata.
+   *
+   * @return sanitized filename assembled from URIs or, if unavailable, the original local file
+   *     name; {@code null} when neither source exposes a usable value.
+   */
   @Override
   public String getPreferredFilename() {
     String s = super.getPreferredFilename();
@@ -105,6 +197,17 @@ public class UploadFileRequestStatus extends UploadRequestStatus {
     return s;
   }
 
+  /**
+   * Creates an immutable snapshot of this status suitable for hand-off to external callers.
+   *
+   * <p>The returned instance duplicates every scalar and reference visible to clients, including
+   * compression state, so it remains stable even if the originating request continues to mutate
+   * while the snapshot is in use. This is the preferred way to expose status data over APIs because
+   * it upholds the copy-on-read contract assumed by {@link RequestStatusCache}.
+   *
+   * @return a new {@link UploadFileRequestStatus} containing the same values observed at the moment
+   *     {@code copy()} was invoked.
+   */
   @Override
   public UploadFileRequestStatus copy() {
     return new UploadFileRequestStatus(this);

--- a/src/main/java/network/crypta/clients/fcp/UploadRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadRequestStatus.java
@@ -57,6 +57,15 @@ public abstract class UploadRequestStatus extends RequestStatus {
     this.failureReasonLong = failureReasonLong;
   }
 
+  protected UploadRequestStatus(UploadRequestStatus source) {
+    super(source);
+    this.finalURI = source.finalURI;
+    this.targetURI = source.targetURI;
+    this.failureCode = source.failureCode;
+    this.failureReasonShort = source.failureReasonShort;
+    this.failureReasonLong = source.failureReasonLong;
+  }
+
   synchronized void setFinished(
       boolean success,
       FreenetURI finalURI,

--- a/src/main/java/network/crypta/clients/fcp/UploadRequestStatus.java
+++ b/src/main/java/network/crypta/clients/fcp/UploadRequestStatus.java
@@ -5,7 +5,36 @@ import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 
-/** Base class for cached status of uploads */
+/**
+ * Represents the cached, queryable status of a client upload handled through the FCP interface.
+ *
+ * <p>Instances of this class mirror the life-cycle of {@link ClientRequest} objects: they persist
+ * identifiers, byte counts, timing information, and the last known outcome so user interfaces and
+ * monitoring endpoints can present progress even after a restart. A status object can be queried at
+ * any time to determine whether an insert has started, whether it finished successfully, and which
+ * human-readable explanations should be surfaced when failures happened.
+ *
+ * <p>The state captured here is mutable for as long as the upload proceeds. Callers must expect the
+ * fields to change concurrently as worker threads finalize inserts or propagate fatal errors. This
+ * class therefore exposes synchronized accessors for the derived URI data while leaving other
+ * counters to be managed by {@link RequestStatus}. Consumers should treat the exposed references as
+ * snapshots rather than authoritative handles and re-query when presenting long-running UI flows.
+ *
+ * <ul>
+ *   <li>Tracks both the desired target URI and the final published URI.
+ *   <li>Records summary and verbose failure descriptions.
+ *   <li>Provides helper logic for deriving a preferred filename for client dialogs.
+ * </ul>
+ *
+ * <pre>{@code
+ * UploadRequestStatus status = cache.lookup(identifier);
+ * if (status.getFinalURI() != null) {
+ *   ui.showResult(status.getFinalURI());
+ * }
+ * }</pre>
+ *
+ * @see RequestStatus
+ */
 public abstract class UploadRequestStatus extends RequestStatus {
 
   private FreenetURI finalURI;
@@ -57,6 +86,17 @@ public abstract class UploadRequestStatus extends RequestStatus {
     this.failureReasonLong = failureReasonLong;
   }
 
+  /**
+   * Initializes a new status instance that mirrors the values contained in another entry.
+   *
+   * <p>This copy constructor is primarily used when code needs to offer callers a detached snapshot
+   * while keeping the original object mutable for internal bookkeeping. The source status is read
+   * once at construction time, so future mutations applied to either instance do not propagate to
+   * the other. This is useful when a status is inserted into caches or published to remote clients
+   * and should no longer be affected by worker-thread updates.
+   *
+   * @param source status entry to duplicate, typically the live, mutable record managed internally
+   */
   protected UploadRequestStatus(UploadRequestStatus source) {
     super(source);
     this.finalURI = source.finalURI;
@@ -79,22 +119,83 @@ public abstract class UploadRequestStatus extends RequestStatus {
     this.failureReasonLong = failureReasonLong;
   }
 
-  public FreenetURI getFinalURI() {
+  /**
+   * Returns the URI that was ultimately published by the upload, if a value exists yet.
+   *
+   * <p>The reference represents the canonical URI under which the inserted data became available.
+   * When the upload is still running or failed before committing, the value may be {@code null} and
+   * callers should fall back to {@link #getTargetURI()}. Thread-safety is guaranteed through the
+   * synchronized accessor because the URI is frequently updated by worker threads upon completion
+   * or retry of an insert.
+   *
+   * @return immutable {@link FreenetURI} describing the published location, or {@code null} when
+   *     the upload has not produced a final handle
+   */
+  public synchronized FreenetURI getFinalURI() {
     return finalURI;
   }
 
+  /**
+   * Provides the originally requested URI, allowing clients to distinguish intent from outcomes.
+   *
+   * <p>This value is stable for the lifetime of the status entry and typically represents the key
+   * chosen by the user or remote caller. Even when {@link #getFinalURI()} returns {@code null}, the
+   * target value helps diagnose routing decisions, index selections, and access rights. It is never
+   * modified after construction, so the returned instance can safely be cached or inspected without
+   * extra synchronization.
+   *
+   * @return immutable {@link FreenetURI} representing the user-requested target, or {@code null} if
+   *     the request was synthesized without a specific key
+   */
   public FreenetURI getTargetURI() {
     return targetURI;
   }
 
+  /**
+   * Retrieves the URI that best reflects the current completion state for this upload.
+   *
+   * <p>The method first consults {@link #getFinalURI()} to surface a completed handle and falls
+   * back to the target URI if no final value is yet available. Callers that only need a single URI
+   * to display can use this helper instead of performing the null-check logic themselves. The
+   * returned reference must be treated as a snapshot, because concurrent updates may expose a final
+   * URI after this method returns.
+   *
+   * @return {@link FreenetURI} reporting either the finalized or intended key, or {@code null} when
+   *     neither exists
+   */
   @Override
   public FreenetURI getURI() {
-    return finalURI;
+    return getFinalURI();
   }
 
+  /**
+   * Reports the size of the payload that this upload attempts to publish, expressed in bytes.
+   *
+   * <p>Implementations should provide the best-known estimate so that progress meters and client
+   * heuristics can reason about completion ratios. The value may be final, rounded, or only an
+   * early guess depending on how the derived subclass acquires metadata. Callers should therefore
+   * treat it as advisory and may re-query if the associated {@link ClientRequest} enumerates
+   * additional segments later in its life-cycle.
+   *
+   * @return positive byte count describing content length, or zero when no estimate exists yet
+   */
   @Override
   public abstract long getDataSize();
 
+  /**
+   * Obtains the most recent textual explanation describing why the upload failed or stalled.
+   *
+   * <p>The status maintains both concise and expanded variants so different presentation layers can
+   * select an appropriate verbosity. The short text typically fits notifications or compact tables,
+   * while the long text is suitable for logs, REST responses, or troubleshooting dialogs. Messages
+   * are updated whenever the associated request transitions into a fatal state, so callers should
+   * not cache the result unless they also snapshot the surrounding {@link RequestStatus} fields.
+   *
+   * @param longDescription {@code true} to request the expanded explanation, {@code false} for the
+   *     concise human-readable summary
+   * @return descriptive message conveying the observed failure, or {@code null} when no failure is
+   *     recorded yet
+   */
   @Override
   public String getFailureReason(boolean longDescription) {
     return longDescription ? failureReasonLong : failureReasonShort;
@@ -104,6 +205,19 @@ public abstract class UploadRequestStatus extends RequestStatus {
     this.finalURI = finalURI2;
   }
 
+  /**
+   * Suggests a filename derived from the known URIs for display in client save dialogs.
+   *
+   * <p>The method inspects the final URI first to honor any filenames assigned by the completed
+   * insert, including meta strings distributed through Freenet. If the upload has not produced a
+   * final URI, it falls back to the target URI so callers can still infer a meaningful label, for
+   * example when pre-populating a download request. No normalization is performed beyond delegating
+   * to {@link FreenetURI#getPreferredFilename()}, therefore callers should sanitize values before
+   * writing them to disk.
+   *
+   * @return filename hint derived from meta strings or doc names, or {@code null} when neither URI
+   *     contains sufficient metadata
+   */
   @Override
   public String getPreferredFilename() {
     FreenetURI uri = getFinalURI();

--- a/src/test/java/network/crypta/clients/fcp/DownloadRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DownloadRequestStatusTest.java
@@ -1,0 +1,237 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.Date;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class DownloadRequestStatusTest {
+
+  @Mock private Bucket initialShadow;
+
+  private static final String IDENTIFIER = "req-1";
+  private static final short PRIORITY = 3;
+  private static final CompatibilityMode[] COMPAT_SAMPLE =
+      new CompatibilityMode[] {CompatibilityMode.COMPAT_1250};
+  private static final byte[] SPLITFILE_KEY = new byte[] {1, 2, 3};
+
+  @Test
+  void toTempSpace_whenDestFilenameMissing_returnsTrue() {
+    DownloadRequestStatus status =
+        buildStatus(null, new FreenetURI("KSK", "index.html"), false, initialShadow);
+
+    assertTrue(status.toTempSpace());
+  }
+
+  @Test
+  void toTempSpace_whenDestFilenamePresent_returnsFalse() {
+    File destination = new File("/tmp/result.dat");
+    DownloadRequestStatus status =
+        buildStatus(destination, new FreenetURI("KSK", "index.html"), false, initialShadow);
+
+    assertFalse(status.toTempSpace());
+    assertSame(destination, status.getDestFilename());
+  }
+
+  @Test
+  void getPreferredFilename_whenDestFileExists_returnsBasename() {
+    File destination = new File("/var/tmp/archive.tar");
+    DownloadRequestStatus status =
+        buildStatus(destination, new FreenetURI("KSK", "main.html"), false, initialShadow);
+
+    assertEquals("archive.tar", status.getPreferredFilename());
+  }
+
+  @Test
+  void getPreferredFilename_whenUriProvidesNames_usesUriPreferredName() {
+    DownloadRequestStatus status =
+        buildStatus(null, new FreenetURI("KSK", "main-page.html"), false, initialShadow);
+
+    assertEquals("main-page.html", status.getPreferredFilename());
+  }
+
+  @Test
+  void getPreferredFilename_whenUriLacksMetadata_returnsNull() {
+    DownloadRequestStatus status =
+        buildStatus(null, new FreenetURI("CHK", null), false, initialShadow);
+
+    assertNull(status.getPreferredFilename());
+  }
+
+  @Test
+  void detectedDontCompress_whenConstructedWithFlag_propagatesValue() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), true, initialShadow);
+
+    assertTrue(status.detectedDontCompress());
+  }
+
+  @Test
+  void getFailureReason_whenShortRequested_returnsShortText() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), false, initialShadow);
+
+    assertEquals("Short reason", status.getFailureReason(false));
+  }
+
+  @Test
+  void getFailureReason_whenLongRequested_returnsLongText() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), false, initialShadow);
+
+    assertEquals("Detailed long reason", status.getFailureReason(true));
+  }
+
+  @Test
+  void setFinished_whenCalled_updatesTerminalFieldsAndFlags() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), false, initialShadow);
+    Bucket completedBucket = org.mockito.Mockito.mock(Bucket.class);
+
+    status.setFinished(
+        true,
+        2048L,
+        "image/png",
+        FetchExceptionMode.CONTENT_HASH_FAILED,
+        "new long",
+        "new short",
+        completedBucket,
+        true);
+
+    assertTrue(status.hasFinished());
+    assertTrue(status.hasSucceeded());
+    assertEquals(2048L, status.getDataSize());
+    assertEquals("image/png", status.getMIMEType());
+    assertEquals(FetchExceptionMode.CONTENT_HASH_FAILED, status.getFailureCode());
+    assertEquals("new short", status.getFailureReason(false));
+    assertEquals("new long", status.getFailureReason(true));
+    assertSame(completedBucket, status.getDataShadow());
+    assertTrue(status.filterData);
+  }
+
+  @Test
+  void updateDetectedCompatModes_whenCalled_replacesModesAndDontCompressFlag() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), false, initialShadow);
+    CompatibilityMode[] newModes =
+        new CompatibilityMode[] {CompatibilityMode.COMPAT_1255, CompatibilityMode.COMPAT_1468};
+
+    status.updateDetectedCompatModes(newModes, true);
+
+    assertSame(newModes, status.getCompatibilityMode());
+    assertTrue(status.detectedDontCompress());
+  }
+
+  @Test
+  void updateDetectedSplitfileKey_whenCalled_replacesKeyReference() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), false, initialShadow);
+    byte[] newKey = new byte[] {9, 8, 7};
+
+    status.updateDetectedSplitfileKey(newKey);
+
+    assertSame(newKey, status.getOverriddenSplitfileCryptoKey());
+  }
+
+  @Test
+  void updateExpectedFields_whenCalled_updatesMimeAndLength() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), false, initialShadow);
+
+    status.updateExpectedMIME("application/json");
+    status.updateExpectedDataLength(8192L);
+
+    assertEquals("application/json", status.getMIMEType());
+    assertEquals(8192L, status.getDataSize());
+  }
+
+  @Test
+  void redirect_whenCalled_updatesUri() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), false, initialShadow);
+    FreenetURI redirected = new FreenetURI("KSK", "new-doc.txt");
+
+    status.redirect(redirected);
+
+    assertSame(redirected, status.getURI());
+  }
+
+  @Test
+  void copy_whenInvoked_returnsDeepCopyOfMutableArrays() {
+    DownloadRequestStatus status =
+        buildStatus(
+            new File("/tmp/file.bin"), new FreenetURI("KSK", "file.bin"), false, initialShadow);
+
+    DownloadRequestStatus copy = status.copy();
+
+    assertNotSame(status, copy);
+    assertEquals(status.getDataSize(), copy.getDataSize());
+    assertArrayEquals(
+        status.getOverriddenSplitfileCryptoKey(), copy.getOverriddenSplitfileCryptoKey());
+    assertNotSame(status.getOverriddenSplitfileCryptoKey(), copy.getOverriddenSplitfileCryptoKey());
+    assertArrayEquals(status.getCompatibilityMode(), copy.getCompatibilityMode());
+    if (status.getCompatibilityMode() != null) {
+      assertNotSame(status.getCompatibilityMode(), copy.getCompatibilityMode());
+    }
+    assertEquals(status.getFailureCode(), copy.getFailureCode());
+    assertEquals(status.getFailureReason(true), copy.getFailureReason(true));
+    assertEquals(status.getFailureReason(false), copy.getFailureReason(false));
+  }
+
+  private static DownloadRequestStatus buildStatus(
+      File destination, FreenetURI uri, boolean dontCompress, Bucket dataShadow) {
+    return new DownloadRequestStatus(
+        IDENTIFIER,
+        Persistence.CONNECTION,
+        true,
+        false,
+        false,
+        10,
+        5,
+        3,
+        new Date(0L),
+        0,
+        0,
+        null,
+        true,
+        PRIORITY,
+        FetchExceptionMode.DATA_NOT_FOUND,
+        "text/plain",
+        1024L,
+        destination,
+        COMPAT_SAMPLE.clone(),
+        SPLITFILE_KEY.clone(),
+        uri,
+        "Short reason",
+        "Detailed long reason",
+        false,
+        dataShadow,
+        false,
+        dontCompress);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/UploadDirRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UploadDirRequestStatusTest.java
@@ -1,0 +1,119 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.Date;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class UploadDirRequestStatusTest {
+
+  private static final Date SUCCESS_DATE = new Date(5_000L);
+  private static final Date FAILURE_DATE = new Date(10_000L);
+
+  @Test
+  void constructor_whenInitialized_preservesDirectoryMetadata() {
+    FreenetURI finalUri = new FreenetURI("KSK", "final-index.html");
+    FreenetURI targetUri = new FreenetURI("KSK", "target-index.html");
+
+    UploadDirRequestStatus status =
+        createStatus(
+            finalUri,
+            targetUri,
+            InsertExceptionMode.COLLISION,
+            "initial short",
+            "initial long",
+            4_096L,
+            8);
+
+    assertEquals(4_096L, status.getTotalDataSize());
+    assertEquals(8, status.getNumberOfFiles());
+    assertEquals(4_096L, status.getDataSize());
+    assertEquals(finalUri, status.getFinalURI());
+    assertEquals(targetUri, status.getTargetURI());
+  }
+
+  @Test
+  void constructor_whenDirectoryEmpty_allowsZeroValues() {
+    UploadDirRequestStatus status =
+        createStatus(null, null, InsertExceptionMode.TOO_BIG, "zero short", "zero long", 0L, 0);
+
+    assertEquals(0L, status.getTotalDataSize());
+    assertEquals(0, status.getNumberOfFiles());
+    assertEquals(0L, status.getDataSize());
+  }
+
+  @Test
+  void copy_whenSourceMutates_copyRetainsSnapshot() {
+    FreenetURI initialFinalUri = new FreenetURI("KSK", "initial.html");
+    FreenetURI initialTargetUri = new FreenetURI("KSK", "target.html");
+    UploadDirRequestStatus status =
+        createStatus(
+            initialFinalUri,
+            initialTargetUri,
+            InsertExceptionMode.INTERNAL_ERROR,
+            "short",
+            "long",
+            1_024L,
+            3);
+
+    UploadDirRequestStatus copy = status.copy();
+
+    assertNotSame(status, copy);
+    assertEquals(status.getTotalDataSize(), copy.getTotalDataSize());
+    assertEquals(status.getNumberOfFiles(), copy.getNumberOfFiles());
+    assertEquals(status.getFinalURI(), copy.getFinalURI());
+    assertEquals(status.getFailureReason(false), copy.getFailureReason(false));
+    assertEquals(status.getFailureReason(true), copy.getFailureReason(true));
+
+    FreenetURI updatedFinalUri = new FreenetURI("KSK", "updated.html");
+    status.setFinished(
+        true,
+        updatedFinalUri,
+        InsertExceptionMode.BINARY_BLOB_FORMAT_ERROR,
+        "updated short",
+        "updated long");
+
+    assertEquals(initialFinalUri, copy.getFinalURI());
+    assertEquals("short", copy.getFailureReason(false));
+    assertEquals("long", copy.getFailureReason(true));
+    assertEquals(updatedFinalUri, status.getFinalURI());
+    assertEquals("updated short", status.getFailureReason(false));
+  }
+
+  private static UploadDirRequestStatus createStatus(
+      FreenetURI finalUri,
+      FreenetURI targetUri,
+      InsertExceptionMode failureCode,
+      String failureReasonShort,
+      String failureReasonLong,
+      long totalSize,
+      int files) {
+    return new UploadDirRequestStatus(
+        "identifier",
+        Persistence.REBOOT,
+        true,
+        false,
+        false,
+        20,
+        10,
+        5,
+        SUCCESS_DATE,
+        1,
+        2,
+        FAILURE_DATE,
+        true,
+        (short) 5,
+        finalUri,
+        targetUri,
+        failureCode,
+        failureReasonShort,
+        failureReasonLong,
+        totalSize,
+        files);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/UploadFileRequestStatusTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UploadFileRequestStatusTest.java
@@ -1,0 +1,146 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.File;
+import java.util.Date;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class UploadFileRequestStatusTest {
+
+  private static final Date SUCCESS_DATE = new Date(1_000L);
+  private static final Date FAILURE_DATE = new Date(2_000L);
+
+  @Test
+  void constructor_whenInitialized_preservesProvidedMetadata() {
+    File orig = new File("/tmp/out.dat");
+
+    UploadFileRequestStatus status =
+        createStatus(null, null, orig, 42L, "application/octet-stream", COMPRESS_STATE.WAITING);
+
+    assertEquals(42L, status.getDataSize());
+    assertEquals("application/octet-stream", status.getMIMEType());
+    assertSame(orig, status.getOrigFilename());
+    assertEquals(COMPRESS_STATE.WAITING, status.isCompressing());
+  }
+
+  @Test
+  void getPreferredFilename_whenSuperProvidesName_returnsUriName() {
+    FreenetURI finalUri = new FreenetURI("KSK", "final-name.txt");
+    File orig = new File("/tmp/local.bin");
+    UploadFileRequestStatus status =
+        createStatus(finalUri, null, orig, 100L, "text/plain", COMPRESS_STATE.COMPRESSING);
+
+    String preferred = status.getPreferredFilename();
+
+    assertEquals("final-name.txt", preferred);
+  }
+
+  @Test
+  void getPreferredFilename_whenSuperReturnsNull_usesOriginalFilename() {
+    File orig = new File("/tmp/report.bin");
+    UploadFileRequestStatus status =
+        createStatus(null, null, orig, 10L, "text/plain", COMPRESS_STATE.COMPRESSING);
+
+    String preferred = status.getPreferredFilename();
+
+    assertEquals("report.bin", preferred);
+  }
+
+  @Test
+  void getPreferredFilename_whenTargetHasName_prefersTargetUri() {
+    FreenetURI targetUri = new FreenetURI("KSK", "target-name.txt");
+    UploadFileRequestStatus status =
+        createStatus(null, targetUri, null, 10L, "text/plain", COMPRESS_STATE.WORKING);
+
+    String preferred = status.getPreferredFilename();
+
+    assertEquals("target-name.txt", preferred);
+  }
+
+  @Test
+  void getPreferredFilename_whenNoUriOrFile_returnsNull() {
+    UploadFileRequestStatus status =
+        createStatus(null, null, null, 0L, "text/plain", COMPRESS_STATE.WORKING);
+
+    assertNull(status.getPreferredFilename());
+  }
+
+  @Test
+  void updateCompressionStatus_whenStateChanges_reflectsLatestValue() {
+    UploadFileRequestStatus status =
+        createStatus(null, null, null, 10L, "text/plain", COMPRESS_STATE.WAITING);
+
+    status.updateCompressionStatus(COMPRESS_STATE.COMPRESSING);
+    assertEquals(COMPRESS_STATE.COMPRESSING, status.isCompressing());
+
+    status.updateCompressionStatus(COMPRESS_STATE.WORKING);
+    assertEquals(COMPRESS_STATE.WORKING, status.isCompressing());
+  }
+
+  @Test
+  void copy_whenSourceMutates_copyRemainsIndependent() {
+    UploadFileRequestStatus status =
+        createStatus(
+            null,
+            null,
+            new File("source.txt"),
+            256L,
+            "application/json",
+            COMPRESS_STATE.COMPRESSING);
+
+    UploadFileRequestStatus copy = status.copy();
+
+    assertNotSame(status, copy);
+    assertEquals(status.getDataSize(), copy.getDataSize());
+    assertEquals(status.getMIMEType(), copy.getMIMEType());
+    assertEquals(status.getOrigFilename(), copy.getOrigFilename());
+    assertEquals(status.isCompressing(), copy.isCompressing());
+
+    status.updateCompressionStatus(COMPRESS_STATE.WORKING);
+
+    assertEquals(COMPRESS_STATE.COMPRESSING, copy.isCompressing());
+    assertEquals(COMPRESS_STATE.WORKING, status.isCompressing());
+  }
+
+  private static UploadFileRequestStatus createStatus(
+      FreenetURI finalUri,
+      FreenetURI targetUri,
+      File origFile,
+      long dataSize,
+      String mimeType,
+      COMPRESS_STATE compressState) {
+    return new UploadFileRequestStatus(
+        "identifier",
+        Persistence.CONNECTION,
+        true,
+        false,
+        false,
+        10,
+        5,
+        3,
+        SUCCESS_DATE,
+        1,
+        2,
+        FAILURE_DATE,
+        true,
+        (short) 3,
+        finalUri,
+        targetUri,
+        InsertExceptionMode.INTERNAL_ERROR,
+        "short",
+        "long",
+        dataSize,
+        mimeType,
+        origFile,
+        compressState);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the legacy Object#clone() usage with explicit copy constructors for RequestStatus and each FCP status subtype, and update RequestStatusCache to hand back defensive snapshots
- greatly expand the RequestStatus/UploadRequestStatus/DownloadRequestStatus documentation, including MIME logging cleanups and clearer field descriptions
- add focused unit tests for DownloadRequestStatus, UploadFileRequestStatus, and UploadDirRequestStatus to ensure metadata, preferred filenames, and copy semantics stay correct

## Testing
- not run (not requested)
