### PR TITLE
Improve GenerateSSKMessage Javadoc and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/GenerateSSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/GenerateSSKMessage.java
@@ -4,37 +4,87 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Generates a new signed subspace key (SSK) pair for an FCP client and relays it back over the
+ * connection. The message is created from the parsed field set of an inbound request and, when
+ * executed, allocates a fresh {@link InsertableClientSSK} using the node's secure random source.
+ * Clients use this flow when they need a write-capable insert URI and a corresponding request URI
+ * without transmitting their own key material.
+ *
+ * <p>The instance is intentionally lightweight and stateless: all protocol information lives in the
+ * supplied {@link SimpleFieldSet}, and all cryptographic material is produced during {@link
+ * #run(FCPConnectionHandler, Node)}. This makes it safe to reuse a single instance per incoming
+ * request in a multithreaded FCP server loop. The generated keypair is ephemeral until persisted
+ * elsewhere; no on-disk side effects occur in this class. The optional client identifier is echoed
+ * back so callers can correlate responses to their session or outstanding command queue. Typical
+ * usage calls {@link #getFieldSet()} during serialization, then {@link #run(FCPConnectionHandler,
+ * Node)} when the command should be fulfilled.
+ *
+ * <ul>
+ *   <li>Parses the caller-supplied identifier, if present, from the inbound field set.
+ *   <li>Creates a random SSK insert/request pair using the node's randomness provider.
+ *   <li>Wraps the resulting URIs in an {@link SSKKeypairMessage} and sends it via the handler.
+ * </ul>
+ *
+ * @see SSKKeypairMessage
+ * @see InsertableClientSSK
+ */
 public class GenerateSSKMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(GenerateSSKMessage.class);
 
   static final String NAME = "GenerateSSK";
-  final String identifier;
+  final String clientIdentifier;
 
   GenerateSSKMessage(SimpleFieldSet fs) {
-    identifier = fs.get("Identifier");
+    clientIdentifier = fs.get("Identifier");
   }
 
