### PR TITLE
Refactor DarknetConnectionsToadlet and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -8,16 +8,16 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.fcp.AddPeer;
@@ -52,48 +52,111 @@ import network.crypta.support.SizeUtil;
 import network.crypta.support.TimeUtil;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.io.FileUtil;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Base class for DarknetConnectionsToadlet and OpennetConnectionsToadlet */
+/**
+ * Base HTTP toadlet used by both darknet and opennet connection pages.
+ *
+ * <p>This class renders peer connection state, accepts noderef submissions, and provides helpers
+ * for subclasses that tailor per-network presentation. It centralizes sorting, pagination,
+ * validation, and noderef ingestion so downstream pages can focus on the specifics of each
+ * topology. Instances are long-lived and reused across requests; state comes from the injected
+ * {@link Node} and {@link NodeClientCore} rather than per-request mutability.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Rendering peer summaries, trust/visibility columns, and message-type breakdowns.
+ *   <li>Parsing noderefs from form uploads, pasted text, or URLs, then delegating to {@link Node}
+ *       for peer creation.
+ *   <li>Handling redirects and guidance when no peers exist or when access checks fail.
+ * </ul>
+ *
+ * <p>Thread-safety: instances rely on externally synchronized {@link Node}/{@link PeerManager}
+ * methods. The toadlet itself holds no mutable request-scoped state except transient flags on the
+ * stack, so it can service concurrent requests when the surrounding HTTP server invokes it in
+ * parallel. Subclasses should preserve this behaviour when adding fields or caching.
+ */
 public abstract class ConnectionsToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionsToadlet.class);
+  private static final String ATTR_CLASS = "class";
+  private static final String ELEMENT_TABLE = "table";
+  private static final String INFOBOX_CLASS = "infobox";
+  private static final String INFOBOX_NORMAL_CLASS = "infobox infobox-normal";
+  private static final String INFOBOX_HEADER_CLASS = "infobox-header";
+  private static final String INFOBOX_CONTENT_CLASS = "infobox-content";
+  private static final String DISPLAY_MESSAGE_TYPES = "displaymessagetypes.html";
+  private static final String DARKNET_CONNECTIONS = "darknet_connections";
+  private static final String ATTR_TITLE = "title";
+  private static final String ATTR_STYLE = "style";
+  private static final String HELP_STYLE = "border-bottom: 1px dotted; cursor: help;";
+  private static final String ELEMENT_INPUT = "input";
+  private static final String TRUST = "trust";
+  private static final String COUNT = "count";
+  private static final String REF_FILE = "reffile";
+  private static final String PEER_PRIVATE_NOTE = "peerPrivateNote";
+  private static final String REPORT_OF_NODE_ADDITION = "reportOfNodeAddition";
+  private static final String PEER_IDLE_CLASS = "peer-idle";
 
+  /**
+   * Comparator that orders {@link PeerNodeStatus} instances for table rendering.
+   *
+   * <p>Sorting honours a user-selected column when present and otherwise falls back to status code
+   * and peer hash for deterministic ordering. The {@code reversed} flag inverts the final result so
+   * callers can reuse one comparator for ascending and descending views without allocating extra
+   * helpers.
+   */
   protected class ComparatorByStatus implements Comparator<PeerNodeStatus> {
+    /** Column key requested by the client, may be {@code null} for default ordering. */
     protected final String sortBy;
+
+    /** Whether the comparator should invert its result for descending presentation. */
     protected final boolean reversed;
 
+    /**
+     * Creates a comparator configured for a column and direction.
+     *
+     * @param sortBy column key requested by the HTTP client; may be {@code null} to use defaults.
+     * @param reversed whether the ordering should be inverted for descending presentation.
+     */
     ComparatorByStatus(String sortBy, boolean reversed) {
       this.sortBy = sortBy;
       this.reversed = reversed;
     }
 
+    /**
+     * Orders two peer rows using configured sort behaviour.
+     *
+     * @param firstNode the first peer candidate; never mutated by this comparator.
+     * @param secondNode the second peer candidate; never mutated by this comparator.
+     * @return negative when the first precedes the second, positive when after, or zero when ties.
+     */
     @Override
     public int compare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      int result = 0;
-      boolean isSet = true;
-
-      if (sortBy != null) {
-        result = customCompare(firstNode, secondNode, sortBy);
-        isSet = (result != 0);
-
-      } else isSet = false;
-
-      if (!isSet) {
-        int statusDifference = firstNode.getStatusValue() - secondNode.getStatusValue();
-        if (statusDifference != 0) result = (statusDifference < 0 ? -1 : 1);
-        else result = lastResortCompare(firstNode, secondNode);
-      }
-
+      isReversed = reversed;
+      int result = compareWithSort(firstNode, secondNode);
       if (result == 0) {
-        return 0;
-      } else if (reversed) {
-        isReversed = true;
-        return result > 0 ? -1 : 1;
-      } else {
-        isReversed = false;
-        return result < 0 ? -1 : 1;
+        result = compareByStatus(firstNode, secondNode);
       }
+      return reversed ? -Integer.signum(result) : Integer.signum(result);
+    }
+
+    private int compareByStatus(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+      int statusDifference =
+          Integer.compare(firstNode.getStatusValue(), secondNode.getStatusValue());
+      if (statusDifference != 0) {
+        return statusDifference;
+      }
+      return lastResortCompare(firstNode, secondNode);
+    }
+
+    private int compareWithSort(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+      if (sortBy == null) {
+        return 0;
+      }
+      return customCompare(firstNode, secondNode);
     }
 
     // xor: check why we do not just return the result of (long1-long2)
@@ -110,8 +173,19 @@ public abstract class ConnectionsToadlet extends Toadlet {
       else return (diff > 0 ? 1 : -1);
     }
 
-    protected int customCompare(
-        PeerNodeStatus firstNode, PeerNodeStatus secondNode, String sortBy2) {
+    /**
+     * Applies column-specific ordering chosen by the requester.
+     *
+     * <p>Each branch matches a sortable column and compares the corresponding values using
+     * type-appropriate ordering. When the column key is unrecognised the method returns {@code 0}
+     * so callers can rely on default or tie-breaker ordering.
+     *
+     * @param firstNode first peer candidate considered in the comparison.
+     * @param secondNode second peer candidate considered in the comparison.
+     * @return a negative number when the first node should precede the second, positive when it
+     *     should follow, or zero when the column is not supported.
+     */
+    protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
       switch (sortBy) {
         case "address":
           return firstNode.getPeerAddress().compareToIgnoreCase(secondNode.getPeerAddress());
@@ -175,42 +249,84 @@ public abstract class ConnectionsToadlet extends Toadlet {
       return diff > 0 ? 1 : -1;
     }
 
-    /** Default comparison, after taking into account status */
+    /**
+     * Provides deterministic ordering after higher-priority comparisons tie.
+     *
+     * <p>This implementation compares the peer locations to ensure stable presentation across
+     * renders. Subclasses can override by altering location calculation in {@link PeerNodeStatus}.
+     *
+     * @param firstNode first peer candidate to order.
+     * @param secondNode second peer candidate to order.
+     * @return negative when the first node is earlier, positive when later, zero when equal.
+     */
     protected int lastResortCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
       return compareLocations(firstNode, secondNode);
     }
   }
 
+  /** Reference to the running node that backs all connection state and operations. */
   protected final Node node;
+
+  /** Core services used for filesystem paths, configuration, and network integration. */
   protected final NodeClientCore core;
+
+  /** Node statistics helper used to populate dashboard sections. */
   protected final NodeStats stats;
+
+  /** Peer manager providing live peer state and addition helpers. */
   protected final PeerManager peers;
+
+  /** Tracks whether the current comparator reversed flag was requested by the user. */
   protected boolean isReversed = false;
+
+  /** Whether trivial FOAF connections should be displayed alongside non-trivial groups. */
   protected boolean showTrivialFoafConnections = false;
 
+  /**
+   * Outcomes returned when attempting to add a peer from a supplied noderef.
+   *
+   * <p>Values map directly to user-visible result codes in the add-peer report table. They
+   * distinguish validation failures, parsing errors, identity clashes, and success.
+   */
   public enum PeerAdditionReturnCodes {
+    /** Peer was added successfully without warnings. */
     OK,
+    /** Noderef contained malformed encoding or incorrect end marker. */
     WRONG_ENCODING,
+    /** Parsing of the noderef failed before verification could run. */
     CANT_PARSE,
+    /** Unexpected internal problem occurred during peer creation. */
     INTERNAL_ERROR,
+    /** Noderef signature could not be validated against provided keys. */
     INVALID_SIGNATURE,
+    /** Submitted noderef belongs to this node; self-adding is blocked. */
     TRY_TO_ADD_SELF,
+    /** Peer already exists in the local peer set. */
     ALREADY_IN_REFERENCE
   }
 
+  /**
+   * Creates a toadlet bound to shared node infrastructure used by connection pages.
+   *
+   * @param n live {@link Node} supplying peer state and creation helpers; must not be {@code null}.
+   * @param core {@link NodeClientCore} providing filesystem access and runtime paths used for
+   *     noderef files.
+   * @param client high-level client used to retrieve noderefs via Freenet or HTTP when users submit
+   *     URLs instead of pasted references.
+   */
   protected ConnectionsToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
     super(client);
     this.node = n;
     this.core = core;
     this.stats = n.getNodeStats();
     this.peers = n.getPeers();
-    REF_LINK = HTMLNode.link(path() + "myref.fref").setReadOnly();
-    REFTEXT_LINK = HTMLNode.link(path() + "myref.txt").setReadOnly();
+    refLink = HTMLNode.link(path() + "myref.fref").setReadOnly();
+    reftextLink = HTMLNode.link(path() + "myref.txt").setReadOnly();
   }
 
   abstract SimpleColumn[] endColumnHeaders(boolean advancedModeEnabled);
 
-  abstract class SimpleColumn {
+  abstract static class SimpleColumn {
     protected abstract void drawColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus);
 
     public abstract String getSortString();
@@ -220,653 +336,69 @@ public abstract class ConnectionsToadlet extends Toadlet {
     public abstract String getExplanationKey();
   }
 
+  /**
+   * Renders the connections page and optional message-type breakdowns.
+   *
+   * <p>The handler validates access, resolves download endpoints for the current node reference,
+   * builds sorted peer tables, and writes the resulting HTML response. When no peers exist it still
+   * renders guidance and, depending on mode, may redirect to friend-adding flows. Download requests
+   * for {@code myref.fref} or {@code myref.txt} are served directly with appropriate headers.
+   *
+   * @param uri request target URI, used to detect message-type view and download paths.
+   * @param request HTTP request wrapper supplying parameters such as {@code sortBy} and {@code
+   *     reversed}.
+   * @param ctx toadlet context providing authorization checks and HTML generation utilities.
+   * @throws ToadletContextClosedException when the client connection is already closed while
+   *     writing output.
+   * @throws IOException when generating the page or serving downloads fails due to I/O errors.
+   * @throws RedirectException when control flow chooses to redirect instead of rendering.
+   */
   public void handleMethodGET(URI uri, final HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     if (!ctx.checkFullAccess(this)) return;
 
     String path = uri.getPath();
-    if (path.endsWith("myref.fref")) {
-      SimpleFieldSet fs = getNoderef();
-      String noderefString = fs.toOrderedStringWithBase64();
-      MultiValueTable<String, String> extraHeaders =
-          MultiValueTable.from(
-              // Force download to disk
-              "Content-Disposition", "attachment; filename=myref.fref");
-      writeReply(ctx, 200, "application/x-freenet-reference", "OK", extraHeaders, noderefString);
+    if (serveReferenceDownload(path, ctx)) {
       return;
     }
 
-    if (path.endsWith("myref.txt")) {
-      SimpleFieldSet fs = getNoderef();
-      String noderefString = fs.toOrderedStringWithBase64();
-      writeTextReply(ctx, 200, "OK", noderefString);
-      return;
-    }
+    DecimalFormat percentageFormat = new DecimalFormat("##0.0%");
+    boolean drawMessageTypes = path.endsWith(DISPLAY_MESSAGE_TYPES);
 
-    final DecimalFormat fix1 = new DecimalFormat("##0.0%");
-
-    final boolean fProxyJavascriptEnabled = node.isFProxyJavascriptEnabled();
-    boolean drawMessageTypes = path.endsWith("displaymessagetypes.html");
-
-    /* gather connection statistics */
     PeerNodeStatus[] peerNodeStatuses = getPeerNodeStatuses(!drawMessageTypes);
     Arrays.sort(
         peerNodeStatuses,
         comparator(request.getParam("sortBy", null), request.isParameterSet("reversed")));
 
-    int numberOfConnected =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED);
-    int numberOfRoutingBackedOff =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF);
-    int numberOfTooNew =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW);
-    int numberOfTooOld =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD);
-    int numberOfDisconnected =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTED);
-    int numberOfNeverConnected =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED);
-    int numberOfDisabled =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED);
-    int numberOfBursting =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING);
-    int numberOfListening =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING);
-    int numberOfListenOnly =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY);
-    int numberOfClockProblem =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM);
-    int numberOfConnError =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR);
-    int numberOfDisconnecting =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING);
-    int numberOfRoutingDisabled =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED);
-    int numberOfNoLoadStats =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS);
-
-    int numberOfSimpleConnected = numberOfConnected + numberOfRoutingBackedOff;
-    int numberOfNotConnected =
-        numberOfTooNew
-            + numberOfTooOld
-            + numberOfNoLoadStats
-            + numberOfDisconnected
-            + numberOfNeverConnected
-            + numberOfDisabled
-            + numberOfBursting
-            + numberOfListening
-            + numberOfListenOnly
-            + numberOfClockProblem
-            + numberOfConnError;
-    String titleCountString = null;
-    if (node.isAdvancedModeEnabled()) {
-      titleCountString =
-          "("
-              + numberOfConnected
-              + '/'
-              + numberOfRoutingBackedOff
-              + '/'
-              + numberOfTooNew
-              + '/'
-              + numberOfTooOld
-              + '/'
-              + numberOfNoLoadStats
-              + '/'
-              + numberOfRoutingDisabled
-              + '/'
-              + numberOfNotConnected
-              + ')';
-    } else {
-      titleCountString =
-          (numberOfNotConnected + numberOfSimpleConnected) > 0
-              ? String.valueOf(numberOfSimpleConnected)
-              : "";
-    }
+    ConnectionCounts counts = computeConnectionCounts(peerNodeStatuses);
+    String titleCountString = buildTitleCountString(counts);
 
     PageNode page = ctx.getPageMaker().getPageNode(getPageTitle(titleCountString), ctx);
-    final boolean advancedMode = ctx.isAdvancedModeEnabled();
+    boolean advancedMode = ctx.isAdvancedModeEnabled();
     HTMLNode contentNode = page.getContentNode();
-
-    // FIXME! We need some nice images
     long now = System.currentTimeMillis();
 
