### PR TITLE
Refactor SubscribeUSK identifier handling

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
@@ -10,7 +10,7 @@ public class SubscribeUSK implements USKProgressCallback {
 
   // FIXME allow client to specify priorities
   final FCPConnectionHandler handler;
-  final String identifier;
+  final String clientIdentifier;
   final NodeClientCore core;
   final boolean dontPoll;
   final short prio;
@@ -23,12 +23,12 @@ public class SubscribeUSK implements USKProgressCallback {
       throws IdentifierCollisionException {
     this.handler = handler;
     this.dontPoll = message.dontPoll;
-    this.identifier = message.identifier;
+    this.clientIdentifier = message.clientIdentifier;
     this.core = core;
     this.usk = message.key;
     prio = message.prio;
     prioProgress = message.prioProgress;
-    handler.addUSKSubscription(identifier, this);
+    handler.addUSKSubscription(clientIdentifier, this);
     if ((!message.dontPoll) && message.sparsePoll)
       toUnsub =
           core.getUskManager()
@@ -64,7 +64,7 @@ public class SubscribeUSK implements USKProgressCallback {
       return;
     }
     // if(newKnownGood && !newSlotToo) return;
-    FCPMessage msg = new SubscribedUSKUpdate(identifier, l, key, newKnownGood, newSlotToo);
+    FCPMessage msg = new SubscribedUSKUpdate(clientIdentifier, l, key, newKnownGood, newSlotToo);
     handler.send(msg);
   }
 
@@ -84,11 +84,11 @@ public class SubscribeUSK implements USKProgressCallback {
 
   @Override
   public void onSendingToNetwork(ClientContext context) {
-    handler.send(new SubscribedUSKSendingToNetworkMessage(identifier));
+    handler.send(new SubscribedUSKSendingToNetworkMessage(clientIdentifier));
   }
 
   @Override
   public void onRoundFinished(ClientContext context) {
-    handler.send(new SubscribedUSKRoundFinishedMessage(identifier));
+    handler.send(new SubscribedUSKRoundFinishedMessage(clientIdentifier));
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
@@ -6,50 +6,79 @@ import network.crypta.keys.USK;
 import network.crypta.node.Node;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Sent by a client to subscribe to a USK. The client will then be notified by a
- * SubscribedUSKMessage that his request has been taken into account and whenever a new latest
- * version of the USK is available. There is a flag for whether the node should actively probe for
- * the USK.
+ * Client-to-node message instructing the node to subscribe to a {@link USK} and report updates.
  *
- * <p>SubscribeUSK
- * URI=USK@60I8H8HinpgZSOuTSD66AVlIFAy-xsppFr0YCzCar7c,NzdivUGCGOdlgngOGRbbKDNfSCnjI0FXjHLzJM4xkJ4,AQABAAE/index/4
- * DontPoll=true // meaning passively subscribe, don't cause the node to actively probe for it
- * Identifier=identifier End
+ * <p>This message is part of the FCP request/response flow: a client sends it to the node to
+ * register interest in a particular USK. Once accepted, the node replies with {@link
+ * SubscribedUSKMessage} and later pushes update messages whenever a newer edition of the USK
+ * becomes available. Clients can choose whether the node should actively probe for new editions or
+ * merely observe traffic. Typical usage is to subscribe once during session setup and keep the
+ * connection open to receive asynchronous notifications. The object is immutable after parsing and
+ * therefore safe to share between handler threads, while the underlying request lifecycle is
+ * managed by {@link SubscribeUSK}.
+ *
+ * <p><b>Responsibilities</b>
+ *
+ * <ul>
+ *   <li>Validate and normalize the incoming USK URI and client identifier.
+ *   <li>Record subscription flags such as polling strategy and priority settings.
+ *   <li>Initiate the backend {@link SubscribeUSK} workflow and acknowledge the client.
+ * </ul>
+ *
+ * @see SubscribeUSK
+ * @see SubscribedUSKMessage
  */
 public class SubscribeUSKMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(SubscribeUSKMessage.class);
 
+  /**
+   * Message name sent over FCP to denote a USK subscription request. Constant value is stable
+   * across releases so client implementations can rely on it when constructing field sets or
+   * parsing incoming traffic without hard-coding multiple variants.
+   */
   public static final String NAME = "SubscribeUSK";
 
   final USK key;
   final boolean dontPoll;
-  final String identifier;
+  final String clientIdentifier;
   final short prio;
   final short prioProgress;
   final boolean realTimeFlag;
   final boolean sparsePoll;
   final boolean ignoreUSKDatehints;
 
+  /**
+   * Parses a subscription request from a field set and captures all subscription options.
+   *
+   * <p>The constructor expects the caller to have already extracted the FCP message into a {@link
+   * SimpleFieldSet}. It validates the presence of the client identifier and a well-formed USK URI,
+   * derives polling preferences, and stores priority settings for the downstream request scheduler.
+   * The instance contains no mutable state after construction, so callers may reuse it across
+   * pipeline stages without additional synchronization.
+   *
+   * @param fs parsed fields from the incoming FCP message; must include URI and Identifier values
+   * @throws MessageInvalidException if mandatory fields are missing or the USK URI cannot be parsed
+   */
   public SubscribeUSKMessage(SimpleFieldSet fs) throws MessageInvalidException {
-    this.identifier = fs.get("Identifier");
-    if (identifier == null)
+    this.clientIdentifier = fs.get("Identifier");
+    if (clientIdentifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "No Identifier!", null, false);
     String suri = fs.get("URI");
     if (suri == null)
       throw new MessageInvalidException(
-          ProtocolErrorMessage.MISSING_FIELD, "Expected a URI on SubscribeUSK", identifier, false);
+          ProtocolErrorMessage.MISSING_FIELD,
+          "Expected a URI on SubscribeUSK",
+          clientIdentifier,
+          false);
     FreenetURI uri;
     try {
       uri = new FreenetURI(suri);
       key = USK.create(uri);
     } catch (MalformedURLException e) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD, "Could not parse URI: " + e, identifier, false);
+          ProtocolErrorMessage.INVALID_FIELD, "Could not parse URI: " + e, clientIdentifier, false);
     }
     this.dontPoll = fs.getBoolean("DontPoll", false);
     if (!dontPoll) this.sparsePoll = fs.getBoolean("SparsePoll", false);
@@ -60,6 +89,17 @@ public class SubscribeUSKMessage extends FCPMessage {
     ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);
   }
 
