### PR TITLE
test: add PluginRemovedMessage coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates all persistent requests issued by a single FCP client connection. The client is
  * identified by the {@link #name} exchanged during {@code ClientHello}, and the instance maintains
- * the authoritative view of running and completed requests for either {@code PERSISTENCE_REBOOT}
- * or {@code PERSISTENCE_FOREVER} lifetimes.
+ * the authoritative view of running and completed requests for either {@code PERSISTENCE_REBOOT} or
+ * {@code PERSISTENCE_FOREVER} lifetimes.
  *
  * <p>Typical usage wires this class between the raw {@link FCPConnectionHandler} and request
  * objects. Callers register new {@link ClientRequest} instances, forward completion callbacks, and
@@ -41,10 +41,10 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Tracks request life cycle (queued, running, completed/unacknowledged) and exposes
- *       reconnection helpers.</li>
- *   <li>Fan-outs watch lists so the global queue can mirror updates to per-client queues.</li>
+ *       reconnection helpers.
+ *   <li>Fan-outs watch lists so the global queue can mirror updates to per-client queues.
  *   <li>Integrates with {@link RequestStatusCache} so UI and API callers can query progress without
- *       polling individual requests.</li>
+ *       polling individual requests.
  * </ul>
  *
  * @see FCPConnectionHandler
@@ -57,11 +57,11 @@ public class PersistentRequestClient {
    * Builds a new persistent request coordinator bound to a single named FCP client.
    *
    * <p>The constructor seeds the per-client queues, establishes the low-level request clients for
-   * real-time and bulk traffic, and optionally hooks an initial completion callback. In
-   * {@code PERSISTENCE_FOREVER} mode the provided {@link PersistentRequestRoot} is retained so
-   * completed requests can be rehydrated from disk across restarts; reboot-persistent instances do
-   * not keep a root reference. Callers should provide the current connection handler when available
-   * so outbound messages can be delivered immediately.
+   * real-time and bulk traffic, and optionally hooks an initial completion callback. In {@code
+   * PERSISTENCE_FOREVER} mode the provided {@link PersistentRequestRoot} is retained so completed
+   * requests can be rehydrated from disk across restarts; reboot-persistent instances do not keep a
+   * root reference. Callers should provide the current connection handler when available so
+   * outbound messages can be delivered immediately.
    *
    * @param name2 stable name sent during {@code ClientHello}; must be non-null and unique per
    *     client.
@@ -157,9 +157,9 @@ public class PersistentRequestClient {
   /**
    * Returns the currently attached FCP connection handler.
    *
-   * <p>The returned handler is mutable over the lifetime of the client and may be {@code null}
-   * when the peer is disconnected. Callers should snapshot the value once and avoid reusing it
-   * after reconnection events to prevent sending on a stale socket.
+   * <p>The returned handler is mutable over the lifetime of the client and may be {@code null} when
+   * the peer is disconnected. Callers should snapshot the value once and avoid reusing it after
+   * reconnection events to prevent sending on a stale socket.
    *
    * @return active {@link FCPConnectionHandler} for this client, or {@code null} when disconnected.
    */
@@ -175,8 +175,8 @@ public class PersistentRequestClient {
    * lifecycle management and should ensure {@link #onLostConnection(FCPConnectionHandler)} is
    * called when the socket drops.
    *
-   * @param handler new {@link FCPConnectionHandler} to associate with this client; may be
-   *     {@code null} to clear the link.
+   * @param handler new {@link FCPConnectionHandler} to associate with this client; may be {@code
+   *     null} to clear the link.
    */
   public synchronized void setConnection(FCPConnectionHandler handler) {
     this.currentConnection = handler;
@@ -201,11 +201,11 @@ public class PersistentRequestClient {
    * Marks a persistent request as finished and stages it for acknowledgment.
    *
    * <p>This method moves the request from the running list into the completed-but-unacknowledged
-   * list so the client can emit completion messages on reconnect. It also updates the
-   * {@link RequestStatusCache} with the final download or upload status. Callers must only invoke
-   * this for requests whose {@link ClientRequest#persistence} matches the client; mixing lifetimes
-   * is treated as a programmer error. The operation is idempotent for already-moved requests but
-   * still replays status caching.
+   * list so the client can emit completion messages on reconnect. It also updates the {@link
+   * RequestStatusCache} with the final download or upload status. Callers must only invoke this for
+   * requests whose {@link ClientRequest#persistence} matches the client; mixing lifetimes is
+   * treated as a programmer error. The operation is idempotent for already-moved requests but still
+   * replays status caching.
    *
    * @param get finished {@link ClientRequest} that has not yet been acknowledged by the peer; must
    *     belong to this client and have matching persistence.
@@ -380,14 +380,14 @@ public class PersistentRequestClient {
    *
    * <p>The request is added to the running or completed list depending on its current state and is
    * indexed by identifier for later lookups. The method enforces that the request’s persistence
-   * matches the client and that no other distinct request already uses the same identifier.
-   * Status caching is updated to include the new request’s initial state.
+   * matches the client and that no other distinct request already uses the same identifier. Status
+   * caching is updated to include the new request’s initial state.
    *
    * @param cg request to register; must carry a unique identifier for this client and matching
    *     persistence.
    * @throws IllegalArgumentException if the persistence differs from the client policy.
-   * @throws IdentifierCollisionException if another request with the same identifier already
-   *     exists in the mapping.
+   * @throws IdentifierCollisionException if another request with the same identifier already exists
+   *     in the mapping.
    */
   public void register(ClientRequest cg) throws IdentifierCollisionException {
     if (cg.persistence != persistence) {
@@ -586,9 +586,9 @@ public class PersistentRequestClient {
    *     global queue; only messages matching the mask are relayed.
    * @param server owning {@link FCPServer} used to access the global queue instances; must not be
    *     {@code null} when enabling watch.
-   * @return {@code true} when the requested state change was applied or already in effect;
-   *     {@code false} if the operation is invalid (e.g., called on the global queue itself or when
-   *     no global forever client exists).
+   * @return {@code true} when the requested state change was applied or already in effect; {@code
+   *     false} if the operation is invalid (e.g., called on the global queue itself or when no
+   *     global forever client exists).
    */
   public boolean setWatchGlobal(boolean enabled, int verbosityMask, FCPServer server) {
     if (isGlobalQueue) {
@@ -696,8 +696,8 @@ public class PersistentRequestClient {
   /**
    * Looks up a tracked request by its identifier without altering state.
    *
-   * @param identifier request identifier previously registered with this client; must not be
-   *     {@code null}.
+   * @param identifier request identifier previously registered with this client; must not be {@code
+   *     null}.
    * @return matching {@link ClientRequest} or {@code null} if none is tracked under that name.
    */
   public synchronized ClientRequest getRequest(String identifier) {
@@ -783,9 +783,8 @@ public class PersistentRequestClient {
   /**
    * Clears all tracked requests and status cache entries for this client.
    *
-   * <p>Both running and completed queues are emptied and the identifier map is reset. The
-   * operation does not cancel in-flight work; callers should cancel or disconnect separately if
-   * required.
+   * <p>Both running and completed queues are emptied and the identifier map is reset. The operation
+   * does not cancel in-flight work; callers should cancel or disconnect separately if required.
    */
   public void removeAll() {
     if (statusCache != null) statusCache.clear();
@@ -799,8 +798,8 @@ public class PersistentRequestClient {
   /**
    * Finds a completed download request for the specified key.
    *
-   * <p>Searches only the completed-but-unacknowledged list and returns the first matching
-   * {@link ClientGet}. Running requests are ignored to keep lookups deterministic.
+   * <p>Searches only the completed-but-unacknowledged list and returns the first matching {@link
+   * ClientGet}. Running requests are ignored to keep lookups deterministic.
    *
    * @param key URI of the desired completed request; must not be {@code null}.
    * @return matching {@link ClientGet} instance or {@code null} if no completed request with the

--- a/src/main/java/network/crypta/clients/fcp/PluginRemovedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PluginRemovedMessage.java
@@ -2,39 +2,91 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * @author saces
+ * Message sent from the node to an FCP client when a previously loaded plugin is removed.
+ *
+ * <p>The payload carries the client-provided identifier and the human-readable plugin name so the
+ * client can correlate the event with earlier management requests or UI state. Instances are
+ * created on the server side only; if a client attempts to emit this message it is rejected as an
+ * invalid request. This class does not mutate after construction, making it safe to share across
+ * threads that stream FCP responses or audit network traffic.
+ *
+ * <p>Typical consumers subscribe to removal events while maintaining a synchronized plugin list in
+ * the UI or persistence layer. After receiving the message, clients should drop any cached
+ * capabilities for the named plugin and update in-progress workflows that relied on it. The message
+ * is small and allocates only the two string fields it exposes, so multiple instances can be
+ * buffered without noticeable overhead during bursts of plugin churn.
+ *
+ * <ul>
+ *   <li>Direction: server to client only; outbound client use is rejected.
+ *   <li>Thread-safety: immutable after construction; safe for concurrent dispatch.
+ *   <li>Correlates: identifier echoes client request tokens; pluginName matches plugin manifest.
+ * </ul>
+ *
+ * @see FCPMessage
  */
 public class PluginRemovedMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(PluginRemovedMessage.class);
 
   static final String NAME = "PluginRemoved";
 
-  private final String identifier;
+  private final String identifierValue;
 
   private final String plugname;
 
   PluginRemovedMessage(String plugname2, String identifier2) {
-    this.identifier = identifier2;
+    this.identifierValue = identifier2;
     this.plugname = plugname2;
   }
 
+  /**
+   * Builds the serialized representation of this message for transmission over the FCP wire format.
+   * It returns a new {@link SimpleFieldSet} containing the caller-provided identifier under the
+   * {@code Identifier} key and the human-readable plugin name under {@code PluginName}. The
+   * resulting structure is independent of the original instance and can be queued or reused by the
+   * transport layer without additional synchronization. Neither field is optional; callers should
+   * ensure meaningful values were provided at construction time before invoking this method.
+   *
+   * @return a {@link SimpleFieldSet} with single-valued Identifier and PluginName entries ready for
+   *     sending
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
-    sfs.putSingle("Identifier", identifier);
+    sfs.putSingle("Identifier", identifierValue);
     sfs.putSingle("PluginName", plugname);
     return sfs;
   }
 
+  /**
+   * Returns the canonical FCP name for this message type, which remains constant across protocol
+   * versions and is used by both the server dispatcher and clients to route handling logic. The
+   * value is stable and can be logged or compared without additional normalization. Because the
+   * name never changes for the lifetime of the object, repeated invocations are safe and allocate
+   * no new state.
+   *
+   * @return the literal message name {@code PluginRemoved} used on the FCP wire protocol
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Rejects inbound handling because {@code PluginRemoved} is strictly a server-to-client
+   * notification. Any attempt by a client to send this message back to the server is converted into
+   * a {@link MessageInvalidException} with the {@link ProtocolErrorMessage#INVALID_MESSAGE} code so
+   * callers receive consistent protocol-level feedback. The method does not inspect the connection
+   * or node state; it unconditionally signals the error to prevent accidental misuse and maintain
+   * the one-way contract of plugin removal notifications.
+   *
+   * @param handler the connection handler that attempted to process the incoming message; never
+   *     modified but included for protocol parity
+   * @param node the running node instance associated with the handler; ignored because processing
+   *     is unsupported in this direction
+   * @throws MessageInvalidException always thrown to indicate the message is invalid from client to
+   *     server
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/test/java/network/crypta/clients/fcp/PluginRemovedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PluginRemovedMessageTest.java
@@ -1,0 +1,79 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PluginRemovedMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void getFieldSet_whenIdentifierAndPluginProvided_containsBothFields() {
+    PluginRemovedMessage message = new PluginRemovedMessage("ExamplePlugin", "req-123");
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertEquals("req-123", fieldSet.get("Identifier"));
+    assertEquals("ExamplePlugin", fieldSet.get("PluginName"));
+    assertEquals("Identifier=req-123\nPluginName=ExamplePlugin\nEnd\n", fieldSet.toOrderedString());
+  }
+
+  @Test
+  void getFieldSet_whenPluginNameIsNull_skipsPluginNameField() {
+    PluginRemovedMessage message = new PluginRemovedMessage(null, "identifier-only");
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("identifier-only", fieldSet.get("Identifier"));
+    assertNull(fieldSet.get("PluginName"));
+    assertEquals("Identifier=identifier-only\nEnd\n", fieldSet.toOrderedString());
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierIsNull_skipsIdentifierField() {
+    PluginRemovedMessage message = new PluginRemovedMessage("PluginOnly", null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNull(fieldSet.get("Identifier"));
+    assertEquals("PluginOnly", fieldSet.get("PluginName"));
+    assertEquals("PluginName=PluginOnly\nEnd\n", fieldSet.toOrderedString());
+  }
+
+  @Test
+  void getName_always_returnsPluginRemoved() {
+    PluginRemovedMessage message = new PluginRemovedMessage("any", "id");
+
+    assertEquals("PluginRemoved", message.getName());
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidExceptionWithExpectedDetails() {
+    PluginRemovedMessage message = new PluginRemovedMessage("plug", "id");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "PluginRemoved goes from server to client not the other way around",
+        exception.getMessage());
+    assertNull(exception.ident);
+    assertFalse(exception.global);
+  }
+}


### PR DESCRIPTION
## Summary
- add coverage for PluginRemovedMessage serialization and invalid inbound handling
- tidy PluginRemovedMessage internals (immutable identifier field) and expand Javadoc
- reflow PersistentRequestClient Javadoc for readability

## Testing
- Not run (not requested)
