### PR TITLE
refactor: clarify reload plugin handler

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ReloadPlugin.java
+++ b/src/main/java/network/crypta/clients/fcp/ReloadPlugin.java
@@ -3,51 +3,132 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.pluginmanager.PluginInfoWrapper;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/** reload a plugin */
+/**
+ * Handles the {@code ReloadPlugin} FCP command by stopping and restarting an existing plugin.
+ *
+ * <p>This message type is used by privileged FCP clients that need to refresh a plugin after
+ * updating its code or configuration without restarting the entire node. The handler validates that
+ * the caller has full access, locates the plugin by its {@code PluginName}, stops it while honoring
+ * the configured maximum wait time, optionally purges any cached copy, and then launches the plugin
+ * again using the cached or stored source. All heavy work is dispatched onto the node executor to
+ * keep the FCP connection responsive and to isolate plugin shutdown/startup lifecycles from the
+ * message thread.
+ *
+ * <ul>
+ *   <li>Fails fast with protocol errors when the plugin identifier is unknown.
+ *   <li>Supports an optional purge step to discard cached archives before restart.
+ *   <li>Replies with {@link PluginInfoMessage} on success or a detailed error otherwise.
+ * </ul>
+ *
+ * <p>Instances are effectively stateless after construction and may be created per incoming
+ * message. Reload operations are not idempotent; repeated requests will stop and start the plugin
+ * each time they are executed.
+ *
+ * @see FCPMessage
+ * @see network.crypta.pluginmanager.PluginManager
+ */
 public class ReloadPlugin extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ReloadPlugin.class);
 
   static final String NAME = "ReloadPlugin";
 
-  private final String identifier;
+  private final String clientIdentifier;
   private final String plugname;
   private final int maxWaitTime;
   private final boolean purge;
   private final boolean store;
 
+  /**
+   * Creates a reload request from fields supplied by an incoming FCP message.
+   *
+   * <p>The constructor validates that the caller provided a non-null {@code Identifier} and {@code
+   * PluginName}. Optional fields include {@code MaxWaitTime} (milliseconds to wait for a clean
+   * shutdown before forcing) and flags {@code Purge} and {@code Store}, both of which default to
+   * {@code false}. No additional validation beyond presence is performed here; the runtime behavior
+   * is handled in {@link #run(FCPConnectionHandler, Node)}.
+   *
+   * @param fs field set containing {@code Identifier}, plugin name, timing, and purge/store flags;
+   *     must not be {@code null}.
+   * @throws MessageInvalidException when mandatory fields are missing or cannot be parsed from the
+   *     provided field set representation.
+   */
   public ReloadPlugin(SimpleFieldSet fs) throws MessageInvalidException {
-    identifier = fs.get("Identifier");
-    if (identifier == null)
+    clientIdentifier = fs.get("Identifier");
+    if (clientIdentifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "Must contain an Identifier field", null, false);
     plugname = fs.get("PluginName");
     if (plugname == null)
       throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "Must contain a PluginName field", identifier, false);
+          ProtocolErrorMessage.MISSING_FIELD,
+          "Must contain a PluginName field",
+          clientIdentifier,
+          false);
     maxWaitTime = fs.getInt("MaxWaitTime", 0);
     purge = fs.getBoolean("Purge", false);
     store = fs.getBoolean("Store", false);
   }
 
+  /**
+   * Produces an empty field set because this command does not serialize additional payload.
+   *
+   * <p>The returned instance is freshly allocated on each call and may be mutated by the caller
+   * without affecting internal state. It primarily exists to satisfy the {@link FCPMessage}
+   * contract for messages that are command-only and convey their data through parameters rather
+   * than serialized fields.
+   *
+   * @return new {@link SimpleFieldSet} instance with no keys or values populated.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Returns the protocol-level name associated with this message type.
+   *
+   * <p>The name is used when routing incoming messages and when emitting responses so that the peer
+   * can correlate behavior with the original command. It is a constant defined by the FCP
+   * specification and should remain stable across releases for compatibility.
+   *
+   * @return immutable message name string {@code "ReloadPlugin"} for protocol routing purposes.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the reload workflow on the node executor to avoid blocking the FCP thread.
+   *
+   * <p>The handler first ensures the connection has full access; otherwise it raises an access
+   * denial error. It then resolves the plugin by name, stops it while honoring the configured
+   * maximum wait time, optionally purges any cached copy, and starts it again with the requested
+   * persistence flag. Success results in a {@link PluginInfoMessage}; failures return protocol
+   * errors that explain whether the plugin was missing or invalid.
+   *
+   * <pre>{@code
+   * // Typical server-side call path
+   * new ReloadPlugin(fs).run(handler, node);
+   * }</pre>
+   *
+   * <p>This method is not idempotent; repeated invocations will repeatedly stop and restart the
+   * plugin, which may disrupt in-flight work inside the plugin itself.
+   *
+   * @param handler connection handler that enforces permissions and sends replies to the client.
+   * @param node node instance providing the executor and plugin manager used for lifecycle actions.
+   * @throws MessageInvalidException if the caller lacks full access or if permission validation
+   *     fails before the reload operation is dispatched.
+   */
   @Override
   public void run(final FCPConnectionHandler handler, final Node node)
       throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "LoadPlugin requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "LoadPlugin requires full access",
