### PR TITLE
Add coverage and docs for IdentifierCollisionMessage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/IdentifierCollisionException.java
+++ b/src/main/java/network/crypta/clients/fcp/IdentifierCollisionException.java
@@ -2,7 +2,43 @@ package network.crypta.clients.fcp;
 
 import java.io.Serial;
 
-/** Thrown to indicate reuse of an Identifier. */
+/**
+ * Signals that a client-supplied identifier conflicts with one already registered in the FCP
+ * session or broader node context. The exception travels on the client-facing surface of the
+ * protocol layer so callers can distinguish collision failures from transport issues or generic
+ * validation errors. It carries no mutable state beyond the inherited message/cause chain, keeping
+ * instances lightweight and safe to propagate across threads, log, or retry pipelines without
+ * additional guarding. Typical usage is to throw this exception from code that rejects the
+ * conflicting identifier immediately and then map it to an {@code IdentifierCollision} reply for
+ * wire transmission.
+ *
+ * <p>Callers may choose whether to attach a human-readable message; a null message remains valid
+ * and preserves symmetry with the zero-argument constructor. Because this type extends {@link
+ * Exception}, it is a checked signal and encourages explicit handling at boundaries where
+ * user-supplied identifiers are parsed or reserved. It intentionally avoids automatic fallback
+ * behavior so the application can present clearer guidance to the user about selecting a unique
+ * identifier.
+ *
+ * <ul>
+ *   <li>Used when an identifier cannot be accepted due to duplication.
+ *   <li>Intended for immediate propagation to client-visible error mapping.
+ *   <li>Immutable and thread-safe; contains only the standard exception payload.
+ * </ul>
+ *
+ * @see IdentifierCollisionMessage
+ * @see FCPMessage
+ */
 public class IdentifierCollisionException extends Exception {
   @Serial private static final long serialVersionUID = -1;
+
+  /**
+   * Creates a new collision exception with no detail message so callers may add context later or
+   * rely on higher-level error mapping to produce user-facing text. The cause remains unset, which
+   * keeps the instance lightweight when constructed on hot paths where collisions are expected and
+   * not indicative of infrastructure failure.
+   */
+  public IdentifierCollisionException() {
+    // Intentionally empty: state lives in the base Exception and defaults suffice for collision
+    // signalling without extra payload.
+  }
 }

