### PR TITLE
Fix PersistentPut serialization and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/PersistentPut.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPut.java
@@ -8,15 +8,34 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Represents a persistent insert description sent over the FCP channel.
+ *
+ * <p>This immutable message wrapper bundles the parameters describing a long-lived insert request,
+ * including URIs, compression preferences, and retry behavior, so they can be serialized into a
+ * {@link SimpleFieldSet} for transmission. Instances are constructed on the server side when
+ * enumerating or mirroring client requests and are never executed in the inbound direction, as
+ * {@link #run(FCPConnectionHandler, Node)} always rejects client-sourced messages.
+ *
+ * <p>Use this type when a caller needs to:
+ *
+ * <ul>
+ *   <li>Report the state of an insert back to an FCP client.
+ *   <li>Preserve the identifiers and upload source used during request creation.
+ *   <li>Emit metadata such as MIME type, compression codecs, and crypto keys alongside persistence
+ *       settings.
+ * </ul>
+ *
+ * <p>All fields are final, making the instances thread-safe to publish and reuse across handlers.
+ * Optional attributes accept {@code null} values to keep the serialized payload compact when data
+ * is unavailable.
+ */
 public class PersistentPut extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(PersistentPut.class);
 
-  static final String name = "PersistentPut";
+  static final String NAME = "PersistentPut";
 
-  final String identifier;
+  final String requestIdentifier;
   final FreenetURI uri;
   final FreenetURI privateURI;
   final int verbosity;
@@ -39,6 +58,39 @@ public class PersistentPut extends FCPMessage {
   final byte[] splitfileCryptoKey;
   final String compressorDescriptor;
 
+  /**
+   * Creates a {@code PersistentPut} message populated with the supplied insert parameters.
+   *
+   * <p>The constructor performs no additional validation beyond assigning the provided values, so
+   * callers must ensure that the public and private URIs, upload source, and persistence level are
+   * consistent with the originating request. Optional properties such as filenames, MIME type, and
+   * compression descriptor may be {@code null} and will be omitted when {@link #getFieldSet()}
+   * serializes the message. The splitfile crypto key and compatibility mode are stored verbatim so
+   * downstream components can honor the client's encryption and codec expectations.
+   *
+   * @param identifier unique request token echoed back to clients when listing
+   * @param publicURI public insert URI associated with the persistent request
+   * @param privateURI optional private insert URI used for future control
+   * @param verbosity numeric verbosity flag requested by the originating client
+   * @param priorityClass scheduler priority assigned to the insert operation
+   * @param uploadFrom source indicating how the payload is supplied to FCP
+   * @param targetURI optional destination URI when the insert is redirected
+   * @param persistence desired persistence policy for the underlying request
+   * @param origFilename local file backing the upload when present on disk
+   * @param mimeType declared MIME type to include in metadata, if available
+   * @param global whether the request was marked global across client sessions
+   * @param size content length in bytes, or {@code -1} when unspecified
+   * @param clientToken opaque client-provided token preserved in responses
+   * @param started whether the insert has already begun processing
+   * @param maxRetries maximum retry attempts configured for this insert
+   * @param targetFilename preferred filename for on-disk storage when provided
+   * @param binaryBlob whether the payload should bypass metadata processing
+   * @param compatMode insert compatibility mode requested by the client
+   * @param dontCompress indicates compression avoidance despite default behavior
+   * @param compressorDescriptor explicit codec pipeline description, if supplied
+   * @param realTime whether the request should be treated with real-time bias
+   * @param splitfileCryptoKey encryption key for splitfile segments, if known
+   */
   public PersistentPut(
       String identifier,
       FreenetURI publicURI,
@@ -62,7 +114,7 @@ public class PersistentPut extends FCPMessage {
       String compressorDescriptor,
       boolean realTime,
       byte[] splitfileCryptoKey) {
-    this.identifier = identifier;
+    this.requestIdentifier = identifier;
     this.uri = publicURI;
     this.privateURI = privateURI;
     this.verbosity = verbosity;
@@ -86,10 +138,22 @@ public class PersistentPut extends FCPMessage {
     this.splitfileCryptoKey = splitfileCryptoKey;
   }
 
+  /**
+   * Serializes the persistent insert description into an {@link SimpleFieldSet}.
+   *
+   * <p>The resulting structure contains only the populated attributes, preserving optional fields
+   * such as private URIs, filenames, and codec descriptors when present while omitting them when
+   * null. Boolean flags mirror the constructor values verbatim, allowing downstream consumers to
+   * reconstruct the original request intent without altering defaults or applying extra policy. Any
+   * provided splitfile crypto key is hex-encoded to ensure safe transport in the textual field-set
+   * representation used by the FCP wire format.
+   *
+   * @return immutable {@code SimpleFieldSet} snapshot ready for transmission to clients
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", requestIdentifier);
     fs.putSingle("URI", uri.toString(false, false));
     if (privateURI != null) fs.putSingle("PrivateURI", privateURI.toString(false, false));
     fs.put("Verbosity", verbosity);
@@ -105,7 +169,7 @@ public class PersistentPut extends FCPMessage {
     fs.put("Started", started);
     fs.put("MaxRetries", maxRetries);
     if (targetFilename != null) fs.putSingle("TargetFilename", targetFilename);
-    if (binaryBlob) fs.put("BinaryBlob", binaryBlob);
+    if (binaryBlob) fs.put("BinaryBlob", true);
     fs.putOverwrite("CompatibilityMode", compatMode.name());
     fs.put("DontCompress", dontCompress);
     if (compressorDescriptor != null) fs.putSingle("Codecs", compressorDescriptor);
@@ -115,17 +179,38 @@ public class PersistentPut extends FCPMessage {
     return fs;
   }
 
+  /**
+   * Returns the protocol-level name for this FCP message type.
+   *
+   * <p>The value is constant ({@code "PersistentPut"}) and is used when encoding the message onto
+   * the wire or when matching inbound message types. It does not vary with request parameters and
+   * can be safely cached by protocol dispatchers.
+   *
+   * @return stable message type identifier expected by the FCP protocol
+   */
   @Override
   public String getName() {
-    return name;
+    return NAME;
   }
 
+  /**
+   * Rejects inbound attempts to execute a {@code PersistentPut} from a client.
+   *
+   * <p>This message is intended to flow from the server to the client when describing existing
+   * persistent insert requests; executing it in the opposite direction would represent a protocol
+   * error. Consequently, this method always throws {@link MessageInvalidException} to signal the
+   * invalid direction while preserving the identifier and global flag for diagnostics.
+   *
+   * @param handler connection handler that attempted to process the message
+   * @param node node reference supplied by the caller, unused because of rejection
+   * @throws MessageInvalidException always thrown to indicate the invalid message direction
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PersistentPut goes from server to client not the other way around",
-        identifier,
+        requestIdentifier,
         global);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/PersistentPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentPutTest.java
@@ -1,0 +1,199 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.nio.file.Path;
+import network.crypta.client.InsertContext;
+import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.Node;
+import network.crypta.support.HexUtil;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PersistentPutTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void getFieldSet_whenAllFieldsProvided_populatesAllKeys() {
+    FreenetURI publicUri = new FreenetURI("KSK", "public");
+    FreenetURI privateUri = new FreenetURI("KSK", "private");
+    FreenetURI targetUri = new FreenetURI("KSK", "target");
+    File originalFile = tempDir.resolve("upload.bin").toFile();
+    byte[] cryptoKey = new byte[] {0x01, 0x02, 0x0A, (byte) 0xFF};
+
+    PersistentPut put =
+        new PersistentPut(
+            "id-123",
+            publicUri,
+            privateUri,
+            2,
+            (short) 5,
+            UploadFrom.DIRECT,
+            targetUri,
+            Persistence.FOREVER,
+            originalFile,
+            "text/plain",
+            true,
+            1024L,
+            "token-abc",
+            true,
+            3,
+            "target.dat",
+            true,
+            InsertContext.CompatibilityMode.COMPAT_1468,
+            true,
+            "lzma",
+            true,
+            cryptoKey);
+
+    SimpleFieldSet fs = put.getFieldSet();
+
+    assertEquals("id-123", fs.get("Identifier"));
+    assertEquals(publicUri.toString(false, false), fs.get("URI"));
+    assertEquals(privateUri.toString(false, false), fs.get("PrivateURI"));
+    assertEquals("2", fs.get("Verbosity"));
+    assertEquals("5", fs.get("PriorityClass"));
+    assertEquals("direct", fs.get("UploadFrom"));
+    assertEquals("forever", fs.get("Persistence"));
+    assertEquals(originalFile.getAbsolutePath(), fs.get("Filename"));
+    assertEquals(targetUri.toString(), fs.get("TargetURI"));
+    assertEquals("text/plain", fs.get("Metadata.ContentType"));
+    assertEquals("true", fs.get("Global"));
+    assertEquals("1024", fs.get("DataLength"));
+    assertEquals("token-abc", fs.get("ClientToken"));
+    assertEquals("true", fs.get("Started"));
+    assertEquals("3", fs.get("MaxRetries"));
+    assertEquals("target.dat", fs.get("TargetFilename"));
+    assertEquals("true", fs.get("BinaryBlob"));
+    assertEquals("COMPAT_1468", fs.get("CompatibilityMode"));
+    assertEquals("true", fs.get("DontCompress"));
+    assertEquals("lzma", fs.get("Codecs"));
+    assertEquals("true", fs.get("RealTime"));
+    assertEquals(HexUtil.bytesToHex(cryptoKey), fs.get("SplitfileCryptoKey"));
+  }
+
+  @Test
+  void getFieldSet_whenOptionalFieldsNull_omitsThoseKeys() {
+    FreenetURI publicUri = new FreenetURI("KSK", "public");
+    PersistentPut put =
+        createMinimalPut(
+            "id-optional", publicUri, Persistence.CONNECTION, false, UploadFrom.REDIRECT);
+
+    SimpleFieldSet fs = put.getFieldSet();
+
+    assertEquals("id-optional", fs.get("Identifier"));
+    assertEquals(publicUri.toString(false, false), fs.get("URI"));
+    assertEquals("redirect", fs.get("UploadFrom"));
+    assertEquals("connection", fs.get("Persistence"));
+    assertEquals("false", fs.get("Global"));
+    assertEquals("false", fs.get("Started"));
+    assertEquals("0", fs.get("MaxRetries"));
+    assertEquals("COMPAT_UNKNOWN", fs.get("CompatibilityMode"));
+    assertEquals("false", fs.get("DontCompress"));
+    assertEquals("false", fs.get("RealTime"));
+
+    assertNull(fs.get("PrivateURI"));
+    assertNull(fs.get("Filename"));
+    assertNull(fs.get("TargetURI"));
+    assertNull(fs.get("Metadata.ContentType"));
+    assertNull(fs.get("DataLength"));
+    assertNull(fs.get("ClientToken"));
+    assertNull(fs.get("TargetFilename"));
+    assertNull(fs.get("BinaryBlob"));
+    assertNull(fs.get("Codecs"));
+    assertNull(fs.get("SplitfileCryptoKey"));
+  }
+
+  @Test
+  void getName_alwaysReturnsConstant() {
+    PersistentPut put =
+        new PersistentPut(
+            "id-name",
+            new FreenetURI("KSK", "name"),
+            null,
+            1,
+            (short) 1,
+            UploadFrom.DIRECT,
+            null,
+            Persistence.REBOOT,
+            null,
+            null,
+            false,
+            -1,
+            null,
+            false,
+            0,
+            null,
+            false,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT,
+            false,
+            null,
+            false,
+            null);
+
+    assertEquals("PersistentPut", put.getName());
+  }
+
+  @Test
+  void run_whenInvoked_throwsInvalidMessageExceptionWithDetails() {
+    boolean global = true;
+    FreenetURI publicUri = new FreenetURI("KSK", "run");
+    PersistentPut put =
+        createMinimalPut("id-run", publicUri, Persistence.REBOOT, global, UploadFrom.DIRECT);
+
+    MessageInvalidException ex =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> put.run(mock(FCPConnectionHandler.class), mock(Node.class)));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
+    assertEquals(
+        "PersistentPut goes from server to client not the other way around", ex.getMessage());
+    assertEquals("id-run", ex.ident);
+    assertTrue(ex.global);
+  }
+
+  private PersistentPut createMinimalPut(
+      String identifier,
+      FreenetURI publicUri,
+      Persistence persistence,
+      boolean global,
+      UploadFrom uploadFrom) {
+    return new PersistentPut(
+        identifier,
+        publicUri,
+        null,
+        0,
+        (short) 0,
+        uploadFrom,
+        null,
+        persistence,
+        null,
+        null,
+        global,
+        -1,
+        null,
+        false,
+        0,
+        null,
+        false,
+        InsertContext.CompatibilityMode.COMPAT_UNKNOWN,
+        false,
+        null,
+        false,
+        null);
+  }
+}


### PR DESCRIPTION
## Summary
- rename PersistentPut identifier field to be protocol-accurate and make BinaryBlob flag emit explicit true
- add detailed KDoc clarifying PersistentPut directionality and serialization behavior
- introduce unit tests for field set serialization, constant name, and run() rejection

## Testing
- ./gradlew spotlessApply