### PR TITLE
Refactor GetRequestStatusMessage flow and add tests

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/GetRequestStatusMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/GetRequestStatusMessage.java
@@ -5,38 +5,112 @@ import network.crypta.client.async.PersistentJob;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.NativeThread;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * FCP message that asks the node to stream the most recent status (and optionally data) for a
+ * client request identified by an {@code Identifier} token.
+ *
+ * <p>The instance is immutable: the identifier and accompanying flags are captured from the parsed
+ * {@link SimpleFieldSet} and reused whenever the message is serialized or executed. Typical callers
+ * construct it from an inbound request, hand it to the active {@link FCPConnectionHandler}, and let
+ * {@link #run(FCPConnectionHandler, Node)} walk the reboot-time and persistent queues. When a match
+ * is found, pending progress or data messages are forwarded; missing identifiers trigger a {@link
+ * ProtocolErrorMessage} with {@link ProtocolErrorMessage#NO_SUCH_IDENTIFIER}.
+ *
+ * <p>Concurrency: the object is thread-safe through immutability. Execution normally occurs on the
+ * connection handler's thread while persistence lookups are offloaded at normal priority to avoid
+ * blocking I/O. Each call re-queries live state; no caching is retained between invocations.
+ *
+ * <ul>
+ *   <li>Field propagation: only the {@code Identifier} is re-emitted; flags stay local.
+ *   <li>Error handling: silently returns when the client database is already killed.
+ *   <li>Data-only mode: {@code onlyData=true} limits replies to payload-bearing messages.
+ * </ul>
+ *
+ * <pre>{@code
+ * // Example: forwarding a parsed message to the handler
+ * var message = new GetRequestStatusMessage(parsedFields);
+ * message.run(handler, node);
+ * }</pre>
+ */
 public class GetRequestStatusMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(GetRequestStatusMessage.class);
-
-  final String identifier;
+  final String requestIdentifier;
   final boolean global;
   final boolean onlyData;
   static final String NAME = "GetRequestStatus";
 
+  /**
+   * Creates a message from the incoming field set emitted by an FCP client. The constructor copies
+   * the text identifier and optional booleans immediately so later mutations to {@code fs} do not
+   * leak in. The {@code Global} flag is forwarded unchanged to downstream lookups, allowing the
+   * handler to choose the scope of the request search, while {@code OnlyData} controls whether
+   * status updates or solely data messages are returned when pending responses are replayed.
+   *
+   * @param fs field container carrying {@code Identifier} plus optional {@code Global} and {@code
+   *     OnlyData} flags; must be non-null, already parsed from the wire, and logically consistent
+   *     with the caller's protocol validation.
+   */
   public GetRequestStatusMessage(SimpleFieldSet fs) {
-    this.identifier = fs.get("Identifier");
+    this.requestIdentifier = fs.get("Identifier");
     this.global = fs.getBoolean("Global", false);
     this.onlyData = fs.getBoolean("OnlyData", false);
   }
 
+  /**
+   * Serializes this command back into an FCP field set for transmission.
+   *
+   * <p>The returned structure is freshly allocated on each call to avoid cross-request mutation and
+   * contains only the identifier field required by the remote peer. The runtime-only flags
+   * intentionally remain local to prevent accidental leakage of connection-scoped preferences to
+   * other clients or to diagnostic tooling that echoes FCP messages. Callers may use the result to
+   * mirror the original request on another connection or to log the canonical wire representation.
+   *
+   * @return a new {@link SimpleFieldSet} containing the {@code Identifier} originally supplied;
+   *     flags are runtime-only and are not re-emitted.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", requestIdentifier);
     return fs;
   }
 
+  /**
+   * Returns the canonical FCP message name for status queries.
+   *
+   * <p>The literal string is used by both protocol dispatchers and logging facilities to label the
+   * message type. Keeping the value in a single constant avoids drift between serialization,
+   * documentation, and switch-based handling inside {@link FCPConnectionHandler}. The name does not
+   * vary with flags or runtime state, ensuring stable routing keys even when multiple status
+   * requests for different identifiers are in flight.
+   *
+   * @return the literal {@code "GetRequestStatus"} string used on the wire.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the query against the node and streams any pending status or data responses back to
+   * the requesting connection.
+   *
+   * <p>The handler is consulted for reboot-time queues first; if no match is found, the lookup is
+   * delegated to the persistent job runner. When a request is located, pending messages are pushed
+   * to the caller in the order maintained by {@link ClientRequest#sendPendingMessages}. If neither
+   * queue contains the identifier, a {@link ProtocolErrorMessage} is sent. When the client database
+   * has been killed, the method exits silently to match legacy behavior.
+   *
+   * @param handler connection-scoped dispatcher that resolves client requests and emits replies;
+   *     must not be null and typically represents the active FCP session.
+   * @param node owning node instance providing access to client cores and persistence; expected to
+   *     be fully initialized for job submission.
+   * @throws MessageInvalidException if the handler detects protocol-level validation problems
+   *     unrelated to missing identifiers.
+   */
   @Override
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    ClientRequest req = handler.getRebootRequest(global, handler, identifier);
+    ClientRequest req = handler.getRebootRequest(global, handler, requestIdentifier);
     if (req == null) {
       if (node.getClientCore().killedDatabase()) {
         // Ignore.
@@ -49,19 +123,20 @@ public class GetRequestStatusMessage extends FCPMessage {
             .queue(
                 (PersistentJob)
                     context -> {
-                      ClientRequest req1 = handler.getForeverRequest(global, handler, identifier);
+                      ClientRequest req1 =
+                          handler.getForeverRequest(global, handler, requestIdentifier);
                       if (req1 == null) {
                         ProtocolErrorMessage msg =
                             new ProtocolErrorMessage(
                                 ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
                                 false,
                                 null,
-                                identifier,
+                                requestIdentifier,
                                 global);
                         handler.send(msg);
                       } else {
                         req1.sendPendingMessages(
-                            handler.getOutputHandler(), identifier, true, onlyData);
+                            handler.getOutputHandler(), requestIdentifier, true, onlyData);
                       }
                       return false;
                     },
@@ -69,11 +144,11 @@ public class GetRequestStatusMessage extends FCPMessage {
       } catch (PersistenceDisabledException e) {
         ProtocolErrorMessage msg =
             new ProtocolErrorMessage(
-                ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
+                ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, requestIdentifier, global);
         handler.send(msg);
       }
     } else {
-      req.sendPendingMessages(handler.getOutputHandler(), identifier, true, onlyData);
+      req.sendPendingMessages(handler.getOutputHandler(), requestIdentifier, true, onlyData);
     }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GetRequestStatusMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetRequestStatusMessageTest.java
@@ -1,0 +1,226 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.io.NativeThread;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class GetRequestStatusMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FCPConnectionOutputHandler outputHandler;
+  @Mock private Node node;
+  @Mock private NodeClientCore nodeClientCore;
+
+  @Test
+  void constructor_whenFieldsPresent_setsFlagsAndIdentifier() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "abc");
+    fs.putSingle("Global", "true");
+    fs.putSingle("OnlyData", "true");
+
+    GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
+
+    assertEquals("abc", message.requestIdentifier);
+    assertTrue(message.global);
+    assertTrue(message.onlyData);
+  }
+
+  @Test
+  void getFieldSet_roundTripsIdentifier() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "roundTripId");
+    GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("roundTripId", fieldSet.get("Identifier"));
+    // Ensure other flags are not unintentionally copied into the outgoing field set
+    assertNull(fieldSet.get("Global"));
+    assertNull(fieldSet.get("OnlyData"));
+  }
+
+  @Test
+  void getName_returnsConstantName() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "id");
+
+    String result = new GetRequestStatusMessage(fs).getName();
+
+    assertEquals(GetRequestStatusMessage.NAME, result);
+  }
+
+  @Test
+  void run_whenRebootRequestExists_sendsPendingMessagesImmediately() throws Exception {
+    String identifier = "existing";
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", identifier);
+    fs.putSingle("OnlyData", "true");
+    GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
+
+    ClientRequest request = mock(ClientRequest.class);
+    when(handler.getRebootRequest(false, handler, identifier)).thenReturn(request);
+    when(handler.getOutputHandler()).thenReturn(outputHandler);
+
+    message.run(handler, node);
+
+    verify(request).sendPendingMessages(outputHandler, identifier, true, /* onlyData */ true);
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenRequestMissingAndDatabaseKilled_returnsWithoutSending() throws Exception {
+    String identifier = "missing";
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", identifier);
+    GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
+
+    when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    when(nodeClientCore.killedDatabase()).thenReturn(true);
+
+    message.run(handler, node);
+
+    verify(handler, never()).send(any());
+    verify(nodeClientCore).killedDatabase();
+    verifyNoMoreInteractions(nodeClientCore);
+  }
+
+  @Test
+  void run_whenMissingQueuesForeverRequestFound_sendsPendingMessages() throws Exception {
+    String identifier = "queued";
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", identifier);
+    GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
+
+    ClientRequest queuedRequest = mock(ClientRequest.class);
+    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
+    ClientContext context = contextWithJobRunner(jobRunner);
+
+    when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
+    when(handler.getForeverRequest(false, handler, identifier)).thenReturn(queuedRequest);
+    when(handler.getOutputHandler()).thenReturn(outputHandler);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    when(nodeClientCore.killedDatabase()).thenReturn(false);
+    when(nodeClientCore.getClientContext()).thenReturn(context);
+
+    message.run(handler, node);
+
+    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
+    verify(jobRunner).queue(jobCaptor.capture(), eq(normPriority()));
+
+    PersistentJob persistedJob = jobCaptor.getValue();
+    boolean checkpointRequested = persistedJob.run(context);
+
+    assertFalse(checkpointRequested);
+    verify(handler).getForeverRequest(false, handler, identifier);
+    verify(queuedRequest)
+        .sendPendingMessages(outputHandler, identifier, true, /* onlyData */ false);
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenMissingQueuesForeverRequestMissing_sendsProtocolError() throws Exception {
+    String identifier = "unknown";
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", identifier);
+    GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
+
+    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
+    ClientContext context = contextWithJobRunner(jobRunner);
+
+    when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
+    when(handler.getForeverRequest(false, handler, identifier)).thenReturn(null);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    when(nodeClientCore.killedDatabase()).thenReturn(false);
+    when(nodeClientCore.getClientContext()).thenReturn(context);
+
+    message.run(handler, node);
+
+    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
+    verify(jobRunner).queue(jobCaptor.capture(), eq(normPriority()));
+
+    PersistentJob persistedJob = jobCaptor.getValue();
+    persistedJob.run(context);
+
+    ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
+        ArgumentCaptor.forClass(ProtocolErrorMessage.class);
+    verify(handler).send(errorCaptor.capture());
+
+    ProtocolErrorMessage sent = errorCaptor.getValue();
+    assertNotNull(sent);
+    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, sent.code);
+    assertEquals(identifier, sent.ident);
+    assertFalse(sent.fatal);
+  }
+
+  @Test
+  void run_whenPersistenceDisabledOnQueue_sendsProtocolErrorImmediately() throws Exception {
+    String identifier = "noPersistence";
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", identifier);
+    GetRequestStatusMessage message = new GetRequestStatusMessage(fs);
+
+    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
+    ClientContext context = contextWithJobRunner(jobRunner);
+
+    when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    when(nodeClientCore.killedDatabase()).thenReturn(false);
+    when(nodeClientCore.getClientContext()).thenReturn(context);
+    doThrow(new PersistenceDisabledException()).when(jobRunner).queue(any(), eq(normPriority()));
+
+    message.run(handler, node);
+
+    ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
+        ArgumentCaptor.forClass(ProtocolErrorMessage.class);
+    verify(handler).send(errorCaptor.capture());
+
+    ProtocolErrorMessage error = errorCaptor.getValue();
+    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.code);
+    assertEquals(identifier, error.ident);
+    assertFalse(error.fatal);
+  }
+
+  private ClientContext contextWithJobRunner(PersistentJobRunner jobRunner) {
+    ClientContext context = mock(ClientContext.class);
+    try {
+      Field field = ClientContext.class.getDeclaredField("jobRunner");
+      field.setAccessible(true);
+      field.set(context, jobRunner);
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+    return context;
+  }
+
+  private int normPriority() {
+    return NativeThread.PriorityLevel.NORM_PRIORITY.value;
+  }
+}


### PR DESCRIPTION
## Summary
- rename the FCP status message identifier to requestIdentifier for clarity and add detailed Javadoc
- ensure pending-message replay uses the copied identifier consistently and improves error reporting
- add comprehensive unit tests covering reboot queue, persistent queue, and error paths

## Testing
- not run (not requested)