### PR TITLE
fix: improve ModifyPersistentRequest handling

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.node.Node;
@@ -11,11 +10,32 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * FCP message: Modify a persistent request.
+ * FCP message: Modify an existing persistent request associated with an FCP client.
  *
- * <p>ModifyPersistentRequest Identifier=request identifier Verbosity=1023 // change verbosity
- * PriorityClass=1 // change priority class ClientToken=new client token // change client token
- * MaxRetries=100 // change max retries Global=true EndMessage
+ * <p>This message is sent by an FCP client when it wants to adjust how a previously created
+ * persistent request is handled by the node without recreating the request. Typical adjustments
+ * include changing the request priority, switching between global and connection-local lifetimes,
+ * or updating the client token used to correlate notifications with the client application. The
+ * message does not itself create or remove a request; it only targets an already known identifier.
+ *
+ * <p>On receipt the node resolves the request identifier against its in-memory and, if enabled,
+ * persistent request stores. If the request is found, the node delegates to {@link
+ * ClientRequest#modifyRequest(String, short, FCPServer)} to apply the modifications and propagate
+ * them to the internal scheduling layer. If the identifier cannot be resolved, or if persistence is
+ * disabled when a globally persistent request is required, an appropriate {@link
+ * ProtocolErrorMessage} is sent back to the client instead of silently ignoring the request.
+ *
+ * <p>Wire format example:
+ *
+ * <pre>{@code
+ * ModifyPersistentRequest
+ * Identifier=request identifier
+ * Verbosity=1023          # optional, not interpreted here
+ * PriorityClass=1         # change priority class, -1 means leave unchanged
+ * ClientToken=new token   # change client token used in callbacks
+ * Global=true             # true for global (forever) requests, false for reboot-persistent
+ * EndMessage
+ * }</pre>
  */
 public class ModifyPersistentRequest extends FCPMessage {
   private static final Logger LOG = LoggerFactory.getLogger(ModifyPersistentRequest.class);
@@ -60,6 +80,24 @@ public class ModifyPersistentRequest extends FCPMessage {
     } else priorityClass = -1;
   }
 
+  /**
+   * Builds the {@link SimpleFieldSet} representation of this message for transmission over the FCP
+   * connection.
+   *
+   * <p>The returned structure always contains the {@code Identifier} field and a {@code Global}
+   * flag mirroring the values supplied by the client. The {@code PriorityClass} field is also
+   * present for every message instance; a negative value indicates that the node should leave the
+   * existing priority unchanged. When a non-{@code null} client token is supplied, it is encoded as
+   * the {@code ClientToken} field so that subsequent status notifications can be correlated by the
+   * client application.
+   *
+   * <p>A new {@link SimpleFieldSet} is allocated on each call and populated only from the immutable
+   * fields of this instance, so callers are free to modify the returned instance without affecting
+   * other invocations.
+   *
+   * @return a newly created field set containing the wire representation of this {@code
+   *     ModifyPersistentRequest}, suitable for sending over an FCP connection
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
@@ -70,11 +108,49 @@ public class ModifyPersistentRequest extends FCPMessage {
     return fs;
   }
 
+  /**
+   * Returns the protocol-level name used to identify this FCP message type.
+   *
+   * <p>The name is a stable constant defined by the FCP specification and is used both by clients
+   * when composing requests and by the node when emitting responses that refer back to this message
+   * type. Implementations of {@link FCPMessage} typically delegate to this method when deciding how
+   * to label a message on the wire or in diagnostic logs. The value never changes for the lifetime
+   * of the JVM and is shared by all instances of this class.
+   *
+   * @return the constant string {@code "ModifyPersistentRequest"} that identifies this message
+   *     type; never {@code null}
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the modification against the node, updating the matching persistent request if it can
+   * be found.
+   *
+   * <p>The method first consults the connection's reboot-persistent request store via {@link
+   * FCPConnectionHandler#getRebootRequest(boolean, FCPConnectionHandler, String)}. When a matching
+   * request is found, the change is applied immediately on the caller's thread by invoking {@link
+   * ClientRequest#modifyRequest(String, short, FCPServer)} with the stored client token and
+   * priority. If no reboot-persistent request is present, a {@link PersistentJob} is queued on the
+   * client's job runner to search the forever-persistent store using {@link
+   * FCPConnectionHandler#getForeverRequest(boolean, FCPConnectionHandler, String)} and apply the
+   * same modification there.
+   *
+   * <p>If neither store contains the referenced identifier, a {@link ProtocolErrorMessage} with
+   * code {@link ProtocolErrorMessage#NO_SUCH_IDENTIFIER} is sent back to the client. When the
+   * persistence layer is disabled and a forever-persistent lookup would be required, the client is
+   * likewise informed that the identifier cannot be resolved. The operation is best-effort and does
+   * not retry automatically; callers should handle failures surfaced through the FCP connection.
+   *
+   * @param handler connection handler used to resolve the request identifier and send any protocol
+   *     error responses; must not be {@code null}
+   * @param node node instance providing access to the client core, persistent job runner, and FCP
+   *     server used to apply the modification; must not be {@code null}
+   * @throws MessageInvalidException if the identifier or request parameters violate protocol
+   *     constraints while attempting to execute the modification
+   */
   @Override
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
 
@@ -85,28 +161,25 @@ public class ModifyPersistentRequest extends FCPMessage {
             .getClientContext()
             .jobRunner
             .queue(
-                new PersistentJob() {
-
-                  @Override
-                  public boolean run(ClientContext context) {
-                    ClientRequest req = handler.getForeverRequest(global, handler, identifier);
-                    if (req == null) {
-                      LOG.error("Huh ? the request is null!");
-                      ProtocolErrorMessage msg =
-                          new ProtocolErrorMessage(
-                              ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
-                              false,
-                              null,
-                              identifier,
-                              global);
-                      handler.send(msg);
-                      return false;
-                    } else {
-                      req.modifyRequest(clientToken, priorityClass, handler.getServer());
-                    }
-                    return true;
-                  }
-                },
+                (PersistentJob)
+                    context -> {
+                      ClientRequest req1 = handler.getForeverRequest(global, handler, identifier);
+                      if (req1 == null) {
+                        LOG.error("Huh ? the request is null!");
+                        ProtocolErrorMessage msg =
+                            new ProtocolErrorMessage(
+                                ProtocolErrorMessage.NO_SUCH_IDENTIFIER,
+                                false,
+                                null,
+                                identifier,
+                                global);
+                        handler.send(msg);
+                        return false;
+                      } else {
+                        req1.modifyRequest(clientToken, priorityClass, handler.getServer());
+                      }
+                      return true;
+                    },
                 NativeThread.PriorityLevel.NORM_PRIORITY.value);
       } catch (PersistenceDisabledException e) {
         ProtocolErrorMessage msg =

--- a/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
@@ -1,0 +1,411 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Random;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientLayerPersister;
+import network.crypta.client.async.DatastoreChecker;
+import network.crypta.client.async.HealingQueue;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.USKManager;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.config.Config;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.NativeThread;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // test method naming: method_whenCondition_expectOutcome
+class ModifyPersistentRequestTest {
+
+  // ---------- Constructor validation ----------
+
+  @Test
+  void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.put("Global", true);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new ModifyPersistentRequest(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals("Missing field: Identifier", ex.getMessage());
+    assertNull(ex.ident);
+    assertTrue(ex.global);
+  }
+
+  @Test
+  void constructor_whenPriorityClassNotNumber_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-1");
+    fs.putSingle("PriorityClass", "not-a-number");
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new ModifyPersistentRequest(fs));
+
+    assertEquals(ProtocolErrorMessage.ERROR_PARSING_NUMBER, ex.protocolCode);
+    assertEquals("req-1", ex.ident);
+    assertTrue(ex.getMessage().startsWith("Could not parse PriorityClass:"));
+    assertFalse(ex.global);
+  }
+
+  @Test
+  void constructor_whenPriorityClassOutOfRange_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-2");
+    // RequestStarter.PAUSED_PRIORITY_CLASS == 6, MAXIMUM_PRIORITY_CLASS == 0
+    fs.putSingle("PriorityClass", "7");
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new ModifyPersistentRequest(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
+    assertEquals("req-2", ex.ident);
+    assertTrue(ex.getMessage().contains("Invalid priority class 7"));
+    assertFalse(ex.global);
+  }
+
+  @Test
+  void constructor_whenPriorityClassMissing_usesNegativeOneAndRespectsGlobal() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-3");
+    fs.put("Global", true);
+
+    ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
+
+    assertEquals("req-3", message.identifier);
+    assertTrue(message.global);
+    assertEquals(-1, message.priorityClass);
+    assertNull(message.clientToken);
+  }
+
+  // ---------- getFieldSet / getName ----------
+
+  @Test
+  void getFieldSet_whenClientTokenPresent_includesAllFields() throws Exception {
+    SimpleFieldSet input = new SimpleFieldSet(true);
+    input.putSingle("Identifier", "req-4");
+    input.put("Global", false);
+    input.putSingle("PriorityClass", "3");
+    input.putSingle("ClientToken", "token-123");
+    ModifyPersistentRequest message = new ModifyPersistentRequest(input);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals("req-4", result.get("Identifier"));
+    assertFalse(result.getBoolean("Global", true));
+    assertEquals("3", result.get("PriorityClass"));
+    assertEquals("token-123", result.get("ClientToken"));
+  }
+
+  @Test
+  void getFieldSet_whenClientTokenMissing_doesNotEmitClientToken() throws Exception {
+    SimpleFieldSet input = new SimpleFieldSet(true);
+    input.putSingle("Identifier", "req-5");
+    input.put("Global", false);
+    input.putSingle("PriorityClass", "2");
+    ModifyPersistentRequest message = new ModifyPersistentRequest(input);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals("req-5", result.get("Identifier"));
+    assertEquals("2", result.get("PriorityClass"));
+    assertNull(result.get("ClientToken"));
+  }
+
+  @Test
+  void getName_whenCalled_returnsConstantName() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-6");
+    ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
+
+    assertEquals("ModifyPersistentRequest", message.getName());
+  }
+
+  // ---------- run(): reboot request path ----------
+
+  @Test
+  void run_whenRebootRequestExists_modifiesRequestViaNodeFcpServer() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-7");
+    fs.put("Global", false);
+    fs.putSingle("PriorityClass", "1");
+    fs.putSingle("ClientToken", "tok");
+    ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    ClientRequest rebootRequest = mock(ClientRequest.class);
+    Node node = mock(Node.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    FCPServer server = mock(FCPServer.class);
+
+    when(handler.getRebootRequest(false, handler, "req-7")).thenReturn(rebootRequest);
+    when(node.getClientCore()).thenReturn(core);
+    when(core.getFCPServer()).thenReturn(server);
+
+    message.run(handler, node);
+
+    verify(handler, times(1)).getRebootRequest(false, handler, "req-7");
+    verify(rebootRequest, times(1)).modifyRequest("tok", (short) 1, server);
+    verify(handler, never()).send(any(FCPMessage.class));
+  }
+
+  // ---------- run(): forever request path via job runner ----------
+
+  @Test
+  void run_whenRebootRequestMissingAndForeverRequestExists_modifiesRequestViaHandlerServer()
+      throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-8");
+    fs.put("Global", false);
+    fs.putSingle("PriorityClass", "4");
+    fs.putSingle("ClientToken", "new-token");
+    ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    ClientRequest foreverRequest = mock(ClientRequest.class);
+    FCPServer server = mock(FCPServer.class);
+    when(handler.getRebootRequest(false, handler, "req-8")).thenReturn(null);
+    when(handler.getForeverRequest(false, handler, "req-8")).thenReturn(foreverRequest);
+    when(handler.getServer()).thenReturn(server);
+
+    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
+    Ticker ticker = mock(Ticker.class);
+    ClientContext context = newClientContext(jobRunner, ticker);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getClientContext()).thenReturn(context);
+    Node node = mock(Node.class);
+    when(node.getClientCore()).thenReturn(core);
+
+    doAnswer(
+            invocation -> {
+              PersistentJob job = invocation.getArgument(0);
+              job.run(context);
+              return null;
+            })
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+
+    message.run(handler, node);
+
+    verify(jobRunner, times(1))
+        .queue(any(PersistentJob.class), eq(NativeThread.PriorityLevel.NORM_PRIORITY.value));
+    verify(handler, times(1)).getForeverRequest(false, handler, "req-8");
+    verify(foreverRequest, times(1)).modifyRequest("new-token", (short) 4, server);
+    verify(handler, never()).send(any(ProtocolErrorMessage.class));
+  }
+
+  @Test
+  void run_whenRebootAndForeverRequestsMissing_sendsNoSuchIdentifierErrorFromJob()
+      throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-9");
+    fs.put("Global", false);
+    ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.getRebootRequest(false, handler, "req-9")).thenReturn(null);
+    when(handler.getForeverRequest(false, handler, "req-9")).thenReturn(null);
+
+    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
+    Ticker ticker = mock(Ticker.class);
+    ClientContext context = newClientContext(jobRunner, ticker);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getClientContext()).thenReturn(context);
+    Node node = mock(Node.class);
+    when(node.getClientCore()).thenReturn(core);
+
+    ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
+        ArgumentCaptor.forClass(ProtocolErrorMessage.class);
+
+    doAnswer(
+            invocation -> {
+              PersistentJob job = invocation.getArgument(0);
+              job.run(context);
+              return null;
+            })
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+
+    message.run(handler, node);
+
+    verify(handler, times(1)).send(errorCaptor.capture());
+    ProtocolErrorMessage error = errorCaptor.getValue();
+    assertNotNull(error);
+    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.code);
+    assertFalse(error.fatal);
+    assertEquals("req-9", error.ident);
+    assertFalse(error.global);
+    assertNull(error.extra);
+  }
+
+  // ---------- run(): persistence disabled path ----------
+
+  @Test
+  void run_whenPersistenceDisabled_sendsNoSuchIdentifierErrorImmediately() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-10");
+    fs.put("Global", true);
+    ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.getRebootRequest(true, handler, "req-10")).thenReturn(null);
+
+    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
+    Ticker ticker = mock(Ticker.class);
+    ClientContext context = newClientContext(jobRunner, ticker);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getClientContext()).thenReturn(context);
+    Node node = mock(Node.class);
+    when(node.getClientCore()).thenReturn(core);
+
+    doThrow(new PersistenceDisabledException())
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+
+    ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
+        ArgumentCaptor.forClass(ProtocolErrorMessage.class);
+
+    message.run(handler, node);
+
+    verify(handler, times(1)).send(errorCaptor.capture());
+    verify(handler, never())
+        .getForeverRequest(anyBoolean(), any(FCPConnectionHandler.class), anyString());
+    ProtocolErrorMessage error = errorCaptor.getValue();
+    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.code);
+    assertFalse(error.fatal);
+    assertEquals("req-10", error.ident);
+    assertTrue(error.global);
+    assertNull(error.extra);
+  }
+
+  @Test
+  void run_whenRebootRequestExists_doesNotInteractWithJobRunner() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "req-11");
+    fs.put("Global", false);
+    ModifyPersistentRequest message = new ModifyPersistentRequest(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    ClientRequest rebootRequest = mock(ClientRequest.class);
+    when(handler.getRebootRequest(false, handler, "req-11")).thenReturn(rebootRequest);
+
+    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getFCPServer()).thenReturn(mock(FCPServer.class));
+    Node node = mock(Node.class);
+    when(node.getClientCore()).thenReturn(core);
+
+    message.run(handler, node);
+
+    verifyNoInteractions(jobRunner);
+  }
+
+  // ---------- Test helpers ----------
+
+  private static ClientContext newClientContext(ClientLayerPersister jobRunner, Ticker ticker) {
+    PriorityAwareExecutor executor =
+        new PriorityAwareExecutor() {
+
+          @Override
+          public void execute(@NotNull Runnable job) {
+            job.run();
+          }
+
+          @Override
+          public void execute(@NotNull Runnable job, String jobName) {
+            job.run();
+          }
+
+          @Override
+          public void execute(@NotNull Runnable job, String jobName, boolean fromTicker) {
+            job.run();
+          }
+
+          @Override
+          public int[] waitingThreads() {
+            return new int[0];
+          }
+
+          @Override
+          public int[] runningThreads() {
+            return new int[0];
+          }
+
+          @Override
+          public int getWaitingThreadsCount() {
+            return 0;
+          }
+        };
+
+    return new ClientContext(
+        1L,
+        jobRunner,
+        executor,
+        mock(ArchiveManager.class),
+        mock(PersistentTempBucketFactory.class),
+        mock(TempBucketFactory.class),
+        mock(PersistentFileTracker.class),
+        mock(HealingQueue.class),
+        mock(USKManager.class),
+        mock(RandomSource.class),
+        new Random(0),
+        ticker,
+        mock(MemoryLimitedJobRunner.class),
+        mock(FilenameGenerator.class),
+        mock(FilenameGenerator.class),
+        mock(LockableRandomAccessBufferFactory.class),
+        mock(LockableRandomAccessBufferFactory.class),
+        mock(FileRandomAccessBufferFactory.class),
+        mock(FileRandomAccessBufferFactory.class),
+        mock(RealCompressor.class),
+        mock(DatastoreChecker.class),
+        mock(PersistentRequestRoot.class),
+        mock(MasterSecret.class),
+        mock(LinkFilterExceptionProvider.class),
+        mock(FetchContext.class),
+        mock(InsertContext.class),
+        mock(Config.class));
+  }
+}


