### PR TITLE
Add RequestIdentifier serialization coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/RequestIdentifier.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestIdentifier.java
@@ -5,19 +5,48 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 /**
- * Identifies a request and its client. Stable serialization format - must not change without
- * version bump, must maintain back compatibility within reason. This is initially used to check for
- * whether we've already loaded a request, but it will also be used for last-resort restarting a
- * request when serialization has failed.
+ * Immutable handle that uniquely identifies a client request in the FCP bridge and carries enough
+ * metadata to serialize the identity across process or JVM boundaries. The identifier is used
+ * primarily to detect already-loaded requests and to restart requests when regular serialization
+ * fails, so the on-wire layout must remain backward compatible.
  *
- * @author toad
+ * <p>Instances record whether a request belongs to the node-global queue or a specific client, the
+ * user-facing client name when applicable, the stable request identifier string, and the {@link
+ * RequestType}. All fields are final. The class is immutable, thread-safe, and performs no I/O
+ * outside {@link #writeTo(DataOutput)}.
+ *
+ * <ul>
+ *   <li>Serialization format: magic int {@link #MAGIC}, version {@link #VERSION}, queue flag,
+ *       optional client name, identifier string, and request-type ordinal.
+ *   <li>Equality includes {@link RequestType}; {@link #sameIdentifier(RequestIdentifier)} ignores
+ *       it for deduplication.
+ *   <li>Layout changes require a version bump to stay compatible.
+ * </ul>
+ *
+ * @see RequestType
+ * @see #writeTo(DataOutput)
  */
 public final class RequestIdentifier {
 
-  enum RequestType {
-    // Ordinals matter!
+  /**
+   * Request category conveyed alongside the identifier to describe how the node should interpret
+   * the stored request metadata.
+   */
+  public enum RequestType {
+    /**
+     * Fetch operation that retrieves existing network content identified by keys such as CHK or
+     * SSK; ordinal position is part of the serialized form.
+     */
     GET,
+    /**
+     * Insertion of a single data item (for example, a file or message) into the network; serialized
+     * using the enum ordinal and therefore order must remain stable.
+     */
     PUT,
+    /**
+     * Insertion of a directory or bundle where the identifier refers to a manifest rather than a
+     * single block; ordinal stability is required for deserialization.
+     */
     PUTDIR
   }
 
@@ -27,8 +56,25 @@ public final class RequestIdentifier {
   final boolean globalQueue;
   final String clientName;
   final String identifier;
+
+  /**
+   * Type of request represented by this identifier; immutable and included in {@link
+   * #equals(Object)} but not in {@link #sameIdentifier(RequestIdentifier)}. Always non-null after
+   * construction.
+   */
   public final RequestType type;
 
+  /**
+   * Creates a new identifier from discrete components for immediate in-memory use or later
+   * serialization. When {@code globalQueue} is {@code true}, {@code clientName} is ignored and may
+   * be {@code null}; otherwise {@code clientName} should hold the human-readable name used by the
+   * originating client.
+   *
+   * @param globalQueue true for the node-global queue; otherwise the client queue is used.
+   * @param clientName readable client name when {@code globalQueue} is false; non-null then.
+   * @param identifier stable string that uniquely identifies the request within its queue.
+   * @param type {@link RequestType} describing how the node should process the request; non-null.
+   */
   public RequestIdentifier(
       boolean globalQueue, String clientName, String identifier, RequestType type) {
     this.globalQueue = globalQueue;
@@ -37,6 +83,14 @@ public final class RequestIdentifier {
     this.type = type;
   }
 
+  /**
+   * Reconstructs an identifier by consuming its serialized form from a {@link DataInput} stream.
+   * The method expects the exact layout produced by {@link #writeTo(DataOutput)}: magic integer,
+   * version short, queue flag, optional UTF client name, UTF identifier, and request-type ordinal.
+   *
+   * @param dis data source positioned at the start of the serialized identifier.
+   * @throws IOException if the magic or version differ, type is invalid, or input fails.
+   */
   public RequestIdentifier(DataInput dis) throws IOException {
     int magic = dis.readInt();
     if (magic != MAGIC) throw new IOException("Bad magic");
@@ -52,6 +106,14 @@ public final class RequestIdentifier {
     type = types[typeKey];
   }
 
+  /**
+   * Serializes this identifier to a {@link DataOutput} using the stable wire format expected by the
+   * corresponding {@link #RequestIdentifier(DataInput)} constructor. Callers should treat the
+   * output as versioned binary metadata suitable for persistence or interprocess transfer.
+   *
+   * @param dos destination output that receives all fields in the documented order.
+   * @throws IOException if the output stream cannot write any portion of the record.
+   */
   public void writeTo(DataOutput dos) throws IOException {
     dos.writeInt(MAGIC);
     dos.writeShort(VERSION);
@@ -61,16 +123,21 @@ public final class RequestIdentifier {
     dos.writeShort(type.ordinal());
   }
 
-  /** Only compare the identifier, not the type. */
+  /**
+   * Determines whether another identifier represents the same queued request while deliberately
+   * ignoring {@link #type}. Use this when de-duplicating enqueue attempts that should coalesce
+   * based on queue scope, client name, and stable identifier string.
+   *
+   * @param other candidate identifier compared by queue flag, client name, and identifier string.
+   * @return {@code true} when queue scope and identifier match, even if request types differ.
+   */
   public boolean sameIdentifier(RequestIdentifier other) {
     if (globalQueue != other.globalQueue) return false;
-    if (!globalQueue) {
-      if (!clientName.equals(other.clientName)) return false;
-    }
-    if (globalQueue != other.globalQueue) return false;
+    if (!globalQueue && !clientName.equals(other.clientName)) return false;
     return identifier.equals(other.identifier);
   }
 
+  /** Hash code aligned with {@link #equals(Object)}; omits {@link #type} by design. */
   @Override
   public int hashCode() {
     final int prime = 31;
@@ -82,16 +149,21 @@ public final class RequestIdentifier {
     return result;
   }
 
+  /**
+   * Compares identifiers for full equality, including queue scope, client name (when applicable),
+   * base identifier string, and {@link #type}. Suitable for maps and sets that must distinguish
+   * between different request categories.
+   *
+   * @param obj other object, expected to be another {@code RequestIdentifier}.
+   * @return {@code true} when all significant fields match; {@code false} otherwise.
+   */
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
     if (obj == null) return false;
     if (!(obj instanceof RequestIdentifier other)) return false;
     if (globalQueue != other.globalQueue) return false;
-    if (!globalQueue) {
-      if (!clientName.equals(other.clientName)) return false;
-    }
-    if (globalQueue != other.globalQueue) return false;
+    if (!globalQueue && !clientName.equals(other.clientName)) return false;
     if (!identifier.equals(other.identifier)) return false;
     return type == other.type;
   }

--- a/src/test/java/network/crypta/clients/fcp/RequestIdentifierTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RequestIdentifierTest.java
@@ -1,0 +1,139 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class RequestIdentifierTest {
+
+  @Test
+  void writeTo_andConstructor_whenNonGlobalQueue_roundTripsFields() throws Exception {
+    RequestIdentifier original =
+        new RequestIdentifier(false, "clientA", "identifier-1", RequestIdentifier.RequestType.PUT);
+
+    RequestIdentifier restored = roundTrip(original);
+
+    assertEquals(original, restored);
+    assertFalse(restored.globalQueue);
+    assertEquals("clientA", restored.clientName);
+    assertEquals("identifier-1", restored.identifier);
+    assertEquals(RequestIdentifier.RequestType.PUT, restored.type);
+  }
+
+  @Test
+  void writeTo_andConstructor_whenGlobalQueue_roundTripsFields() throws Exception {
+    RequestIdentifier original =
+        new RequestIdentifier(true, null, "global-id", RequestIdentifier.RequestType.GET);
+
+    RequestIdentifier restored = roundTrip(original);
+
+    assertEquals(original, restored);
+    assertTrue(restored.globalQueue);
+    assertNull(restored.clientName);
+    assertEquals("global-id", restored.identifier);
+    assertEquals(RequestIdentifier.RequestType.GET, restored.type);
+  }
+
+  @Test
+  void sameIdentifier_whenTypeDiffers_stillMatches() {
+    RequestIdentifier first =
+        new RequestIdentifier(false, "clientA", "shared-id", RequestIdentifier.RequestType.GET);
+    RequestIdentifier second =
+        new RequestIdentifier(false, "clientA", "shared-id", RequestIdentifier.RequestType.PUT);
+
+    assertTrue(first.sameIdentifier(second));
+    assertNotEquals(first, second);
+  }
+
+  @Test
+  void hashCode_whenTypeDiffers_ignoresTypeInComputation() {
+    RequestIdentifier first =
+        new RequestIdentifier(false, "clientA", "shared-id", RequestIdentifier.RequestType.GET);
+    RequestIdentifier second =
+        new RequestIdentifier(false, "clientA", "shared-id", RequestIdentifier.RequestType.PUT);
+
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  void equals_whenTypeDiffers_returnsFalse() {
+    RequestIdentifier first =
+        new RequestIdentifier(false, "clientA", "shared-id", RequestIdentifier.RequestType.GET);
+    RequestIdentifier second =
+        new RequestIdentifier(false, "clientA", "shared-id", RequestIdentifier.RequestType.PUT);
+
+    assertNotEquals(first, second);
+  }
+
+  @Test
+  void constructor_whenMagicInvalid_throwsIOException() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(RequestIdentifier.MAGIC + 1);
+      dos.writeShort(RequestIdentifier.VERSION);
+      dos.writeBoolean(false);
+      dos.writeUTF("clientA");
+      dos.writeUTF("identifier-1");
+      dos.writeShort(RequestIdentifier.RequestType.GET.ordinal());
+    }
+
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      assertThrows(IOException.class, () -> new RequestIdentifier(dis));
+    }
+  }
+
+  @Test
+  void constructor_whenVersionInvalid_throwsIOException() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(RequestIdentifier.MAGIC);
+      dos.writeShort(RequestIdentifier.VERSION + 1);
+      dos.writeBoolean(false);
+      dos.writeUTF("clientA");
+      dos.writeUTF("identifier-1");
+      dos.writeShort(RequestIdentifier.RequestType.GET.ordinal());
+    }
+
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      assertThrows(IOException.class, () -> new RequestIdentifier(dis));
+    }
+  }
+
+  @Test
+  void constructor_whenTypeInvalid_throwsIOException() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(RequestIdentifier.MAGIC);
+      dos.writeShort(RequestIdentifier.VERSION);
+      dos.writeBoolean(false);
+      dos.writeUTF("clientA");
+      dos.writeUTF("identifier-1");
+      dos.writeShort(Short.MAX_VALUE);
+    }
+
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      assertThrows(IOException.class, () -> new RequestIdentifier(dis));
+    }
+  }
+
+  private RequestIdentifier roundTrip(RequestIdentifier original) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      original.writeTo(dos);
+    }
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      return new RequestIdentifier(dis);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- improve RequestIdentifier Javadoc and clarify semantics for equality/sameIdentifier
- add round-trip serialization/deserialization tests, error cases, and type-specific behaviors

## Testing
- not run (CI should cover)