### PR TITLE
refactor: clarify ModifyPeer handling

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ModifyPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeer.java
@@ -1,54 +1,120 @@
 package network.crypta.clients.fcp;
 
+import java.util.function.Consumer;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.support.Fields;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Handles the FCP {@code ModifyPeer} command, allowing a client to toggle operational flags on an
+ * existing darknet peer. The message is constructed from a {@link SimpleFieldSet} that contains the
+ * peer identifier and optional boolean switches. During execution, the handler verifies that the
+ * caller has full access, resolves the target peer, enforces that it is a darknet node, and then
+ * applies the requested changes before returning the updated peer description to the client.
+ *
+ * <p>Use this class when a client needs to adjust connectivity characteristics for a known peer
+ * without recreating or deleting it. Typical call patterns originate from the FCP server loop,
+ * which instantiates this message from incoming fields and delegates execution to {@link #run}. The
+ * implementation delegates synchronization and persistence concerns to {@link Node} and peer
+ * implementations; it performs only the protocol-level validation and flag translation. Flags are
+ * optional and omitted values leave existing peer settings unchanged.
+ *
+ * <ul>
+ *   <li>Checks for full-access permissions before applying any change.
+ *   <li>Supports toggling disabled, listen-only, burst-only, source-port ignoring, and
+ *       local-address allowance states.
+ *   <li>Always responds with a refreshed {@link PeerMessage} so clients can observe the resulting
+ *       configuration.
+ * </ul>
+ *
+ * @see FCPMessage
+ * @see PeerMessage
+ * @see DarknetPeerNode
+ */
 public class ModifyPeer extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ModifyPeer.class);
-
   static final String NAME = "ModifyPeer";
 
   final SimpleFieldSet fs;
-  final String identifier;
+  final String requestIdentifier;
 
+  /**
+   * Creates a new message instance sourced from the provided field set and extracts the request
+   * identifier for later error reporting. The constructor removes the {@code Identifier} entry from
+   * the payload so it is not forwarded when the message is echoed back to clients after processing.
+   * The field set is not deep-copied; callers should avoid reusing it after construction if they
+   * need the identifier value.
+   *
+   * @param fs field set containing incoming {@code ModifyPeer} parameters; must include an {@code
+   *     Identifier} token and peer-selection fields.
+   */
   public ModifyPeer(SimpleFieldSet fs) {
     this.fs = fs;
-    this.identifier = fs.get("Identifier");
+    this.requestIdentifier = fs.get(IDENTIFIER);
     fs.removeValue("Identifier");
   }
 