### PR DESCRIPTION
Summary

This PR improves the FCP `ModifyPersistentRequest` handling and adds targeted unit tests.

Changes

- Expand and clarify the Javadoc for `ModifyPersistentRequest` to document:
  - The role of the FCP message and its wire format.
  - How identifiers are resolved against reboot-persistent and forever-persistent request stores.
  - When and how `ProtocolErrorMessage` instances are emitted for missing identifiers or disabled persistence.
- Document `getFieldSet()` and `getName()` to describe their wire-level behavior and guarantees.
- Refactor the forever-persistent modification path in `run(...)` to use a `PersistentJob` lambda instead of an anonymous class while preserving the existing error handling and logging.
- Add `ModifyPersistentRequestTest` to cover:
  - Constructor validation for missing/invalid fields and out-of-range priority classes.
  - `getFieldSet()` and `getName()` behavior, including priority handling and optional client tokens.
  - `run(...)` behavior for:
    - Reboot-persistent requests.
    - Forever-persistent requests via the job runner.
    - Missing identifiers (sending `NO_SUCH_IDENTIFIER`).
    - Disabled persistence (immediate `NO_SUCH_IDENTIFIER` without `getForeverRequest()` calls).

Testing

- Gradle formatting: `./gradlew spotlessApply`
- Branch builds and tests are expected to be exercised by the standard CI pipeline.