### PR TITLE
Improve FCP input handler cleanup and documentation

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
@@ -10,8 +10,37 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tanukisoftware.wrapper.WrapperManager;
 
+/**
+ * Parses and dispatches Freenet Client Protocol (FCP) messages arriving over a single socket
+ * connection.
+ *
+ * <p>The handler is instantiated per accepted socket and acts as the dedicated reader for that
+ * client until the connection is closed. It streams bytes through a {@link LineReadingInputStream},
+ * enforces the protocol framing rules (line-oriented headers and an optional payload), and
+ * coordinates message-specific execution through {@link #handleNextMessage(LineReadingInputStream,
+ * boolean)}. The same instance maintains minimal state, namely whether the initial {@code
+ * ClientHello} arrived, because the node rejects clients that attempt to pipeline requests before
+ * authenticating.
+ *
+ * <p>Instances are run on a pooled executor thread configured by {@code FCPConnectionHandler}; the
+ * class itself is not thread-safe and assumes a single consumer of the socket. Errors are logged
+ * with informative severity while the {@linkplain #run() run loop} always performs cleanup to
+ * release sockets promptly, even when unexpected {@link Throwable}s occur. Because the node may
+ * receive malformed or malicious data, validations are strict and err on the side of disconnecting
+ * noisy peers rather than risking resource exhaustion.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> Read input, validate message envelopes, and route to the
+ *       owning {@link FCPConnectionHandler}.
+ *   <li><strong>Lifecycle:</strong> Created during connection setup, scheduled via {@link
+ *       #start()}, and shut down as soon as {@link #run()} completes.
+ *   <li><strong>Threading:</strong> Single-threaded; caller must ensure each instance is executed
+ *       once.
+ * </ul>
+ */
 public class FCPConnectionInputHandler implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(FCPConnectionInputHandler.class);
+  private static final String CAUGHT_LOG_TEMPLATE = "Caught {}";
 
   // Legacy threshold callback removed.
 
@@ -30,134 +59,219 @@ public class FCPConnectionInputHandler implements Runnable {
         .execute(this, "FCP input handler for " + handler.getSocket().getRemoteSocketAddress());
   }
 
+  /**
+   * Drives the connection read loop until the socket closes or an unrecoverable error occurs.
+   *
+   * <p>The executor invokes this entry point after {@link #start()} queues the handler. The method
+   * blocks while draining messages, logging {@link TooLongException} instances at info level,
+   * network {@link IOException}s for operational insight, and unexpected {@link Exception}s at
+   * error level. Regardless of the outcome it reliably closes the handler, which in turn tears down
+   * the socket, unregisters listeners, and notifies {@code FCPConnectionHandler} that no additional
+   * input will arrive. Because cleanup happens in a {@code finally} block, even {@link Error}s such
+   * as {@link OutOfMemoryError} trigger the same resource release path.
+   */
   @Override
   public void run() {
     try {
       realRun();
     } catch (TooLongException e) {
-      LOG.info("Caught " + e.getMessage(), e);
+      LOG.info(CAUGHT_LOG_TEMPLATE, e.getMessage(), e);
     } catch (IOException e) {
-      LOG.info("Caught " + e, e);
-    } catch (Throwable t) {
-      LOG.error("Caught " + t, t);
-      t.printStackTrace();
+      LOG.info(CAUGHT_LOG_TEMPLATE, e, e);
+    } catch (Exception e) {
+      LOG.error(CAUGHT_LOG_TEMPLATE, e, e);
+    } finally {
+      handler.close();
+      handler.closedInput();
     }
-    handler.close();
-    handler.closedInput();
   }
 
