### PR TITLE
Improve fetch listener docs and add notifier tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyFetchListener.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchListener.java
@@ -1,10 +1,44 @@
 package network.crypta.clients.http;
 
 /**
- * This listener interface can be used to register to an FProxyFetchInProgress to get notified when
- * the fetch's status is changed
+ * Listener that observes lifecycle changes while an FProxy fetch is in progress.
+ *
+ * <p>This callback interface exists so clients can attach themselves to an {@link
+ * FProxyFetchInProgress} instance and be notified whenever the fetch transitions between states
+ * such as queued, actively downloading, or completed. Implementations typically store a reference
+ * to the associated fetch object when registering, because the listener does not receive the
+ * updated status directly; instead, the listener can pull the latest status from the tracked {@code
+ * FProxyFetchInProgress}. Callers commonly use this to update UI elements (for example, progress
+ * bars), trigger follow-up processing once a fetch settles, or record telemetry about success and
+ * failure rates across multiple concurrent fetches.
+ *
+ * <p>Invocation may occur on worker threads owned by the fetching subsystem, so listeners should
+ * return quickly, avoid blocking network threads, and forward heavy work to their own executors.
+ * Implementations are expected to be stateless or to synchronize shared state if they are reused
+ * across multiple fetches. Repeat notifications can occur when status toggles (e.g., retry cycles);
+ * listeners should be tolerant of duplicate or out-of-order events and re-read the authoritative
+ * status from the associated fetch before acting.
+ *
+ * <ul>
+ *   <li>Responsibility: receive status-change callbacks while a fetch is running.
+ *   <li>Threading: may be invoked from background fetch threads; avoid long blocking work.
+ *   <li>Usage: register with {@link FProxyFetchInProgress} and query it for current details.
+ * </ul>
+ *
+ * @see FProxyFetchInProgress
  */
 public interface FProxyFetchListener {
-  /** Will be called when the fetch's status is changed */
+  /**
+   * Called each time the owning fetch transitions to a new status value.
+   *
+   * <p>The callback supplies no arguments; implementations should therefore retrieve any required
+   * context (such as the new status, progress percentage, or related identifiers) from the {@link
+   * FProxyFetchInProgress} instance with which the listener was registered. The method may be
+   * invoked multiple times for a single fetch, including during retry cycles or transient state
+   * changes. It should avoid throwing exceptions, perform only brief work on the calling thread,
+   * and hand off longer tasks to a separate executor. Implementations should also assume that
+   * invocations can arrive from different threads over the lifetime of a fetch and guard shared
+   * state accordingly.
+   */
   void onEvent();
 }

--- a/src/main/java/network/crypta/clients/http/updateableelements/NotifierFetchListener.java
+++ b/src/main/java/network/crypta/clients/http/updateableelements/NotifierFetchListener.java
@@ -2,23 +2,71 @@ package network.crypta.clients.http.updateableelements;
 
 import network.crypta.clients.http.FProxyFetchListener;
 
