### PR TITLE
Improve BrowserTestToadlet docs and tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/BrowserTestToadlet.java
+++ b/src/main/java/network/crypta/clients/http/BrowserTestToadlet.java
@@ -7,14 +7,31 @@ import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
 /**
- * Browser Test Toadlet. Accessible from <code>http://.../test/</code>.
+ * Toadlet that renders a browser capability self-test page for Crypta clients.
  *
- * <p>Useful to test browser's capabilities:
+ * <p>This handler serves under {@code /test/} and generates HTML sections that probe features often
+ * constrained by hardened browsers, including inline {@code data:} image rendering, concurrent
+ * connection limits, and basic JavaScript execution. It is intended for node operators to manually
+ * visit when verifying that their configured browser can interact with FProxy without silently
+ * blocking required resources. Output is created on demand and carries no mutable state, so
+ * repeated visits always reflect the user's current browser configuration and any active content
+ * filters.
+ *
+ * <p>The page composition uses {@link PageMaker} and the surrounding {@link ToadletContext} to
+ * build themed infoboxes and alerts while avoiding external network fetches. The class itself is
+ * stateless; thread safety is provided by the hosting toadlet framework, which typically handles
+ * one request per invocation. When the client supplies {@code wontload}, the handler skips certain
+ * probes to let automated checks detect connection limits without triggering unnecessary network
+ * noise.
  *
  * <ul>
- *   <li>warn the user about useless enabled features/plugins which might be dangerous
- *   <li>Assist the user in configuring his browser properly to surf on freenet
- *       <ul>
+ *   <li><strong>Responsibilities:</strong> Present browser diagnostics, warn about unsafe plugin
+ *       configurations, and surface alert summaries when full access is allowed.
+ *   <li><strong>Notable behaviors:</strong> Embeds a warning GIF as a data URI to check inline MIME
+ *       support and generates ten parallel image requests to expose per-host connection caps.
+ * </ul>
+ *
+ * @see Toadlet
  */
 public class BrowserTestToadlet extends Toadlet {
 
@@ -22,7 +39,7 @@ public class BrowserTestToadlet extends Toadlet {
     super(client);
   }
 
-  private static final String imgWarningMime =
+  private static final String IMG_WARNING_MIME =
       "R0lGODdh1AE8AOf9AAABAAcAAAkBAAoDARAAAQcECRYAAxoCAB4BACIBARMK"
           + "ACUBBCcBACoAABQMAw0PDBMPAC4BAiUHADQBABkQASMLAjoABRQSFj0CAUEA"
           + "AyASAC0MASQSAB8VAUYCAk4AAUkEAEgEBS8SAFYAAFEDAFEDBVkCBGAAAVwE"
@@ -175,6 +192,26 @@ public class BrowserTestToadlet extends Toadlet {
           + "TTfltFP4CgA1VFFFraqAAAIANUIAYJzwRFRHhRVWT2eltVZbb8U1V1135bVX"
           + "X38FNlhhhyW2WGOPRTZZZbEMCAA7";
 
+  private static final String INFOBOX_WARNING_CLASS = "infobox-warning";
+
+  /**
+   * Handles an HTTP GET by emitting a diagnostic page that exercises multiple browser features in
+   * isolation.
+   *
+   * <p>The handler builds a themed {@link PageNode} that includes three infoboxes: a MIME-inline
+   * data URI test, a connection saturation test that spawns more than ten parallel image fetches,
+   * and a JavaScript mutation test that rewrites an image source at runtime. If the client sets the
+   * {@code wontload} parameter, connection probes are suppressed to reduce noise during scripted
+   * checks. When the caller is permitted full access, the page also includes any queued alert
+   * summaries sourced from the context's alert manager.
+   *
+   * @param uri URI identifying the resource path within the test toadlet.
+   * @param request HTTPRequest containing query parameters and browser capability hints sent by
+   *     client.
+   * @param ctx Context that renders HTML, manages permissions, and writes response safely.
+   * @throws ToadletContextClosedException if the connection closes before the response is written.
+   * @throws IOException if writing the generated HTML to the client stream fails.
+   */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     // Yes, we need that in order to test the browser (number of connections per server)
@@ -189,19 +226,19 @@ public class BrowserTestToadlet extends Toadlet {
     /* for test (for allow <img src="data:...) add "; img-src 'self' data:"
      * to freenet.clients.http.ToadletContextImpl#generateCSP return statement */
     ctx.getPageMaker()
-        .getInfobox("infobox-warning", "MIME Inline", contentNode, "mime-inline-test", true)
+        .getInfobox(INFOBOX_WARNING_CLASS, "MIME Inline", contentNode, "mime-inline-test", true)
         .addChild(
             "img",
             new String[] {"src", "alt"},
             new String[] {
-              "data:image/gif;base64," + imgWarningMime, "Your browser is probably safe."
+              "data:image/gif;base64," + IMG_WARNING_MIME, "Your browser is probably safe."
             });
 
     // #### Test whether we can have more than 10 simultaneous connections to fproxy
     HTMLNode maxConnectionsPerServerContent =
         ctx.getPageMaker()
             .getInfobox(
-                "infobox-warning",
+                INFOBOX_WARNING_CLASS,
                 "Number of connections",
                 contentNode,
                 "browser-connections",
@@ -217,9 +254,9 @@ public class BrowserTestToadlet extends Toadlet {
         new String[] {"src", "alt"},
         new String[] {"/static/themes/clean/success.png", "fail!"});
 
-    // #### Test whether JS is available. : should do the test with pictures instead!
+    // #### Test whether JS is available. Should do the test with pictures instead!
     ctx.getPageMaker()
-        .getInfobox("infobox-warning", "Javascript", contentNode, "javascript-test", true)
+        .getInfobox(INFOBOX_WARNING_CLASS, "Javascript", contentNode, "javascript-test", true)
         .addChild("div")
         .addChild(
             "img",
@@ -232,6 +269,11 @@ public class BrowserTestToadlet extends Toadlet {
     this.writeHTMLReply(ctx, 200, "OK", null, page.generate(), true);
   }
 
+  /**
+   * Returns the mount path where this toadlet exposes its diagnostic page.
+   *
+   * @return String representing the public path {@code "/test/"} served by the toadlet.
+   */
   @Override
   public String path() {
     return "/test/";

--- a/src/test/java/network/crypta/clients/http/BrowserTestToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/BrowserTestToadletTest.java
@@ -1,0 +1,183 @@
+package network.crypta.clients.http;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.Arrays;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class BrowserTestToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+
+  @Mock private HTTPRequest request;
+
+  @Mock private ToadletContext ctx;
+
+  @Mock private PageMaker pageMaker;
+
+  @Mock private PageNode pageNode;
+
+  @Mock private UserAlertManager alertManager;
+
+  @Test
+  void path_whenCalled_returnsTestEndpoint() {
+    BrowserTestToadlet toadlet = new BrowserTestToadlet(client);
+
+    String result = toadlet.path();
+
+    assertEquals("/test/", result);
+  }
+
+  @Test
+  void handleMethodGET_whenWontloadParameterSet_exitsEarly() throws Exception {
+    BrowserTestToadlet toadlet = new BrowserTestToadlet(client);
+    when(request.isParameterSet("wontload")).thenReturn(true);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/test/"), request, ctx);
+
+    verify(request, times(1)).isParameterSet("wontload");
+    verify(ctx, never()).getPageMaker();
+    verify(ctx, never())
+        .sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong(), anyBoolean());
+    verify(ctx, never()).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void handleMethodGET_whenFullAccess_addsSummaryAndWritesPage() throws Exception {
+    BrowserTestToadlet toadlet = new BrowserTestToadlet(client);
+    HTMLNode contentNode = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    HTMLNode mimeInfobox = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    HTMLNode maxConnections = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    HTMLNode javascriptBox = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    HTMLNode summaryNode = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    String generatedHtml = "page-html";
+
+    when(request.isParameterSet("wontload")).thenReturn(false);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(alertManager.createSummary()).thenReturn(summaryNode);
+    when(pageMaker.getPageNode("Crypta browser testing tool", ctx)).thenReturn(pageNode);
+    when(pageNode.getContentNode()).thenReturn(contentNode);
+    when(pageNode.generate()).thenReturn(generatedHtml);
+    when(pageMaker.getInfobox(
+            "infobox-warning", "MIME Inline", contentNode, "mime-inline-test", true))
+        .thenReturn(mimeInfobox);
+    when(pageMaker.getInfobox(
+            "infobox-warning", "Number of connections", contentNode, "browser-connections", true))
+        .thenReturn(maxConnections);
+    when(pageMaker.getInfobox(
+            "infobox-warning", "Javascript", contentNode, "javascript-test", true))
+        .thenReturn(javascriptBox);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/test/"), request, ctx);
+
+    verify(contentNode).addChild(summaryNode);
+
+    ArgumentCaptor<String> mimeTag = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String[]> mimeAttrs = ArgumentCaptor.forClass(String[].class);
+    ArgumentCaptor<String[]> mimeValues = ArgumentCaptor.forClass(String[].class);
+    verify(mimeInfobox).addChild(mimeTag.capture(), mimeAttrs.capture(), mimeValues.capture());
+    String[] capturedAttrs = mimeAttrs.getValue();
+    String[] capturedValues = mimeValues.getValue();
+    assertEquals("img", mimeTag.getValue());
+    assertEquals(Arrays.asList("src", "alt"), Arrays.asList(capturedAttrs));
+    assertTrue(capturedValues[0].startsWith("data:image/gif;base64,"));
+    assertEquals("Your browser is probably safe.", capturedValues[1]);
+
+    ArgumentCaptor<String> connTag = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> connText = ArgumentCaptor.forClass(String.class);
+    verify(maxConnections).addChild(connTag.capture(), connText.capture());
+    assertEquals("#", connTag.getValue());
+    assertTrue(connText.getValue().contains("more than 10 connections per server"));
+    verify(maxConnections, times(10)).addChild("img", "src", ".?wontload");
+    ArgumentCaptor<String> successTag = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String[]> successAttrs = ArgumentCaptor.forClass(String[].class);
+    ArgumentCaptor<String[]> successValues = ArgumentCaptor.forClass(String[].class);
+    verify(maxConnections)
+        .addChild(successTag.capture(), successAttrs.capture(), successValues.capture());
+    assertEquals("img", successTag.getValue());
+    assertArrayEquals(new String[] {"src", "alt"}, successAttrs.getValue());
+    assertArrayEquals(
+        new String[] {"/static/themes/clean/success.png", "fail!"}, successValues.getValue());
+
+    verify(javascriptBox).addChild("div");
+    ArgumentCaptor<String> jsTag = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String[]> jsAttrs = ArgumentCaptor.forClass(String[].class);
+    ArgumentCaptor<String[]> jsValues = ArgumentCaptor.forClass(String[].class);
+    verify(javascriptBox).addChild(jsTag.capture(), jsAttrs.capture(), jsValues.capture());
+    assertEquals("img", jsTag.getValue());
+    assertArrayEquals(new String[] {"id", "src", "alt"}, jsAttrs.getValue());
+    assertArrayEquals(
+        new String[] {"JSTEST", "/static/themes/clean/success.png", "fail!"}, jsValues.getValue());
+    verify(javascriptBox).addChild("script", "type", "text/javascript");
+    verify(javascriptBox)
+        .addChild(
+            "%", "document.getElementById('JSTEST').src = '/static/themes/clean/warning.png';");
+
+    byte[] htmlBytes = generatedHtml.getBytes(UTF_8);
+    verify(ctx)
+        .sendReplyHeaders(200, "OK", null, "text/html; charset=utf-8", htmlBytes.length, true);
+    verify(ctx).writeData(htmlBytes, 0, htmlBytes.length);
+  }
+
+  @Test
+  void handleMethodGET_whenFullAccessDenied_skipsAlertSummary() throws Exception {
+    BrowserTestToadlet toadlet = new BrowserTestToadlet(client);
+    HTMLNode contentNode = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    HTMLNode mimeInfobox = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    HTMLNode maxConnections = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    HTMLNode javascriptBox = mock(HTMLNode.class, Answers.RETURNS_SELF);
+    String generatedHtml = "html";
+
+    when(request.isParameterSet("wontload")).thenReturn(false);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    when(pageMaker.getPageNode("Crypta browser testing tool", ctx)).thenReturn(pageNode);
+    when(pageNode.getContentNode()).thenReturn(contentNode);
+    when(pageNode.generate()).thenReturn(generatedHtml);
+    when(pageMaker.getInfobox(
+            "infobox-warning", "MIME Inline", contentNode, "mime-inline-test", true))
+        .thenReturn(mimeInfobox);
+    when(pageMaker.getInfobox(
+            "infobox-warning", "Number of connections", contentNode, "browser-connections", true))
+        .thenReturn(maxConnections);
+    when(pageMaker.getInfobox(
+            "infobox-warning", "Javascript", contentNode, "javascript-test", true))
+        .thenReturn(javascriptBox);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/test/"), request, ctx);
+
+    verify(ctx, never()).getAlertManager();
+    verify(contentNode, never()).addChild(any(HTMLNode.class));
+    byte[] htmlBytes = generatedHtml.getBytes(UTF_8);
+    verify(ctx)
+        .sendReplyHeaders(200, "OK", null, "text/html; charset=utf-8", htmlBytes.length, true);
+    verify(ctx).writeData(htmlBytes, 0, htmlBytes.length);
+  }
+}


### PR DESCRIPTION
## Summary
- expand BrowserTestToadlet KDoc and clarify intent of the diagnostics page
- extract constants for warning class and image MIME data for readability
- add BrowserTestToadletTest covering path, wontload early exit, full-access rendering, and restricted-access behavior

## Testing
- not run (not requested)