### PR TITLE
Add tests for ModifyPeerNote FCP handler

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
@@ -10,6 +10,31 @@ import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * FCP message that updates the note associated with a single darknet peer.
+ *
+ * <p>The {@code ModifyPeerNote} message is sent by a client over the Freenet Client Protocol (FCP)
+ * when it wants to attach or change a human-readable note on a known darknet peer. The message
+ * carries the target peer identifier, a numeric peer-note type, and a Base64-encoded note body.
+ * This implementation focuses on the private darknet comment note type used for descriptive or
+ * operational annotations that are not exposed publicly on the network.
+ *
+ * <p>On execution, the message handler validates that the connection has full access, resolves the
+ * referenced peer within the running {@link Node}, and verifies that the peer is a {@link
+ * DarknetPeerNode}. It then parses the note type, decodes the supplied Base64 payload into UTF-8
+ * text, and applies the change to the peer instance when the type is supported. Errors in access
+ * control, field presence, parsing, or peer lookup are surfaced as protocol-level failures, either
+ * by throwing {@link MessageInvalidException} or by sending dedicated FCP error messages back
+ * through the connection handler.
+ *
+ * <p>This class is stateless beyond the parsed request fields and is typically used only for the
+ * lifetime of a single inbound message. Instances are not intended to be shared across threads
+ * after construction.
+ *
+ * @see PeerNote
+ * @see DarknetPeerNode
+ * @see FCPMessage
+ */
 public class ModifyPeerNote extends FCPMessage {
   private static final Logger LOG = LoggerFactory.getLogger(ModifyPeerNote.class);
 
@@ -18,22 +43,76 @@ public class ModifyPeerNote extends FCPMessage {
   final SimpleFieldSet fs;
   final String identifier;
 
+  /**
+   * Creates a new {@code ModifyPeerNote} message wrapper from an incoming field set.
+   *
+   * <p>The provided {@link SimpleFieldSet} is expected to contain the standard FCP fields used by
+   * this message, including the client {@code Identifier} and all note-related values. The
+   * constructor extracts and stores the identifier for later use, then removes it from the backing
+   * field set so that only message-specific fields remain. No validation of required fields is
+   * performed here; it is deferred to {@link #run(FCPConnectionHandler, Node)}.
+   *
+   * @param fs the non-{@code null} field set describing the request, including {@code Identifier}
+   *     and note-related fields supplied by the FCP client
+   */
   public ModifyPeerNote(SimpleFieldSet fs) {
     this.fs = fs;
     identifier = fs.get("Identifier");
     fs.removeValue("Identifier");
   }
 
+  /**
+   * Returns the field template for this message type.
+   *
+   * <p>The current implementation returns a new, empty {@link SimpleFieldSet} instance. This is
+   * sufficient because {@code ModifyPeerNote} is handled primarily as an inbound message parsed
+   * from the client, and the node does not need to advertise additional fields when constructing
+   * responses. Callers should not rely on the returned instance being reused.
+   *
+   * @return a new, empty field set instance representing the message fields for this type
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Returns the protocol-level name for this FCP message.
+   *
+   * <p>The name identifies this message type on the wire and is used by both client and node code
+   * when routing or dispatching FCP commands. The value is stable and should not be localized or
+   * modified by callers.
+   *
+   * @return the constant {@code "ModifyPeerNote"} used as the FCP message name
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the {@code ModifyPeerNote} request against the running node.
+   *
+   * <p>This method enforces full-access permissions on the connection, extracts the target peer
+   * identifier and peer-note type from the backing field set, and resolves the peer within the
+   * supplied {@link Node}. Only darknet peers are accepted; other peer types cause a protocol
+   * error. The handler then decodes the Base64-encoded {@code NoteText} value, applies the note to
+   * the peer when the note type is supported, and sends a {@link PeerNote} message back to the
+   * client reflecting the new state. Invalid or missing fields cause {@link
+   * MessageInvalidException} to be thrown or a specific error response to be sent.
+   *
+   * <p>The method is not idempotent with respect to note contents: subsequent calls with the same
+   * peer and note type overwrite the existing note. The call relies on the caller to provide a
+   * valid, running {@link Node} instance; behaviour is undefined if the node is stopping or the
+   * referenced peer disappears concurrently.
+   *
+   * @param handler the connection handler that received the request and is used to send any reply
+   *     or error messages back to the client; must have full access for the operation to proceed
+   * @param node the owning node instance used to resolve peers and persist note changes; must not
+   *     be {@code null}
+   * @throws MessageInvalidException if the caller lacks access rights, required fields are missing
+   *     or malformed, or the peer cannot be updated under the current protocol rules
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
@@ -1,0 +1,228 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.support.Base64;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ModifyPeerNoteTest {
+
+  private static final String IDENTIFIER = "req-1";
+  private static final String NODE_IDENTIFIER = "peer-123";
+  private static final String NOTE_TEXT = "Private darknet note";
+  private static final int UNKNOWN_PEER_NOTE_TYPE = 99;
+
+  @Mock FCPConnectionHandler handler;
+  @Mock Node node;
+  @Mock DarknetPeerNode darknetPeerNode;
+  @Mock PeerNode peerNode;
+
+  @Test
+  void constructor_whenIdentifierPresent_removesIdentifierFromFieldSet() {
+    SimpleFieldSet fs = baseFieldSet();
+
+    new ModifyPeerNote(fs);
+
+    assertNull(fs.get("Identifier"));
+    assertEquals(NODE_IDENTIFIER, fs.get("NodeIdentifier"));
+  }
+
+  @Test
+  void getName_returnsModifyPeerNoteLiteral() {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+
+    assertEquals("ModifyPeerNote", modifyPeerNote.getName());
+  }
+
+  @Test
+  void getFieldSet_returnsEmptyFieldSet() {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+
+    assertTrue(modifyPeerNote.getFieldSet().isEmpty());
+  }
+
+  @Test
+  void run_whenAccessDenied_throwsAccessDenied() {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verifyNoInteractions(node);
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenNodeIdentifierMissing_throwsMissingField() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verify(node, never()).getPeerNode(anyString());
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenPeerNotFound_sendsUnknownNodeIdentifierMessage() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(null);
+
+    modifyPeerNote.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(1)).send(captor.capture());
+    assertInstanceOf(UnknownNodeIdentifierMessage.class, captor.getValue());
+    UnknownNodeIdentifierMessage sent = (UnknownNodeIdentifierMessage) captor.getValue();
+    assertEquals(NODE_IDENTIFIER, sent.nodeIdentifier);
+    assertEquals(IDENTIFIER, sent.identifier);
+  }
+
+  @Test
+  void run_whenPeerIsNotDarknet_throwsDarknetOnly() {
+    SimpleFieldSet fs = baseFieldSet();
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(peerNode);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.DARKNET_ONLY, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenPeerNoteTypeNotANumber_throwsInvalidField() {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("PeerNoteType", "not-a-number");
+    fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verify(handler, never()).send(any());
+    verify(darknetPeerNode, never()).setPrivateDarknetCommentNote(anyString());
+  }
+
+  @Test
+  void run_whenNoteTextMissing_throwsMissingField() {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals(IDENTIFIER, ex.ident);
+    verify(handler, never()).send(any());
+    verify(darknetPeerNode, never()).setPrivateDarknetCommentNote(anyString());
+  }
+
+  @Test
+  void run_whenNoteTextInvalidBase64_doesNotSendOrModifyPeer() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
+    fs.putSingle("NoteText", "%%%"); // invalid Base64
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+
+    modifyPeerNote.run(handler, node);
+
+    verify(darknetPeerNode, never()).setPrivateDarknetCommentNote(anyString());
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void run_whenUnknownPeerNoteType_sendsUnknownPeerNoteTypeMessage() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("PeerNoteType", UNKNOWN_PEER_NOTE_TYPE);
+    fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+
+    modifyPeerNote.run(handler, node);
+
+    verify(darknetPeerNode, never()).setPrivateDarknetCommentNote(anyString());
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(1)).send(captor.capture());
+    assertInstanceOf(UnknownPeerNoteTypeMessage.class, captor.getValue());
+    UnknownPeerNoteTypeMessage sent = (UnknownPeerNoteTypeMessage) captor.getValue();
+    assertEquals(UNKNOWN_PEER_NOTE_TYPE, sent.peerNoteType);
+    assertEquals(IDENTIFIER, sent.identifier);
+  }
+
+  @Test
+  void run_whenPrivateDarknetComment_updatesPeerAndSendsPeerNote() throws Exception {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.put("PeerNoteType", Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT);
+    fs.putSingle("NoteText", Base64.encodeUTF8(NOTE_TEXT, true));
+    ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+
+    modifyPeerNote.run(handler, node);
+
+    verify(darknetPeerNode, times(1)).setPrivateDarknetCommentNote(NOTE_TEXT);
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler, times(1)).send(captor.capture());
+    assertInstanceOf(PeerNote.class, captor.getValue());
+    PeerNote sent = (PeerNote) captor.getValue();
+    assertEquals(NODE_IDENTIFIER, sent.nodeIdentifier);
+    assertEquals(NOTE_TEXT, sent.noteText);
+    assertEquals(Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT, sent.peerNoteType);
+    assertEquals(IDENTIFIER, sent.identifier);
+  }
+
+  private static SimpleFieldSet baseFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("NodeIdentifier", NODE_IDENTIFIER);
+    return fs;
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds unit test coverage for the `ModifyPeerNote` FCP message handler and improves its JavaDoc.

### Changes
- Document `ModifyPeerNote` with class-level and method-level JavaDoc, describing its role in updating darknet peer notes, access control expectations, and error behavior.
- Add `ModifyPeerNoteTest` to exercise the various control-flow paths in `ModifyPeerNote.run(...)`, including:
  - Missing or malformed fields (`Identifier`, `NodeIdentifier`, `PeerNoteType`, `NoteText`).
  - Access-control failures (connection without full access).
  - Unknown peers and non-darknet peers.
  - Invalid `PeerNoteType` (non-numeric), missing `NoteText`, and invalid Base64 payloads.
  - Successful update for `PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT`, asserting both the peer state and the emitted `PeerNote` message.
  - Unsupported peer-note types, asserting that `UnknownPeerNoteTypeMessage` is sent and no peer mutation occurs.

### Rationale
`ModifyPeerNote` has subtle protocol rules (full-access only, darknet-only peers, and specific error codes for field problems and unknown note types). These tests codify the expected behavior and help guard against regressions in future refactors.

## Testing
- `./gradlew --parallel test --tests *ModifyPeerNoteTest` (or broader test suites) should pass.

