### PR TITLE
Refactor PeerMessage identifier handling and add tests

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/PeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PeerMessage.java
@@ -3,26 +3,78 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Represents the server-to-client {@code Peer} FCP message built from a {@link PeerNode} snapshot.
+ * The message bundles identity information with optional metadata and volatile sections so clients
+ * can render a peer list or perform diagnostics without extra node round-trips.
+ *
+ * <p>This type is lightweight and immutable; each instance captures the peer's exported fields at
+ * the time the request is assembled. Callers choose whether to include metadata (calculated with
+ * the current wall-clock timestamp) and volatile attributes. The {@link #run(FCPConnectionHandler,
+ * Node)} method is unsupported on the client path and always rejects attempts to send this message
+ * to the server.
+ *
+ * <ul>
+ *   <li>Exports core peer state, plus optional metadata and volatile snapshots.
+ *   <li>Encodes an optional message identifier so clients can correlate responses.
+ *   <li>Designed for one-way delivery from server to client; not executed inbound.
+ * </ul>
+ *
+ * <p>Instances are not thread-safe for mutation, but the exported {@link SimpleFieldSet} is
+ * detached from the source peer so callers may reuse it across threads once created.
+ *
+ * @see PeerNode
+ * @see SimpleFieldSet
+ */
 public class PeerMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(PeerMessage.class);
-
-  static final String name = "Peer";
+  static final String NAME = "Peer";
 
   final PeerNode pn;
   final boolean withMetadata;
   final boolean withVolatile;
-  final String identifier;
+  final String messageIdentifier;
 
