### PR TITLE
Refactor: document RemovePeer handler and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/RemovePeer.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePeer.java
@@ -3,55 +3,141 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Handles the FCP {@code RemovePeer} command by orchestrating the removal of a peer that is
+ * currently known to the node and reporting the outcome back to the client session.
+ *
+ * <p>The handler extracts the peer identifier, validates full-access privileges, resolves the peer
+ * in the routing table, and either removes the connection with a {@link PeerRemoved} acknowledgment
+ * or reports an {@link UnknownNodeIdentifierMessage}. It preserves the caller-provided message
+ * identifier so asynchronous replies can be correlated and avoids touching the node when required
+ * fields are missing.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Enforcing that only fully privileged clients may remove peers.
+ *   <li>Resolving and validating the requested peer before any destructive action.
+ *   <li>Emitting protocol-level acknowledgments that reflect success or descriptive failure.
+ * </ul>
+ *
+ * <p>Instances are short-lived and not thread-safe; a single {@link #run(FCPConnectionHandler,
+ * Node)} invocation should be used per incoming request on the handler thread. The original {@link
+ * SimpleFieldSet} is retained by reference, so callers should not reuse it concurrently.
+ *
+ * @see PeerRemoved
+ * @see UnknownNodeIdentifierMessage
+ * @see Node
+ * @see PeerNode
+ */
 public class RemovePeer extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(RemovePeer.class);
 
   static final String NAME = "RemovePeer";
 
   final SimpleFieldSet fs;
-  final String identifier;
+  final String messageIdentifier;
 
+  /**
+   * Creates a handler for an incoming {@code RemovePeer} request and captures the message
+   * identifier used for correlating responses.
+   *
+   * <p>The constructor reads the {@code Identifier} field from the supplied {@link SimpleFieldSet}
+   * to keep it available for later replies and removes it from the mutable field set to avoid
+   * accidental forwarding. The remaining fields, including {@code NodeIdentifier}, are processed
+   * during {@link #run(FCPConnectionHandler, Node)}. The supplied field set is retained by
+   * reference, so callers should not modify it after construction if consistent behavior is
+   * required.
+   *
+   * @param fs inbound protocol fields for this request; must contain {@code Identifier} and is
+   *     expected to contain {@code NodeIdentifier} when {@link #run(FCPConnectionHandler, Node)} is
+   *     invoked; must be non-null and remain stable for the lifetime of this instance.
+   */
   public RemovePeer(SimpleFieldSet fs) {
     this.fs = fs;
-    identifier = fs.get("Identifier");
+    messageIdentifier = fs.get("Identifier");
     fs.removeValue("Identifier");
   }
 
