### PR TITLE
Add tests for SubscribedUSKSendingToNetworkMessage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKSendingToNetworkMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKSendingToNetworkMessage.java
@@ -2,31 +2,90 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Message emitted by the client layer to tell the node that a subscribed USK is now being forwarded
+ * to the network rather than served from local cache.
+ *
+ * <p>This command wraps only a single identifier, mirroring the subscription handle originally
+ * assigned by the server. The surrounding FCP session uses the identifier to correlate updates
+ * flowing from the node back to the client that requested the subscription. Callers typically emit
+ * this message immediately after receiving a {@code SubscribedUSK} notification, at the moment they
+ * decide to publish the content upstream. The message is intentionally minimal: it contains no
+ * payload beyond the identifier, does not alter subscription state, and never retries.
+ *
+ * <p>Thread-safety: instances are immutable and safe for reuse across threads, but the surrounding
+ * {@link FCPConnectionHandler} is not guaranteed to be. Construction is cheap; allocate per
+ * notification to avoid shared mutable state. Because this message is an instruction rather than a
+ * data carrier, it should be sent only once per subscription lifecycle stage to avoid confusing the
+ * remote peer.
+ *
+ * <ul>
+ *   <li>Responsibility: signal intent to send the subscribed USK back into the network.
+ *   <li>Correlation: {@code Identifier} must match the token assigned in the original subscription.
+ *   <li>Scope: carries no file data and does not acknowledge receipt.
+ * </ul>
+ *
+ * @see SubscribedUSKMessage
+ */
 public class SubscribedUSKSendingToNetworkMessage extends FCPMessage {
-  private static final Logger LOG =
-      LoggerFactory.getLogger(SubscribedUSKSendingToNetworkMessage.class);
 
-  final String identifier;
+  final String messageIdentifier;
 
   SubscribedUSKSendingToNetworkMessage(String id) {
-    identifier = id;
+    messageIdentifier = id;
   }
 
+  /**
+   * Creates the FCP field set containing the subscription identifier that the peer expects.
+   *
+   * <p>The field set uses a single boolean-friendly map with the key {@code Identifier}. The value
+   * must exactly match the identifier issued by the server when the subscription was created;
+   * otherwise the node will ignore or reject the message. The returned structure is newly allocated
+   * and can be modified by callers without affecting this message instance.
+   *
+   * @return mutable {@link SimpleFieldSet} with one {@code Identifier} entry representing this
+   *     message's subscription token
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", messageIdentifier);
     return fs;
   }
 
+  /**
+   * Reports the FCP message name used on the wire.
+   *
+   * <p>The name is a stable constant defined by the protocol. It is used by the connection layer to
+   * serialize outbound messages and to route incoming acknowledgements. No localization or dynamic
+   * formatting is performed; callers can rely on the exact casing for protocol matching.
+   *
+   * @return fixed string {@code "SubscribedUSKSendingToNetwork"} required by the FCP protocol
+   */
   @Override
   public String getName() {
     return "SubscribedUSKSendingToNetwork";
   }
 
+  /**
+   * This message is outbound-only and should never be executed as an inbound command.
+   *
+   * <p>The FCP dispatcher calls {@link FCPMessage#run(FCPConnectionHandler, Node)} for messages
+   * received from peers. Because {@code SubscribedUSKSendingToNetwork} is emitted by clients rather
+   * than consumed by them, invoking this method represents a protocol misuse and results in an
+   * {@link UnsupportedOperationException}. No state is changed and the provided handler and node
+   * references are left untouched.
+   *
+   * @param handler active connection context for the current FCP session; never used here but
+   *     required by the interface
+   * @param node target node instance associated with the connection; unused because the message is
+   *     not processed inbound
+   * @throws MessageInvalidException declared for interface compatibility; never intentionally
+   *     thrown by this implementation
+   * @throws UnsupportedOperationException always thrown to signal that inbound execution is
+   *     unsupported
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new UnsupportedOperationException();

--- a/src/test/java/network/crypta/clients/fcp/SubscribedUSKSendingToNetworkMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribedUSKSendingToNetworkMessageTest.java
@@ -1,0 +1,74 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class SubscribedUSKSendingToNetworkMessageTest {
+
+  @Test
+  void getFieldSet_whenIdentifierProvided_containsIdentifierField() {
+    // Arrange
+    SubscribedUSKSendingToNetworkMessage message =
+        new SubscribedUSKSendingToNetworkMessage("abc123");
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    // Assert
+    assertNotNull(fieldSet);
+    assertEquals("abc123", fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierNull_skipsIdentifierEntry() {
+    // Arrange
+    SubscribedUSKSendingToNetworkMessage message = new SubscribedUSKSendingToNetworkMessage(null);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    // Assert
+    assertNotNull(fieldSet);
+    assertNull(fieldSet.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenCalledMultipleTimes_returnsNewInstances() {
+    // Arrange
+    SubscribedUSKSendingToNetworkMessage message = new SubscribedUSKSendingToNetworkMessage("id");
+
+    // Act
+    SimpleFieldSet first = message.getFieldSet();
+    SimpleFieldSet second = message.getFieldSet();
+
+    // Assert
+    assertNotSame(first, second);
+    assertEquals("id", first.get("Identifier"));
+    assertEquals("id", second.get("Identifier"));
+  }
+
+  @Test
+  void getName_alwaysReturnsFixedMessageName() {
+    // Arrange
+    SubscribedUSKSendingToNetworkMessage message = new SubscribedUSKSendingToNetworkMessage("id");
+
+    // Act & Assert
+    assertEquals("SubscribedUSKSendingToNetwork", message.getName());
+  }
+
+  @Test
+  void run_whenInvoked_throwsUnsupportedOperationException() {
+    // Arrange
+    SubscribedUSKSendingToNetworkMessage message = new SubscribedUSKSendingToNetworkMessage("id");
+
+    // Act & Assert
+    assertThrows(UnsupportedOperationException.class, () -> message.run(null, null));
+  }
+}


### PR DESCRIPTION
## Summary
- rename the message identifier field for clarity and remove unused logger
- expand KDoc to document outbound behaviour and protocol expectations
- add JUnit 6 coverage for field set, name constant, and unsupported run execution

## Testing
- not run (not requested)
