### PR TITLE
Add coverage for UnsubscribeUSKMessage handling

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/UnsubscribeUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/UnsubscribeUSKMessage.java
@@ -2,34 +2,108 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * FCP message instructing the node to stop sending updates for a previously subscribed USK.
+ *
+ * <p>This inbound-only message is emitted by a client after it no longer wishes to receive
+ * notifications for a {@code SubscribeUSK} request. The message body carries only the stable
+ * subscription identifier so the server can cancel the corresponding watcher and release any
+ * resources associated with queued updates. Typical usage pairs the identifier supplied in {@link
+ * SubscribeUSKMessage} with this class and is handled synchronously by the {@link
+ * FCPConnectionHandler} that accepted the original subscription.
+ *
+ * <p>Instances are immutable and represent a single unsubscribe request. The lifecycle is short:
+ * the message is parsed from the incoming field set, validated for the presence of the identifier,
+ * and then executed once via {@link #run(FCPConnectionHandler, Node)}. Thread-safety is provided by
+ * the caller; this class maintains no shared state. Use this type when tearing down long-lived USK
+ * feeds to avoid unnecessary bandwidth and server-side cache usage.
+ *
+ * <ul>
+ *   <li>Responsibility: convey which subscription to cancel.
+ *   <li>Notable behavior: rejects requests missing the {@code Identifier} field.
+ *   <li>Serialization: not emitted to peers; {@link #getFieldSet()} is unsupported.
+ * </ul>
+ *
+ * @see SubscribeUSKMessage
+ * @see FCPConnectionHandler#unsubscribeUSK(String)
+ */
 public class UnsubscribeUSKMessage extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(UnsubscribeUSKMessage.class);
 
+  /** Canonical message name advertised to FCP handlers for unsubscribe operations. */
   public static final String NAME = "UnsubscribeUSK";
-  private final String identifier;
 
+  private final String subscriptionIdentifier;
+
+  /**
+   * Constructs an unsubscribe request from a parsed field set and validates required data.
+   *
+   * <p>The constructor reads the {@code Identifier} field supplied by the client. If the field is
+   * missing or empty, it raises a {@link MessageInvalidException} to signal malformed input to the
+   * caller. Successful construction guarantees that {@link #run(FCPConnectionHandler, Node)} can
+   * reference a non-null identifier when delegating to the connection handler.
+   *
+   * @param fs parsed fields for this message; must contain an Identifier entry.
+   * @throws MessageInvalidException if Identifier is absent or empty in the provided field set.
+   */
   public UnsubscribeUSKMessage(SimpleFieldSet fs) throws MessageInvalidException {
-    this.identifier = fs.get("Identifier");
-    if (identifier == null)
+    this.subscriptionIdentifier = fs.get(IDENTIFIER);
+    if (subscriptionIdentifier == null)
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "No Identifier!", null, false);
   }
 
+  /**
+   * Unsupported because inbound-only messages are not serialized back onto the wire.
+   *
+   * <p>Unsubscribe requests originate from the client and are never forwarded or echoed by the
+   * node. As such, serialization through a {@link SimpleFieldSet} is intentionally unavailable.
+   * Callers should rely on the original decoded representation rather than attempting to
+   * reconstruct one.
+   *
+   * @return never returns because this inbound-only message is not serialized outward.
+   * @throws UnsupportedOperationException always thrown because this message is not serialized
+   *     outbound.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Returns the fixed FCP message name used to register unsubscribe handlers.
+   *
+   * <p>The name is stable and shared across all instances so dispatchers can route incoming field
+   * sets without inspecting their contents. Because the value is constant, callers may safely cache
+   * it and compare by identity or equality when mapping handlers. The returned string must not be
+   * mutated or localized; it is part of the protocol surface.
+   *
+   * @return constant message name advertised to peers and protocol handlers.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Executes the unsubscribe operation against the connection handler using the stored identifier.
+   *
+   * <p>The method delegates directly to {@link FCPConnectionHandler#unsubscribeUSK(String)} with
+   * the validated subscription identifier extracted during construction. It completes
+   * synchronously; any removal errors propagate as {@link MessageInvalidException} according to the
+   * handler’s policy. Callers should ensure the handler instance matches the session that produced
+   * the subscription to avoid orphaned watchers or missed cancellations. No state is retained after
+   * invocation, making repeated calls idempotent only if the handler itself treats unknown
+   * identifiers as no-ops.
+   *
+   * @param handler connection-scoped dispatcher that tracks USK subscriptions for this client.
+   * @param node node instance receiving the command; not used directly but provided for parity with
+   *     other message handlers.
+   * @throws MessageInvalidException if the handler rejects the identifier or cannot remove the
+   *     subscription.
+   */
   @Override
   public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    handler.unsubscribeUSK(identifier);
+    handler.unsubscribeUSK(subscriptionIdentifier);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/UnsubscribeUSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UnsubscribeUSKMessageTest.java
@@ -1,0 +1,91 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import network.crypta.node.Node;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class UnsubscribeUSKMessageTest {
+
+  @Mock private FCPConnectionHandler handler;
+
+  @Mock private Node node;
+
+  @Test
+  void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
+    // Arrange
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+
+    // Act
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> new UnsubscribeUSKMessage(fieldSet));
+
+    // Assert
+    assertEquals(ProtocolErrorMessage.MISSING_FIELD, thrown.protocolCode);
+    assertEquals("No Identifier!", thrown.getMessage());
+    assertNull(thrown.ident);
+  }
+
+  @Test
+  void getName_whenInvoked_returnsConstantName() throws MessageInvalidException {
+    // Arrange
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", "id-123");
+    UnsubscribeUSKMessage message = new UnsubscribeUSKMessage(fieldSet);
+
+    // Act & Assert
+    assertEquals(UnsubscribeUSKMessage.NAME, message.getName());
+  }
+
+  @Test
+  void getFieldSet_whenCalled_throwsUnsupportedOperationException() throws MessageInvalidException {
+    // Arrange
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", "id-123");
+    UnsubscribeUSKMessage message = new UnsubscribeUSKMessage(fieldSet);
+
+    // Act & Assert
+    assertThrows(UnsupportedOperationException.class, message::getFieldSet);
+  }
+
+  @Test
+  void run_whenInvoked_callsHandlerWithIdentifier() throws Exception {
+    // Arrange
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", "abc");
+    UnsubscribeUSKMessage message = new UnsubscribeUSKMessage(fieldSet);
+
+    // Act
+    message.run(handler, node);
+
+    // Assert
+    verify(handler).unsubscribeUSK("abc");
+  }
+
+  @Test
+  void run_whenHandlerThrows_propagatesMessageInvalidException() throws Exception {
+    // Arrange
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("Identifier", "abc");
+    UnsubscribeUSKMessage message = new UnsubscribeUSKMessage(fieldSet);
+    MessageInvalidException failure =
+        new MessageInvalidException(
+            ProtocolErrorMessage.NO_SUCH_IDENTIFIER, "missing", "abc", false);
+    doThrow(failure).when(handler).unsubscribeUSK("abc");
+
+    // Act & Assert
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+    assertEquals(failure, thrown);
+  }
+}


### PR DESCRIPTION
## Summary
- expand UnsubscribeUSKMessage Javadoc and clarify identifier handling
- add unit tests covering identifier validation, name, serialization rejection, handler invocation, and exception propagation

## Testing
- not run (not requested)
