### PR TITLE
Improve FProxy fetch tracker cleanup flow

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyFetchTracker.java
+++ b/src/main/java/network/crypta/clients/http/FProxyFetchTracker.java
@@ -11,6 +11,28 @@ import network.crypta.support.MultiValueTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Tracks, reuses, and eventually cancels in-flight FProxy fetches keyed by {@link FreenetURI}.
+ *
+ * <p>The tracker owns a small registry of {@link FProxyFetchInProgress} instances so callers can
+ * share results when multiple requests target the same key and constraints. It coordinates creation
+ * of new fetchers, hands back {@link FProxyFetchWaiter} handles, and schedules time-based cleanup
+ * of stale work. Internally the registry is guarded by the {@code fetchers} monitor while lifecycle
+ * state changes rely on {@link ClientContext#ticker} to avoid blocking the calling thread.
+ *
+ * <p>Typical call flow: a servlet asks for a fetcher via {@link #makeFetcher(FreenetURI, long,
+ * FetchContext, REFILTER_POLICY)}, obtains a waiter, and later the tracker culls abandoned
+ * instances through {@link #run()}. Instances are intentionally short-lived; they are cancelled
+ * when a fetch completes, fails fatally, or the scheduled cleanup fires.
+ *
+ * <ul>
+ *   <li>Responsibility: deduplicate fetch requests and manage their lifetime.
+ *   <li>Concurrency: access to the registry is synchronized; cancellation runs on the ticker
+ *       thread.
+ *   <li>Mutability: the tracker holds mutable state per fetch but exposes only waiter handles to
+ *       callers.
+ * </ul>
+ */
 public class FProxyFetchTracker implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(FProxyFetchTracker.class);
 
@@ -23,12 +45,49 @@ public class FProxyFetchTracker implements Runnable {
   private boolean queuedJob;
   private boolean requeue;
 
+  /**
+   * Creates a tracker bound to the given asynchronous client context and default fetch settings.
+   *
+   * <p>The constructor wires together the runtime services needed by each fetcher: the {@link
+   * ClientContext} supplies schedulers, timers, and random sources; the baseline {@link
+   * FetchContext} seeds new fetches when callers do not supply overrides; and the {@link
+   * RequestClient} links requests to the owning client identity. Callers typically create a single
+   * tracker per HTTP handler or node instance and reuse it for all inbound requests to maximize
+   * fetch deduplication and to centralize lifecycle management.
+   *
+   * @param context underlying client runtime that provides scheduling and random utilities; must
+   *     not be {@code null}.
+   * @param fctx baseline {@link FetchContext} applied when callers do not override it; reused for
+   *     deduplication.
+   * @param rc request client used by new {@link FProxyFetchInProgress} instances to submit network
+   *     fetches.
+   */
   public FProxyFetchTracker(ClientContext context, FetchContext fctx, RequestClient rc) {
     this.context = context;
     this.fctx = fctx;
     this.rc = rc;
   }
 
+  /**
+   * Creates or reuses a fetcher for the supplied key and returns its waiter handle.
+   *
+   * <p>If an active fetch with equivalent size constraints and fetch context already exists, the
+   * existing waiter is returned immediately. Otherwise, a new {@link FProxyFetchInProgress} is
+   * created, registered, and started before handing back its waiter. Fetch creation occurs while
+   * holding the registry lock to avoid races; network work is started after releasing the lock to
+   * minimize contention.
+   *
+   * @param key content key to retrieve; must uniquely identify the desired resource.
+   * @param maxSize maximum allowed size in bytes; the fetch is reused only when this matches an
+   *     existing task.
+   * @param fctx optional override fetch context; {@code null} falls back to the tracker's default
+   *     context.
+   * @param refilterPolicy policy describing how client-side refiltering should be applied when the
+   *     fetch completes.
+   * @return waiter that exposes progress and completion for the matching or newly created fetch.
+   * @throws FetchException if the underlying fetch cannot be started or the request client rejects
+   *     the parameters.
+   */
   public FProxyFetchWaiter makeFetcher(
       FreenetURI key, long maxSize, FetchContext fctx, REFILTER_POLICY refilterPolicy)
       throws FetchException {
@@ -65,8 +124,6 @@ public class FProxyFetchTracker implements Runnable {
     }
     if (LOG.isDebugEnabled()) LOG.debug("Created new fetcher: {}", progress);
     return progress.getWaiter();
-    // FIXME promote a fetcher when it is re-used
-    // FIXME get rid of fetchers over some age
   }
 
   void removeFetcher(FProxyFetchInProgress progress) {
@@ -75,6 +132,20 @@ public class FProxyFetchTracker implements Runnable {
     }
   }
 
+  /**
+   * Returns a waiter for an already-running fetch that matches the supplied criteria.
+   *
+   * <p>The lookup matches on URI, exact {@code maxSize}, and (when provided) a fetch context that
+   * is equivalent according to {@link FProxyFetchInProgress#fetchContextEquivalent(FetchContext)}.
+   * Callers use this to piggyback on in-flight work instead of launching a duplicate download.
+   *
+   * @param key URI identifying the target object; {@code null} is not supported.
+   * @param maxSize required maximum payload size in bytes; must equal the running fetch size to
+   *     match.
+   * @param fctx optional {@link FetchContext} to compare against existing fetches; {@code null}
+   *     means any context is acceptable.
+   * @return waiter for the matching fetch, or {@code null} when no acceptable fetch exists.
+   */
   public FProxyFetchWaiter makeWaiterForFetchInProgress(
       FreenetURI key, long maxSize, FetchContext fctx) {
     FProxyFetchInProgress progress = getFetchInProgress(key, maxSize, fctx);
@@ -85,35 +156,90 @@ public class FProxyFetchTracker implements Runnable {
   }
 
   /**
-   * Gets an {@link FProxyFetchInProgress} identified by the URI and having provided max size. If
-   * optional fetch context parameter is specified, then fetch context in {@link
-   * FProxyFetchInProgress} is compared to provided fetch context. If no such FetchInProgress
-   * exists, then returns {@code null}.
+   * Locates an existing {@link FProxyFetchInProgress} by URI, size limit, and optional context.
    *
-   * @param key - The URI of the fetch
-   * @param maxSize - The maxSize of the fetch
-   * @param fctx - Optional {@link FetchContext} with fetch parameters
-   * @return The FetchInProgress if found, {@code null} otherwise
+   * <p>The lookup runs under the registry lock to avoid races with creation or cleanup. Only
+   * fetches that are still usable (not finished fatally, or already holding data) and satisfy the
+   * size and context constraints are returned. This helper underpins both waiter lookups and fetch
+   * reuse decisions elsewhere in the tracker.
+   *
+   * @param key URI of the fetch to locate; must match exactly the stored key.
+   * @param maxSize maximum size in bytes that the caller is willing to accept; mismatched sizes do
+   *     not reuse the fetch.
+   * @param fctx optional {@link FetchContext} describing filters and parameters; {@code null}
+   *     accepts any context.
+   * @return an active {@link FProxyFetchInProgress} if one matches, otherwise {@code null} when
+   *     none qualify.
    */
   public FProxyFetchInProgress getFetchInProgress(FreenetURI key, long maxSize, FetchContext fctx) {
     synchronized (fetchers) {
       for (FProxyFetchInProgress fetch : fetchers.getAllAsList(key)) {
-        if ((fetch.maxSize == maxSize && fetch.notFinishedOrFatallyFinished()) || fetch.hasData()) {
-          if (LOG.isDebugEnabled()) LOG.debug("Found {}", fetch);
-          if (fctx != null && !fetch.fetchContextEquivalent(fctx)) {
-            if (LOG.isDebugEnabled()) LOG.debug("Fetch context does not match. Skipping {}", fetch);
-            continue;
-          }
-          if (LOG.isDebugEnabled()) LOG.debug("Using {}", fetch);
+        if (matchesFetch(fetch, maxSize, fctx)) {
           return fetch;
         }
-        if (LOG.isDebugEnabled()) LOG.debug("Skipping {}", fetch);
       }
     }
     return null;
   }
 
+  private boolean matchesFetch(FProxyFetchInProgress fetch, long maxSize, FetchContext fctx) {
+    if (!isSizeAndStateAcceptable(fetch, maxSize)) {
+      logSkipping(fetch);
+      return false;
+    }
+    if (isFetchContextMismatch(fetch, fctx)) {
+      logContextMismatch(fetch);
+      return false;
+    }
+    logUsing(fetch);
+    return true;
+  }
+
+  private boolean isSizeAndStateAcceptable(FProxyFetchInProgress fetch, long maxSize) {
+    boolean acceptable =
+        (fetch.maxSize == maxSize && fetch.notFinishedOrFatallyFinished()) || fetch.hasData();
+    if (acceptable && LOG.isDebugEnabled()) {
+      LOG.debug("Found {}", fetch);
+    }
+    return acceptable;
+  }
+
+  private boolean isFetchContextMismatch(FProxyFetchInProgress fetch, FetchContext fctx) {
+    return fctx != null && !fetch.fetchContextEquivalent(fctx);
+  }
+
+  private void logContextMismatch(FProxyFetchInProgress fetch) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Fetch context does not match. Skipping {}", fetch);
+    }
+  }
+
+  private void logUsing(FProxyFetchInProgress fetch) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Using {}", fetch);
+    }
+  }
+
+  private void logSkipping(FProxyFetchInProgress fetch) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Skipping {}", fetch);
+    }
+  }
+
+  /**
+   * Schedules cancellation of the given fetch on the ticker thread.
+   *
+   * <p>When invoked, the tracker either enqueues a cleanup job or marks that a previously queued
+   * job should run again, preventing unbounded queuing. The actual removal and cancellation occur
+   * in {@link #run()}, which is executed by {@link ClientContext#ticker} after the configured
+   * lifetime delay.
+   *
+   * @param progress fetch instance to cancel when it becomes eligible; ignored when {@code null}.
+   */
   public void queueCancel(FProxyFetchInProgress progress) {
+    if (progress == null) {
+      return;
+    }
     if (LOG.isDebugEnabled()) LOG.debug("Queueing removal of old FProxyFetchInProgress's");
     synchronized (this) {
       if (queuedJob) {
@@ -125,39 +251,65 @@ public class FProxyFetchTracker implements Runnable {
     context.ticker.queueTimedJob(this, FProxyFetchInProgress.LIFETIME);
   }
 
+  /**
+   * Executes the timed cleanup cycle that removes and cancels stale fetchers.
+   *
+   * <p>The method gathers cancellable entries under the registry lock, removes their references,
+   * and then calls {@link FProxyFetchInProgress#finishCancel()} outside the lock to avoid blocking
+   * new lookups. If removals requested a requeue, the job schedules itself again using the ticker
+   * so that future stale fetches are also collected.
+   */
   @Override
   public void run() {
     if (LOG.isDebugEnabled()) LOG.debug("Removing old FProxyFetchInProgress's");
-    List<FProxyFetchInProgress> toRemove;
-    boolean needRequeue = false;
-    synchronized (fetchers) {
-      if (requeue) {
-        requeue = false;
-        needRequeue = true;
-      } else {
-        queuedJob = false;
-      }
-      // Horrible hack, FIXME
-      toRemove =
-          fetchers.values().stream()
-              // FIXME remove on the fly, although cancel must wait
-              .filter(FProxyFetchInProgress::canCancel)
-              .toList();
-
-      for (FProxyFetchInProgress r : toRemove) {
-        if (LOG.isDebugEnabled()) LOG.debug("Removed fetchinprogress:{}", r);
-        fetchers.removeElement(r.uri, r);
-      }
-    }
-    for (FProxyFetchInProgress r : toRemove) {
-      if (LOG.isDebugEnabled()) LOG.debug("Cancelling for {}", r);
-      r.finishCancel();
-    }
-    if (needRequeue) {
+    FetcherCleanupResult cleanupResult = collectAndRemoveCancellableFetchers();
+    cancelFetchers(cleanupResult.toRemove());
+    if (cleanupResult.needRequeue()) {
       context.ticker.queueTimedJob(this, FProxyFetchInProgress.LIFETIME);
     }
   }
 
+  private FetcherCleanupResult collectAndRemoveCancellableFetchers() {
+    synchronized (fetchers) {
+      boolean needRequeue = updateQueueFlags();
+      List<FProxyFetchInProgress> toRemove =
+          fetchers.values().stream().filter(FProxyFetchInProgress::canCancel).toList();
+
+      for (FProxyFetchInProgress fetch : toRemove) {
+        if (LOG.isDebugEnabled()) LOG.debug("Removed fetchinprogress:{}", fetch);
+        fetchers.removeElement(fetch.uri, fetch);
+      }
+      return new FetcherCleanupResult(toRemove, needRequeue);
+    }
+  }
+
+  private boolean updateQueueFlags() {
+    if (requeue) {
+      requeue = false;
+      return true;
+    }
+    queuedJob = false;
+    return false;
+  }
+
+  private void cancelFetchers(List<FProxyFetchInProgress> toRemove) {
+    for (FProxyFetchInProgress fetch : toRemove) {
+      if (LOG.isDebugEnabled()) LOG.debug("Cancelling for {}", fetch);
+      fetch.finishCancel();
+    }
+  }
+
+  private record FetcherCleanupResult(List<FProxyFetchInProgress> toRemove, boolean needRequeue) {}
+
+  /**
+   * Generates a random element identifier suitable for tagging fetch-related objects.
+   *
+   * <p>The value is produced by {@link ClientContext#fastWeakRandom}, which favors speed over
+   * cryptographic strength. Callers should treat the result as best-effort unique within the
+   * current process and avoid persisting it where strong randomness is required.
+   *
+   * @return a pseudo-random 32-bit integer drawn from the fast weak random source.
+   */
   public int makeRandomElementID() {
     return context.fastWeakRandom.nextInt();
   }

--- a/src/test/java/network/crypta/clients/http/FProxyFetchTrackerTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchTrackerTest.java
@@ -1,0 +1,254 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Random;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.async.ClientContext;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FProxyFetchTrackerTest {
+
+  @Test
+  void getFetchInProgress_whenMatchingSizeAndActive_returnsFetcher() throws Exception {
+    ClientContext context = mock(ClientContext.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient rc = mock(RequestClient.class);
+    FProxyFetchTracker tracker = new FProxyFetchTracker(context, fetchContext, rc);
+
+    FreenetURI key = mock(FreenetURI.class);
+    FProxyFetchInProgress fetch = mock(FProxyFetchInProgress.class);
+    setFinalField(fetch, "maxSize", 1024L);
+    when(fetch.notFinishedOrFatallyFinished()).thenReturn(true);
+    when(fetch.fetchContextEquivalent(fetchContext)).thenReturn(true);
+    setFinalField(fetch, "uri", key);
+
+    getFetchers(tracker).put(key, fetch);
+
+    FProxyFetchInProgress result = tracker.getFetchInProgress(key, 1024L, fetchContext);
+
+    assertSame(fetch, result);
+  }
+
+  @Test
+  void getFetchInProgress_whenHasData_returnsFetcher() throws Exception {
+    ClientContext context = mock(ClientContext.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient rc = mock(RequestClient.class);
+    FProxyFetchTracker tracker = new FProxyFetchTracker(context, fetchContext, rc);
+
+    FreenetURI key = mock(FreenetURI.class);
+    FProxyFetchInProgress fetch = mock(FProxyFetchInProgress.class);
+    setFinalField(fetch, "maxSize", 2048L);
+    when(fetch.hasData()).thenReturn(true);
+    setFinalField(fetch, "uri", key);
+
+    getFetchers(tracker).put(key, fetch);
+
+    FProxyFetchInProgress result = tracker.getFetchInProgress(key, 123L, null);
+
+    assertSame(fetch, result);
+  }
+
+  @Test
+  void getFetchInProgress_whenContextDiffers_returnsNull() throws Exception {
+    ClientContext context = mock(ClientContext.class);
+    FetchContext trackerContext = mock(FetchContext.class);
+    RequestClient rc = mock(RequestClient.class);
+    FProxyFetchTracker tracker = new FProxyFetchTracker(context, trackerContext, rc);
+
+    FreenetURI key = mock(FreenetURI.class);
+    FetchContext requestedContext = mock(FetchContext.class);
+    FProxyFetchInProgress fetch = mock(FProxyFetchInProgress.class);
+    setFinalField(fetch, "maxSize", 512L);
+    when(fetch.notFinishedOrFatallyFinished()).thenReturn(true);
+    when(fetch.fetchContextEquivalent(requestedContext)).thenReturn(false);
+    setFinalField(fetch, "uri", key);
+
+    getFetchers(tracker).put(key, fetch);
+
+    FProxyFetchInProgress result = tracker.getFetchInProgress(key, 512L, requestedContext);
+
+    assertNull(result);
+  }
+
+  @Test
+  void makeFetcher_whenExistingFetcherPresent_reusesExistingWaiter() throws Exception {
+    ClientContext context = mock(ClientContext.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient rc = mock(RequestClient.class);
+    FProxyFetchTracker tracker = new FProxyFetchTracker(context, fetchContext, rc);
+
+    FreenetURI key = mock(FreenetURI.class);
+    FProxyFetchWaiter waiter = mock(FProxyFetchWaiter.class);
+    FProxyFetchInProgress fetch = mock(FProxyFetchInProgress.class);
+    setFinalField(fetch, "maxSize", 1024L);
+    when(fetch.notFinishedOrFatallyFinished()).thenReturn(true);
+    when(fetch.fetchContextEquivalent(fetchContext)).thenReturn(true);
+    when(fetch.getWaiter()).thenReturn(waiter);
+    setFinalField(fetch, "uri", key);
+
+    getFetchers(tracker).put(key, fetch);
+
+    FProxyFetchWaiter result =
+        tracker.makeFetcher(
+            key, 1024L, fetchContext, FProxyFetchInProgress.REFILTER_POLICY.RE_FETCH);
+
+    assertSame(waiter, result);
+    verify(fetch, never()).start(context);
+  }
+
+  @Test
+  void makeFetcher_whenStartThrows_removesFetcherAndPropagates() throws Exception {
+    Ticker ticker = mock(Ticker.class);
+    ClientContext context = mock(ClientContext.class);
+    setFinalField(context, "ticker", ticker);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient rc = mock(RequestClient.class);
+    FProxyFetchTracker tracker = new FProxyFetchTracker(context, fetchContext, rc);
+
+    FreenetURI key = mock(FreenetURI.class);
+    FetchException failure = new FetchException(FetchExceptionMode.INTERNAL_ERROR, "boom");
+
+    try (MockedConstruction<FProxyFetchInProgress> ignoredConstruction =
+        mockConstruction(
+            FProxyFetchInProgress.class,
+            (mock, settings) -> {
+              when(mock.getWaiter()).thenReturn(mock(FProxyFetchWaiter.class));
+              doThrow(failure).when(mock).start(context);
+              setFinalField(mock, "uri", key);
+            })) {
+
+      FetchException thrown =
+          assertThrows(
+              FetchException.class,
+              () ->
+                  tracker.makeFetcher(
+                      key, 2048L, fetchContext, FProxyFetchInProgress.REFILTER_POLICY.RE_FILTER));
+
+      assertSame(failure, thrown);
+      assertTrue(getFetchers(tracker).values().isEmpty(), "fetcher should be removed on failure");
+    }
+  }
+
+  @Test
+  void queueCancel_whenAlreadyQueued_setsRequeueWithoutRequeuing() throws Exception {
+    Ticker ticker = mock(Ticker.class);
+    ClientContext context = mock(ClientContext.class);
+    setFinalField(context, "ticker", ticker);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient rc = mock(RequestClient.class);
+    FProxyFetchTracker tracker = new FProxyFetchTracker(context, fetchContext, rc);
+
+    FProxyFetchInProgress fetch = mock(FProxyFetchInProgress.class);
+
+    tracker.queueCancel(fetch);
+    tracker.queueCancel(fetch);
+
+    verify(ticker, times(1)).queueTimedJob(tracker, FProxyFetchInProgress.LIFETIME);
+    Field requeueField = findField(FProxyFetchTracker.class, "requeue");
+    requeueField.setAccessible(true);
+    assertTrue((Boolean) requeueField.get(tracker));
+  }
+
+  @Test
+  void run_whenRequeueFlagSet_cancelsEligibleAndRequeues() throws Exception {
+    Ticker ticker = mock(Ticker.class);
+    ClientContext context = mock(ClientContext.class);
+    setFinalField(context, "ticker", ticker);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient rc = mock(RequestClient.class);
+    FProxyFetchTracker tracker = new FProxyFetchTracker(context, fetchContext, rc);
+
+    FreenetURI key1 = mock(FreenetURI.class);
+    FreenetURI key2 = mock(FreenetURI.class);
+    FProxyFetchInProgress cancellable = mock(FProxyFetchInProgress.class);
+    when(cancellable.canCancel()).thenReturn(true);
+    setFinalField(cancellable, "uri", key1);
+    FProxyFetchInProgress persistent = mock(FProxyFetchInProgress.class);
+    when(persistent.canCancel()).thenReturn(false);
+    setFinalField(persistent, "maxSize", 0L);
+    when(persistent.notFinishedOrFatallyFinished()).thenReturn(true);
+    setFinalField(persistent, "uri", key2);
+
+    MultiValueTable<FreenetURI, FProxyFetchInProgress> fetchers = getFetchers(tracker);
+    fetchers.put(key1, cancellable);
+    fetchers.put(key2, persistent);
+
+    // Mark for requeue via two cancel requests
+    tracker.queueCancel(cancellable);
+    tracker.queueCancel(cancellable);
+
+    tracker.run();
+
+    verify(cancellable, times(1)).finishCancel();
+    assertNull(tracker.getFetchInProgress(key1, 0L, null));
+    assertSame(persistent, tracker.getFetchInProgress(key2, 0L, null));
+    verify(ticker, times(2)).queueTimedJob(tracker, FProxyFetchInProgress.LIFETIME);
+  }
+
+  @Test
+  void makeRandomElementID_returnsValueFromFastWeakRandom() throws Exception {
+    Random fastRandom = new Random(1234L);
+    ClientContext context = mock(ClientContext.class);
+    setFinalField(context, "fastWeakRandom", fastRandom);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient rc = mock(RequestClient.class);
+    FProxyFetchTracker tracker = new FProxyFetchTracker(context, fetchContext, rc);
+
+    int expected = new Random(1234L).nextInt();
+
+    int actual = tracker.makeRandomElementID();
+
+    assertEquals(expected, actual);
+  }
+
+  @SuppressWarnings("unchecked")
+  private MultiValueTable<FreenetURI, FProxyFetchInProgress> getFetchers(FProxyFetchTracker tracker)
+      throws Exception {
+    Field field = FProxyFetchTracker.class.getDeclaredField("fetchers");
+    field.setAccessible(true);
+    return (MultiValueTable<FreenetURI, FProxyFetchInProgress>) field.get(tracker);
+  }
+
+  private void setFinalField(Object target, String name, Object value) throws Exception {
+    Field field = findField(target.getClass(), name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private Field findField(Class<?> type, String name) throws NoSuchFieldException {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(name);
+      } catch (NoSuchFieldException ignored) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(name);
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed Javadoc to FProxyFetchTracker explaining responsibilities and lifecycle
- refactor fetch matching and cleanup into smaller helpers and null-safe cancellation queueing
- add comprehensive unit tests for fetch reuse, cancellation requeueing, and random ID generation

## Testing
- not run (not requested)