### PR TITLE
Clarify and harden FCP plugin connection lifecycle

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/FCPPluginClientMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginClientMessage.java
@@ -183,7 +183,7 @@ public class FCPPluginClientMessage extends DataCarryingMessage {
 
   /**
    * Resolves the target {@link FCPPluginConnection} and delivers the message using {@link
-   * SendDirection#ToServer}, translating lookup or transport failures into protocol-friendly
+   * SendDirection#TO_SERVER}, translating lookup or transport failures into protocol-friendly
    * exceptions.
    *
    * <p>The handler grants access to plugin-scoped connections; if the desired plugin cannot be
@@ -226,7 +226,7 @@ public class FCPPluginClientMessage extends DataCarryingMessage {
     FCPPluginMessage message = constructFCPPluginMessage();
 
     try {
-      serverConnection.send(SendDirection.ToServer, message);
+      serverConnection.send(SendDirection.TO_SERVER, message);
     } catch (IOException e) {
       throw pluginUnavailable();
     }

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginConnection.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginConnection.java
@@ -8,384 +8,208 @@ import network.crypta.pluginmanager.FredPluginFCPMessageHandler.ClientSideFCPMes
 import network.crypta.pluginmanager.PluginRespirator;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
-import org.slf4j.Logger;
 
 /**
- * An FCP connection between:<br>
- * - a fred plugin which provides its services by a FCP server.<br>
- * - a client application which uses those services. The client may be a plugin as well, or be
- * connected by a networked FCP connection.<br>
- * <br>
+ * Defines the bidirectional channel that carries FCP plugin messages between a server plugin and a
+ * client-side peer.
  *
- * <h1>How to use this properly</h1>
+ * <p>Connections are created through {@link PluginRespirator} helpers such as {@link
+ * PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)}, allowing a plugin to
+ * expose services to in-node components or remote clients that speak FCP. Each connection tracks a
+ * stable {@link UUID} so requests and responses stay correlated even when multiple logical
+ * operations are interleaved.
  *
- * <br>
- * You can read the following JavaDoc for a nice overview of how to use this properly from the
- * perspective of your server or client implementation:<br>
- * - {@link PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)}<br>
- * - {@link PluginRespirator#getPluginConnectionByID(UUID)}<br>
- * - {@link FredPluginFCPMessageHandler}<br>
- * - {@link FredPluginFCPMessageHandler.ServerSideFCPMessageHandler}<br>
- * - {@link FredPluginFCPMessageHandler.ClientSideFCPMessageHandler}<br>
- * - {@link FCPPluginMessage}<br>
- * <br>
+ * <p>The interface documents the lifecycle expectations: clients keep the connection alive by
+ * retaining a strong reference, while server implementations typically interact through adapters
+ * retrieved via {@link PluginRespirator#getPluginConnectionByID(UUID)}. No persistence is provided
+ * beyond the lifetime of the owning plugin or socket, so callers must recreate the connection after
+ * restarts and re-establish subscriptions or outstanding synchronous operations.
  *
- * <h1>Debugging</h1>
+ * <p>Concurrency is central: asynchronous sends merely enqueue work, synchronous sends coordinate
+ * reply routing, and the default direction depends on whether the connection originated on the
+ * client or server side. Detailed logging can be enabled through the {@code
+ * freenet.clients.fcp.FCPPluginConnection} logger to diagnose message ordering, remembering that
+ * entries reflect queuing time rather than delivery time.
  *
- * <br>
- * You can configure the {@link Logger} to log "freenet.clients.fcp.FCPPluginConnection:DEBUG" to
- * cause logging of all sent and received messages.<br>
- * This is usually done on the Freenet web interface at Configuration / Logs / Detailed priority
- * thresholds.<br>
- * ATTENTION: The log entries will appear at the time when the messages were queued for sending, not
- * when they were delivered. Delivery usually happens in a separate thread. Thus, the relative order
- * of arrival of messages can be different to the order of their appearance in the log file.<br>
- * If you need to know the order of arrival, add logging to your message handler. Also don't forget
- * that {@link #sendSynchronous(SendDirection, FCPPluginMessage, long)} will not deliver replies to
- * the message handler but only return them instead.<br>
- * <br>
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> carry typed messages, report connection state, and
+ *       bridge synchronous as well as asynchronous FCP flows.
+ *   <li><strong>Invariants:</strong> identifiers remain stable, exactly one connection exists per
+ *       plugin pair and transport, and replies echo the identifier of their originating request.
+ *   <li><strong>Threading:</strong> send operations may execute on pooled threads, while callbacks
+ *       execute on whichever handler registered with {@link FredPluginFCPMessageHandler}.
+ * </ul>
  *
- * <h1>Connection lifecycle</h1>
- *
- * <h2>Intra-node FCP - server and client both running within the same node as plugin</h2>
- *
- * The client plugin dictates connection and disconnection. Connections are opened by it via {@link
- * PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)}. It keeps them open
- * by keeping a strong reference to the FCPPluginConnection. Once it does not strongly reference it
- * anymore, Freenet detects that by monitoring garbage collection, and considers the connection as
- * closed then. A closed connection is indicated to the server plugin by the send functions throwing
- * {@link IOException}.<br>
- *
- * <h2>Networked FCP - server is running in the node as plugin, client connects by network</h2>
- *
- * The client plugin again dictates connection and disconnection by opening and closing the FCP
- * network connection as it pleases.<br>
- * Additionally, a single network connection can only have a single FCPPluginConnection to each
- * server plugin.<br>
- * If you nevertheless need multiple connections to a plugin, you have to create multiple network
- * connections to the FCP server.<br>
- * (The reason for this is the following: Certain server plugins might need to store the {@link
- * UUID} of a client connection in their database so they are able to send data to the client if an
- * event of interest to the client happens in the future. Therefore, the {@link UUID} of a
- * connection must not change during the lifetime of the connection. To ensure a permanent {@link
- * UUID} of a connection, only a single FCPPluginConnection can exist per server plugin per network
- * connection).
- *
- * <h2>Persistence</h2>
- *
- * <p>In opposite to a FCP connection to fred itself, which is represented by {@link
- * PersistentRequestClient} and can exist across restarts, a FCPPluginConnection is kept in
- * existence by fred only while the actual client is connected. In case of networked plugin FCP,
- * this is while the parent network connection is open; or in case of non-networked plugin FCP,
- * while the FCPPluginConnection is strong-referenced by the client plugin.<br>
- * There is no such thing as persistence beyond client disconnection / restarts.<br>
- * This was decided to simplify implementation:<br>
- * - Persistence should have been implemented by using the existing persistence framework of {@link
- * PersistentRequestClient}. That would require extending the class though, and it is a complex
- * class. The work for extending it was out of scope of the time limit for implementing this class.
- * <br>
- * - FCPPluginConnection instances need to be created without a network connection for intra-node
- * plugin connections. If we extended class {@link PersistentRequestClient}, a lot of care would
- * have to be taken to allow it to exist without a network connection - that would even be more
- * work.<br>
- *
- * <h1>Internals</h1>
- *
- * <br>
- * If you plan to work on the fred-side implementation of FCP plugin connections, please see the
- * "Internals" section at the implementation {@link FCPPluginConnectionImpl} of this interface.
- * Notably, the said section provides an overview of the flow of messages.<br>
- * <br>
- *
+ * @see FredPluginFCPMessageHandler
+ * @see FCPPluginMessage
+ * @see PluginRespirator
  * @author xor (xor@freenetproject.org)
  */
 public interface FCPPluginConnection {
 
   /**
-   * The send functions are fully symmetrical: They work the same way no matter whether client is
-   * sending to server or server is sending to client.<br>
-   * Thus, to prevent us from having to duplicate the send functions, this enum specifies in which
-   * situation we are.
+   * Enumerates the direction used when routing messages so callers can unambiguously express
+   * whether the next hop is a server-side handler or a client-side handler.
+   *
+   * <p>The direction also drives the automatic permission stamping performed by the implementation:
+   * messages headed toward the server carry the client's permission snapshot, whereas replies to
+   * clients omit that metadata. Knowing the direction ahead of time allows the send logic to pick
+   * the right transport path, reuse local message handlers when possible, and decide whether a weak
+   * reference or a network queue must be consulted.
    */
   enum SendDirection {
-    ToServer,
-    ToClient;
+    /**
+     * Sends toward the plugin offering services; typically chosen by client-side code and by server
+     * tests that want to self-address a request for validation.
+     */
+    TO_SERVER,
+    /**
+     * Sends toward the connected client; typically chosen by server-side code and by client tests
+     * that simulate callbacks or push-style traffic.
+     */
+    TO_CLIENT;
 
+    /**
+     * Inverts the direction so bidirectional workflows can bounce messages back without hard coding
+     * both constants.
+     *
+     * <p>This helper is thread-safe and does not mutate the enum. It is useful inside
+     * acknowledgement loops, where code needs to address the reply to the counterpart of the
+     * current hop without branching on raw enums. Because the enumeration only contains two values,
+     * the operation runs in constant time and allocates no new objects.
+     *
+     * @return {@link SendDirection#TO_CLIENT} when invoked on {@link SendDirection#TO_SERVER}, or
+     *     the opposite when starting from {@link SendDirection#TO_CLIENT}.
+     */
     public final SendDirection invert() {
-      return (this == ToServer) ? ToClient : ToServer;
+      return (this == TO_SERVER) ? TO_CLIENT : TO_SERVER;
     }
   }
 
   /**
-   * Can be used by both server and client implementations to send messages to each other.<br>
-   * The messages sent by this function will be delivered to the remote side at either: - the
-   * message handler {@link FredPluginFCPMessageHandler# handlePluginFCPMessage(FCPPluginConnection,
-   * FCPPluginMessage)}.<br>
-   * - or, if existing, a thread waiting for a reply message in {@link
-   * #sendSynchronous(SendDirection, FCPPluginMessage, long)}.<br>
-   * <br>
-   * This is an <b>asynchronous</b>, non-blocking send function.<br>
-   * This has the following differences to the blocking send {@link #sendSynchronous( SendDirection,
-   * FCPPluginMessage, long)}:<br>
-   * - It may return <b>before</b> the message has been sent.<br>
-   * The message sending happens in another thread so this function can return immediately.<br>
-   * In opposite to that, a sendSynchronous() would wait for a reply to arrive, so once it returns,
-   * the message is guaranteed to have been sent.<br>
-   * - The reply is delivered to your message handler {@link FredPluginFCPMessageHandler}. It will
-   * not be directly available to the thread which called this function.<br>
-   * A sendSynchronous() would return the reply to the caller.<br>
-   * - You have no guarantee whatsoever that the message will be delivered.<br>
-   * A sendSynchronous() will tell you that a reply was received, which guarantees that the message
-   * was delivered.<br>
-   * - The order of arrival of messages is random.<br>
-   * A sendSynchronous() only returns after the message was delivered already, so by calling it
-   * multiple times in a row on the same thread, you would enforce the order of the messages
-   * arriving at the remote side.<br>
-   * <br>
-   * ATTENTION: The consequences of this are:<br>
-   * - Even if the function returned without throwing an {@link IOException} you nevertheless must
-   * <b>not</b> assume that the message has been sent.<br>
-   * - If the function did throw an {@link IOException}, you <b>must</b> assume that the connection
-   * is dead and the message has not been sent.<br>
-   * You <b>must</b> consider this FCPPluginConnection as dead then and create a fresh one.<br>
-   * - You can only be sure that a message has been delivered if your message handler receives a
-   * reply message with the same value of {@link FCPPluginMessage#identifier} as the original
-   * message.<br>
-   * - You <b>can</b> send many messages in parallel by calling this many times in a row.<br>
-   * But you <b>must not</b> call this too often in a row to prevent excessive threads creation.
-   * <br>
-   * <br>
-   * ATTENTION: If you plan to use this inside of message handling functions of your implementations
-   * of the interfaces {@link FredPluginFCPMessageHandler.ServerSideFCPMessageHandler} or {@link
-   * FredPluginFCPMessageHandler.ClientSideFCPMessageHandler}, be sure to read the JavaDoc of the
-   * message handling functions first as it puts additional constraints on the usage of the
-   * FCPPluginConnection they receive.
+   * Enqueues a message for asynchronous delivery in the specified direction.
    *
-   * @param direction Whether to send the message to the server or the client message handler.<br>
-   *     You <b>can</b> use this to send messages to yourself.<br>
-   *     You may use {@link #send(FCPPluginMessage)} to avoid having to specify this.<br>
-   *     <br>
-   * @param message You <b>must not</b> send the same message twice: This can break {@link
-   *     #sendSynchronous( SendDirection, FCPPluginMessage, long)}.<br>
-   *     To ensure this, always construct a fresh FCPPluginMessage object when re-sending a message.
-   *     If you use the constructor which allows specifying your own identifier, always generate a
-   *     fresh, random identifier.<br>
-   *     TODO: Code quality: Add a flag to FCPPluginMessage which marks the message as sent and use
-   *     it to log an error if someone tries to send the same message twice. <br>
-   *     <br>
-   * @throws IOException If the connection has been closed meanwhile.<br>
-   *     This FCPPluginConnection <b>should be</b> considered as dead once this happens, you should
-   *     then discard it and obtain a fresh one.
-   *     <p><b>ATTENTION:</b> If this is not thrown, that does NOT mean that the connection is
-   *     alive. Messages are sent asynchronously, so it can happen that a closed connection is not
-   *     detected before this function returns.<br>
-   *     The only way of knowing that a send succeeded is by receiving a reply message in your
-   *     {@link FredPluginFCPMessageHandler}.<br>
-   *     If you need to know whether the send succeeded on the same thread which shall call the send
-   *     function, you can also use {@link #sendSynchronous(SendDirection, FCPPluginMessage, long)}
-   *     which will return the reply right away.
-   * @see #sendSynchronous(SendDirection, FCPPluginMessage, long) You may instead use the blocking
-   *     sendSynchronous() if your thread needs to know whether messages arrived, to ensure a
-   *     certain order of arrival, or to know the reply to a message.
+   * <p>The implementation stamps client permissions, persists the identifier, and dispatches the
+   * work to either a network transport or the relevant {@link
+   * FredPluginFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}
+   * callback. Because the call returns before transmission completes, delivery is only confirmed
+   * after a reply arrives or when {@link #sendSynchronous(SendDirection, FCPPluginMessage, long)}
+   * is used; multiple sends may run in parallel, and ordering is not enforced.
+   *
+   * <p>Reusing a {@link FCPPluginMessage} instance is forbidden and results in error logging while
+   * only the first payload copy is honored. To analyze delivery timing, enable the {@code
+   * freenet.clients.fcp.FCPPluginConnection} logger and cross-check identifiers on both sides of
+   * the connection.
+   *
+   * <pre>{@code
+   * // Example: enqueue an asynchronous request toward the server plugin.
+   * connection.send(SendDirection.TO_SERVER, FCPPluginMessage.construct(params, null));
+   * }</pre>
+   *
+   * @param direction indicates whether the message targets the server-side handler or the
+   *     client-side handler; {@link SendDirection#invert()} is useful when flipping replies.
+   * @param message immutable payload created through {@link
+   *     FCPPluginMessage#construct(SimpleFieldSet, Bucket)} or one of the reply helpers; must not
+   *     be null or re-sent.
+   * @throws IOException if the underlying transport has been closed or cannot accept further
+   *     traffic; callers should treat the connection as defunct after receiving this signal.
+   * @see #sendSynchronous(SendDirection, FCPPluginMessage, long)
    */
   void send(SendDirection direction, FCPPluginMessage message) throws IOException;
 
   /**
-   * Same as {@link #send(SendDirection, FCPPluginMessage)} with the {@link SendDirection} parameter
-   * being the default direction.<br>
-   * <b>Please do read its JavaDoc as it contains a very precise specification how to use it and
-   * thereby also this function.</b><br>
-   * <br>
-   * The default direction is determined automatically depending on whether you are a client or
-   * server.<br>
-   * <br>
-   * You are acting as a client, and thus by default send to the server, when you obtain a
-   * FCPPluginConnection...:<br>
-   * - from the return value of {@link PluginRespirator#connectToOtherPlugin(String,
-   * ClientSideFCPMessageHandler)}.<br>
-   * - as parameter to your message handler callback {@link ClientSideFCPMessageHandler#
-   * handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}.<br>
-   * <br>
-   * You are acting as a server, and thus by default send to the client, when you obtain a
-   * FCPPluginConnection...:<br>
-   * - as parameter to your message handler callback {@link ServerSideFCPMessageHandler#
-   * handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}.<br>
-   * - from the return value of {@link PluginRespirator#getPluginConnectionByID(UUID)}.<br>
+   * Sends a message using the connection's default direction.
+   *
+   * <p>The default is {@link SendDirection#TO_SERVER} for connections handed to clients (for
+   * example via {@link PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)})
+   * and {@link SendDirection#TO_CLIENT} for connections handed to servers (for example via {@link
+   * PluginRespirator#getPluginConnectionByID(UUID)} or the {@link ClientSideFCPMessageHandler} /
+   * {@link FredPluginFCPMessageHandler.ServerSideFCPMessageHandler} callbacks). Choosing this
+   * overload keeps usage terse when most calls travel in one direction, while still allowing {@link
+   * #send(SendDirection, FCPPluginMessage)} for explicit overrides.
+   *
+   * @param message immutable payload constructed through {@link FCPPluginMessage} helpers; the same
+   *     instance must not be reused for multiple sends or replies.
+   * @throws IOException if the connection is closed or if the implementation detects broken
+   *     transport while queuing the message.
    */
   void send(FCPPluginMessage message) throws IOException;
 
   /**
-   * Can be used by both server and client implementations to send messages in a blocking manner to
-   * each other.<br>
-   * The messages sent by this function will be delivered to the message handler {@link
-   * FredPluginFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)} of
-   * the remote side.<br>
-   * <br>
-   * This has the following differences to a regular non-synchronous {@link #send(SendDirection,
-   * FCPPluginMessage)}:<br>
-   * - It will <b>wait</b> for a reply message of the remote side before returning.<br>
-   * A regular send() would instead queue the message for sending, and then return immediately. -
-   * The reply message will be <b>returned to the calling thread</b> instead of being passed to the
-   * message handler {@link FredPluginFCPMessageHandler#handlePluginFCPMessage( FCPPluginConnection,
-   * FCPPluginMessage)} in another thread.<br>
-   * NOTICE: It is possible that the reply message <b>is</b> passed to the message handler upon
-   * certain error conditions, for example if the timeout you specify when calling this function
-   * expires before the reply arrives. This is not guaranteed though.<br>
-   * - Once this function returns without throwing, it is <b>guaranteed</b> that the message has
-   * arrived at the remote side.<br>
-   * - The <b>order</b> of messages can be preserved: If you call sendSynchronous() twice in a row,
-   * the second call cannot execute before the first one has returned, and the returning of the
-   * first call guarantees that the first message was delivered already.<br>
-   * Regular send() calls deploy each message in a thread. This means that the order of delivery can
-   * be different than the order of sending.<br>
-   * <br>
-   * ATTENTION: This function can cause the current thread to block for a long time, while bypassing
-   * the thread limit. Therefore, only use this if the desired operation at the remote side is
-   * expected to execute quickly and the thread which sends the message <b>immediately</b> needs one
-   * of these after sending it to continue its computations:<br>
-   * - An guarantee that the message arrived at the remote side.<br>
-   * - An indication of whether the operation requested by the message succeeded.<br>
-   * - The reply to the message.<br>
-   * - A guaranteed order of arrival of messages at the remote side.<br>
-   * A typical example for a place where this is needed is a user interface which has a user click a
-   * button and want to see the result of the operation as soon as possible. A detailed example is
-   * given at the documentation of the return value below.<br>
-   * Notice that even this could be done asynchronously with certain UI frameworks: An event handler
-   * could wait asynchronously for the result and fill it in the UI. However, for things such as web
-   * interfaces, you might need JavaScript then, so a synchronous call will simplify the code.<br>
-   * In addition to only using synchronous calls when absolutely necessary, please make sure to set
-   * a timeout parameter which is as small as possible.<br>
-   * <br>
-   * ATTENTION: While remembering that this function can block for a long time, you have to consider
-   * that this class will <b>not</b> call {@link Thread#interrupt()} upon pending calls to this
-   * function during shutdown. You <b>must</b> keep track of threads which are executing this
-   * function on your own, and call {@link Thread#interrupt()} upon them at shutdown of your plugin.
-   * The interruption will then cause the function to throw {@link InterruptedException} quickly,
-   * which your calling threads should obey by exiting to ensure a fast shutdown.<br>
-   * <br>
-   * ATTENTION: This function can only work properly as long the message which you passed to this
-   * function does contain a message identifier which does not collide with one of another message.
-   * <br>
-   * To ensure this, you <b>must</b> use the constructor {@link FCPPluginMessage#construct(
-   * SimpleFieldSet, Bucket)} (or one of its shortcuts) and do not call this function twice upon the
-   * same message.<br>
-   * If you do not follow this rule and use colliding message identifiers, there might be side
-   * effects such as:<br>
-   * - This function might return the reply to the colliding message instead of the reply to your
-   * message. Notice that this implicitly means that you cannot be sure anymore that a message was
-   * delivered successfully if this function does not throw.<br>
-   * - The reply might be passed to the {@link FredPluginFCPMessageHandler} instead of being
-   * returned from this function.<br>
-   * Please notice that both these side effects can also happen if the remote partner erroneously
-   * sends multiple replies to the same message identifier.<br>
-   * As long as the remote side is implemented using FCPPluginConnection as well, and uses it
-   * properly, this shouldn't happen though. Thus in general, you should assume that the reply which
-   * this function returns <b>is</b> the right one, and your {@link FredPluginFCPMessageHandler}
-   * should just drop reply messages which were not expected and log them as at {@link
-   * LogLevel#WARNING}. The information here was merely provided to help you with debugging the
-   * cause of these events, <b>not</b> to make you change your code to assume that sendSynchronous
-   * does not work. For clean code, please write it in a way which assumes that the function works
-   * properly.<br>
-   * <br>
-   * ATTENTION: If you plan to use this inside of message handling functions of your implementations
-   * of the interfaces {@link FredPluginFCPMessageHandler.ServerSideFCPMessageHandler} or {@link
-   * FredPluginFCPMessageHandler.ClientSideFCPMessageHandler}, be sure to read the JavaDoc of the
-   * message handling functions first as it puts additional constraints on the usage of the
-   * FCPPluginConnection they receive.<br>
-   * <br>
+   * Sends a message and blocks until its paired reply arrives or the timeout elapses.
    *
-   * @param direction Whether to send the message to the server or the client message handler.<br>
-   *     You <b>can</b> use this to send messages to yourself.<br>
-   *     You may use {@link #sendSynchronous(FCPPluginMessage, long)} to avoid having to specify
-   *     this.<br>
-   *     <br>
-   * @param message <b>Must be</b> constructed using {@link
-   *     FCPPluginMessage#construct(SimpleFieldSet, Bucket)} or one of its shortcuts.<br>
-   *     <br>
-   *     Must <b>not</b> be a reply message: This function needs determine when the remote side has
-   *     finished processing the message so it knows when to return. That requires the remote side
-   *     to send a reply to indicate that the FCP call is finished. Replies to replies are not
-   *     allowed though (to prevent infinite bouncing).<br>
-   *     <br>
-   * @param timeoutNanoSeconds The function will wait for a reply to arrive for this amount of time.
-   *     <br>
-   *     Must be greater than 0 and below or equal to 1 minute.<br>
-   *     <br>
-   *     If the timeout expires, an {@link IOException} is thrown.<br>
-   *     This FCPPluginConnection <b>should be</b> considered as dead once this happens, you should
-   *     then discard it and obtain a fresh one.<br>
-   *     <br>
-   *     ATTENTION: The sending of the message is not affected by this timeout, it only affects how
-   *     long we wait for a reply. The sending is done in another thread, so if your message is very
-   *     large, and takes longer to transfer than the timeout grants, this function will throw
-   *     before the message has been sent.<br>
-   *     Additionally, the sending of the message is <b>not</b> terminated if the timeout expires
-   *     before it was fully transferred. Thus, the message can arrive at the remote side even if
-   *     this function has thrown, and you might receive an off-thread reply to the message in the
-   *     {@link FredPluginFCPMessageHandler}.<br>
-   *     <br>
-   *     Notice: For convenience, use class {@link TimeUnit} to easily convert seconds,
-   *     milliseconds, etc. to nanoseconds.<br>
-   *     <br>
-   * @return The reply {@link FCPPluginMessage} which the remote partner sent to your message.<br>
-   *     <br>
-   *     <b>ATTENTION</b>: Even if this function did not throw, the reply might indicate an error
-   *     with the field {link FCPPluginMessage#success}: This can happen if the message was
-   *     delivered but the remote message handler indicated that the FCP operation you initiated
-   *     failed.<br>
-   *     The fields {@link FCPPluginMessage#errorCode} and {@link FCPPluginMessage#errorMessage}
-   *     might indicate the type of the error.<br>
-   *     <br>
-   *     This can be used to decide to retry certain operations. A practical example would be a user
-   *     trying to create an account at an FCP server application:<br>
-   *     - Your UI would use this function to try to create the account by FCP.<br>
-   *     - The user might type an invalid character in the username.<br>
-   *     - The server could then indicate failure of creating the account by sending a reply with
-   *     success == false.<br>
-   *     - Your UI could detect the problem by success == false at the reply and an errorCode of
-   *     "InvalidUsername". The errorCode can be used to decide to highlight the username field with
-   *     a red color.<br>
-   *     - The UI then could prompt the user to chose a valid username by displaying the
-   *     errorMessage which the server provides to ship a translated, human readable explanation of
-   *     what is wrong with the username.<br>
-   * @throws IOException If the given timeout expired before a reply was received <b>or</b> if the
-   *     connection has been closed before even sending the message.<br>
-   *     This FCPPluginConnection <b>should be</b> considered as dead once this happens, you should
-   *     then discard it and obtain a fresh one.
-   * @throws InterruptedException If another thread called {@link Thread#interrupt()} upon the
-   *     thread which you used to execute this function.<br>
-   *     This is a shutdown mechanism: You can use it to abort a call to this function which is
-   *     waiting for the timeout to expire.<br>
-   *     <br>
-   * @see FCPPluginConnectionImpl#synchronousSends An overview of how synchronous sends and
-   *     especially their threading work internally is provided at the map which stores them.
-   * @see #send(SendDirection, FCPPluginMessage) The non-blocking, asynchronous send() should be
-   *     used instead of this whenever possible.
+   * <p>This variant gives explicit control over the direction and is suitable when either side
+   * needs strict request/response sequencing, deterministic throttling, or immediate access to the
+   * reply without involving the asynchronous handler. A successful return guarantees that the
+   * remote node accepted the request and emitted a reply, although the reply can still report an
+   * application-level failure through {@link FCPPluginMessage#success}.
+   *
+   * <p>The timeout only governs how long the caller waits; sending continues on internal threads
+   * even if the wait expires. If a timeout or transport failure occurs, the connection should be
+   * considered unusable and rebuilt through {@link PluginRespirator}. {@link TimeUnit} is helpful
+   * for passing nanosecond values.
+   *
+   * @param direction indicates which side should receive the message; use {@link
+   *     #sendSynchronous(FCPPluginMessage, long)} when the default direction suffices.
+   * @param message outbound payload constructed through {@link FCPPluginMessage#construct(
+   *     SimpleFieldSet, Bucket)}; replies to replies are disallowed because the handshake would not
+   *     complete.
+   * @param timeoutNanoSeconds positive timeout expressed in nanoseconds; exceeding it triggers a
+   *     failure even if the remote side eventually processes the request.
+   * @return the reply {@link FCPPluginMessage}, potentially with {@link FCPPluginMessage#success}
+   *     set to {@code false} along with {@link FCPPluginMessage#errorCode}.
+   * @throws IOException if the connection closes before the reply is obtained or if the timeout
+   *     expires without a response.
+   * @throws InterruptedException if the waiting thread is interrupted before completion, allowing
+   *     shutdown code to cancel in-flight exchanges.
+   * @see FCPPluginConnectionImpl Implementation notes describe how synchronous sends are tracked.
+   * @see #send(SendDirection, FCPPluginMessage)
    */
   FCPPluginMessage sendSynchronous(
       SendDirection direction, FCPPluginMessage message, long timeoutNanoSeconds)
       throws IOException, InterruptedException;
 
   /**
-   * Same as {@link #sendSynchronous(SendDirection, FCPPluginMessage, long)} with the {@link
-   * SendDirection} parameter being the default direction.<br>
-   * <b>Please do read its JavaDoc as it contains a very precise specification how to use it and
-   * thereby also this function.</b><br>
-   * <br>
-   * For an explanation of how the default send direction is determined, see {@link
-   * #send(FCPPluginMessage)}.
+   * Convenience overload of {@link #sendSynchronous(SendDirection, FCPPluginMessage, long)} that
+   * uses the default direction.
+   *
+   * <p>This is the most common form for client callers, which almost always route traffic to the
+   * server, and for server callbacks that mostly target the active client. The guidance on timeouts
+   * and error handling mirrors the directional overload, and replies still need to be inspected for
+   * {@link FCPPluginMessage#success}.
+   *
+   * @param message outbound payload that must not already be marked as a reply.
+   * @param timeoutNanoSeconds wait time expressed in nanoseconds; see {@link TimeUnit} helpers for
+   *     conversion.
+   * @return the reply message supplied by the remote endpoint.
+   * @throws IOException if the connection fails before the reply is available or if the wait times
+   *     out.
+   * @throws InterruptedException if the waiting thread is interrupted while blocked.
    */
   FCPPluginMessage sendSynchronous(FCPPluginMessage message, long timeoutNanoSeconds)
       throws IOException, InterruptedException;
 
   /**
-   * @return A unique identifier among all FCPPluginConnections.
-   * @see The ID can be used with {@link PluginRespirator#getPluginConnectionByID(UUID)}.
+   * Exposes the stable identifier assigned to this connection.
+   *
+   * <p>The identifier survives for as long as the connection remains strongly referenced and is
+   * used by the node to correlate network transports with plugin-side adapters. Server plugins can
+   * stash the value to look up a connection later through {@link PluginRespirator} or to store
+   * per-client metadata in their own persistence layer.
+   *
+   * @return unique {@link UUID} across all live connections owned by the node.
+   * @see PluginRespirator#getPluginConnectionByID(UUID)
    */
   UUID getID();
 
   /**
-   * @return A verbose String containing the internal state. Useful for debug logs.
+   * Provides a human-readable description of the connection state for logging.
+   *
+   * <p>The exact contents are implementation specific but typically include the connection
+   * identifier, direction defaults, and the addresses of attached message handlers. The string is
+   * intended for diagnostics only and should not be parsed programmatically.
+   *
+   * @return descriptive snapshot highlighting identity and lifecycle state.
    */
   String toString();
 }

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginConnectionImpl.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginConnectionImpl.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.EnumMap;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -22,119 +22,47 @@ import network.crypta.pluginmanager.PluginNotFoundException;
 import network.crypta.pluginmanager.PluginRespirator;
 import network.crypta.support.PooledExecutor;
 import network.crypta.support.PriorityAwareExecutor;
-import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * <b>Please first read the JavaDoc of the interface {@link FCPPluginConnection} which specifies
- * this class.</b><br>
- * <br>
- * ATTENTION:<br>
- * Objects of this class shall not be handed out directly to server or client applications. Instead,
- * only hand out a {@link DefaultSendDirectionAdapter} - which can be obtained by {@link
- * #getDefaultSendDirectionAdapter(SendDirection)}.<br>
- * This has two reasons:<br>
- * - The send functions which do not require a {@link SendDirection} will always throw an exception
- * without an adapter ({@link #send(FCPPluginMessage)} and {@link #sendSynchronous(FCPPluginMessage,
- * long)}).<br>
- * - Server plugins must not keep a strong reference to the FCPPluginConnectionImpl to ensure that
- * the client disconnection mechanism of monitoring garbage collection works, see {@link
- * PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)}. The adapter prevents
- * servers from keeping a strong reference by internally only keeping a {@link WeakReference} to the
- * FCPPluginConnectionImpl.<br>
+ * Implements {@link FCPPluginConnection} for both networked and intra-node plugin interactions,
+ * providing routing, lifecycle tracking, and synchronous reply coordination.
  *
