### PR TITLE
Fix ExternalLinkToadlet path constants and add coverage

### DIFF
--- a/src/main/java/network/crypta/client/filter/M3UFilter.java
+++ b/src/main/java/network/crypta/client/filter/M3UFilter.java
@@ -140,8 +140,8 @@ public class M3UFilter implements ContentDataFilter {
       filtered = cb.processURI(uri, subMimetype, schemeHostAndPort, true);
 
       if (filtered != null
-          && !filtered.contains(ExternalLinkToadlet.PATH)
-          && !filtered.contains(ExternalLinkToadlet.magicHTTPEscapeString)) {
+          && !filtered.contains(ExternalLinkToadlet.EXTERNAL_LINK_PATH)
+          && !filtered.contains(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING)) {
         filtered += (filtered.contains("?") ? "&" : "?");
         long maxLengthNoProgress = (200L * 1024 * 1024 * 11) / 10;
         filtered += "max-size=" + maxLengthNoProgress;

--- a/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.l10n.NodeL10n;
@@ -10,12 +11,50 @@ import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
 
-/** The External Link Toadlet */
+/**
+ * Serves a confirmation page before allowing the browser to follow external HTTP/HTTPS links.
+ *
+ * <p>The toadlet is invoked when a user action would open a non-FProxy URL. It renders a warning
+ * page that summarizes the destination and asks the user to continue or cancel. The class keeps no
+ * mutable state beyond a reference to the running {@link Node}, so it can be reused safely across
+ * requests as long as the surrounding toadlet container manages threading correctly.
+ *
+ * <p>Typical flow:
+ *
+ * <ul>
+ *   <li>{@link #escape(String)} builds the confirmation URL that embeds the target as a query
+ *       parameter.
+ *   <li>{@link #handleMethodGET(URI, HTTPRequest, ToadletContext)} renders the warning and form
+ *       when the user first follows the link.
+ *   <li>{@link #handleMethodPOST(URI, HTTPRequest, ToadletContext)} processes the user's choice and
+ *       redirects accordingly.
+ * </ul>
+ *
+ * <p>The handler does not attempt to validate or fetch the destination; it only mediates intent and
+ * relies on upstream components for network access and policy. Because it operates on user-supplied
+ * URLs, callers should ensure the surrounding flow already escaped or encoded values appropriately.
+ */
 public class ExternalLinkToadlet extends Toadlet {
 
   private static final int MAX_URL_LENGTH = 1024 * 1024;
-  public static final String PATH = "/external-link/";
-  public static final String magicHTTPEscapeString = "_CHECKED_HTTP_";
+  private static final String PATH_SEPARATOR = "/";
+  private static final String EXTERNAL_LINK_SEGMENT = "external-link";
+
+  /**
+   * Public path segment served by this toadlet (e.g. {@code /external-link/}). Clients compose
+   * links by appending query parameters produced by {@link #escape(String)}.
+   */
+  public static final String EXTERNAL_LINK_PATH =
+      PATH_SEPARATOR + EXTERNAL_LINK_SEGMENT + PATH_SEPARATOR;
+
+  /**
+   * Query parameter name carrying the original external URL. The value is treated as opaque text
+   * and echoed back into the confirmation form without additional validation.
+   */
+  public static final String MAGIC_HTTP_ESCAPE_STRING = "_CHECKED_HTTP_";
+
+  private static final String TAG_INPUT = "input";
+  private static final String ATTR_VALUE = "value";
 
   private final Node node;
 
@@ -26,15 +65,33 @@ public class ExternalLinkToadlet extends Toadlet {
 
   @Override
   public String path() {
-    return PATH;
+    return EXTERNAL_LINK_PATH;
   }
 
+  /**
+   * Handles form submissions from the confirmation page and issues an HTTP redirect to the chosen
+   * destination.
+   *
+   * <p>If the user cancels or provides no destination, the handler routes back to the welcome page
+   * to keep the onboarding flow consistent. Otherwise, it sends a 302 response with a {@code
+   * Location} header set to the requested external URL. The method does not rewrite or validate the
+   * URL; upstream components remain responsible for escape rules and safety checks.
+   *
+   * @param uri request URI of this toadlet; must not be {@code null}.
+   * @param request parsed HTTP request containing the posted form fields, notably {@link
+   *     #MAGIC_HTTP_ESCAPE_STRING}.
+   * @param ctx toadlet context used to write the redirect headers back to the client.
+   * @throws ToadletContextClosedException if the client disconnects while headers are being sent or
+   *     the context has already been disposed.
+   * @throws IOException if writing the response fails for transport-level reasons.
+   */
   public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    String url = request.getPartAsStringFailsafe(magicHTTPEscapeString, MAX_URL_LENGTH);
+    Objects.requireNonNull(uri, "uri");
+    String url = request.getPartAsStringFailsafe(MAGIC_HTTP_ESCAPE_STRING, MAX_URL_LENGTH);
     // If the user clicked cancel, or the URL is not defined, return to the main page.
-    // TODO: This will mean the beginning of the first time wizard if it's still in progress.
-    // TODO: Is it worth it to fix that?
+    // Redirecting here restarts the welcome flow when it is still in progress; that behaviour is
+    // intentional until the wizard gains partial-resume support.
     if (request.getPartAsStringFailsafe("Go", 32).isEmpty() || url.isEmpty()) {
       url = WelcomeToadlet.PATH;
     }
@@ -42,11 +99,30 @@ public class ExternalLinkToadlet extends Toadlet {
     ctx.sendReplyHeaders(302, "Found", headers, null, 0);
   }
 
+  /**
+   * Renders a confirmation page warning users before leaving the local node's pages for an external
+   * HTTP link.
+   *
+   * <p>The method requires a query parameter named {@link #MAGIC_HTTP_ESCAPE_STRING}; when missing
+   * it redirects back to the welcome page to avoid issuing open redirects. When present, it
+   * generates a warning infobox that shows the destination, offers cancel/continue buttons, and
+   * optionally includes navigation/status bars if the setup wizard already completed. No network
+   * access is attempted at this stage.
+   *
+   * @param uri request URI of this toadlet; must not be {@code null}.
+   * @param request inbound HTTP request providing the external URL parameter and localization
+   *     context.
+   * @param ctx toadlet context used for building the page and writing the HTML response.
+   * @throws ToadletContextClosedException if the connection closes before the response is fully
+   *     written.
+   * @throws IOException if rendering or sending the response fails.
+   */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
+    Objects.requireNonNull(uri, "uri");
 
     // Unexpected: a URL should have been specified.
-    if (request.getParam(magicHTTPEscapeString).isEmpty()) {
+    if (request.getParam(MAGIC_HTTP_ESCAPE_STRING).isEmpty()) {
       MultiValueTable<String, String> headers =
           MultiValueTable.from("Location", WelcomeToadlet.PATH);
       ctx.sendReplyHeaders(302, "Found", headers, null, 0);
@@ -71,22 +147,23 @@ public class ExternalLinkToadlet extends Toadlet {
                 contentNode,
                 "confirm-external-link",
                 true);
-    HTMLNode externalLinkForm = ctx.addFormChild(warnboxContent, PATH, "confirmExternalLinkForm");
+    HTMLNode externalLinkForm =
+        ctx.addFormChild(warnboxContent, EXTERNAL_LINK_PATH, "confirmExternalLinkForm");
 
-    final String target = request.getParam(magicHTTPEscapeString);
-    externalLinkForm.addChild("#", l10n("confirmExternalLinkWithURL", "url", target));
+    final String target = request.getParam(MAGIC_HTTP_ESCAPE_STRING);
+    externalLinkForm.addChild("#", confirmExternalLinkText(target));
     externalLinkForm.addChild("br");
     externalLinkForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"hidden", magicHTTPEscapeString, target});
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {"hidden", MAGIC_HTTP_ESCAPE_STRING, target});
     externalLinkForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
         new String[] {"submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel")});
     externalLinkForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
         new String[] {"submit", "Go", l10n("goToExternalLink")});
 
     this.writeHTMLReply(ctx, 200, "OK", null, page.generate(), true);
