### PR TITLE
Refactor SubscribedUSKRoundFinishedMessage docs and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessage.java
@@ -2,31 +2,102 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Notifies an FCP client that a subscribed USK polling round has completed for a given subscription
+ * identifier.
+ *
+ * <p>This message is emitted by the node after it has finished probing the requested update
+ * sequence key (USK) for newer editions. Clients typically subscribe using the higher-level USK
+ * subscription commands and receive this message to learn that the current polling interval has
+ * reached its natural end, regardless of whether fresh data was discovered. The message is
+ * intentionally lightweight: it only echoes the identifier provided at subscription time so the
+ * client can correlate the lifecycle of concurrent subscriptions without holding additional state
+ * inside the protocol layer.
+ *
+ * <p>Responsibilities and notable behaviors:
+ *
+ * <ul>
+ *   <li>Communicates completion of a single subscription round, not the overall subscription.
+ *   <li>Contains no payload beyond the subscription identifier to keep transport overhead low.
+ *   <li>Intended for outbound delivery to clients; the server-side {@link #run} method is a guard.
+ * </ul>
+ *
+ * <p>The class is immutable and thread-safe by construction. Instances are created per event and
+ * can be shared across threads without synchronization because the identifier field is final and no
+ * additional mutable state is held. Consumers should treat it as a short-lived notification object
+ * that mirrors the wire format used by the FCP layer.
+ *
+ * @see FCPMessage
+ * @see FCPConnectionHandler
+ */
 public class SubscribedUSKRoundFinishedMessage extends FCPMessage {
-  private static final Logger LOG =
-      LoggerFactory.getLogger(SubscribedUSKRoundFinishedMessage.class);
+  private final String subscriptionIdentifier;
 
-  final String identifier;
-
+  /**
+   * Creates a completion notification for the given subscription identifier so it can be emitted to
+   * the subscribing FCP client after a polling round concludes.
+   *
+   * @param id unique token assigned by the subscriber when registering the USK interest; must not
+   *     be {@code null} and should match the identifier used in the originating request.
+   */
   SubscribedUSKRoundFinishedMessage(String id) {
-    identifier = id;
+    subscriptionIdentifier = id;
   }
 
+  /**
+   * Builds the {@link SimpleFieldSet} representation sent over the wire for this message.
+   *
+   * <p>The returned structure always contains the {@code Identifier} key so the receiving client
+   * can match the completion event to an existing subscription context. No additional fields are
+   * added, keeping the payload small and predictable even when multiple subscriptions are active at
+   * once. Callers should not modify the resulting field set because it is constructed specifically
+   * for immediate transmission.
+   *
+   * @return field set containing the single {@code Identifier} entry referencing the originating
+   *     subscription; ownership remains with the caller after creation.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", subscriptionIdentifier);
     return fs;
   }
 
+  /**
+   * Returns the fixed FCP message name used to serialize this notification on the network.
+   *
+   * <p>The name is stable and lower camel case as required by the FCP specification. Clients use it
+   * to route incoming messages to the appropriate subscription handlers, and servers rely on the
+   * constant to produce predictable logs and metrics. Because the name is invariant, callers can
+   * cache the value freely without risking behavioral changes between releases.
+   *
+   * @return constant string {@code "SubscribedUSKRoundFinished"} identifying the message type in
+   *     FCP traffic.
+   */
   @Override
   public String getName() {
     return "SubscribedUSKRoundFinished";
   }
 
+  /**
+   * Guard method for inbound handling; this outbound-only message should never be executed on the
+   * server side and therefore throws unconditionally.
+   *
+   * <p>The FCP framework still requires a {@code run} implementation for completeness, so the
+   * method remains to satisfy the contract but signals misuse via an {@link
+   * UnsupportedOperationException} at runtime. Implementations that invoke this method should treat
+   * such calls as programming errors or protocol violations. No state is modified and no
+   * interaction with {@link Node} occurs before the exception is thrown.
+   *
+   * @param handler connection handler associated with the subscription; never used because the
+   *     method aborts immediately.
+   * @param node node instance representing the local Crypta daemon; unused in this guard path.
+   * @throws MessageInvalidException never thrown directly here but retained for signature parity
+   *     with the superclass contract and related message types.
+   * @throws UnsupportedOperationException always thrown to indicate that this message is not meant
+   *     to be executed on the receiving side.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new UnsupportedOperationException();

--- a/src/test/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessageTest.java
@@ -1,0 +1,57 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class SubscribedUSKRoundFinishedMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
+
+  @Test
+  void getName_whenCalled_returnsSubscribedUSKRoundFinished() {
+    SubscribedUSKRoundFinishedMessage message =
+        new SubscribedUSKRoundFinishedMessage("identifier-value");
+
+    String result = message.getName();
+
+    assertEquals("SubscribedUSKRoundFinished", result);
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierProvided_containsIdentifierEntry() {
+    String identifier = "test-id";
+    SubscribedUSKRoundFinishedMessage message = new SubscribedUSKRoundFinishedMessage(identifier);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertEquals(identifier, fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierIsNull_identifierEntryOmitted() {
+    SubscribedUSKRoundFinishedMessage message = new SubscribedUSKRoundFinishedMessage(null);
+
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    assertNull(fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void run_whenInvoked_throwsUnsupportedOperationException() {
+    SubscribedUSKRoundFinishedMessage message =
+        new SubscribedUSKRoundFinishedMessage("irrelevant-id");
+
+    assertThrows(UnsupportedOperationException.class, () -> message.run(handler, node));
+  }
+}


### PR DESCRIPTION
## Summary
- document SubscribedUSKRoundFinishedMessage with detailed KDoc and make the identifier field private/finally named `subscriptionIdentifier`
- keep wire format unchanged while clarifying outbound-only intent and invariants
- add JUnit 6 tests covering name, field set population (including null identifier), and guard run behavior

## Testing
- ./gradlew spotlessApply
- not run: tests (maintainer may run the full suite)
