### PR TITLE
Refactor PeerNote naming and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/PeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/PeerNote.java
@@ -3,47 +3,118 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.support.Base64;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Represents an FCP {@code PeerNote} message delivered from a node to a client.
+ *
+ * <p>The message packages a node identifier, a classified note type, and a UTF-8 note body that is
+ * Base64 encoded to comply with the text-only framing used by the Freenet Client Protocol. It is
+ * created server side and emitted toward connected clients; when invoked in the opposite direction
+ * it is rejected as invalid. Instances are immutable after construction, so they can be safely
+ * retained or shared between threads as long as the underlying note content does not change.
+ * Typical consumers forward the produced {@link SimpleFieldSet} to the outbound FCP transport and
+ * rely on the note type to decide how the recipient should interpret the note.
+ *
+ * <ul>
+ *   <li>Encodes note text in Base64 with UTF-8 input semantics.
+ *   <li>Includes the origin node identifier so clients can correlate notes to peers.
+ *   <li>Optionally carries a message identifier for request/response correlation.
+ * </ul>
+ *
+ * @see FCPMessage
+ * @see SimpleFieldSet
+ */
 public class PeerNote extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(PeerNote.class);
 
-  static final String name = "PeerNote";
+  static final String NAME = "PeerNote";
 
   final String noteText;
   final int peerNoteType;
   final String nodeIdentifier;
-  final String identifier;
+  final String messageIdentifier;
 
+  /**
+   * Creates a peer note payload ready for transmission to an FCP client.
+   *
+   * <p>The constructor captures the immutable node identifier, the textual note content, and a
+   * numeric type that indicates how the receiver should categorize the note. The optional message
+   * identifier allows callers to correlate responses when a note is sent in reply to a previous
+   * request; it may be {@code null} for unsolicited notifications. Note text is accepted verbatim
+   * here and is Base64 encoded later when the field set is built, keeping construction lightweight
+   * and deferring encoding costs to the serialization step.
+   *
+   * <pre>{@code
+   * // Example: create a categorized note for a known peer
+   * PeerNote note = new PeerNote(peerId, "Peer capacity changed", 2, "note-42");
+   * }</pre>
+   *
+   * @param nodeIdentifier stable identifier of the peer that the note concerns; never {@code null}.
+   * @param noteText human-readable note body in UTF-8; empty strings are permitted but discouraged.
+   * @param peerNoteType integer classification flag understood by the remote endpoint; non-negative
+   *     values typically map to predefined categories.
+   * @param identifier optional correlation identifier attached to the outbound message; may be
+   *     {@code null} when no response is expected.
+   */
   public PeerNote(String nodeIdentifier, String noteText, int peerNoteType, String identifier) {
     this.nodeIdentifier = nodeIdentifier;
     this.noteText = noteText;
     this.peerNoteType = peerNoteType;
-    this.identifier = identifier;
+    this.messageIdentifier = identifier;
   }
 
+  /**
+   * Builds the {@link SimpleFieldSet} representation for outbound transmission.
+   *
+   * <p>The returned field set contains the node identifier, the numeric note type, and the note
+   * text encoded with {@link Base64#encodeUTF8(String, boolean)} to maintain transport safety in
+   * the text-oriented FCP protocol. When a message identifier was supplied at construction time, it
+   * is added under the {@code Identifier} key; otherwise the key is omitted. A fresh field set is
+   * created on every call to avoid unintended sharing between multiple dispatches.
+   *
+   * @return new field set containing all message parts encoded for the FCP wire format.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("NodeIdentifier", nodeIdentifier);
     fs.put("PeerNoteType", peerNoteType);
     fs.putSingle("NoteText", Base64.encodeUTF8(noteText, true));
-    if (identifier != null) fs.putSingle("Identifier", identifier);
+    if (messageIdentifier != null) fs.putSingle("Identifier", messageIdentifier);
     return fs;
   }
 
+  /**
+   * Returns the protocol name for this message type.
+   *
+   * <p>The name is a fixed constant ({@value #NAME}) used by the FCP framing layer to advertise the
+   * message kind to peer implementations. The value never changes across instances or executions.
+   *
+   * @return constant string {@code "PeerNote"} expected by FCP clients and servers.
+   */
   @Override
   public String getName() {
-    return name;
+    return NAME;
   }
 