-    if (ctx.isAllowedFullAccess()) contentNode.addChild(ctx.getAlertManager().createSummary());
-
-    if (peerNodeStatuses.length > 0) {
-
-      if (advancedMode) {
-
-        /* node status values */
-        long nodeUptimeSeconds = SECONDS.convert(now - node.getStartupTime(), MILLISECONDS);
-        int bwlimitDelayTime = (int) stats.getBwlimitDelayTime();
-        int nodeAveragePingTime = (int) stats.getNodeAveragePingTime();
-        int networkSizeEstimateSession = stats.getDarknetSizeEstimate(-1);
-        int networkSizeEstimateRecent = 0;
-        if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
-          networkSizeEstimateRecent = stats.getDarknetSizeEstimate(now - HOURS.toMillis(48));
-        }
-        DecimalFormat fix4 = new DecimalFormat("0.0000");
-        double routingMissDistanceLocal = stats.routingMissDistanceLocal.currentValue();
-        double routingMissDistanceRemote = stats.routingMissDistanceRemote.currentValue();
-        double routingMissDistanceOverall = stats.routingMissDistanceOverall.currentValue();
-        double routingMissDistanceBulk = stats.routingMissDistanceBulk.currentValue();
-        double routingMissDistanceRT = stats.routingMissDistanceRT.currentValue();
-        double backedOffPercent = stats.backedOffPercent.currentValue();
-        String nodeUptimeString =
-            TimeUtil.formatTime(MILLISECONDS.convert(nodeUptimeSeconds, SECONDS));
-
-        // BEGIN OVERVIEW TABLE
-        HTMLNode overviewTable = contentNode.addChild("table", "class", "column");
-        HTMLNode overviewTableRow = overviewTable.addChild("tr");
-        HTMLNode nextTableCell = overviewTableRow.addChild("td", "class", "first");
-
-        HTMLNode overviewInfobox = nextTableCell.addChild("div", "class", "infobox");
-        overviewInfobox.addChild("div", "class", "infobox-header", "Node status overview");
-        HTMLNode overviewInfoboxContent =
-            overviewInfobox.addChild("div", "class", "infobox-content");
-        HTMLNode overviewList = overviewInfoboxContent.addChild("ul");
-        overviewList.addChild("li", "bwlimitDelayTime:\u00a0" + bwlimitDelayTime + "ms");
-        overviewList.addChild("li", "nodeAveragePingTime:\u00a0" + nodeAveragePingTime + "ms");
-        overviewList.addChild(
-            "li", "darknetSizeEstimateSession:\u00a0" + networkSizeEstimateSession + "\u00a0nodes");
-        if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
-          overviewList.addChild(
-              "li", "darknetSizeEstimateRecent:\u00a0" + networkSizeEstimateRecent + "\u00a0nodes");
-        }
-        overviewList.addChild("li", "nodeUptime:\u00a0" + nodeUptimeString);
-        overviewList.addChild(
-            "li", "routingMissDistanceLocal:\u00a0" + fix4.format(routingMissDistanceLocal));
-        overviewList.addChild(
-            "li", "routingMissDistanceRemote:\u00a0" + fix4.format(routingMissDistanceRemote));
-        overviewList.addChild(
-            "li", "routingMissDistanceOverall:\u00a0" + fix4.format(routingMissDistanceOverall));
-        overviewList.addChild(
-            "li", "routingMissDistanceBulk:\u00a0" + fix4.format(routingMissDistanceBulk));
-        overviewList.addChild(
-            "li", "routingMissDistanceRT:\u00a0" + fix4.format(routingMissDistanceRT));
-        overviewList.addChild("li", "backedOffPercent:\u00a0" + fix1.format(backedOffPercent));
-        overviewList.addChild(
-            "li", "pInstantReject:\u00a0" + fix1.format(stats.pRejectIncomingInstantly()));
-        nextTableCell = overviewTableRow.addChild("td");
-
-        // Activity box
-        int numARKFetchers = node.getNumARKFetchers();
-
-        HTMLNode activityInfobox = nextTableCell.addChild("div", "class", "infobox");
-        activityInfobox.addChild("div", "class", "infobox-header", l10n("activityTitle"));
-        HTMLNode activityInfoboxContent =
-            activityInfobox.addChild("div", "class", "infobox-content");
-        HTMLNode activityList = StatisticsToadlet.drawActivity(activityInfoboxContent, node);
-        if (advancedMode && (activityList != null)) {
-          if (numARKFetchers > 0) {
-            activityList.addChild("li", "ARK\u00a0Fetch\u00a0Requests:\u00a0" + numARKFetchers);
-          }
-          StatisticsToadlet.drawBandwidth(activityList, node, nodeUptimeSeconds, advancedMode);
-        }
-
-        nextTableCell = overviewTableRow.addChild("td", "class", "last");
-
-        // Peer statistics box
-        HTMLNode peerStatsInfobox = nextTableCell.addChild("div", "class", "infobox");
-        StatisticsToadlet.drawPeerStatsBox(
-            peerStatsInfobox,
-            advancedMode,
-            numberOfConnected,
-            numberOfRoutingBackedOff,
-            numberOfTooNew,
-            numberOfTooOld,
-            numberOfDisconnected,
-            numberOfNeverConnected,
-            numberOfDisabled,
-            numberOfBursting,
-            numberOfListening,
-            numberOfListenOnly,
-            0,
-            0,
-            numberOfRoutingDisabled,
-            numberOfClockProblem,
-            numberOfConnError,
-            numberOfDisconnecting,
-            numberOfNoLoadStats,
-            node);
-
-        // Peer routing backoff reason box
-        if (advancedMode) {
-          HTMLNode backoffReasonInfobox = nextTableCell.addChild("div", "class", "infobox");
-          HTMLNode title =
-              backoffReasonInfobox.addChild(
-                  "div", "class", "infobox-header", "Peer backoff reasons (realtime)");
-          HTMLNode backoffReasonContent =
-              backoffReasonInfobox.addChild("div", "class", "infobox-content");
-          String[] routingBackoffReasons = peers.getPeerNodeRoutingBackoffReasons(true);
-          int total = 0;
-          if (routingBackoffReasons.length == 0) {
-            backoffReasonContent.addChild(
-                "#", NodeL10n.getBase().getString("StatisticsToadlet.notBackedOff"));
-          } else {
-            HTMLNode reasonList = backoffReasonContent.addChild("ul");
-            for (String routingBackoffReason : routingBackoffReasons) {
-              int reasonCount =
-                  peers.getPeerNodeRoutingBackoffReasonSize(routingBackoffReason, true);
-              if (reasonCount > 0) {
-                total += reasonCount;
-                reasonList.addChild("li", routingBackoffReason + '\u00a0' + reasonCount);
-              }
-            }
-          }
-          if (total > 0) title.addChild("#", ": " + total);
-          backoffReasonInfobox = nextTableCell.addChild("div", "class", "infobox");
-          title =
-              backoffReasonInfobox.addChild(
-                  "div", "class", "infobox-header", "Peer backoff reasons (bulk)");
-          backoffReasonContent = backoffReasonInfobox.addChild("div", "class", "infobox-content");
-          routingBackoffReasons = peers.getPeerNodeRoutingBackoffReasons(false);
-          total = 0;
-          if (routingBackoffReasons.length == 0) {
-            backoffReasonContent.addChild(
-                "#", NodeL10n.getBase().getString("StatisticsToadlet.notBackedOff"));
-          } else {
-            HTMLNode reasonList = backoffReasonContent.addChild("ul");
-            for (String routingBackoffReason : routingBackoffReasons) {
-              int reasonCount =
-                  peers.getPeerNodeRoutingBackoffReasonSize(routingBackoffReason, false);
-              if (reasonCount > 0) {
-                total += reasonCount;
-                reasonList.addChild("li", routingBackoffReason + '\u00a0' + reasonCount);
-              }
-            }
-          }
-          if (total > 0) title.addChild("#", ": " + total);
-        }
-        // END OVERVIEW TABLE
-      }
-
-      boolean enablePeerActions = showPeerActionsBox();
-
-      // BEGIN PEER TABLE
-      if (fProxyJavascriptEnabled) {
-        String js =
-            """
-              function peerNoteChange() {
-                document.getElementById("action").value = "update_notes";\
-                document.getElementById("peersForm").doAction.click();
-              }
-            """;
-        contentNode.addChild("script", "type", "text/javascript").addChild("%", js);
-        contentNode.addChild(
-            "script",
-            new String[] {"type", "src"},
-            new String[] {"text/javascript", "/static/js/checkall.js"});
-      }
-      HTMLNode peerTableInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
-      HTMLNode peerTableInfoboxHeader = peerTableInfobox.addChild("div", "class", "infobox-header");
-      peerTableInfoboxHeader.addChild("#", getPeerListTitle());
-      if (advancedMode) {
-        if (!path.endsWith("displaymessagetypes.html")) {
-          peerTableInfoboxHeader.addChild("#", " ");
-          peerTableInfoboxHeader.addChild(
-              "a", "href", "displaymessagetypes.html", l10n("bracketedMoreDetailed"));
-        }
-      }
-      HTMLNode peerTableInfoboxContent =
-          peerTableInfobox.addChild("div", "class", "infobox-content");
-
-      if (!isOpennet()) {
-        HTMLNode myName = peerTableInfoboxContent.addChild("p");
-        myName.addChild(
-            "span",
-            NodeL10n.getBase()
-                .getString("DarknetConnectionsToadlet.myName", "name", node.getMyName()));
-        myName.addChild("span", " [");
-        myName
-            .addChild("span")
-            .addChild(
-                "a",
-                "href",
-                "/config/node#name",
-                NodeL10n.getBase().getString("DarknetConnectionsToadlet.changeMyName"));
-        myName.addChild("span", "]");
-      }
-
-      if (peerNodeStatuses.length == 0) {
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                peerTableInfoboxContent,
-                "DarknetConnectionsToadlet.noPeersWithHomepageLink",
-                new String[] {"link"},
-                new HTMLNode[] {HTMLNode.link("/")});
-      } else {
-        HTMLNode peerForm = null;
-        HTMLNode peerTable;
-        if (enablePeerActions) {
-          peerForm = ctx.addFormChild(peerTableInfoboxContent, ".", "peersForm");
-          peerTable = peerForm.addChild("table", "class", "darknet_connections");
-        } else {
-          peerTable = peerTableInfoboxContent.addChild("table", "class", "darknet_connections");
-        }
-        HTMLNode peerTableHeaderRow = peerTable.addChild("tr");
-        if (enablePeerActions) {
-          if (fProxyJavascriptEnabled) {
-            peerTableHeaderRow
-                .addChild("th")
-                .addChild(
-                    "input",
-                    new String[] {"type", "onclick"},
-                    new String[] {"checkbox", "checkAll(this, 'darknet_connections')"});
-          } else {
-            peerTableHeaderRow.addChild("th");
-          }
-        }
-        peerTableHeaderRow
-            .addChild("th")
-            .addChild("a", "href", sortString(isReversed, "status"))
-            .addChild("#", l10n("statusTitle"));
-        if (hasNameColumn())
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "name"))
-              .addChild(
-                  "span",
-                  new String[] {"title", "style"},
-                  new String[] {
-                    l10n("nameClickToMessage"), "border-bottom: 1px dotted; cursor: help;"
-                  },
-                  l10n("nameTitle"));
-        if (hasTrustColumn())
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "trust"))
-              .addChild(
-                  "span",
-                  new String[] {"title", "style"},
-                  new String[] {l10n("trustMessage"), "border-bottom: 1px dotted; cursor: help;"},
-                  l10n("trustTitle"));
-        if (hasVisibilityColumn())
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "trust"))
-              .addChild(
-                  "span",
-                  new String[] {"title", "style"},
-                  new String[] {
-                    l10n("visibilityMessage" + (advancedMode ? "Advanced" : "Simple")),
-                    "border-bottom: 1px dotted; cursor: help;"
-                  },
-                  l10n("visibilityTitle"));
-        peerTableHeaderRow
-            .addChild("th")
-            .addChild("a", "href", sortString(isReversed, "address"))
-            .addChild(
-                "span",
-                new String[] {"title", "style"},
-                new String[] {l10n("ipAddress"), "border-bottom: 1px dotted; cursor: help;"},
-                l10n("ipAddressTitle"));
-        peerTableHeaderRow
-            .addChild("th")
-            .addChild("a", "href", sortString(isReversed, "version"))
-            .addChild("#", l10n("versionTitle"));
-        if (advancedMode) {
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "location"))
-              .addChild("#", l10n("locationTitle"));
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "backoffRT"))
-              .addChild(
-                  "span",
-                  new String[] {"title", "style"},
-                  new String[] {
-                    "Other node busy (realtime)? Display: Percentage of time the node is"
-                        + " overloaded, Current wait time remaining (0=not overloaded)/total/last"
-                        + " overload reason",
-                    "border-bottom: 1px dotted; cursor: help;"
-                  },
-                  "Backoff (realtime)");
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "backoffBulk"))
-              .addChild(
-                  "span",
-                  new String[] {"title", "style"},
-                  new String[] {
-                    "Other node busy (bulk)? Display: Percentage of time the node is overloaded,"
-                        + " Current wait time remaining (0=not overloaded)/total/last overload"
-                        + " reason",
-                    "border-bottom: 1px dotted; cursor: help;"
-                  },
-                  "Backoff (bulk)");
-
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "overload_p"))
-              .addChild(
-                  "span",
-                  new String[] {"title", "style"},
-                  new String[] {
-                    "Probability of the node rejecting a request due to overload or causing a"
-                        + " timeout.",
-                    "border-bottom: 1px dotted; cursor: help;"
-                  },
-                  "Overload Probability");
-        }
-        peerTableHeaderRow
-            .addChild("th")
-            .addChild("a", "href", sortString(isReversed, "idle"))
-            .addChild(
-                "span",
-                new String[] {"title", "style"},
-                new String[] {l10n("idleTime"), "border-bottom: 1px dotted; cursor: help;"},
-                l10n("idleTimeTitle"));
-        if (hasPrivateNoteColumn())
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "privnote"))
-              .addChild(
-                  "span",
-                  new String[] {"title", "style"},
-                  new String[] {l10n("privateNote"), "border-bottom: 1px dotted; cursor: help;"},
-                  l10n("privateNoteTitle"));
-
-        if (advancedMode) {
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "time_routable"))
-              .addChild("#", "%\u00a0Time Routable");
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "selection_percentage"))
-              .addChild("#", "%\u00a0Selection");
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "total_traffic"))
-              .addChild("#", "Total\u00a0Traffic\u00a0(in/out/resent)");
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "total_traffic_since_startup"))
-              .addChild("#", "Total\u00a0Traffic\u00a0(in/out) since startup");
-          peerTableHeaderRow.addChild("th", "Congestion\u00a0Control");
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "time_delta"))
-              .addChild("#", "Time\u00a0Delta");
-          peerTableHeaderRow
-              .addChild("th")
-              .addChild("a", "href", sortString(isReversed, "uptime"))
-              .addChild("#", "Reported\u00a0Uptime");
-          peerTableHeaderRow.addChild("th", "Transmit\u00a0Queue");
-          peerTableHeaderRow.addChild("th", "Peer\u00a0Capacity\u00a0Bulk");
-          peerTableHeaderRow.addChild("th", "Peer\u00a0Capacity\u00a0Realtime");
-        }
-
-        SimpleColumn[] endCols = endColumnHeaders(advancedMode);
-        if (endCols != null) {
-          for (SimpleColumn col : endCols) {
-            HTMLNode header = peerTableHeaderRow.addChild("th");
-            String sortString = col.getSortString();
-            if (sortString != null)
-              header = header.addChild("a", "href", sortString(isReversed, sortString));
-            header.addChild(
-                "span",
-                new String[] {"title", "style"},
-                new String[] {
-                  NodeL10n.getBase().getString(col.getExplanationKey()),
-                  "border-bottom: 1px dotted; cursor: help;"
-                },
-                NodeL10n.getBase().getString(col.getTitleKey()));
-          }
-        }
-
-        double totalSelectionRate = 0.0;
-        // calculate the total selection rate using all peers, not just the peers for the current
-        // mode,
-        PeerNodeStatus[] allPeerNodeStatuses = node.getPeers().getPeerNodeStatuses(true);
-        for (PeerNodeStatus status : allPeerNodeStatuses) {
-          totalSelectionRate += status.getSelectionRate();
-        }
-        for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
-          drawRow(
-              peerTable,
-              peerNodeStatus,
-              advancedMode,
-              fProxyJavascriptEnabled,
-              now,
-              path,
-              enablePeerActions,
-              endCols,
-              drawMessageTypes,
-              totalSelectionRate,
-              fix1);
-        }
-
-        if (peerForm != null) {
-          drawPeerActionSelectBox(peerForm, advancedMode);
-        }
-      }
-      // END PEER TABLE
-
-      // FOAF locations table.
-      if (advancedMode) {
-        // requires a location-to-list/count in-memory transform
-        List<Double> locations = new ArrayList<>();
-        List<List<PeerNodeStatus>> peerGroups = new ArrayList<>();
-        {
-          for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
-            double[] peersLoc = peerNodeStatus.getPeersLocation();
-            if (peersLoc != null) {
-              for (double location : peersLoc) {
-                int i;
-                int max = locations.size();
-                // FIXME Fix O(n^2): Use Arrays.binarySearch or use a TreeMap.
-                for (i = 0; i < max && locations.get(i) < location; i++)
-                  ;
-                // i now points to the proper location (equal, insertion point, or end-of-list)
-                // maybe better called "reverseGroup"?
-                List<PeerNodeStatus> peerGroup;
-                if (i < max && locations.get(i) == location) {
-                  peerGroup = peerGroups.get(i);
-                } else {
-                  peerGroup = new ArrayList<>();
-                  locations.add(i, location);
-                  peerGroups.add(i, peerGroup);
-                }
-                peerGroup.add(peerNodeStatus);
-              }
-            }
-          }
-        }
-        // transform complete.... now we have peers listed by foaf's ordered by ascending location
-        int trivialCount = 0;
-        int nonTrivialCount = 0;
-        int transitiveCount = 0;
-        for (List<PeerNodeStatus> list : peerGroups) {
-          if (list.size() == 1) trivialCount++;
-          else nonTrivialCount++;
-        }
-        peerTableInfoboxContent.addChild(
-            "b",
-            l10n("secondDegreeConnectionsCountTitle", "count", Integer.toString(locations.size())));
-        peerTableInfoboxContent.addChild("br");
-        if (!showTrivialFoafConnections) {
-          peerTableInfoboxContent.addChild(
-              "i", l10n("secondDegreeTrivialHiddenCount", "count", Integer.toString(trivialCount)));
-          // @todo: add "show these" link
-        } else {
-          peerTableInfoboxContent.addChild(
-              "i", l10n("secondDegreeNonTrivialCount", "count", Integer.toString(nonTrivialCount)));
-          // @todo: add "hide these" link
-        }
-        HTMLNode foafTable =
-            peerTableInfoboxContent.addChild(
-                "table", "class", "darknet_connections"); // @todo: change css class?
-        HTMLNode foafRow = foafTable.addChild("tr");
-        {
-          foafRow.addChild("th", l10n("locationTitle"));
-          foafRow.addChild("th", l10n("countTitle"));
-          foafRow.addChild("th", l10n("foafReachableThroughTitle"));
-        }
-        int max = locations.size();
-        for (int i = 0; i < max; i++) {
-          double location = locations.get(i);
-          List<PeerNodeStatus> peersWithFriend = peerGroups.get(i);
-          boolean isTransitivePeer = false;
-          {
-            for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
-              if (location == peerNodeStatus.getLocation()) {
-                isTransitivePeer = true;
-                transitiveCount++;
-                break;
-              }
-            }
-          }
-          if (peersWithFriend.size() == 1 && !showTrivialFoafConnections && !isTransitivePeer)
-            continue;
-          foafRow = foafTable.addChild("tr");
-          {
-            if (isTransitivePeer) {
-              foafRow.addChild("td").addChild("b", String.valueOf(location));
-            } else {
-              foafRow.addChild("td", String.valueOf(location));
-            }
-            foafRow.addChild("td", String.valueOf(peersWithFriend.size()));
-            HTMLNode locationCell = foafRow.addChild("td", "class", "peer-location");
-            for (PeerNodeStatus peerNodeStatus : peersWithFriend) {
-              String address =
-                  ((peerNodeStatus.getPeerAddress() != null)
-                      ? peerNodeStatus.getPeerAddressAndPort()
-                      : (l10n("unknownAddress")));
-              locationCell.addChild("i", address);
-              locationCell.addChild("br");
-            }
-          }
-        }
-        if (transitiveCount > 0) {
-          peerTableInfoboxContent.addChild(
-              "i", l10n("secondDegreeAlsoOurs", "count", Integer.toString(transitiveCount)));
-        }
-      }
-      // END FOAF TABLE
-
-    } else {
-      if (!isOpennet()) {
-        try {
-          throw new RedirectException("/addfriend/");
-        } catch (URISyntaxException e) {
-          LOG.error("Impossible: {} for /addfriend/", e.toString(), e);
-        }
-      }
+    if (ctx.isAllowedFullAccess()) {
+      contentNode.addChild(ctx.getAlertManager().createSummary());
     }
 
-    // our reference
+    RenderContext renderContext =
+        new RenderContext(
+            ctx,
+            path,
+            peerNodeStatuses,
+            drawMessageTypes,
+            percentageFormat,
+            advancedMode,
+            contentNode,
+            now,
+            counts);
+    renderContent(renderContext);
+
+    if (peerNodeStatuses.length == 0) {
+      handleMissingPeers();
+    }
+
     if (shouldDrawNoderefBox(advancedMode)) {
       drawAddPeerBox(contentNode, ctx);
       drawNoderefBox(contentNode, getNoderef());
@@ -875,13 +407,828 @@ public abstract class ConnectionsToadlet extends Toadlet {
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
   }
 
+  private boolean serveReferenceDownload(String path, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if (path.endsWith("myref.fref")) {
+      SimpleFieldSet fs = getNoderef();
+      String noderefString = fs.toOrderedStringWithBase64();
+      MultiValueTable<String, String> extraHeaders =
+          MultiValueTable.from("Content-Disposition", "attachment; filename=myref.fref");
+      writeReply(ctx, 200, "application/x-freenet-reference", "OK", extraHeaders, noderefString);
+      return true;
+    }
+
+    if (path.endsWith("myref.txt")) {
+      SimpleFieldSet fs = getNoderef();
+      String noderefString = fs.toOrderedStringWithBase64();
+      writeTextReply(ctx, 200, "OK", noderefString);
+      return true;
+    }
+    return false;
+  }
+
+  private ConnectionCounts computeConnectionCounts(PeerNodeStatus[] peerNodeStatuses) {
+    return new ConnectionCounts(
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF),
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW),
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTED),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED),
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED),
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING),
+        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED),
+        PeerNodeStatus.getPeerStatusCount(
+            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS));
+  }
+
+  private String buildTitleCountString(ConnectionCounts counts) {
+    if (!node.isAdvancedModeEnabled()) {
+      int numberOfSimpleConnected = counts.connected + counts.routingBackedOff;
+      int numberOfNotConnected = counts.notConnected();
+      return (numberOfNotConnected + numberOfSimpleConnected) > 0
+          ? String.valueOf(numberOfSimpleConnected)
+          : "";
+    }
+
+    return "("
+        + counts.connected
+        + '/'
+        + counts.routingBackedOff
+        + '/'
+        + counts.tooNew
+        + '/'
+        + counts.tooOld
+        + '/'
+        + counts.noLoadStats
+        + '/'
+        + counts.routingDisabled
+        + '/'
+        + counts.notConnected()
+        + ')';
+  }
+
+  private void renderContent(RenderContext renderContext) {
+    if (renderContext.advancedMode()) {
+      addOverviewSection(
+          renderContext.contentNode(),
+          renderContext.percentageFormat(),
+          renderContext.now(),
+          renderContext.counts());
+    }
+
+    addPeerTableSection(renderContext);
+
+    if (renderContext.advancedMode()) {
+      addFoafTable(renderContext.contentNode(), renderContext.peerNodeStatuses());
+    }
+  }
+
+  private void addOverviewSection(
+      HTMLNode contentNode, DecimalFormat percentageFormat, long now, ConnectionCounts counts) {
+    long nodeUptimeSeconds = SECONDS.convert(now - node.getStartupTime(), MILLISECONDS);
+    int bwlimitDelayTime = (int) stats.getBwlimitDelayTime();
+    int nodeAveragePingTime = (int) stats.getNodeAveragePingTime();
+    int networkSizeEstimateSession = stats.getDarknetSizeEstimate(-1);
+    int networkSizeEstimateRecent = 0;
+    if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
+      networkSizeEstimateRecent = stats.getDarknetSizeEstimate(now - HOURS.toMillis(48));
+    }
+    DecimalFormat routingFormat = new DecimalFormat("0.0000");
+    double routingMissDistanceLocal = stats.routingMissDistanceLocal.currentValue();
+    double routingMissDistanceRemote = stats.routingMissDistanceRemote.currentValue();
+    double routingMissDistanceOverall = stats.routingMissDistanceOverall.currentValue();
+    double routingMissDistanceBulk = stats.routingMissDistanceBulk.currentValue();
+    double routingMissDistanceRT = stats.routingMissDistanceRT.currentValue();
+    double backedOffPercent = stats.backedOffPercent.currentValue();
+    String nodeUptimeString = TimeUtil.formatTime(MILLISECONDS.convert(nodeUptimeSeconds, SECONDS));
+
+    HTMLNode overviewTable = contentNode.addChild(ELEMENT_TABLE, ATTR_CLASS, "column");
+    HTMLNode overviewTableRow = overviewTable.addChild("tr");
+    HTMLNode nextTableCell = overviewTableRow.addChild("td", ATTR_CLASS, "first");
+
+    HTMLNode overviewInfobox = nextTableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
+    overviewInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS, "Node status overview");
+    HTMLNode overviewInfoboxContent =
+        overviewInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+    HTMLNode overviewList = overviewInfoboxContent.addChild("ul");
+    overviewList.addChild("li", "bwlimitDelayTime:\u00a0" + bwlimitDelayTime + "ms");
+    overviewList.addChild("li", "nodeAveragePingTime:\u00a0" + nodeAveragePingTime + "ms");
+    overviewList.addChild(
+        "li", "darknetSizeEstimateSession:\u00a0" + networkSizeEstimateSession + "\u00a0nodes");
+    if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
+      overviewList.addChild(
+          "li", "darknetSizeEstimateRecent:\u00a0" + networkSizeEstimateRecent + "\u00a0nodes");
+    }
+    overviewList.addChild("li", "nodeUptime:\u00a0" + nodeUptimeString);
+    overviewList.addChild(
+        "li", "routingMissDistanceLocal:\u00a0" + routingFormat.format(routingMissDistanceLocal));
+    overviewList.addChild(
+        "li", "routingMissDistanceRemote:\u00a0" + routingFormat.format(routingMissDistanceRemote));
+    overviewList.addChild(
+        "li",
+        "routingMissDistanceOverall:\u00a0" + routingFormat.format(routingMissDistanceOverall));
+    overviewList.addChild(
+        "li", "routingMissDistanceBulk:\u00a0" + routingFormat.format(routingMissDistanceBulk));
+    overviewList.addChild(
+        "li", "routingMissDistanceRT:\u00a0" + routingFormat.format(routingMissDistanceRT));
+    overviewList.addChild(
+        "li", "backedOffPercent:\u00a0" + percentageFormat.format(backedOffPercent));
+    overviewList.addChild(
+        "li", "pInstantReject:\u00a0" + percentageFormat.format(stats.pRejectIncomingInstantly()));
+    nextTableCell = overviewTableRow.addChild("td");
+
+    addActivitySection(nextTableCell, nodeUptimeSeconds);
+    addPeerStatsSection(nextTableCell, counts);
+  }
+
+  private void addActivitySection(HTMLNode tableCell, long nodeUptimeSeconds) {
+    int numARKFetchers = node.getNumARKFetchers();
+
+    HTMLNode activityInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
+    activityInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS, l10n("activityTitle"));
+    HTMLNode activityInfoboxContent =
+        activityInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+    HTMLNode activityList = StatisticsToadlet.drawActivity(activityInfoboxContent, node);
+    if (activityList != null) {
+      if (numARKFetchers > 0) {
+        activityList.addChild("li", "ARK\u00a0Fetch\u00a0Requests:\u00a0" + numARKFetchers);
+      }
+      StatisticsToadlet.drawBandwidth(activityList, node, nodeUptimeSeconds, true);
+    }
+  }
+
+  private void addPeerStatsSection(HTMLNode tableCell, ConnectionCounts counts) {
+    HTMLNode peerStatsInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
+    StatisticsToadlet.drawPeerStatsBox(
+        peerStatsInfobox,
+        true,
+        counts.connected,
+        counts.routingBackedOff,
+        counts.tooNew,
+        counts.tooOld,
+        counts.disconnected,
+        counts.neverConnected,
+        counts.disabled,
+        counts.bursting,
+        counts.listening,
+        counts.listenOnly,
+        0,
+        0,
+        counts.routingDisabled,
+        counts.clockProblem,
+        counts.connError,
+        counts.disconnecting,
+        counts.noLoadStats,
+        node);
+
+    addBackoffReasonBoxes(tableCell);
+  }
+
+  private void addBackoffReasonBoxes(HTMLNode tableCell) {
+    addBackoffReasonBox(tableCell, true, "Peer backoff reasons (realtime)");
+    addBackoffReasonBox(tableCell, false, "Peer backoff reasons (bulk)");
+  }
+
+  private void addBackoffReasonBox(HTMLNode tableCell, boolean realtime, String headerText) {
+    HTMLNode backoffReasonInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
+    HTMLNode title =
+        backoffReasonInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS, headerText);
+    HTMLNode backoffReasonContent =
+        backoffReasonInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+    String[] routingBackoffReasons = peers.getPeerNodeRoutingBackoffReasons(realtime);
+    int total = 0;
+    if (routingBackoffReasons.length == 0) {
+      backoffReasonContent.addChild(
+          "#", NodeL10n.getBase().getString("StatisticsToadlet.notBackedOff"));
+    } else {
+      HTMLNode reasonList = backoffReasonContent.addChild("ul");
+      for (String routingBackoffReason : routingBackoffReasons) {
+        int reasonCount = peers.getPeerNodeRoutingBackoffReasonSize(routingBackoffReason, realtime);
+        if (reasonCount > 0) {
+          total += reasonCount;
+          reasonList.addChild("li", routingBackoffReason + '\u00a0' + reasonCount);
+        }
+      }
+    }
+    if (total > 0) {
+      title.addChild("#", ": " + total);
+    }
+  }
+
+  private void addPeerTableSection(RenderContext renderContext) {
+    boolean enablePeerActions = showPeerActionsBox();
+    boolean fProxyJavascriptEnabled = node.isFProxyJavascriptEnabled();
+
+    if (fProxyJavascriptEnabled) {
+      injectJavascript(renderContext.contentNode());
+    }
+
+    HTMLNode peerTableInfobox =
+        renderContext.contentNode().addChild("div", ATTR_CLASS, INFOBOX_NORMAL_CLASS);
+    HTMLNode peerTableInfoboxHeader =
+        peerTableInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS);
+    peerTableInfoboxHeader.addChild("#", getPeerListTitle());
+    if (renderContext.advancedMode() && !renderContext.path().endsWith(DISPLAY_MESSAGE_TYPES)) {
+      peerTableInfoboxHeader.addChild("#", " ");
+      peerTableInfoboxHeader.addChild(
+          "a", "href", DISPLAY_MESSAGE_TYPES, l10n("bracketedMoreDetailed"));
+    }
+    HTMLNode peerTableInfoboxContent =
+        peerTableInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+
+    if (!isOpennet()) {
+      addNameSection(peerTableInfoboxContent);
+    }
+
+    if (renderContext.peerNodeStatuses().length == 0) {
+      addNoPeersMessage(peerTableInfoboxContent);
+      return;
+    }
+
+    PeerTableContext peerTableContext =
+        buildPeerTable(
+            renderContext.ctx(),
+            peerTableInfoboxContent,
+            enablePeerActions,
+            fProxyJavascriptEnabled,
+            renderContext.advancedMode());
+
+    fillPeerTable(
+        peerTableContext,
+        renderContext.peerNodeStatuses(),
+        renderContext.drawMessageTypes(),
+        renderContext.percentageFormat(),
+        renderContext.advancedMode(),
+        renderContext.now());
+  }
+
+  private void injectJavascript(HTMLNode contentNode) {
+    String js =
+        """
+          function peerNoteChange() {
+            document.getElementById("action").value = "update_notes";            document.getElementById("peersForm").doAction.click();
+          }
+        """;
+    contentNode.addChild("script", "type", "text/javascript").addChild("%", js);
+    contentNode.addChild(
+        "script",
+        new String[] {"type", "src"},
+        new String[] {"text/javascript", "/static/js/checkall.js"});
+  }
+
+  private void addNameSection(HTMLNode peerTableInfoboxContent) {
+    HTMLNode myName = peerTableInfoboxContent.addChild("p");
+    myName.addChild(
+        "span",
+        NodeL10n.getBase().getString("DarknetConnectionsToadlet.myName", "name", node.getMyName()));
+    myName.addChild("span", " [");
+    myName
+        .addChild("span")
+        .addChild(
+            "a",
+            "href",
+            "/config/node#name",
+            NodeL10n.getBase().getString("DarknetConnectionsToadlet.changeMyName"));
+    myName.addChild("span", "]");
+  }
+
+  private void addNoPeersMessage(HTMLNode peerTableInfoboxContent) {
+    NodeL10n.getBase()
+        .addL10nSubstitution(
+            peerTableInfoboxContent,
+            "DarknetConnectionsToadlet.noPeersWithHomepageLink",
+            new String[] {"link"},
+            new HTMLNode[] {HTMLNode.link("/")});
+  }
+
+  private PeerTableContext buildPeerTable(
+      ToadletContext ctx,
+      HTMLNode peerTableInfoboxContent,
+      boolean enablePeerActions,
+      boolean fProxyJavascriptEnabled,
+      boolean advancedMode) {
+    HTMLNode peerForm = null;
+    HTMLNode peerTable;
+    if (enablePeerActions) {
+      peerForm = ctx.addFormChild(peerTableInfoboxContent, ".", "peersForm");
+      peerTable = peerForm.addChild(ELEMENT_TABLE, ATTR_CLASS, DARKNET_CONNECTIONS);
+    } else {
+      peerTable = peerTableInfoboxContent.addChild(ELEMENT_TABLE, ATTR_CLASS, DARKNET_CONNECTIONS);
+    }
+    HTMLNode peerTableHeaderRow = peerTable.addChild("tr");
+    addPeerTableHeader(
+        enablePeerActions, fProxyJavascriptEnabled, peerTableHeaderRow, advancedMode);
+
+    SimpleColumn[] endCols = endColumnHeaders(advancedMode);
+    if (endCols != null) {
+      for (SimpleColumn col : endCols) {
+        HTMLNode header = peerTableHeaderRow.addChild("th");
+        String sortString = col.getSortString();
+        if (sortString != null) {
+          header = header.addChild("a", "href", sortString(isReversed, sortString));
+        }
+        header.addChild(
+            "span",
+            new String[] {ATTR_TITLE, ATTR_STYLE},
+            new String[] {NodeL10n.getBase().getString(col.getExplanationKey()), HELP_STYLE},
+            NodeL10n.getBase().getString(col.getTitleKey()));
+      }
+    }
+
+    List<SimpleColumn> endColsList = endCols == null ? List.of() : List.of(endCols);
+    return new PeerTableContext(peerForm, peerTable, endColsList);
+  }
+
+  private void addPeerTableHeader(
+      boolean enablePeerActions,
+      boolean fProxyJavascriptEnabled,
+      HTMLNode peerTableHeaderRow,
+      boolean advancedMode) {
+    if (enablePeerActions) {
+      if (fProxyJavascriptEnabled) {
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild(
+                ELEMENT_INPUT,
+                new String[] {"type", "onclick"},
+                new String[] {"checkbox", "checkAll(this, 'darknet_connections')"});
+      } else {
+        peerTableHeaderRow.addChild("th");
+      }
+    }
+    peerTableHeaderRow
+        .addChild("th")
+        .addChild("a", "href", sortString(isReversed, "status"))
+        .addChild("#", l10n("statusTitle"));
+    if (hasNameColumn()) {
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, "name"))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {l10n("nameClickToMessage"), HELP_STYLE},
+              l10n("nameTitle"));
+    }
+    if (hasTrustColumn()) {
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, TRUST))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {l10n("trustMessage"), HELP_STYLE},
+              l10n("trustTitle"));
+    }
+    if (hasVisibilityColumn()) {
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, TRUST))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {
+                l10n("visibilityMessage" + (advancedMode ? "Advanced" : "Simple")), HELP_STYLE
+              },
+              l10n("visibilityTitle"));
+    }
+    peerTableHeaderRow
+        .addChild("th")
+        .addChild("a", "href", sortString(isReversed, "address"))
+        .addChild(
+            "span",
+            new String[] {ATTR_TITLE, ATTR_STYLE},
+            new String[] {l10n("ipAddress"), HELP_STYLE},
+            l10n("ipAddressTitle"));
+    peerTableHeaderRow
+        .addChild("th")
+        .addChild("a", "href", sortString(isReversed, "version"))
+        .addChild("#", l10n("versionTitle"));
+    if (advancedMode) {
+      addAdvancedPeerTableHeaders(peerTableHeaderRow);
+    }
+    peerTableHeaderRow
+        .addChild("th")
+        .addChild("a", "href", sortString(isReversed, "idle"))
+        .addChild(
+            "span",
+            new String[] {ATTR_TITLE, ATTR_STYLE},
+            new String[] {l10n("idleTime"), HELP_STYLE},
+            l10n("idleTimeTitle"));
+    if (hasPrivateNoteColumn()) {
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, "privnote"))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {l10n("privateNote"), HELP_STYLE},
+              l10n("privateNoteTitle"));
+    }
+
+    if (advancedMode) {
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, "time_routable"))
+          .addChild("#", "%\u00a0Time Routable");
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, "selection_percentage"))
+          .addChild("#", "%\u00a0Selection");
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, "total_traffic"))
+          .addChild("#", "Total\u00a0Traffic\u00a0(in/out/resent)");
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, "total_traffic_since_startup"))
+          .addChild("#", "Total\u00a0Traffic\u00a0(in/out) since startup");
+      peerTableHeaderRow.addChild("th", "Congestion\u00a0Control");
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, "time_delta"))
+          .addChild("#", "Time\u00a0Delta");
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(isReversed, "uptime"))
+          .addChild("#", "Reported\u00a0Uptime");
+      peerTableHeaderRow.addChild("th", "Transmit\u00a0Queue");
+      peerTableHeaderRow.addChild("th", "Peer\u00a0Capacity\u00a0Bulk");
+      peerTableHeaderRow.addChild("th", "Peer\u00a0Capacity\u00a0Realtime");
+    }
+  }
+
+  private void addAdvancedPeerTableHeaders(HTMLNode peerTableHeaderRow) {
+    peerTableHeaderRow
+        .addChild("th")
+        .addChild("a", "href", sortString(isReversed, "location"))
+        .addChild("#", l10n("locationTitle"));
+    peerTableHeaderRow
+        .addChild("th")
+        .addChild("a", "href", sortString(isReversed, "backoffRT"))
+        .addChild(
+            "span",
+            new String[] {ATTR_TITLE, ATTR_STYLE},
+            new String[] {
+              "Other node busy (realtime)? Display: Percentage of time the node is"
+                  + " overloaded, Current wait time remaining (0=not overloaded)/total/last"
+                  + " overload reason",
+              HELP_STYLE
+            },
+            "Backoff (realtime)");
+    peerTableHeaderRow
+        .addChild("th")
+        .addChild("a", "href", sortString(isReversed, "backoffBulk"))
+        .addChild(
+            "span",
+            new String[] {ATTR_TITLE, ATTR_STYLE},
+            new String[] {
+              "Other node busy (bulk)? Display: Percentage of time the node is overloaded,"
+                  + " Current wait time remaining (0=not overloaded)/total/last overload"
+                  + " reason",
+              HELP_STYLE
+            },
+            "Backoff (bulk)");
+
+    peerTableHeaderRow
+        .addChild("th")
+        .addChild("a", "href", sortString(isReversed, "overload_p"))
+        .addChild(
+            "span",
+            new String[] {ATTR_TITLE, ATTR_STYLE},
+            new String[] {
+              "Probability of the node rejecting a request due to overload or causing a timeout.",
+              HELP_STYLE
+            },
+            "Overload Probability");
+  }
+
+  private void fillPeerTable(
+      PeerTableContext peerTableContext,
+      PeerNodeStatus[] peerNodeStatuses,
+      boolean drawMessageTypes,
+      DecimalFormat percentageFormat,
+      boolean advancedMode,
+      long now) {
+    double totalSelectionRate = 0.0;
+    PeerNodeStatus[] allPeerNodeStatuses = node.getPeers().getPeerNodeStatuses(true);
+    for (PeerNodeStatus status : allPeerNodeStatuses) {
+      totalSelectionRate += status.getSelectionRate();
+    }
+    for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
+      RowContext rowContext =
+          new RowContext(
+              peerTableContext.peerTable(),
+              peerNodeStatus,
+              advancedMode,
+              node.isFProxyJavascriptEnabled(),
+              now,
+              peerTableContext.peerForm() != null,
+              peerTableContext.endCols(),
+              drawMessageTypes,
+              totalSelectionRate,
+              percentageFormat);
+      drawRow(rowContext);
+    }
+
+    if (peerTableContext.peerForm() != null) {
+      drawPeerActionSelectBox(peerTableContext.peerForm(), advancedMode);
+    }
+  }
+
+  private void addFoafTable(HTMLNode peerTableInfoboxContent, PeerNodeStatus[] peerNodeStatuses) {
+    FoafGrouping grouping = buildFoafGrouping(peerNodeStatuses);
+    addFoafSummary(peerTableInfoboxContent, grouping);
+    addFoafRows(peerTableInfoboxContent, peerNodeStatuses, grouping);
+  }
+
+  private void addFoafSummary(HTMLNode peerTableInfoboxContent, FoafGrouping grouping) {
+    peerTableInfoboxContent.addChild(
+        "b",
+        l10nCount(
+            "secondDegreeConnectionsCountTitle", Integer.toString(grouping.locations().size())));
+    peerTableInfoboxContent.addChild("br");
+    if (!showTrivialFoafConnections) {
+      peerTableInfoboxContent.addChild(
+          "i",
+          l10nCount("secondDegreeTrivialHiddenCount", Integer.toString(grouping.trivialCount())));
+    } else {
+      peerTableInfoboxContent.addChild(
+          "i",
+          l10nCount("secondDegreeNonTrivialCount", Integer.toString(grouping.nonTrivialCount())));
+    }
+  }
+
+  private void addFoafRows(
+      HTMLNode peerTableInfoboxContent, PeerNodeStatus[] peerNodeStatuses, FoafGrouping grouping) {
+    HTMLNode foafTable =
+        peerTableInfoboxContent.addChild(ELEMENT_TABLE, ATTR_CLASS, DARKNET_CONNECTIONS);
+    HTMLNode foafRow = foafTable.addChild("tr");
+    foafRow.addChild("th", l10n("locationTitle"));
+    foafRow.addChild("th", l10n("countTitle"));
+    foafRow.addChild("th", l10n("foafReachableThroughTitle"));
+    int max = grouping.locations().size();
+    int transitiveCount = 0;
+    for (int i = 0; i < max; i++) {
+      double location = grouping.locations().get(i);
+      List<PeerNodeStatus> peersWithFriend = grouping.peerGroups().get(i);
+      boolean isTransitivePeer = isTransitivePeer(peerNodeStatuses, location);
+      if (peersWithFriend.size() == 1 && !showTrivialFoafConnections && !isTransitivePeer) {
+        continue;
+      }
+      foafRow = foafTable.addChild("tr");
+      if (isTransitivePeer) {
+        foafRow.addChild("td").addChild("b", String.valueOf(location));
+      } else {
+        foafRow.addChild("td", String.valueOf(location));
+      }
+      foafRow.addChild("td", String.valueOf(peersWithFriend.size()));
+      HTMLNode locationCell = foafRow.addChild("td", ATTR_CLASS, "peer-location");
+      for (PeerNodeStatus peerNodeStatus : peersWithFriend) {
+        String address =
+            ((peerNodeStatus.getPeerAddress() != null)
+                ? peerNodeStatus.getPeerAddressAndPort()
+                : (l10n("unknownAddress")));
+        locationCell.addChild("i", address);
+        locationCell.addChild("br");
+      }
+      if (isTransitivePeer) {
+        transitiveCount++;
+      }
+    }
+    if (transitiveCount > 0) {
+      peerTableInfoboxContent.addChild(
+          "i", l10nCount("secondDegreeAlsoOurs", Integer.toString(transitiveCount)));
+    }
+  }
+
+  private FoafGrouping buildFoafGrouping(PeerNodeStatus[] peerNodeStatuses) {
+    List<Double> locations = new ArrayList<>();
+    List<List<PeerNodeStatus>> peerGroups = new ArrayList<>();
+    for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
+      double[] peersLoc = peerNodeStatus.getPeersLocation();
+      if (peersLoc == null) {
+        continue;
+      }
+      for (double location : peersLoc) {
+        int i = 0;
+        int max = locations.size();
+        while (i < max && locations.get(i) < location) {
+          i++;
+        }
+        List<PeerNodeStatus> peerGroup;
+        if (i < max && locations.get(i) == location) {
+          peerGroup = peerGroups.get(i);
+        } else {
+          peerGroup = new ArrayList<>();
+          locations.add(i, location);
+          peerGroups.add(i, peerGroup);
+        }
+        peerGroup.add(peerNodeStatus);
+      }
+    }
+    return new FoafGrouping(locations, peerGroups);
+  }
+
+  private boolean isTransitivePeer(PeerNodeStatus[] peerNodeStatuses, double location) {
+    for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
+      if (location == peerNodeStatus.getLocation()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void handleMissingPeers() throws RedirectException {
+    if (isOpennet()) {
+      return;
+    }
+    throw new RedirectException(URI.create("/addfriend/"));
+  }
+
+  private record ConnectionCounts(
+      int connected,
+      int routingBackedOff,
+      int tooNew,
+      int tooOld,
+      int disconnected,
+      int neverConnected,
+      int disabled,
+      int bursting,
+      int listening,
+      int listenOnly,
+      int clockProblem,
+      int connError,
+      int disconnecting,
+      int routingDisabled,
+      int noLoadStats) {
+
+    int notConnected() {
+      return tooNew
+          + tooOld
+          + noLoadStats
+          + disconnected
+          + neverConnected
+          + disabled
+          + bursting
+          + listening
+          + listenOnly
+          + clockProblem
+          + connError;
+    }
+  }
+
+  private record PeerTableContext(
+      HTMLNode peerForm, HTMLNode peerTable, List<SimpleColumn> endCols) {}
+
+  private record FoafGrouping(List<Double> locations, List<List<PeerNodeStatus>> peerGroups) {
+    int trivialCount() {
+      return (int) peerGroups.stream().filter(list -> list.size() == 1).count();
+    }
+
+    int nonTrivialCount() {
+      return (int) peerGroups.stream().filter(list -> list.size() > 1).count();
+    }
+  }
+
+  private record AddPeerRequestData(
+      String urltext,
+      String reftext,
+      String privateComment,
+      FRIEND_TRUST trust,
+      FRIEND_VISIBILITY visibility) {}
+
+  private record RenderContext(
+      ToadletContext ctx,
+      String path,
+      PeerNodeStatus[] peerNodeStatuses,
+      boolean drawMessageTypes,
+      DecimalFormat percentageFormat,
+      boolean advancedMode,
+      HTMLNode contentNode,
+      long now,
+      ConnectionCounts counts) {
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      RenderContext that = (RenderContext) o;
+      return drawMessageTypes == that.drawMessageTypes
+          && advancedMode == that.advancedMode
+          && now == that.now
+          && Objects.equals(ctx, that.ctx)
+          && Objects.equals(path, that.path)
+          && Arrays.equals(peerNodeStatuses, that.peerNodeStatuses)
+          && Objects.equals(percentageFormat, that.percentageFormat)
+          && Objects.equals(contentNode, that.contentNode)
+          && Objects.equals(counts, that.counts);
+    }
+
+    @Override
+    public int hashCode() {
+      int result =
+          Objects.hash(
+              ctx,
+              path,
+              drawMessageTypes,
+              percentageFormat,
+              advancedMode,
+              contentNode,
+              now,
+              counts);
+      result = 31 * result + Arrays.hashCode(peerNodeStatuses);
+      return result;
+    }
+
+    @Override
+    public @NotNull String toString() {
+      return "RenderContext{"
+          + "ctx="
+          + ctx
+          + ", path='"
+          + path
+          + '\''
+          + ", peerNodeStatuses="
+          + Arrays.toString(peerNodeStatuses)
+          + ", drawMessageTypes="
+          + drawMessageTypes
+          + ", percentageFormat="
+          + percentageFormat
+          + ", advancedMode="
+          + advancedMode
+          + ", contentNode="
+          + contentNode
+          + ", now="
+          + now
+          + ", counts="
+          + counts
+          + '}';
+    }
+  }
+
+  private record RowContext(
+      HTMLNode peerTable,
+      PeerNodeStatus peerNodeStatus,
+      boolean advancedModeEnabled,
+      boolean fProxyJavascriptEnabled,
+      long now,
+      boolean enablePeerActions,
+      List<SimpleColumn> endCols,
+      boolean drawMessageTypes,
+      double totalSelectionRate,
+      DecimalFormat percentageFormat) {}
+
+  /**
+   * Indicates whether noderef POST submissions are accepted for this toadlet.
+   *
+   * <p>Subclasses can deny uploads based on network mode or feature flags, in which case POST
+   * requests are answered with an unauthorized page.
+   *
+   * @return {@code true} when reference uploads are allowed; {@code false} when they should be
+   *     rejected.
+   */
   protected abstract boolean acceptRefPosts();
 
-  /** Where to redirect to if there is an error */
+  /**
+   * Provides the destination used when POST processing opts to redirect instead of rendering.
+   *
+   * @return a relative or absolute path that receives the user after recoverable errors.
+   */
+  @SuppressWarnings("unused")
   protected abstract String defaultRedirectLocation();
 
+  /**
+   * Handles connection-related POST requests, including noderef uploads.
+   *
+   * <p>The handler verifies permissions, checks whether uploads are permitted, and dispatches to
+   * add-peer logic or alternate actions based on submitted form parts. It logs debug detail only
+   * when enabled and leaves state unchanged if validation fails.
+   *
+   * @param uri target URI, used to route auxiliary POST actions.
+   * @param request HTTP request containing multipart fields such as {@code add}, {@code ref}, or
+   *     {@code reffile}.
+   * @param ctx toadlet context supplying authorization checks and response builders.
+   * @throws ToadletContextClosedException if the client connection is already closed.
+   * @throws IOException on I/O failures while reading parts or writing responses.
+   * @throws ConfigException when submitted trust or visibility values violate constraints.
+   * @throws RedirectException when processing elects to redirect instead of generating a page.
+   */
   public void handleMethodPOST(URI uri, final HTTPRequest request, ToadletContext ctx)
-      throws ToadletContextClosedException, IOException, RedirectException, ConfigException {
+      throws ToadletContextClosedException, IOException, ConfigException, RedirectException {
     boolean logMINOR = LOG.isDebugEnabled();
 
     if (!acceptRefPosts()) {
@@ -892,211 +1239,252 @@ public abstract class ConnectionsToadlet extends Toadlet {
     if (!ctx.checkFullAccess(this)) return;
 
     if (request.isPartSet("add")) {
-      // add a new node
-      String urltext = request.getPartAsStringFailsafe("url", 200);
-      urltext = urltext.trim();
-      String reftext = request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE);
-      reftext = reftext.trim();
-      if (reftext.length() < 200) {
-        reftext = request.getPartAsStringFailsafe("reffile", Integer.MAX_VALUE);
-        reftext = reftext.trim();
-      }
-      String privateComment = null;
-      if (!isOpennet())
-        privateComment = request.getPartAsStringFailsafe("peerPrivateNote", 250).trim();
-
-      if (Boolean.parseBoolean(request.getPartAsStringFailsafe("peers-offers-files", 5))) {
-        File[] files = core.getNode().runDir().file("peers-offers").listFiles();
-        if (files != null && files.length > 0) {
-          StringBuilder peersOffersFilesContent = new StringBuilder();
-          for (final File file : files) {
-            if (file.isFile()) {
-              String filename = file.getName();
-              if (filename.endsWith(".fref"))
-                peersOffersFilesContent.append(FileUtil.readUTF(file));
-            }
-          }
-          reftext = peersOffersFilesContent.toString();
-        }
-
-        node.getConfig().get("node").set("peersOffersDismissed", true);
-      }
-
-      String trustS = request.getPartAsStringFailsafe("trust", 10);
-      FRIEND_TRUST trust = null;
-      if (trustS != null && !trustS.isEmpty()) trust = FRIEND_TRUST.valueOf(trustS);
-
-      String visibilityS = request.getPartAsStringFailsafe("visibility", 10);
-      FRIEND_VISIBILITY visibility = null;
-      if (visibilityS != null && !visibilityS.isEmpty())
-        visibility = FRIEND_VISIBILITY.valueOf(visibilityS);
-
-      if (trust == null && !isOpennet()) {
-        // FIXME: Layering violation. Ideally DarknetPeerNode would do this check.
-        this.sendErrorPage(
-            ctx,
-            200,
-            l10n("noTrustLevelAddingFriendTitle"),
-            l10n("noTrustLevelAddingFriend"),
-            !isOpennet());
-        return;
-      }
-
-      if (visibility == null && !isOpennet()) {
-        // FIXME: Layering violation. Ideally DarknetPeerNode would do this check.
-        this.sendErrorPage(
-            ctx,
-            200,
-            l10n("noVisibilityLevelAddingFriendTitle"),
-            l10n("noVisibilityLevelAddingFriend"),
-            !isOpennet());
-        return;
-      }
-
-      StringBuilder ref = null;
-      if (!urltext.isEmpty()) {
-        // fetch reference from a URL
-        try {
-          try {
-            FreenetURI refUri = new FreenetURI(urltext);
-            ref = AddPeer.getReferenceFromFreenetURI(refUri, client);
-          } catch (MalformedURLException | FetchException e) {
-            LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: {}", urltext);
-            URL url;
-            try {
-              url = URI.create(urltext).toURL();
-            } catch (IllegalArgumentException uriException) {
-              throw new MalformedURLException(uriException.getMessage());
-            }
-            ref = AddPeer.getReferenceFromURL(url);
-          }
-        } catch (IOException e) {
-          this.sendErrorPage(
-              ctx,
-              200,
-              l10n("failedToAddNodeTitle"),
-              NodeL10n.getBase()
-                  .getString(
-                      "DarknetConnectionsToadlet.cantFetchNoderefURL",
-                      new String[] {"url"},
-                      new String[] {urltext}),
-              !isOpennet());
-          return;
-        }
-      } else if (!reftext.isEmpty()) {
-        // read from post data or file upload
-        // this slightly scary looking regexp chops any extra characters off the beginning or ends
-        // of lines and removes extra line breaks
-        ref =
-            new StringBuilder(
-                reftext.replaceAll(
-                    ".*?((?:[\\w,\\.]+\\=[^\r\n]+?)|(?:End))[ \\t]*(?:\\r?\\n)+", "$1\n"));
-      } else {
-        this.sendErrorPage(
-            ctx, 200, l10n("failedToAddNodeTitle"), l10n("noRefOrURL"), !isOpennet());
-        request.freeParts();
-        return;
-      }
-      ref = new StringBuilder(ref.toString().trim());
-
-      request.freeParts();
-
-      // Split the references string, because the peers are added individually
-      // FIXME split by lines at this point rather than in addNewNode would be more efficient
-      int idx;
-      while ((idx = ref.indexOf("\r\n")) > -1) {
-        ref.deleteCharAt(idx);
-      }
-      while ((idx = ref.indexOf("\r")) > -1) {
-        // Mac's just use \r
-        ref.setCharAt(idx, '\n');
-      }
-      String[] nodesToAdd = ref.toString().split("\nEnd\n");
-      for (int i = 0; i < nodesToAdd.length; i++) {
-        String[] split = nodesToAdd[i].split("\n");
-        StringBuilder sb = new StringBuilder(nodesToAdd[i].length());
-        boolean first = true;
-        for (String s : split) {
-          if (s.equals("End")) break;
-          if (s.indexOf('=') > -1) {
-            if (!first) sb.append('\n');
-          } else {
-            // Try appending it - don't add a newline.
-            // This will make broken refs work sometimes.
-          }
-          sb.append(s);
-          first = false;
-        }
-        nodesToAdd[i] = sb.toString();
-        // Don't need to add a newline at the end, we will do that later.
-      }
-      // The peer's additions results
-      Map<PeerAdditionReturnCodes, Integer> results = new HashMap<>();
-      for (int i = 0; i < nodesToAdd.length; i++) {
-        // We need to trim then concat 'End' to the node's reference, this way we have a normal
-        // reference(the split() removes the 'End'-s!)
-        PeerAdditionReturnCodes result =
-            addNewNode(nodesToAdd[i].trim().concat("\nEnd"), privateComment, trust, visibility);
-        // Store the result
-        Integer prev = results.get(result);
-        if (prev == null) prev = 0;
-        results.put(result, prev + 1);
-      }
-
-      PageNode page = ctx.getPageMaker().getPageNode(l10n("reportOfNodeAddition"), ctx);
-      HTMLNode contentNode = page.getContentNode();
-
-      // We create a table to show the results
-      HTMLNode detailedStatusBox = new HTMLNode("table");
-      // Header of the table
-      detailedStatusBox
-          .addChild(new HTMLNode("tr"))
-          .addChildren(
-              new HTMLNode[] {
-                new HTMLNode("th", l10n("resultName")), new HTMLNode("th", l10n("numOfResults"))
-              });
-      HTMLNode statusBoxTable = detailedStatusBox.addChild(new HTMLNode("tbody"));
-      // Iterate through the return codes
-      for (PeerAdditionReturnCodes returnCode : PeerAdditionReturnCodes.values()) {
-        if (results.containsKey(returnCode)) {
-          // Add a <tr> and 2 <td> with the name of the code and the number of occasions it
-          // happened. If the code is OK, we use green, red elsewhere.
-          statusBoxTable
-              .addChild(
-                  new HTMLNode(
-                      "tr",
-                      "style",
-                      "color:" + (returnCode == PeerAdditionReturnCodes.OK ? "green" : "red")))
-              .addChildren(
-                  new HTMLNode[] {
-                    new HTMLNode("td", l10n("peerAdditionCode." + returnCode.toString())),
-                    new HTMLNode("td", results.get(returnCode).toString())
-                  });
-        }
-      }
-
-      HTMLNode infoboxContent =
-          ctx.getPageMaker()
-              .getInfobox("infobox", l10n("reportOfNodeAddition"), contentNode, "node-added", true);
-      infoboxContent.addChild(detailedStatusBox);
-      if (!isOpennet())
-        infoboxContent.addChild("p").addChild("a", "href", "/addfriend/", l10n("addAnotherFriend"));
-      infoboxContent.addChild("p").addChild("a", "href", path(), l10n("goFriendConnectionStatus"));
-      addHomepageLink(infoboxContent.addChild("p"));
-
-      writeHTMLReply(ctx, 500, l10n("reportOfNodeAddition"), page.generate());
-    } else handleAltPost(uri, request, ctx, logMINOR);
+      handleAddPeer(request, ctx);
+    } else {
+      handleAltPost(uri, request, ctx, logMINOR);
+    }
   }
 
-  /**
-   * Adds a new node. If any error arises, it returns the appropriate return code.
-   *
-   * @param nodeReference - The reference to the new node
-   * @param privateComment - The private comment when adding a Darknet node
-   * @param trust - The trust level for the peer
-   * @param visibility - The visibility level for the peer
-   * @return The result of the addition
-   */
+  private void handleAddPeer(HTTPRequest request, ToadletContext ctx)
+      throws IOException, ToadletContextClosedException, ConfigException {
+    AddPeerRequestData data = extractAddPeerRequestData(request);
+    if (!validateTrustAndVisibility(ctx, data)) {
+      return;
+    }
+
+    StringBuilder ref = fetchReference(data, ctx);
+    if (ref == null) {
+      return;
+    }
+
+    request.freeParts();
+    processReferences(data, ref, ctx);
+  }
+
+  private AddPeerRequestData extractAddPeerRequestData(HTTPRequest request)
+      throws IOException, ConfigException {
+    String urltext = request.getPartAsStringFailsafe("url", 200).trim();
+    String reftext = request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE).trim();
+    if (reftext.length() < 200) {
+      reftext = request.getPartAsStringFailsafe(REF_FILE, Integer.MAX_VALUE).trim();
+    }
+    String privateComment = null;
+    if (!isOpennet()) {
+      privateComment = request.getPartAsStringFailsafe(PEER_PRIVATE_NOTE, 250).trim();
+    }
+
+    if (Boolean.parseBoolean(request.getPartAsStringFailsafe("peers-offers-files", 5))) {
+      String peersOffersRefs = readPeersOffersFiles();
+      if (!peersOffersRefs.isBlank()) {
+        reftext = peersOffersRefs;
+      }
+      node.getConfig().get("node").set("peersOffersDismissed", true);
+    }
+
+    FRIEND_TRUST trust = parseTrust(request);
+    FRIEND_VISIBILITY visibility = parseVisibility(request);
+
+    return new AddPeerRequestData(urltext, reftext, privateComment, trust, visibility);
+  }
+
+  private String readPeersOffersFiles() throws IOException {
+    File[] files = core.getNode().runDir().file("peers-offers").listFiles();
+    if (files == null || files.length == 0) {
+      return "";
+    }
+    StringBuilder peersOffersFilesContent = new StringBuilder();
+    for (final File file : files) {
+      if (file.isFile() && file.getName().endsWith(".fref")) {
+        peersOffersFilesContent.append(FileUtil.readUTF(file));
+      }
+    }
+    return peersOffersFilesContent.toString();
+  }
+
+  private FRIEND_TRUST parseTrust(HTTPRequest request) {
+    String trustS = request.getPartAsStringFailsafe(TRUST, 10);
+    if (trustS == null || trustS.isEmpty()) {
+      return null;
+    }
+    return FRIEND_TRUST.valueOf(trustS);
+  }
+
+  private FRIEND_VISIBILITY parseVisibility(HTTPRequest request) {
+    String visibilityS = request.getPartAsStringFailsafe("visibility", 10);
+    if (visibilityS == null || visibilityS.isEmpty()) {
+      return null;
+    }
+    return FRIEND_VISIBILITY.valueOf(visibilityS);
+  }
+
+  private boolean validateTrustAndVisibility(ToadletContext ctx, AddPeerRequestData data)
+      throws ToadletContextClosedException, IOException {
+    if (isOpennet()) {
+      return true;
+    }
+    if (data.trust() == null) {
+      this.sendErrorPage(
+          ctx, 200, l10n("noTrustLevelAddingFriendTitle"), l10n("noTrustLevelAddingFriend"), true);
+      return false;
+    }
+    if (data.visibility() == null) {
+      this.sendErrorPage(
+          ctx,
+          200,
+          l10n("noVisibilityLevelAddingFriendTitle"),
+          l10n("noVisibilityLevelAddingFriend"),
+          true);
+      return false;
+    }
+    return true;
+  }
+
+  private StringBuilder fetchReference(AddPeerRequestData data, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if (!data.urltext().isEmpty()) {
+      return fetchReferenceFromUrl(data.urltext(), ctx);
+    }
+    if (!data.reftext().isEmpty()) {
+      return new StringBuilder(cleanReferenceText(data.reftext()));
+    }
+    this.sendErrorPage(ctx, 200, l10n("failedToAddNodeTitle"), l10n("noRefOrURL"), !isOpennet());
+    return null;
+  }
+
+  private StringBuilder fetchReferenceFromUrl(String urltext, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    try {
+      return fetchReferenceViaUrl(urltext);
+    } catch (IOException e) {
+      this.sendErrorPage(
+          ctx,
+          200,
+          l10n("failedToAddNodeTitle"),
+          NodeL10n.getBase()
+              .getString(
+                  "DarknetConnectionsToadlet.cantFetchNoderefURL",
+                  new String[] {"url"},
+                  new String[] {urltext}),
+          !isOpennet());
+      return null;
+    }
+  }
+
+  private StringBuilder fetchReferenceViaUrl(String urltext) throws IOException {
+    try {
+      FreenetURI refUri = new FreenetURI(urltext);
+      return AddPeer.getReferenceFromFreenetURI(refUri, client);
+    } catch (MalformedURLException | FetchException e) {
+      LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: {}", urltext);
+      URL url = buildUrl(urltext);
+      return AddPeer.getReferenceFromURL(url);
+    }
+  }
+
+  private URL buildUrl(String urltext) throws MalformedURLException {
+    try {
+      return URI.create(urltext).toURL();
+    } catch (IllegalArgumentException uriException) {
+      throw new MalformedURLException(uriException.getMessage());
+    }
+  }
+
+  private void processReferences(AddPeerRequestData data, StringBuilder ref, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    String[] nodesToAdd = splitReferences(new StringBuilder(ref.toString().trim()));
+    Map<PeerAdditionReturnCodes, Integer> results = new EnumMap<>(PeerAdditionReturnCodes.class);
+    for (String nodeToAdd : nodesToAdd) {
+      if (nodeToAdd.isBlank()) {
+        continue;
+      }
+      PeerAdditionReturnCodes result =
+          addNewNode(
+              nodeToAdd.trim().concat("\nEnd"),
+              data.privateComment(),
+              data.trust(),
+              data.visibility());
+      Integer prev = results.get(result);
+      if (prev == null) prev = 0;
+      results.put(result, prev + 1);
+    }
+    renderAddPeerResult(ctx, results);
+  }
+
+  private String[] splitReferences(StringBuilder ref) {
+    replaceCarriageReturns(ref);
+    String[] nodesToAdd = ref.toString().split("\nEnd\n");
+    for (int i = 0; i < nodesToAdd.length; i++) {
+      String[] split = nodesToAdd[i].split("\n");
+      StringBuilder sb = new StringBuilder(nodesToAdd[i].length());
+      boolean first = true;
+      for (String s : split) {
+        if (s.equals("End")) {
+          break;
+        }
+        if (s.indexOf('=') > -1 && !first) {
+          sb.append('\n');
+        }
+        sb.append(s);
+        first = false;
+      }
+      nodesToAdd[i] = sb.toString();
+    }
+    return nodesToAdd;
+  }
+
+  private void replaceCarriageReturns(StringBuilder ref) {
+    int idx;
+    while ((idx = ref.indexOf("\r\n")) > -1) {
+      ref.deleteCharAt(idx);
+    }
+    while ((idx = ref.indexOf("\r")) > -1) {
+      ref.setCharAt(idx, '\n');
+    }
+  }
+
+  private void renderAddPeerResult(
+      ToadletContext ctx, Map<PeerAdditionReturnCodes, Integer> results)
+      throws ToadletContextClosedException, IOException {
+    PageNode page = ctx.getPageMaker().getPageNode(l10n(REPORT_OF_NODE_ADDITION), ctx);
+    HTMLNode contentNode = page.getContentNode();
+
+    HTMLNode detailedStatusBox = new HTMLNode(ELEMENT_TABLE);
+    detailedStatusBox
+        .addChild(new HTMLNode("tr"))
+        .addChildren(
+            new HTMLNode[] {
+              new HTMLNode("th", l10n("resultName")), new HTMLNode("th", l10n("numOfResults"))
+            });
+    HTMLNode statusBoxTable = detailedStatusBox.addChild(new HTMLNode("tbody"));
+    for (PeerAdditionReturnCodes returnCode : PeerAdditionReturnCodes.values()) {
+      if (results.containsKey(returnCode)) {
+        statusBoxTable
+            .addChild(
+                new HTMLNode(
+                    "tr",
+                    ATTR_STYLE,
+                    "color:" + (returnCode == PeerAdditionReturnCodes.OK ? "green" : "red")))
+            .addChildren(
+                new HTMLNode[] {
+                  new HTMLNode("td", l10n("peerAdditionCode." + returnCode.toString())),
+                  new HTMLNode("td", results.get(returnCode).toString())
+                });
+      }
+    }
+
+    HTMLNode infoboxContent =
+        ctx.getPageMaker()
+            .getInfobox(
+                INFOBOX_CLASS, l10n(REPORT_OF_NODE_ADDITION), contentNode, "node-added", true);
+    infoboxContent.addChild(detailedStatusBox);
+    if (!isOpennet())
+      infoboxContent.addChild("p").addChild("a", "href", "/addfriend/", l10n("addAnotherFriend"));
+    infoboxContent.addChild("p").addChild("a", "href", path(), l10n("goFriendConnectionStatus"));
+    addHomepageLink(infoboxContent.addChild("p"));
+
+    writeHTMLReply(ctx, 500, l10n(REPORT_OF_NODE_ADDITION), page.generate());
+  }
+
   private PeerAdditionReturnCodes addNewNode(
       String nodeReference,
       String privateComment,
@@ -1110,12 +1498,12 @@ public abstract class ConnectionsToadlet extends Toadlet {
         LOG.error("Trying to add noderef with end marker \"{}\"", fs.getEndMarker());
         return PeerAdditionReturnCodes.WRONG_ENCODING;
       }
-      fs.setEndMarker("End"); // It's always End ; the regex above doesn't always grok this
+      fs.setEndMarker("End");
     } catch (IOException e) {
       LOG.error("IOException adding reference :{}", e.getMessage(), e);
       return PeerAdditionReturnCodes.CANT_PARSE;
-    } catch (Throwable t) {
-      LOG.error("Internal error adding reference :{}", t.getMessage(), t);
+    } catch (Exception e) {
+      LOG.error("Internal error adding reference :{}", e.getMessage(), e);
       return PeerAdditionReturnCodes.INTERNAL_ERROR;
     }
     PeerNode pn;
@@ -1130,8 +1518,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
       return PeerAdditionReturnCodes.CANT_PARSE;
     } catch (ReferenceSignatureVerificationException e1) {
       return PeerAdditionReturnCodes.INVALID_SIGNATURE;
-    } catch (Throwable t) {
-      LOG.error("Internal error adding reference :{}", t.getMessage(), t);
+    } catch (Exception e) {
+      LOG.error("Internal error adding reference :{}", e.getMessage(), e);
       return PeerAdditionReturnCodes.INTERNAL_ERROR;
     }
     if (Arrays.equals(pn.peerECDSAPubKeyHash, node.getDarknetPubKeyHash())) {
@@ -1141,6 +1529,20 @@ public abstract class ConnectionsToadlet extends Toadlet {
       return PeerAdditionReturnCodes.ALREADY_IN_REFERENCE;
     }
     return PeerAdditionReturnCodes.OK;
+  }
+
+  private String cleanReferenceText(String reftext) {
+    String[] lines = reftext.replace('\r', '\n').split("\n");
+    StringBuilder builder = new StringBuilder(reftext.length());
+    for (String line : lines) {
+      String trimmed = line.trim();
+      int equalsAt = trimmed.indexOf('=');
+      boolean isFieldLine = equalsAt >= 0 || trimmed.equals("End");
+      if (!trimmed.isEmpty() && isFieldLine) {
+        builder.append(trimmed).append('\n');
+      }
+    }
+    return builder.toString();
   }
 
   private static SimpleFieldSet parseNoderefLiberally(String nodeReference) throws IOException {
@@ -1156,58 +1558,110 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
   }
 
