### PR TITLE
Add tests and documentation for WatchGlobal FCP message

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/WatchGlobal.java
+++ b/src/main/java/network/crypta/clients/fcp/WatchGlobal.java
@@ -2,16 +2,57 @@ package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+/**
+ * FCP control message that enables or disables global event watching for a client connection.
+ *
+ * <p>This message is sent by an FCP client when it wants to receive node-wide notifications (such
+ * as request lifecycle updates) beyond its own request scope. The handler stores the preference on
+ * both the reboot-persistent client and the in-memory forever client so the subscription survives
+ * across reconnections when persistence is available. Applications typically send this once during
+ * session initialization and keep the returned verbosity mask aligned with their logging strategy.
+ *
+ * <p>Key behaviors:
+ *
+ * <ul>
+ *   <li>Reads {@code Enabled} and {@code VerbosityMask} from the provided field set, defaulting to
+ *       enabled with a mask that accepts all events when the mask is absent.
+ *   <li>Propagates the setting to both reboot-persistent and ephemeral clients so future messages
+ *       follow the same filter.
+ *   <li>Falls back to a protocol error when persistence has been disabled on the server, leaving
+ *       the session unchanged.
+ * </ul>
+ *
+ * <p>The class is thread-confined to the handling thread; it carries immutable fields after
+ * construction and performs no synchronized work. Use separate instances per incoming message to
+ * avoid unintended cross-session state sharing.
+ *
+ * @see FCPMessage
+ * @see ProtocolErrorMessage
+ */
 public class WatchGlobal extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(WatchGlobal.class);
 
   final boolean enabled;
   final int verbosityMask;
   static final String NAME = "WatchGlobal";
 
