### PR TITLE
Refactor diagnostic toadlet reporting

### DIFF
--- a/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
@@ -18,6 +18,7 @@ import network.crypta.clients.fcp.RequestStatus;
 import network.crypta.clients.fcp.UploadDirRequestStatus;
 import network.crypta.clients.fcp.UploadFileRequestStatus;
 import network.crypta.config.SubConfig;
+import network.crypta.fs.AppEnv;
 import network.crypta.io.xfer.BlockReceiver;
 import network.crypta.io.xfer.BlockTransmitter;
 import network.crypta.l10n.BaseL10n;
@@ -41,15 +42,57 @@ import network.crypta.support.BandwidthStatsContainer;
 import network.crypta.support.SizeUtil;
 import network.crypta.support.api.HTTPRequest;
 
+/**
+ * Serves the `/diagnostic/` HTTP endpoint that aggregates runtime status for a running Crypta node.
+ *
+ * <p>This toadlet renders a plain-text snapshot that combines JVM resource details, datastore
+ * sizes, success rates, bandwidth usage, peer health, plugin state, work queues, and thread
+ * diagnostics into a single page intended for administrators. Callers typically access it via the
+ * built-in web interface when troubleshooting connectivity, storage pressure, or performance
+ * anomalies. The handler executes synchronously on the toadlet thread and consults live {@link
+ * Node} services, so values reflect the moment of invocation rather than cached metrics.
+ *
+ * <p>The instance is tied to a specific node and reuses shared formatters to ensure stable numeric
+ * output. No state is retained between requests beyond these formatters, making the class safe for
+ * concurrent reads under the servlet-style contract imposed by {@link Toadlet}. Thread safety
+ * relies on short synchronized sections around formatting to protect {@link DecimalFormat}
+ * instances from concurrent use.
+ *
+ * <ul>
+ *   <li>Gathers node, datastore, bandwidth, peer, plugin, queue, and thread information.
+ *   <li>Requires full-access authentication before emitting diagnostics.
+ *   <li>Designed for operational observability rather than end-user presentation.
+ * </ul>
+ *
+ * @see network.crypta.clients.http.ToadletContext
+ * @see Node
+ */
 public class DiagnosticToadlet extends Toadlet {
 
-  // private final DecimalFormat fix3p1US = new DecimalFormat("##0.0", new DecimalFormatSymbols
-  // (Locale.US));
-  // private final DecimalFormat fix3pctUS = new DecimalFormat("##0%", new DecimalFormatSymbols
-  // (Locale.US));
-  // private final DecimalFormat fix6p6 = new DecimalFormat("#####0.0#####");
+  /**
+   * Relative path where this toadlet is mounted within the HTTP interface.
+   *
+   * <p>The value is shared with router configuration and should remain stable so bookmarked
+   * diagnostic URLs and automated monitoring checks continue to resolve.
+   */
   public static final String TOADLET_URL = "/diagnostic/";
 
+  private static final String PATTERN_MEMORY = "memory";
+  private static final String PATTERN_VERSION = "version";
+  private static final String PATTERN_TOTAL = "total";
+  private static final String PATTERN_PERCENT = "percent";
+  private static final String STATISTICS_PREFIX = "StatisticsToadlet.";
+
+  /**
+   * Builds a diagnostic toadlet bound to the provided node and client plumbing.
+   *
+   * @param n live {@link Node} instance that exposes stats, peers, and diagnostics; must be
+   *     non-null for correct operation.
+   * @param fcp FCP server used to collect queue information and request statuses; expected to be
+   *     initialized and running.
+   * @param client HTTP client facade supplied to the superclass for response handling; reused for
+   *     outbound interactions initiated by the toadlet.
+   */
   protected DiagnosticToadlet(Node n, FCPServer fcp, HighLevelSimpleClient client) {
     super(client);
     this.node = n;
@@ -65,6 +108,29 @@ public class DiagnosticToadlet extends Toadlet {
             BaseL10n.LANGUAGE.ENGLISH);
   }
 
+  /**
+   * Handles authenticated GET requests for the diagnostic page and streams a textual snapshot of
+   * node health.
+   *
+   * <p>The handler first enforces full-access permissions on the {@link ToadletContext}, then
+   * refreshes bandwidth statistics and gathers a series of live metrics: version data, system
+   * memory and CPU figures, datastore usage and success rates, activity counters, peer summaries,
+   * bandwidth caps, plugin state, queued requests, and thread diagnostics. Formatting occurs inside
+   * a synchronized block to guard shared {@link DecimalFormat} instances. On success, it responds
+   * with HTTP 200 and the assembled plaintext body; on failure it lets I/O and toadlet-specific
+   * exceptions propagate to the caller for higher-level handling.
+   *
+   * @param uri request target; path should match {@link #path()} and query parameters are ignored.
+   * @param request parsed HTTP request wrapper providing headers and authorization state; must not
+   *     be {@code null}.
+   * @param ctx toadlet context used for access control and writing the response; must be open for
+   *     the duration of the call.
+   * @throws ToadletContextClosedException if the client disconnects or the context closes before a
+   *     response is written.
+   * @throws IOException if reading from the request or writing the diagnostic output fails.
+   * @throws RedirectException if the caller lacks permission and the framework triggers a redirect
+   *     to the login or permissions page.
+   */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     if (!ctx.checkFullAccess(this)) {
@@ -79,771 +145,777 @@ public class DiagnosticToadlet extends Toadlet {
 
     // Synchronize to avoid problems with DecimalFormat.
     synchronized (this) {
-      // drawNodeVersionBox
-      textBuilder.append("Crypta Version:\n");
-      textBuilder
-          .append(
-              baseL10n.getString(
-                  "WelcomeToadlet.version",
-                  new String[] {"fullVersion", "build", "rev"},
-                  new String[] {
-                    Long.toString(Version.currentBuildNumber()),
-                    Integer.toString(Version.currentBuildNumber()),
-                    Version.gitRevision()
-                  }))
-          .append("\n");
-
-      // drawNodeVersionBox
-      textBuilder.append("System Information:\n");
-      Runtime rt = Runtime.getRuntime();
-      long freeMemory = rt.freeMemory();
-      long totalMemory = rt.totalMemory();
-      long maxMemory = rt.maxMemory();
-      long usedJavaMem = totalMemory - freeMemory;
-      int availableCpus = rt.availableProcessors();
-      int threadCount = stats.getActiveThreadCount();
-      textBuilder
-          .append(l10n("usedMemory", "memory", SizeUtil.formatSize(usedJavaMem, true)))
-          .append("\n");
-      textBuilder
-          .append(l10n("allocMemory", "memory", SizeUtil.formatSize(totalMemory, true)))
-          .append("\n");
-      textBuilder
-          .append(l10n("maxMemory", "memory", SizeUtil.formatSize(maxMemory, true)))
-          .append("\n");
-      textBuilder
-          .append(
-              l10n(
-                  "threads",
-                  new String[] {"running", "max"},
-                  new String[] {
-                    thousandPoint.format(threadCount), Integer.toString(stats.getThreadLimit())
-                  }))
-          .append("\n");
-      textBuilder.append(l10n("cpus", "count", Integer.toString(availableCpus))).append("\n");
-      textBuilder
-          .append(l10n("javaVersion", "version", System.getProperty("java.version")))
-          .append("\n");
-      textBuilder
-          .append(l10n("jvmVendor", "vendor", System.getProperty("java.vendor")))
-          .append("\n");
-      textBuilder.append(l10n("jvmName", "name", System.getProperty("java.vm.name"))).append("\n");
-      textBuilder
-          .append(l10n("jvmVersion", "version", System.getProperty("java.vm.version")))
-          .append("\n");
-      textBuilder
-          .append(l10n("osName", "name", new network.crypta.fs.AppEnv().osNameRaw()))
-          .append("\n");
-      textBuilder
-          .append(l10n("osVersion", "version", System.getProperty("os.version")))
-          .append("\n");
-      textBuilder.append(l10n("osArch", "arch", System.getProperty("os.arch"))).append("\n");
-      textBuilder.append("\n");
-
-      // drawStoreSizeBox
-      textBuilder.append("Store Size:\n");
-      Map<DataStoreInstanceType, DataStoreStats> storeStats = node.getDataStoreStats();
-      for (Map.Entry<DataStoreInstanceType, DataStoreStats> entry : storeStats.entrySet()) {
-        DataStoreInstanceType instance = entry.getKey();
-        DataStoreStats stats = entry.getValue();
-        StoreAccessStats sessionAccess = stats.getSessionAccessStats();
-        StoreAccessStats totalAccess;
-        try {
-          totalAccess = stats.getTotalAccessStats();
-        } catch (StatsNotAvailableException e) {
-          totalAccess = null;
-        }
-        textBuilder
-            .append(l10n(instance.store.name()))
-            .append(": (")
-            .append(l10n(instance.key.name()))
-            .append(")\n");
-        textBuilder
-            .append("  ")
-            .append(l10n("keys"))
-            .append(": ")
-            .append(thousandPoint.format(stats.keys()))
-            .append("\n");
-        textBuilder
-            .append("  ")
-            .append(l10n("capacity"))
-            .append(": ")
-            .append(thousandPoint.format(stats.capacity()))
-            .append("\n");
-        textBuilder
-            .append("  ")
-            .append(l10n("datasize"))
-            .append(": ")
-            .append(SizeUtil.formatSize(stats.dataSize()))
-            .append("\n");
-        textBuilder
-            .append("  ")
-            .append(l10n("utilization"))
-            .append(": ")
-            .append(fix3p1pct.format(stats.utilization()))
-            .append("\n");
-        textBuilder
-            .append("  ")
-            .append(l10n("readRequests"))
-            .append(": ")
-            .append(thousandPoint.format(sessionAccess.readRequests()))
-            .append(
-                totalAccess == null
-                    ? ""
-                    : (" (" + thousandPoint.format(totalAccess.readRequests()) + ")"))
-            .append("\n");
-        textBuilder
-            .append("  ")
-            .append(l10n("successfulReads"))
-            .append(": ")
-            .append(thousandPoint.format(sessionAccess.successfulReads()))
-            .append(
-                totalAccess == null
-                    ? ""
-                    : (" (" + thousandPoint.format(totalAccess.successfulReads()) + ")"))
-            .append("\n");
-        try {
-          textBuilder.append(fix1p4.format(sessionAccess.successRate())).append("%");
-          if (totalAccess != null) {
-            try {
-              textBuilder
-                  .append(" (")
-                  .append(fix1p4.format(totalAccess.successRate()))
-                  .append("%)");
-            } catch (StatsNotAvailableException e) {
-              // Ignore
-            }
-          }
-          textBuilder.append("\n");
-        } catch (StatsNotAvailableException e) {
-        }
-      }
-      textBuilder.append("\n");
-
-      // drawActivity
-      textBuilder.append("Activity:\n");
-      RequestTracker tracker = node.getTracker();
-      int numLocalCHKInserts = tracker.getNumLocalCHKInserts();
-      int numRemoteCHKInserts = tracker.getNumRemoteCHKInserts();
-      int numLocalSSKInserts = tracker.getNumLocalSSKInserts();
-      int numRemoteSSKInserts = tracker.getNumRemoteSSKInserts();
-      int numLocalCHKRequests = tracker.getNumLocalCHKRequests();
-      int numRemoteCHKRequests = tracker.getNumRemoteCHKRequests();
-      int numLocalSSKRequests = tracker.getNumLocalSSKRequests();
-      int numRemoteSSKRequests = tracker.getNumRemoteSSKRequests();
-      int numTransferringRequests = tracker.getNumTransferringRequestSenders();
-      int numTransferringRequestHandlers = tracker.getNumTransferringRequestHandlers();
-      int numCHKOfferReplys = tracker.getNumCHKOfferReplies();
-      int numSSKOfferReplys = tracker.getNumSSKOfferReplies();
-      int numCHKRequests = numLocalCHKRequests + numRemoteCHKRequests;
-      int numSSKRequests = numLocalSSKRequests + numRemoteSSKRequests;
-      int numCHKInserts = numLocalCHKInserts + numRemoteCHKInserts;
-      int numSSKInserts = numLocalSSKInserts + numRemoteSSKInserts;
-      if ((numTransferringRequests == 0)
-          && (numCHKRequests == 0)
-          && (numSSKRequests == 0)
-          && (numCHKInserts == 0)
-          && (numSSKInserts == 0)
-          && (numTransferringRequestHandlers == 0)
-          && (numCHKOfferReplys == 0)
-          && (numSSKOfferReplys == 0)) {
-        textBuilder.append(l10n("noRequests")).append("\n");
-      } else {
-        if (numCHKInserts > 0 || numSSKInserts > 0) {
-          textBuilder
-              .append(
-                  l10n(
-                      "activityInserts",
-                      new String[] {"CHKhandlers", "SSKhandlers", "local"},
-                      new String[] {
-                        Integer.toString(numCHKInserts),
-                        Integer.toString(numSSKInserts),
-                        numLocalCHKInserts + "/" + numLocalSSKInserts
-                      }))
-              .append("\n");
-        }
-        if (numCHKRequests > 0 || numSSKRequests > 0) {
-          textBuilder
-              .append(
-                  l10n(
-                      "activityRequests",
-                      new String[] {"CHKhandlers", "SSKhandlers", "local"},
-                      new String[] {
-                        Integer.toString(numCHKRequests),
-                        Integer.toString(numSSKRequests),
-                        numLocalCHKRequests + "/" + numLocalSSKRequests
-                      }))
-              .append("\n");
-        }
-        if (numTransferringRequests > 0 || numTransferringRequestHandlers > 0) {
-          textBuilder
-              .append(
-                  l10n(
-                      "transferringRequests",
-                      new String[] {"senders", "receivers", "turtles"},
-                      new String[] {
-                        Integer.toString(numTransferringRequests),
-                        Integer.toString(numTransferringRequestHandlers),
-                        "0"
-                      }))
-              .append("\n");
-        }
-        if (numCHKOfferReplys > 0 || numSSKOfferReplys > 0) {
-          textBuilder
-              .append(
-                  l10n(
-                      "offerReplys",
-                      new String[] {"chk", "ssk"},
-                      new String[] {
-                        Integer.toString(numCHKOfferReplys), Integer.toString(numSSKOfferReplys)
-                      }))
-              .append("\n");
-        }
-        textBuilder
-            .append(
-                l10n(
-                    "runningBlockTransfers",
-                    new String[] {"sends", "receives"},
-                    new String[] {
-                      Integer.toString(BlockTransmitter.getRunningSends()),
-                      Integer.toString(BlockReceiver.getRunningReceives())
-                    }))
-            .append("\n");
-      }
-      textBuilder.append("\n");
-
-      // drawPeerStatsBox
-      textBuilder.append("Peer Statistics:\n");
-      PeerNodeStatus[] peerNodeStatuses = peers.getPeerNodeStatuses(true);
-      Arrays.sort(
-          peerNodeStatuses,
-          (firstNode, secondNode) -> firstNode.getStatusValue() - secondNode.getStatusValue());
-      int numberOfConnected =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED);
-      int numberOfRoutingBackedOff =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF);
-      int numberOfTooNew =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW);
-      int numberOfTooOld =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD);
-      int numberOfDisconnected =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTED);
-      int numberOfNeverConnected =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED);
-      int numberOfDisabled =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED);
-      int numberOfBursting =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING);
-      int numberOfListening =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING);
-      int numberOfListenOnly =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY);
-      int numberOfSeedServers = getCountSeedServers(peerNodeStatuses);
-      int numberOfSeedClients = getCountSeedClients(peerNodeStatuses);
-      int numberOfRoutingDisabled =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED);
-      int numberOfClockProblem =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM);
-      int numberOfConnError =
-          getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR);
-      int numberOfDisconnecting =
-          PeerNodeStatus.getPeerStatusCount(
-              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING);
-      int numberOfNoLoadStats =
-          PeerNodeStatus.getPeerStatusCount(
-              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS);
-      if (numberOfConnected > 0) {
-        textBuilder
-            .append(l10nDark("connectedShort"))
-            .append(": ")
-            .append(numberOfConnected)
-            .append("\n");
-      }
-      if (numberOfRoutingBackedOff > 0) {
-        textBuilder
-            .append(l10nDark("backedOffShort"))
-            .append(": ")
-            .append(numberOfRoutingBackedOff)
-            .append("\n");
-      }
-      if (numberOfTooNew > 0) {
-        textBuilder
-            .append(l10nDark("tooNewShort"))
-            .append(": ")
-            .append(numberOfTooNew)
-            .append("\n");
-      }
-      if (numberOfTooOld > 0) {
-        textBuilder
-            .append(l10nDark("tooOldShort"))
-            .append(": ")
-            .append(numberOfTooOld)
-            .append("\n");
-      }
-      if (numberOfDisconnected > 0) {
-        textBuilder
-            .append(l10nDark("notConnectedShort"))
-            .append(": ")
-            .append(numberOfDisconnected)
-            .append("\n");
-      }
-      if (numberOfNeverConnected > 0) {
-        textBuilder
-            .append(l10nDark("neverConnectedShort"))
-            .append(": ")
-            .append(numberOfNeverConnected)
-            .append("\n");
-      }
-      if (numberOfDisabled > 0) {
-        textBuilder
-            .append(l10nDark("disabledShort"))
-            .append(": ")
-            .append(numberOfDisabled)
-            .append("\n");
-      }
-      if (numberOfBursting > 0) {
-        textBuilder
-            .append(l10nDark("burstingShort"))
-            .append(": ")
-            .append(numberOfBursting)
-            .append("\n");
-      }
-      if (numberOfListening > 0) {
-        textBuilder
-            .append(l10nDark("listeningShort"))
-            .append(": ")
-            .append(numberOfListening)
-            .append("\n");
-      }
-      if (numberOfListenOnly > 0) {
-        textBuilder
-            .append(l10nDark("listenOnlyShort"))
-            .append(": ")
-            .append(numberOfListenOnly)
-            .append("\n");
-      }
-      if (numberOfClockProblem > 0) {
-        textBuilder
-            .append(l10nDark("clockProblemShort"))
-            .append(": ")
-            .append(numberOfClockProblem)
-            .append("\n");
-      }
-      if (numberOfConnError > 0) {
-        textBuilder
-            .append(l10nDark("connErrorShort"))
-            .append(": ")
-            .append(numberOfConnError)
-            .append("\n");
-      }
-      if (numberOfDisconnecting > 0) {
-        textBuilder
-            .append(l10nDark("disconnectingShort"))
-            .append(": ")
-            .append(numberOfDisconnecting)
-            .append("\n");
-      }
-      if (numberOfSeedServers > 0) {
-        textBuilder
-            .append(l10nDark("seedServersShort"))
-            .append(": ")
-            .append(numberOfSeedServers)
-            .append("\n");
-      }
-      if (numberOfSeedClients > 0) {
-        textBuilder
-            .append(l10nDark("seedClientsShort"))
-            .append(": ")
-            .append(numberOfSeedClients)
-            .append("\n");
-      }
-      if (numberOfRoutingDisabled > 0) {
-        textBuilder
-            .append(l10nDark("routingDisabledShort"))
-            .append(": ")
-            .append(numberOfRoutingDisabled)
-            .append("\n");
-      }
-      if (numberOfNoLoadStats > 0) {
-        textBuilder
-            .append(l10nDark("noLoadStatsShort"))
-            .append(": ")
-            .append(numberOfNoLoadStats)
-            .append("\n");
-      }
-      OpennetManager om = node.getOpennet();
-      if (om != null) {
-        textBuilder
-            .append(l10n("maxTotalPeers"))
-            .append(": ")
-            .append(om.getNumberOfConnectedPeersToAimIncludingDarknet())
-            .append("\n");
-        textBuilder
-            .append(l10n("maxOpennetPeers"))
-            .append(": ")
-            .append(om.getNumberOfConnectedPeersToAim())
-            .append("\n");
-      }
-      textBuilder.append("\n");
-
-      // drawBandwidth
-      textBuilder.append("Bandwidth:\n");
-      long[] total = node.getCollector().getTotalIO();
-      if (total[0] == 0 || total[1] == 0) {
-        textBuilder.append("bandwidth error\n");
-      } else {
-        final long now = System.currentTimeMillis();
-        final long nodeUptimeSeconds = (now - node.getStartupTime()) / 1000;
-        long total_output_rate = (total[0]) / nodeUptimeSeconds;
-        long total_input_rate = (total[1]) / nodeUptimeSeconds;
-        long totalPayload = node.getTotalPayloadSent();
-        long total_payload_rate = totalPayload / nodeUptimeSeconds;
-        if (node.getClientCore() == null) {
-          throw new NullPointerException();
-        }
-        BandwidthStatsContainer stats =
-            node.getClientCore().getBandwidthStatsPutter().getLatestBWData();
-        if (stats == null) {
-          throw new NullPointerException();
-        }
-        long overall_total_out = stats.getTotalBytesOut();
-        long overall_total_in = stats.getTotalBytesIn();
-        int percent = (int) (100 * totalPayload / total[0]);
-        long[] rate = node.getNodeStats().getNodeIOStats();
-        long delta = (rate[5] - rate[2]) / 1000;
-        if (delta > 0) {
-          long output_rate = (rate[3] - rate[0]) / delta;
-          long input_rate = (rate[4] - rate[1]) / delta;
-          int outputBandwidthLimit = nodeConfig.getInt("outputBandwidthLimit");
-          int inputBandwidthLimit = nodeConfig.getInt("inputBandwidthLimit");
-          if (inputBandwidthLimit == -1) {
-            inputBandwidthLimit = outputBandwidthLimit * 4;
-          }
-          textBuilder
-              .append(
-                  l10n(
-                      "inputRate",
-                      new String[] {"rate", "max"},
-                      new String[] {
-                        SizeUtil.formatSize(input_rate, true),
-                        SizeUtil.formatSize(inputBandwidthLimit, true)
-                      }))
-              .append("\n");
-          textBuilder
-              .append(
-                  l10n(
-                      "outputRate",
-                      new String[] {"rate", "max"},
-                      new String[] {
-                        SizeUtil.formatSize(output_rate, true),
-                        SizeUtil.formatSize(outputBandwidthLimit, true)
-                      }))
-              .append("\n");
-        }
-        textBuilder
-            .append(
-                l10n(
-                    "totalInputSession",
-                    new String[] {"total", "rate"},
-                    new String[] {
-                      SizeUtil.formatSize(total[1], true),
-                      SizeUtil.formatSize(total_input_rate, true)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "totalOutputSession",
-                    new String[] {"total", "rate"},
-                    new String[] {
-                      SizeUtil.formatSize(total[0], true),
-                      SizeUtil.formatSize(total_output_rate, true)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "payloadOutput",
-                    new String[] {"total", "rate", "percent"},
-                    new String[] {
-                      SizeUtil.formatSize(totalPayload, true),
-                      SizeUtil.formatSize(total_payload_rate, true),
-                      Integer.toString(percent)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "totalInput",
-                    new String[] {"total"},
-                    new String[] {SizeUtil.formatSize(overall_total_in, true)}))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "totalOutput",
-                    new String[] {"total"},
-                    new String[] {SizeUtil.formatSize(overall_total_out, true)}))
-            .append("\n");
-        long totalBytesSentCHKRequests = node.getNodeStats().getCHKRequestTotalBytesSent();
-        long totalBytesSentSSKRequests = node.getNodeStats().getSSKRequestTotalBytesSent();
-        long totalBytesSentCHKInserts = node.getNodeStats().getCHKInsertTotalBytesSent();
-        long totalBytesSentSSKInserts = node.getNodeStats().getSSKInsertTotalBytesSent();
-        long totalBytesSentOfferedKeys = node.getNodeStats().getOfferedKeysTotalBytesSent();
-        long totalBytesSendOffers = node.getNodeStats().getOffersSentBytesSent();
-        long totalBytesSentSwapOutput = node.getNodeStats().getSwappingTotalBytesSent();
-        long totalBytesSentAuth = node.getNodeStats().getTotalAuthBytesSent();
-        long totalBytesSentAckOnly = node.getNodeStats().getNotificationOnlyPacketsSentBytes();
-        long totalBytesSentResends = node.getNodeStats().getResendBytesSent();
-        long totalBytesSentUOM = node.getNodeStats().getUOMBytesSent();
-        long totalBytesSentAnnounce = node.getNodeStats().getAnnounceBytesSent();
-        long totalBytesSentAnnouncePayload = node.getNodeStats().getAnnounceBytesPayloadSent();
-        long totalBytesSentRoutingStatus = node.getNodeStats().getRoutingStatusBytes();
-        long totalBytesSentNetworkColoring = node.getNodeStats().getNetworkColoringSentBytes();
-        long totalBytesSentPing = node.getNodeStats().getPingSentBytes();
-        long totalBytesSentProbeRequest = node.getNodeStats().getProbeRequestSentBytes();
-        long totalBytesSentRouted = node.getNodeStats().getRoutedMessageSentBytes();
-        long totalBytesSentDisconn = node.getNodeStats().getDisconnBytesSent();
-        long totalBytesSentInitial = node.getNodeStats().getInitialMessagesBytesSent();
-        long totalBytesSentChangedIP = node.getNodeStats().getChangedIPBytesSent();
-        long totalBytesSentNodeToNode = node.getNodeStats().getNodeToNodeBytesSent();
-        long totalBytesSentAllocationNotices = node.getNodeStats().getAllocationNoticesBytesSent();
-        long totalBytesSentFOAF = node.getNodeStats().getFOAFBytesSent();
-        long totalBytesSentRemaining =
-            total[0]
-                - (totalPayload
-                    + totalBytesSentCHKRequests
-                    + totalBytesSentSSKRequests
-                    + totalBytesSentCHKInserts
-                    + totalBytesSentSSKInserts
-                    + totalBytesSentOfferedKeys
-                    + totalBytesSendOffers
-                    + totalBytesSentSwapOutput
-                    + totalBytesSentAuth
-                    + totalBytesSentAckOnly
-                    + totalBytesSentResends
-                    + totalBytesSentUOM
-                    + totalBytesSentAnnounce
-                    + totalBytesSentRoutingStatus
-                    + totalBytesSentNetworkColoring
-                    + totalBytesSentPing
-                    + totalBytesSentProbeRequest
-                    + totalBytesSentRouted
-                    + totalBytesSentDisconn
-                    + totalBytesSentInitial
-                    + totalBytesSentChangedIP
-                    + totalBytesSentNodeToNode
-                    + totalBytesSentAllocationNotices
-                    + totalBytesSentFOAF);
-        textBuilder
-            .append(
-                l10n(
-                    "requestOutput",
-                    new String[] {"chk", "ssk"},
-                    new String[] {
-                      SizeUtil.formatSize(totalBytesSentCHKRequests, true),
-                      SizeUtil.formatSize(totalBytesSentSSKRequests, true)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "insertOutput",
-                    new String[] {"chk", "ssk"},
-                    new String[] {
-                      SizeUtil.formatSize(totalBytesSentCHKInserts, true),
-                      SizeUtil.formatSize(totalBytesSentSSKInserts, true)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "offeredKeyOutput",
-                    new String[] {"total", "offered"},
-                    new String[] {
-                      SizeUtil.formatSize(totalBytesSentOfferedKeys, true),
-                      SizeUtil.formatSize(totalBytesSendOffers, true)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n("swapOutput", "total", SizeUtil.formatSize(totalBytesSentSwapOutput, true)))
-            .append("\n");
-        textBuilder
-            .append(l10n("authBytes", "total", SizeUtil.formatSize(totalBytesSentAuth, true)))
-            .append("\n");
-        textBuilder
-            .append(l10n("ackOnlyBytes", "total", SizeUtil.formatSize(totalBytesSentAckOnly, true)))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "resendBytes",
-                    new String[] {"total", "percent"},
-                    new String[] {
-                      SizeUtil.formatSize(totalBytesSentResends, true),
-                      Long.toString((100 * totalBytesSentResends) / Math.max(1, total[0]))
-                    }))
-            .append("\n");
-        textBuilder
-            .append(l10n("uomBytes", "total", SizeUtil.formatSize(totalBytesSentUOM, true)))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "announceBytes",
-                    new String[] {"total", "payload"},
-                    new String[] {
-                      SizeUtil.formatSize(totalBytesSentAnnounce, true),
-                      SizeUtil.formatSize(totalBytesSentAnnouncePayload, true)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "adminBytes",
-                    new String[] {"routingStatus", "disconn", "initial", "changedIP"},
-                    new String[] {
-                      SizeUtil.formatSize(totalBytesSentRoutingStatus, true),
-                      SizeUtil.formatSize(totalBytesSentDisconn, true),
-                      SizeUtil.formatSize(totalBytesSentInitial, true),
-                      SizeUtil.formatSize(totalBytesSentChangedIP, true)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "debuggingBytes",
-                    new String[] {"netColoring", "ping", "probe", "routed"},
-                    new String[] {
-                      SizeUtil.formatSize(totalBytesSentNetworkColoring, true),
-                      SizeUtil.formatSize(totalBytesSentPing, true),
-                      SizeUtil.formatSize(totalBytesSentProbeRequest, true),
-                      SizeUtil.formatSize(totalBytesSentRouted, true)
-                    }))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "nodeToNodeBytes",
-                    "total",
-                    SizeUtil.formatSize(totalBytesSentNodeToNode, true)))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "loadAllocationNoticesBytes",
-                    "total",
-                    SizeUtil.formatSize(totalBytesSentAllocationNotices, true)))
-            .append("\n");
-        textBuilder
-            .append(l10n("foafBytes", "total", SizeUtil.formatSize(totalBytesSentFOAF, true)))
-            .append("\n");
-        textBuilder
-            .append(
-                l10n(
-                    "unaccountedBytes",
-                    new String[] {"total", "percent"},
-                    new String[] {
-                      SizeUtil.formatSize(totalBytesSentRemaining, true),
-                      Integer.toString((int) (totalBytesSentRemaining * 100 / total[0]))
-                    }))
-            .append("\n");
-        double sentOverheadPerSecond = node.getNodeStats().getSentOverheadPerSecond();
-        textBuilder
-            .append(
-                l10n(
-                    "totalOverhead",
-                    new String[] {"rate", "percent"},
-                    new String[] {
-                      SizeUtil.formatSize((long) sentOverheadPerSecond),
-                      Integer.toString((int) ((100 * sentOverheadPerSecond) / total_output_rate))
-                    }))
-            .append("\n");
-      }
-      textBuilder.append("\n");
-
-      // showStartingPlugins
-      textBuilder.append("Plugins:\n");
-      PluginManager pm = node.getPluginManager();
-      if (!pm.getPlugins().isEmpty()) {
-        textBuilder.append(baseL10n.getString("PluginToadlet.pluginListTitle")).append("\n");
-        for (PluginInfoWrapper pi : pm.getPlugins()) {
-          long ver = pi.getPluginLongVersion();
-          if (ver != -1) {
-            textBuilder
-                .append(pi.getFilename())
-                .append(" (")
-                .append(pi.getPluginClassName())
-                .append(") - ")
-                .append(pi.getPluginVersion())
-                .append(" (")
-                .append(ver)
-                .append(")")
-                .append(" ")
-                .append(pi.getThreadName())
-                .append("\n");
-          } else {
-            textBuilder
-                .append(pi.getFilename())
-                .append(" (")
-                .append(pi.getPluginClassName())
-                .append(") - ")
-                .append(pi.getPluginVersion())
-                .append(" ")
-                .append(pi.getThreadName())
-                .append("\n");
-          }
-        }
-      }
-      textBuilder.append("\n");
-
-      // handleGetInner
-      textBuilder.append("Queue:\n");
-      try {
-        RequestStatus[] reqs = fcp.getGlobalRequests();
-        if (reqs.length < 1) {
-          textBuilder.append(baseL10n.getString("QueueToadlet.globalQueueIsEmpty")).append("\n");
-        } else {
-          long totalQueuedDownload = 0;
-          long totalQueuedUpload = 0;
-          for (RequestStatus req : reqs) {
-            if (req instanceof DownloadRequestStatus) {
-              totalQueuedDownload++;
-            } else if (req instanceof UploadFileRequestStatus) {
-              totalQueuedUpload++;
-            } else if (req instanceof UploadDirRequestStatus) {
-              totalQueuedUpload++;
-            }
-          }
-          textBuilder
-              .append("Downloads Queued: ")
-              .append(totalQueuedDownload)
-              .append(" (")
-              .append(totalQueuedDownload)
-              .append(")\n");
-          textBuilder
-              .append("Uploads Queued: ")
-              .append(totalQueuedUpload)
-              .append(" (")
-              .append(totalQueuedUpload)
-              .append(")\n");
-        }
-      } catch (PersistenceDisabledException e) {
-        textBuilder.append("DatabaseDisabledException\n");
-      }
-      textBuilder.append("\n");
-
-      // drawThreadPriorityStatsBox
-      if (node.isNodeDiagnosticsEnabled()) {
-        textBuilder.append(threadsStats());
-        textBuilder.append("\n");
-      }
+      appendNodeVersion(textBuilder);
+      appendSystemInformation(textBuilder);
+      appendStoreSize(textBuilder);
+      appendActivity(textBuilder);
+      appendPeerStatistics(textBuilder);
+      appendBandwidth(textBuilder, nodeConfig);
+      appendPlugins(textBuilder);
+      appendQueue(textBuilder);
+      appendThreadDiagnostics(textBuilder);
     }
 
     this.writeTextReply(ctx, 200, "OK", textBuilder.toString());
   }
 