-  /** Adding a darknet node or an opennet node? */
+  /**
+   * Indicates whether this toadlet represents the opennet view rather than the darknet view.
+   *
+   * <p>Opennet pages skip darknet-only controls (names, trust sliders) and relax some redirects.
+   * Implementations should return a consistent value per instance; callers rely on it to decide UI
+   * branches and validation rules.
+   *
+   * @return {@code true} when rendering the opennet connections page; {@code false} for darknet.
+   */
   protected abstract boolean isOpennet();
 
   /**
-   * Rest of handlePost() method - supplied by subclass.
+   * Delegates POST actions not handled by {@link #handleMethodPOST} to subclass-specific logic.
    *
-   * @throws IOException
-   * @throws ToadletContextClosedException
-   * @throws RedirectException
+   * <p>Default behaviour proxies the POST to the GET handler so subclasses only implementing GET
+   * still behave correctly. Override to support extra form actions such as bulk operations.
+   *
+   * @param uri original request URI that determines routing of alternative actions.
+   * @param request HTTP request wrapper containing posted fields beyond add-peer.
+   * @param ctx toadlet context used to render responses or perform redirects.
+   * @param logMINOR whether debug/trace logging is enabled for the current request.
+   * @throws IOException when rendering fails or forwarding to GET encounters I/O errors.
+   * @throws ToadletContextClosedException if the client disconnects while responses are written.
+   * @throws RedirectException when subclass logic chooses to redirect instead of rendering.
    */
   protected void handleAltPost(URI uri, HTTPRequest request, ToadletContext ctx, boolean logMINOR)
       throws ToadletContextClosedException, IOException, RedirectException {
+    if (logMINOR && LOG.isDebugEnabled()) {
+      LOG.debug("Delegating POST to GET for {}", uri);
+    }
+    if (logMINOR && LOG.isTraceEnabled()) {
+      LOG.trace("Original request snapshot: {}", request);
+    }
     // Do nothing - we only support adding nodes
     handleMethodGET(uri, new HTTPRequestImpl(uri, "GET"), ctx);
   }
 