--- a/src/main/java/network/crypta/clients/fcp/IdentifierCollisionMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/IdentifierCollisionMessage.java
@@ -2,39 +2,106 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Represents the FCP notification emitted when a client-supplied identifier collides with an
+ * existing one on the node. The message is immutable, created by the server side, and sent to the
+ * client that attempted to register the duplicate identifier so the caller can pick a unique value
+ * before retrying. The {@code global} flag conveys whether the collision originated from a broader
+ * scope (for example, one shared across connections) or only within the current request context;
+ * higher layers decide how to interpret that scope and whether to retry automatically.
+ *
+ * <p>The class only serializes the collision metadata; it does not attempt to resolve or mutate any
+ * node state. It is safe for concurrent use because all fields are final and no mutable state is
+ * exposed. Typical usage is server-side construction followed by {@link #getFieldSet()} when
+ * marshalling an outbound FCP response. The {@link #run(FCPConnectionHandler, Node)} method
+ * intentionally rejects inbound execution because this message must not be sent from clients to the
+ * node.
+ *
+ * <ul>
+ *   <li>Encapsulates the offending client identifier and collision scope.
+ *   <li>Provides a stable, symbolic message name for FCP routing.
+ * </ul>
+ *
+ * @see FCPMessage
+ * @see FCPConnectionHandler
+ */
 public class IdentifierCollisionMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(IdentifierCollisionMessage.class);
 
-  final String identifier;
+  /** Client-specified identifier that triggered the collision. */
+  final String clientIdentifier;
+
   final boolean global;
 
+  /**
+   * Builds a collision message carrying the identifier supplied by the client and the collision
+   * scope indicator. The constructor performs no validation so that {@code null} identifiers and
+   * both possible scope values are preserved exactly as observed by the node when the conflict was
+   * detected. Instances produced here are intended for server-to-client delivery only.
+   *
+   * @param id client-provided identifier that already exists; may be {@code null} when the caller
+   *     omitted a value or sent an empty token.
+   * @param global whether the collision originated from a shared/global namespace rather than being
+   *     limited to the current connection or request context.
+   */
   public IdentifierCollisionMessage(String id, boolean global) {
-    this.identifier = id;
+    this.clientIdentifier = id;
     this.global = global;
   }
 
+  /**
+   * Produces the wire-ready {@link SimpleFieldSet} describing this collision. A fresh {@code
+   * SimpleFieldSet} instance is created on every call so callers can further mutate the payload
+   * without affecting other threads. The set always contains an {@code Identifier} entry reflecting
+   * the provided client value (which may be {@code null} or empty) and a boolean {@code Global}
+   * entry mirroring the stored scope flag. No normalization or de-duplication is performed here;
+   * higher layers are expected to interpret or sanitize values as needed before transmission.
+   *
+   * @return new field set with {@code Identifier} and {@code Global} keys suitable for outbound FCP
+   *     serialization; ownership is transferred to the caller.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
-    sfs.putSingle("Identifier", identifier);
+    sfs.putSingle("Identifier", clientIdentifier);
     sfs.put("Global", global);
     return sfs;
   }
 
+  /**
+   * Returns the canonical FCP message name used on the wire. The value is constant across all
+   * instances and callers and is suitable for routing, logging, or switch statements that dispatch
+   * on message type names. The method performs no allocation and is safe to call frequently from
+   * serialization pipelines or diagnostic code paths.
+   *
+   * @return the literal {@code "IdentifierCollision"} string identifying this message type in FCP
+   *     exchanges.
+   */
   @Override
   public String getName() {
     return "IdentifierCollision";
   }
 
+  /**
+   * Rejects attempts to execute this message in the client-to-server direction. If invoked, it
+   * immediately throws a {@link MessageInvalidException} describing that {@code
+   * IdentifierCollision} messages are outbound-only. The handler and node parameters are not used
+   * because the method always fails fast; they remain in the signature to comply with the
+   * superclass contract for inbound messages. Callers should never rely on this method returning
+   * normally.
+   *
+   * @param handler connection handler that received the message; ignored because execution always
+   *     aborts.
+   * @param node node instance tied to the connection; ignored because no processing occurs.
+   * @throws MessageInvalidException always thrown to signal the invalid message direction before
+   *     any state is modified or work is scheduled.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "IdentifierCollision goes from server to client not the other way around",
-        identifier,
+        clientIdentifier,
         global);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/IdentifierCollisionMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/IdentifierCollisionMessageTest.java
@@ -1,0 +1,69 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class IdentifierCollisionMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void getFieldSet_whenIdentifierAndGlobalProvided_expectFieldsSet() {
+    IdentifierCollisionMessage message = new IdentifierCollisionMessage("dup-id", true);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertEquals("dup-id", fieldSet.get("Identifier"));
+    assertEquals("true", fieldSet.get("Global"));
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierNull_expectIdentifierAbsentButGlobalPresent() {
+    IdentifierCollisionMessage message = new IdentifierCollisionMessage(null, false);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertNull(fieldSet.get("Identifier"));
+    assertEquals("false", fieldSet.get("Global"));
+  }
+
+  @Test
+  void getName_always_returnsIdentifierCollision() {
+    IdentifierCollisionMessage message = new IdentifierCollisionMessage("any", true);
+
+    assertEquals("IdentifierCollision", message.getName());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true,collision-one", "false,collision-two"})
+  void run_whenInvoked_expectMessageInvalidExceptionWithDetails(boolean global, String ident) {
+    IdentifierCollisionMessage message = new IdentifierCollisionMessage(ident, global);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "IdentifierCollision goes from server to client not the other way around",
+        exception.getMessage());
+    assertEquals(ident, exception.ident);
+    assertEquals(global, exception.global);
+  }
+}


### PR DESCRIPTION
## Summary
- clarify IdentifierCollision exception/message docs and field names
- add unit coverage for IdentifierCollisionMessage getFieldSet, getName, and run behaviors

## Testing
- not run (not requested)