+  private void appendNodeVersion(StringBuilder textBuilder) {
+    textBuilder.append("Crypta Version:\n");
+    textBuilder
+        .append(
+            baseL10n.getString(
+                "WelcomeToadlet.version",
+                new String[] {"fullVersion", "build", "rev"},
+                new String[] {
+                  Long.toString(Version.currentBuildNumber()),
+                  Integer.toString(Version.currentBuildNumber()),
+                  Version.gitRevision()
+                }))
+        .append("\n");
+  }
+
+  private void appendSystemInformation(StringBuilder textBuilder) {
+    textBuilder.append("System Information:\n");
+    Runtime runtime = Runtime.getRuntime();
+    long freeMemory = runtime.freeMemory();
+    long totalMemory = runtime.totalMemory();
+    long maxMemory = runtime.maxMemory();
+    long usedJavaMem = totalMemory - freeMemory;
+    int availableCpus = runtime.availableProcessors();
+    int threadCount = stats.getActiveThreadCount();
+    textBuilder
+        .append(
+            statisticsL10n("usedMemory", PATTERN_MEMORY, SizeUtil.formatSize(usedJavaMem, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n("allocMemory", PATTERN_MEMORY, SizeUtil.formatSize(totalMemory, true)))
+        .append("\n");
+    textBuilder
+        .append(statisticsL10n("maxMemory", PATTERN_MEMORY, SizeUtil.formatSize(maxMemory, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "threads",
+                new String[] {"running", "max"},
+                new String[] {
+                  thousandPoint.format(threadCount), Integer.toString(stats.getThreadLimit())
+                }))
+        .append("\n");
+    textBuilder
+        .append(statisticsL10n("cpus", "count", Integer.toString(availableCpus)))
+        .append("\n");
+    textBuilder
+        .append(statisticsL10n("javaVersion", PATTERN_VERSION, System.getProperty("java.version")))
+        .append("\n");
+    textBuilder
+        .append(statisticsL10n("jvmVendor", "vendor", System.getProperty("java.vendor")))
+        .append("\n");
+    textBuilder
+        .append(statisticsL10n("jvmName", "name", System.getProperty("java.vm.name")))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n("jvmVersion", PATTERN_VERSION, System.getProperty("java.vm.version")))
+        .append("\n");
+    textBuilder.append(statisticsL10n("osName", "name", new AppEnv().osNameRaw())).append("\n");
+    textBuilder
+        .append(statisticsL10n("osVersion", PATTERN_VERSION, System.getProperty("os.version")))
+        .append("\n");
+    textBuilder
+        .append(statisticsL10n("osArch", "arch", System.getProperty("os.arch")))
+        .append("\n");
+    textBuilder.append("\n");
+  }
+
+  private void appendStoreSize(StringBuilder textBuilder) {
+    textBuilder.append("Store Size:\n");
+    Map<DataStoreInstanceType, DataStoreStats> storeStats = node.getDataStoreStats();
+    for (Map.Entry<DataStoreInstanceType, DataStoreStats> entry : storeStats.entrySet()) {
+      DataStoreInstanceType instance = entry.getKey();
+      DataStoreStats storeStatsEntry = entry.getValue();
+      StoreAccessStats sessionAccess = storeStatsEntry.getSessionAccessStats();
+      StoreAccessStats totalAccess = getTotalAccessStats(storeStatsEntry);
+      textBuilder
+          .append(statisticsL10n(instance.store.name()))
+          .append(": (")
+          .append(statisticsL10n(instance.key.name()))
+          .append(")\n");
+      textBuilder
+          .append("  ")
+          .append(statisticsL10n("keys"))
+          .append(": ")
+          .append(thousandPoint.format(storeStatsEntry.keys()))
+          .append("\n");
+      textBuilder
+          .append("  ")
+          .append(statisticsL10n("capacity"))
+          .append(": ")
+          .append(thousandPoint.format(storeStatsEntry.capacity()))
+          .append("\n");
+      textBuilder
+          .append("  ")
+          .append(statisticsL10n("datasize"))
+          .append(": ")
+          .append(SizeUtil.formatSize(storeStatsEntry.dataSize()))
+          .append("\n");
+      textBuilder
+          .append("  ")
+          .append(statisticsL10n("utilization"))
+          .append(": ")
+          .append(fix3p1pct.format(storeStatsEntry.utilization()))
+          .append("\n");
+      textBuilder
+          .append("  ")
+          .append(statisticsL10n("readRequests"))
+          .append(": ")
+          .append(thousandPoint.format(sessionAccess.readRequests()))
+          .append(
+              totalAccess == null
+                  ? ""
+                  : (" (" + thousandPoint.format(totalAccess.readRequests()) + ")"))
+          .append("\n");
+      textBuilder
+          .append("  ")
+          .append(statisticsL10n("successfulReads"))
+          .append(": ")
+          .append(thousandPoint.format(sessionAccess.successfulReads()))
+          .append(
+              totalAccess == null
+                  ? ""
+                  : (" (" + thousandPoint.format(totalAccess.successfulReads()) + ")"))
+          .append("\n");
+      appendSuccessRates(textBuilder, sessionAccess, totalAccess);
+    }
+    textBuilder.append("\n");
+  }
+
+  private StoreAccessStats getTotalAccessStats(DataStoreStats storeStatsEntry) {
+    try {
+      return storeStatsEntry.getTotalAccessStats();
+    } catch (StatsNotAvailableException e) {
+      return null;
+    }
+  }
+
+  private void appendSuccessRates(
+      StringBuilder textBuilder, StoreAccessStats sessionAccess, StoreAccessStats totalAccess) {
+    try {
+      textBuilder.append(fix1p4.format(sessionAccess.successRate())).append("%");
+    } catch (StatsNotAvailableException e) {
+      textBuilder.append("\n");
+      return;
+    }
+    try {
+      appendTotalSuccessRate(textBuilder, totalAccess);
+    } catch (StatsNotAvailableException ignored) {
+      // Ignore failures from total stats so we still show the session success rate.
+    }
+    textBuilder.append("\n");
+  }
+
+  private void appendTotalSuccessRate(StringBuilder textBuilder, StoreAccessStats totalAccess)
+      throws StatsNotAvailableException {
+    if (totalAccess == null) {
+      return;
+    }
+    textBuilder.append(" (").append(fix1p4.format(totalAccess.successRate())).append("%)");
+  }
+
+  private void appendActivity(StringBuilder textBuilder) {
+    textBuilder.append("Activity:\n");
+    RequestTracker tracker = node.getTracker();
+    int numLocalCHKInserts = tracker.getNumLocalCHKInserts();
+    int numRemoteCHKInserts = tracker.getNumRemoteCHKInserts();
+    int numLocalSSKInserts = tracker.getNumLocalSSKInserts();
+    int numRemoteSSKInserts = tracker.getNumRemoteSSKInserts();
+    int numLocalCHKRequests = tracker.getNumLocalCHKRequests();
+    int numRemoteCHKRequests = tracker.getNumRemoteCHKRequests();
+    int numLocalSSKRequests = tracker.getNumLocalSSKRequests();
+    int numRemoteSSKRequests = tracker.getNumRemoteSSKRequests();
+    int numTransferringRequests = tracker.getNumTransferringRequestSenders();
+    int numTransferringRequestHandlers = tracker.getNumTransferringRequestHandlers();
+    int numCHKOfferReplies = tracker.getNumCHKOfferReplies();
+    int numSSKOfferReplies = tracker.getNumSSKOfferReplies();
+    int numCHKRequests = numLocalCHKRequests + numRemoteCHKRequests;
+    int numSSKRequests = numLocalSSKRequests + numRemoteSSKRequests;
+    int numCHKInserts = numLocalCHKInserts + numRemoteCHKInserts;
+    int numSSKInserts = numLocalSSKInserts + numRemoteSSKInserts;
+    if ((numTransferringRequests == 0)
+        && (numCHKRequests == 0)
+        && (numSSKRequests == 0)
+        && (numCHKInserts == 0)
+        && (numSSKInserts == 0)
+        && (numTransferringRequestHandlers == 0)
+        && (numCHKOfferReplies == 0)
+        && (numSSKOfferReplies == 0)) {
+      textBuilder.append(statisticsL10n("noRequests")).append("\n\n");
+      return;
+    }
+    appendActivityLine(
+        textBuilder,
+        numCHKInserts > 0 || numSSKInserts > 0,
+        "activityInserts",
+        new String[] {"CHKhandlers", "SSKhandlers", "local"},
+        new String[] {
+          Integer.toString(numCHKInserts),
+          Integer.toString(numSSKInserts),
+          numLocalCHKInserts + "/" + numLocalSSKInserts
+        });
+    appendActivityLine(
+        textBuilder,
+        numCHKRequests > 0 || numSSKRequests > 0,
+        "activityRequests",
+        new String[] {"CHKhandlers", "SSKhandlers", "local"},
+        new String[] {
+          Integer.toString(numCHKRequests),
+          Integer.toString(numSSKRequests),
+          numLocalCHKRequests + "/" + numLocalSSKRequests
+        });
+    appendActivityLine(
+        textBuilder,
+        numTransferringRequests > 0 || numTransferringRequestHandlers > 0,
+        "transferringRequests",
+        new String[] {"senders", "receivers", "turtles"},
+        new String[] {
+          Integer.toString(numTransferringRequests),
+          Integer.toString(numTransferringRequestHandlers),
+          "0"
+        });
+    appendActivityLine(
+        textBuilder,
+        numCHKOfferReplies > 0 || numSSKOfferReplies > 0,
+        "offerReplys",
+        new String[] {"chk", "ssk"},
+        new String[] {Integer.toString(numCHKOfferReplies), Integer.toString(numSSKOfferReplies)});
+    textBuilder
+        .append(
+            statisticsL10n(
+                "runningBlockTransfers",
+                new String[] {"sends", "receives"},
+                new String[] {
+                  Integer.toString(BlockTransmitter.getRunningSends()),
+                  Integer.toString(BlockReceiver.getRunningReceives())
+                }))
+        .append("\n\n");
+  }
+
+  private void appendActivityLine(
+      StringBuilder textBuilder,
+      boolean shouldAppend,
+      String key,
+      String[] patterns,
+      String[] values) {
+    if (shouldAppend) {
+      textBuilder.append(statisticsL10n(key, patterns, values)).append("\n");
+    }
+  }
+
+  private void appendPeerStatistics(StringBuilder textBuilder) {
+    textBuilder.append("Peer Statistics:\n");
+    PeerNodeStatus[] peerNodeStatuses = peers.getPeerNodeStatuses(true);
+    Arrays.sort(peerNodeStatuses, Comparator.comparingInt(PeerNodeStatus::getStatusValue));
+    appendPeerCount(
+        textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED, "connectedShort");
+    appendPeerCount(
+        textBuilder,
+        peerNodeStatuses,
+        PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF,
+        "backedOffShort");
+    appendPeerCount(
+        textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW, "tooNewShort");
+    appendPeerCount(
+        textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD, "tooOldShort");
+    appendPeerCount(
+        textBuilder,
+        peerNodeStatuses,
+        PeerManager.PEER_NODE_STATUS_DISCONNECTED,
+        "notConnectedShort");
+    appendPeerCount(
+        textBuilder,
+        peerNodeStatuses,
+        PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED,
+        "neverConnectedShort");
+    appendPeerCount(
+        textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED, "disabledShort");
+    appendPeerCount(
+        textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING, "burstingShort");
+    appendPeerCount(
+        textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING, "listeningShort");
+    appendPeerCount(
+        textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY, "listenOnlyShort");
+    appendPeerCount(
+        textBuilder,
+        peerNodeStatuses,
+        PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM,
+        "clockProblemShort");
+    appendPeerCount(
+        textBuilder, peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR, "connErrorShort");
+    appendPeerCount(
+        textBuilder,
+        peerNodeStatuses,
+        PeerManager.PEER_NODE_STATUS_DISCONNECTING,
+        "disconnectingShort");
+    appendSeedCounts(textBuilder, peerNodeStatuses);
+    appendPeerCount(
+        textBuilder,
+        peerNodeStatuses,
+        PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED,
+        "routingDisabledShort");
+    appendPeerCount(
+        textBuilder,
+        peerNodeStatuses,
+        PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS,
+        "noLoadStatsShort");
+    appendOpennetTargets(textBuilder);
+    textBuilder.append("\n");
+  }
+
+  private void appendSeedCounts(StringBuilder textBuilder, PeerNodeStatus[] peerNodeStatuses) {
+    int numberOfSeedServers = getCountSeedServers(peerNodeStatuses);
+    int numberOfSeedClients = getCountSeedClients(peerNodeStatuses);
+    if (numberOfSeedServers > 0) {
+      textBuilder
+          .append(darknetL10n("seedServersShort"))
+          .append(": ")
+          .append(numberOfSeedServers)
+          .append("\n");
+    }
+    if (numberOfSeedClients > 0) {
+      textBuilder
+          .append(darknetL10n("seedClientsShort"))
+          .append(": ")
+          .append(numberOfSeedClients)
+          .append("\n");
+    }
+  }
+
+  private void appendPeerCount(
+      StringBuilder textBuilder, PeerNodeStatus[] peerNodeStatuses, int status, String key) {
+    int count = getPeerStatusCount(peerNodeStatuses, status);
+    if (count > 0) {
+      textBuilder.append(darknetL10n(key)).append(": ").append(count).append("\n");
+    }
+  }
+
+  private void appendOpennetTargets(StringBuilder textBuilder) {
+    OpennetManager opennetManager = node.getOpennet();
+    if (opennetManager != null) {
+      textBuilder
+          .append(statisticsL10n("maxTotalPeers"))
+          .append(": ")
+          .append(opennetManager.getNumberOfConnectedPeersToAimIncludingDarknet())
+          .append("\n");
+      textBuilder
+          .append(statisticsL10n("maxOpennetPeers"))
+          .append(": ")
+          .append(opennetManager.getNumberOfConnectedPeersToAim())
+          .append("\n");
+    }
+  }
+
+  private void appendBandwidth(StringBuilder textBuilder, SubConfig nodeConfig) {
+    textBuilder.append("Bandwidth:\n");
+    long[] total = node.getCollector().getTotalIO();
+    if (total[0] == 0 || total[1] == 0) {
+      textBuilder.append("bandwidth error\n\n");
+      return;
+    }
+    long now = System.currentTimeMillis();
+    long nodeUptimeSeconds = (now - node.getStartupTime()) / 1000;
+    long totalOutputRate = total[0] / nodeUptimeSeconds;
+    long totalInputRate = total[1] / nodeUptimeSeconds;
+    long totalPayload = node.getTotalPayloadSent();
+    long totalPayloadRate = totalPayload / nodeUptimeSeconds;
+    if (node.getClientCore() == null) {
+      throw new NullPointerException();
+    }
+    BandwidthStatsContainer bandwidthStats =
+        node.getClientCore().getBandwidthStatsPutter().getLatestBWData();
+    if (bandwidthStats == null) {
+      throw new NullPointerException();
+    }
+    long overallTotalOut = bandwidthStats.getTotalBytesOut();
+    long overallTotalIn = bandwidthStats.getTotalBytesIn();
+    int payloadPercent = (int) (100 * totalPayload / total[0]);
+    long[] rate = node.getNodeStats().getNodeIOStats();
+    long delta = (rate[5] - rate[2]) / 1000;
+    appendInstantaneousRates(textBuilder, nodeConfig, rate, delta);
+    long[] sessionRates = new long[] {totalInputRate, totalOutputRate, totalPayloadRate};
+    long[] overallTotals = new long[] {overallTotalIn, overallTotalOut};
+    BandwidthSessionData sessionData =
+        new BandwidthSessionData(total, totalPayload, sessionRates, payloadPercent, overallTotals);
+    appendSessionTotals(textBuilder, sessionData);
+    appendCategoryBreakdown(textBuilder, total, totalPayload);
+    double sentOverheadPerSecond = node.getNodeStats().getSentOverheadPerSecond();
+    textBuilder
+        .append(
+            statisticsL10n(
+                "totalOverhead",
+                new String[] {"rate", PATTERN_PERCENT},
+                new String[] {
+                  SizeUtil.formatSize((long) sentOverheadPerSecond),
+                  Integer.toString((int) ((100 * sentOverheadPerSecond) / totalOutputRate))
+                }))
+        .append("\n\n");
+  }
+
+  private void appendInstantaneousRates(
+      StringBuilder textBuilder, SubConfig nodeConfig, long[] rate, long delta) {
+    if (delta <= 0) {
+      return;
+    }
+    long outputRate = (rate[3] - rate[0]) / delta;
+    long inputRate = (rate[4] - rate[1]) / delta;
+    int outputBandwidthLimit = nodeConfig.getInt("outputBandwidthLimit");
+    int inputBandwidthLimit = nodeConfig.getInt("inputBandwidthLimit");
+    if (inputBandwidthLimit == -1) {
+      inputBandwidthLimit = outputBandwidthLimit * 4;
+    }
+    textBuilder
+        .append(
+            statisticsL10n(
+                "inputRate",
+                new String[] {"rate", "max"},
+                new String[] {
+                  SizeUtil.formatSize(inputRate, true),
+                  SizeUtil.formatSize(inputBandwidthLimit, true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "outputRate",
+                new String[] {"rate", "max"},
+                new String[] {
+                  SizeUtil.formatSize(outputRate, true),
+                  SizeUtil.formatSize(outputBandwidthLimit, true)
+                }))
+        .append("\n");
+  }
+
+  private void appendSessionTotals(StringBuilder textBuilder, BandwidthSessionData sessionData) {
+    textBuilder
+        .append(
+            statisticsL10n(
+                "totalInputSession",
+                new String[] {PATTERN_TOTAL, "rate"},
+                new String[] {
+                  SizeUtil.formatSize(sessionData.total[1], true),
+                  SizeUtil.formatSize(sessionData.sessionRates[0], true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "totalOutputSession",
+                new String[] {PATTERN_TOTAL, "rate"},
+                new String[] {
+                  SizeUtil.formatSize(sessionData.total[0], true),
+                  SizeUtil.formatSize(sessionData.sessionRates[1], true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "payloadOutput",
+                new String[] {PATTERN_TOTAL, "rate", PATTERN_PERCENT},
+                new String[] {
+                  SizeUtil.formatSize(sessionData.totalPayload, true),
+                  SizeUtil.formatSize(sessionData.sessionRates[2], true),
+                  Integer.toString(sessionData.payloadPercent)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "totalInput",
+                new String[] {PATTERN_TOTAL},
+                new String[] {SizeUtil.formatSize(sessionData.overallTotals[0], true)}))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "totalOutput",
+                new String[] {PATTERN_TOTAL},
+                new String[] {SizeUtil.formatSize(sessionData.overallTotals[1], true)}))
+        .append("\n");
+  }
+
+  private static final class BandwidthSessionData {
+    private final long[] total;
+    private final long totalPayload;
+    private final long[] sessionRates;
+    private final int payloadPercent;
+    private final long[] overallTotals;
+
+    BandwidthSessionData(
+        long[] total,
+        long totalPayload,
+        long[] sessionRates,
+        int payloadPercent,
+        long[] overallTotals) {
+      this.total = total;
+      this.totalPayload = totalPayload;
+      this.sessionRates = sessionRates;
+      this.payloadPercent = payloadPercent;
+      this.overallTotals = overallTotals;
+    }
+  }
+
+  private void appendCategoryBreakdown(StringBuilder textBuilder, long[] total, long totalPayload) {
+    long totalBytesSentCHKRequests = node.getNodeStats().getCHKRequestTotalBytesSent();
+    long totalBytesSentSSKRequests = node.getNodeStats().getSSKRequestTotalBytesSent();
+    long totalBytesSentCHKInserts = node.getNodeStats().getCHKInsertTotalBytesSent();
+    long totalBytesSentSSKInserts = node.getNodeStats().getSSKInsertTotalBytesSent();
+    long totalBytesSentOfferedKeys = node.getNodeStats().getOfferedKeysTotalBytesSent();
+    long totalBytesSendOffers = node.getNodeStats().getOffersSentBytesSent();
+    long totalBytesSentSwapOutput = node.getNodeStats().getSwappingTotalBytesSent();
+    long totalBytesSentAuth = node.getNodeStats().getTotalAuthBytesSent();
+    long totalBytesSentAckOnly = node.getNodeStats().getNotificationOnlyPacketsSentBytes();
+    long totalBytesSentResends = node.getNodeStats().getResendBytesSent();
+    long totalBytesSentUOM = node.getNodeStats().getUOMBytesSent();
+    long totalBytesSentAnnounce = node.getNodeStats().getAnnounceBytesSent();
+    long totalBytesSentAnnouncePayload = node.getNodeStats().getAnnounceBytesPayloadSent();
+    long totalBytesSentRoutingStatus = node.getNodeStats().getRoutingStatusBytes();
+    long totalBytesSentNetworkColoring = node.getNodeStats().getNetworkColoringSentBytes();
+    long totalBytesSentPing = node.getNodeStats().getPingSentBytes();
+    long totalBytesSentProbeRequest = node.getNodeStats().getProbeRequestSentBytes();
+    long totalBytesSentRouted = node.getNodeStats().getRoutedMessageSentBytes();
+    long totalBytesSentDisconn = node.getNodeStats().getDisconnBytesSent();
+    long totalBytesSentInitial = node.getNodeStats().getInitialMessagesBytesSent();
+    long totalBytesSentChangedIP = node.getNodeStats().getChangedIPBytesSent();
+    long totalBytesSentNodeToNode = node.getNodeStats().getNodeToNodeBytesSent();
+    long totalBytesSentAllocationNotices = node.getNodeStats().getAllocationNoticesBytesSent();
+    long totalBytesSentFOAF = node.getNodeStats().getFOAFBytesSent();
+    long totalBytesSentRemaining =
+        total[0]
+            - (totalPayload
+                + totalBytesSentCHKRequests
+                + totalBytesSentSSKRequests
+                + totalBytesSentCHKInserts
+                + totalBytesSentSSKInserts
+                + totalBytesSentOfferedKeys
+                + totalBytesSendOffers
+                + totalBytesSentSwapOutput
+                + totalBytesSentAuth
+                + totalBytesSentAckOnly
+                + totalBytesSentResends
+                + totalBytesSentUOM
+                + totalBytesSentAnnounce
+                + totalBytesSentRoutingStatus
+                + totalBytesSentNetworkColoring
+                + totalBytesSentPing
+                + totalBytesSentProbeRequest
+                + totalBytesSentRouted
+                + totalBytesSentDisconn
+                + totalBytesSentInitial
+                + totalBytesSentChangedIP
+                + totalBytesSentNodeToNode
+                + totalBytesSentAllocationNotices
+                + totalBytesSentFOAF);
+    textBuilder
+        .append(
+            statisticsL10n(
+                "requestOutput",
+                new String[] {"chk", "ssk"},
+                new String[] {
+                  SizeUtil.formatSize(totalBytesSentCHKRequests, true),
+                  SizeUtil.formatSize(totalBytesSentSSKRequests, true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "insertOutput",
+                new String[] {"chk", "ssk"},
+                new String[] {
+                  SizeUtil.formatSize(totalBytesSentCHKInserts, true),
+                  SizeUtil.formatSize(totalBytesSentSSKInserts, true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "offeredKeyOutput",
+                new String[] {PATTERN_TOTAL, "offered"},
+                new String[] {
+                  SizeUtil.formatSize(totalBytesSentOfferedKeys, true),
+                  SizeUtil.formatSize(totalBytesSendOffers, true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "swapOutput", PATTERN_TOTAL, SizeUtil.formatSize(totalBytesSentSwapOutput, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "authBytes", PATTERN_TOTAL, SizeUtil.formatSize(totalBytesSentAuth, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "ackOnlyBytes", PATTERN_TOTAL, SizeUtil.formatSize(totalBytesSentAckOnly, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "resendBytes",
+                new String[] {PATTERN_TOTAL, PATTERN_PERCENT},
+                new String[] {
+                  SizeUtil.formatSize(totalBytesSentResends, true),
+                  Long.toString((100 * totalBytesSentResends) / Math.max(1, total[0]))
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n("uomBytes", PATTERN_TOTAL, SizeUtil.formatSize(totalBytesSentUOM, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "announceBytes",
+                new String[] {PATTERN_TOTAL, "payload"},
+                new String[] {
+                  SizeUtil.formatSize(totalBytesSentAnnounce, true),
+                  SizeUtil.formatSize(totalBytesSentAnnouncePayload, true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "adminBytes",
+                new String[] {"routingStatus", "disconn", "initial", "changedIP"},
+                new String[] {
+                  SizeUtil.formatSize(totalBytesSentRoutingStatus, true),
+                  SizeUtil.formatSize(totalBytesSentDisconn, true),
+                  SizeUtil.formatSize(totalBytesSentInitial, true),
+                  SizeUtil.formatSize(totalBytesSentChangedIP, true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "debuggingBytes",
+                new String[] {"netColoring", "ping", "probe", "routed"},
+                new String[] {
+                  SizeUtil.formatSize(totalBytesSentNetworkColoring, true),
+                  SizeUtil.formatSize(totalBytesSentPing, true),
+                  SizeUtil.formatSize(totalBytesSentProbeRequest, true),
+                  SizeUtil.formatSize(totalBytesSentRouted, true)
+                }))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "nodeToNodeBytes",
+                PATTERN_TOTAL,
+                SizeUtil.formatSize(totalBytesSentNodeToNode, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "loadAllocationNoticesBytes",
+                PATTERN_TOTAL,
+                SizeUtil.formatSize(totalBytesSentAllocationNotices, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "foafBytes", PATTERN_TOTAL, SizeUtil.formatSize(totalBytesSentFOAF, true)))
+        .append("\n");
+    textBuilder
+        .append(
+            statisticsL10n(
+                "unaccountedBytes",
+                new String[] {PATTERN_TOTAL, PATTERN_PERCENT},
+                new String[] {
+                  SizeUtil.formatSize(totalBytesSentRemaining, true),
+                  Integer.toString((int) (totalBytesSentRemaining * 100 / total[0]))
+                }))
+        .append("\n");
+  }
+
+  private void appendPlugins(StringBuilder textBuilder) {
+    textBuilder.append("Plugins:\n");
+    PluginManager pluginManager = node.getPluginManager();
+    if (!pluginManager.getPlugins().isEmpty()) {
+      textBuilder.append(baseL10n.getString("PluginToadlet.pluginListTitle")).append("\n");
+      for (PluginInfoWrapper plugin : pluginManager.getPlugins()) {
+        appendPlugin(textBuilder, plugin);
+      }
+    }
+    textBuilder.append("\n");
+  }
+
+  private void appendPlugin(StringBuilder textBuilder, PluginInfoWrapper plugin) {
+    long version = plugin.getPluginLongVersion();
+    textBuilder
+        .append(plugin.getFilename())
+        .append(" (")
+        .append(plugin.getPluginClassName())
+        .append(") - ")
+        .append(plugin.getPluginVersion());
+    if (version != -1) {
+      textBuilder.append(" (").append(version).append(")");
+    }
+    textBuilder.append(" ").append(plugin.getThreadName()).append("\n");
+  }
+
+  private void appendQueue(StringBuilder textBuilder) {
+    textBuilder.append("Queue:\n");
+    try {
+      RequestStatus[] reqs = fcp.getGlobalRequests();
+      if (reqs.length < 1) {
+        textBuilder.append(baseL10n.getString("QueueToadlet.globalQueueIsEmpty")).append("\n");
+      } else {
+        appendQueueCounts(textBuilder, reqs);
+      }
+    } catch (PersistenceDisabledException e) {
+      textBuilder.append("DatabaseDisabledException\n");
+    }
+    textBuilder.append("\n");
+  }
+
+  private void appendQueueCounts(StringBuilder textBuilder, RequestStatus[] reqs) {
+    long totalQueuedDownload = 0;
+    long totalQueuedUpload = 0;
+    for (RequestStatus req : reqs) {
+      if (req instanceof DownloadRequestStatus) {
+        totalQueuedDownload++;
+      } else if (req instanceof UploadFileRequestStatus || req instanceof UploadDirRequestStatus) {
+        totalQueuedUpload++;
+      }
+    }
+    textBuilder
+        .append("Downloads Queued: ")
+        .append(totalQueuedDownload)
+        .append(" (")
+        .append(totalQueuedDownload)
+        .append(")\n");
+    textBuilder
+        .append("Uploads Queued: ")
+        .append(totalQueuedUpload)
+        .append(" (")
+        .append(totalQueuedUpload)
+        .append(")\n");
+  }
+
+  private void appendThreadDiagnostics(StringBuilder textBuilder) {
+    if (node.isNodeDiagnosticsEnabled()) {
+      textBuilder.append(threadsStats());
+      textBuilder.append("\n");
+    }
+  }
+
+  /**
+   * Returns the HTTP path that maps to this toadlet within the embedded server.
+   *
+   * @return immutable path string beginning with a slash; callers do not take ownership.
+   */
   @Override
   public String path() {
     return TOADLET_URL;
@@ -851,7 +923,7 @@ public class DiagnosticToadlet extends Toadlet {
 
   /**
    * Retrieves ThreadDiagnostics (through NodeDiagnostics) to display thread information (id, name,
-   * group, % cpu, etc).
+   * group, % cpu, etc.).
    *
    * @return Thread information in tab separated format.
    */
@@ -924,21 +996,21 @@ public class DiagnosticToadlet extends Toadlet {
     return count;
   }
 
-  private String l10n(String key) {
-    return baseL10n.getString("StatisticsToadlet." + key);
+  private String statisticsL10n(String key) {
+    return baseL10n.getString(STATISTICS_PREFIX + key);
   }
 
-  private String l10nDark(String key) {
+  private String darknetL10n(String key) {
     return baseL10n.getString("DarknetConnectionsToadlet." + key);
   }
 
-  private String l10n(String key, String pattern, String value) {
+  private String statisticsL10n(String key, String pattern, String value) {
     return baseL10n.getString(
-        "StatisticsToadlet." + key, new String[] {pattern}, new String[] {value});
+        STATISTICS_PREFIX + key, new String[] {pattern}, new String[] {value});
   }
 
-  private String l10n(String key, String[] patterns, String[] values) {
-    return baseL10n.getString("StatisticsToadlet." + key, patterns, values);
+  private String statisticsL10n(String key, String[] patterns, String[] values) {
+    return baseL10n.getString(STATISTICS_PREFIX + key, patterns, values);
   }
 
   private final Node node;
@@ -946,10 +1018,7 @@ public class DiagnosticToadlet extends Toadlet {
   private final PeerManager peers;
   private final NumberFormat thousandPoint = NumberFormat.getInstance();
   private final FCPServer fcp;
-  // private final DecimalFormat fix1p1 = new DecimalFormat("0.0");
-  // private final DecimalFormat fix1p2 = new DecimalFormat("0.00");
   private final DecimalFormat fix1p4 = new DecimalFormat("0.0000");
-  // private final DecimalFormat fix1p6sci = new DecimalFormat("0.######E0");
   private final DecimalFormat fix3p1pct = new DecimalFormat("##0.0%");
   private final BaseL10n baseL10n;
 }

--- a/src/test/java/network/crypta/clients/http/DiagnosticToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DiagnosticToadletTest.java
@@ -1,0 +1,201 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.node.Node;
+import network.crypta.node.NodeStats;
+import network.crypta.node.PeerManager;
+import network.crypta.node.PeerNodeStatus;
+import network.crypta.node.diagnostics.NodeDiagnostics;
+import network.crypta.node.diagnostics.ThreadDiagnostics;
+import network.crypta.node.diagnostics.threads.NodeThreadInfo;
+import network.crypta.node.diagnostics.threads.NodeThreadSnapshot;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class DiagnosticToadletTest {
+
+  private Node node;
+  private NodeStats nodeStats;
+  private PeerManager peerManager;
+  private FCPServer fcpServer;
+  private HighLevelSimpleClient client;
+
+  @BeforeEach
+  void setUp() {
+    node = mock(Node.class);
+    nodeStats = mock(NodeStats.class);
+    peerManager = mock(PeerManager.class);
+    fcpServer = mock(FCPServer.class);
+    client = mock(HighLevelSimpleClient.class);
+
+    when(node.getNodeStats()).thenReturn(nodeStats);
+    when(node.getPeers()).thenReturn(peerManager);
+  }
+
+  @Test
+  void path_returnsDiagnosticUrl() {
+    DiagnosticToadlet toadlet = new DiagnosticToadlet(node, fcpServer, client);
+
+    assertEquals(DiagnosticToadlet.TOADLET_URL, toadlet.path());
+  }
+
+  @Test
+  void handleMethodGET_whenAccessDenied_doesNotProceed() throws Exception {
+    DiagnosticToadlet toadlet = spy(new DiagnosticToadlet(node, fcpServer, client));
+
+    // Ignore constructor interactions when asserting later.
+    reset(node, nodeStats, peerManager, fcpServer, client);
+
+    ToadletContext ctx = mock(ToadletContext.class);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(false);
+
+    URI uri = new URI("http://localhost/diagnostic/");
+    HTTPRequest request = mock(HTTPRequest.class);
+
+    toadlet.handleMethodGET(uri, request, ctx);
+
+    verify(ctx).checkFullAccess(toadlet);
+    verify(toadlet, never()).writeTextReply(any(), anyInt(), anyString(), anyString());
+    verifyNoMoreInteractions(ctx);
+    verifyNoInteractions(node, nodeStats, peerManager, fcpServer, client);
+  }
+
+  @Test
+  void getPeerStatusCount_whenRecordingAndStatusMatches_countsOnlyMatching() throws Exception {
+    DiagnosticToadlet toadlet = new DiagnosticToadlet(node, fcpServer, client);
+
+    PeerNodeStatus matching = mock(PeerNodeStatus.class);
+    when(matching.recordStatus()).thenReturn(true);
+    when(matching.getStatusValue()).thenReturn(5);
+
+    PeerNodeStatus differentStatus = mock(PeerNodeStatus.class);
+    when(differentStatus.recordStatus()).thenReturn(true);
+    when(differentStatus.getStatusValue()).thenReturn(6);
+
+    PeerNodeStatus notRecording = mock(PeerNodeStatus.class);
+    when(notRecording.recordStatus()).thenReturn(false);
+
+    PeerNodeStatus[] statuses = {matching, differentStatus, notRecording};
+
+    int count = invokeGetPeerStatusCount(toadlet, statuses);
+
+    assertEquals(1, count);
+  }
+
+  @Test
+  void getCountSeedServers_whenMixed_countsOnlyFlagged() throws Exception {
+    DiagnosticToadlet toadlet = new DiagnosticToadlet(node, fcpServer, client);
+
+    PeerNodeStatus server = mock(PeerNodeStatus.class);
+    when(server.isSeedServer()).thenReturn(true);
+
+    PeerNodeStatus nonServer = mock(PeerNodeStatus.class);
+    when(nonServer.isSeedServer()).thenReturn(false);
+
+    int count = invokeGetCountSeedServers(toadlet, new PeerNodeStatus[] {server, nonServer});
+
+    assertEquals(1, count);
+  }
+
+  @Test
+  void getCountSeedClients_whenMixed_countsOnlyFlagged() throws Exception {
+    DiagnosticToadlet toadlet = new DiagnosticToadlet(node, fcpServer, client);
+
+    PeerNodeStatus clientStatus = mock(PeerNodeStatus.class);
+    when(clientStatus.isSeedClient()).thenReturn(true);
+
+    PeerNodeStatus nonClientStatus = mock(PeerNodeStatus.class);
+    when(nonClientStatus.isSeedClient()).thenReturn(false);
+
+    int count =
+        invokeGetCountSeedClients(toadlet, new PeerNodeStatus[] {clientStatus, nonClientStatus});
+
+    assertEquals(1, count);
+  }
+
+  @Test
+  void threadsStats_whenSnapshotProvided_formatsSortedAndTruncated() throws Exception {
+    Locale originalLocale = Locale.getDefault();
+    Locale.setDefault(Locale.US);
+    try {
+      NodeDiagnostics nodeDiagnostics = mock(NodeDiagnostics.class);
+      ThreadDiagnostics threadDiagnostics = mock(ThreadDiagnostics.class);
+      when(node.getNodeDiagnostics()).thenReturn(nodeDiagnostics);
+      when(nodeDiagnostics.getThreadDiagnostics()).thenReturn(threadDiagnostics);
+
+      String longName = "ThreadName".repeat(15);
+      String longGroup = "GroupNameLong";
+      NodeThreadInfo lowUsage =
+          new NodeThreadInfo(2L, 200L, 200_000_000L, "WorkerLow", 3, "GroupA", "RUNNABLE");
+      NodeThreadInfo highUsage =
+          new NodeThreadInfo(1L, 100L, 600_000_000L, longName, 7, longGroup, "BLOCKED");
+
+      List<NodeThreadInfo> threads = Arrays.asList(lowUsage, highUsage);
+      NodeThreadSnapshot snapshot = new NodeThreadSnapshot(threads, 1000);
+      when(threadDiagnostics.getThreadSnapshot()).thenReturn(snapshot);
+
+      DiagnosticToadlet toadlet = new DiagnosticToadlet(node, fcpServer, client);
+
+      String output = invokeThreadsStats(toadlet).toString();
+
+      assertTrue(output.contains("Threads (2):"));
+      String truncatedName = longName.substring(0, 90);
+      assertTrue(output.contains(truncatedName));
+      assertFalse(output.contains(longName));
+
+      String truncatedGroup = longGroup.substring(0, 10);
+      assertTrue(output.contains(truncatedGroup));
+
+      int highIndex = output.indexOf("60.00");
+      int lowIndex = output.indexOf("20.00");
+      assertTrue(highIndex > -1 && lowIndex > -1 && highIndex < lowIndex);
+    } finally {
+      Locale.setDefault(originalLocale);
+    }
+  }
+
+  private int invokeGetPeerStatusCount(DiagnosticToadlet toadlet, PeerNodeStatus[] statuses)
+      throws Exception {
+    Method method =
+        DiagnosticToadlet.class.getDeclaredMethod(
+            "getPeerStatusCount", PeerNodeStatus[].class, int.class);
+    method.setAccessible(true);
+    return (int) method.invoke(toadlet, (Object) statuses, 5);
+  }
+
+  private int invokeGetCountSeedServers(DiagnosticToadlet toadlet, PeerNodeStatus[] statuses)
+      throws Exception {
+    Method method =
+        DiagnosticToadlet.class.getDeclaredMethod("getCountSeedServers", PeerNodeStatus[].class);
+    method.setAccessible(true);
+    return (int) method.invoke(toadlet, (Object) statuses);
+  }
+
+  private int invokeGetCountSeedClients(DiagnosticToadlet toadlet, PeerNodeStatus[] statuses)
+      throws Exception {
+    Method method =
+        DiagnosticToadlet.class.getDeclaredMethod("getCountSeedClients", PeerNodeStatus[].class);
+    method.setAccessible(true);
+    return (int) method.invoke(toadlet, (Object) statuses);
+  }
+
+  private StringBuilder invokeThreadsStats(DiagnosticToadlet toadlet) throws Exception {
+    Method method = DiagnosticToadlet.class.getDeclaredMethod("threadsStats");
+    method.setAccessible(true);
+    return (StringBuilder) method.invoke(toadlet);
+  }
+}


### PR DESCRIPTION
## Summary
- refactor DiagnosticToadlet to break up rendering into focused helpers and add richer KDoc
- swap raw OS property usage for AppEnv and reorganize statistics localization helpers
- add unit coverage for access control, peer counts, seed client/server counting, and thread diagnostics formatting

## Testing
- not run (not requested)