-  /** What should the heading (before "(more detailed)") be on the peers table? */
+  /**
+   * Supplies the primary heading displayed above the peers table.
+   *
+   * <p>Implementations return a localization key or literal that signals whether the view targets
+   * darknet or opennet users. The value is combined with counts in {@link #buildTitleCountString}
+   * to form the browser-visible page title and the on-page heading.
+   *
+   * @return title text or localization key describing the current connection view.
+   */
   protected abstract String getPeerListTitle();
 
   /**
-   * Should there be a checkbox for each peer, and drawPeerActionSelectBox() be called directly
-   * after drawing the peers list?
+   * Indicates whether bulk peer actions should be presented to the user.
+   *
+   * <p>When {@code true}, the renderer adds checkboxes next to each peer row and invokes {@link
+   * #drawPeerActionSelectBox(HTMLNode, boolean)} to render action controls. Subclasses typically
+   * enable this in advanced mode or when authenticated users manage darknet peers.
+   *
+   * @return {@code true} when bulk actions and selection controls should be displayed.
    */
   protected abstract boolean showPeerActionsBox();
 
   /**
-   * If showPeerActionsBox() is true, this will be called directly after drawing the peers table. A
-   * form has been added, and checkboxes added for each peer. This function should draw the rest of
-   * the form - any additional controls and one or more submit buttons.
+   * Renders additional peer actions when {@link #showPeerActionsBox()} is enabled.
+   *
+   * <p>A form and per-peer checkboxes are already present. Implementations should add controls and
+   * submit buttons appropriate for their network mode.
+   *
+   * @param peerForm form node that already wraps the peer table and checkboxes; implementations add
+   *     controls directly to this element.
+   * @param advancedModeEnabled whether the UI is in advanced mode, enabling additional actions or
+   *     diagnostics.
    */
   protected abstract void drawPeerActionSelectBox(HTMLNode peerForm, boolean advancedModeEnabled);
 
+  /**
+   * Determines whether the noderef textarea/download box should be displayed.
+   *
+   * <p>Darknet pages often show noderef exchange controls even for new users, whereas opennet pages
+   * may hide them unless advanced mode is active. Implementations should keep behaviour stable
+   * within a session so users are not surprised by disappearing controls.
+   *
+   * @param advancedModeEnabled whether the user requested advanced UI features.
+   * @return {@code true} to render the noderef box; {@code false} to omit it for simpler layouts.
+   */
   protected abstract boolean shouldDrawNoderefBox(boolean advancedModeEnabled);
 
-  final HTMLNode REF_LINK;
-  final HTMLNode REFTEXT_LINK;
+  final HTMLNode refLink;
+  final HTMLNode reftextLink;
 
   /**
    * @param contentNode Node to add noderef box to.
    * @param fs Noderef to render as text if requested.
    */
   void drawNoderefBox(HTMLNode contentNode, SimpleFieldSet fs) {
-    HTMLNode referenceInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
-    HTMLNode headerReferenceInfobox = referenceInfobox.addChild("div", "class", "infobox-header");
-    // FIXME better way to deal with this sort of thing???
+    HTMLNode referenceInfobox = contentNode.addChild("div", ATTR_CLASS, INFOBOX_NORMAL_CLASS);
+    HTMLNode headerReferenceInfobox =
+        referenceInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS);
+    // Better way to deal with this sort of thing???
     NodeL10n.getBase()
         .addL10nSubstitution(
             headerReferenceInfobox,
             "DarknetConnectionsToadlet.myReferenceHeader",
             new String[] {"linkref", "linktext"},
-            new HTMLNode[] {REF_LINK, REFTEXT_LINK});
-    HTMLNode referenceInfoboxContent = referenceInfobox.addChild("div", "class", "infobox-content");
+            new HTMLNode[] {refLink, reftextLink});
+    HTMLNode referenceInfoboxContent =
+        referenceInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
 
     if (!isOpennet()) {
       HTMLNode myName = referenceInfoboxContent.addChild("p");
@@ -1245,23 +1699,55 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
   }
 
+  /**
+   * Computes the full page title, optionally including connection counts.
+   *
+   * <p>The title appears in the browser chrome and at the top of the page. Implementations may
+   * append the supplied count string or replace it entirely to match opennet/darknet conventions.
+   * The method should remain deterministic for a given count input to aid testing.
+   *
+   * @param titleCountString preformatted count string built from {@link ConnectionCounts}.
+   * @return complete title text to render for the current request.
+   */
   protected abstract String getPageTitle(String titleCountString);
 
   /**
-   * Draw the add a peer box. This comes immediately after the main peers table and before the
-   * noderef box. Implementors may skip it by not doing anything in this method.
+   * Draws the add-a-peer box that follows the main peers table.
+   *
+   * <p>The box includes textarea input, file upload control, and optional private note field.
+   * Subclasses may override to hide or extend the UI but should avoid altering form names to keep
+   * POST handling compatible.
+   *
+   * @param contentNode container to which the infobox and form are appended.
+   * @param ctx toadlet context providing form helpers and localization strings.
    */
   protected void drawAddPeerBox(HTMLNode contentNode, ToadletContext ctx) {
     drawAddPeerBox(contentNode, ctx, isOpennet(), path());
   }
 
+  /**
+   * Static helper that renders the add-peer form with configurable target and mode.
+   *
+   * <p>Used by both opennet and darknet views to avoid code duplication. The contents include
+   * textarea paste input, file chooser, optional private note, and a submit button. The form posts
+   * to {@code formTarget} using multipart encoding.
+   *
+   * @param contentNode HTML container receiving the generated infobox and form.
+   * @param ctx toadlet context used to build forms and resolve localization keys.
+   * @param isOpennet whether the UI should hide darknet-only controls like private notes.
+   * @param formTarget path that receives the POST submission for adding peers.
+   */
   protected static void drawAddPeerBox(
       HTMLNode contentNode, ToadletContext ctx, boolean isOpennet, String formTarget) {
     // BEGIN PEER ADDITION BOX
-    HTMLNode peerAdditionInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
+    HTMLNode peerAdditionInfobox = contentNode.addChild("div", ATTR_CLASS, INFOBOX_NORMAL_CLASS);
     peerAdditionInfobox.addChild(
-        "div", "class", "infobox-header", l10n(isOpennet ? "addOpennetPeerTitle" : "addPeerTitle"));
-    HTMLNode peerAdditionContent = peerAdditionInfobox.addChild("div", "class", "infobox-content");
+        "div",
+        ATTR_CLASS,
+        INFOBOX_HEADER_CLASS,
+        l10n(isOpennet ? "addOpennetPeerTitle" : "addPeerTitle"));
+    HTMLNode peerAdditionContent =
+        peerAdditionInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
     HTMLNode peerAdditionForm = ctx.addFormChild(peerAdditionContent, formTarget, "addPeerForm");
     peerAdditionForm.addChild("#", l10n("pasteReference"));
     peerAdditionForm.addChild("br");
@@ -1272,11 +1758,13 @@ public abstract class ConnectionsToadlet extends Toadlet {
     peerAdditionForm.addChild("br");
     peerAdditionForm.addChild("#", (l10n("urlReference") + ' '));
     peerAdditionForm.addChild(
-        "input", new String[] {"id", "type", "name"}, new String[] {"refurl", "text", "url"});
+        ELEMENT_INPUT, new String[] {"id", "type", "name"}, new String[] {"refurl", "text", "url"});
     peerAdditionForm.addChild("br");
     peerAdditionForm.addChild("#", (l10n("fileReference") + ' '));
     peerAdditionForm.addChild(
-        "input", new String[] {"id", "type", "name"}, new String[] {"reffile", "file", "reffile"});
+        ELEMENT_INPUT,
+        new String[] {"id", "type", "name"},
+        new String[] {REF_FILE, "file", REF_FILE});
     peerAdditionForm.addChild("br");
     if (!isOpennet) {
       peerAdditionForm.addChild(new PeerTrustInputForAddPeerBoxNode());
@@ -1286,86 +1774,132 @@ public abstract class ConnectionsToadlet extends Toadlet {
     if (!isOpennet) {
       peerAdditionForm.addChild("#", (l10n("enterDescription") + ' '));
       peerAdditionForm.addChild(
-          "input",
+          ELEMENT_INPUT,
           new String[] {"id", "type", "name", "size", "maxlength", "value"},
-          new String[] {"peerPrivateNote", "text", "peerPrivateNote", "16", "250", ""});
+          new String[] {PEER_PRIVATE_NOTE, "text", PEER_PRIVATE_NOTE, "16", "250", ""});
       peerAdditionForm.addChild("br");
     }
     peerAdditionForm.addChild(
-        "input",
+        ELEMENT_INPUT,
         new String[] {"type", "name", "value"},
         new String[] {"submit", "add", l10n("add")});
   }
 
+  /**
+   * Creates a comparator for peer listings using the requested column and direction.
+   *
+   * @param sortBy column key requested via HTTP parameter; may be {@code null} for default order.
+   * @param reversed whether the comparator should invert the natural ordering to sort descending.
+   * @return comparator suitable for {@link Arrays#sort(Object[])} on peer status arrays.
+   */
   protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
     return new ComparatorByStatus(sortBy, reversed);
   }
 
+  /**
+   * Retrieves peer statuses to render, optionally omitting heavy computations.
+   *
+   * @param noHeavy when {@code true}, callers request a lightweight snapshot without expensive
+   *     statistics; used for message-type drill-downs.
+   * @return array of peer statuses; never {@code null}, may be empty when no peers exist.
+   */
   protected abstract PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy);
 
+  /**
+   * Returns the node's own reference for download or display.
+   *
+   * @return immutable {@link SimpleFieldSet} representing this node's noderef.
+   */
   protected abstract SimpleFieldSet getNoderef();
 
