### PR TITLE
Clarify GetNode identifier handling and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/GetNode.java
+++ b/src/main/java/network/crypta/clients/fcp/GetNode.java
@@ -2,44 +2,112 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * FCP message that requests node metadata to send back to a privileged client connection.
+ *
+ * <p>This message acts as a thin wrapper around {@link NodeData}, capturing caller preferences
+ * about which portions of the node description should be exposed. Typical flows construct the
+ * {@code GetNode} from an inbound {@link SimpleFieldSet}, validate access, and then let the
+ * connection handler serialize the resulting {@code NodeData}. Instances are short-lived and carry
+ * only immutable flags, so multiple threads can safely reuse them once created. The request only
+ * succeeds for callers with full access, ensuring that private or volatile state is not leaked to
+ * limited-control peers. Consumers should prefer this operation when they need a snapshot of
+ * current node capabilities or contact references without performing additional network I/O.
+ *
+ * <ul>
+ *   <li>Honors optional flags to include opennet references, private state, and volatile details.
+ *   <li>Copies a caller-supplied identifier so responses can be correlated by clients.
+ *   <li>Does not mutate the source field set beyond removing the identifier key.
+ * </ul>
+ */
 public class GetNode extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(GetNode.class);
 
   final boolean giveOpennetRef;
   final boolean withPrivate;
   final boolean withVolatile;
   static final String NAME = "GetNode";
-  final String identifier;
+  final String requestIdentifier;
 
+  /**
+   * Creates a {@code GetNode} message by extracting request flags from the supplied field set.
+   *
+   * <p>The constructor reads the caller's desired visibility settings, records the optional request
+   * identifier, and removes that identifier from the source {@link SimpleFieldSet} to prevent
+   * duplicate propagation. The resulting instance is immutable, making it safe to hand off to
+   * message handlers without further synchronization. Callers are expected to supply a field set
+   * constructed from FCP input; missing flags fall back to {@code false}, keeping the response
+   * minimal unless extra details are explicitly requested.
+   *
+   * @param fs field set carrying GiveOpennetRef/WithPrivate/WithVolatile flags and optional
+   *     identifier.
+   */
   public GetNode(SimpleFieldSet fs) {
     giveOpennetRef = fs.getBoolean("GiveOpennetRef", false);
     withPrivate = fs.getBoolean("WithPrivate", false);
     withVolatile = fs.getBoolean("WithVolatile", false);
-    identifier = fs.get("Identifier");
-    fs.removeValue("Identifier");
+    requestIdentifier = fs.get(FCPMessage.IDENTIFIER);
+    fs.removeValue(FCPMessage.IDENTIFIER);
   }
 