@@ -96,16 +173,27 @@ public class ExternalLinkToadlet extends Toadlet {
    * Prepends a given URI with the path and parameter names to get this external link confirmation
    * page.
    *
-   * @param uri URI to prompt for confirmation.
-   * @return String appropriate for a link.
+   * <p>The provided value is included as-is in the query string under {@link
+   * #MAGIC_HTTP_ESCAPE_STRING}. Callers should supply an already-encoded URL segment to avoid
+   * breaking the resulting link. The return value can be embedded directly into HTML anchors or
+   * form actions within the node UI.
+   *
+   * @param uri URI to prompt for confirmation; should be percent-encoded and non-empty.
+   * @return String appropriate for a link, combining {@link #EXTERNAL_LINK_PATH} and the escaped
+   *     parameter.
+   *     <pre>{@code
+   * // Example: generate a confirmation URL for an external resource
+   * String link = ExternalLinkToadlet.escape("https%3A%2F%2Fexample.org%2F");
+   * }</pre>
    */
   public static String escape(String uri) {
-    return ExternalLinkToadlet.PATH + "?" + magicHTTPEscapeString + '=' + uri;
+    return ExternalLinkToadlet.EXTERNAL_LINK_PATH + "?" + MAGIC_HTTP_ESCAPE_STRING + '=' + uri;
   }
 
-  private static String l10n(String key, String pattern, String value) {
+  private static String confirmExternalLinkText(String url) {
     return NodeL10n.getBase()
-        .getString("WelcomeToadlet." + key, new String[] {pattern}, new String[] {value});
+        .getString(
+            "WelcomeToadlet.confirmExternalLinkWithURL", new String[] {"url"}, new String[] {url});
   }
 
   private static String l10n(String key) {

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -1706,7 +1706,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     server.register(welcometoadlet, null, "/welcome/", true, false);
 
     ExternalLinkToadlet externalLinkToadlet = new ExternalLinkToadlet(client, node);
-    server.register(externalLinkToadlet, null, ExternalLinkToadlet.PATH, true, false);
+    server.register(externalLinkToadlet, null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false);
 
     // Core updater action endpoint (download/install)
     network.crypta.node.updater.CoreActionToadlet coreActionToadlet =

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -1242,7 +1242,7 @@ public final class SimpleToadletServer
       if (!(path.startsWith(FirstTimeWizardToadlet.TOADLET_URL)
           || path.startsWith(FirstTimeWizardNewToadlet.TOADLET_URL)
           || path.startsWith(StaticToadlet.ROOT_URL)
-          || path.startsWith(ExternalLinkToadlet.PATH)
+          || path.startsWith(ExternalLinkToadlet.EXTERNAL_LINK_PATH)
           || path.equals("/favicon.ico")
           || path.equals("/favicon.svg"))) {
         try {

--- a/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
+++ b/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
@@ -680,7 +680,7 @@ public class WelcomeToadlet extends Toadlet {
       } else if (uri.getQuery() != null && uri.getQuery().startsWith("_CHECKED_HTTP_=")) {
         // Redirect requests for escaped URLs using the old destination to ExternalLinkToadlet.
         super.writeTemporaryRedirect(
-            ctx, "Depreciated", ExternalLinkToadlet.PATH + '?' + uri.getQuery());
+            ctx, "Depreciated", ExternalLinkToadlet.EXTERNAL_LINK_PATH + '?' + uri.getQuery());
         return;
       }
     }

--- a/src/test/java/network/crypta/client/filter/ContentFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/ContentFilterTest.java
@@ -106,7 +106,7 @@ public class ContentFilterTest {
 
     // External links are stripped/redirected
     assertTrue(htmlFilter(EXTERNAL_LINK_CHECK1).startsWith(EXTERNAL_LINK_OK));
-    assertTrue(htmlFilter(EXTERNAL_LINK_CHECK2).contains(ExternalLinkToadlet.PATH));
+    assertTrue(htmlFilter(EXTERNAL_LINK_CHECK2).contains(ExternalLinkToadlet.EXTERNAL_LINK_PATH));
     assertTrue(htmlFilter(EXTERNAL_LINK_CHECK3).startsWith(EXTERNAL_LINK_OK));
   }
 
@@ -142,7 +142,7 @@ public class ContentFilterTest {
     // bug #2451
     assertEquals(POUNT_CHARACTER_ENCODING_TEST_RESULT, htmlFilter(POUNT_CHARACTER_ENCODING_TEST));
     // bug #2297
-    assertTrue(htmlFilter(PREVENT_FPROXY_ACCESS).contains(ExternalLinkToadlet.PATH));
+    assertTrue(htmlFilter(PREVENT_FPROXY_ACCESS).contains(ExternalLinkToadlet.EXTERNAL_LINK_PATH));
     // bug #2921
     assertTrue(htmlFilter(PREVENT_EXTERNAL_ACCESS_CSS_SIMPLE).contains(DIV_BLOCK));
     assertTrue(htmlFilter(PREVENT_EXTERNAL_ACCESS_CSS_ESCAPE).contains(DIV_BLOCK));

--- a/src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java
+++ b/src/test/java/network/crypta/client/filter/GenericReadFilterCallbackTest.java
@@ -121,7 +121,8 @@ class GenericReadFilterCallbackTest {
     String result = cb.processURI(input, null);
 
     assertEquals(
-        ExternalLinkToadlet.PATH + "?_CHECKED_HTTP_=http://example.com/path?q=a%20b", result);
+        ExternalLinkToadlet.EXTERNAL_LINK_PATH + "?_CHECKED_HTTP_=http://example.com/path?q=a%20b",
+        result);
   }
 
   @Test

--- a/src/test/java/network/crypta/client/filter/M3UFilterTest.java
+++ b/src/test/java/network/crypta/client/filter/M3UFilterTest.java
@@ -98,23 +98,25 @@ class M3UFilterTest {
   void readFilter_whenSanitizedUriIsExternalLink_doesNotAppendMaxSize() throws Exception {
     FilterCallback callback = mock(FilterCallback.class);
     when(callback.processURI("song.mp3", "audio/mpeg", SCHEME_HOST_PORT, true))
-        .thenReturn(ExternalLinkToadlet.PATH + "?target=example");
+        .thenReturn(ExternalLinkToadlet.EXTERNAL_LINK_PATH + "?target=example");
 
     String result = runFilter("song.mp3\n", callback);
 
-    assertEquals(ExternalLinkToadlet.PATH + "?target=example\n", result);
+    assertEquals(ExternalLinkToadlet.EXTERNAL_LINK_PATH + "?target=example\n", result);
   }
 
   @Test
   void readFilter_whenSanitizedUriContainsMagicEscape_doesNotAppendMaxSize() throws Exception {
     FilterCallback callback = mock(FilterCallback.class);
     when(callback.processURI("second.mp3", "audio/mpeg", SCHEME_HOST_PORT, true))
-        .thenReturn("http://filtered/" + ExternalLinkToadlet.magicHTTPEscapeString + "/second.mp3");
+        .thenReturn(
+            "http://filtered/" + ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING + "/second.mp3");
 
     String result = runFilter("second.mp3\n", callback);
 
     assertEquals(
-        "http://filtered/" + ExternalLinkToadlet.magicHTTPEscapeString + "/second.mp3\n", result);
+        "http://filtered/" + ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING + "/second.mp3\n",
+        result);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/ExternalLinkToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ExternalLinkToadletTest.java
@@ -1,0 +1,226 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.PageMaker.RenderParameters;
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ExternalLinkToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private Node node;
+  @Mock private NodeClientCore nodeClientCore;
+  @Mock private SimpleToadletServer toadletContainer;
+  @Mock private ToadletContext context;
+  @Mock private PageMaker pageMaker;
+  @Mock private HTTPRequest request;
+
+  private ExternalLinkToadlet toadlet;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    toadlet = new ExternalLinkToadlet(client, node);
+
+    when(context.getPageMaker()).thenReturn(pageMaker);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    when(nodeClientCore.getToadletContainer()).thenReturn(toadletContainer);
+
+    doNothing()
+        .when(context)
+        .sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong());
+    doNothing()
+        .when(context)
+        .sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong(), anyBoolean());
+    doNothing().when(context).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void path_whenCalled_returnsExternalLinkPath() {
+    assertEquals(ExternalLinkToadlet.EXTERNAL_LINK_PATH, toadlet.path());
+  }
+
+  @Test
+  void escape_whenUriProvided_prependsMagicParameter() {
+    String input = "http://example.com/resource";
+
+    String result = ExternalLinkToadlet.escape(input);
+
+    assertEquals(
+        ExternalLinkToadlet.EXTERNAL_LINK_PATH
+            + "?"
+            + ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING
+            + '='
+            + input,
+        result);
+  }
+
+  @Test
+  void handleMethodPOST_whenGoParameterEmpty_redirectsToWelcome() throws Exception {
+    when(request.getPartAsStringFailsafe(
+            eq(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING), anyInt()))
+        .thenReturn("http://example.com");
+    when(request.getPartAsStringFailsafe(eq("Go"), anyInt())).thenReturn("");
+
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(multiValueTableClass());
+
+    toadlet.handleMethodPOST(URI.create(ExternalLinkToadlet.EXTERNAL_LINK_PATH), request, context);
+
+    verify(context)
+        .sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), isNull(), eq(0L));
+    assertEquals(WelcomeToadlet.PATH, headersCaptor.getValue().getFirst("Location"));
+  }
+
+  @Test
+  void handleMethodPOST_whenUrlProvided_redirectsToTarget() throws Exception {
+    String target = "http://example.org/page";
+    when(request.getPartAsStringFailsafe(
+            eq(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING), anyInt()))
+        .thenReturn(target);
+    when(request.getPartAsStringFailsafe(eq("Go"), anyInt())).thenReturn("submit");
+
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(multiValueTableClass());
+
+    toadlet.handleMethodPOST(URI.create(ExternalLinkToadlet.EXTERNAL_LINK_PATH), request, context);
+
+    verify(context)
+        .sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), isNull(), eq(0L));
+    assertEquals(target, headersCaptor.getValue().getFirst("Location"));
+  }
+
+  @Test
+  void handleMethodGET_whenParamMissing_redirectsToWelcome() throws Exception {
+    when(request.getParam(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING)).thenReturn("");
+
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(multiValueTableClass());
+
+    toadlet.handleMethodGET(URI.create(ExternalLinkToadlet.EXTERNAL_LINK_PATH), request, context);
+
+    verify(context)
+        .sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), isNull(), eq(0L));
+    verify(context, never()).writeData(any(byte[].class), anyInt(), anyInt());
+    assertEquals(WelcomeToadlet.PATH, headersCaptor.getValue().getFirst("Location"));
+  }
+
+  @Test
+  void handleMethodGET_whenParamProvided_rendersConfirmationForm() throws Exception {
+    String target = "http://external.example/path";
+    when(request.getParam(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING)).thenReturn(target);
+    when(toadletContainer.fproxyHasCompletedWizard()).thenReturn(false);
+
+    HTMLNode page = new HTMLNode("html");
+    HTMLNode head = new HTMLNode("head");
+    HTMLNode content = new HTMLNode("div");
+    page.addChild(head);
+    page.addChild(content);
+    PageNode pageNode = new PageNode(page, head, content);
+
+    AtomicReference<RenderParameters> renderParameters = new AtomicReference<>();
+
+    when(pageMaker.getPageNode(anyString(), eq(context), any(RenderParameters.class)))
+        .thenAnswer(
+            invocation -> {
+              RenderParameters params = invocation.getArgument(2);
+              renderParameters.set(params);
+              return pageNode;
+            });
+
+    when(pageMaker.getInfobox(
+            anyString(), anyString(), any(HTMLNode.class), anyString(), anyBoolean()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(2);
+              HTMLNode infobox = new HTMLNode("div");
+              parent.addChild(infobox);
+              return infobox;
+            });
+
+    when(context.addFormChild(
+            any(HTMLNode.class),
+            eq(ExternalLinkToadlet.EXTERNAL_LINK_PATH),
+            eq("confirmExternalLinkForm")))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              HTMLNode form = new HTMLNode("form");
+              parent.addChild(form);
+              return form;
+            });
+
+    ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+
+    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class)) {
+      BaseL10n baseL10n = mock(BaseL10n.class);
+      nodeL10n.when(NodeL10n::getBase).thenReturn(baseL10n);
+      when(baseL10n.getString(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+      when(baseL10n.getString(anyString(), any(String[].class), any(String[].class)))
+          .thenAnswer(
+              invocation -> {
+                String key = invocation.getArgument(0);
+                String[] values = invocation.getArgument(2);
+                return key + ":" + values[0];
+              });
+
+      toadlet.handleMethodGET(URI.create(ExternalLinkToadlet.EXTERNAL_LINK_PATH), request, context);
+    }
+
+    verify(context)
+        .sendReplyHeaders(
+            eq(200), eq("OK"), isNull(), eq("text/html; charset=utf-8"), anyLong(), eq(true));
+    verify(context).writeData(dataCaptor.capture(), anyInt(), anyInt());
+
+    String html = new String(dataCaptor.getValue(), StandardCharsets.UTF_8);
+    assertTrue(html.contains(target));
+    assertTrue(html.contains(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING));
+
+    RenderParameters params = renderParameters.get();
+    assertNotNull(params);
+    assertFalse(params.isRenderNavigationLinks());
+    assertFalse(params.isRenderStatus());
+  }
+
+  @SuppressWarnings("unchecked")
+  private Class<MultiValueTable<String, String>> multiValueTableClass() {
+    return (Class<MultiValueTable<String, String>>) (Class<?>) MultiValueTable.class;
+  }
+}


### PR DESCRIPTION
## Summary
- replace magic string path usage with explicit EXTERNAL_LINK_PATH and MAGIC_HTTP_ESCAPE_STRING constants
- document ExternalLinkToadlet behaviour, null-guard inputs, and reuse shared form field helpers
- update filters and HTTP toadlets to use new constants and add dedicated ExternalLinkToadlet tests

## Testing
- not run (not requested)
