### PR TITLE
Content filter toadlet path configurability and validation improvements

### DIFF
--- a/src/main/java/network/crypta/clients/http/BadRequestException.java
+++ b/src/main/java/network/crypta/clients/http/BadRequestException.java
@@ -3,33 +3,116 @@ package network.crypta.clients.http;
 import java.io.Serial;
 
 /**
- * Indicates that a request cannot be processed by the toadlet, due to missing or invalid data in
- * the request.
+ * Signals that a request cannot be processed by a toadlet because required input is malformed or
+ * missing.
+ *
+ * <p>This exception is thrown by HTTP-facing components when they detect client-side faults such as
+ * absent query parameters, unreadable payloads, or unsupported encodings. It lets callers abort
+ * processing early while retaining the specific part of the request that failed validation for
+ * logging or error reporting. The class is mutable only through construction; once created, the
+ * {@link #getInvalidRequestPart()} value remains stable, making instances safe to propagate across
+ * threads for diagnostic purposes. Typical usage involves catching this exception at the toadlet
+ * boundary, returning an HTTP 400 response, and including a human-friendly description derived from
+ * the message or invalid component reference.
+ *
+ * <ul>
+ *   <li><strong>Scope:</strong> Represents client errors only; server-side faults should use other
+ *       exception types.
+ *   <li><strong>Stability:</strong> Captures the failing request fragment for consistent reporting
+ *       and logging.
+ *   <li><strong>Thread-safety:</strong> Immutable after construction, allowing reuse across threads
+ *       without synchronization.
+ * </ul>
+ *
+ * @see #getInvalidRequestPart()
  */
 public class BadRequestException extends Exception {
   @Serial private static final long serialVersionUID = 1L;
 
+  /**
+   * Name or description of the request fragment that failed validation and triggered this
+   * exception, typically a parameter, header, or body section identifier.
+   */
   private final String invalidRequestPart;
 
+  /**
+   * Creates an exception describing a bad request and the part that failed validation.
+   *
+   * <p>Use this constructor when no additional explanatory message is available beyond the
+   * problematic request fragment. The stored request part should be concise, such as a parameter
+   * name or header key, to aid error responses and logs.
+   *
+   * @param invalidRequestPart identifier for the malformed or missing portion of the request; may
+   *     be {@code null} when the failing element cannot be isolated.
+   */
   public BadRequestException(String invalidRequestPart) {
     this.invalidRequestPart = invalidRequestPart;
   }
 
+  /**
+   * Creates an exception with a detail message describing why the request is invalid.
+   *
+   * <p>The message should be suitable for operator logs or sanitized error responses. Include
+   * contextual hints such as expected formats or missing keys when safe to expose.
+   *
+   * @param invalidRequestPart identifier for the malformed or missing portion of the request; may
+   *     be {@code null} when unavailable or not applicable.
+   * @param message human-readable detail explaining the validation failure; callers should avoid
+   *     embedding sensitive request contents.
+   */
+  @SuppressWarnings("unused")
   public BadRequestException(String invalidRequestPart, String message) {
     super(message);
     this.invalidRequestPart = invalidRequestPart;
   }
 
+  /**
+   * Creates an exception that wraps a root cause while identifying the invalid request portion.
+   *
+   * <p>Use this overload when a downstream component throws an exception while parsing or
+   * validating input, and the higher layer wants to mark the request as bad while retaining the
+   * causal stack trace.
+   *
+   * @param invalidRequestPart identifier for the malformed or missing portion of the request; may
+   *     be {@code null} when the failing element cannot be isolated.
+   * @param cause originating exception encountered during request parsing or validation; may be
+   *     {@code null} when no underlying throwable exists.
+   */
   public BadRequestException(String invalidRequestPart, Throwable cause) {
     super(cause);
     this.invalidRequestPart = invalidRequestPart;
   }
 
+  /**
+   * Creates an exception with both a descriptive message and a root cause for invalid requests.
+   *
+   * <p>This overload is useful when callers need to surface a concise message to clients while
+   * still preserving the original exception for logging or debugging. The message should focus on
+   * client-actionable guidance, whereas the cause may contain lower-level parsing details.
+   *
+   * @param invalidRequestPart identifier for the malformed or missing portion of the request; may
+   *     be {@code null} if the problematic fragment is unknown.
+   * @param message explanatory text describing why the request is considered bad; keep sensitive
+   *     data out of this string when it might reach clients.
+   * @param cause underlying throwable that triggered the bad request determination; may be {@code
+   *     null} when no specific cause is available.
+   */
+  @SuppressWarnings("unused")
   public BadRequestException(String invalidRequestPart, String message, Throwable cause) {
     super(message, cause);
     this.invalidRequestPart = invalidRequestPart;
   }
 
+  /**
+   * Returns the portion of the request that failed validation or was missing.
+   *
+   * <p>The value typically names a query parameter, form field, header, or body segment that
+   * triggered the exception. Implementations do not modify this value after construction, making it
+   * safe to cache or include in structured error payloads.
+   *
+   * @return identifier of the malformed or absent request fragment, or {@code null} if no precise
+   *     part could be determined.
+   */
   public String getInvalidRequestPart() {
     return invalidRequestPart;
   }

--- a/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.filter.ContentFilter;
@@ -25,36 +26,135 @@ import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Allows the user to run the content filter on a file and view the result. */
+/**
+ * Exposes a small HTTP UI that lets advanced users run the content filter against uploaded or local
+ * files and inspect the sanitized output.
+ *
+ * <p>This toadlet acts as the bridge between browser clients and the {@link ContentFilter}. It
+ * renders a simple form, validates MIME type and filter intent, and streams the submitted data into
+ * the node's filtering pipeline. When configured, it also supports browsing the local filesystem so
+ * operators can run ad hoc checks without leaving the web console. Requests are only served when
+ * advanced mode and full access are enabled, preventing exposure on public gateways.
+ *
+ * <p>Typical lifecycle: callers mount the toadlet at {@link #CONTENT_FILTER_PATH}, the browser
+ * issues GET to render the form, and POST to submit either an uploaded file or a selection from the
+ * local browser. The toadlet streams data into the filter, chooses whether to display or save the
+ * result, and writes structured HTML responses with localized messages. The class is not
+ * thread-safe by itself but relies on the surrounding server framework for concurrency control.
+ *
+ * <ul>
+ *   <li>Responsibilities: render UI, validate parameters, feed data into the filter, report
+ *       outcomes.
+ *   <li>Notable behaviors: respects configurable endpoint path, enforces advanced-mode access, and
+ *       cleans up upload parts to conserve memory.
+ * </ul>
+ *
+ * @see LocalFileFilterToadlet
+ * @see ContentFilter
+ */
 public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback {
   private static final Logger LOG = LoggerFactory.getLogger(ContentFilterToadlet.class);
 
-  public static final String PATH = "/filterfile/";
+  private static final String PATH_PROPERTY =
+      "network.crypta.clients.http.ContentFilterToadlet.path";
+  private static final String DEFAULT_PATH_SEGMENT = "filterfile";
+  private static final String DEFAULT_PATH = String.join("/", "", DEFAULT_PATH_SEGMENT, "");
 
-  /** What to do the the output from the content filter. */
+  /**
+   * Resolved URL path where the content filter UI and submission endpoint are mounted. The path is
+   * derived from the {@code network.crypta.clients.http.ContentFilterToadlet.path} system property
+   * when present; otherwise it defaults to {@code /filterfile/}. The trailing slash is preserved so
+   * relative links in rendered forms remain stable.
+   */
+  public static final String CONTENT_FILTER_PATH = resolvePath();
+
+  private static final String MIME_TYPE_PART = "mime-type";
+  private static final String FILTER_OPERATION_PART = "filter-operation";
+  private static final String RESULT_HANDLING_PART = "result-handling";
+  private static final String INPUT_ELEMENT = "input";
+  private static final String VALUE_ATTR = "value";
+  private static final String FILENAME_PART = "filename";
+
+  private static final String FILTER_URI_PROPERTY =
+      "network.crypta.clients.http.ContentFilterToadlet.loopbackUri";
+  private static final URI DEFAULT_FILTER_URI = URI.create("http://127.0.0.1:8888/");
+
+  /**
+   * Controls what the node does with filtered output once processing completes.
+   *
+   * <p>The option is selected by the user via the filter UI and is persisted during round-trips
+   * between the main form and the local file browser.
+   */
   public enum ResultHandling {
+    /** Render the filtered content directly back to the browser in the HTTP response. */
     DISPLAY,
+    /** Save the filtered content to disk using the node's standard download location. */
     SAVE
   }
 
   private final NodeClientCore core;
 
+  /**
+   * Creates a content filter toadlet bound to the given client core and HTTP client abstraction.
+   *
+   * @param client HTTP client utility used for link-aware rendering and helper operations; must not
+   *     be {@code null}.
+   * @param clientCore node client core providing access to filtering services and access-control
+   *     checks; must not be {@code null}.
+   */
   public ContentFilterToadlet(HighLevelSimpleClient client, NodeClientCore clientCore) {
     super(client);
     this.core = clientCore;
   }
 
-  @Override
-  public String path() {
-    return PATH;
+  private static String resolvePath() {
+    String configuredPath = System.getProperty(PATH_PROPERTY);
+    if (configuredPath == null || configuredPath.isBlank()) {
+      return DEFAULT_PATH;
+    }
+    return configuredPath;
   }
 
+  @Override
+  public String path() {
+    return CONTENT_FILTER_PATH;
+  }
+
+  /**
+   * Indicates whether the toadlet should serve the current request context.
+   *
+   * <p>Access is granted only when advanced mode is enabled and the caller has full access (or the
+   * node is not acting as a public gateway). This gate keeps the filter UI from being reachable in
+   * restricted environments.
+   *
+   * @param ctx request context containing authentication and mode flags; may be {@code null} to
+   *     signify no access.
+   * @return {@code true} when advanced mode and full access allow serving the request; otherwise
+   *     {@code false}.
+   */
   public boolean isEnabled(ToadletContext ctx) {
     if (ctx == null) return false;
     boolean fullAccess = !container.publicGatewayMode() || ctx.isAllowedFullAccess();
     return ctx.isAdvancedModeEnabled() && fullAccess;
   }
 
+  /**
+   * Renders the content filter form for GET requests and returns it as HTML.
+   *
+   * <p>The method enforces full-access requirements, injects any pending alerts, and builds the
+   * filter form with defaults. It never mutates server state and is safe to call repeatedly. When
+   * access is denied, it emits an unauthorized response instead of redirecting.
+   *
+   * @param uri target URI of the request, used for context binding; must not be {@code null}.
+   * @param request parsed HTTP request carrying query parameters; must not be {@code null}.
+   * @param ctx toadlet context used for authorization, localization, and response writing; must not
+   *     be {@code null}.
+   * @throws ToadletContextClosedException if the client connection closes before the response is
+   *     fully written.
+   * @throws IOException if the response cannot be streamed to the caller.
+   * @throws RedirectException if a redirect is required by the underlying framework while building
+   *     the page.
+   */
   public void handleMethodGET(URI uri, final HTTPRequest request, final ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     if (container.publicGatewayMode() && !ctx.isAllowedFullAccess()) {
@@ -74,6 +174,24 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
     writeHTMLReply(ctx, 200, "OK", null, page.generate());
   }
 
+  /**
+   * Processes POST submissions for both direct uploads and local file selections.
+   *
+   * <p>The method branches on form parts: launching the local browser, filtering a locally browsed
+   * file, or handling an uploaded payload. It validates required fields, preserves stateful
+   * parameters between steps, and frees request parts in a {@code finally} block to avoid resource
+   * leaks. Access control mirrors {@link #handleMethodGET(URI, HTTPRequest, ToadletContext)}.
+   *
+   * @param uri target URI of the request, retained for compatibility with the Toadlet contract; may
+   *     be unused by some branches.
+   * @param request multipart POST request containing user input and optional file data; must not be
+   *     {@code null} and is released after processing.
+   * @param ctx context for permission checks, localization, and response handling; must not be
+   *     {@code null}.
+   * @throws ToadletContextClosedException if the client disconnects before the response completes.
+   * @throws IOException if streaming responses or temporary file operations fail.
+   * @throws RedirectException if a redirect is required by the framework during processing.
+   */
   public void handleMethodPOST(URI uri, final HTTPRequest request, final ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     if (container.publicGatewayMode() && !ctx.isAllowedFullAccess()) {
@@ -86,35 +204,26 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
         try {
           FilterOperation filterOperation = getFilterOperation(request);
           ResultHandling resultHandling = getResultHandling(request);
-          String mimeType = request.getPartAsStringFailsafe("mime-type", 100);
+          String mimeType = request.getPartAsStringFailsafe(MIME_TYPE_PART, 100);
           String location =
               LocalFileFilterToadlet.PATH
-                  + "?filter-operation="
+                  + '?'
+                  + FILTER_OPERATION_PART
+                  + '='
                   + filterOperation
-                  + "&result-handling="
+                  + '&'
+                  + RESULT_HANDLING_PART
+                  + '='
                   + resultHandling
-                  + "&mime-type="
+                  + '&'
+                  + MIME_TYPE_PART
+                  + '='
                   + mimeType;
           MultiValueTable<String, String> responseHeaders =
               MultiValueTable.from("Location", location);
           ctx.sendReplyHeaders(302, "Found", responseHeaders, null, 0);
         } catch (BadRequestException e) {
-          String invalidPart = e.getInvalidRequestPart();
-          if ("filter-operation".equals(invalidPart)) {
-            writeBadRequestError(
-                l10n("errorMustSpecifyFilterOperationTitle"),
-                l10n("errorMustSpecifyFilterOperation"),
-                ctx,
-                true);
-          } else if ("result-handling".equals(invalidPart)) {
-            writeBadRequestError(
-                l10n("errorMustSpecifyResultHandlingTitle"),
-                l10n("errorMustSpecifyResultHandling"),
-                ctx,
-                true);
-          } else {
-            writeBadRequestError(l10n("errorBadRequestTitle"), l10n("errorBadRequest"), ctx, true);
-          }
+          handleInvalidPart(e.getInvalidRequestPart(), ctx);
         }
         // Filter button on local file browser
       } else if (request.isPartSet(LocalFileBrowserToadlet.selectFile)) {
@@ -130,26 +239,49 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
     }
   }
 
+  private void handleInvalidPart(String invalidPart, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    switch (invalidPart) {
+      case FILTER_OPERATION_PART ->
+          writeBadRequestError(
+              l10n("errorMustSpecifyFilterOperationTitle"),
+              l10n("errorMustSpecifyFilterOperation"),
+              ctx);
+      case RESULT_HANDLING_PART ->
+          writeBadRequestError(
+              l10n("errorMustSpecifyResultHandlingTitle"),
+              l10n("errorMustSpecifyResultHandling"),
+              ctx);
+      case FILENAME_PART ->
+          writeBadRequestError(l10n("errorNoFileSelectedTitle"), l10n("errorNoFileSelected"), ctx);
+      default -> writeBadRequestError(l10n("errorBadRequestTitle"), l10n("errorBadRequest"), ctx);
+    }
+  }
+
   private HTMLNode createContent(PageMaker pageMaker, ToadletContext ctx) {
     InfoboxNode infobox = pageMaker.getInfobox(l10n("filterFile"), "filter-file", true);
     HTMLNode filterBox = infobox.getOuterNode();
     HTMLNode filterContent = infobox.getContentNode();
 
-    HTMLNode filterForm = ctx.addFormChild(filterContent, PATH, "filterForm");
+    HTMLNode filterForm = ctx.addFormChild(filterContent, CONTENT_FILTER_PATH, "filterForm");
 
     // apply read filter, write filter, or both
-    // TODO: radio buttons to select, once ContentFilter supports write filtering
+    // ContentFilter currently only supports read filtering; write selection will be added once
+    // the filter exposes write-side operations.
     filterForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"hidden", "filter-operation", FilterOperation.BOTH.toString()});
+        INPUT_ELEMENT,
+        new String[] {"type", "name", VALUE_ATTR},
+        new String[] {"hidden", FILTER_OPERATION_PART, FilterOperation.BOTH.toString()});
 
     // display in browser or save to disk
     filterForm.addChild(
-        "input",
-        new String[] {"type", "name", "value", "id"},
+        INPUT_ELEMENT,
+        new String[] {"type", "name", VALUE_ATTR, "id"},
         new String[] {
-          "radio", "result-handling", ResultHandling.DISPLAY.toString(), "result-handling-display"
+          "radio",
+          RESULT_HANDLING_PART,
+          ResultHandling.DISPLAY.toString(),
+          "result-handling-display"
         });
     filterForm.addChild(
         "label",
@@ -158,10 +290,10 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
         l10n("displayResultLabel"));
     filterForm.addChild("br");
     filterForm.addChild(
-        "input",
-        new String[] {"type", "name", "value", "id"},
+        INPUT_ELEMENT,
+        new String[] {"type", "name", VALUE_ATTR, "id"},
         new String[] {
-          "radio", "result-handling", ResultHandling.SAVE.toString(), "result-handling-save"
+          "radio", RESULT_HANDLING_PART, ResultHandling.SAVE.toString(), "result-handling-save"
         });
     filterForm.addChild(
         "label",
@@ -174,7 +306,9 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
     // mime type
     filterForm.addChild("#", l10n("mimeTypeLabel") + ": ");
     filterForm.addChild(
-        "input", new String[] {"type", "name", "value"}, new String[] {"text", "mime-type", ""});
+        INPUT_ELEMENT,
+        new String[] {"type", "name", VALUE_ATTR},
+        new String[] {"text", MIME_TYPE_PART, ""});
     filterForm.addChild("br");
     filterForm.addChild("#", l10n("mimeTypeText"));
     filterForm.addChild("br");
@@ -184,26 +318,27 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
     if (ctx.isAllowedFullAccess()) {
       filterForm.addChild("#", l10n("filterFileBrowseLabel") + ": ");
       filterForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
+          INPUT_ELEMENT,
+          new String[] {"type", "name", VALUE_ATTR},
           new String[] {"submit", "filter-local", l10n("filterFileBrowseButton") + "..."});
       filterForm.addChild("br");
     }
     filterForm.addChild("#", l10n("filterFileUploadLabel") + ": ");
     filterForm.addChild(
-        "input", new String[] {"type", "name", "value"}, new String[] {"file", "filename", ""});
+        INPUT_ELEMENT,
+        new String[] {"type", "name", VALUE_ATTR},
+        new String[] {"file", FILENAME_PART, ""});
     filterForm.addChild("#", " \u00a0 ");
     filterForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
