### PR TITLE
Improve GetConfig documentation and tests

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/GetConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/GetConfig.java
@@ -2,11 +2,32 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * FCP message that asks the node to stream its configuration metadata to the caller.
+ *
+ * <p>Instances are created from a {@link SimpleFieldSet} received over the socket and become
+ * immutable thereafter; each boolean flag records whether the client wants current values,
+ * defaults, ordering hints, expert visibility, force-write allowances, and both short and long
+ * textual descriptions. The request is executed by the FCP server thread that owns the connection
+ * and never touches mutable node state directly, making it safe to reuse across concurrent
+ * connections as long as each instance is used once.
+ *
+ * <p>Typical usage constructs {@code GetConfig} immediately after parsing inbound fields and calls
+ * {@link #run(FCPConnectionHandler, Node)} to validate access and send a {@link ConfigData}
+ * response. The message refuses to run when the connection lacks full access, preventing
+ * configuration disclosure to limited clients and aligning with the FCP access-control contract.
+ *
+ * <ul>
+ *   <li>Responsibilities: capture client preferences and dispatch the configuration payload.
+ *   <li>Notable behavior: strips the identifier from the inbound field set after caching it.
+ *   <li>Concurrency: stateless after construction; thread-safe when each instance is single-use.
+ * </ul>
+ *
+ * @see ConfigData
+ * @see FCPConnectionHandler
+ */
 public class GetConfig extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(GetConfig.class);
 
   final boolean withCurrent;
   final boolean withDefaults;
@@ -17,8 +38,20 @@ public class GetConfig extends FCPMessage {
   final boolean withLongDescription;
   final boolean withDataTypes;
   static final String NAME = "GetConfig";
-  final String identifier;
+  final String requestIdentifier;
 
+  /**
+   * Builds a {@code GetConfig} message from fields supplied by an FCP client.
+   *
+   * <p>The constructor copies all optional inclusion flags from the provided field set, falling
+   * back to {@code false} when a flag is absent, and captures the caller-specified identifier for
+   * correlation in the response. After extracting the identifier it removes it from the mutable
+   * {@link SimpleFieldSet} to avoid leaking the token into subsequent processing. The resulting
+   * instance is ready to be executed once and does not modify the provided field set again.
+   *
+   * @param fs incoming fields that describe which configuration details the caller wants; must not
+   *     be {@code null} and is consumed for flag and identifier extraction.
+   */
   public GetConfig(SimpleFieldSet fs) {
     withCurrent = fs.getBoolean("WithCurrent", false);
     withDefaults = fs.getBoolean("WithDefaults", false);
@@ -28,25 +61,66 @@ public class GetConfig extends FCPMessage {
     withShortDescription = fs.getBoolean("WithShortDescription", false);
     withLongDescription = fs.getBoolean("WithLongDescription", false);
     withDataTypes = fs.getBoolean("WithDataTypes", false);
-    this.identifier = fs.get("Identifier");
+    this.requestIdentifier = fs.get("Identifier");
     fs.removeValue("Identifier");
   }
 
+  /**
+   * Returns an empty field set because this message is built solely from incoming data.
+   *
+   * <p>The FCP framework invokes this method when it needs to serialise a request. For {@code
+   * GetConfig} instances created from client input, the outbound representation is blank and acts
+   * only as a signal to trigger the configuration transfer using the previously cached flags.
+   * Callers should treat the returned field set as immutable and discard it after sending.
+   *
+   * @return a newly allocated {@link SimpleFieldSet} with no entries to transmit over FCP.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Returns the protocol-level message name used to route this request.
+   *
+   * <p>The value is constant for the lifetime of the application and matches the token expected by
+   * FCP clients when sending command lines. FCP infrastructure uses the name to look up the handler
+   * class, log activity, and map responses back to originating clients. Because the value is
+   * immutable and public messages are keyed by it, the method is idempotent and inexpensive to call
+   * repeatedly in routing, metrics collection, or debugging output.
+   *
+   * @return the fixed string {@code "GetConfig"} advertised in the FCP specification.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Validates the caller and sends the configuration snapshot back over the FCP connection.
+   *
+   * <p>The handler must present full-access credentials; otherwise this method halts execution by
+   * raising a {@link MessageInvalidException} describing the access denial. When authorized, it
+   * constructs a {@link ConfigData} response using the cached flags to decide whether to include
+   * current values, defaults, sort order, expert-only markers, force-write allowances, short or
+   * long descriptions, and data-type metadata. The response is streamed via the provided handler
+   * without mutating the {@link Node}. Invocations are single-shot per instance; repeated calls
+   * would resend identical configuration data until the connection closes.
+   *
+   * @param handler connection context responsible for permission checks and outbound delivery; must
+   *     not be {@code null} and must expose full access for the call to proceed.
+   * @param node backing node that supplies the configuration values reflected in the response; may
+   *     be queried but is not modified during processing.
+   * @throws MessageInvalidException if the caller lacks full access or message validation fails.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "GetConfig requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "GetConfig requires full access",
+          requestIdentifier,
+          false);
     }
     handler.send(
         new ConfigData(
@@ -59,6 +133,6 @@ public class GetConfig extends FCPMessage {
             withShortDescription,
             withLongDescription,
             withDataTypes,
-            identifier));
+            requestIdentifier));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
@@ -1,0 +1,121 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class GetConfigTest {
+
+  @Mock FCPConnectionHandler handler;
+
+  @Mock Node node;
+
+  @Test
+  void constructor_whenFieldsPresent_setsFlagsAndIdentifierAndRemovesIdentifierFromSource() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("WithCurrent", "true");
+    fs.putSingle("WithDefaults", "false");
+    fs.putSingle("WithSortOrder", "true");
+    fs.putSingle("WithExpertFlag", "false");
+    fs.putSingle("WithForceWriteFlag", "true");
+    fs.putSingle("WithShortDescription", "false");
+    fs.putSingle("WithLongDescription", "true");
+    fs.putSingle("Identifier", "test-id");
+
+    GetConfig getConfig = new GetConfig(fs);
+
+    assertTrue(getConfig.withCurrent);
+    assertFalse(getConfig.withDefaults);
+    assertTrue(getConfig.withSortOrder);
+    assertFalse(getConfig.withExpertFlag);
+    assertTrue(getConfig.withForceWriteFlag);
+    assertFalse(getConfig.withShortDescription);
+    assertTrue(getConfig.withLongDescription);
+    assertEquals("test-id", getConfig.requestIdentifier);
+    assertNull(fs.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenCalled_returnsEmptyFieldSet() {
+    GetConfig getConfig = new GetConfig(new SimpleFieldSet(true));
+
+    SimpleFieldSet fieldSet = getConfig.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertTrue(fieldSet.isEmpty());
+  }
+
+  @Test
+  void getName_whenCalled_returnsConstantName() {
+    GetConfig getConfig = new GetConfig(new SimpleFieldSet(true));
+
+    assertEquals("GetConfig", getConfig.getName());
+  }
+
+  @Test
+  void run_whenHandlerLacksFullAccess_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-123");
+    GetConfig getConfig = new GetConfig(fs);
+    when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> getConfig.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
+    assertEquals("req-123", thrown.ident);
+    assertEquals("GetConfig requires full access", thrown.getMessage());
+    assertFalse(thrown.global);
+    verify(handler, never()).send(any(FCPMessage.class));
+  }
+
+  @Test
+  void run_whenHandlerHasFullAccess_sendsConfigDataWithMatchingFlags() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("WithCurrent", "true");
+    fs.putSingle("WithDefaults", "true");
+    fs.putSingle("WithSortOrder", "false");
+    fs.putSingle("WithExpertFlag", "true");
+    fs.putSingle("WithForceWriteFlag", "false");
+    fs.putSingle("WithShortDescription", "true");
+    fs.putSingle("WithLongDescription", "false");
+    fs.putSingle("WithDataTypes", "true");
+    fs.putSingle("Identifier", "cfg-7");
+    GetConfig getConfig = new GetConfig(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    getConfig.run(handler, node);
+
+    ArgumentCaptor<ConfigData> captor = ArgumentCaptor.forClass(ConfigData.class);
+    verify(handler).send(captor.capture());
+    ConfigData sent = captor.getValue();
+
+    assertEquals(node, sent.node);
+    assertTrue(sent.withCurrent);
+    assertTrue(sent.withDefaults);
+    assertFalse(sent.withSortOrder);
+    assertTrue(sent.withExpertFlag);
+    assertFalse(sent.withForceWriteFlag);
+    assertTrue(sent.withShortDescription);
+    assertFalse(sent.withLongDescription);
+    assertTrue(sent.withDataTypes);
+    assertEquals("cfg-7", sent.requestIdentifier);
+  }
+}


### PR DESCRIPTION
## Summary
- expand Javadoc on the GetConfig FCP message with detailed semantics and access control
- add unit coverage for flag parsing, name lookup, and access checks for GetConfig

## Testing
- ./gradlew spotlessApply
- (no additional tests were run in this task)