### PR TITLE
Add documentation and unit tests for FCPPluginMessage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/FCPPluginMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPPluginMessage.java
@@ -2,143 +2,203 @@ package network.crypta.clients.fcp;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import network.crypta.pluginmanager.FredPluginFCPMessageHandler;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.StringValidityChecker;
 import network.crypta.support.api.Bucket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/** Container class for both incoming and outgoing FCP messages. */
+/**
+ * Represents a container for both incoming and outgoing FCP (Freenet Client Protocol) messages.
+ *
+ * <p>This class serves as a unified envelope for message data, metadata, and status information
+ * exchanged between the FCP server and client plugins. It encapsulates the message identifier,
+ * parameters, bulk data, and optional reply status. Instances are designed to be immutable, except
+ * the internal {@link #markSent()} state which tracks transmission.
+ *
+ * <p>Typical usage involves constructing a message using one of the static factory methods (e.g.,
+ * {@link #construct(SimpleFieldSet, Bucket)} for new requests, or {@link
+ * #constructReplyMessage(FCPPluginMessage, SimpleFieldSet, Bucket, boolean, String, String)} for
+ * responses) and passing it to an {@link FCPPluginConnection}.
+ *
+ * <p>This class enforces strict validation on construction to ensure that message identifiers are
+ * present and that reply-specific fields (success, error code, error message) are consistent with
+ * the message type.
+ */
 public final class FCPPluginMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(FCPPluginMessage.class);
 
