### PR TITLE
Refactor RemovePlugin handling and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/RemovePlugin.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePlugin.java
@@ -3,49 +3,121 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.pluginmanager.PluginInfoWrapper;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/** remove a plugin */
+/**
+ * Represents the {@code RemovePlugin} FCP message sent by a client to stop a running plugin and
+ * optionally delete its cached copy. The message is validated eagerly to ensure the identifier and
+ * plugin name are present, and execution later delegates the heavy work to the node's executor so
+ * the connection thread remains responsive.
+ *
+ * <p>Typical callers construct this message from a parsed {@link SimpleFieldSet}, then pass it to
+ * the connection handler which invokes {@link #run(FCPConnectionHandler, Node)}. Removal requires
+ * full-access credentials and will fail fast with an access error otherwise. When allowed, the
+ * handler locates the plugin by its registered identifier, requests a graceful stop bounded by the
+ * supplied maximum wait time, and purges any cached installer file if requested.
+ *
+ * <p>Concurrency: {@link #run(FCPConnectionHandler, Node)} schedules work on the node executor and
+ * does not block the calling thread. The {@link FCPConnectionHandler} remains responsible for
+ * serializing responses back to the client.
+ *
+ * <ul>
+ *   <li>Message name: {@link #NAME}
+ *   <li>Required fields: {@code Identifier}, {@code PluginName}
+ *   <li>Optional fields: {@code MaxWaitTime}, {@code Purge}
+ * </ul>
+ *
+ * @see PluginRemovedMessage
+ * @see network.crypta.pluginmanager.PluginManager#findPluginByIdentifier(String)
+ */
 public class RemovePlugin extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(RemovePlugin.class);
 
   static final String NAME = "RemovePlugin";
 
-  private final String identifier;
+  private final String messageIdentifier;
   private final String plugname;
   private final int maxWaitTime;
   private final boolean purge;
 
+  /**
+   * Creates a new message instance from the provided field set, validating that mandatory fields
+   * are present and extracting optional tuning flags. Parsing happens immediately so malformed
+   * requests fail fast and do not reach the executor stage. The constructor is idempotent with
+   * respect to input, storing only primitive or immutable values for later execution.
+   *
+   * @param fs incoming request fields; must supply {@code Identifier} and {@code PluginName};
+   *     optional {@code MaxWaitTime} (milliseconds) and {@code Purge} flag are respected when set.
+   * @throws MessageInvalidException if any required field is missing or cannot be parsed; the
+   *     exception is sent back to the client with the identifier when available.
+   */
   public RemovePlugin(SimpleFieldSet fs) throws MessageInvalidException {
-    identifier = fs.get("Identifier");
-    if (identifier == null)
+    messageIdentifier = fs.get("Identifier");
+    if (messageIdentifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "Must contain an Identifier field", null, false);
     plugname = fs.get("PluginName");
     if (plugname == null)
       throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "Must contain a PluginName field", identifier, false);
+          ProtocolErrorMessage.MISSING_FIELD,
+          "Must contain a PluginName field",
+          messageIdentifier,
+          false);
     maxWaitTime = fs.getInt("MaxWaitTime", 0);
     purge = fs.getBoolean("Purge", false);
   }
 
+  /**
+   * Returns an empty response payload for this control message. Remove operations do not embed
+   * additional fields in the request body beyond those supplied at construction time. The returned
+   * {@link SimpleFieldSet} is freshly allocated for each call so callers can serialize the message
+   * without worrying about cross-request mutation or shared state. Because the message is fully
+   * defined by constructor arguments, the field set intentionally contains no optional fields; any
+   * future extensions should remain compatible with this choice.
+   *
+   * @return immutable empty field set instance used when serializing the message over FCP; callers
+   *     may treat it as read-only and short-lived.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return new SimpleFieldSet(true);
   }
 
+  /**
+   * Provides the protocol-visible message name so dispatchers can route it to the correct handler.
+   * The value remains constant for the lifetime of the application and mirrors the string clients
+   * use on the wire, ensuring that logging, routing, and equality checks are consistent across the
+   * FCP implementation. This method is side effect free and safe to call repeatedly.
+   *
+   * @return constant string {@code "RemovePlugin"} identifying the message type.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the remove operation on the node executor, enforcing access checks before scheduling.
+   * The handler receives either a {@link PluginRemovedMessage} on success or an appropriate error
+   * message when the plugin cannot be found or access is denied. Execution is asynchronous; the
+   * calling thread returns immediately after enqueuing work, while the plugin shutdown observes the
+   * configured maximum wait time before forcing termination. If {@code purge} is set, any cached
+   * installer artifacts are deleted after the stop attempt to keep disk usage predictable.
+   *
+   * @param handler connection handler that performs authorization and sends responses; must expose
+   *     the calling client's privilege level and messaging queue.
+   * @param node active node instance supplying executor access and plugin management facilities;
+   *     must be alive for the removal to proceed.
+   * @throws MessageInvalidException if the caller lacks full access rights; other failures are
+   *     reported asynchronously via error messages rather than exceptions.
+   */
   @Override
   public void run(final FCPConnectionHandler handler, final Node node)
       throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.ACCESS_DENIED, "LoadPlugin requires full access", identifier, false);