+  /**
+   * Executes the low-level read loop that converts the socket stream into validated FCP messages.
+   *
+   * <p>Callers should prefer {@link #run()} for lifecycle management; this helper mainly exists to
+   * make testing easier by exposing the parsing logic separately. The method wraps the socket input
+   * in a {@link BufferedInputStream} to minimize read syscalls, enforces the maximum header length
+   * per FCP specification, ensures {@code ClientHello} is the first accepted message, and reads any
+   * declared payloads before dispatching. Returning from the method indicates graceful completion,
+   * whereas exceptions propagate to signal abnormal termination so the caller can apply policy.
+   *
+   * <pre>{@code
+   * // Example: exercising the parser with a mock handler in tests
+   * new FCPConnectionInputHandler(mockHandler).realRun();
+   * }</pre>
+   *
+   * @throws IOException if reading from the socket stream fails, including EOF or transport aborts
+   */
   public void realRun() throws IOException {
     try (InputStream is = new BufferedInputStream(handler.getSocket().getInputStream(), 4096)) {
       LineReadingInputStream lis = new LineReadingInputStream(is);
-
       boolean firstMessage = true;
 
       while (true) {
-        SimpleFieldSet fs;
-        if (WrapperManager.hasShutdownHookBeenTriggered()) {
-          FCPMessage msg =
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.SHUTTING_DOWN,
-                  true,
-                  "The node is shutting down",
-                  "Node",
-                  false);
-          handler.send(msg);
+        LoopDirective directive = handleNextMessage(lis, firstMessage);
+        if (directive == LoopDirective.STOP) {
           return;
         }
-        // Read a message
-        String messageType = lis.readLine(128, 128, true);
-        if (messageType == null) {
-          return;
-        }
-        if (messageType.isEmpty()) continue;
-        fs = new SimpleFieldSet(lis, 4096, 128, true, true, true);
-
-        // check for valid endmarker
-        if (!firstMessage
-            && fs.getEndMarker() != null
-            && (!fs.getEndMarker().startsWith("End"))
-            && (!"Data".equals(fs.getEndMarker()))) {
-          FCPMessage err =
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.MESSAGE_PARSE_ERROR,
-                  false,
-                  "Invalid end marker: " + fs.getEndMarker(),
-                  fs.get("Identifer"),
-                  fs.getBoolean("Global", false));
-          handler.send(err);
-          continue;
-        }
-
-        FCPMessage msg;
-        try {
-          if (LOG.isTraceEnabled()) LOG.trace("Incoming FCP message:\n" + messageType + '\n' + fs);
-          msg =
-              FCPMessage.create(
-                  messageType,
-                  fs,
-                  handler.bf,
-                  handler.getServer().getCore().getPersistentTempBucketFactory());
-          if (msg == null) continue;
-        } catch (MessageInvalidException e) {
-          if (firstMessage) {
-            FCPMessage err =
-                new ProtocolErrorMessage(
-                    ProtocolErrorMessage.CLIENT_HELLO_MUST_BE_FIRST_MESSAGE,
-                    true,
-                    null,
-                    null,
-                    false);
-            handler.send(err);
-            handler.close();
-            return;
-          } else {
-            FCPMessage err =
-                new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global);
-            handler.send(err);
-          }
-          continue;
-        }
-        if (firstMessage && !(msg instanceof ClientHelloMessage)) {
-          FCPMessage err =
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.CLIENT_HELLO_MUST_BE_FIRST_MESSAGE, true, null, null, false);
-          handler.send(err);
-          handler.close();
-          return;
-        }
-        if (msg instanceof BaseDataCarryingMessage message) {
-          // FIXME tidy up - coalesce with above and below try { } catch (MIE) {}'s?
-          try {
-            message.readFrom(lis, handler.bf, handler.getServer());
-          } catch (MessageInvalidException e) {
-            FCPMessage err =
-                new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global);
-            handler.send(err);
-            continue;
-          }
-        }
-        if ((!firstMessage) && (msg instanceof ClientHelloMessage)) {
-          FCPMessage err =
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.NO_LATE_CLIENT_HELLOS, false, null, null, false);
-          handler.send(err);
-          continue;
-        }
-        try {
-          if (LOG.isTraceEnabled()) LOG.trace("Parsed message: " + msg + " for " + handler);
-          msg.run(handler, handler.getServer().getNode());
-        } catch (MessageInvalidException e) {
-          FCPMessage err =
-              new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global);
-          handler.send(err);
-          continue;
-        }
-        firstMessage = false;
-        if (handler.isClosed()) {
-          return;
+        if (directive == LoopDirective.CONTINUE_PROCESSED) {
+          firstMessage = false;
         }
       }
     }
