### PR TITLE
Add coverage and docs for ListPeerNotesMessage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ListPeerNotesMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeerNotesMessage.java
@@ -4,39 +4,110 @@ import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Message that responds to an FCP request for a peer's private darknet note.
+ *
+ * <p>This message instance is created from an incoming {@link SimpleFieldSet} and keeps the
+ * provided request identifier so responses can be correlated by the requester. The message is
+ * effectively read-only after construction: it strips the {@code Identifier} field from the field
+ * set to prevent accidental forwarding and retains only the minimal state needed for routing.
+ * Typical use flows through {@link #run(FCPConnectionHandler, Node)} exactly once, where the
+ * handler performs access checks, resolves the targeted peer, and returns the current note content
+ * followed by {@link EndListPeerNotesMessage}.
+ *
+ * <p>Concurrency considerations: each instance is used by a single handler invocation and stores no
+ * mutable global state, so it is thread-confined by design. The lifetime is short-lived—created
+ * when the client issues the command and discarded immediately after the two response messages are
+ * sent. Persistent data (the note text) remains managed by the underlying {@link DarknetPeerNode}.
+ *
+ * <ul>
+ *   <li>Validates full-access session credentials before revealing peer notes.
+ *   <li>Checks that the target peer exists and belongs to the darknet subset.
+ *   <li>Streams the peer note and a terminator marker so clients can delimit the response.
+ * </ul>
+ */
 public class ListPeerNotesMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ListPeerNotesMessage.class);
 
   static final String NAME = "ListPeerNotes";
   final SimpleFieldSet fs;
-  final String identifier;
+  final String requestIdentifier;
 
+  /**
+   * Builds a message from raw fields supplied by the client transport layer.
+   *
+   * <p>The constructor copies the provided field set, extracts the optional {@code Identifier} into
+   * {@link #requestIdentifier}, and removes that key from the retained fields so it is not
+   * forwarded upstream. The remaining data is used to validate and locate the target peer when the
+   * message executes. Callers should supply a field set that already contains the {@code
+   * NodeIdentifier} describing the peer whose note should be listed.
+   *
+   * @param fs mutable field set received from the client; must include {@code Identifier} and
+   *     {@code NodeIdentifier} keys used to correlate the response
+   */
   public ListPeerNotesMessage(SimpleFieldSet fs) {
     this.fs = fs;
-    this.identifier = fs.get("Identifier");
+    this.requestIdentifier = fs.get("Identifier");
     fs.removeValue("Identifier");
   }
 
