### PR TITLE
Fix legacy FCP plugin detection in PluginInfoMessage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates all persistent requests issued by a single FCP client connection. The client is
  * identified by the {@link #name} exchanged during {@code ClientHello}, and the instance maintains
- * the authoritative view of running and completed requests for either {@code PERSISTENCE_REBOOT}
- * or {@code PERSISTENCE_FOREVER} lifetimes.
+ * the authoritative view of running and completed requests for either {@code PERSISTENCE_REBOOT} or
+ * {@code PERSISTENCE_FOREVER} lifetimes.
  *
  * <p>Typical usage wires this class between the raw {@link FCPConnectionHandler} and request
  * objects. Callers register new {@link ClientRequest} instances, forward completion callbacks, and
@@ -41,10 +41,10 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li>Tracks request life cycle (queued, running, completed/unacknowledged) and exposes
- *       reconnection helpers.</li>
- *   <li>Fan-outs watch lists so the global queue can mirror updates to per-client queues.</li>
+ *       reconnection helpers.
+ *   <li>Fan-outs watch lists so the global queue can mirror updates to per-client queues.
  *   <li>Integrates with {@link RequestStatusCache} so UI and API callers can query progress without
- *       polling individual requests.</li>
+ *       polling individual requests.
  * </ul>
  *
  * @see FCPConnectionHandler
@@ -57,11 +57,11 @@ public class PersistentRequestClient {
    * Builds a new persistent request coordinator bound to a single named FCP client.
    *
    * <p>The constructor seeds the per-client queues, establishes the low-level request clients for
-   * real-time and bulk traffic, and optionally hooks an initial completion callback. In
-   * {@code PERSISTENCE_FOREVER} mode the provided {@link PersistentRequestRoot} is retained so
-   * completed requests can be rehydrated from disk across restarts; reboot-persistent instances do
-   * not keep a root reference. Callers should provide the current connection handler when available
-   * so outbound messages can be delivered immediately.
+   * real-time and bulk traffic, and optionally hooks an initial completion callback. In {@code
+   * PERSISTENCE_FOREVER} mode the provided {@link PersistentRequestRoot} is retained so completed
+   * requests can be rehydrated from disk across restarts; reboot-persistent instances do not keep a
+   * root reference. Callers should provide the current connection handler when available so
+   * outbound messages can be delivered immediately.
    *
    * @param name2 stable name sent during {@code ClientHello}; must be non-null and unique per
    *     client.
@@ -157,9 +157,9 @@ public class PersistentRequestClient {
   /**
    * Returns the currently attached FCP connection handler.
    *
-   * <p>The returned handler is mutable over the lifetime of the client and may be {@code null}
-   * when the peer is disconnected. Callers should snapshot the value once and avoid reusing it
-   * after reconnection events to prevent sending on a stale socket.
+   * <p>The returned handler is mutable over the lifetime of the client and may be {@code null} when
+   * the peer is disconnected. Callers should snapshot the value once and avoid reusing it after
+   * reconnection events to prevent sending on a stale socket.
    *
    * @return active {@link FCPConnectionHandler} for this client, or {@code null} when disconnected.
    */
@@ -175,8 +175,8 @@ public class PersistentRequestClient {
    * lifecycle management and should ensure {@link #onLostConnection(FCPConnectionHandler)} is
    * called when the socket drops.
    *
-   * @param handler new {@link FCPConnectionHandler} to associate with this client; may be
-   *     {@code null} to clear the link.
+   * @param handler new {@link FCPConnectionHandler} to associate with this client; may be {@code
+   *     null} to clear the link.
    */
   public synchronized void setConnection(FCPConnectionHandler handler) {
     this.currentConnection = handler;
@@ -201,11 +201,11 @@ public class PersistentRequestClient {
    * Marks a persistent request as finished and stages it for acknowledgment.
    *
    * <p>This method moves the request from the running list into the completed-but-unacknowledged
-   * list so the client can emit completion messages on reconnect. It also updates the
-   * {@link RequestStatusCache} with the final download or upload status. Callers must only invoke
-   * this for requests whose {@link ClientRequest#persistence} matches the client; mixing lifetimes
-   * is treated as a programmer error. The operation is idempotent for already-moved requests but
-   * still replays status caching.
+   * list so the client can emit completion messages on reconnect. It also updates the {@link
+   * RequestStatusCache} with the final download or upload status. Callers must only invoke this for
+   * requests whose {@link ClientRequest#persistence} matches the client; mixing lifetimes is
+   * treated as a programmer error. The operation is idempotent for already-moved requests but still
+   * replays status caching.
    *
    * @param get finished {@link ClientRequest} that has not yet been acknowledged by the peer; must
    *     belong to this client and have matching persistence.
@@ -380,14 +380,14 @@ public class PersistentRequestClient {
    *
    * <p>The request is added to the running or completed list depending on its current state and is
    * indexed by identifier for later lookups. The method enforces that the request’s persistence
-   * matches the client and that no other distinct request already uses the same identifier.
-   * Status caching is updated to include the new request’s initial state.
+   * matches the client and that no other distinct request already uses the same identifier. Status
+   * caching is updated to include the new request’s initial state.
    *
    * @param cg request to register; must carry a unique identifier for this client and matching
    *     persistence.
    * @throws IllegalArgumentException if the persistence differs from the client policy.
-   * @throws IdentifierCollisionException if another request with the same identifier already
-   *     exists in the mapping.
+   * @throws IdentifierCollisionException if another request with the same identifier already exists
+   *     in the mapping.
    */
   public void register(ClientRequest cg) throws IdentifierCollisionException {
     if (cg.persistence != persistence) {
@@ -586,9 +586,9 @@ public class PersistentRequestClient {
    *     global queue; only messages matching the mask are relayed.
    * @param server owning {@link FCPServer} used to access the global queue instances; must not be
    *     {@code null} when enabling watch.
-   * @return {@code true} when the requested state change was applied or already in effect;
-   *     {@code false} if the operation is invalid (e.g., called on the global queue itself or when
-   *     no global forever client exists).
+   * @return {@code true} when the requested state change was applied or already in effect; {@code
+   *     false} if the operation is invalid (e.g., called on the global queue itself or when no
+   *     global forever client exists).
    */
   public boolean setWatchGlobal(boolean enabled, int verbosityMask, FCPServer server) {
     if (isGlobalQueue) {
@@ -696,8 +696,8 @@ public class PersistentRequestClient {
   /**
    * Looks up a tracked request by its identifier without altering state.
    *
-   * @param identifier request identifier previously registered with this client; must not be
-   *     {@code null}.
+   * @param identifier request identifier previously registered with this client; must not be {@code
+   *     null}.
    * @return matching {@link ClientRequest} or {@code null} if none is tracked under that name.
    */
   public synchronized ClientRequest getRequest(String identifier) {
@@ -783,9 +783,8 @@ public class PersistentRequestClient {
   /**
    * Clears all tracked requests and status cache entries for this client.
    *
-   * <p>Both running and completed queues are emptied and the identifier map is reset. The
-   * operation does not cancel in-flight work; callers should cancel or disconnect separately if
-   * required.
+   * <p>Both running and completed queues are emptied and the identifier map is reset. The operation
+   * does not cancel in-flight work; callers should cancel or disconnect separately if required.
    */
   public void removeAll() {
     if (statusCache != null) statusCache.clear();
@@ -799,8 +798,8 @@ public class PersistentRequestClient {
   /**
    * Finds a completed download request for the specified key.
    *
-   * <p>Searches only the completed-but-unacknowledged list and returns the first matching
-   * {@link ClientGet}. Running requests are ignored to keep lookups deterministic.
+   * <p>Searches only the completed-but-unacknowledged list and returns the first matching {@link
+   * ClientGet}. Running requests are ignored to keep lookups deterministic.
    *
    * @param key URI of the desired completed request; must not be {@code null}.
    * @return matching {@link ClientGet} instance or {@code null} if no completed request with the

--- a/src/main/java/network/crypta/clients/fcp/PluginInfoMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PluginInfoMessage.java
@@ -1,20 +1,42 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
+import network.crypta.pluginmanager.FredPlugin;
 import network.crypta.pluginmanager.PluginInfoWrapper;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
+ * Server-to-client message that conveys metadata about a single plugin in response to the FCP
+ * {@code GetPluginInfo} request.
+ *
+ * <p>This message is built on the server side and serialized over FCP to help clients discover
+ * whether a plugin is present, which FCP interfaces it supports, and whether it is currently
+ * running. Typical callers construct one instance per plugin and immediately send it via the {@link
+ * FCPConnectionHandler}; there is no persistence or reuse beyond the lifetime of the enclosing
+ * request. The instance captures a snapshot of talkability and version information at construction
+ * time and does not track later lifecycle changes.
+ *
+ * <p>Instances are immutable after construction; all fields are derived from the provided {@link
+ * PluginInfoWrapper} without additional I/O. The class is thread-safe for concurrent reads because
+ * it performs no mutation, but callers should avoid sharing it across requests if the underlying
+ * plugin state is expected to change rapidly. Message creation assumes the plugin is already
+ * loaded; unloaded plugins are not modeled by this type. When populating fields, the class defers
+ * to the plugin wrapper for authoritative class names, version numbers, and talkability so
+ * consumers can rely on consistent values.
+ *
+ * <ul>
+ *   <li>Encodes legacy and server-side FCP support into the {@code IsTalkable} flag.
+ *   <li>Optionally includes origin path and start timestamp for detailed queries.
+ *   <li>Uses {@link SimpleFieldSet} for wire formatting to match other FCP messages.
+ * </ul>
+ *
  * @author saces
  */
 public class PluginInfoMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(PluginInfoMessage.class);
 
   static final String NAME = "PluginInfo";
 
-  private final String identifier;
+  private final String messageIdentifier;
 
   private final boolean detailed;
 
@@ -25,8 +47,22 @@ public class PluginInfoMessage extends FCPMessage {
   private final long longVersion;
   private final String version;
 
+  /**
+   * Builds a new {@code PluginInfoMessage} snapshot for the given plugin wrapper.
+   *
+   * <p>The constructor gathers all required fields immediately, including talkability flags and
+   * version strings, so the resulting message can be sent without further access to the plugin
+   * manager. It does not perform any network I/O and assumes the supplied wrapper represents a
+   * currently loaded plugin.
+   *
+   * @param pi wrapper that exposes plugin metadata and runtime instance; must not be {@code null}.
+   * @param identifier optional caller-supplied correlation identifier echoed back to the client;
+   *     may be {@code null} to omit the field.
+   * @param detail {@code true} to include origin URI and start timestamp in the payload; {@code
+   *     false} produces a minimal response.
+   */
   PluginInfoMessage(PluginInfoWrapper pi, String identifier, boolean detail) {
-    this.identifier = identifier;
+    this.messageIdentifier = identifier;
     this.detailed = detail;
     classname = pi.getPluginClassName();
     originuri = pi.getFilename();
@@ -34,17 +70,54 @@ public class PluginInfoMessage extends FCPMessage {
     // isFCPPlugin() is the deprecated old plugin FCP API, isFCPServerPlugin() the new one.
     // Plugins may implement only the old, or the new, or both. As the on-network format is
     // backwards compatible, we report them as talkable if any is implemented.
-    boolean legacyFcp = pi.isFCPPlugin();
+    boolean legacyFcp = isLegacyFcpPlugin(pi);
     isTalkable = legacyFcp || pi.isFCPServerPlugin();
     longVersion = pi.getPluginLongVersion();
     version = pi.getPluginVersion();
   }
 
+  /**
+   * Determines whether the plugin implements the legacy FCP interface.
+   *
+   * <p>The check uses the live plugin instance to test assignability against {@code FredPluginFCP}.
+   * It tolerates environments where the legacy class might be absent by catching {@link
+   * ClassNotFoundException} and treating the plugin as non-legacy in that scenario.
+   *
+   * @param pluginInfo wrapper that provides access to the plugin instance being inspected.
+   * @return {@code true} when the plugin instance implements the legacy FCP API; {@code false}
+   *     otherwise or when the legacy interface cannot be resolved.
+   */
+  private boolean isLegacyFcpPlugin(PluginInfoWrapper pluginInfo) {
+    FredPlugin plugin = pluginInfo.getPlugin();
+    if (plugin == null) {
+      return false;
+    }
+    try {
+      Class<?> legacyApi = Class.forName("network.crypta.pluginmanager.FredPluginFCP");
+      return legacyApi.isInstance(plugin);
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Exports this message into a {@link SimpleFieldSet} suitable for wire transmission.
+   *
+   * <p>The returned structure contains the plugin name, talkability flags, and version identifiers
+   * required by FCP clients. When {@code detailed} was requested at construction time, the field
+   * set also includes the plugin's origin URI and start timestamp. The returned instance is mutable
+   * by callers, but mutations do not affect the original message object.
+   *
+   * @return a new {@link SimpleFieldSet} containing all currently configured message fields in FCP
+   *     format; never {@code null}.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
-    if (identifier != null) // is optional on these two only
-    sfs.putSingle("Identifier", identifier);
+    if (messageIdentifier != null) {
+      // Identifier is optional on these two only
+      sfs.putSingle("Identifier", messageIdentifier);
+    }
     sfs.putSingle("PluginName", classname);
     sfs.put("IsTalkable", isTalkable);
     sfs.put("LongVersion", longVersion);
@@ -53,16 +126,35 @@ public class PluginInfoMessage extends FCPMessage {
     if (detailed) {
       sfs.putSingle("OriginUri", originuri);
       sfs.put("Started", started);
-      // sfs.putSingle("TempFilename", tempfilename);
     }
     return sfs;
   }
 
+  /**
+   * Returns the FCP message name for this type.
+   *
+   * <p>The name is constant and used by the protocol layer to route messages; it does not depend on
+   * any plugin-specific state.
+   *
+   * @return constant {@code "PluginInfo"} identifying this message type.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This message is server-originated only; invoking {@code run} from a client-initiated context
+   * results in an {@link MessageInvalidException} with an {@code INVALID_MESSAGE} protocol error.
+   * It performs no state changes and always throws when executed.
+   *
+   * @param handler connection that attempted to execute the message; must not be {@code null}.
+   * @param node active node instance; unused because execution is not permitted.
+   * @throws MessageInvalidException always thrown to signal that this direction is invalid for the
+   *     message type.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/test/java/network/crypta/clients/fcp/GetPluginInfoTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetPluginInfoTest.java
@@ -4,15 +4,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import network.crypta.node.Node;
+import network.crypta.pluginmanager.FredPlugin;
+import network.crypta.pluginmanager.FredPluginFCP;
 import network.crypta.pluginmanager.PluginInfoWrapper;
 import network.crypta.pluginmanager.PluginManager;
+import network.crypta.pluginmanager.PluginReplySender;
+import network.crypta.pluginmanager.PluginRespirator;
 import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -166,7 +172,7 @@ class GetPluginInfoTest {
       long started,
       boolean includeDetails) {
     when(pluginInfoWrapper.getPluginClassName()).thenReturn(PLUGIN_NAME);
-    when(pluginInfoWrapper.isFCPPlugin()).thenReturn(isFcpPlugin);
+    when(pluginInfoWrapper.getPlugin()).thenReturn(createPlugin(isFcpPlugin));
     if (!isFcpPlugin || includeDetails) {
       when(pluginInfoWrapper.isFCPServerPlugin()).thenReturn(isFcpServerPlugin);
     }
@@ -176,5 +182,25 @@ class GetPluginInfoTest {
       when(pluginInfoWrapper.getFilename()).thenReturn(filename);
       when(pluginInfoWrapper.getStarted()).thenReturn(started);
     }
+  }
+
+  private FredPlugin createPlugin(boolean isFcpPlugin) {
+    if (isFcpPlugin) {
+      return new LegacyFcpTestPlugin();
+    }
+    return mock(FredPlugin.class);
+  }
+
+  private static class LegacyFcpTestPlugin implements FredPlugin, FredPluginFCP {
+
+    @Override
+    public void terminate() {}
+
+    @Override
+    public void runPlugin(PluginRespirator pr) {}
+
+    @Override
+    public void handle(
+        PluginReplySender replysender, SimpleFieldSet params, Bucket data, int accesstype) {}
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/PluginInfoMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PluginInfoMessageTest.java
@@ -1,0 +1,110 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.pluginmanager.FredPlugin;
+import network.crypta.pluginmanager.PluginInfoWrapper;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PluginInfoMessageTest {
+
+  @Mock private PluginInfoWrapper pluginInfoWrapper;
+
+  @Test
+  void getFieldSet_whenDetailedFalse_expectBasicFieldsOnly() {
+    when(pluginInfoWrapper.getPluginClassName()).thenReturn("network.crypta.plugins.TestPlugin");
+    when(pluginInfoWrapper.getFilename()).thenReturn("test-plugin.jar");
+    when(pluginInfoWrapper.getStarted()).thenReturn(123L);
+    when(pluginInfoWrapper.getPlugin()).thenReturn(mock(FredPlugin.class));
+    when(pluginInfoWrapper.isFCPServerPlugin()).thenReturn(true);
+    when(pluginInfoWrapper.getPluginLongVersion()).thenReturn(5L);
+    when(pluginInfoWrapper.getPluginVersion()).thenReturn("5.0.0");
+
+    PluginInfoMessage message = new PluginInfoMessage(pluginInfoWrapper, "id-123", false);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("id-123", fieldSet.get("Identifier"));
+    assertEquals("network.crypta.plugins.TestPlugin", fieldSet.get("PluginName"));
+    assertEquals("5", fieldSet.get("LongVersion"));
+    assertEquals("5.0.0", fieldSet.get("Version"));
+    assertTrue(Boolean.parseBoolean(fieldSet.get("IsTalkable")));
+    assertNull(fieldSet.get("OriginUri"));
+    assertNull(fieldSet.get("Started"));
+  }
+
+  @Test
+  void getFieldSet_whenDetailedTrueAndNoIdentifier_expectDetailedFieldsWithoutIdentifier() {
+    when(pluginInfoWrapper.getPluginClassName()).thenReturn("network.crypta.plugins.DetailPlugin");
+    when(pluginInfoWrapper.getFilename()).thenReturn("detail-plugin.jar");
+    when(pluginInfoWrapper.getStarted()).thenReturn(9876L);
+    when(pluginInfoWrapper.getPlugin()).thenReturn(mock(FredPlugin.class));
+    when(pluginInfoWrapper.isFCPServerPlugin()).thenReturn(false);
+    when(pluginInfoWrapper.getPluginLongVersion()).thenReturn(9L);
+    when(pluginInfoWrapper.getPluginVersion()).thenReturn("9.1");
+
+    PluginInfoMessage message = new PluginInfoMessage(pluginInfoWrapper, null, true);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNull(fieldSet.get("Identifier"));
+    assertEquals("network.crypta.plugins.DetailPlugin", fieldSet.get("PluginName"));
+    assertEquals("detail-plugin.jar", fieldSet.get("OriginUri"));
+    assertEquals("9876", fieldSet.get("Started"));
+    assertEquals("9", fieldSet.get("LongVersion"));
+    assertEquals("9.1", fieldSet.get("Version"));
+    assertFalse(Boolean.parseBoolean(fieldSet.get("IsTalkable")));
+  }
+
+  @Test
+  void getName_whenCalled_returnsPluginInfo() {
+    when(pluginInfoWrapper.getPluginClassName()).thenReturn("network.crypta.plugins.NamePlugin");
+    when(pluginInfoWrapper.getFilename()).thenReturn("name-plugin.jar");
+    when(pluginInfoWrapper.getStarted()).thenReturn(1L);
+    when(pluginInfoWrapper.getPlugin()).thenReturn(mock(FredPlugin.class));
+    when(pluginInfoWrapper.isFCPServerPlugin()).thenReturn(false);
+    when(pluginInfoWrapper.getPluginLongVersion()).thenReturn(1L);
+    when(pluginInfoWrapper.getPluginVersion()).thenReturn("1.0");
+
+    PluginInfoMessage message = new PluginInfoMessage(pluginInfoWrapper, "identifier", false);
+
+    assertEquals("PluginInfo", message.getName());
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidException() {
+    when(pluginInfoWrapper.getPluginClassName()).thenReturn("network.crypta.plugins.RunPlugin");
+    when(pluginInfoWrapper.getFilename()).thenReturn("run-plugin.jar");
+    when(pluginInfoWrapper.getStarted()).thenReturn(10L);
+    when(pluginInfoWrapper.getPlugin()).thenReturn(mock(FredPlugin.class));
+    when(pluginInfoWrapper.isFCPServerPlugin()).thenReturn(false);
+    when(pluginInfoWrapper.getPluginLongVersion()).thenReturn(2L);
+    when(pluginInfoWrapper.getPluginVersion()).thenReturn("2.0");
+
+    PluginInfoMessage message = new PluginInfoMessage(pluginInfoWrapper, "run-id", false);
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> message.run(mock(FCPConnectionHandler.class), mock(Node.class)));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "PluginInfo goes from server to client not the other way around", exception.getMessage());
+    assertFalse(exception.global);
+    assertNull(exception.ident);
+  }
+}


### PR DESCRIPTION
## Summary
- detect legacy FCP plugins by inspecting the live plugin instance for FredPluginFCP instead of PluginInfoWrapper#isFCPPlugin
- make PluginInfoMessage immutable and clarify documentation; serialize identifier safely
- add focused unit tests for PluginInfoMessage and extend GetPluginInfoTest coverage

## Testing
- not run (not requested)
