### PR TITLE
Document darknet add ref toadlet and refresh tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
@@ -12,11 +12,54 @@ import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.io.FileBucket;
 
+/**
+ * Serves the “Add Friend” HTTP endpoint for darknet peers, including helper links to packaged node
+ * installers and the current public node reference.
+ *
+ * <p>This toadlet is invoked when a remote browser navigates to the add-friend URL exposed by the
+ * node. It renders explanatory text about darknet peering, inserts the alert summary, and offers
+ * OS-specific installer downloads if they are already present on disk. The handler also embeds the
+ * current darknet noderef so that users can import it directly into compatible clients. Typical
+ * call flow is: the UI router dispatches to this toadlet, {@link #handleMethodGET(URI, HTTPRequest,
+ * ToadletContext)} builds the page via {@link PageMaker}, and {@link #getNoderef()} supplies the
+ * serialized public fields.
+ *
+ * <p>Thread safety: the class is stateless beyond references to {@link Node} and the companion
+ * toadlet; it relies on the surrounding HTTP framework for synchronization. Instances are usually
+ * constructed once at node startup and reused for many requests. It assumes the {@link Node}
+ * provides up-to-date installers and noderefs and that callers perform access checks via the
+ * provided {@link ToadletContext}.
+ *
+ * <ul>
+ *   <li>Renders localized explanations and guidance for adding a friend.
+ *   <li>Streams prebuilt installers when available to simplify onboarding.
+ *   <li>Publishes the node’s darknet reference for import by trusted peers.
+ * </ul>
+ *
+ * @see DarknetConnectionsToadlet
+ * @see Node#exportDarknetPublicFieldSet()
+ */
 public class DarknetAddRefToadlet extends Toadlet {
 
   private final Node node;
   private final DarknetConnectionsToadlet friendsToadlet;
 
+  /**
+   * Creates the toadlet with the dependencies required to generate darknet onboarding pages.
+   *
+   * <p>The constructor wires the owning {@link Node} for state such as installer paths and noderef
+   * export, the high-level client for inherited toadlet functionality, and the companion
+   * connections toadlet used to draw peer-related UI sections. Callers typically instantiate this
+   * once during HTTP handler setup and keep it alive for the lifetime of the node so that cached
+   * installers remain accessible and localization resources stay loaded.
+   *
+   * @param n node instance supplying installer access and noderef export; must not be {@code null}
+   *     and should outlive the toadlet.
+   * @param client high-level HTTP client the superclass relies on for responses and redirects; may
+   *     share the lifecycle of the enclosing HTTP server.
+   * @param friendsToadlet companion toadlet used to render friend lists and noderef boxes within
+   *     this page; should correspond to the same node instance.
+   */
   protected DarknetAddRefToadlet(
       Node n, HighLevelSimpleClient client, DarknetConnectionsToadlet friendsToadlet) {
     super(client);
@@ -24,6 +67,34 @@ public class DarknetAddRefToadlet extends Toadlet {
     this.friendsToadlet = friendsToadlet;
   }
 
+  /**
+   * Handles a GET request to the add-friend page, streaming installers or rendering guidance as
+   * appropriate.
+   *
+   * <p>The method first enforces full-access permissions through the supplied {@link
+   * ToadletContext}. When the requested path matches a platform-specific installer filename, it
+   * streams the file directly with the correct MIME type. Otherwise, it generates an HTML page with
+   * localized explanations, download links, and the node’s exported darknet reference. The response
+   * always terminates with a 200 status unless access is denied or a redirect is triggered by the
+   * framework.
+   *
+   * <pre>{@code
+   * // Typical usage from routing layer
+   * toadlet.handleMethodGET(uri, request, context);
+   * }</pre>
+   *
+   * @param uri requested URI used to detect installer downloads and to build relative links; must
+   *     include the path component.
+   * @param request HTTP request carrying headers and parameters; not modified by this method.
+   * @param ctx toadlet context providing authorization checks, page rendering helpers, and reply
+   *     writers; must be open for the duration of the call.
+   * @throws ToadletContextClosedException if the context is closed before the response is written
+   *     or when permission checks cannot complete.
+   * @throws IOException if reading installer files or writing the response stream fails due to
+   *     underlying I/O issues.
+   * @throws RedirectException if the framework requests a redirect instead of returning content in
+   *     this handler.
+   */
   public void handleMethodGET(URI uri, final HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     if (!ctx.checkFullAccess(this)) return;
@@ -124,6 +195,19 @@ public class DarknetAddRefToadlet extends Toadlet {
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
   }
 
+  /**
+   * Exposes the public darknet noderef for this node as a field set suitable for embedding in
+   * responses.
+   *
+   * <p>The returned {@link SimpleFieldSet} contains only public fields and is constructed by the
+   * underlying {@link Node} at call time, ensuring that peers receive up-to-date routing and key
+   * material. Callers should treat the object as read-only and avoid persisting it beyond the
+   * immediate HTTP response, because it reflects the node’s current configuration and may change
+   * when peers or keys are rotated.
+   *
+   * @return immutable view of the node’s exported darknet reference fields; ownership remains with
+   *     the caller for serialization but should not be mutated.
+   */
   protected SimpleFieldSet getNoderef() {
     return node.exportDarknetPublicFieldSet();
   }
@@ -132,8 +216,23 @@ public class DarknetAddRefToadlet extends Toadlet {
     return NodeL10n.getBase().getString("DarknetAddRefToadlet." + string);
   }
 
-  static final String PATH = "/addfriend/";
+  private static String buildPath() {
+    return "/" + "addfriend" + "/";
+  }
 
+  static final String PATH = buildPath();
+
+  /**
+   * Returns the routing path under which this toadlet is exposed to clients.
+   *
+   * <p>The path is stable for the lifetime of the application and is derived from a static helper
+   * to keep URL construction centralized. Callers can rely on this value to build links to the
+   * add-friend page or to register the toadlet with the HTTP router. The returned string always
+   * includes leading and trailing slashes to match the expected endpoint shape.
+   *
+   * @return canonical toadlet path beginning and ending with {@code /} for router registration and
+   *     link generation.
+   */
   @Override
   public String path() {
     return PATH;

--- a/src/test/java/network/crypta/clients/http/DarknetAddRefToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetAddRefToadletTest.java
@@ -1,0 +1,223 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.keys.FreenetURI;
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.Node;
+import network.crypta.node.NodeFile;
+import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.io.FileBucket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class DarknetAddRefToadletTest {
+
+  @Mock private Node node;
+  @Mock private NodeUpdateManager nodeUpdater;
+  @Mock private HighLevelSimpleClient client;
+  @Mock private DarknetConnectionsToadlet friendsToadlet;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
+
+  private TestableDarknetAddRefToadlet toadlet;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(node.getNodeUpdater()).thenReturn(nodeUpdater);
+    toadlet = new TestableDarknetAddRefToadlet(node, client, friendsToadlet);
+  }
+
+  @Test
+  void handleMethodGET_whenWindowsInstallerExists_servesExecutableBucket() throws Exception {
+    File installer = File.createTempFile("installer-win", ".exe");
+    installer.deleteOnExit();
+    try (FileWriter writer = new FileWriter(installer)) {
+      writer.write("win");
+    }
+
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(nodeUpdater.getInstallerWindows()).thenReturn(installer);
+
+    URI path = new URI(toadlet.path() + NodeFile.INSTALLER_WINDOWS.getFilename());
+    toadlet.handleMethodGET(path, request, ctx);
+
+    assertTrue(toadlet.writeReplyCalled);
+    assertEquals(200, toadlet.lastCode);
+    assertEquals("application/x-msdownload", toadlet.lastMimeType);
+    assertEquals("OK", toadlet.lastDescription);
+    assertInstanceOf(FileBucket.class, toadlet.lastBucket);
+    assertEquals(installer.getAbsoluteFile(), ((FileBucket) toadlet.lastBucket).getFile());
+  }
+
+  @Test
+  void handleMethodGET_whenNonWindowsInstallerExists_servesJarBucket() throws Exception {
+    File installer = File.createTempFile("installer-nonwin", ".jar");
+    installer.deleteOnExit();
+    try (FileWriter writer = new FileWriter(installer)) {
+      writer.write("jar");
+    }
+
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(nodeUpdater.getInstallerNonWindows()).thenReturn(installer);
+
+    URI path = new URI(toadlet.path() + NodeFile.INSTALLER_NON_WINDOWS.getFilename());
+    toadlet.handleMethodGET(path, request, ctx);
+
+    assertTrue(toadlet.writeReplyCalled);
+    assertEquals(200, toadlet.lastCode);
+    assertEquals("application/x-java-archive", toadlet.lastMimeType);
+    assertEquals("OK", toadlet.lastDescription);
+    assertInstanceOf(FileBucket.class, toadlet.lastBucket);
+    assertEquals(installer.getAbsoluteFile(), ((FileBucket) toadlet.lastBucket).getFile());
+  }
+
+  @Test
+  void handleMethodGET_whenAccessDenied_doesNotTouchNode() throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(false);
+
+    URI path = new URI(toadlet.path() + NodeFile.INSTALLER_WINDOWS.getFilename());
+    toadlet.handleMethodGET(path, request, ctx);
+
+    assertFalse(toadlet.writeReplyCalled);
+    verify(ctx, times(1)).checkFullAccess(toadlet);
+    verifyNoMoreInteractions(nodeUpdater);
+  }
+
+  @Test
+  void handleMethodGET_whenInstallersMissing_rendersHtmlPage() throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(nodeUpdater.getInstallerWindows()).thenReturn(null);
+    when(nodeUpdater.getInstallerNonWindows()).thenReturn(null);
+    when(nodeUpdater.getInstallerWindowsURI()).thenReturn(new FreenetURI("CHK", "win"));
+    when(nodeUpdater.getInstallerNonWindowsURI()).thenReturn(new FreenetURI("CHK", "unix"));
+
+    HTMLNode content = new HTMLNode("div");
+    HTMLNode pageOuter = new HTMLNode("div");
+    HTMLNode head = pageOuter.addChild("head");
+    pageOuter.addChild(content);
+    PageNode page = new PageNode(pageOuter, head, content);
+
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(pageMaker.getPageNode(anyString(), eq(ctx))).thenReturn(page);
+    when(ctx.getAlertManager())
+        .thenReturn(mock(network.crypta.node.useralerts.UserAlertManager.class));
+    when(ctx.getAlertManager().createSummary()).thenReturn(new HTMLNode("#", "summary"));
+
+    when(pageMaker.getInfobox(anyString(), anyString(), eq(content), anyString(), eq(true)))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(2);
+              HTMLNode infobox = new HTMLNode("div", "id", "infobox");
+              parent.addChild(infobox);
+              HTMLNode boxContent = new HTMLNode("div", "class", "content");
+              infobox.addChild(boxContent);
+              return boxContent;
+            });
+
+    SimpleFieldSet noderef = new SimpleFieldSet(false);
+    when(node.exportDarknetPublicFieldSet()).thenReturn(noderef);
+    when(friendsToadlet.path()).thenReturn("/friends/");
+    doNothing().when(friendsToadlet).drawNoderefBox(content, noderef);
+
+    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
+        MockedStatic<ConnectionsToadlet> connections = mockStatic(ConnectionsToadlet.class)) {
+
+      BaseL10n baseL10n = mock(BaseL10n.class);
+      nodeL10n.when(NodeL10n::getBase).thenReturn(baseL10n);
+      when(baseL10n.getString(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+      doAnswer(invocation -> null)
+          .when(baseL10n)
+          .addL10nSubstitution(any(), anyString(), any(), any());
+
+      toadlet.handleMethodGET(new URI(toadlet.path()), request, ctx);
+
+      assertTrue(toadlet.writeHtmlCalled);
+      assertEquals(200, toadlet.lastCode);
+      assertTrue(toadlet.lastHtml.contains("summary"));
+
+      connections.verify(
+          () -> ConnectionsToadlet.drawAddPeerBox(content, ctx, false, friendsToadlet.path()),
+          times(1));
+      verify(friendsToadlet, times(1)).drawNoderefBox(content, noderef);
+    }
+  }
+
+  @Test
+  void getNoderef_returnsNodeExport() {
+    SimpleFieldSet expected = new SimpleFieldSet(false);
+    when(node.exportDarknetPublicFieldSet()).thenReturn(expected);
+
+    assertSame(expected, toadlet.getNoderef());
+  }
+
+  @Test
+  void path_returnsConstantAddFriendPath() {
+    assertEquals(DarknetAddRefToadlet.PATH, toadlet.path());
+  }
+
+  private static final class TestableDarknetAddRefToadlet extends DarknetAddRefToadlet {
+    boolean writeReplyCalled;
+    boolean writeHtmlCalled;
+    int lastCode;
+    String lastMimeType;
+    String lastDescription;
+    Bucket lastBucket;
+    String lastHtml;
+
+    TestableDarknetAddRefToadlet(
+        Node node, HighLevelSimpleClient client, DarknetConnectionsToadlet friendsToadlet) {
+      super(node, client, friendsToadlet);
+    }
+
+    @Override
+    protected void writeReply(
+        ToadletContext ctx, int code, String mimeType, String desc, Bucket data) {
+      this.writeReplyCalled = true;
+      this.lastCode = code;
+      this.lastMimeType = mimeType;
+      this.lastDescription = desc;
+      this.lastBucket = data;
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      this.writeHtmlCalled = true;
+      this.lastCode = code;
+      this.lastDescription = desc;
+      this.lastHtml = reply;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed Javadoc and path helper for `DarknetAddRefToadlet`
- align `DarknetAddRefToadletTest` with new behavior using lenient stubs and `assertInstanceOf`
- ensure noderef creation uses non-strict `SimpleFieldSet(false)` and capture HTML as string in test double

## Testing
- not run (not requested)
