### PR TITLE
Add coverage and KDoc for StartedCompressionMessage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/StartedCompressionMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/StartedCompressionMessage.java
@@ -3,43 +3,120 @@ package network.crypta.clients.fcp;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * FCP notice emitted when a peer begins compressing traffic for a request or the entire connection.
+ *
+ * <p>The message carries a caller-supplied identifier so the receiver can match the compression
+ * change to a specific client request or session scope. The {@code global} flag mirrors the wire
+ * protocol hint that determines whether subsequent messages for the whole connection or only a
+ * scoped exchange should be compressed. The chosen codec is exposed via its stable {@link
+ * COMPRESSOR_TYPE#codecName} so the far end can initialize the corresponding decompressor without
+ * inspecting implementation details.
+ *
+ * <p>Instances are immutable and safe to share across threads because all state is provided at
+ * construction time and never mutated. Typical callers build the message server-side, hand it to
+ * the FCP output pipeline, and never invoke {@link #run(FCPConnectionHandler, Node)} because this
+ * type is not meant to be received from clients. Client-side receipt is treated as a protocol
+ * violation and rejected immediately.
+ *
+ * <ul>
+ *   <li>Serializes as a {@link SimpleFieldSet} with {@code Identifier}, {@code Codec}, and {@code
+ *       Global} keys.
+ *   <li>Always reports the canonical FCP name {@code StartedCompression}.
+ *   <li>{@link #run(FCPConnectionHandler, Node)} exists only to guard against misrouted traffic.
+ * </ul>
+ *
+ * @see FCPMessage
+ * @see COMPRESSOR_TYPE
+ */
 public class StartedCompressionMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(StartedCompressionMessage.class);
 
-  final String identifier;
+  final String messageIdentifier;
   final boolean global;
 
   final COMPRESSOR_TYPE codec;
 
+  /**
+   * Creates a compression start message with the supplied identifier, scope, and codec metadata.
+   *
+   * <p>The constructor does not validate inputs; callers must ensure the identifier is unique for
+   * the connection context and that the codec is negotiated or otherwise acceptable to the peer.
+   * The {@code global} hint is written verbatim to the wire format so downstream handlers can
+   * decide whether to apply compression to subsequent traffic for a single request or for all
+   * messages on the connection. All parameters are stored exactly as provided to preserve protocol
+   * fidelity.
+   *
+   * @param identifier correlation token provided by the sender; non-null and typically
+   *     request-scoped
+   * @param global {@code true} when compression applies to the entire connection; {@code false}
+   *     when scoped
+   * @param codec negotiated compressor implementation whose {@link COMPRESSOR_TYPE#codecName}
+   *     travels on the wire
+   */
   public StartedCompressionMessage(String identifier, boolean global, COMPRESSOR_TYPE codec) {
-    this.identifier = identifier;
+    this.messageIdentifier = identifier;
     this.codec = codec;
     this.global = global;
   }
 
+  /**
+   * Builds the {@link SimpleFieldSet} sent over FCP to announce compression activation.
+   *
+   * <p>The returned structure always includes the identifier, the stable codec name, and the
+   * boolean global flag. The method allocates a fresh {@link SimpleFieldSet} on each invocation so
+   * callers may modify the result without affecting other send operations. No null filtering or
+   * value normalization is performed; inputs supplied at construction are inserted verbatim to
+   * honor protocol expectations and avoid lossy transformations.
+   *
+   * @return newly allocated field set containing {@code Identifier}, {@code Codec}, and {@code
+   *     Global} entries representing this message
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", messageIdentifier);
     fs.putSingle("Codec", codec.codecName);
     fs.put("Global", global);
     return fs;
   }
 
+  /**
+   * Reports the canonical FCP message name for routing and serialization.
+   *
+   * <p>The name is constant for all instances and is used by the framing layer to tag outgoing
+   * messages and by client dispatch code when validating inbound traffic. Because the value is
+   * immutable and universally recognized across the protocol, callers can safely use it as a map
+   * key or switch discriminator without additional normalization.
+   *
+   * @return fixed string {@code StartedCompression} used by the FCP dispatcher
+   */
   @Override
   public String getName() {
     return "StartedCompression";
   }
 
+  /**
+   * Rejects attempts to process this message from the client side by throwing a protocol error.
+   *
+   * <p>This type is emitted by servers and must not be accepted from clients. If a client sends it
+   * inbound, the handler triggers {@link MessageInvalidException} with context about the invalid
+   * direction, preserving the original identifier and scope flag for diagnostics. The method is
+   * intentionally side effect free beyond raising the exception so no partial state is committed
+   * before the failure is reported upstream.
+   *
+   * @param handler connection handler requesting execution; ignored because the message is invalid
+   *     inbound
+   * @param node active node instance; not used because execution always aborts
+   * @throws MessageInvalidException always thrown to signal that the message direction violates the
+   *     FCP contract
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "StartedCompression goes from server to client not the other way around",
-        identifier,
+        messageIdentifier,
         global);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/StartedCompressionMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/StartedCompressionMessageTest.java
@@ -1,0 +1,69 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class StartedCompressionMessageTest {
+
+  @Mock FCPConnectionHandler handler;
+  @Mock Node node;
+
+  @Test
+  void getFieldSet_whenGzipGlobalTrue_setsIdentifierCodecAndGlobalFlag() {
+    StartedCompressionMessage message =
+        new StartedCompressionMessage("req-123", true, COMPRESSOR_TYPE.GZIP);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("req-123", fieldSet.get("Identifier"));
+    assertEquals("GZIP", fieldSet.get("Codec"));
+    assertEquals("true", fieldSet.get("Global"));
+  }
+
+  @Test
+  void getFieldSet_whenBzip2GlobalFalse_setsCodecNameAndFalseFlag() {
+    StartedCompressionMessage message =
+        new StartedCompressionMessage("another-id", false, COMPRESSOR_TYPE.BZIP2);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals("another-id", fieldSet.get("Identifier"));
+    assertEquals("BZIP2", fieldSet.get("Codec"));
+    assertEquals("false", fieldSet.get("Global"));
+  }
+
+  @Test
+  void getName_always_returnsStartedCompression() {
+    StartedCompressionMessage message =
+        new StartedCompressionMessage("id", false, COMPRESSOR_TYPE.LZMA_NEW);
+
+    assertEquals("StartedCompression", message.getName());
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidExceptionWithDetails() {
+    StartedCompressionMessage message =
+        new StartedCompressionMessage("identifier", true, COMPRESSOR_TYPE.LZMA);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "StartedCompression goes from server to client not the other way around",
+        exception.getMessage());
+    assertEquals("identifier", exception.ident);
+    assertTrue(exception.global);
+  }
+}


### PR DESCRIPTION
## Summary
- clarify StartedCompressionMessage naming and add detailed KDoc
- align identifier field name to messageIdentifier for clarity
- add unit tests covering field set, name, and invalid inbound handling

## Testing
- not run (not requested)