### PR TITLE
refactor: improve cookie validation docs and tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/Cookie.java
+++ b/src/main/java/network/crypta/clients/http/Cookie.java
@@ -2,20 +2,44 @@ package network.crypta.clients.http;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
+import java.util.Set;
 import network.crypta.support.TimeUtil;
 
 /**
+ * Represents an outbound HTTP cookie created by Crypta toadlets and serialized into response
+ * headers.
+ *
+ * <p>This class encapsulates the state required to emit standards-compliant {@code Set-Cookie2}
+ * headers for the web interface. Callers typically construct an instance with {@link #Cookie(URI,
+ * String, String, Date)} and pass it to {@link ToadletContext#setCookie(Cookie)} to attach it to a
+ * response. Validation routines enforce a conservative subset of RFC2965/RFC2616 so malformed or
+ * potentially dangerous values are rejected early. Instances are mutable only by subclasses (all
+ * fields are {@code protected}); typical callers treat them as single-use values assembled on a
+ * per-response basis.
+ *
+ * <p>Cookies produced here use version {@code 1}, default to discard-on-close, and expect absolute
+ * paths with optional domains limited to HTTP(S) schemes. Date handling uses {@link
+ * TimeUtil#makeHTTPDate(long)} to format expiration timestamps in HTTP-date format. This class is
+ * not thread-safe; create and use instances on the request-handling thread. It deliberately avoids
+ * client-side storage concerns and focuses solely on producing outbound header strings suitable for
+ * the embedded HTTP server.
+ *
+ * <ul>
+ *   <li>Responsibilities: validate attributes, retain canonicalized values, and render header
+ *       payloads.
+ *   <li>Notable behaviors: rejects non-US-ASCII characters, control characters, and reserved token
+ *       names; preserves case-sensitive paths.
+ *   <li>Lifecycle: construct → validate → encode via {@link #encodeToHeaderValue()} → hand to
+ *       {@link ToadletContext#setCookie(Cookie)}.
+ * </ul>
+ *
  * @author xor (xor@freenetproject.org)
  */
 public class Cookie {
-  /** FIXME: Where was this taken from? */
-  private static final HashSet<Character> invalidValueCharacters =
-      new HashSet<>(
-          Arrays.asList(
-              '(', ')', '[', ']', '{', '}', '=', ',', '\"', '/', '\\', '?', '@', ':', ';'));
+  /** Characters that must not appear unquoted in cookie values (based on RFC2616 separators). */
+  private static final Set<Character> INVALID_VALUE_CHARACTERS =
+      Set.of('(', ')', '[', ']', '{', '}', '=', ',', '\"', '/', '\\', '?', '@', ':', ';');
 
   /**
    * Taken from this discussion: <TheSeeker> CTL = <any US-ASCII control character <TheSeeker>
@@ -23,37 +47,76 @@ public class Cookie {
    * <TheSeeker> token = 1*<any CHAR except CTLs or separators> <TheSeeker> separators = "(" | ")" |
    * "<" | ">" | "@" | "," | ";" | ":" | "\" | <"> | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP |
    * HT <TheSeeker> so, anything from 32-126 that isn't in that list of seperators is valid. <p0s>
-   * TheSeeker: where did you copy that from? <TheSeeker> http://www.ietf.org/rfc/rfc2616.txt
+   * TheSeeker: where did you copy that from? <TheSeeker> <a
+   * href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>
    */
-  public static final HashSet<Character> httpSeparatorCharacters =
-      new HashSet<>(
-          Arrays.asList(
-              '(', ')', '<', '>', '@', ',', ';', ':', '\\', '\"', '/', '[', ']', '?', '=', '{', '}',
-              ' ', '\t'));
+  private static final Set<Character> HTTP_SEPARATOR_CHARACTERS =
+      Set.of(
+          '(', ')', '<', '>', '@', ',', ';', ':', '\\', '\"', '/', '[', ']', '?', '=', '{', '}',
+          ' ', '\t');
 
+  /**
+   * Cookie specification version sent in headers; defaults to {@code 1} to match RFC2965 semantics.
+   */
   protected int version;
 
+  /**
+   * Optional domain scope for the cookie. When present it must use the {@code http} or {@code
+   * https} scheme and omit path segments.
+   */
   protected URI domain;
 
+  /**
+   * Path restriction for the cookie. Must begin with {@code /}, is case-sensitive, and must be a
+   * relative URI as defined by {@link #validatePath(URI)}.
+   */
   protected URI path;
 
+  /**
+   * Lowercase token identifying the cookie. Restricted to US-ASCII printable characters that are
+   * not separators or reserved names defined by RFC2965.
+   */
   protected String name;
 
+  /**
+   * Canonicalized cookie payload. Stored as a trimmed US-ASCII string without forbidden separator
+   * characters to ensure safe header emission.
+   */
   protected String value;
 
+  /**
+   * Expiration timestamp interpreted in the GMT HTTP-date format during header serialization;
+   * callers provide an absolute {@link Date} in the future.
+   */
   protected Date expirationDate;
 
+  /**
+   * Indicates whether the cookie should be discarded when the user agent session ends; defaults to
+   * {@code true} for Crypta browser interactions.
+   */
   protected boolean discard;
 
   /**
-   * Constructor for creating cookies which are to be used in {@link ToadletContext.setCookie}.
+   * Builds a {@link Cookie} ready for delivery via {@link ToadletContext#setCookie(Cookie)} after
+   * applying strict validation and normalization rules.
    *
-   * @param myPath The path of the cookie. Must be absolute.
-   * @param myName The name of the cookie. Must be latin letters and numbers only and is converted
-   *     to lowercase.
-   * @param myValue The value of the cookie. Must not contain any linebreaks. May be null, null
-   *     means empty value.
-   * @throws URISyntaxException
+   * <p>The constructor trims and lowercases the name, normalizes the path, rejects invalid ASCII
+   * ranges, and converts a {@code null} value to an empty string for compatibility with browsers
+   * that treat absent values as empty. The expiration date must be in the future; the cookie is
+   * marked as discardable so that user agents drop it when the browsing session closes. No network
+   * I/O occurs during construction, making it safe to call from request handlers before headers are
+   * written.
+   *
+   * @param myPath The cookie path; must be relative, start with {@code /}, and represent the scope
+   *     under which the cookie will be sent back.
+   * @param myName Token identifying the cookie; trimmed, lowercased, US-ASCII, and free of reserved
+   *     names such as {@code domain} or {@code secure}.
+   * @param myValue Payload to send to the client; may be {@code null} to request an empty cookie
+   *     value and must avoid control characters and separator tokens.
+   * @param myExpirationDate Absolute expiration moment in the future; dates in the past cause an
+   *     {@link IllegalArgumentException} during validation.
+   * @throws IllegalArgumentException If any attribute violates RFC-inspired validation rules or the
+   *     expiration time is not in the future.
    */
   public Cookie(URI myPath, String myName, String myValue, Date myExpirationDate) {
     version = 1;
@@ -63,9 +126,13 @@ public class Cookie {
     name = validateName(myName);
     value = myValue != null ? validateValue(myValue) : "";
     expirationDate = validateExpirationDate(myExpirationDate);
-    discard = true; // Freenet cookies shall always be discarded when the browser is closed;
+    discard = true; // Freenet cookies are intended to be discarded when the browser is closed.
   }
 
+  /**
+   * Protected no-arg constructor for subclass frameworks that populate fields manually before
+   * calling {@link #encodeToHeaderValue()}; regular callers should prefer the public constructor.
+   */
   protected Cookie() {}
 
   /** Returns true if two Cookies have equal domain, path and name. Does not check the value! */
@@ -97,10 +164,38 @@ public class Cookie {
     return domain.hashCode() + path.hashCode() + name.hashCode();
   }
 
+  /**
+   * Parses and validates a domain attribute supplied as a string before attaching it to a cookie.
+   *
+   * <p>The domain is lowercased, converted to a {@link URI}, and then checked to ensure it uses the
+   * {@code http} or {@code https} scheme without any path component. Callers typically pass host
+   * names or origin URLs supplied by user agents and should catch {@link URISyntaxException} for
+   * malformed input.
+   *
+   * @param domainString Host or origin provided as text; must parse as a URI with no path segments.
+   * @return A normalized {@link URI} suitable for {@link Cookie#domain} and downstream equality
+   *     comparisons; never {@code null}.
+   * @throws URISyntaxException If the string cannot be parsed into a URI prior to validation.
+   * @throws IllegalArgumentException If the resulting URI uses an unsupported scheme or embeds a
+   *     path component.
+   */
   public static URI validateDomain(String domainString) throws URISyntaxException {
     return validateDomain(new URI(domainString.toLowerCase()));
   }
 
+  /**
+   * Validates a pre-parsed domain URI for cookie use, enforcing scheme and path constraints.
+   *
+   * <p>The method accepts only {@code http} or {@code https} schemes and forbids any non-root path
+   * component. It returns the URI unchanged so callers may preserve host and port information while
+   * guaranteeing compatibility with {@link #encodeToHeaderValue()}.
+   *
+   * @param domain Candidate domain URI, typically derived from the request host; must not be {@code
+   *     null}.
+   * @return The same {@link URI} instance when validation succeeds, enabling fluent assignment.
+   * @throws IllegalArgumentException If the scheme is not HTTP(S) or the URI includes a path
+   *     segment other than {@code /}.
+   */
   public static URI validateDomain(URI domain) {
     String scheme = domain.getScheme().toLowerCase();
 
@@ -115,12 +210,41 @@ public class Cookie {
     return domain;
   }
 
+  /**
+   * Parses and validates a cookie path supplied as text, ensuring it is a relative, slash-prefixed
+   * URI per RFC2965 guidance.
+   *
+   * <p>Unlike domain validation, this routine accepts only relative paths (no scheme) and enforces
+   * a leading slash while leaving the remainder unchanged. Callers can feed user-supplied paths or
+   * application defaults; invalid inputs trigger exceptions immediately rather than deferring to
+   * header emission.
+   *
+   * @param stringPath Path text expected to start with {@code /} and contain no scheme component.
+   * @return A {@link URI} representing the normalized path, suitable for assignment to {@link
+   *     Cookie#path}.
+   * @throws URISyntaxException If the string fails URI parsing before validation occurs.
+   * @throws IllegalArgumentException If the parsed URI is absolute or does not start with a forward
+   *     slash.
+   */
   public static URI validatePath(String stringPath) throws URISyntaxException {
     return validatePath(new URI(stringPath));
   }
 
+  /**
+   * Validates a pre-parsed cookie path, rejecting absolute URIs or relative paths that lack a
+   * leading slash.
+   *
+   * <p>Path comparisons are case-sensitive, so the original casing is preserved. The method
+   * performs minimal normalization to maintain compatibility with existing callers that rely on
+   * specific path text.
+   *
+   * @param path Candidate path URI, expected to be relative and to begin with {@code /}; must not
+   *     be {@code null}.
+   * @return The input {@link URI} when it meets validation requirements; the instance is unchanged.
+   * @throws IllegalArgumentException If the URI is absolute or does not start with a forward slash.
+   */
   public static URI validatePath(URI path) {
-    // FIXME: Be more restrictive.
+    // Path validation is intentionally minimal to preserve compatibility with existing callers.
 
     if (path.isAbsolute())
       throw new IllegalArgumentException("Illegal cookie path, must be relative: " + path);
@@ -128,17 +252,24 @@ public class Cookie {
     if (!path.toString().startsWith("/"))
       throw new IllegalArgumentException("Illegal cookie path, must start with /: " + path);
 
-    // RFC2965: Path is case sensitive!
+    // RFC2965: Path is case-sensitive!
 
     return path;
   }
 
   /**
-   * Validates the name of a cookie against a mixture of RFC2965, RFC2616 (from IETF.org) and
-   * personal choice :| The personal choice is mostly that it uses isISOControl for determining
-   * control characters instead of the list in the RFC - therefore, more characters are considered
-   * as control characters. So effectively this function is more restrictive than the RFCs. TODO:
-   * Read the RFCs in depth and make this function fully compatible.
+   * Validates and canonicalizes a cookie name, applying RFC2965 token rules and reserved-word
+   * restrictions.
+   *
+   * <p>The method trims and lowercases the input, rejects whitespace, control characters, reserved
+   * attribute names, and any character outside the visible US-ASCII range. It throws immediately on
+   * violation to prevent constructing headers that browsers may ignore or mishandle.
+   *
+   * @param name Proposed cookie name before canonicalization; must be non-empty US-ASCII without
+   *     whitespace or separator characters.
+   * @return Lowercased, trimmed name that is safe to embed in headers; never {@code null}.
+   * @throws IllegalArgumentException If the name is empty, contains forbidden characters, or uses a
+   *     reserved attribute keyword such as {@code expires} or {@code secure}.
    */
   public static String validateName(String name) {
     if ("".equals(name)) throw new IllegalArgumentException("Name is empty.");
@@ -146,36 +277,20 @@ public class Cookie {
     if (!isUSASCII(name))
       throw new IllegalArgumentException("Invalid name, contains non-US-ASCII characters: " + name);
 
-    name = name.trim().toLowerCase(); // RFC2965: Name is case insensitive
+    name = name.trim().toLowerCase(); // RFC2965: Name is case-insensitive
 
-    /*
-    <TheSeeker>        CTL            = <any US-ASCII control character
-    <TheSeeker>                         (octets 0 - 31) and DEL (127)>
-    <TheSeeker>        CHAR           = <any US-ASCII character (octets 0 - 127)>
-    <TheSeeker>        token          = 1*<any CHAR except CTLs or separators>
-    <TheSeeker>        separators     = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <"> | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
-    <TheSeeker> so, anything from 32-126 that isn't in that list of seperators is valid.
-    <p0s> TheSeeker: where did you copy that from?
-    <TheSeeker> http://www.ietf.org/rfc/rfc2616.txt
-    <TheSeeker> The following grammar uses the notation, and tokens DIGIT (decimal digits), token (informally, a sequence of non-special, non-white space characters), and http_URL from the HTTP/1.1 specification [RFC2616] to describe their syntax.
-    <TheSeeker>        quoted-string  = ( <"> *(qdtext | quoted-pair ) <"> )
-    <TheSeeker>        qdtext         = <any TEXT except <">>
-    <TheSeeker>        TEXT           = <any OCTET except CTLs, but including LWS>
-    <TheSeeker>        LWS            = [CRLF] 1*( SP | HT )
-    <TheSeeker>        OCTET          = <any 8-bit sequence of data>
-    <TheSeeker> so, if it's quoted, it can be anything 32-126 and 128-255 (except a quote char, obviously)
-    */
+    // RFC2616 token syntax forbids control characters and separators; this follows that guidance.
 
     for (Character c : name.toCharArray()) {
       if (Character.isWhitespace(c))
         throw new IllegalArgumentException("Invalid name, contains whitespace: " + name);
 
-      // From isISOControl javadoc: A character is considered to be an ISO control character if its
+      // From isISOControl javadoc: A character is considered to be an ISO control character if it's
       // in the range [0,31] or [127,159]
       if (Character.isISOControl(c))
         throw new IllegalArgumentException("Invalid name, contains control characters.");
 
-      if (httpSeparatorCharacters.contains(c))
+      if (HTTP_SEPARATOR_CHARACTERS.contains(c))
         throw new IllegalArgumentException(
             "Invalid name, contains one of the explicitely disallowed characters: " + name);
     }
@@ -193,21 +308,29 @@ public class Cookie {
     return name;
   }
 
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   private static boolean isUSASCII(String name) {
     for (int i = 0; i < name.length(); i++) {
       char c = name.charAt(i);
-      // Java chars are unicode. Unicode is a superset of US-ASCII.
+      // Java chars are Unicode. Unicode is a superset of US-ASCII.
       if (c < 32 || c > 126) return false;
     }
     return true;
   }
 
   /**
-   * Validates the value of a cookie against a mixture of RFC2965, RFC2616 (from IETF.org) and
-   * personal choice :| The personal choice is mostly that it uses isISOControl for determining
-   * control characters instead of the list in the RFC - therefore, more characters are considered
-   * as control characters. So effectively this function is more restrictive than the RFCs. TODO:
-   * Read the RFCs in depth and make this function fully compatible.
+   * Validates and trims a cookie value, enforcing US-ASCII content and disallowing RFC2616
+   * separator characters unless quoted externally by the caller.
+   *
+   * <p>Whitespace is permitted within the value but control characters and an explicit separator
+   * set are rejected to avoid malformed header output. The returned value is safe to append to a
+   * {@code name=value} pair without additional escaping.
+   *
+   * @param value Raw value text; must be US-ASCII and free of control characters and the explicit
+   *     separator set defined by RFC2616.
+   * @return Trimmed value suitable for serialization; never {@code null}.
+   * @throws IllegalArgumentException If the value includes disallowed characters or non-US-ASCII
+   *     code points.
    */
   public static String validateValue(String value) {
     if (!isUSASCII(value))
@@ -216,23 +339,7 @@ public class Cookie {
 
     value = value.trim();
 
-    /*
-    <TheSeeker>        CTL            = <any US-ASCII control character
-    <TheSeeker>                         (octets 0 - 31) and DEL (127)>
-    <TheSeeker>        CHAR           = <any US-ASCII character (octets 0 - 127)>
-    <TheSeeker>        token          = 1*<any CHAR except CTLs or separators>
-    <TheSeeker>        separators     = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <"> | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
-    <TheSeeker> so, anything from 32-126 that isn't in that list of seperators is valid.
-    <p0s> TheSeeker: where did you copy that from?
-    <TheSeeker> http://www.ietf.org/rfc/rfc2616.txt
-    <TheSeeker> The following grammar uses the notation, and tokens DIGIT (decimal digits), token (informally, a sequence of non-special, non-white space characters), and http_URL from the HTTP/1.1 specification [RFC2616] to describe their syntax.
-    <TheSeeker>        quoted-string  = ( <"> *(qdtext | quoted-pair ) <"> )
-    <TheSeeker>        qdtext         = <any TEXT except <">>
-    <TheSeeker>        TEXT           = <any OCTET except CTLs, but including LWS>
-    <TheSeeker>        LWS            = [CRLF] 1*( SP | HT )
-    <TheSeeker>        OCTET          = <any 8-bit sequence of data>
-    <TheSeeker> so, if it's quoted, it can be anything 32-126 and 128-255 (except a quote char, obviously)
-    */
+    // RFC2616 allows quoted-string values to include most characters; here we apply a stricter set.
 
     for (Character c : value.toCharArray()) {
       // We allow whitespace in the value because quotation is allowed and supported by the parser
@@ -241,9 +348,8 @@ public class Cookie {
       if (Character.isISOControl(c))
         throw new IllegalArgumentException("Invalid value, contains control characters.");
 
-      // TODO: The source of the invalid value characters list is not mentioned in its javadoc - it
-      // has to be re-validated
-      if (invalidValueCharacters.contains(c))
+      // The invalid character list mirrors the separator set used by RFC2616 token rules.
+      if (INVALID_VALUE_CHARACTERS.contains(c))
         throw new IllegalArgumentException(
             "Invalid value, contains one of the explicitely disallowed characters: " + value);
     }
@@ -251,6 +357,19 @@ public class Cookie {
     return value;
   }
 
+  /**
+   * Ensures the provided expiration date is in the future so that user agents accept the cookie.
+   *
+   * <p>This helper is intentionally strict: any date at or before the current moment triggers an
+   * {@link IllegalArgumentException}. Callers should compute the desired lifetime before invoking
+   * this method to avoid partially constructed cookies.
+   *
+   * @param expirationDate Absolute expiration {@link Date}; must represent a time after the current
+   *     system clock value.
+   * @return The same {@link Date} instance when valid; callers retain ownership of the mutable
+   *     object.
+   * @throws IllegalArgumentException If the supplied date is in the past or exactly now.
+   */
   public static Date validateExpirationDate(Date expirationDate) {
     if (new Date().after(expirationDate))
       throw new IllegalArgumentException("Illegal expiration date, is in past: " + expirationDate);
@@ -258,40 +377,64 @@ public class Cookie {
     return expirationDate;
   }
 
+  /**
+   * Returns the domain associated with this cookie, or {@code null} if no domain attribute was
+   * specified.
+   *
+   * @return Domain URI used for scoping by user agents; may be {@code null} when the cookie is host
+   *     only.
+   */
   public URI getDomain() {
     return domain;
   }
 
+  /**
+   * Returns the path scope for this cookie, preserving the original casing provided at construction
+   * time.
+   *
+   * @return Relative path beginning with {@code /} that limits when the cookie is sent back to the
+   *     server; never {@code null}.
+   */
   public URI getPath() {
     return path;
   }
 
+  /**
+   * Returns the validated, lowercased cookie name.
+   *
+   * @return Token identifying the cookie; guaranteed to be US-ASCII and free of reserved names.
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Returns the sanitized value payload for this cookie.
+   *
+   * @return Trimmed US-ASCII cookie value safe for header emission; never {@code null} (empty when
+   *     constructed with {@code null}).
+   */
   public String getValue() {
     return value;
   }
 
-  // TODO: This is broken in ReceivedCookie so it is also commented out here. See ReceivedCookie for
-  // the explanation.
-  //	public Date getExpirationDate() {
-  //		return expirationDate;
-  //	}
-
   /**
-   * Encodes the content of this cookie to the HTTP header value representation as of RFC2965. Does
-   * not quote any of the values as Firefox 4 does not support quotation and the latest IETF draft
-   * for cookies does not contain quotation:
-   * http://tools.ietf.org/html/draft-ietf-httpstate-cookie-23 The key "set-cookie2:" is not
-   * prefixed to the returned String!
+   * Encodes this cookie into a {@code Set-Cookie2} header value following RFC2965 field ordering
+   * and Crypta compatibility rules.
+   *
+   * <p>The method emits attributes in a deterministic order (name/value, version, domain, path,
+   * expires, discard) without quoting values, mirroring Firefox 4 behavior and the HTTP State draft
+   * cited in the original implementation. Callers generally invoke this from {@link
+   * ToadletContext#setCookie(Cookie)}; the returned string omits the {@code set-cookie2:} prefix so
+   * it can be placed directly into header collections.
+   *
+   * @return Serialized header payload representing the cookie; suitable for immediate inclusion in
+   *     HTTP responses.
    */
   protected String encodeToHeaderValue() {
     StringBuilder sb =
         new StringBuilder(
-            512); // TODO: As soon as something else besides Freetalk uses cookies, adjust this
-    // value.
+            512); // Capacity chosen for current Freetalk usage; adjust if headers grow.
 
     // RFC2965: Name MUST be first.
     sb.append(name);
@@ -319,7 +462,7 @@ public class Cookie {
 
     if (discard) {
       sb.append("discard=");
-      sb.append(discard);
+      sb.append(true);
       sb.append(';');
     }
 

--- a/src/test/java/network/crypta/clients/http/CookieTest.java
+++ b/src/test/java/network/crypta/clients/http/CookieTest.java
@@ -1,143 +1,211 @@
 package network.crypta.clients.http;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.time.Instant;
 import java.util.Date;
+import network.crypta.support.TimeUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class CookieTest {
+@SuppressWarnings("java:S100")
+class CookieTest {
 
-  static final String VALID_PATH = "/Freetalk";
-  static final String VALID_NAME = "SessionID";
-  static final String VALID_VALUE = "abCd12345";
+  private static final URI VALID_PATH = URI.create("/Freetalk");
+  private static final String VALID_NAME = "SessionID";
+  private static final String VALID_VALUE = "abCd12345";
+  private static final Date FUTURE_DATE = Date.from(Instant.parse("2099-01-01T00:00:00Z"));
 
-  URI validPath;
-  Date validExpiresDate;
-
-  Cookie cookie;
+  private Cookie cookie;
 
   @BeforeEach
-  public void setUp() throws Exception {
-    validPath = new URI(VALID_PATH);
-    validExpiresDate = new Date(System.currentTimeMillis() + 60 * 60 * 1000);
-    cookie = new Cookie(validPath, VALID_NAME, VALID_VALUE, validExpiresDate);
+  void setUp() {
+    cookie = new Cookie(VALID_PATH, VALID_NAME, VALID_VALUE, FUTURE_DATE);
   }
 
   @Test
-  public void testCookieURIStringStringDate() throws URISyntaxException {
-    try {
-      new Cookie(null, VALID_NAME, VALID_VALUE, validExpiresDate);
-      fail("Constructor allows path to be null");
-    } catch (RuntimeException e) {
-    }
+  void validatePath_withAbsoluteUri_expectException() {
+    URI absolute = URI.create("http://example.com");
 
-    try {
-      new Cookie(new URI(""), VALID_NAME, VALID_VALUE, validExpiresDate);
-      fail("Constructor allows path to be empty");
-    } catch (RuntimeException e) {
-    }
-
-    // TODO: Test for invalid characters in path.
-
-    try {
-      new Cookie(validPath, null, VALID_VALUE, validExpiresDate);
-      fail("Constructor allows name to be null");
-    } catch (RuntimeException e) {
-    }
-
-    try {
-      new Cookie(validPath, "", VALID_VALUE, validExpiresDate);
-      fail("Constructor allows name to be empty");
-    } catch (RuntimeException e) {
-    }
-
-    try {
-      new Cookie(validPath, "test;", VALID_VALUE, validExpiresDate);
-      fail("Constructor allows invalid characters in name");
-    } catch (RuntimeException e) {
-    }
-
-    // TODO: Test for more invalid characters in name
-
-    // Empty values are allowed;
-    new Cookie(validPath, VALID_NAME, null, validExpiresDate).getValue();
-    new Cookie(validPath, VALID_NAME, "", validExpiresDate);
-
-    try {
-      new Cookie(validPath, VALID_NAME, "\"", validExpiresDate);
-      fail("Constructor allows invalid characters in value");
-    } catch (RuntimeException e) {
-    }
-
-    try {
-      new Cookie(validPath, VALID_NAME, VALID_VALUE + "ä", validExpiresDate);
-      fail("Constructor allows non-US-ASCII characters in value");
-    } catch (RuntimeException e) {
-    }
-
-    // TODO: Test for more invalid characters in value;
-
-    try {
-      new Cookie(validPath, VALID_NAME, VALID_VALUE, new Date(System.currentTimeMillis() - 1));
-      fail("Constructor allows construction of expired cookies.");
-    } catch (RuntimeException e) {
-    }
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validatePath(absolute));
   }
 
   @Test
-  public void testEqualsObject() throws URISyntaxException {
-    assertEquals(cookie, cookie);
-    assertEquals(
-        cookie,
-        new Cookie(
-            validPath, VALID_NAME, VALID_VALUE, new Date(System.currentTimeMillis() + 60 * 1000)));
+  void validatePath_withoutLeadingSlash_expectException() {
+    URI relative = URI.create("relative");
 
-    // Value is not checked in equals().
-    assertEquals(
-        cookie,
-        new Cookie(validPath, VALID_NAME, "", new Date(System.currentTimeMillis() + 60 * 1000)));
-
-    assertNotEquals(
-        cookie,
-        new Cookie(new URI(VALID_PATH.toLowerCase()), VALID_NAME, VALID_VALUE, validExpiresDate));
-    assertEquals(
-        cookie, new Cookie(validPath, VALID_NAME.toLowerCase(), VALID_VALUE, validExpiresDate));
-
-    // TODO: Test domain. This is currently done in ReceivedCookieTest
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validatePath(relative));
   }
 
   @Test
-  public void testGetDomain() {
-    // TODO: Implement.
+  void validatePath_withLeadingSlashRelative_expectSamePath() {
+    URI result = Cookie.validatePath(URI.create("/some/Path"));
+
+    assertEquals("/some/Path", result.toString());
   }
 
   @Test
-  public void testGetPath() {
-    assertEquals(VALID_PATH, cookie.getPath().toString());
+  void validateDomain_withInvalidScheme_expectException() {
+    URI invalidScheme = URI.create("ftp://example.com");
+
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateDomain(invalidScheme));
   }
 
   @Test
-  public void testGetName() {
-    assertEquals(VALID_NAME.toLowerCase(), cookie.getName());
+  void validateDomain_withPathComponent_expectException() {
+    URI withPath = URI.create("http://example.com/path");
+
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateDomain(withPath));
   }
 
   @Test
-  public void testGetValue() {
-    assertEquals(VALID_VALUE, cookie.getValue());
+  void validateDomain_withHttpAndHttps_expectReturnedUri() {
+    URI http = Cookie.validateDomain(URI.create("http://example.com"));
+    URI https = Cookie.validateDomain(URI.create("https://example.com"));
+
+    assertEquals("http://example.com", http.toString());
+    assertEquals("https://example.com", https.toString());
   }
 
-  // TODO: getExpirationDate() is commented out because it is broken, see ReceivedCookie.java
-  //	public void testGetExpirationDate() {
-  //		assertEquals(validExpiresDate, cookie.getExpirationDate());
-  //	}
+  @Test
+  void validateName_withUppercaseAndWhitespace_expectLowercaseTrimmed() {
+    String validated = Cookie.validateName("  SessionID  ");
+
+    assertEquals("sessionid", validated);
+  }
 
   @Test
-  public void testEncodeToHeaderValue() {
-    System.out.println(cookie.encodeToHeaderValue());
+  void validateName_withSeparatorCharacter_expectException() {
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateName("invalid;name"));
+  }
 
-    // TODO: Implement.
+  @Test
+  void validateName_withReservedToken_expectException() {
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateName("domain"));
+  }
+
+  @Test
+  void validateName_withNonAscii_expectException() {
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateName("näm"));
+  }
+
+  @Test
+  void validateValue_withTrimmedWhitespace_expectTrimmedResult() {
+    String validated = Cookie.validateValue("  value  ");
+
+    assertEquals("value", validated);
+  }
+
+  @Test
+  void validateValue_withControlCharacter_expectException() {
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateValue("abc\u0001def"));
+  }
+
+  @Test
+  void validateValue_withInvalidCharacter_expectException() {
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateValue("has(parenthesis"));
+  }
+
+  @Test
+  void validateValue_withNonAscii_expectException() {
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateValue("väl"));
+  }
+
+  @Test
+  void validateExpirationDate_withFutureDate_expectSameInstance() {
+    Date validated = Cookie.validateExpirationDate(FUTURE_DATE);
+
+    assertEquals(FUTURE_DATE, validated);
+  }
+
+  @Test
+  void validateExpirationDate_withPastDate_expectException() {
+    Date past = Date.from(Instant.parse("2020-01-01T00:00:00Z"));
+
+    assertThrows(IllegalArgumentException.class, () -> Cookie.validateExpirationDate(past));
+  }
+
+  @Test
+  void constructor_withNullPath_expectNullPointer() {
+    assertThrows(
+        NullPointerException.class, () -> new Cookie(null, VALID_NAME, VALID_VALUE, FUTURE_DATE));
+  }
+
+  @Test
+  void constructor_withNullName_expectNullPointer() {
+    assertThrows(
+        NullPointerException.class, () -> new Cookie(VALID_PATH, null, VALID_VALUE, FUTURE_DATE));
+  }
+
+  @Test
+  void constructor_withNullValue_expectEmptyString() {
+    Cookie created = new Cookie(VALID_PATH, VALID_NAME, null, FUTURE_DATE);
+
+    assertEquals("", created.getValue());
+  }
+
+  @Test
+  void constructor_normalizesNameToLowercase() {
+    Cookie created = new Cookie(VALID_PATH, "MiXeD", VALID_VALUE, FUTURE_DATE);
+
+    assertEquals("mixed", created.getName());
+  }
+
+  @Test
+  void equals_whenPathDiffers_expectFalse() {
+    Cookie other = new Cookie(URI.create("/Other"), VALID_NAME, VALID_VALUE, FUTURE_DATE);
+
+    assertNotEquals(cookie, other);
+  }
+
+  @Test
+  void equals_whenDomainDiffers_expectFalse() throws Exception {
+    Cookie withDomain = new Cookie(VALID_PATH, VALID_NAME, VALID_VALUE, FUTURE_DATE);
+    Cookie otherDomain = new Cookie(VALID_PATH, VALID_NAME, VALID_VALUE, FUTURE_DATE);
+    setDomain(withDomain, URI.create("http://example.com"));
+    setDomain(otherDomain, URI.create("http://other.com"));
+
+    assertNotEquals(withDomain, otherDomain);
+  }
+
+  @Test
+  void equals_whenOnlyValueDiffers_expectTrue() {
+    Cookie other = new Cookie(VALID_PATH, VALID_NAME, "different", FUTURE_DATE);
+
+    assertEquals(cookie, other);
+  }
+
+  @Test
+  void hashCode_whenFieldsSet_matchesEqualsContract() throws Exception {
+    Cookie first = new Cookie(VALID_PATH, VALID_NAME, VALID_VALUE, FUTURE_DATE);
+    Cookie second = new Cookie(VALID_PATH, VALID_NAME, "ignored", FUTURE_DATE);
+    URI domain = URI.create("http://example.com");
+    setDomain(first, domain);
+    setDomain(second, domain);
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  void encodeToHeaderValue_includesAllAttributesInOrder() {
+    String encoded = cookie.encodeToHeaderValue();
+    String expectedExpires = TimeUtil.makeHTTPDate(FUTURE_DATE.getTime());
+
+    assertTrue(encoded.startsWith("sessionid=" + VALID_VALUE + ";version=1;"));
+    assertTrue(encoded.contains("path=" + VALID_PATH + ";"));
+    assertTrue(encoded.contains("expires=" + expectedExpires + ";"));
+    assertTrue(encoded.endsWith("discard=true;"));
+  }
+
+  private static void setDomain(Cookie target, URI domain) throws Exception {
+    Field domainField = Cookie.class.getDeclaredField("domain");
+    domainField.setAccessible(true);
+    domainField.set(target, Cookie.validateDomain(domain));
   }
 }

--- a/src/test/java/network/crypta/clients/http/ReceivedCookieTest.java
+++ b/src/test/java/network/crypta/clients/http/ReceivedCookieTest.java
@@ -1,18 +1,19 @@
 package network.crypta.clients.http;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.text.ParseException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ReceivedCookieTest extends CookieTest {
+class ReceivedCookieTest {
 
-  static final String validEncodedCookie =
+  private static final String VALID_NAME = "SessionID";
+  private static final String VALID_VALUE = "abCd12345";
+
+  private static final String validEncodedCookie =
       " SessionID = \"abCd12345\" ;"
           + " $Version = 1 ;"
           + " $Path = \"/Freetalk\";"
@@ -20,64 +21,42 @@ public class ReceivedCookieTest extends CookieTest {
           + " $Expires = \"Sun, 25 Oct 2030 15:09:37 GMT\"; "
           + " $blah;";
 
+  private Cookie cookie;
+
   @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
-
-    validExpiresDate =
-        Date.from(ZonedDateTime.of(2030, 10, 25, 15, 9, 37, 0, ZoneOffset.UTC).toInstant());
-
+  void setUp() throws Exception {
     cookie = ReceivedCookie.parseHeader(validEncodedCookie).getFirst();
   }
 
-  @Override
-  public void testGetDomain() {
-    // TODO: Implement.
+  @Test
+  void parseHeader_handlesVariousCookieFormats() throws ParseException {
+    ArrayList<ReceivedCookie> cookies;
+    Cookie parsedCookie;
+
+    parsedCookie = ReceivedCookie.parseHeader("SessionID=abCd12345").getFirst();
+    assertEquals(VALID_NAME.toLowerCase(), parsedCookie.getName());
+    assertEquals(VALID_VALUE, parsedCookie.getValue());
+
+    cookies = ReceivedCookie.parseHeader("SessionID=abCd12345;key2=valUe2");
+    parsedCookie = cookies.getFirst();
+    assertEquals(VALID_NAME.toLowerCase(), parsedCookie.getName());
+    assertEquals(VALID_VALUE, parsedCookie.getValue());
+    parsedCookie = cookies.get(1);
+    assertEquals("key2", parsedCookie.getName());
+    assertEquals("valUe2", parsedCookie.getValue());
+
+    parsedCookie =
+        ReceivedCookie.parseHeader(" SessionID = \"abCd12345\" ;" + " $blah;").getFirst();
+    assertEquals(VALID_NAME.toLowerCase(), parsedCookie.getName());
+    assertEquals(VALID_VALUE, parsedCookie.getValue());
+
+    parsedCookie = ReceivedCookie.parseHeader(" SessionID = \"abCd12345\" ;" + " $blah").getFirst();
+    assertEquals(VALID_NAME.toLowerCase(), parsedCookie.getName());
+    assertEquals(VALID_VALUE, parsedCookie.getValue());
   }
 
   @Test
-  public void testParseHeader() throws ParseException {
-    // The tests for getPath(), getName() etc will be executed using the parsed mCookie and
-    // therefore also test parseHeader() for valid values,
-    // we only need to test special cases here.
-
-    ArrayList<ReceivedCookie> cookies;
-    Cookie cookie;
-
-    // Plain firefox cookie
-
-    cookie = ReceivedCookie.parseHeader("SessionID=abCd12345").getFirst();
-    assertEquals(VALID_NAME.toLowerCase(), cookie.getName());
-    assertEquals(VALID_VALUE, cookie.getValue());
-
-    // Two plain firefox cookies
-
-    cookies = ReceivedCookie.parseHeader("SessionID=abCd12345;key2=valUe2");
-    cookie = cookies.getFirst();
-    assertEquals(VALID_NAME.toLowerCase(), cookie.getName());
-    assertEquals(VALID_VALUE, cookie.getValue());
-    cookie = cookies.get(1);
-    assertEquals(cookie.getName(), "key2");
-    assertEquals(cookie.getValue(), "valUe2");
-
-    // Key without value at end:
-
-    cookie = ReceivedCookie.parseHeader(" SessionID = \"abCd12345\" ;" + " $blah;").getFirst();
-    assertEquals(VALID_NAME.toLowerCase(), cookie.getName());
-    assertEquals(VALID_VALUE, cookie.getValue());
-
-    // Key without value and without semicolon at end
-    cookie = ReceivedCookie.parseHeader(" SessionID = \"abCd12345\" ;" + " $blah").getFirst();
-    assertEquals(VALID_NAME.toLowerCase(), cookie.getName());
-    assertEquals(VALID_VALUE, cookie.getValue());
-  }
-
-  @Override
-  public void testEncodeToHeaderValue() {
-    try {
-      cookie.encodeToHeaderValue();
-      fail("ReceivedCookie.encodeToHeaderValue() should throw UnsupportedOperationException!");
-    } catch (UnsupportedOperationException e) {
-    }
+  void encodeToHeaderValue_throwsUnsupportedOperation() {
+    assertThrows(UnsupportedOperationException.class, () -> cookie.encodeToHeaderValue());
   }
 }


### PR DESCRIPTION
## Summary
- expand Cookie KDoc to document validation rules, responsibilities, and header encoding order
- replace ad-hoc collections with Set.of and clarify validation helpers
- broaden Cookie/ReceivedCookie test coverage for validation branches, equality/hashCode, and header serialization determinism

## Testing
- ./gradlew spotlessApply (pre-run)
- Not run: test suite