+  /**
+   * Parses a {@link SimpleFieldSet} into an immutable watch directive for an FCP client.
+   *
+   * <p>The constructor accepts the raw fields transmitted by the peer and converts them into the
+   * normalized boolean/bitmask pair used at runtime. Missing {@code Enabled} values default to
+   * {@code true}; missing {@code VerbosityMask} values default to {@link Integer#MAX_VALUE} so all
+   * events are delivered. Invalid masks trigger {@link MessageInvalidException} and halt message
+   * processing for the current request.
+   *
+   * <p>Usage is straightforward: instantiate within an FCP handler when a {@code WatchGlobal}
+   * message arrives, then invoke {@link #run(FCPConnectionHandler, Node)} to apply the preference.
+   *
+   * @param fs non-null set of key/value pairs received from the peer; expects {@code Enabled}
+   *     (boolean) and optional {@code VerbosityMask} (integer) entries and tolerates absent fields.
+   * @throws MessageInvalidException if {@code VerbosityMask} is present but cannot be parsed as an
+   *     integer, preserving the client-visible protocol error semantics.
+   */
   public WatchGlobal(SimpleFieldSet fs) throws MessageInvalidException {
     enabled = fs.getBoolean("Enabled", true);
     String s = fs.get("VerbosityMask");
@@ -25,6 +66,19 @@ public class WatchGlobal extends FCPMessage {
     else verbosityMask = Integer.MAX_VALUE;
   }
 
+  /**
+   * Serializes the watch preference back into an FCP field set for transmission or logging.
+   *
+   * <p>The returned {@link SimpleFieldSet} always contains {@code Enabled} and {@code
+   * VerbosityMask} keys, mirroring the values normalized during construction so callers can forward
+   * the message without re-reading instance fields. The field set is mutable, but the method
+   * creates a fresh instance on each call, making it safe to hand off to downstream encoders
+   * without synchronization. Callers should avoid mutating the set after sending to prevent
+   * divergence from the stored state.
+   *
+   * @return a new field set containing the enabled flag and verbosity bitmask ready for FCP
+   *     serialization; the caller owns the returned instance.
+   */
   @Override
   public SimpleFieldSet getFieldSet() {
     SimpleFieldSet fs = new SimpleFieldSet(true);
@@ -33,11 +87,44 @@ public class WatchGlobal extends FCPMessage {
     return fs;
   }
 
+  /**
+   * Reports the canonical FCP message name used on the wire.
+   *
+   * <p>This identifier is stable and must match the token used by peers when constructing requests.
+   * It is constant for the lifetime of the application and requires no synchronization.
+   *
+   * @return the literal {@code WatchGlobal} string used in FCP framing.
+   */
   @Override
   public String getName() {
     return NAME;
   }
 
+  /**
+   * Applies the watch setting to the current connection and, when persistence is available, to the
+   * reboot-resilient client state.
+   *
+   * <p>The method updates both the reboot client (for on-disk persistence) and the forever client
+   * (for the active session) so verbosity and enablement stay aligned across restarts. If the
+   * server has disabled persistence, it sends a {@link ProtocolErrorMessage} back to the caller and
+   * leaves the existing configuration untouched. The operation is idempotent with respect to
+   * repeated calls that supply the same values and performs no background work beyond delegating to
+   * the handler and node-provided clients.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * var msg = new WatchGlobal(fields);
+   * msg.run(connectionHandler, node);
+   * }</pre>
+   *
+   * @param handler active connection handler that owns both persistent and in-memory clients; must
+   *     not be {@code null} and is expected to originate the incoming FCP message.
+   * @param node current node instance supplying the client core and FCP server used to register the
+   *     watch; must expose a non-null client core when invoked.
+   * @throws MessageInvalidException if subordinate clients reject the configuration change or the
+   *     handler signals a protocol-level validation failure.
+   */
   @Override
   public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
     if (!handler

--- a/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
+++ b/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
@@ -1,0 +1,146 @@
+package network.crypta.clients.fcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class WatchGlobalTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private PersistentRequestClient rebootClient;
+  @Mock private PersistentRequestClient foreverClient;
+  @Mock private Node node;
+  @Mock private NodeClientCore nodeClientCore;
+  @Mock private FCPServer nodeFcpServer;
+  @Mock private FCPServer handlerFcpServer;
+
+  @Test
+  void constructor_withValidFields_setsEnabledAndVerbosityMask() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.put("Enabled", false);
+    fs.put("VerbosityMask", 7);
+
+    WatchGlobal watchGlobal = new WatchGlobal(fs);
+
+    SimpleFieldSet result = watchGlobal.getFieldSet();
+    assertFalse(result.getBoolean("Enabled", true));
+    assertEquals(7, result.getInt("VerbosityMask", -1));
+  }
+
+  @Test
+  void constructor_withoutFields_defaultsEnabledTrueAndMaxVerbosity() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+
+    WatchGlobal watchGlobal = new WatchGlobal(fs);
+
+    SimpleFieldSet result = watchGlobal.getFieldSet();
+    assertTrue(result.getBoolean("Enabled", false));
+    assertEquals(Integer.MAX_VALUE, result.getInt("VerbosityMask", -1));
+  }
+
+  @Test
+  void constructor_withInvalidVerbosityMask_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("VerbosityMask", "not-a-number");
+
+    MessageInvalidException thrown =
+        assertThrows(MessageInvalidException.class, () -> new WatchGlobal(fs));
+
+    assertEquals(ProtocolErrorMessage.ERROR_PARSING_NUMBER, thrown.protocolCode);
+    assertTrue(thrown.getMessage().contains("not-a-number"));
+  }
+
+  @Test
+  void getName_returnsWatchGlobalConstant() throws Exception {
+    WatchGlobal watchGlobal = new WatchGlobal(new SimpleFieldSet(true));
+
+    assertEquals("WatchGlobal", watchGlobal.getName());
+  }
+
+  @Test
+  void run_whenRebootSetWatchGlobalFails_sendsProtocolErrorAndUpdatesForeverClient()
+      throws Exception {
+    prepareSharedMocks();
+    when(handler.getServer()).thenReturn(handlerFcpServer);
+    when(rebootClient.setWatchGlobal(true, 3, nodeFcpServer)).thenReturn(false);
+    when(handler.getForeverClient()).thenReturn(foreverClient);
+
+    WatchGlobal watchGlobal = new WatchGlobal(fieldSet(true, 3));
+
+    watchGlobal.run(handler, node);
+
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(handler).send(messageCaptor.capture());
+    ProtocolErrorMessage error = (ProtocolErrorMessage) messageCaptor.getValue();
+    SimpleFieldSet errorFs = error.getFieldSet();
+    assertEquals(ProtocolErrorMessage.PERSISTENCE_DISABLED, errorFs.getInt("Code", -1));
+    assertFalse(errorFs.getBoolean("Fatal", true));
+    assertTrue(errorFs.getBoolean("Global", false));
+    assertEquals("Persistence disabled", errorFs.get("ExtraDescription"));
+
+    verify(rebootClient).setWatchGlobal(true, 3, nodeFcpServer);
+    verify(foreverClient).setWatchGlobal(true, 3, handlerFcpServer);
+  }
+
+  @Test
+  void run_whenForeverClientMissing_skipsForeverWatchWithoutError() throws Exception {
+    prepareSharedMocks();
+    when(rebootClient.setWatchGlobal(false, 9, nodeFcpServer)).thenReturn(true);
+    when(handler.getForeverClient()).thenReturn(null);
+
+    WatchGlobal watchGlobal = new WatchGlobal(fieldSet(false, 9));
+
+    watchGlobal.run(handler, node);
+
+    verify(rebootClient).setWatchGlobal(false, 9, nodeFcpServer);
+    verify(handler, never()).send(org.mockito.ArgumentMatchers.any(FCPMessage.class));
+    verify(handler).getRebootClient();
+    verify(handler).getForeverClient();
+    verifyNoMoreInteractions(handler, rebootClient, node, nodeClientCore, nodeFcpServer);
+  }
+
+  @Test
+  void run_whenSetWatchGlobalSucceeds_updatesBothClientsWithoutError() throws Exception {
+    prepareSharedMocks();
+    when(handler.getServer()).thenReturn(handlerFcpServer);
+    when(rebootClient.setWatchGlobal(false, 7, nodeFcpServer)).thenReturn(true);
+    when(handler.getForeverClient()).thenReturn(foreverClient);
+
+    WatchGlobal watchGlobal = new WatchGlobal(fieldSet(false, 7));
+
+    watchGlobal.run(handler, node);
+
+    verify(rebootClient).setWatchGlobal(false, 7, nodeFcpServer);
+    verify(foreverClient).setWatchGlobal(false, 7, handlerFcpServer);
+    verify(handler, never()).send(org.mockito.ArgumentMatchers.any(FCPMessage.class));
+  }
+
+  private void prepareSharedMocks() {
+    when(handler.getRebootClient()).thenReturn(rebootClient);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    when(nodeClientCore.getFCPServer()).thenReturn(nodeFcpServer);
+  }
+
+  private SimpleFieldSet fieldSet(boolean enabled, int verbosityMask) {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.put("Enabled", enabled);
+    fs.put("VerbosityMask", verbosityMask);
+    return fs;
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
+++ b/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
@@ -112,6 +112,8 @@ class WatchGlobalTest {
     verify(handler, never()).send(org.mockito.ArgumentMatchers.any(FCPMessage.class));
     verify(handler).getRebootClient();
     verify(handler).getForeverClient();
+    verify(node).getClientCore();
+    verify(nodeClientCore).getFCPServer();
     verifyNoMoreInteractions(handler, rebootClient, node, nodeClientCore, nodeFcpServer);
   }
 


### PR DESCRIPTION
## Summary
- add comprehensive Javadoc for the `WatchGlobal` FCP message describing behaviors and defaults
- cover constructor and run logic with new `WatchGlobalTest` using Mockito
- ensure protocol error path and mask parsing are validated

## Testing
- spotlessApply
- not run (tests not requested)