### PR TITLE
Clarify DDA response handling

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/TestDdaResponseMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaResponseMessage.java
@@ -2,32 +2,69 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * client -> node: DDARequest { WantRead=true, WantWrite=true, Dir=/tmp/blah } node -> client:
- * DDAReply { Dir=/tmp/blah, ReadFilename=random1, WriteFilename=random2, ContentToWrite=random3 }
- * client -> node: DDAResponse { Dir=/tmp/blah, ReadContent=blah } node -> client: DDAComplete {
- * Dir=/tmp/blah, ReadAllowed=true, WriteAllowed=true }
+ * Handles the client-to-node {@code TestDDAResponse} FCP message that finalizes a temporary
+ * direct-disk-access (DDA) capability check.
+ *
+ * <p>This message participates in a probe that verifies whether the client can read or write within
+ * a node-provided directory. Typical flow:
+ *
+ * <ul>
+ *   <li>Client sends {@link TestDdaRequestMessage} with desired permissions and a directory hint.
+ *   <li>Node replies with file names and optional content to write.
+ *   <li>Client responds with this message containing the directory and any data read back.
+ *   <li>Node returns {@link TestDdaCompleteMessage} summarizing what succeeded.
+ * </ul>
+ *
+ * <p>The class performs minimal validation of the supplied directory and read payload before
+ * delegating to the handler. It remains immutable after construction, carries only the request
+ * parameters, and typically runs on the connection handler thread. Use it to drive DDA diagnostics
+ * or integration tests verifying directory access without mutating node state.
  *
  * @author Florent Daigni&egrave;re &lt;nextgens@freenetproject.org&gt;
+ * @see TestDdaRequestMessage
+ * @see TestDdaCompleteMessage
  */
 public class TestDdaResponseMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(TestDdaResponseMessage.class);
 
+  /**
+   * Protocol identifier that labels this message on the wire and inside routing tables. Immutable
+   * and shared across all instances, it should match the {@code Name} field observed in FCP
+   * exchanges initiated by clients performing DDA tests.
+   */
   public static final String NAME = "TestDDAResponse";
+
+  /**
+   * Field name carrying the data read from the temporary file created by the node during the DDA
+   * probe. The value is expected to mirror the content the node placed in the file when {@link
+   * TestDdaRequestMessage#WANT_READ} was set, allowing the node to confirm read access.
+   */
   public static final String READ_CONTENT = "ReadContent";
 
-  final String identifier;
+  final String directory;
   final String readContent;
 
