### PR TITLE
Improve URIGeneratedMessage docs and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/URIGeneratedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/URIGeneratedMessage.java
@@ -3,42 +3,90 @@ package network.crypta.clients.fcp;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * Message emitted by the node when a {@link FreenetURI} has been produced for a request that
+ * previously supplied an identifier. The message carries the freshly generated URI along with the
+ * client-provided identifier so receivers can correlate responses to their outstanding operations.
+ *
+ * <p>Typical use cases include responding to insert or key-generation requests where the caller did
+ * not know the final URI ahead of time. The message is immutable and only exposes read-only state;
+ * instances can therefore be safely shared between threads, but they are generally short-lived and
+ * serialized immediately to the wire via {@link #getFieldSet()}.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Expose the generated URI and identifier in the FCP wire format.
+ *   <li>Advertise the standard message name {@code URIGenerated} to the protocol layer.
+ *   <li>Guard against incorrect client-to-server usage by rejecting {@link
+ *       #run(FCPConnectionHandler, Node)} calls.
+ * </ul>
+ *
+ * Concurrency: the object is immutable once constructed. Protocol handlers may reuse it across
+ * threads, but outbound serialization should occur promptly to avoid holding stale references to
+ * completed operations.
+ */
 public class URIGeneratedMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(URIGeneratedMessage.class);
 
   private final FreenetURI uri;
-  private final String identifier;
+  private final String messageIdentifier;
   private final boolean global;
 
+  /**
+   * Builds a message that pairs a generated {@link FreenetURI} with the client-supplied identifier
+   * that initiated the generation request.
+   *
+   * @param uri concrete {@link FreenetURI} produced by the node; must not be {@code null}.
+   * @param identifier correlation token from requester; empty values allowed for response matching.
+   * @param global flags identifier as connection-global or confined to single request.
+   */
   public URIGeneratedMessage(FreenetURI uri, String identifier, boolean global) {
     this.uri = uri;
-    this.identifier = identifier;
+    this.messageIdentifier = identifier;
     this.global = global;
   }
 
+  /**
+   * Serializes this message into a {@link SimpleFieldSet} suitable for transmission over the FCP
+   * wire protocol, including {@code URI}, {@code Identifier}, and {@code Global} entries.
+   *
+   * @return immutable snapshot of the message fields encoded for FCP serialization.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle("URI", uri.toString());
-    fs.putSingle("Identifier", identifier);
+    fs.putSingle("Identifier", messageIdentifier);
     fs.put("Global", global);
     return fs;
   }
 
+  /**
+   * Provides the canonical FCP message name associated with URI generation responses.
+   *
+   * @return constant string {@code "URIGenerated"} recognized by FCP peers.
+   */
   @Override
   public String getName() {
     return "URIGenerated";
   }
 
+  /**
+   * Rejects inbound handling of this message from clients, enforcing its server-to-client direction
+   * in the FCP protocol.
+   *
+   * @param handler active connection handler attempting to process the message.
+   * @param node reference to the local node instance; unused because execution always fails.
+   * @throws MessageInvalidException always thrown to indicate incorrect message direction on the
+   *     wire.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "URIGenerated goes from server to client not the other way around",
-        identifier,
+        messageIdentifier,
         false);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/URIGeneratedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/URIGeneratedMessageTest.java
@@ -1,0 +1,89 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.net.MalformedURLException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100") // Test method naming: method_whenCondition_expectOutcome
+@ExtendWith(MockitoExtension.class)
+class URIGeneratedMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private Node node;
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void getFieldSet_whenConstructedWithValues_containsUriIdentifierAndGlobalFlag(boolean global)
+      throws MalformedURLException {
+    // Arrange
+    FreenetURI uri = new FreenetURI("KSK@some-doc");
+    String identifier = "id-123";
+    URIGeneratedMessage message = new URIGeneratedMessage(uri, identifier, global);
+
+    // Act
+    SimpleFieldSet fieldSet = message.getFieldSet();
+
+    // Assert
+    assertEquals(uri.toString(), fieldSet.get("URI"));
+    assertEquals(identifier, fieldSet.get("Identifier"));
+    assertEquals(Boolean.toString(global), fieldSet.get("Global"));
+    assertEquals(Set.of("URI", "Identifier", "Global"), toKeySet(fieldSet));
+  }
+
+  @Test
+  void getName_whenCalled_returnsURIGeneratedLiteral() throws MalformedURLException {
+    // Arrange
+    URIGeneratedMessage message =
+        new URIGeneratedMessage(new FreenetURI("KSK@another"), "name-test", false);
+
+    // Act
+    String result = message.getName();
+
+    // Assert
+    assertEquals("URIGenerated", result);
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidExceptionWithProtocolDetails()
+      throws MalformedURLException {
+    // Arrange
+    String identifier = "client-identifier";
+    URIGeneratedMessage message =
+        new URIGeneratedMessage(new FreenetURI("KSK@run-check"), identifier, true);
+
+    // Act + Assert
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
+    assertEquals(
+        "URIGenerated goes from server to client not the other way around", exception.getMessage());
+    assertEquals(identifier, exception.ident);
+    assertFalse(exception.global);
+    verifyNoInteractions(handler, node);
+  }
+
+  private Set<String> toKeySet(SimpleFieldSet fieldSet) {
+    Set<String> keys = new HashSet<>();
+    Iterator<String> iterator = fieldSet.toplevelKeyIterator();
+    while (iterator.hasNext()) {
+      keys.add(iterator.next());
+    }
+    return keys;
+  }
+}


### PR DESCRIPTION
## Summary
- clarify URIGeneratedMessage by renaming the identifier field and documenting its server-to-client role
- add unit tests validating field set serialization, message name, and rejection of inbound handling

## Testing
- not run (tests not requested)