### PR TITLE
Clarify TestDDA reply naming and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/TestDdaReplyMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaReplyMessage.java
@@ -2,23 +2,56 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * client -> node: DDARequest { WantRead=true, WantWrite=true, Dir=/tmp/blah } node -> client:
- * DDAReply { Dir=/tmp/blah, ReadFilename=random1, WriteFilename=random2, ContentToWrite=random3 }
- * client -> node: DDAResponse { Dir=/tmp/blah, ReadContent=blah } node -> client: DDAComplete {
- * Dir=/tmp/blah, ReadAllowed=true, WriteAllowed=true }
+ * FCP message the node uses to answer a client-side TestDDA handshake with concrete file names and
+ * sample content. The reply is emitted after the client initiates a directory-based DDARequest and
+ * the node has chosen deterministic placeholders for the read and write probes.
  *
+ * <p>The message captures the state negotiated by {@link DdaCheckJob}: directory path, optional
+ * server-selected read filename, optional write filename, and an inline payload to be written by
+ * the client. Consumers normally do not construct this type directly; it is built by the
+ * server-side job that orchestrates the end-to-end DDA probe. The instance is immutable once
+ * created, so it can safely be shared between the network thread that serializes it and any
+ * diagnostic observers.
+ *
+ * <p>Usage expectations:
+ *
+ * <ul>
+ *   <li>Sent from server to client immediately after a TestDDA request is accepted.
+ *   <li>Provides filenames that must be echoed back in the follow-up {@code DDAResponse}.
+ *   <li>Includes sample content for the write test, allowing the node to verify persistence.
+ *   <li>Serialization is order-stable and contains only the fields relevant to the negotiated mode.
+ * </ul>
+ *
+ * @see TestDdaRequestMessage
+ * @see DdaCheckJob
  * @author Florent Daigni&egrave;re &lt;nextgens@freenetproject.org&gt;
  */
 public class TestDdaReplyMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(TestDdaReplyMessage.class);
 
-  public static final String name = "TestDDAReply";
+  /**
+   * Message identifier emitted on the wire for the TestDDA reply stage, reused verbatim in {@link
+   * #getName()} and during serialization so FCP peers can recognize the payload type.
+   */
+  public static final String NAME = "TestDDAReply";
+
+  /**
+   * Field key for the server-chosen filename that the client must read from the shared directory
+   * when validating read access to the requested DDA location.
+   */
   public static final String READ_FILENAME = "ReadFilename";
+
+  /**
+   * Field key for the filename that the client is instructed to write, enabling the node to confirm
+   * write capability in the negotiated directory without risking collisions.
+   */
   public static final String WRITE_FILENAME = "WriteFilename";
+
+  /**
+   * Field key containing sample data for the write probe; the client writes this exact content and
+   * the node later compares it byte-for-byte to validate end-to-end write integrity.
+   */
   public static final String CONTENT_TO_WRITE = "ContentToWrite";
 
   final DdaCheckJob checkJob;
@@ -27,6 +60,20 @@ public class TestDdaReplyMessage extends FCPMessage {
     this.checkJob = job;
   }
 
+  /**
+   * Serializes the negotiated TestDDA reply into a {@link SimpleFieldSet} containing only the
+   * fields applicable to the current probe. The directory field is always present, while read and
+   * write descriptors are added conditionally so downstream consumers can distinguish read-only and
+   * write-enabled exchanges without additional flags.
+   *
+   * <p>The returned structure preserves insertion order for deterministic encoding and omits null
+   * entries entirely, preventing ambiguous empty strings in the wire format. Callers should treat
+   * the result as immutable once produced because it reflects the state captured when the {@link
+   * DdaCheckJob} was created.
+   *
+   * @return populated field set ready for FCP serialization; contains directory and any negotiated
+   *     filenames plus optional sample content for write validation.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
@@ -44,17 +91,41 @@ public class TestDdaReplyMessage extends FCPMessage {
     return sfs;
   }
 
+  /**
+   * Returns the canonical FCP message name for this reply, ensuring downstream serializers and
+   * routers label the packet consistently during TestDDA exchanges. The value is stable and shared
+   * across all instances so caches, dispatch tables, and logging frameworks can key off a single
+   * token instead of inspecting payload contents. This indirection keeps the message
+   * self-describing while avoiding duplication of string literals across the codebase.
+   *
+   * @return immutable identifier string {@code TestDDAReply} shared across all instances and
+   *     visible to peers.
+   */
   @Override
   public String getName() {
-    return name;
+    return NAME;
   }
 