+        INPUT_ELEMENT,
+        new String[] {"type", "name", VALUE_ATTR},
         new String[] {"submit", "filter-upload", l10n("filterFileFilterLabel")});
     filterForm.addChild("#", " \u00a0 ");
 
     return filterBox;
   }
 
-  private void writeBadRequestError(
-      String header, String message, ToadletContext context, boolean returnToFilterPage)
+  private void writeBadRequestError(String header, String message, ToadletContext context)
       throws ToadletContextClosedException, IOException {
     PageMaker pageMaker = context.getPageMaker();
     PageNode page = pageMaker.getPageNode(header, context);
@@ -214,14 +349,12 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
     HTMLNode infoboxContent =
         pageMaker.getInfobox("infobox-error", header, contentNode, "filter-error", false);
     infoboxContent.addChild("#", message);
-    if (returnToFilterPage) {
-      NodeL10n.getBase()
-          .addL10nSubstitution(
-              infoboxContent.addChild("div"),
-              "ContentFilterToadlet.tryAgainFilterFilePage",
-              new String[] {"link"},
-              new HTMLNode[] {HTMLNode.link(ContentFilterToadlet.PATH)});
-    }
+    NodeL10n.getBase()
+        .addL10nSubstitution(
+            infoboxContent.addChild("div"),
+            "ContentFilterToadlet.tryAgainFilterFilePage",
+            new String[] {"link"},
+            new HTMLNode[] {HTMLNode.link(ContentFilterToadlet.CONTENT_FILTER_PATH)});
     writeHTMLReply(context, 400, "Bad request", page.generate());
   }
 