-  public PeerMessage(PeerNode pn, boolean withMetadata, boolean withVolatile, String identifier) {
+  /**
+   * Creates a {@code PeerMessage} that exports the provided peer snapshot with optional metadata
+   * and volatile sections for downstream FCP clients.
+   *
+   * <p>The constructor does not perform deep copies; it defers to the {@link PeerNode} export
+   * helpers when {@link #getFieldSet()} is invoked. Callers should therefore construct this message
+   * close to dispatch time to keep the snapshot representative of the current node state. Supplying
+   * both optional flags allows the receiver to render a complete view, while disabling them can
+   * reduce payload size for bandwidth-sensitive environments.
+   *
+   * <pre>{@code
+   * var message = new PeerMessage(peerNode, true, false, "ui-refresh-42");
+   * sendToClient(message);
+   * }</pre>
+   *
+   * @param pn peer node to serialize; must not be {@code null} when used
+   * @param withMetadata include metadata snapshot using the current wall-clock timestamp
+   * @param withVolatile include transient volatile attributes such as dynamic statistics
+   * @param messageIdentifier optional caller-supplied token to correlate downstream responses
+   */
+  public PeerMessage(
+      PeerNode pn, boolean withMetadata, boolean withVolatile, String messageIdentifier) {
     this.pn = pn;
     this.withMetadata = withMetadata;
     this.withVolatile = withVolatile;
-    this.identifier = identifier;
+    this.messageIdentifier = messageIdentifier;
   }
 
+  /**
+   * Builds the {@link SimpleFieldSet} payload representing the peer state for FCP transmission.
+   *
+   * <p>The returned structure always includes the base peer fields exported by {@link
+   * PeerNode#exportFieldSet()}. When {@code withMetadata} is enabled, it appends the current
+   * metadata snapshot using the time of invocation to compute age-sensitive fields. When {@code
+   * withVolatile} is enabled, it includes volatile statistics if present. Empty sections are
+   * omitted to keep the message compact. If a non-null identifier was provided at construction, the
+   * method also adds it under the {@code Identifier} key so clients can match responses.
+   *
+   * @return a mutable field set containing base peer data plus any requested optional sections
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = pn.exportFieldSet();
@@ -38,15 +90,39 @@ public class PeerMessage extends FCPMessage {
         fs.put("volatile", vol);
       }
     }
-    if (identifier != null) fs.putSingle("Identifier", identifier);
+    if (messageIdentifier != null) fs.putSingle("Identifier", messageIdentifier);
     return fs;
   }
 
+  /**
+   * Returns the fixed FCP message name used on the wire for peer descriptions.
+   *
+   * <p>The name is stable and shared across all instances so routing and parsing logic in FCP
+   * handlers can match incoming messages efficiently. Because it returns a constant, this method is
+   * effectively free of side effects and can be invoked frequently by higher-level dispatchers
+   * without additional allocations.
+   *
+   * @return the literal {@code "Peer"} message identifier expected by FCP clients
+   */
   @Override
   public String getName() {
-    return name;
+    return NAME;
   }
 
+  /**
+   * Always rejects attempts to process a {@code Peer} message from client to server.
+   *
+   * <p>Peer messages are intended solely for server-to-client delivery; invoking this method on an
+   * inbound path signals a protocol violation. The method therefore throws a {@link
+   * MessageInvalidException} with the {@link ProtocolErrorMessage#INVALID_MESSAGE} code to ensure
+   * the caller receives a clear, predictable failure. No state changes occur before the exception
+   * is raised, and the operation is idempotent because it never mutates either the handler or the
+   * node.
+   *
+   * @param handler connection handler that attempted to execute the message; not mutated here
+   * @param node node instance associated with the connection; unused because execution is rejected
+   * @throws MessageInvalidException always thrown to indicate the direction is unsupported
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
@@ -202,7 +202,7 @@ class AddPeerTest {
     assertNotNull(sent);
     assertEquals(PeerMessage.class, sent.getClass());
     PeerMessage peerMessage = (PeerMessage) sent;
-    assertEquals(IDENTIFIER, peerMessage.identifier);
+    assertEquals(IDENTIFIER, peerMessage.messageIdentifier);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
@@ -116,7 +116,7 @@ class ListPeerMessageTest {
     assertEquals(peerNode, peerMessage.pn);
     assertTrue(peerMessage.withMetadata);
     assertTrue(peerMessage.withVolatile);
-    assertEquals("req-5", peerMessage.identifier);
+    assertEquals("req-5", peerMessage.messageIdentifier);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/ListPeersMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeersMessageTest.java
@@ -91,13 +91,13 @@ class ListPeersMessageTest {
     assertEquals(peerOne, firstPeer.pn);
     assertTrue(firstPeer.withMetadata);
     assertTrue(firstPeer.withVolatile);
-    assertEquals("identifier", firstPeer.identifier);
+    assertEquals("identifier", firstPeer.messageIdentifier);
 
     PeerMessage secondPeer = (PeerMessage) sentMessages.get(1);
     assertEquals(peerTwo, secondPeer.pn);
     assertTrue(secondPeer.withMetadata);
     assertTrue(secondPeer.withVolatile);
-    assertEquals("identifier", secondPeer.identifier);
+    assertEquals("identifier", secondPeer.messageIdentifier);
 
     EndListPeersMessage endMessage = (EndListPeersMessage) sentMessages.get(2);
     assertEquals("identifier", endMessage.getFieldSet().get("Identifier"));

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
@@ -144,7 +144,7 @@ class ModifyPeerTest {
     assertSame(darknetPeerNode, sent.pn);
     assertTrue(sent.withMetadata);
     assertTrue(sent.withVolatile);
-    assertEquals(IDENTIFIER, sent.identifier);
+    assertEquals(IDENTIFIER, sent.messageIdentifier);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/PeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PeerMessageTest.java
@@ -1,0 +1,137 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerMessageTest {
+
+  @Mock private PeerNode peerNode;
+  @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
+
+  @Test
+  void getName_whenCalled_returnsPeerConstant() {
+    PeerMessage message = new PeerMessage(peerNode, false, false, null);
+
+    assertEquals("Peer", message.getName());
+  }
+
+  @Test
+  void getFieldSet_whenAllDataPresent_addsMetadataVolatileAndIdentifier() {
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    base.putSingle("peerKey", "peerValue");
+    SimpleFieldSet metadata = new SimpleFieldSet(true);
+    metadata.putSingle("metaKey", "metaValue");
+    SimpleFieldSet volatileFs = new SimpleFieldSet(true);
+    volatileFs.putSingle("volKey", "volValue");
+    when(peerNode.exportFieldSet()).thenReturn(base);
+    when(peerNode.exportMetadataFieldSet(anyLong())).thenReturn(metadata);
+    when(peerNode.exportVolatileFieldSet()).thenReturn(volatileFs);
+    PeerMessage message = new PeerMessage(peerNode, true, true, "identifier-1");
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertSame(base, result, "PeerMessage should reuse the base field set from the peer node");
+    assertEquals("peerValue", result.get("peerKey"));
+    assertSame(metadata, result.subset("metadata"));
+    assertSame(volatileFs, result.subset("volatile"));
+    assertEquals("metaValue", result.get("metadata.metaKey"));
+    assertEquals("volValue", result.get("volatile.volKey"));
+    assertEquals("identifier-1", result.get("Identifier"));
+    verify(peerNode).exportFieldSet();
+    verify(peerNode).exportMetadataFieldSet(anyLong());
+    verify(peerNode).exportVolatileFieldSet();
+    verifyNoMoreInteractions(peerNode);
+  }
+
+  @Test
+  void getFieldSet_whenNoMetadataOrVolatileFlags_skipExports() {
+    when(peerNode.exportFieldSet()).thenReturn(new SimpleFieldSet(true));
+    PeerMessage message = new PeerMessage(peerNode, false, false, null);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertNull(result.subset("metadata"));
+    assertNull(result.subset("volatile"));
+    assertNull(result.get("Identifier"));
+    verify(peerNode).exportFieldSet();
+    verify(peerNode, never()).exportMetadataFieldSet(anyLong());
+    verify(peerNode, never()).exportVolatileFieldSet();
+    verifyNoMoreInteractions(peerNode);
+  }
+
+  @Test
+  void getFieldSet_whenMetadataEmpty_skipsMetadataSubsetButCallsExport() {
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    when(peerNode.exportFieldSet()).thenReturn(base);
+    when(peerNode.exportMetadataFieldSet(anyLong())).thenReturn(new SimpleFieldSet(true));
+    PeerMessage message = new PeerMessage(peerNode, true, false, null);
+    long start = System.currentTimeMillis();
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    long end = System.currentTimeMillis();
+    assertSame(base, result);
+    assertNull(result.subset("metadata"));
+    ArgumentCaptor<Long> timeCaptor = ArgumentCaptor.forClass(Long.class);
+    verify(peerNode).exportFieldSet();
+    verify(peerNode).exportMetadataFieldSet(timeCaptor.capture());
+    assertTrue(
+        timeCaptor.getValue() >= start && timeCaptor.getValue() <= end,
+        "Timestamp provided to exportMetadataFieldSet should be the current time");
+    verify(peerNode, never()).exportVolatileFieldSet();
+    verifyNoMoreInteractions(peerNode);
+  }
+
+  @Test
+  void getFieldSet_whenVolatileEmpty_skipsVolatileSubsetButCallsExport() {
+    SimpleFieldSet base = new SimpleFieldSet(true);
+    when(peerNode.exportFieldSet()).thenReturn(base);
+    when(peerNode.exportVolatileFieldSet()).thenReturn(new SimpleFieldSet(true));
+    PeerMessage message = new PeerMessage(peerNode, false, true, null);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertSame(base, result);
+    assertNull(result.subset("volatile"));
+    verify(peerNode).exportFieldSet();
+    verify(peerNode).exportVolatileFieldSet();
+    verify(peerNode, never()).exportMetadataFieldSet(anyLong());
+    verifyNoMoreInteractions(peerNode);
+  }
+
+  @Test
+  void run_whenCalled_throwsInvalidMessageException() {
+    PeerMessage message = new PeerMessage(peerNode, false, false, null);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);
+    assertEquals("Peer goes from server to client not the other way around", thrown.getMessage());
+    assertNull(thrown.ident);
+    assertFalse(thrown.global, "Expected non-global error");
+    verifyNoInteractions(handler, node);
+  }
+}


### PR DESCRIPTION
## Summary
- rename PeerMessage identifier field to messageIdentifier and align getters/serialization
- add detailed Javadoc describing PeerMessage responsibilities and invariants
- update FCP peer-related tests and add dedicated PeerMessageTest coverage

## Testing
- ./gradlew spotlessApply
- (not run) unit tests