+  /**
+   * Returns a minimal field set representing this server-generated response.
+   *
+   * <p>The listing logic sends dedicated response messages rather than encoding data inside this
+   * object's field set. Consequently, this call intentionally returns a fresh, empty {@link
+   * SimpleFieldSet} with freenet-specific escaping enabled. The method is idempotent and creates a
+   * new instance each time so callers cannot accidentally mutate shared state. It should be used
+   * primarily by generic message code paths that expect a field-set representation even when none
+   * is meaningful.
+   *
+   * @return new empty field set ready for serialization by the FCP layer; callers may modify the
+   *     returned instance without affecting this message's internal state
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Provides the protocol-level name for this message type.
+   *
+   * <p>The returned value matches the identifier expected by FCP clients when requesting darknet
+   * peer notes. It is a stable constant so log messages and routing tables can rely on it for
+   * comparisons or switch statements. Because it performs no allocation beyond returning a string
+   * literal, it is safe for frequent use in performance-sensitive paths.
+   *
+   * @return string literal {@code "ListPeerNotes"} used for message dispatch and diagnostics
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the message by validating access and streaming the current note for a darknet peer.
+   *
+   * <p>The handler must possess full access privileges; otherwise a {@link MessageInvalidException}
+   * is thrown immediately. The method requires the {@code NodeIdentifier} field to be present in
+   * the stored {@link SimpleFieldSet}; missing or unknown identifiers trigger protocol-compliant
+   * error responses so clients can retry or repair the request. For darknet peers, the method sends
+   * a {@link PeerNote} containing the private comment text followed by an {@link
+   * EndListPeerNotesMessage} marker. Execution is single-pass and does not modify peer state.
+   *
+   * @param handler connection context used to check privileges and emit responses; must not be
+   *     {@code null}
+   * @param node local node context that resolves peer identifiers and provides stored note content;
+   *     must not be {@code null}
+   * @throws MessageInvalidException if access is denied, required fields are missing, or the target
+   *     peer is not a darknet peer
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,
           "ListPeerNotes requires full access",
-          identifier,
+          requestIdentifier,
           false);
     }
     String nodeIdentifier = fs.get("NodeIdentifier");
@@ -44,12 +115,12 @@ public class ListPeerNotesMessage extends FCPMessage {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "Error: NodeIdentifier field missing",
-          identifier,
+          requestIdentifier,
           false);
     }
     PeerNode pn = node.getPeerNode(nodeIdentifier);
     if (pn == null) {
-      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
+      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
       handler.send(msg);
       return;
     }
@@ -57,15 +128,17 @@ public class ListPeerNotesMessage extends FCPMessage {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DARKNET_ONLY,
           "ModifyPeer only available for darknet peers",
-          identifier,
+          requestIdentifier,
           false);
     }
-    // **FIXME** this should be generalized for multiple peer notes per peer, after PeerNode is
-    // similarly generalized
+    // Future enhancement: generalize for multiple peer notes per peer after PeerNode is updated
     String noteText = dpn.getPrivateDarknetCommentNote();
     handler.send(
         new PeerNote(
-            nodeIdentifier, noteText, Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT, identifier));
-    handler.send(new EndListPeerNotesMessage(nodeIdentifier, identifier));
+            nodeIdentifier,
+            noteText,
+            Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT,
+            requestIdentifier));
+    handler.send(new EndListPeerNotesMessage(nodeIdentifier, requestIdentifier));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
@@ -1,0 +1,170 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ListPeerNotesMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
+  @Mock private PeerNode peerNode;
+  @Mock private DarknetPeerNode darknetPeerNode;
+
+  @Test
+  void constructor_whenIdentifierProvided_removesIdentifierFromFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-1");
+    fs.putSingle("NodeIdentifier", "node-123");
+
+    ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
+
+    assertEquals("req-1", message.requestIdentifier);
+    assertNull(fs.get("Identifier"));
+    assertEquals("node-123", fs.get("NodeIdentifier"));
+  }
+
+  @Test
+  void getFieldSet_alwaysReturnsEmptyFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-2");
+
+    ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertTrue(fieldSet.isEmpty());
+  }
+
+  @Test
+  void getName_returnsConstantName() {
+    ListPeerNotesMessage message = new ListPeerNotesMessage(new SimpleFieldSet(true));
+
+    assertEquals(ListPeerNotesMessage.NAME, message.getName());
+  }
+
+  @Test
+  void run_whenHandlerLacksFullAccess_throwsAccessDenied() {
+    when(handler.hasFullAccess()).thenReturn(false);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-3");
+    fs.putSingle("NodeIdentifier", "node-1");
+    ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
+    assertEquals("ListPeerNotes requires full access", thrown.getMessage());
+    assertEquals("req-3", thrown.ident);
+    assertFalse(thrown.global, "Expected non-global error");
+    verify(handler, never()).send(any());
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void run_whenNodeIdentifierMissing_throwsMissingField() {
+    when(handler.hasFullAccess()).thenReturn(true);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-4");
+    ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, thrown.protocolCode);
+    assertEquals("Error: NodeIdentifier field missing", thrown.getMessage());
+    assertEquals("req-4", thrown.ident);
+    assertFalse(thrown.global, "Expected non-global error");
+    verify(handler, never()).send(any());
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws MessageInvalidException {
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode("node-unknown")).thenReturn(null);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-5");
+    fs.putSingle("NodeIdentifier", "node-unknown");
+    ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
+
+    message.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    UnknownNodeIdentifierMessage unknownMsg =
+        assertInstanceOf(UnknownNodeIdentifierMessage.class, captor.getValue());
+    assertEquals("node-unknown", unknownMsg.nodeIdentifier);
+    assertEquals("req-5", unknownMsg.identifier);
+    verifyNoMoreInteractions(handler);
+  }
+
+  @Test
+  void run_whenPeerIsNotDarknet_throwsDarknetOnly() {
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode("node-2")).thenReturn(peerNode);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-6");
+    fs.putSingle("NodeIdentifier", "node-2");
+    ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.DARKNET_ONLY, thrown.protocolCode);
+    assertEquals("ModifyPeer only available for darknet peers", thrown.getMessage());
+    assertEquals("req-6", thrown.ident);
+    assertFalse(thrown.global, "Expected non-global error");
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenPeerIsDarknet_sendsPeerNoteAndEndMessage() throws MessageInvalidException {
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode("node-3")).thenReturn(darknetPeerNode);
+    when(darknetPeerNode.getPrivateDarknetCommentNote()).thenReturn("secret-note");
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-7");
+    fs.putSingle("NodeIdentifier", "node-3");
+    ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
+
+    message.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(2)).send(captor.capture());
+    verifyNoMoreInteractions(handler);
+
+    PeerNote peerNote = assertInstanceOf(PeerNote.class, captor.getAllValues().getFirst());
+    assertEquals("node-3", peerNote.nodeIdentifier);
+    assertEquals("secret-note", peerNote.noteText);
+    assertEquals(Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT, peerNote.peerNoteType);
+    assertEquals("req-7", peerNote.identifier);
+
+    EndListPeerNotesMessage endMessage =
+        assertInstanceOf(EndListPeerNotesMessage.class, captor.getAllValues().get(1));
+    assertEquals("node-3", endMessage.nodeIdentifier);
+  }
+}


### PR DESCRIPTION
## Summary
- document ListPeerNotesMessage lifecycle and identifier handling
- rename internal identifier field to requestIdentifier for clarity
- add comprehensive unit tests covering access control, missing fields, unknown peers, non-darknet peers, and darknet success path

## Testing
- not run (not requested)