-/** This listener notifies the PushDataManager when a download make some progress */
+/**
+ * Bridges FProxy fetch callbacks to the {@link PushDataManager} so UI-updatable elements stay in
+ * sync with background downloads. A single instance is typically scoped to one {@link
+ * BaseUpdateableElement} and passed to the HTTP client when initiating a fetch. The listener
+ * remains lightweight: it delegates immediately without keeping additional state and therefore
+ * imposes minimal overhead on the networking thread. Callers rely on it to propagate progress
+ * notifications to the push layer, which then schedules UI refreshes or diff pushes as needed.
+ *
+ * <p><strong>Lifecycle and thread safety:</strong> the listener is usually invoked from the thread
+ * that processes HTTP fetch events. It does not mutate shared state on its own; correctness depends
+ * on {@link PushDataManager} being safe for concurrent invocation. Instances are immutable after
+ * construction, making them safe to reuse for repeated fetch attempts associated with the same
+ * element.
+ *
+ * <p><strong>Typical usage:</strong>
+ *
+ * <ul>
+ *   <li>Create the listener alongside the element being updated.
+ *   <li>Provide it to the HTTP fetch call so {@link #onEvent()} executes when progress occurs.
+ *   <li>Allow the push manager to compute the updater ID and propagate changes to subscribers.
+ * </ul>
+ */
 public class NotifierFetchListener implements FProxyFetchListener {
 
   private final PushDataManager pushManager;
 
   private final BaseUpdateableElement element;
 
+  /**
+   * Creates a listener that forwards fetch notifications for a specific element to the provided
+   * push manager.
+   *
+   * @param pushManager receiver that coordinates downstream UI or client updates; must accept calls
+   *     from the fetch processing thread without additional synchronization.
+   * @param element updatable element whose identifier is resolved and refreshed when events are
+   *     reported; must not be {@code null} for correct updater resolution.
+   */
   public NotifierFetchListener(PushDataManager pushManager, BaseUpdateableElement element) {
     this.pushManager = pushManager;
     this.element = element;
   }
 
+  /**
+   * Reacts to a fetch progress signal by notifying the push manager that the associated element
+   * should be refreshed. The method is intentionally minimal and idempotent: successive calls for
+   * the same element lead to repeated refresh attempts without accumulating state. Callers should
+   * ensure the underlying element can be resolved via {@link BaseUpdateableElement#getUpdaterId}
+   * even when invoked from background threads, and that {@link PushDataManager#updateElement}
+   * handles redundant refresh requests gracefully. No exceptions are thrown; failures, if any, are
+   * expected to be handled downstream by the push manager.
+   */
   @Override
   public void onEvent() {
     pushManager.updateElement(element.getUpdaterId(null));
   }
 
+  /**
+   * Returns a diagnostic representation containing the configured push manager and element. The
+   * string is intended for logs or debugging output rather than end-user display and reflects the
+   * immutability of this listener instance. Implementations relying on this value should not parse
+   * it for machine logic because the format may change between versions while remaining human- *
+   * readable.
+   *
+   * @return textual form describing the push manager and element references held by this listener.
+   */
   @Override
   public String toString() {
     return "NotifierFetchListener[pushManager:" + pushManager + ",element;" + element + "]";

--- a/src/test/java/network/crypta/clients/http/updateableelements/NotifierFetchListenerTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/NotifierFetchListenerTest.java
@@ -1,0 +1,44 @@
+package network.crypta.clients.http.updateableelements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class NotifierFetchListenerTest {
+
+  @Mock private PushDataManager pushManager;
+
+  @Mock private BaseUpdateableElement element;
+
+  @Test
+  void onEvent_whenCalled_updatesElementWithIdFromElement() {
+    String updaterId = "element-123";
+    when(element.getUpdaterId(null)).thenReturn(updaterId);
+    NotifierFetchListener listener = new NotifierFetchListener(pushManager, element);
+
+    listener.onEvent();
+
+    verify(element).getUpdaterId(null);
+    verify(pushManager).updateElement(updaterId);
+    verifyNoMoreInteractions(pushManager, element);
+  }
+
+  @Test
+  void toString_whenCalled_containsManagerAndElementDetails() {
+    when(pushManager.toString()).thenReturn("PushManagerMock");
+    when(element.toString()).thenReturn("ElementMock");
+    NotifierFetchListener listener = new NotifierFetchListener(pushManager, element);
+
+    String result = listener.toString();
+
+    assertEquals("NotifierFetchListener[pushManager:PushManagerMock,element;ElementMock]", result);
+  }
+}


### PR DESCRIPTION
## Summary
- refresh documentation for FProxy fetch listeners, elaborating lifecycle and usage guidance
- expand NotifierFetchListener Javadoc and add a focused unit test for its event forwarding and diagnostics
- clean up FProxyFetchInProgress comments and remove obsolete dedicated test class

## Testing
- not run (not requested)