+  /**
+   * Returns the outgoing field set for this message. {@code ModifyPeer} replies do not carry
+   * additional fields at this stage because the updated peer details are encapsulated in the
+   * resulting {@link PeerMessage}. A fresh, empty {@link SimpleFieldSet} is returned to satisfy the
+   * FCP message contract while avoiding redundant data.
+   *
+   * @return new {@link SimpleFieldSet} with no entries, ready for protocol serialization.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Provides the protocol-level name used to register and dispatch this message type within the FCP
+   * handler. The name is stable and matches the {@code ModifyPeer} verb understood by clients,
+   * enabling straightforward routing from the message parser to this implementation without
+   * additional aliasing or negotiation steps.
+   *
+   * @return constant string {@code "ModifyPeer"} representing this FCP message name.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the {@code ModifyPeer} request against the supplied node on behalf of the current
+   * connection. The method enforces full-access permissions, validates that a {@code
+   * NodeIdentifier} is provided, and confirms that the referenced peer exists and belongs to the
+   * darknet cohort. For each optional flag supplied in the field set, it toggles the corresponding
+   * state on the peer; absent flags leave existing settings unchanged. After updates, it returns
+   * the refreshed peer description to the client.
+   *
+   * @param handler connection handler that mediates access checks and message delivery for the
+   *     caller; must support full-access operations.
+   * @param node node instance that stores peer records and applies requested state changes.
+   * @throws MessageInvalidException if access is denied, required fields are missing, or the target
+   *     peer is not available as a darknet peer.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "ModifyPeer requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "ModifyPeer requires full access",
+          requestIdentifier,
+          false);
     }
     String nodeIdentifier = fs.get("NodeIdentifier");
     if (nodeIdentifier == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "Error: NodeIdentifier field missing",
-          identifier,
+          requestIdentifier,
           false);
     }
     PeerNode pn = node.getPeerNode(nodeIdentifier);
     if (pn == null) {
-      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
+      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, requestIdentifier);
       handler.send(msg);
       return;
     }
@@ -56,43 +122,34 @@ public class ModifyPeer extends FCPMessage {
       throw new MessageInvalidException(
           ProtocolErrorMessage.DARKNET_ONLY,
           "ModifyPeer only available for darknet peers",
-          identifier,
+          requestIdentifier,
           false);
     }
-    String isDisabledString = fs.get("IsDisabled");
-    if (isDisabledString != null) {
-      if (!isDisabledString.isEmpty()) {
-        if (Fields.stringToBool(isDisabledString, false)) {
-          dpn.disablePeer();
-        } else {
-          dpn.enablePeer();
-        }
+    applyDisableFlag(dpn, fs.get("IsDisabled"));
+    applyBooleanFlag(dpn::setListenOnly, fs.get("IsListenOnly"));
+    applyBooleanFlag(dpn::setBurstOnly, fs.get("IsBurstOnly"));
+    applyBooleanFlag(dpn::setIgnoreSourcePort, fs.get("IgnoreSourcePort"));
+    applyBooleanFlag(dpn::setAllowLocalAddresses, fs.get("AllowLocalAddresses"));
+    handler.send(new PeerMessage(pn, true, true, requestIdentifier));
+  }
+
+  private static void applyDisableFlag(DarknetPeerNode dpn, String disableFlag) {
+    if (isNonEmpty(disableFlag)) {
+      if (Fields.stringToBool(disableFlag, false)) {
+        dpn.disablePeer();
+      } else {
+        dpn.enablePeer();
       }
     }
-    String isListenOnlyString = fs.get("IsListenOnly");
-    if (isListenOnlyString != null) {
-      if (!isListenOnlyString.isEmpty()) {
-        dpn.setListenOnly(Fields.stringToBool(isListenOnlyString, false));
-      }
+  }
+
+  private static void applyBooleanFlag(Consumer<Boolean> setter, String flagValue) {
+    if (isNonEmpty(flagValue)) {
+      setter.accept(Fields.stringToBool(flagValue, false));
     }
-    String isBurstOnlyString = fs.get("IsBurstOnly");
-    if (isBurstOnlyString != null) {
-      if (!isBurstOnlyString.isEmpty()) {
-        dpn.setBurstOnly(Fields.stringToBool(isBurstOnlyString, false));
-      }
-    }
-    String ignoreSourcePortString = fs.get("IgnoreSourcePort");
-    if (ignoreSourcePortString != null) {
-      if (!ignoreSourcePortString.isEmpty()) {
-        dpn.setIgnoreSourcePort(Fields.stringToBool(ignoreSourcePortString, false));
-      }
-    }
-    String allowLocalAddressesString = fs.get("AllowLocalAddresses");
-    if (allowLocalAddressesString != null) {
-      if (!allowLocalAddressesString.isEmpty()) {
-        dpn.setAllowLocalAddresses(Fields.stringToBool(allowLocalAddressesString, false));
-      }
-    }
-    handler.send(new PeerMessage(pn, true, true, identifier));
+  }
+
+  private static boolean isNonEmpty(String value) {
+    return value != null && !value.isEmpty();
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
@@ -1,0 +1,196 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ModifyPeerTest {
+
+  private static final String IDENTIFIER = "req-1";
+  private static final String NODE_IDENTIFIER = "peer-123";
+
+  @Mock FCPConnectionHandler handler;
+  @Mock Node node;
+  @Mock DarknetPeerNode darknetPeerNode;
+  @Mock PeerNode peerNode;
+
+  @Test
+  void getName_returnsModifyPeerLiteral() {
+    SimpleFieldSet fs = baseFieldSet();
+
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+
+    assertEquals("ModifyPeer", modifyPeer.getName());
+  }
+
+  @Test
+  void getFieldSet_returnsEmptyFieldSet() {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+
+    assertTrue(modifyPeer.getFieldSet().isEmpty());
+  }
+
+  @Test
+  void run_whenAccessDenied_throwsAccessDenied() {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+    when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verifyNoInteractions(node);
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenNodeIdentifierMissing_throwsMissingField() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verify(node, never()).getPeerNode(anyString());
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenPeerNotFound_sendsUnknownNodeIdentifierMessage() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(null);
+
+    modifyPeer.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(1)).send(captor.capture());
+    assertInstanceOf(UnknownNodeIdentifierMessage.class, captor.getValue());
+    UnknownNodeIdentifierMessage sent = (UnknownNodeIdentifierMessage) captor.getValue();
+    assertEquals(NODE_IDENTIFIER, sent.nodeIdentifier);
+    assertEquals(IDENTIFIER, sent.identifier);
+  }
+
+  @Test
+  void run_whenPeerIsNotDarknet_throwsDarknetOnly() {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(peerNode);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.DARKNET_ONLY, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenFlagsProvided_updatesPeerAndSendsPeerMessage() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("IsDisabled", "true");
+    fs.putSingle("IsListenOnly", "TrUe");
+    fs.putSingle("IsBurstOnly", "false");
+    fs.putSingle("IgnoreSourcePort", "true");
+    fs.putSingle("AllowLocalAddresses", "FALSE");
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+
+    modifyPeer.run(handler, node);
+
+    verify(darknetPeerNode, times(1)).disablePeer();
+    verify(darknetPeerNode, never()).enablePeer();
+    verify(darknetPeerNode, times(1)).setListenOnly(true);
+    verify(darknetPeerNode, times(1)).setBurstOnly(false);
+    verify(darknetPeerNode, times(1)).setIgnoreSourcePort(true);
+    verify(darknetPeerNode, times(1)).setAllowLocalAddresses(false);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(1)).send(captor.capture());
+    assertInstanceOf(PeerMessage.class, captor.getValue());
+    PeerMessage sent = (PeerMessage) captor.getValue();
+    assertSame(darknetPeerNode, sent.pn);
+    assertTrue(sent.withMetadata);
+    assertTrue(sent.withVolatile);
+    assertEquals(IDENTIFIER, sent.identifier);
+  }
+
+  @Test
+  void run_whenIsDisabledFalse_enablesPeer() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("IsDisabled", "false");
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+
+    modifyPeer.run(handler, node);
+
+    verify(darknetPeerNode, never()).disablePeer();
+    verify(darknetPeerNode, times(1)).enablePeer();
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    assertInstanceOf(PeerMessage.class, captor.getValue());
+  }
+
+  @Test
+  void run_whenOptionalFieldsEmpty_doesNotInvokeMutators() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("IsDisabled", "");
+    fs.putSingle("IsListenOnly", "");
+    fs.putSingle("IsBurstOnly", "");
+    fs.putSingle("IgnoreSourcePort", "");
+    fs.putSingle("AllowLocalAddresses", "");
+    ModifyPeer modifyPeer = new ModifyPeer(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+
+    modifyPeer.run(handler, node);
+
+    verify(darknetPeerNode, never()).disablePeer();
+    verify(darknetPeerNode, never()).enablePeer();
+    verify(darknetPeerNode, never()).setListenOnly(anyBoolean());
+    verify(darknetPeerNode, never()).setBurstOnly(anyBoolean());
+    verify(darknetPeerNode, never()).setIgnoreSourcePort(anyBoolean());
+    verify(darknetPeerNode, never()).setAllowLocalAddresses(anyBoolean());
+    verify(handler, times(1)).send(any(PeerMessage.class));
+  }
+
+  private static SimpleFieldSet baseFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("NodeIdentifier", NODE_IDENTIFIER);
+    return fs;
+  }
+}


### PR DESCRIPTION
## Summary
- refactor ModifyPeer to reuse identifier safely and streamline boolean flag updates
- add unit tests covering ModifyPeer validation and flag application paths

## Testing
- ./gradlew spotlessApply (format only)
- Not run: ./gradlew test