### PR TITLE
Add coverage for SubscribeUSK callback flows

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
@@ -6,9 +6,35 @@ import network.crypta.client.async.USKProgressCallback;
 import network.crypta.keys.USK;
 import network.crypta.node.NodeClientCore;
 
+/**
+ * Bridges an FCP client subscription to the node's USK manager.
+ *
+ * <p>This helper wires a {@link SubscribeUSKMessage} received over FCP into the asynchronous USK
+ * subscription facilities provided by {@link NodeClientCore}. It registers itself as the {@link
+ * USKProgressCallback} so that progress, network activity, and discovered editions are fed back to
+ * the originating {@link FCPConnectionHandler}. Instances are intentionally lightweight and
+ * short-lived: they register with the node on construction and can be removed via {@link
+ * #unsubscribe()} when the client disconnects or no longer requires updates.
+ *
+ * <p>Typical usage is driven by the FCP protocol flow: the handler constructs this class when a
+ * client issues a subscribe request, lets the node push progress callbacks, and eventually calls
+ * {@link #unsubscribe()} during teardown. The object does not perform retries itself; it relies on
+ * the underlying USK manager for polling cadence, sparse polling decisions, and cache ownership.
+ * All callbacks are expected to be invoked on the node's internal threads, so callers should avoid
+ * long-running work and keep message emission cheap. Thread-safety is limited to delegating into
+ * the handler and USK manager; the class itself is effectively single-use per subscription.
+ *
+ * <ul>
+ *   <li>Relays edition discoveries, including whether data was newly accepted.
+ *   <li>Reports network-send phases and polling round completion to the FCP client.
+ *   <li>Preserves the polling priorities supplied by the client for normal and progress phases.
+ * </ul>
+ *
+ * @see USKProgressCallback
+ * @see network.crypta.client.async.USKManager#subscribe
+ * @see network.crypta.client.async.USKManager#subscribeSparse
+ */
 public class SubscribeUSK implements USKProgressCallback {
-
-  // FIXME allow client to specify priorities
   final FCPConnectionHandler handler;
   final String identifier;
   final NodeClientCore core;
@@ -18,6 +44,20 @@ public class SubscribeUSK implements USKProgressCallback {
   final USK usk;
   final USKCallback toUnsub;
 
+  /**
+   * Creates and registers a subscription that reflects the caller's FCP request parameters.
+   *
+   * <p>The constructor immediately adds this callback to both the connection handler and the USK
+   * manager. Depending on the {@code dontPoll} and {@code sparsePoll} flags in the supplied
+   * message, it chooses either sparse subscription mode or the default polling behavior. No
+   * additional initialization is required after construction.
+   *
+   * @param message parsed FCP subscribe request containing keys, flags, and priorities; never null.
+   * @param core node client core that owns the USK manager and executes polling logic.
+   * @param handler connection handler used to emit FCP responses back to the requesting client.
+   * @throws IdentifierCollisionException if the identifier already exists on this handler and
+   *     cannot be reused for another subscription.
+   */
   public SubscribeUSK(
       SubscribeUSKMessage message, NodeClientCore core, FCPConnectionHandler handler)
       throws IdentifierCollisionException {
@@ -49,6 +89,23 @@ public class SubscribeUSK implements USKProgressCallback {
     }
   }
 
+  /**
+   * Receives notification that a specific USK edition was located and processed.
+   *
+   * <p>The callback is triggered by the USK manager whenever it fetches an edition for this
+   * subscription. It forwards a {@link SubscribedUSKUpdate} over FCP unless the handler has been
+   * closed, in which case it unsubscribes to conserve resources. Data bytes are not sent here; only
+   * edition and freshness metadata travel across the connection.
+   *
+   * @param l edition number that was found; typically monotonically increasing over time.
+   * @param key USK key associated with the subscription; matches the key provided at construction.
+   * @param context client context for the ongoing fetch; may provide shared state across callbacks.
+   * @param wasMetadata {@code true} when the retrieved payload consists solely of metadata blocks.
+   * @param codec codec hint used during retrieval; supplied by the node to describe the data type.
+   * @param data raw payload bytes; may be empty if only metadata was requested or delivered.
+   * @param newKnownGood {@code true} when this edition improved the known-good marker for the key.
+   * @param newSlotToo {@code true} when a newer slot (latest edition) was discovered alongside it.
+   */
   @Override
   public void onFoundEdition(
       long l,
@@ -63,30 +120,73 @@ public class SubscribeUSK implements USKProgressCallback {
       core.getUskManager().unsubscribe(key, toUnsub);
       return;
     }
-    // if(newKnownGood && !newSlotToo) return;
     FCPMessage msg = new SubscribedUSKUpdate(identifier, l, key, newKnownGood, newSlotToo);
     handler.send(msg);
   }
 
+  /**
+   * Returns the client-requested priority for regular polling cycles.
+   *
+   * <p>The value originates from the FCP subscribe message and is passed through unchanged so the
+   * USK manager can schedule this subscription relative to others. Lower values typically denote
+   * higher priority depending on the underlying scheduler configuration.
+   *
+   * @return priority hint for normal polling, as supplied by the subscribing client.
+   */
   @Override
   public short getPollingPriorityNormal() {
     return prio;
   }
 
+  /**
+   * Returns the client-requested priority used while progress feedback is being emitted.
+   *
+   * <p>This priority can differ from the normal polling priority to bias subscriptions that are
+   * mid-transfer or issuing updates to clients. It is not modified by this class; the USK manager
+   * is free to interpret the value according to its scheduling rules.
+   *
+   * @return priority hint for progress phases, mirroring the value in the original request.
+   */
   @Override
   public short getPollingPriorityProgress() {
     return prioProgress;
   }
 
+  /**
+   * Cancels the active subscription with the USK manager.
+   *
+   * <p>Callers should invoke this when the FCP connection closes or when the client issues an
+   * unsubscribe request. The method forwards the removal to the node's USK manager using the key
+   * captured at construction. It is safe to call multiple times; redundant calls are ignored by the
+   * manager.
+   */
   public void unsubscribe() {
     core.getUskManager().unsubscribe(usk, toUnsub);
   }
 
+  /**
+   * Signals that a polling cycle is actively sending a request to the network.
+   *
+   * <p>The callback relays a {@link SubscribedUSKSendingToNetworkMessage} to the FCP client so it
+   * can display activity state. It does not include payload details; its purpose is purely
+   * observational, allowing clients to track when network traffic begins for a given subscription.
+   *
+   * @param context client context for the poll; may be shared with other progress callbacks.
+   */
   @Override
   public void onSendingToNetwork(ClientContext context) {
     handler.send(new SubscribedUSKSendingToNetworkMessage(identifier));
   }
 
+  /**
+   * Notifies listeners that a polling round completed for this subscription.
+   *
+   * <p>When invoked, the method emits a {@link SubscribedUSKRoundFinishedMessage} to the FCP client
+   * to mark the end of the current poll cycle. No guarantees are made about the presence of new
+   * editions; the signal merely brackets a batch of network activity.
+   *
+   * @param context client context associated with the concluded round; may be reused by the caller.
+   */
   @Override
   public void onRoundFinished(ClientContext context) {
     handler.send(new SubscribedUSKRoundFinishedMessage(identifier));

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
@@ -1,0 +1,198 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.USKManager;
+import network.crypta.client.async.USKSparseProxyCallback;
+import network.crypta.keys.USK;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SubscribeUSKTest {
+
+  private static final String TEST_USK =
+      "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/";
+
+  @Mock private NodeClientCore core;
+  @Mock private USKManager uskManager;
+  @Mock private FCPConnectionHandler handler;
+  @Mock private PersistentRequestClient persistentRequestClient;
+  @Mock private RequestClient requestClient;
+  @Mock private USKSparseProxyCallback sparseProxyCallback;
+  @Mock private ClientContext clientContext;
+
+  @Test
+  void constructor_whenSparsePollRequested_usesSubscribeSparseAndStoresProxyForUnsubscribe()
+      throws Exception {
+    SubscribeUSKMessage message =
+        buildSubscribeUSKMessage("id-sparse", false, true, (short) 5, (short) 4, true, true);
+    mockCommonBehavior();
+    when(uskManager.subscribeSparse(eq(message.key), any(), eq(true), eq(requestClient)))
+        .thenReturn(sparseProxyCallback);
+
+    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+
+    verify(handler).addUSKSubscription("id-sparse", subscription);
+    verify(persistentRequestClient).lowLevelClient(true);
+    verify(uskManager).subscribeSparse(message.key, subscription, true, requestClient);
+    verify(uskManager, never()).subscribe(any(USK.class), any(), anyBoolean(), anyBoolean(), any());
+
+    subscription.unsubscribe();
+
+    verify(uskManager).unsubscribe(message.key, sparseProxyCallback);
+  }
+
+  @Test
+  void constructor_whenBackgroundPollingEnabled_subscribesWithPollingAndUsesSelfForUnsubscribe()
+      throws Exception {
+    SubscribeUSKMessage message =
+        buildSubscribeUSKMessage("id-poll", false, false, (short) 6, (short) 5, false, false);
+    mockCommonBehavior();
+
+    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+
+    verify(handler).addUSKSubscription("id-poll", subscription);
+    verify(persistentRequestClient).lowLevelClient(false);
+    verify(uskManager).subscribe(message.key, subscription, true, false, requestClient);
+    verify(uskManager, never())
+        .subscribeSparse(eq(message.key), eq(subscription), anyBoolean(), eq(requestClient));
+
+    subscription.unsubscribe();
+
+    verify(uskManager).unsubscribe(message.key, subscription);
+  }
+
+  @Test
+  void onFoundEdition_whenHandlerClosed_unsubscribesWithoutSending() throws Exception {
+    SubscribeUSKMessage message =
+        buildSubscribeUSKMessage("id-closed", true, false, (short) 2, (short) 1, false, false);
+    mockCommonBehavior();
+    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    when(handler.isClosed()).thenReturn(true);
+
+    subscription.onFoundEdition(
+        7L, message.key, clientContext, false, (short) 1, new byte[0], true, false);
+
+    verify(uskManager).unsubscribe(message.key, subscription);
+    verify(handler, never()).send(any());
+  }
+
+  @Test
+  void onFoundEdition_whenHandlerOpen_sendsSubscribedUSKUpdate() throws Exception {
+    SubscribeUSKMessage message =
+        buildSubscribeUSKMessage("id-open", true, false, (short) 3, (short) 1, false, false);
+    mockCommonBehavior();
+    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    when(handler.isClosed()).thenReturn(false);
+
+    subscription.onFoundEdition(
+        12L, message.key, clientContext, false, (short) 1, null, true, false);
+
+    ArgumentCaptor<SubscribedUSKUpdate> captor = ArgumentCaptor.forClass(SubscribedUSKUpdate.class);
+    verify(handler).send(captor.capture());
+
+    SubscribedUSKUpdate update = captor.getValue();
+    assertEquals("id-open", update.identifier);
+    assertEquals(12L, update.edition);
+    assertSame(message.key, update.key);
+    assertTrue(update.newKnownGood);
+    assertFalse(update.newSlotToo);
+
+    verify(uskManager, never()).unsubscribe(any(), any());
+  }
+
+  @Test
+  void getPollingPriorityMethods_whenCalled_returnValuesFromMessage() throws Exception {
+    SubscribeUSKMessage message =
+        buildSubscribeUSKMessage("id-prio", true, false, (short) 9, (short) 2, false, false);
+    mockCommonBehavior();
+
+    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+
+    assertEquals(9, subscription.getPollingPriorityNormal());
+    assertEquals(2, subscription.getPollingPriorityProgress());
+  }
+
+  @Test
+  void onSendingToNetwork_whenInvoked_sendsSendingToNetworkMessage() throws Exception {
+    SubscribeUSKMessage message =
+        buildSubscribeUSKMessage("id-send", true, false, (short) 1, (short) 0, false, false);
+    mockCommonBehavior();
+    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+
+    subscription.onSendingToNetwork(clientContext);
+
+    ArgumentCaptor<SubscribedUSKSendingToNetworkMessage> captor =
+        ArgumentCaptor.forClass(SubscribedUSKSendingToNetworkMessage.class);
+    verify(handler).send(captor.capture());
+
+    SubscribedUSKSendingToNetworkMessage sending = captor.getValue();
+    assertEquals("id-send", sending.messageIdentifier);
+  }
+
+  @Test
+  void onRoundFinished_whenInvoked_sendsRoundFinishedMessage() throws Exception {
+    SubscribeUSKMessage message =
+        buildSubscribeUSKMessage("id-round", true, false, (short) 1, (short) 0, false, false);
+    mockCommonBehavior();
+    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+
+    subscription.onRoundFinished(clientContext);
+
+    ArgumentCaptor<SubscribedUSKRoundFinishedMessage> captor =
+        ArgumentCaptor.forClass(SubscribedUSKRoundFinishedMessage.class);
+    verify(handler).send(captor.capture());
+
+    SubscribedUSKRoundFinishedMessage finished = captor.getValue();
+    assertEquals("id-round", finished.getFieldSet().get("Identifier"));
+  }
+
+  private void mockCommonBehavior() {
+    when(core.getUskManager()).thenReturn(uskManager);
+    when(handler.getRebootClient()).thenReturn(persistentRequestClient);
+    when(persistentRequestClient.lowLevelClient(anyBoolean())).thenReturn(requestClient);
+    lenient().when(requestClient.persistent()).thenReturn(false);
+  }
+
+  private SubscribeUSKMessage buildSubscribeUSKMessage(
+      String identifier,
+      boolean dontPoll,
+      boolean sparsePoll,
+      short prio,
+      short prioProgress,
+      boolean realTimeFlag,
+      boolean ignoreUSKDatehints)
+      throws MessageInvalidException {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", identifier);
+    fieldSet.putSingle("URI", TEST_USK);
+    fieldSet.put("DontPoll", dontPoll);
+    if (!dontPoll) {
+      fieldSet.put("SparsePoll", sparsePoll);
+    }
+    fieldSet.put("PriorityClass", prio);
+    fieldSet.put("PriorityClassProgress", prioProgress);
+    fieldSet.put("RealTimeFlag", realTimeFlag);
+    fieldSet.put("IgnoreUSKDatehints", ignoreUSKDatehints);
+    return new SubscribeUSKMessage(fieldSet);
+  }
+}


### PR DESCRIPTION
## Summary
- document SubscribeUSK lifecycle and callbacks with detailed Javadoc
- add unit tests exercising sparse vs polling subscriptions, priority passthrough, and progress callbacks

## Testing
- not run (tests not requested)