+  }
+
+  private LoopDirective handleNextMessage(LineReadingInputStream lis, boolean firstMessage)
+      throws IOException {
+    if (sendShutdownNoticeIfNeeded()) {
+      return LoopDirective.STOP;
+    }
+
+    String messageType = lis.readLine(128, 128, true);
+    if (messageType == null) {
+      return LoopDirective.STOP;
+    }
+    if (messageType.isEmpty()) {
+      return LoopDirective.CONTINUE;
+    }
+
+    SimpleFieldSet fs = new SimpleFieldSet(lis, 4096, 128, true, true, true);
+    if (hasInvalidEndMarker(firstMessage, fs)) {
+      sendInvalidEndMarker(fs);
+      return LoopDirective.CONTINUE;
+    }
+
+    FCPMessage msg;
+    try {
+      msg = createMessage(messageType, fs);
+      if (msg == null) {
+        return LoopDirective.CONTINUE;
+      }
+    } catch (MessageInvalidException e) {
+      if (firstMessage) {
+        sendClientHelloRequiredError();
+        handler.close();
+        return LoopDirective.STOP;
+      }
+      sendProtocolError(e);
+      return LoopDirective.CONTINUE;
+    }
+
+    if (firstMessage && !(msg instanceof ClientHelloMessage)) {
+      sendClientHelloRequiredError();
+      handler.close();
+      return LoopDirective.STOP;
+    }
+
+    if (!readPayloadIfRequired(msg, lis)) {
+      return LoopDirective.CONTINUE;
+    }
+
+    if (!firstMessage && msg instanceof ClientHelloMessage) {
+      sendLateClientHelloError();
+      return LoopDirective.CONTINUE;
+    }
+
+    if (!runMessage(msg)) {
+      return LoopDirective.CONTINUE;
+    }
+
+    if (handler.isClosed()) {
+      return LoopDirective.STOP;
+    }
+
+    return LoopDirective.CONTINUE_PROCESSED;
+  }
+
+  private boolean sendShutdownNoticeIfNeeded() {
+    if (!WrapperManager.hasShutdownHookBeenTriggered()) {
+      return false;
+    }
+    FCPMessage msg =
+        new ProtocolErrorMessage(
+            ProtocolErrorMessage.SHUTTING_DOWN, true, "The node is shutting down", "Node", false);
+    handler.send(msg);
+    return true;
+  }
+
+  private boolean hasInvalidEndMarker(boolean firstMessage, SimpleFieldSet fs) {
+    return !firstMessage
+        && fs.getEndMarker() != null
+        && !fs.getEndMarker().startsWith("End")
+        && !"Data".equals(fs.getEndMarker());
+  }
+
+  private void sendInvalidEndMarker(SimpleFieldSet fs) {
+    FCPMessage err =
+        new ProtocolErrorMessage(
+            ProtocolErrorMessage.MESSAGE_PARSE_ERROR,
+            false,
+            "Invalid end marker: " + fs.getEndMarker(),
+            fs.get("Identifer"),
+            fs.getBoolean("Global", false));
+    handler.send(err);
+  }
+
+  private FCPMessage createMessage(String messageType, SimpleFieldSet fs)
+      throws MessageInvalidException {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("Incoming FCP message:\n{}\n{}", messageType, fs);
+    }
+    return FCPMessage.create(
+        messageType,
+        fs,
+        handler.bf,
+        handler.getServer().getCore().getPersistentTempBucketFactory());
+  }
+
+  private boolean readPayloadIfRequired(FCPMessage msg, LineReadingInputStream lis)
+      throws IOException {
+    if (msg instanceof BaseDataCarryingMessage message) {
+      try {
+        message.readFrom(lis, handler.bf, handler.getServer());
+      } catch (MessageInvalidException e) {
+        sendProtocolError(e);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void sendProtocolError(MessageInvalidException e) {
+    FCPMessage err =
+        new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global);
+    handler.send(err);
+  }
+
+  private void sendClientHelloRequiredError() {
+    FCPMessage err =
+        new ProtocolErrorMessage(
+            ProtocolErrorMessage.CLIENT_HELLO_MUST_BE_FIRST_MESSAGE, true, null, null, false);
+    handler.send(err);
+  }
+
+  private void sendLateClientHelloError() {
+    FCPMessage err =
+        new ProtocolErrorMessage(
+            ProtocolErrorMessage.NO_LATE_CLIENT_HELLOS, false, null, null, false);
+    handler.send(err);
+  }
+
+  private boolean runMessage(FCPMessage msg) {
+    try {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Parsed message: {} for {}", msg, handler);
+      }
+      msg.run(handler, handler.getServer().getNode());
+      return true;
+    } catch (MessageInvalidException e) {
+      sendProtocolError(e);
+      return false;
+    }
+  }
+
+  private enum LoopDirective {
+    CONTINUE,
+    CONTINUE_PROCESSED,
+    STOP
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
@@ -1,0 +1,417 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.io.LineReadingInputStream;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FCPConnectionInputHandlerTest {
+
+  @Test
+  void start_whenSocketIsNull_doesNotSubmitToExecutor() {
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    FCPConnectionInputHandler inputHandler = new FCPConnectionInputHandler(handler);
+
+    when(handler.getSocket()).thenReturn(null);
+
+    inputHandler.start();
+
+    verify(handler, never()).getServer();
+  }
+
+  @Test
+  void start_whenSocketPresent_submitsRunnableWithRemoteAddress() {
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    FCPServer server = mock(FCPServer.class);
+    Node node = mock(Node.class);
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    Socket socket = mock(Socket.class);
+    InetSocketAddress address = new InetSocketAddress("127.0.0.1", 9481);
+
+    when(handler.getSocket()).thenReturn(socket);
+    when(socket.getRemoteSocketAddress()).thenReturn(address);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getNode()).thenReturn(node);
+    when(node.getExecutor()).thenReturn(executor);
+
+    FCPConnectionInputHandler inputHandler = new FCPConnectionInputHandler(handler);
+
+    inputHandler.start();
+
+    verify(executor).execute(eq(inputHandler), contains(address.toString()));
+  }
+
+  @Test
+  void run_whenRealRunThrowsIOException_invokesCloseAndClosedInput() {
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    FCPConnectionInputHandler inputHandler =
+        new FCPConnectionInputHandler(handler) {
+          @Override
+          public void realRun() throws IOException {
+            throw new IOException("boom");
+          }
+        };
+
+    inputHandler.run();
+
+    InOrder order = inOrder(handler);
+    order.verify(handler).close();
+    order.verify(handler).closedInput();
+  }
+
+  @Test
+  void realRun_whenFirstMessageNotClientHello_sendsFatalErrorAndCloses() throws Exception {
+    TestContext ctx = createContext(message("Custom", "EndMessage", "Field=Value"));
+    FakeSimpleMessage unexpected = new FakeSimpleMessage();
+    List<String> lines = List.of("Custom", "Field=Value", "EndMessage");
+
+    try (MockedStatic<FCPMessage> ignored = mockFactory(unexpected, "Custom")) {
+      withLineSequence(lines, ctx.inputHandler::realRun);
+    }
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(ctx.handler).send(captor.capture());
+    ProtocolErrorMessage error = (ProtocolErrorMessage) captor.getValue();
+    assertEquals(ProtocolErrorMessage.CLIENT_HELLO_MUST_BE_FIRST_MESSAGE, error.code);
+    verify(ctx.handler).close();
+  }
+
+  @Test
+  void realRun_whenSubsequentClientHelloArrives_sendsNoLateHelloError() throws Exception {
+    TestContext ctx = createContext(clientHello("One"), clientHello("Two"));
+
+    List<String> lines =
+        List.of(
+            "ClientHello",
+            "Name=One",
+            "ExpectedVersion=2.0",
+            "EndMessage",
+            "ClientHello",
+            "Name=Two",
+            "ExpectedVersion=2.0",
+            "EndMessage");
+    withLineSequence(lines, ctx.inputHandler::realRun);
+
+    ProtocolErrorMessage error = findError(ctx.handler, ProtocolErrorMessage.NO_LATE_CLIENT_HELLOS);
+    assertEquals(ProtocolErrorMessage.NO_LATE_CLIENT_HELLOS, error.code);
+    verify(ctx.handler, never()).close();
+  }
+
+  @Test
+  void realRun_whenEndMarkerInvalid_sendsParseError() throws Exception {
+    TestContext ctx = createContext(clientHello("One"), message("Bad", "Oops", "Key=Value"));
+    List<String> lines =
+        List.of(
+            "ClientHello",
+            "Name=One",
+            "ExpectedVersion=2.0",
+            "EndMessage",
+            "Bad",
+            "Key=Value",
+            "Oops");
+    withLineSequence(lines, ctx.inputHandler::realRun);
+
+    ProtocolErrorMessage error = findError(ctx.handler, ProtocolErrorMessage.MESSAGE_PARSE_ERROR);
+    assertEquals("Invalid end marker: Oops", error.extra);
+  }
+
+  @Test
+  void realRun_whenBaseDataPayloadParsingFails_sendsProtocolErrorFromException() throws Exception {
+    MessageInvalidException mie =
+        new MessageInvalidException(
+            ProtocolErrorMessage.INVALID_FIELD, "broken", "dataIdent", true);
+    FakeDataMessage failingData = new FakeDataMessage(mie);
+
+    TestContext ctx = createContext(clientHello("One"), message("StubData", "EndMessage"));
+
+    List<String> lines =
+        List.of(
+            "ClientHello",
+            "Name=One",
+            "ExpectedVersion=2.0",
+            "EndMessage",
+            "StubData",
+            "EndMessage");
+    try (MockedStatic<FCPMessage> ignored = mockFactory(failingData, "StubData")) {
+      withLineSequence(lines, ctx.inputHandler::realRun);
+    }
+
+    ProtocolErrorMessage error = findError(ctx.handler, ProtocolErrorMessage.INVALID_FIELD);
+    assertEquals("broken", error.extra);
+    assertEquals("dataIdent", error.ident);
+    assertTrue(error.global);
+  }
+
+  @Test
+  void realRun_whenMessageHandlerThrows_sendsProtocolErrorFromException() throws Exception {
+    MessageInvalidException mie =
+        new MessageInvalidException(ProtocolErrorMessage.INTERNAL_ERROR, "boom", "ident", false);
+    FakeSimpleMessage throwingMessage = new FakeSimpleMessage(() -> {}, mie);
+
+    TestContext ctx = createContext(clientHello("One"), message("AfterHello", "EndMessage"));
+
+    List<String> lines =
+        List.of(
+            "ClientHello",
+            "Name=One",
+            "ExpectedVersion=2.0",
+            "EndMessage",
+            "AfterHello",
+            "EndMessage");
+    try (MockedStatic<FCPMessage> ignored = mockFactory(throwingMessage, "AfterHello")) {
+      withLineSequence(lines, ctx.inputHandler::realRun);
+    }
+
+    ProtocolErrorMessage error = findError(ctx.handler, ProtocolErrorMessage.INTERNAL_ERROR);
+    assertEquals("boom", error.extra);
+  }
+
+  @Test
+  void realRun_whenHandlerIndicatesClosed_stopsConsumingFurtherMessages() throws Exception {
+    AtomicBoolean closed = new AtomicBoolean(false);
+    FakeSimpleMessage stopMessage = new FakeSimpleMessage(() -> closed.set(true), null);
+    TestContext ctx =
+        createContext(
+            clientHello("One"), message("Stop", "EndMessage"), message("NeverRead", "EndMessage"));
+
+    lenient().when(ctx.handler.isClosed()).thenAnswer(invocation -> closed.get());
+    List<String> lines =
+        List.of(
+            "ClientHello",
+            "Name=One",
+            "ExpectedVersion=2.0",
+            "EndMessage",
+            "Stop",
+            "EndMessage",
+            "NeverRead",
+            "EndMessage");
+
+    try (MockedStatic<FCPMessage> mocked = mockFactory(stopMessage, "Stop")) {
+      withLineSequence(lines, ctx.inputHandler::realRun);
+      mocked.verify(
+          () -> FCPMessage.create(eq("NeverRead"), any(SimpleFieldSet.class), any(), any()),
+          never());
+    }
+  }
+
+  private static MockedStatic<FCPMessage> mockFactory(FCPMessage message, String name) {
+    MockedStatic<FCPMessage> mocked =
+        mockStatic(FCPMessage.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    mocked
+        .when(() -> FCPMessage.create(eq(name), any(SimpleFieldSet.class), any(), any()))
+        .thenReturn(message);
+    return mocked;
+  }
+
+  private ProtocolErrorMessage findError(FCPConnectionHandler handler, int code) {
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, atLeastOnce()).send(captor.capture());
+    return captor.getAllValues().stream()
+        .filter(ProtocolErrorMessage.class::isInstance)
+        .map(ProtocolErrorMessage.class::cast)
+        .filter(err -> err.code == code)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new AssertionError(
+                    "ProtocolError " + code + " not emitted. Sent=" + captor.getAllValues()));
+  }
+
+  private TestContext createContext(String... messages) throws Exception {
+    String payload = String.join("\n", messages);
+    InputStream stream = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
+
+    TestContext ctx = new TestContext();
+    ctx.handler = mock(FCPConnectionHandler.class);
+    ctx.bucketFactory = mock(BucketFactory.class);
+    setBucketFactory(ctx.handler, ctx.bucketFactory);
+    ctx.server = mock(FCPServer.class);
+    ctx.node = mock(Node.class);
+    ctx.core = mock(NodeClientCore.class);
+    ctx.persistentFactory = mock(PersistentTempBucketFactory.class);
+    ctx.socket = mock(Socket.class);
+
+    when(ctx.handler.getSocket()).thenReturn(ctx.socket);
+    when(ctx.socket.getInputStream()).thenReturn(stream);
+    when(ctx.handler.getServer()).thenReturn(ctx.server);
+    lenient().when(ctx.server.getNode()).thenReturn(ctx.node);
+    lenient().when(ctx.server.getCore()).thenReturn(ctx.core);
+    lenient().when(ctx.core.getPersistentTempBucketFactory()).thenReturn(ctx.persistentFactory);
+    lenient().when(ctx.handler.isClosed()).thenReturn(false);
+    lenient().when(ctx.handler.getConnectionIdentifierUUID()).thenReturn(UUID.randomUUID());
+
+    ctx.inputHandler = new FCPConnectionInputHandler(ctx.handler);
+    return ctx;
+  }
+
+  private static void setBucketFactory(FCPConnectionHandler handler, BucketFactory bucketFactory) {
+    try {
+      Field field = FCPConnectionHandler.class.getDeclaredField("bf");
+      field.setAccessible(true);
+      field.set(handler, bucketFactory);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalStateException("Unable to assign bucket factory", e);
+    }
+  }
+
+  private static String message(String name, String endMarker, String... kvPairs) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(name).append('\n');
+    for (String pair : kvPairs) {
+      builder.append(pair).append('\n');
+    }
+    builder.append(endMarker).append('\n');
+    return builder.toString();
+  }
+
+  private static String clientHello(String clientName) {
+    return message("ClientHello", "EndMessage", "Name=" + clientName, "ExpectedVersion=2.0");
+  }
+
+  private void withLineSequence(List<String> lines, ThrowingRunnable runnable) throws Exception {
+    Deque<String> queue = new ArrayDeque<>(lines);
+    try (MockedConstruction<LineReadingInputStream> ignored =
+        mockConstruction(
+            LineReadingInputStream.class,
+            (mock, context) ->
+                when(mock.readLine(anyInt(), anyInt(), anyBoolean()))
+                    .thenAnswer(invocation -> queue.isEmpty() ? null : queue.removeFirst()))) {
+      runnable.run();
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  private static final class TestContext {
+    FCPConnectionInputHandler inputHandler;
+    FCPConnectionHandler handler;
+    FCPServer server;
+    Node node;
+    NodeClientCore core;
+    Socket socket;
+    BucketFactory bucketFactory;
+    PersistentTempBucketFactory persistentFactory;
+  }
+
+  private static final class FakeDataMessage extends BaseDataCarryingMessage {
+    private final MessageInvalidException readFailure;
+
+    FakeDataMessage(MessageInvalidException readFailure) {
+      this.readFailure = readFailure;
+    }
+
+    @Override
+    public void readFrom(InputStream is, BucketFactory bf, FCPServer server)
+        throws MessageInvalidException {
+      if (readFailure != null) {
+        throw readFailure;
+      }
+    }
+
+    @Override
+    public void run(FCPConnectionHandler handler, Node node) {
+      // Intentionally empty: run() must remain inert so that tests focus solely on readFrom().
+    }
+
+    @Override
+    protected void writeData(OutputStream os) {
+      // Intentionally empty: tests never serialize this stub, so no payload is written.
+    }
+
+    @Override
+    long dataLength() {
+      return 0;
+    }
+
+    @Override
+    public SimpleFieldSet getFieldSet() {
+      return new SimpleFieldSet(true);
+    }
+
+    @Override
+    public String getName() {
+      return "StubData";
+    }
+  }
+
+  private static class FakeSimpleMessage extends FCPMessage {
+    private final Runnable runHook;
+    private final MessageInvalidException runFailure;
+
+    FakeSimpleMessage() {
+      this(() -> {}, null);
+    }
+
+    FakeSimpleMessage(Runnable runHook, MessageInvalidException runFailure) {
+      this.runHook = runHook;
+      this.runFailure = runFailure;
+    }
+
+    @Override
+    public SimpleFieldSet getFieldSet() {
+      return new SimpleFieldSet(true);
+    }
+
+    @Override
+    public String getName() {
+      return "Fake";
+    }
+
+    @Override
+    public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+      if (runHook != null) {
+        runHook.run();
+      }
+      if (runFailure != null) {
+        throw runFailure;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- ensure `FCPConnectionInputHandler` always closes the underlying socket by moving cleanup into a `finally` block and logging consistently
- expand the class and method Javadoc to explain lifecycle, threading, and parsing responsibilities for the handler
- add focused unit tests covering the handler run loop and protocol edge cases so regressions are caught earlier

## Testing
- `./gradlew test --tests '*FCPConnectionInputHandlerTest'`