+  /**
+   * Produces the outbound field set that echoes the request identifier when available.
+   *
+   * <p>The generated {@link SimpleFieldSet} intentionally omits the visibility flags because they
+   * are consumed server side and only the identifier is required to correlate responses. The field
+   * set is newly allocated for each call to avoid sharing mutable state across message processors.
+   *
+   * @return immutable-style field set containing only the identifier key when present; otherwise an
+   *     empty set.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    if (identifier != null) fs.putSingle("Identifier", identifier);
+    if (requestIdentifier != null) fs.putSingle(FCPMessage.IDENTIFIER, requestIdentifier);
     return fs;
   }
 
+  /**
+   * Returns the protocol-visible name of this FCP message.
+   *
+   * <p>The name is constant and aligns with the value the peer expects when dispatching message
+   * handlers, allowing callers to log or route the request predictably. Because the value is shared
+   * by both client and server components, downstream code can key metrics, debugging logs, or
+   * feature gates off this identifier without recalculating or duplicating literals. The monotonic
+   * string also aids backwards compatibility by keeping the wire token stable even when internal
+   * implementation details evolve.
+   *
+   * @return fixed {@code "GetNode"} token that identifies the message type on the wire.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the request by validating access and sending node details back to the client.
+   *
+   * <p>The handler must already be associated with a fully authorized connection; otherwise a
+   * {@link ProtocolErrorMessage#ACCESS_DENIED} failure is raised. On success, it emits a {@link
+   * NodeData} response populated according to the stored flags, ensuring the caller receives only
+   * the amount of information it asked for. The method performs no retries or partial responses;
+   * any failure propagates via the thrown exception.
+   *
+   * @param handler connection handler performing access checks and delivering responses; must be
+   *     authenticated.
+   * @param node node instance providing current state and references to serialize; not null.
+   * @throws MessageInvalidException if the client lacks full access or the request violates
+   *     protocol constraints.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "GetNode requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "GetNode requires full access",
+          requestIdentifier,
+          false);
     }
-    handler.send(new NodeData(node, giveOpennetRef, withPrivate, withVolatile, identifier));
+    handler.send(new NodeData(node, giveOpennetRef, withPrivate, withVolatile, requestIdentifier));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GetNodeTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetNodeTest.java
@@ -1,0 +1,129 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+import java.util.List;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class GetNodeTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void constructor_whenFieldsPresent_setsFlagsAndRemovesIdentifier() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("GiveOpennetRef", "true");
+    fs.putSingle("WithPrivate", "true");
+    fs.putSingle("WithVolatile", "true");
+    String identifier = "abc12345";
+    fs.putSingle("Identifier", identifier);
+
+    GetNode getNode = new GetNode(fs);
+
+    assertTrue(getNode.giveOpennetRef);
+    assertTrue(getNode.withPrivate);
+    assertTrue(getNode.withVolatile);
+    assertEquals(identifier, getNode.requestIdentifier);
+    assertNull(fs.get("Identifier"));
+  }
+
+  @Test
+  void constructor_whenOptionalFieldsMissing_usesDefaults() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+
+    GetNode getNode = new GetNode(fs);
+
+    assertFalse(getNode.giveOpennetRef);
+    assertFalse(getNode.withPrivate);
+    assertFalse(getNode.withVolatile);
+    assertNull(getNode.requestIdentifier);
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierPresent_returnsFieldSetWithIdentifierOnly() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "node-123");
+    GetNode getNode = new GetNode(fs);
+
+    SimpleFieldSet result = getNode.getFieldSet();
+
+    List<String> keys = new java.util.ArrayList<>();
+    Iterator<String> iterator = result.keyIterator();
+    iterator.forEachRemaining(keys::add);
+
+    assertEquals(List.of("Identifier"), keys);
+    assertEquals("node-123", result.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierMissing_returnsEmptyFieldSet() {
+    GetNode getNode = new GetNode(new SimpleFieldSet(true));
+
+    SimpleFieldSet result = getNode.getFieldSet();
+
+    assertFalse(result.keyIterator().hasNext());
+  }
+
+  @Test
+  void getName_returnsConstantName() {
+    GetNode getNode = new GetNode(new SimpleFieldSet(true));
+
+    assertEquals("GetNode", getNode.getName());
+  }
+
+  @Test
+  void run_whenNoFullAccess_throwsAccessDeniedMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "restricted-client");
+    GetNode getNode = new GetNode(fs);
+    when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> getNode.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
+    assertEquals("restricted-client", exception.ident);
+    assertFalse(exception.global);
+    assertEquals("GetNode requires full access", exception.getMessage());
+  }
+
+  @Test
+  void run_whenFullAccess_sendsNodeDataWithFlags() throws MessageInvalidException {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("GiveOpennetRef", "true");
+    fs.putSingle("WithPrivate", "false");
+    fs.putSingle("WithVolatile", "true");
+    fs.putSingle("Identifier", "req-42");
+    GetNode getNode = new GetNode(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    ArgumentCaptor<NodeData> messageCaptor = ArgumentCaptor.forClass(NodeData.class);
+
+    getNode.run(handler, node);
+
+    verify(handler).send(messageCaptor.capture());
+    NodeData sent = messageCaptor.getValue();
+    assertSame(node, sent.node);
+    assertTrue(sent.giveOpennetRef);
+    assertFalse(sent.withPrivate);
+    assertTrue(sent.withVolatile);
+    assertEquals("req-42", sent.identifier);
+  }
+}


### PR DESCRIPTION
## Summary
- rename the GetNode identifier field and wire it through the FCP identifier constant for consistency
- expand Javadoc for GetNode to describe behavior and flags clearly
- add unit tests covering flag parsing, field-set generation, access validation, and send behavior

## Testing
- Not run (not requested)