+  /**
+   * Defines the access levels granted to an FCP client connecting to the node.
+   *
+   * <p>This enumeration categorizes the trust level and capabilities associated with a client
+   * connection. The permissions are determined by the node's configuration and the client's
+   * connection origin (e.g., local vs. remote, specific IP allowlists).
+   *
+   * <p>These permissions control which FCP messages and commands the client is authorized to send
+   * and receive. For example, a client with {@link #ACCESS_FCP_RESTRICTED} may be barred from
+   * performing administrative actions or accessing sensitive data, whereas {@link #ACCESS_DIRECT}
+   * implies the client is running as a plugin within the node's own process space, effectively
+   * granting it full privileges.
+   *
+   * <p>The permission level is typically assigned during the connection handshake and remains
+   * constant for the duration of the session. It is exposed via {@link
+   * FCPPluginMessage#permissions} to allow message handlers to enforce access controls based on the
+   * sender's authorization.
+   */
   public enum ClientPermissions {
     /**
-     * The client is connected by network and the owner of the node has configured restricted access
-     * for the client's IP
+     * Indicates that the client is connected via the network and the node owner has configured
+     * restricted access for the client's IP address.
+     *
+     * <p>Clients with this permission level may be limited in the types of commands they can
+     * execute or the data they can access.
      */
     ACCESS_FCP_RESTRICTED,
+
     /**
-     * The client is connected by network and the owner of the node has configured full access for
-     * the client's IP
+     * Indicates that the client is connected via the network and the node owner has configured full
+     * access for the client's IP address.
+     *
+     * <p>Clients with this permission level generally have unrestricted access to FCP commands and
+     * data.
      */
     ACCESS_FCP_FULL,
+
     /**
-     * The client plugin is running within the same node as the server plugin.<br>
-     * This probably should be interpreted as {@link #ACCESS_FCP_FULL}: If the client plugin is
-     * running inside the node, it can probably do whatever it wants. We're nevertheless shipping
-     * this information to you as it is available anyway.
+     * Indicates that the client plugin is running within the same Java Virtual Machine as the
+     * server plugin.
+     *
+     * <p>This permission level implies the highest level of trust. Since the client code is
+     * executing directly within the node's process, it effectively has full control. This value is
+     * provided for completeness and informational purposes.
      */
     ACCESS_DIRECT
   }
 
   /**
-   * The permissions of the client which sent the messages. Null for server-to-client and outgoing
-   * messages.<br>
-   * Will be set by the {@link FCPPluginConnection} before delivery of the message. Thus, you can
-   * pass null for this in all constructors.
+   * The permissions granted to the client that sent the message.
+   *
+   * <p>This field indicates the authorization level of the message sender. It is typically
+   * populated by the {@link FCPPluginConnection} before the message is delivered to the handler.
+   *
+   * <p>For server-to-client messages or outgoing messages constructed by the plugin, this field is
+   * {@code null}.
    */
   public final ClientPermissions permissions;
 
   /**
-   * The unique identifier of the message.<br>
-   * Can be used by server and client to track the progress of messages.<br>
-   * This especially applies to {@link FCPPluginConnection#sendSynchronous(SendDirection,
-   * FCPPluginMessage, long)} which will wait for a reply with the same identifier as the original
-   * message until it returns.<br>
-   * <br>
-   * For reply messages, this shall be the same as the identifier of the message to which this is a
-   * reply.<br>
-   * For non-reply message, this shall be a sufficiently random {@link String} to prevent collisions
-   * with any previous message identifiers. The default is a random {@link UUID}, and alternate
-   * implementations are recommended to use a random {@link UUID} as well.<br>
-   * <br>
-   * <b>Notice:</b> Custom client implementations can chose the identifier freely when sending
-   * messages, and thus violate these rules. This is highly discouraged though, as non-unique
-   * identifiers make tracking messages impossible. But if a client does violate the rules and
-   * thereby breaks its message tracking, thats not the server's problem, and thus should not cause
-   * complexification of the server code.<br>
-   * So server implementations <b>should</b> assume that the client chooses the identifier in a sane
-   * manner which follows the rules.<br>
-   * This class does follow the rules, and thus client and server implementations using it will do
-   * so as well.
+   * The unique identifier for the message.
+   *
+   * <p>This identifier is used to correlate requests with their corresponding replies and to track
+   * message progress. For synchronous operations, such as {@link
+   * FCPPluginConnection#sendSynchronous(FCPPluginConnection.SendDirection, FCPPluginMessage,
+   * long)}, the caller waits for a reply message bearing the same identifier.
+   *
+   * <p>For reply messages, this field must match the identifier of the original request message.
+   * For new (non-reply) messages, this must be a globally unique string to prevent collisions. The
+   * default implementation uses a random {@link UUID}.
+   *
+   * <p>While the FCP protocol allows arbitrary strings, using a random {@link UUID} is strongly
+   * recommended to ensure uniqueness. Non-unique identifiers can break message tracking and
+   * response correlation.
    */
   public final String identifier;
 
   /**
-   * Part 1 of the actual message: Human-readable parameters. Shall be small amount of data.<br>
-   * Can be null for data-only or success-indicator messages.
+   * The structured parameters of the message.
+   *
+   * <p>This field contains the human-readable, key-value pairs associated with the message. It is
+   * typically used for metadata, command arguments, or status information.
+   *
+   * <p>This field may be {@code null} for messages that only transfer bulk data or indicate simple
+   * success/failure status without additional details.
    */
   public final SimpleFieldSet params;
 
   /**
-   * Part 2 of the actual message: Non-human readable, large size bulk data.<br>
-   * Can be null if no large amount of data is to be transfered.
+   * The bulk data payload of the message.
+   *
+   * <p>This field holds large, non-human-readable data, such as file contents or binary blobs. It
+   * is represented as a {@link Bucket}, which may be backed by memory or a temporary file.
+   *
+   * <p>This field may be {@code null} if the message does not contain any bulk data.
    */
   public final Bucket data;
 
   /**
-   * For messages which are a reply to another message, this is always non-null. It then is true if
-   * the operation to which this is a reply succeeded, false if it failed.<br>
-   * For non-reply messages, this is always null.<br>
-   * <br>
-   * Notice: Whether this is null or non-null is used to determine the return value of {@link
-   * #isReplyMessage()} - a reply message has success != null, a non-reply message has success ==
-   * null.
+   * The success status for reply messages.
+   *
+   * <p>This field indicates the outcome of the operation triggered by the original message. It is
+   * {@code true} if the operation succeeded, and {@code false} if it failed.
+   *
+   * <p>For messages that are not replies (i.e., new requests), this field is always {@code null}.
+   * The presence of a non-null value in this field is used by {@link #isReplyMessage()} to
+   * determine if the message is a reply.
    */
   public final Boolean success;
 
   /**
-   * For reply messages with {@link #success} == false, may contain an alpha-numeric String which
-   * identifies a reason for the failure in a standardized representation which software can parse
-   * easily. May also be null in that case, but please try to not do that.<br>
-   * For {@link #success} == null or true, this must be null.<br>
-   * <br>
-   * The String shall be for programming purposes and thus <b>must</b> be alpha-numeric.<br>
-   * For unclassified errors, such as Exceptions which you do not expect, use "InternalError".
+   * The machine-readable error code for failed reply messages.
+   *
+   * <p>If {@link #success} is {@code false}, this field may contain an alphanumeric string
+   * identifying the specific error condition. This allows software to programmatically handle
+   * different failure modes.
+   *
+   * <p>This field must be {@code null} if {@link #success} is {@code true} or {@code null}. Common
+   * practice is to use "InternalError" for unexpected exceptions.
    */
   public final String errorCode;
 
   /**
-   * For reply messages with {@link #errorCode} != null, may contain a String which describes the
-   * problem in a human-readable, user-friendly manner. May also be null in that case, but please
-   * try to not do that.<br>
-   * For {@link #errorCode} == null, this must be null.<br>
-   * <br>
-   * You are encouraged to provide it translated to the configured language already.<br>
-   * The String shall not be used for identifying problems in programming.<br>
-   * There, use {@link #errorCode}. For Exceptions which you do not expect, {@link
-   * Exception#toString()} will return a sufficient errorMessage (containing the name of the
-   * Exception and the localized error message, or non-localized if there is no translation).<br>
-   * <br>
-   * (Notice: This may only be non-null if {@link #errorCode} is non-null instead of just if {@link
-   * #success} == false to ensure that a developer-friendly error signaling is implemented:
-   * errorCode is designed to be easy to parse, errorMessage is designed to be human readable and
-   * thus cannot be parsed. Therefore, the errorCode field should be more mandatory than this
-   * field.)
+   * The human-readable error message for failed reply messages.
+   *
+   * <p>If {@link #errorCode} is present, this field may contain a descriptive string explaining the
+   * error to a user. It is encouraged to provide localized messages where possible.
+   *
+   * <p>This field must be {@code null} if {@link #errorCode} is {@code null}. Unlike the error
+   * code, this string is not intended for programmatic parsing.
    */
   public final String errorMessage;
 
   /**
-   * Guard flag to detect accidental reuse of the same message instance. The flag is intentionally
-   * mutable to allow tracking whether this immutable message container has been handed to the send
-   * pipeline already.
+   * A guard flag to detect and prevent accidental reuse of the same message instance.
+   *
+   * <p>This mutable flag tracks whether this message container has already been passed to the send
+   * pipeline. It ensures that a single message object is not sent multiple times, which could lead
+   * to protocol confusion or race conditions.
    */
   private final AtomicBoolean sent = new AtomicBoolean(false);
 
   /**
-   * @return True if the message is merely a reply to a previous message from your side.<br>
-   *     In that case, you <b>must not</b> send another reply message back to prevent infinite
-   *     bouncing of "success!" replies.
+   * Determines whether this message is a reply to a previous message.
+   *
+   * <p>A message is considered a reply if its {@link #success} field is non-null. Reply messages
+   * indicate the outcome (success or failure) of a previous operation identified by the same {@link
+   * #identifier}.
+   *
+   * <p>It is important not to send a reply to a message that is itself a reply, as this could lead
+   * to an infinite loop of acknowledgments.
+   *
+   * @return {@code true} if this message is a reply (i.e., {@link #success} is not null); {@code
+   *     false} otherwise.
    */
   public boolean isReplyMessage() {
     return success != null;
   }
 
   /**
-   * See the JavaDoc of the member variables with the same name as the parameters for an explanation
-   * of the parameters.
+   * Internal constructor for creating an {@code FCPPluginMessage} with all fields specified.
+   *
+   * <p>This constructor performs strict validation of the parameters to ensure consistency, such as
+   * ensuring that error codes are only present for failed replies and that identifiers are never
+   * null.
+   *
+   * @param permissions the permissions of the sender, or {@code null} for outgoing messages.
+   * @param identifier the unique identifier for the message; must not be {@code null}.
+   * @param params the structured parameters of the message; may be {@code null}.
+   * @param data the bulk data payload; may be {@code null}.
+   * @param success the success status for replies, or {@code null} for non-replies.
+   * @param errorCode the error code for failed replies; must be {@code null} if success is true.
+   * @param errorMessage the human-readable error message; must be {@code null} if errorCode is
+   *     null.
    */
   private FCPPluginMessage(
       ClientPermissions permissions,
@@ -150,11 +210,7 @@ public final class FCPPluginMessage {
       String errorMessage) {
 
     // See JavaDoc of member variables with the same name for reasons of the requirements
-    assert (permissions != null || permissions == null);
     assert (identifier != null);
-    assert (params != null || params == null);
-    assert (data != null || data == null);
-    assert (success != null || success == null);
 
     assert (params != null || data != null || success != null) : "Messages should not be empty";
 
@@ -177,27 +233,24 @@ public final class FCPPluginMessage {
   }
 
   /**
-   * For being used by server or client to construct outgoing messages.<br>
-   * Those can then be passed to the send functions of {@link FCPPluginConnection} or returned in
-   * the message handlers of {@link FredPluginFCPMessageHandler}.<br>
-   * <br>
-   * <b>ATTENTION</b>: Messages constructed with this constructor here are <b>not</b> reply
-   * messages.<br>
-   * If you are replying to a message, notably when returning a message in the message handler
-   * interface implementation, you must use {@link #constructReplyMessage(FCPPluginMessage,
-   * SimpleFieldSet, Bucket, boolean, String, String)} (or one of its shortcuts) instead.<br>
-   * <br>
-   * See the JavaDoc of the member variables with the same name as the parameters for an explanation
-   * of the parameters.<br>
-   * <br>
-   * There is a shortcut to this constructor for typical choice of parameters:<br>
-   * {@link #construct()}.
+   * Constructs a new outgoing message with the specified parameters and data.
+   *
+   * <p>This method creates a new request message (not a reply) with a randomly generated {@link
+   * UUID} as its identifier. This ensures that the message can be uniquely tracked and that any
+   * future replies can be correctly correlated.
+   *
+   * <p>The generated message will have {@code success}, {@code errorCode}, and {@code errorMessage}
+   * set to {@code null}, as these are only used for replies.
+   *
+   * @param params the structured parameters to include in the message; may be {@code null}.
+   * @param data the bulk data payload to include in the message; may be {@code null}.
+   * @return a new {@link FCPPluginMessage} instance ready to be sent.
    */
   public static FCPPluginMessage construct(SimpleFieldSet params, Bucket data) {
     // Notice: While the specification of FCP formally allows the client to freely chose the
     // ID, we hereby restrict it to be a random UUID instead of allowing the client
     // (or server) to chose it. This is to prevent accidental collisions with the IDs of
-    // other messages. I cannot think of any usecase of free-choice identifiers. And
+    // other messages. I cannot think of any use cases of free-choice identifiers. And
     // collisions are *bad*: They can break the "ACK" mechanism of the "success" variable.
     // This would in turn break things such as the sendSynchronous() functions of
     // FCPPluginConnection.
@@ -214,41 +267,38 @@ public final class FCPPluginMessage {
   }
 
   /**
-   * Same as {@link #construct(SimpleFieldSet, Bucket)} with the missing parameters being:<br>
-   * <code>SimpleFieldSet params = new SimpleFieldSet(shortLived = true);<br>
-   * Bucket data = null;</code><br>
-   * <br>
-   * <b>ATTENTION</b>: Messages constructed with this constructor here are <b>not</b> reply
-   * messages.<br>
-   * If you are replying to a message, notably when returning a message in the message handler
-   * interface implementation, you must use {@link #constructReplyMessage(FCPPluginMessage,
-   * SimpleFieldSet, Bucket, boolean, String, String)} (or one of its shortcuts) instead.<br>
+   * Constructs a new outgoing message with default parameters and no data.
+   *
+   * <p>This is a convenience method equivalent to calling {@link #construct(SimpleFieldSet,
+   * Bucket)} with a new, short-lived {@link SimpleFieldSet} and {@code null} data.
+   *
+   * <p>This is useful for simple commands or signals that do not require extensive parameters or
+   * bulk data transfer.
+   *
+   * @return a new {@link FCPPluginMessage} instance with a unique identifier.
    */
   public static FCPPluginMessage construct() {
     return construct(new SimpleFieldSet(true), null);
   }
 
   /**
-   * For being used by server or client to construct outgoing messages which are a reply to an
-   * original message.<br>
-   * Those then can be returned from the message handler {@link
-   * FredPluginFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}.<br>
-   * <br>
-   * See the JavaDoc of the member variables with the same name as the parameters for an explanation
-   * of the parameters.<br>
-   * <br>
-   * There are shortcuts to this constructor for typical choice of parameters:<br>
-   * {@link #constructSuccessReply(FCPPluginMessage)}.<br>
-   * {@link #constructErrorReply(FCPPluginMessage, String, String)}.<br>
+   * Constructs a reply message in response to an incoming message.
    *
-   * @throws IllegalStateException If the original message was a reply message already.<br>
-   *     Replies often shall only indicate success / failure instead of triggering actual
-   *     operations, so it could cause infinite bouncing if you reply to them again.<br>
-   *     Consider the whole of this as a remote procedure call process: A non-reply message is the
-   *     procedure call, a reply message is the procedure result. When receiving the result, the
-   *     procedure call is finished, and thus shouldn't cause further replies to be sent.<br>
-   *     <b>Notice</b>: The JavaDoc of the aforementioned message handling function explains how you
-   *     can nevertheless send a reply to reply messages.
+   * <p>This method creates a new message that shares the same {@link #identifier} as the {@code
+   * originalMessage}. This allows the recipient to correlate this reply with their original
+   * request.
+   *
+   * <p>This method enforces that one cannot reply to a message that is itself already a reply. This
+   * prevents infinite loops of automated responses.
+   *
+   * @param originalMessage the message being replied to; must not be a reply itself.
+   * @param params the parameters to include in the reply; may be {@code null}.
+   * @param data the bulk data to include in the reply; may be {@code null}.
+   * @param success {@code true} if the operation succeeded, {@code false} otherwise.
+   * @param errorCode the error code if the operation failed; must be {@code null} on success.
+   * @param errorMessage the error message if the operation failed; must be {@code null} on success.
+   * @return a new {@link FCPPluginMessage} representing the reply.
+   * @throws IllegalStateException if {@code originalMessage} is already a reply message.
    */
   public static FCPPluginMessage constructReplyMessage(
       FCPPluginMessage originalMessage,
@@ -269,28 +319,32 @@ public final class FCPPluginMessage {
   }
 
   /**
-   * Same as {@link #constructReplyMessage(FCPPluginMessage, SimpleFieldSet, Bucket, boolean,
-   * String, String)} with the missing parameters being:<br>
-   * <code>
-   * SimpleFieldSet params = new SimpleFieldSet(shortLived = true);<br>
-   * Bucket data = null;<br>
-   * boolean success = true;<br>
-   * errorCode = null;<br>
-   * errorMessage = null;<br>
-   * </code>
+   * Constructs a successful reply message with default parameters.
+   *
+   * <p>This is a convenience method for creating a standard success response. It sets {@code
+   * success} to {@code true}, and both error fields to {@code null}. It uses a default short-lived
+   * {@link SimpleFieldSet} for parameters and includes no bulk data.
+   *
+   * @param originalMessage the message being replied to; must not be a reply itself.
+   * @return a new {@link FCPPluginMessage} indicating success.
+   * @throws IllegalStateException if {@code originalMessage} is already a reply message.
    */
   public static FCPPluginMessage constructSuccessReply(FCPPluginMessage originalMessage) {
     return constructReplyMessage(originalMessage, new SimpleFieldSet(true), null, true, null, null);
   }
 
   /**
-   * Same as {@link #constructReplyMessage(FCPPluginMessage, SimpleFieldSet, Bucket, boolean,
-   * String, String)} with the missing parameters being:<br>
-   * <code>
-   * SimpleFieldSet params = new SimpleFieldSet(shortLived = true);<br>
-   * Bucket data = null;<br>
-   * boolean success = false;<br>
-   * </code>
+   * Constructs a failure reply message with the specified error details.
+   *
+   * <p>This is a convenience method for creating a standard error response. It sets {@code success}
+   * to {@code false}, and populates the {@code errorCode} and {@code errorMessage} fields. It uses
+   * a default short-lived {@link SimpleFieldSet} for parameters and includes no bulk data.
+   *
+   * @param originalMessage the message being replied to; must not be a reply itself.
+   * @param errorCode the alphanumeric error code identifying the failure type.
+   * @param errorMessage the human-readable description of the error.
+   * @return a new {@link FCPPluginMessage} indicating failure.
+   * @throws IllegalStateException if {@code originalMessage} is already a reply message.
    */
   public static FCPPluginMessage constructErrorReply(
       FCPPluginMessage originalMessage, String errorCode, String errorMessage) {
@@ -300,16 +354,21 @@ public final class FCPPluginMessage {
   }
 
   /**
-   * ATTENTION: Only for being used by internal network code.<br>
-   * <br>
-   * You <b>must not</b> use this for constructing outgoing messages in server or client
-   * implementations.<br>
-   * This function is typically to construct incoming messages for passing them to the message
-   * handling function {@link
-   * FredPluginFCPMessageHandler#handlePluginFCPMessage(FCPPluginConnection, FCPPluginMessage)}.<br>
-   * <br>
-   * See the JavaDoc of the member variables with the same name as the parameters for an explanation
-   * of the parameters.<br>
+   * Internal factory method for constructing raw messages, typically from network data.
+   *
+   * <p><b>Attention:</b> This method is intended for use by the internal network layer when parsing
+   * incoming messages. It allows setting all fields directly, including the identifier and
+   * permissions. Application code should generally use {@link #construct(SimpleFieldSet, Bucket)}
+   * or the reply constructors instead.
+   *
+   * @param permissions the permissions of the sender.
+   * @param identifier the unique identifier of the message.
+   * @param params the message parameters.
+   * @param data the bulk data payload.
+   * @param success the success status (for replies).
+   * @param errorCode the error code (for failed replies).
+   * @param errorMessage the error message (for failed replies).
+   * @return a new {@link FCPPluginMessage} instance.
    */
   static FCPPluginMessage constructRawMessage(
       ClientPermissions permissions,
@@ -325,15 +384,27 @@ public final class FCPPluginMessage {
   }
 
   /**
-   * Marks this message as having been sent already.
+   * Atomically marks this message as having been sent.
    *
-   * @return {@code true} if this call marks the first send attempt, {@code false} if the message
-   *     was previously sent.
+   * <p>This method is used by the network layer to ensure that a message is not accidentally sent
+   * multiple times. It uses an atomic state transition to provide thread safety.
+   *
+   * @return {@code true} if this call successfully marked the message as sent (i.e., it was the
+   *     first time); {@code false} if the message had already been marked as sent.
    */
   public boolean markSent() {
     return sent.compareAndSet(false, true);
   }
 
+  /**
+   * Returns a string representation of this message.
+   *
+   * <p>The returned string includes the values of all major fields, including permissions,
+   * identifier, data presence, success status, and error details. The parameters are appended at
+   * the end, potentially spanning multiple lines.
+   *
+   * @return a string describing the message state.
+   */
   @Override
   public String toString() {
     return super.toString()

--- a/src/test/java/network/crypta/clients/fcp/FCPPluginMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPPluginMessageTest.java
@@ -1,0 +1,164 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // Allow snake_case method names for tests
+class FCPPluginMessageTest {
+
+  @Mock private Bucket mockBucket;
+
+  @Test
+  void construct_noArgs_shouldCreateDefaultMessage() {
+    FCPPluginMessage message = FCPPluginMessage.construct();
+
+    assertNull(message.permissions);
+    assertNotNull(message.identifier);
+    // Verify identifier is a UUID
+    assertDoesNotThrow(() -> UUID.fromString(message.identifier));
+
+    assertNotNull(message.params);
+    // Check if params is shortLived (not directly exposed, but we can assume from constructor)
+
+    assertNull(message.data);
+    assertNull(message.success);
+    assertNull(message.errorCode);
+    assertNull(message.errorMessage);
+
+    assertFalse(message.isReplyMessage());
+  }
+
+  @Test
+  void construct_withParamsAndBucket_shouldSetFields() {
+    SimpleFieldSet params = new SimpleFieldSet(true);
+    params.putOverwrite("key", "value");
+
+    FCPPluginMessage message = FCPPluginMessage.construct(params, mockBucket);
+
+    assertNull(message.permissions);
+    assertNotNull(message.identifier);
+    assertEquals(params, message.params);
+    assertEquals(mockBucket, message.data);
+    assertNull(message.success);
+    assertNull(message.errorCode);
+    assertNull(message.errorMessage);
+
+    assertFalse(message.isReplyMessage());
+  }
+
+  @Test
+  void constructReplyMessage_shouldCreateReplyWithSameIdentifier() {
+    FCPPluginMessage original = FCPPluginMessage.construct();
+    SimpleFieldSet replyParams = new SimpleFieldSet(true);
+
+    FCPPluginMessage reply =
+        FCPPluginMessage.constructReplyMessage(original, replyParams, mockBucket, true, null, null);
+
+    assertNull(reply.permissions);
+    assertEquals(original.identifier, reply.identifier);
+    assertEquals(replyParams, reply.params);
+    assertEquals(mockBucket, reply.data);
+    assertEquals(Boolean.TRUE, reply.success);
+    assertNull(reply.errorCode);
+    assertNull(reply.errorMessage);
+
+    assertTrue(reply.isReplyMessage());
+  }
+
+  @Test
+  void constructReplyMessage_whenOriginalIsReply_shouldThrowException() {
+    FCPPluginMessage original = FCPPluginMessage.construct();
+    FCPPluginMessage reply = FCPPluginMessage.constructSuccessReply(original);
+
+    assertThrows(IllegalStateException.class, () -> FCPPluginMessage.constructSuccessReply(reply));
+  }
+
+  @Test
+  void constructSuccessReply_shouldSetSuccessTrue() {
+    FCPPluginMessage original = FCPPluginMessage.construct();
+
+    FCPPluginMessage reply = FCPPluginMessage.constructSuccessReply(original);
+
+    assertEquals(original.identifier, reply.identifier);
+    assertEquals(Boolean.TRUE, reply.success);
+    assertNull(reply.errorCode);
+    assertNull(reply.errorMessage);
+    assertNotNull(reply.params);
+    assertNull(reply.data);
+  }
+
+  @Test
+  void constructErrorReply_shouldSetSuccessFalseAndErrorFields() {
+    FCPPluginMessage original = FCPPluginMessage.construct();
+    String errorCode = "Error123";
+    String errorMessage = "Something went wrong";
+
+    FCPPluginMessage reply =
+        FCPPluginMessage.constructErrorReply(original, errorCode, errorMessage);
+
+    assertEquals(original.identifier, reply.identifier);
+    assertEquals(Boolean.FALSE, reply.success);
+    assertEquals(errorCode, reply.errorCode);
+    assertEquals(errorMessage, reply.errorMessage);
+    assertNotNull(reply.params);
+    assertNull(reply.data);
+  }
+
+  @Test
+  void markSent_shouldReturnTrueFirstTimeAndFalseSubsequently() {
+    FCPPluginMessage message = FCPPluginMessage.construct();
+
+    assertTrue(message.markSent(), "First call to markSent should return true");
+    assertFalse(message.markSent(), "Second call to markSent should return false");
+    assertFalse(message.markSent(), "Third call to markSent should return false");
+  }
+
+  @Test
+  void toString_shouldContainKeyFields() {
+    FCPPluginMessage message = FCPPluginMessage.construct();
+    String stringRep = message.toString();
+
+    assertTrue(stringRep.contains(message.identifier));
+    assertTrue(stringRep.contains("permissions"));
+    assertTrue(stringRep.contains("success"));
+  }
+
+  // Tests for assertion logic (requires -ea to be effective, but good to document expectations)
+
+  @Test
+  void constructRawMessage_invalidErrorCode_shouldFailAssertion() {
+    // This test expects an AssertionError if assertions are enabled.
+    // If assertions are disabled, it will pass (or we can skip it).
+    // For now, we'll write it to document the constraint, but wrap in try-catch or assumeTrue
+    // if we could detect assertion status.
+    // Since we can't easily force assertions on/off in this env, we will just test the logic
+    // if we can, or skip if it's purely assertion based.
+    // The class uses `assert` keyword.
+
+    // Let's try to trigger it. If it doesn't throw, it means assertions are off.
+    if (FCPPluginMessage.class.desiredAssertionStatus()) {
+      String uuid = UUID.randomUUID().toString();
+      assertThrows(
+          AssertionError.class,
+          () ->
+              FCPPluginMessage.constructRawMessage(
+                  null, uuid, null, null, false, "Invalid Code!", null));
+    } else {
+      assertTrue(true, "Assertions are disabled; skipping assertion check.");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand FCPPluginMessage Javadoc for permissions, identifiers, replies, payloads, and guard flag
- add unit coverage for constructors, reply helpers, markSent state, and string representation

## Testing
- Not run (not requested)