-  private void drawRow(
-      HTMLNode peerTable,
-      PeerNodeStatus peerNodeStatus,
-      boolean advancedModeEnabled,
-      boolean fProxyJavascriptEnabled,
-      long now,
-      String path,
-      boolean enablePeerActions,
-      SimpleColumn[] endCols,
-      boolean drawMessageTypes,
-      double totalSelectionRate,
-      DecimalFormat fix1) {
-    double selectionRate = peerNodeStatus.getSelectionRate();
-    int peerSelectionPercentage = 0;
-    if (totalSelectionRate > 0)
-      peerSelectionPercentage = (int) (selectionRate * 100 / totalSelectionRate);
+  private void drawRow(RowContext rowContext) {
+    PeerNodeStatus peerNodeStatus = rowContext.peerNodeStatus();
+    double totalSelectionRate = rowContext.totalSelectionRate();
+    DecimalFormat fix1 = rowContext.percentageFormat();
+    HTMLNode peerTable = rowContext.peerTable();
+    boolean advancedModeEnabled = rowContext.advancedModeEnabled();
+    boolean enablePeerActions = rowContext.enablePeerActions();
+    int peerSelectionPercentage = calculateSelectionPercentage(totalSelectionRate, peerNodeStatus);
     HTMLNode peerRow =
         peerTable.addChild(
             "tr",
-            "class",
+            ATTR_CLASS,
             "darknet_connections_"
                 + (peerSelectionPercentage > PeerNode.SELECTION_PERCENTAGE_WARNING
                     ? "warning"
                     : "normal"));
 
     if (enablePeerActions) {
-      // check box column
-      peerRow
-          .addChild("td", "class", "peer-marker")
-          .addChild(
-              "input",
-              new String[] {"type", "name"},
-              new String[] {"checkbox", "node_" + peerNodeStatus.hashCode()});
+      addSelectionCheckbox(peerRow, peerNodeStatus);
     }
 
-    // status column
+    addStatusColumn(peerRow, peerNodeStatus, advancedModeEnabled);
+
+    drawNameColumn(peerRow, peerNodeStatus, advancedModeEnabled);
+    drawTrustColumn(peerRow, peerNodeStatus);
+    drawVisibilityColumn(peerRow, peerNodeStatus, advancedModeEnabled);
+    addAddressColumn(peerRow, peerNodeStatus);
+    addVersionColumn(peerRow, peerNodeStatus);
+
+    if (advancedModeEnabled) {
+      addLocationColumn(peerRow, peerNodeStatus);
+      addBackoffColumns(peerRow, peerNodeStatus, rowContext.now(), fix1);
+      addPRejectColumn(peerRow, peerNodeStatus, fix1);
+    }
+
+    addIdleColumn(peerRow, peerNodeStatus, rowContext.now());
+
+    if (hasPrivateNoteColumn()) {
+      drawPrivateNoteColumn(peerRow, peerNodeStatus, rowContext.fProxyJavascriptEnabled());
+    }
+
+    if (advancedModeEnabled) {
+      addAdvancedStatistics(
+          peerRow, peerNodeStatus, fix1, peerSelectionPercentage, totalSelectionRate);
+    }
+
+    addEndColumns(peerRow, peerNodeStatus, rowContext.endCols());
+
+    if (rowContext.drawMessageTypes()) {
+      drawMessageTypes(peerTable, peerNodeStatus);
+    }
+  }
+
+  private int calculateSelectionPercentage(
+      double totalSelectionRate, PeerNodeStatus peerNodeStatus) {
+    if (totalSelectionRate <= 0) {
+      return 0;
+    }
+    return (int) (peerNodeStatus.getSelectionRate() * 100 / totalSelectionRate);
+  }
+
+  private void addSelectionCheckbox(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+    peerRow
+        .addChild("td", ATTR_CLASS, "peer-marker")
+        .addChild(
+            ELEMENT_INPUT,
+            new String[] {"type", "name"},
+            new String[] {"checkbox", "node_" + peerNodeStatus.hashCode()});
+  }
+
+  private void addStatusColumn(
+      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
     String statusString = peerNodeStatus.getStatusName();
     if (!advancedModeEnabled
         && (peerNodeStatus.getStatusValue() == PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF)) {
       statusString = "BUSY";
     }
-    /*
-     * Some status names have spaces, but a space separates key and value if not immediately followed by '='.
-     * Changing the names is not an option because they are exposed over FCP and TMCI.
-     */
     final String key = "ConnectionsToadlet.nodeStatus." + statusString.replace(' ', '_');
     peerRow
-        .addChild("td", "class", "peer-status")
+        .addChild("td", ATTR_CLASS, "peer-status")
         .addChild(
             "span",
-            "class",
+            ATTR_CLASS,
             peerNodeStatus.getStatusCSSName(),
             NodeL10n.getBase().getString(key) + (peerNodeStatus.isFetchingARK() ? "*" : ""));
+  }
 
-    drawNameColumn(peerRow, peerNodeStatus, advancedModeEnabled);
-
-    drawTrustColumn(peerRow, peerNodeStatus);
-
-    drawVisibilityColumn(peerRow, peerNodeStatus, advancedModeEnabled);
-
-    // address column
+  private void addAddressColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
     String pingTime = "";
     if (peerNodeStatus.isConnected()) {
       pingTime =
@@ -1375,8 +1909,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
               + (int) peerNodeStatus.getAveragePingTimeCorrected()
               + "ms)";
     }
-    HTMLNode addressRow = peerRow.addChild("td", "class", "peer-address");
-    // Ip to country + Flags
+    HTMLNode addressRow = peerRow.addChild("td", ATTR_CLASS, "peer-address");
     IPConverter ipc = IPConverter.getInstance(NodeFile.IPV4_TO_COUNTRY.getFile(node));
     byte[] addr = peerNodeStatus.getPeerAddressBytes();
 
@@ -1391,263 +1924,289 @@ public abstract class ConnectionsToadlet extends Toadlet {
                 ? peerNodeStatus.getPeerAddressAndPort()
                 : (l10n("unknownAddress")))
             + pingTime);
+  }
 
-    // version column
+  private void addVersionColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+    HTMLNode versionCell = peerRow.addChild("td", ATTR_CLASS, "peer-version");
     if (peerNodeStatus.getStatusValue() != PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED
         && (peerNodeStatus.isPublicInvalidVersion()
-            || peerNodeStatus
-                .isPublicReverseInvalidVersion())) { // Don't draw attention to a version problem if
-      // NEVER CONNECTED
-      peerRow
-          .addChild("td", "class", "peer-version")
-          .addChild(
-              "span",
-              "class",
-              "peer_version_problem",
-              Integer.toString(peerNodeStatus.getSimpleVersion()));
-    } else {
-      peerRow
-          .addChild("td", "class", "peer-version")
-          .addChild("#", Integer.toString(peerNodeStatus.getSimpleVersion()));
+            || peerNodeStatus.isPublicReverseInvalidVersion())) {
+      versionCell.addChild(
+          "span",
+          ATTR_CLASS,
+          "peer_version_problem",
+          Integer.toString(peerNodeStatus.getSimpleVersion()));
+      return;
     }
+    versionCell.addChild("#", Integer.toString(peerNodeStatus.getSimpleVersion()));
+  }
 
-    // location column
-    if (advancedModeEnabled) {
-      HTMLNode locationNode = peerRow.addChild("td", "class", "peer-location");
-      locationNode.addChild("b", String.valueOf(peerNodeStatus.getLocation()));
-      locationNode.addChild("br");
-      double[] peersLoc = peerNodeStatus.getPeersLocation();
-      if (peersLoc != null) {
-        locationNode.addChild("i", "+" + (peersLoc.length) + " friends");
-      }
+  private void addLocationColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+    HTMLNode locationNode = peerRow.addChild("td", ATTR_CLASS, "peer-location");
+    locationNode.addChild("b", String.valueOf(peerNodeStatus.getLocation()));
+    locationNode.addChild("br");
+    double[] peersLoc = peerNodeStatus.getPeersLocation();
+    if (peersLoc != null) {
+      locationNode.addChild("i", "+" + (peersLoc.length) + " friends");
     }
+  }
 
-    if (advancedModeEnabled) {
-      // backoff column
-      HTMLNode backoffCell = peerRow.addChild("td", "class", "peer-backoff");
-      backoffCell.addChild("#", fix1.format(peerNodeStatus.getBackedOffPercent(true)));
-      int backoff = (int) (Math.max(peerNodeStatus.getRoutingBackedOffUntil(true) - now, 0));
-      // Don't list the backoff as zero before it's actually zero
-      if ((backoff > 0) && (backoff < 1000)) {
-        backoff = 1000;
-      }
-      backoffCell.addChild(
-          "#",
-          ' '
-              + String.valueOf(backoff / 1000)
-              + '/'
-              + peerNodeStatus.getRoutingBackoffLength(true) / 1000);
-      backoffCell.addChild(
-          "#",
-          (peerNodeStatus.getLastBackoffReason(true) == null)
-              ? ""
-              : ('/' + (peerNodeStatus.getLastBackoffReason(true))));
+  private void addBackoffColumns(
+      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, long now, DecimalFormat fix1) {
+    addBackoffColumn(peerRow, peerNodeStatus, now, fix1, true);
+    addBackoffColumn(peerRow, peerNodeStatus, now, fix1, false);
+  }
 
-      // backoff column
-      backoffCell = peerRow.addChild("td", "class", "peer-backoff");
-      backoffCell.addChild("#", fix1.format(peerNodeStatus.getBackedOffPercent(false)));
-      backoff = (int) (Math.max(peerNodeStatus.getRoutingBackedOffUntil(false) - now, 0));
-      // Don't list the backoff as zero before it's actually zero
-      if ((backoff > 0) && (backoff < 1000)) {
-        backoff = 1000;
-      }
-      backoffCell.addChild(
-          "#",
-          ' '
-              + String.valueOf(backoff / 1000)
-              + '/'
-              + peerNodeStatus.getRoutingBackoffLength(false) / 1000);
-      backoffCell.addChild(
-          "#",
-          (peerNodeStatus.getLastBackoffReason(false) == null)
-              ? ""
-              : ('/' + (peerNodeStatus.getLastBackoffReason(false))));
-
-      // overload probability column
-      HTMLNode pRejectCell = peerRow.addChild("td", "class", "peer-backoff"); // FIXME
-      pRejectCell.addChild("#", fix1.format(peerNodeStatus.getPReject()));
+  private void addBackoffColumn(
+      HTMLNode peerRow,
+      PeerNodeStatus peerNodeStatus,
+      long now,
+      DecimalFormat fix1,
+      boolean realtime) {
+    HTMLNode backoffCell = peerRow.addChild("td", ATTR_CLASS, "peer-backoff");
+    backoffCell.addChild("#", fix1.format(peerNodeStatus.getBackedOffPercent(realtime)));
+    int backoff = (int) (Math.max(peerNodeStatus.getRoutingBackedOffUntil(realtime) - now, 0));
+    if ((backoff > 0) && (backoff < 1000)) {
+      backoff = 1000;
     }
+    backoffCell.addChild(
+        "#",
+        ' '
+            + String.valueOf(backoff / 1000)
+            + '/'
+            + peerNodeStatus.getRoutingBackoffLength(realtime) / 1000);
+    backoffCell.addChild(
+        "#",
+        (peerNodeStatus.getLastBackoffReason(realtime) == null)
+            ? ""
+            : ('/' + (peerNodeStatus.getLastBackoffReason(realtime))));
+  }
 
-    // idle column
+  private void addPRejectColumn(
+      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, DecimalFormat fix1) {
+    HTMLNode pRejectCell = peerRow.addChild("td", ATTR_CLASS, "peer-backoff");
+    pRejectCell.addChild("#", fix1.format(peerNodeStatus.getPReject()));
+  }
+
+  private void addIdleColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus, long now) {
     long idle = peerNodeStatus.getTimeLastRoutable();
     if (peerNodeStatus.isRoutable()) {
       idle = peerNodeStatus.getTimeLastConnectionCompleted();
     } else if (peerNodeStatus.getStatusValue() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED) {
       idle = peerNodeStatus.getPeerAddedTime();
     }
-    if (!peerNodeStatus.isConnected()
-        && (now - idle) > (2 * 7 * 24 * 60 * 60 * (long) 1000)) { // 2 weeks
-      peerRow
-          .addChild("td", "class", "peer-idle")
-          .addChild("span", "class", "peer_idle_old", idleToString(now, idle));
+    HTMLNode idleNode;
+    if (!peerNodeStatus.isConnected() && (now - idle) > (2 * 7 * 24 * 60 * 60 * (long) 1000)) {
+      idleNode = peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS);
+      idleNode.addChild("span", ATTR_CLASS, "peer_idle_old", idleToString(now, idle));
+      return;
+    }
+    peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS, idleToString(now, idle));
+  }
+
+  private void addAdvancedStatistics(
+      HTMLNode peerRow,
+      PeerNodeStatus peerNodeStatus,
+      DecimalFormat fix1,
+      int peerSelectionPercentage,
+      double totalSelectionRate) {
+    peerRow
+        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+        .addChild("#", fix1.format(peerNodeStatus.getPercentTimeRoutableConnection()));
+    peerRow
+        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+        .addChild("#", (totalSelectionRate > 0 ? (peerSelectionPercentage + "%") : "N/A"));
+    addTrafficColumns(peerRow, peerNodeStatus, fix1);
+    addTrafficSinceStartupColumn(peerRow, peerNodeStatus);
+    addCongestionControl(peerRow, peerNodeStatus);
+    peerRow
+        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+        .addChild("#", TimeUtil.formatTime(peerNodeStatus.getClockDelta()));
+    peerRow
+        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+        .addChild("#", peerNodeStatus.getReportedUptimePercentage() + "%");
+    peerRow
+        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+        .addChild(
+            "#",
+            SizeUtil.formatSize(peerNodeStatus.getMessageQueueLengthBytes())
+                + ":"
+                + TimeUtil.formatTime(peerNodeStatus.getMessageQueueLengthTime()));
+    addIncomingLoad(peerRow, peerNodeStatus.incomingLoadStatsBulk);
+    addIncomingLoad(peerRow, peerNodeStatus.incomingLoadStatsRealTime);
+  }
+
+  private void addTrafficColumns(
+      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, DecimalFormat fix1) {
+    long sent = peerNodeStatus.getTotalOutputBytes();
+    long resent = peerNodeStatus.getResendBytesSent();
+    long received = peerNodeStatus.getTotalInputBytes();
+    peerRow
+        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+        .addChild(
+            "#",
+            SizeUtil.formatSize(received)
+                + " / "
+                + SizeUtil.formatSize(sent)
+                + "/"
+                + SizeUtil.formatSize(resent)
+                + " ("
+                + fix1.format(((double) resent) / ((double) sent))
+                + ")");
+  }
+
+  private void addTrafficSinceStartupColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+    peerRow
+        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+        .addChild(
+            "#",
+            SizeUtil.formatSize(peerNodeStatus.getTotalInputSinceStartup())
+                + " / "
+                + SizeUtil.formatSize(peerNodeStatus.getTotalOutputSinceStartup()));
+  }
+
+  private void addCongestionControl(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+    PacketThrottle throttle = peerNodeStatus.getThrottle();
+    String val;
+    if (throttle == null) {
+      val = "none";
     } else {
-      peerRow.addChild("td", "class", "peer-idle", idleToString(now, idle));
+      val =
+          (int) throttle.getBandwidth()
+              + "B/sec delay "
+              + throttle.getDelay()
+              + "ms (RTT "
+              + throttle.getRoundTripTime()
+              + "ms window "
+              + throttle.getWindowSize()
+              + ')';
     }
+    peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS).addChild("#", val);
+  }
 
-    if (hasPrivateNoteColumn())
-      drawPrivateNoteColumn(peerRow, peerNodeStatus, fProxyJavascriptEnabled);
-
-    if (advancedModeEnabled) {
-      // percent of time connected column
-      peerRow
-          .addChild("td", "class", "peer-idle" /* FIXME */)
-          .addChild("#", fix1.format(peerNodeStatus.getPercentTimeRoutableConnection()));
-      // selection stats
-      peerRow
-          .addChild("td", "class", "peer-idle" /* FIXME */)
-          .addChild("#", (totalSelectionRate > 0 ? (peerSelectionPercentage + "%") : "N/A"));
-      // total traffic column
-      long sent = peerNodeStatus.getTotalOutputBytes();
-      long resent = peerNodeStatus.getResendBytesSent();
-      long received = peerNodeStatus.getTotalInputBytes();
-      peerRow
-          .addChild("td", "class", "peer-idle" /* FIXME */)
-          .addChild(
-              "#",
-              SizeUtil.formatSize(received)
-                  + " / "
-                  + SizeUtil.formatSize(sent)
-                  + "/"
-                  + SizeUtil.formatSize(resent)
-                  + " ("
-                  + fix1.format(((double) resent) / ((double) sent))
-                  + ")");
-      // total traffic column startup
-      peerRow
-          .addChild("td", "class", "peer-idle" /* FIXME */)
-          .addChild(
-              "#",
-              SizeUtil.formatSize(peerNodeStatus.getTotalInputSinceStartup())
-                  + " / "
-                  + SizeUtil.formatSize(peerNodeStatus.getTotalOutputSinceStartup()));
-      // congestion control
-      PacketThrottle t = peerNodeStatus.getThrottle();
-      String val;
-      if (t == null) val = "none";
-      else
-        val =
-            (int) t.getBandwidth()
-                + "B/sec delay "
-                + t.getDelay()
-                + "ms (RTT "
-                + t.getRoundTripTime()
-                + "ms window "
-                + t.getWindowSize()
-                + ')';
-      peerRow.addChild("td", "class", "peer-idle" /* FIXME */).addChild("#", val);
-      // time delta
-      peerRow
-          .addChild("td", "class", "peer-idle" /* FIXME */)
-          .addChild("#", TimeUtil.formatTime(peerNodeStatus.getClockDelta()));
-      peerRow
-          .addChild("td", "class", "peer-idle" /* FIXME */)
-          .addChild("#", peerNodeStatus.getReportedUptimePercentage() + "%");
-      peerRow
-          .addChild("td", "class", "peer-idle" /* FIXME */)
-          .addChild(
-              "#",
-              SizeUtil.formatSize(peerNodeStatus.getMessageQueueLengthBytes())
-                  + ":"
-                  + TimeUtil.formatTime(peerNodeStatus.getMessageQueueLengthTime()));
-      IncomingLoadSummaryStats loadStatsBulk = peerNodeStatus.incomingLoadStatsBulk;
-      if (loadStatsBulk == null) peerRow.addChild("td", "class", "peer-idle" /* FIXME */);
-      else
-        peerRow
-            .addChild("td", "class", "peer-idle" /* FIXME */)
-            .addChild(
-                "#",
-                loadStatsBulk.runningRequestsTotal
-                    + "reqs:out:"
-                    + SizeUtil.formatSize(loadStatsBulk.usedCapacityOutputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsBulk.othersUsedCapacityOutputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsBulk.peerCapacityOutputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsBulk.totalCapacityOutputBytes)
-                    + ":in:"
-                    + SizeUtil.formatSize(loadStatsBulk.usedCapacityInputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsBulk.othersUsedCapacityInputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsBulk.peerCapacityInputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsBulk.totalCapacityInputBytes));
-      IncomingLoadSummaryStats loadStatsRT = peerNodeStatus.incomingLoadStatsRealTime;
-      if (loadStatsRT == null) peerRow.addChild("td", "class", "peer-idle" /* FIXME */);
-      else
-        peerRow
-            .addChild("td", "class", "peer-idle" /* FIXME */)
-            .addChild(
-                "#",
-                loadStatsRT.runningRequestsTotal
-                    + "reqs:out:"
-                    + SizeUtil.formatSize(loadStatsRT.usedCapacityOutputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsRT.othersUsedCapacityOutputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsRT.peerCapacityOutputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsRT.totalCapacityOutputBytes)
-                    + ":in:"
-                    + SizeUtil.formatSize(loadStatsRT.usedCapacityInputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsRT.othersUsedCapacityInputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsRT.peerCapacityInputBytes)
-                    + "/"
-                    + SizeUtil.formatSize(loadStatsRT.totalCapacityInputBytes));
+  private void addIncomingLoad(HTMLNode peerRow, IncomingLoadSummaryStats loadStats) {
+    if (loadStats == null) {
+      peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS);
+      return;
     }
+    peerRow
+        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+        .addChild(
+            "#",
+            loadStats.runningRequestsTotal
+                + "reqs:out:"
+                + SizeUtil.formatSize(loadStats.usedCapacityOutputBytes)
+                + "/"
+                + SizeUtil.formatSize(loadStats.othersUsedCapacityOutputBytes)
+                + "/"
+                + SizeUtil.formatSize(loadStats.peerCapacityOutputBytes)
+                + "/"
+                + SizeUtil.formatSize(loadStats.totalCapacityOutputBytes)
+                + ":in:"
+                + SizeUtil.formatSize(loadStats.usedCapacityInputBytes)
+                + "/"
+                + SizeUtil.formatSize(loadStats.othersUsedCapacityInputBytes)
+                + "/"
+                + SizeUtil.formatSize(loadStats.peerCapacityInputBytes)
+                + "/"
+                + SizeUtil.formatSize(loadStats.totalCapacityInputBytes));
+  }
 
-    if (endCols != null) {
-      for (SimpleColumn col : endCols) {
-        col.drawColumn(peerRow, peerNodeStatus);
-      }
+  private void addEndColumns(
+      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, List<SimpleColumn> endCols) {
+    if (endCols == null || endCols.isEmpty()) {
+      return;
     }
-
-    if (drawMessageTypes) {
-      drawMessageTypes(peerTable, peerNodeStatus);
+    for (SimpleColumn col : endCols) {
+      col.drawColumn(peerRow, peerNodeStatus);
     }
   }
 
+  /**
+   * Indicates whether the peer table should include a trust column.
+   *
+   * <p>Darknet views usually show user-configurable trust, while opennet hides it. Subclasses
+   * should return a stable value so column layouts remain predictable.
+   *
+   * @return {@code true} when a trust column should be rendered; {@code false} otherwise.
+   */
   protected boolean hasTrustColumn() {
     return false;
   }
 
+  /**
+   * Renders the trust column when enabled by {@link #hasTrustColumn()}.
+   *
+   * @param peerRow row node corresponding to the peer being rendered.
+   * @param peerNodeStatus status snapshot containing trust information to display.
+   */
   protected void drawTrustColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
     // Do nothing
   }
 
+  /**
+   * Indicates whether a visibility column should be shown for peers.
+   *
+   * @return {@code true} to render visibility, {@code false} to omit it from the table.
+   */
   protected boolean hasVisibilityColumn() {
     return false;
   }
 
+  /**
+   * Renders the visibility column when enabled.
+   *
+   * @param peerRow row node receiving the visibility cell.
+   * @param peerNodeStatus peer status with visibility settings.
+   * @param advancedModeEnabled whether advanced UI should expose additional context.
+   */
   protected void drawVisibilityColumn(
       HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
     // Do nothing
   }
 
-  /** Is there a name column? */
+  /**
+   * Indicates whether a peer name column should be displayed.
+   *
+   * @return {@code true} to show names; {@code false} when names are not applicable.
+   */
   protected abstract boolean hasNameColumn();
 
-  /** Draw the name column, if there is one. This will be directly after the status column. */
+  /**
+   * Draws the name column immediately after the status column when enabled.
+   *
+   * @param peerRow row node to which the name cell should be appended.
+   * @param peerNodeStatus peer status that may contain a user-defined name.
+   * @param advanced flag indicating whether advanced UI elements may be shown.
+   */
   protected abstract void drawNameColumn(
       HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advanced);
 
-  /** Is there a private note column? */
+  /**
+   * Indicates whether a private note column should be rendered for peers.
+   *
+   * @return {@code true} when private notes should appear; {@code false} otherwise.
+   */
   protected abstract boolean hasPrivateNoteColumn();
 
-  /** Draw the private note column. */
+  /**
+   * Draws the private note column when enabled by {@link #hasPrivateNoteColumn()}.
+   *
+   * @param peerRow row node receiving the private note cell.
+   * @param peerNodeStatus peer status containing any private notes.
+   * @param fProxyJavascriptEnabled whether JavaScript helpers are available for the view.
+   */
   protected abstract void drawPrivateNoteColumn(
       HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled);
 
   private void drawMessageTypes(HTMLNode peerTable, PeerNodeStatus peerNodeStatus) {
-    HTMLNode messageCountRow = peerTable.addChild("tr", "class", "message-status");
+    HTMLNode messageCountRow = peerTable.addChild("tr", ATTR_CLASS, "message-status");
     messageCountRow.addChild("td", "colspan", "2");
     HTMLNode messageCountCell =
         messageCountRow.addChild(
             "td", "colspan", "9"); // = total table row width - 2 from above colspan
-    HTMLNode messageCountTable = messageCountCell.addChild("table", "class", "message-count");
+    HTMLNode messageCountTable =
+        messageCountCell.addChild(ELEMENT_TABLE, ATTR_CLASS, "message-count");
     HTMLNode countHeaderRow = messageCountTable.addChild("tr");
     countHeaderRow.addChild("th", "Message");
     countHeaderRow.addChild("th", "Incoming");
@@ -1673,13 +2232,13 @@ public abstract class ConnectionsToadlet extends Toadlet {
         existingCounts[1] = messageCount;
       }
     }
-    Collections.sort(messageNames, (first, second) -> first.compareToIgnoreCase(second));
+    messageNames.sort(String::compareToIgnoreCase);
     for (String messageName : messageNames) {
       Long[] messageCount = messageCounts.get(messageName);
       HTMLNode messageRow = messageCountTable.addChild("tr");
       messageRow.addChild("td", messageName);
-      messageRow.addChild("td", "class", "right-align", String.valueOf(messageCount[0]));
-      messageRow.addChild("td", "class", "right-align", String.valueOf(messageCount[1]));
+      messageRow.addChild("td", ATTR_CLASS, "right-align", String.valueOf(messageCount[0]));
+      messageRow.addChild("td", ATTR_CLASS, "right-align", String.valueOf(messageCount[1]));
     }
   }
 
@@ -1695,15 +2254,26 @@ public abstract class ConnectionsToadlet extends Toadlet {
     return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + string);
   }
 
-  private static String l10n(String string, String pattern, String value) {
-    return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + string, pattern, value);
+  private static String l10nCount(String string, String value) {
+    return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + string, COUNT, value);
   }
 
   private String sortString(boolean isReversed, String type) {
     return (isReversed ? ("?sortBy=" + type) : ("?sortBy=" + type + "&reversed"));
   }
 