+  /**
+   * Returns an empty field set because this message type does not send a body back to the client
+   * during dispatch.
+   *
+   * <p>The returned instance is freshly allocated and marked as case-insensitive, matching the
+   * expectations of other FCP message builders. Callers can treat it as immutable for the purposes
+   * of sending but should avoid caching it across messages because it carries no payload.
+   *
+   * @return new {@link SimpleFieldSet} with no entries, suitable for immediate transmission.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Reports the protocol-level name for this FCP message.
+   *
+   * <p>The name is a constant string defined by the FCP specification and is used by connection
+   * handlers to route messages to the correct implementation. It does not vary per instance and can
+   * be compared using reference equality in performance-sensitive paths if desired.
+   *
+   * @return the literal {@code "RemovePeer"} identifier used by the protocol.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the removal request against the provided node, validating access and sending the
+   * appropriate protocol response.
+   *
+   * <p>The handler must have full access; otherwise a {@link MessageInvalidException} with an
+   * {@link ProtocolErrorMessage#ACCESS_DENIED} error is thrown. When the {@code NodeIdentifier}
+   * field is missing, the method signals a {@link ProtocolErrorMessage#MISSING_FIELD} error. If a
+   * matching peer exists, it is detached via {@link Node#removePeerConnection(PeerNode)} and a
+   * {@link PeerRemoved} acknowledgment is sent. Unknown peer identifiers yield an {@link
+   * UnknownNodeIdentifierMessage}. No state beyond the current invocation is retained, and the
+   * method is not idempotent if the peer list changes between calls.
+   *
+   * <pre>{@code
+   * // Example: remove a peer by its node identifier
+   * var message = new RemovePeer(fields);
+   * message.run(handler, node);
+   * }</pre>
+   *
+   * @param handler connection handler responsible for sending responses; must provide full-access
+   *     privileges for the operation to proceed and must not be null.
+   * @param node target node on which the peer should be removed; must not be null and must support
+   *     lookup of the specified node identifier.
+   * @throws MessageInvalidException when access is denied or required fields are absent, halting
+   *     further processing and surfacing a protocol-level error to the caller.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, NAME + " requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          NAME + " requires full access",
+          messageIdentifier,
+          false);
     }
     String nodeIdentifier = fs.get("NodeIdentifier");
     if (nodeIdentifier == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "Error: NodeIdentifier field missing",
-          identifier,
+          messageIdentifier,
           false);
     }
     PeerNode pn = node.getPeerNode(nodeIdentifier);
     if (pn == null) {
-      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
+      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, messageIdentifier);
       handler.send(msg);
       return;
     }
     String identity = pn.getIdentityString();
     node.removePeerConnection(pn);
-    handler.send(new PeerRemoved(identity, nodeIdentifier, identifier));
+    handler.send(new PeerRemoved(identity, nodeIdentifier, messageIdentifier));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/RemovePeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RemovePeerTest.java
@@ -1,0 +1,157 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class RemovePeerTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Mock private PeerNode peerNode;
+
+  @Test
+  void constructor_removesIdentifierFromFieldSet() {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", "id-123");
+    fieldSet.putSingle("NodeIdentifier", "node-abc");
+
+    RemovePeer removePeer = new RemovePeer(fieldSet);
+
+    assertNull(fieldSet.get("Identifier"));
+    assertEquals("node-abc", fieldSet.get("NodeIdentifier"));
+    assertEquals("id-123", removePeer.messageIdentifier);
+    assertSame(fieldSet, removePeer.fs);
+  }
+
+  @Test
+  void getName_returnsRemovePeer() {
+    RemovePeer removePeer = new RemovePeer(buildFieldSet("node-abc", "id-1"));
+
+    assertEquals("RemovePeer", removePeer.getName());
+  }
+
+  @Test
+  void getFieldSet_returnsEmptyFieldSet() {
+    RemovePeer removePeer = new RemovePeer(buildFieldSet("node-abc", "id-1"));
+
+    SimpleFieldSet result = removePeer.getFieldSet();
+
+    assertNotNull(result);
+    assertNull(result.get("Identifier"));
+    assertNull(result.get("NodeIdentifier"));
+  }
+
+  @Test
+  void run_whenNoFullAccess_throwsAccessDenied() {
+    when(handler.hasFullAccess()).thenReturn(false);
+    RemovePeer removePeer = new RemovePeer(buildFieldSet("node-abc", "id-123"));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> removePeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
+    assertEquals("RemovePeer requires full access", exception.getMessage());
+    assertEquals("id-123", exception.ident);
+    assertFalse(exception.global);
+    verify(handler).hasFullAccess();
+    verifyNoMoreInteractions(handler);
+    verifyNoMoreInteractions(node);
+  }
+
+  @Test
+  void run_whenNodeIdentifierMissing_throwsMissingField() {
+    when(handler.hasFullAccess()).thenReturn(true);
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", "id-456");
+    RemovePeer removePeer = new RemovePeer(fieldSet);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> removePeer.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("Error: NodeIdentifier field missing", exception.getMessage());
+    assertEquals("id-456", exception.ident);
+    assertFalse(exception.global);
+    verify(handler).hasFullAccess();
+    verifyNoMoreInteractions(handler);
+    verifyNoMoreInteractions(node);
+  }
+
+  @Test
+  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws MessageInvalidException {
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode("node-missing")).thenReturn(null);
+    RemovePeer removePeer = new RemovePeer(buildFieldSet("node-missing", "id-789"));
+
+    removePeer.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).hasFullAccess();
+    verify(node).getPeerNode("node-missing");
+    verify(handler).send(captor.capture());
+    verify(node, never()).removePeerConnection(any(PeerNode.class));
+    verifyNoMoreInteractions(handler, node);
+
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(UnknownNodeIdentifierMessage.class, sent);
+    SimpleFieldSet sentFields = sent.getFieldSet();
+    assertEquals("node-missing", sentFields.get("NodeIdentifier"));
+    assertEquals("id-789", sentFields.get("Identifier"));
+  }
+
+  @Test
+  void run_whenPeerPresent_removesPeerAndSendsPeerRemoved() throws MessageInvalidException {
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(node.getPeerNode("node-123")).thenReturn(peerNode);
+    when(peerNode.getIdentityString()).thenReturn("identity-xyz");
+    RemovePeer removePeer = new RemovePeer(buildFieldSet("node-123", "id-555"));
+
+    removePeer.run(handler, node);
+
+    verify(handler).hasFullAccess();
+    verify(node).getPeerNode("node-123");
+    verify(peerNode).getIdentityString();
+    verify(node).removePeerConnection(peerNode);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    verifyNoMoreInteractions(handler, node, peerNode);
+
+    FCPMessage sent = captor.getValue();
+    assertInstanceOf(PeerRemoved.class, sent);
+    SimpleFieldSet sentFields = sent.getFieldSet();
+    assertEquals("identity-xyz", sentFields.get("Identity"));
+    assertEquals("node-123", sentFields.get("NodeIdentifier"));
+    assertEquals("id-555", sentFields.get("Identifier"));
+  }
+
+  private SimpleFieldSet buildFieldSet(String nodeIdentifier, String identifier) {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", identifier);
+    fieldSet.putSingle("NodeIdentifier", nodeIdentifier);
+    return fieldSet;
+  }
+}


### PR DESCRIPTION
## Summary
- add comprehensive Javadoc to RemovePeer FCP handler and clarify identifier handling
- adjust handler to use messageIdentifier field consistently for replies
- introduce unit tests covering access checks, missing fields, unknown peers, and successful removal

## Testing
- not run (documentation + tests only change)