### PR TITLE
Refactor protocol error handling and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ProtocolErrorMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ProtocolErrorMessage.java
@@ -2,18 +2,34 @@ package network.crypta.clients.fcp;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Map;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * ProtocolError (some problem parsing the other side's FCP messages, or other problem not related
- * to Freenet)
+ * Represents an FCP {@code ProtocolError} message produced when a peer cannot process a command
+ * cleanly.
  *
- * <p>ProtocolError Code=1 CodeDescription=ClientHello must be first message ExtraDescription=Duh
- * Fatal=false // means the connection stays open [Identifier=<ident> if we managed to parse one]
- * EndMessage
+ * <p>This immutable value object bundles the numeric protocol error code, the fatality flag, an
+ * optional free-form explanation, and the identifier of the request that triggered the failure.
+ * Instances are typically created immediately after a parser detects malformed input or an
+ * unsupported operation, and the data they carry is serialized back to the remote peer without
+ * alteration. The internal code-to-description map keeps the canonical protocol text so callers do
+ * not need to reimplement it.
+ *
+ * <p>The message is safe to share across threads because all fields are final and exposed only
+ * through accessors or a {@link SimpleFieldSet} representation. Callers remain responsible for
+ * closing the connection when {@code fatal} is {@code true} and for deciding whether a {@code
+ * global} error should cancel outstanding requests. This class does not attempt retries or
+ * translation; it merely preserves what the protocol already communicated.
+ *
+ * <ul>
+ *   <li>Encodes a single protocol error with optional human-readable context.
+ *   <li>Supports construction from parsed field sets or explicit parameter values.
+ *   <li>Maintains the official descriptions for all known FCP error codes.
+ * </ul>
  */
 public class ProtocolErrorMessage extends FCPMessage implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(ProtocolErrorMessage.class);