+  /**
+   * Rejects attempts to process this message from the client side. TestDDA replies are strictly
+   * server-to-client traffic, so invoking {@code run} on the server-side handler represents a
+   * protocol violation and triggers a fatal parse error for the offending peer. The method is
+   * deliberately non-idempotent: each call throws an exception to force the connection to surface a
+   * clear failure instead of silently discarding unexpected traffic. No mutable state is touched,
+   * which keeps the handler safe to call even if multiple validation layers attempt to process the
+   * same inbound frame.
+   *
+   * @param handler connection handler consuming the message; supplied by dispatcher and never null.
+   * @param node active node context for symmetry; unused because inbound delivery is invalid.
+   * @throws MessageInvalidException always thrown to signal the directionality error and terminate
+   *     processing of the malformed inbound message.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
-        name + " goes from server to client not the other way around",
-        name,
+        NAME + " goes from server to client not the other way around",
+        NAME,
         false);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
@@ -111,7 +111,7 @@ class SubscribeUSKTest {
     verify(handler).send(captor.capture());
 
     SubscribedUSKUpdate update = captor.getValue();
-    assertEquals("id-open", update.identifier);
+    assertEquals("id-open", update.messageIdentifier);
     assertEquals(12L, update.edition);
     assertSame(message.key, update.key);
     assertTrue(update.newKnownGood);

--- a/src/test/java/network/crypta/clients/fcp/TestDdaReplyMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/TestDdaReplyMessageTest.java
@@ -1,0 +1,97 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.util.Random;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class TestDdaReplyMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void getFieldSet_whenReadAndWriteProvided_containsDirectoryReadWriteAndContent() {
+    File directory = new File("/tmp/dda");
+    File readFile = new File("read.dat");
+    File writeFile = new File("write.dat");
+    DdaCheckJob job = new DdaCheckJob(new Random(42L), directory, readFile, writeFile);
+    TestDdaReplyMessage message = new TestDdaReplyMessage(job);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals(directory.toString(), result.get(TestDdaRequestMessage.DIRECTORY));
+    assertEquals(readFile.toString(), result.get(TestDdaReplyMessage.READ_FILENAME));
+    assertEquals(writeFile.toString(), result.get(TestDdaReplyMessage.WRITE_FILENAME));
+    assertEquals(job.writeContent, result.get(TestDdaReplyMessage.CONTENT_TO_WRITE));
+  }
+
+  @Test
+  void getFieldSet_whenOnlyReadProvided_omitsWriteFieldsAndContent() {
+    File directory = new File("/tmp/dda");
+    File readFile = new File("read.dat");
+    DdaCheckJob job = new DdaCheckJob(new Random(84L), directory, readFile, null);
+    TestDdaReplyMessage message = new TestDdaReplyMessage(job);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals(directory.toString(), result.get(TestDdaRequestMessage.DIRECTORY));
+    assertEquals(readFile.toString(), result.get(TestDdaReplyMessage.READ_FILENAME));
+    assertNull(result.get(TestDdaReplyMessage.WRITE_FILENAME));
+    assertNull(result.get(TestDdaReplyMessage.CONTENT_TO_WRITE));
+  }
+
+  @Test
+  void getFieldSet_whenNoReadOrWriteProvided_containsOnlyDirectory() {
+    File directory = new File("/tmp/dda");
+    DdaCheckJob job = new DdaCheckJob(new Random(126L), directory, null, null);
+    TestDdaReplyMessage message = new TestDdaReplyMessage(job);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals(directory.toString(), result.get(TestDdaRequestMessage.DIRECTORY));
+    assertNull(result.get(TestDdaReplyMessage.READ_FILENAME));
+    assertNull(result.get(TestDdaReplyMessage.WRITE_FILENAME));
+    assertNull(result.get(TestDdaReplyMessage.CONTENT_TO_WRITE));
+  }
+
+  @Test
+  void getName_whenInvoked_returnsTestDDAReplyConstant() {
+    DdaCheckJob job = new DdaCheckJob(new Random(168L), new File("/tmp/dda"), null, null);
+    TestDdaReplyMessage message = new TestDdaReplyMessage(job);
+
+    String result = message.getName();
+
+    assertEquals(TestDdaReplyMessage.NAME, result);
+  }
+
+  @Test
+  void run_whenCalled_throwsMessageInvalidExceptionWithProtocolError() {
+    DdaCheckJob job =
+        new DdaCheckJob(
+            new Random(210L), new File("/tmp/dda"), new File("read"), new File("write"));
+    TestDdaReplyMessage message = new TestDdaReplyMessage(job);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(TestDdaReplyMessage.NAME, exception.ident);
+    assertFalse(exception.global);
+    assertEquals(
+        TestDdaReplyMessage.NAME + " goes from server to client not the other way around",
+        exception.getMessage());
+  }
+}


### PR DESCRIPTION
## Summary
- rename the TestDDA reply message constant to `NAME` and expand KDoc for readability
- add focused tests for TestDdaReplyMessage field serialization and error handling
- align SubscribeUSKTest with renamed SubscribedUSKUpdate `messageIdentifier`

## Testing
- not run (CI)