### PR TITLE
Improve FCP output handler cleanup

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionOutputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionOutputHandler.java
@@ -8,8 +8,35 @@ import java.util.Deque;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Serializes and transmits queued {@link FCPMessage} instances over an FCP socket.
+ *
+ * <p>This handler owns the write side of a {@link FCPConnectionHandler}, draining the in-memory
+ * queue until the peer or node closes the connection. It batches writes through a buffered stream,
+ * flushes opportunistically to minimize latency, and shuts down cleanly when the local handler
+ * transitions into the closed state. The instance lives for the lifetime of a single socket and is
+ * meant to be submitted to the node executor immediately after creation.
+ *
+ * <p>The class is stateful and thread-aware: producers enqueue messages while the {@link #run()}
+ * loop waits, flushes, and writes under synchronization. Interrupted waits trigger a best-effort
+ * flush before closing so callers can observe deterministic cleanup even during shutdowns. The
+ * queue itself is intentionally simple—there is no prioritization beyond FIFO ordering, and
+ * backpressure is exposed to callers via {@link #isQueueHalfFull()} for coarse throttling.
+ *
+ * <ul>
+ *   <li>Responsibilities: drain {@link #outQueue}, flush as needed, and close sockets.
+ *   <li>Thread-safety: external synchronization is required when inspecting or modifying shared
+ *       state beyond provided helpers.
+ *   <li>Typical usage: create via {@link #FCPConnectionOutputHandler(FCPConnectionHandler)}, call
+ *       {@link #start()} and rely on {@link #onClosed()} during teardown.
+ * </ul>
+ *
+ * @see FCPConnectionHandler
+ */
 public class FCPConnectionOutputHandler implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(FCPConnectionOutputHandler.class);
+  private static final long OUT_QUEUE_WAIT_MS = 1000L;
+  private static final long ON_CLOSED_WAIT_MS = 1500L;
 
   final FCPConnectionHandler handler;
   final Deque<FCPMessage> outQueue;
@@ -18,6 +45,18 @@ public class FCPConnectionOutputHandler implements Runnable {
 
   // Legacy threshold callback removed.
 
+  /**
+   * Creates a handler bound to the given connection coordinator.
+   *
+   * <p>The constructor stores references to the handler and allocates an empty deque for outgoing
+   * messages. Callers are expected to enqueue messages quickly after instantiation and to invoke
+   * {@link #start()} once the socket has been negotiated. The provided handler must remain alive
+   * for the full lifetime of this instance because executor callbacks, queue size checks, and
+   * shutdown signaling all dereference it without further null checks.
+   *
+   * @param handler non-null owner that exposes the socket, server, and lifecycle callbacks needed
+   *     to write and tear down the connection safely
+   */
   public FCPConnectionOutputHandler(FCPConnectionHandler handler) {
     this.handler = handler;
     this.outQueue = new ArrayDeque<>();
@@ -37,14 +76,30 @@ public class FCPConnectionOutputHandler implements Runnable {
                 + handler.getSocket().getPort());
   }
 
+  /**
+   * Continuously drains the outgoing queue and writes each message to the socket.
+   *
+   * <p>The loop blocks until messages arrive, flushes buffered bytes whenever the queue stays empty
+   * for a full wait cycle, and breaks only when either the handler reports a closed state or the
+   * socket write fails. Unexpected interruptions trigger a final flush before the stream is closed
+   * to keep wire state consistent. Any {@link IOException} is logged at debug level, while other
+   * exceptions are logged as errors. Regardless of failure mode, the method always runs the handler
+   * cleanup hooks so callers can assume the socket resources are released exactly once.
+   *
+   * <pre>{@code
+   * // Typical usage from the connection handler
+   * FCPConnectionOutputHandler output = new FCPConnectionOutputHandler(handler);
+   * output.start();
+   * }</pre>
+   */
   @Override
   public void run() {
     try {
       realRun();
     } catch (IOException e) {
-      if (LOG.isDebugEnabled()) LOG.debug("Caught " + e, e);
-    } catch (Throwable t) {
-      LOG.error("Caught " + t, t);
+      if (LOG.isDebugEnabled()) LOG.debug("Caught {}", e, e);
+    } catch (Exception e) {
+      LOG.error("Caught {}", e, e);
     } finally {
       // Set the closed flag so that onClosed(), both on this thread and the input thread, doesn't
       // wait forever.
@@ -54,62 +109,83 @@ public class FCPConnectionOutputHandler implements Runnable {
       synchronized (outQueue) {
         closedOutputQueue = true;
       }
+      handler.close();
+      handler.closedOutput();
     }
-    handler.close();
-    handler.closedOutput();
   }
 
   private void realRun() throws IOException {
     OutputStream os = new BufferedOutputStream(handler.getSocket().getOutputStream(), 4096);
+    boolean flushedSinceLastSend = false;
     while (true) {
-      boolean closed;
-      FCPMessage msg = null;
-      boolean flushed = false;
-      while (true) {
-        closed = handler.isClosed();
-        boolean shouldFlush = false;
-        synchronized (outQueue) {
-          if (outQueue.isEmpty()) {
-            if (closed) {
-              closedOutputQueue = true;
-              outQueue.notifyAll();
-              break;
-            }
-            if (!flushed) shouldFlush = true;
-            else {
-              try {
-                outQueue.wait(1000);
-              } catch (InterruptedException e) {
-                // Ignore
-              }
-              continue;
-            }
-          } else {
-            msg = outQueue.removeFirst();
-          }
-        }
-        if (shouldFlush) {
-          if (LOG.isDebugEnabled()) LOG.debug("Flushing");
-          os.flush();
-          flushed = true;
-        } else {
-          break;
-        }
+      QueueAction action;
+      try {
+        action = nextQueueAction(flushedSinceLastSend);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        flushAndClose(os);
+        return;
       }
-      if (msg == null) {
-        if (closed) {
-          os.flush();
-          os.close();
+      switch (action.type()) {
+        case MESSAGE:
+          sendMessage(os, action.message());
+          flushedSinceLastSend = false;
+          break;
+        case FLUSH:
+          flushOutput(os);
+          flushedSinceLastSend = true;
+          break;
+        case CLOSED:
+          flushAndClose(os);
           return;
-        }
-      } else {
-        if (LOG.isDebugEnabled()) LOG.debug("Sending " + msg);
-        msg.send(os);
-        flushed = false;
       }
     }
   }
 
+  private void sendMessage(OutputStream os, FCPMessage msg) throws IOException {
+    if (LOG.isDebugEnabled()) LOG.debug("Sending {}", msg);
+    msg.send(os);
+  }
+
+  private void flushAndClose(OutputStream os) throws IOException {
+    flushOutput(os);
+    os.close();
+  }
+
+  private void flushOutput(OutputStream os) throws IOException {
+    if (LOG.isDebugEnabled()) LOG.debug("Flushing");
+    os.flush();
+  }
+
+  private QueueAction nextQueueAction(boolean flushedSinceLastSend) throws InterruptedException {
+    synchronized (outQueue) {
+      while (true) {
+        boolean closed = handler.isClosed();
+        if (!outQueue.isEmpty()) {
+          return QueueAction.message(outQueue.removeFirst());
+        }
+        if (closed) {
+          closedOutputQueue = true;
+          outQueue.notifyAll();
+          return QueueAction.closed();
+        }
+        if (!flushedSinceLastSend) {
+          return QueueAction.flush();
+        }
+        outQueue.wait(OUT_QUEUE_WAIT_MS);
+      }
+    }
+  }
+
+  /**
+   * Waits for the output queue to empty when the input counterpart reports closure.
+   *
+   * <p>This method allows the socket-owning thread to block briefly so the writer can flush the
+   * remaining buffered messages prior to shutdown. It wakes whenever the queue is drained or when
+   * {@link #closedOutputQueue} becomes {@code true}. Interruptions propagate by resetting the
+   * interrupt flag and returning immediately, enabling higher-level shutdown coordination to take
+   * the lead without losing the signal.
+   */
   public void onClosed() {
     synchronized (outQueue) {
       outQueue.notifyAll();
@@ -119,17 +195,53 @@ public class FCPConnectionOutputHandler implements Runnable {
       while (!outQueue.isEmpty()) {
         if (closedOutputQueue) return;
         try {
-          outQueue.wait(1500);
+          outQueue.wait(ON_CLOSED_WAIT_MS);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
         }
       }
     }
   }
 
+  /**
+   * Reports whether the output queue exceeds half of the configured capacity.
+   *
+   * <p>The helper offers callers a cheap backpressure signal so they can throttle message
+   * production or reroute work before the queue reaches the server-imposed hard limit. The method
+   * performs its computation under the same lock used for enqueueing to avoid exposing stale data
+   * in concurrent scenarios.
+   *
+   * @return {@code true} when more than half the allowed entries are in the queue; {@code false}
+   *     otherwise, meaning the handler still has comfortable headroom
+   */
   public boolean isQueueHalfFull() {
-    int MAX_QUEUE_LENGTH = handler.getServer().maxMessageQueueLength();
+    int maxQueueLength = handler.getServer().maxMessageQueueLength();
     synchronized (outQueue) {
-      return outQueue.size() > MAX_QUEUE_LENGTH / 2;
+      return outQueue.size() > maxQueueLength / 2;
+    }
+  }
+
+  private enum QueueActionType {
+    MESSAGE,
+    FLUSH,
+    CLOSED
+  }
+
+  private record QueueAction(QueueActionType type, FCPMessage message) {
+    private static final QueueAction FLUSH = new QueueAction(QueueActionType.FLUSH, null);
+    private static final QueueAction CLOSED = new QueueAction(QueueActionType.CLOSED, null);
+
+    static QueueAction message(FCPMessage message) {
+      return new QueueAction(QueueActionType.MESSAGE, message);
+    }
+
+    static QueueAction flush() {
+      return FLUSH;
+    }
+
+    static QueueAction closed() {
+      return CLOSED;
     }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionOutputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionOutputHandlerTest.java
@@ -1,0 +1,144 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.stream.IntStream;
+import network.crypta.node.Node;
+import network.crypta.support.PriorityAwareExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FCPConnectionOutputHandlerTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
+  @Mock private Node node;
+  @Mock private PriorityAwareExecutor executor;
+  @Mock private Socket socket;
+  @Mock private OutputStream outputStream;
+  @Mock private SocketAddress socketAddress;
+
+  private FCPConnectionOutputHandler outputHandler;
+
+  @BeforeEach
+  void setUp() {
+    outputHandler = new FCPConnectionOutputHandler(handler);
+  }
+
+  @Test
+  void start_whenSocketPresent_submitsRunnableWithLabel() {
+    when(handler.getSocket()).thenReturn(socket);
+    when(socket.getRemoteSocketAddress()).thenReturn(socketAddress);
+    when(socketAddress.toString()).thenReturn("remote");
+    when(socket.getPort()).thenReturn(9481);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getNode()).thenReturn(node);
+    when(node.getExecutor()).thenReturn(executor);
+
+    outputHandler.start();
+
+    verify(executor).execute(outputHandler, "FCP output handler for remote:9481");
+  }
+
+  @Test
+  void start_whenSocketMissing_doesNotScheduleExecutor() {
+    when(handler.getSocket()).thenReturn(null);
+
+    outputHandler.start();
+
+    verifyNoInteractions(executor);
+  }
+
+  @Test
+  void run_whenHandlerAlreadyClosed_flushesAndClosesStream() throws IOException {
+    when(handler.getSocket()).thenReturn(socket);
+    when(socket.getOutputStream()).thenReturn(outputStream);
+    when(handler.isClosed()).thenReturn(true);
+
+    outputHandler.run();
+
+    verify(outputStream, atLeastOnce()).flush();
+    verify(outputStream).close();
+    verify(handler).close();
+    verify(handler).closedOutput();
+    assertTrue(outputHandler.closedOutputQueue);
+  }
+
+  @Test
+  void run_whenMessageQueued_sendsMessageBeforeClosing() throws IOException {
+    FCPMessage message = mock(FCPMessage.class);
+    outputHandler.outQueue.addLast(message);
+    when(handler.getSocket()).thenReturn(socket);
+    when(socket.getOutputStream()).thenReturn(outputStream);
+    when(handler.isClosed()).thenReturn(false, true);
+
+    outputHandler.run();
+
+    verify(message).send(any(OutputStream.class));
+    verify(outputStream, atLeastOnce()).flush();
+    verify(outputStream).close();
+    verify(handler).close();
+    verify(handler).closedOutput();
+    assertTrue(outputHandler.closedOutputQueue);
+  }
+
+  @Test
+  void run_whenMessageSendThrowsIOException_stillClosesHandler() throws IOException {
+    FCPMessage message = mock(FCPMessage.class);
+    outputHandler.outQueue.addLast(message);
+    when(handler.getSocket()).thenReturn(socket);
+    when(socket.getOutputStream()).thenReturn(outputStream);
+    when(handler.isClosed()).thenReturn(false);
+    doThrow(new IOException("boom")).when(message).send(any(OutputStream.class));
+
+    outputHandler.run();
+
+    verify(handler).close();
+    verify(handler).closedOutput();
+    assertTrue(outputHandler.closedOutputQueue);
+  }
+
+  @Test
+  void onClosed_whenClosedFlagSet_returnsWithoutWaiting() {
+    outputHandler.outQueue.addLast(mock(FCPMessage.class));
+    outputHandler.closedOutputQueue = true;
+
+    assertTimeoutPreemptively(Duration.ofMillis(200), () -> outputHandler.onClosed());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"4,false", "5,false", "6,true"})
+  void isQueueHalfFull_whenQueueSizeVaries_matchesExpectation(int queueSize, boolean expected) {
+    when(handler.getServer()).thenReturn(server);
+    when(server.maxMessageQueueLength()).thenReturn(10);
+    fillQueue(queueSize);
+
+    assertEquals(expected, outputHandler.isQueueHalfFull());
+  }
+
+  private void fillQueue(int messages) {
+    IntStream.range(0, messages)
+        .forEach(index -> outputHandler.outQueue.addLast(mock(FCPMessage.class)));
+  }
+}


### PR DESCRIPTION
## Summary
- document and refactor `FCPConnectionOutputHandler` so its run loop, waits, and close paths are explicit and easier to reason about
- add a Mockito-based regression test suite that covers executor scheduling, queue draining, flush semantics, and error handling

## Testing
- not run (not requested)