+  /**
+   * Creates the response from an incoming field set provided by the client-side parser.
+   *
+   * <p>The constructor performs structural validation: it requires a non-empty directory path and
+   * optionally accepts the payload read from the node-provided test file. It does not touch the
+   * filesystem and leaves permission evaluation to {@link #run(FCPConnectionHandler, Node)}. The
+   * instance is fully initialized after construction and can be executed immediately or queued for
+   * later handling.
+   *
+   * @param sfs parsed fields from the FCP layer, expected to contain directory and optional read
+   *     content values; must not be {@code null}.
+   * @throws MessageInvalidException if required fields are missing or the directory field is an
+   *     empty string after parsing.
+   */
   public TestDdaResponseMessage(SimpleFieldSet sfs) throws MessageInvalidException {
-    identifier = sfs.get(TestDdaRequestMessage.DIRECTORY);
-    if (identifier == null)
+    directory = sfs.get(TestDdaRequestMessage.DIRECTORY);
+    if (directory == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "No Directory given!", null, false);
-    if (identifier.isEmpty())
+    if (directory.isEmpty())
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD,
           "The specified Directory can't be empty!",
@@ -37,30 +74,60 @@ public class TestDdaResponseMessage extends FCPMessage {
     readContent = sfs.get(READ_CONTENT);
   }
 
+  /**
+   * Returns the field set representation for outbound use.
+   *
+   * <p>This message is only accepted inbound during testing flows, so the outbound rendering is
+   * intentionally not implemented and returns {@code null}. Callers should not attempt to resend or
+   * serialize this instance directly.
+   *
+   * @return always {@code null} because this message is not serialized for outbound transport.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     return null;
   }
 
+  /**
+   * Reports the protocol name used to identify this message type.
+   *
+   * @return constant value {@link #NAME}, suitable for routing through the FCP dispatcher.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes validation of the test response and triggers completion reporting to the client.
+   *
+   * <p>The handler is asked to look up the pending {@link DdaCheckJob} using the directory token
+   * supplied at construction time. Missing or mismatched jobs raise a protocol error. When a read
+   * was requested, the caller must have supplied {@link #READ_CONTENT}; otherwise a missing-field
+   * error is surfaced. On success a {@link TestDdaCompleteMessage} is assembled and sent back to
+   * the client to convey which operations were allowed.
+   *
+   * @param handler active connection handler coordinating DDA checks for this client; must not be
+   *     {@code null} and must have a pending check entry for the directory.
+   * @param node current node instance; present for interface symmetry but unused directly in this
+   *     implementation.
+   * @throws MessageInvalidException if the directory is unknown, required content is absent, or the
+   *     handler rejects the lookup parameters.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     DdaCheckJob job;
     try {
-      job = handler.popDDACheck(identifier);
+      job = handler.popDDACheck(directory);
     } catch (IllegalArgumentException e) {
       throw new MessageInvalidException(
-          ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), identifier, false);
+          ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), directory, false);
     }
     if (job == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.INVALID_MESSAGE,
-          "The node doesn't know that testDDA identifier! double check it! (" + identifier + ").",
-          identifier,
+          "The node doesn't know that testDDA identifier! double check it! (" + directory + ").",
+          directory,
           false);
     else if ((job.readFilename != null) && (readContent == null))
       throw new MessageInvalidException(
@@ -72,7 +139,7 @@ public class TestDdaResponseMessage extends FCPMessage {
               + " in "
               + TestDdaRequestMessage.NAME
               + '.',
-          identifier,
+          directory,
           false);
 
     TestDdaCompleteMessage reply = new TestDdaCompleteMessage(handler, job, readContent);

--- a/src/test/java/network/crypta/clients/fcp/TestDdaResponseMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/TestDdaResponseMessageTest.java
@@ -1,0 +1,124 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Random;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class TestDdaResponseMessageTest {
+
+  private static final String DIRECTORY = "/tmp/dir";
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void constructor_whenDirectoryMissing_throwsMessageInvalidException() {
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new TestDdaResponseMessage(sfs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("No Directory given!", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenDirectoryEmpty_throwsMessageInvalidException() {
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle(TestDdaRequestMessage.DIRECTORY, "");
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new TestDdaResponseMessage(sfs));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertEquals("The specified Directory can't be empty!", exception.getMessage());
+  }
+
+  @Test
+  void run_whenHandlerThrowsIllegalArgument_wrapsInMessageInvalidException() throws Exception {
+    SimpleFieldSet sfs = createFieldSet(null);
+    TestDdaResponseMessage message = new TestDdaResponseMessage(sfs);
+    when(handler.popDDACheck(DIRECTORY))
+        .thenThrow(new IllegalArgumentException("unsupported directory"));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals("unsupported directory", exception.getMessage());
+    assertEquals(DIRECTORY, exception.ident);
+  }
+
+  @Test
+  void run_whenJobUnknown_throwsInvalidMessage() throws Exception {
+    SimpleFieldSet sfs = createFieldSet(null);
+    TestDdaResponseMessage message = new TestDdaResponseMessage(sfs);
+    when(handler.popDDACheck(DIRECTORY)).thenReturn(null);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertTrue(exception.getMessage().contains(DIRECTORY));
+  }
+
+  @Test
+  void run_whenReadRequestedButNoContent_throwsMissingField() throws Exception {
+    SimpleFieldSet sfs = createFieldSet(null);
+    TestDdaResponseMessage message = new TestDdaResponseMessage(sfs);
+    DdaCheckJob job =
+        new DdaCheckJob(new Random(0), new File(DIRECTORY), new File(DIRECTORY + "/read"), null);
+    when(handler.popDDACheck(DIRECTORY)).thenReturn(job);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
+    assertTrue(exception.getMessage().contains(TestDdaResponseMessage.READ_CONTENT));
+  }
+
+  @Test
+  void run_whenJobPresent_sendsCompleteMessage() throws Exception {
+    DdaCheckJob job =
+        new DdaCheckJob(new Random(1), new File(DIRECTORY), new File(DIRECTORY + "/read"), null);
+    SimpleFieldSet sfs = createFieldSet(job.readContent);
+    TestDdaResponseMessage message = new TestDdaResponseMessage(sfs);
+    when(handler.popDDACheck(DIRECTORY)).thenReturn(job);
+    ArgumentCaptor<TestDdaCompleteMessage> captor =
+        ArgumentCaptor.forClass(TestDdaCompleteMessage.class);
+
+    message.run(handler, node);
+
+    verify(handler, times(1)).popDDACheck(DIRECTORY);
+    verify(handler).send(captor.capture());
+
+    TestDdaCompleteMessage completeMessage = captor.getValue();
+    assertEquals(job, completeMessage.checkJob);
+    assertEquals(job.readContent, completeMessage.readContentFromClient);
+  }
+
+  private static SimpleFieldSet createFieldSet(String readContent) {
+    SimpleFieldSet sfs = new SimpleFieldSet(true);
+    sfs.putSingle(TestDdaRequestMessage.DIRECTORY, DIRECTORY);
+    if (readContent != null) {
+      sfs.putSingle(TestDdaResponseMessage.READ_CONTENT, readContent);
+    }
+    return sfs;
+  }
+}


### PR DESCRIPTION
## Summary
- strengthen TestDDAResponse validation messages and field naming
- document DDA response flow and responsibilities
- add unit coverage for DDA response error paths and success

## Testing
- not run (not requested)