@@ -232,79 +365,95 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
     try {
       FilterOperation filterOperation = getFilterOperation(request);
       ResultHandling resultHandling = getResultHandling(request);
-      String mimeType = request.getPartAsStringFailsafe("mime-type", 100);
-      String filename;
-      Bucket bucket;
+      String mimeType = request.getPartAsStringFailsafe(MIME_TYPE_PART, 100);
       if (localFile) {
-        filename = request.getPartAsStringFailsafe("filename", QueueToadlet.MAX_FILENAME_LENGTH);
-        if (mimeType.isEmpty()) {
-          mimeType = DefaultMIMETypes.guessMIMEType(filename, false);
-        }
-        File file = new File(filename);
-        bucket = new FileBucket(file, true, false, false, false);
+        handleLocalFilterRequest(request, ctx, core, filterOperation, resultHandling, mimeType);
       } else {
-        HTTPUploadedFile file = request.getUploadedFile("filename");
-        if (file == null) {
-          throw new BadRequestException("filename");
-        }
-        filename = file.getFilename();
-        if (mimeType.isEmpty()) {
-          mimeType = file.getContentType();
-        }
-        bucket = file.getData();
-      }
-      if (filename.isEmpty()) {
-        throw new BadRequestException("filename");
-      }
-      String resultFilename = makeResultFilename(filename, mimeType);
-      try {
-        handleFilter(bucket, mimeType, filterOperation, resultHandling, resultFilename, ctx, core);
-      } catch (FileNotFoundException e) {
-        writeBadRequestError(
-            l10n("errorNoFileOrCannotReadTitle"),
-            l10n("errorNoFileOrCannotRead", "file", filename),
-            ctx,
-            true);
+        handleUploadedFilterRequest(request, ctx, core, filterOperation, resultHandling, mimeType);
       }
     } catch (BadRequestException e) {
-      String invalidPart = e.getInvalidRequestPart();
-      if ("filter-operation".equals(invalidPart)) {
-        writeBadRequestError(
-            l10n("errorMustSpecifyFilterOperationTitle"),
-            l10n("errorMustSpecifyFilterOperation"),
-            ctx,
-            true);
-      } else if ("result-handling".equals(invalidPart)) {
-        writeBadRequestError(
-            l10n("errorMustSpecifyResultHandlingTitle"),
-            l10n("errorMustSpecifyResultHandling"),
-            ctx,
-            true);
-      } else if ("filename".equals(invalidPart)) {
-        writeBadRequestError(
-            l10n("errorNoFileSelectedTitle"), l10n("errorNoFileSelected"), ctx, true);
-      } else {
-        writeBadRequestError(l10n("errorBadRequestTitle"), l10n("errorBadRequest"), ctx, true);
-      }
+      handleInvalidPart(e.getInvalidRequestPart(), ctx);
+    }
+  }
+
+  private void handleLocalFilterRequest(
+      HTTPRequest request,
+      ToadletContext ctx,
+      NodeClientCore core,
+      FilterOperation filterOperation,
+      ResultHandling resultHandling,
+      String mimeType)
+      throws ToadletContextClosedException, IOException, BadRequestException {
+    String filename =
+        request.getPartAsStringFailsafe(FILENAME_PART, QueueToadlet.MAX_FILENAME_LENGTH);
+    String resolvedMimeType =
+        mimeType.isEmpty() ? DefaultMIMETypes.guessMIMEType(filename, false) : mimeType;
+    if (filename.isEmpty()) {
+      throw new BadRequestException(FILENAME_PART);
+    }
+    File file = new File(filename);
+    try (Bucket bucket = new FileBucket(file, true, false, false, false)) {
+      processFilter(bucket, filename, resolvedMimeType, filterOperation, resultHandling, ctx, core);
+    } catch (FileNotFoundException e) {
+      writeBadRequestError(
+          l10n("errorNoFileOrCannotReadTitle"), cannotReadFileMessage(filename), ctx);
+    }
+  }
+
+  private void handleUploadedFilterRequest(
+      HTTPRequest request,
+      ToadletContext ctx,
+      NodeClientCore core,
+      FilterOperation filterOperation,
+      ResultHandling resultHandling,
+      String mimeType)
+      throws ToadletContextClosedException, IOException, BadRequestException {
+    HTTPUploadedFile file = request.getUploadedFile(FILENAME_PART);
+    if (file == null) {
+      throw new BadRequestException(FILENAME_PART);
+    }
+    String filename = file.getFilename();
+    String resolvedMimeType = mimeType.isEmpty() ? file.getContentType() : mimeType;
+    if (filename.isEmpty()) {
+      throw new BadRequestException(FILENAME_PART);
+    }
+    try (Bucket bucket = file.getData()) {
+      processFilter(bucket, filename, resolvedMimeType, filterOperation, resultHandling, ctx, core);
+    } catch (FileNotFoundException e) {
+      writeBadRequestError(
+          l10n("errorNoFileOrCannotReadTitle"), cannotReadFileMessage(filename), ctx);
     }
   }
 
   private FilterOperation getFilterOperation(HTTPRequest request) throws BadRequestException {
-    String s = request.getPartAsStringFailsafe("filter-operation", 100);
+    String s = request.getPartAsStringFailsafe(FILTER_OPERATION_PART, 100);
     try {
       return FilterOperation.valueOf(s);
     } catch (IllegalArgumentException e) {
-      throw new BadRequestException("filter-operation", e);
+      throw new BadRequestException(FILTER_OPERATION_PART, e);
     }
   }
 
   private ResultHandling getResultHandling(HTTPRequest request) throws BadRequestException {
-    String s = request.getPartAsStringFailsafe("result-handling", 100);
+    String s = request.getPartAsStringFailsafe(RESULT_HANDLING_PART, 100);
     try {
       return ResultHandling.valueOf(s);
     } catch (IllegalArgumentException e) {
-      throw new BadRequestException("result-handling", e);
+      throw new BadRequestException(RESULT_HANDLING_PART, e);
     }
+  }
+
+  private void processFilter(
+      Bucket bucket,
+      String filename,
+      String mimeType,
+      FilterOperation filterOperation,
+      ResultHandling resultHandling,
+      ToadletContext ctx,
+      NodeClientCore core)
+      throws ToadletContextClosedException, IOException, BadRequestException {
+    String resultFilename = makeResultFilename(filename, mimeType);
+    handleFilter(bucket, mimeType, filterOperation, resultHandling, resultFilename, ctx, core);
   }
 
   private String makeResultFilename(String originalFilename, String mimeType) {
@@ -337,26 +486,29 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
       resultMimeType = status.mimeType;
     } catch (UnsafeContentTypeException e) {
       unsafe = true;
-    } catch (IOException e) {
-      LOG.error("IO error running content filter", e);
-      throw e;
     }
 
     if (unsafe) {
       sendErrorPage(ctx, 200, l10n("errorUnsafeContentTitle"), l10n("errorUnsafeContent"));
     } else {
-      if (resultHandling == ResultHandling.DISPLAY) {
-        ctx.sendReplyHeaders(200, "OK", null, resultMimeType, resultBucket.size());
-        ctx.writeData(resultBucket);
-      } else if (resultHandling == ResultHandling.SAVE) {
-        MultiValueTable<String, String> headers = new MultiValueTable<>();
-        headers.put("Content-Disposition", "attachment; filename=\"" + resultFilename + '"');
-        headers.put("Cache-Control", "private");
-        headers.put("Content-Transfer-Encoding", "binary");
-        ctx.sendReplyHeaders(200, "OK", headers, "application/force-download", resultBucket.size());
-        ctx.writeData(resultBucket);
-      } else {
-        throw new BadRequestException("result-handling");
+      if (resultHandling == null) {
+        throw new BadRequestException(RESULT_HANDLING_PART);
+      }
+      switch (resultHandling) {
+        case DISPLAY -> {
+          ctx.sendReplyHeaders(200, "OK", null, resultMimeType, resultBucket.size());
+          ctx.writeData(resultBucket);
+        }
+        case SAVE -> {
+          MultiValueTable<String, String> headers = new MultiValueTable<>();
+          headers.put("Content-Disposition", "attachment; filename=\"" + resultFilename + '"');
+          headers.put("Cache-Control", "private");
+          headers.put("Content-Transfer-Encoding", "binary");
+          ctx.sendReplyHeaders(
+              200, "OK", headers, "application/force-download", resultBucket.size());
+          ctx.writeData(resultBucket);
+        }
+        default -> throw new BadRequestException(RESULT_HANDLING_PART);
       }
     }
   }
