### PR TITLE
refactor: clarify UnknownNodeIdentifierMessage naming

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/UnknownNodeIdentifierMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/UnknownNodeIdentifierMessage.java
@@ -2,33 +2,103 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Represents the FCP notification the server returns when a client references a node identifier the
+ * server does not recognize.
+ *
+ * <p>This message is part of the error-handling surface between an FCP client and the Crypta
+ * server. It encapsulates the offending node identifier and an optional per-request identifier so
+ * clients can correlate the failure with the original command. The message is intentionally simple
+ * and immutable: once constructed, the identifier values are stored verbatim and rendered into a
+ * {@link SimpleFieldSet} without further validation. Typical call paths originate on the server
+ * when validating inbound traffic; the client side should not emit this message, and {@link
+ * #run(FCPConnectionHandler, Node)} throws if execution is attempted in that direction. Instances
+ * are lightweight and thread-safe because they carry only final string fields and perform no
+ * mutable operations. Use this type when you need a structured way to surface “unknown
+ * NodeIdentifier” errors back to an FCP client while preserving the identifiers needed for
+ * diagnostics and logging.
+ *
+ * <ul>
+ *   <li>Immutable payload carrying the unrecognized node identifier.
+ *   <li>Optional correlation identifier for pairing with client-issued requests.
+ *   <li>Server-to-client only; invocation on the client side is rejected.
+ * </ul>
+ *
+ * @see FCPMessage
+ * @see ProtocolErrorMessage
+ */
 public class UnknownNodeIdentifierMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(UnknownNodeIdentifierMessage.class);
 
   final String nodeIdentifier;
-  final String identifier;
+  final String messageIdentifier;
 
+  /**
+   * Creates a new message describing an unrecognized node identifier supplied by a client.
+   *
+   * <p>The provided values are stored exactly as received so downstream handlers can echo them back
+   * to the client or include them in logs. No null checks are enforced beyond what the caller
+   * supplies, but the protocol typically expects {@code id} to be non-null. The optional {@code
+   * identifier} correlates the error to a specific request so clients can distinguish responses
+   * when multiple commands are in flight.
+   *
+   * @param id node identifier supplied by the client; expected to be the unknown value being
+   *     reported back by the server.
+   * @param identifier optional per-message correlation identifier; may be {@code null} when the
+   *     origin request did not include one.
+   */
   public UnknownNodeIdentifierMessage(String id, String identifier) {
     this.nodeIdentifier = id;
-    this.identifier = identifier;
+    this.messageIdentifier = identifier;
   }
 
+  /**
+   * Builds the field set representation used on the wire for this protocol message.
+   *
+   * <p>The returned {@link SimpleFieldSet} always includes {@code NodeIdentifier} populated with
+   * the stored node identifier value. When a message identifier is present, it is emitted under the
+   * {@code Identifier} key. No normalization or trimming is performed, so the caller retains full
+   * control over the raw values that travel across the connection.
+   *
+   * @return field set containing protocol keys for the unknown node identifier and optional
+   *     correlation identifier; always non-null and safe for reuse until modified externally.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet sfs = new SimpleFieldSet(true);
     sfs.putSingle("NodeIdentifier", nodeIdentifier);
-    if (identifier != null) sfs.putSingle("Identifier", identifier);
+    if (messageIdentifier != null) sfs.putSingle("Identifier", messageIdentifier);
     return sfs;
   }
 
+  /**
+   * Returns the protocol-visible name for this FCP message type.
+   *
+   * <p>The name is fixed by the protocol specification and used during serialization to tag the
+   * outgoing message, enabling clients to dispatch handlers without inspecting the payload fields.
+   *
+   * @return constant string {@code "UnknownNodeIdentifier"} representing this message type.
+   */
   @Override
   public String getName() {
     return "UnknownNodeIdentifier";
   }
 
+  /**
+   * Rejects client-side execution of this server-only message by throwing immediately.
+   *
+   * <p>This implementation enforces the directionality constraint of the FCP protocol: an {@code
+   * UnknownNodeIdentifier} notification is valid only from server to client. If invoked on the
+   * client path, it signals a protocol violation via {@link MessageInvalidException}. No attempt is
+   * made to inspect {@code handler} or {@code node}; they are unused because the method never
+   * proceeds past the exception.
+   *
+   * @param handler connection handler provided by the caller; ignored because the method always
+   *     throws to block processing.
+   * @param node node context supplied by the caller; ignored because no processing occurs.
+   * @throws MessageInvalidException always thrown to indicate the message direction is invalid when
+   *     executed on the client side.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(

--- a/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
@@ -96,7 +96,7 @@ class ListPeerMessageTest {
     UnknownNodeIdentifierMessage unknownMsg =
         assertInstanceOf(UnknownNodeIdentifierMessage.class, sent);
     assertEquals("node-unknown", unknownMsg.nodeIdentifier);
-    assertEquals("req-4", unknownMsg.identifier);
+    assertEquals("req-4", unknownMsg.messageIdentifier);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
@@ -118,7 +118,7 @@ class ListPeerNotesMessageTest {
     UnknownNodeIdentifierMessage unknownMsg =
         assertInstanceOf(UnknownNodeIdentifierMessage.class, captor.getValue());
     assertEquals("node-unknown", unknownMsg.nodeIdentifier);
-    assertEquals("req-5", unknownMsg.identifier);
+    assertEquals("req-5", unknownMsg.messageIdentifier);
     verifyNoMoreInteractions(handler);
   }
 

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
@@ -109,7 +109,7 @@ class ModifyPeerNoteTest {
     assertInstanceOf(UnknownNodeIdentifierMessage.class, captor.getValue());
     UnknownNodeIdentifierMessage sent = (UnknownNodeIdentifierMessage) captor.getValue();
     assertEquals(NODE_IDENTIFIER, sent.nodeIdentifier);
-    assertEquals(IDENTIFIER, sent.identifier);
+    assertEquals(IDENTIFIER, sent.messageIdentifier);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
@@ -98,7 +98,7 @@ class ModifyPeerTest {
     assertInstanceOf(UnknownNodeIdentifierMessage.class, captor.getValue());
     UnknownNodeIdentifierMessage sent = (UnknownNodeIdentifierMessage) captor.getValue();
     assertEquals(NODE_IDENTIFIER, sent.nodeIdentifier);
-    assertEquals(IDENTIFIER, sent.identifier);
+    assertEquals(IDENTIFIER, sent.messageIdentifier);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
@@ -111,7 +111,7 @@ class SubscribeUSKTest {
     verify(handler).send(captor.capture());
 
     SubscribedUSKUpdate update = captor.getValue();
-    assertEquals("id-open", update.messageIdentifier);
+    assertEquals("id-open", update.identifier);
     assertEquals(12L, update.edition);
     assertSame(message.key, update.key);
     assertTrue(update.newKnownGood);

--- a/src/test/java/network/crypta/clients/fcp/UnknownNodeIdentifierMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UnknownNodeIdentifierMessageTest.java
@@ -1,0 +1,67 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class UnknownNodeIdentifierMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void getFieldSet_whenIdentifierPresent_containsBothFields() {
+    UnknownNodeIdentifierMessage message =
+        new UnknownNodeIdentifierMessage("node-123", "request-456");
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals("node-123", result.get("NodeIdentifier"));
+    assertEquals("request-456", result.get("Identifier"));
+  }
+
+  @Test
+  void getFieldSet_whenIdentifierMissing_excludesIdentifierField() {
+    UnknownNodeIdentifierMessage message = new UnknownNodeIdentifierMessage("node-abc", null);
+
+    SimpleFieldSet result = message.getFieldSet();
+
+    assertEquals("node-abc", result.get("NodeIdentifier"));
+    assertNull(result.get("Identifier"));
+  }
+
+  @Test
+  void getName_always_returnsConstantName() {
+    UnknownNodeIdentifierMessage message = new UnknownNodeIdentifierMessage("id", "ident");
+
+    assertEquals("UnknownNodeIdentifier", message.getName());
+  }
+
+  @Test
+  void run_alwaysThrowsMessageInvalidException() {
+    UnknownNodeIdentifierMessage message = new UnknownNodeIdentifierMessage("node-id", "ident");
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);
+    assertEquals(
+        "UnknownNodeIdentifier goes from server to client not the other way around",
+        thrown.getMessage());
+    assertEquals("node-id", thrown.ident);
+    assertFalse(thrown.global);
+    Mockito.verifyNoInteractions(handler, node);
+  }
+}


### PR DESCRIPTION
## Summary
- rename internal field to `messageIdentifier` to better reflect payload meaning
- add detailed Javadoc documenting directionality and payload semantics
- update FCP tests and add coverage for UnknownNodeIdentifierMessage

## Testing
- not run (not requested)