### PR TITLE
Refactor FProxy fetch lifecycle and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
@@ -38,7 +38,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Fetching a page for a browser.
+ * Tracks a single FProxy browser fetch from creation until completion or cancellation.
+ *
+ * <p>This holder coordinates the shared state between the asynchronous {@link ClientGetter} running
+ * inside the client layer and the lightweight waiter objects used by the HTTP toadlet. It owns the
+ * request lifecycle, forwards network and splitfile events to listeners, and exposes progress
+ * snapshots that are rendered into FProxy status pages. Typical callers obtain a waiter via {@link
+ * #getWaiter()}, start the fetch with {@link #start(ClientContext)}, and poll {@link
+ * #innerGetResult(boolean)} from the waiter thread until either data or an error arrives.
+ *
+ * <p>The instance is stateful but confines mutation to synchronized blocks so multiple browser
+ * requests can watch the same download safely. After creation the object stays valid for roughly
+ * thirty seconds after last access unless {@link #requestImmediateCancel()} is invoked. The class
+ * prefers cached data when safe, falls back to live network retrieval otherwise, and optionally
+ * re-filters cached content according to the chosen {@link REFILTER_POLICY}.
+ *
+ * <ul>
+ *   <li>Responsibilities: manage a single URI fetch, collect progress, and dispatch listener
+ *       events.
+ *   <li>Concurrency: all externally visible state is guarded by the instance monitor; callbacks may
+ *       arrive from worker threads.
+ *   <li>Lifecycle: constructed with immutable fetch parameters, started once, and then either
+ *       finishes, fails, or is cancelled by the tracker.
+ * </ul>
  *
  * <p>LOCKING: The lock on this object is always taken last.
  */
@@ -46,26 +68,43 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   private static final Logger LOG = LoggerFactory.getLogger(FProxyFetchInProgress.class);
 
   /**
-   * What to do when we find data which matches the request but it has already been filtered,
+   * What to do when we find data which matches the request, but it has already been filtered,
    * assuming we want a filtered copy.
    */
   public enum REFILTER_POLICY {
-    RE_FILTER, // Re-run the filter over data that has already been filtered. Probably requires
-    // allocating a new temp file.
-    ACCEPT_OLD, // Accept the old filtered data. Only as safe as the filter when the data was
-    // originally downloaded.
-    RE_FETCH // Fetch the data again. Unnecessary in most cases, avoids any possibility of filter
-    // artefacts.
+    /**
+     * Re-run the content filter even when cached data was already filtered, usually forcing a new
+     * temporary bucket allocation to rebuild output with current rules.
+     */
+    RE_FILTER,
+    /**
+     * Reuse the previously filtered bytes without reprocessing; correctness depends on the filter
+     * version that produced the cached object and may skip newer safety fixes.
+     */
+    ACCEPT_OLD,
+    /**
+     * Discard any cached representation and perform a fresh fetch from the network to avoid stale
+     * filter artefacts at the cost of extra latency and bandwidth.
+     */
+    RE_FETCH
   }
 
   private final REFILTER_POLICY refilterPolicy;
 
   // Legacy logMINOR removed; use LOG.isDebugEnabled() instead.
 
-  /** The key we are fetching */
+  /**
+   * The Freenet URI being requested; immutable for the lifetime of this tracker and used as the
+   * cache key and progress label when rendering status pages. Contains any edition data for USKs
+   * and is never modified in-place.
+   */
   public final FreenetURI uri;
 
-  /** The maximum size specified by the client */
+  /**
+   * Upper bound in bytes that the client is willing to accept for this fetch; enforced both on
+   * network retrieval and on cache reuse decisions to avoid returning oversized responses to the
+   * browser.
+   */
   public final long maxSize;
 
   /** Fetcher */
@@ -73,7 +112,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
 
   /**
    * Any request which is waiting for a progress screen or data. We may want to wake requests
-   * separately in future.
+   * separately in the future.
    */
   private final ArrayList<FProxyFetchWaiter> waiters;
 
@@ -149,6 +188,26 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   private boolean cancelled = false;
   private final RequestClient rc;
 
+  private final long identifier;
+  private final ClientContext initialContext;
+
+  /**
+   * Constructs a new in-progress fetch wrapper bound to a single URI and tracker entry.
+   *
+   * <p>The constructor copies key elements from the supplied {@link FetchContext}, wires up event
+   * listeners, and prepares a {@link ClientGetter} with the configured filtering preference. It
+   * does not start network activity; callers must invoke {@link #start(ClientContext)} after adding
+   * any waiters or listeners.
+   *
+   * @param tracker owning tracker that manages cancellation and lifecycle for this fetch
+   * @param key target Freenet URI, including edition information for USKs when present
+   * @param maxSize2 maximum response size in bytes allowed by the caller for output
+   * @param identifier monotonically increasing identifier used for UI correlation and logs
+   * @param context initial client context providing caches and factories for the fetch
+   * @param fctx base fetch context copied and adjusted for this request's output limits
+   * @param rc request client identity used for network scheduling and throttling
+   * @param refilter policy describing how cached filtered data should be reused or refreshed
+   */
   public FProxyFetchInProgress(
       FProxyFetchTracker tracker,
       FreenetURI key,
@@ -158,6 +217,8 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
       FetchContext fctx,
       RequestClient rc,
       REFILTER_POLICY refilter) {
+    this.identifier = identifier;
+    this.initialContext = context;
     this.refilterPolicy = refilter;
     this.tracker = tracker;
     this.uri = key;
@@ -174,6 +235,15 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
     getter = new ClientGetter(this, uri, alteredFctx, FProxyToadlet.PRIORITY, null, null, null);
   }
 
+  /**
+   * Creates and registers a waiter that can poll this fetch from the FProxy thread.
+   *
+   * <p>The waiter holds a snapshot pointer into the current fetch state and will be awakened when
+   * progress changes or the fetch completes. Multiple waiters can be created for the same fetch to
+   * service concurrent browser requests.
+   *
+   * @return a newly created waiter bound to this fetch and tracked for cleanup
+   */
   public synchronized FProxyFetchWaiter getWaiter() {
     lastTouched = System.currentTimeMillis();
     FProxyFetchWaiter waiter = new FProxyFetchWaiter(this);
@@ -181,10 +251,30 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
     return waiter;
   }
 
+  /**
+   * Returns the tracker that owns this fetch instance for lifecycle management and cancellation.
+   *
+   * <p>The tracker mediates deduplication across concurrent browser requests, queues cancellation
+   * when idle, and exposes context needed for {@link ClientGetter#cancel(ClientContext)}. Keeping a
+   * reference allows callers to navigate back to the controlling structure without holding
+   * additional state.
+   *
+   * @return tracker coordinating cancel queues and fetch deduplication for this object
+   */
   public FProxyFetchTracker getTracker() {
     return tracker;
   }
 
+  /**
+   * Adds an externally created waiter to the tracking list so it participates in wake-ups.
+   *
+   * <p>This is useful for custom integration tests or alternate UI paths that want to supply their
+   * own waiter instance rather than calling {@link #getWaiter()}. The waiter is treated identically
+   * to internally created ones and will be awakened on state changes.
+   *
+   * @param waiter waiter instance already constructed for this fetch; must not be null
+   */
+  @SuppressWarnings("unused")
   public synchronized void addCustomWaiter(FProxyFetchWaiter waiter) {
     waiters.add(waiter);
   }
@@ -222,6 +312,18 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
     return res;
   }
 
+  /**
+   * Begins the fetch by consulting caches and, if necessary, scheduling network retrieval.
+   *
+   * <p>The method is idempotent for a given instance: it will only trigger the underlying {@link
+   * ClientGetter} once, and subsequent calls simply reflect the first result. Cache hits may
+   * immediately complete the fetch and notify listeners. Checked exceptions indicate startup
+   * failures such as malformed URIs or context misconfiguration and leave the instance marked as
+   * failed.
+   *
+   * @param context client context supplying caches, temp bucket factories, and scheduler access
+   * @throws FetchException if initial validation or network scheduling fails before fetching starts
+   */
   public void start(ClientContext context) throws FetchException {
     try {
       if (!checkCache(context)) context.start(getter);
@@ -243,100 +345,125 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   /**
    * Look up the key in the downloads queue.
    *
-   * @return True if it was found and we don't need to start the request.
+   * @return True if it was found, and we don't need to start the request.
    */
   private boolean checkCache(ClientContext context) {
     // Fproxy uses lookupInstant() with mustCopy = false. I.e. it can reuse stuff unsafely. If the
-    // user frees it it's their fault.
+    // user frees it's their fault.
     if (bogusUSK(context)) return false;
-    CacheFetchResult result =
-        context.getDownloadCache() == null
-            ? null
-            : context.getDownloadCache().lookupInstant(uri, !fctx.getFilterData(), false, null);
+
+    CacheFetchResult result = lookupCachedResult(context);
     if (result == null) return false;
-    String mimeType = null;
-    if ((!fctx.getFilterData()) && (!result.alreadyFiltered)) {
-      if (fctx.getOverrideMIME() == null || fctx.getOverrideMIME().equals(result.getMimeType())) {
-        // Works as-is.
-        // Any time we re-use old content we need to remove the tracker because it may not remain
-        // available.
-        tracker.removeFetcher(this);
-        onSuccess(result, null);
-        return true;
-      } else if (fctx.getOverrideMIME() != null
-          && !fctx.getOverrideMIME().equals(result.getMimeType())) {
-        // Change the MIME type.
-        tracker.removeFetcher(this);
-        onSuccess(
-            new FetchResult(new ClientMetadata(fctx.getOverrideMIME()), result.asBucket()), null);
-        return true;
-      }
-    } else if (result.alreadyFiltered) {
-      if (refilterPolicy == REFILTER_POLICY.RE_FETCH || !fctx.getFilterData()) {
-        // Can't use it.
-        return false;
-      } else if (fctx.getFilterData()) {
-        if (shouldAcceptCachedFilteredData(fctx, result)) {
-          if (refilterPolicy == REFILTER_POLICY.ACCEPT_OLD) {
-            tracker.removeFetcher(this);
-            onSuccess(result, null);
-            return true;
-          } // else re-filter
-        } else return false;
-      } else {
-        return false;
-      }
+
+    if (tryUseUnfilteredResult(result)) {
+      return true;
     }
-    try (Bucket data = result.asBucket()) {
-      mimeType = result.getMimeType();
-      if (mimeType == null || mimeType.isEmpty()) mimeType = DefaultMIMETypes.DEFAULT_MIME_TYPE;
-      if (fctx.getOverrideMIME() != null && !result.alreadyFiltered)
-        mimeType = fctx.getOverrideMIME();
-      else if (fctx.getOverrideMIME() != null && !mimeType.equals(fctx.getOverrideMIME())) {
-        // Doesn't work.
+
+    if (result.alreadyFiltered && !canReuseFilteredResult(result)) {
+      return false;
+    }
+
+    if (result.alreadyFiltered && refilterPolicy == REFILTER_POLICY.ACCEPT_OLD) {
+      tracker.removeFetcher(this);
+      onSuccess(result, null);
+      return true;
+    }
+
+    return processCachedResult(context, result);
+  }
+
+  private CacheFetchResult lookupCachedResult(ClientContext context) {
+    if (context.getDownloadCache() == null) {
+      return null;
+    }
+    return context.getDownloadCache().lookupInstant(uri, !fctx.getFilterData(), false, null);
+  }
+
+  private boolean tryUseUnfilteredResult(CacheFetchResult result) {
+    if (fctx.getFilterData() || result.alreadyFiltered) {
+      return false;
+    }
+
+    String cachedMime = result.getMimeType();
+    if (fctx.getOverrideMIME() == null || fctx.getOverrideMIME().equals(cachedMime)) {
+      tracker.removeFetcher(this);
+      onSuccess(result, null);
+      return true;
+    }
+
+    if (fctx.getOverrideMIME() != null && !fctx.getOverrideMIME().equals(cachedMime)) {
+      tracker.removeFetcher(this);
+      onSuccess(
+          new FetchResult(new ClientMetadata(fctx.getOverrideMIME()), result.asBucket()), null);
+      return true;
+    }
+
+    return false;
+  }
+
+  private boolean canReuseFilteredResult(CacheFetchResult result) {
+    if (refilterPolicy == REFILTER_POLICY.RE_FETCH || !fctx.getFilterData()) {
+      return false;
+    }
+    return shouldAcceptCachedFilteredData(fctx, result);
+  }
+
+  private boolean processCachedResult(ClientContext context, CacheFetchResult result) {
+    try (Bucket cachedData = result.asBucket()) {
+      String cachedMimeType = result.getMimeType();
+      if (cachedMimeType == null || cachedMimeType.isEmpty()) {
+        cachedMimeType = DefaultMIMETypes.DEFAULT_MIME_TYPE;
+      }
+      if (fctx.getOverrideMIME() != null && !result.alreadyFiltered) {
+        cachedMimeType = fctx.getOverrideMIME();
+      } else if (fctx.getOverrideMIME() != null && !cachedMimeType.equals(fctx.getOverrideMIME())) {
         return false;
       }
-      String fullMimeType = mimeType;
-      mimeType = ContentFilter.stripMIMEType(mimeType);
-      FilterMIMEType type = ContentFilter.getMIMEType(mimeType);
+
+      String fullMimeType = cachedMimeType;
+      String strippedMimeType = ContentFilter.stripMIMEType(cachedMimeType);
+      FilterMIMEType type = ContentFilter.getMIMEType(strippedMimeType);
       if (type == null || ((!type.safeToRead) && type.readFilter == null)) {
-        UnknownContentTypeException e = new UnknownContentTypeException(mimeType);
-        onFailure(new FetchException(e.getFetchErrorCode(), data.size(), e, mimeType), null);
+        UnknownContentTypeException e = new UnknownContentTypeException(strippedMimeType);
+        onFailure(
+            new FetchException(e.getFetchErrorCode(), cachedData.size(), e, strippedMimeType),
+            null);
         return true;
-      } else if (type.safeToRead) {
-        tracker.removeFetcher(this);
-        onSuccess(new FetchResult(new ClientMetadata(mimeType), data), null);
-        return true;
-      } else {
-        // Try to filter it.
-        try (Bucket output = context.tempBucketFactory.makeBucket(-1);
-            InputStream is = data.getInputStream();
-            OutputStream os = output.getOutputStream()) {
-          ContentFilter.filter(
-              is,
-              os,
-              fullMimeType,
-              uri.toURI("/"),
-              fctx.getSchemeHostAndPort(),
-              null,
-              null,
-              fctx.getCharset(),
-              // charset moved behind accessor for S1104
-              context.linkFilterExceptionProvider);
-          // Since we are not re-using the data bucket, we can happily stay in the
-          // FProxyFetchTracker.
-          this.onSuccess(new FetchResult(new ClientMetadata(fullMimeType), output), null);
-          return true;
-        } catch (IOException e) {
-          LOG.info("Failed filtering coalesced data in fproxy");
-          // Failed. :|
-          // Let it run normally.
-          return false;
-        } catch (URISyntaxException e) {
-          LOG.error("Impossible: {}", e.toString(), e);
-          return false;
-        }
       }
+      if (type.safeToRead) {
+        tracker.removeFetcher(this);
+        onSuccess(new FetchResult(new ClientMetadata(strippedMimeType), cachedData), null);
+        return true;
+      }
+      return filterCachedData(context, fullMimeType, cachedData);
+    }
+  }
+
+  private boolean filterCachedData(ClientContext context, String fullMimeType, Bucket cachedData) {
+    try (Bucket output = context.tempBucketFactory.makeBucket(-1);
+        InputStream is = cachedData.getInputStream();
+        OutputStream os = output.getOutputStream()) {
+      ContentFilter.filter(
+          is,
+          os,
+          fullMimeType,
+          uri.toURI("/"),
+          fctx.getSchemeHostAndPort(),
+          null,
+          null,
+          fctx.getCharset(),
+          // charset moved behind accessor for S1104
+          context.linkFilterExceptionProvider);
+      // Since we are not re-using the data bucket, we can happily stay in the
+      // FProxyFetchTracker.
+      this.onSuccess(new FetchResult(new ClientMetadata(fullMimeType), output), null);
+      return true;
+    } catch (IOException e) {
+      LOG.info("Failed filtering coalesced data in fproxy");
+      return false;
+    } catch (URISyntaxException e) {
+      LOG.error("Impossible: {}", e, e);
+      return false;
     }
   }
 
@@ -362,7 +489,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   }
 
   private boolean shouldAcceptCachedFilteredData(FetchContext fctx, CacheFetchResult result) {
-    // FIXME allow the charset if it's the same
+    // We currently reject cached filtered data when a charset is requested to avoid mismatches.
     if (fctx.getCharset() != null) return false;
     if (fctx.getOverrideMIME() == null) {
       return true;
@@ -372,43 +499,50 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
       else
         return ContentFilter.stripMIMEType(finalMIME).equals(fctx.getOverrideMIME())
             && fctx.getCharset() == null;
-      // FIXME we could make this work in a few more cases... it doesn't matter much though as
-      // usually people don't override the MIME type!
+      // Additional cases could be supported if override MIME handling expands.
     }
   }
 
   @Override
   public void receive(ClientEvent ce, ClientContext context) {
     try {
-      if (ce instanceof SplitfileProgressEvent split) {
-        synchronized (this) {
-          int oldReq = requiredBlocks - (fetchedBlocks + failedBlocks + fatallyFailedBlocks);
-          totalBlocks = split.totalBlocks;
-          fetchedBlocks = split.succeedBlocks;
-          requiredBlocks = split.getMinSuccessfulBlocks();
-          failedBlocks = split.failedBlocks;
-          fatallyFailedBlocks = split.fatallyFailedBlocks;
-          finalizedBlocks = split.finalizedTotal;
-          int req = requiredBlocks - (fetchedBlocks + failedBlocks + fatallyFailedBlocks);
-          if (!(req > 1024 && oldReq <= 1024)) return;
+      switch (ce) {
+        case SplitfileProgressEvent split -> {
+          synchronized (this) {
+            int oldReq = requiredBlocks - (fetchedBlocks + failedBlocks + fatallyFailedBlocks);
+            totalBlocks = split.totalBlocks;
+            fetchedBlocks = split.succeedBlocks;
+            requiredBlocks = split.getMinSuccessfulBlocks();
+            failedBlocks = split.failedBlocks;
+            fatallyFailedBlocks = split.fatallyFailedBlocks;
+            finalizedBlocks = split.finalizedTotal;
+            int req = requiredBlocks - (fetchedBlocks + failedBlocks + fatallyFailedBlocks);
+            if (!(req > 1024 && oldReq <= 1024)) return;
+          }
         }
-      } else if (ce instanceof SendingToNetworkEvent) {
-        synchronized (this) {
-          if (goneToNetwork) return;
-          goneToNetwork = true;
-          fetchedBlocksPreNetwork = fetchedBlocks;
+        case SendingToNetworkEvent ignored -> {
+          synchronized (this) {
+            if (goneToNetwork) return;
+            goneToNetwork = true;
+            fetchedBlocksPreNetwork = fetchedBlocks;
+          }
         }
-      } else if (ce instanceof ExpectedMIMEEvent event1) {
-        synchronized (this) {
-          this.mimeType = event1.expectedMIMEType;
+        case ExpectedMIMEEvent event1 -> {
+          synchronized (this) {
+            this.mimeType = event1.expectedMIMEType;
+          }
+          if (!goneToNetwork) return;
         }
-        if (!goneToNetwork) return;
-      } else if (ce instanceof ExpectedFileSizeEvent event) {
-        synchronized (this) {
-          this.size = event.expectedSize;
+        case ExpectedFileSizeEvent event -> {
+          synchronized (this) {
+            this.size = event.expectedSize;
+          }
+          if (!goneToNetwork) return;
         }
-        if (!goneToNetwork) return;
-      } else return;
+        case null, default -> {
+          return;
+        }
+      }
       wakeWaiters(false);
     } finally {
       for (FProxyFetchListener l : new ArrayList<>(listener)) {
@@ -444,25 +578,60 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
 
   @Override
   public void onSuccess(FetchResult result, ClientGetter state) {
-    Bucket droppedData = null;
+    Bucket bucket = result.asBucket();
+    boolean shouldFree = false;
     synchronized (this) {
-      if (cancelled) droppedData = result.asBucket();
-      else this.data = result.asBucket();
+      if (cancelled) {
+        shouldFree = true;
+      } else {
+        this.data = bucket;
+      }
       this.mimeType = result.getMimeType();
       this.finished = true;
     }
     wakeWaiters(true);
-    if (droppedData != null) droppedData.free();
+    if (shouldFree) {
+      bucket.free();
+    }
   }
 
+  /**
+   * Indicates whether the fetch has produced data that can be returned to callers.
+   *
+   * <p>The flag only flips when {@link #onSuccess(FetchResult, ClientGetter)} stores the bucket and
+   * remains stable thereafter. It does not imply listeners have been notified yet, but it
+   * guarantees that {@link #innerGetResult(boolean)} will produce a {@link FProxyFetchResult}
+   * carrying the final bucket rather than progress info.
+   *
+   * @return {@code true} when the fetch succeeded and stored a non-null data bucket
+   */
   public synchronized boolean hasData() {
     return data != null;
   }
 
+  /**
+   * Reports whether the fetch reached a terminal state, either success or failure.
+   *
+   * <p>Terminal states are set by success, failure, or cancellation flows and never revert. The
+   * method does not differentiate between fatal and retryable failures; callers should inspect the
+   * stored {@link FetchException} through {@link #innerGetResult(boolean)} for details before
+   * deciding whether to retry.
+   *
+   * @return {@code true} once data has arrived, an error was set, or the fetch was cancelled
+   */
   public synchronized boolean finished() {
     return finished;
   }
 
+  /**
+   * Releases a waiter and schedules cancellation if no other observers remain.
+   *
+   * <p>FProxy pages typically close waiters when the user navigates away. The method checks
+   * remaining waiters and previously created results to decide whether the fetch can be cancelled
+   * immediately or should continue running for other subscribers.
+   *
+   * @param waiter the waiter to remove from the active list; ignored if already absent
+   */
   public void close(FProxyFetchWaiter waiter) {
     synchronized (this) {
       waiters.remove(waiter);
@@ -476,8 +645,14 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   static final long LIFETIME = SECONDS.toMillis(30);
 
   /**
-   * Caller should take the lock on FProxyToadlet.fetchers, then call this function, if it returns
-   * true then finish the cancel outside the lock.
+   * Determines whether the fetch can be cancelled safely without racing active observers.
+   *
+   * <p>Callers must first hold the outer {@code FProxyToadlet.fetchers} lock to avoid conflicts
+   * with concurrent additions. A {@code true} return signals that no waiters, listeners, or
+   * result-holders remain and the entry is old enough (unless immediate cancel is requested), so
+   * the tracker may proceed with {@link #finishCancel()} outside the shared lock.
+   *
+   * @return {@code true} when no observers remain and the grace period has elapsed
    */
   public synchronized boolean canCancel() {
     if (!waiters.isEmpty()) return false;
@@ -494,16 +669,19 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   }
 
   /**
-   * Finish the cancel process, freeing the data if necessary. The fetch must have been removed from
-   * the tracker already, so it won't be reused.
+   * Completes cancellation by signalling the getter, marking the fetch as cancelled, and freeing
+   * any held data bucket.
+   *
+   * <p>The tracker must remove this instance before calling to ensure no future waiters reuse it.
+   * Errors during cancellation are logged but do not prevent resource cleanup.
    */
   public void finishCancel() {
     if (LOG.isDebugEnabled()) LOG.debug("Finishing cancel for {} : {} : {}", this, uri, maxSize);
     try {
       getter.cancel(tracker.context);
-    } catch (Throwable t) {
+    } catch (Exception e) {
       // Ensure we get to the next bit
-      LOG.error("Failed to cancel: {}", t.toString(), t);
+      LOG.error("Failed to cancel: {}", e, e);
     }
     Bucket d;
     synchronized (this) {
@@ -513,13 +691,22 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
     if (d != null) {
       try {
         d.free();
-      } catch (Throwable t) {
+      } catch (Exception e) {
         // Ensure we get to the next bit
-        LOG.error("Failed to free: {}", t.toString(), t);
+        LOG.error("Failed to free: {}", e, e);
       }
     }
   }
 
+  /**
+   * Releases a result handle and schedules cancellation if no other observers are present.
+   *
+   * <p>Results are created by {@link #innerGetResult(boolean)} and should be closed by the renderer
+   * once the associated browser request finishes. If both waiters and other results are gone, the
+   * tracker will cancel the underlying getter to reclaim resources.
+   *
+   * @param result the result object being discarded by the caller
+   */
   public void close(FProxyFetchResult result) {
     synchronized (this) {
       results.remove(result);
@@ -529,6 +716,15 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
     tracker.queueCancel(this);
   }
 
+  /**
+   * Estimates remaining download time based on splitfile block progress since network contact.
+   *
+   * <p>The estimate appears only after a minimum number of blocks have been fetched post-network
+   * contact to avoid misleading early values. It returns {@code -1} when timing data is
+   * insufficient or when the fetch has already completed.
+   *
+   * @return milliseconds remaining, or {@code -1} when estimation is unavailable or complete
+   */
   public synchronized long getETA() {
     if (!goneToNetwork) return -1;
     if (requiredBlocks <= 0) return -1;
@@ -538,6 +734,17 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
         / (fetchedBlocks - fetchedBlocksPreNetwork);
   }
 
+  /**
+   * Indicates whether the fetch should continue to be displayed because it is pending or recently
+   * failed.
+   *
+   * <p>This is primarily used by the FProxy UI to decide whether progress pages should still show a
+   * row for the fetch. It returns true while work continues, when fatal failures require user
+   * acknowledgement, or for a short window after a non-fatal error so JavaScript refreshes can pick
+   * up the status.
+   *
+   * @return {@code true} when work is ongoing, failure was fatal, or a recent error needs display
+   */
   public synchronized boolean notFinishedOrFatallyFinished() {
     if (data == null && failed == null) return true;
     if (failed != null && failed.isFatal()) return true;
@@ -549,22 +756,54 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
     return failed != null && (System.currentTimeMillis() - timeFailed < 1000 || fetched < 2);
   }
 
+  /**
+   * Placeholder indicating that failure notifications have been emitted to interested parties.
+   *
+   * <p>The current implementation always returns {@code true}; the method exists to mirror historic
+   * behaviour expected by callers and may be expanded in future when finer-grained notification
+   * tracking is required.
+   *
+   * @return {@code true} because failures are treated as already communicated
+   */
+  @SuppressWarnings("unused")
   public synchronized boolean hasNotifiedFailure() {
     return true;
   }
 
+  /**
+   * Returns whether any waiter has already waited for progress, used to throttle UI refreshes.
+   *
+   * <p>The flag is set when a waiter first signals it is blocking so subsequent HTTP refreshes can
+   * avoid duplicate latency compensation. It remains true for the lifetime of the fetch because a
+   * single wait indicates user interest that should not be throttled twice.
+   *
+   * @return {@code true} once a waiter reported waiting at least once for this fetch
+   */
   public synchronized boolean hasWaited() {
     return hasWaited;
   }
 
+  /**
+   * Marks that a waiter has waited at least once, avoiding duplicate throttling.
+   *
+   * <p>The flag reduces spurious UI refreshes by signalling that the associated browser request has
+   * already paused for progress. Subsequent calls are idempotent and keep the fetch state intact,
+   * ensuring race-free cooperation between multiple waiter threads that may report waits
+   * concurrently.
+   */
   public synchronized void setHasWaited() {
     hasWaited = true;
   }
 
   /**
-   * Adds a listener that will be notified when a change occurs to this fetch
+   * Registers a listener that will be notified whenever fetch state changes or events arrive.
    *
-   * @param listener - The listener to be added
+   * <p>Listeners are invoked outside the synchronized blocks but may still be called from worker
+   * threads that deliver {@link ClientEvent}s, so implementations must be thread-safe and quick. If
+   * a listener slows down excessively it can delay UI refresh notifications for other watchers.
+   *
+   * @param listener the callback to add; must be thread-safe because notifications may cross
+   *     threads
    */
   public synchronized void addListener(FProxyFetchListener listener) {
     if (LOG.isDebugEnabled()) {
@@ -574,9 +813,13 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   }
 
   /**
-   * Removes a listener
+   * Unregisters a previously added listener and logs whether cancellation is now possible.
    *
-   * @param listener - The listener to be removed
+   * <p>If this removal empties the listener set, the tracker may soon cancel the fetch once waiters
+   * and results are also gone. Logging is performed at debug level to aid lifecycle diagnostics
+   * without noisy production output.
+   *
+   * @param listener the callback to remove; ignored if not currently registered
    */
   public synchronized void removeListener(FProxyFetchListener listener) {
     if (LOG.isDebugEnabled()) {
@@ -588,15 +831,42 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
     }
   }
 
-  /** Allows the fetch to be removed immediately */
+  /**
+   * Allows the fetch to be removed immediately.
+   *
+   * <p>Setting this flag bypasses the usual thirty-second grace period used to serve late browser
+   * refreshes. It is intended for explicit user cancellation or cleanup operations where keeping
+   * the entry alive provides no value.
+   */
   public synchronized void requestImmediateCancel() {
     requestImmediateCancel = true;
   }
 
+  /**
+   * Returns the timestamp (milliseconds since epoch) of the most recent waiter or result access.
+   *
+   * <p>The tracker uses this value to decide when the fetch entry has been idle long enough to
+   * cancel. It is updated on waiter creation and result reads; callers should treat it as a
+   * monotonic indicator of user interest.
+   *
+   * @return epoch millisecond timestamp of the last interaction with this fetch
+   */
+  @SuppressWarnings("unused")
   public synchronized long lastTouched() {
     return lastTouched;
   }
 
+  /**
+   * Compares a fetch context against the stored one to determine deduplication compatibility.
+   *
+   * <p>Only a subset of {@link FetchContext} fields influence deduplication: filtering toggle,
+   * output/temp limits, charset override, and MIME override. The method ignores other options such
+   * as priority and persistent request flags because FProxy reuse focuses on data equivalence. Null
+   * and non-null charsets are compared carefully to avoid unintended mismatches.
+   *
+   * @param context candidate context to compare; may contain charset and MIME overrides
+   * @return {@code true} when filtering, sizing, and charset rules are semantically identical
+   */
   public boolean fetchContextEquivalent(FetchContext context) {
     if (this.fctx.getFilterData() != context.getFilterData()) return false;
     if (this.fctx.getMaxOutputLength() != context.getMaxOutputLength()) return false;
@@ -609,13 +879,54 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
         || this.fctx.getOverrideMIME().equals(context.getOverrideMIME());
   }
 
+  /**
+   * Unsupported resume hook because FProxy fetchers are intentionally non-persistent.
+   *
+   * <p>Resume callbacks are part of the {@link ClientGetCallback} contract for persistent requests.
+   * Because FProxy fetches are transient and tied to browser interactions, persistence is disabled
+   * and any attempt to resume would indicate a misuse. The exception keeps this behaviour explicit
+   * for maintainers.
+   *
+   * @param context unused context supplied by the persistence mechanism
+   * @throws UnsupportedOperationException always, to signal the lifecycle limitation
+   */
   @Override
   public void onResume(ClientContext context) {
     throw new UnsupportedOperationException(); // Not persistent.
   }
 
+  /**
+   * Exposes the {@link RequestClient} identity used for quota enforcement and statistics.
+   *
+   * <p>The request client anchors the fetch within node-level accounting such as bandwidth
+   * throttling or trust metrics. It is set during construction and remains constant so auxiliary
+   * components can attribute traffic correctly.
+   *
+   * @return request client associated with this fetch; never null after construction
+   */
   @Override
   public RequestClient getRequestClient() {
     return rc;
+  }
+
+  /**
+   * Returns a diagnostic string containing the identifier, URI, and initial client context.
+   *
+   * <p>The format is stable enough for logging and troubleshooting but not intended as a
+   * serialization contract. It avoids revealing internal mutable state and therefore remains safe
+   * to print even while callbacks mutate other fields.
+   *
+   * @return human-readable summary suitable for debug logging and progress pages
+   */
+  @Override
+  public String toString() {
+    return "FProxyFetchInProgress{"
+        + "identifier="
+        + identifier
+        + ", uri="
+        + uri
+        + ", context="
+        + initialContext
+        + '}';
   }
 }

--- a/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
@@ -1,0 +1,150 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchResult;
+import network.crypta.client.HighLevelSimpleClientImpl;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import network.crypta.support.io.ArrayBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FProxyFetchInProgressTest {
+
+  @Test
+  void fetchContextEquivalent_returnsTrueForIdenticalCopy() {
+    FetchContext context = newFetchContext();
+    FProxyFetchInProgress progress = newProgress(context);
+
+    FetchContext identicalCopy = new FetchContext(context, FetchContext.IDENTICAL_MASK);
+
+    assertTrue(progress.fetchContextEquivalent(identicalCopy));
+  }
+
+  @Test
+  void fetchContextEquivalent_whenOverrideMimeDiff_returnsFalse() {
+    FetchContext context = newFetchContext();
+    FProxyFetchInProgress progress = newProgress(context);
+
+    FetchContext different = new FetchContext(context, FetchContext.IDENTICAL_MASK);
+    different.setOverrideMIME("text/plain");
+
+    assertFalse(progress.fetchContextEquivalent(different));
+  }
+
+  @Test
+  void canCancel_whenRecentlyTouchedWithoutImmediateCancel_returnsFalse() throws Exception {
+    FProxyFetchInProgress progress = newProgress(newFetchContext());
+    long now = System.currentTimeMillis();
+    setField(progress, "lastTouched", now);
+
+    assertFalse(progress.canCancel());
+  }
+
+  @Test
+  void canCancel_whenImmediateCancelRequested_allowsCancellationDuringLifetime() throws Exception {
+    FProxyFetchInProgress progress = newProgress(newFetchContext());
+    setField(progress, "lastTouched", System.currentTimeMillis());
+
+    progress.requestImmediateCancel();
+
+    assertTrue(progress.canCancel());
+  }
+
+  @Test
+  void getETA_whenInsufficientProgress_returnsMinusOne() throws Exception {
+    FProxyFetchInProgress progress = newProgress(newFetchContext());
+    setField(progress, "goneToNetwork", true);
+    setField(progress, "requiredBlocks", 10);
+    setField(progress, "fetchedBlocks", 3);
+    setField(progress, "fetchedBlocksPreNetwork", 1);
+
+    assertEquals(-1, progress.getETA());
+  }
+
+  @Test
+  void getETA_whenProgressMade_returnsPositiveEstimate() throws Exception {
+    FProxyFetchInProgress progress = newProgress(newFetchContext());
+    setField(progress, "goneToNetwork", true);
+    setField(progress, "requiredBlocks", 10);
+    setField(progress, "fetchedBlocks", 7);
+    setField(progress, "fetchedBlocksPreNetwork", 1);
+    setField(progress, "timeStarted", System.currentTimeMillis() - 1000);
+
+    long eta = progress.getETA();
+
+    assertTrue(eta > 0);
+  }
+
+  @Test
+  void notFinishedOrFatallyFinished_whenDataPresent_returnsFalse() {
+    FProxyFetchInProgress progress = newProgress(newFetchContext());
+    Bucket bucket = new ArrayBucket();
+    FetchResult result = new FetchResult(new ClientMetadata("text/plain"), bucket);
+
+    progress.onSuccess(result, null);
+
+    assertFalse(progress.notFinishedOrFatallyFinished());
+    assertTrue(progress.hasData());
+  }
+
+  @Test
+  void notFinishedOrFatallyFinished_whenFatalFailure_returnsTrue() {
+    FProxyFetchInProgress progress = newProgress(newFetchContext());
+
+    progress.onFailure(new FetchException(FetchExceptionMode.TOO_BIG), null);
+
+    assertTrue(progress.notFinishedOrFatallyFinished());
+  }
+
+  @Test
+  void notFinishedOrFatallyFinished_whenNonFatalFailureEventuallyReturnsFalse() throws Exception {
+    FProxyFetchInProgress progress = newProgress(newFetchContext());
+
+    progress.onFailure(new FetchException(FetchExceptionMode.DATA_NOT_FOUND), null);
+    assertTrue(progress.notFinishedOrFatallyFinished());
+
+    setField(progress, "timeFailed", System.currentTimeMillis() - 1500);
+    setField(progress, "fetched", 2);
+
+    assertFalse(progress.notFinishedOrFatallyFinished());
+  }
+
+  private static FProxyFetchInProgress newProgress(FetchContext context) {
+    ClientContext clientContext = Mockito.mock(ClientContext.class);
+    FProxyFetchTracker tracker = Mockito.mock(FProxyFetchTracker.class);
+    RequestClient requestClient = Mockito.mock(RequestClient.class);
+    FreenetURI uri = new FreenetURI("KSK", "doc");
+
+    return new FProxyFetchInProgress(
+        tracker, uri, 1024L, 1L, clientContext, context, requestClient, REFILTER_POLICY.ACCEPT_OLD);
+  }
+
+  private static FetchContext newFetchContext() {
+    return HighLevelSimpleClientImpl.makeDefaultFetchContext(
+        2048L, 4096L, new ArrayBucketFactory(), new SimpleEventProducer());
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}


### PR DESCRIPTION
## Summary
- document and clarify FProxyFetchInProgress lifecycle, caching, and cancellation behaviors
- refactor cache reuse logic for readability with helper methods and richer logging
- add dedicated unit tests covering ETA, cancellation, failure handling, and fetch context equivalence

## Testing
- not run (not requested)