@@ -377,14 +529,8 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
       FilterOperation operation,
       NodeClientCore core)
       throws IOException {
-    URI fakeUri;
-    try {
-      fakeUri = new URI("http://127.0.0.1:8888/");
-    } catch (URISyntaxException e) {
-      LOG.error("Inexplicable URI error", e);
-      return null;
-    }
-    // TODO: check operation, once ContentFilter supports write filtering
+    validateOperation(operation);
+    URI fakeUri = resolveFilterUri();
     return ContentFilter.filter(
         input,
         output,
@@ -397,11 +543,34 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
         core.getLinkFilterExceptionProvider());
   }
 
+  private void validateOperation(FilterOperation operation) {
+    Objects.requireNonNull(operation, "operation");
+  }
+
+  private URI resolveFilterUri() {
+    String configuredUri = System.getProperty(FILTER_URI_PROPERTY);
+    if (configuredUri == null || configuredUri.isBlank()) {
+      return DEFAULT_FILTER_URI;
+    }
+    try {
+      return new URI(configuredUri);
+    } catch (URISyntaxException e) {
+      LOG.warn(
+          "Invalid value for {}: {}. Falling back to {}",
+          FILTER_URI_PROPERTY,
+          configuredUri,
+          DEFAULT_FILTER_URI,
+          e);
+      return DEFAULT_FILTER_URI;
+    }
+  }
+
   static String l10n(String key) {
     return NodeL10n.getBase().getString("ContentFilterToadlet." + key);
   }
 
