### PR TITLE
Improve NodeHelloMessage docs and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/NodeHelloMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/NodeHelloMessage.java
@@ -5,29 +5,63 @@ import network.crypta.node.Node;
 import network.crypta.node.Version;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.compress.Compressor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * NodeHello
+ * Outbound server greeting sent over the Freenet Client Protocol (FCP).
  *
- * <p>NodeHello FCPVersion=<protocol version> Node=Fred Version=0.7.0,401 EndMessage
+ * <p>The message is emitted immediately after accepting an FCP connection so the client can learn
+ * peer capabilities before issuing further commands. It advertises the negotiated protocol version,
+ * build number, Git revision, and supported compression codecs. The greeting echoes a
+ * connection-scoped identifier supplied at construction time so clients can correlate socket
+ * handshakes with session state, and it carries a language hint for locale selection.
+ *
+ * <p>Instances are immutable after construction and only assemble metadata; they never write to the
+ * network or mutate node state. Threads may reuse the same instance safely because all fields are
+ * final and {@link #getFieldSet()} returns a fresh {@link SimpleFieldSet} each time. Typical usage
+ * creates one instance per accepted connection and hands its field set to the surrounding {@link
+ * FCPConnectionHandler} for serialization.
+ *
+ * <ul>
+ *   <li>Responsibilities: assemble greeting metadata for new FCP connections.
+ *   <li>Notable behavior: always rejects inbound use via {@link MessageInvalidException}.
+ * </ul>
  */
 public class NodeHelloMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(NodeHelloMessage.class);
 
+  /**
+   * Canonical FCP message name used by the wire protocol and registry lookups.
+   *
+   * <p>This constant is stable across releases so downstream components can perform equality checks
+   * without depending on instantiated objects.
+   */
   public static final String NAME = "NodeHello";
 
   private final String id;
 
+  /**
+   * Creates a greeting message bound to a connection identifier supplied by the FCP server.
+   *
+   * @param id opaque connection identifier chosen by the server; never {@code null}; echoed back to
+   *     clients so they can match greetings to sockets or queued session metadata.
+   */
   public NodeHelloMessage(String id) {
     this.id = id;
   }
 
+  /**
+   * Builds a {@link SimpleFieldSet} describing the node and its negotiated connection settings.
+   *
+   * <p>The returned set is freshly allocated on each call and includes protocol version, node
+   * identity, build number, Git revision, testnet flag, supported compression codecs, the supplied
+   * connection identifier, and a language hint derived from {@link NodeL10n}. All values are
+   * formatted using primitive types or strings ready for FCP serialization.
+   *
+   * @return mutable field set ready for encoding; callers may add additional keys before sending
+   *     without affecting subsequent invocations because a new instance is produced each time.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
-    // FIXME
     sfs.putSingle("FCPVersion", "2.0");
     sfs.putSingle("Node", "Cryptad");
     sfs.putSingle("Version", Version.getVersionString());
@@ -40,11 +74,31 @@ public class NodeHelloMessage extends FCPMessage {
     return sfs;
   }
 
+  /**
+   * Returns the static FCP message name used on the wire.
+   *
+   * @return constant {@code "NodeHello"} identifying this message type during encoding and
+   *     dispatch.
+   */
   @Override
   public String getName() {
     return NodeHelloMessage.NAME;
   }
 
+  /**
+   * Rejects any inbound invocation of this message from a client.
+   *
+   * <p>The FCP specification defines {@code NodeHello} as a server-to-client greeting only. If a
+   * client attempts to send it, the handler treats the message as invalid and surfaces a protocol
+   * error.
+   *
+   * @param handler connection context that delivered the message; never {@code null}; not used in
+   *     the rejection path but present to satisfy {@link FCPMessage} dispatch signatures.
+   * @param node node instance backing the handler; never {@code null}; unused because the operation
+   *     always fails.
+   * @throws MessageInvalidException always thrown to signal that {@code NodeHello} is outbound-only
+   *     and must not be received from clients.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/test/java/network/crypta/clients/fcp/NodeHelloMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/NodeHelloMessageTest.java
@@ -1,0 +1,91 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.Node;
+import network.crypta.node.Version;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.compress.Compressor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class NodeHelloMessageTest {
+
+  @Test
+  void getFieldSet_whenCalled_populatesExpectedFields() {
+    try (MockedStatic<Version> version = Mockito.mockStatic(Version.class);
+        MockedStatic<Node> node = Mockito.mockStatic(Node.class);
+        MockedStatic<NodeL10n> nodeL10n = Mockito.mockStatic(NodeL10n.class);
+        MockedStatic<Compressor.COMPRESSOR_TYPE> compressor =
+            Mockito.mockStatic(Compressor.COMPRESSOR_TYPE.class)) {
+
+      version.when(Version::getVersionString).thenReturn("v-string");
+      version.when(Version::currentBuildNumber).thenReturn(123);
+      version.when(Version::gitRevision).thenReturn("rev-xyz");
+      //noinspection ResultOfMethodCallIgnored
+      node.when(Node::isTestnetEnabled).thenReturn(true);
+      compressor
+          .when(Compressor.COMPRESSOR_TYPE::getHelloCompressorDescriptor)
+          .thenReturn("descriptor");
+
+      BaseL10n base = Mockito.mock(BaseL10n.class);
+      Mockito.when(base.getSelectedLanguage()).thenReturn(BaseL10n.LANGUAGE.ENGLISH);
+      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
+
+      NodeHelloMessage message = new NodeHelloMessage("connection-1");
+
+      SimpleFieldSet sfs = message.getFieldSet();
+
+      assertAll(
+          () -> assertEquals("2.0", sfs.get("FCPVersion")),
+          () -> assertEquals("Cryptad", sfs.get("Node")),
+          () -> assertEquals("v-string", sfs.get("Version")),
+          () -> assertEquals("123", sfs.get("Build")),
+          () -> assertEquals("rev-xyz", sfs.get("Revision")),
+          () -> assertTrue(Node.isTestnetEnabled()),
+          () -> assertEquals("true", sfs.get("Testnet")),
+          () -> assertEquals("descriptor", sfs.get("CompressionCodecs")),
+          () -> assertEquals("connection-1", sfs.get("ConnectionIdentifier")),
+          () -> assertEquals(BaseL10n.LANGUAGE.ENGLISH.toString(), sfs.get("NodeLanguage")),
+          () -> assertEquals(9, sfs.directKeys().size()));
+    }
+  }
+
+  @Test
+  void getName_whenCalled_returnsNodeHello() {
+    NodeHelloMessage message = new NodeHelloMessage("id");
+
+    assertEquals(NodeHelloMessage.NAME, message.getName());
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidException() {
+    NodeHelloMessage message = new NodeHelloMessage("id");
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> message.run(Mockito.mock(FCPConnectionHandler.class), Mockito.mock(Node.class)));
+
+    assertAll(
+        () -> assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode),
+        () ->
+            assertEquals(
+                "NodeHello goes from server to client not the other way around",
+                exception.getMessage()),
+        () -> assertNull(exception.ident),
+        () -> assertFalse(exception.global));
+  }
+}


### PR DESCRIPTION
## Summary
- expand NodeHelloMessage Javadoc to clarify outbound-only behavior and connection metadata
- add NodeHelloMessageTest covering field set content, name constant, and rejection of inbound messages
- assert testnet flag and language hints in greeting fields

## Testing
- ./gradlew spotlessApply
- (tests not run in this change)