+          clientIdentifier,
+          false);
     }
 
     node.getExecutor()
@@ -60,7 +141,7 @@ public class ReloadPlugin extends FCPMessage {
                         ProtocolErrorMessage.NO_SUCH_PLUGIN,
                         false,
                         "Plugin '" + plugname + "' does not exist or is not a FCP plugin",
-                        identifier,
+                        clientIdentifier,
                         false));
               } else {
                 String source = pi.getFilename();
@@ -75,10 +156,10 @@ public class ReloadPlugin extends FCPMessage {
                           ProtocolErrorMessage.NO_SUCH_PLUGIN,
                           false,
                           "Plugin '" + plugname + "' does not exist or is not a FCP plugin",
-                          identifier,
+                          clientIdentifier,
                           false));
                 } else {
-                  handler.send(new PluginInfoMessage(pi, identifier, true));
+                  handler.send(new PluginInfoMessage(pi, clientIdentifier, true));
                 }
               }
             },

--- a/src/test/java/network/crypta/clients/fcp/ReloadPluginTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ReloadPluginTest.java
@@ -1,0 +1,219 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.pluginmanager.PluginInfoWrapper;
+import network.crypta.pluginmanager.PluginManager;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings({"java:S100", "resource"})
+@ExtendWith(MockitoExtension.class)
+class ReloadPluginTest {
+
+  private static final String IDENTIFIER = "reload-ident";
+  private static final String PLUGIN_NAME = "TestPlugin";
+
+  @Test
+  void constructor_whenIdentifierMissing_throwsMissingFieldException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("PluginName", PLUGIN_NAME);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ReloadPlugin(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("Must contain an Identifier field", exception.getMessage());
+    assertNull(exception.ident);
+  }
+
+  @Test
+  void constructor_whenPluginNameMissing_throwsMissingFieldException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ReloadPlugin(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("Must contain a PluginName field", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
+  void getName_whenCalled_returnsReloadPluginConstant() throws MessageInvalidException {
+    ReloadPlugin reloadPlugin = new ReloadPlugin(minimalFieldSet());
+
+    assertEquals(ReloadPlugin.NAME, reloadPlugin.getName());
+  }
+
+  @Test
+  void getFieldSet_whenCalled_returnsNewEmptyFieldSet() throws MessageInvalidException {
+    ReloadPlugin reloadPlugin = new ReloadPlugin(minimalFieldSet());
+
+    SimpleFieldSet fieldSet = reloadPlugin.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertNull(fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void run_whenHandlerHasNoFullAccess_throwsAccessDenied() throws MessageInvalidException {
+    ReloadPlugin reloadPlugin = new ReloadPlugin(minimalFieldSet());
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(false);
+    Node node = mock(Node.class);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> reloadPlugin.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
+    assertEquals("LoadPlugin requires full access", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+    verifyNoMoreInteractions(node);
+  }
+
+  @Test
+  void run_whenPluginNotFound_sendsNoSuchPluginError() throws MessageInvalidException {
+    ReloadPlugin reloadPlugin = new ReloadPlugin(minimalFieldSet());
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    PriorityAwareExecutor executor = inlineExecutor();
+    PluginManager pluginManager = mock(PluginManager.class);
+    when(pluginManager.findPluginByIdentifier(PLUGIN_NAME)).thenReturn(null);
+
+    Node node = mock(Node.class);
+    when(node.getExecutor()).thenReturn(executor);
+    when(node.getPluginManager()).thenReturn(pluginManager);
+
+    reloadPlugin.run(handler, node);
+
+    ArgumentCaptor<ProtocolErrorMessage> captor =
+        ArgumentCaptor.forClass(ProtocolErrorMessage.class);
+    verify(handler).send(captor.capture());
+    ProtocolErrorMessage errorMessage = captor.getValue();
+    int code = Integer.parseInt(errorMessage.getFieldSet().get("Code"));
+    assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, code);
+    assertEquals(
+        "Plugin '" + PLUGIN_NAME + "' does not exist or is not a FCP plugin", errorMessage.extra);
+    assertEquals(IDENTIFIER, errorMessage.ident);
+    verify(pluginManager).findPluginByIdentifier(PLUGIN_NAME);
+    verify(pluginManager, never()).startPluginAuto(anyString(), anyBoolean());
+  }
+
+  @Test
+  void run_whenStartPluginAutoReturnsNull_sendsErrorAfterStoppingAndPurging()
+      throws MessageInvalidException {
+    SimpleFieldSet fs = minimalFieldSet();
+    fs.put("Purge", true);
+    fs.put("MaxWaitTime", 42);
+    ReloadPlugin reloadPlugin = new ReloadPlugin(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    PriorityAwareExecutor executor = inlineExecutor();
+    PluginManager pluginManager = mock(PluginManager.class);
+    PluginInfoWrapper existingPlugin = mock(PluginInfoWrapper.class);
+    when(existingPlugin.getFilename()).thenReturn("plugin.jar");
+    when(pluginManager.findPluginByIdentifier(PLUGIN_NAME)).thenReturn(existingPlugin);
+    when(pluginManager.startPluginAuto("plugin.jar", false)).thenReturn(null);
+
+    Node node = mock(Node.class);
+    when(node.getExecutor()).thenReturn(executor);
+    when(node.getPluginManager()).thenReturn(pluginManager);
+
+    reloadPlugin.run(handler, node);
+
+    verify(existingPlugin).stopPlugin(pluginManager, 42, true);
+    verify(pluginManager).removeCachedCopy("plugin.jar");
+    ArgumentCaptor<ProtocolErrorMessage> captor =
+        ArgumentCaptor.forClass(ProtocolErrorMessage.class);
+    verify(handler).send(captor.capture());
+    ProtocolErrorMessage errorMessage = captor.getValue();
+    int code = Integer.parseInt(errorMessage.getFieldSet().get("Code"));
+    assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, code);
+    assertEquals(IDENTIFIER, errorMessage.ident);
+  }
+
+  @Test
+  void run_whenPluginReloadSucceeds_sendsPluginInfoMessage() throws MessageInvalidException {
+    SimpleFieldSet fs = minimalFieldSet();
+    fs.put("Store", true);
+    fs.put("MaxWaitTime", 7);
+    ReloadPlugin reloadPlugin = new ReloadPlugin(fs);
+
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    when(handler.hasFullAccess()).thenReturn(true);
+
+    PriorityAwareExecutor executor = inlineExecutor();
+    PluginManager pluginManager = mock(PluginManager.class);
+    PluginInfoWrapper existingPlugin = mock(PluginInfoWrapper.class);
+    when(existingPlugin.getFilename()).thenReturn("plugin.jar");
+    when(pluginManager.findPluginByIdentifier(PLUGIN_NAME)).thenReturn(existingPlugin);
+
+    PluginInfoWrapper reloadedPlugin = mock(PluginInfoWrapper.class);
+    when(reloadedPlugin.getPluginClassName()).thenReturn("example.Plugin");
+    when(reloadedPlugin.getFilename()).thenReturn("plugin.jar");
+    when(reloadedPlugin.getStarted()).thenReturn(123L);
+    when(reloadedPlugin.isFCPServerPlugin()).thenReturn(false);
+    when(reloadedPlugin.getPluginLongVersion()).thenReturn(1L);
+    when(reloadedPlugin.getPluginVersion()).thenReturn("1.0.0");
+    when(pluginManager.startPluginAuto("plugin.jar", true)).thenReturn(reloadedPlugin);
+
+    Node node = mock(Node.class);
+    when(node.getExecutor()).thenReturn(executor);
+    when(node.getPluginManager()).thenReturn(pluginManager);
+
+    reloadPlugin.run(handler, node);
+
+    verify(existingPlugin).stopPlugin(pluginManager, 7, true);
+    verify(pluginManager, never()).removeCachedCopy(anyString());
+    verify(pluginManager).startPluginAuto("plugin.jar", true);
+
+    ArgumentCaptor<PluginInfoMessage> captor = ArgumentCaptor.forClass(PluginInfoMessage.class);
+    verify(handler).send(captor.capture());
+    PluginInfoMessage infoMessage = captor.getValue();
+    SimpleFieldSet result = infoMessage.getFieldSet();
+    assertEquals(IDENTIFIER, result.get("Identifier"));
+    assertEquals("example.Plugin", result.get("PluginName"));
+  }
+
+  private static SimpleFieldSet minimalFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("PluginName", PLUGIN_NAME);
+    return fs;
+  }
+
+  private static PriorityAwareExecutor inlineExecutor() {
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    doAnswer(
+            invocation -> {
+              Runnable job = invocation.getArgument(0);
+              job.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class), anyString());
+    return executor;
+  }
+}


### PR DESCRIPTION
## Summary
- clarify ReloadPlugin handler naming and identifier usage
- add comprehensive ReloadPlugin tests covering success and failure paths

## Testing
- not run (logic-only changes)