+  /**
+   * Rejects attempts to process {@code PeerNote} messages sent from a client to the server.
+   *
+   * <p>{@code PeerNote} is a server-to-client notification, so receiving it from a client indicates
+   * protocol misuse or a buggy peer. This method enforces the direction constraint by always
+   * throwing a {@link MessageInvalidException}, allowing the caller to generate a protocol error
+   * response that explains the violation. No state is modified prior to raising the exception.
+   *
+   * @param handler connection context invoking the message handler; used only for validation.
+   * @param node active node instance representing the running server; not used when rejecting the
+   *     message but provided to satisfy the superclass contract.
+   * @throws MessageInvalidException always thrown to signal that the message direction is invalid.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PeerNote goes from server to client not the other way around",
-        identifier,
+        messageIdentifier,
         false);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
@@ -161,7 +161,7 @@ class ListPeerNotesMessageTest {
     assertEquals("node-3", peerNote.nodeIdentifier);
     assertEquals("secret-note", peerNote.noteText);
     assertEquals(Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT, peerNote.peerNoteType);
-    assertEquals("req-7", peerNote.identifier);
+    assertEquals("req-7", peerNote.messageIdentifier);
 
     EndListPeerNotesMessage endMessage =
         assertInstanceOf(EndListPeerNotesMessage.class, captor.getAllValues().get(1));

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
@@ -216,7 +216,7 @@ class ModifyPeerNoteTest {
     assertEquals(NODE_IDENTIFIER, sent.nodeIdentifier);
     assertEquals(NOTE_TEXT, sent.noteText);
     assertEquals(Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT, sent.peerNoteType);
-    assertEquals(IDENTIFIER, sent.identifier);
+    assertEquals(IDENTIFIER, sent.messageIdentifier);
   }
 
   private static SimpleFieldSet baseFieldSet() {

--- a/src/test/java/network/crypta/clients/fcp/PeerNoteTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PeerNoteTest.java
@@ -1,0 +1,87 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import network.crypta.node.Node;
+import network.crypta.support.Base64;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PeerNoteTest {
+
+  private static final String NODE_IDENTIFIER = "peer-123";
+  private static final String NOTE_TEXT = "A short note";
+  private static final int PEER_NOTE_TYPE = 2;
+  private static final String IDENTIFIER = "req-99";
+
+  @Mock FCPConnectionHandler handler;
+  @Mock Node node;
+
+  @Test
+  void getFieldSet_whenIdentifierProvided_containsEncodedFields() {
+    PeerNote peerNote = new PeerNote(NODE_IDENTIFIER, NOTE_TEXT, PEER_NOTE_TYPE, IDENTIFIER);
+
+    SimpleFieldSet fieldSet = peerNote.getFieldSet();
+
+    assertEquals(NODE_IDENTIFIER, fieldSet.get("NodeIdentifier"));
+    assertEquals(Integer.toString(PEER_NOTE_TYPE), fieldSet.get("PeerNoteType"));
+    assertEquals(Base64.encodeUTF8(NOTE_TEXT, true), fieldSet.get("NoteText"));
+    assertEquals(IDENTIFIER, fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierNull_omitsIdentifierField() {
+    PeerNote peerNote = new PeerNote(NODE_IDENTIFIER, NOTE_TEXT, PEER_NOTE_TYPE, null);
+
+    SimpleFieldSet fieldSet = peerNote.getFieldSet();
+
+    assertEquals(NODE_IDENTIFIER, fieldSet.get("NodeIdentifier"));
+    assertEquals(Integer.toString(PEER_NOTE_TYPE), fieldSet.get("PeerNoteType"));
+    assertEquals(Base64.encodeUTF8(NOTE_TEXT, true), fieldSet.get("NoteText"));
+    assertNull(fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void getName_returnsPeerNoteLiteral() {
+    PeerNote peerNote = new PeerNote(NODE_IDENTIFIER, NOTE_TEXT, PEER_NOTE_TYPE, IDENTIFIER);
+
+    assertEquals("PeerNote", peerNote.getName());
+  }
+
+  @Test
+  void run_always_throwsInvalidMessageWithDetails() {
+    PeerNote peerNote = new PeerNote(NODE_IDENTIFIER, NOTE_TEXT, PEER_NOTE_TYPE, IDENTIFIER);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> peerNote.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
+    assertEquals("PeerNote goes from server to client not the other way around", ex.getMessage());
+    assertEquals(IDENTIFIER, ex.ident);
+    assertFalse(ex.global);
+    verifyNoInteractions(handler, node);
+  }
+
+  @Test
+  void run_whenIdentifierNull_throwsInvalidMessageWithNullIdent() {
+    PeerNote peerNote = new PeerNote(NODE_IDENTIFIER, NOTE_TEXT, PEER_NOTE_TYPE, null);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> peerNote.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
+    assertEquals("PeerNote goes from server to client not the other way around", ex.getMessage());
+    assertNull(ex.ident);
+    assertFalse(ex.global);
+    verifyNoInteractions(handler, node);
+  }
+}


### PR DESCRIPTION
## Summary
- rename PeerNote identifiers to clearer constants/field names and add documentation
- update FCP peer note tests to align with renamed field
- add dedicated PeerNote tests for field set encoding, name, and invalid direction handling

## Testing
- not run