+          ProtocolErrorMessage.ACCESS_DENIED,
+          "LoadPlugin requires full access",
+          messageIdentifier,
+          false);
     }
 
     node.getExecutor()
@@ -58,14 +130,14 @@ public class RemovePlugin extends FCPMessage {
                         ProtocolErrorMessage.NO_SUCH_PLUGIN,
                         false,
                         "Plugin '" + plugname + "' does not exist or is not a FCP plugin",
-                        identifier,
+                        messageIdentifier,
                         false));
               } else {
                 pi.stopPlugin(node.getPluginManager(), maxWaitTime, false);
                 if (purge) {
                   node.getPluginManager().removeCachedCopy(pi.getFilename());
                 }
-                handler.send(new PluginRemovedMessage(plugname, identifier));
+                handler.send(new PluginRemovedMessage(plugname, messageIdentifier));
               }
             },
             "Remove Plugin");

--- a/src/test/java/network/crypta/clients/fcp/RemovePluginTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RemovePluginTest.java
@@ -1,0 +1,206 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import network.crypta.node.Node;
+import network.crypta.pluginmanager.PluginInfoWrapper;
+import network.crypta.pluginmanager.PluginManager;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings({"java:S100", "java:S2095"})
+@ExtendWith(MockitoExtension.class)
+class RemovePluginTest {
+
+  private static final String IDENTIFIER = "identifier-123";
+  private static final String PLUGIN_NAME = "ExamplePlugin";
+
+  @Test
+  void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("PluginName", PLUGIN_NAME);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new RemovePlugin(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("Must contain an Identifier field", exception.getMessage());
+    assertNull(exception.ident);
+  }
+
+  @Test
+  void constructor_whenPluginNameMissing_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new RemovePlugin(fs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("Must contain a PluginName field", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
+  void getName_whenCalled_returnsRemovePluginConstant() throws MessageInvalidException {
+    RemovePlugin removePlugin = new RemovePlugin(minimalFieldSet());
+
+    assertEquals(RemovePlugin.NAME, removePlugin.getName());
+  }
+
+  @Test
+  void getFieldSet_whenCalled_returnsEmptyFieldSet() throws MessageInvalidException {
+    RemovePlugin removePlugin = new RemovePlugin(minimalFieldSet());
+
+    SimpleFieldSet result = removePlugin.getFieldSet();
+
+    assertNotNull(result);
+    assertNull(result.get("Identifier"));
+    assertNull(result.get("PluginName"));
+  }
+
+  @Test
+  void run_whenHandlerHasNoFullAccess_throwsAccessDenied() throws MessageInvalidException {
+    RemovePlugin removePlugin = new RemovePlugin(minimalFieldSet());
+    @SuppressWarnings("resource")
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    Node node = mock(Node.class);
+
+    org.mockito.Mockito.when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> removePlugin.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
+    assertEquals("LoadPlugin requires full access", exception.getMessage());
+    assertEquals(IDENTIFIER, exception.ident);
+    verifyNoInteractions(node);
+  }
+
+  @Test
+  void run_whenPluginNotFound_sendsProtocolError() throws MessageInvalidException {
+    RemovePlugin removePlugin = new RemovePlugin(minimalFieldSet());
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    Node node = mock(Node.class);
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    PluginManager pluginManager = mock(PluginManager.class);
+
+    org.mockito.Mockito.when(handler.hasFullAccess()).thenReturn(true);
+    org.mockito.Mockito.when(node.getExecutor()).thenReturn(executor);
+    org.mockito.Mockito.when(node.getPluginManager()).thenReturn(pluginManager);
+    org.mockito.Mockito.when(pluginManager.findPluginByIdentifier(PLUGIN_NAME)).thenReturn(null);
+    doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class), anyString());
+
+    removePlugin.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    ProtocolErrorMessage message = (ProtocolErrorMessage) captor.getValue();
+
+    assertEquals(ProtocolErrorMessage.NO_SUCH_PLUGIN, message.getCode());
+    assertEquals(
+        "Plugin '" + PLUGIN_NAME + "' does not exist or is not a FCP plugin", message.extra);
+    assertEquals(IDENTIFIER, message.ident);
+    verify(pluginManager, never()).removeCachedCopy(anyString());
+  }
+
+  @Test
+  void run_whenPluginFoundWithoutPurge_stopsPluginAndSendsRemoved() throws MessageInvalidException {
+    SimpleFieldSet fs = minimalFieldSet();
+    fs.put("MaxWaitTime", 15);
+    RemovePlugin removePlugin = new RemovePlugin(fs);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    Node node = mock(Node.class);
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    PluginManager pluginManager = mock(PluginManager.class);
+    PluginInfoWrapper pluginInfoWrapper = mock(PluginInfoWrapper.class);
+
+    org.mockito.Mockito.when(handler.hasFullAccess()).thenReturn(true);
+    org.mockito.Mockito.when(node.getExecutor()).thenReturn(executor);
+    org.mockito.Mockito.when(node.getPluginManager()).thenReturn(pluginManager);
+    org.mockito.Mockito.when(pluginManager.findPluginByIdentifier(PLUGIN_NAME))
+        .thenReturn(pluginInfoWrapper);
+    doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class), eq("Remove Plugin"));
+
+    removePlugin.run(handler, node);
+
+    verify(pluginInfoWrapper).stopPlugin(pluginManager, 15, false);
+    verify(pluginManager, never()).removeCachedCopy(anyString());
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    PluginRemovedMessage message = (PluginRemovedMessage) captor.getValue();
+    SimpleFieldSet fieldSet = message.getFieldSet();
+    assertEquals(IDENTIFIER, fieldSet.get("Identifier"));
+    assertEquals(PLUGIN_NAME, fieldSet.get("PluginName"));
+  }
+
+  @Test
+  void run_whenPurgeTrue_removesCachedCopyAfterStopping() throws MessageInvalidException {
+    SimpleFieldSet fs = minimalFieldSet();
+    fs.put("Purge", true);
+    RemovePlugin removePlugin = new RemovePlugin(fs);
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    Node node = mock(Node.class);
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+    PluginManager pluginManager = mock(PluginManager.class);
+    PluginInfoWrapper pluginInfoWrapper = mock(PluginInfoWrapper.class);
+
+    org.mockito.Mockito.when(handler.hasFullAccess()).thenReturn(true);
+    org.mockito.Mockito.when(node.getExecutor()).thenReturn(executor);
+    org.mockito.Mockito.when(node.getPluginManager()).thenReturn(pluginManager);
+    org.mockito.Mockito.when(pluginManager.findPluginByIdentifier(PLUGIN_NAME))
+        .thenReturn(pluginInfoWrapper);
+    org.mockito.Mockito.when(pluginInfoWrapper.getFilename()).thenReturn("plugin-file.jar");
+    doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class), anyString());
+
+    removePlugin.run(handler, node);
+
+    verify(pluginInfoWrapper).stopPlugin(pluginManager, 0, false);
+    verify(pluginManager).removeCachedCopy("plugin-file.jar");
+    verify(handler).send(any(PluginRemovedMessage.class));
+  }
+
+  private SimpleFieldSet minimalFieldSet() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", IDENTIFIER);
+    fs.putSingle("PluginName", PLUGIN_NAME);
+    return fs;
+  }
+}


### PR DESCRIPTION
## Summary
- clarify RemovePlugin message lifecycle and identifier usage in code docs
- use message identifier consistently when reporting access and existence errors
- add comprehensive unit tests for RemovePlugin covering validation, access control, missing plugin, and purge behavior

## Testing
- Not run (CI will cover)
