### PR TITLE
refactor: clarify ListPeersMessage handling

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ListPeersMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeersMessage.java
@@ -3,45 +3,113 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Represents the {@code ListPeers} FCP command sent from a client to the node to obtain the current
+ * set of known peers.
+ *
+ * <p>This message is read-only and simply instructs the node to enumerate its peers without
+ * changing state. Instances are immutable once created; the flags provided by the client are stored
+ * in final fields and reused when generating individual peer responses. Typical callers create one
+ * instance per request, hand it to the {@link FCPConnectionHandler}, and rely on the handler to
+ * stream {@link PeerMessage} objects back to the client followed by {@link EndListPeersMessage} as
+ * a terminator.
+ *
+ * <p>Use this command when a UI or monitoring tool needs a snapshot of active peers along with
+ * optional metadata or volatile runtime statistics. The message runs within the handler's thread
+ * and assumes the handler has full access; access checks occur before any network I/O to avoid
+ * exposing partial data. Because processing only iterates over the current peer array and sends
+ * each entry, runtime scales linearly with peer count.
+ *
+ * <ul>
+ *   <li>Includes metadata when {@code WithMetadata=true} in the source field set.
+ *   <li>Includes volatile runtime counters when {@code WithVolatile=true} is present.
+ *   <li>Always appends a terminal {@code EndListPeers} message to mark completion.
+ * </ul>
+ */
 public class ListPeersMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ListPeersMessage.class);
 
   final boolean withMetadata;
   final boolean withVolatile;
-  final String identifier;
+  final String requestIdentifier;
   static final String NAME = "ListPeers";
 