@@ -25,11 +41,13 @@ public class ProtocolErrorMessage extends FCPMessage implements Serializable {
   static final int FREENET_URI_PARSE_ERROR = 4;
   static final int MISSING_FIELD = 5;
   static final int ERROR_PARSING_NUMBER = 6;
+
+  /** Numeric code indicating the peer sent a message type the node cannot process. */
   public static final int INVALID_MESSAGE = 7;
+
   static final int INVALID_FIELD = 8;
   static final int FILE_NOT_FOUND = 9;
   static final int DISK_TARGET_EXISTS = 10;
-  // static final int FILENAME_AND_TEMP_FILENAME_MUST_BE_IN_SAME_DIR = 11;
   static final int COULD_NOT_CREATE_FILE = 12;
   static final int COULD_NOT_WRITE_FILE = 13;
   static final int COULD_NOT_RENAME_FILE = 14;
@@ -58,124 +76,162 @@ public class ProtocolErrorMessage extends FCPMessage implements Serializable {
   static final int IO_ERROR = 37;
   static final int PLUGINS_DISABLED = 38;
 
-  final int code;
+  private static final Map<Integer, String> CODE_DESCRIPTIONS =
+      Map.ofEntries(
+          Map.entry(CLIENT_HELLO_MUST_BE_FIRST_MESSAGE, "ClientHello must be first message"),
+          Map.entry(NO_LATE_CLIENT_HELLOS, "No late ClientHello's accepted"),
+          Map.entry(MESSAGE_PARSE_ERROR, "Unknown message parsing error"),
+          Map.entry(FREENET_URI_PARSE_ERROR, "Error parsing freenet URI"),
+          Map.entry(MISSING_FIELD, "Missing field"),
+          Map.entry(ERROR_PARSING_NUMBER, "Error parsing a numeric field"),
+          Map.entry(INVALID_MESSAGE, "Don't know what to do with message"),
+          Map.entry(INVALID_FIELD, "Invalid field value"),
+          Map.entry(FILE_NOT_FOUND, "File not found, not a file or not readable"),
+          Map.entry(
+              DISK_TARGET_EXISTS, "Disk target exists, refusing to overwrite for security reasons"),
+          Map.entry(COULD_NOT_CREATE_FILE, "Could not create file"),
+          Map.entry(COULD_NOT_WRITE_FILE, "Could not write file"),
+          Map.entry(COULD_NOT_RENAME_FILE, "Could not rename file"),
+          Map.entry(NO_SUCH_IDENTIFIER, "No such identifier"),
+          Map.entry(NOT_SUPPORTED, "Not supported"),
+          Map.entry(INTERNAL_ERROR, "Internal error"),
+          Map.entry(SHUTTING_DOWN, "Shutting down"),
+          Map.entry(NO_SUCH_NODE_IDENTIFIER, "No such nodeIdentifier"),
+          Map.entry(URL_PARSE_ERROR, "Error parsing URL"),
+          Map.entry(REF_PARSE_ERROR, "Reference could not be parsed"),
+          Map.entry(FILE_PARSE_ERROR, "File could not be read"),
+          Map.entry(NOT_A_FILE_ERROR, "Filepath is not a file"),
+          Map.entry(ACCESS_DENIED, "Access denied"),
+          Map.entry(
+              DIRECT_DISK_ACCESS_DENIED,
+              "Direct Disk Access operation denied: did you send a FileHash field ? Did you use"
+                  + " TestDDA?"),
+          Map.entry(COULD_NOT_READ_FILE, "Could not read file"),
+          Map.entry(REF_SIGNATURE_INVALID, "Reference signature failed to verify"),
+          Map.entry(CANNOT_PEER_WITH_SELF, "Node cannot peer with itself"),
+          Map.entry(DUPLICATE_PEER_REF, "Node already has a peer with that ref"),
+          Map.entry(OPENNET_DISABLED, "Opennet is currently disabled in the node's configuration"),
+          Map.entry(DARKNET_ONLY, "Operation only available on a darknet peer"),
+          Map.entry(NO_SUCH_PLUGIN, "No such plugin"),
+          Map.entry(
+              PERSISTENCE_DISABLED,
+              "Persistence disabled (e.g. encrypted queue waiting for password?)"),
+          Map.entry(
+              TOO_MANY_FILES_IN_INSERT, "Too many files in a single folder on a freesite insert"),
+          Map.entry(BAD_MIME_TYPE, "Bad MIME type"),
+          Map.entry(WRONG_RETURN_TYPE, "Not supported for that return type"),
+          Map.entry(IO_ERROR, "Disk I/O error"),
+          Map.entry(PLUGINS_DISABLED, "Plugins are disabled"));
+
+  /** Numeric protocol error code preserved exactly as received or specified. */
+  private final int protocolCode;
+
+  /** Optional explanatory text supplied by the remote peer; may be {@code null}. */
   final String extra;
+
+  /**
+   * Indicates whether the sending peer regards the error as connection-fatal; callers should close
+   * if {@code true}.
+   */
   final boolean fatal;
+
+  /** Identifier of the request that triggered the error, or {@code null} if unavailable. */
   final String ident;
+
+  /**
+   * Marks the error as affecting the entire connection or session rather than a single request
+   * only.
+   */
   final boolean global;
 
   private String codeDescription() {
-    // FIXME l10n?
-    switch (code) {
-      case CLIENT_HELLO_MUST_BE_FIRST_MESSAGE:
-        return "ClientHello must be first message";
-      case NO_LATE_CLIENT_HELLOS:
-        return "No late ClientHello's accepted";
-      case MESSAGE_PARSE_ERROR:
-        return "Unknown message parsing error";
-      case FREENET_URI_PARSE_ERROR:
-        return "Error parsing freenet URI";
-      case MISSING_FIELD:
-        return "Missing field";
-      case ERROR_PARSING_NUMBER:
-        return "Error parsing a numeric field";
-      case INVALID_MESSAGE:
-        return "Don't know what to do with message";
-      case INVALID_FIELD:
-        return "Invalid field value";
-      case FILE_NOT_FOUND:
-        return "File not found, not a file or not readable";
-      case DISK_TARGET_EXISTS:
-        return "Disk target exists, refusing to overwrite for security reasons";
-      case COULD_NOT_CREATE_FILE:
-        return "Could not create file";
-      case COULD_NOT_WRITE_FILE:
-        return "Could not write file";
-      case COULD_NOT_RENAME_FILE:
-        return "Could not rename file";
-      case NO_SUCH_IDENTIFIER:
-        return "No such identifier";
-      case NOT_SUPPORTED:
-        return "Not supported";
-      case INTERNAL_ERROR:
-        return "Internal error";
-      case SHUTTING_DOWN:
-        return "Shutting down";
-      case NO_SUCH_NODE_IDENTIFIER: // Unused
-        return "No such nodeIdentifier";
-      case URL_PARSE_ERROR:
-        return "Error parsing URL";
-      case REF_PARSE_ERROR:
-        return "Reference could not be parsed";
-      case FILE_PARSE_ERROR:
-        return "File could not be read";
-      case NOT_A_FILE_ERROR:
-        return "Filepath is not a file";
-      case ACCESS_DENIED:
-        return "Access denied";
-      case DIRECT_DISK_ACCESS_DENIED:
-        return "Direct Disk Access operation denied: did you send a FileHash field ? Did you use"
-            + " TestDDA?";
-      case COULD_NOT_READ_FILE:
-        return "Could not read file";
-      case REF_SIGNATURE_INVALID:
-        return "Reference signature failed to verify";
-      case CANNOT_PEER_WITH_SELF:
-        return "Node cannot peer with itself";
-      case DUPLICATE_PEER_REF:
-        return "Node already has a peer with that ref";
-      case OPENNET_DISABLED:
-        return "Opennet is currently disabled in the node's configuration";
-      case DARKNET_ONLY:
-        return "Operation only available on a darknet peer";
-      case NO_SUCH_PLUGIN:
-        return "No such plugin";
-      case TOO_MANY_FILES_IN_INSERT:
-        return "Too many files in a single folder on a freesite insert";
-      case BAD_MIME_TYPE:
-        return "Bad MIME type";
-      case WRONG_RETURN_TYPE:
-        return "Not supported for that return type";
-      case IO_ERROR:
-        return "Disk I/O error";
-      case PERSISTENCE_DISABLED:
-        return "Persistence disabled (e.g. encrypted queue waiting for password?)";
-      default:
-        LOG.warn("Unknown error code: {}", code);
-        return "(Unknown)";
+    String description = CODE_DESCRIPTIONS.get(protocolCode);
+    if (description != null) {
+      return description;
     }
+    LOG.warn("Unknown error code: {}", protocolCode);
+    return "(Unknown)";
   }
 
+  /**
+   * Creates a protocol error message with explicitly supplied values for every field.
+   *
+   * <p>Use this when emitting a new {@code ProtocolError} in response to a parsing or validation
+   * failure you just detected. The parameters are stored verbatim, allowing the instance to be
+   * serialized, logged, and reused without further normalization. Unknown codes are accepted; when
+   * serialized, they receive the generic {@code (Unknown)} description so downstream peers can
+   * still understand that an error occurred even if they do not recognize the code. The object is
+   * immutable and safe for concurrent reads after construction.
+   *
+   * @param code numeric protocol error code matching one of the defined constants
+   * @param fatal true when the sender regards the error as connection-terminating
+   * @param extra optional human-readable explanation; may be {@code null} or empty
+   * @param ident identifier linked to the failing request; {@code null} if parsing failed early
+   * @param global true when the error should be treated as affecting the whole connection state
+   */
   public ProtocolErrorMessage(int code, boolean fatal, String extra, String ident, boolean global) {
-    this.code = code;
+    this.protocolCode = code;
     this.extra = extra;
     this.fatal = fatal;
     this.ident = ident;
     this.global = global;
   }
 
+  /**
+   * Reconstructs a protocol error from a parsed {@link SimpleFieldSet} received over FCP.
+   *
+   * <p>This constructor pulls the canonical field names ({@code Identifier}, {@code Code}, {@code
+   * ExtraDescription}, {@code Fatal}, and {@code Global}) from the supplied structure. It mirrors
+   * the serialization format produced by {@link #getFieldSet()}, enabling round-trip tests and
+   * bridge components to treat messages uniformly. The caller is responsible for ensuring the field
+   * set originates from a trusted parser; missing or malformed numeric values will trigger a {@link
+   * NumberFormatException}. All extracted values are stored exactly as provided.
+   *
+   * @param fs parsed field set containing the protocol error fields; must not be {@code null}
+   * @throws NumberFormatException if the {@code Code} field cannot be parsed as an integer
+   */
   public ProtocolErrorMessage(SimpleFieldSet fs) {
     ident = fs.get("Identifier");
-    code = Integer.parseInt(fs.get("Code"));
+    protocolCode = Integer.parseInt(fs.get("Code"));
     extra = fs.get("ExtraDescription");
     fatal = fs.getBoolean("Fatal", false);
     global = fs.getBoolean("Global", false);
   }
 
+  /**
+   * Initializes an empty protocol error suitable for serialization frameworks that require a
+   * no-argument constructor.
+   *
+   * <p>The fields are set to harmless defaults and should be overwritten by the deserializer before
+   * the instance is used. This constructor is not intended for direct application use; prefer the
+   * parameterized constructors when constructing real messages. The resulting object is mutable
+   * only during deserialization because the fields are final once the constructor completes.
+   */
   protected ProtocolErrorMessage() {
     // For serialization.
-    code = 0;
+    protocolCode = 0;
     extra = null;
     fatal = false;
     ident = null;
     global = false;
   }
 
+  /**
+   * Serializes this message into a {@link SimpleFieldSet} using the canonical FCP field names.
+   *
+   * <p>The returned structure always contains {@code Code}, {@code CodeDescription}, {@code Fatal},
+   * and {@code Global}; optional fields are included only when present. Descriptions are resolved
+   * from the static code map so that downstream components receive protocol-approved text even when
+   * they were constructed with only a numeric code. The method performs no network I/O and can be
+   * invoked repeatedly without side effects.
+   *
+   * @return immutable field set representation appropriate for immediate transmission to a peer
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
     if (ident != null) sfs.putSingle("Identifier", ident);
-    sfs.put("Code", code);
+    sfs.put("Code", protocolCode);
     sfs.putSingle("CodeDescription", codeDescription());
     if (extra != null) sfs.putSingle("ExtraDescription", extra);
     sfs.put("Fatal", fatal);
@@ -183,18 +239,74 @@ public class ProtocolErrorMessage extends FCPMessage implements Serializable {
     return sfs;
   }
 
+  /**
+   * Notifies the local handler that the client reported a protocol error.
+   *
+   * <p>This implementation simply logs the occurrence because protocol errors are already fully
+   * represented in the object. It does not attempt automatic recovery or connection management; the
+   * caller should decide whether to close the session based on the {@code fatal} flag or higher
+   * level policies. The method is safe to call multiple times and does not mutate state.
+   *
+   * @param handler active FCP connection handler receiving the message; never {@code null} during
+   *     normal operation
+   * @param node current node instance that owns the connection; used by higher-level handlers
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) {
     LOG.error("Client reported protocol error");
   }
 
+  /**
+   * Returns the protocol message name used when serializing this object over FCP.
+   *
+   * <p>The value is constant for all instances because the class models only the {@code
+   * ProtocolError} message type. Callers commonly use it when dispatching or logging outbound
+   * messages so the receiving side can match on well-known names. The string does not include any
+   * additional qualifiers or formatting.
+   *
+   * @return constant message name {@code ProtocolError} suitable for FCP framing
+   */
   @Override
   public String getName() {
     return "ProtocolError";
   }
 
+  /**
+   * Exposes the raw numeric error code preserved within this message.
+   *
+   * <p>The value corresponds to one of the constants defined in this class when the sender adhered
+   * to the protocol, but arbitrary numbers are allowed for forward compatibility. The method
+   * performs no translation and never returns {@code null}. Callers may use it to map to localized
+   * descriptions or to branch logic without reparsing the field set.
+   *
+   * @return integer code representing the specific protocol error condition
+   */
+  public int getCode() {
+    return protocolCode;
+  }
+
+  /**
+   * Builds a human-readable representation containing the superclass string plus key fields.
+   *
+   * <p>The output concatenates the superclass value, numeric code, extra description, fatal flag,
+   * request identifier, and global flag, separated by colons. It is intended for diagnostics and
+   * should not be parsed back into a message. The format remains stable to ease log search but is
+   * not part of the wire protocol.
+   *
+   * @return string summary of the error content for logging or debugging purposes
+   */
   @Override
   public String toString() {
-    return super.toString() + ":" + code + ":" + extra + ":" + fatal + ":" + ident + ":" + global;
+    return super.toString()
+        + ":"
+        + protocolCode
+        + ":"
+        + extra
+        + ":"
+        + fatal
+        + ":"
+        + ident
+        + ":"
+        + global;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
@@ -116,7 +116,7 @@ class FCPConnectionInputHandlerTest {
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(ctx.handler).send(captor.capture());
     ProtocolErrorMessage error = (ProtocolErrorMessage) captor.getValue();
-    assertEquals(ProtocolErrorMessage.CLIENT_HELLO_MUST_BE_FIRST_MESSAGE, error.code);
+    assertEquals(ProtocolErrorMessage.CLIENT_HELLO_MUST_BE_FIRST_MESSAGE, error.getCode());
     verify(ctx.handler).close();
   }
 
@@ -137,7 +137,7 @@ class FCPConnectionInputHandlerTest {
     withLineSequence(lines, ctx.inputHandler::realRun);
 
     ProtocolErrorMessage error = findError(ctx.handler, ProtocolErrorMessage.NO_LATE_CLIENT_HELLOS);
-    assertEquals(ProtocolErrorMessage.NO_LATE_CLIENT_HELLOS, error.code);
+    assertEquals(ProtocolErrorMessage.NO_LATE_CLIENT_HELLOS, error.getCode());
     verify(ctx.handler, never()).close();
   }
 
@@ -253,7 +253,7 @@ class FCPConnectionInputHandlerTest {
     return captor.getAllValues().stream()
         .filter(ProtocolErrorMessage.class::isInstance)
         .map(ProtocolErrorMessage.class::cast)
-        .filter(err -> err.code == code)
+        .filter(err -> err.getCode() == code)
         .findFirst()
         .orElseThrow(
             () ->

--- a/src/test/java/network/crypta/clients/fcp/GetPluginInfoTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetPluginInfoTest.java
@@ -84,7 +84,7 @@ class GetPluginInfoTest {
     verify(handler).send(captor.capture());
     ProtocolErrorMessage sent = captor.getValue();
 
-    assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, sent.code);
+    assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, sent.getCode());
     assertFalse(sent.fatal);
     assertFalse(sent.global);
     assertEquals(IDENTIFIER, sent.ident);

--- a/src/test/java/network/crypta/clients/fcp/GetRequestStatusMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetRequestStatusMessageTest.java
@@ -175,7 +175,7 @@ class GetRequestStatusMessageTest {
 
     ProtocolErrorMessage sent = errorCaptor.getValue();
     assertNotNull(sent);
-    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, sent.code);
+    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, sent.getCode());
     assertEquals(identifier, sent.ident);
     assertFalse(sent.fatal);
   }
@@ -203,7 +203,7 @@ class GetRequestStatusMessageTest {
     verify(handler).send(errorCaptor.capture());
 
     ProtocolErrorMessage error = errorCaptor.getValue();
-    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.code);
+    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.getCode());
     assertEquals(identifier, error.ident);
     assertFalse(error.fatal);
   }

--- a/src/test/java/network/crypta/clients/fcp/LoadPluginTest.java
+++ b/src/test/java/network/crypta/clients/fcp/LoadPluginTest.java
@@ -133,7 +133,7 @@ class LoadPluginTest {
     ArgumentCaptor<ProtocolErrorMessage> message =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
     verify(handler).send(message.capture());
-    assertEquals(ProtocolErrorMessage.PLUGINS_DISABLED, message.getValue().code);
+    assertEquals(ProtocolErrorMessage.PLUGINS_DISABLED, message.getValue().getCode());
     assertEquals("Plugins disabled", message.getValue().extra);
     assertEquals("abc", message.getValue().ident);
     verifyNoInteractions(executor);
@@ -151,7 +151,7 @@ class LoadPluginTest {
     ArgumentCaptor<ProtocolErrorMessage> message =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
     verify(handler).send(message.capture());
-    assertEquals(ProtocolErrorMessage.INVALID_FIELD, message.getValue().code);
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, message.getValue().getCode());
     assertNotNull(message.getValue().extra);
     assertTrue(message.getValue().extra.contains("Was not able to guess"));
     verify(pluginManager, never()).startPluginOfficial(anyString(), anyBoolean());
@@ -236,7 +236,7 @@ class LoadPluginTest {
     ArgumentCaptor<ProtocolErrorMessage> message =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
     verify(handler).send(message.capture());
-    assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, message.getValue().code);
+    assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, message.getValue().getCode());
     assertEquals("abc", message.getValue().ident);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
@@ -273,7 +273,7 @@ class ModifyPersistentRequestTest {
     verify(handler, times(1)).send(errorCaptor.capture());
     ProtocolErrorMessage error = errorCaptor.getValue();
     assertNotNull(error);
-    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.code);
+    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.getCode());
     assertFalse(error.fatal);
     assertEquals("req-9", error.ident);
     assertFalse(error.global);
