### PR TITLE
Add coverage for PersistentRequestRoot registry behaviors

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates all persistent requests issued by a single FCP client connection. The client is
  * identified by the {@link #name} exchanged during {@code ClientHello}, and the instance maintains
- * the authoritative view of running and completed requests for either {@code PERSISTENCE_REBOOT}
- * or {@code PERSISTENCE_FOREVER} lifetimes.
+ * the authoritative view of running and completed requests for either {@code PERSISTENCE_REBOOT} or
+ * {@code PERSISTENCE_FOREVER} lifetimes.
  *
  * <p>Typical usage wires this class between the raw {@link FCPConnectionHandler} and request
  * objects. Callers register new {@link ClientRequest} instances, forward completion callbacks, and
@@ -41,10 +41,10 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Tracks request life cycle (queued, running, completed/unacknowledged) and exposes
- *       reconnection helpers.</li>
- *   <li>Fan-outs watch lists so the global queue can mirror updates to per-client queues.</li>
+ *       reconnection helpers.
+ *   <li>Fan-outs watch lists so the global queue can mirror updates to per-client queues.
  *   <li>Integrates with {@link RequestStatusCache} so UI and API callers can query progress without
- *       polling individual requests.</li>
+ *       polling individual requests.
  * </ul>
  *
  * @see FCPConnectionHandler
@@ -57,11 +57,11 @@ public class PersistentRequestClient {
    * Builds a new persistent request coordinator bound to a single named FCP client.
    *
    * <p>The constructor seeds the per-client queues, establishes the low-level request clients for
-   * real-time and bulk traffic, and optionally hooks an initial completion callback. In
-   * {@code PERSISTENCE_FOREVER} mode the provided {@link PersistentRequestRoot} is retained so
-   * completed requests can be rehydrated from disk across restarts; reboot-persistent instances do
-   * not keep a root reference. Callers should provide the current connection handler when available
-   * so outbound messages can be delivered immediately.
+   * real-time and bulk traffic, and optionally hooks an initial completion callback. In {@code
+   * PERSISTENCE_FOREVER} mode the provided {@link PersistentRequestRoot} is retained so completed
+   * requests can be rehydrated from disk across restarts; reboot-persistent instances do not keep a
+   * root reference. Callers should provide the current connection handler when available so
+   * outbound messages can be delivered immediately.
    *
    * @param name2 stable name sent during {@code ClientHello}; must be non-null and unique per
    *     client.
@@ -157,9 +157,9 @@ public class PersistentRequestClient {
   /**
    * Returns the currently attached FCP connection handler.
    *
-   * <p>The returned handler is mutable over the lifetime of the client and may be {@code null}
-   * when the peer is disconnected. Callers should snapshot the value once and avoid reusing it
-   * after reconnection events to prevent sending on a stale socket.
+   * <p>The returned handler is mutable over the lifetime of the client and may be {@code null} when
+   * the peer is disconnected. Callers should snapshot the value once and avoid reusing it after
+   * reconnection events to prevent sending on a stale socket.
    *
    * @return active {@link FCPConnectionHandler} for this client, or {@code null} when disconnected.
    */
@@ -175,8 +175,8 @@ public class PersistentRequestClient {
    * lifecycle management and should ensure {@link #onLostConnection(FCPConnectionHandler)} is
    * called when the socket drops.
    *
-   * @param handler new {@link FCPConnectionHandler} to associate with this client; may be
-   *     {@code null} to clear the link.
+   * @param handler new {@link FCPConnectionHandler} to associate with this client; may be {@code
+   *     null} to clear the link.
    */
   public synchronized void setConnection(FCPConnectionHandler handler) {
     this.currentConnection = handler;
@@ -201,11 +201,11 @@ public class PersistentRequestClient {
    * Marks a persistent request as finished and stages it for acknowledgment.
    *
    * <p>This method moves the request from the running list into the completed-but-unacknowledged
-   * list so the client can emit completion messages on reconnect. It also updates the
-   * {@link RequestStatusCache} with the final download or upload status. Callers must only invoke
-   * this for requests whose {@link ClientRequest#persistence} matches the client; mixing lifetimes
-   * is treated as a programmer error. The operation is idempotent for already-moved requests but
-   * still replays status caching.
+   * list so the client can emit completion messages on reconnect. It also updates the {@link
+   * RequestStatusCache} with the final download or upload status. Callers must only invoke this for
+   * requests whose {@link ClientRequest#persistence} matches the client; mixing lifetimes is
+   * treated as a programmer error. The operation is idempotent for already-moved requests but still
+   * replays status caching.
    *
    * @param get finished {@link ClientRequest} that has not yet been acknowledged by the peer; must
    *     belong to this client and have matching persistence.
@@ -380,14 +380,14 @@ public class PersistentRequestClient {
    *
    * <p>The request is added to the running or completed list depending on its current state and is
    * indexed by identifier for later lookups. The method enforces that the request’s persistence
-   * matches the client and that no other distinct request already uses the same identifier.
-   * Status caching is updated to include the new request’s initial state.
+   * matches the client and that no other distinct request already uses the same identifier. Status
+   * caching is updated to include the new request’s initial state.
    *
    * @param cg request to register; must carry a unique identifier for this client and matching
    *     persistence.
    * @throws IllegalArgumentException if the persistence differs from the client policy.
-   * @throws IdentifierCollisionException if another request with the same identifier already
-   *     exists in the mapping.
+   * @throws IdentifierCollisionException if another request with the same identifier already exists
+   *     in the mapping.
    */
   public void register(ClientRequest cg) throws IdentifierCollisionException {
     if (cg.persistence != persistence) {
@@ -586,9 +586,9 @@ public class PersistentRequestClient {
    *     global queue; only messages matching the mask are relayed.
    * @param server owning {@link FCPServer} used to access the global queue instances; must not be
    *     {@code null} when enabling watch.
-   * @return {@code true} when the requested state change was applied or already in effect;
-   *     {@code false} if the operation is invalid (e.g., called on the global queue itself or when
-   *     no global forever client exists).
+   * @return {@code true} when the requested state change was applied or already in effect; {@code
+   *     false} if the operation is invalid (e.g., called on the global queue itself or when no
+   *     global forever client exists).
    */
   public boolean setWatchGlobal(boolean enabled, int verbosityMask, FCPServer server) {
     if (isGlobalQueue) {
@@ -696,8 +696,8 @@ public class PersistentRequestClient {
   /**
    * Looks up a tracked request by its identifier without altering state.
    *
-   * @param identifier request identifier previously registered with this client; must not be
-   *     {@code null}.
+   * @param identifier request identifier previously registered with this client; must not be {@code
+   *     null}.
    * @return matching {@link ClientRequest} or {@code null} if none is tracked under that name.
    */
   public synchronized ClientRequest getRequest(String identifier) {
@@ -783,9 +783,8 @@ public class PersistentRequestClient {
   /**
    * Clears all tracked requests and status cache entries for this client.
    *
-   * <p>Both running and completed queues are emptied and the identifier map is reset. The
-   * operation does not cancel in-flight work; callers should cancel or disconnect separately if
-   * required.
+   * <p>Both running and completed queues are emptied and the identifier map is reset. The operation
+   * does not cancel in-flight work; callers should cancel or disconnect separately if required.
    */
   public void removeAll() {
     if (statusCache != null) statusCache.clear();
@@ -799,8 +798,8 @@ public class PersistentRequestClient {
   /**
    * Finds a completed download request for the specified key.
    *
-   * <p>Searches only the completed-but-unacknowledged list and returns the first matching
-   * {@link ClientGet}. Running requests are ignored to keep lookups deterministic.
+   * <p>Searches only the completed-but-unacknowledged list and returns the first matching {@link
+   * ClientGet}. Running requests are ignored to keep lookups deterministic.
    *
    * @param key URI of the desired completed request; must not be {@code null}.
    * @return matching {@link ClientGet} instance or {@code null} if no completed request with the

--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestRoot.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestRoot.java
@@ -9,30 +9,74 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tracks persistent requests by PersistentRequestClient. Not persistent itself. Populated on
- * startup.
+ * Coordinates the in-memory registry of {@link PersistentRequestClient} instances that own
+ * long-lived FCP requests.
+ *
+ * <p>The root is reconstructed at node startup from the set of persisted requests and does not
+ * store any data by itself. Callers resolve clients via their connection handler or by the
+ * per-client name, and the root keeps a dedicated {@code globalForeverClient} for requests that are
+ * not associated with an individual FCP session. Synchronization on {@code this} guards map
+ * updates, while read paths avoid holding the lock longer than necessary so request lookups remain
+ * responsive to network traffic.
+ *
+ * <p>Typical usage:
+ *
+ * <ul>
+ *   <li>During client login, call {@link #registerForeverClient(String, FCPConnectionHandler)} to
+ *       reuse or create the durable client context.
+ *   <li>On resume, call {@link #resume(ClientRequest, boolean, String)} to attach a reloaded
+ *       request to its owning client.
+ *   <li>Periodically call {@link #maybeUnregisterClient(PersistentRequestClient)} to release empty,
+ *       non-global clients.
+ * </ul>
+ *
+ * <p>Thread-safety: the registry is mutable but guarded; returned {@link PersistentRequestClient}
+ * instances are still responsible for their own internal synchronization and request bookkeeping.
  *
  * @author toad
+ * @see PersistentRequestClient
+ * @see ClientRequest
  */
 public class PersistentRequestRoot {
   private static final Logger LOG = LoggerFactory.getLogger(PersistentRequestRoot.class);
-
-  private static final long serialVersionUID = 1L;
 
   final PersistentRequestClient globalForeverClient;
   private final Map<String, PersistentRequestClient> clients;
 
   // Legacy threshold callback removed.
 
+  /**
+   * Builds a new registry with an always-present global queue client.
+   *
+   * <p>The constructor eagerly creates {@code globalForeverClient} so callers can immediately
+   * attach requests that are not tied to a specific FCP connection. No IO or persistence is
+   * performed here; population of per-client queues is expected to happen during startup replay or
+   * on-demand registration by FCP handlers.
+   */
   public PersistentRequestRoot() {
     globalForeverClient =
         new PersistentRequestClient("Global Queue", null, true, null, Persistence.FOREVER, this);
     clients = new TreeMap<>();
   }
 
+  /**
+   * Obtain a persistent client, creating it if missing, and bind it to the provided connection.
+   *
+   * <p>This method is idempotent per {@code name} and safe to call concurrently from multiple
+   * threads. It keeps the global registry synchronized while looking up or inserting the client,
+   * then associates the optional {@link FCPConnectionHandler} outside the lock to avoid blocking
+   * other lookups. The returned client remains valid even if the handler later disconnects; callers
+   * should ensure subsequent request operations honor that lifecycle.
+   *
+   * @param name stable client identifier used as the registry key; must not be blank or null.
+   * @param handler connection used to deliver replies and state callbacks; may be {@code null} when
+   *     recovering from disk.
+   * @return persistent client instance tied to {@code name}; shared across repeated calls until
+   *     explicitly removed.
+   */
   public PersistentRequestClient registerForeverClient(
       final String name, FCPConnectionHandler handler) {
-    if (LOG.isDebugEnabled()) LOG.debug("Registering forever-client for " + name);
+    if (LOG.isDebugEnabled()) LOG.debug("Registering forever-client for {}", name);
     PersistentRequestClient client;
     synchronized (this) {
       client = clients.get(name);
@@ -45,9 +89,19 @@ public class PersistentRequestRoot {
   }
 
   /**
-   * Get the PersistentRequestClient if it exists.
+   * Retrieve an existing persistent client and optionally refresh its connection binding.
    *
-   * @param handler
+   * <p>The registry is not mutated when the client does not yet exist; in that case the method
+   * returns {@code null} so callers can decide whether to register a new client or reject the
+   * request. When a handler is supplied the method updates the client outside the synchronized
+   * block, keeping lock contention low while still ensuring consistent lookup semantics.
+   *
+   * @param name registry key that identifies the persistent client to fetch; must match the value
+   *     used during registration.
+   * @param handler optional FCP connection to attach to the client for reply routing; may be {@code
+   *     null} to leave the existing connection unchanged.
+   * @return previously registered client or {@code null} when no client with that name is known to
+   *     the root at the time of the call.
    */
   public PersistentRequestClient getForeverClient(final String name, FCPConnectionHandler handler) {
     PersistentRequestClient client;
@@ -59,6 +113,17 @@ public class PersistentRequestRoot {
     return client;
   }
 
+  /**
+   * Remove a non-global client from the registry when it no longer owns any persistent requests.
+   *
+   * <p>This helper prevents the client map from accumulating inactive entries after requests have
+   * been canceled or completed. The global queue client is never removed. Callers should invoke
+   * this after request teardown to keep memory usage predictable; the method itself performs a
+   * cheap state check and synchronized removal.
+   *
+   * @param client persistent client to consider for removal; ignored when {@code null} or when the
+   *     instance represents the shared global queue.
+   */
   public void maybeUnregisterClient(PersistentRequestClient client) {
     if ((!client.isGlobalQueue) && !client.hasPersistentRequests()) {
       synchronized (this) {
@@ -67,6 +132,19 @@ public class PersistentRequestRoot {
     }
   }
 
+  /**
+   * Collect all currently tracked persistent requests across the global queue and per-client queues
+   * in registration order.
+   *
+   * <p>The returned array is a snapshot; subsequent request additions or removals are not
+   * reflected. The method delegates to {@link PersistentRequestClient#addPersistentRequests(List,
+   * boolean)} for each client and therefore includes only requests marked as persistent. Consumers
+   * should not mutate the returned request objects unless they hold the appropriate synchronization
+   * required by {@link PersistentRequestClient}.
+   *
+   * @return array of persistent requests currently registered in the node; may be empty but never
+   *     {@code null}.
+   */
   public ClientRequest[] getPersistentRequests() {
     List<ClientRequest> requests = new ArrayList<>();
     globalForeverClient.addPersistentRequests(requests, true);
@@ -89,6 +167,20 @@ public class PersistentRequestRoot {
     }
   }
 
+  /**
+   * Determine whether a request identifier refers to an active persistent request.
+   *
+   * <p>The lookup first resolves the owning client (global queue or named client) and then queries
+   * the client for the request by its identifier. The method holds the registry lock only during
+   * client resolution, allowing concurrent lookups to proceed. It does not verify request state
+   * beyond existence; callers must perform further validation if they need status or ownership
+   * checks.
+   *
+   * @param req request identifier that includes the client name and whether the global queue is
+   *     targeted; must not be {@code null}.
+   * @return {@code true} when a matching persistent request is currently registered; {@code false}
+   *     otherwise.
+   */
   public synchronized boolean hasRequest(RequestIdentifier req) {
     PersistentRequestClient client;
     if (req.globalQueue) client = globalForeverClient;
@@ -97,6 +189,15 @@ public class PersistentRequestRoot {
     return client.getRequest(req.identifier) != null;
   }
 
+  /**
+   * Accessor for the shared global persistent client used by queue-independent requests.
+   *
+   * <p>The instance is created during construction and never removed. It is intended for system
+   * requests or client operations that outlive a specific FCP session.
+   *
+   * @return always-present global persistent client instance suitable for storing long-lived
+   *     requests.
+   */
   public PersistentRequestClient getGlobalForeverClient() {
     return globalForeverClient;
   }

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
@@ -1,0 +1,263 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.clients.fcp.RequestIdentifier.RequestType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PersistentRequestRootTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Test
+  void registerForeverClient_whenNew_createsAndStoresClient() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+
+    PersistentRequestClient client = root.registerForeverClient("clientA", handler);
+
+    assertNotNull(client);
+    assertFalse(client.isGlobalQueue);
+    assertSame(client, root.getForeverClient("clientA", null));
+    assertSame(handler, client.getConnection());
+  }
+
+  @Test
+  void registerForeverClient_whenExisting_reusesInstanceAndUpdatesConnection() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient first = root.registerForeverClient("clientA", null);
+
+    PersistentRequestClient result = root.registerForeverClient("clientA", handler);
+
+    assertSame(first, result);
+    assertSame(handler, first.getConnection());
+  }
+
+  @Test
+  void getForeverClient_whenMissing_returnsNull() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+
+    PersistentRequestClient client = root.getForeverClient("missing", handler);
+
+    assertNull(client);
+  }
+
+  @Test
+  void maybeUnregisterClient_removesClientWithoutRequests() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient client = root.registerForeverClient("clientA", null);
+
+    root.maybeUnregisterClient(client);
+
+    assertNull(root.getForeverClient("clientA", null));
+  }
+
+  @Test
+  void maybeUnregisterClient_keepsClientWithRequests() throws Exception {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient client = root.registerForeverClient("clientA", null);
+    TestClientRequest request = new TestClientRequest(client, "id-1", false, false, true);
+    client.register(request);
+
+    root.maybeUnregisterClient(client);
+
+    assertSame(client, root.getForeverClient("clientA", null));
+  }
+
+  @Test
+  void getPersistentRequests_returnsRequestsFromGlobalAndClients() throws Exception {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient client = root.registerForeverClient("clientA", null);
+    TestClientRequest globalReq =
+        new TestClientRequest(root.getGlobalForeverClient(), "global-1", true, false, true);
+    TestClientRequest clientReq = new TestClientRequest(client, "client-1", false, false, true);
+    root.getGlobalForeverClient().register(globalReq);
+    client.register(clientReq);
+
+    ClientRequest[] requests = root.getPersistentRequests();
+
+    assertArrayEquals(new ClientRequest[] {globalReq, clientReq}, requests);
+  }
+
+  @Test
+  void hasRequest_returnsTrueForExistingRequests() throws Exception {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient client = root.registerForeverClient("clientA", null);
+    TestClientRequest globalReq =
+        new TestClientRequest(root.getGlobalForeverClient(), "global-1", true, false, true);
+    TestClientRequest clientReq = new TestClientRequest(client, "client-1", false, false, true);
+    root.getGlobalForeverClient().register(globalReq);
+    client.register(clientReq);
+
+    assertTrue(root.hasRequest(new RequestIdentifier(true, null, "global-1", RequestType.GET)));
+    assertTrue(
+        root.hasRequest(new RequestIdentifier(false, "clientA", "client-1", RequestType.GET)));
+    assertFalse(
+        root.hasRequest(new RequestIdentifier(false, "clientA", "missing", RequestType.GET)));
+    assertFalse(
+        root.hasRequest(new RequestIdentifier(false, "missing", "client-1", RequestType.GET)));
+  }
+
+  @Test
+  void resume_nonGlobalClientRegistersRequest() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient client = root.registerForeverClient("clientA", null);
+    TestClientRequest request = new TestClientRequest(client, "id-1", false, false, true);
+
+    PersistentRequestClient resumed = root.resume(request, false, "clientA");
+
+    assertSame(client, resumed);
+    assertTrue(root.hasRequest(new RequestIdentifier(false, "clientA", "id-1", RequestType.GET)));
+  }
+
+  @Test
+  void resume_globalQueuesRequestWithoutCreatingClient() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    TestClientRequest request =
+        new TestClientRequest(root.getGlobalForeverClient(), "id-1", true, true, true);
+
+    root.resume(request, true, "ignored-name");
+
+    assertTrue(root.hasRequest(new RequestIdentifier(true, null, "id-1", RequestType.GET)));
+    assertNull(root.getForeverClient("ignored-name", null));
+  }
+
+  /**
+   * Minimal concrete ClientRequest used to exercise PersistentRequestRoot behaviour without
+   * touching networked code.
+   */
+  private static final class TestClientRequest extends ClientRequest {
+    private final boolean succeeded;
+
+    TestClientRequest(
+        PersistentRequestClient client,
+        String identifier,
+        boolean global,
+        boolean finished,
+        boolean succeeded) {
+      super(null, identifier, 0, null, client, (short) 0, Persistence.FOREVER, false, null, global);
+      this.finished = finished;
+      this.succeeded = succeeded;
+    }
+
+    @Override
+    public void onLostConnection(ClientContext context) {
+      // No-op: connection lifecycle is irrelevant for this stubbed request.
+    }
+
+    @Override
+    public void sendPendingMessages(
+        FCPConnectionOutputHandler handler,
+        String listRequestIdentifier,
+        boolean includeData,
+        boolean onlyData) {
+      // No-op: tests don't exercise message replay.
+    }
+
+    @Override
+    void register(boolean noTags) {
+      // No-op: registration is handled directly by PersistentRequestClient in tests.
+    }
+
+    @Override
+    protected ClientRequester getClientRequest() {
+      return null;
+    }
+
+    @Override
+    protected void freeData() {
+      // No-op: stub request doesn't allocate data buffers.
+    }
+
+    @Override
+    public double getSuccessFraction() {
+      return 0;
+    }
+
+    @Override
+    public double getTotalBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getMinBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFetchedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFatalyFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public String getFailureReason(boolean longDescription) {
+      return "";
+    }
+
+    @Override
+    public boolean isTotalFinalized() {
+      return true;
+    }
+
+    @Override
+    public void start(ClientContext context) {
+      // No-op: start lifecycle isn't needed in these tests.
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return succeeded;
+    }
+
+    @Override
+    public boolean canRestart() {
+      return false;
+    }
+
+    @Override
+    public boolean restart(ClientContext context, boolean disableFilterData) {
+      return false;
+    }
+
+    @Override
+    RequestStatus getStatus() {
+      return null;
+    }
+
+    @Override
+    protected void innerResume(ClientContext context) {
+      // No-op: resume side effects are unnecessary for the stub.
+    }
+
+    @Override
+    RequestType getType() {
+      return RequestType.GET;
+    }
+
+    @Override
+    public boolean fullyResumed() {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand documentation in PersistentRequestRoot to clarify registry responsibilities and lifecycle
- tighten debug logging placeholder usage
- add unit tests covering register/get/maybeUnregister/resume paths and request presence checks

## Testing
- not run (not requested)