+  /**
+   * Builds a message instance from the inbound {@link SimpleFieldSet} supplied by the FCP client.
+   *
+   * <p>The field set is expected to contain boolean flags named {@code WithMetadata} and {@code
+   * WithVolatile}; missing entries default to {@code false}. The constructor also captures the
+   * caller-provided {@code Identifier} so downstream responses can be correlated by the client
+   * connection. The identifier is removed from the field set to avoid forwarding it back in peer
+   * responses.
+   *
+   * @param fs field collection originating from the client request; must not be {@code null} and
+   *     may include {@code WithMetadata}, {@code WithVolatile}, and {@code Identifier} entries.
+   */
   public ListPeersMessage(SimpleFieldSet fs) {
     withMetadata = fs.getBoolean("WithMetadata", false);
     withVolatile = fs.getBoolean("WithVolatile", false);
-    this.identifier = fs.get("Identifier");
-    fs.removeValue("Identifier");
+    this.requestIdentifier = fs.get(FCPMessage.IDENTIFIER);
+    fs.removeValue(FCPMessage.IDENTIFIER);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This command does not require a request body, so it returns an empty, ordered {@link
+   * SimpleFieldSet}. Callers should not mutate the returned instance.
+   *
+   * @return fresh field set containing only a root node, suitable for immediate serialization.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The literal name {@code ListPeers} is stable and defined by the FCP protocol. Clients send
+   * this value in the {@code MessageName} field to request peer enumeration.
+   *
+   * @return static protocol string {@code ListPeers} used to dispatch this message type.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the request by streaming peer details to the connected client.
+   *
+   * <p>The handler must have full access; otherwise a {@link ProtocolErrorMessage#ACCESS_DENIED}
+   * response is sent via {@link MessageInvalidException}. When authorized, the method iterates the
+   * node's current peer list, emits a {@link PeerMessage} for each peer with the selected metadata
+   * flags, and finally emits {@link EndListPeersMessage} to signal completion. Execution occurs on
+   * the handler's thread, so callers should avoid invoking it from long-running blocking contexts
+   * to keep connection responsiveness predictable.
+   *
+   * @param handler connection handler responsible for sending responses; must already be
+   *     authenticated for full access.
+   * @param node node instance supplying the current peers; expected to return a live snapshot via
+   *     {@link Node#getPeerNodes()}.
+   * @throws MessageInvalidException when the handler lacks required access rights or when message
+   *     validation fails before any peer data is returned.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "ListPeers requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "ListPeers requires full access",
+          requestIdentifier,
+          false);
     }
     PeerNode[] nodes = node.getPeerNodes();
     for (PeerNode pn : nodes) {
-      handler.send(new PeerMessage(pn, withMetadata, withVolatile, identifier));
+      handler.send(new PeerMessage(pn, withMetadata, withVolatile, requestIdentifier));
     }
 
-    handler.send(new EndListPeersMessage(identifier));
+    handler.send(new EndListPeersMessage(requestIdentifier));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ListPeersMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeersMessageTest.java
@@ -1,0 +1,147 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ListPeersMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
+  @Mock private PeerNode peerOne;
+  @Mock private PeerNode peerTwo;
+
+  @Test
+  void constructor_whenFieldsPresent_setsFlagsAndStripsIdentifierFromFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(false);
+    fs.putSingle("WithMetadata", "true");
+    fs.putSingle("WithVolatile", "false");
+    fs.putSingle("Identifier", "req-123");
+
+    ListPeersMessage message = new ListPeersMessage(fs);
+
+    assertTrue(message.withMetadata);
+    assertFalse(message.withVolatile);
+    assertEquals("req-123", message.requestIdentifier);
+    assertNull(fs.get("Identifier"));
+  }
+
+  @Test
+  void constructor_whenFieldsMissing_usesDefaults() {
+    SimpleFieldSet fs = new SimpleFieldSet(false);
+
+    ListPeersMessage message = new ListPeersMessage(fs);
+
+    assertFalse(message.withMetadata);
+    assertFalse(message.withVolatile);
+    assertNull(message.requestIdentifier);
+  }
+
+  @Test
+  void run_whenNoFullAccess_throwsAccessDeniedAndDoesNotSend() {
+    ListPeersMessage message = new ListPeersMessage(buildFieldSet(false, false, "id-1"));
+    when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
+    assertEquals("id-1", ex.ident);
+    verify(node, never()).getPeerNodes();
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenFullAccess_sendsEachPeerFollowedByEnd() throws MessageInvalidException {
+    ListPeersMessage message = new ListPeersMessage(buildFieldSet(true, true, "identifier"));
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNodes()).thenReturn(new PeerNode[] {peerOne, peerTwo});
+
+    message.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(3)).send(captor.capture());
+
+    List<FCPMessage> sentMessages = captor.getAllValues();
+    assertEquals(3, sentMessages.size());
+
+    PeerMessage firstPeer = (PeerMessage) sentMessages.getFirst();
+    assertEquals(peerOne, firstPeer.pn);
+    assertTrue(firstPeer.withMetadata);
+    assertTrue(firstPeer.withVolatile);
+    assertEquals("identifier", firstPeer.identifier);
+
+    PeerMessage secondPeer = (PeerMessage) sentMessages.get(1);
+    assertEquals(peerTwo, secondPeer.pn);
+    assertTrue(secondPeer.withMetadata);
+    assertTrue(secondPeer.withVolatile);
+    assertEquals("identifier", secondPeer.identifier);
+
+    EndListPeersMessage endMessage = (EndListPeersMessage) sentMessages.get(2);
+    assertEquals("identifier", endMessage.getFieldSet().get("Identifier"));
+
+    InOrder order = inOrder(handler);
+    order.verify(handler).send(sentMessages.get(0));
+    order.verify(handler).send(sentMessages.get(1));
+    order.verify(handler).send(sentMessages.get(2));
+  }
+
+  @Test
+  void run_whenNoPeersStillEmitsEndMarker() throws MessageInvalidException {
+    ListPeersMessage message = new ListPeersMessage(buildFieldSet(false, false, null));
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNodes()).thenReturn(new PeerNode[0]);
+
+    message.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(1)).send(captor.capture());
+    assertInstanceOf(EndListPeersMessage.class, captor.getValue());
+  }
+
+  @Test
+  void getName_returnsProtocolLiteral() {
+    ListPeersMessage message = new ListPeersMessage(buildFieldSet(false, false, null));
+
+    assertEquals("ListPeers", message.getName());
+  }
+
+  @Test
+  void getFieldSet_returnsEmptyFieldSet() {
+    ListPeersMessage message = new ListPeersMessage(buildFieldSet(false, false, null));
+
+    assertTrue(message.getFieldSet().isEmpty());
+  }
+
+  private SimpleFieldSet buildFieldSet(boolean withMetadata, boolean withVolatile, String id) {
+    SimpleFieldSet fs = new SimpleFieldSet(false);
+    fs.putSingle("WithMetadata", Boolean.toString(withMetadata));
+    fs.putSingle("WithVolatile", Boolean.toString(withVolatile));
+    if (id != null) {
+      fs.putSingle("Identifier", id);
+    }
+    return fs;
+  }
+}


### PR DESCRIPTION
## Summary
- document ListPeersMessage and rename identifier field to requestIdentifier for clarity and consistent routing
- use the captured identifier when sending peer and end messages
- add Mockito-based ListPeersMessageTest covering access checks, peer streaming order, end marker emission, and defaults

## Testing
- Not run (not requested)