-  /** Send a simple error page. */
+  /**
+   * Sends a simple error page with optional navigation hints.
+   *
+   * @param ctx toadlet context used to build and send the HTML reply.
+   * @param code HTTP status code to return to the client.
+   * @param desc short description used as the page title and infobox heading.
+   * @param message localized body text explaining the failure to the user.
+   * @param returnToAddFriends whether to show a link back to the add-friend page or to the previous
+   *     page.
+   * @throws ToadletContextClosedException if the client connection is closed while sending output.
+   * @throws IOException when writing the response fails.
+   */
   protected void sendErrorPage(
       ToadletContext ctx, int code, String desc, String message, boolean returnToAddFriends)
       throws ToadletContextClosedException, IOException {

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -4,8 +4,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.config.ConfigException;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
@@ -23,8 +24,62 @@ import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Toadlet that renders and manages the darknet "friends" page and its form actions.
+ *
+ * <p>This toadlet presents the list of trusted darknet peers, allows users to adjust trust and
+ * visibility settings, and exposes bulk actions such as enabling, disabling, or removing peers. It
+ * reuses the shared table rendering logic from {@link ConnectionsToadlet} but specializes it for
+ * darknet-only concepts like private notes, friend references, and transfer confirmations. Typical
+ * callers route HTTP GET and POST traffic from the node's web interface to this class, which then
+ * populates HTML structures using {@link network.crypta.support.HTMLNode} builders and performs
+ * side effects against {@link network.crypta.node.DarknetPeerNode} instances. The class is stateful
+ * only through its reference to the owning {@link network.crypta.node.Node}, and operations are
+ * expected to run on the single request-handling thread that invoked the toadlet; no internal
+ * synchronization is performed.
+ *
+ * <ul>
+ *   <li>Renders friend metadata, noderef download links, and private notes.
+ *   <li>Handles bulk updates for trust, visibility, and routing flags.
+ *   <li>Redirects or replies with downloadable references when appropriate.
+ * </ul>
+ *
+ * @see ConnectionsToadlet
+ * @see network.crypta.node.DarknetPeerNode
+ */
 public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(DarknetConnectionsToadlet.class);
+  private static final String ATTR_CLASS = "class";
+  private static final String ELEMENT_INPUT = "input";
+  private static final String ELEMENT_SELECT = "select";
+  private static final String ELEMENT_OPTION = "option";
+  private static final String ATTR_VALUE = "value";
+  private static final String PEER_PRIVATE_NOTE_PREFIX = "peerPrivateNote_";
+  private static final String FRIEND_PREFIX = "friend-";
+  private static final String FREF_SUFFIX = ".fref";
+  private static final String SUBMIT = "submit";
+  private static final String ACTION = "action";
+  private static final String DO_ACTION = "doAction";
+  private static final String CHANGE_TRUST = "changeTrust";
+  private static final String CHANGE_VISIBILITY = "changeVisibility";
+  private static final String REMOVE = "remove";
+  private static final char PATH_SEPARATOR = '/';
+  private static final String FRIENDS_PATH = PATH_SEPARATOR + "friends" + PATH_SEPARATOR;
+  private static final String NODE_PREFIX = "node_";
+  private static final Map<String, Consumer<DarknetPeerNode>> SIMPLE_ACTIONS =
+      Map.ofEntries(
+          Map.entry("enable", DarknetPeerNode::enablePeer),
+          Map.entry("disable", DarknetPeerNode::disablePeer),
+          Map.entry("set_burst_only", pn -> pn.setBurstOnly(true)),
+          Map.entry("clear_burst_only", pn -> pn.setBurstOnly(false)),
+          Map.entry("set_ignore_source_port", pn -> pn.setIgnoreSourcePort(true)),
+          Map.entry("clear_ignore_source_port", pn -> pn.setIgnoreSourcePort(false)),
+          Map.entry("set_dont_route", pn -> pn.setRoutingStatus(false, true)),
+          Map.entry("clear_dont_route", pn -> pn.setRoutingStatus(true, true)),
+          Map.entry("set_listen_only", pn -> pn.setListenOnly(true)),
+          Map.entry("clear_listen_only", pn -> pn.setListenOnly(false)),
+          Map.entry("set_allow_local", pn -> pn.setAllowLocalAddresses(true)),
+          Map.entry("clear_allow_local", pn -> pn.setAllowLocalAddresses(false)));
 
   DarknetConnectionsToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
     super(n, core, client);
@@ -34,6 +89,17 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + string);
   }
 
+  /**
+   * Comparator that extends the base status ordering with darknet-specific columns.
+   *
+   * <p>The comparator first honors the configured sort key and reversal flag inherited from {@link
+   * ComparatorByStatus}. When the caller requests name, private note, trust, or visibility
+   * ordering, this comparator extracts the corresponding values from {@link DarknetPeerNodeStatus}
+   * instances, falling back to the parent comparison rules for other columns. Ties on visibility
+   * resolve by comparing both local and remote visibility preferences to provide deterministic
+   * ordering. Instances are short-lived and created per request to avoid storing mutable sorting
+   * preferences globally.
+   */
   protected class DarknetComparator extends ComparatorByStatus {
 
     DarknetComparator(String sortBy, boolean reversed) {
@@ -70,7 +136,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
       }
     }
 
-    /** Default comparison, after taking into account status */
+    /** Default comparison, after taking into account status. */
     @Override
     protected int lastResortCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
       return ((DarknetPeerNodeStatus) firstNode)
@@ -79,20 +145,57 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     }
   }
 
+  /**
+   * Build a comparator that orders darknet peers according to the chosen column.
+   *
+   * <p>The comparator encapsulates the caller's sorting preference instead of mutating shared
+   * state, ensuring concurrent page renders cannot influence each other's ordering. Supported sort
+   * keys include the generic status columns provided by the parent and darknet-specific fields such
+   * as private notes, trust, and visibility. The {@code reversed} flag flips the natural ordering
+   * so both ascending and descending views are available without recomputing the source data.
+   *
+   * @param sortBy column identifier accepted by {@link DarknetComparator}, including name,
+   *     privnote, trust, visibility, or the inherited defaults.
+   * @param reversed whether to invert the comparator to produce descending order results.
+   * @return a stateless comparator instance tuned to the requested ordering.
+   */
   @Override
   protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
     return new DarknetComparator(sortBy, reversed);
   }
 
+  /**
+   * Indicate that the darknet table always displays a peer name column.
+   *
+   * <p>The name column serves as the primary identifier for friends, enabling both navigation to
+   * the confidential messaging form and, in advanced mode, access to downloadable references.
+   * Hiding it would prevent users from distinguishing peers, so the method consistently returns
+   * {@code true} regardless of UI mode or configuration.
+   *
+   * @return {@code true}, signalling that a name column must be rendered for every row.
+   */
   @Override
   protected boolean hasNameColumn() {
     return true;
   }
 
+  /**
+   * Render the peer name cell with an optional noderef download link for advanced users.
+   *
+   * <p>The method writes a table cell containing the peer's display name and a link to the
+   * confidential messaging endpoint. When advanced mode is active and a full noderef is available,
+   * it also exposes a secondary link that triggers a download of the sanitized friend reference.
+   * The cell contents remain purely presentational; selection and bulk actions are handled
+   * elsewhere in the form.
+   *
+   * @param peerRow table row receiving the name content; must be non-null and part of the page.
+   * @param peerNodeStatus status wrapper for the darknet peer whose name is shown.
+   * @param advanced whether to include the noderef download link beside the name.
+   */
   @Override
   protected void drawNameColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advanced) {
     // name column
-    HTMLNode cell = peerRow.addChild("td", "class", "peer-name");
+    HTMLNode cell = peerRow.addChild("td", ATTR_CLASS, "peer-name");
     cell.addChild(
         "a",
         "href",
@@ -103,43 +206,103 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
       cell.addChild(
           "a",
           "href",
-          path() + "friend-" + peerNodeStatus.hashCode() + ".fref",
+          path() + FRIEND_PREFIX + peerNodeStatus.hashCode() + FREF_SUFFIX,
           l10n("noderefLink"));
       cell.addChild("#", ")");
     }
   }
 
+  /**
+   * Signal that the trust column should always be rendered for darknet peers.
+   *
+   * <p>Trust is a primary tuning mechanism for darknet routing, so the column remains visible in
+   * both basic and advanced modes. The consistent presence of the column also keeps the table
+   * layout stable when users toggle feature flags.
+   *
+   * @return {@code true}, indicating the trust column is required in the output table.
+   */
   @Override
   protected boolean hasTrustColumn() {
     return true;
   }
 
+  /**
+   * Populate the trust column with the peer's configured trust enum value.
+   *
+   * <p>The method writes a simple text cell that mirrors the underlying {@link FRIEND_TRUST} value
+   * so users can quickly scan relative trust levels. No editing controls are embedded here;
+   * adjustments are performed through the bulk actions box to avoid per-row form sprawl.
+   *
+   * @param peerRow row node that will receive the trust cell; must already exist in the DOM.
+   * @param peerNodeStatus status describing the peer whose trust value is being rendered.
+   */
   @Override
   protected void drawTrustColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
     peerRow
-        .addChild("td", "class", "peer-trust")
+        .addChild("td", ATTR_CLASS, "peer-trust")
         .addChild("#", ((DarknetPeerNodeStatus) peerNodeStatus).getTrustLevel().name());
   }
 
+  /**
+   * Declare that visibility settings should always be displayed for darknet peers.
+   *
+   * <p>Visibility reflects whether peers may reveal each other's identity to others, making it a
+   * critical safety control. Showing it unconditionally keeps the user aware of both inbound and
+   * outbound sharing preferences and avoids layout shifts between basic and advanced views.
+   *
+   * @return {@code true}, ensuring the visibility column is rendered.
+   */
   @Override
   protected boolean hasVisibilityColumn() {
     return true;
   }
 
+  /**
+   * Render local and optionally remote visibility settings in a compact text cell.
+   *
+   * <p>The local visibility always appears so users can confirm how their node shares the
+   * connection. When advanced mode is enabled, the peer's visibility toward this node is appended
+   * in parentheses to highlight asymmetries. No formatting or icons are used to keep the table
+   * printable and screen-reader friendly.
+   *
+   * @param peerRow destination row that receives the visibility cell.
+   * @param peerNodeStatus status object containing local and remote visibility values.
+   * @param advancedModeEnabled whether to append the peer's visibility toward this node.
+   */
   @Override
   protected void drawVisibilityColumn(
       HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
     String content = ((DarknetPeerNodeStatus) peerNodeStatus).getOurVisibility().name();
     if (advancedModeEnabled)
       content += " (" + ((DarknetPeerNodeStatus) peerNodeStatus).getTheirVisibility().name() + ")";
-    peerRow.addChild("td", "class", "peer-trust").addChild("#", content);
+    peerRow.addChild("td", ATTR_CLASS, "peer-trust").addChild("#", content);
   }
 
+  /**
+   * Indicate that the private note column should always be present on the friends table.
+   *
+   * <p>Private notes allow operators to annotate friends with context or trust cues; keeping the
+   * column consistently visible avoids data loss and maintains table alignment across modes.
+   *
+   * @return {@code true}, signalling that note inputs should be rendered for each peer.
+   */
   @Override
   protected boolean hasPrivateNoteColumn() {
     return true;
   }
 
+  /**
+   * Render the editable private note field for a peer, enabling JS onchange when available.
+   *
+   * <p>The method emits an {@code input type="text"} element sized for short annotations and limits
+   * user input to 250 characters. When the FProxy JavaScript helpers are enabled, an {@code
+   * onChange} hook triggers the client-side note tracking logic; otherwise a plain input is
+   * provided so accessibility and non-scripted environments remain functional.
+   *
+   * @param peerRow row node to which the note input cell is appended.
+   * @param peerNodeStatus status describing the peer whose note value is being edited.
+   * @param fProxyJavascriptEnabled whether to attach the JavaScript change handler attribute.
+   */
   @Override
   protected void drawPrivateNoteColumn(
       HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled) {
@@ -147,13 +310,13 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     DarknetPeerNodeStatus status = (DarknetPeerNodeStatus) peerNodeStatus;
     if (fProxyJavascriptEnabled) {
       peerRow
-          .addChild("td", "class", "peer-private-darknet-comment-note")
+          .addChild("td", ATTR_CLASS, "peer-private-darknet-comment-note")
           .addChild(
-              "input",
-              new String[] {"type", "name", "size", "maxlength", "onChange", "value"},
+              ELEMENT_INPUT,
+              new String[] {"type", "name", "size", "maxlength", "onChange", ATTR_VALUE},
               new String[] {
                 "text",
-                "peerPrivateNote_" + peerNodeStatus.hashCode(),
+                PEER_PRIVATE_NOTE_PREFIX + peerNodeStatus.hashCode(),
                 "16",
                 "250",
                 "peerNoteChange();",
@@ -161,13 +324,13 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
               });
     } else {
       peerRow
-          .addChild("td", "class", "peer-private-darknet-comment-note")
+          .addChild("td", ATTR_CLASS, "peer-private-darknet-comment-note")
           .addChild(
-              "input",
-              new String[] {"type", "name", "size", "maxlength", "value"},
+              ELEMENT_INPUT,
+              new String[] {"type", "name", "size", "maxlength", ATTR_VALUE},
               new String[] {
                 "text",
-                "peerPrivateNote_" + peerNodeStatus.hashCode(),
+                PEER_PRIVATE_NOTE_PREFIX + peerNodeStatus.hashCode(),
                 "16",
                 "250",
                 status.getPrivateDarknetCommentNote()
@@ -175,16 +338,47 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     }
   }
 
+  /**
+   * Export the local node's public darknet reference for distribution.
+   *
+   * <p>The exported field set omits private data and contains only the values needed for a remote
+   * peer to add this node as a friend. Callers typically embed the returned structure in the
+   * noderef download box so users can save or transmit it securely.
+   *
+   * @return a {@link SimpleFieldSet} containing the sanitized public darknet reference.
+   */
   @Override
   protected SimpleFieldSet getNoderef() {
     return node.exportDarknetPublicFieldSet();
   }
 
+  /**
+   * Collect status snapshots for all darknet peers, optionally skipping heavy calculations.
+   *
+   * <p>When {@code noHeavy} is true, the returned statuses avoid expensive metrics so lightweight
+   * pages can render quickly. The array ordering matches that provided by the node's peer manager
+   * and is later sorted by {@link #comparator(String, boolean)} according to user preferences.
+   *
+   * @param noHeavy whether to omit heavy computations such as aggregated statistics.
+   * @return array of {@link DarknetPeerNodeStatus} instances representing current darknet peers.
+   */
   @Override
   protected PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
     return node.getPeers().getDarknetPeerNodeStatuses(noHeavy);
   }
 
+  /**
+   * Build a localized page title that embeds the formatted friend count.
+   *
+   * <p>The title text is fetched from localization resources and accepts the {@code counts}
+   * placeholder, allowing the caller to present short summaries such as "(5 friends)" without
+   * duplicating translation keys. Returning the fully interpolated string keeps the template logic
+   * centralized within the toadlet rather than scattering title construction throughout the UI
+   * layer.
+   *
+   * @param titleCountString localized or numeric friend count already formatted for display.
+   * @return localized title string ready for insertion into the page header.
+   */
   @Override
   protected String getPageTitle(String titleCountString) {
     return NodeL10n.getBase()
@@ -194,399 +388,474 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
             new String[] {titleCountString});
   }
 
+  /**
+   * Determine whether the page should include the self noderef download box.
+   *
+   * <p>The box is useful for power users distributing their own references but can overwhelm new
+   * users. By tying visibility to the advanced mode flag, the method keeps the standard workflow
+   * simple while still giving experienced operators quick access to their public noderef without
+   * navigating away from the friends page.
+   *
+   * @param advancedModeEnabled whether the user interface is currently in advanced mode.
+   * @return {@code true} when the noderef box should be rendered alongside the friends table.
+   */
   @Override
   protected boolean shouldDrawNoderefBox(boolean advancedModeEnabled) {
-    return advancedModeEnabled; // Convenient for advanced users, but normally we will use the "Add
-    // a friend" box.
+    // Convenient for advanced users, but normally we will use the "Add a friend" box.
+    return advancedModeEnabled;
   }
 
+  /**
+   * Indicate that the bulk peer actions form must always be visible.
+   *
+   * <p>Even in simplified mode, operators benefit from quick access to note updates and removals,
+   * so the actions box is never hidden. The contained controls gate advanced operations internally
+   * rather than being removed from the DOM.
+   *
+   * @return {@code true}, signalling callers to render the actions box unconditionally.
+   */
   @Override
   protected boolean showPeerActionsBox() {
     return true;
   }
 
+  /**
+   * Append the select box and buttons that drive bulk peer operations for the friends list.
+   *
+   * <p>The method constructs a form section containing send-message, note-update, trust,
+   * visibility, and removal actions. When advanced mode is active, additional toggles expose
+   * routing and transport flags that may disrupt connectivity; these options are intentionally
+   * hidden from basic users. The controls rely on the parent form to provide checkbox selections
+   * whose names follow the {@code node_<hashcode>} convention.
+   *
+   * @param peerForm form node to which controls are appended; must already exist in the page.
+   * @param advancedModeEnabled whether to include advanced-only routing and security options.
+   */
   @Override
   protected void drawPeerActionSelectBox(HTMLNode peerForm, boolean advancedModeEnabled) {
     peerForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"submit", "doSendMessageToPeers", l10n("sendConfidentialMessage")});
+        ELEMENT_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {SUBMIT, "doSendMessageToPeers", l10n("sendConfidentialMessage")});
     peerForm.addChild("br");
 
     HTMLNode actionSelect =
-        peerForm.addChild("select", new String[] {"id", "name"}, new String[] {"action", "action"});
-    actionSelect.addChild("option", "value", "", l10n("selectAction"));
-    actionSelect.addChild("option", "value", "update_notes", l10n("updateChangedPrivnotes"));
+        peerForm.addChild(
+            ELEMENT_SELECT, new String[] {"id", "name"}, new String[] {ACTION, ACTION});
+    actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, "", l10n("selectAction"));
+    actionSelect.addChild(
+        ELEMENT_OPTION, ATTR_VALUE, "update_notes", l10n("updateChangedPrivnotes"));
     if (advancedModeEnabled) {
-      actionSelect.addChild("option", "value", "enable", l10n("peersEnable"));
-      actionSelect.addChild("option", "value", "disable", l10n("peersDisable"));
-      actionSelect.addChild("option", "value", "set_burst_only", l10n("peersSetBurstOnly"));
-      actionSelect.addChild("option", "value", "clear_burst_only", l10n("peersClearBurstOnly"));
-      actionSelect.addChild("option", "value", "set_listen_only", l10n("peersSetListenOnly"));
-      actionSelect.addChild("option", "value", "clear_listen_only", l10n("peersClearListenOnly"));
-      actionSelect.addChild("option", "value", "set_allow_local", l10n("peersSetAllowLocal"));
-      actionSelect.addChild("option", "value", "clear_allow_local", l10n("peersClearAllowLocal"));
+      actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, "enable", l10n("peersEnable"));
+      actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, "disable", l10n("peersDisable"));
       actionSelect.addChild(
-          "option", "value", "set_ignore_source_port", l10n("peersSetIgnoreSourcePort"));
+          ELEMENT_OPTION, ATTR_VALUE, "set_burst_only", l10n("peersSetBurstOnly"));
       actionSelect.addChild(
-          "option", "value", "clear_ignore_source_port", l10n("peersClearIgnoreSourcePort"));
-      actionSelect.addChild("option", "value", "set_dont_route", l10n("peersSetDontRoute"));
-      actionSelect.addChild("option", "value", "clear_dont_route", l10n("peersClearDontRoute"));
+          ELEMENT_OPTION, ATTR_VALUE, "clear_burst_only", l10n("peersClearBurstOnly"));
+      actionSelect.addChild(
+          ELEMENT_OPTION, ATTR_VALUE, "set_listen_only", l10n("peersSetListenOnly"));
+      actionSelect.addChild(
+          ELEMENT_OPTION, ATTR_VALUE, "clear_listen_only", l10n("peersClearListenOnly"));
+      actionSelect.addChild(
+          ELEMENT_OPTION, ATTR_VALUE, "set_allow_local", l10n("peersSetAllowLocal"));
+      actionSelect.addChild(
+          ELEMENT_OPTION, ATTR_VALUE, "clear_allow_local", l10n("peersClearAllowLocal"));
+      actionSelect.addChild(
+          ELEMENT_OPTION, ATTR_VALUE, "set_ignore_source_port", l10n("peersSetIgnoreSourcePort"));
+      actionSelect.addChild(
+          ELEMENT_OPTION,
+          ATTR_VALUE,
+          "clear_ignore_source_port",
+          l10n("peersClearIgnoreSourcePort"));
+      actionSelect.addChild(
+          ELEMENT_OPTION, ATTR_VALUE, "set_dont_route", l10n("peersSetDontRoute"));
+      actionSelect.addChild(
+          ELEMENT_OPTION, ATTR_VALUE, "clear_dont_route", l10n("peersClearDontRoute"));
     }
-    actionSelect.addChild("option", "value", "", l10n("separator"));
-    actionSelect.addChild("option", "value", "remove", l10n("removePeers"));
+    actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, "", l10n("separator"));
+    actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, REMOVE, l10n("removePeers"));
     peerForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"submit", "doAction", l10n("go")});
+        ELEMENT_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {SUBMIT, DO_ACTION, l10n("go")});
     peerForm.addChild("br");
     peerForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"submit", "doChangeTrust", l10n("changeTrustButton")});
+        ELEMENT_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {SUBMIT, "doChangeTrust", l10n("changeTrustButton")});
     HTMLNode changeTrustLevelSelect =
         peerForm.addChild(
-            "select", new String[] {"id", "name"}, new String[] {"changeTrust", "changeTrust"});
+            ELEMENT_SELECT, new String[] {"id", "name"}, new String[] {CHANGE_TRUST, CHANGE_TRUST});
     for (FRIEND_TRUST trust : FRIEND_TRUST.valuesBackwards()) {
       changeTrustLevelSelect.addChild(
-          "option", "value", trust.name(), l10n("peerTrust." + trust.name()));
+          ELEMENT_OPTION, ATTR_VALUE, trust.name(), l10n("peerTrust." + trust.name()));
     }
     peerForm.addChild("br");
     peerForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"submit", "doChangeVisibility", l10n("changeVisibilityButton")});
+        ELEMENT_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {SUBMIT, "doChangeVisibility", l10n("changeVisibilityButton")});
     HTMLNode changeVisibilitySelect =
         peerForm.addChild(
-            "select",
+            ELEMENT_SELECT,
             new String[] {"id", "name"},
-            new String[] {"changeVisibility", "changeVisibility"});
+            new String[] {CHANGE_VISIBILITY, CHANGE_VISIBILITY});
     for (FRIEND_VISIBILITY trust : FRIEND_VISIBILITY.values()) {
       changeVisibilitySelect.addChild(
-          "option", "value", trust.name(), l10n("peerVisibility." + trust.name()));
+          ELEMENT_OPTION, ATTR_VALUE, trust.name(), l10n("peerVisibility." + trust.name()));
     }
   }
 
+  /**
+   * Return the localized heading that labels the darknet friends table.
+   *
+   * <p>The title is intentionally short to keep table layouts compact while still providing clear
+   * context when embedded inside larger pages or infoboxes. It is reused by multiple rendering
+   * paths so the same wording appears in both standard and advanced layouts, reducing localization
+   * overhead and preserving consistency when the table is refreshed after POST actions.
+   *
+   * @return localized string representing the section title for friends.
+   */
   @Override
   protected String getPeerListTitle() {
     return l10n("myFriends");
   }
 
+  /**
+   * State that the toadlet processes POST requests containing friend references.
+   *
+   * <p>Returning {@code true} allows the base class to accept reference submissions alongside the
+   * other actions handled here, enabling a single endpoint to cover both add-friend and bulk
+   * maintenance flows. This keeps user bookmarks stable and ensures any CSRF protections or
+   * authentication checks configured on the friends endpoint automatically apply to noderef
+   * submissions as well.
+   *
+   * @return {@code true}, enabling noderef POST handling by the superclass.
+   */
   @Override
   protected boolean acceptRefPosts() {
     return true;
   }
 