-  static String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("ContentFilterToadlet." + key, pattern, value);
+  private String cannotReadFileMessage(String filename) {
+    return NodeL10n.getBase()
+        .getString("ContentFilterToadlet.errorNoFileOrCannotRead", "file", filename);
   }
 }

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -1642,7 +1642,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     server.register(
         contentFilterToadlet,
         "FProxyToadlet.categoryQueue",
-        ContentFilterToadlet.PATH,
+        ContentFilterToadlet.CONTENT_FILTER_PATH,
         true,
         "FProxyToadlet.filterFileTitle",
         "FProxyToadlet.filterFile",

--- a/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
@@ -210,7 +210,8 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
     HTMLNode insertBox = infobox.getOuterNode();
     HTMLNode insertContent = infobox.getContentNode();
     HTMLNode insertForm =
-        ctx.addFormChild(insertContent, ContentFilterToadlet.PATH, "filterPreviewForm");
+        ctx.addFormChild(
+            insertContent, ContentFilterToadlet.CONTENT_FILTER_PATH, "filterPreviewForm");
     insertForm.addChild("#", l10n("filterFileLabel"));
     insertForm.addChild("br");
     insertForm.addChild("br");

--- a/src/main/java/network/crypta/clients/http/LinkEnabledCallback.java
+++ b/src/main/java/network/crypta/clients/http/LinkEnabledCallback.java
@@ -1,11 +1,50 @@
 package network.crypta.clients.http;
 
+/**
+ * Callback consulted to decide whether an HTTP link should be shown to a client.
+ *
+ * <p>This interface is invoked by UI or routing components before rendering or advertising a link
+ * to the outside world. Implementations can examine the {@link ToadletContext}, current
+ * configuration, or internal state to decide if a link should be visible. Typical uses include
+ * hiding links while a service is disabled, requiring authentication before exposing controls, or
+ * gating experimental endpoints during gradual rollout. The callback is expected to be cheap to
+ * execute and free of side effects so it can be invoked repeatedly during page generation or
+ * capability discovery. Unless stated otherwise by the implementation, callers should treat it as
+ * thread-safe and idempotent so the same decision can be reused across request handling code paths.
+ *
+ * <ul>
+ *   <li><strong>Visibility guard:</strong> Centralizes link availability decisions in one place.
+ *   <li><strong>Policy enforcement:</strong> Allows integration of authentication or feature flags
+ *       without scattering conditional logic.
+ *   <li><strong>Context-aware:</strong> May leverage request metadata from {@link ToadletContext}
+ *       when available; callers should tolerate {@code null} contexts.
+ * </ul>
+ *
+ * @see #isEnabled(ToadletContext)
+ */
 public interface LinkEnabledCallback {
-
   /**
-   * Whether to show the link?
+   * Determines whether a specific link should be rendered or advertised for the provided request
+   * context.
    *
-   * @param ctx The request which is asking. Can be null.
+   * <p>Callers invoke this method before surfacing navigation elements, action buttons, or embedded
+   * links. The implementation may inspect authentication state, feature flags, or request metadata
+   * exposed by {@link ToadletContext} to decide if the link remains visible. Because the method can
+   * be called multiple times during a single page render or capability probe, it should avoid
+   * observable side effects and run quickly. When the supplied context is {@code null},
+   * implementations should apply a conservative default, such as disabling the link unless a safe
+   * fallback is appropriate.
+   *
+   * <pre>{@code
+   * if (callback.isEnabled(ctx)) {
+   *   renderLink();
+   * }
+   * }</pre>
+   *
+   * @param ctx request context supplying user and connection details; may be {@code null} for
+   *     background checks or non-request invocations where no context is available.
+   * @return {@code true} when the link may be displayed to the requesting client; {@code false}
+   *     when it should remain hidden, disabled, or otherwise withheld.
    */
   boolean isEnabled(ToadletContext ctx);
 }

--- a/src/main/java/network/crypta/clients/http/LocalFileFilterToadlet.java
+++ b/src/main/java/network/crypta/clients/http/LocalFileFilterToadlet.java
@@ -9,7 +9,7 @@ import network.crypta.support.HTMLNode;
 /** Local file browser for the content filter toadlet. */
 public class LocalFileFilterToadlet extends LocalFileBrowserToadlet {
   public static final String PATH = "/filter-browse/";
-  public static final String POST_TO = "/filterfile/";
+  public static final String POST_TO = ContentFilterToadlet.CONTENT_FILTER_PATH;
 
   public LocalFileFilterToadlet(NodeClientCore core, HighLevelSimpleClient highLevelSimpleClient) {
     super(core, highLevelSimpleClient);

--- a/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
@@ -1,0 +1,316 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.OutputStream;
+import java.io.Serial;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.filter.ContentFilter;
+import network.crypta.client.filter.ContentFilter.FilterStatus;
+import network.crypta.client.filter.FilterOperation;
+import network.crypta.client.filter.UnsafeContentTypeException;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ContentFilterToadletTest {
+
+  private HighLevelSimpleClient client;
+  private NodeClientCore core;
+  private ToadletContainer container;
+  private ToadletContext ctx;
+  private BucketFactory bucketFactory;
+
+  @BeforeEach
+  void setUp() {
+    client = mock(HighLevelSimpleClient.class);
+    core = mock(NodeClientCore.class);
+    container = mock(ToadletContainer.class);
+    ctx = mock(ToadletContext.class);
+    bucketFactory = mock(BucketFactory.class);
+  }
+
+  @Test
+  void isEnabled_whenAdvancedAndPrivateMode_returnsTrue() {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client, core);
+    toadlet.container = container;
+
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(true);
+
+    assertTrue(toadlet.isEnabled(ctx));
+  }
+
+  @Test
+  void isEnabled_whenPublicGatewayWithoutFullAccess_returnsFalse() {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client, core);
+    toadlet.container = container;
+
+    when(container.publicGatewayMode()).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(true);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+
+    assertFalse(toadlet.isEnabled(ctx));
+  }
+
+  @Test
+  void getFilterOperation_whenInvalidValue_throwsBadRequestException() throws Exception {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client, core);
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.getPartAsStringFailsafe("filter-operation", 100)).thenReturn("not-an-enum");
+
+    Method method =
+        ContentFilterToadlet.class.getDeclaredMethod("getFilterOperation", HTTPRequest.class);
+    method.setAccessible(true);
+
+    assertThrows(BadRequestException.class, () -> invokeWithException(method, toadlet, request));
+  }
+
+  @Test
+  void handleFilter_whenDisplayHandling_writesHeadersAndBucket() throws Exception {
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client, core));
+    toadlet.container = container;
+    try (ArrayBucket inputBucket = new ArrayBucket("input".getBytes(StandardCharsets.UTF_8));
+        ArrayBucket resultBucket = new ArrayBucket()) {
+      when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+      when(bucketFactory.makeBucket(-1)).thenReturn(resultBucket);
+
+      byte[] filtered = "filtered".getBytes(StandardCharsets.UTF_8);
+
+      try (MockedStatic<ContentFilter> mockedFilter =
+          org.mockito.Mockito.mockStatic(ContentFilter.class)) {
+        mockedFilter
+            .when(
+                () ->
+                    ContentFilter.filter(
+                        any(), any(), anyString(), any(), any(), any(), any(), any(), any()))
+            .thenAnswer(
+                invocation -> {
+                  OutputStream output = invocation.getArgument(1);
+                  output.write(filtered);
+                  try {
+                    return newFilterStatus("utf-8", "text/plain");
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+        invokeHandleFilter(
+            toadlet,
+            inputBucket,
+            "text/plain",
+            FilterOperation.BOTH,
+            ContentFilterToadlet.ResultHandling.DISPLAY,
+            "result.txt");
+      }
+
+      assertEquals(filtered.length, resultBucket.size());
+      verify(ctx).sendReplyHeaders(200, "OK", null, "text/plain", resultBucket.size());
+      verify(ctx).writeData(resultBucket);
+    }
+  }
+
+  @Test
+  void handleFilter_whenSaveHandling_setsAttachmentHeaders() throws Exception {
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client, core));
+    toadlet.container = container;
+    try (ArrayBucket inputBucket = new ArrayBucket("input".getBytes(StandardCharsets.UTF_8));
+        ArrayBucket resultBucket = new ArrayBucket()) {
+      when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+      when(bucketFactory.makeBucket(-1)).thenReturn(resultBucket);
+
+      byte[] filtered = "bytes".getBytes(StandardCharsets.UTF_8);
+
+      try (MockedStatic<ContentFilter> mockedFilter =
+          org.mockito.Mockito.mockStatic(ContentFilter.class)) {
+        mockedFilter
+            .when(
+                () ->
+                    ContentFilter.filter(
+                        any(), any(), anyString(), any(), any(), any(), any(), any(), any()))
+            .thenAnswer(
+                invocation -> {
+                  OutputStream output = invocation.getArgument(1);
+                  output.write(filtered);
+                  try {
+                    return newFilterStatus(null, "application/octet-stream");
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+        invokeHandleFilter(
+            toadlet,
+            inputBucket,
+            "application/octet-stream",
+            FilterOperation.READ,
+            ContentFilterToadlet.ResultHandling.SAVE,
+            "file.filtered.bin");
+      }
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+          ArgumentCaptor.forClass(MultiValueTable.class);
+      verify(ctx)
+          .sendReplyHeaders(
+              eq(200),
+              eq("OK"),
+              headersCaptor.capture(),
+              eq("application/force-download"),
+              eq(resultBucket.size()));
+      MultiValueTable<String, String> captured = headersCaptor.getValue();
+      assertEquals(
+          "attachment; filename=\"file.filtered.bin\"", captured.getFirst("Content-Disposition"));
+      assertEquals("private", captured.getFirst("Cache-Control"));
+      assertEquals("binary", captured.getFirst("Content-Transfer-Encoding"));
+      verify(ctx).writeData(resultBucket);
+    }
+  }
+
+  @Test
+  void handleFilter_whenResultHandlingUnknown_throwsBadRequestException() throws Exception {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client, core);
+    toadlet.container = container;
+    try (ArrayBucket inputBucket = new ArrayBucket();
+        ArrayBucket resultBucket = new ArrayBucket()) {
+      when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+      when(bucketFactory.makeBucket(-1)).thenReturn(resultBucket);
+
+      assertThrows(
+          BadRequestException.class,
+          () ->
+              invokeHandleFilter(
+                  toadlet, inputBucket, "text/plain", FilterOperation.WRITE, null, "result.txt"));
+    }
+  }
+
+  @Test
+  void handleFilter_whenFilterMarksUnsafe_sendsErrorPage() throws Exception {
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client, core));
+    toadlet.container = container;
+    try (ArrayBucket inputBucket = new ArrayBucket();
+        ArrayBucket resultBucket = new ArrayBucket()) {
+      when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+      when(bucketFactory.makeBucket(-1)).thenReturn(resultBucket);
+      doNothing().when(toadlet).sendErrorPage(any(), anyInt(), anyString(), anyString());
+
+      try (MockedStatic<ContentFilter> mockedFilter =
+          org.mockito.Mockito.mockStatic(ContentFilter.class)) {
+        mockedFilter
+            .when(
+                () ->
+                    ContentFilter.filter(
+                        any(), any(), anyString(), any(), any(), any(), any(), any(), any()))
+            .thenThrow(
+                new UnsafeContentTypeException() {
+                  @Serial private static final long serialVersionUID = 1L;
+
+                  @Override
+                  public String getHTMLEncodedTitle() {
+                    return "unsafe";
+                  }
+
+                  @Override
+                  public String getRawTitle() {
+                    return "unsafe";
+                  }
+
+                  @Override
+                  public String getMessage() {
+                    return "unsafe";
+                  }
+                });
+
+        invokeHandleFilter(
+            toadlet,
+            inputBucket,
+            "text/plain",
+            FilterOperation.READ,
+            ContentFilterToadlet.ResultHandling.DISPLAY,
+            "result.txt");
+      }
+
+      verify(toadlet).sendErrorPage(eq(ctx), eq(200), anyString(), anyString());
+      verify(ctx, never()).sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong());
+      verify(ctx, never()).writeData(any(Bucket.class));
+    }
+  }
+
+  private FilterStatus newFilterStatus(String charset, String mimeType) throws Exception {
+    Constructor<FilterStatus> constructor =
+        FilterStatus.class.getDeclaredConstructor(String.class, String.class);
+    constructor.setAccessible(true);
+    return constructor.newInstance(charset, mimeType);
+  }
+
+  private void invokeHandleFilter(
+      ContentFilterToadlet toadlet,
+      Bucket data,
+      String mimeType,
+      FilterOperation operation,
+      ContentFilterToadlet.ResultHandling handling,
+      String resultFilename)
+      throws Exception {
+    Method method =
+        ContentFilterToadlet.class.getDeclaredMethod(
+            "handleFilter",
+            Bucket.class,
+            String.class,
+            FilterOperation.class,
+            ContentFilterToadlet.ResultHandling.class,
+            String.class,
+            ToadletContext.class,
+            NodeClientCore.class);
+    method.setAccessible(true);
+    try {
+      method.invoke(toadlet, data, mimeType, operation, handling, resultFilename, ctx, core);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw e;
+    }
+  }
+
+  private void invokeWithException(Method method, Object target, Object... args) throws Exception {
+    try {
+      method.invoke(target, args);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- make content filter toadlet path configurable via system property and centralize constants
- harden request handling (invalid parts, safer URI resolution, stronger null checks) and refactor filtering flow
- update related toadlets to use the new path constant and expand ContentFilterToadlet test coverage

## Testing
- ./gradlew spotlessApply