+  /**
+   * Builds the field set representation of this request for transmission over FCP. The return value
+   * contains only protocol fields required for the node to recognize the request type and, if
+   * present, the optional client-specified correlation identifier.
+   *
+   * @return a mutable {@link SimpleFieldSet} containing {@code Identifier} when provided; callers
+   *     may append additional entries before serialization without affecting existing semantics.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    if (identifier != null) fs.putSingle("Identifier", identifier);
+    if (clientIdentifier != null) fs.putSingle("Identifier", clientIdentifier);
     return fs;
   }
 
+  /**
+   * Returns the canonical FCP message name associated with this request. The name is used by
+   * routing and serialization layers to map protocol frames back to handlers.
+   *
+   * @return immutable message name {@code GenerateSSK} used when emitting protocol frames.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Generates a new random SSK keypair and sends it to the client as an {@link SSKKeypairMessage}.
+   * The method is synchronous with respect to the caller: key generation occurs immediately using
+   * the node's random source, and the response is dispatched on the provided connection handler. No
+   * state is retained after sending; callers may invoke this repeatedly to obtain multiple
+   * independent keypairs.
+   *
+   * @param handler active connection handler that delivers the generated keypair back to the
+   *     requesting client; must not be {@code null}.
+   * @param node running node that supplies randomness and environment context for creating the SSK
+   *     pair; expected to be fully initialized.
+   * @throws MessageInvalidException if the response message cannot be encoded or sent according to
+   *     FCP protocol rules or if the handler rejects the outbound payload.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     InsertableClientSSK key = InsertableClientSSK.createRandom(node.getRandom(), "");
     FreenetURI insertURI = key.getInsertURI();
     FreenetURI requestURI = key.getURI();
-    SSKKeypairMessage msg = new SSKKeypairMessage(insertURI, requestURI, identifier);
+    SSKKeypairMessage msg = new SSKKeypairMessage(insertURI, requestURI, clientIdentifier);
     handler.send(msg);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GenerateSSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GenerateSSKMessageTest.java
@@ -1,0 +1,127 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.InsertableClientSSK;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class GenerateSSKMessageTest {
+
+  @Test
+  void getFieldSet_withIdentifier_returnsIdentifier() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "id-123");
+    GenerateSSKMessage message = new GenerateSSKMessage(fs);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals("id-123", result.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_withoutIdentifier_omitsIdentifier() {
+    GenerateSSKMessage message = new GenerateSSKMessage(new SimpleFieldSet(true));
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertNull(result.get("Identifier"));
+  }
+
+  @Test
+  void getName_always_returnsWireName() {
+    GenerateSSKMessage message = new GenerateSSKMessage(new SimpleFieldSet(true));
+
+    assertEquals("GenerateSSK", message.getName());
+  }
+
+  @Test
+  void run_whenIdentifierPresent_sendsKeypairMessageWithIdentifier() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "client-1");
+    GenerateSSKMessage message = new GenerateSSKMessage(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    Node node = mock(Node.class);
+    RandomSource randomSource = mock(RandomSource.class);
+    when(node.getRandom()).thenReturn(randomSource);
+
+    FreenetURI insertUri =
+        new FreenetURI("SSK", "insert", new byte[] {1, 2}, new byte[32], new byte[] {3});
+    FreenetURI requestUri =
+        new FreenetURI("SSK", "request", new byte[] {4, 5}, new byte[32], new byte[] {6});
+
+    InsertableClientSSK generatedKey = mock(InsertableClientSSK.class);
+    when(generatedKey.getInsertURI()).thenReturn(insertUri);
+    when(generatedKey.getURI()).thenReturn(requestUri);
+
+    try (MockedStatic<InsertableClientSSK> mocked = mockStatic(InsertableClientSSK.class)) {
+      mocked
+          .when(() -> InsertableClientSSK.createRandom(randomSource, ""))
+          .thenReturn(generatedKey);
+
+      message.run(handler, node);
+
+      mocked.verify(() -> InsertableClientSSK.createRandom(randomSource, ""), times(1));
+      verify(node, times(1)).getRandom();
+
+      ArgumentCaptor<SSKKeypairMessage> captor = ArgumentCaptor.forClass(SSKKeypairMessage.class);
+      verify(handler, times(1)).send(captor.capture());
+      SimpleFieldSet sentFieldSet = captor.getValue().getFieldSet();
+
+      assertEquals(insertUri.toString(), sentFieldSet.get("InsertURI"));
+      assertEquals(requestUri.toString(), sentFieldSet.get("RequestURI"));
+      assertEquals("client-1", sentFieldSet.get("Identifier"));
+    }
+  }
+
+  @Test
+  void run_whenIdentifierMissing_sendsKeypairMessageWithoutIdentifier() throws Exception {
+    GenerateSSKMessage message = new GenerateSSKMessage(new SimpleFieldSet(true));
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    Node node = mock(Node.class);
+    RandomSource randomSource = mock(RandomSource.class);
+    when(node.getRandom()).thenReturn(randomSource);
+
+    FreenetURI insertUri =
+        new FreenetURI("SSK", "insert", new byte[] {7, 8}, new byte[32], new byte[] {9});
+    FreenetURI requestUri =
+        new FreenetURI("SSK", "request", new byte[] {10, 11}, new byte[32], new byte[] {12});
+
+    InsertableClientSSK generatedKey = mock(InsertableClientSSK.class);
+    when(generatedKey.getInsertURI()).thenReturn(insertUri);
+    when(generatedKey.getURI()).thenReturn(requestUri);
+
+    try (MockedStatic<InsertableClientSSK> mocked = mockStatic(InsertableClientSSK.class)) {
+      mocked
+          .when(() -> InsertableClientSSK.createRandom(randomSource, ""))
+          .thenReturn(generatedKey);
+
+      message.run(handler, node);
+
+      ArgumentCaptor<SSKKeypairMessage> captor = ArgumentCaptor.forClass(SSKKeypairMessage.class);
+      verify(handler, times(1)).send(captor.capture());
+      SimpleFieldSet sentFieldSet = captor.getValue().getFieldSet();
+
+      assertEquals(insertUri.toString(), sentFieldSet.get("InsertURI"));
+      assertEquals(requestUri.toString(), sentFieldSet.get("RequestURI"));
+      assertNull(sentFieldSet.get("Identifier"));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand long-form Javadoc on GenerateSSKMessage to satisfy doclint and clarify usage
- align identifier naming with client correlation wording and document protocol fields
- add unit tests covering field set rendering, name reporting, and keypair response handling

## Testing
- ./gradlew spotlessApply
- javadoc -quiet -Xdoclint:all -classpath "build/classes/java/main:build/resources/main" -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/clients/fcp/GenerateSSKMessage.java
