### PR TITLE
Simplify RequestStatusCache bookkeeping and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/RequestStatusCache.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestStatusCache.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,22 +17,42 @@ import network.crypta.support.io.NoFreeBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Per-PersistentRequestClient cache of status of requests. */
+/**
+ * In-memory cache tracking the lifecycle of client requests handled via FCP identifiers and URIs.
+ *
+ * <p>The cache keeps a primary index by request identifier and secondary indexes for download
+ * requests (by {@link FreenetURI}) and uploads (by final URI). It is designed for callers that
+ * routinely look up, update, and remove request state while UI components render progress or while
+ * protocol handlers process asynchronous callbacks. Most mutating operations are synchronized on
+ * the cache instance so readers can safely reuse the same instance across threads; {@link
+ * #updateCompressionStatus(String, COMPRESS_STATE)} and {@link #setPriority(String, short)} rely on
+ * callers to provide any external ordering they require. Missing identifiers are treated as benign
+ * to accommodate races between completion and cancellation.
+ *
+ * <p>Typical usage is: add a request when it starts, update status as events arrive, then remove it
+ * when it finishes or is cancelled. Secondary indexes are pruned in tandem so lookup by URI never
+ * returns stale entries. The class does not persist data; callers should rebuild it after node
+ * restarts. Because it holds live {@code RequestStatus} objects, consumers should avoid long-lived
+ * references outside synchronized blocks unless they copy them via {@link #addTo(List)}.
+ *
+ * <ul>
+ *   <li>Provides fast lookup by identifier for all request kinds.
+ *   <li>Keeps auxiliary maps in sync for download and upload specific flows.
+ *   <li>Tolerates duplicate removals and late updates without throwing.
+ * </ul>
+ *
+ * @see RequestStatus
+ * @see DownloadRequestStatus
+ * @see UploadRequestStatus
+ */
 public class RequestStatusCache {
   private static final Logger LOG = LoggerFactory.getLogger(RequestStatusCache.class);
 
-  static {
-  }
-
-  private final ArrayList<RequestStatus> downloads;
-  private final ArrayList<RequestStatus> uploads;
   private final Map<String, RequestStatus> requestsByIdentifier;
   private final MultiValueTable<FreenetURI, DownloadRequestStatus> downloadsByURI;
   private final MultiValueTable<FreenetURI, RequestStatus> uploadsByFinalURI;
 
   RequestStatusCache() {
-    downloads = new ArrayList<>();
-    uploads = new ArrayList<>();
     requestsByIdentifier = new HashMap<>();
     downloadsByURI = new MultiValueTable<>();
     uploadsByFinalURI = new MultiValueTable<>();
@@ -41,19 +60,15 @@ public class RequestStatusCache {
 
   synchronized void addDownload(DownloadRequestStatus status) {
     RequestStatus old = requestsByIdentifier.put(status.getIdentifier(), status);
-    if (LOG.isDebugEnabled()) LOG.debug("Starting download " + status.getIdentifier());
+    if (LOG.isDebugEnabled()) LOG.debug("Starting download {}", status.getIdentifier());
     if (old == status) return;
-    if (old != null) downloads.remove(old);
-    downloads.add(status);
     downloadsByURI.put(status.getURI(), status);
   }
 
   synchronized void addUpload(UploadRequestStatus status) {
     RequestStatus old = requestsByIdentifier.put(status.getIdentifier(), status);
     if (old == status) return;
-    if (LOG.isDebugEnabled()) LOG.debug("Starting upload " + status.getIdentifier());
-    if (old != null) uploads.remove(old);
-    uploads.add(status);
+    if (LOG.isDebugEnabled()) LOG.debug("Starting upload {}", status.getIdentifier());
     FreenetURI uri = status.getURI();
     if (uri != null) uploadsByFinalURI.put(uri, status);
   }
@@ -124,51 +139,113 @@ public class RequestStatusCache {
 
   synchronized void removeByIdentifier(String identifier) {
     RequestStatus status = requestsByIdentifier.remove(identifier);
-    if (status == null) return;
-    if (status instanceof DownloadRequestStatus requestStatus1) {
-      downloads.remove(status);
-      FreenetURI uri = status.getURI();
-      assert (uri != null);
-      downloadsByURI.removeElement(uri, requestStatus1);
-    } else if (status instanceof UploadRequestStatus requestStatus) {
-      uploads.remove(status);
-      FreenetURI uri = requestStatus.getFinalURI();
-      if (uri != null) uploadsByFinalURI.removeElement(uri, status);
+    if (status == null) return; // Already removed or never existed.
+    switch (status) {
+      case DownloadRequestStatus requestStatus1 -> {
+        FreenetURI uri = status.getURI();
+        assert (uri != null);
+        downloadsByURI.removeElement(uri, requestStatus1);
+      }
+      case UploadRequestStatus requestStatus -> {
+        FreenetURI uri = requestStatus.getFinalURI();
+        if (uri != null) uploadsByFinalURI.removeElement(uri, status);
+      }
+      default -> {
+        // Other RequestStatus implementations have no additional indexes to update.
+      }
     }
   }
 
   synchronized void clear() {
-    downloads.clear();
-    uploads.clear();
     requestsByIdentifier.clear();
     downloadsByURI.clear();
     uploadsByFinalURI.clear();
   }
 
+  /**
+   * Updates the compression phase for an upload request if it is still tracked.
+   *
+   * <p>The method is intentionally unsynchronized because it only touches a single status instance
+   * and is expected to be called from the same thread that initiated the upload. If the identifier
+   * is unknown the call is ignored, allowing callers to send speculative or late updates without
+   * raising errors. Compression state transitions should follow the sequence defined by {@link
+   * ClientPut.COMPRESS_STATE}; no validation is enforced here.
+   *
+   * @param identifier identifier of the upload being compressed; must reference an active entry to
+   *     have any effect.
+   * @param compressing new compression state describing the current stage; values come from the FCP
+   *     client pipeline and are not null-checked here.
+   */
   public void updateCompressionStatus(String identifier, COMPRESS_STATE compressing) {
     UploadFileRequestStatus status = (UploadFileRequestStatus) requestsByIdentifier.get(identifier);
     if (status == null) return; // Can happen during cancel etc.
     status.updateCompressionStatus(compressing);
   }
 
+  /**
+   * Copies current request snapshots into the supplied collection without exposing internal
+   * instances.
+   *
+   * <p>The method iterates over all cached entries under the cache lock, clones each via {@link
+   * RequestStatus#copy()}, and appends them to the provided list. It enables user interfaces to
+   * render progress without retaining locks for the duration of the render cycle. The target list
+   * is not cleared, so callers may accumulate historical states if they reuse the same list across
+   * invocations. Null identifiers are ignored implicitly because the cache never stores them.
+   *
+   * @param status mutable collection that receives copies of every tracked request; must accept the
+   *     added elements.
+   */
   public synchronized void addTo(List<RequestStatus> status) {
-    // FIXME is it better to just synchronize on the RequestStatusCache when
-    // rendering the downloads page, and when updating? Ugly though ...
+    // The copy allows rendering without holding the cache lock for the entire UI render.
     for (RequestStatus req : requestsByIdentifier.values()) status.add(req.copy());
   }
 
+  /**
+   * Updates the expected MIME type for a pending download if it remains present in the cache.
+   *
+   * <p>The method is tolerant of late notifications; when the identifier is no longer tracked it
+   * returns silently. Callers typically invoke this after metadata discovery but before final data
+   * delivery so UI components can present a more accurate content type. The provided MIME string is
+   * stored as-is; callers should supply normalized values when necessary.
+   *
+   * @param identifier request identifier supplied by the client; must not be {@code null}.
+   * @param foundDataMimeType MIME type detected during fetch; may be any well-formed value.
+   */
   public synchronized void updateExpectedMIME(String identifier, String foundDataMimeType) {
     DownloadRequestStatus status = (DownloadRequestStatus) requestsByIdentifier.get(identifier);
     if (status == null) return; // Can happen during cancel etc.
     status.updateExpectedMIME(foundDataMimeType);
   }
 
+  /**
+   * Records the expected data length for an in-flight download so progress bars can estimate work.
+   *
+   * <p>If the identifier is missing the method exits without side effects, enabling callers to send
+   * redundant or late updates safely. The value is interpreted as bytes; negative values are not
+   * rejected here but may be validated downstream by {@link DownloadRequestStatus}.
+   *
+   * @param identifier request identifier whose download metadata is being updated; non-null.
+   * @param expectedDataLength anticipated byte length of the payload; callers should supply
+   *     non-negative values.
+   */
   public synchronized void updateExpectedDataLength(String identifier, long expectedDataLength) {
     DownloadRequestStatus status = (DownloadRequestStatus) requestsByIdentifier.get(identifier);
     if (status == null) return; // Can happen during cancel etc.
     status.updateExpectedDataLength(expectedDataLength);
   }
 
+  /**
+   * Adjusts the priority class of a tracked request when it is still present in the cache.
+   *
+   * <p>This method is intentionally lightweight and not synchronized; callers invoking it from
+   * multiple threads should serialize calls if they need deterministic ordering. If the identifier
+   * is unknown, the call is ignored to avoid surfacing races between completion and priority
+   * updates.
+   *
+   * @param identifier request identifier to reprioritize; must refer to an active request.
+   * @param newPriorityClass priority class value accepted by the underlying client; see caller docs
+   *     for valid ranges.
+   */
   public void setPriority(String identifier, short newPriorityClass) {
     RequestStatus status = requestsByIdentifier.get(identifier);
     if (status == null) return; // Can happen during cancel etc.
@@ -179,6 +256,16 @@ public class RequestStatusCache {
    * Restart a request. Caller should call ,false first, at which point we setStarted, and ,true
    * when it has actually started (a race condition means we don't setStarted at that point since
    * it's possible the success/failure callback might happen first).
+   *
+   * <p>The boolean overload clears finished state when invoked with {@code false} and marks the
+   * request as started when invoked with {@code true}. It tolerates late or duplicate updates by
+   * ignoring identifiers that are no longer tracked. All mutations are serialized on the cache lock
+   * so callers can safely use the same cache across worker and UI threads.
+   *
+   * @param identifier request identifier being restarted; must be non-null and match a cached entry
+   *     to take effect.
+   * @param started flag indicating whether the request is now considered started ({@code true}) or
+   *     being reset prior to start ({@code false}).
    */
   public synchronized void updateStarted(String identifier, boolean started) {
     RequestStatus status = requestsByIdentifier.get(identifier);
@@ -190,7 +277,7 @@ public class RequestStatusCache {
       status.restart(false);
     else
       // Already restarted, just set started = true.
-      status.setStarted(started);
+      status.setStarted(true);
   }
 
   /**
@@ -198,7 +285,14 @@ public class RequestStatusCache {
    * when it has actually started (a race condition means we don't setStarted at that point since
    * it's possible the success/failure callback might happen first).
    *
-   * @param redirect If non-null, the request followed a redirect.
+   * <p>This overload restarts the request and updates the download URI when a redirect is followed.
+   * It removes the old URI from the secondary index, applies the redirect, and re-registers the
+   * request under the new key. Absent identifiers are ignored to remain resilient to races between
+   * redirect handling and cancellation.
+   *
+   * @param identifier request identifier being restarted after a redirect; non-null for cache hits.
+   * @param redirect new target URI if the request was redirected; may be {@code null} to skip URI
+   *     remapping.
    */
   public synchronized void updateStarted(String identifier, FreenetURI redirect) {
     DownloadRequestStatus status = (DownloadRequestStatus) requestsByIdentifier.get(identifier);
@@ -211,25 +305,33 @@ public class RequestStatusCache {
     }
   }
 
+  /**
+   * Returns a cached download bucket that already holds data for the given URI when it is usable.
+   *
+   * <p>The method scans all download entries indexed by the supplied key and returns the first that
+   * contains non-empty data meeting the caller's filter expectations. It wraps the bucket in {@link
+   * NoFreeBucket} to prevent caller-driven free operations from disturbing shared buffers. When no
+   * suitable entry exists the method returns {@code null}. Callers should treat the returned bucket
+   * as read-only and respect the {@code filterData} flag conveyed in the {@link CacheFetchResult}.
+   *
+   * @param key URI used to locate matching downloads in the cache; must not be {@code null}.
+   * @param noFilter when {@code true}, only returns data that did not request filtering during
+   *     download; otherwise filtered data may be returned.
+   * @return a {@link CacheFetchResult} wrapping a shadow bucket and metadata, or {@code null} when
+   *     no cached data fits the criteria.
+   */
   public synchronized CacheFetchResult getShadowBucket(FreenetURI key, boolean noFilter) {
     for (DownloadRequestStatus download : downloadsByURI.getAllAsList(key)) {
       Bucket data = download.getDataShadow();
-      if (data == null) {
-        continue;
+      boolean hasData = data != null && data.size() > 0;
+      boolean filterAllowed = !(noFilter && download.filterData);
+      boolean dataTypeMatches = !download.overriddenDataType;
+      if (hasData && filterAllowed && dataTypeMatches) {
+        return new CacheFetchResult(
+            new ClientMetadata(download.getMIMEType()),
+            new NoFreeBucket(data),
+            download.filterData);
       }
-      if (data.size() == 0) {
-        continue;
-      }
-      if (noFilter && download.filterData) {
-        continue;
-      }
-      // FIXME it probably *is* worth the effort to allow this when it is overridden on the fetcher,
-      // since the user changed the type???
-      if (download.overriddenDataType) {
-        continue;
-      }
-      return new CacheFetchResult(
-          new ClientMetadata(download.getMIMEType()), new NoFreeBucket(data), download.filterData);
     }
     return null;
   }

--- a/src/test/java/network/crypta/clients/fcp/RequestStatusCacheTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RequestStatusCacheTest.java
@@ -1,0 +1,508 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.async.CacheFetchResult;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class RequestStatusCacheTest {
+
+  @Mock private SplitfileProgressEvent progressEvent;
+
+  @Test
+  void addDownload_whenIdentifierReused_expectOnlyLatestInSnapshot() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    FreenetURI uri1 = mock(FreenetURI.class);
+    FreenetURI uri2 = mock(FreenetURI.class);
+
+    DownloadRequestStatus first = mock(DownloadRequestStatus.class);
+    when(first.getIdentifier()).thenReturn("id");
+    when(first.getURI()).thenReturn(uri1);
+
+    DownloadRequestStatus second = mock(DownloadRequestStatus.class);
+    when(second.getIdentifier()).thenReturn("id");
+    when(second.getURI()).thenReturn(uri2);
+    DownloadRequestStatus secondCopy = mock(DownloadRequestStatus.class);
+    when(second.copy()).thenReturn(secondCopy);
+
+    cache.addDownload(first);
+    cache.addDownload(second);
+
+    List<RequestStatus> snapshot = new ArrayList<>();
+    cache.addTo(snapshot);
+
+    assertEquals(1, snapshot.size());
+    assertSame(secondCopy, snapshot.getFirst());
+  }
+
+  @Test
+  void finishedDownload_whenPresent_delegatesToStatus() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    DownloadRequestStatus status = mock(DownloadRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("download-1");
+    when(status.getURI()).thenReturn(mock(FreenetURI.class));
+    cache.addDownload(status);
+
+    Bucket bucket = mock(Bucket.class);
+    cache.finishedDownload(
+        "download-1",
+        true,
+        42L,
+        "text/plain",
+        FetchExceptionMode.BUCKET_ERROR,
+        "long",
+        "short",
+        bucket,
+        false);
+
+    verify(status)
+        .setFinished(
+            true,
+            42L,
+            "text/plain",
+            FetchExceptionMode.BUCKET_ERROR,
+            "long",
+            "short",
+            bucket,
+            false);
+  }
+
+  @Test
+  void updateStarted_withFalseThenTrue_invokesRestartAndSetStarted() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    UploadRequestStatus status = mock(UploadRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("upload-1");
+    when(status.getURI()).thenReturn(null);
+    cache.addUpload(status);
+
+    cache.updateStarted("upload-1", false);
+    cache.updateStarted("upload-1", true);
+
+    verify(status).restart(false);
+    verify(status).setStarted(true);
+  }
+
+  @Test
+  void updateStarted_withRedirect_updatesUriIndex() throws Exception {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    FreenetURI originalUri = mock(FreenetURI.class);
+    FreenetURI redirectUri = mock(FreenetURI.class);
+
+    DownloadRequestStatus status =
+        new DownloadRequestStatus(
+            "dl",
+            Persistence.CONNECTION,
+            false,
+            false,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            false,
+            (short) 1,
+            null,
+            "text/plain",
+            1L,
+            null,
+            null,
+            null,
+            originalUri,
+            null,
+            null,
+            false,
+            null,
+            false,
+            false);
+
+    cache.addDownload(status);
+
+    cache.updateStarted("dl", redirectUri);
+
+    MultiValueTable<FreenetURI, DownloadRequestStatus> downloadsByUri =
+        getField(cache, "downloadsByURI");
+
+    assertFalse(downloadsByUri.containsKey(originalUri));
+    assertTrue(downloadsByUri.containsKey(redirectUri));
+  }
+
+  @Test
+  void getShadowBucket_whenDataAvailable_returnsWrappedResult() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    FreenetURI uri = mock(FreenetURI.class);
+    Bucket bucket = new FixedBucket(8);
+
+    DownloadRequestStatus status =
+        new DownloadRequestStatus(
+            "shadow",
+            Persistence.CONNECTION,
+            true,
+            false,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            false,
+            (short) 1,
+            null,
+            "image/png",
+            8L,
+            null,
+            null,
+            null,
+            uri,
+            null,
+            null,
+            false,
+            bucket,
+            false,
+            false);
+
+    cache.addDownload(status);
+
+    CacheFetchResult result = cache.getShadowBucket(uri, false);
+
+    assertNotNull(result);
+    assertEquals("image/png", result.getMetadata().getMIMEType());
+    assertEquals(8L, result.size());
+    assertFalse(result.alreadyFiltered);
+  }
+
+  @Test
+  void getShadowBucket_whenFilteredAndNoFilterRequested_returnsNull() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    FreenetURI uri = mock(FreenetURI.class);
+    Bucket bucket = new FixedBucket(2);
+
+    DownloadRequestStatus status =
+        new DownloadRequestStatus(
+            "shadow-filter",
+            Persistence.CONNECTION,
+            true,
+            false,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            false,
+            (short) 1,
+            null,
+            "text/plain",
+            2L,
+            null,
+            null,
+            null,
+            uri,
+            null,
+            null,
+            false,
+            bucket,
+            true,
+            false);
+
+    cache.addDownload(status);
+
+    assertNull(cache.getShadowBucket(uri, true));
+  }
+
+  @Test
+  void removeByIdentifier_whenDownload_presentEntriesAreRemoved() throws Exception {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    FreenetURI uri = mock(FreenetURI.class);
+    DownloadRequestStatus status =
+        new DownloadRequestStatus(
+            "remove-dl",
+            Persistence.CONNECTION,
+            true,
+            false,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            false,
+            (short) 1,
+            null,
+            "text/plain",
+            1L,
+            null,
+            null,
+            null,
+            uri,
+            null,
+            null,
+            false,
+            new FixedBucket(1),
+            false,
+            false);
+
+    cache.addDownload(status);
+
+    cache.removeByIdentifier("remove-dl");
+
+    MultiValueTable<FreenetURI, DownloadRequestStatus> downloadsByUri =
+        getField(cache, "downloadsByURI");
+    assertFalse(downloadsByUri.containsKey(uri));
+    assertNull(cache.getShadowBucket(uri, false));
+  }
+
+  @Test
+  void finishedUpload_whenFinalUriMissing_addsIndexAndDelegates() throws Exception {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    UploadRequestStatus status = mock(UploadRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("up1");
+    when(status.getURI()).thenReturn(null);
+    when(status.getFinalURI()).thenReturn(null);
+    cache.addUpload(status);
+
+    FreenetURI finalUri = mock(FreenetURI.class);
+
+    cache.finishedUpload("up1", true, finalUri, InsertExceptionMode.INTERNAL_ERROR, "s", "l");
+
+    verify(status).setFinished(true, finalUri, InsertExceptionMode.INTERNAL_ERROR, "s", "l");
+
+    MultiValueTable<FreenetURI, RequestStatus> uploadsByFinalUri =
+        getField(cache, "uploadsByFinalURI");
+    assertTrue(uploadsByFinalUri.containsKey(finalUri));
+  }
+
+  @Test
+  void gotFinalURI_whenMissing_setsFinalUriAndIndexes() throws Exception {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    UploadRequestStatus status = mock(UploadRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("up2");
+    when(status.getURI()).thenReturn(null);
+    when(status.getFinalURI()).thenReturn(null);
+    cache.addUpload(status);
+
+    FreenetURI finalUri = mock(FreenetURI.class);
+
+    cache.gotFinalURI("up2", finalUri);
+
+    verify(status).setFinalURI(finalUri);
+
+    MultiValueTable<FreenetURI, RequestStatus> uploadsByFinalUri =
+        getField(cache, "uploadsByFinalURI");
+    assertTrue(uploadsByFinalUri.containsKey(finalUri));
+  }
+
+  @Test
+  void updateDetectedCompatModes_whenPresent_updatesModesAndSplitfileKey() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    DownloadRequestStatus status = mock(DownloadRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("dl-compat");
+    when(status.getURI()).thenReturn(mock(FreenetURI.class));
+    cache.addDownload(status);
+
+    CompatibilityMode[] compat = new CompatibilityMode[] {CompatibilityMode.COMPAT_UNKNOWN};
+    byte[] key = new byte[] {1, 2, 3};
+
+    cache.updateDetectedCompatModes("dl-compat", compat, key, true);
+
+    verify(status).updateDetectedCompatModes(compat, true);
+    verify(status).updateDetectedSplitfileKey(key);
+  }
+
+  @Test
+  void updateCompressionStatus_whenUploadFilePresent_updatesState() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    UploadFileRequestStatus status = mock(UploadFileRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("file-up");
+    when(status.getURI()).thenReturn(null);
+    cache.addUpload(status);
+
+    cache.updateCompressionStatus("file-up", COMPRESS_STATE.COMPRESSING);
+
+    verify(status).updateCompressionStatus(COMPRESS_STATE.COMPRESSING);
+  }
+
+  @Test
+  void updateExpectedMetadata_whenDownloadPresent_propagatesToStatus() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    DownloadRequestStatus status = mock(DownloadRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("dl-meta");
+    when(status.getURI()).thenReturn(mock(FreenetURI.class));
+    cache.addDownload(status);
+
+    cache.updateExpectedMIME("dl-meta", "application/json");
+    cache.updateExpectedDataLength("dl-meta", 123L);
+
+    verify(status).updateExpectedMIME("application/json");
+    verify(status).updateExpectedDataLength(123L);
+  }
+
+  @Test
+  void setPriority_whenPresent_delegatesToStatus() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    UploadRequestStatus status = mock(UploadRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("prio");
+    when(status.getURI()).thenReturn(null);
+    cache.addUpload(status);
+
+    cache.setPriority("prio", (short) 5);
+
+    verify(status).setPriority((short) 5);
+  }
+
+  @Test
+  void updateStatus_whenPresent_delegatesEvent() {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    DownloadRequestStatus status = mock(DownloadRequestStatus.class);
+    when(status.getIdentifier()).thenReturn("dl-status");
+    when(status.getURI()).thenReturn(mock(FreenetURI.class));
+    cache.addDownload(status);
+
+    cache.updateStatus("dl-status", progressEvent);
+
+    verify(status).updateStatus(progressEvent);
+  }
+
+  @Test
+  void clear_afterEntries_removesAllState() throws Exception {
+    RequestStatusCache cache = new RequestStatusCache();
+
+    DownloadRequestStatus download = mock(DownloadRequestStatus.class);
+    when(download.getIdentifier()).thenReturn("dl-clear");
+    when(download.getURI()).thenReturn(mock(FreenetURI.class));
+    cache.addDownload(download);
+
+    UploadRequestStatus upload = mock(UploadRequestStatus.class);
+    when(upload.getIdentifier()).thenReturn("up-clear");
+    when(upload.getURI()).thenReturn(mock(FreenetURI.class));
+    cache.addUpload(upload);
+
+    cache.clear();
+
+    List<RequestStatus> snapshot = new ArrayList<>();
+    cache.addTo(snapshot);
+    assertTrue(snapshot.isEmpty());
+
+    MultiValueTable<?, ?> downloadsByUri = getField(cache, "downloadsByURI");
+    MultiValueTable<?, ?> uploadsByFinalUri = getField(cache, "uploadsByFinalURI");
+    assertTrue(downloadsByUri.isEmpty());
+    assertTrue(uploadsByFinalUri.isEmpty());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T getField(Object target, String name) throws Exception {
+    var field = RequestStatusCache.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return (T) field.get(target);
+  }
+
+  private static final class FixedBucket implements Bucket {
+    private final long size;
+
+    FixedBucket(long size) {
+      this.size = size;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OutputStream getOutputStreamUnbuffered() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+      return "fixed";
+    }
+
+    @Override
+    public long size() {
+      return size;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return false;
+    }
+
+    @Override
+    public void setReadOnly() {
+      // no-op
+    }
+
+    @Override
+    public void free() {
+      // no-op
+    }
+
+    @Override
+    public Bucket createShadow() {
+      return this;
+    }
+
+    @Override
+    public void onResume(ClientContext context) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeTo(java.io.DataOutputStream dos) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor RequestStatusCache to rely solely on keyed maps and tighten log formatting
- add comprehensive JUnit 6 coverage for request lifecycle, indexes, and shadow bucket behavior
- improve documentation comments explaining threading and cache usage patterns

## Testing
- not run (not requested)