- * <h1>Internals</h1>
+ * <p>The implementation bridges {@link FCPConnectionHandler} instances, plugin-side handlers, and
+ * {@link PriorityAwareExecutor} workers so that plugins can exchange {@link FCPPluginMessage}
+ * objects with strict ordering guarantees. Each connection keeps weak references to plugins where
+ * required, and callers are expected to obtain {@link DefaultSendDirectionAdapter} instances via
+ * {@link #getDefaultSendDirectionAdapter(SendDirection)} instead of storing a raw connection. That
+ * indirection prevents leaking strong references, which would break garbage-collection-based
+ * disconnect detection.
  *
- * <br>
- * This section is not interesting to server or client implementations. You might want to read it if
- * you plan to work on the fred-side implementation of FCP plugin messaging.
+ * <p>Internally the class maintains synchronized maps of outstanding synchronous calls, guards
+ * every wait with a timeout, and turns handler failures into structured {@code InternalError}
+ * replies so dispatcher threads never die silently. Send paths accept both remote clients (messages
+ * arrive via {@link FCPPluginClientMessage} from {@link FCPServer}) and intra-node clients (bound
+ * through {@link PluginRespirator}). Regardless of origin, messages ultimately reach {@link
+ * ServerSideFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}.
  *
- * <h2>Code path of sending messages</h2>
+ * <p>Key behaviors that plugin developers should remember:
  *
- * <p>There are two possible code paths for client connections, depending upon the location of the
- * client. The server is always running inside the node.<br>
- * <br>
- * NOTICE: These two code paths only apply to asynchronous, non-blocking messages. For blocking,
- * synchronous messages sent by {@link #sendSynchronous(SendDirection, FCPPluginMessage, long)},
- * there is an overview at {@link #synchronousSends}. The overview was left out here because they
- * are built on top of regular messages, so the code paths mentioned here mostly apply.<br>
- * <br>
- * The two possible paths are:<br>
+ * <ul>
+ *   <li>Always call {@link #getDefaultSendDirectionAdapter(SendDirection)} and interact with the
+ *       adapter, otherwise direction-less sends throw immediately and the tracker cannot reclaim
+ *       the connection.
+ *   <li>Synchronous waits are expensive; prefer asynchronous handlers when possible, and use
+ *       generous timeouts that reflect remote workload.
+ *   <li>The connection UUID is stable for the lifetime of the transport and can be cached by
+ *       servers to send unsolicited replies via {@link
+ *       PluginRespirator#getPluginConnectionByID(UUID)}.
+ * </ul>
  *
- * <p>1. The server is running in the node, the client is not - also called networked FCP
- * connections:<br>
- * - The client connects to the node via network and sends FCP message of type <a
- * href="https://wiki.freenetproject.org/FCPv2/FCPPluginMessage">FCPPluginMessage</a> (which will be
- * internally represented by class {@link FCPPluginClientMessage}).<br>
- * - The {@link FCPServer} creates a {@link FCPConnectionHandler} whose {@link
- * FCPConnectionInputHandler} receives the FCP message.<br>
- * - The {@link FCPConnectionInputHandler} uses {@link FCPMessage#create(String, SimpleFieldSet)} to
- * parse the message and obtain the actual {@link FCPPluginClientMessage}.<br>
- * - The {@link FCPPluginClientMessage} uses {@link FCPConnectionHandler#getFCPPluginConnection(
- * String)} to obtain the FCPPluginConnection to the server.<br>
- * - The {@link FCPPluginClientMessage} uses {@link FCPPluginConnection#send(SendDirection,
- * FCPPluginMessage)} to send the message to the server plugin.<br>
- * - The FCP server plugin handles the message at {@link
- * ServerSideFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}.<br>
- * - As each FCPPluginConnection object exists for the lifetime of a network connection, the FCP
- * server plugin may store the UUID of the FCPPluginConnection and query it via {@link
- * PluginRespirator#getPluginConnectionByID(UUID)}. It can use this to send messages to the client
- * application on its own, that is not triggered by any client messages.<br>
- *
- * <p>2. The server and the client are running in the same node, also called intra-node FCP
- * connections:</br> - The client plugin uses {@link PluginRespirator#connectToOtherPlugin(String,
- * FredPluginFCPMessageHandler.ClientSideFCPMessageHandler)} to try to create a connection.<br>
- * - The {@link PluginRespirator} uses {@link FCPServer#createFCPPluginConnectionForIntraNodeFCP(
- * String, FredPluginFCPMessageHandler.ClientSideFCPMessageHandler)} to get a FCPPluginConnection.
- * <br>
- * - The client plugin uses the send functions of the FCPPluginConnection. Those are the same as
- * with networked FCP connections.<br>
- * - The FCP server plugin handles the message at {@link
- * ServerSideFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}. That
- * is the same handler as with networked FCP connections.<br>
- * - The client plugin keeps a strong reference to the FCPPluginConnection in memory as long as it
- * wants to keep the connection open.<br>
- * - Same as with networked FCP connections, the FCP server plugin can store the UUID of the
- * FCPPluginConnection and in the future re-obtain the connection by {@link
- * PluginRespirator#getPluginConnectionByID(UUID)}. It can use this to send messages to the client
- * application on its own, that is not triggered by any client messages. <br>
- * - Once the client plugin is done with the connection, it discards the strong reference to the
- * FCPPluginConnection. Because the {@link FCPPluginConnectionTracker} monitors garbage collection
- * of FCPPluginConnection objects, getting rid of all strong references to a FCPPluginConnection is
- * sufficient as a disconnection mechanism.<br>
- * Thus, an intra-node client connection is considered as disconnected once the FCPPluginConnection
- * is not strongly referenced by the client plugin anymore. If a server plugin then tries to obtain
- * the client connection by its UUID again (via the aforementioned {@link
- * PluginRespirator#getPluginConnectionByID(UUID)}, the get will fail. So if the server plugin
- * stores connection UUIDs, it needs no special disconnection mechanism except for periodically
- * trying to send a message to each client. Once obtaining the client connection by its UUID fails,
- * or sending the message fails, the server can opportunistically purge the UUID from its database.
- * <br>
- * This mechanism also works for networked FCP.<br>
+ * <p>The remainder of this file documents the dispatcher paths so maintainers can reason about
+ * prioritization, failure handling, and GC-triggered disconnects.
  */
 final class FCPPluginConnectionImpl implements FCPPluginConnection {
   private static final Logger LOG = LoggerFactory.getLogger(FCPPluginConnectionImpl.class);
-
-  /**
-   * Automatically set to true by {@link Logger} if the log level is set to {@link LogLevel#DEBUG}
-   * for this class. Used as performance optimization to prevent construction of the log strings if
-   * it is not necessary.
-   */
-  private static final boolean logDEBUG = false;
-
-  /**
-   * Automatically set to true by {@link Logger} if the log level is set to {@link LogLevel#MINOR}
-   * for this class. Used as performance optimization to prevent construction of the log strings if
-   * it is not necessary.
-   */
-  private static final boolean logMINOR = false;
-
-  static {
-    // Necessary for automatic setting of logDEBUG and logMINOR
-
-  }
 
   /**
    * Unique identifier among all {@link FCPPluginConnection}s.
@@ -157,9 +85,9 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
   /**
    * The FCP server plugin to which this connection is connected.
    *
-   * <p>TODO: Optimization / Memory leak fix: Monitor this with a {@link ReferenceQueue} and if it
-   * becomes nulled, remove this FCPPluginConnectionImpl from the map {@link
-   * FCPConnectionHandler#pluginConnectionsByServerName}.<br>
+   * <p>Design note: Monitor this with a {@link ReferenceQueue} and if it becomes nulled, remove
+   * this FCPPluginConnectionImpl from the internal {@code pluginConnectionsByServerName} map held
+   * by {@link FCPConnectionHandler}.<br>
    * Currently, it seems not necessary:<br>
    * - It can only become null if the server plugin is unloaded / reloaded. Plugin unloading /
    * reloading requires user interaction or auto update and shouldn't happen frequently.<br>
@@ -175,7 +103,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
    * the past.<br>
    * NOTICE: If you do implement this, make sure to not rewrite the ReferenceQueue polling thread
    * but instead base it upon {@link FCPPluginConnectionTracker}. You should probably extract a
-   * generic class WeakValueMap from that one and use to to power both the existing class and the
+   * generic class WeakValueMap from that one and use it to power both the existing class and the
    * one which deals with this variable here.<br>
    * Also, once you've implemented ReferenceQueue monitoring, remove {@link #isServerDead()} as it
    * only was added for the opportunistic cleaning due to lack of a ReferenceQueue and is an ugly
@@ -212,7 +140,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
      */
     private final Condition completionSignal;
 
-    public FCPPluginMessage reply = null;
+    private FCPPluginMessage reply;
 
     public SynchronousSend(Condition completionSignal) {
       this.completionSignal = completionSignal;
@@ -258,12 +186,12 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
    * sendSynchronous() though, which could confuse it. But in that case it will probably just log an
    * error message and continue working as normal. <br>
    * <br>
-   * TODO: Optimization: We do not need the order of the map, and thus this could be a HashMap
-   * instead of a TreeMap. We do not use a HashMap for scalability: Java HashMaps never shrink, they
-   * only grow. As we cannot predict how much parallel synchronous sends server/client
-   * implementations will run, we do need a shrinking map. So we use TreeMap. We should use an
-   * automatically shrinking HashMap instead once we have one. This is also documented <a
-   * href="https://bugs.freenetproject.org/view.php?id=6320">in the bugtracker</a>.
+   * Design note: We do not need the order of the map, and thus this could be a HashMap instead of a
+   * TreeMap. We do not use a HashMap for scalability: Java HashMaps never shrink, they only grow.
+   * As we cannot predict how much parallel synchronous sends server/client implementations will
+   * run, we do need a shrinking map. So we use TreeMap until we have an automatically shrinking
+   * HashMap. This is also documented <a href="https://bugs.freenetproject.org/view.php?id=6320">in
+   * the bugtracker</a>.
    */
   private final TreeMap<String, SynchronousSend> synchronousSends = new TreeMap<>();
 
@@ -292,14 +220,20 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
       new EnumMap<>(SendDirection.class);
 
   /**
-   * For being used by networked FCP connections:<br>
-   * The server is running within the node, and its message handler is accessible as an implementor
-   * of {@link ServerSideFCPMessageHandler}.<br>
-   * The client is not running within the node, it is attached by network with a {@link
-   * FCPConnectionHandler}.<br>
+   * Creates an implementation for the case where the server plugin executes inside the node and the
+   * client communicates over the network via {@link FCPConnectionHandler}.
    *
-   * @see #constructForNetworkedFCP(FCPPluginConnectionTracker, PriorityAwareExecutor,
-   *     PluginManager, String, FCPConnectionHandler) The public interface to this constructor.
+   * <p>The constructor wires the executor, stores the weak reference to the {@link
+   * ServerSideFCPMessageHandler}, registers the connection with the tracker—notably before creating
+   * the client adapter—and attaches the inbound {@link FCPConnectionHandler}. Public callers should
+   * prefer {@link #constructForNetworkedFCP(FCPPluginConnectionTracker, PriorityAwareExecutor,
+   * PluginManager, String, FCPConnectionHandler)} so registration and validation remain consistent.
+   *
+   * @param tracker tracker responsible for garbage-collection-based disconnect detection
+   * @param executor shared executor on which handler calls run with priority awareness
+   * @param serverPluginName human-readable server identifier that appears in logs
+   * @param serverPlugin concrete server-side handler that consumes the routed messages
+   * @param clientConnection inbound handler bound to the network socket for this client
    */
   private FCPPluginConnectionImpl(
       FCPPluginConnectionTracker tracker,
@@ -328,27 +262,23 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
   }
 
   /**
-   * For being used by networked FCP connections:<br>
-   * The server is running within the node, and its message handler will be queried from the {@link
-   * PluginManager} via the given String serverPluginName.<br>
-   * The client is not running within the node, it is attached by network with the given {@link
-   * FCPConnectionHandler} clientConnection.<br>
-   * <br>
-   * The returned connection is registered at the given {@link FCPPluginConnectionTracker}. <br>
-   * <br>
-   * ATTENTION:<br>
-   * Objects of this class shall not be handed out directly to server or client applications.
-   * Instead, only hand out a {@link DefaultSendDirectionAdapter} - which can be obtained by {@link
-   * #getDefaultSendDirectionAdapter(SendDirection)}.<br>
-   * This has two reasons:<br>
-   * - The send functions which do not require a {@link SendDirection} will always throw an
-   * exception without an adapter ({@link #send(FCPPluginMessage)} and {@link
-   * #sendSynchronous(FCPPluginMessage, long)}).<br>
-   * - Server plugins must not keep a strong reference to the FCPPluginConnectionImpl to ensure that
-   * the client disconnection mechanism of monitoring garbage collection works, see {@link
-   * PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)}. The adapter
-   * prevents servers from keeping a strong reference by internally only keeping a {@link
-   * WeakReference} to the FCPPluginConnectionImpl.<br>
+   * Factory for networked FCP conversations where the server stays local and the client connects
+   * through {@link FCPConnectionHandler}.
+   *
+   * <p>The method locates the server plug-in via {@link PluginManager}, registers the resulting
+   * connection with the tracker, and returns an instance whose default direction adapters can be
+   * given to plugins. Always hand out adapters rather than this raw instance so GC-based disconnect
+   * logic remains effective.
+   *
+   * @param tracker tracker that observes created connections and provides GC notifications
+   * @param executor execution pool shared by plugin dispatchers, honoring {@link
+   *     PrioritizedMessageHandler} hints
+   * @param serverPluginManager plugin registry used to look up the server-side handler
+   * @param serverPluginName canonical server identifier passed to the plugin manager
+   * @param clientConnection network-side handler representing the remote client
+   * @return fully initialized connection ready for adapter exposure
+   * @throws PluginNotFoundException if the requested server plug-in is not loaded or lacks an FCP
+   *     handler
    */
   static FCPPluginConnectionImpl constructForNetworkedFCP(
       FCPPluginConnectionTracker tracker,
@@ -373,17 +303,19 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
   }
 
   /**
-   * For being used by intra-node connections between two plugins:<br>
-   * Both the server and the client are running within the same node, so objects of their FCP
-   * message handling interfaces are available:<br>
-   * The server's message handler is accessible as an implementor of {@link
-   * ServerSideFCPMessageHandler}.<br>
-   * The client's message handler is accessible as an implementor of {@link
-   * ClientSideFCPMessageHandler}.<br>
+   * Creates an implementation for intra-node connections where both sides execute inside the same
+   * JVM and expose handler interfaces directly.
    *
-   * @see #constructForIntraNodeFCP(FCPPluginConnectionTracker, PriorityAwareExecutor,
-   *     PluginManager, String, ClientSideFCPMessageHandler) The public interface to this
-   *     constructor.
+   * <p>This variant stores both handler references strongly, registers the connection before
+   * building the {@link SendToClientAdapter}, and omits any {@link FCPConnectionHandler} because
+   * the client lives in-process. The tracker registration ensures GC monitoring is active from the
+   * moment the connection exists.
+   *
+   * @param tracker tracker responsible for monitoring connection lifetimes
+   * @param executor executor pool powering message dispatch
+   * @param serverPluginName canonical server identifier used for logging and lookups
+   * @param server concrete server-side handler implementation
+   * @param client concrete client-side handler implementation
    */
   private FCPPluginConnectionImpl(
       FCPPluginConnectionTracker tracker,
@@ -412,29 +344,20 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
   }
 
   /**
-   * For being used by intra-node connections between two plugins:<br>
-   * Both the server and the client are running within the same node, so their FCP interfaces are
-   * available:<br>
-   * The server plugin will be queried from given {@link PluginManager} via the given String
-   * serverPluginName.<br>
-   * The client message handler is available as the passed {@link ClientSideFCPMessageHandler}
-   * client.<br>
-   * <br>
-   * The returned connection is registered at the given {@link FCPPluginConnectionTracker}. <br>
-   * <br>
-   * ATTENTION:<br>
-   * Objects of this class shall not be handed out directly to server or client applications.
-   * Instead, only hand out a {@link DefaultSendDirectionAdapter} - which can be obtained by {@link
-   * #getDefaultSendDirectionAdapter(SendDirection)}.<br>
-   * This has two reasons:<br>
-   * - The send functions which do not require a {@link SendDirection} will always throw an
-   * exception without an adapter ({@link #send(FCPPluginMessage)} and {@link
-   * #sendSynchronous(FCPPluginMessage, long)}).<br>
-   * - Server plugins must not keep a strong reference to the FCPPluginConnectionImpl to ensure that
-   * the client disconnection mechanism of monitoring garbage collection works, see {@link
-   * PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)}. The adapter
-   * prevents servers from keeping a strong reference by internally only keeping a {@link
-   * WeakReference} to the FCPPluginConnectionImpl.<br>
+   * Factory for intra-node plug-in conversations where both handlers run inside the same JVM.
+   *
+   * <p>The method looks up the server from the {@link PluginManager}, registers the connection with
+   * the tracker, and returns an instance whose adapters can safely be handed to plugins. Default
+   * direction adapters should again be used instead of exposing the raw connection to avoid strong
+   * references leaking beyond the tracker.
+   *
+   * @param tracker tracker that keeps weak references and observes garbage-collection events
+   * @param executor executor powering message dispatch threads
+   * @param serverPluginManager plugin registry that exposes server handlers
+   * @param serverPluginName canonical server name used for lookups and logging
+   * @param client client-side handler owned by the requesting plug-in
+   * @return initialized connection with adapters for both directions
+   * @throws PluginNotFoundException if the requested server plug-in cannot be resolved
    */
   static FCPPluginConnectionImpl constructForIntraNodeFCP(
       FCPPluginConnectionTracker tracker,
@@ -458,36 +381,39 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
   }
 
   /**
-   * ONLY for being used in unit tests.<br>
-   * This is similar to intra-node connections in regular operation: Both the server and client are
-   * running in the same VM. You must implement both the server and client side message handler in
-   * the unit test and pass them to this constructor.<br>
-   * <br>
-   * Notice: Some server plugins might use {@link PluginRespirator#getPluginConnectionByID(UUID)} to
-   * obtain FCPPluginConnectionImpl objects. They likely won't work with connections created by this
-   * because it doesn't create a PluginRespirator. To get a {@link PluginRespirator} available in
-   * unit tests, you might want to use {@link
-   * NodeStarter#createTestNode(NodeStarter.TestNodeParameters)} instead of this constructor:<br>
-   * - The test node can be used to load the plugin as a JAR.<br>
-   * - As loading a plugin by JAR is the same mode of operation as with a regular node, there will
-   * be a PluginRespirator available to it.<br>
-   * - {@link PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)} can then
-   * be used for obtaining a FCPPluginConnection instead of this constructor. This also is the
-   * function to obtain a FCPPluginConnection which is used in regular mode of operation.<br>
-   * - The aforementioned {@link PluginRespirator#getPluginConnectionByID(UUID)} will then work for
-   * FCPPluginConnections obtained through the connectToOtherPlugin().
+   * Creates a lightweight connection pair for unit tests where both handlers are supplied directly.
+   *
+   * <p>The helper mirrors an intra-node setup: both handlers run in-process, the tracker is started
+   * automatically, and a {@link PooledExecutor} provides the necessary threading. It does
+   * <em>not</em> instantiate a {@link PluginRespirator}, so code that depends on {@link
+   * PluginRespirator#getPluginConnectionByID(UUID)} should instead spin up a full {@link
+   * NodeStarter#createTestNode(NodeStarter.TestNodeParameters)} instance to exercise the same code
+   * paths as production.
+   *
+   * @param server server-side handler implementation under test
+   * @param client client-side handler used to capture replies inside the unit test
+   * @return connection wired to the supplied handlers and backed by a fresh tracker
    */
   public static FCPPluginConnectionImpl constructForUnitTest(
       ServerSideFCPMessageHandler server, ClientSideFCPMessageHandler client) {
 
-    assert (server != null);
-    assert (client != null);
+    Objects.requireNonNull(server, "server");
+    Objects.requireNonNull(client, "client");
     FCPPluginConnectionTracker tracker = new FCPPluginConnectionTracker();
     tracker.start();
     return new FCPPluginConnectionImpl(
         tracker, new PooledExecutor(), server.toString(), server, client);
   }
 
+  /**
+   * Returns the stable UUID assigned to this connection when it was created.
+   *
+   * <p>The identifier remains valid for the lifetime of the transport and is used by {@link
+   * PluginRespirator#getPluginConnectionByID(UUID)} so plugins can send unsolicited messages later.
+   * Treat it as opaque; callers should not attempt to parse any structure from the UUID.
+   *
+   * @return immutable identifier unique among all live {@link FCPPluginConnection} instances
+   */
   @Override
   public UUID getID() {
     return id;
@@ -539,6 +465,20 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     }
   }
 
+  /**
+   * Sends a message in the specified direction without waiting for a reply.
+   *
+   * <p>The method stamps the correct {@link ClientPermissions}, pushes the payload onto either the
+   * network connection or the local handler, and logs a warning if callers attempt to reuse the
+   * same {@link FCPPluginMessage} instance twice. It is safe to invoke concurrently from multiple
+   * threads; prioritization is determined by {@link PrioritizedMessageHandler} implementations.
+   *
+   * @param direction direction to deliver the message; determines which adapter or connection is
+   *     used
+   * @param message immutable payload created through {@link FCPPluginMessage} helpers; must not be
+   *     reused
+   * @throws IOException if the underlying transport closes or cannot accept more data
+   */
   @Override
   public void send(final SendDirection direction, FCPPluginMessage message) throws IOException {
     if (!message.markSent()) {
@@ -569,7 +509,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
 
     // Now that the message is completely initialized, we can dump it to the logfile.
     if (LOG.isTraceEnabled()) {
-      LOG.trace("send(): direction = " + direction + "; " + "message = " + message);
+      LOG.trace("send(): direction = {}; message = {}", direction, message);
     }
 
     // True if the target server or client message handler is running in this VM.
@@ -584,10 +524,6 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
       dispatchMessageByNetwork(direction, message);
       return;
     }
-
-    assert (direction == SendDirection.TO_SERVER ? server != null : client != null)
-        : "We already decided that the message handler exists locally. "
-            + "We should have only decided so if the handler is not null.";
 
     // The message handler is determined to be local at this point. There are two possible
     // types of local message handlers:
@@ -605,7 +541,9 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     // sendSynchronous().
     // If there was no sendSynchronous() thread, it returns false, and we must continue to
     // handle case 1.
-    if (dispatchMessageLocallyToSendSynchronousThreadIfExisting(direction, message)) return;
+    if (dispatchMessageLocallyToSendSynchronousThreadIfExisting(message)) {
+      return;
+    }
 
     // We now know that the message handler is not attached by network, and that it is not a
     // sendSynchronous() thread. So the only thing it can be is a FredPluginFCPMessageHandler,
@@ -621,7 +559,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
       throw new IOException("The server plugin has been unloaded.");
     }
 
-    // We now have the right FredPluginFCPMessageHandler, it is still alive, and so we can can
+    // We now have the right FredPluginFCPMessageHandler, it is still alive, and so we can
     // pass the message to it.
     dispatchMessageLocallyToMessageHandler(messageHandler, direction, message);
   }
@@ -679,7 +617,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
    *     especially their threading work internally is provided at the map which stores them.
    */
   private boolean dispatchMessageLocallyToSendSynchronousThreadIfExisting(
-      final SendDirection direction, final FCPPluginMessage message) {
+      final FCPPluginMessage message) {
 
     // Since the message handler is determined to be local at this point, we now must check
     // whether it is a blocking sendSynchronous() thread instead of a regular
@@ -704,8 +642,8 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     // by *multiple* threads at once. We then read the map to check whether there is a
     //  waiter, and if there is, take the write lock to hand the message to it.
     // (The implementation of ReentrantReadWritelock does not allow upgrading a readLock()
-    // to a writeLock(), so we must release it in between and re-check afterwards.)
-    // TODO: Performance: If this turns out to be a bottleneck, add a
+    // to a writeLock(), so we must release it in between and re-check afterward.)
+    // Performance note: If this turns out to be a bottleneck, add a
     // "Synchronous={True, False}" flag to messages so we only have to check the table if
     // Synchronous=True, and can return false immediately otherwise. (If Synchronous=True, we
     // still will have to check the table whether a waiter is existing because it might have
@@ -731,8 +669,10 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
         return false;
       }
 
-      assert (synchronousSend.reply == null)
-          : "One identifier should not be used for multiple messages or replies";
+      if (synchronousSend.reply != null) {
+        throw new IllegalStateException(
+            "One identifier should not be used for multiple messages or replies");
+      }
 
       synchronousSend.reply = message;
       // Wake up the waiting synchronousSend() thread
@@ -762,169 +702,20 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
         new PrioRunnable() {
           @Override
           public void run() {
-            FCPPluginMessage reply = null;
+            FCPPluginMessage reply =
+                validateReply(
+                    direction, message, invokeHandlerForReply(messageHandler, direction, message));
 
-            try {
-              try {
-                reply =
-                    messageHandler.handlePluginFCPMessage(
-                        getDefaultSendDirectionAdapter(direction.invert()), message);
-              } catch (Error e) {
-                // TODO: Code quality: This is a workaround for Java 6 not having
-                // "catch(RuntimeException | Error e)". Once we are on Java 7, remove this
-                // catch() block, and catch both types with the catch() block below.
-                throw new RuntimeException(e);
-              }
-            } catch (RuntimeException e) {
-              // The message handler is a server or client implementation, and thus as third
-              // party code might have bugs. So we need to catch any undeclared throwables.
-              // Notice that this is not normal mode of operation: Instead of throwing,
-              // the JavaDoc requests message handlers to return a reply with success=false.
-
-              String errorMessage =
-                  "CryptadPluginFCPMessageHandler threw."
-                      + " See JavaDoc of its member interfaces for how signal errors properly."
-                      + " connection = "
-                      + FCPPluginConnectionImpl.this
-                      + "; SendDirection = "
-                      + direction
-                      + "; message = "
-                      + message;
-
-              LOG.error(errorMessage, e);
-
-              if (!message.isReplyMessage()) {
-                // If the original message was not a reply already, we are allowed to send a
-                // reply with success=false to indicate the error to the remote side.
-                // This allows possibly existing, waiting sendSynchronous() calls to fail
-                // quickly instead of having to wait for the timeout because no reply
-                // arrives.
-                reply =
-                    FCPPluginMessage.constructReplyMessage(
-                        message,
-                        null,
-                        null,
-                        false,
-                        "InternalError",
-                        errorMessage + "; Throwable = " + e);
-              }
-            }
-
-            if (reply != null) {
-              // TODO: Performance: The below checks might be converted to assert() or
-              // be prefixed with if (LOG.isDebugEnabled()).
-              // Not doing this now since the CryptadPluginFCPMessageHandler API which specifies
-              // those requirements is new and thus quite a few client applications might be
-              // converted to it soon, and do those beginners mistakes.
-              // After everyone has gotten used to it, we can move to the more lax checking.
-              // An alternate solution would be to not use the FCPPluginMessage object
-              // which was returned by the message handler but always re-construct it to
-              // follow the standards.
-
-              // Replying to replies is disallowed to prevent infinite bouncing.
-              if (message.isReplyMessage()) {
-                LOG.error(
-                    "CryptadPluginFCPMessageHandler tried to send a"
-                        + " reply to a reply. Discarding it. See JavaDoc of its member"
-                        + " interfaces for how to do this properly."
-                        + " connection = "
-                        + FCPPluginConnectionImpl.this
-                        + "; original message SendDirection = "
-                        + direction
-                        + "; original message = "
-                        + message
-                        + "; reply = "
-                        + reply);
-
-                reply = null;
-              } else if (!reply.isReplyMessage()) {
-                LOG.error(
-                    "CryptadPluginFCPMessageHandler tried to send a"
-                        + " non-reply message as reply. See JavaDoc of its member interfaces"
-                        + " for how to do this properly."
-                        + " connection = "
-                        + FCPPluginConnectionImpl.this
-                        + "; original message SendDirection = "
-                        + direction
-                        + "; original message = "
-                        + message
-                        + "; reply = "
-                        + reply);
-
-                reply = null;
-              } else if (!reply.identifier.equals(message.identifier)) {
-                LOG.error(
-                    "CryptadPluginFCPMessageHandler tried to send a"
-                        + " reply with with different identifier than original message."
-                        + " See JavaDoc of its member interfaces for how to do this properly."
-                        + " connection = "
-                        + FCPPluginConnectionImpl.this
-                        + "; original message SendDirection = "
-                        + direction
-                        + "; original message = "
-                        + message
-                        + "; reply = "
-                        + reply);
-
-                reply = null;
-              }
-            } else if (reply == null) {
-              if (!message.isReplyMessage()) {
-                // The message handler did not not ship a reply even though it would have
-                // been allowed to because the original message was not a reply.
-                // This shouldn't be done: Not sending a success reply at least will cause
-                // sendSynchronous() threads to keep waiting for the reply until timeout.
-                LOG.warn(
-                    "Cryptad did not receive a reply from the message "
-                        + "handler even though it was allowed to reply. "
-                        + "This would cause sendSynchronous() to timeout! "
-                        + " connection = "
-                        + FCPPluginConnectionImpl.this
-                        + "; SendDirection = "
-                        + direction
-                        + "; message = "
-                        + message);
-              }
-            }
-
-            // We already tried to set a reply if one is needed. If it is still null now, then
-            // we do not have to send one for sure, so we can return.
             if (reply == null) {
+              warnAboutMissingReply(direction, message);
               return;
             }
 
-            try {
-              send(direction.invert(), reply);
-            } catch (IOException e) {
-              // The remote partner has disconnected, which can happen during normal
-              // operation.
-              // There is nothing we can do to get the IOException out to the caller of the
-              // initial send() of the original message which triggered the reply sending.
-              // - We are in a different thread, the initial send() has returned already.
-              // So we just log it, because it still might indicate problems if we try to
-              // send after disconnection.
-              // We log it marked as from the messageHandler instead of the
-              // FCPPluginConnectionImpl:
-              // The messageHandler will be an object of the server or client plugin,
-              // from a class contained in it. So there is a chance that the developer
-              // has logging enabled for that class, and thus we log it marked as from that.
-
-              LOG.warn(
-                  "Sending reply from CryptadPluginFCPMessageHandler"
-                      + " failed, the connection was closed already."
-                      + " connection = "
-                      + FCPPluginConnectionImpl.this
-                      + "; original message SendDirection = "
-                      + direction
-                      + "; original message = "
-                      + message
-                      + "; reply = "
-                      + reply,
-                  e);
-            }
+            sendReplyFromHandler(direction, message, reply);
           }
 
           @Override
+          @SuppressWarnings("java:S1181")
           public int getPriority() {
             NativeThread.PriorityLevel priority = NativeThread.PriorityLevel.NORM_PRIORITY;
 
@@ -953,6 +744,145 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     executor.execute(messageDispatcher, messageDispatcher.toString());
   }
 
+  @SuppressWarnings("java:S1181")
+  private FCPPluginMessage invokeHandlerForReply(
+      FredPluginFCPMessageHandler messageHandler,
+      SendDirection direction,
+      FCPPluginMessage message) {
+    try {
+      return messageHandler.handlePluginFCPMessage(
+          getDefaultSendDirectionAdapter(direction.invert()), message);
+    } catch (Throwable t) {
+      return handleHandlerFailure(direction, message, t);
+    }
+  }
+
+  private FCPPluginMessage handleHandlerFailure(
+      SendDirection direction, FCPPluginMessage message, Throwable error) {
+    String errorMessage =
+        "CryptadPluginFCPMessageHandler threw."
+            + " See JavaDoc of its member interfaces for how signal errors properly."
+            + " connection = "
+            + this
+            + "; SendDirection = "
+            + direction
+            + "; message = "
+            + message;
+
+    LOG.error(errorMessage, error);
+
+    if (message.isReplyMessage()) {
+      return null;
+    }
+
+    return FCPPluginMessage.constructReplyMessage(
+        message, null, null, false, "InternalError", errorMessage + "; Throwable = " + error);
+  }
+
+  private FCPPluginMessage validateReply(
+      SendDirection direction, FCPPluginMessage original, FCPPluginMessage reply) {
+    if (reply == null) {
+      return null;
+    }
+
+    // Performance note: The below checks might be converted to assert() or be prefixed with if
+    // (LOG.isDebugEnabled()). They are intentionally kept active for clarity because the newer
+    // API is still easy to misuse.
+
+    if (original.isReplyMessage()) {
+      LOG.error(
+          "CryptadPluginFCPMessageHandler tried to send a reply to a reply. Discarding it. See"
+              + " JavaDoc of its member interfaces for how to do this properly. connection = {};"
+              + " original message SendDirection = {}; original message = {}; reply = {}",
+          this,
+          direction,
+          original,
+          reply);
+      return null;
+    }
+
+    if (!reply.isReplyMessage()) {
+      LOG.error(
+          "CryptadPluginFCPMessageHandler tried to send a non-reply message as reply. See JavaDoc"
+              + " of its member interfaces for how to do this properly. connection = {}; original"
+              + " message SendDirection = {}; original message = {}; reply = {}",
+          this,
+          direction,
+          original,
+          reply);
+      return null;
+    }
+
+    if (!reply.identifier.equals(original.identifier)) {
+      LOG.error(
+          "CryptadPluginFCPMessageHandler tried to send a reply with different identifier than the"
+              + " original message. connection = {}; original message SendDirection = {}; original"
+              + " message = {}; reply = {}",
+          this,
+          direction,
+          original,
+          reply);
+
+      return null;
+    }
+
+    return reply;
+  }
+
+  private void warnAboutMissingReply(SendDirection direction, FCPPluginMessage message) {
+    if (message.isReplyMessage()) {
+      return;
+    }
+
+    LOG.warn(
+        "Cryptad did not receive a reply from the message handler even though it was allowed to"
+            + " reply. This would cause sendSynchronous() to timeout! connection = {};"
+            + " SendDirection = {}; message = {}",
+        this,
+        direction,
+        message);
+  }
+
+  private void sendReplyFromHandler(
+      SendDirection direction, FCPPluginMessage message, FCPPluginMessage reply) {
+    try {
+      send(direction.invert(), reply);
+    } catch (IOException e) {
+      LOG.warn(
+          "Sending reply from CryptadPluginFCPMessageHandler failed, the connection was closed"
+              + " already. connection = {}; original message SendDirection = {}; original message"
+              + " = {}; reply = {}",
+          this,
+          direction,
+          message,
+          reply,
+          e);
+    }
+  }
+
+  /**
+   * Sends a request and blocks until its paired reply arrives or the timeout elapses.
+   *
+   * <p>The method installs a {@link SynchronousSend} record keyed by the message identifier, sends
+   * the payload using {@link #send(SendDirection, FCPPluginMessage)}, then waits on a {@link
+   * Condition}. Spurious wakeups are tolerated by re-checking the reply slot, and every code path
+   * removes its entry to avoid leaking memory. Timeouts raise {@link IOException} so callers can
+   * rebuild the connection. Reply messages are forbidden because they would deadlock the handshake.
+   *
+   * <pre>{@code
+   * var reply = connection.sendSynchronous(
+   *     SendDirection.TO_SERVER,
+   *     request,
+   *     TimeUnit.SECONDS.toNanos(30));
+   * }</pre>
+   *
+   * @param direction direction to deliver the outbound request
+   * @param message immutable request that must not already represent a reply
+   * @param timeoutNanoSeconds positive wait duration expressed in nanoseconds
+   * @return reply returned by the remote endpoint; {@link FCPPluginMessage#success} may be false
+   * @throws IOException if the timeout expires or the transport closes mid-flight
+   * @throws InterruptedException if the calling thread is interrupted while waiting
+   */
   @Override
   public FCPPluginMessage sendSynchronous(
       SendDirection direction, FCPPluginMessage message, long timeoutNanoSeconds)
@@ -965,10 +895,9 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
               + "But a reply is needed for sendSynchronous() to determine when to return.");
     }
 
-    assert (timeoutNanoSeconds > 0) : "Timeout should not be negative";
-
-    assert (timeoutNanoSeconds <= TimeUnit.MINUTES.toNanos(1))
-        : "Please use sane timeouts to prevent thread congestion";
+    if (timeoutNanoSeconds <= 0) {
+      throw new IllegalArgumentException("Timeout should be positive");
+    }
 
     synchronousSendsLock.writeLock().lock();
     try {
@@ -979,25 +908,25 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
       // - The constructor of FCPPluginMessage which we tell the user to use in the JavaDoc
       //   does generate a random identifier, so collisions will only happen if the user
       //   ignores the JavaDoc or changes the constructor.
-      // - If the assert is not true, then the following put() will replace the old
+      // - If the assertion is not true, then the following put() will replace the old
       //   SynchronousSend, so its Condition will never get signaled, and its
       //   thread waiting in sendSynchronous() will timeout safely. It IS possible that this
       //   thread will then get a reply which does not belong to it. But the wrong reply will
       //   only affect the caller, the FCPPluginConnectionImpl will keep working fine,
-      //   especially no threads will become stalled for ever. As the caller is at fault for
+      //   especially no threads will become stalled forever. As the caller is at fault for
       //   the issue, it is fine if he breaks his own stuff :) The JavaDoc also documents this
 
-      assert (!synchronousSends.containsKey(message.identifier))
-          : "FCPPluginMessage.identifier should be unique";
+      if (synchronousSends.containsKey(message.identifier)) {
+        throw new IllegalStateException("FCPPluginMessage.identifier should be unique");
+      }
 
       synchronousSends.put(message.identifier, synchronousSend);
 
       if (LOG.isDebugEnabled()) {
         LOG.debug(
-            "sendSynchronous(): Started for identifier "
-                + message.identifier
-                + "; synchronousSends table size: "
-                + synchronousSends.size());
+            "sendSynchronous(): Started for identifier {}; synchronousSends table size: {}",
+            message.identifier,
+            synchronousSends.size());
       }
 
       send(direction, message);
@@ -1039,12 +968,15 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
         // signaled we still need to check whether the semantic condition which would
         // trigger signaling is *really* met, which we do with this if:
         if (synchronousSend.reply != null) {
-          assert (synchronousSend.reply.identifier.equals(message.identifier));
+          if (!synchronousSend.reply.identifier.equals(message.identifier)) {
+            throw new IllegalStateException(
+                "Reply identifier does not match the original message identifier");
+          }
 
           return synchronousSend.reply;
         }
 
-        // The spurious wakeup described at the above if() has happened, so we loop.
+        // A spurious wakeup occurred, so loop again and continue waiting.
       } while (true);
     } finally {
       // We MUST always remove the SynchronousSend object which we added to the map,
@@ -1053,10 +985,9 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
 
       if (LOG.isDebugEnabled()) {
         LOG.debug(
-            "sendSynchronous(): Done for identifier "
-                + message.identifier
-                + "; synchronousSends table size: "
-                + synchronousSends.size());
+            "sendSynchronous(): Done for identifier {}; synchronousSends table size: {}",
+            message.identifier,
+            synchronousSends.size());
       }
 
       synchronousSendsLock.writeLock().unlock();
@@ -1070,8 +1001,8 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
    * - {@link FCPPluginConnection#sendSynchronous(FCPPluginMessage, long)}<br>
    * <br>
    * An adapter is needed instead of storing this as a member variable in FCPPluginConnectionImpl
-   * because a single FCPPluginConnectionImpl object is used by both to the the server AND the
-   * client which it connects, and their default send direction will be different:<br>
+   * because a single FCPPluginConnectionImpl object is used by both to the server AND the client
+   * which it connects, and their default send direction will be different:<br>
    * A server will want to send to the client by default, but the client will want to default to
    * sending to the server.<br>
    * <br>
@@ -1190,7 +1121,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
         // FCPPluginConnectionImpl. While it is being constructed, it should not be
         // considered as disconnected already, and thus the FCPPluginConnectionTracker
         // should never throw IOException.
-        throw new RuntimeException("SHOULD NOT HAPPEN: ", e);
+        throw new IllegalStateException("Tracker unexpectedly reported a disconnect", e);
       }
     }
 
@@ -1266,12 +1197,16 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
   }
 
   /**
-   * Returns a {@link DefaultSendDirectionAdapter} (which implements FCPPluginConnection) wrapped
-   * around this FCPPluginConnectionImpl for which the following send functions will then always
-   * send to the {@link SendDirection} which was passed to this function:<br>
-   * - {@link FCPPluginConnection#send(FCPPluginMessage)}<br>
-   * - {@link FCPPluginConnection#sendSynchronous(FCPPluginMessage, long)}<br>
-   * <br>
+   * Returns an adapter that locks the default {@link SendDirection} for callers lacking explicit
+   * routing.
+   *
+   * <p>Adapters keep weak references when facing server plugins so garbage-collection-based
+   * disconnects still work. Callers must use these adapters instead of caching {@code
+   * FCPPluginConnectionImpl} directly; otherwise synchronous send restrictions and lifecycle
+   * monitoring are bypassed.
+   *
+   * @param direction direction the adapter should target for all direction-less calls
+   * @return adapter implementing {@link FCPPluginConnection} with the requested default direction
    */
   public FCPPluginConnection getDefaultSendDirectionAdapter(SendDirection direction) {
     return defaultSendDirectionAdapters.get(direction);
@@ -1307,7 +1242,6 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
    * @see FCPPluginConnectionImpl#send(FCPPluginMessage)
    * @see FCPPluginConnectionImpl#sendSynchronous(FCPPluginMessage, long)
    */
-  @SuppressWarnings("serial")
   private static final class NoSendDirectionSpecifiedException
       extends UnsupportedOperationException {
 

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginConnectionImpl.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginConnectionImpl.java
@@ -319,12 +319,12 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     this.server = new WeakReference<>(serverPlugin);
     this.client = null;
     this.clientConnection = clientConnection;
-    this.defaultSendDirectionAdapters.put(SendDirection.ToServer, new SendToServerAdapter(this));
+    this.defaultSendDirectionAdapters.put(SendDirection.TO_SERVER, new SendToServerAdapter(this));
     // new SendToClientAdapter() will need to query this connection from the tracker already.
     // Thus, we have to register before constructing it.
     tracker.registerConnection(this);
     this.defaultSendDirectionAdapters.put(
-        SendDirection.ToClient, new SendToClientAdapter(tracker, id));
+        SendDirection.TO_CLIENT, new SendToClientAdapter(tracker, id));
   }
 
   /**
@@ -403,12 +403,12 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     this.server = new WeakReference<>(server);
     this.client = client;
     this.clientConnection = null;
-    this.defaultSendDirectionAdapters.put(SendDirection.ToServer, new SendToServerAdapter(this));
+    this.defaultSendDirectionAdapters.put(SendDirection.TO_SERVER, new SendToServerAdapter(this));
     // new SendToClientAdapter() will need to query this connection from the tracker already.
     // Thus, we have to register before constructing it.
     tracker.registerConnection(this);
     this.defaultSendDirectionAdapters.put(
-        SendDirection.ToClient, new SendToClientAdapter(tracker, id));
+        SendDirection.TO_CLIENT, new SendToClientAdapter(tracker, id));
   }
 
   /**
@@ -541,10 +541,17 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
 
   @Override
   public void send(final SendDirection direction, FCPPluginMessage message) throws IOException {
+    if (!message.markSent()) {
+      LOG.error(
+          "send(): Attempted to send FCPPluginMessage {} twice on {}. "
+              + "Re-sending the same instance is unsupported.",
+          message.identifier,
+          direction);
+    }
     // We first have to compute the message.permissions field ourselves - we shall ignore what
     // caller said for security.
     ClientPermissions currentClientPermissions =
-        (direction == SendDirection.ToClient)
+        (direction == SendDirection.TO_CLIENT)
             ? null // Server-to-client messages do not have permissions.
             : getCurrentClientPermissions();
 
@@ -570,15 +577,15 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     // sending a message over the network.
     // Notice that we do not check for server != null because that is not allowed by this class.
     final boolean messageHandlerExistsLocally =
-        (direction == SendDirection.ToServer)
-            || (direction == SendDirection.ToClient && client != null);
+        (direction == SendDirection.TO_SERVER)
+            || (direction == SendDirection.TO_CLIENT && client != null);
 
     if (!messageHandlerExistsLocally) {
       dispatchMessageByNetwork(direction, message);
       return;
     }
 
-    assert (direction == SendDirection.ToServer ? server != null : client != null)
+    assert (direction == SendDirection.TO_SERVER ? server != null : client != null)
         : "We already decided that the message handler exists locally. "
             + "We should have only decided so if the handler is not null.";
 
@@ -604,7 +611,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     // sendSynchronous() thread. So the only thing it can be is a FredPluginFCPMessageHandler,
     // and we now determine whether it is the one of the client or the server.
     final FredPluginFCPMessageHandler messageHandler =
-        (direction == SendDirection.ToServer) ? server.get() : client;
+        (direction == SendDirection.TO_SERVER) ? server.get() : client;
 
     if (messageHandler == null) {
       // server is a WeakReference which can be nulled if the server plugin was unloaded.
@@ -639,7 +646,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
     // So instead, for simplicity and reduced thread count, we just queue the message directly
     // to the network queue here and return.
 
-    assert (direction == SendDirection.ToClient)
+    assert (direction == SendDirection.TO_CLIENT)
         : "By design, this class always shall execute in the same VM as the server plugin. "
             + "So for networked messages, we should always be sending to the client.";
 
@@ -1070,8 +1077,8 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
    * <br>
    * Is abstract and has two implementing child classes (to implement differing internal
    * requirements, see {@link #getConnection()}):<br>
-   * - {@link SendToClientAdapter} for default direction {@link SendDirection#ToClient}.<br>
-   * - {@link SendToServerAdapter} for default direction {@link SendDirection#ToServer}.<br>
+   * - {@link SendToClientAdapter} for default direction {@link SendDirection#TO_CLIENT}.<br>
+   * - {@link SendToServerAdapter} for default direction {@link SendDirection#TO_SERVER}.<br>
    * <br>
    * NOTICE: Server plugins must not keep a strong reference to the FCPPluginConnectionImpl to
    * ensure that the client disconnection mechanism of monitoring garbage collection works. This
@@ -1130,7 +1137,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
 
   /**
    * Encapsulates a FCPPluginConnectionImpl object with a default {@link SendDirection} of {@link
-   * SendDirection#ToClient} to implement the send functions which don't require a direction
+   * SendDirection#TO_CLIENT} to implement the send functions which don't require a direction
    * parameter:<br>
    * - {@link FCPPluginConnection#send(FCPPluginMessage)}<br>
    * - {@link FCPPluginConnection#sendSynchronous(FCPPluginMessage, long)}<br>
@@ -1171,7 +1178,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
      * reuse adapters instead of creating new ones with this constructor.
      */
     SendToClientAdapter(FCPPluginConnectionTracker tracker, UUID connectionID) {
-      super(SendDirection.ToClient);
+      super(SendDirection.TO_CLIENT);
 
       // Reuse the WeakReference from the FCPPluginConnectionTracker instead of creating our
       // own one since it has to keep a WeakReference for every connection anyway, and
@@ -1215,7 +1222,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
 
   /**
    * Encapsulates a FCPPluginConnectionImpl object with a default {@link SendDirection} of {@link
-   * SendDirection#ToServer} to implement the send functions which don't require a direction
+   * SendDirection#TO_SERVER} to implement the send functions which don't require a direction
    * parameter:<br>
    * - {@link FCPPluginConnection#send(FCPPluginMessage)}<br>
    * - {@link FCPPluginConnection#sendSynchronous(FCPPluginMessage, long)}<br>
@@ -1238,7 +1245,7 @@ final class FCPPluginConnectionImpl implements FCPPluginConnection {
      * whenever possible to reuse adapters instead of creating new ones with this constructor.
      */
     SendToServerAdapter(FCPPluginConnectionImpl parent) {
-      super(SendDirection.ToServer);
+      super(SendDirection.TO_SERVER);
       this.parent = parent;
     }
 

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginConnectionTracker.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginConnectionTracker.java
@@ -17,36 +17,42 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Keeps a list of all {@link FCPPluginConnectionImpl}s which are connected to server plugins
- * running in the node. Allows the server plugins to query a client connection by its {@link UUID}.
- * <br>
- * <br>
+ * Tracks all {@link FCPPluginConnectionImpl} instances that represent in-progress plugin client
+ * connections so server plugins can retrieve a {@link UUID}-addressable handle whenever they need
+ * to resume a long-running workflow.
  *
- * <p>To understand the purpose of this, please consider the following:<br>
- * The normal flow of plugin FCP is that clients send messages to a server plugin, and the server
- * plugin immediately returns a reply from its message handling function {@link
- * ServerSideFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}.<br>
- * This might not be sufficient for certain usecases: The reply to a message might take quite some
- * time to compute, possibly hours. Then a reference to the original client connection needs to be
- * stored in the plugin's database, not memory. A {@link FCPPluginConnection} cannot be serialized
- * into a database, but an {@link UUID} can.<br>
- * Thus, this class exists to serve the purpose of allowing plugin servers to query client
- * connections by their ID (see {@link FCPPluginConnection#getID()}).
+ * <p>The tracker sits between {@link ServerSideFCPMessageHandler} implementations and the {@link
+ * PluginRespirator}: the latter still creates the connections, but once registered here a server
+ * can safely persist only the identifier and later call {@link #getConnection(UUID)} to recover the
+ * live channel. Connections are weakly referenced; when the client discards its strong reference,
+ * the tracker observes the {@link WeakReference} cleanup and treats the peer as closed, avoiding
+ * stale handles while still keeping lookup time logarithmic through the {@link TreeMap} index. The
+ * approach is deliberately conservative—no persistence is attempted—because only the client knows
+ * when state is safe to discard and because plugins may restart independently of the node.
  *
- * <p>Client connections are considered as closed once the client discards all strong references to
- * the {@link FCPPluginConnection}. Or in other words: A {@link FCPPluginConnection} is closed once
- * it becomes weakly reachable.<br>
- * Thus, this class is implemented by keeping {@link WeakReference}s to plugin client connections,
- * so they only stay in the memory of the tracker as long as they are still connected.
+ * <p>Lifecycle-wise, callers instantiate the tracker early during plugin startup, immediately call
+ * {@link #start()} to run the garbage-collection loop, and then invoke {@link
+ * #registerConnection(FCPPluginConnectionImpl)} for every client-side channel handed to a server
+ * handler. Shutdown requires no action because the supervising thread is a daemon. The class is
+ * thread-safe through an internal {@link ReadWriteLock}, so lookups and automatic pruning can run
+ * concurrently even under high churn.
  *
- * <p>After constructing an object of this class, you must call {@link #start()} to start its
- * garbage collection thread.<br>
- * For shutdown, no action is required: The thread will be a daemon thread and thus the JVM will
- * deal with shutdown.
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> maintain a weak-reference index, expose lookups by ID,
+ *       and prune connections whose clients disconnected or crashed.
+ *   <li><strong>Threading:</strong> lookups use the read lock while the background thread holds the
+ *       write lock for removals; registration holds the write lock briefly.
+ *   <li><strong>Constraints:</strong> callers must not leak {@link FCPPluginConnectionImpl}
+ *       references to server plugins; they should provide adapters via {@link
+ *       FCPPluginConnectionImpl#getDefaultSendDirectionAdapter(SendDirection)} instead.
+ * </ul>
  *
+ * @see FCPPluginConnection
+ * @see PluginRespirator
  * @author xor (xor@freenetproject.org)
  */
 final class FCPPluginConnectionTracker extends NativeThread {
+  /** Logger dedicated to reporting tracker activity and unexpected shutdown signals. */
   private static final Logger LOG = LoggerFactory.getLogger(FCPPluginConnectionTracker.class);
 
   /**
@@ -62,7 +68,7 @@ final class FCPPluginConnectionTracker extends NativeThread {
    * Lock to guard {@link #connectionsByID} against concurrent modification.<br>
    * A {@link ReadWriteLock} because the suspected usage pattern is mostly reads, very few writes -
    * {@link ReadWriteLock} can do that faster than a regular Lock.<br>
-   * (A {@link ReentrantReadWriteLock} because thats the only implementation of {@link
+   * (A {@link ReentrantReadWriteLock} because that's the only implementation of {@link
    * ReadWriteLock}.)
    */
   private final ReadWriteLock connectionsByIDLock = new ReentrantReadWriteLock();
@@ -75,16 +81,32 @@ final class FCPPluginConnectionTracker extends NativeThread {
       new ReferenceQueue<>();
 
   /**
-   * We extend class {@link WeakReference} so we can store the ID of the connection:<br>
-   * When using a {@link ReferenceQueue} to get notified about nulled {@link WeakReference} values
-   * in {@link FCPPluginConnectionTracker#connectionsByID}, we need to remove those values from the
-   * {@link TreeMap}. For fast removal, we need their key in the map, which is the connection ID, so
-   * we should store it in the {@link WeakReference}.
+   * Weak reference wrapper that remembers the {@link UUID} belonging to a tracked connection so the
+   * enclosing tracker can erase map entries as soon as the referent becomes weakly reachable.
+   *
+   * <p>The {@link ReferenceQueue}-driven cleanup needs constant-time removal from the {@link
+   * #connectionsByID} index. Capturing the identifier on construction avoids an additional lookup
+   * or synchronization step when the queue is polled by {@link #realRun()}.
    */
   static final class ConnectionWeakReference extends WeakReference<FCPPluginConnectionImpl> {
 
+    /**
+     * Identifier copied from the referent to allow quick removal from {@link #connectionsByID}. The
+     * value exactly mirrors {@link FCPPluginConnection#getID()} and never mutates, so log
+     * statements and tree-map operations can correlate pruned entries with the plugin state that
+     * recorded the identifier originally.
+     */
     public final UUID connectionID;
 
+    /**
+     * Creates a weak reference for the supplied connection and immediately registers it with the
+     * {@link ReferenceQueue} monitored by the background thread.
+     *
+     * @param referent live connection to monitor; same object retrieved through {@link
+     *     #getConnection(UUID)}.
+     * @param referenceQueue queue shared by the tracker; receives signal when the referent
+     *     vanishes.
+     */
     public ConnectionWeakReference(
         FCPPluginConnectionImpl referent, ReferenceQueue<FCPPluginConnectionImpl> referenceQueue) {
 
@@ -94,14 +116,39 @@ final class FCPPluginConnectionTracker extends NativeThread {
   }
 
   /**
-   * Stores the {@link FCPPluginConnectionImpl} so in the future it can be obtained by its ID with
-   * {@link #getConnection(UUID)}.
+   * Signals that the daemon garbage-collection thread received an interrupt even though it is
+   * expected to run until JVM shutdown, allowing callers to preserve the cause.
+   */
+  private static final class TrackerInterruptedException extends IllegalStateException {
+    /**
+     * Wraps the original {@link InterruptedException} so logging retains the stack trace and
+     * shutdown hooks can differentiate between graceful stops and misconfiguration.
+     *
+     * @param cause interrupt raised while polling the queue; preserved for diagnostics.
+     */
+    TrackerInterruptedException(InterruptedException cause) {
+      super(
+          "Thread interruption requested even though this is a daemon thread!"
+              + " Exiting tracker thread.",
+          cause);
+    }
+  }
+
+  /**
+   * Registers a newly created client connection so it can later be located by callers that only
+   * know its {@link UUID}.
    *
-   * <p><b>Must</b> be called for any newly created {@link FCPPluginConnectionImpl} before passing
-   * it to {@link ServerSideFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection,
-   * FCPPluginMessage)}.
+   * <p>Server plugins must invoke this immediately after creating an {@link
+   * FCPPluginConnectionImpl}, before handing the instance to {@link
+   * ServerSideFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}. The
+   * tracker retains only a {@link WeakReference}, so holding a strong reference remains the
+   * client's responsibility. Duplicate registrations are harmless because {@link UUID}s are
+   * randomly generated; a later registration simply overwrites the previous weak reference entry.
+   * Explicit unregister operations are intentionally omitted because garbage collection provides
+   * the correct lifetime semantics.
    *
-   * <p>Unregistration is not supported and not necessary.
+   * @param connection newly created connection awaiting tracking; caller still retains strong
+   *     reference.
    */
   void registerConnection(FCPPluginConnectionImpl connection) {
     connectionsByIDLock.writeLock().lock();
@@ -115,35 +162,29 @@ final class FCPPluginConnectionTracker extends NativeThread {
   }
 
   /**
-   * For being indirectly exposed to implementors of server plugins, i.e. implementors of {@link
-   * ServerSideFCPMessageHandler}.<br>
-   * NOT for being used by clients: Clients using a {@link FCPPluginConnection} to connect to a
-   * server plugin have to keep a reference to the {@link FCPPluginConnection} in memory. See {@link
-   * PluginRespirator#connectToOtherPlugin(String, ClientSideFCPMessageHandler)}. <br>
-   * This is necessary because this class only keeps {@link WeakReference}s to the {@link
-   * FCPPluginConnection} objects. Once they are not referenced by a strong reference anymore they
-   * will be garbage collected and thus considered as disconnected.<br>
-   * The job of keeping the strong references is at the client.<br>
-   * <br>
-   * ATTENTION:<br>
-   * The returned FCPPluginConnectionImpl objects class shall not be handed out directly to server
-   * applications. Instead, only hand out a {@link DefaultSendDirectionAdapter} - which can be
-   * obtained by {@link FCPPluginConnectionImpl#getDefaultSendDirectionAdapter(SendDirection)}. <br>
-   * This has two reasons:<br>
-   * - The send functions which do not require a {@link SendDirection} will always throw an
-   * exception without an adapter ({@link #send(FCPPluginMessage)} and {@link
-   * #sendSynchronous(FCPPluginMessage, long)}).<br>
-   * - Server plugins must not keep a strong reference to the FCPPluginConnectionImpl to ensure that
-   * the client disconnection mechanism of monitoring garbage collection works. The adapter prevents
-   * servers from keeping a strong reference by internally only keeping a {@link WeakReference} to
-   * the FCPPluginConnectionImpl.<br>
+   * Returns the still-live connection whose identifier matches the supplied value so server-side
+   * plugins can continue a dialogue that outlived the original handler invocation.
    *
-   * @param connectionID The value of {@link FCPPluginConnection#getID()} of a client connection
-   *     which has already sent a message to the server plugin via {@link
-   *     ServerSideFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}.
-   * @return The client connection with the given ID, for as long as the client is still connected.
-   * @throws IOException If there has been no connection with the given ID or if the client has
-   *     disconnected.
+   * <p>Only {@link ServerSideFCPMessageHandler} implementations should invoke this method. Clients
+   * must keep their own strong reference via {@link PluginRespirator#connectToOtherPlugin(String,
+   * ClientSideFCPMessageHandler)}; the tracker merely provides a lookup table backed by {@link
+   * WeakReference}s. If a client stops referencing the {@link FCPPluginConnection}, garbage
+   * collection removes it from the tracker and the lookup fails with {@link IOException}. Returned
+   * connections should not be handed to untrusted plugin code; instead, wrap them immediately using
+   * {@link FCPPluginConnectionImpl#getDefaultSendDirectionAdapter(SendDirection)} so consumers only
+   * interact with lightweight direction-specific facades.
+   *
+   * <pre>{@code
+   * var adapter = tracker.getConnection(clientId)
+   *     .getDefaultSendDirectionAdapter(SendDirection.TO_CLIENT);
+   * adapter.send(message);
+   * }</pre>
+   *
+   * @param connectionID identifier retrieved via {@link FCPPluginConnection#getID()} that the
+   *     plugin persisted for future reuse.
+   * @return live connection instance; release promptly so garbage collection still detects
+   *     disconnects.
+   * @throws IOException if the tracker lacks the entry or the client released its reference.
    */
   public FCPPluginConnectionImpl getConnection(UUID connectionID) throws IOException {
     ConnectionWeakReference ref = getConnectionWeakReference(connectionID);
@@ -159,9 +200,21 @@ final class FCPPluginConnectionTracker extends NativeThread {
   }
 
   /**
-   * Same as {@link #getConnection(UUID)} with the only difference of returning a {@link
-   * WeakReference} to the connection instead of the connection itself.<br>
-   * <b>Please do read its JavaDoc to understand when to use this!</b>
+   * Provides access to the {@link WeakReference} entry associated with a connection ID so callers
+   * can inspect reachability without creating a new strong reference.
+   *
+   * <p>This helper is primarily for advanced monitoring and should rarely be needed by plugin
+   * authors. It mirrors {@link #getConnection(UUID)} but preserves the weak semantics: if the
+   * referent has vanished, the returned reference already reports {@code null}, allowing the caller
+   * to surface a disconnect without momentarily reviving the object. Obtaining the weak reference
+   * still requires a {@link ReadWriteLock#readLock()} acquisition, so it is inexpensive even when
+   * performed frequently.
+   *
+   * @param connectionID identifier registered via {@link
+   *     #registerConnection(FCPPluginConnectionImpl)}; stale values signal disconnects.
+   * @return weak reference mirroring the tracker entry; clears when the client disconnects.
+   * @throws IOException if the identifier was never tracked or garbage collection removed the
+   *     entry.
    */
   ConnectionWeakReference getConnectionWeakReference(UUID connectionID) throws IOException {
 
@@ -179,7 +232,10 @@ final class FCPPluginConnectionTracker extends NativeThread {
             + connectionID);
   }
 
-  /** You must call {@link #start()} afterwards! */
+  /**
+   * Creates a tracker configured with the lowest thread priority and daemon status so it runs in
+   * the background without preventing JVM shutdown; callers must invoke {@link #start()}.
+   */
   public FCPPluginConnectionTracker() {
     super(
         "FCPPluginConnectionTracker Garbage-collector",
@@ -189,15 +245,19 @@ final class FCPPluginConnectionTracker extends NativeThread {
   }
 
   /**
-   * Garbage-collection thread: Polls {@link #closedConnectionsQueue} for connections whose {@link
-   * WeakReference} has been nulled and removes them from the {@link #connectionsByID} {@link
-   * TreeMap}.<br>
-   * <br>
-   * Notice: Do not call this function directly. To execute this, call {@link #start()}. This
-   * function is merely public because this class extends {@link NativeThread}.
+   * Main loop of the tracker thread that blocks on {@link #closedConnectionsQueue}, removes stale
+   * entries from the {@link #connectionsByID} map, and logs anomalies or interrupt requests.
+   *
+   * <p>Callers never invoke this method directly; {@link NativeThread#start()} arranges for it to
+   * run on a dedicated daemon thread. The loop intentionally never terminates, relying on the JVM
+   * to stop daemon threads during shutdown. Interrupts are promoted to {@link
+   * TrackerInterruptedException} after the interrupt flag is restored so diagnostic tools can
+   * capture the root cause. All other exceptions are logged and swallowed to keep the tracker alive
+   * even if a plugin sends malformed data.
    */
   @Override
   public void realRun() {
+    //noinspection InfiniteLoopStatement
     while (true) {
       try {
         ConnectionWeakReference closedConnection =
@@ -211,11 +271,10 @@ final class FCPPluginConnectionTracker extends NativeThread {
           assert (closedConnection == removedFromTree);
           if (LOG.isDebugEnabled()) {
             LOG.debug(
-                "Garbage-collecting closed connection: "
-                    + "remaining connections = "
-                    + connectionsByID.size()
-                    + "; connection ID = "
-                    + closedConnection.connectionID);
+                "Garbage-collecting closed connection: remaining connections = {}; connection ID ="
+                    + " {}",
+                connectionsByID.size(),
+                closedConnection.connectionID);
           }
         } finally {
           connectionsByIDLock.writeLock().unlock();
@@ -225,12 +284,13 @@ final class FCPPluginConnectionTracker extends NativeThread {
         // running: Daemon threads are force terminated during shutdown.
         // Thus, this thread does not need an exit mechanism, it can be an infinite loop. So
         // nothing should try to terminate it by InterruptedException. If it does happen
-        // nevertheless, we honor it by exiting the thread, because interrupt requests
-        // should never be ignored, but log it as an error.
-        LOG.error("Thread interruption requested even though this is a daemon thread!", e);
-        throw new RuntimeException(e);
-      } catch (Throwable t) {
-        LOG.error("Error in thread " + getName(), t);
+        // nevertheless, we honor it by exiting the thread because interrupt requests
+        // should never be ignored. Re-set the interrupted flag so callers can observe it and
+        // propagate context for debugging.
+        Thread.currentThread().interrupt();
+        throw new TrackerInterruptedException(e);
+      } catch (Exception e) {
+        LOG.error("Error in thread {}", getName(), e);
       }
     }
   }

--- a/src/main/java/network/crypta/clients/fcp/FCPPluginMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginMessage.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import network.crypta.pluginmanager.FredPluginFCPMessageHandler;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.StringValidityChecker;
@@ -118,6 +119,13 @@ public final class FCPPluginMessage {
    * field.)
    */
   public final String errorMessage;
+
+  /**
+   * Guard flag to detect accidental reuse of the same message instance. The flag is intentionally
+   * mutable to allow tracking whether this immutable message container has been handed to the send
+   * pipeline already.
+   */
+  private final AtomicBoolean sent = new AtomicBoolean(false);
 
   /**
    * @return True if the message is merely a reply to a previous message from your side.<br>
@@ -314,6 +322,16 @@ public final class FCPPluginMessage {
 
     return new FCPPluginMessage(
         permissions, identifier, params, data, success, errorCode, errorMessage);
+  }
+
+  /**
+   * Marks this message as having been sent already.
+   *
+   * @return {@code true} if this call marks the first send attempt, {@code false} if the message
+   *     was previously sent.
+   */
+  public boolean markSent() {
+    return sent.compareAndSet(false, true);
   }
 
   @Override

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -658,7 +658,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * FredPluginFCPMessageHandler.ClientSideFCPMessageHandler)}. Plugins must use that instead.
    * ATTENTION: Since this function is only to be used by the aforementioned connectToPlugin() which
    * in turn is only to be used by clients, the returned connection will have a default send
-   * direction of {@link SendDirection#ToServer}.
+   * direction of {@link SendDirection#TO_SERVER}.
    *
    * @see FCPPluginConnectionImpl The class JavaDoc of FCPPluginConnectionImpl explains the code
    *     path for both networked and non-networked FCP.
@@ -676,7 +676,7 @@ public class FCPServer implements Runnable, DownloadCache {
             messageHandler);
     // The constructor function already did this for us
     /* pluginConnectionTracker.registerConnection(connection); */
-    return connection.getDefaultSendDirectionAdapter(SendDirection.ToServer);
+    return connection.getDefaultSendDirectionAdapter(SendDirection.TO_SERVER);
   }
 
   /**
@@ -686,7 +686,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * <br>
    * ATTENTION: Since this function is only to be used by the aforementioned
    * getPluginConnectionByID() which in turn is only to be used by servers, the returned connection
-   * will have a default send direction of {@link SendDirection#ToClient}.
+   * will have a default send direction of {@link SendDirection#TO_CLIENT}.
    *
    * @see FCPPluginConnectionTracker The JavaDoc of FCPPluginConnectionTracker explains the general
    *     purpose of this mechanism.
@@ -694,7 +694,7 @@ public class FCPServer implements Runnable, DownloadCache {
   public final FCPPluginConnection getPluginConnectionByID(UUID connectionID) throws IOException {
     return pluginConnectionTracker
         .getConnection(connectionID)
-        .getDefaultSendDirectionAdapter(SendDirection.ToClient);
+        .getDefaultSendDirectionAdapter(SendDirection.TO_CLIENT);
   }
 
   public PersistentRequestClient registerRebootClient(

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginClientMessageTest.java
@@ -162,7 +162,7 @@ class FCPPluginClientMessageTest {
 
       ArgumentCaptor<FCPPluginMessage> messageCaptor =
           ArgumentCaptor.forClass(FCPPluginMessage.class);
-      Mockito.verify(connection).send(Mockito.eq(SendDirection.ToServer), messageCaptor.capture());
+      Mockito.verify(connection).send(Mockito.eq(SendDirection.TO_SERVER), messageCaptor.capture());
 
       FCPPluginMessage captured = messageCaptor.getValue();
       assertEquals(IDENTIFIER, captured.identifier);
@@ -180,7 +180,7 @@ class FCPPluginClientMessageTest {
       Mockito.when(handler.getFCPPluginConnection(PLUGIN_NAME)).thenReturn(connection);
       Mockito.doThrow(new IOException("boom"))
           .when(connection)
-          .send(Mockito.eq(SendDirection.ToServer), Mockito.any());
+          .send(Mockito.eq(SendDirection.TO_SERVER), Mockito.any());
       Node node = Mockito.mock(Node.class);
 
       MessageInvalidException ex =

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginConnectionImplTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginConnectionImplTest.java
@@ -81,7 +81,7 @@ public final class FCPPluginConnectionImplTest {
                   try {
                     final FCPPluginMessage reply =
                         connection.sendSynchronous(
-                            SendDirection.ToServer, message, TimeUnit.SECONDS.toNanos(10));
+                            SendDirection.TO_SERVER, message, TimeUnit.SECONDS.toNanos(10));
 
                     if (!threadIndex.equals(reply.params.get("replyToThread"))) {
                       failure.set(true);

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginConnectionImplTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginConnectionImplTest.java
@@ -2,17 +2,123 @@ package network.crypta.clients.fcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.clients.fcp.FCPPluginConnection.SendDirection;
+import network.crypta.clients.fcp.FCPPluginMessage.ClientPermissions;
 import network.crypta.pluginmanager.FredPluginFCPMessageHandler.ClientSideFCPMessageHandler;
 import network.crypta.pluginmanager.FredPluginFCPMessageHandler.ServerSideFCPMessageHandler;
 import org.junit.jupiter.api.Test;
 
-public final class FCPPluginConnectionImplTest {
+@SuppressWarnings("java:S100")
+final class FCPPluginConnectionImplTest {
+
+  @Test
+  void send_whenServerHandlerThrows_returnsInternalErrorReplyToClient() throws Exception {
+    // Arrange
+    ServerSideFCPMessageHandler server =
+        (connection, message) -> {
+          throw new IllegalStateException("boom");
+        };
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<FCPPluginMessage> replyRef = new AtomicReference<>();
+    ClientSideFCPMessageHandler client =
+        (connection, message) -> {
+          replyRef.set(message);
+          latch.countDown();
+          return null;
+        };
+    FCPPluginConnectionImpl connection =
+        FCPPluginConnectionImpl.constructForUnitTest(server, client);
+    FCPPluginMessage message = FCPPluginMessage.construct();
+
+    // Act
+    connection.send(SendDirection.TO_SERVER, message);
+
+    // Assert
+    assertTrue(latch.await(5, TimeUnit.SECONDS), "Client should see the generated error reply");
+    FCPPluginMessage reply = replyRef.get();
+    assertNotNull(reply);
+    assertTrue(reply.isReplyMessage());
+    assertFalse(reply.success);
+    assertEquals("InternalError", reply.errorCode);
+    assertNotNull(reply.errorMessage);
+    assertTrue(reply.errorMessage.contains("IllegalStateException"));
+  }
+
+  @Test
+  void getDefaultSendDirectionAdapter_whenSendingToServer_setsPermissionsAndCopiesMessage()
+      throws Exception {
+    // Arrange
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<FCPPluginMessage> delivered = new AtomicReference<>();
+    ServerSideFCPMessageHandler server =
+        (connection, message) -> {
+          delivered.set(message);
+          latch.countDown();
+          return null;
+        };
+    ClientSideFCPMessageHandler client = (connection, message) -> null;
+    FCPPluginConnectionImpl connection =
+        FCPPluginConnectionImpl.constructForUnitTest(server, client);
+    FCPPluginConnection adapter =
+        connection.getDefaultSendDirectionAdapter(SendDirection.TO_SERVER);
+    FCPPluginMessage original = FCPPluginMessage.construct();
+
+    // Act
+    adapter.send(original);
+
+    // Assert
+    assertTrue(latch.await(5, TimeUnit.SECONDS), "Server should receive the message");
+    FCPPluginMessage received = delivered.get();
+    assertNotNull(received);
+    assertEquals(ClientPermissions.ACCESS_DIRECT, received.permissions);
+    assertNotSame(original, received, "send() should wrap messages to stamp permissions");
+  }
+
+  @Test
+  void sendSynchronous_whenReplyMissing_timesOutAndCleansUpState() {
+    // Arrange
+    ServerSideFCPMessageHandler server = (connection, message) -> null;
+    ClientSideFCPMessageHandler client = (connection, message) -> null;
+    FCPPluginConnectionImpl connection =
+        FCPPluginConnectionImpl.constructForUnitTest(server, client);
+    FCPPluginMessage message = FCPPluginMessage.construct();
+
+    // Act + Assert
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () ->
+                connection.sendSynchronous(
+                    SendDirection.TO_SERVER, message, TimeUnit.MILLISECONDS.toNanos(20)),
+            "Timed out calls should surface as IOExceptions");
+    assertTrue(ex.getMessage().contains("timed out"));
+    assertEquals(0, connection.getSendSynchronousCount());
+  }
+
+  @Test
+  void send_whenDefaultDirectionMissing_throwsNoSendDirectionSpecifiedException() {
+    // Arrange
+    ServerSideFCPMessageHandler server = (connection, message) -> null;
+    ClientSideFCPMessageHandler client = (connection, message) -> null;
+    FCPPluginConnectionImpl connection =
+        FCPPluginConnectionImpl.constructForUnitTest(server, client);
+    FCPPluginMessage message = FCPPluginMessage.construct();
+
+    // Act + Assert
+    assertThrows(UnsupportedOperationException.class, () -> connection.send(message));
+  }
+
   /**
    * {@link FCPPluginConnectionImpl#sendSynchronous(SendDirection, FCPPluginMessage, long)} is
    * powered by an internal map which keeps track of synchronous sends which are waiting for a
@@ -27,14 +133,14 @@ public final class FCPPluginConnectionImplTest {
    * checking whether it is empty after all send threads have terminated.<br>
    */
   @Test
-  public void testSendSynchronousThreadSafety() throws InterruptedException {
+  void sendSynchronous_whenHundredThreadsRunInParallel_preservesRepliesAndCleansTable()
+      throws InterruptedException {
     // JUnit ignores failures in threads other than the threads which it runs tests from.
-    // Thus we pass failures out with this boolean.
-    // NOTICE: We also use JUnit assert*() / fail() even though they won't work in threads
-    // - to produce logging on stderr so you can tell where the failure happened. When adding
-    // more of those, make sure to do failure.set(true) BEFORE the assert*() / fail() as they
-    // will throw.
+    // Thus, we pass failures out with this boolean.
+    // NOTICE: Use the asyncErrors queue instead of direct assertions so failures surface on the
+    // main test thread after all workers join.
     final AtomicBoolean failure = new AtomicBoolean(false);
+    final ConcurrentLinkedQueue<String> asyncErrors = new ConcurrentLinkedQueue<>();
 
     // Notice: server must be kept referenced by our local variable for the whole duration of
     // the test, otherwise it would get GCed because the FCPPluginConnectionImpl which we will
@@ -51,10 +157,8 @@ public final class FCPPluginConnectionImplTest {
     final ClientSideFCPMessageHandler client =
         (connection, message) -> {
           failure.set(true);
-          fail(
-              "This test is about sendSynchronous() so the reply messages should not "
-                  + "hit the client message handler");
-          throw new UnsupportedOperationException();
+          asyncErrors.add("Reply unexpectedly routed to client handler");
+          return null;
         };
 
     final FCPPluginConnectionImpl connection =
@@ -85,14 +189,18 @@ public final class FCPPluginConnectionImplTest {
 
                     if (!threadIndex.equals(reply.params.get("replyToThread"))) {
                       failure.set(true);
+                      asyncErrors.add(
+                          "Thread "
+                              + threadIndex
+                              + " received reply for "
+                              + reply.params.get("replyToThread"));
                     }
-                    assertEquals(threadIndex, reply.params.get("replyToThread"));
                   } catch (IOException e) {
                     failure.set(true);
-                    fail("IOException " + e);
+                    asyncErrors.add("IOException " + e);
                   } catch (InterruptedException e) {
                     failure.set(true);
-                    fail("InterruptedException " + e);
+                    asyncErrors.add("InterruptedException " + e);
                   }
                 }
               });
@@ -109,7 +217,9 @@ public final class FCPPluginConnectionImplTest {
 
     assertFalse(
         failure.get(),
-        "JUnit failures cannot be passed out of threads, please check stdout/stderr.");
+        asyncErrors.isEmpty()
+            ? "No background failures expected"
+            : String.join(System.lineSeparator(), asyncErrors));
 
     assertEquals(
         0,

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginConnectionTrackerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginConnectionTrackerTest.java
@@ -1,0 +1,231 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FCPPluginConnectionTrackerTest {
+
+  private static final Field CONNECTIONS_BY_ID_FIELD = locateField("connectionsByID");
+  private static final Field CONNECTIONS_LOCK_FIELD = locateField("connectionsByIDLock");
+
+  @Test
+  void getConnection_whenRegistered_expectSameInstance() throws IOException {
+    FCPPluginConnectionTracker tracker = new FCPPluginConnectionTracker();
+    UUID id = UUID.randomUUID();
+    FCPPluginConnectionImpl connection = mockConnection(id);
+
+    tracker.registerConnection(connection);
+
+    FCPPluginConnectionImpl result = tracker.getConnection(id);
+
+    assertSame(connection, result);
+  }
+
+  @Test
+  void getConnection_whenConnectionMissing_expectIOException() {
+    FCPPluginConnectionTracker tracker = new FCPPluginConnectionTracker();
+    UUID id = UUID.randomUUID();
+
+    IOException exception = assertThrows(IOException.class, () -> tracker.getConnection(id));
+
+    assertTrue(exception.getMessage().contains(id.toString()));
+  }
+
+  @Test
+  void getConnection_whenReferenceCleared_expectIOException() {
+    FCPPluginConnectionTracker tracker = new FCPPluginConnectionTracker();
+    UUID id = UUID.randomUUID();
+    FCPPluginConnectionImpl connection = mockConnection(id);
+    tracker.registerConnection(connection);
+
+    FCPPluginConnectionTracker.ConnectionWeakReference reference =
+        getConnectionReference(tracker, id);
+    assertNotNull(reference);
+    reference.clear();
+
+    IOException exception = assertThrows(IOException.class, () -> tracker.getConnection(id));
+
+    assertTrue(exception.getMessage().contains(id.toString()));
+  }
+
+  @Test
+  void getConnectionWeakReference_whenRegistered_expectStoredWeakReference() throws IOException {
+    FCPPluginConnectionTracker tracker = new FCPPluginConnectionTracker();
+    UUID id = UUID.randomUUID();
+    FCPPluginConnectionImpl connection = mockConnection(id);
+    tracker.registerConnection(connection);
+
+    FCPPluginConnectionTracker.ConnectionWeakReference returned =
+        tracker.getConnectionWeakReference(id);
+
+    ReadWriteLock lock = connectionsLock(tracker);
+    lock.readLock().lock();
+    try {
+      FCPPluginConnectionTracker.ConnectionWeakReference stored = connectionsById(tracker).get(id);
+      assertSame(stored, returned);
+      assertSame(connection, returned.get());
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Test
+  void getConnectionWeakReference_whenMissing_expectIOException() {
+    FCPPluginConnectionTracker tracker = new FCPPluginConnectionTracker();
+
+    assertThrows(IOException.class, () -> tracker.getConnectionWeakReference(UUID.randomUUID()));
+  }
+
+  @Test
+  void realRun_whenWeakReferenceEnqueued_expectRemovalAndShutdown() throws Exception {
+    FCPPluginConnectionTracker tracker = new FCPPluginConnectionTracker();
+    UUID id = UUID.randomUUID();
+    FCPPluginConnectionImpl connection = mockConnection(id);
+    tracker.registerConnection(connection);
+
+    FCPPluginConnectionTracker.ConnectionWeakReference reference =
+        getConnectionReference(tracker, id);
+    assertNotNull(reference);
+    reference.clear();
+    assertTrue(reference.enqueue());
+
+    AtomicReference<Throwable> uncaught = new AtomicReference<>();
+    Thread worker = new Thread(tracker::realRun, "FCPPluginConnectionTrackerTest-realRun");
+    worker.setDaemon(true);
+    worker.setUncaughtExceptionHandler((t, e) -> uncaught.set(e));
+    worker.start();
+
+    try {
+      waitForCondition(() -> getConnectionsSize(tracker) == 0, Duration.ofSeconds(2));
+      waitForCondition(() -> worker.getState() == Thread.State.WAITING, Duration.ofSeconds(2));
+    } finally {
+      worker.interrupt();
+      worker.join(1000);
+    }
+
+    assertEquals(0, getConnectionsSize(tracker));
+    Throwable termination = uncaught.get();
+    assertNotNull(termination);
+    assertInstanceOf(RuntimeException.class, termination);
+    assertInstanceOf(InterruptedException.class, termination.getCause());
+  }
+
+  private static FCPPluginConnectionImpl mockConnection(UUID id) {
+    FCPPluginConnectionImpl connection = mock(FCPPluginConnectionImpl.class);
+    when(connection.getID()).thenReturn(id);
+    return connection;
+  }
+
+  private static TreeMap<UUID, FCPPluginConnectionTracker.ConnectionWeakReference> connectionsById(
+      FCPPluginConnectionTracker tracker) {
+    try {
+      @SuppressWarnings("unchecked")
+      TreeMap<UUID, FCPPluginConnectionTracker.ConnectionWeakReference> map =
+          (TreeMap<UUID, FCPPluginConnectionTracker.ConnectionWeakReference>)
+              CONNECTIONS_BY_ID_FIELD.get(tracker);
+      return map;
+    } catch (IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static ReadWriteLock connectionsLock(FCPPluginConnectionTracker tracker) {
+    try {
+      return (ReadWriteLock) CONNECTIONS_LOCK_FIELD.get(tracker);
+    } catch (IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static FCPPluginConnectionTracker.ConnectionWeakReference getConnectionReference(
+      FCPPluginConnectionTracker tracker, UUID id) {
+    ReadWriteLock lock = connectionsLock(tracker);
+    lock.readLock().lock();
+    try {
+      return connectionsById(tracker).get(id);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  private static int getConnectionsSize(FCPPluginConnectionTracker tracker) {
+    ReadWriteLock lock = connectionsLock(tracker);
+    lock.readLock().lock();
+    try {
+      return connectionsById(tracker).size();
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  private static Field locateField(String name) {
+    try {
+      Field field = FCPPluginConnectionTracker.class.getDeclaredField(name);
+      field.setAccessible(true);
+      return field;
+    } catch (NoSuchFieldException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static void waitForCondition(BooleanSupplier condition, Duration timeout)
+      throws InterruptedException {
+    if (condition.getAsBoolean()) {
+      return;
+    }
+
+    CountDownLatch latch = new CountDownLatch(1);
+    ThreadFactory factory =
+        runnable -> {
+          Thread t = new Thread(runnable, "FCPPluginConnectionTrackerTest-await");
+          t.setDaemon(true);
+          return t;
+        };
+    try (ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(factory)) {
+      ScheduledFuture<?> monitor =
+          scheduler.scheduleAtFixedRate(
+              () -> {
+                if (condition.getAsBoolean()) {
+                  latch.countDown();
+                }
+              },
+              0,
+              5,
+              TimeUnit.MILLISECONDS);
+      try {
+        if (!latch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+          fail("Condition not satisfied within " + timeout);
+        }
+      } finally {
+        monitor.cancel(true);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refresh the FCP plugin connection/connection tracker documentation so plugin authors understand lifecycle, permissions, and directionality rules
- refactor the implementation to remove legacy state, enforce direction-safe adapters, guard against reusing message instances, and modernize synchronous send handling
- add focused regression tests that cover error propagation, timeout cleanup, adapter behavior, and tracker GC semantics

## Testing
- ./gradlew test --tests "network.crypta.clients.fcp.FCPPluginConnection*Test"
