### PR TITLE
Improve ModifyConfig option updates

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ModifyConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyConfig.java
@@ -8,68 +8,160 @@ import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Handles the {@code ModifyConfig} FCP request by applying configuration updates supplied by the
+ * client.
+ *
+ * <p>This message consumes a {@link SimpleFieldSet} whose keys mirror the hierarchical names of
+ * {@link Option} instances in the node configuration. The constructor captures the request
+ * identifier up front and strips it from the field set so only option names remain. During {@link
+ * #run(FCPConnectionHandler, Node)} every {@link SubConfig} is traversed and each option is updated
+ * when a matching key exists. Values identical to the current configuration are ignored to avoid
+ * redundant writes.
+ *
+ * <p>The message requires the connection to possess full access; otherwise it terminates early with
+ * a {@link MessageInvalidException}. After successful updates, the configuration is persisted via
+ * the client core and a fresh {@link ConfigData} response is sent so callers can confirm the
+ * effective state.
+ *
+ * <ul>
+ *   <li>Responsibility: reconcile client-supplied option values with the in-memory configuration.
+ *   <li>Persistence: flushes changes to disk before replying.
+ *   <li>Threading: intended for use on the handler thread; no internal synchronization is added.
+ * </ul>
+ *
+ * @see ConfigData
+ * @see Option
+ * @see SubConfig
+ */
 public class ModifyConfig extends FCPMessage {
   private static final Logger LOG = LoggerFactory.getLogger(ModifyConfig.class);
 
   static final String NAME = "ModifyConfig";
 
   final SimpleFieldSet fs;
-  final String identifier;
+  final String requestIdentifier;
 
+  /**
+   * Builds a new message wrapper around the incoming field set so option updates can be applied
+   * later.
+   *
+   * <p>The supplied field set should contain the {@code Identifier} key alongside option values in
+   * dotted form (for example {@code node.opennet.enabled}). The identifier is removed from the
+   * stored copy because it is forwarded separately when the response is emitted.
+   *
+   * @param fs mutable field set holding the message identifier and requested option values; must
+   *     not be {@code null} and should use fully qualified option names as keys.
+   */
   public ModifyConfig(SimpleFieldSet fs) {
     this.fs = fs;
-    this.identifier = fs.get("Identifier");
+    this.requestIdentifier = fs.get("Identifier");
     fs.removeValue("Identifier");
   }
 
+  /**
+   * Returns an empty field set because outgoing {@code ModifyConfig} messages carry no payload.
+   *
+   * <p>This message type is purely request-oriented: clients send option overrides and expect a
+   * {@link ConfigData} reply rather than a chained payload. Returning a fresh, empty structure
+   * maintains symmetry with other message classes while signalling to callers that no additional
+   * fields need to be serialized. The field set remains mutable so downstream code can augment it
+   * if protocol extensions are introduced.
+   *
+   * @return new {@link SimpleFieldSet} instance with {@code true} indicating case-insensitive key
+   *     handling; callers receive ownership of the returned object.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Reports the protocol-level message name recognized by FCP peers.
+   *
+   * <p>The name is stable and used for dispatch tables, access-control checks, and logging so that
+   * FCP clients can map responses to the initiating command. Keeping the constant centralized in
+   * {@link #NAME} ensures the identifier stays synchronized across factory methods and tests, and
+   * avoids typos in protocol exchanges.
+   *
+   * @return fixed string {@code "ModifyConfig"} used when registering or dispatching the message
+   *     type.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Applies the requested configuration updates and emits the latest configuration snapshot.
+   *
+   * <p>The method first enforces that the connection holds full access privileges; otherwise a
+   * {@link MessageInvalidException} is thrown back to the caller. It then iterates through every
+   * {@link SubConfig} and {@link Option} pairing, invoking {@link #updateOption(String, Option)} to
+   * reconcile differences between the incoming field set and the node's current configuration. When
+   * modifications occur, the configuration is persisted before a {@link ConfigData} message is
+   * returned so clients can verify the applied values.
+   *
+   * <pre>{@code
+   * // Typical server-side handling path
+   * new ModifyConfig(requestFields).run(handler, node);
+   * }</pre>
+   *
+   * @param handler connection-specific dispatcher required to validate access and send responses;
+   *     must not be {@code null} and should support full access for this message.
+   * @param node target node whose configuration is adjusted; expected to be initialized and ready
+   *     for persistence operations.
+   * @throws MessageInvalidException if the connection lacks full access or the message is not
+   *     permitted in the current context.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,
           "ModifyConfig requires full access",
-          identifier,
+          requestIdentifier,
           false);
     }
     Config config = node.getConfig();
 
-    boolean logMINOR = LOG.isDebugEnabled();
-
     for (SubConfig sc : config.getConfigs()) {
       String prefix = sc.getPrefix();
-      for (Option<?> o : sc.getOptions()) {
-        String configName = o.getName();
-        if (LOG.isDebugEnabled()) LOG.debug("Setting " + prefix + '.' + configName);
-
-        // we ignore unreconized parameters
-        String s = fs.get(prefix + '.' + configName);
-        if (s != null) {
-          if (!(o.getValueString().equals(s))) {
-            if (LOG.isDebugEnabled())
-              LOG.debug("Setting " + prefix + '.' + configName + " to " + s);
-            try {
-              o.setValue(s);
-            } catch (Exception e) {
-              // Bad values silently fail from an FCP perspective, but the FCP client can tell if a
-              // change took by comparing ConfigData messages before and after
-              LOG.error("Caught " + e, e);
-            }
-          }
-        }
+      for (Option<?> option : sc.getOptions()) {
+        updateOption(prefix, option);
       }
     }
     node.getClientCore().storeConfig();
     handler.send(
-        new ConfigData(node, true, false, false, false, false, false, false, false, identifier));
+        new ConfigData(
+            node, true, false, false, false, false, false, false, false, requestIdentifier));
+  }
+
+  /**
+   * Updates a single option when the incoming field set provides a new value.
+   *
+   * <p>Only different values are applied; unchanged entries are skipped to avoid unnecessary work
+   * and log noise. Invalid values are reported via the logger but do not interrupt processing so
+   * the remaining options can still be evaluated.
+   */
+  private void updateOption(String prefix, Option<?> option) {
+    String configName = option.getName();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Setting {}.{}", prefix, configName);
+    }
+    String value = fs.get(prefix + '.' + configName);
+    if (value == null || option.getValueString().equals(value)) {
+      return;
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Setting {}.{} to {}", prefix, configName, value);
+    }
+    try {
+      option.setValue(value);
+    } catch (Exception e) {
+      // Bad values silently fail from an FCP perspective, but the FCP client can tell if a change
+      // took by comparing ConfigData messages before and after
+      LOG.error("Caught {}", e, e);
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ModifyConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyConfigTest.java
@@ -1,0 +1,207 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.StringOption;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.StringCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ModifyConfigTest {
+
+  @Mock FCPConnectionHandler handler;
+
+  @Mock Node node;
+
+  @Mock NodeClientCore clientCore;
+
+  @Test
+  void constructor_whenIdentifierPresent_storesItAndRemovesFromFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "id-42");
+
+    ModifyConfig modifyConfig = new ModifyConfig(fs);
+
+    assertEquals("id-42", modifyConfig.requestIdentifier);
+    assertNull(fs.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenCalled_returnsEmptySimpleFieldSet() {
+    ModifyConfig modifyConfig = new ModifyConfig(new SimpleFieldSet(true));
+
+    SimpleFieldSet result = modifyConfig.getFieldSet();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void getName_whenCalled_returnsConstantName() {
+    ModifyConfig modifyConfig = new ModifyConfig(new SimpleFieldSet(true));
+
+    assertEquals("ModifyConfig", modifyConfig.getName());
+  }
+
+  @Test
+  void run_whenHandlerLacksFullAccess_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "blocked-id");
+    ModifyConfig modifyConfig = new ModifyConfig(fs);
+    when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> modifyConfig.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
+    assertEquals("blocked-id", thrown.ident);
+    assertEquals("ModifyConfig requires full access", thrown.getMessage());
+    assertFalse(thrown.global);
+    verify(handler, never()).send(any(FCPMessage.class));
+  }
+
+  @Test
+  void run_whenValueDiffers_updatesOptionStoresConfigAndSendsReply() throws Exception {
+    PersistentConfig config = new PersistentConfig(null);
+    SubConfig subConfig = config.createSubConfig("node");
+    CountingStringCallback callback = new CountingStringCallback("5");
+    StringOption option =
+        new StringOption(subConfig, "maxPeers", "5", 0, false, false, null, null, callback);
+    subConfig.register(option);
+    when(node.getConfig()).thenReturn(config);
+    when(node.getClientCore()).thenReturn(clientCore);
+    when(handler.hasFullAccess()).thenReturn(true);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "cfg-1");
+    fs.putSingle("node.maxPeers", "10");
+    ModifyConfig modifyConfig = new ModifyConfig(fs);
+
+    modifyConfig.run(handler, node);
+
+    assertEquals(1, callback.getSetCount());
+    assertEquals("10", option.getValueString());
+    assertEquals("10", callback.getCurrentValue());
+    InOrder order = inOrder(clientCore, handler);
+    order.verify(clientCore).storeConfig();
+    ArgumentCaptor<ConfigData> captor = ArgumentCaptor.forClass(ConfigData.class);
+    order.verify(handler).send(captor.capture());
+    ConfigData sent = captor.getValue();
+    assertEquals(node, sent.node);
+    assertEquals("cfg-1", sent.requestIdentifier);
+  }
+
+  @Test
+  void run_whenValueUnchanged_doesNotInvokeSetValueButStillStoresAndSends() throws Exception {
+    PersistentConfig config = new PersistentConfig(null);
+    SubConfig subConfig = config.createSubConfig("ui");
+    CountingStringCallback callback = new CountingStringCallback("light");
+    StringOption option =
+        new StringOption(subConfig, "theme", "light", 0, false, false, null, null, callback);
+    subConfig.register(option);
+    when(node.getConfig()).thenReturn(config);
+    when(node.getClientCore()).thenReturn(clientCore);
+    when(handler.hasFullAccess()).thenReturn(true);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "cfg-2");
+    fs.putSingle("ui.theme", "light");
+    ModifyConfig modifyConfig = new ModifyConfig(fs);
+
+    modifyConfig.run(handler, node);
+
+    assertEquals(0, callback.getSetCount());
+    assertEquals("light", option.getValueString());
+    verify(clientCore).storeConfig();
+    verify(handler).send(any(ConfigData.class));
+  }
+
+  @Test
+  void run_whenOptionUpdateFails_continuesToStoreAndRespond() throws Exception {
+    PersistentConfig config = new PersistentConfig(null);
+    SubConfig subConfig = config.createSubConfig("net");
+    ThrowingStringCallback callback = new ThrowingStringCallback("8080");
+    StringOption failingOption =
+        new StringOption(subConfig, "port", "8080", 0, false, false, null, null, callback);
+    subConfig.register(failingOption);
+    when(node.getConfig()).thenReturn(config);
+    when(node.getClientCore()).thenReturn(clientCore);
+    when(handler.hasFullAccess()).thenReturn(true);
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "cfg-3");
+    fs.putSingle("net.port", "9090");
+    ModifyConfig modifyConfig = new ModifyConfig(fs);
+
+    modifyConfig.run(handler, node);
+
+    assertEquals("8080", failingOption.getValueString());
+    verify(clientCore).storeConfig();
+    verify(handler).send(any(ConfigData.class));
+  }
+
+  private static final class CountingStringCallback extends StringCallback {
+    private int setCount;
+    private String currentValue;
+
+    CountingStringCallback(String initialValue) {
+      this.currentValue = initialValue;
+    }
+
+    @Override
+    public String get() {
+      return currentValue;
+    }
+
+    @Override
+    public void set(String val) {
+      setCount++;
+      currentValue = val;
+    }
+
+    int getSetCount() {
+      return setCount;
+    }
+
+    String getCurrentValue() {
+      return currentValue;
+    }
+  }
+
+  private static final class ThrowingStringCallback extends StringCallback {
+    private final String currentValue;
+
+    ThrowingStringCallback(String currentValue) {
+      this.currentValue = currentValue;
+    }
+
+    @Override
+    public String get() {
+      return currentValue;
+    }
+
+    @Override
+    public void set(String val) throws InvalidConfigValueException {
+      throw new InvalidConfigValueException("boom");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor ModifyConfig to streamline option updates and add richer Javadoc
- extract option update into helper with clearer logging/error handling
- add unit coverage for ModifyConfig happy path, unchanged values, and invalid updates

## Testing
- not run (not requested)