+  /**
+   * Provide the redirect target used after completing POST actions.
+   *
+   * <p>Using a single canonical location ensures browsers follow a standard post-redirect-get
+   * cycle, preventing form resubmission warnings and keeping the navigation consistent with the
+   * friends table URL. It also centralizes cache headers and content negotiation on one endpoint,
+   * simplifying upstream proxy configuration and logging.
+   *
+   * @return canonical friends path used for redirect responses.
+   */
   @Override
   protected String defaultRedirectLocation() {
-    return "/friends/"; // FIXME
+    return path();
   }
 
   /**
-   * Implement other post actions than adding nodes.
+   * Implement POST-side actions that are not covered by noderef submission.
    *
-   * @throws IOException
-   * @throws ToadletContextClosedException
-   * @throws RedirectException
+   * <p>The handler orchestrates bulk operations based on the submitted form parts: sending
+   * confidential messages, toggling routing flags, updating trust or visibility, removing peers,
+   * and handling transfer confirmations. Unrecognized submissions fall back to the GET view to
+   * avoid user-visible errors. The method assumes form inputs follow the conventions established by
+   * {@link #drawPeerActionSelectBox(HTMLNode, boolean)}.
+   *
+   * @param uri request URI used for contextual redirects after processing.
+   * @param request multipart request containing action flags and selected peer identifiers.
+   * @param ctx toadlet context that supplies page makers and is used to issue redirects.
+   * @param logMINOR whether minor events should be logged by the superclass hooks.
+   * @throws IOException if writing responses or redirects fails mid-stream.
+   * @throws ToadletContextClosedException if the client disconnects while a reply is generated.
+   * @throws RedirectException if the superclass chooses to redirect during fallback handling.
    */
   @Override
   protected void handleAltPost(URI uri, HTTPRequest request, ToadletContext ctx, boolean logMINOR)
       throws ToadletContextClosedException, IOException, RedirectException {
     if (request.isPartSet("doSendMessageToPeers")) {
-      PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessageTitle"), ctx);
-      HTMLNode contentNode = page.getContentNode();
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      HashMap<String, String> peers = new HashMap<>();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          String peer_name = pn.getName();
-          String peer_hash = String.valueOf(pn.hashCode());
-          if (!peers.containsKey(peer_hash)) {
-            peers.put(peer_hash, peer_name);
-          }
-        }
-      }
-      N2NTMToadlet.createN2NTMSendForm(ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
-      writeHTMLReply(ctx, 200, "OK", page.generate());
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("update_notes")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
+      handleSendMessageToPeers(request, ctx);
+      return;
+    }
 
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("peerPrivateNote_" + pn.hashCode())) {
-          if (!request
-              .getPartAsStringFailsafe("peerPrivateNote_" + pn.hashCode(), 250)
-              .equals(pn.getPrivateDarknetCommentNote())) {
-            pn.setPrivateDarknetCommentNote(
-                request.getPartAsStringFailsafe("peerPrivateNote_" + pn.hashCode(), 250));
-          }
-        }
+    if (request.isPartSet(DO_ACTION)) {
+      String action = request.getPartAsStringFailsafe(ACTION, 25);
+      if (handleDoAction(action, request, ctx)) {
+        return;
       }
-      redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("enable")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
+    }
 
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.enablePeer();
-        }
-      }
+    if (request.isPartSet(CHANGE_TRUST) && request.isPartSet("doChangeTrust")) {
+      handleChangeTrust(request);
       redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("disable")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
+      return;
+    }
 
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.disablePeer();
-        }
-      }
+    if (request.isPartSet(CHANGE_VISIBILITY) && request.isPartSet("doChangeVisibility")) {
+      handleChangeVisibility(request);
       redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("set_burst_only")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
+      return;
+    }
 
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setBurstOnly(true);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("clear_burst_only")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
+    if (request.isPartSet(REMOVE)) {
+      handleRemove(request, ctx);
+      return;
+    }
 
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setBurstOnly(false);
-        }
-      }
+    if (request.isPartSet("acceptTransfer")) {
+      handleTransfer(request, true);
       redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("set_ignore_source_port")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
+      return;
+    }
 
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setIgnoreSourcePort(true);
-        }
-      }
+    if (request.isPartSet("rejectTransfer")) {
+      handleTransfer(request, false);
       redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("clear_ignore_source_port")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
+      return;
+    }
 
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setIgnoreSourcePort(false);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("clear_dont_route")) {
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setRoutingStatus(true, true);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("set_dont_route")) {
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setRoutingStatus(false, true);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("set_listen_only")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
+    this.handleMethodGET(uri, new HTTPRequestImpl(uri, "GET"), ctx);
+  }
 
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setListenOnly(true);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("clear_listen_only")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
-
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setListenOnly(false);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("set_allow_local")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
-
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setAllowLocalAddresses(true);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("doAction")
-        && request.getPartAsStringFailsafe("action", 25).equals("clear_allow_local")) {
-      // int hashcode = Integer.decode(request.getParam("node")).intValue();
-
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setAllowLocalAddresses(false);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("changeTrust") && request.isPartSet("doChangeTrust")) {
-      FRIEND_TRUST trust = FRIEND_TRUST.valueOf(request.getPartAsStringFailsafe("changeTrust", 10));
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setTrustLevel(trust);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("changeVisibility") && request.isPartSet("doChangeVisibility")) {
-      FRIEND_VISIBILITY trust =
-          FRIEND_VISIBILITY.valueOf(request.getPartAsStringFailsafe("changeVisibility", 10));
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          pn.setVisibility(trust);
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("remove")
-        || (request.isPartSet("doAction")
-            && request.getPartAsStringFailsafe("action", 25).equals("remove"))) {
-      if (LOG.isDebugEnabled()) LOG.debug("Remove node");
-
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          if ((pn.timeLastConnectionCompleted()
-                  < (System.currentTimeMillis() - 1000 * 60 * 60 * 24 * 7) /* one week */)
-              || (pn.getPeerNodeStatus() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED)
-              || request.isPartSet("forceit")) {
-            this.node.removePeerConnection(pn);
-            if (LOG.isDebugEnabled()) LOG.debug("Removed node: node_" + pn.hashCode());
-          } else {
-            if (LOG.isDebugEnabled())
-              LOG.debug(
-                  "Refusing to remove : node_"
-                      + pn.hashCode()
-                      + " (trying to prevent network churn) : let's display the warning message.");
-            PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmRemoveNodeTitle"), ctx);
-            HTMLNode contentNode = page.getContentNode();
-            HTMLNode content =
-                ctx.getPageMaker()
-                    .getInfobox(
-                        "infobox-warning",
-                        l10n("confirmRemoveNodeWarningTitle"),
-                        contentNode,
-                        "darknet-remove-node",
-                        true);
-            content
-                .addChild("p")
-                .addChild(
-                    "#",
-                    NodeL10n.getBase()
-                        .getString(
-                            "DarknetConnectionsToadlet.confirmRemoveNode",
-                            new String[] {"name"},
-                            new String[] {pn.getName()}));
-            HTMLNode removeForm = ctx.addFormChild(content, "/friends/", "removeConfirmForm");
-            removeForm.addChild(
-                "input",
-                new String[] {"type", "name", "value"},
-                new String[] {"hidden", "node_" + pn.hashCode(), "remove"});
-            removeForm.addChild(
-                "input",
-                new String[] {"type", "name", "value"},
-                new String[] {"submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel")});
-            removeForm.addChild(
-                "input",
-                new String[] {"type", "name", "value"},
-                new String[] {"submit", "remove", l10n("remove")});
-            removeForm.addChild(
-                "input",
-                new String[] {"type", "name", "value"},
-                new String[] {"hidden", "forceit", l10n("forceRemove")});
-
-            writeHTMLReply(ctx, 200, "OK", page.generate());
-            return; // FIXME: maybe it breaks multi-node removing
-          }
-        } else {
-          if (LOG.isDebugEnabled()) LOG.debug("Part not set: node_" + pn.hashCode());
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("acceptTransfer")) {
-      // FIXME this is ugly, should probably move both this code and the PeerNode code somewhere.
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          long id =
-              Long.parseLong(
-                  request.getPartAsStringFailsafe("id", 32)); // FIXME handle NumberFormatException
-          pn.acceptTransfer(id);
-          break;
-        }
-      }
-      redirectHere(ctx);
-    } else if (request.isPartSet("rejectTransfer")) {
-      // FIXME this is ugly, should probably move both this code and the PeerNode code somewhere.
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          long id =
-              Long.parseLong(
-                  request.getPartAsStringFailsafe("id", 32)); // FIXME handle NumberFormatException
-          pn.rejectTransfer(id);
-          break;
-        }
-      }
-      redirectHere(ctx);
+  private void handleTransfer(HTTPRequest request, boolean acceptTransfer) {
+    Long transferId = parseTransferId(request);
+    if (transferId == null) {
+      return;
+    }
+    DarknetPeerNode peer = findFirstSelectedPeer(request);
+    if (peer == null) {
+      return;
+    }
+    if (acceptTransfer) {
+      peer.acceptTransfer(transferId);
     } else {
-      this.handleMethodGET(uri, new HTTPRequestImpl(uri, "GET"), ctx);
+      peer.rejectTransfer(transferId);
     }
   }
 
+  private Long parseTransferId(HTTPRequest request) {
+    String idPart = request.getPartAsStringFailsafe("id", 32);
+    try {
+      return Long.parseLong(idPart);
+    } catch (NumberFormatException e) {
+      if (LOG.isWarnEnabled()) {
+        LOG.warn("Invalid transfer id: {}", idPart);
+      }
+      return null;
+    }
+  }
+
+  private DarknetPeerNode findFirstSelectedPeer(HTTPRequest request) {
+    for (DarknetPeerNode pn : node.getDarknetConnections()) {
+      if (request.isPartSet(NODE_PREFIX + pn.hashCode())) {
+        return pn;
+      }
+    }
+    return null;
+  }
+
+  private void handleChangeVisibility(HTTPRequest request) {
+    FRIEND_VISIBILITY visibility =
+        FRIEND_VISIBILITY.valueOf(request.getPartAsStringFailsafe(CHANGE_VISIBILITY, 10));
+    forSelectedPeers(request, pn -> pn.setVisibility(visibility));
+  }
+
+  private void handleChangeTrust(HTTPRequest request) {
+    FRIEND_TRUST trust = FRIEND_TRUST.valueOf(request.getPartAsStringFailsafe(CHANGE_TRUST, 10));
+    forSelectedPeers(request, pn -> pn.setTrustLevel(trust));
+  }
+
+  private boolean handleDoAction(String action, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if ("update_notes".equals(action)) {
+      handleUpdateNotes(request);
+      redirectHere(ctx);
+      return true;
+    }
+
+    Consumer<DarknetPeerNode> peerAction = SIMPLE_ACTIONS.get(action);
+    if (peerAction != null) {
+      forSelectedPeers(request, peerAction);
+      redirectHere(ctx);
+      return true;
+    }
+
+    if (REMOVE.equals(action)) {
+      handleRemove(request, ctx);
+      return true;
+    }
+
+    return false;
+  }
+
+  private void handleRemove(HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if (LOG.isDebugEnabled()) LOG.debug("Remove node");
+
+    for (DarknetPeerNode pn : node.getDarknetConnections()) {
+      if (!request.isPartSet(NODE_PREFIX + pn.hashCode())) {
+        if (LOG.isDebugEnabled()) LOG.debug("Part not set: node_{}", pn.hashCode());
+      } else if (shouldRemovePeer(pn, request)) {
+        node.removePeerConnection(pn);
+        if (LOG.isDebugEnabled()) LOG.debug("Removed node: node_{}", pn.hashCode());
+      } else {
+        showRemovalConfirmation(ctx, pn);
+        return;
+      }
+    }
+    redirectHere(ctx);
+  }
+
+  private void showRemovalConfirmation(ToadletContext ctx, DarknetPeerNode pn)
+      throws ToadletContextClosedException, IOException {
+    PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmRemoveNodeTitle"), ctx);
+    HTMLNode contentNode = page.getContentNode();
+    HTMLNode content =
+        ctx.getPageMaker()
+            .getInfobox(
+                "infobox-warning",
+                l10n("confirmRemoveNodeWarningTitle"),
+                contentNode,
+                "darknet-remove-node",
+                true);
+    content
+        .addChild("p")
+        .addChild(
+            "#",
+            NodeL10n.getBase()
+                .getString(
+                    "DarknetConnectionsToadlet.confirmRemoveNode",
+                    new String[] {"name"},
+                    new String[] {pn.getName()}));
+    HTMLNode removeForm = ctx.addFormChild(content, path(), "removeConfirmForm");
+    removeForm.addChild(
+        ELEMENT_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {"hidden", NODE_PREFIX + pn.hashCode(), REMOVE});
+    removeForm.addChild(
+        ELEMENT_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {SUBMIT, "cancel", NodeL10n.getBase().getString("Toadlet.cancel")});
+    removeForm.addChild(
+        ELEMENT_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {SUBMIT, REMOVE, l10n(REMOVE)});
+    removeForm.addChild(
+        ELEMENT_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {"hidden", "forceit", l10n("forceRemove")});
+
+    writeHTMLReply(ctx, 200, "OK", page.generate());
+  }
+
+  private boolean shouldRemovePeer(DarknetPeerNode pn, HTTPRequest request) {
+    long oneWeekAgo = System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 7;
+    return pn.timeLastConnectionCompleted() < oneWeekAgo
+        || (pn.getPeerNodeStatus() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED)
+        || request.isPartSet("forceit");
+  }
+
+  private void handleUpdateNotes(HTTPRequest request) {
+    for (DarknetPeerNode pn : node.getDarknetConnections()) {
+      String partName = PEER_PRIVATE_NOTE_PREFIX + pn.hashCode();
+      if (!request.isPartSet(partName)) {
+        continue;
+      }
+      String newNote = request.getPartAsStringFailsafe(partName, 250);
+      if (!newNote.equals(pn.getPrivateDarknetCommentNote())) {
+        pn.setPrivateDarknetCommentNote(newNote);
+      }
+    }
+  }
+
+  private void forSelectedPeers(HTTPRequest request, Consumer<DarknetPeerNode> action) {
+    for (DarknetPeerNode pn : node.getDarknetConnections()) {
+      if (request.isPartSet(NODE_PREFIX + pn.hashCode())) {
+        action.accept(pn);
+      }
+    }
+  }
+
+  private void handleSendMessageToPeers(HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessageTitle"), ctx);
+    HTMLNode contentNode = page.getContentNode();
+    HashMap<String, String> peers = new HashMap<>();
+    for (DarknetPeerNode pn : node.getDarknetConnections()) {
+      String nodePart = NODE_PREFIX + pn.hashCode();
+      if (request.isPartSet(nodePart)) {
+        String peerHash = String.valueOf(pn.hashCode());
+        peers.putIfAbsent(peerHash, pn.getName());
+      }
+    }
+    N2NTMToadlet.createN2NTMSendForm(ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
+    writeHTMLReply(ctx, 200, "OK", page.generate());
+  }
+
   private void redirectHere(ToadletContext ctx) throws ToadletContextClosedException, IOException {
-    MultiValueTable<String, String> headers = MultiValueTable.from("Location", "/friends/");
+    MultiValueTable<String, String> headers = MultiValueTable.from("Location", FRIENDS_PATH);
     ctx.sendReplyHeaders(302, "Found", headers, null, 0);
   }
 
+  /**
+   * Identify the scope of this toadlet as darknet-only rather than opennet.
+   *
+   * <p>The return value informs the parent class which set of peers to query and which UI labels to
+   * present. Returning {@code false} ensures opennet-specific options never appear on the friends
+   * page.
+   *
+   * @return {@code false} because opennet peers are not handled here.
+   */
   @Override
   protected boolean isOpennet() {
     return false;
   }
 
+  /**
+   * Provide additional column headers appended after the standard set.
+   *
+   * <p>Darknet connections do not require trailing columns beyond those defined in the base class,
+   * so this implementation returns an empty array. Advanced mode status does not influence the
+   * outcome, preserving a consistent column layout.
+   *
+   * @param advancedMode whether advanced mode is enabled for the current render.
+   * @return an empty array, indicating no extra headers are added.
+   */
   @Override
   SimpleColumn[] endColumnHeaders(boolean advancedMode) {
-    return null;
+    return new SimpleColumn[0];
   }
 
+  /**
+   * Expose the URL path handled by this toadlet for routing purposes.
+   *
+   * <p>The path is shared across GET and POST handlers so form actions and links consistently
+   * resolve to the friends' endpoint. Centralizing the path string here avoids duplication in
+   * templates and makes it easy for callers to build absolute links when issuing redirects or
+   * constructing downloadable noderef URLs.
+   *
+   * @return {@code "/friends/"}, the canonical path for darknet friend management.
+   */
   @Override
   public String path() {
-    return "/friends/";
+    return FRIENDS_PATH;
   }
 
+  /**
+   * Render the friends page or serve a peer noderef download when requested.
+   *
+   * <p>The method first checks whether the URI targets a specific friend reference ending in {@code
+   * .fref}; if so, it streams the sanitized reference as an attachment. Otherwise, it defers to the
+   * superclass to build the full darknet connections page. Callers are expected to provide a fully
+   * populated {@link HTTPRequest} even when serving downloads so that advanced mode decisions
+   * remain consistent.
+   *
+   * @param uri request URI to inspect for friend reference downloads.
+   * @param request HTTP request wrapper carrying query parameters and advanced-mode state.
+   * @param ctx toadlet context used to write the HTML page or attachment response.
+   * @throws ToadletContextClosedException if the client disconnects during output.
+   * @throws IOException if streaming the response fails.
+   * @throws RedirectException if the superclass initiates a redirect during page handling.
+   */
   @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
@@ -596,48 +865,58 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
 
   private boolean tryHandlePeerNoderef(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    String path = uri.getPath();
-    if (path.endsWith(".fref") && path.startsWith(path() + "friend-")) {
-      // Get noderef for a peer
-      String input_hashcode_string = path.substring((path() + "friend-").length());
-      input_hashcode_string =
-          input_hashcode_string.substring(0, input_hashcode_string.length() - ".fref".length());
-      int input_hashcode;
-      try {
-        input_hashcode = Integer.parseInt(input_hashcode_string);
-      } catch (NumberFormatException e) {
-        // ignore here, handle below
-        return false;
-      }
-      String peernode_name = null;
-      SimpleFieldSet fs = null;
-      if (input_hashcode != -1) {
-        DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-        for (DarknetPeerNode pn : peerNodes) {
-          int peer_hashcode = pn.hashCode();
-          if (peer_hashcode == input_hashcode) {
-            peernode_name = pn.getName();
-            fs = pn.getFullNoderef();
-            break;
-          }
-        }
-      }
-
-      if (fs == null) return false;
-      String filename = FileUtil.sanitizeFileNameWithExtras(peernode_name + ".fref", "\" ");
-      String content = fs.toString();
-      MultiValueTable<String, String> extraHeaders =
-          MultiValueTable.from(
-              // Force download to disk
-              "Content-Disposition", "attachment; filename=" + filename);
-      this.writeReply(ctx, 200, "application/x-freenet-reference", "OK", extraHeaders, content);
-      return true;
-    } else return false;
+    if (request == null) {
+      return false;
+    }
+    return tryHandlePeerNoderef(uri, ctx);
   }
 
-  @Override
-  public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
-      throws ToadletContextClosedException, IOException, RedirectException, ConfigException {
-    super.handleMethodPOST(uri, request, ctx);
+  private boolean tryHandlePeerNoderef(URI uri, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    String path = uri.getPath();
+    if (!path.endsWith(FREF_SUFFIX) || !path.startsWith(path() + FRIEND_PREFIX)) {
+      return false;
+    }
+
+    String inputHashcodeString = path.substring((path() + FRIEND_PREFIX).length());
+    inputHashcodeString =
+        inputHashcodeString.substring(0, inputHashcodeString.length() - FREF_SUFFIX.length());
+    int inputHashcode = parseHashcode(inputHashcodeString);
+    if (inputHashcode == -1) {
+      return false;
+    }
+
+    DarknetPeerNode peerNode = findPeerByHashcode(inputHashcode);
+    if (peerNode == null) {
+      return false;
+    }
+
+    SimpleFieldSet fs = peerNode.getFullNoderef();
+    if (fs == null) return false;
+    String filename = FileUtil.sanitizeFileNameWithExtras(peerNode.getName() + FREF_SUFFIX, "\" ");
+    String content = fs.toString();
+    MultiValueTable<String, String> extraHeaders =
+        MultiValueTable.from(
+            // Force download to disk
+            "Content-Disposition", "attachment; filename=" + filename);
+    this.writeReply(ctx, 200, "application/x-freenet-reference", "OK", extraHeaders, content);
+    return true;
+  }
+
+  private int parseHashcode(String inputHashcodeString) {
+    try {
+      return Integer.parseInt(inputHashcodeString);
+    } catch (NumberFormatException e) {
+      return -1;
+    }
+  }
+
+  private DarknetPeerNode findPeerByHashcode(int targetHashcode) {
+    for (DarknetPeerNode peerNode : node.getDarknetConnections()) {
+      if (peerNode.hashCode() == targetHashcode) {
+        return peerNode;
+      }
+    }
+    return null;
   }
 }

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -41,9 +41,8 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     }
 
     @Override
-    protected int customCompare(
-        PeerNodeStatus firstNode, PeerNodeStatus secondNode, String sortBy) {
-      switch (sortBy) {
+    protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+      switch (this.sortBy) {
         case "name":
           return ((DarknetPeerNodeStatus) firstNode)
               .getName()
@@ -67,7 +66,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
               .getTheirVisibility()
               .compareTo(((DarknetPeerNodeStatus) secondNode).getTheirVisibility());
         default:
-          return super.customCompare(firstNode, secondNode, sortBy);
+          return super.customCompare(firstNode, secondNode);
       }
     }
 

--- a/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -110,15 +110,14 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
     }
 
     @Override
-    protected int customCompare(
-        PeerNodeStatus firstNode, PeerNodeStatus secondNode, String sortBy) {
-      if (sortBy.equals("successTime")) {
+    protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+      if (this.sortBy.equals("successTime")) {
         long t1 = ((OpennetPeerNodeStatus) firstNode).timeLastSuccess;
         long t2 = ((OpennetPeerNodeStatus) secondNode).timeLastSuccess;
         if (t1 > t2) return reversed ? 1 : -1;
         else if (t2 > t1) return reversed ? -1 : 1;
       }
-      return super.customCompare(firstNode, secondNode, sortBy);
+      return super.customCompare(firstNode, secondNode);
     }
   }
 

--- a/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -1,10 +1,7 @@
 package network.crypta.clients.http;
 
-import java.io.IOException;
-import java.net.URI;
 import java.util.Comparator;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.config.ConfigException;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
@@ -13,50 +10,158 @@ import network.crypta.node.PeerNodeStatus;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.TimeUtil;
-import network.crypta.support.api.HTTPRequest;
 
+/**
+ * Toadlet that renders the opennet peer list for the FProxy UI, focusing on anonymous stranger
+ * connections rather than trust-based friend links. It delegates common table layout to the {@link
+ * ConnectionsToadlet} base while stripping features that depend on identities, such as names or
+ * user-supplied notes. The handler exposes a noderef box only in advanced mode, surfaces the
+ * last-success metric for troubleshooting, and otherwise provides a minimal, read-only view of
+ * current opennet connectivity. It assumes the surrounding node keeps peer status up to date and is
+ * enabled for opennet operation.
+ *
+ * <p>Typical callers rely on the base routing that maps {@link #path()} to the stranger list. The
+ * instance is stateless between requests: it reads fresh peer snapshots for each render and does
+ * not cache noderefs or per-peer actions. The table is intentionally sparse to discourage behavior
+ * that could deanonymize peers or encourage targeted management.
+ *
+ * <p>Thread-safety mirrors the base toadlet: instances are expected to be used on the request
+ * thread managed by the HTTP layer, and no shared mutable state is introduced here. It is suitable
+ * for multithreaded servlet environments as long as the injected {@link Node} and supporting
+ * collaborators are themselves thread-safe.
+ */
 public class OpennetConnectionsToadlet extends ConnectionsToadlet implements LinkEnabledCallback {
 
+  /**
+   * Builds an opennet-specific toadlet using the shared node components required to render peer
+   * state. Callers supply the node, client core, and a high-level client wrapper; the constructor
+   * merely stores them for the base class without adding additional side effects. The instance can
+   * be created eagerly during UI wiring because it defers all data retrieval to per-request
+   * handlers, avoiding heavy startup costs.
+   *
+   * @param n node that owns the peer set and opennet configuration; must remain reachable
+   *     throughout the toadlet lifetime.
+   * @param core client core used by the base toadlet for noderef export and related helpers; not
+   *     null when opennet is enabled.
+   * @param client high-level client for UI links and redirects; expected to be configured for
+   *     opennet-safe operations.
+   */
   protected OpennetConnectionsToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
     super(n, core, client);
   }
 
+  /**
+   * Suppresses name rendering for opennet peers because identities are intentionally unavailable.
+   * This override keeps the table layout consistent with the base class while ensuring no empty
+   * cells or misleading headings are produced when names cannot be derived safely.
+   *
+   * @param peerRow table row node that would normally receive the name cell output.
+   * @param peerNodeStatus status snapshot for the peer whose row is being rendered in the table.
+   * @param advanced whether advanced UI mode is active; retained for signature compatibility only.
+   */
   @Override
   protected void drawNameColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advanced) {
     // Do nothing - no names on opennet
   }
 
+  /**
+   * Disables the private-note column because the opennet model lacks user-managed trust metadata.
+   * Keeping this method as a no-op prevents accidental rendering of fields that would suggest
+   * mutable annotations on strangers, which the UI and persistence layers do not support.
+   *
+   * @param peerRow table row node for the current peer being rendered in the list view.
+   * @param peerNodeStatus status object describing connectivity and performance for the peer.
+   * @param fProxyJavascriptEnabled flag indicating whether JavaScript helpers are available in the
+   *     browser session; unused because the column is suppressed unconditionally.
+   */
   @Override
   protected void drawPrivateNoteColumn(
       HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled) {
     // Do nothing - no private notes either (no such thing as negative trust in cyberspace)
   }
 
+  /**
+   * Indicates that the opennet table omits the name column entirely.
+   *
+   * <p>Opennet peers present only cryptographic identifiers, so exposing a name column would either
+   * remain blank or mislead users into thinking a stable label exists. Keeping this flag false also
+   * simplifies column counts elsewhere in the table layout and prevents localization strings for
+   * names from being loaded unnecessarily.
+   *
+   * @return always {@code false} because opennet peers are not associated with human-readable
+   *     names.
+   */
   @Override
   protected boolean hasNameColumn() {
     return false;
   }
 
+  /**
+   * Reports that the private note column is unavailable for opennet peers.
+   *
+   * <p>The design intentionally removes ad hoc annotations on strangers to reduce risk of leaking
+   * identifiable hints or encouraging user-managed reputation for anonymous participants.
+   * Downstream renderers and CSV exporters can rely on this flag to avoid allocating unused cells
+   * or headers and to align other columns correctly when opennet mode is active.
+   *
+   * @return always {@code false} because private annotations are not supported in opennet mode.
+   */
   @Override
   protected boolean hasPrivateNoteColumn() {
     return false;
   }
 
+  /**
+   * Exports the public opennet noderef from the hosting node so that advanced users can copy it.
+   * The returned field set reflects the node's current opennet identity and is fetched fresh for
+   * each request to avoid stale values.
+   *
+   * @return field set containing the opennet noderef, ready for serialization into the response
+   *     page.
+   */
   @Override
   protected SimpleFieldSet getNoderef() {
     return node.exportOpennetPublicFieldSet();
   }
 
