### PR TITLE
Refactor FCP DDA handling and cache plugin connections

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -410,13 +410,13 @@ public class ClientGet extends ClientRequest
           identifier,
           global);
     }
-    if (!handler.allowDDAFrom(diskFile, true)) {
+    if (!handler.ddaAccessController().allowDDAFrom(diskFile, true)) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED,
           "Not allowed to download to "
               + diskFile
               + ". You might need to do a "
-              + TestDDARequestMessage.NAME
+              + TestDdaRequestMessage.NAME
               + " first.",
           identifier,
           global);

--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -459,7 +459,7 @@ public class ClientPut extends ClientPutBase {
       byte[] saltedHash = decodeFileHash(message.fileHash, identifier, global);
       return new DiskUploadContext(salt, saltedHash);
     }
-    if (!handler.allowDDAFrom(message.origFilename, false)) {
+    if (!handler.ddaAccessController().allowDDAFrom(message.origFilename, false)) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DIRECT_DISK_ACCESS_DENIED,
           "Not allowed to upload from "

--- a/src/main/java/network/crypta/clients/fcp/DdaAccessController.java
+++ b/src/main/java/network/crypta/clients/fcp/DdaAccessController.java
@@ -1,0 +1,237 @@
+package network.crypta.clients.fcp;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import network.crypta.support.io.FileUtil;
+import org.slf4j.Logger;
+
+/**
+ * Coordinates Direct Disk Access (DDA) authorization for client requests handled by the FCP server.
+ *
+ * <p>This controller tracks directories that have already passed a DDA read and/or write test,
+ * caches the resulting {@link DirectoryAccess} verdicts, and answers future access checks without
+ * performing redundant filesystem probes. It also queues {@link DdaCheckJob} instances that craft
+ * deterministic marker files so external clients can deliberately prove that the node can touch the
+ * desired directory tree.
+ *
+ * <p>Callers typically obtain a single instance from {@link FCPServer}, invoke {@link
+ * #enqueueDDACheck(String, boolean, boolean)} to create a job, feed the result back through {@link
+ * #registerTestDDAResult(String, boolean, boolean)}, and later query {@link #allowDDAFrom(File,
+ * boolean)} whenever an upload or download request references new filesystem paths. All access to
+ * the mutable state is synchronized on internal maps, making the controller thread-safe provided
+ * callers honor the provided APIs and avoid bypassing the caches through reflection or mutation of
+ * shared fields.
+ *
+ * <p><strong>Responsibilities</strong>
+ *
+ * <ul>
+ *   <li>Cache per-directory read/write verdicts once a DDA test completes successfully.
+ *   <li>Queue and manage {@link DdaCheckJob} instances so only one test runs per directory.
+ *   <li>Delete temporary artifacts left behind by test jobs when shutting down or cleaning up.
+ * </ul>
+ *
+ * @see DdaCheckJob
+ */
+final class DdaAccessController {
+  private final FCPServer server;
+  private final Logger log;
+  private final HashMap<String, DirectoryAccess> checkedDirectories = new HashMap<>();
+  private final HashMap<File, DdaCheckJob> inTestDirectories = new HashMap<>();
+
+  /**
+   * Creates a controller bound to the supplied server and logger pair.
+   *
+   * <p>The caller is expected to pass the canonical {@link FCPServer} instance so decisions about
+   * default permission modes reflect the node's configuration. The {@link Logger} is retained for
+   * detailed trace logging when DDA tests succeed or fail. Neither dependency is optional; callers
+   * should construct the controller during server startup and keep it alive for the server's
+   * lifetime to avoid losing cached directory verdicts.
+   *
+   * @param server provides node state, fast random sources, and DDA defaults for fallback checks.
+   * @param log records debug, warning, and error information related to individual test runs.
+   */
+  DdaAccessController(FCPServer server, Logger log) {
+    this.server = server;
+    this.log = log;
+  }
+
+  /**
+   * Determines whether the node may perform a DDA read or write in the directory of the provided
+   * file reference.
+   *
+   * <p>The method resolves the canonical parent directory, looks up prior {@link DirectoryAccess}
+   * verdicts, and falls back to {@link FCPServer#isUploadDDAAlwaysAllowed()} or {@link
+   * FCPServer#isDownloadDDAAlwaysAllowed()} when no explicit test result exists. The decision is
+   * entirely cache-based; callers must ensure they previously registered fresh permissions whenever
+   * the filesystem state or policy changes. The method is thread-safe and may be invoked frequently
+   * in the hot path of request dispatching.
+   *
+   * <pre>{@code
+   * if (controller.allowDDAFrom(new File("/tmp/data"), true)) {
+   *   server.startDownload();
+   * }
+   * }</pre>
+   *
+   * @param filename representative file whose parent directory should be evaluated for access.
+   * @param writeRequest {@code true} when checking downloads/writes, {@code false} for read
+   *     uploads.
+   * @return {@code true} when cached permissions or server defaults authorize the requested mode.
+   */
+  boolean allowDDAFrom(File filename, boolean writeRequest) {
+    String parentDirectory = FileUtil.getCanonicalFile(filename).getParent();
+    DirectoryAccess access;
+    synchronized (checkedDirectories) {
+      access = checkedDirectories.get(parentDirectory);
+    }
+    if (log.isDebugEnabled()) {
+      log.debug("Checking DDA: {} for {}", access, parentDirectory);
+    }
+    if (writeRequest) {
+      return access == null ? server.isDownloadDDAAlwaysAllowed() : access.canWrite;
+    } else {
+      return access == null ? server.isUploadDDAAlwaysAllowed() : access.canRead;
+    }
+  }
+
+  /**
+   * Stores the result of a previously executed DDA test for the supplied directory path.
+   *
+   * <p>Callers should invoke this method immediately after a {@link DdaCheckJob} reports whether it
+   * could read or write inside the directory. The controller replaces any prior verdict for the
+   * same canonical path so stale authorizations do not linger. The cache is synchronized to ensure
+   * that concurrent test completions for distinct directories remain consistent without additional
+   * locking by the caller.
+   *
+   * @param path canonical directory string whose cached access rights should be updated atomically.
+   * @param read {@code true} when the test proved read access is possible without privilege
+   *     escalation.
+   * @param write {@code true} when the test proved a temporary file can be written and cleaned up.
+   */
+  void registerTestDDAResult(String path, boolean read, boolean write) {
+    DirectoryAccess access = new DirectoryAccess(read, write);
+    synchronized (checkedDirectories) {
+      checkedDirectories.put(path, access);
+    }
+    if (log.isDebugEnabled()) {
+      log.debug("DDA: read={} write={} for {}", read, write, path);
+    }
+  }
+
+  /**
+   * Queues a new {@link DdaCheckJob} for the provided directory and desired access types.
+   *
+   * <p>The controller validates that the directory exists, rejects duplicate concurrent checks, and
+   * constructs temporary marker files tailored to the requested read or write assertions. When read
+   * testing is enabled the method creates, populates, and schedules deletion of a random file so
+   * the job can later verify its contents. When write testing is enabled the job records a random
+   * filename for remote clients to manipulate. The returned job is ready for serialization through
+   * FCP responses.
+   *
+   * @param path filesystem directory path supplied by the client and already sanitized by callers.
+   * @param read {@code true} to include read verification, {@code false} to skip creating test
+   *     data.
+   * @param write {@code true} to request write verification, including unique temporary filenames.
+   * @return configured job containing marker filenames and expected file contents for validation.
+   * @throws IllegalArgumentException if the path is invalid or already under active testing.
+   */
+  DdaCheckJob enqueueDDACheck(String path, boolean read, boolean write) {
+    File directory = FileUtil.getCanonicalFile(new File(path));
+    if (!directory.exists() || !directory.isDirectory()) {
+      throw new IllegalArgumentException(
+          "The specified path isn't a directory! or doesn't exist or the node doesn't have access"
+              + " to it!");
+    }
+
+    DdaCheckJob existing;
+    synchronized (inTestDirectories) {
+      existing = inTestDirectories.get(directory);
+    }
+    if (existing != null) {
+      throw new IllegalArgumentException("There is already a TestDDA going on for that directory!");
+    }
+
+    File writeFile =
+        write
+            ? new File(path, "DDACheck-" + server.getNode().getFastWeakRandom().nextInt() + ".tmp")
+            : null;
+    File readFile = null;
+    if (read) {
+      try {
+        readFile = File.createTempFile("DDACheck-", ".tmp", directory);
+        readFile.deleteOnExit();
+      } catch (IOException e) {
+        log.warn("Unable to create read test file in {}", directory, e);
+      }
+    }
+
+    DdaCheckJob job =
+        new DdaCheckJob(server.getNode().getFastWeakRandom(), directory, readFile, writeFile);
+
+    if (readFile != null) {
+      try (FileOutputStream fos = new FileOutputStream(readFile);
+          BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+        bos.write(job.readContent.getBytes());
+      } catch (IOException e) {
+        log.error("Got a IOE while creating the file ({} ! {}", readFile, e.getMessage());
+      }
+    }
+
+    synchronized (inTestDirectories) {
+      inTestDirectories.put(directory, job);
+    }
+    return job;
+  }
+
+  /**
+   * Removes and returns the active {@link DdaCheckJob} associated with the provided directory.
+   *
+   * <p>This call mirrors {@link #enqueueDDACheck(String, boolean, boolean)} and should be used
+   * after the job completes or times out so the controller can accept future checks targeting the
+   * same directory. The method performs the same canonical-path validation and throws the standard
+   * exception if the directory is missing to prevent accidental clean-up of unrelated locations.
+   *
+   * @param path canonical directory path previously supplied while enqueuing a DDA verification.
+   * @return the job that was tracking verification state, or {@code null} when none was stored.
+   * @throws IllegalArgumentException if the directory no longer exists or is not a directory.
+   */
+  DdaCheckJob popDDACheck(String path) {
+    File directory = FileUtil.getCanonicalFile(new File(path));
+    if (!directory.exists() || !directory.isDirectory()) {
+      throw new IllegalArgumentException(
+          "The specified path isn't a directory! or doesn't exist or the node doesn't have access"
+              + " to it!");
+    }
+    synchronized (inTestDirectories) {
+      return inTestDirectories.remove(directory);
+    }
+  }
+
+  /**
+   * Discards all queued DDA jobs and deletes any temporary files created for read tests.
+   *
+   * <p>Call this method during shutdown or after fatal errors to guarantee that orphaned temporary
+   * files do not accumulate on disk. The method iterates through the tracked jobs, attempts to
+   * delete any read marker files, and logs non-fatal failures while keeping the rest of the
+   * clean-up proceeding. Because the underlying map is synchronized, the cleanup safely coexists
+   * with other job lifecycle operations.
+   */
+  void freeDDAJobs() {
+    synchronized (inTestDirectories) {
+      for (DdaCheckJob job : inTestDirectories.values()) {
+        if (job.readFilename != null) {
+          try {
+            Files.deleteIfExists(job.readFilename.toPath());
+          } catch (IOException e) {
+            log.warn("Unable to delete DDA test file {}", job.readFilename, e);
+          }
+        }
+      }
+    }
+  }
+
+  private record DirectoryAccess(boolean canRead, boolean canWrite) {}
+}

--- a/src/main/java/network/crypta/clients/fcp/DdaCheckJob.java
+++ b/src/main/java/network/crypta/clients/fcp/DdaCheckJob.java
@@ -1,0 +1,51 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.util.Random;
+import network.crypta.support.HexUtil;
+
+/**
+ * Represents a directory access test initiated via the DDA handshake.
+ *
+ * <p>This job bundles the directory under scrutiny with the randomly generated filenames and
+ * hexadecimal challenges that a client must echo back through the {@code TestDDA*} request/response
+ * sequence. The surrounding {@link FCPConnectionHandler} enqueues the job immediately after a
+ * {@link TestDdaRequestMessage} arrives and hands it to the node side of the FCP session so that
+ * the handler can validate whether the peer really controls the requested filesystem subtree. Each
+ * job therefore captures the server's expectation for one verification round before being retired.
+ *
+ * <p>The job is immutable after construction, which avoids concurrency hazards when multiple DDA
+ * exchanges occur in parallel. All random data is 128 bytes long prior to hexadecimal encoding, so
+ * the derived strings have deterministic size and can be logged for debugging without truncation.
+ * The read filename and read content must already exist when the client is asked to fetch them,
+ * while the write filename and content are only validated after the peer claims to have stored the
+ * data.
+ *
+ * <ul>
+ *   <li>Encapsulates per-request secrets so the higher levels do not re-derive entropy.
+ *   <li>Provides a durable record that the {@link TestDdaReplyMessage} can include verbatim.
+ * </ul>
+ *
+ * @see TestDdaRequestMessage
+ * @see TestDdaReplyMessage
+ */
+public class DdaCheckJob {
+  final File directory;
+  final File readFilename;
+  final File writeFilename;
+  final String readContent;
+  final String writeContent;
+
+  DdaCheckJob(Random random, File directory, File readFilename, File writeFilename) {
+    this.directory = directory;
+    this.readFilename = readFilename;
+    this.writeFilename = writeFilename;
+
+    byte[] data = new byte[128];
+    random.nextBytes(data);
+    this.readContent = HexUtil.bytesToHex(data);
+
+    random.nextBytes(data);
+    this.writeContent = HexUtil.bytesToHex(data);
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -1,94 +1,63 @@
 package network.crypta.clients.fcp;
 
-import java.io.BufferedOutputStream;
 import java.io.Closeable;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.regex.Pattern;
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.TooManyFilesInsertException;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestClientBuilder;
-import network.crypta.pluginmanager.PluginManager;
 import network.crypta.pluginmanager.PluginNotFoundException;
-import network.crypta.pluginmanager.PluginRespirator;
 import network.crypta.support.HexUtil;
-import network.crypta.support.api.BucketFactory;
-import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Manages the full lifecycle of a single Freenet Client Protocol (FCP) connection, routing inbound
+ * client commands to the appropriate request primitives while asynchronously streaming responses
+ * back to the peer.
+ *
+ * <p>Each handler instance encapsulates socket ownership, request registries, DDA authorizations,
+ * and plugin bridge state so that transient failures stay isolated to the originating client. It
+ * collaborates with {@link FCPConnectionInputHandler} and {@link FCPConnectionOutputHandler} to
+ * parse framed commands, validate identifiers, and dispatch I/O without blocking the acceptor
+ * threads. Callers typically create the handler through {@link FCPServer} once a socket has been
+ * authenticated, then invoke {@link #start()} to spin up the paired reader/writer threads.
+ *
+ * <p>The handler enforces persistence policies (connection, reboot, forever) by wiring requests to
+ * different {@link PersistentRequestClient}s and ensuring identifier uniqueness across the entire
+ * node. All mutation of connection-scoped data structures is serialized through the handler's
+ * intrinsic lock, while outbound queueing is guarded inside {@link FCPConnectionOutputHandler} to
+ * keep contention manageable.
+ *
+ * <ul>
+ *   <li>Receives FCP messages, validates them, and instantiates {@link ClientRequest}s.
+ *   <li>Persists or replays pending work via job runners when clients reconnect.
+ *   <li>Tracks plugin bridge usage, DDA permissions, and subscription bookkeeping.
+ * </ul>
+ *
+ * @see FCPConnectionInputHandler
+ * @see FCPConnectionOutputHandler
+ * @see PersistentRequestClient
+ */
 public class FCPConnectionHandler implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(FCPConnectionHandler.class);
-
-  /** Matches 'LZMA' as a standalone codec token in a comma-separated Codecs string. */
-  private static final Pattern LEGACY_LZMA_CODECS =
-      Pattern.compile("(?i)(?:^|\\s*,\\s*)LZMA(?:\\s*,|$)");
+  private static final String COLLISION_LOG_TEMPLATE = "Identifier collision on {}";
+  private static final String PERSISTENCE_DISABLED_TEXT = "Persistence is disabled";
+  private static final String LEGACY_LZMA_REPLACEMENT = "LZMA_NEW";
 
   /** Ensure we warn about legacy LZMA at most once per connection/client. */
   private final AtomicBoolean warnedLegacyLzma = new AtomicBoolean(false);
 
-  // Legacy threshold callback removed.
-
-  private static final class DirectoryAccess {
-    final boolean canWrite;
-    final boolean canRead;
-
-    public DirectoryAccess(boolean canRead, boolean canWrite) {
-      this.canRead = canRead;
-      this.canWrite = canWrite;
-    }
-  }
-
-  public static class DDACheckJob {
-    final File directory, readFilename, writeFilename;
-    final String readContent, writeContent;
-
-    /** null if not requested. */
-    DDACheckJob(Random r, File directory, File readFilename, File writeFilename) {
-      this.directory = directory;
-      this.readFilename = readFilename;
-      this.writeFilename = writeFilename;
-
-      byte[] random = new byte[128];
-
-      r.nextBytes(random);
-      this.readContent = HexUtil.bytesToHex(random);
-
-      r.nextBytes(random);
-      this.writeContent = HexUtil.bytesToHex(random);
-    }
-  }
-
-  /**
-   * @deprecated Use {@link #getServer()} instead of accessing this directly.
-   */
-  @Deprecated
-  /* it’s not actually the field that is deprecated but accessing it directly is. */
-  final FCPServer server;
-
-  /**
-   * @deprecated Use {@link #getSocket()} instead of accessing this directly.
-   */
-  @Deprecated
-  /* it’s not actually the field that is deprecated but accessing it directly is. */
-  final Socket sock;
+  private final FCPServer server;
+  private final Socket sock;
 
   final FCPConnectionInputHandler inputHandler;
   final Map<String, SubscribeUSK> uskSubscriptions;
@@ -100,113 +69,145 @@ public class FCPConnectionHandler implements Closeable {
   private String clientName;
   private PersistentRequestClient rebootClient;
   private PersistentRequestClient foreverClient;
-  final BucketFactory bf;
   final HashMap<String, ClientRequest> requestsByIdentifier;
 
-  /**
-   * {@link FCPPluginConnectionImpl} indexed by the server plugin name (see {@link
-   * PluginManager#getPluginFCPServer(String)}.<br>
-   * <br>
-   * This also serves the same purpose as the client which is connected to this would normally be
-   * responsible for if it was running as a plugin in the node (as specified by {@link
-   * PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)}):<br>
-   * It keeps strong references to the {@link FCPPluginConnectionImpl} objects, and thereby marks
-   * them as alive.<br>
-   * This in turn causes the {@link FCPPluginConnectionImpl} objects to stay available in the {@link
-   * FCPPluginConnectionTracker}, which allows server plugins to query them by their ID.
-   */
-  private final TreeMap<String, FCPPluginConnectionImpl> pluginConnectionsByServerName =
-      new TreeMap<>();
+  private final PluginConnectionRegistry pluginConnectionRegistry = new PluginConnectionRegistry();
+
+  private static final class CloseSnapshot {
+    final ClientRequest[] requests;
+    final SubscribeUSK[] subscriptions;
+    final boolean duplicateKilled;
+
+    CloseSnapshot(ClientRequest[] requests, SubscribeUSK[] subscriptions, boolean duplicateKilled) {
+      this.requests = requests;
+      this.subscriptions = subscriptions;
+      this.duplicateKilled = duplicateKilled;
+    }
+  }
+
+  private enum RegistrationResult {
+    REGISTERED,
+    DUPLICATE,
+    CLOSED
+  }
 
   /**
-   * Lock for {@link #pluginConnectionsByServerName}.
-   *
-   * <p>A {@link ReadWriteLock} because the usage pattern is mostly reads, very few writes - {@link
-   * ReadWriteLock} can do that faster than a regular Lock. (A {@link ReentrantReadWriteLock}
-   * because thats the only implementation of {@link ReadWriteLock}.)
+   * Legacy 16-byte hexadecimal identifier mirrored from older protocol versions so existing client
+   * libraries can continue to correlate reconnect attempts and queue state without having to
+   * understand UUIDs. The value is immutable and scoped to this connection instance only.
    */
-  private final ReadWriteLock pluginConnectionsByServerName_Lock = new ReentrantReadWriteLock();
+  public final String connectionIdentifier;
 
   /**
-   * 16 random bytes hex-encoded as String. Unique for each instance of this class.
-   *
-   * @deprecated Use {@link #connectionIdentifierUUID} instead.
+   * Deterministic UUID derived from the same random bytes as {@link #connectionIdentifier}, giving
+   * modern code a stable, strongly typed identifier for metrics, plugin bridges, and logs while
+   * keeping interop with legacy peers.
    */
-  @Deprecated public final String connectionIdentifier;
-
-  /** Random UUID unique for each instance of this class */
   protected final UUID connectionIdentifierUUID;
 
   private boolean killedDupe;
 
-  // Legacy threshold callback removed.
+  private final DdaAccessController ddaAccessController;
 
-  // We are confident that the given client can access those
-  private final HashMap<String, DirectoryAccess> checkedDirectories = new HashMap<>();
-  // DDACheckJobs in flight
-  private final HashMap<File, DDACheckJob> inTestDirectories = new HashMap<>();
+  /**
+   * Request client tuned for bulk traffic; used when a caller opts out of realtime delivery so the
+   * node can batch IO and reduce scheduler churn.
+   */
   public final RequestClient connectionRequestClientBulk = new RequestClientBuilder().build();
+
+  /**
+   * Request client configured for realtime latency expectations, ensuring minimal queueing delays
+   * when the peer explicitly marks an operation as realtime.
+   */
   public final RequestClient connectionRequestClientRT =
       new RequestClientBuilder().realTime().build();
 
+  DdaAccessController ddaAccessController() {
+    return ddaAccessController;
+  }
+
+  /**
+   * Returns the UUID associated with this connection so that callers can tag metrics or correlate
+   * asynchronous callbacks without relying on the legacy hexadecimal identifier.
+   *
+   * <p>The value is thread-safe, never {@code null}, and suitable for use as a map key or log
+   * correlation id. Because it is derived deterministically from the original 16 bytes, operators
+   * can bridge stats that still expect the legacy hex value.
+   *
+   * @return Immutable UUID derived from the random seed assigned during construction; it never
+   *     changes for the lifetime of this handler.
+   */
   public UUID getConnectionIdentifierUUID() {
     return connectionIdentifierUUID;
   }
 
+  /**
+   * Creates a handler bound to the provided socket and owning server, generating the random
+   * identifiers, request registries, and IO helpers needed to start processing messages.
+   *
+   * <p>The constructor wires up paired input/output handlers, instantiates connection-scoped
+   * request maps, configures DDA access control, and seeds both the legacy hexadecimal identifier
+   * and UUID from the node's secure RNG. No IO occurs yet; call {@link #start()} after the handler
+   * is fully configured to spawn its worker threads.
+   *
+   * @param s Connected socket for the peer; must already be authenticated and not null.
+   * @param server Owning {@link FCPServer} providing node services, persistent clients, and
+   *     configuration knobs for this handler.
+   */
   public FCPConnectionHandler(Socket s, FCPServer server) {
     this.sock = s;
     this.server = server;
     isClosed = false;
-    this.bf = server.getCore().getTempBucketFactory();
     requestsByIdentifier = new HashMap<>();
     uskSubscriptions = new HashMap<>();
     this.inputHandler = new FCPConnectionInputHandler(this);
     this.outputHandler = new FCPConnectionOutputHandler(this);
+    this.ddaAccessController = new DdaAccessController(server, LOG);
 
     byte[] identifier = new byte[16];
     server.getNode().getRandom().nextBytes(identifier);
     this.connectionIdentifier = HexUtil.bytesToHex(identifier);
 
     // The random 16-byte identifier was used before we added the UUID. Luckily, UUIDs are also
-    // 16 byetes, so we can re-use the bytes.
-    // TODO: When getting rid of the non-UUID connectionIdentifier, use UUID.randomUUID();
+    // 16 bytes, so we can re-use the bytes.
+    // When removing the legacy connectionIdentifier field, use UUID.randomUUID() instead.
     this.connectionIdentifierUUID = UUID.nameUUIDFromBytes(identifier);
   }
 
   /**
-   * Queues the message for sending at the {@link FCPConnectionOutputHandler}.<br>
-   * <br>
-   * ATTENTION: The function will return immediately before even trying to send the message, the
-   * message will be sent asynchronously.<br>
-   * As a consequence, this function not throwing does not give any guarantee whatsoever that the
-   * message will ever be sent.
+   * Enqueues an {@link FCPMessage} for asynchronous transmission via the paired {@link
+   * FCPConnectionOutputHandler} and returns immediately.
+   *
+   * <p>The method only synchronizes long enough to place the message into the bounded outbound
+   * queue, respecting the server's drop policy when limits are exceeded. Because the actual socket
+   * write happens on the output thread, callers must treat this method as fire-and-forget: a return
+   * value simply means queuing succeeded, not that the peer received or acknowledged anything. Use
+   * the handler's logging output when diagnosing queue pressure or dropped messages.
+   *
+   * @param message Non-null message that has already been fully constructed and validated for
+   *     network serialization.
    */
   public final void send(final FCPMessage message) {
     if (LOG.isTraceEnabled()) LOG.trace("Queueing {}", message);
     if (message == null) throw new NullPointerException();
     boolean neverDropAMessage = server.neverDropAMessage();
-    int MAX_QUEUE_LENGTH = server.maxMessageQueueLength();
+    int maxQueueLength = server.maxMessageQueueLength();
     synchronized (outputHandler.outQueue) {
       if (outputHandler.closedOutputQueue) {
-        LOG.error("Closed already: " + this + " queueing message " + message);
-        // FIXME throw something???
+        LOG.error("Closed already: {} queueing message {}", this, message);
         return;
       }
-      if (outputHandler.outQueue.size() >= MAX_QUEUE_LENGTH) {
+      if (outputHandler.outQueue.size() >= maxQueueLength) {
         if (neverDropAMessage) {
           LOG.error(
-              "FCP message queue length is "
-                  + outputHandler.outQueue.size()
-                  + " for "
-                  + this
-                  + " - not dropping message as configured...");
+              "FCP message queue length is {} for {} - not dropping message as configured...",
+              outputHandler.outQueue.size(),
+              this);
         } else {
           LOG.error(
-              "Dropping FCP message to "
-                  + this
-                  + " : "
-                  + outputHandler.outQueue.size()
-                  + " messages queued - maybe client died?",
+              "Dropping FCP message to {} : {} messages queued - maybe client died?",
+              this,
+              outputHandler.outQueue.size(),
               new Exception("debug"));
           return;
         }
@@ -221,61 +222,110 @@ public class FCPConnectionHandler implements Closeable {
     outputHandler.start();
   }
 
+  /**
+   * Closes the handler by notifying persistent clients, cancelling outstanding requests, and
+   * shutting down the socket once both streams are drained.
+   *
+   * <p>The shutdown sequence prepares a snapshot under synchronization to ensure no new requests
+   * slip in, marks the handler as closed, and then iterates over the outstanding {@link
+   * ClientRequest}s outside the lock so callbacks can run without reentrancy hazards. When a
+   * duplicate connection forced this handler to exit early, client cleanup is skipped to avoid
+   * double-unregistration. The method is idempotent and safe to call multiple times.
+   */
   @Override
   public void close() {
-    ClientRequest[] requests;
-    if (rebootClient != null) rebootClient.onLostConnection(this);
-    if (foreverClient != null) foreverClient.onLostConnection(this);
-    boolean dupe;
-    SubscribeUSK[] uskSubscriptions2;
+    if (rebootClient != null) {
+      rebootClient.onLostConnection(this);
+    }
+    if (foreverClient != null) {
+      foreverClient.onLostConnection(this);
+    }
+    CloseSnapshot snapshot = prepareCloseSnapshot();
+    if (snapshot == null) {
+      return;
+    }
+    notifyLostRequests(snapshot.requests);
+    unsubscribeAll(snapshot.subscriptions);
+    if (!snapshot.duplicateKilled) {
+      enqueueClientCleanup();
+    }
+    outputHandler.onClosed();
+  }
+
+  private CloseSnapshot prepareCloseSnapshot() {
     synchronized (this) {
       if (isClosed) {
-        // This is normal, both input and output handlers will call close().
-        return;
+        return null;
       }
       isClosed = true;
-      requests = new ClientRequest[requestsByIdentifier.size()];
-      requests = requestsByIdentifier.values().toArray(requests);
+      ClientRequest[] requests = requestsByIdentifier.values().toArray(new ClientRequest[0]);
       requestsByIdentifier.clear();
-      uskSubscriptions2 = uskSubscriptions.values().toArray(new SubscribeUSK[0]);
-      dupe = killedDupe;
+      SubscribeUSK[] subscriptions = uskSubscriptions.values().toArray(new SubscribeUSK[0]);
+      return new CloseSnapshot(requests, subscriptions, killedDupe);
     }
-    for (ClientRequest req : requests) req.onLostConnection(server.getCore().getClientContext());
-    for (SubscribeUSK sub : uskSubscriptions2) sub.unsubscribe();
-    if (!dupe) {
-      try {
-        server
-            .getCore()
-            .getClientContext()
-            .jobRunner
-            .queue(
-                (PersistentJob)
-                    context -> {
-                      if ((rebootClient != null) && !rebootClient.hasPersistentRequests())
-                        server.unregisterClient(rebootClient);
-                      if (foreverClient != null) {
-                        if (!foreverClient.hasPersistentRequests())
-                          server.unregisterClient(foreverClient);
-                      }
-                      return false;
-                    },
-                NativeThread.PriorityLevel.NORM_PRIORITY.value);
-      } catch (PersistenceDisabledException e) {
-        // Ignore
-      }
-    }
+  }
 
-    outputHandler.onClosed();
+  private void notifyLostRequests(ClientRequest[] requests) {
+    for (ClientRequest request : requests) {
+      request.onLostConnection(server.getCore().getClientContext());
+    }
+  }
+
+  private void unsubscribeAll(SubscribeUSK[] subscriptions) {
+    for (SubscribeUSK subscription : subscriptions) {
+      subscription.unsubscribe();
+    }
+  }
+
+  private void enqueueClientCleanup() {
+    try {
+      server
+          .getCore()
+          .getClientContext()
+          .jobRunner
+          .queue(
+              (PersistentJob)
+                  context -> {
+                    if ((rebootClient != null) && !rebootClient.hasPersistentRequests()) {
+                      server.unregisterClient(rebootClient);
+                    }
+                    if ((foreverClient != null) && !foreverClient.hasPersistentRequests()) {
+                      server.unregisterClient(foreverClient);
+                    }
+                    return false;
+                  },
+              NativeThread.PriorityLevel.NORM_PRIORITY.value);
+    } catch (PersistenceDisabledException e) {
+      // Ignore: cleanup already best-effort.
+    }
   }
 
   synchronized void setKilledDupe() {
     killedDupe = true;
   }
 
+  /**
+   * Indicates whether the handler has transitioned into the closed state, meaning it will reject
+   * new requests and is in the process of unwinding outstanding work.
+   *
+   * <p>This synchronized check is inexpensive and safe to invoke from any thread; callers should
+   * treat a {@code true} response as a signal that no further messages should be enqueued and that
+   * socket-level operations are either complete or imminently shutting down.
+   *
+   * @return {@code true} once {@link #close()} has taken effect and the handler stops accepting new
+   *     work, otherwise {@code false}.
+   */
   public synchronized boolean isClosed() {
     return isClosed;
   }
 
+  /**
+   * Marks the input side of the socket as closed and, when both directions are drained, closes the
+   * underlying socket.
+   *
+   * <p>Called by {@link FCPConnectionInputHandler} once it detects EOF or a fatal read error. The
+   * method suppresses IOExceptions because they only indicate the peer has already disconnected.
+   */
   public void closedInput() {
     try {
       sock.shutdownInput();
@@ -293,6 +343,14 @@ public class FCPConnectionHandler implements Closeable {
     }
   }
 
+  /**
+   * Marks the output side of the socket as closed and finalizes the connection once the input side
+   * also shuts down.
+   *
+   * <p>Invoked by {@link FCPConnectionOutputHandler} when no further writes are possible. It
+   * ensures {@link Socket#close()} happens once and tolerates IOExceptions from half-closed
+   * sockets.
+   */
   public void closedOutput() {
     try {
       sock.shutdownOutput();
@@ -310,14 +368,25 @@ public class FCPConnectionHandler implements Closeable {
     }
   }
 
+  /**
+   * Associates this connection with the supplied client name, wiring or creating the corresponding
+   * persistent {@link PersistentRequestClient}s and replaying any queued messages.
+   *
+   * <p>The method registers reboot- and forever-scope clients on demand, kicks off asynchronous
+   * replays of pending messages back to the peer, and caches the chosen name for diagnostics. It is
+   * safe to call once per connection handshake before any request scheduling occurs.
+   *
+   * @param name Logical identifier supplied by the peer; should be non-null and consistent across
+   *     reconnects to benefit from persistence.
+   */
   public void setClientName(final String name) {
     this.clientName = name;
     rebootClient = server.registerRebootClient(name, server.getCore(), this);
     rebootClient.queuePendingMessagesOnConnectionRestartAsync(
         outputHandler, server.getCore().getClientContext());
-    // Create foreverClient lazily. Everything that needs it (especially creating ClientGet's etc)
+    // Create foreverClient lazily. Everything that needs it (especially creating ClientGet's etc.)
     // runs on a database job.
-    if (LOG.isDebugEnabled()) LOG.debug("Set client name: " + name);
+    if (LOG.isDebugEnabled()) LOG.debug("Set client name: {}", name);
     PersistentRequestClient client = server.getForeverClient(name, server.getCore(), this);
     if (client != null) {
       synchronized (this) {
@@ -328,6 +397,17 @@ public class FCPConnectionHandler implements Closeable {
     }
   }
 
+  /**
+   * Lazily creates or retrieves the forever-scope {@link PersistentRequestClient} associated with
+   * the supplied name, ensuring only one instance exists per handler.
+   *
+   * <p>Synchronization occurs twice: initially to short-circuit when a client already exists and
+   * again after registration so any waiters observing {@link #foreverClient} get notified. The
+   * returned client immediately begins replaying pending messages on the current connection.
+   *
+   * @param name Identifier shared across reconnections so persistent requests remain addressable.
+   * @return Initialized persistent client ready to accept forever-scope requests.
+   */
   protected PersistentRequestClient createForeverClient(String name) {
     synchronized (FCPConnectionHandler.this) {
       if (foreverClient != null) return foreverClient;
@@ -343,494 +423,465 @@ public class FCPConnectionHandler implements Closeable {
     return foreverClient;
   }
 
+  /**
+   * Returns the client-supplied identifier previously registered through {@link
+   * #setClientName(String)}.
+   *
+   * <p>The value may be {@code null} until the handshake completes, so callers should defensively
+   * handle that case when logging or composing error messages. Once set, the name remains stable
+   * for the connection and is used when looking up persistent request queues or plugin bridges.
+   *
+   * @return Current client name or {@code null} if the connection has not announced one.
+   */
   public String getClientName() {
     return clientName;
   }
 
-  // FIXME next 3 methods are in need of refactoring!
-
   /**
-   * Start a ClientGet. If there is an identifier collision, queue an IdentifierCollisionMessage.
-   * Hence, we can run stuff on other threads if we need to, as long as we send the right messages.
+   * Starts a {@link ClientGet} according to the persistence requested by the peer, scheduling it
+   * immediately for connection scope or deferring through the persistent job runner.
+   *
+   * <p>The method instantiates a {@link ClientGet}, attempts to register it under the provided
+   * identifier, and handles collisions by sending {@link IdentifierCollisionMessage}s without
+   * throwing back to the caller. FOREVER requests are enqueued on a background job so disk-backed
+   * state can be opened safely, while reboot and connection scopes run inline.
+   *
+   * @param message Parsed {@code ClientGetMessage} received from the peer; must contain a unique
+   *     identifier, persistence policy, and routing metadata.
    */
   public void startClientGet(final ClientGetMessage message) {
-    final String id = message.identifier;
-    final boolean global = message.global;
-    ClientGet cg = null;
-    boolean success;
-    boolean persistent = message.persistence != Persistence.CONNECTION;
-    synchronized (this) {
-      if (isClosed) return;
-      // We need to track non-persistent requests anyway, so we may as well check
-      if (persistent) success = true;
-      else success = !requestsByIdentifier.containsKey(id);
-      if (success) {
-        try {
-
-          if (!persistent) {
-            cg = new ClientGet(this, message, server.getCore());
-            requestsByIdentifier.put(id, cg);
-          } else if (message.persistence == Persistence.FOREVER) {
-            try {
-              server
-                  .getCore()
-                  .getClientContext()
-                  .jobRunner
-                  .queue(
-                      new PersistentJob() {
-
-                        @Override
-                        public boolean run(ClientContext context) {
-                          ClientGet getter;
-                          try {
-                            getter =
-                                new ClientGet(FCPConnectionHandler.this, message, server.getCore());
-                          } catch (IdentifierCollisionException e1) {
-                            LOG.info("Identifier collision on " + this);
-                            FCPMessage msg = new IdentifierCollisionMessage(id, message.global);
-                            send(msg);
-                            return false;
-                          } catch (MessageInvalidException e1) {
-                            send(
-                                new ProtocolErrorMessage(
-                                    e1.protocolCode, false, e1.getMessage(), e1.ident, e1.global));
-                            return false;
-                          }
-                          try {
-                            getter.register(false);
-                          } catch (IdentifierCollisionException e) {
-                            LOG.info("Identifier collision on " + this);
-                            FCPMessage msg = new IdentifierCollisionMessage(id, global);
-                            send(msg);
-                            return false;
-                          }
-                          getter.start(context);
-                          return true;
-                        }
-                      },
-                      NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
-            } catch (PersistenceDisabledException e) {
-              send(
-                  new ProtocolErrorMessage(
-                      ProtocolErrorMessage.PERSISTENCE_DISABLED,
-                      false,
-                      "Persistence is disabled",
-                      id,
-                      global));
-              return;
-            }
-            return; // Don't run the start() below
-          } else {
-            cg = new ClientGet(this, message, server.getCore());
-          }
-        } catch (IdentifierCollisionException e) {
-          success = false;
-        } catch (MessageInvalidException e) {
-          send(new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global));
-          return;
-        }
-      }
-    }
-    if (message.persistence == Persistence.REBOOT)
-      try {
-        cg.register(false);
-      } catch (IdentifierCollisionException e) {
-        success = false;
-      }
-    if (!success) {
-      LOG.info("Identifier collision on " + this);
-      FCPMessage msg = new IdentifierCollisionMessage(id, message.global);
-      send(msg);
-    } else {
-      cg.start(server.getCore().getClientContext());
+    switch (message.persistence) {
+      case FOREVER:
+        startForeverClientGet(message);
+        break;
+      case REBOOT:
+        startRebootClientGet(message);
+        break;
+      case CONNECTION:
+      default:
+        startConnectionClientGet(message);
+        break;
     }
   }
 
+  private void startConnectionClientGet(ClientGetMessage message) {
+    if (isClosed()) {
+      return;
+    }
+    ClientGet request = buildClientGet(message);
+    if (request == null) {
+      return;
+    }
+    RegistrationResult registration = registerConnectionScopedRequest(message.identifier, request);
+    if (registration == RegistrationResult.DUPLICATE) {
+      request.freeData();
+      handleIdentifierCollision(message.identifier, message.global);
+      return;
+    }
+    if (registration == RegistrationResult.CLOSED) {
+      request.freeData();
+      return;
+    }
+    request.start(server.getCore().getClientContext());
+  }
+
+  private void startRebootClientGet(ClientGetMessage message) {
+    ClientGet request = buildClientGet(message);
+    if (request == null) {
+      return;
+    }
+    if (!registerPersistentRequest(request, message.identifier, message.global)) {
+      return;
+    }
+    request.start(server.getCore().getClientContext());
+  }
+
+  private void startForeverClientGet(ClientGetMessage message) {
+    queuePersistentJob(
+        context -> {
+          ClientGet request = buildClientGet(message);
+          if (request == null) {
+            return false;
+          }
+          if (!registerPersistentRequest(request, message.identifier, message.global)) {
+            request.freeData();
+            return false;
+          }
+          request.start(context);
+          return true;
+        },
+        message.identifier,
+        message.global);
+  }
+
+  private ClientGet buildClientGet(ClientGetMessage message) {
+    try {
+      return new ClientGet(this, message, server.getCore());
+    } catch (IdentifierCollisionException e) {
+      handleIdentifierCollision(message.identifier, message.global);
+    } catch (MessageInvalidException e) {
+      sendProtocolError(e);
+    }
+    return null;
+  }
+
+  /**
+   * Begins processing a {@link ClientPut} insert, validating compression descriptors, registering
+   * the request under the desired persistence scope, and launching the actual insert on the proper
+   * execution context.
+   *
+   * <p>Legacy LZMA usage triggers a one-time warning so operators know to update their codec list.
+   * Requests scoped to FOREVER are dispatched through the persistent job runner to avoid blocking
+   * the caller thread, while REBOOT and CONNECTION inserts start immediately. Identifier collisions
+   * are resolved deterministically and never leak to the caller as exceptions.
+   *
+   * @param message Parsed {@code ClientPutMessage} describing the insert parameters, target key,
+   *     and persistence choice supplied by the client.
+   */
   public void startClientPut(final ClientPutMessage message) {
-    if (LOG.isDebugEnabled()) LOG.debug("Starting insert ID=\"" + message.identifier + '"');
-    // Instrumentation: warn when client requests legacy LZMA via FCP Codecs
-    if (message.compressorDescriptor != null
-        && LEGACY_LZMA_CODECS.matcher(message.compressorDescriptor).find()
-        && warnedLegacyLzma.compareAndSet(false, true)) {
-      Socket s = getSocket();
-      Object remote = (s != null) ? s.getRemoteSocketAddress() : "unknown";
-      LOG.warn(
-          "FCP ClientPut uses legacy LZMA in Codecs; advise {} instead. id={}, token={}, client={},"
-              + " remote={}",
-          "LZMA_NEW",
-          message.identifier,
-          message.clientToken,
-          getClientName(),
-          remote);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Starting insert ID=\"{}\"", message.identifier);
     }
-    final String id = message.identifier;
-    final boolean global = message.global;
-    ClientPut cp = null;
-    boolean persistent = message.persistence != Persistence.CONNECTION;
-    FCPMessage failedMessage = null;
-    synchronized (this) {
-      boolean success;
-      if (isClosed) {
-        if (LOG.isDebugEnabled()) LOG.debug("Connection is closed");
-        return;
-      }
-      // We need to track non-persistent requests anyway, so we may as well check
-      if (persistent) success = true;
-      else success = !requestsByIdentifier.containsKey(id);
-      if (success) {
-        if (!persistent) {
-          try {
-            cp = new ClientPut(this, message, server);
-            requestsByIdentifier.put(id, cp);
-          } catch (IdentifierCollisionException e) {
-            success = false;
-          } catch (MessageInvalidException e) {
-            send(
-                new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global));
-            return;
-          } catch (MalformedURLException e) {
-            failedMessage =
-                new ProtocolErrorMessage(
-                    ProtocolErrorMessage.FREENET_URI_PARSE_ERROR,
-                    true,
-                    e.getMessage(),
-                    id,
-                    message.global);
-          } catch (IOException e) {
-            failedMessage =
-                new ProtocolErrorMessage(
-                    ProtocolErrorMessage.IO_ERROR, true, e.getMessage(), id, message.global);
-          }
-        } else if (message.persistence == Persistence.FOREVER) {
-          try {
-            server
-                .getCore()
-                .getClientContext()
-                .jobRunner
-                .queue(
-                    new PersistentJob() {
-
-                      @Override
-                      public boolean run(ClientContext context) {
-                        ClientPut putter;
-                        try {
-                          putter = new ClientPut(FCPConnectionHandler.this, message, server);
-                        } catch (IdentifierCollisionException e) {
-                          LOG.info("Identifier collision on " + this);
-                          FCPMessage msg = new IdentifierCollisionMessage(id, message.global);
-                          send(msg);
-                          return false;
-                        } catch (MessageInvalidException e) {
-                          send(
-                              new ProtocolErrorMessage(
-                                  e.protocolCode, false, e.getMessage(), e.ident, e.global));
-                          return false;
-                        } catch (MalformedURLException e) {
-                          send(
-                              new ProtocolErrorMessage(
-                                  ProtocolErrorMessage.FREENET_URI_PARSE_ERROR,
-                                  true,
-                                  null,
-                                  id,
-                                  message.global));
-                          return false;
-                        } catch (IOException e) {
-                          send(
-                              new ProtocolErrorMessage(
-                                  ProtocolErrorMessage.IO_ERROR, true, null, id, message.global));
-                          return false;
-                        }
-                        try {
-                          putter.register(false);
-                        } catch (IdentifierCollisionException e) {
-                          LOG.info("Identifier collision on " + this);
-                          FCPMessage msg = new IdentifierCollisionMessage(id, global);
-                          send(msg);
-                          return false;
-                        }
-                        putter.start(context);
-                        return true;
-                      }
-                    },
-                    NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
-          } catch (PersistenceDisabledException e) {
-            send(
-                new ProtocolErrorMessage(
-                    ProtocolErrorMessage.PERSISTENCE_DISABLED,
-                    false,
-                    "Persistence is disabled",
-                    id,
-                    global));
-          }
-          return; // Don't run the start() below
-        } else {
-          try {
-            cp = new ClientPut(this, message, server);
-          } catch (IdentifierCollisionException e) {
-            success = false;
-          } catch (MessageInvalidException e) {
-            send(
-                new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global));
-            return;
-          } catch (MalformedURLException e) {
-            failedMessage =
-                new ProtocolErrorMessage(
-                    ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, true, null, id, message.global);
-          } catch (IOException e) {
-            failedMessage =
-                new ProtocolErrorMessage(
-                    ProtocolErrorMessage.IO_ERROR, true, null, id, message.global);
-          }
-        }
-      }
-      if (!success) {
-        LOG.info("Identifier collision on " + this);
-        failedMessage = new IdentifierCollisionMessage(id, message.global);
-      }
-    }
-    if (message.persistence == Persistence.REBOOT && cp != null)
-      try {
-        cp.register(false);
-      } catch (IdentifierCollisionException e) {
-        failedMessage = new IdentifierCollisionMessage(id, message.global);
-      }
-    if (failedMessage != null) {
-      if (LOG.isDebugEnabled()) LOG.debug("Failed: " + failedMessage);
-      send(failedMessage);
-      if (cp != null) cp.freeData();
-      else message.freeData();
-    } else {
-      LOG.debug("Starting " + cp);
-      cp.start(server.getCore().getClientContext());
+    warnLegacyLzmaIfNeeded(
+        message.compressorDescriptor, "ClientPut", message.identifier, message.clientToken);
+    switch (message.persistence) {
+      case FOREVER:
+        startForeverClientPut(message);
+        break;
+      case REBOOT:
+        startRebootClientPut(message);
+        break;
+      case CONNECTION:
+      default:
+        startConnectionClientPut(message);
+        break;
     }
   }
 
+  private void startConnectionClientPut(ClientPutMessage message) {
+    if (isClosed()) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Connection is closed");
+      }
+      return;
+    }
+    ClientPut request = buildClientPut(message, true);
+    if (request == null) {
+      return;
+    }
+    RegistrationResult registration = registerConnectionScopedRequest(message.identifier, request);
+    if (registration == RegistrationResult.DUPLICATE) {
+      request.freeData();
+      handleIdentifierCollision(message.identifier, message.global);
+      return;
+    }
+    if (registration == RegistrationResult.CLOSED) {
+      request.freeData();
+      return;
+    }
+    request.start(server.getCore().getClientContext());
+  }
+
+  private void startRebootClientPut(ClientPutMessage message) {
+    ClientPut request = buildClientPut(message, true);
+    if (request == null) {
+      return;
+    }
+    if (!registerPersistentRequest(request, message.identifier, message.global)) {
+      request.freeData();
+      return;
+    }
+    request.start(server.getCore().getClientContext());
+  }
+
+  private void startForeverClientPut(ClientPutMessage message) {
+    queuePersistentJob(
+        context -> {
+          ClientPut request = buildClientPut(message, false);
+          if (request == null) {
+            return false;
+          }
+          if (!registerPersistentRequest(request, message.identifier, message.global)) {
+            request.freeData();
+            return false;
+          }
+          request.start(context);
+          return true;
+        },
+        message.identifier,
+        message.global);
+  }
+
+  /**
+   * Initiates a directory insert, wiring each bucket of content into a {@link ClientPutDir} and
+   * routing it through the requested persistence tier.
+   *
+   * <p>The handler optionally reuses disk-backed buckets when {@code wasDiskPut} is {@code true},
+   * validates identifier uniqueness, and mirrors the same queuing semantics as {@link
+   * #startClientPut(ClientPutMessage)}. Drops and collisions generate protocol errors rather than
+   * unchecked exceptions.
+   *
+   * @param message Client-supplied directory insert descriptor referencing metadata and codecs.
+   * @param buckets Map of bucket identifiers to either {@link network.crypta.support.api.Bucket}
+   *     instances or literal data blobs that the insert will stream.
+   * @param wasDiskPut {@code true} when the source content already resides on disk, allowing the
+   *     insert to skip redundant buffering.
+   */
   public void startClientPutDir(
       final ClientPutDirMessage message,
-      final HashMap<String, Object> buckets,
+      final Map<String, Object> buckets,
       final boolean wasDiskPut) {
-    if (LOG.isDebugEnabled()) LOG.debug("Start ClientPutDir");
-    // Instrumentation: warn when client requests legacy LZMA via FCP Codecs
-    if (message.compressorDescriptor != null
-        && LEGACY_LZMA_CODECS.matcher(message.compressorDescriptor).find()
-        && warnedLegacyLzma.compareAndSet(false, true)) {
-      Socket s = getSocket();
-      Object remote = (s != null) ? s.getRemoteSocketAddress() : "unknown";
-      LOG.warn(
-          "FCP ClientPutDir uses legacy LZMA in Codecs; advise {} instead. id={}, token={},"
-              + " client={}, remote={}",
-          "LZMA_NEW",
-          message.identifier,
-          message.clientToken,
-          getClientName(),
-          remote);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Start ClientPutDir");
     }
-    final String id = message.identifier;
-    final boolean global = message.global;
-    ClientPutDir cp = null;
-    FCPMessage failedMessage = null;
-    boolean persistent = message.persistence != Persistence.CONNECTION;
-    // We need to track non-persistent requests anyway, so we may as well check
-    boolean success;
-    synchronized (this) {
-      if (isClosed) return;
-      if (!persistent) success = true;
-      else success = !requestsByIdentifier.containsKey(id);
-    }
-    if (success) {
-      if (!persistent) {
-        try {
-          cp = new ClientPutDir(this, message, buckets, wasDiskPut, server);
-          synchronized (this) {
-            requestsByIdentifier.put(id, cp);
-          }
-        } catch (MalformedURLException e) {
-          failedMessage =
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, true, null, id, message.global);
-        } catch (TooManyFilesInsertException e) {
-          failedMessage =
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.TOO_MANY_FILES_IN_INSERT, true, null, id, message.global);
-        }
-        // FIXME register non-persistent requests in the constructors also, we already register
-        // persistent ones...
-      } else if (message.persistence == Persistence.FOREVER) {
-        try {
-          server
-              .getCore()
-              .getClientContext()
-              .jobRunner
-              .queue(
-                  new PersistentJob() {
-
-                    @Override
-                    public boolean run(ClientContext context) {
-                      ClientPutDir putter;
-                      try {
-                        putter =
-                            new ClientPutDir(
-                                FCPConnectionHandler.this, message, buckets, wasDiskPut, server);
-                      } catch (MalformedURLException e) {
-                        send(
-                            new ProtocolErrorMessage(
-                                ProtocolErrorMessage.FREENET_URI_PARSE_ERROR,
-                                true,
-                                null,
-                                id,
-                                message.global));
-                        return false;
-                      } catch (TooManyFilesInsertException e) {
-                        send(
-                            new ProtocolErrorMessage(
-                                ProtocolErrorMessage.TOO_MANY_FILES_IN_INSERT,
-                                true,
-                                null,
-                                id,
-                                message.global));
-                        return false;
-                      }
-                      try {
-                        putter.register(false);
-                      } catch (IdentifierCollisionException e) {
-                        LOG.info("Identifier collision on " + this);
-                        FCPMessage msg = new IdentifierCollisionMessage(id, message.global);
-                        send(msg);
-                        return false;
-                      }
-                      putter.start(context);
-                      return true;
-                    }
-                  },
-                  NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
-        } catch (PersistenceDisabledException e) {
-          send(
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.PERSISTENCE_DISABLED,
-                  false,
-                  "Persistence is disabled",
-                  id,
-                  global));
-        }
-        return; // Don't run the start() below
-
-      } else {
-        try {
-          cp = new ClientPutDir(this, message, buckets, wasDiskPut, server);
-        } catch (MalformedURLException e) {
-          failedMessage =
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, true, null, id, message.global);
-        } catch (TooManyFilesInsertException e) {
-          failedMessage =
-              new ProtocolErrorMessage(
-                  ProtocolErrorMessage.TOO_MANY_FILES_IN_INSERT, true, null, id, message.global);
-        }
-      }
-      if (!success) {
-        LOG.info("Identifier collision on " + this);
-        failedMessage = new IdentifierCollisionMessage(id, message.global);
-      }
-    }
-
-    if (message.persistence == Persistence.REBOOT && cp != null)
-      try {
-        cp.register(false);
-      } catch (IdentifierCollisionException e) {
-        failedMessage = new IdentifierCollisionMessage(id, message.global);
-      }
-    if (failedMessage != null) {
-      // FIXME do we need to freeData???
-      send(failedMessage);
-      if (cp != null) cp.cancel(server.getCore().getClientContext());
-    } else if (cp != null) {
-      if (LOG.isDebugEnabled()) LOG.debug("Starting " + cp);
-      cp.start(server.getCore().getClientContext());
-    } else {
-      // Defensive fallback: cp can be null when constructor setup was skipped.
-      LOG.warn("ClientPutDir was not created for identifier {}", id);
+    warnLegacyLzmaIfNeeded(
+        message.compressorDescriptor, "ClientPutDir", message.identifier, message.clientToken);
+    switch (message.persistence) {
+      case FOREVER:
+        startForeverClientPutDir(message, buckets, wasDiskPut);
+        break;
+      case REBOOT:
+        startRebootClientPutDir(message, buckets, wasDiskPut);
+        break;
+      case CONNECTION:
+      default:
+        startConnectionClientPutDir(message, buckets, wasDiskPut);
+        break;
     }
   }
 
+  private void startConnectionClientPutDir(
+      ClientPutDirMessage message, Map<String, Object> buckets, boolean wasDiskPut) {
+    if (isClosed()) {
+      return;
+    }
+    ClientPutDir request = buildClientPutDir(message, buckets, wasDiskPut, true);
+    if (request == null) {
+      return;
+    }
+    RegistrationResult registration = registerConnectionScopedRequest(message.identifier, request);
+    if (registration == RegistrationResult.DUPLICATE) {
+      request.cancel(server.getCore().getClientContext());
+      handleIdentifierCollision(message.identifier, message.global);
+      return;
+    }
+    if (registration == RegistrationResult.CLOSED) {
+      request.cancel(server.getCore().getClientContext());
+      return;
+    }
+    request.start(server.getCore().getClientContext());
+  }
+
+  private void startRebootClientPutDir(
+      ClientPutDirMessage message, Map<String, Object> buckets, boolean wasDiskPut) {
+    ClientPutDir request = buildClientPutDir(message, buckets, wasDiskPut, true);
+    if (request == null) {
+      return;
+    }
+    if (!registerPersistentRequest(request, message.identifier, message.global)) {
+      request.cancel(server.getCore().getClientContext());
+      return;
+    }
+    request.start(server.getCore().getClientContext());
+  }
+
+  private void startForeverClientPutDir(
+      ClientPutDirMessage message, Map<String, Object> buckets, boolean wasDiskPut) {
+    queuePersistentJob(
+        context -> {
+          ClientPutDir request = buildClientPutDir(message, buckets, wasDiskPut, false);
+          if (request == null) {
+            return false;
+          }
+          if (!registerPersistentRequest(request, message.identifier, message.global)) {
+            request.cancel(server.getCore().getClientContext());
+            return false;
+          }
+          request.start(context);
+          return true;
+        },
+        message.identifier,
+        message.global);
+  }
+
+  private ClientPut buildClientPut(ClientPutMessage message, boolean includeErrorDetail) {
+    try {
+      return new ClientPut(this, message, server);
+    } catch (IdentifierCollisionException e) {
+      handleIdentifierCollision(message.identifier, message.global);
+    } catch (MessageInvalidException e) {
+      sendProtocolError(e);
+    } catch (MalformedURLException e) {
+      sendUriParseError(
+          includeErrorDetail ? e.getMessage() : null, message.identifier, message.global);
+    } catch (IOException e) {
+      sendIoError(includeErrorDetail ? e.getMessage() : null, message.identifier, message.global);
+    }
+    message.freeData();
+    return null;
+  }
+
+  private ClientPutDir buildClientPutDir(
+      ClientPutDirMessage message,
+      Map<String, Object> buckets,
+      boolean wasDiskPut,
+      boolean includeErrorDetail) {
+    try {
+      return new ClientPutDir(this, message, buckets, wasDiskPut, server);
+    } catch (MalformedURLException e) {
+      sendUriParseError(
+          includeErrorDetail ? e.getMessage() : null, message.identifier, message.global);
+    } catch (TooManyFilesInsertException e) {
+      sendTooManyFilesError(message.identifier, message.global);
+    }
+    return null;
+  }
+
+  private RegistrationResult registerConnectionScopedRequest(
+      String identifier, ClientRequest request) {
+    synchronized (this) {
+      if (isClosed) {
+        return RegistrationResult.CLOSED;
+      }
+      if (requestsByIdentifier.containsKey(identifier)) {
+        return RegistrationResult.DUPLICATE;
+      }
+      requestsByIdentifier.put(identifier, request);
+      return RegistrationResult.REGISTERED;
+    }
+  }
+
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+  private boolean registerPersistentRequest(
+      ClientRequest request, String identifier, boolean global) {
+    try {
+      request.register(false);
+      return true;
+    } catch (IdentifierCollisionException e) {
+      handleIdentifierCollision(identifier, global);
+      return false;
+    }
+  }
+
+  private void handleIdentifierCollision(String identifier, boolean global) {
+    LOG.info(COLLISION_LOG_TEMPLATE, this);
+    send(new IdentifierCollisionMessage(identifier, global));
+  }
+
+  private void sendPersistenceDisabled(String identifier, boolean global) {
+    send(
+        new ProtocolErrorMessage(
+            ProtocolErrorMessage.PERSISTENCE_DISABLED,
+            false,
+            PERSISTENCE_DISABLED_TEXT,
+            identifier,
+            global));
+  }
+
+  private void sendProtocolError(MessageInvalidException e) {
+    send(new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global));
+  }
+
+  private void sendUriParseError(String detail, String identifier, boolean global) {
+    send(
+        new ProtocolErrorMessage(
+            ProtocolErrorMessage.FREENET_URI_PARSE_ERROR, true, detail, identifier, global));
+  }
+
+  private void sendIoError(String detail, String identifier, boolean global) {
+    send(new ProtocolErrorMessage(ProtocolErrorMessage.IO_ERROR, true, detail, identifier, global));
+  }
+
+  private void sendTooManyFilesError(String identifier, boolean global) {
+    send(
+        new ProtocolErrorMessage(
+            ProtocolErrorMessage.TOO_MANY_FILES_IN_INSERT, true, null, identifier, global));
+  }
+
+  private void queuePersistentJob(PersistentJob job, String identifier, boolean global) {
+    try {
+      server
+          .getCore()
+          .getClientContext()
+          .jobRunner
+          .queue(job, NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
+    } catch (PersistenceDisabledException e) {
+      sendPersistenceDisabled(identifier, global);
+    }
+  }
+
+  private boolean containsLegacyLzma(String descriptor) {
+    if (descriptor == null || descriptor.isBlank()) {
+      return false;
+    }
+    String[] tokens = descriptor.split(",");
+    for (String token : tokens) {
+      if ("LZMA".equalsIgnoreCase(token.trim())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void warnLegacyLzmaIfNeeded(
+      String descriptor, String requestKind, String identifier, String clientToken) {
+    if (!containsLegacyLzma(descriptor)) {
+      return;
+    }
+    if (!warnedLegacyLzma.compareAndSet(false, true)) {
+      return;
+    }
+    Socket socket = getSocket();
+    Object remote = (socket != null) ? socket.getRemoteSocketAddress() : "unknown";
+    LOG.warn(
+        "FCP {} uses legacy LZMA in Codecs; advise {} instead. id={}, token={}, client={},"
+            + " remote={}",
+        requestKind,
+        LEGACY_LZMA_REPLACEMENT,
+        identifier,
+        clientToken,
+        getClientName(),
+        remote);
+  }
+
+  /**
+   * Returns the reboot-scope {@link PersistentRequestClient} backing this connection, creating it
+   * lazily when {@link #setClientName(String)} is first invoked.
+   *
+   * <p>Reboot clients persist on disk between node restarts but are scoped per client name. This
+   * accessor allows callers to query or manipulate persistent state without repeating registration
+   * logic; however, it can return {@code null} prior to the initial handshake completing.
+   *
+   * @return Persistent client that survives node restarts but not manual deletion; may be {@code
+   *     null} until a client name is registered.
+   */
   public PersistentRequestClient getRebootClient() {
     return rebootClient;
   }
 
   /**
-   * @return The {@link FCPPluginConnection} for the given serverPluginName (see {@link
-   *     PluginManager#getPluginFCPServer(String)}). Atomically creates and stores it if there does
-   *     not exist one yet. This ensures that for each FCPConnectionHandler, there can be only one
-   *     {@link FCPPluginConnection} for a given serverPluginName.
+   * @return The {@link FCPPluginConnection} for the given serverPluginName. Atomically creates and
+   *     stores it if there does not exist one yet. This ensures that for each FCPConnectionHandler,
+   *     there can be only one {@link FCPPluginConnection} for a given serverPluginName.
    * @throws PluginNotFoundException If the specified plugin is not loaded or does not provide an
    *     FCP server.
    */
   FCPPluginConnection getFCPPluginConnection(String serverPluginName)
       throws PluginNotFoundException {
-
-    // The suspected typical usage pattern of this function is that the great majority of calls
-    // will return an existing FCPPluginConnection. Creating a fresh one will typically only
-    // happen at the start of a connection and then it will be re-used a lot.
-    // Therefore, it would cost a lot of performance to use synchronized() and we instead use a
-    // ReadWriteLock which is optimal for such patterns.
-    //
-    // The double-checked locking pattern which this induces is necessary due to the fact that a
-    // read-lock cannot be upgraded to a write lock.
-    // The JavaDoc of ReentrantReadWriteLock specifically recommends this pattern, so it ought
-    // to be a safe version of double-checked locking.
-
-    pluginConnectionsByServerName_Lock.readLock().lock();
-    try {
-      // We use the actual *Impl instead of the interface because the implementation provides
-      // isServerDead(), which the interface does not.
-      FCPPluginConnectionImpl peekOldConnection =
-          pluginConnectionsByServerName.get(serverPluginName);
-
-      if (peekOldConnection != null && !peekOldConnection.isServerDead()) {
-        return peekOldConnection;
-      }
-    } finally {
-      // A read-lock cannot be upgraded to a write-lock so we must always unlock
-      pluginConnectionsByServerName_Lock.readLock().unlock();
-    }
-
-    pluginConnectionsByServerName_Lock.writeLock().lock();
-    try {
-      // Re-check whether there is an existing connection since we had to re-acquire the lock
-      // meanwhile.
-      FCPPluginConnectionImpl oldConnection = pluginConnectionsByServerName.get(serverPluginName);
-
-      if (oldConnection != null) {
-        if (!oldConnection.isServerDead()) {
-          return oldConnection;
-        } else {
-          // oldConnection.isDead() returned true because the WeakReference to the server
-          // has been nulled because the plugin was unloaded or reloaded.
-          // The connection should be discarded then. We have no ReferenceQueue to discard
-          // affected connections from the pluginConnectionsByServerName table, so we
-          // opportunistically clean nulled connections from it here.
-          // The reason why this is sufficient memory management is explained at
-          // FCPPluginConnectionImpl.server
-          // NOTICE: Even if there was automatic disposal of nulled references, we still
-          // would have to manually remove dead ones here: I have observed that it can
-          // take minutes until the JVM flushes a ReferenceQueue. So if we relied upon
-          // that only, during those minutes a client would be unable to send messages to
-          // a re-loaded server plugin because the continued existence of the dead old
-          // connection would prevent a new one from being created.
-          pluginConnectionsByServerName.remove(serverPluginName);
-        }
-      }
-
-      FCPPluginConnectionImpl newConnection =
-          server.createFCPPluginConnectionForNetworkedFCP(serverPluginName, this);
-
-      pluginConnectionsByServerName.put(serverPluginName, newConnection);
-
-      return newConnection;
-    } finally {
-      pluginConnectionsByServerName_Lock.writeLock().unlock();
-    }
+    return pluginConnectionRegistry.get(serverPluginName, server, this);
   }
 
+  /**
+   * Provides access to this handler's forever-scope {@link PersistentRequestClient}, instantiating
+   * it if necessary so new inserts can reuse previously stored state.
+   *
+   * <p>Forever clients live across reboots and reconnections, so this accessor synchronizes and, if
+   * needed, invokes {@link #createForeverClient(String)} to populate {@link #foreverClient}. The
+   * returned instance queues pending messages back to the output handler automatically.
+   *
+   * @return Non-null persistent client once the connection has an assigned name; the reference is
+   *     cached for subsequent calls.
+   */
   public PersistentRequestClient getForeverClient() {
     synchronized (this) {
       if (foreverClient == null) {
@@ -840,156 +891,121 @@ public class FCPConnectionHandler implements Closeable {
     }
   }
 
+  /**
+   * Removes the supplied {@link ClientRequest} from the connection-scoped registry once it has
+   * completed, freeing the identifier for reuse.
+   *
+   * <p>Callers should invoke this exactly once per request completion path so the handler can
+   * detect future identifier collisions accurately.
+   *
+   * @param get Request that triggered a completion callback; must not be {@code null}.
+   */
   public void finishedClientRequest(ClientRequest get) {
     synchronized (this) {
       requestsByIdentifier.remove(get.getIdentifier());
     }
   }
 
+  /**
+   * Reports whether the reboot-scope persistent client currently watches the global queue, meaning
+   * it receives broadcasts rather than only this connection's identifiers.
+   *
+   * <p>This is primarily surfaced for diagnostics and tests so they can assert that a connection is
+   * subscribed before sending synthetic updates.
+   *
+   * @return {@code true} when {@link #rebootClient} is configured for global traffic, otherwise
+   *     {@code false}. Primarily used by diagnostic commands.
+   */
+  @SuppressWarnings("unused")
   public boolean isGlobalSubscribed() {
     return rebootClient.watchGlobal;
   }
 
+  /**
+   * Evaluates whether the remote socket is included in the server's full-access host list, allowing
+   * privileged DDA operations and unrestricted commands.
+   *
+   * <p>This check delegates to {@link network.crypta.io.AllowedHosts#allowed(java.net.InetAddress)}
+   * so allowlist changes take effect immediately without restarting the connection.
+   *
+   * @return {@code true} when the peer's IP matches the configured full-access mask.
+   */
   public boolean hasFullAccess() {
     return server.allowedHostsFullAccess.allowed(sock.getInetAddress());
   }
 
   /**
-   * That method ought to be called before any DirectDiskAccess operation is performed by the node
+   * Records the outcome of a DDA test initiated by {@code TestDdaCompleteMessage}, allowing the
+   * access controller to short-circuit future checks on the same path.
    *
-   * @param filename
-   * @param writeRequest : Are willing to write or to read ?
-   * @return boolean : allowed or not
-   */
-  protected boolean allowDDAFrom(File filename, boolean writeRequest) {
-    String parentDirectory = FileUtil.getCanonicalFile(filename).getParent();
-    DirectoryAccess da = null;
-
-    synchronized (checkedDirectories) {
-      da = checkedDirectories.get(parentDirectory);
-    }
-
-    if (LOG.isDebugEnabled()) LOG.debug("Checking DDA: " + da + " for " + parentDirectory);
-
-    if (writeRequest) return (da == null ? server.isDownloadDDAAlwaysAllowed() : da.canWrite);
-    else return (da == null ? server.isUploadDDAAlwaysAllowed() : da.canRead);
-  }
-
-  /**
-   * SHOULD BE CALLED ONLY FROM TestDDAComplete!
+   * <p>Only test harnesses should call this; production paths learn results through {@link
+   * #enqueueDDACheck(String, boolean, boolean)}.
    *
-   * @param path
-   * @param read
-   * @param write
+   * @param path Absolute or canonical path that was probed during the DDA test.
+   * @param read {@code true} when read permissions were confirmed for {@code path}.
+   * @param write {@code true} when write permissions were confirmed for {@code path}.
    */
   protected void registerTestDDAResult(String path, boolean read, boolean write) {
-    DirectoryAccess da = new DirectoryAccess(read, write);
-
-    synchronized (checkedDirectories) {
-      checkedDirectories.put(path, da);
-    }
-
-    if (LOG.isDebugEnabled()) LOG.debug("DDA: read=" + read + " write=" + write + " for " + path);
+    ddaAccessController.registerTestDDAResult(path, read, write);
   }
 
   /**
-   * Return a DDACheckJob : the one we created and have enqueued
+   * Registers a deferred direct-disk-access (DDA) permission check for the supplied path and
+   * returns the job handle that was queued.
    *
-   * @param path
-   * @param read : is Read access requested ?
-   * @param write : is Write access requested ?
-   * @return
-   * @throws IllegalArgumentException
-   *     <p>FIXME: Maybe we need to enqueue a PS job to delete the created file after something like
-   *     ... 5 mins ?
+   * <p>Callers typically invoke this before asking the peer for confirmation so the eventual
+   * acknowledgement can resume the request. Each job tracks whether read and/or write permissions
+   * need confirmation and records temporary files that must later be deleted via {@link
+   * #freeDDAJobs()}.
+   *
+   * @param path Canonical path whose permissions need to be verified; must pass safety validation.
+   * @param read {@code true} to test read capability; {@code false} skips read probing.
+   * @param write {@code true} to test write capability; {@code false} keeps the check read-only.
+   * @return Non-null {@link DdaCheckJob} enqueued on the controller, representing the pending work.
+   * @throws IllegalArgumentException If the path falls outside allowed roots or violates validation
+   *     constraints enforced by {@link DdaAccessController}.
    */
-  protected DDACheckJob enqueueDDACheck(String path, boolean read, boolean write)
+  protected DdaCheckJob enqueueDDACheck(String path, boolean read, boolean write)
       throws IllegalArgumentException {
-    File directory = FileUtil.getCanonicalFile(new File(path));
-    if (!directory.exists() || !directory.isDirectory())
-      throw new IllegalArgumentException(
-          "The specified path isn't a directory! or doesn't exist or the node doesn't have access"
-              + " to it!");
-
-    // See #1856
-    DDACheckJob job = null;
-    synchronized (inTestDirectories) {
-      job = inTestDirectories.get(directory);
-    }
-    if (job != null)
-      throw new IllegalArgumentException("There is already a TestDDA going on for that directory!");
-
-    File writeFile =
-        (write
-            ? new File(path, "DDACheck-" + server.getNode().getFastWeakRandom().nextInt() + ".tmp")
-            : null);
-    File readFile = null;
-    if (read) {
-      try {
-        readFile = File.createTempFile("DDACheck-", ".tmp", directory);
-        readFile.deleteOnExit();
-      } catch (IOException e) {
-        // Now we know it: we can't write there ;)
-        readFile = null;
-      }
-    }
-
-    DDACheckJob result =
-        new DDACheckJob(server.getNode().getFastWeakRandom(), directory, readFile, writeFile);
-    synchronized (inTestDirectories) {
-      inTestDirectories.put(directory, result);
-    }
-
-    if (read && (readFile != null) && readFile.canWrite()) {
-      // We don't want to attempt to write before: in case an IOException is raised, we want to
-      // inform the
-      // client somehow that the node can't write there... And setting readFile to null means we
-      // won't inform
-      // it on the status (as if it hadn't requested us to do the test).
-      try (FileOutputStream fos = new FileOutputStream(result.readFilename);
-          BufferedOutputStream bos = new BufferedOutputStream(fos)) {
-
-        bos.write(result.readContent.getBytes(StandardCharsets.UTF_8));
-        bos.flush();
-      } catch (IOException e) {
-        LOG.error("Got a IOE while creating the file (" + readFile + " ! " + e.getMessage());
-      }
-    }
-
-    return result;
+    return ddaAccessController.enqueueDDACheck(path, read, write);
   }
 
   /**
-   * Return a DDACheckJob or null if not found
+   * Retrieves and removes the pending DDA check for the specified path if one exists.
    *
-   * @param path
-   * @return the DDACheckJob
-   * @throws IllegalArgumentException
+   * <p>This is typically called once the peer has responded so we can resume the original request
+   * using the recorded permissions.
+   *
+   * @param path Path originally used to queue the DDA job; must match exactly.
+   * @return Matching {@link DdaCheckJob} if it remains queued; {@code null} otherwise.
+   * @throws IllegalArgumentException If the path fails validation or the controller rejects it.
    */
-  protected DDACheckJob popDDACheck(String path) throws IllegalArgumentException {
-    File directory = FileUtil.getCanonicalFile(new File(path));
-    if (!directory.exists() || !directory.isDirectory())
-      throw new IllegalArgumentException(
-          "The specified path isn't a directory! or doesn't exist or the node doesn't have access"
-              + " to it!");
-
-    synchronized (inTestDirectories) {
-      return inTestDirectories.remove(directory);
-    }
+  protected DdaCheckJob popDDACheck(String path) throws IllegalArgumentException {
+    return ddaAccessController.popDDACheck(path);
   }
 
   /**
-   * Delete the files we have created using DDATest called by
-   * PersistentRequestClient.onDisconnect(handler)
+   * Deletes any temporary files left behind by outstanding DDA tests and clears the tracking
+   * structures so the handler can be safely closed or recycled between reconnects.
+   *
+   * <p>Invoke this after the peer completes DDA verification or when the handler disconnects so
+   * background checks do not leak disk state.
    */
   protected void freeDDAJobs() {
-    synchronized (inTestDirectories) {
-      for (DDACheckJob job : inTestDirectories.values()) {
-        if (job.readFilename != null) job.readFilename.delete();
-      }
-    }
+    ddaAccessController.freeDDAJobs();
   }
 
+  /**
+   * Removes and optionally cancels the {@link ClientRequest} currently registered under the given
+   * identifier.
+   *
+   * <p>If {@code kill} is {@code true}, the request receives a cancel callback before the handler
+   * notifies it about removal, which lets callers align cleanup with de-registration.
+   *
+   * @param identifier Unique token previously provided by the client; must not be {@code null}.
+   * @param kill {@code true} to cancel the request before removal, {@code false} otherwise.
+   * @return Removed request or {@code null} when no matching identifier was registered.
+   */
   public ClientRequest removeRequestByIdentifier(String identifier, boolean kill) {
     ClientRequest req;
     synchronized (this) {
@@ -1003,17 +1019,16 @@ public class FCPConnectionHandler implements Closeable {
   }
 
   ClientRequest getRebootRequest(boolean global, FCPConnectionHandler handler, String identifier) {
-    if (global) return handler.server.getGlobalRebootClient().getRequest(identifier);
+    if (global) return handler.getServer().getGlobalRebootClient().getRequest(identifier);
     else return handler.getRebootClient().getRequest(identifier);
   }
 
   ClientRequest getForeverRequest(boolean global, FCPConnectionHandler handler, String identifier) {
-    if (global) return handler.server.getGlobalForeverClient().getRequest(identifier);
+    if (global) return handler.getServer().getGlobalForeverClient().getRequest(identifier);
     else return handler.getForeverClient().getRequest(identifier);
   }
 
-  ClientRequest removePersistentRebootRequest(boolean global, String identifier)
-      throws MessageInvalidException {
+  ClientRequest removePersistentRebootRequest(boolean global, String identifier) {
     PersistentRequestClient client = global ? server.getGlobalRebootClient() : getRebootClient();
     ClientRequest req = client.getRequest(identifier);
     if (req != null) {
@@ -1022,8 +1037,7 @@ public class FCPConnectionHandler implements Closeable {
     return req;
   }
 
-  ClientRequest removePersistentForeverRequest(boolean global, String identifier)
-      throws MessageInvalidException {
+  ClientRequest removePersistentForeverRequest(boolean global, String identifier) {
     PersistentRequestClient client = global ? server.getGlobalForeverClient() : getForeverClient();
     ClientRequest req = client.getRequest(identifier);
     if (req != null) {
@@ -1032,12 +1046,34 @@ public class FCPConnectionHandler implements Closeable {
     return req;
   }
 
+  /**
+   * Registers a {@link SubscribeUSK} under the provided identifier, enforcing uniqueness across the
+   * connection.
+   *
+   * <p>The subscription map is guarded by this handler's monitor so concurrent add/remove
+   * operations stay consistent even when clients open many subscriptions at once.
+   *
+   * @param identifier Token supplied by the client to track the subscription lifecycle.
+   * @param subscribeUSK Subscription wrapper coordinating callbacks to the requester.
+   * @throws IdentifierCollisionException If another subscription already uses the same identifier.
+   */
   public synchronized void addUSKSubscription(String identifier, SubscribeUSK subscribeUSK)
       throws IdentifierCollisionException {
     if (uskSubscriptions.containsKey(identifier)) throw new IdentifierCollisionException();
     uskSubscriptions.put(identifier, subscribeUSK);
   }
 
+  /**
+   * Cancels the USK subscription bound to the supplied identifier and notifies the subscription of
+   * the change.
+   *
+   * <p>The removal is synchronized with {@link #addUSKSubscription(String, SubscribeUSK)} so no
+   * updates race while the unsubscribe runs.
+   *
+   * @param identifier Subscription token previously registered via {@link
+   *     #addUSKSubscription(String, SubscribeUSK)}.
+   * @throws MessageInvalidException If no subscription exists for the identifier.
+   */
   public void unsubscribeUSK(String identifier) throws MessageInvalidException {
     SubscribeUSK sub;
     synchronized (this) {
@@ -1052,19 +1088,55 @@ public class FCPConnectionHandler implements Closeable {
     sub.unsubscribe();
   }
 
+  /**
+   * Returns the connection-scoped {@link RequestClient} tuned either for realtime or bulk
+   * scheduling, depending on the caller's hint.
+   *
+   * <p>Realtime clients minimize latency and skip batching, whereas bulk clients favor throughput
+   * and larger queues. The choice affects how requests compete for resources on the node.
+   *
+   * @param realTime {@code true} for low-latency handling, {@code false} for throughput-optimized
+   *     handling.
+   * @return Either {@link #connectionRequestClientRT} or {@link #connectionRequestClientBulk}.
+   */
   public RequestClient connectionRequestClient(boolean realTime) {
     if (realTime) return connectionRequestClientRT;
     else return connectionRequestClientBulk;
   }
 
+  /**
+   * Returns the owning {@link FCPServer} used to look up persistent clients and configuration.
+   *
+   * <p>APIs outside the handler often need this pointer to access the global client context or
+   * shared job runners, so exposing it avoids tightly coupling helper classes to the handler.
+   *
+   * @return Non-null server reference that created this handler.
+   */
   public FCPServer getServer() {
     return server;
   }
 
+  /**
+   * Provides the underlying {@link Socket} used for network IO so auxiliary routines can inspect it
+   * for diagnostics.
+   *
+   * <p>The caller must not close the socket directly; use {@link #close()} so the handler can wind
+   * down gracefully.
+   *
+   * @return Socket passed during construction; may be {@code null} if the connection is torn down.
+   */
   public Socket getSocket() {
     return sock;
   }
 
+  /**
+   * Returns the {@link FCPConnectionOutputHandler} responsible for serializing outbound messages.
+   *
+   * <p>External helpers use this to enqueue protocol responses or flush pending data when
+   * performing maintenance operations.
+   *
+   * @return Non-null output handler that was instantiated alongside this connection.
+   */
   public FCPConnectionOutputHandler getOutputHandler() {
     return outputHandler;
   }

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
@@ -219,7 +219,7 @@ public class FCPConnectionInputHandler implements Runnable {
     return FCPMessage.create(
         messageType,
         fs,
-        handler.bf,
+        handler.getServer().getCore().getTempBucketFactory(),
         handler.getServer().getCore().getPersistentTempBucketFactory());
   }
 
@@ -227,7 +227,8 @@ public class FCPConnectionInputHandler implements Runnable {
       throws IOException {
     if (msg instanceof BaseDataCarryingMessage message) {
       try {
-        message.readFrom(lis, handler.bf, handler.getServer());
+        message.readFrom(
+            lis, handler.getServer().getCore().getTempBucketFactory(), handler.getServer());
       } catch (MessageInvalidException e) {
         sendProtocolError(e);
         return false;

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
@@ -96,7 +96,7 @@ public class FCPConnectionInputHandler implements Runnable {
               FCPMessage.create(
                   messageType,
                   fs,
-                  handler.bf,
+                  handler.getServer().getCore().getTempBucketFactory(),
                   handler.getServer().getCore().getPersistentTempBucketFactory());
           if (msg == null) continue;
         } catch (MessageInvalidException e) {
@@ -129,7 +129,8 @@ public class FCPConnectionInputHandler implements Runnable {
         if (msg instanceof BaseDataCarryingMessage message) {
           // FIXME tidy up - coalesce with above and below try { } catch (MIE) {}'s?
           try {
-            message.readFrom(lis, handler.bf, handler.getServer());
+            message.readFrom(
+                lis, handler.getServer().getCore().getTempBucketFactory(), handler.getServer());
           } catch (MessageInvalidException e) {
             FCPMessage err =
                 new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global);

--- a/src/main/java/network/crypta/clients/fcp/FCPMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPMessage.java
@@ -370,8 +370,8 @@ public abstract class FCPMessage {
           new ClientPutComplexDirMessage(fs, bfTemp, bfPersistent);
       case SubscribeUSKMessage.NAME -> new SubscribeUSKMessage(fs);
       case UnsubscribeUSKMessage.NAME -> new UnsubscribeUSKMessage(fs);
-      case TestDDARequestMessage.NAME -> new TestDDARequestMessage(fs);
-      case TestDDAResponseMessage.NAME -> new TestDDAResponseMessage(fs);
+      case TestDdaRequestMessage.NAME -> new TestDdaRequestMessage(fs);
+      case TestDdaResponseMessage.NAME -> new TestDdaResponseMessage(fs);
       case ProbeRequest.NAME -> new ProbeRequest(fs);
       case FilterMessage.NAME -> new FilterMessage(fs, bfTemp);
       default -> null;

--- a/src/main/java/network/crypta/clients/fcp/PluginConnectionRegistry.java
+++ b/src/main/java/network/crypta/clients/fcp/PluginConnectionRegistry.java
@@ -1,0 +1,98 @@
+package network.crypta.clients.fcp;
+
+import java.util.TreeMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import network.crypta.pluginmanager.PluginNotFoundException;
+
+/**
+ * Coordinates cached {@link FCPPluginConnection} instances per server plugin so a connection
+ * handler does not thrash the server with redundant bridges. The registry lives inside {@link
+ * FCPConnectionHandler} and brokers requests from the inbound FCP stream, ensuring each plugin name
+ * resolves to one reusable {@link FCPPluginConnectionImpl} until the underlying server reports
+ * itself as dead. A striped read/write lock guards the internal {@link TreeMap} so the common fast
+ * path (reading an already healthy entry) avoids writer contention while the less frequent creation
+ * path performs serialized maintenance.
+ *
+ * <p>Clients typically call {@link #get(String, FCPServer, FCPConnectionHandler)} every time they
+ * need a connection, even during bursts, trusting the registry to hand back a stable object or
+ * transparently rebuild it. The registry never proactively prunes entries; it removes them only
+ * when the {@link FCPPluginConnectionImpl#isServerDead()} signal indicates the server side cannot
+ * be reused. All returned references therefore stay valid until the owning handler closes or the
+ * server plugin becomes unreachable, at which point the caller must request another instance.
+ *
+ * <ul>
+ *   <li>Maintains a monotonically growing map keyed by canonical plugin name.
+ *   <li>Enforces single-writer semantics whenever the server must allocate a new bridge.
+ *   <li>Guarantees that concurrent readers always either reuse a healthy connection or block until
+ *       a replacement is published.
+ * </ul>
+ *
+ * @see FCPServer#createFCPPluginConnectionForNetworkedFCP(String, FCPConnectionHandler)
+ */
+final class PluginConnectionRegistry {
+  private final TreeMap<String, FCPPluginConnectionImpl> connections = new TreeMap<>();
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+  /**
+   * Creates an empty registry scoped to a single {@link FCPConnectionHandler} instance so the
+   * handler can manage per-plugin bridges without sharing mutable state globally.
+   */
+  PluginConnectionRegistry() {
+    // Intentionally empty; field declarations already set up the map and lock.
+  }
+
+  /**
+   * Looks up the connection for {@code serverPluginName}, creating and caching one if necessary,
+   * while coordinating concurrent callers via an internal read/write lock.
+   *
+   * <p>The method first attempts a non-blocking read to keep the hot path inexpensive; if no
+   * healthy entry exists it escalates to the write lock, double-checks the map, and then asks the
+   * {@link FCPServer} to build a fresh {@link FCPPluginConnectionImpl}. Dead entries are purged
+   * lazily. Callers should expect {@link PluginNotFoundException} if the server refuses to build a
+   * bridge, and they must retry later once the plugin becomes available again.
+   *
+   * <pre>{@code
+   * FCPPluginConnection connection =
+   *     registry.get("ContentPlugin", server, handler);
+   * connection.send(...);
+   * }</pre>
+   *
+   * @param serverPluginName canonical plugin identifier, case-sensitive, never {@code null}.
+   * @param server owning {@link FCPServer} that can mint new bridges when cache misses occur.
+   * @param handler connection handler that will receive inbound client traffic for this bridge.
+   * @return cached connection when alive, otherwise the freshly created replacement instance.
+   * @throws PluginNotFoundException when the requested plugin is absent or declined by the server.
+   */
+  FCPPluginConnection get(String serverPluginName, FCPServer server, FCPConnectionHandler handler)
+      throws PluginNotFoundException {
+    lock.readLock().lock();
+    try {
+      FCPPluginConnectionImpl existing = connections.get(serverPluginName);
+      if (existing != null && !existing.isServerDead()) {
+        return existing;
+      }
+    } finally {
+      lock.readLock().unlock();
+    }
+
+    lock.writeLock().lock();
+    try {
+      FCPPluginConnectionImpl oldConnection = connections.get(serverPluginName);
+      if (oldConnection != null) {
+        if (!oldConnection.isServerDead()) {
+          return oldConnection;
+        } else {
+          connections.remove(serverPluginName);
+        }
+      }
+
+      FCPPluginConnectionImpl newConnection =
+          server.createFCPPluginConnectionForNetworkedFCP(serverPluginName, handler);
+      connections.put(serverPluginName, newConnection);
+      return newConnection;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
@@ -57,21 +57,12 @@ public class RemovePersistentRequest extends FCPMessage {
 
                   @Override
                   public boolean run(ClientContext context) {
-                    try {
-                      ClientRequest req =
-                          handler.removePersistentForeverRequest(global, identifier);
-                      if (req == null) {
-                        LOG.error("Huh ? the request is null!");
-                        return false;
-                      }
-                      return true;
-                    } catch (MessageInvalidException e) {
-                      FCPMessage err =
-                          new ProtocolErrorMessage(
-                              e.protocolCode, false, e.getMessage(), e.ident, e.global);
-                      handler.send(err);
+                    ClientRequest req = handler.removePersistentForeverRequest(global, identifier);
+                    if (req == null) {
+                      LOG.error("Huh ? the request is null!");
                       return false;
                     }
+                    return true;
                   }
                 },
                 NativeThread.PriorityLevel.HIGH_PRIORITY.value);

--- a/src/main/java/network/crypta/clients/fcp/TestDdaCompleteMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaCompleteMessage.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.io.File;
 import java.io.IOException;
-import network.crypta.clients.fcp.FCPConnectionHandler.DDACheckJob;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.FileUtil;
@@ -17,18 +16,18 @@ import org.slf4j.LoggerFactory;
  *
  * @author Florent Daigni&egrave;re &lt;nextgens@freenetproject.org&gt;
  */
-public class TestDDACompleteMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(TestDDACompleteMessage.class);
+public class TestDdaCompleteMessage extends FCPMessage {
+  private static final Logger LOG = LoggerFactory.getLogger(TestDdaCompleteMessage.class);
 
   public static final String name = "TestDDAComplete";
   public static final String READ_ALLOWED = "ReadDirectoryAllowed";
   public static final String WRITE_ALLOWED = "WriteDirectoryAllowed";
 
-  final DDACheckJob checkJob;
+  final DdaCheckJob checkJob;
   final String readContentFromClient;
   private final FCPConnectionHandler handler;
 
-  public TestDDACompleteMessage(FCPConnectionHandler handler, DDACheckJob job, String readContent) {
+  public TestDdaCompleteMessage(FCPConnectionHandler handler, DdaCheckJob job, String readContent) {
     this.checkJob = job;
     this.readContentFromClient = readContent;
     this.handler = handler;
@@ -38,7 +37,7 @@ public class TestDDACompleteMessage extends FCPMessage {
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
 
-    sfs.putSingle(TestDDARequestMessage.DIRECTORY, checkJob.directory.toString());
+    sfs.putSingle(TestDdaRequestMessage.DIRECTORY, checkJob.directory.toString());
 
     boolean isReadAllowed = false;
     boolean isWriteAllowed = false;

--- a/src/main/java/network/crypta/clients/fcp/TestDdaReplyMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaReplyMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.clients.fcp.FCPConnectionHandler.DDACheckJob;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
@@ -14,24 +13,24 @@ import org.slf4j.LoggerFactory;
  *
  * @author Florent Daigni&egrave;re &lt;nextgens@freenetproject.org&gt;
  */
-public class TestDDAReplyMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(TestDDAReplyMessage.class);
+public class TestDdaReplyMessage extends FCPMessage {
+  private static final Logger LOG = LoggerFactory.getLogger(TestDdaReplyMessage.class);
 
   public static final String name = "TestDDAReply";
   public static final String READ_FILENAME = "ReadFilename";
   public static final String WRITE_FILENAME = "WriteFilename";
   public static final String CONTENT_TO_WRITE = "ContentToWrite";
 
-  final DDACheckJob checkJob;
+  final DdaCheckJob checkJob;
 
-  TestDDAReplyMessage(DDACheckJob job) {
+  TestDdaReplyMessage(DdaCheckJob job) {
     this.checkJob = job;
   }
 
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
-    sfs.putSingle(TestDDARequestMessage.DIRECTORY, checkJob.directory.toString());
+    sfs.putSingle(TestDdaRequestMessage.DIRECTORY, checkJob.directory.toString());
 
     if (checkJob.readFilename != null) {
       sfs.putSingle(READ_FILENAME, checkJob.readFilename.toString());

--- a/src/main/java/network/crypta/clients/fcp/TestDdaRequestMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaRequestMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.clients.fcp.FCPConnectionHandler.DDACheckJob;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
@@ -14,17 +13,22 @@ import org.slf4j.LoggerFactory;
  *
  * @author Florent Daigni&egrave;re &lt;nextgens@freenetproject.org&gt;
  */
-public class TestDDAResponseMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(TestDDAResponseMessage.class);
+public class TestDdaRequestMessage extends FCPMessage {
+  private static final Logger LOG = LoggerFactory.getLogger(TestDdaRequestMessage.class);
 
-  public static final String NAME = "TestDDAResponse";
-  public static final String READ_CONTENT = "ReadContent";
+  public static final String NAME = "TestDDARequest";
+  public static final String DIRECTORY = "Directory";
+  public static final String WANT_READ = "WantReadDirectory";
+  public static final String WANT_WRITE = "WantWriteDirectory";
 
   final String identifier;
-  final String readContent;
+  final boolean wantRead, wantWrite;
 
-  public TestDDAResponseMessage(SimpleFieldSet sfs) throws MessageInvalidException {
-    identifier = sfs.get(TestDDARequestMessage.DIRECTORY);
+  /**
+   * @throws MessageInvalidException
+   */
+  public TestDdaRequestMessage(SimpleFieldSet fs) throws MessageInvalidException {
+    identifier = fs.get(DIRECTORY);
     if (identifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "No Directory given!", null, false);
@@ -35,7 +39,18 @@ public class TestDDAResponseMessage extends FCPMessage {
           null,
           false);
 
-    readContent = sfs.get(READ_CONTENT);
+    wantRead = fs.getBoolean(WANT_READ, false);
+    wantWrite = fs.getBoolean(WANT_WRITE, false);
+    if ((!wantRead) && (!wantWrite))
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_MESSAGE,
+          "Both "
+              + WANT_READ
+              + " and "
+              + WANT_WRITE
+              + " are set to false: what's the point of sending a message?",
+          identifier,
+          false);
   }
 
   @Override
@@ -50,33 +65,14 @@ public class TestDDAResponseMessage extends FCPMessage {
 
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    DDACheckJob job;
+    DdaCheckJob job;
     try {
-      job = handler.popDDACheck(identifier);
+      job = handler.enqueueDDACheck(identifier, wantRead, wantWrite);
     } catch (IllegalArgumentException e) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), identifier, false);
     }
-    if (job == null)
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_MESSAGE,
-          "The node doesn't know that testDDA identifier! double check it! (" + identifier + ").",
-          identifier,
-          false);
-    else if ((job.readFilename != null) && (readContent == null))
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD,
-          "You need to send "
-              + READ_CONTENT
-              + " back to the node if you specify "
-              + TestDDARequestMessage.WANT_READ
-              + " in "
-              + TestDDARequestMessage.NAME
-              + '.',
-          identifier,
-          false);
-
-    TestDDACompleteMessage reply = new TestDDACompleteMessage(handler, job, readContent);
+    TestDdaReplyMessage reply = new TestDdaReplyMessage(job);
     handler.send(reply);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/TestDdaResponseMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaResponseMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.clients.fcp.FCPConnectionHandler.DDACheckJob;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
@@ -14,22 +13,17 @@ import org.slf4j.LoggerFactory;
  *
  * @author Florent Daigni&egrave;re &lt;nextgens@freenetproject.org&gt;
  */
-public class TestDDARequestMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(TestDDARequestMessage.class);
+public class TestDdaResponseMessage extends FCPMessage {
+  private static final Logger LOG = LoggerFactory.getLogger(TestDdaResponseMessage.class);
 
-  public static final String NAME = "TestDDARequest";
-  public static final String DIRECTORY = "Directory";
-  public static final String WANT_READ = "WantReadDirectory";
-  public static final String WANT_WRITE = "WantWriteDirectory";
+  public static final String NAME = "TestDDAResponse";
+  public static final String READ_CONTENT = "ReadContent";
 
   final String identifier;
-  final boolean wantRead, wantWrite;
+  final String readContent;
 
-  /**
-   * @throws MessageInvalidException
-   */
-  public TestDDARequestMessage(SimpleFieldSet fs) throws MessageInvalidException {
-    identifier = fs.get(DIRECTORY);
+  public TestDdaResponseMessage(SimpleFieldSet sfs) throws MessageInvalidException {
+    identifier = sfs.get(TestDdaRequestMessage.DIRECTORY);
     if (identifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "No Directory given!", null, false);
@@ -40,18 +34,7 @@ public class TestDDARequestMessage extends FCPMessage {
           null,
           false);
 
-    wantRead = fs.getBoolean(WANT_READ, false);
-    wantWrite = fs.getBoolean(WANT_WRITE, false);
-    if ((!wantRead) && (!wantWrite))
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_MESSAGE,
-          "Both "
-              + WANT_READ
-              + " and "
-              + WANT_WRITE
-              + " are set to false: what's the point of sending a message?",
-          identifier,
-          false);
+    readContent = sfs.get(READ_CONTENT);
   }
 
   @Override
@@ -66,14 +49,33 @@ public class TestDDARequestMessage extends FCPMessage {
 
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    DDACheckJob job;
+    DdaCheckJob job;
     try {
-      job = handler.enqueueDDACheck(identifier, wantRead, wantWrite);
+      job = handler.popDDACheck(identifier);
     } catch (IllegalArgumentException e) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), identifier, false);
     }
-    TestDDAReplyMessage reply = new TestDDAReplyMessage(job);
+    if (job == null)
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.INVALID_MESSAGE,
+          "The node doesn't know that testDDA identifier! double check it! (" + identifier + ").",
+          identifier,
+          false);
+    else if ((job.readFilename != null) && (readContent == null))
+      throw new MessageInvalidException(
+          ProtocolErrorMessage.MISSING_FIELD,
+          "You need to send "
+              + READ_CONTENT
+              + " back to the node if you specify "
+              + TestDdaRequestMessage.WANT_READ
+              + " in "
+              + TestDdaRequestMessage.NAME
+              + '.',
+          identifier,
+          false);
+
+    TestDdaCompleteMessage reply = new TestDdaCompleteMessage(handler, job, readContent);
     handler.send(reply);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/DdaAccessControllerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DdaAccessControllerTest.java
@@ -1,0 +1,181 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import network.crypta.node.Node;
+import network.crypta.support.io.FileUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class DdaAccessControllerTest {
+
+  @Mock private FCPServer server;
+  @Mock private Logger log;
+  @Mock private Node node;
+
+  @TempDir private Path tempDir;
+
+  private DdaAccessController controller;
+  private Random random;
+
+  @BeforeEach
+  void setUp() {
+    controller = new DdaAccessController(server, log);
+    random = new Random(42L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    controller.freeDDAJobs();
+  }
+
+  private void stubRandomAccess() {
+    when(server.getNode()).thenReturn(node);
+    when(node.getFastWeakRandom()).thenReturn(random);
+  }
+
+  @Test
+  void allowDDAFrom_whenWriteRequestAndNoEntry_usesServerDownloadFlag() throws IOException {
+    File testFile = Files.createFile(tempDir.resolve("write.bin")).toFile();
+    when(server.isDownloadDDAAlwaysAllowed()).thenReturn(false);
+
+    boolean allowed = controller.allowDDAFrom(testFile, true);
+
+    assertFalse(allowed);
+  }
+
+  @Test
+  void allowDDAFrom_whenReadRequestAndNoEntry_usesServerUploadFlag() throws IOException {
+    File testFile = Files.createFile(tempDir.resolve("read.bin")).toFile();
+    when(server.isUploadDDAAlwaysAllowed()).thenReturn(true);
+
+    boolean allowed = controller.allowDDAFrom(testFile, false);
+
+    assertTrue(allowed);
+  }
+
+  @Test
+  void allowDDAFrom_whenDirectoryRegistered_returnsStoredReadFlag() throws IOException {
+    Path directory = Files.createDirectory(tempDir.resolve("registered-read"));
+    String canonicalPath = FileUtil.getCanonicalFile(directory.toFile()).getPath();
+    controller.registerTestDDAResult(canonicalPath, false, true);
+    File file = Files.createFile(directory.resolve("child.bin")).toFile();
+
+    boolean allowed = controller.allowDDAFrom(file, false);
+
+    assertFalse(allowed);
+  }
+
+  @Test
+  void allowDDAFrom_whenDirectoryRegistered_returnsStoredWriteFlag() throws IOException {
+    Path directory = Files.createDirectory(tempDir.resolve("registered-write"));
+    String canonicalPath = FileUtil.getCanonicalFile(directory.toFile()).getPath();
+    controller.registerTestDDAResult(canonicalPath, true, false);
+    File file = Files.createFile(directory.resolve("child.bin")).toFile();
+
+    boolean allowed = controller.allowDDAFrom(file, true);
+
+    assertFalse(allowed);
+  }
+
+  @Test
+  void enqueueDDACheck_whenDirectoryMissing_throwsIllegalArgumentException() {
+    String missingPath = tempDir.resolve("missing").toString();
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> controller.enqueueDDACheck(missingPath, true, false));
+
+    assertTrue(thrown.getMessage().contains("directory"));
+  }
+
+  @Test
+  void enqueueDDACheck_whenJobAlreadyInProgress_throwsIllegalArgumentException()
+      throws IOException {
+    Path directory = Files.createDirectory(tempDir.resolve("duplicate"));
+    stubRandomAccess();
+    String directoryPath = directory.toString();
+    controller.enqueueDDACheck(directoryPath, false, false);
+
+    Runnable duplicateCheck = () -> controller.enqueueDDACheck(directoryPath, true, true);
+    assertThrows(IllegalArgumentException.class, duplicateCheck::run);
+  }
+
+  @Test
+  void enqueueDDACheck_whenReadRequested_createsReadChallengeFile() throws IOException {
+    Path directory = Files.createDirectory(tempDir.resolve("read"));
+    stubRandomAccess();
+
+    DdaCheckJob job = controller.enqueueDDACheck(directory.toString(), true, false);
+
+    assertNotNull(job.readFilename);
+    assertTrue(job.readFilename.exists());
+    String content = Files.readString(job.readFilename.toPath());
+    assertEquals(job.readContent, content);
+  }
+
+  @Test
+  void enqueueDDACheck_whenWriteRequested_generatesWriteFileUnderDirectory() throws IOException {
+    Path directory = Files.createDirectory(tempDir.resolve("write"));
+    stubRandomAccess();
+
+    DdaCheckJob job = controller.enqueueDDACheck(directory.toString(), false, true);
+
+    assertNotNull(job.writeFilename);
+    assertEquals(directory.toFile(), job.writeFilename.getParentFile());
+    assertTrue(job.writeFilename.getName().startsWith("DDACheck-"));
+    assertTrue(job.writeFilename.getName().endsWith(".tmp"));
+  }
+
+  @Test
+  void popDDACheck_whenDirectoryMissing_throwsIllegalArgumentException() {
+    String missingPath = tempDir.resolve("missing-pop").toString();
+
+    assertThrows(IllegalArgumentException.class, () -> controller.popDDACheck(missingPath));
+  }
+
+  @Test
+  void popDDACheck_whenJobExists_returnsAndRemovesJob() throws IOException {
+    Path directory = Files.createDirectory(tempDir.resolve("pop"));
+    stubRandomAccess();
+    DdaCheckJob job = controller.enqueueDDACheck(directory.toString(), true, false);
+
+    DdaCheckJob popped = controller.popDDACheck(directory.toString());
+
+    assertSame(job, popped);
+    assertNull(controller.popDDACheck(directory.toString()));
+  }
+
+  @Test
+  void freeDDAJobs_whenReadFilePresent_deletesIt() throws IOException {
+    Path directory = Files.createDirectory(tempDir.resolve("cleanup"));
+    stubRandomAccess();
+    DdaCheckJob job = controller.enqueueDDACheck(directory.toString(), true, false);
+    assertTrue(job.readFilename.exists());
+
+    controller.freeDDAJobs();
+
+    assertFalse(job.readFilename.exists());
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
@@ -1,0 +1,287 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Deque;
+import java.util.Random;
+import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.EntropySource;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FCPConnectionHandlerTest {
+
+  @Mock private FCPServer server;
+  @Mock private NodeClientCore core;
+  @Mock private ClientContext clientContext;
+  @Mock private TempBucketFactory tempBucketFactory;
+  @Mock private Socket socket;
+  @Mock private Node node;
+
+  private FCPConnectionHandler handler;
+  private Random fastRandom;
+
+  @BeforeEach
+  void setUp() {
+    DeterministicRandomSource randomSource = new DeterministicRandomSource(1234L);
+    fastRandom = new Random(5678L);
+
+    lenient().when(server.getCore()).thenReturn(core);
+    lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
+    lenient().when(server.getNode()).thenReturn(node);
+    lenient().when(node.getRandom()).thenReturn(randomSource);
+
+    handler = new FCPConnectionHandler(socket, server);
+  }
+
+  @Test
+  void send_whenMessageNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> handler.send(null));
+  }
+
+  @Test
+  void send_whenQueueHasCapacity_enqueuesMessage() {
+    FCPMessage message = mock(FCPMessage.class);
+    when(server.maxMessageQueueLength()).thenReturn(10);
+    when(server.neverDropAMessage()).thenReturn(false);
+
+    handler.send(message);
+
+    Deque<FCPMessage> queue = handler.getOutputHandler().outQueue;
+    assertEquals(1, queue.size());
+    assertSame(message, queue.peekLast());
+  }
+
+  @Test
+  void send_whenQueueFullAndDroppingAllowed_doesNotQueueNewMessage() {
+    Deque<FCPMessage> queue = handler.getOutputHandler().outQueue;
+    queue.add(mock(FCPMessage.class));
+    when(server.maxMessageQueueLength()).thenReturn(1);
+    when(server.neverDropAMessage()).thenReturn(false);
+
+    handler.send(mock(FCPMessage.class));
+
+    assertEquals(1, queue.size());
+  }
+
+  @Test
+  void send_whenQueueFullAndDroppingDisabled_enqueuesMessage() {
+    Deque<FCPMessage> queue = handler.getOutputHandler().outQueue;
+    queue.add(mock(FCPMessage.class));
+    when(server.maxMessageQueueLength()).thenReturn(1);
+    when(server.neverDropAMessage()).thenReturn(true);
+    FCPMessage message = mock(FCPMessage.class);
+
+    handler.send(message);
+
+    assertEquals(2, queue.size());
+    assertSame(message, queue.peekLast());
+  }
+
+  @Test
+  void removeRequestByIdentifier_whenKillTrue_cancelsAndNotifies() {
+    ClientRequest request = mock(ClientRequest.class);
+    handler.requestsByIdentifier.put("id", request);
+    when(core.getClientContext()).thenReturn(clientContext);
+
+    ClientRequest removed = handler.removeRequestByIdentifier("id", true);
+
+    assertSame(request, removed);
+    verify(request).cancel(clientContext);
+    verify(request).requestWasRemoved(clientContext);
+    verifyNoMoreInteractions(request);
+  }
+
+  @Test
+  void removeRequestByIdentifier_whenKillFalse_onlyNotifies() {
+    ClientRequest request = mock(ClientRequest.class);
+    handler.requestsByIdentifier.put("id", request);
+    when(core.getClientContext()).thenReturn(clientContext);
+
+    ClientRequest removed = handler.removeRequestByIdentifier("id", false);
+
+    assertSame(request, removed);
+    verify(request).requestWasRemoved(clientContext);
+    verifyNoMoreInteractions(request);
+  }
+
+  @Test
+  void allowDDAFrom_withoutCachedEntry_returnsServerPolicy(@TempDir Path tempDir)
+      throws IOException {
+    File file = tempDir.resolve("test.txt").toFile();
+    if (!file.exists()) {
+      assertTrue(file.createNewFile());
+    }
+    when(server.isDownloadDDAAlwaysAllowed()).thenReturn(false);
+
+    assertFalse(handler.ddaAccessController().allowDDAFrom(file, true));
+  }
+
+  @Test
+  void registerTestDDAResult_thenAllowDDAFrom_respectsCachedPermissions(@TempDir Path tempDir)
+      throws IOException {
+    File dir = tempDir.toFile();
+    handler.registerTestDDAResult(dir.getCanonicalPath(), true, false);
+    File child = new File(dir, "foo.bin");
+    if (!child.exists()) {
+      assertTrue(child.createNewFile());
+    }
+
+    assertTrue(handler.ddaAccessController().allowDDAFrom(child, false));
+    assertFalse(handler.ddaAccessController().allowDDAFrom(child, true));
+  }
+
+  @Test
+  void enqueueDDACheck_withInvalidDirectory_throwsException(@TempDir Path tempDir)
+      throws IOException {
+    File file = tempDir.resolve("not-a-dir").toFile();
+    if (!file.exists()) {
+      assertTrue(file.createNewFile());
+    }
+    String invalidPath = file.getPath();
+
+    assertThrows(
+        IllegalArgumentException.class, () -> handler.enqueueDDACheck(invalidPath, true, true));
+  }
+
+  @Test
+  void enqueueDDACheck_whenJobAlreadyInFlight_throws(@TempDir Path tempDir) {
+    when(node.getFastWeakRandom()).thenReturn(fastRandom);
+    String directory = tempDir.toString();
+    handler.enqueueDDACheck(directory, true, false);
+
+    assertThrows(
+        IllegalArgumentException.class, () -> handler.enqueueDDACheck(directory, true, false));
+  }
+
+  @Test
+  void enqueueAndPopDDACheck_roundTripCreatesAndRemovesJob(@TempDir Path tempDir) throws Exception {
+    when(node.getFastWeakRandom()).thenReturn(fastRandom);
+    DdaCheckJob job = handler.enqueueDDACheck(tempDir.toString(), true, true);
+
+    assertNotNull(job);
+    assertNotNull(job.directory);
+    assertTrue(job.directory.exists());
+    DdaCheckJob popped = handler.popDDACheck(tempDir.toString());
+    assertSame(job, popped);
+    if (job.readFilename != null) {
+      String content = Files.readString(job.readFilename.toPath(), StandardCharsets.UTF_8);
+      assertEquals(job.readContent, content);
+      assertTrue(job.readFilename.delete());
+    }
+    if (job.writeFilename != null && job.writeFilename.exists()) {
+      assertTrue(job.writeFilename.delete());
+    }
+  }
+
+  @Test
+  void freeDDAJobs_deletesOutstandingFiles(@TempDir Path tempDir) {
+    when(node.getFastWeakRandom()).thenReturn(fastRandom);
+    DdaCheckJob job = handler.enqueueDDACheck(tempDir.toString(), true, false);
+    assertNotNull(job.readFilename);
+    assertTrue(job.readFilename.exists());
+
+    handler.freeDDAJobs();
+
+    assertFalse(job.readFilename.exists());
+  }
+
+  @Test
+  void addUSKSubscription_whenDuplicate_throws() throws IdentifierCollisionException {
+    SubscribeUSK usk = mock(SubscribeUSK.class);
+    handler.addUSKSubscription("sub", usk);
+
+    assertThrows(IdentifierCollisionException.class, () -> handler.addUSKSubscription("sub", usk));
+  }
+
+  @Test
+  void unsubscribeUSK_whenIdentifierMissing_throws() {
+    assertThrows(MessageInvalidException.class, () -> handler.unsubscribeUSK("missing"));
+  }
+
+  @Test
+  void unsubscribeUSK_whenPresent_callsUnsubscribe() throws Exception {
+    SubscribeUSK subscription = mock(SubscribeUSK.class);
+    handler.addUSKSubscription("sub", subscription);
+
+    handler.unsubscribeUSK("sub");
+
+    verify(subscription).unsubscribe();
+  }
+
+  @Test
+  void connectionRequestClient_whenRealTimeTrue_returnsRealTimeClient() {
+    RequestClient client = handler.connectionRequestClient(true);
+
+    assertTrue(client.realTimeFlag());
+    assertFalse(client.persistent());
+  }
+
+  @Test
+  void connectionRequestClient_whenRealTimeFalse_returnsBulkClient() {
+    RequestClient client = handler.connectionRequestClient(false);
+
+    assertFalse(client.realTimeFlag());
+    assertFalse(client.persistent());
+  }
+
+  private static final class DeterministicRandomSource extends RandomSource {
+    DeterministicRandomSource(long seed) {
+      super();
+      setSeed(seed);
+    }
+
+    @Override
+    public int acceptEntropy(EntropySource source, long data, int entropyGuess) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(EntropySource timer) {
+      return 0;
+    }
+
+    @Override
+    public int acceptTimerEntropy(EntropySource fnpTimingSource, double bias) {
+      return 0;
+    }
+
+    @Override
+    public int acceptEntropyBytes(
+        EntropySource myPacketDataSource, byte[] buf, int offset, int length, double bias) {
+      return 0;
+    }
+
+    @Override
+    public void close() {
+      // No-op: deterministic test double does not allocate external resources.
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -39,6 +38,7 @@ import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.LineReadingInputStream;
 import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -267,8 +267,7 @@ class FCPConnectionInputHandlerTest {
 
     TestContext ctx = new TestContext();
     ctx.handler = mock(FCPConnectionHandler.class);
-    ctx.bucketFactory = mock(BucketFactory.class);
-    setBucketFactory(ctx.handler, ctx.bucketFactory);
+    ctx.bucketFactory = mock(TempBucketFactory.class);
     ctx.server = mock(FCPServer.class);
     ctx.node = mock(Node.class);
     ctx.core = mock(NodeClientCore.class);
@@ -280,22 +279,13 @@ class FCPConnectionInputHandlerTest {
     when(ctx.handler.getServer()).thenReturn(ctx.server);
     lenient().when(ctx.server.getNode()).thenReturn(ctx.node);
     lenient().when(ctx.server.getCore()).thenReturn(ctx.core);
+    lenient().when(ctx.core.getTempBucketFactory()).thenReturn(ctx.bucketFactory);
     lenient().when(ctx.core.getPersistentTempBucketFactory()).thenReturn(ctx.persistentFactory);
     lenient().when(ctx.handler.isClosed()).thenReturn(false);
     lenient().when(ctx.handler.getConnectionIdentifierUUID()).thenReturn(UUID.randomUUID());
 
     ctx.inputHandler = new FCPConnectionInputHandler(ctx.handler);
     return ctx;
-  }
-
-  private static void setBucketFactory(FCPConnectionHandler handler, BucketFactory bucketFactory) {
-    try {
-      Field field = FCPConnectionHandler.class.getDeclaredField("bf");
-      field.setAccessible(true);
-      field.set(handler, bucketFactory);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new IllegalStateException("Unable to assign bucket factory", e);
-    }
   }
 
   private static String message(String name, String endMarker, String... kvPairs) {
@@ -336,7 +326,7 @@ class FCPConnectionInputHandlerTest {
     Node node;
     NodeClientCore core;
     Socket socket;
-    BucketFactory bucketFactory;
+    TempBucketFactory bucketFactory;
     PersistentTempBucketFactory persistentFactory;
   }
 

--- a/src/test/java/network/crypta/clients/fcp/PluginConnectionRegistryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PluginConnectionRegistryTest.java
@@ -1,0 +1,89 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.pluginmanager.PluginNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PluginConnectionRegistryTest {
+
+  private static final String PLUGIN_NAME = "TestPlugin";
+
+  private final PluginConnectionRegistry registry = new PluginConnectionRegistry();
+
+  @Mock private FCPServer server;
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FCPPluginConnectionImpl cachedConnection;
+  @Mock private FCPPluginConnectionImpl replacementConnection;
+
+  @Test
+  void get_whenConnectionCachedAndAlive_returnsExistingWithoutNewCreation()
+      throws PluginNotFoundException {
+    when(server.createFCPPluginConnectionForNetworkedFCP(PLUGIN_NAME, handler))
+        .thenReturn(cachedConnection);
+    when(cachedConnection.isServerDead()).thenReturn(false);
+
+    FCPPluginConnection first = registry.get(PLUGIN_NAME, server, handler);
+    FCPPluginConnection second = registry.get(PLUGIN_NAME, server, handler);
+
+    assertSame(cachedConnection, first);
+    assertSame(cachedConnection, second);
+    verify(server, times(1)).createFCPPluginConnectionForNetworkedFCP(PLUGIN_NAME, handler);
+    verify(cachedConnection, times(1)).isServerDead();
+    verifyNoMoreInteractions(server);
+  }
+
+  @Test
+  void get_whenExistingConnectionDead_createsReplacementAndCachesIt()
+      throws PluginNotFoundException {
+    when(server.createFCPPluginConnectionForNetworkedFCP(PLUGIN_NAME, handler))
+        .thenReturn(cachedConnection, replacementConnection);
+    when(cachedConnection.isServerDead()).thenReturn(true);
+    when(replacementConnection.isServerDead()).thenReturn(false);
+
+    FCPPluginConnection first = registry.get(PLUGIN_NAME, server, handler);
+    FCPPluginConnection second = registry.get(PLUGIN_NAME, server, handler);
+    FCPPluginConnection third = registry.get(PLUGIN_NAME, server, handler);
+
+    assertSame(cachedConnection, first);
+    assertSame(replacementConnection, second);
+    assertSame(replacementConnection, third);
+
+    verify(server, times(2)).createFCPPluginConnectionForNetworkedFCP(PLUGIN_NAME, handler);
+    verify(cachedConnection, times(2)).isServerDead();
+    verify(replacementConnection, times(1)).isServerDead();
+  }
+
+  @Test
+  void get_whenServerThrows_propagatesAndDoesNotCachePartialEntry() throws PluginNotFoundException {
+    PluginNotFoundException failure = new PluginNotFoundException("missing");
+    when(server.createFCPPluginConnectionForNetworkedFCP(PLUGIN_NAME, handler))
+        .thenThrow(failure)
+        .thenReturn(cachedConnection);
+    when(cachedConnection.isServerDead()).thenReturn(false);
+
+    PluginNotFoundException thrown =
+        assertThrows(
+            PluginNotFoundException.class, () -> registry.get(PLUGIN_NAME, server, handler));
+    assertSame(failure, thrown);
+
+    FCPPluginConnection second = registry.get(PLUGIN_NAME, server, handler);
+    FCPPluginConnection third = registry.get(PLUGIN_NAME, server, handler);
+
+    assertSame(cachedConnection, second);
+    assertSame(cachedConnection, third);
+
+    verify(server, times(2)).createFCPPluginConnectionForNetworkedFCP(PLUGIN_NAME, handler);
+    verify(cachedConnection, times(1)).isServerDead();
+  }
+}


### PR DESCRIPTION
## Summary
- Extract the DDA state machine from `FCPConnectionHandler` into `DdaAccessController`/`DdaCheckJob`, rename the `TestDda*` message classes, and route uploads/downloads through the shared controller so direct disk access rules stay consistent.
- Tighten `FCPConnectionHandler` with clearer docs, a dedicated `PluginConnectionRegistry`, and better identifier/queue handling so plugin bridges are reused instead of recreated on every request.
- Add unit tests that exercise the controller, the handler queue/DDAs, and the new registry to keep the refactor covered.

## Testing
- Not Run (not requested)
