### PR TITLE
Refactor NodeData documentation and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/NodeData.java
+++ b/src/main/java/network/crypta/clients/fcp/NodeData.java
@@ -2,33 +2,83 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Packages node reference data for transmission from the server to an FCP client.
+ *
+ * <p>This message captures a snapshot of the current node identity and connectivity information
+ * produced by the supplied {@link Node}. Callers choose whether to emit opennet or darknet
+ * references, whether to include private details intended only for trusted peers, and whether to
+ * append transient volatile metadata. Instances are immutable after construction; serialization is
+ * deferred until {@link #getFieldSet()} is invoked, so the referenced {@code Node} should remain
+ * stable while export occurs. The message is intentionally one-directional: it is created by the
+ * server side when answering discovery or status requests and must not be sent from clients.
+ * Concurrency expectations match the node: callers should invoke export methods within the node's
+ * usual synchronization regime to avoid racing configuration updates.
+ *
+ * <ul>
+ *   <li>Selects opennet or darknet representations based on {@code giveOpennetRef}.
+ *   <li>Optionally includes private and volatile subsets for richer diagnostics.
+ *   <li>Echoes an optional identifier to correlate responses with client requests.
+ * </ul>
+ */
 public class NodeData extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(NodeData.class);
 
-  static final String name = "NodeData";
+  static final String NAME = "NodeData";
 
   final Node node;
   final boolean giveOpennetRef;
   final boolean withPrivate;
   final boolean withVolatile;
-  final String identifier;
+  final String requestIdentifier;
 
+  /**
+   * Creates an immutable message wrapper around the node's reference exports.
+   *
+   * <p>The constructor only stores references and flags; it does not perform expensive exports.
+   * Actual serialization happens when {@link #getFieldSet()} is called, allowing callers to defer
+   * work until just before a response is written. No validation is performed here, so callers must
+   * ensure the {@link Node} has up-to-date reference data and that privacy flags reflect the
+   * intended audience. Providing a {@code null} identifier omits the {@code Identifier} field and
+   * yields an anonymous response. Instances are safe to reuse across requests as long as the
+   * underlying node state remains consistent with the chosen visibility settings.
+   *
+   * <pre>{@code
+   * NodeData payload = new NodeData(node, true, true, false, "req-42");
+   * SimpleFieldSet fs = payload.getFieldSet();
+   * }</pre>
+   *
+   * @param node Node providing reference data to serialize; must not be null.
+   * @param giveOpennetRef true to export opennet reference, false for darknet details instead.
+   * @param withPrivate true to include private elements intended for trusted peers only.
+   * @param withVolatile true to append transient volatile metadata when available from the node.
+   * @param requestIdentifier optional identifier echoed in the {@code Identifier} field; nullable.
+   */
   public NodeData(
       Node node,
       boolean giveOpennetRef,
       boolean withPrivate,
       boolean withVolatile,
-      String identifier) {
+      String requestIdentifier) {
     this.node = node;
     this.giveOpennetRef = giveOpennetRef;
     this.withPrivate = withPrivate;
     this.withVolatile = withVolatile;
-    this.identifier = identifier;
+    this.requestIdentifier = requestIdentifier;
   }
 
+  /**
+   * Builds the {@link SimpleFieldSet} containing the requested node reference details.
+   *
+   * <p>This method invokes the appropriate export routine on the backing {@link Node}, choosing
+   * between opennet and darknet forms and adding private content when requested. When {@code
+   * withVolatile} is set, it merges the node's volatile field set under the {@code volatile} key if
+   * present. If a {@code requestIdentifier} was provided at construction time, it is written under
+   * the {@code Identifier} key so clients can correlate responses. The returned field set is newly
+   * allocated by the node export routines; callers may modify it without affecting shared state.
+   *
+   * @return SimpleFieldSet containing the selected node reference data; never null.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs;
@@ -51,21 +101,46 @@ public class NodeData extends FCPMessage {
         fs.put("volatile", vol);
       }
     }
-    if (identifier != null) fs.putSingle("Identifier", identifier);
+    if (requestIdentifier != null) {
+      fs.putSingle("Identifier", requestIdentifier);
+    }
     return fs;
   }
 
+  /**
+   * Provides the FCP message name associated with this payload.
+   *
+   * <p>The name is constant and used by framing logic when sending the message over the wire. It is
+   * independent of the export flags, ensuring consistent dispatch handling on the client side.
+   *
+   * @return Constant message name {@code NodeData} used in outbound FCP frames.
+   */
   @Override
   public String getName() {
-    return name;
+    return NAME;
   }
 
+  /**
+   * Rejects client-originated execution because {@code NodeData} is server-to-client only.
+   *
+   * <p>Any attempt to process this message on the server side results in an explicit {@link
+   * MessageInvalidException}. This guards against misuse of the class for inbound traffic and
+   * preserves the directional contract of the FCP exchange. Callers should never invoke this method
+   * directly; it exists solely to satisfy the {@link FCPMessage} interface and enforce protocol
+   * correctness.
+   *
+   * @param handler connection handler that attempted to route the message; ignored after failure.
+   * @param node node instance associated with the connection; not used because execution is
+   *     blocked.
+   * @throws MessageInvalidException whenever invoked because clients must not send {@code
+   *     NodeData}.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "NodeData goes from server to client not the other way around",
-        identifier,
+        requestIdentifier,
         false);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GetNodeTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetNodeTest.java
@@ -124,6 +124,6 @@ class GetNodeTest {
     assertTrue(sent.giveOpennetRef);
     assertFalse(sent.withPrivate);
     assertTrue(sent.withVolatile);
-    assertEquals("req-42", sent.identifier);
+    assertEquals("req-42", sent.requestIdentifier);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/NodeDataTest.java
+++ b/src/test/java/network/crypta/clients/fcp/NodeDataTest.java
@@ -1,0 +1,138 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class NodeDataTest {
+
+  private static final String VOLATILE_KEY = "volatile";
+
+  @Mock private Node node;
+
+  @ParameterizedTest
+  @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+  void getFieldSet_whenFlagsCombination_selectsCorrectBaseFieldSet(
+      boolean giveOpennetRef, boolean withPrivate) {
+    SimpleFieldSet expected = new SimpleFieldSet(true);
+
+    if (giveOpennetRef && withPrivate) {
+      when(node.exportOpennetPrivateFieldSet()).thenReturn(expected);
+    } else if (giveOpennetRef) {
+      when(node.exportOpennetPublicFieldSet()).thenReturn(expected);
+    } else if (withPrivate) {
+      when(node.exportDarknetPrivateFieldSet()).thenReturn(expected);
+    } else {
+      when(node.exportDarknetPublicFieldSet()).thenReturn(expected);
+    }
+
+    NodeData nodeData =
+        new NodeData(node, giveOpennetRef, withPrivate, /* withVolatile= */ false, null);
+
+    SimpleFieldSet result = nodeData.getFieldSet();
+
+    assertSame(expected, result);
+    assertNull(result.subset(VOLATILE_KEY));
+    assertNull(result.get("Identifier"));
+    verify(node, never()).exportVolatileFieldSet();
+  }
+
+  @Test
+  void getFieldSet_whenWithVolatileAndNonEmpty_exportAddsVolatileSubset() {
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    SimpleFieldSet vol = new SimpleFieldSet(true);
+    vol.putSingle("stat", "value");
+    when(node.exportOpennetPublicFieldSet()).thenReturn(base);
+    when(node.exportVolatileFieldSet()).thenReturn(vol);
+    NodeData nodeData =
+        new NodeData(node, /* giveOpennetRef= */ true, /* withPrivate= */ false, true, null);
+
+    SimpleFieldSet result = nodeData.getFieldSet();
+
+    assertSame(base, result);
+    assertSame(vol, result.subset(VOLATILE_KEY));
+  }
+
+  @Test
+  void getFieldSet_whenWithVolatileAndEmpty_exportDoesNotAddVolatileSubset() {
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    SimpleFieldSet emptyVol = new SimpleFieldSet(true);
+    when(node.exportDarknetPrivateFieldSet()).thenReturn(base);
+    when(node.exportVolatileFieldSet()).thenReturn(emptyVol);
+    NodeData nodeData =
+        new NodeData(node, /* giveOpennetRef= */ false, /* withPrivate= */ true, true, null);
+
+    SimpleFieldSet result = nodeData.getFieldSet();
+
+    assertSame(base, result);
+    assertNull(result.subset(VOLATILE_KEY));
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierProvided_addsIdentifierField() {
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    when(node.exportOpennetPrivateFieldSet()).thenReturn(base);
+    String identifier = "node-identifier-1";
+    NodeData nodeData =
+        new NodeData(node, /* giveOpennetRef= */ true, /* withPrivate= */ true, false, identifier);
+
+    SimpleFieldSet result = nodeData.getFieldSet();
+
+    assertSame(base, result);
+    assertEquals(identifier, result.get("Identifier"));
+  }
+
+  @Test
+  void getName_returnsStaticName() {
+    NodeData nodeData =
+        new NodeData(node, /* giveOpennetRef= */ true, /* withPrivate= */ false, false, null);
+
+    assertEquals("NodeData", nodeData.getName());
+  }
+
+  @Test
+  void run_whenCalled_throwsInvalidMessageExceptionWithIdentifier() {
+    String identifier = "client-id-123";
+    NodeData nodeData =
+        new NodeData(
+            node, /* giveOpennetRef= */ false, /* withPrivate= */ false, false, identifier);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> nodeData.run(null, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "NodeData goes from server to client not the other way around", exception.getMessage());
+    assertEquals(identifier, exception.ident);
+    assertFalse(exception.global);
+  }
+
+  @Test
+  void run_whenIdentifierNull_throwsInvalidMessageExceptionWithNullIdentifier() {
+    NodeData nodeData =
+        new NodeData(node, /* giveOpennetRef= */ false, /* withPrivate= */ true, false, null);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> nodeData.run(null, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertNull(exception.ident);
+    assertFalse(exception.global);
+  }
+}


### PR DESCRIPTION
## Summary
- add comprehensive Javadoc to NodeData describing export behaviour and intent
- rename identifier field to requestIdentifier for clarity and adjust references
- add unit tests for NodeData export paths and identifier handling

## Testing
- not run (not requested)