+  /**
+   * Serializes this subscription request back into an FCP field set suitable for transmission.
+   *
+   * <p>The returned {@link SimpleFieldSet} contains the normalized USK URI and the current polling
+   * directive. It intentionally omits optional fields such as priority classes because those values
+   * are applied internally by the scheduler and do not need to be echoed to the peer. Callers
+   * receive a fresh, mutable instance on every invocation; modifying it does not alter the {@link
+   * SubscribeUSKMessage} state.
+   *
+   * @return a new field set containing the USK URI and polling flag in wire format
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
@@ -68,17 +108,45 @@ public class SubscribeUSKMessage extends FCPMessage {
     return fs;
   }
 
+  /**
+   * Returns the FCP message name used to identify this command on the wire.
+   *
+   * <p>The name is constant for all instances and matches the token expected by the node-side
+   * dispatcher when routing incoming messages. It is safe to cache or compare by reference in
+   * performance-sensitive code paths because the returned string is interned by virtue of being a
+   * static constant.
+   *
+   * @return the literal message name {@code "SubscribeUSK"} used in FCP exchanges
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the subscription by wiring the parsed options into the node and acknowledging the
+   * client.
+   *
+   * <p>This method is invoked on the connection handler thread. It instantiates the backend {@link
+   * SubscribeUSK} workflow, which registers the subscription with the request starter using the
+   * specified priorities and polling hints. If another subscription with the same identifier is
+   * already active, the handler replies with {@link IdentifierCollisionMessage} and no new
+   * subscription is created. On success, a {@link SubscribedUSKMessage} is sent immediately to
+   * confirm that updates will be delivered asynchronously. The method performs no retries; callers
+   * should interpret thrown exceptions as fatal for this message instance.
+   *
+   * @param handler connection-scoped handler responsible for sending replies and managing session
+   *     state; must not be {@code null}
+   * @param node node instance that provides client core access and scheduling services; must not be
+   *     {@code null}
+   * @throws MessageInvalidException if validation fails while creating the backend subscription
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     try {
       new SubscribeUSK(this, node.getClientCore(), handler);
     } catch (IdentifierCollisionException e) {
-      handler.send(new IdentifierCollisionMessage(identifier, false));
+      handler.send(new IdentifierCollisionMessage(clientIdentifier, false));
       return;
     }
     SubscribedUSKMessage reply = new SubscribedUSKMessage(this);

--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKMessage.java
@@ -76,7 +76,7 @@ public class SubscribedUSKMessage extends FCPMessage {
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
-    sfs.putSingle("Identifier", message.identifier);
+    sfs.putSingle("Identifier", message.clientIdentifier);
     sfs.putSingle("URI", message.key.getURI().toString());
     sfs.put("DontPoll", message.dontPoll);
 

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKMessageTest.java
@@ -1,0 +1,182 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import network.crypta.client.async.USKManager;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.node.RequestStarter;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SubscribeUSKMessageTest {
+
+  private static final String VALID_USK_URI =
+      "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,"
+          + "3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
+
+  @Mock private Node node;
+  @Mock private NodeClientCore nodeClientCore;
+  @Mock private USKManager uskManager;
+  @Mock private FCPConnectionHandler handler;
+  @Mock private PersistentRequestClient rebootClient;
+  @Mock private RequestClient requestClient;
+
+  @Test
+  void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
+    SimpleFieldSet fields = new SimpleFieldSet(true);
+    fields.putSingle("URI", VALID_USK_URI);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new SubscribeUSKMessage(fields));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertNull(exception.ident);
+    assertEquals("No Identifier!", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenUriMissing_throwsMessageInvalidException() {
+    SimpleFieldSet fields = new SimpleFieldSet(true);
+    fields.putSingle("Identifier", "my-id");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new SubscribeUSKMessage(fields));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("my-id", exception.ident);
+    assertEquals("Expected a URI on SubscribeUSK", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenUriMalformed_throwsMessageInvalidException() {
+    SimpleFieldSet fields = new SimpleFieldSet(true);
+    fields.putSingle("Identifier", "bad-uri-id");
+    fields.putSingle("URI", "not-a-valid-usk");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new SubscribeUSKMessage(fields));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals("bad-uri-id", exception.ident);
+    assertTrue(exception.getMessage().contains("Could not parse URI"));
+  }
+
+  @Test
+  void constructor_whenPriorityClassMissing_usesDefaultsAndDerivedProgress() throws Exception {
+    SimpleFieldSet fields = baseFields();
+
+    SubscribeUSKMessage message = new SubscribeUSKMessage(fields);
+
+    assertEquals(RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS, message.prio);
+    assertEquals((short) 3, message.prioProgress);
+    assertFalse(message.dontPoll);
+    assertFalse(message.sparsePoll);
+    assertFalse(message.realTimeFlag);
+    assertFalse(message.ignoreUSKDatehints);
+    assertNotNull(message.key);
+  }
+
+  @Test
+  void constructor_whenDontPollTrueSparsePollIgnored_setsFlagsFromFieldSet() throws Exception {
+    SimpleFieldSet fields = baseFields();
+    fields.put("DontPoll", true);
+    fields.put("SparsePoll", true); // Should be ignored because DontPoll is true.
+    fields.putSingle("PriorityClass", Short.toString(RequestStarter.UPDATE_PRIORITY_CLASS));
+    fields.putSingle("PriorityClassProgress", "1");
+    fields.put("RealTimeFlag", true);
+    fields.put("IgnoreUSKDatehints", true);
+
+    SubscribeUSKMessage message = new SubscribeUSKMessage(fields);
+
+    assertEquals("identifier", message.clientIdentifier);
+    assertTrue(message.dontPoll);
+    assertFalse(message.sparsePoll);
+    assertEquals(RequestStarter.UPDATE_PRIORITY_CLASS, message.prio);
+    assertEquals((short) 1, message.prioProgress);
+    assertTrue(message.realTimeFlag);
+    assertTrue(message.ignoreUSKDatehints);
+  }
+
+  @Test
+  void getFieldSet_whenCalled_returnsUriAndDontPoll() throws Exception {
+    SimpleFieldSet fields = baseFields();
+    fields.put("DontPoll", true);
+    SubscribeUSKMessage message = new SubscribeUSKMessage(fields);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals(message.key.getURI().toString(), result.get("URI"));
+    assertTrue(result.getBoolean("DontPoll", false));
+    assertNull(result.get("Identifier"));
+  }
+
+  @Test
+  void run_whenSubscriptionSucceeds_sendsSubscribedUSKMessage() throws Exception {
+    wireHandlerForSuccessfulSubscribe();
+    SubscribeUSKMessage message = new SubscribeUSKMessage(baseFields());
+
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    when(nodeClientCore.getUskManager()).thenReturn(uskManager);
+    doNothing().when(uskManager).subscribe(any(), any(), anyBoolean(), anyBoolean(), any());
+
+    message.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(captor.capture());
+    FCPMessage sent = captor.getValue();
+    SubscribedUSKMessage subscribed = assertInstanceOf(SubscribedUSKMessage.class, sent);
+    assertEquals(message.clientIdentifier, subscribed.message.clientIdentifier);
+  }
+
+  @Test
+  void run_whenIdentifierCollides_sendsIdentifierCollisionMessage() throws Exception {
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    doThrow(new IdentifierCollisionException())
+        .when(handler)
+        .addUSKSubscription(any(), any(SubscribeUSK.class));
+
+    SubscribeUSKMessage message = new SubscribeUSKMessage(baseFields());
+
+    message.run(handler, node);
+
+    verify(handler).send(isA(IdentifierCollisionMessage.class));
+    verify(handler, never()).send(isA(SubscribedUSKMessage.class));
+  }
+
+  private SimpleFieldSet baseFields() {
+    SimpleFieldSet fields = new SimpleFieldSet(true);
+    fields.putSingle("Identifier", "identifier");
+    fields.putSingle("URI", VALID_USK_URI);
+    return fields;
+  }
+
+  private void wireHandlerForSuccessfulSubscribe() throws IdentifierCollisionException {
+    when(handler.getRebootClient()).thenReturn(rebootClient);
+    when(rebootClient.lowLevelClient(false)).thenReturn(requestClient);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    when(nodeClientCore.getUskManager()).thenReturn(uskManager);
+    doNothing().when(handler).addUSKSubscription(any(), any(SubscribeUSK.class));
+  }
+}


### PR DESCRIPTION
## Summary
- rename FCP subscription identifier field to `clientIdentifier` for clarity and propagate through handler callbacks
- expand SubscribeUSKMessage javadoc and validation details
- add unit coverage for SubscribeUSKMessage parsing and run behavior (happy path and error cases)

## Testing
- ./gradlew spotlessApply
- Not run: full test suite (not requested)