### PR TITLE
Clarify persistent request removal and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.node.Node;
@@ -9,41 +8,117 @@ import network.crypta.support.io.NativeThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Client telling node to remove a (completed or not) persistent request. */
+/**
+ * Removes a persistent client request from the node on behalf of an FCP client.
+ *
+ * <p>This message is emitted by a client that wishes to cancel a request which was previously
+ * registered for persistence, regardless of whether it has finished or is still queued. It carries
+ * the opaque request identifier and a flag indicating whether the request was global. Instances are
+ * immutable after creation; they simply transport the parameters required for removal and delegate
+ * the actual work to the {@link FCPConnectionHandler} when {@link #run(FCPConnectionHandler, Node)}
+ * is invoked. Because persistence and request queues may span multiple subsystems, the class favors
+ * clarity and explicit branching over silent failure.
+ *
+ * <p>The handler treats three stages distinctly: removal from reboot-persistent queues, removal
+ * from in-memory queues, and finally removal from the long-term persistence store via a scheduled
+ * job. This mirrors the lifecycle of a request across restarts. The type itself is thread-safe
+ * because it holds only final fields and performs no mutation. Consumers should assume the work is
+ * executed on the handler's dispatcher thread and avoid blocking operations in callbacks.
+ *
+ * <ul>
+ *   <li>Responsibilities: validate required fields and forward removal instructions.
+ *   <li>Scope: applies to both global and client-specific persistent requests.
+ *   <li>Error handling: reports persistence-disabled states with an explicit protocol error.
+ * </ul>
+ *
+ * @see FCPMessage
+ * @see FCPConnectionHandler
+ * @see ClientRequest
+ */
 public class RemovePersistentRequest extends FCPMessage {
   private static final Logger LOG = LoggerFactory.getLogger(RemovePersistentRequest.class);
 
   static final String NAME = "RemoveRequest";
   static final String ALT_NAME = "RemovePersistentRequest";
 
-  final String identifier;
+  final String requestIdentifier;
   final boolean global;
 
+  /**
+   * Constructs the request wrapper from an incoming {@link SimpleFieldSet} payload.
+   *
+   * <p>The constructor validates that the {@code Identifier} field is present and extracts the
+   * optional {@code Global} flag. Callers normally pass the parsed field set from the raw FCP
+   * message. The created instance is safe to reuse across handler invocations because it contains
+   * only immutable state derived from the original message.
+   *
+   * @param fs field set decoded from the client message; must contain {@code Identifier} and may
+   *     include {@code Global} when the request spans the entire node scope rather than a single
+   *     client session.
+   * @throws MessageInvalidException if the identifier is absent or otherwise fails validation
+   *     required by the protocol.
+   */
   public RemovePersistentRequest(SimpleFieldSet fs) throws MessageInvalidException {
     this.global = fs.getBoolean("Global", false);
-    this.identifier = fs.get("Identifier");
-    if (identifier == null)
+    this.requestIdentifier = fs.get(IDENTIFIER);
+    if (requestIdentifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "Must have Identifier", null, global);
   }
 
+  /**
+   * Builds a minimal field set representing this message for transmission.
+   *
+   * <p>Only the persistent request identifier is serialized because removal requests do not carry
+   * payload data. The returned structure is newly allocated and independent of the instance so it
+   * can be freely mutated by downstream serialization layers without affecting the stored state.
+   *
+   * @return a new {@link SimpleFieldSet} containing the {@code Identifier} entry required by the
+   *     FCP protocol for removal messages.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle(IDENTIFIER, requestIdentifier);
     return fs;
   }
 
+  /**
+   * Provides the protocol name for this FCP message type.
+   *
+   * <p>The name is stable and used by the dispatcher to route requests to the proper handler. It
+   * aligns with the legacy {@value #NAME} constant while {@link #ALT_NAME} remains available for
+   * compatibility when parsing inbound messages.
+   *
+   * @return the canonical FCP message name used during serialization and routing.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the removal of the persistent request within the provided handler context.
+   *
+   * <p>The method first attempts to remove the request from reboot-persistent queues, then from
+   * in-memory queues for non-global requests. If neither path succeeds, it schedules a
+   * high-priority job to remove the request from the long-term persistence store, ensuring the
+   * operation eventually completes even when persistence is handled asynchronously. When
+   * persistence is disabled and the request cannot be found, the client receives a protocol error
+   * message instead of silent failure.
+   *
+   * @param handler connection handler responsible for coordinating client requests; must not be
+   *     {@code null} and is assumed to execute callbacks on its internal dispatcher thread.
+   * @param node current node instance supplied by the dispatcher; the parameter is reserved for
+   *     interface compliance and is not modified by this implementation.
+   * @throws MessageInvalidException if the handler detects that the request parameters violate
+   *     protocol rules or if downstream validation fails during removal.
+   */
   @Override
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    ClientRequest req = handler.removePersistentRebootRequest(global, identifier);
+    ClientRequest req = handler.removePersistentRebootRequest(global, requestIdentifier);
     if (req == null && !global) {
-      req = handler.removeRequestByIdentifier(identifier, true);
+      req = handler.removeRequestByIdentifier(requestIdentifier, true);
     }
     if (req == null) {
       try {
@@ -53,18 +128,16 @@ public class RemovePersistentRequest extends FCPMessage {
             .getClientContext()
             .jobRunner
             .queue(
-                new PersistentJob() {
-
-                  @Override
-                  public boolean run(ClientContext context) {
-                    ClientRequest req = handler.removePersistentForeverRequest(global, identifier);
-                    if (req == null) {
-                      LOG.error("Huh ? the request is null!");
-                      return false;
-                    }
-                    return true;
-                  }
-                },
+                (PersistentJob)
+                    context -> {
+                      ClientRequest req1 =
+                          handler.removePersistentForeverRequest(global, requestIdentifier);
+                      if (req1 == null) {
+                        LOG.error("Huh ? the request is null!");
+                        return false;
+                      }
+                      return true;
+                    },
                 NativeThread.PriorityLevel.HIGH_PRIORITY.value);
       } catch (PersistenceDisabledException e) {
         FCPMessage err =
@@ -72,7 +145,7 @@ public class RemovePersistentRequest extends FCPMessage {
                 ProtocolErrorMessage.PERSISTENCE_DISABLED,
                 false,
                 "Persistence disabled and non-persistent request not found",
-                identifier,
+                requestIdentifier,
                 global);
         handler.send(err);
       }

--- a/src/test/java/network/crypta/clients/fcp/RemovePersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RemovePersistentRequestTest.java
@@ -1,0 +1,173 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.io.NativeThread;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100") // method naming: method_whenCondition_expectOutcome
+class RemovePersistentRequestTest {
+
+  private static final String IDENTIFIER = "req-id";
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
+  @Mock private NodeClientCore core;
+  @Mock private ClientContext clientContext;
+  @Mock private PersistentJobRunner jobRunner;
+  @Mock private ClientRequest clientRequest;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    Field jobRunnerField = ClientContext.class.getField("jobRunner");
+    jobRunnerField.setAccessible(true);
+    jobRunnerField.set(clientContext, jobRunner);
+  }
+
+  @Test
+  void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new RemovePersistentRequest(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
+    assertEquals("Must have Identifier", ex.getMessage());
+    assertNull(ex.ident);
+    assertFalse(ex.global);
+  }
+
+  @Test
+  void getFieldSet_whenCalled_emitsIdentifierOnly() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    RemovePersistentRequest message = new RemovePersistentRequest(fs);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals(IDENTIFIER, result.get("Identifier"));
+    assertNull(result.get("Global"));
+  }
+
+  @Test
+  void getName_whenCalled_returnsConstantName() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    RemovePersistentRequest message = new RemovePersistentRequest(fs);
+
+    assertEquals(RemovePersistentRequest.NAME, message.getName());
+  }
+
+  @Test
+  void run_whenRebootRequestExists_stopsAfterInitialRemoval() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    RemovePersistentRequest message = new RemovePersistentRequest(fs);
+    when(handler.removePersistentRebootRequest(false, IDENTIFIER)).thenReturn(clientRequest);
+
+    message.run(handler, null);
+
+    verify(handler).removePersistentRebootRequest(false, IDENTIFIER);
+    verify(handler, never()).removeRequestByIdentifier(any(), anyBoolean());
+    verifyNoInteractions(jobRunner);
+  }
+
+  @Test
+  void run_whenNonPersistentRequestFound_skipsPersistenceJob() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    RemovePersistentRequest message = new RemovePersistentRequest(fs);
+    when(handler.removePersistentRebootRequest(false, IDENTIFIER)).thenReturn(null);
+    when(handler.removeRequestByIdentifier(IDENTIFIER, true)).thenReturn(clientRequest);
+
+    message.run(handler, null);
+
+    verify(handler).removePersistentRebootRequest(false, IDENTIFIER);
+    verify(handler).removeRequestByIdentifier(IDENTIFIER, true);
+    verify(handler, never()).removePersistentForeverRequest(anyBoolean(), any());
+    verifyNoInteractions(jobRunner);
+  }
+
+  @Test
+  void run_whenQueuedJobRuns_removesForeverRequest() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.put("Global", true);
+    RemovePersistentRequest message = new RemovePersistentRequest(fs);
+    when(handler.removePersistentRebootRequest(true, IDENTIFIER)).thenReturn(null);
+    when(handler.removePersistentForeverRequest(true, IDENTIFIER)).thenReturn(clientRequest);
+    stubJobRunnerChain();
+    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
+    doAnswer(invocation -> null)
+        .when(jobRunner)
+        .queue(jobCaptor.capture(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
+
+    message.run(handler, null);
+
+    verify(handler).removePersistentRebootRequest(true, IDENTIFIER);
+    verify(handler, never()).removeRequestByIdentifier(any(), anyBoolean());
+    verify(jobRunner)
+        .queue(any(PersistentJob.class), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
+
+    PersistentJob captured = jobCaptor.getValue();
+    boolean result = captured.run(clientContext);
+
+    assertTrue(result);
+    verify(handler).removePersistentForeverRequest(true, IDENTIFIER);
+  }
+
+  @Test
+  void run_whenPersistenceDisabled_sendsProtocolError() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    RemovePersistentRequest message = new RemovePersistentRequest(fs);
+    when(handler.removePersistentRebootRequest(false, IDENTIFIER)).thenReturn(null);
+    when(handler.removeRequestByIdentifier(IDENTIFIER, true)).thenReturn(null);
+    stubJobRunnerChain();
+    doThrow(new PersistenceDisabledException())
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+
+    message.run(handler, null);
+
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(messageCaptor.capture());
+    ProtocolErrorMessage error = (ProtocolErrorMessage) messageCaptor.getValue();
+    assertEquals(ProtocolErrorMessage.PERSISTENCE_DISABLED, error.getCode());
+    assertEquals(IDENTIFIER, error.ident);
+    assertEquals("Persistence disabled and non-persistent request not found", error.extra);
+  }
+
+  private void stubJobRunnerChain() {
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.getClientContext()).thenReturn(clientContext);
+  }
+}


### PR DESCRIPTION
## Summary
- rename identifier field and enrich Javadoc for RemovePersistentRequest
- streamline persistence removal workflow and protocol error propagation
- add JUnit 6 tests covering reboot, in-memory, persistence-disabled, and forever removal paths

## Testing
- not run (not requested)
