### PR TITLE
Improve PeerRemoved message clarity and add tests

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/PeerRemoved.java
+++ b/src/main/java/network/crypta/clients/fcp/PeerRemoved.java
@@ -2,43 +2,109 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Notifies an FCP client that a peer was removed from the node's peer list.
+ *
+ * <p>The server emits this message when it drops a previously known peer, allowing clients that
+ * cache peer metadata to evict stale entries and stop scheduling activity for that peer. The
+ * message carries the remote peer's identity, the locally assigned node identifier, and the
+ * optional client-supplied identifier used to correlate asynchronous events. Instances are
+ * immutable after creation and are intended to be serialized directly to the FCP wire format via
+ * {@link #getFieldSet()}.
+ *
+ * <p>Typical consumers enqueue the message for delivery to a connected client session, and do not
+ * reuse or modify it across threads. The class itself is thread-safe because it exposes only final
+ * state, but concurrent dispatchers should still avoid sharing mutable transport buffers. As part
+ * of the server-to-client event stream it obeys the FCP rule that clients never send this message
+ * back to the server; attempts to do so are rejected by {@link #run(FCPConnectionHandler, Node)}.
+ *
+ * <ul>
+ *   <li>Represents a peer removal event originating from the server.
+ *   <li>Encapsulates identity, node identifier, and an optional correlation token.
+ *   <li>Serializable through {@link SimpleFieldSet} for FCP transport.
+ * </ul>
+ *
+ * @see FCPMessage
+ * @see SimpleFieldSet
+ */
 public class PeerRemoved extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(PeerRemoved.class);
 
-  static final String name = "PeerRemoved";
+  static final String NAME = "PeerRemoved";
   final String identity;
   final String nodeIdentifier;
-  final String identifier;
+  final String messageIdentifier;
 
+  /**
+   * Creates a removal notification with the identifiers needed by downstream FCP clients.
+   *
+   * <p>The constructor captures the remote peer's long-term {@code identity}, the local {@code
+   * nodeIdentifier} used within this node's peer registry, and an optional {@code identifier}
+   * chosen by the client when it subscribed to peer events. All arguments are stored verbatim and
+   * are not validated here; callers should pass canonical values. The resulting instance is
+   * immutable and can be safely shared for read-only use across components that emit FCP messages.
+   *
+   * @param identity canonical identity string for the removed peer; never {@code null}
+   * @param nodeIdentifier local node identifier associated with the peer; never {@code null}
+   * @param identifier optional client correlation token; may be {@code null} when unspecified
+   */
   public PeerRemoved(String identity, String nodeIdentifier, String identifier) {
     this.identity = identity;
     this.nodeIdentifier = nodeIdentifier;
-    this.identifier = identifier;
+    this.messageIdentifier = identifier;
   }
 
+  /**
+   * Builds the FCP field set representing this removal event for wire transmission.
+   *
+   * <p>The returned {@link SimpleFieldSet} includes the mandatory {@code Identity} and {@code
+   * NodeIdentifier} entries. When a client-supplied message identifier is present it is emitted as
+   * {@code Identifier}; otherwise that field is omitted. The field set is created fresh on each
+   * call and is safe for the caller to mutate or serialize without affecting this instance.
+   *
+   * @return new field set containing identity, node identifier, and optional correlation token
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("Identity", identity);
     fs.putSingle("NodeIdentifier", nodeIdentifier);
-    if (identifier != null) fs.putSingle("Identifier", identifier);
+    if (messageIdentifier != null) fs.putSingle("Identifier", messageIdentifier);
     return fs;
   }
 
+  /**
+   * Returns the protocol-level name that identifies this FCP message type.
+   *
+   * <p>The name is a stable constant used by encoders and decoders to route messages through the
+   * correct handlers. It does not vary with instance state and is always {@code "PeerRemoved"}.
+   *
+   * @return constant string {@code "PeerRemoved"} identifying the message on the wire
+   */
   @Override
   public String getName() {
-    return name;
+    return NAME;
   }
 
+  /**
+   * Rejects client attempts to send this server-only event back to the node.
+   *
+   * <p>Because {@code PeerRemoved} is defined as a server-to-client notification, any invocation of
+   * this method from a client handler results in a {@link MessageInvalidException} that maps to the
+   * {@link ProtocolErrorMessage#INVALID_MESSAGE} error. The exception includes the original message
+   * identifier, when provided, so clients can correlate the rejection. The method performs no other
+   * side effects and is intentionally non-idempotent only in that it always throws.
+   *
+   * @param handler connection handler that attempted to process the message; never {@code null}
+   * @param node current node instance that received the invalid message; never {@code null}
+   * @throws MessageInvalidException always thrown to signal that the direction is unsupported
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PeerRemoved goes from server to client not the other way around",
-        identifier,
+        messageIdentifier,
         false);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/PeerRemovedTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PeerRemovedTest.java
@@ -1,0 +1,61 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class PeerRemovedTest {
+
+  @Test
+  void getFieldSet_whenIdentifierPresent_containsAllFields() {
+    PeerRemoved message = new PeerRemoved("identity-123", "node-abc", "request-42");
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertEquals("identity-123", fieldSet.get("Identity"));
+    assertEquals("node-abc", fieldSet.get("NodeIdentifier"));
+    assertEquals("request-42", fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierNull_excludesIdentifierField() {
+    PeerRemoved message = new PeerRemoved("identity-123", "node-abc", null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertEquals("identity-123", fieldSet.get("Identity"));
+    assertEquals("node-abc", fieldSet.get("NodeIdentifier"));
+    assertNull(fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void getName_whenInvoked_returnsPeerRemoved() {
+    PeerRemoved message = new PeerRemoved("identity", "node", "id");
+
+    String name = message.getName();
+
+    assertEquals("PeerRemoved", name);
+  }
+
+  @Test
+  void run_whenCalled_throwsMessageInvalidExceptionWithDetails() {
+    PeerRemoved message = new PeerRemoved("identity-123", "node-abc", "request-42");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "PeerRemoved goes from server to client not the other way around", exception.getMessage());
+    assertEquals("request-42", exception.ident);
+    assertFalse(exception.global);
+  }
+}


### PR DESCRIPTION
## Summary
- rewrite PeerRemoved FCP message to use clearer naming and comprehensive Javadoc
- add focused unit tests covering field set emission, naming, and invalid run handling
- remove unused logger and ensure optional identifier handling is explicit

## Testing
- spotlessApply
- not run: gradle test