### PR TITLE
Improve DecodeToadlet docs and redirect tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/DecodeToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DecodeToadlet.java
@@ -8,9 +8,26 @@ import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
 /**
- * Decode URL Toadlet. Accessible from <code>http://.../decode/</code>.
+ * HTTP toadlet that decodes user-supplied Freenet-style keys and issues a redirect to the canonical
+ * location.
  *
- * <p>Allow for Firefox about:config option keyword.URL to work properly.
+ * <p>This endpoint is mounted at {@code /decode/} and keeps the encoded path segment intact before
+ * issuing a 301 pointing at the decoded key. It supports browser keyword searches (for example,
+ * Firefox {@code keyword.URL}) and other helpers that feed Freenet-style links through the HTTP
+ * gateway. The generated HTML body also embeds a manual link for agents that ignore redirects.
+ *
+ * <p>Instances rely on {@link ToadletContext} for request-scoped state and keep no mutable fields.
+ * Deployments typically register one instance and let the dispatcher invoke it concurrently; no
+ * internal synchronization is necessary because state lives in the supplied context and page maker.
+ *
+ * <ul>
+ *   <li>Responsible for translating {@code /decode/<key>} to the {@code /<key>} target.
+ *   <li>Provides a visible fallback link when redirect handling is disabled or blocked.
+ *   <li>Honors full-access checks by surfacing any configured alert summaries in the response.
+ * </ul>
+ *
+ * @see Toadlet
+ * @see ToadletContext
  */
 public class DecodeToadlet extends Toadlet {
   DecodeToadlet(HighLevelSimpleClient client, NodeClientCore c) {
@@ -20,6 +37,25 @@ public class DecodeToadlet extends Toadlet {
 
   final NodeClientCore core;
 
+  /**
+   * Handles GET requests under {@code /decode/} by emitting a 301 redirect and a manual fallback
+   * link.
+   *
+   * <p>The method preserves the request path after the toadlet mount point, prepends a leading
+   * slash to form a Freenet key, and builds a small HTML page that includes both an automatic
+   * redirect and a clickable anchor. When full access is permitted, any configured alert summary is
+   * added to the page so callers still see status banners while being forwarded. The method writes
+   * the response immediately; callers should not attempt further output after invocation.
+   *
+   * @param uri fully qualified request URI supplied by the HTTP stack; never mutated by this
+   *     handler
+   * @param request HTTP request wrapper containing the original path segment after the decode mount
+   *     point
+   * @param ctx toadlet context used for permission checks, page creation, and response streaming
+   * @throws ToadletContextClosedException if the context output channel closes before the reply is
+   *     written
+   * @throws IOException if generating or sending the redirect page encounters an I/O failure
+   */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
 
@@ -41,6 +77,17 @@ public class DecodeToadlet extends Toadlet {
     this.writeHTMLReply(ctx, 301, "Moved Permanently\nLocation: " + keyToFetch, page.generate());
   }
 
+  /**
+   * Returns the mount path used to dispatch decode requests to this toadlet.
+   *
+   * <p>The path is a constant {@code /decode/} with a trailing slash so that subsequent path
+   * segments are treated as the encoded key to redirect. Dispatchers rely on this value to strip
+   * the prefix before handing the remaining portion to {@link #handleMethodGET(URI, HTTPRequest,
+   * ToadletContext)}; callers should avoid trimming or normalizing it further to preserve
+   * compatibility with existing bookmarks and browser integrations.
+   *
+   * @return immutable mount path string {@code /decode/} used during HTTP registration
+   */
   @Override
   public String path() {
     return "/decode/";

--- a/src/test/java/network/crypta/clients/http/DecodeToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DecodeToadletTest.java
@@ -1,0 +1,117 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class DecodeToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private NodeClientCore core;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
+  @Mock private PageMaker pageMaker;
+  @Mock private PageNode pageNode;
+  @Mock private HTMLNode contentNode;
+  @Mock private HTMLNode infoboxContentNode;
+  @Mock private UserAlertManager alertManager;
+
+  private DecodeToadlet toadlet;
+
+  @BeforeEach
+  void setUp() {
+    toadlet = spy(new DecodeToadlet(client, core));
+  }
+
+  private void mockPageRenderingChain() {
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(pageMaker.getPageNode("Redirect to Decoded link", ctx)).thenReturn(pageNode);
+    when(pageNode.getContentNode()).thenReturn(contentNode);
+    when(pageMaker.getInfobox(
+            "infobox-warning", "Decode Link", contentNode, "decode-not-redirected", true))
+        .thenReturn(infoboxContentNode);
+  }
+
+  @Test
+  void handleMethodGET_whenFullAccess_addsAlertSummaryAndRedirects() throws Exception {
+    mockPageRenderingChain();
+    String generatedHtml = "<html>page</html>";
+    when(pageNode.generate()).thenReturn(generatedHtml);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    HTMLNode summaryNode = new HTMLNode("div", "summary");
+    when(alertManager.createSummary()).thenReturn(summaryNode);
+    when(request.getPath()).thenReturn("/decode/abc");
+
+    doNothing()
+        .when(toadlet)
+        .writeHTMLReply(ctx, 301, "Moved Permanently\nLocation: /abc", generatedHtml);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/decode/abc"), request, ctx);
+
+    verify(contentNode).addChild(summaryNode);
+    verify(pageMaker)
+        .getInfobox("infobox-warning", "Decode Link", contentNode, "decode-not-redirected", true);
+    verify(infoboxContentNode).addChild("a", "href", "/abc", "Click Here to be re-directed");
+    verify(toadlet).writeHTMLReply(ctx, 301, "Moved Permanently\nLocation: /abc", generatedHtml);
+  }
+
+  @Test
+  void handleMethodGET_whenNotFullAccess_skipsAlertSummary() throws Exception {
+    mockPageRenderingChain();
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    when(request.getPath()).thenReturn("/decode/test");
+    when(pageNode.generate()).thenReturn("<html>body</html>");
+
+    doNothing()
+        .when(toadlet)
+        .writeHTMLReply(ctx, 301, "Moved Permanently\nLocation: /test", "<html>body</html>");
+
+    toadlet.handleMethodGET(URI.create("http://localhost/decode/test"), request, ctx);
+
+    verify(alertManager, never()).createSummary();
+    verify(contentNode, never()).addChild(org.mockito.ArgumentMatchers.<HTMLNode>any());
+  }
+
+  @Test
+  void handleMethodGET_whenRequestIsRoot_redirectsToRootPath() throws Exception {
+    mockPageRenderingChain();
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    when(request.getPath()).thenReturn("/decode/");
+    when(pageNode.generate()).thenReturn("<html>root</html>");
+
+    doNothing()
+        .when(toadlet)
+        .writeHTMLReply(ctx, 301, "Moved Permanently\nLocation: /", "<html>root</html>");
+
+    toadlet.handleMethodGET(URI.create("http://localhost/decode/"), request, ctx);
+
+    verify(infoboxContentNode).addChild("a", "href", "/", "Click Here to be re-directed");
+    verify(toadlet).writeHTMLReply(ctx, 301, "Moved Permanently\nLocation: /", "<html>root</html>");
+  }
+
+  @Test
+  void path_whenInvoked_returnsDecodePath() {
+    DecodeToadlet freshToadlet = new DecodeToadlet(mock(HighLevelSimpleClient.class), core);
+
+    assertEquals("/decode/", freshToadlet.path());
+  }
+}


### PR DESCRIPTION
## Summary
- Document DecodeToadlet behaviour and path expectations with fuller Javadoc
- Add DecodeToadlet unit tests covering redirect targets, alert summaries, and root path handling
- Keep redirect HTML generation exercised without altering runtime logic

## Testing
- gradlew spotlessApply (formatting)