+  /**
+   * Retrieves the current opennet peer status snapshots used to populate the table rows. The caller
+   * controls whether heavy data (such as bandwidth histories) should be excluded to reduce
+   * rendering cost when the page is not in advanced mode.
+   *
+   * @param noHeavy when {@code true}, request lightweight status objects that omit expensive
+   *     metrics to keep UI responses fast.
+   * @return array of {@link PeerNodeStatus} entries describing each opennet peer known to the node;
+   *     never {@code null} but may be empty.
+   */
   @Override
   protected PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
     return node.getPeers().getOpennetPeerNodeStatuses(noHeavy);
   }
 
+  /**
+   * Checks whether opennet support is currently enabled on the hosting node before serving the
+   * toadlet. Requests are only allowed when opennet is active, preventing exposure of partial UI
+   * state while the feature is disabled or unavailable.
+   *
+   * @param ctx HTTP context passed by the caller; used by the base class for permission checks and
+   *     locale selection.
+   * @return {@code true} when opennet is enabled on the node and the page may be rendered.
+   */
   @Override
   public boolean isEnabled(ToadletContext ctx) {
     return node.isOpennetEnabled();
   }
 
+  /**
+   * Builds the localized page title string, embedding the formatted peer count supplied by the base
+   * class. The title is used by the surrounding FProxy layout and should remain short while still
+   * distinguishing opennet content from friend connections.
+   *
+   * @param titleCountString pre-formatted text representing the current peer counts shown in the
+   *     header.
+   * @return localized title string describing the opennet connections page with embedded counts.
+   */
   @Override
   protected String getPageTitle(String titleCountString) {
     return NodeL10n.getBase()
@@ -66,11 +171,26 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
             new String[] {titleCountString});
   }
 
+  /**
+   * Determines whether to show the noderef export box. The box is only shown when advanced mode is
+   * enabled to avoid overwhelming casual users and to reduce accidental sharing of noderefs.
+   *
+   * @param advancedModeEnabled {@code true} when the UI is in advanced mode, typically toggled by
+   *     the user.
+   * @return {@code true} if the noderef box should be displayed for the current request.
+   */
   @Override
   protected boolean shouldDrawNoderefBox(boolean advancedModeEnabled) {
     return advancedModeEnabled;
   }
 
+  /**
+   * Indicates that per-peer action controls are hidden for opennet peers. The opennet model makes
+   * peer-specific management ineffective because peers can reconnect with fresh identities, and the
+   * UI avoids exposing controls that could be misused for targeted spam.
+   *
+   * @return always {@code false}, meaning no action box is rendered for any peer row.
+   */
   @Override
   protected boolean showPeerActionsBox() {
     // No per-peer actions supported on opennet - there's no point, they'll only reconnect,
@@ -78,37 +198,108 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
     return false;
   }
 
+  /**
+   * Omits the peer action select box because opennet peers do not support direct actions. The
+   * method remains to satisfy the base class contract and to document why the UI intentionally
+   * leaves this area blank.
+   *
+   * @param peerForm table row form node that would ordinarily host action controls for the peer.
+   * @param advancedModeEnabled flag indicating advanced mode; unused because the box is always
+   *     suppressed.
+   */
   @Override
   protected void drawPeerActionSelectBox(HTMLNode peerForm, boolean advancedModeEnabled) {
     // Do nothing, see showPeerActionsBox().
   }
 
+  /**
+   * Supplies the localized title for the opennet peers list. The title appears above the table and
+   * clarifies that entries correspond to stranger connections rather than friend nodes.
+   *
+   * <p>Localization is resolved on each request so the title reflects the active language choice of
+   * the current user, and separating the text from code keeps the wording aligned with the rest of
+   * the UI. The returned string is short to fit within common header constraints while remaining
+   * distinct from friend connection screens.
+   *
+   * @return localized list title pulled from the node localization bundle.
+   */
   @Override
   protected String getPeerListTitle() {
     return NodeL10n.getBase().getString("OpennetConnectionsToadlet.peersListTitle");
   }
 
+  /**
+   * Accepts posted noderefs so opennet peers can be added from the web interface. The base class
+   * uses this flag to determine whether to parse and handle submission payloads on this toadlet.
+   * Accepting posts keeps the page functional for bootstrap and manual additions where peers share
+   * their references out-of-band, while still letting higher layers enforce authentication and CSRF
+   * protections applicable to FProxy forms.
+   *
+   * @return {@code true} to allow noderef form submissions for opennet stranger connections.
+   */
   @Override
   protected boolean acceptRefPosts() {
     return true;
   }
 
+  /**
+   * Provides the redirect target used when the toadlet needs to bounce the user after processing a
+   * form or encountering an error. It always returns the opennet landing path to keep navigation
+   * consistent.
+   *
+   * <p>Using a fixed location avoids leaking intermediate URLs and reduces the chance of confusing
+   * users with partial states after submitting a noderef. The target matches the canonical entry
+   * point of this page so refreshed state is immediately visible after the redirect completes.
+   *
+   * @return fixed redirect path {@code "/opennet/"} for opennet UI flows.
+   */
   @Override
   protected String defaultRedirectLocation() {
     return "/opennet/";
   }
 
+  /**
+   * Identifies this toadlet as serving opennet content. The base class uses this to branch between
+   * friend and stranger behaviors when shared hooks are invoked.
+   *
+   * <p>Returning a hardcoded {@code true} keeps downstream logic simple: caching layers, menu
+   * builders, and link helpers can specialize styling or wording without re-inspecting the class
+   * hierarchy. This method should remain consistent with {@link #path()} and other opennet-specific
+   * toggles.
+   *
+   * @return always {@code true} to mark the opennet flavor of the connections page.
+   */
   @Override
   protected boolean isOpennet() {
     return true;
   }
 
+  /**
+   * Comparator tailored to opennet peers that optionally prioritizes the time of last successful
+   * communication. It augments the base {@link ComparatorByStatus} sorting logic with opennet-only
+   * metrics while preserving support for reversed ordering when requested by the caller.
+   *
+   * <p>The comparator is created per request to encapsulate the active sort key and direction,
+   * ensuring thread-safety and allowing multiple concurrent sorts without shared mutable state.
+   */
   protected class OpennetComparator extends ComparatorByStatus {
 
     OpennetComparator(String sortBy, boolean reversed) {
       super(sortBy, reversed);
     }
 
+    /**
+     * Adds custom comparison for the {@code successTime} sort key by inspecting the
+     * opennet-specific last-success timestamps. When the key does not match, the method falls back
+     * to the base comparator behavior, preserving existing ordering semantics for other columns.
+     *
+     * @param firstNode first peer node considered by the comparison routine; expected to be an
+     *     {@link OpennetPeerNodeStatus} instance.
+     * @param secondNode second peer node considered by the comparison routine; expected to be an
+     *     {@link OpennetPeerNodeStatus} instance.
+     * @return negative, zero, or positive according to the configured ordering and reversal flag,
+     *     using last-success timestamps when available.
+     */
     @Override
     protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
       if (this.sortBy.equals("successTime")) {
@@ -121,14 +312,33 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
     }
   }
 
+  /**
+   * Creates the comparator to be used for sorting the opennet peer list. The method instantiates a
+   * fresh {@link OpennetComparator} so caller-specific sort keys and directions do not interfere
+   * across requests or threads.
+   *
+   * @param sortBy column identifier specifying which property to sort on, such as {@code
+   *     \"successTime\"}.
+   * @param reversed when {@code true}, invert the natural ordering produced by the comparator.
+   * @return comparator that respects the provided sort key and reversal flag for opennet peers.
+   */
   @Override
   protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
     return new OpennetComparator(sortBy, reversed);
   }
 
+  /**
+   * Defines the trailing columns for the peer table. In advanced mode the method adds a single
+   * column showing the elapsed time since the last successful communication with each peer; in
+   * basic mode it returns an empty array to keep the layout compact.
+   *
+   * @param advancedMode flag indicating whether advanced UI elements should be included in the
+   *     response.
+   * @return array of simple column definitions to append to the table; never {@code null}.
+   */
   @Override
   SimpleColumn[] endColumnHeaders(boolean advancedMode) {
-    if (!advancedMode) return null;
+    if (!advancedMode) return new SimpleColumn[0];
     return new SimpleColumn[] {
       new SimpleColumn() {
 
@@ -163,20 +373,19 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
     };
   }
 
+  /**
+   * Returns the relative path that maps HTTP requests to this toadlet within the FProxy routing
+   * tree. The path is intentionally distinct from friend connections to help users differentiate
+   * stranger links.
+   *
+   * <p>The trailing slash matches existing routing conventions and helps browser refreshes stay on
+   * the same page even when query parameters are stripped. External links and navigation menus
+   * should treat this path as stable while the opennet feature set remains available.
+   *
+   * @return constant path string {@code "/strangers/"} identifying the opennet connections page.
+   */
   @Override
   public String path() {
     return "/strangers/";
-  }
-
-  @Override
-  public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
-      throws ToadletContextClosedException, IOException, RedirectException {
-    super.handleMethodGET(uri, request, ctx);
-  }
-
-  @Override
-  public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
-      throws ToadletContextClosedException, IOException, RedirectException, ConfigException {
-    super.handleMethodPOST(uri, request, ctx);
   }
 }

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -1,0 +1,246 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.node.DarknetPeerNodeStatus;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class DarknetConnectionsToadletTest {
+
+  @Mock private Node node;
+  @Mock private NodeClientCore core;
+  @Mock private HighLevelSimpleClient client;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
+
+  private DarknetConnectionsToadlet toadlet;
+
+  @BeforeEach
+  void setUp() {
+    toadlet = new DarknetConnectionsToadlet(node, core, client);
+    Mockito.lenient().when(request.isPartSet(anyString())).thenReturn(false);
+  }
+
+  @Test
+  void comparator_nameSort_respectsCaseInsensitiveAndReversed() {
+    DarknetConnectionsToadlet.DarknetComparator comparator =
+        (DarknetConnectionsToadlet.DarknetComparator) toadlet.comparator("name", false);
+    DarknetPeerNodeStatus alice = mock(DarknetPeerNodeStatus.class);
+    DarknetPeerNodeStatus bob = mock(DarknetPeerNodeStatus.class);
+    when(alice.getName()).thenReturn("alice");
+    when(bob.getName()).thenReturn("Bob");
+
+    int result = comparator.compare(alice, bob);
+    assertTrue(result < 0, "alice should sort before Bob ignoring case");
+
+    DarknetConnectionsToadlet.DarknetComparator reversed =
+        (DarknetConnectionsToadlet.DarknetComparator) toadlet.comparator("name", true);
+    int reversedResult = reversed.compare(alice, bob);
+    assertTrue(reversedResult > 0, "reversed comparator should invert ordering");
+  }
+
+  @Test
+  void comparator_visibility_whenOurVisibilityEqual_usesTheirVisibilityAsTieBreaker() {
+    DarknetConnectionsToadlet.DarknetComparator comparator =
+        (DarknetConnectionsToadlet.DarknetComparator) toadlet.comparator("visibility", false);
+
+    DarknetPeerNodeStatus first = mock(DarknetPeerNodeStatus.class);
+    DarknetPeerNodeStatus second = mock(DarknetPeerNodeStatus.class);
+    when(first.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(second.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(first.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.NAME_ONLY);
+    when(second.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.NO);
+
+    int result = comparator.customCompare(first, second);
+
+    assertTrue(result < 0, "NAME_ONLY should sort before NO when our visibility matches");
+  }
+
+  @Test
+  void drawPrivateNoteColumn_whenJavascriptEnabled_includesChangeHandler() {
+    HTMLNode row = new HTMLNode("tr");
+    DarknetPeerNodeStatus status = mock(DarknetPeerNodeStatus.class);
+    when(status.getPrivateDarknetCommentNote()).thenReturn("note");
+    int statusHash = status.hashCode();
+
+    toadlet.drawPrivateNoteColumn(row, status, true);
+
+    String rendered = row.generate();
+    assertTrue(rendered.contains("peerPrivateNote_" + statusHash));
+    assertTrue(rendered.contains("onChange=\"peerNoteChange();\""));
+  }
+
+  @Test
+  void drawPrivateNoteColumn_whenJavascriptDisabled_omitsChangeHandler() {
+    HTMLNode row = new HTMLNode("tr");
+    DarknetPeerNodeStatus status = mock(DarknetPeerNodeStatus.class);
+    when(status.getPrivateDarknetCommentNote()).thenReturn("note");
+    int statusHash = status.hashCode();
+
+    toadlet.drawPrivateNoteColumn(row, status, false);
+
+    String rendered = row.generate();
+    assertTrue(rendered.contains("peerPrivateNote_" + statusHash));
+    assertFalse(rendered.contains("onChange=\"peerNoteChange();\""));
+  }
+
+  @Test
+  void handleAltPost_updateNotes_updatesChangedNotesAndRedirects() throws Exception {
+    DarknetPeerNode peer = mock(DarknetPeerNode.class);
+    when(peer.getPrivateDarknetCommentNote()).thenReturn("old");
+    when(node.getDarknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
+
+    int peerHash = peer.hashCode();
+    when(request.isPartSet("doAction")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("action", 25)).thenReturn("update_notes");
+    when(request.isPartSet("peerPrivateNote_" + peerHash)).thenReturn(true);
+    when(request.getPartAsStringFailsafe("peerPrivateNote_" + peerHash, 250)).thenReturn("new");
+
+    doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    verify(peer).setPrivateDarknetCommentNote("new");
+    assertRedirectIssued();
+  }
+
+  @Test
+  void handleAltPost_enableAction_enablesSelectedPeersAndRedirects() throws Exception {
+    DarknetPeerNode peer = mock(DarknetPeerNode.class);
+    when(node.getDarknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
+
+    int peerHash = peer.hashCode();
+    when(request.isPartSet("doAction")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("action", 25)).thenReturn("enable");
+    when(request.isPartSet("node_" + peerHash)).thenReturn(true);
+
+    doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    verify(peer).enablePeer();
+    assertRedirectIssued();
+  }
+
+  @Test
+  void handleAltPost_removeWithForce_removesPeerAndRedirects() throws Exception {
+    DarknetPeerNode peer = mock(DarknetPeerNode.class);
+    when(peer.timeLastConnectionCompleted()).thenReturn(System.currentTimeMillis());
+    when(peer.getPeerNodeStatus()).thenReturn(0);
+    when(node.getDarknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
+
+    int peerHash = peer.hashCode();
+    when(request.isPartSet("remove")).thenReturn(true);
+    when(request.isPartSet("node_" + peerHash)).thenReturn(true);
+    when(request.isPartSet("forceit")).thenReturn(true);
+
+    doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    verify(node).removePeerConnection(peer);
+    assertRedirectIssued();
+  }
+
+  @Test
+  void tryHandlePeerNoderef_withValidFriendHash_sendsAttachmentResponse() throws Exception {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(false);
+    fieldSet.putSingle("key", "value");
+
+    DarknetPeerNode peer = mock(DarknetPeerNode.class);
+    when(peer.getName()).thenReturn("Friend");
+    when(peer.getFullNoderef()).thenReturn(fieldSet);
+    when(node.getDarknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
+
+    int peerHash = peer.hashCode();
+    URI uri = URI.create("http://localhost/friends/friend-" + peerHash + ".fref");
+
+    doNothing()
+        .when(ctx)
+        .sendReplyHeaders(
+            eq(200), eq("OK"), any(), eq("application/x-freenet-reference"), anyLong(), eq(false));
+    doNothing().when(ctx).writeData(any(byte[].class), eq(0), anyInt());
+
+    boolean handled = invokeTryHandlePeerNoderef(uri);
+
+    assertTrue(handled);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+    ArgumentCaptor<byte[]> bodyCaptor = ArgumentCaptor.forClass(byte[].class);
+
+    int expectedLength = fieldSet.toString().getBytes(StandardCharsets.UTF_8).length;
+    verify(ctx)
+        .sendReplyHeaders(
+            eq(200),
+            eq("OK"),
+            headersCaptor.capture(),
+            eq("application/x-freenet-reference"),
+            eq((long) expectedLength),
+            eq(false));
+    verify(ctx).writeData(bodyCaptor.capture(), eq(0), eq(expectedLength));
+
+    String headerValue = headersCaptor.getValue().getFirst("Content-Disposition");
+    assertEquals("attachment; filename=Friend.fref", headerValue);
+    assertEquals(fieldSet.toString(), new String(bodyCaptor.getValue(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void tryHandlePeerNoderef_withInvalidHash_returnsFalse() throws Exception {
+    URI uri = URI.create("http://localhost/friends/friend-abc.fref");
+
+    boolean handled = invokeTryHandlePeerNoderef(uri);
+
+    assertFalse(handled);
+    verifyNoInteractions(ctx);
+  }
+
+  private boolean invokeTryHandlePeerNoderef(URI uri) throws Exception {
+    Method method =
+        DarknetConnectionsToadlet.class.getDeclaredMethod(
+            "tryHandlePeerNoderef", URI.class, HTTPRequest.class, ToadletContext.class);
+    method.setAccessible(true);
+    return (boolean) method.invoke(toadlet, uri, request, ctx);
+  }
+
+  private void assertRedirectIssued() throws Exception {
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), isNull(), eq(0L));
+    assertEquals("/friends/", headersCaptor.getValue().getFirst("Location"));
+  }
+}

--- a/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
@@ -1,0 +1,234 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Comparator;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.OpennetPeerNodeStatus;
+import network.crypta.node.PeerManager;
+import network.crypta.node.PeerNodeStatus;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class OpennetConnectionsToadletTest {
+
+  @Mock private Node node;
+  @Mock private NodeClientCore core;
+  @Mock private HighLevelSimpleClient client;
+  @Mock private PeerManager peerManager;
+  @Mock private SimpleFieldSet noderef;
+
+  private OpennetConnectionsToadlet toadlet;
+
+  @BeforeEach
+  void setUp() {
+    toadlet = new TestOpennetConnectionsToadlet(node, core, client);
+  }
+
+  @Test
+  void hasNameAndPrivateNoteColumns_disabledForOpennet() {
+    assertFalse(toadlet.hasNameColumn());
+    assertFalse(toadlet.hasPrivateNoteColumn());
+  }
+
+  @Test
+  void getNoderef_delegatesToNodeExport() {
+    when(node.exportOpennetPublicFieldSet()).thenReturn(noderef);
+
+    SimpleFieldSet result = toadlet.getNoderef();
+
+    assertSame(noderef, result);
+    verify(node).exportOpennetPublicFieldSet();
+  }
+
+  @Test
+  void getPeerNodeStatuses_fetchesFromPeerManager() {
+    OpennetPeerNodeStatus[] statuses =
+        new OpennetPeerNodeStatus[] {mock(OpennetPeerNodeStatus.class)};
+    when(node.getPeers()).thenReturn(peerManager);
+    when(peerManager.getOpennetPeerNodeStatuses(false)).thenReturn(statuses);
+
+    PeerNodeStatus[] result = toadlet.getPeerNodeStatuses(false);
+
+    assertSame(statuses, result);
+    verify(node, atLeastOnce()).getPeers();
+    verify(peerManager).getOpennetPeerNodeStatuses(false);
+  }
+
+  @Test
+  void isEnabled_returnsNodeFlag() {
+    when(node.isOpennetEnabled()).thenReturn(true).thenReturn(false);
+
+    assertTrue(toadlet.isEnabled(null));
+    assertFalse(toadlet.isEnabled(null));
+  }
+
+  @Test
+  void shouldDrawNoderefBox_matchesAdvancedMode() {
+    assertTrue(toadlet.shouldDrawNoderefBox(true));
+    assertFalse(toadlet.shouldDrawNoderefBox(false));
+  }
+
+  @Test
+  void peerActionsAndAcceptRefPosts_flagsAreConstant() {
+    assertFalse(toadlet.showPeerActionsBox());
+    assertTrue(toadlet.acceptRefPosts());
+    assertEquals("/opennet/", toadlet.defaultRedirectLocation());
+    assertTrue(toadlet.isOpennet());
+    assertEquals("/strangers/", toadlet.path());
+  }
+
+  @Test
+  void comparator_successTimeOrdersByLastSuccess() {
+    Comparator<PeerNodeStatus> comparator = toadlet.comparator("successTime", false);
+    OpennetConnectionsToadlet.OpennetComparator opennetComparator =
+        (OpennetConnectionsToadlet.OpennetComparator) comparator;
+
+    OpennetPeerNodeStatus newer = statusWithLastSuccess(2000L);
+    OpennetPeerNodeStatus older = statusWithLastSuccess(1000L);
+
+    int result = opennetComparator.customCompare(newer, older);
+
+    assertEquals(-1, result, "Newer success should sort before older by default");
+  }
+
+  @Test
+  void comparator_successTimeHonoursReversedFlag() {
+    OpennetConnectionsToadlet.OpennetComparator comparator =
+        (OpennetConnectionsToadlet.OpennetComparator) toadlet.comparator("successTime", true);
+
+    OpennetPeerNodeStatus newer = statusWithLastSuccess(2000L);
+    OpennetPeerNodeStatus older = statusWithLastSuccess(1000L);
+
+    int result = comparator.customCompare(newer, older);
+
+    assertEquals(1, result, "Reversed comparator should flip ordering");
+  }
+
+  @Test
+  void endColumnHeaders_returnsNullWhenNotAdvanced() {
+    assertEquals(0, toadlet.endColumnHeaders(false).length);
+  }
+
+  @Test
+  void endColumnHeaders_rendersNeverWhenNoSuccess() {
+    OpennetPeerNodeStatus status = statusWithLastSuccess(-1);
+    HTMLNode row = new HTMLNode("tr");
+
+    OpennetConnectionsToadlet.SimpleColumn[] columns = toadlet.endColumnHeaders(true);
+    assertNotNull(columns);
+    columns[0].drawColumn(row, status);
+
+    HTMLNode td = row.getChildren().getFirst();
+    assertEquals("td", td.getName());
+    assertEquals("peer-last-success", td.getAttribute("class"));
+    assertEquals("NEVER", td.getChildren().getFirst().getContent());
+  }
+
+  @Test
+  void endColumnHeaders_rendersFormattedDurationWhenSuccessKnown() {
+    long now = System.currentTimeMillis();
+    OpennetPeerNodeStatus status = statusWithLastSuccess(now - 5000);
+    HTMLNode row = new HTMLNode("tr");
+
+    OpennetConnectionsToadlet.SimpleColumn[] columns = toadlet.endColumnHeaders(true);
+    columns[0].drawColumn(row, status);
+
+    String rendered = row.getChildren().getFirst().getChildren().getFirst().getContent();
+    assertNotNull(rendered);
+    assertNotEquals("NEVER", rendered);
+    assertFalse(rendered.isEmpty());
+  }
+
+  @Test
+  void getPageTitle_usesLocalizationKey() {
+    try (MockedStatic<NodeL10n> mockedStatic = mockStatic(NodeL10n.class)) {
+      BaseL10n l10n = mock(BaseL10n.class);
+      mockedStatic.when(NodeL10n::getBase).thenReturn(l10n);
+      when(l10n.getString(
+              eq("OpennetConnectionsToadlet.fullTitle"),
+              any(String[].class),
+              argThat(values -> Arrays.equals(values, new String[] {"3"}))))
+          .thenReturn("localized");
+
+      String title = toadlet.getPageTitle("3");
+
+      assertEquals("localized", title);
+      mockedStatic.verify(NodeL10n::getBase);
+    }
+  }
+
+  @Test
+  void getPeerListTitle_usesLocalizationKey() {
+    try (MockedStatic<NodeL10n> mockedStatic = mockStatic(NodeL10n.class)) {
+      BaseL10n l10n = mock(BaseL10n.class);
+      mockedStatic.when(NodeL10n::getBase).thenReturn(l10n);
+      when(l10n.getString("OpennetConnectionsToadlet.peersListTitle")).thenReturn("peers");
+
+      assertEquals("peers", toadlet.getPeerListTitle());
+      mockedStatic.verify(NodeL10n::getBase);
+    }
+  }
+
+  private OpennetPeerNodeStatus statusWithLastSuccess(long timestamp) {
+    OpennetPeerNodeStatus status = mock(OpennetPeerNodeStatus.class);
+    setTimeLastSuccess(status, timestamp);
+    return status;
+  }
+
+  private void setTimeLastSuccess(OpennetPeerNodeStatus status, long timestamp) {
+    try {
+      Field field = OpennetPeerNodeStatus.class.getField("timeLastSuccess");
+      field.setAccessible(true);
+      field.setLong(status, timestamp);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Unable to set timeLastSuccess on mock", e);
+    }
+  }
+
+  /** Minimal concrete subclass to expose the protected constructor for testing. */
+  private static final class TestOpennetConnectionsToadlet extends OpennetConnectionsToadlet {
+    TestOpennetConnectionsToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
+      super(n, core, client);
+    }
+
+    @Override
+    public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx) {
+      // Avoid invoking heavy superclass logic during unit tests.
+    }
+
+    @Override
+    public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx) {
+      // Avoid invoking heavy superclass logic during unit tests.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor DarknetConnectionsToadlet to centralize constants, streamline bulk actions, and harden noderef/transfer handling
- add targeted unit tests covering comparator ordering, note updates, bulk actions, and friend noderef downloads
- include spotless formatting updates (OpennetConnectionsToadlet and related test)

## Testing
- not run (not requested)