@@ -313,7 +313,7 @@ class ModifyPersistentRequestTest {
     verify(handler, never())
         .getForeverRequest(anyBoolean(), any(FCPConnectionHandler.class), anyString());
     ProtocolErrorMessage error = errorCaptor.getValue();
-    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.code);
+    assertEquals(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, error.getCode());
     assertFalse(error.fatal);
     assertEquals("req-10", error.ident);
     assertTrue(error.global);

--- a/src/test/java/network/crypta/clients/fcp/ProtocolErrorMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProtocolErrorMessageTest.java
@@ -1,0 +1,92 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ProtocolErrorMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void getFieldSet_whenAllFieldsProvided_containsExpectedValues() {
+    ProtocolErrorMessage message =
+        new ProtocolErrorMessage(
+            ProtocolErrorMessage.INVALID_MESSAGE, true, "details", "identifier", true);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("identifier", fieldSet.get("Identifier"));
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, Integer.parseInt(fieldSet.get("Code")));
+    assertEquals("Don't know what to do with message", fieldSet.get("CodeDescription"));
+    assertEquals("details", fieldSet.get("ExtraDescription"));
+    assertTrue(fieldSet.getBoolean("Fatal", false));
+    assertTrue(fieldSet.getBoolean("Global", false));
+  }
+
+  @Test
+  void getFieldSet_whenOptionalFieldsNull_omitsThem() {
+    ProtocolErrorMessage message = new ProtocolErrorMessage(1234, false, null, null, false);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertFalse(fieldSet.directKeys().contains("Identifier"));
+    assertFalse(fieldSet.directKeys().contains("ExtraDescription"));
+    assertEquals("(Unknown)", fieldSet.get("CodeDescription"));
+    assertFalse(fieldSet.getBoolean("Fatal", true));
+    assertFalse(fieldSet.getBoolean("Global", true));
+  }
+
+  @Test
+  void constructor_withSimpleFieldSet_parsesValues() {
+    SimpleFieldSet source = new SimpleFieldSet(true);
+    source.putSingle("Identifier", "abc");
+    source.put("Code", ProtocolErrorMessage.FILE_NOT_FOUND);
+    source.putSingle("ExtraDescription", "missing");
+    source.put("Fatal", true);
+    source.put("Global", true);
+
+    ProtocolErrorMessage message = new ProtocolErrorMessage(source);
+
+    assertEquals("abc", message.ident);
+    assertEquals(ProtocolErrorMessage.FILE_NOT_FOUND, message.getCode());
+    assertEquals("missing", message.extra);
+    assertTrue(message.fatal);
+    assertTrue(message.global);
+  }
+
+  @Test
+  void run_whenInvoked_doesNotThrow() {
+    ProtocolErrorMessage message = new ProtocolErrorMessage(1, false, null, null, false);
+
+    assertDoesNotThrow(() -> message.run(handler, node));
+  }
+
+  @Test
+  void getName_whenCalled_returnsProtocolError() {
+    ProtocolErrorMessage message = new ProtocolErrorMessage(1, false, null, null, false);
+
+    assertEquals("ProtocolError", message.getName());
+  }
+
+  @Test
+  void toString_whenCalled_containsFieldValues() {
+    ProtocolErrorMessage message = new ProtocolErrorMessage(7, true, "extra", "id", true);
+
+    String result = message.toString();
+
+    assertTrue(result.contains(":7:extra:true:id:true"));
+  }
+}


### PR DESCRIPTION
## Summary
- encapsulate ProtocolErrorMessage code field, centralize descriptions, and enrich documentation
- update FCP tests to use the new accessor and expectations
- add unit coverage for ProtocolErrorMessage serialization, parsing, and output

## Testing
- Not run (not requested)