### PR TITLE
fix: align put failure reporting and persistence safety

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -1004,7 +1004,7 @@ public class ClientPut extends ClientPutBase {
     String failureReasonShort = null;
     String failureReasonLong = null;
     if (putFailedMessage != null) {
-      failureCode = putFailedMessage.code;
+      failureCode = putFailedMessage.failureMode;
       failureReasonShort = putFailedMessage.getShortFailedMessage();
       failureReasonLong = putFailedMessage.getLongFailedMessage();
     }

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -745,7 +745,7 @@ public class ClientPutDir extends ClientPutBase {
     InsertExceptionMode failureCode = null;
     String failureReasonShort = null;
     if (putFailedMessage != null) {
-      failureCode = putFailedMessage.code;
+      failureCode = putFailedMessage.failureMode;
       failureReasonShort = putFailedMessage.getLongFailedMessage();
     }
 

--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -237,7 +237,7 @@ public class PersistentRequestClient {
     String shortFailMessage = null;
     String longFailMessage = null;
     if (msg != null) {
-      failureCode = msg.code;
+      failureCode = msg.failureMode;
       shortFailMessage = msg.getShortFailedMessage();
       longFailMessage = msg.getLongFailedMessage();
     }

--- a/src/main/java/network/crypta/clients/fcp/PutFailedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PutFailedMessage.java
@@ -1,7 +1,13 @@
 package network.crypta.clients.fcp;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamField;
 import java.io.Serial;
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import network.crypta.client.FailureCodeTracker;
 import network.crypta.client.InsertException;
@@ -40,6 +46,20 @@ import network.crypta.support.SimpleFieldSet;
 public class PutFailedMessage extends FCPMessage implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
+
+  private static final ObjectStreamField[] serialPersistentFields = {
+    new ObjectStreamField("failureMode", InsertExceptionMode.class),
+    new ObjectStreamField("code", InsertExceptionMode.class), // legacy name
+    new ObjectStreamField("codeDescription", String.class),
+    new ObjectStreamField("extraDescription", String.class),
+    new ObjectStreamField("shortCodeDescription", String.class),
+    new ObjectStreamField("tracker", FailureCodeTracker.class),
+    new ObjectStreamField("expectedURI", FreenetURI.class),
+    new ObjectStreamField("requestIdentifier", String.class),
+    new ObjectStreamField("identifier", String.class), // legacy name
+    new ObjectStreamField("global", boolean.class),
+    new ObjectStreamField("isFatal", boolean.class)
+  };
 
   /**
    * Failure mode that categorizes the insert error and drives fatality and retry semantics. The
@@ -165,6 +185,73 @@ public class PutFailedMessage extends FCPMessage implements Serializable {
       tracker = new FailureCodeTracker(true, trackerSubset);
     } else {
       tracker = null;
+    }
+  }
+
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    ObjectOutputStream.PutField fields = out.putFields();
+    fields.put("failureMode", failureMode);
+    fields.put("code", null); // legacy field left blank for forward streams
+    fields.put("codeDescription", codeDescription);
+    fields.put("extraDescription", extraDescription);
+    fields.put("shortCodeDescription", shortCodeDescription);
+    fields.put("tracker", tracker);
+    fields.put("expectedURI", expectedURI);
+    fields.put("requestIdentifier", requestIdentifier);
+    fields.put("identifier", null); // legacy field left blank for forward streams
+    fields.put("global", global);
+    fields.put("isFatal", isFatal);
+    out.writeFields();
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    ObjectInputStream.GetField fields = in.readFields();
+
+    InsertExceptionMode mode = (InsertExceptionMode) fields.get("failureMode", null);
+    if (mode == null) {
+      mode = (InsertExceptionMode) fields.get("code", null);
+    }
+    assignDeserializedField("failureMode", mode);
+
+    String identifier = (String) fields.get("requestIdentifier", null);
+    if (identifier == null) {
+      identifier = (String) fields.get("identifier", null);
+    }
+    assignDeserializedField("requestIdentifier", identifier);
+
+    assignDeserializedField("codeDescription", (String) fields.get("codeDescription", null));
+    assignDeserializedField("extraDescription", (String) fields.get("extraDescription", null));
+    assignDeserializedField(
+        "shortCodeDescription", (String) fields.get("shortCodeDescription", null));
+    assignDeserializedField("tracker", (FailureCodeTracker) fields.get("tracker", null));
+    assignDeserializedField("expectedURI", (FreenetURI) fields.get("expectedURI", null));
+    assignDeserializedField("global", fields.get("global", false));
+
+    boolean fatal = fields.get("isFatal", false);
+    if (fields.defaulted("isFatal") && mode != null) {
+      fatal = InsertException.isFatal(mode);
+    }
+    assignDeserializedField("isFatal", fatal);
+
+    if (failureMode == null || requestIdentifier == null) {
+      throw new InvalidObjectException("Missing required fields for PutFailedMessage");
+    }
+  }
+
+  private void assignDeserializedField(String fieldName, Object value)
+      throws InvalidObjectException {
+    try {
+      Field field = PutFailedMessage.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(this, value);
+    } catch (ReflectiveOperationException e) {
+      InvalidObjectException wrapped =
+          new InvalidObjectException(
+              "Failed to set field '" + fieldName + "' during deserialization");
+      wrapped.initCause(e);
+      throw wrapped;
     }
   }
 

--- a/src/main/java/network/crypta/clients/fcp/PutFailedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PutFailedMessage.java
@@ -9,58 +9,151 @@ import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Message sent from the node when a client-initiated {@code ClientPut} fails.
+ *
+ * <p>Instances capture the precise {@link InsertExceptionMode}, human-readable code descriptions,
+ * any extended text provided by the node, and the optional {@link FreenetURI} that had been
+ * expected. The message can be serialized to and from {@link SimpleFieldSet} so it can travel
+ * across FCP, be logged, or be preserved with a persistent request. Most fields are immutable after
+ * construction, allowing callers to safely cache or forward the object without further
+ * synchronization.
+ *
+ * <p>Typical consumers are FCP clients that need to render meaningful diagnostics or decide whether
+ * to retry a failed insert. The class does not attempt recovery itself; it only relays state
+ * reported by the server. When created from field sets, callers may choose between consuming
+ * verbose descriptions or recomputing them from the numeric error code, which can help reduce wire
+ * size. Thread-safety is achieved through immutability; multiple threads may read the same instance
+ * concurrently.
+ *
+ * <ul>
+ *   <li>Encapsulates server-side insert failure metadata.
+ *   <li>Supports compact and verbose FCP serialization forms.
+ *   <li>Provides short and long failure message helpers for UI display.
+ * </ul>
+ *
+ * @see InsertException
+ * @see FailureCodeTracker
+ * @see FreenetURI
+ */
 public class PutFailedMessage extends FCPMessage implements Serializable {
-  private static final Logger LOG = LoggerFactory.getLogger(PutFailedMessage.class);
 
   @Serial private static final long serialVersionUID = 1L;
-  final InsertExceptionMode code;
+
+  /**
+   * Failure mode that categorizes the insert error and drives fatality and retry semantics. The
+   * value maps directly to {@link InsertExceptionMode} so clients can branch on protocol-defined
+   * codes without parsing free-form strings.
+   */
+  final InsertExceptionMode failureMode;
+
+  /**
+   * Human-readable description of the failure code, either read from verbose message fields or
+   * reconstructed from the numeric code. Intended for log output or UI labels where structured
+   * codes are insufficient.
+   */
   final String codeDescription;
+
+  /**
+   * Optional extended diagnostic details supplied by the node; may be {@code null} when absent.
+   * Contents often include specific reasons such as checksum mismatches or connectivity problems
+   * that are not conveyed by the main code description.
+   */
   final String extraDescription;
+
+  /**
+   * Concise description intended for compact displays or log summaries of the failure condition.
+   * This string is shorter than {@link #codeDescription} and suited to status tables or progress
+   * indicators.
+   */
   final String shortCodeDescription;
+
+  /**
+   * Optional tracker containing structured error counts and codes gathered during the insert
+   * attempt. When present it allows clients to render detailed diagnostics or aggregate failure
+   * statistics without parsing textual messages.
+   */
   final FailureCodeTracker tracker;
+
+  /**
+   * Expected URI for the inserted content when provided by the node; can be {@code null}. Clients
+   * may use the value to confirm addressing expectations or to annotate user-facing error reports.
+   */
   final FreenetURI expectedURI;
-  final String identifier;
+
+  /**
+   * Identifier used by the client to correlate this message with the original request. The same
+   * token is echoed back to the server in follow-up interactions and is required by the protocol.
+   */
+  final String requestIdentifier;
+
+  /**
+   * Whether the originating request was submitted as a global request across peers. This flag
+   * informs clients about scope so they can decide whether retries should remain global or fall
+   * back to a local insert.
+   */
   final boolean global;
+
+  /**
+   * Indicates whether the node treats this failure as fatal for subsequent retries. Fatal errors
+   * normally halt automated retry loops, while non-fatal ones may be retried after backoff.
+   */
   final boolean isFatal;
 
+  /**
+   * Builds a failure message directly from an {@link InsertException} raised by the node.
+   *
+   * <p>This constructor is used on the server side before sending the failure to an FCP client. It
+   * copies the detailed error context, short/long descriptions, and request identifier. All copied
+   * values are treated as immutable snapshots of the original exception so later changes to the
+   * source exception do not affect the message.
+   *
+   * @param e insert exception describing why the put failed; never {@code null}.
+   * @param identifier client-supplied identifier that correlates responses to requests.
+   * @param global whether the failing request was global (affects broadcast semantics).
+   */
   public PutFailedMessage(InsertException e, String identifier, boolean global) {
-    this.code = e.getMode();
-    this.codeDescription = InsertException.getMessage(code);
-    this.shortCodeDescription = InsertException.getShortMessage(code);
+    this.failureMode = e.getMode();
+    this.codeDescription = InsertException.getMessage(failureMode);
+    this.shortCodeDescription = InsertException.getShortMessage(failureMode);
     this.extraDescription = e.extra;
     this.tracker = e.getErrorCodes();
     this.expectedURI = e.getUri();
-    this.identifier = identifier;
+    this.requestIdentifier = identifier;
     this.global = global;
-    this.isFatal = InsertException.isFatal(code);
+    this.isFatal = InsertException.isFatal(failureMode);
   }
 
   /**
-   * Construct from a fieldset. Used in serialization of persistent requests. Will need to be made
-   * more tolerant of syntax errors if is used in an FCP client library. FIXME.
+   * Reconstructs a failure message from a {@link SimpleFieldSet} representation.
    *
-   * @param useVerboseFields If true, read in verbose fields (CodeDescription etc), if false,
-   *     reconstruct them from the error code.
-   * @throws MalformedURLException
+   * <p>Used when loading persistent requests or consuming messages from external sources. When
+   * {@code useVerboseFields} is {@code true}, the method reads human-readable descriptions directly
+   * from the field set; otherwise it regenerates them from the numeric {@code Code} value to reduce
+   * storage overhead. The identifier must be present; callers are expected to validate the source
+   * before constructing. URI parsing follows the same rules as {@link FreenetURI} and may raise a
+   * malformed URL error.
+   *
+   * @param fs field set containing the serialized failure fields, including {@code Identifier}.
+   * @param useVerboseFields whether to consume descriptive fields or recompute them from the code.
+   * @throws MalformedURLException when {@code ExpectedURI} is present but cannot be parsed.
    */
   public PutFailedMessage(SimpleFieldSet fs, boolean useVerboseFields)
       throws MalformedURLException {
-    identifier = fs.get("Identifier");
-    if (identifier == null) throw new NullPointerException();
+    requestIdentifier = fs.get("Identifier");
+    if (requestIdentifier == null) throw new NullPointerException();
     global = fs.getBoolean("Global", false);
-    code = InsertExceptionMode.getByCode(Integer.parseInt(fs.get("Code")));
+    failureMode = InsertExceptionMode.getByCode(Integer.parseInt(fs.get("Code")));
 
     if (useVerboseFields) {
       codeDescription = fs.get("CodeDescription");
       isFatal = fs.getBoolean("Fatal", false);
       shortCodeDescription = fs.get("ShortCodeDescription");
     } else {
-      codeDescription = InsertException.getMessage(code);
-      isFatal = InsertException.isFatal(code);
-      shortCodeDescription = InsertException.getShortMessage(code);
+      codeDescription = InsertException.getMessage(failureMode);
+      isFatal = InsertException.isFatal(failureMode);
+      shortCodeDescription = InsertException.getShortMessage(failureMode);
     }
 
     extraDescription = fs.get("ExtraDescription");
@@ -80,12 +173,22 @@ public class PutFailedMessage extends FCPMessage implements Serializable {
     return getFieldSet(true);
   }
 
+  /**
+   * Serializes this failure message into an {@link SimpleFieldSet} suitable for FCP transport.
+   *
+   * <p>When {@code verbose} is {@code true}, descriptive strings and fatality flags are emitted to
+   * aid diagnostics. In compact mode only the essential codes are included, allowing callers to
+   * minimize payload size while still reconstructing messages on the other side.
+   *
+   * @param verbose whether to include descriptive text fields alongside numeric codes.
+   * @return mutable field set populated with message data ready for wire transmission.
+   */
   public SimpleFieldSet getFieldSet(boolean verbose) {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    if (identifier == null) throw new NullPointerException();
-    fs.putSingle("Identifier", identifier);
+    if (requestIdentifier == null) throw new NullPointerException();
+    fs.putSingle("Identifier", requestIdentifier);
     fs.put("Global", global);
-    fs.put("Code", code.code);
+    fs.put("Code", failureMode.code);
     if (verbose) fs.putSingle("CodeDescription", codeDescription);
     if (extraDescription != null) fs.putSingle("ExtraDescription", extraDescription);
     if (tracker != null) {
@@ -102,19 +205,40 @@ public class PutFailedMessage extends FCPMessage implements Serializable {
     return "PutFailed";
   }
 
+  /**
+   * Rejects attempts to send {@code PutFailed} from a client back to the server.
+   *
+   * <p>The FCP protocol defines this message as server-to-client only. Invoking this method on the
+   * client side therefore always results in an exception that includes the offending identifier and
+   * global flag for logging. The method is intentionally non-idempotent because it always throws.
+   *
+   * @param handler connection handler that attempted to process the outbound message.
+   * @param node node instance associated with the connection; unused but required by signature.
+   * @throws MessageInvalidException always thrown to signal protocol misuse by the client.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PutFailed goes from server to client not the other way around",
-        identifier,
+        requestIdentifier,
         global);
   }
 
+  /**
+   * Returns a concise description of the failure suitable for compact displays.
+   *
+   * @return short, human-readable message derived from the insert failure mode.
+   */
   public String getShortFailedMessage() {
     return shortCodeDescription;
   }
 
+  /**
+   * Returns an expanded failure description that includes any extra diagnostic text.
+   *
+   * @return short description optionally suffixed with the extra error context text.
+   */
   public String getLongFailedMessage() {
     if (extraDescription != null) return shortCodeDescription + ": " + extraDescription;
     else return shortCodeDescription;

--- a/src/main/java/network/crypta/clients/fcp/PutFailedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PutFailedMessage.java
@@ -4,10 +4,8 @@ import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.ObjectStreamField;
 import java.io.Serial;
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import network.crypta.client.FailureCodeTracker;
 import network.crypta.client.InsertException;
@@ -47,79 +45,77 @@ public class PutFailedMessage extends FCPMessage implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
 
-  private static final ObjectStreamField[] serialPersistentFields = {
-    new ObjectStreamField("failureMode", InsertExceptionMode.class),
-    new ObjectStreamField("code", InsertExceptionMode.class), // legacy name
-    new ObjectStreamField("codeDescription", String.class),
-    new ObjectStreamField("extraDescription", String.class),
-    new ObjectStreamField("shortCodeDescription", String.class),
-    new ObjectStreamField("tracker", FailureCodeTracker.class),
-    new ObjectStreamField("expectedURI", FreenetURI.class),
-    new ObjectStreamField("requestIdentifier", String.class),
-    new ObjectStreamField("identifier", String.class), // legacy name
-    new ObjectStreamField("global", boolean.class),
-    new ObjectStreamField("isFatal", boolean.class)
-  };
+  private static final String FIELD_FAILURE_MODE = "failureMode";
+  private static final String FIELD_CODE_DESCRIPTION = "codeDescription";
+  private static final String FIELD_EXTRA_DESCRIPTION = "extraDescription";
+  private static final String FIELD_SHORT_CODE_DESCRIPTION = "shortCodeDescription";
+  private static final String FIELD_TRACKER = "tracker";
+  private static final String FIELD_EXPECTED_URI = "expectedURI";
+  private static final String FIELD_REQUEST_IDENTIFIER = "requestIdentifier";
+  private static final String FIELD_LEGACY_CODE = "code";
+  private static final String FIELD_LEGACY_IDENTIFIER = "identifier";
+  private static final String FIELD_GLOBAL = "global";
+  private static final String FIELD_IS_FATAL = "isFatal";
 
   /**
    * Failure mode that categorizes the insert error and drives fatality and retry semantics. The
    * value maps directly to {@link InsertExceptionMode} so clients can branch on protocol-defined
    * codes without parsing free-form strings.
    */
-  final InsertExceptionMode failureMode;
+  InsertExceptionMode failureMode;
 
   /**
    * Human-readable description of the failure code, either read from verbose message fields or
    * reconstructed from the numeric code. Intended for log output or UI labels where structured
    * codes are insufficient.
    */
-  final String codeDescription;
+  String codeDescription;
 
   /**
    * Optional extended diagnostic details supplied by the node; may be {@code null} when absent.
    * Contents often include specific reasons such as checksum mismatches or connectivity problems
    * that are not conveyed by the main code description.
    */
-  final String extraDescription;
+  String extraDescription;
 
   /**
    * Concise description intended for compact displays or log summaries of the failure condition.
    * This string is shorter than {@link #codeDescription} and suited to status tables or progress
    * indicators.
    */
-  final String shortCodeDescription;
+  String shortCodeDescription;
 
   /**
    * Optional tracker containing structured error counts and codes gathered during the insert
    * attempt. When present it allows clients to render detailed diagnostics or aggregate failure
    * statistics without parsing textual messages.
    */
-  final FailureCodeTracker tracker;
+  FailureCodeTracker tracker;
 
   /**
    * Expected URI for the inserted content when provided by the node; can be {@code null}. Clients
    * may use the value to confirm addressing expectations or to annotate user-facing error reports.
    */
-  final FreenetURI expectedURI;
+  FreenetURI expectedURI;
 
   /**
    * Identifier used by the client to correlate this message with the original request. The same
    * token is echoed back to the server in follow-up interactions and is required by the protocol.
    */
-  final String requestIdentifier;
+  String requestIdentifier;
 
   /**
    * Whether the originating request was submitted as a global request across peers. This flag
    * informs clients about scope so they can decide whether retries should remain global or fall
    * back to a local insert.
    */
-  final boolean global;
+  boolean global;
 
   /**
    * Indicates whether the node treats this failure as fatal for subsequent retries. Fatal errors
    * normally halt automated retry loops, while non-fatal ones may be retried after backoff.
    */
-  final boolean isFatal;
+  boolean isFatal;
 
   /**
    * Builds a failure message directly from an {@link InsertException} raised by the node.
@@ -191,17 +187,17 @@ public class PutFailedMessage extends FCPMessage implements Serializable {
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
     ObjectOutputStream.PutField fields = out.putFields();
-    fields.put("failureMode", failureMode);
-    fields.put("code", null); // legacy field left blank for forward streams
-    fields.put("codeDescription", codeDescription);
-    fields.put("extraDescription", extraDescription);
-    fields.put("shortCodeDescription", shortCodeDescription);
-    fields.put("tracker", tracker);
-    fields.put("expectedURI", expectedURI);
-    fields.put("requestIdentifier", requestIdentifier);
-    fields.put("identifier", null); // legacy field left blank for forward streams
-    fields.put("global", global);
-    fields.put("isFatal", isFatal);
+    fields.put(FIELD_FAILURE_MODE, failureMode);
+    fields.put(FIELD_LEGACY_CODE, null); // legacy field left blank for forward streams
+    fields.put(FIELD_CODE_DESCRIPTION, codeDescription);
+    fields.put(FIELD_EXTRA_DESCRIPTION, extraDescription);
+    fields.put(FIELD_SHORT_CODE_DESCRIPTION, shortCodeDescription);
+    fields.put(FIELD_TRACKER, tracker);
+    fields.put(FIELD_EXPECTED_URI, expectedURI);
+    fields.put(FIELD_REQUEST_IDENTIFIER, requestIdentifier);
+    fields.put(FIELD_LEGACY_IDENTIFIER, null); // legacy field left blank for forward streams
+    fields.put(FIELD_GLOBAL, global);
+    fields.put(FIELD_IS_FATAL, isFatal);
     out.writeFields();
   }
 
@@ -209,49 +205,33 @@ public class PutFailedMessage extends FCPMessage implements Serializable {
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
     ObjectInputStream.GetField fields = in.readFields();
 
-    InsertExceptionMode mode = (InsertExceptionMode) fields.get("failureMode", null);
+    InsertExceptionMode mode = (InsertExceptionMode) fields.get(FIELD_FAILURE_MODE, null);
     if (mode == null) {
-      mode = (InsertExceptionMode) fields.get("code", null);
+      mode = (InsertExceptionMode) fields.get(FIELD_LEGACY_CODE, null);
     }
-    assignDeserializedField("failureMode", mode);
+    failureMode = mode;
 
-    String identifier = (String) fields.get("requestIdentifier", null);
+    String identifier = (String) fields.get(FIELD_REQUEST_IDENTIFIER, null);
     if (identifier == null) {
-      identifier = (String) fields.get("identifier", null);
+      identifier = (String) fields.get(FIELD_LEGACY_IDENTIFIER, null);
     }
-    assignDeserializedField("requestIdentifier", identifier);
+    requestIdentifier = identifier;
 
-    assignDeserializedField("codeDescription", (String) fields.get("codeDescription", null));
-    assignDeserializedField("extraDescription", (String) fields.get("extraDescription", null));
-    assignDeserializedField(
-        "shortCodeDescription", (String) fields.get("shortCodeDescription", null));
-    assignDeserializedField("tracker", (FailureCodeTracker) fields.get("tracker", null));
-    assignDeserializedField("expectedURI", (FreenetURI) fields.get("expectedURI", null));
-    assignDeserializedField("global", fields.get("global", false));
+    codeDescription = (String) fields.get(FIELD_CODE_DESCRIPTION, null);
+    extraDescription = (String) fields.get(FIELD_EXTRA_DESCRIPTION, null);
+    shortCodeDescription = (String) fields.get(FIELD_SHORT_CODE_DESCRIPTION, null);
+    tracker = (FailureCodeTracker) fields.get(FIELD_TRACKER, null);
+    expectedURI = (FreenetURI) fields.get(FIELD_EXPECTED_URI, null);
+    global = fields.get(FIELD_GLOBAL, false);
 
-    boolean fatal = fields.get("isFatal", false);
-    if (fields.defaulted("isFatal") && mode != null) {
+    boolean fatal = fields.get(FIELD_IS_FATAL, false);
+    if (fields.defaulted(FIELD_IS_FATAL) && mode != null) {
       fatal = InsertException.isFatal(mode);
     }
-    assignDeserializedField("isFatal", fatal);
+    isFatal = fatal;
 
     if (failureMode == null || requestIdentifier == null) {
       throw new InvalidObjectException("Missing required fields for PutFailedMessage");
-    }
-  }
-
-  private void assignDeserializedField(String fieldName, Object value)
-      throws InvalidObjectException {
-    try {
-      Field field = PutFailedMessage.class.getDeclaredField(fieldName);
-      field.setAccessible(true);
-      field.set(this, value);
-    } catch (ReflectiveOperationException e) {
-      InvalidObjectException wrapped =
-          new InvalidObjectException(
-              "Failed to set field '" + fieldName + "' during deserialization");
-      wrapped.initCause(e);
-      throw wrapped;
     }
   }
 

--- a/src/main/java/network/crypta/node/Persister.java
+++ b/src/main/java/network/crypta/node/Persister.java
@@ -93,6 +93,12 @@ class Persister implements Runnable {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Trying to persist throttles...");
     }
+
+    // Ensure parent directories exist so persistence doesn't fail on missing temp/target paths.
+    if (!ensureParentDirectory(persistTemp) || !ensureParentDirectory(persistTarget)) {
+      return;
+    }
+
     SimpleFieldSet fs = persistable.persistThrottlesToFieldSet();
     try (FileOutputStream fos = new FileOutputStream(persistTemp)) {
       fs.writeToBigBuffer(fos);
@@ -110,6 +116,19 @@ class Persister implements Runnable {
     } catch (Exception e) {
       LOG.error("Could not move temp file to target: {}", e, e);
     }
+  }
+
+  /** Creates the parent directory for a file if it does not already exist. */
+  private boolean ensureParentDirectory(File file) {
+    File parent = file.getAbsoluteFile().getParentFile();
+    if (parent == null || parent.exists()) {
+      return true;
+    }
+    if (parent.mkdirs()) {
+      return true;
+    }
+    LOG.error("Could not create directory for throttle persistence: {}", parent);
+    return false;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/fcp/PutFailedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PutFailedMessageTest.java
@@ -1,0 +1,200 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.util.Map;
+import network.crypta.client.FailureCodeTracker;
+import network.crypta.client.InsertException;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.keys.FreenetURI;
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PutFailedMessageTest {
+
+  private static BaseL10n originalL10n;
+
+  private static final Map<Integer, String> LONG_MESSAGES =
+      Map.of(
+          InsertExceptionMode.COLLISION.code, "Long collision",
+          InsertExceptionMode.REJECTED_OVERLOAD.code, "Long rejected overload",
+          InsertExceptionMode.CANCELLED.code, "Long cancelled",
+          InsertExceptionMode.BUCKET_ERROR.code, "Long bucket error");
+
+  private static final Map<Integer, String> SHORT_MESSAGES =
+      Map.of(
+          InsertExceptionMode.COLLISION.code, "Collision short",
+          InsertExceptionMode.REJECTED_OVERLOAD.code, "Rejected overload short",
+          InsertExceptionMode.CANCELLED.code, "Cancelled short",
+          InsertExceptionMode.BUCKET_ERROR.code, "Bucket short");
+
+  @BeforeAll
+  static void stubLocalization() {
+    originalL10n = NodeL10n.getBase();
+    BaseL10n stub = mock(BaseL10n.class);
+    when(stub.getString(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String key = invocation.getArgument(0);
+              String longPrefix = "InsertException.longError.";
+              String shortPrefix = "InsertException.shortError.";
+              if (key.startsWith(longPrefix)) {
+                int code = Integer.parseInt(key.substring(longPrefix.length()));
+                return LONG_MESSAGES.getOrDefault(code, "long-" + code);
+              }
+              if (key.startsWith(shortPrefix)) {
+                int code = Integer.parseInt(key.substring(shortPrefix.length()));
+                return SHORT_MESSAGES.getOrDefault(code, "short-" + code);
+              }
+              return key;
+            });
+    overrideNodeL10n(stub);
+  }
+
+  @AfterAll
+  static void restoreLocalization() {
+    overrideNodeL10n(originalL10n);
+  }
+
+  private static void overrideNodeL10n(BaseL10n baseL10n) {
+    try {
+      Field field = NodeL10n.class.getDeclaredField("b");
+      field.setAccessible(true);
+      field.set(null, baseL10n);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Unable to override NodeL10n base", e);
+    }
+  }
+
+  @Test
+  void getFieldSet_whenVerbose_includesVerboseFields() {
+    FailureCodeTracker tracker = new FailureCodeTracker(true);
+    tracker.inc(InsertExceptionMode.COLLISION);
+    InsertException exception =
+        new InsertException(
+            InsertExceptionMode.COLLISION, "disk error", tracker, FreenetURI.EMPTY_CHK_URI);
+
+    PutFailedMessage message = new PutFailedMessage(exception, "insert-1", true);
+
+    SimpleFieldSet fieldSet = message.getFieldSet(true);
+
+    assertEquals("insert-1", fieldSet.get("Identifier"));
+    assertTrue(fieldSet.getBoolean("Global", false));
+    assertEquals(InsertExceptionMode.COLLISION.code, fieldSet.getInt("Code", -1));
+    assertEquals("Long collision", fieldSet.get("CodeDescription"));
+    assertEquals("Collision short", fieldSet.get("ShortCodeDescription"));
+    assertEquals("disk error", fieldSet.get("ExtraDescription"));
+    assertEquals(FreenetURI.EMPTY_CHK_URI.toString(), fieldSet.get("ExpectedURI"));
+    assertTrue(fieldSet.getBoolean("Fatal", false));
+    SimpleFieldSet errors = fieldSet.subset("Errors");
+    assertNotNull(errors);
+    assertEquals(1, errors.getInt("9.Count", -1));
+  }
+
+  @Test
+  void getFieldSet_whenNotVerbose_omitsVerboseOnlyKeys() {
+    InsertException exception = new InsertException(InsertExceptionMode.REJECTED_OVERLOAD);
+
+    PutFailedMessage message = new PutFailedMessage(exception, "insert-2", false);
+
+    SimpleFieldSet fieldSet = message.getFieldSet(false);
+
+    assertEquals("insert-2", fieldSet.get("Identifier"));
+    assertEquals(InsertExceptionMode.REJECTED_OVERLOAD.code, fieldSet.getInt("Code", -1));
+    assertNull(fieldSet.get("CodeDescription"));
+    assertNull(fieldSet.get("ShortCodeDescription"));
+    assertNull(fieldSet.get("Fatal"));
+    assertNull(fieldSet.get("ExpectedURI"));
+    assertNull(fieldSet.subset("Errors"));
+  }
+
+  @Test
+  void constructor_withVerboseFieldSet_preservesDescriptions() throws MalformedURLException {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "from-fs");
+    fs.put("Global", true);
+    fs.put("Code", InsertExceptionMode.BUCKET_ERROR.code);
+    fs.putSingle("CodeDescription", "Provided bucket description");
+    fs.put("Fatal", true);
+    fs.putSingle("ShortCodeDescription", "Provided short");
+    fs.putSingle("ExtraDescription", "disk full");
+    fs.putSingle("ExpectedURI", FreenetURI.EMPTY_CHK_URI.toString());
+    FailureCodeTracker tracker = new FailureCodeTracker(true);
+    tracker.inc(InsertExceptionMode.BUCKET_ERROR);
+    fs.tput("Errors", tracker.toFieldSet(true));
+
+    PutFailedMessage message = new PutFailedMessage(fs, true);
+
+    SimpleFieldSet fieldSet = message.getFieldSet(true);
+    assertEquals("Provided bucket description", fieldSet.get("CodeDescription"));
+    assertEquals("Provided short", message.getShortFailedMessage());
+    assertEquals("Provided short: disk full", message.getLongFailedMessage());
+    assertEquals(1, fieldSet.subset("Errors").getInt("2.Count", -1));
+  }
+
+  @Test
+  void constructor_withNonVerboseFieldSet_reconstructsDescriptions() throws MalformedURLException {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "non-verbose");
+    fs.put("Global", true);
+    fs.put("Code", InsertExceptionMode.REJECTED_OVERLOAD.code);
+    fs.putSingle("ExtraDescription", "retry later");
+
+    PutFailedMessage message = new PutFailedMessage(fs, false);
+
+    SimpleFieldSet fieldSet = message.getFieldSet(true);
+    assertEquals("Long rejected overload", fieldSet.get("CodeDescription"));
+    assertEquals("Rejected overload short", fieldSet.get("ShortCodeDescription"));
+    assertEquals("retry later", fieldSet.get("ExtraDescription"));
+    assertEquals(
+        InsertException.isFatal(InsertExceptionMode.REJECTED_OVERLOAD),
+        fieldSet.getBoolean("Fatal", true));
+  }
+
+  @Test
+  void getLongFailedMessage_whenNoExtra_returnsShortMessage() {
+    InsertException exception = new InsertException(InsertExceptionMode.CANCELLED);
+
+    PutFailedMessage message = new PutFailedMessage(exception, "insert-3", true);
+
+    assertEquals("Cancelled short", message.getLongFailedMessage());
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidException() {
+    InsertException exception = new InsertException(InsertExceptionMode.INVALID_URI);
+    PutFailedMessage message = new PutFailedMessage(exception, "insert-4", true);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);
+    assertEquals("insert-4", thrown.ident);
+    assertTrue(thrown.global);
+  }
+
+  @Test
+  void constructor_whenIdentifierMissing_throwsNullPointerException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.put("Code", InsertExceptionMode.COLLISION.code);
+
+    assertThrows(NullPointerException.class, () -> new PutFailedMessage(fs, true));
+  }
+}

--- a/src/test/java/network/crypta/node/PersisterTest.java
+++ b/src/test/java/network/crypta/node/PersisterTest.java
@@ -76,6 +76,32 @@ class PersisterTest {
   }
 
   @Test
+  void run_whenParentDirectoryMissing_createsDirAndPersists() throws Exception {
+    // Arrange: point persister to a nested directory that doesn't exist yet
+    File missingDir = new File(tempDir, "nested/missing");
+    File tmp = new File(missingDir, "throttle.tmp");
+    File tgt = new File(missingDir, "throttle.dat");
+
+    SimpleFieldSet sfs = new SimpleFieldSet(false);
+    sfs.putSingle("k", "v");
+    when(persistable.persistThrottlesToFieldSet()).thenReturn(sfs);
+
+    doAnswer(inv -> null)
+        .when(ticker)
+        .queueTimedJob(org.mockito.Mockito.any(Runnable.class), org.mockito.Mockito.anyLong());
+
+    Persister persister = new Persister(persistable, tmp, tgt, ticker);
+
+    // Act
+    persister.run();
+
+    // Assert: parent directory created, target written with expected content
+    assertTrue(tgt.isFile(), "persist target should exist after creating missing parent dirs");
+    SimpleFieldSet readBack = SimpleFieldSet.readFrom(tgt, false, true);
+    assertEquals("v", readBack.get("k"));
+  }
+
+  @Test
   void run_whenTempIsDirectory_logsAndSkipsWriteAndQueuesNext() {
     // Arrange: make temp path a directory so FileOutputStream throws FileNotFoundException
     // ("Is a directory")


### PR DESCRIPTION
## Summary
- expose `PutFailedMessage` failure mode consistently to clients and document fields
- add coverage for verbose/non-verbose fieldset serialization and message helpers
- ensure throttle persister creates parent directories before writing and test the behavior

## Testing
- Not run (not requested)