### PR TITLE
Refactor PersistentPutDir field set construction

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/PersistentPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPutDir.java
@@ -1,6 +1,6 @@
 package network.crypta.clients.fcp;
 
-import java.util.HashMap;
+import java.util.Map;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.BaseManifestPutter;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
@@ -21,19 +21,44 @@ import network.crypta.support.io.TempBucketFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Builds the wire representation of a persistent directory insert request for the FCP layer.
+ *
+ * <p>This helper gathers the manifest entries, default name, compression hints, persistence
+ * expectations, and encryption material required to serialize a {@code PersistentPutDir} message
+ * that the server sends back to clients. The instance is immutable after construction; all data is
+ * pre-flattened into a {@link SimpleFieldSet} so callers can transmit the message repeatedly
+ * without re-walking the manifest tree. Use this class when the node needs to mirror a client's
+ * persistent directory insertion, for example during reconnects or resumptions where the node must
+ * restate the pending request.
+ *
+ * <p>Concurrency: the object contains only final fields and is thread-safe for read-only access.
+ * Large manifests are supported by avoiding eager string copies where possible; however, the
+ * resulting field set can still be sizeable, so callers should reuse instances rather than building
+ * them per send. The class does not perform I/O beyond inspecting the supplied buckets.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> normalize manifest elements, emit stable message fields,
+ *       attach optional metadata such as compression, retry limits, and crypto keys.
+ *   <li><strong>Notable behaviors:</strong> treats redirected targets as lightweight entries and
+ *       rejects unknown bucket types with a clear {@link IllegalStateException}.
+ * </ul>
+ *
+ * @see BaseManifestPutter#flatten(Map)
+ */
 public class PersistentPutDir extends FCPMessage {
   private static final Logger LOG = LoggerFactory.getLogger(PersistentPutDir.class);
+  private static final String NAME = "PersistentPutDir";
+  private static final String UPLOAD_FROM = "UploadFrom";
 
-  static final String name = "PersistentPutDir";
-
-  final String identifier;
+  final String clientIdentifier;
   final FreenetURI uri;
   final FreenetURI privateURI;
   final int verbosity;
   final short priorityClass;
   final Persistence persistence;
   final boolean global;
-  private final HashMap<String, Object> manifestElements;
+  private final Map<String, Object> manifestElements;
   final String defaultName;
   final String token;
   final boolean started;
@@ -46,8 +71,52 @@ public class PersistentPutDir extends FCPMessage {
   final byte[] splitfileCryptoKey;
   final InsertContext.CompatibilityMode compatMode;
 
+  /**
+   * Creates a persistent directory insert message snapshot with all supporting metadata.
+   *
+   * <p>The constructor performs the manifest flattening immediately and caches the resulting field
+   * set so repeated invocations of {@link #getFieldSet()} are cheap. Callers should pass the URIs
+   * exactly as issued by the node; no additional validation or escaping is performed here.
+   *
+   * @param clientIdentifier unique identifier that ties the message to the originating client
+   *     session; may be any non-null token the client previously registered.
+   * @param publicURI public {@link FreenetURI} that names the target insert; used when announcing
+   *     the put to peers and to reconstruct state after restarts.
+   * @param privateURI optional private {@link FreenetURI} that enables resume or cancellation for
+   *     the same request; may be {@code null} when none was issued.
+   * @param verbosity server verbosity level requested by the client; higher values surface more
+   *     progress updates and diagnostics through FCP callbacks.
+   * @param priorityClass priority band for queueing; lower numbers generally represent faster
+   *     scheduling according to node policy.
+   * @param persistence persistence scope chosen by the client; defines whether the request survives
+   *     restarts or disconnects and maps directly to {@link Persistence} values.
+   * @param global whether the request is globally scoped across the node; {@code true} keeps it
+   *     active even if the originating client disconnects.
+   * @param defaultName default filename applied to manifest entries lacking an explicit name; also
+   *     used by UI layers when constructing links.
+   * @param manifestElements flattened or hierarchical manifest elements supplied by the client; any
+   *     redirect entries must include a target URI while file entries must carry data buckets.
+   * @param token optional opaque token returned in progress callbacks; callers can use it to
+   *     correlate asynchronous updates without inspecting request identifiers.
+   * @param started whether the node should treat the request as already started, typically used
+   *     during resume flows to avoid requeuing work that was previously underway.
+   * @param maxRetries maximum retry attempts the node should perform for transient failures; zero
+   *     disables retries while positive values cap retry loops.
+   * @param dontCompress flag indicating the client disabled compression for the insert; honored as
+   *     a hint when constructing splitfiles.
+   * @param compressorDescriptor optional compressor descriptor string when compression is allowed;
+   *     may be {@code null} to use node defaults.
+   * @param wasDiskPut whether the original request streamed from disk; affects how the node
+   *     represents the upload source within the field set.
+   * @param realTime whether the insert participates in real-time scheduling, prioritizing latency
+   *     over throughput while consuming more bandwidth headroom.
+   * @param splitfileCryptoKey optional raw splitfile encryption key bytes; when provided, they are
+   *     hex-encoded into the outgoing message for client consumption.
+   * @param cmode compatibility mode derived from {@link InsertContext}; governs how manifests are
+   *     serialized for different protocol expectations.
+   */
   public PersistentPutDir(
-      String identifier,
+      String clientIdentifier,
       FreenetURI publicURI,
       FreenetURI privateURI,
       int verbosity,
@@ -55,7 +124,7 @@ public class PersistentPutDir extends FCPMessage {
       Persistence persistence,
       boolean global,
       String defaultName,
-      HashMap<String, Object> manifestElements,
+      Map<String, Object> manifestElements,
       String token,
       boolean started,
       int maxRetries,
@@ -65,7 +134,7 @@ public class PersistentPutDir extends FCPMessage {
       boolean realTime,
       byte[] splitfileCryptoKey,
       InsertContext.CompatibilityMode cmode) {
-    this.identifier = identifier;
+    this.clientIdentifier = clientIdentifier;
     this.uri = publicURI;
     this.privateURI = privateURI;
     this.verbosity = verbosity;
@@ -87,8 +156,17 @@ public class PersistentPutDir extends FCPMessage {
   }
 
   private SimpleFieldSet generateFieldSet() {
+    SimpleFieldSet fs = createBaseFieldSet();
+    ManifestElement[] elements = BaseManifestPutter.flatten(manifestElements);
+    fs.putSingle("DefaultName", defaultName);
+    fs.put("Files", createFilesFieldSet(elements));
+    addOptionalFields(fs);
+    return fs;
+  }
+
+  private SimpleFieldSet createBaseFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(false); // false because this can get HUGE
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle(IDENTIFIER, clientIdentifier);
     fs.putSingle("URI", uri.toString(false, false));
     if (privateURI != null) fs.putSingle("PrivateURI", privateURI.toString(false, false));
     fs.put("Verbosity", verbosity);
@@ -97,92 +175,142 @@ public class PersistentPutDir extends FCPMessage {
     fs.put("Global", global);
     fs.putSingle("PutDirType", wasDiskPut ? "disk" : "complex");
     fs.putOverwrite("CompatibilityMode", compatMode.name());
+    return fs;
+  }
+
+  private SimpleFieldSet createFilesFieldSet(ManifestElement[] elements) {
     SimpleFieldSet files = new SimpleFieldSet(false);
-    // Flatten the hierarchy, it can be reconstructed on restarting.
-    // Storing it directly would be a PITA.
-    // FIXME/RESOLVE: The new BaseManifestPutter's container mode does not hold the origin data,
-    //                 after composing the PutHandlers (done in BaseManifestPutter), they are
-    // 'lost':
-    //                 A resumed half done container put can not get the complete file list from
-    // BaseManifestPutter.
-    //                 Is it really necessary to include the file list here?
-    ManifestElement[] elements = BaseManifestPutter.flatten(manifestElements);
-    fs.putSingle("DefaultName", defaultName);
     for (int i = 0; i < elements.length; i++) {
-      String num = Integer.toString(i);
-      ManifestElement e = elements[i];
-      String mimeOverride = e.getMimeTypeOverride();
-      SimpleFieldSet subset = new SimpleFieldSet(false);
-      FreenetURI tempURI = e.getTargetURI();
-      subset.putSingle("Name", e.getName());
-      if (tempURI != null) {
-        subset.putSingle("UploadFrom", "redirect");
-        subset.putSingle("TargetURI", tempURI.toString());
-      } else {
-        Bucket data = e.getData();
-        if (data instanceof DelayedFreeBucket bucket1) {
-          data = bucket1.getUnderlying();
-        } else if (data instanceof DelayedFreeRandomAccessBucket bucket) {
-          data = bucket.getUnderlying();
-        }
-        subset.put("DataLength", e.getSize());
-        if (mimeOverride != null) subset.putSingle("Metadata.ContentType", mimeOverride);
-        // What to do with the bucket?
-        // It is either a persistent encrypted bucket or a file bucket ...
-        if (data == null) {
-          LOG.error(
-              "Bucket already freed: "
-                  + e.getData()
-                  + " for "
-                  + e
-                  + " for "
-                  + e.getName()
-                  + " for "
-                  + identifier);
-        } else if (data instanceof FileBucket bucket) {
-          subset.putSingle("UploadFrom", "disk");
-          subset.putSingle("Filename", bucket.getFile().getPath());
-        } else if (data instanceof PaddedEphemerallyEncryptedBucket
-            || data instanceof NullBucket
-            || data instanceof PersistentTempFileBucket
-            || data instanceof TempBucketFactory.TempBucket
-            || data instanceof EncryptedRandomAccessBucket) {
-          subset.putSingle("UploadFrom", "direct");
-        } else {
-          throw new IllegalStateException("Don't know what to do with bucket: " + data);
-        }
-      }
-      files.put(num, subset);
+      files.put(Integer.toString(i), createElementFieldSet(elements[i]));
     }
     files.put("Count", elements.length);
-    fs.put("Files", files);
+    return files;
+  }
+
+  private SimpleFieldSet createElementFieldSet(ManifestElement element) {
+    SimpleFieldSet subset = new SimpleFieldSet(false);
+    subset.putSingle("Name", element.getName());
+    FreenetURI targetURI = element.getTargetURI();
+    if (targetURI != null) {
+      subset.putSingle(UPLOAD_FROM, "redirect");
+      subset.putSingle("TargetURI", targetURI.toString());
+      return subset;
+    }
+    Bucket data = unwrapBucket(element.getData());
+    subset.put("DataLength", element.getSize());
+    String mimeOverride = element.getMimeTypeOverride();
+    if (mimeOverride != null) {
+      subset.putSingle("Metadata.ContentType", mimeOverride);
+    }
+    populateUploadSource(subset, data, element);
+    return subset;
+  }
+
+  private void populateUploadSource(SimpleFieldSet subset, Bucket data, ManifestElement element) {
+    if (data == null) {
+      LOG.error(
+          "Bucket already freed: {} for {} for {} for {}",
+          element.getData(),
+          element,
+          element.getName(),
+          clientIdentifier);
+      return;
+    }
+    if (data instanceof FileBucket bucket) {
+      subset.putSingle(UPLOAD_FROM, "disk");
+      subset.putSingle("Filename", bucket.getFile().getPath());
+      return;
+    }
+    if (isDirectUploadBucket(data)) {
+      subset.putSingle(UPLOAD_FROM, "direct");
+      return;
+    }
+    throw new IllegalStateException("Don't know what to do with bucket: " + data);
+  }
+
+  private boolean isDirectUploadBucket(Bucket data) {
+    return data instanceof PaddedEphemerallyEncryptedBucket
+        || data instanceof NullBucket
+        || data instanceof PersistentTempFileBucket
+        || data instanceof TempBucketFactory.TempBucket
+        || data instanceof EncryptedRandomAccessBucket;
+  }
+
+  private Bucket unwrapBucket(Bucket data) {
+    if (data instanceof DelayedFreeBucket bucket) {
+      return bucket.getUnderlying();
+    }
+    if (data instanceof DelayedFreeRandomAccessBucket bucket) {
+      return bucket.getUnderlying();
+    }
+    return data;
+  }
+
+  private void addOptionalFields(SimpleFieldSet fs) {
     if (token != null) fs.putSingle("ClientToken", token);
     fs.put("Started", started);
     fs.put("MaxRetries", maxRetries);
     fs.put("DontCompress", dontCompress);
     if (compressorDescriptor != null) fs.putSingle("Codecs", compressorDescriptor);
     fs.put("RealTime", realTime);
-    if (splitfileCryptoKey != null)
+    if (splitfileCryptoKey != null) {
       fs.putSingle("SplitfileCryptoKey", HexUtil.bytesToHex(splitfileCryptoKey));
-    return fs;
+    }
   }
 
+  /**
+   * Returns the precomputed field set representing this persistent directory insert request.
+   *
+   * <p>The returned {@link SimpleFieldSet} is built once during construction and reused; callers
+   * must not mutate it. The structure contains a flattened manifest, upload sources, and all
+   * optional control flags so it can be sent directly over FCP. Because the field set is cached, it
+   * is safe to reuse this instance across reconnects or retransmissions without re-walking the
+   * manifest. The object is read-only after construction, making it suitable for sharing across
+   * threads that only need to serialize the data.
+   *
+   * @return immutable field set ready for serialization; ownership remains with this instance and
+   *     should not be modified by callers.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return cached;
   }
 
+  /**
+   * Reports the protocol name for this FCP message type.
+   *
+   * <p>The name is a constant required by the FCP framing layer when routing responses. It never
+   * changes across instances and should match the token understood by clients listening for
+   * directory insert status messages. Use this identifier when registering handlers or when logging
+   * message flow so downstream consumers can correlate traffic without inspecting payloads.
+   *
+   * @return stable message type identifier {@code "PersistentPutDir"} for FCP exchanges.
+   */
   @Override
   public String getName() {
-    return name;
+    return NAME;
   }
 
+  /**
+   * Rejects inbound execution because {@code PersistentPutDir} is a server-to-client message only.
+   *
+   * <p>If this method is invoked, the node received an invalid client request. The handler is not
+   * modified; instead a {@link MessageInvalidException} is raised to signal protocol misuse. This
+   * method is intentionally non-idempotent because it always throws.
+   *
+   * @param handler connection handler associated with the client session; not used beyond error
+   *     reporting in this implementation.
+   * @param node node instance that received the message; supplied for interface completeness and
+   *     unchanged here.
+   * @throws MessageInvalidException always thrown to indicate the message direction is incorrect
+   *     when arriving from a client.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PersistentPut goes from server to client not the other way around",
-        identifier,
+        clientIdentifier,
         global);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/PersistentPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentPutDirTest.java
@@ -1,0 +1,342 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import network.crypta.client.InsertContext;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.ManifestElement;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.DelayedFreeRandomAccessBucket;
+import network.crypta.support.io.FileBucket;
+import network.crypta.support.io.NullBucket;
+import network.crypta.support.io.PersistentFileTracker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PersistentPutDirTest {
+
+  private static final String DISK_FILE_NAME = "disk.dat";
+  private static final String REDIRECT_FILE_NAME = "redirect.bin";
+  private static final String UPLOAD_FROM_KEY = "UploadFrom";
+  private static final String DATA_LENGTH_KEY = "DataLength";
+  private static final String CONTENT_TYPE_KEY = "Metadata.ContentType";
+  private static final String PRIVATE_URI_KEY = "PrivateURI";
+  private static final String CLIENT_TOKEN_KEY = "ClientToken";
+  private static final String CODECS_KEY = "Codecs";
+  private static final String SPLITFILE_KEY = "SplitfileCryptoKey";
+  private static final String FILENAME_KEY = "Filename";
+  private static final String FILE_TXT_NAME = "file.txt";
+  private static final String DEFAULT_NAME = "default";
+  private static final String WRAPPED_FILE_NAME = "wrapped.dat";
+  private static final String[] ROOT_KEYS =
+      new String[] {
+        "Identifier",
+        "URI",
+        PRIVATE_URI_KEY,
+        "Verbosity",
+        "Persistence",
+        "PriorityClass",
+        "Global",
+        "PutDirType",
+        "CompatibilityMode",
+        "DefaultName",
+        CLIENT_TOKEN_KEY,
+        "Started",
+        "MaxRetries",
+        "DontCompress",
+        CODECS_KEY,
+        "RealTime",
+        SPLITFILE_KEY
+      };
+
+  @TempDir Path tempDir;
+
+  @Mock FCPConnectionHandler connectionHandler;
+
+  @Mock Node node;
+
+  @Test
+  void getFieldSet_whenDiskDirectAndRedirectElements_populatesAllFields() throws Exception {
+    FreenetURI publicUri = new FreenetURI("CHK", "public");
+    FreenetURI privateUri = new FreenetURI("SSK", "private");
+
+    File diskFile = Files.createFile(tempDir.resolve(DISK_FILE_NAME)).toFile();
+    FileBucket diskBucket = new FileBucket(diskFile, false, false, false, false);
+    ManifestElement diskElement = new ManifestElement(DISK_FILE_NAME, diskBucket, "text/plain", 4);
+
+    NullBucket directBucket = new NullBucket(8);
+    ManifestElement nestedElement =
+        new ManifestElement("nested.bin", directBucket, "application/octet-stream", 8);
+
+    FreenetURI redirectUri = new FreenetURI("CHK", "target");
+    ManifestElement redirectElement = new ManifestElement(REDIRECT_FILE_NAME, redirectUri, null);
+
+    Map<String, Object> manifest = new LinkedHashMap<>();
+    manifest.put(DISK_FILE_NAME, diskElement);
+    Map<String, Object> subdir = new LinkedHashMap<>();
+    subdir.put("nested.bin", nestedElement);
+    manifest.put("subdir", subdir);
+    manifest.put(REDIRECT_FILE_NAME, redirectElement);
+
+    byte[] cryptoKey = new byte[] {0x0a, 0x0b, 0x0c};
+    SimpleFieldSet fs = buildFullFieldSet(manifest, publicUri, privateUri, cryptoKey);
+
+    Map<String, String> expectedRoot = new LinkedHashMap<>();
+    expectedRoot.put("Identifier", "id-123");
+    expectedRoot.put("URI", publicUri.toString(false, false));
+    expectedRoot.put(PRIVATE_URI_KEY, privateUri.toString(false, false));
+    expectedRoot.put("Verbosity", "2");
+    expectedRoot.put("Persistence", "forever");
+    expectedRoot.put("PriorityClass", "3");
+    expectedRoot.put("Global", "true");
+    expectedRoot.put("PutDirType", "disk");
+    expectedRoot.put("CompatibilityMode", "COMPAT_1468");
+    expectedRoot.put("DefaultName", "index.html");
+    expectedRoot.put(CLIENT_TOKEN_KEY, "client-token");
+    expectedRoot.put("Started", "true");
+    expectedRoot.put("MaxRetries", "5");
+    expectedRoot.put("DontCompress", "true");
+    expectedRoot.put(CODECS_KEY, "gzip");
+    expectedRoot.put("RealTime", "true");
+    expectedRoot.put(SPLITFILE_KEY, "0a0b0c");
+    assertEquals(expectedRoot, extract(fs, ROOT_KEYS));
+
+    SimpleFieldSet files = fs.subset("Files");
+    assertNotNull(files);
+    assertEquals("3", files.get("Count"));
+
+    SimpleFieldSet first = files.subset("0");
+    assertNotNull(first);
+    Map<String, String> expectedFirst = new LinkedHashMap<>();
+    expectedFirst.put("Name", DISK_FILE_NAME);
+    expectedFirst.put(UPLOAD_FROM_KEY, "disk");
+    expectedFirst.put(FILENAME_KEY, diskFile.getPath());
+    expectedFirst.put(DATA_LENGTH_KEY, "4");
+    expectedFirst.put(CONTENT_TYPE_KEY, "text/plain");
+    assertEquals(
+        expectedFirst,
+        extract(first, "Name", UPLOAD_FROM_KEY, FILENAME_KEY, DATA_LENGTH_KEY, CONTENT_TYPE_KEY));
+
+    SimpleFieldSet second = files.subset("1");
+    assertNotNull(second);
+    Map<String, String> expectedSecond = new LinkedHashMap<>();
+    expectedSecond.put("Name", "subdir/nested.bin");
+    expectedSecond.put(UPLOAD_FROM_KEY, "direct");
+    expectedSecond.put(DATA_LENGTH_KEY, "8");
+    expectedSecond.put(CONTENT_TYPE_KEY, "application/octet-stream");
+    assertEquals(
+        expectedSecond,
+        extract(second, "Name", UPLOAD_FROM_KEY, DATA_LENGTH_KEY, CONTENT_TYPE_KEY));
+
+    SimpleFieldSet third = files.subset("2");
+    assertNotNull(third);
+    Map<String, String> expectedThird = new LinkedHashMap<>();
+    expectedThird.put("Name", REDIRECT_FILE_NAME);
+    expectedThird.put(UPLOAD_FROM_KEY, "redirect");
+    expectedThird.put("TargetURI", redirectUri.toString());
+    expectedThird.put(DATA_LENGTH_KEY, null);
+    expectedThird.put(CONTENT_TYPE_KEY, null);
+    assertEquals(
+        expectedThird,
+        extract(third, "Name", UPLOAD_FROM_KEY, "TargetURI", DATA_LENGTH_KEY, CONTENT_TYPE_KEY));
+  }
+
+  @Test
+  void getFieldSet_whenOptionalFieldsOmitted_doesNotIncludeThem() {
+    NullBucket bucket = new NullBucket(1);
+    ManifestElement element = new ManifestElement(FILE_TXT_NAME, bucket, null, 1);
+    Map<String, Object> manifest = new LinkedHashMap<>();
+    manifest.put(FILE_TXT_NAME, element);
+
+    SimpleFieldSet fs = buildOptionalFieldSet(manifest);
+
+    assertNull(fs.get(PRIVATE_URI_KEY));
+    assertNull(fs.get(CLIENT_TOKEN_KEY));
+    assertNull(fs.get(CODECS_KEY));
+    assertNull(fs.get(SPLITFILE_KEY));
+  }
+
+  @Test
+  void generateFieldSet_whenBucketWrappedInDelayedFree_usesUnderlyingBucket() {
+    File underlyingFile = tempDir.resolve(WRAPPED_FILE_NAME).toFile();
+    RandomAccessBucket underlyingBucket =
+        new FileBucket(underlyingFile, false, false, false, false);
+    PersistentFileTracker tracker = Mockito.mock(PersistentFileTracker.class);
+    Mockito.when(tracker.commitID()).thenReturn(1L);
+
+    DelayedFreeRandomAccessBucket wrapped =
+        new DelayedFreeRandomAccessBucket(tracker, underlyingBucket);
+    ManifestElement element = new ManifestElement(WRAPPED_FILE_NAME, wrapped, null, 12);
+    Map<String, Object> manifest = new LinkedHashMap<>();
+    manifest.put(WRAPPED_FILE_NAME, element);
+
+    PersistentPutDir message = buildWrappedMessage(manifest);
+    SimpleFieldSet fileSubset = message.getFieldSet().subset("Files").subset("0");
+    assertEquals("disk", fileSubset.get(UPLOAD_FROM_KEY));
+    assertEquals(underlyingFile.getPath(), fileSubset.get(FILENAME_KEY));
+  }
+
+  private Map<String, String> extract(SimpleFieldSet fieldSet, String... keys) {
+    Map<String, String> values = new LinkedHashMap<>();
+    for (String key : keys) {
+      values.put(key, fieldSet.get(key));
+    }
+    return values;
+  }
+
+  private SimpleFieldSet buildFullFieldSet(
+      Map<String, Object> manifest, FreenetURI publicUri, FreenetURI privateUri, byte[] cryptoKey) {
+    PersistentPutDir message =
+        new PersistentPutDir(
+            "id-123",
+            publicUri,
+            privateUri,
+            2,
+            (short) 3,
+            Persistence.FOREVER,
+            true,
+            "index.html",
+            new LinkedHashMap<>(manifest),
+            "client-token",
+            true,
+            5,
+            true,
+            "gzip",
+            true,
+            true,
+            cryptoKey,
+            InsertContext.CompatibilityMode.COMPAT_1468);
+    return message.getFieldSet();
+  }
+
+  private SimpleFieldSet buildOptionalFieldSet(Map<String, Object> manifest) {
+    PersistentPutDir message =
+        new PersistentPutDir(
+            "id-opt",
+            new FreenetURI("CHK", "pub"),
+            null,
+            0,
+            (short) 1,
+            Persistence.CONNECTION,
+            false,
+            DEFAULT_NAME,
+            new LinkedHashMap<>(manifest),
+            null,
+            false,
+            0,
+            false,
+            null,
+            false,
+            false,
+            null,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+    return message.getFieldSet();
+  }
+
+  private PersistentPutDir buildWrappedMessage(Map<String, Object> manifest) {
+    return new PersistentPutDir(
+        "id-wrap",
+        new FreenetURI("CHK", "pub2"),
+        null,
+        1,
+        (short) 1,
+        Persistence.REBOOT,
+        false,
+        "wrapped",
+        new LinkedHashMap<>(manifest),
+        null,
+        false,
+        1,
+        false,
+        null,
+        false,
+        false,
+        null,
+        InsertContext.CompatibilityMode.COMPAT_1250);
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidExceptionWithContext() {
+    NullBucket bucket = new NullBucket();
+    ManifestElement element = new ManifestElement(FILE_TXT_NAME, bucket, null, 1);
+    Map<String, Object> manifest = new LinkedHashMap<>();
+    manifest.put(FILE_TXT_NAME, element);
+
+    PersistentPutDir message =
+        new PersistentPutDir(
+            "ident",
+            new FreenetURI("CHK", "pub3"),
+            null,
+            1,
+            (short) 1,
+            Persistence.CONNECTION,
+            true,
+            DEFAULT_NAME,
+            new LinkedHashMap<>(manifest),
+            null,
+            false,
+            0,
+            false,
+            null,
+            false,
+            false,
+            null,
+            InsertContext.CompatibilityMode.COMPAT_CURRENT);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.run(connectionHandler, node));
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
+    assertEquals("ident", ex.ident);
+    assertTrue(ex.global);
+  }
+
+  @Test
+  void constructor_whenBucketTypeUnknown_throwsIllegalStateException() {
+    RandomAccessBucket unknownBucket = Mockito.mock(RandomAccessBucket.class);
+    ManifestElement element = new ManifestElement("unknown.bin", unknownBucket, null, 2);
+    Map<String, Object> manifest = new LinkedHashMap<>();
+    manifest.put("unknown.bin", element);
+
+    assertThrows(IllegalStateException.class, () -> createPersistentPutDirWith(manifest));
+  }
+
+  private void createPersistentPutDirWith(Map<String, Object> manifest) {
+    new PersistentPutDir(
+        "id-bad",
+        new FreenetURI("CHK", "pub4"),
+        null,
+        0,
+        (short) 1,
+        Persistence.CONNECTION,
+        false,
+        DEFAULT_NAME,
+        new LinkedHashMap<>(manifest),
+        null,
+        false,
+        0,
+        false,
+        null,
+        false,
+        false,
+        null,
+        InsertContext.CompatibilityMode.COMPAT_CURRENT);
+  }
+}


### PR DESCRIPTION
## Summary
- refactor PersistentPutDir to cache the field set via helper methods/constants and improve clarity/KDoc
- add thorough PersistentPutDir tests covering redirects, optional fields, wrapped buckets, and unknown bucket failures

## Testing
- not run (not requested)
