### PR TITLE
Add SubscribedUSKUpdate tests and documentation

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKUpdate.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKUpdate.java
@@ -3,33 +3,78 @@ package network.crypta.clients.fcp;
 import network.crypta.keys.USK;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Announces that a subscribed {@link USK} has advanced to a new edition and should be delivered to
+ * the FCP client.
+ *
+ * <p>This message is created on the server side when a background subscription detects a fresher
+ * slot for the given USK. The object is immutable, so the receiving client can safely hand the
+ * instance across threads while it assembles follow-up requests or updates local state. Typical
+ * consumers enqueue the message toward the client connection, relying on {@link #getFieldSet()} to
+ * serialize the identifier, edition, and flags expected by the FCP protocol. Because this class is
+ * purely descriptive and does not perform any lookups, it is cheap to instantiate and can be reused
+ * in queues without additional synchronization.
+ *
+ * <ul>
+ *   <li>Represents server-to-client notifications for USK subscriptions.
+ *   <li>Encapsulates edition number, canonical URI, and freshness flags.
+ *   <li>Immutable once built; thread-safe for concurrent read-only access.
+ * </ul>
+ *
+ * @see FCPMessage
+ * @see USK
+ */
 public class SubscribedUSKUpdate extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(SubscribedUSKUpdate.class);
 
-  final String identifier;
+  final String messageIdentifier;
   final long edition;
   final USK key;
   final boolean newKnownGood;
   final boolean newSlotToo;
 
-  static final String name = "SubscribedUSKUpdate";
+  static final String NAME = "SubscribedUSKUpdate";
 
+  /**
+   * Builds an update message describing a newly discovered edition for a subscribed USK.
+   *
+   * <p>The constructor captures only immutable value fields; it performs no validation beyond
+   * assigning the arguments. Callers are expected to pass protocol-consistent values sourced from
+   * the subscription logic. Instances constructed with incorrect flags will still serialize, so the
+   * producer should enforce any higher-level invariants before instantiation.
+   *
+   * @param identifier unique message identifier echoed back to the subscriber; never null or blank
+   * @param l edition number advertised for the USK; non-negative and monotonically increasing per
+   *     key
+   * @param key canonical USK pointing to the subscription target; must be resolvable to a URI
+   * @param newKnownGood true when the edition is verified as currently fetchable without retries
+   * @param newSlotToo true when a previously unknown slot index became available alongside the
+   *     known-good edition
+   */
   public SubscribedUSKUpdate(
       String identifier, long l, USK key, boolean newKnownGood, boolean newSlotToo) {
-    this.identifier = identifier;
+    this.messageIdentifier = identifier;
     this.edition = l;
     this.key = key;
     this.newKnownGood = newKnownGood;
     this.newSlotToo = newSlotToo;
   }
 
+  /**
+   * Renders this message into the wire-format {@link SimpleFieldSet} expected by FCP clients.
+   *
+   * <p>The returned structure contains the message identifier, edition number, canonical URI, and
+   * both freshness flags. Callers may reuse the result for multiple sends because the underlying
+   * values are immutable. No additional validation occurs at this stage, so any protocol checks
+   * must be performed prior to calling this method.
+   *
+   * @return a populated {@code SimpleFieldSet} ready for transmission; never null and safe for
+   *     read-only reuse
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", messageIdentifier);
     fs.put("Edition", edition);
     fs.putSingle("URI", key.getURI().toString());
     fs.put("NewKnownGood", newKnownGood);
@@ -37,17 +82,38 @@ public class SubscribedUSKUpdate extends FCPMessage {
     return fs;
   }
 
+  /**
+   * Reports the protocol-level message name used when serializing this update.
+   *
+   * <p>The value is constant and shared across all instances; callers can rely on this method for
+   * routing or logging without additional allocation.
+   *
+   * @return the fixed FCP message name {@code "SubscribedUSKUpdate"}
+   */
   @Override
   public String getName() {
-    return name;
+    return NAME;
   }
 
+  /**
+   * Rejects attempts to process this message on the client-to-server path.
+   *
+   * <p>Subscribed USK updates are emitted by the server and must not originate from clients. This
+   * override enforces that contract by always throwing {@link MessageInvalidException}, allowing
+   * callers to surface a protocol error rather than silently discarding the message. The method is
+   * intentionally non-idempotent because each invocation raises a new exception instance.
+   *
+   * @param handler connection handler attempting to process the message; expected to be non-null
+   * @param node local node context; supplied for interface completeness but unused in this
+   *     implementation
+   * @throws MessageInvalidException always thrown to signal server-only directionality violations
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "SubscribedUSKUpdate goes from server to client not the other way around",
-        identifier,
+        messageIdentifier,
         false);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/SubscribedUSKUpdateTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribedUSKUpdateTest.java
@@ -1,0 +1,92 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.net.MalformedURLException;
+import network.crypta.keys.ClientSSK;
+import network.crypta.keys.Key;
+import network.crypta.keys.KeyBlock;
+import network.crypta.keys.NodeSSK;
+import network.crypta.keys.USK;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SubscribedUSKUpdateTest {
+
+  @Test
+  void getName_whenCalled_returnsSubscribedUSKUpdate() throws Exception {
+    SubscribedUSKUpdate update =
+        new SubscribedUSKUpdate("test-id", 42L, createUsk(42L), true, false);
+
+    assertEquals("SubscribedUSKUpdate", update.getName());
+  }
+
+  @Test
+  void getFieldSet_whenCreated_populatesAllFields() throws Exception {
+    String identifier = "ident-123";
+    long edition = 123L;
+    boolean newKnownGood = true;
+    boolean newSlotToo = false;
+    USK usk = createUsk(edition);
+    SubscribedUSKUpdate update =
+        new SubscribedUSKUpdate(identifier, edition, usk, newKnownGood, newSlotToo);
+
+    SimpleFieldSet fieldSet = update.getFieldSet();
+
+    assertNotNull(fieldSet);
+    assertEquals(identifier, fieldSet.get("Identifier"));
+    assertEquals(Long.toString(edition), fieldSet.get("Edition"));
+    assertEquals(usk.getURI().toString(), fieldSet.get("URI"));
+    assertEquals(Boolean.toString(newKnownGood), fieldSet.get("NewKnownGood"));
+    assertEquals(Boolean.toString(newSlotToo), fieldSet.get("NewSlotToo"));
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidExceptionWithDetails() throws Exception {
+    String identifier = "run-test";
+    long edition = 7L;
+    USK usk = createUsk(edition);
+    SubscribedUSKUpdate update = new SubscribedUSKUpdate(identifier, edition, usk, false, true);
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> update.run(mock(FCPConnectionHandler.class), mock(Node.class)));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(identifier, exception.ident);
+    assertFalse(exception.global);
+    assertEquals(
+        "SubscribedUSKUpdate goes from server to client not the other way around",
+        exception.getMessage());
+  }
+
+  private static USK createUsk(long edition) throws MalformedURLException {
+    byte[] pubKeyHash = new byte[NodeSSK.PUBKEY_HASH_SIZE];
+    for (int i = 0; i < pubKeyHash.length; i++) {
+      pubKeyHash[i] = (byte) i;
+    }
+    byte[] cryptoKey = new byte[ClientSSK.CRYPTO_KEY_LENGTH];
+    for (int i = 0; i < cryptoKey.length; i++) {
+      cryptoKey[i] = (byte) (i + 1);
+    }
+    byte[] extras =
+        new byte[] {
+          (byte) NodeSSK.SSK_VERSION,
+          0,
+          Key.ALGO_AES_PCFB_256_SHA256,
+          0,
+          (byte) KeyBlock.HASH_SHA256
+        };
+    return new USK(pubKeyHash, cryptoKey, extras, "test-site", edition);
+  }
+}


### PR DESCRIPTION
## Summary
- add unit tests exercising SubscribedUSKUpdate name, field set, and run() directionality
- rename identifier field for clarity and add detailed JavaDoc describing message semantics
- ensure getFieldSet uses the renamed identifier constant and run() reports correct identifier

## Testing
- not run (not requested)