### PR TITLE
Clarify ListPeerMessage identifier handling

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ListPeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeerMessage.java
@@ -3,53 +3,120 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Client-to-node FCP message that requests detailed information about a specific peer maintained by
+ * the destination node.
+ *
+ * <p>This lightweight wrapper is used when a client needs the status of a single peer—for example
+ * to display link health or drive automated peer-admission decisions. It stores the caller-provided
+ * request identifier and the field set that supplies {@code NodeIdentifier} during execution. When
+ * run, the message enforces full-access permissions, validates the identifier, and emits either a
+ * populated {@link PeerMessage} or an {@link UnknownNodeIdentifierMessage} error. Instances hold no
+ * mutable state beyond the supplied {@link SimpleFieldSet}, allowing them to be passed across
+ * threads provided that field set is not mutated concurrently.
+ *
+ * <ul>
+ *   <li>Requires authenticated clients to have full FCP access before proceeding.
+ *   <li>Performs strict {@code NodeIdentifier} validation before touching network state.
+ *   <li>Emits structured protocol errors rather than silent failures for missing or unknown peers.
+ * </ul>
+ *
+ * @see PeerMessage
+ * @see UnknownNodeIdentifierMessage
+ */
 public class ListPeerMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ListPeerMessage.class);
 
   static final String NAME = "ListPeer";
 
   final SimpleFieldSet fs;
-  final String identifier;
+  final String requestIdentifier;
 
+  /**
+   * Builds the message from an incoming field set, capturing the request identifier and removing it
+   * from the payload.
+   *
+   * <p>The supplied {@link SimpleFieldSet} must include an {@code Identifier} entry used for
+   * correlating responses; it is extracted and deleted immediately to avoid forwarding client
+   * metadata unnecessarily. Callers may populate additional fields such as {@code NodeIdentifier}
+   * before invoking {@link #run(FCPConnectionHandler, Node)}. The constructor keeps a direct
+   * reference to the field set, so external mutations after construction will be visible during
+   * execution.
+   *
+   * @param fs mutable field set containing request metadata; must include {@code Identifier} and
+   *     should eventually include {@code NodeIdentifier}; must not be {@code null}.
+   */
   public ListPeerMessage(SimpleFieldSet fs) {
     this.fs = fs;
-    this.identifier = fs.get("Identifier");
+    this.requestIdentifier = fs.get("Identifier");
     fs.removeValue("Identifier");
   }
 
+  /**
+   * Provides the outgoing field set for serialization.
+   *
+   * <p>This implementation returns a new, empty {@link SimpleFieldSet} because all request data is
+   * consumed during {@link #run(FCPConnectionHandler, Node)}. Callers may mutate the returned set
+   * without affecting the original message.
+   *
+   * @return a freshly created, empty {@link SimpleFieldSet} instance.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Reports the protocol-level name used when this message travels over FCP.
+   *
+   * <p>The value is constant and shared by all instances; it is relied on by dispatchers to route
+   * incoming traffic and by logs or metrics to tag peer-list requests consistently.
+   *
+   * @return the literal message name {@code "ListPeer"}.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Validates permissions and peer identity, then responds with details or a suitable error.
+   *
+   * <p>The handler must expose full-access credentials; otherwise a {@link MessageInvalidException}
+   * with {@link ProtocolErrorMessage#ACCESS_DENIED} is thrown. A {@code NodeIdentifier} field is
+   * required and validated. Missing values cause a missing-field error; unknown peers produce an
+   * {@link UnknownNodeIdentifierMessage}. When the peer exists, a {@link PeerMessage} describing it
+   * is sent. The method is synchronous and read-only; it does not retry, cache results, or alter
+   * node state.
+   *
+   * @param handler connection handler that validates permissions and dispatches replies; must not
+   *     be {@code null}.
+   * @param node target node queried for peer information; must not be {@code null}.
+   * @throws MessageInvalidException when access is denied or required fields are absent.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "ListPeer requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "ListPeer requires full access",
+          requestIdentifier,
+          false);
     }
     String nodeIdentifier = fs.get("NodeIdentifier");
     if (nodeIdentifier == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "Error: NodeIdentifier field missing",
-          identifier,
+          requestIdentifier,
           false);
     }
     PeerNode pn = node.getPeerNode(nodeIdentifier);
     if (pn == null) {
-      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
+      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
       handler.send(msg);
       return;
     }
-    handler.send(new PeerMessage(pn, true, true, identifier));
+    handler.send(new PeerMessage(pn, true, true, requestIdentifier));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
@@ -1,0 +1,132 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ListPeerMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
+  @Mock private PeerNode peerNode;
+
+  @Test
+  void constructor_whenIdentifierProvided_removesIdentifierFromFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-1");
+    fs.putSingle("NodeIdentifier", "node-123");
+
+    ListPeerMessage message = new ListPeerMessage(fs);
+
+    assertEquals("req-1", message.requestIdentifier);
+    assertNull(fs.get("Identifier"));
+    assertEquals("node-123", fs.get("NodeIdentifier"));
+  }
+
+  @Test
+  void run_whenHandlerLacksFullAccess_throwsAccessDenied() {
+    when(handler.hasFullAccess()).thenReturn(false);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-2");
+    fs.putSingle("NodeIdentifier", "node-1");
+    ListPeerMessage message = new ListPeerMessage(fs);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
+    assertEquals("ListPeer requires full access", thrown.getMessage());
+    assertEquals("req-2", thrown.ident);
+    assertFalse(thrown.global, "Expected non-global error");
+    verify(handler, never()).send(any());
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void run_whenNodeIdentifierMissing_throwsMissingField() {
+    when(handler.hasFullAccess()).thenReturn(true);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-3");
+    ListPeerMessage message = new ListPeerMessage(fs);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, thrown.protocolCode);
+    assertEquals("Error: NodeIdentifier field missing", thrown.getMessage());
+    assertEquals("req-3", thrown.ident);
+    assertFalse(thrown.global, "Expected non-global error");
+    verify(handler, never()).send(any());
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws MessageInvalidException {
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode("node-unknown")).thenReturn(null);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-4");
+    fs.putSingle("NodeIdentifier", "node-unknown");
+    ListPeerMessage message = new ListPeerMessage(fs);
+
+    message.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    UnknownNodeIdentifierMessage unknownMsg =
+        assertInstanceOf(UnknownNodeIdentifierMessage.class, sent);
+    assertEquals("node-unknown", unknownMsg.nodeIdentifier);
+    assertEquals("req-4", unknownMsg.identifier);
+  }
+
+  @Test
+  void run_whenPeerFound_sendsPeerMessageWithMetadataAndVolatile() throws MessageInvalidException {
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode("node-42")).thenReturn(peerNode);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-5");
+    fs.putSingle("NodeIdentifier", "node-42");
+    ListPeerMessage message = new ListPeerMessage(fs);
+
+    message.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    PeerMessage peerMessage = assertInstanceOf(PeerMessage.class, captor.getValue());
+    assertEquals(peerNode, peerMessage.pn);
+    assertTrue(peerMessage.withMetadata);
+    assertTrue(peerMessage.withVolatile);
+    assertEquals("req-5", peerMessage.identifier);
+  }
+
+  @Test
+  void getFieldSet_alwaysReturnsEmptyFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-6");
+    ListPeerMessage message = new ListPeerMessage(fs);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertTrue(fieldSet.isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
- rename internal field to `requestIdentifier` and document ListPeerMessage lifecycle and validation
- add unit tests covering access control, missing identifier, unknown peer, and happy path responses

## Testing
- not run (not requested)