### PR TITLE
docs: clarify shutdown message semantics

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ShutdownMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ShutdownMessage.java
@@ -2,28 +2,96 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Client-to-node FCP message that requests an orderly shutdown of the running Crypta node.
+ *
+ * <p>This message is intentionally payload-free: it relies solely on the message name to convey
+ * intent, and the receiver performs authorization and shutdown orchestration without consulting
+ * additional fields. Typical clients issue it as the final command in a maintenance or automated
+ * upgrade workflow once they have confirmed that no user-facing tasks remain. The handler enforces
+ * that only peers with full access credentials can trigger the operation, ensuring that routine or
+ * partially trusted connections cannot terminate the process unexpectedly.
+ *
+ * <p>Shutdown proceeds synchronously within the handler call: after an acknowledgment error message
+ * is queued to the client, the node exits its process via {@link Node#exit(String)}. The class is
+ * immutable and thread-safe; instances are stateless and may be reused across requests, though the
+ * surrounding protocol usually allocates a fresh instance per inbound frame. Use this type when you
+ * need a minimal, declarative way to signal server termination over FCP rather than invoking
+ * out-of-band administration hooks.
+ *
+ * <ul>
+ *   <li>Responsibilities: identify the shutdown intent and delegate execution to the node.
+ *   <li>Access control: requires {@code hasFullAccess()} on the connection handler.
+ *   <li>State: immutable; carries no parameters or mutable fields.
+ * </ul>
+ */
 public class ShutdownMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(ShutdownMessage.class);
 
+  /**
+   * Protocol-level identifier used to encode and route the shutdown request on the FCP wire.
+   * Exposed for callers that construct raw message frames or need to compare names without
+   * instantiating the message class; the value is stable across releases.
+   */
   public static final String NAME = "Shutdown";
 
-  // No point having an Identifier really...?
+  /**
+   * Constructs a payload-free shutdown message ready to be dispatched over an FCP connection.
+   *
+   * <p>The instance holds no state and is safe to reuse for multiple send operations. Clients often
+   * create it immediately before writing to the socket to avoid retaining references longer than
+   * necessary. No additional initialization is required because all semantics are embedded in the
+   * message name handled by the receiving endpoint.
+   */
+  public ShutdownMessage() {
+    // Intentionally empty: shutdown carries no payload and needs no initialization.
+  }
 
-  public ShutdownMessage() throws MessageInvalidException {}
-
+  /**
+   * Returns {@code null} because shutdown messages never serialize auxiliary fields or parameters.
+   *
+   * <p>This keeps the wire format as compact as possible and signals to the serializer that only
+   * the message name is required. Callers should not attempt to mutate the result or expect any
+   * field-level validation when transmitting this message type.
+   *
+   * @return {@code null}, indicating that no {@link SimpleFieldSet} accompanies the shutdown
+   *     message on the wire.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return null;
   }
 
+  /**
+   * Provides the canonical FCP message name used to encode shutdown requests.
+   *
+   * <p>The value is constant and matches the identifier expected by the receiving side of the
+   * protocol. Use this method when constructing outbound frames or for comparisons within dispatch
+   * tables rather than duplicating the literal string.
+   *
+   * @return immutable message name {@code "Shutdown"} suitable for FCP routing decisions.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the shutdown request by validating access, notifying the client, and exiting the node.
+   *
+   * <p>The handler must expose full-access privileges; otherwise the method rejects the request
+   * with a {@link MessageInvalidException}. On acceptance it first sends a {@link
+   * ProtocolErrorMessage#SHUTTING_DOWN} response so the client can distinguish deliberate shutdown
+   * from transport failures, and then calls {@link Node#exit(String)} to terminate the process. The
+   * call is synchronous and does not retry; callers should therefore ensure idempotency upstream
+   * because repeated invocations will request exit repeatedly once authorization passes.
+   *
+   * @param handler connection handler that issued the request; must provide full-access rights or
+   *     the call fails with an exception
+   * @param node target node instance that will perform the actual process termination on approval
+   * @throws MessageInvalidException when the connection lacks required privileges or protocol
+   *     validation fails prior to triggering the shutdown
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {

--- a/src/test/java/network/crypta/clients/fcp/ShutdownMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ShutdownMessageTest.java
@@ -1,0 +1,83 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ShutdownMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void getName_whenCalled_returnsShutdownConstant() {
+    ShutdownMessage message = new ShutdownMessage();
+
+    String result = message.getName();
+
+    assertEquals(ShutdownMessage.NAME, result);
+  }
+
+  @Test
+  void getFieldSet_whenCalled_returnsNull() {
+    ShutdownMessage message = new ShutdownMessage();
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertNull(result);
+  }
+
+  @Test
+  void run_whenHandlerLacksFullAccess_throwsAccessDenied() {
+    ShutdownMessage message = new ShutdownMessage();
+    when(handler.hasFullAccess()).thenReturn(false);
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
+    assertEquals("Shutdown requires full access", thrown.getMessage());
+    assertNull(thrown.ident);
+    assertFalse(thrown.global);
+    verify(handler, never()).send(any());
+    verify(node, never()).exit(any(String.class));
+  }
+
+  @Test
+  void run_whenHandlerHasFullAccess_sendsShutdownProtocolErrorAndExits()
+      throws MessageInvalidException {
+    ShutdownMessage message = new ShutdownMessage();
+    when(handler.hasFullAccess()).thenReturn(true);
+    ArgumentCaptor<ProtocolErrorMessage> sentMessage =
+        ArgumentCaptor.forClass(ProtocolErrorMessage.class);
+
+    message.run(handler, node);
+
+    verify(handler).send(sentMessage.capture());
+    verify(node).exit("Received FCP shutdown message");
+
+    ProtocolErrorMessage protocolError = sentMessage.getValue();
+    assertEquals(ProtocolErrorMessage.SHUTTING_DOWN, protocolError.getCode());
+    assertTrue(protocolError.fatal);
+    assertEquals("The node is shutting down", protocolError.extra);
+    assertEquals("Node", protocolError.ident);
+    assertFalse(protocolError.global);
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed Javadoc for ShutdownMessage to explain responsibilities, access control, and wire semantics
- remove unused logger and simplify constructor by removing checked exception
- expand ShutdownMessageTest to cover behavior without unnecessary throws

## Testing
- not run (documentation-only changes)