### PR TITLE
chore: run spotless on FileInsertWizardToadlet

### DIFF
--- a/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
@@ -13,8 +13,45 @@ import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
+/**
+ * Renders the web-based wizard for inserting a single file into the node and wires the page to the
+ * queue submission endpoints. The toadlet exposes a simple form for casual users and reveals
+ * advanced tuning controls when the caller has enabled expert mode.
+ *
+ * <p>Instances are short-lived per request but maintain minimal state to remember whether the user
+ * last chose a canonical (CHK) or random (SSK) insert key. That hint influences the default
+ * selection on the next page render, improving usability without altering any server-side
+ * guarantees. The class is not thread-safe; callers should create a fresh instance per request
+ * cycle rather than sharing across threads.
+ *
+ * <p>Typical flow:
+ *
+ * <ul>
+ *   <li>{@link #handleMethodGET(URI, HTTPRequest, ToadletContext)} builds the HTML page and
+ *       enforces access rules.
+ *   <li>{@link #reportCanonicalInsert()} or {@link #reportRandomInsert()} record the user’s last
+ *       selection to bias subsequent renders.
+ * </ul>
+ *
+ * <p>The toadlet relies on {@link NodeClientCore} to derive security defaults, {@link PageMaker} to
+ * assemble infoboxes, and the surrounding {@link ToadletContext} for permissions and localization.
+ * It performs no I/O beyond HTML generation and delegates upload handling to queue endpoints.
+ */
 public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallback {
 
+  /**
+   * Creates the toadlet that renders the file-insert wizard for the given client and node core. The
+   * instance keeps only lightweight preferences and is intended to be short-lived; callers
+   * typically construct one per incoming HTTP request or per handler registration. The constructor
+   * does not perform I/O, and all dependencies are assumed to remain valid for the lifetime of the
+   * toadlet. State stored in the instance is not synchronized and should not be shared across
+   * threads without external coordination.
+   *
+   * @param client high-level client used to bind uploads to the current session; never {@code
+   *     null}.
+   * @param clientCore backing node core providing security defaults and queue endpoints; never
+   *     {@code null}.
+   */
   protected FileInsertWizardToadlet(HighLevelSimpleClient client, NodeClientCore clientCore) {
     super(client);
     this.core = clientCore;
@@ -26,38 +63,71 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
   private boolean rememberedLastTime;
   private boolean wasCanonicalLastTime;
 
-  static final String PATH = "/insertfile/";
+  private static final String PATH_SEGMENT = "insertfile";
+  static final String PATH = '/' + PATH_SEGMENT + '/';
 
+  private static final String TAG_INPUT = "input";
+  private static final String TAG_LABEL = "label";
+  private static final String ATTR_VALUE = "value";
+  private static final String INPUT_RADIO = "radio";
+  private static final String INPUT_SUBMIT = "submit";
+  private static final String INPUT_CHECKED = "checked";
+  private static final String INPUT_KEYTYPE = "keytype";
+  private static final String NBSP = " \u00a0 ";
+
+  /**
+   * Returns the HTTP path served by this toadlet.
+   *
+   * @return trailing-slash path segment used to register the wizard endpoint.
+   */
   @Override
   public String path() {
     return PATH;
   }
 
+  /**
+   * Records that the most recent insert used a canonical CHK key so the next rendered form defaults
+   * to the same choice. The hint influences only UI defaults; it does not persist beyond this
+   * instance and does not bypass explicit user selections on later requests. This method only
+   * updates in-memory hints and is safe to call after a successful queue submission.
+   */
   public void reportCanonicalInsert() {
     rememberedLastTime = true;
     wasCanonicalLastTime = true;
   }
 
+  /**
+   * Records that the most recent insert used a random SSK key so subsequent renders bias toward the
+   * same option. The flag affects only default radio-button selection and never forces a key type
+   * when the caller provides explicit form data. State is retained only for the lifetime of this
+   * toadlet instance.
+   */
   public void reportRandomInsert() {
     rememberedLastTime = true;
     wasCanonicalLastTime = false;
   }
 
+  /**
+   * Builds and writes the HTML page for the insert wizard, enforcing gateway and permission rules
+   * before rendering. The page includes basic controls plus optional advanced settings for key
+   * selection, compression, compatibility modes, and splitfile key overrides. When the caller lacks
+   * sufficient privileges, the method returns an unauthorized response instead of rendering the
+   * wizard. It generates only HTML; file uploads are delegated to other toadlets via generated
+   * forms, keeping this handler free of I/O-heavy work.
+   *
+   * @param uri request target used only for consistency checks; expected to match {@link #path()}.
+   * @param request parsed HTTP request carrying headers and query parameters; must not be {@code
+   *     null}.
+   * @param ctx toadlet context supplying localization, permission flags, and form helpers; must not
+   *     be {@code null}.
+   * @throws ToadletContextClosedException if the context is closed while writing the response
+   *     stream.
+   * @throws IOException if output cannot be written to the client or template resources fail to
+   *     load.
+   * @throws RedirectException if access control redirects the caller to an authorization page.
+   */
   public void handleMethodGET(URI uri, final HTTPRequest request, final ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
-
-    //		// We ensure that we have a FCP server running
-    //		if(!fcp.enabled){
-    //			writeError(NodeL10n.getBase().getString("QueueToadlet.fcpIsMissing"),
-    // NodeL10n.getBase().getString("QueueToadlet.pleaseEnableFCP"), ctx, false);
-    //			return;
-    //		}
-    //		if(!core.hasLoadedQueue()) {
-    //			writeError(NodeL10n.getBase().getString("QueueToadlet.notLoadedYetTitle"),
-    // NodeL10n.getBase().getString("QueueToadlet.notLoadedYet"), ctx, false);
-    //			return;
-    //		}
-
     if (container.publicGatewayMode() && !ctx.isAllowedFullAccess()) {
       sendUnauthorizedPage(ctx);
       return;
@@ -93,97 +163,26 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
         (!rememberedLastTime && seclevel != NETWORK_THREAT_LEVEL.LOW)
             || (rememberedLastTime && !wasCanonicalLastTime)
             || seclevel == NETWORK_THREAT_LEVEL.MAXIMUM;
-    HTMLNode input =
-        insertForm.addChild(
-            "input",
-            new String[] {"type", "name", "value", "id"},
-            new String[] {"radio", "keytype", "CHK", "keytypeChk"});
-    if (!preselectSsk) {
-      input.addAttribute("checked", "checked");
-    }
-    insertForm
-        .addChild("label", new String[] {"for"}, new String[] {"keytypeChk"})
-        .addChild("b", l10n("insertCanonicalTitle"));
-    insertForm.addChild("#", ": " + l10n("insertCanonical"));
-    if (isAdvancedModeEnabled) insertForm.addChild("#", " " + l10n("insertCanonicalAdvanced"));
-    insertForm.addChild("br");
-    input =
-        insertForm.addChild(
-            "input",
-            new String[] {"type", "name", "value", "id"},
-            new String[] {"radio", "keytype", "SSK", "keytypeSsk"});
-    if (preselectSsk) {
-      input.addAttribute("checked", "checked");
-    }
-    insertForm
-        .addChild("label", new String[] {"for"}, new String[] {"keytypeSsk"})
-        .addChild("b", l10n("insertRandomTitle"));
-    insertForm.addChild("#", ": " + l10n("insertRandom"));
-    if (isAdvancedModeEnabled) insertForm.addChild("#", " " + l10n("insertRandomAdvanced"));
-    if (isAdvancedModeEnabled) {
-      insertForm.addChild("br");
-      insertForm.addChild(
-          "input",
-          new String[] {"type", "name", "value", "id"},
-          new String[] {"radio", "keytype", "specify", "keytypeSpecify"});
-      insertForm
-          .addChild("label", new String[] {"for"}, new String[] {"keytypeSpecify"})
-          .addChild("b", l10n("insertSpecificKeyTitle"));
-      insertForm.addChild("#", ": " + l10n("insertSpecificKey") + " ");
-      insertForm.addChild(
-          "input", new String[] {"type", "name", "value"}, new String[] {"text", "key", "KSK@"});
-    }
-    if (isAdvancedModeEnabled) {
-      insertForm.addChild("br");
-      insertForm.addChild("br");
-      insertForm.addChild(
-          "input",
-          new String[] {"type", "name", "checked", "id"},
-          new String[] {"checkbox", "compress", "checked", "checkboxCompress"});
-      insertForm.addChild(
-          "label",
-          new String[] {"for"},
-          new String[] {"checkboxCompress"},
-          ' ' + NodeL10n.getBase().getString("QueueToadlet.insertFileCompressLabel"));
-    } else {
-      insertForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "compress", "true"});
-    }
-    if (isAdvancedModeEnabled) {
-      insertForm.addChild("br");
-      insertForm.addChild("#", NodeL10n.getBase().getString("QueueToadlet.compatModeLabel") + ": ");
-      HTMLNode select = insertForm.addChild("select", "name", "compatibilityMode");
-      for (CompatibilityMode mode : InsertContext.CompatibilityMode.values()) {
-        if (mode == CompatibilityMode.COMPAT_UNKNOWN) continue;
-        // FIXME l10n???
-        HTMLNode option =
-            select.addChild(
-                "option",
-                "value",
-                mode.name(),
-                NodeL10n.getBase().getString("InsertContext.CompatibilityMode." + mode.name()));
-        if (mode == CompatibilityMode.COMPAT_DEFAULT) option.addAttribute("selected", "");
-      }
-      insertForm.addChild("br");
-      insertForm.addChild("#", l10n("splitfileCryptoKeyLabel") + ": ");
-      insertForm.addChild(
-          "input",
-          new String[] {"type", "name", "maxlength"},
-          new String[] {"text", "overrideSplitfileKey", "64"});
-    }
+
+    addKeyTypeOptions(insertForm, preselectSsk, isAdvancedModeEnabled);
+    addCompressionOption(insertForm, isAdvancedModeEnabled);
+    addCompatibilityOptions(insertForm, isAdvancedModeEnabled);
+    addFileInputs(insertForm, ctx);
+
+    return insertBox;
+  }
+
+  private void addFileInputs(HTMLNode insertForm, ToadletContext ctx) {
     insertForm.addChild("br");
     insertForm.addChild("br");
-    // Local file browser
     if (ctx.isAllowedFullAccess()) {
       insertForm.addChild(
           "#", NodeL10n.getBase().getString("QueueToadlet.insertFileBrowseLabel") + ": ");
       insertForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
+          TAG_INPUT,
+          new String[] {"type", "name", ATTR_VALUE},
           new String[] {
-            "submit",
+            INPUT_SUBMIT,
             "insert-local",
             NodeL10n.getBase().getString("QueueToadlet.insertFileBrowseButton") + "..."
           });
@@ -191,17 +190,129 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
     }
     insertForm.addChild("#", NodeL10n.getBase().getString("QueueToadlet.insertFileLabel") + ": ");
     insertForm.addChild(
-        "input", new String[] {"type", "name", "value"}, new String[] {"file", "filename", ""});
-    insertForm.addChild("#", " \u00a0 ");
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {"file", "filename", ""});
+    insertForm.addChild("#", NBSP);
     insertForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
         new String[] {
-          "submit", "insert", NodeL10n.getBase().getString("QueueToadlet.insertFileInsertFileLabel")
+          INPUT_SUBMIT,
+          "insert",
+          NodeL10n.getBase().getString("QueueToadlet.insertFileInsertFileLabel")
         });
-    insertForm.addChild("#", " \u00a0 ");
+    insertForm.addChild("#", NBSP);
+  }
 
-    return insertBox;
+  private void addCompatibilityOptions(HTMLNode insertForm, boolean isAdvancedModeEnabled) {
+    if (!isAdvancedModeEnabled) {
+      return;
+    }
+    insertForm.addChild("br");
+    insertForm.addChild("#", NodeL10n.getBase().getString("QueueToadlet.compatModeLabel") + ": ");
+    HTMLNode select = insertForm.addChild("select", "name", "compatibilityMode");
+    for (CompatibilityMode mode : InsertContext.CompatibilityMode.values()) {
+      if (mode == CompatibilityMode.COMPAT_UNKNOWN) {
+        continue;
+      }
+      HTMLNode option =
+          select.addChild(
+              "option",
+              ATTR_VALUE,
+              mode.name(),
+              NodeL10n.getBase().getString("InsertContext.CompatibilityMode." + mode.name()));
+      if (mode == CompatibilityMode.COMPAT_DEFAULT) {
+        option.addAttribute("selected", "");
+      }
+    }
+    insertForm.addChild("br");
+    insertForm.addChild("#", l10n("splitfileCryptoKeyLabel") + ": ");
+    insertForm.addChild(
+        TAG_INPUT,
+        new String[] {"type", "name", "maxlength"},
+        new String[] {"text", "overrideSplitfileKey", "64"});
+  }
+
+  private void addCompressionOption(HTMLNode insertForm, boolean isAdvancedModeEnabled) {
+    if (isAdvancedModeEnabled) {
+      insertForm.addChild("br");
+      insertForm.addChild("br");
+      insertForm.addChild(
+          TAG_INPUT,
+          new String[] {"type", "name", INPUT_CHECKED, "id"},
+          new String[] {"checkbox", "compress", INPUT_CHECKED, "checkboxCompress"});
+      insertForm.addChild(
+          TAG_LABEL,
+          new String[] {"for"},
+          new String[] {"checkboxCompress"},
+          ' ' + NodeL10n.getBase().getString("QueueToadlet.insertFileCompressLabel"));
+      return;
+    }
+    insertForm.addChild(
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {"hidden", "compress", "true"});
+  }
+
+  private void addKeyTypeOptions(
+      HTMLNode insertForm, boolean preselectSsk, boolean isAdvancedModeEnabled) {
+    addKeyChoice(
+        insertForm,
+        "keytypeChk",
+        "CHK",
+        !preselectSsk,
+        l10n("insertCanonicalTitle"),
+        l10n("insertCanonical"),
+        isAdvancedModeEnabled ? l10n("insertCanonicalAdvanced") : null);
+    insertForm.addChild("br");
+    addKeyChoice(
+        insertForm,
+        "keytypeSsk",
+        "SSK",
+        preselectSsk,
+        l10n("insertRandomTitle"),
+        l10n("insertRandom"),
+        isAdvancedModeEnabled ? l10n("insertRandomAdvanced") : null);
+    if (isAdvancedModeEnabled) {
+      insertForm.addChild("br");
+      addKeyChoice(
+          insertForm,
+          "keytypeSpecify",
+          "specify",
+          false,
+          l10n("insertSpecificKeyTitle"),
+          l10n("insertSpecificKey"),
+          null);
+      insertForm.addChild("#", " ");
+      insertForm.addChild(
+          TAG_INPUT,
+          new String[] {"type", "name", ATTR_VALUE},
+          new String[] {"text", "key", "KSK@"});
+    }
+  }
+
+  private void addKeyChoice(
+      HTMLNode insertForm,
+      String id,
+      String value,
+      boolean checked,
+      String title,
+      String description,
+      String advancedDescription) {
+    HTMLNode input =
+        insertForm.addChild(
+            TAG_INPUT,
+            new String[] {"type", "name", ATTR_VALUE, "id"},
+            new String[] {INPUT_RADIO, INPUT_KEYTYPE, value, id});
+    if (checked) {
+      input.addAttribute(INPUT_CHECKED, INPUT_CHECKED);
+    }
+    insertForm.addChild(TAG_LABEL, new String[] {"for"}, new String[] {id}).addChild("b", title);
+    insertForm.addChild("#", ": " + description);
+    if (advancedDescription != null) {
+      insertForm.addChild("#", " " + advancedDescription);
+    }
   }
 
   private HTMLNode createFilterBox(PageMaker pageMaker, ToadletContext ctx) {
@@ -216,34 +327,34 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
     insertForm.addChild("br");
     insertForm.addChild("br");
 
-    // apply read filter, write filter, or both
-    // TODO: radio buttons to select, once ContentFilter supports write filtering
+    // apply read filter, write filter, or both (write filtering selection will be added once
+    // ContentFilter supports it)
     insertForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
         new String[] {"hidden", "filter-operation", FilterOperation.BOTH.toString()});
 
     // display in browser or save to disk
     insertForm.addChild(
-        "input",
-        new String[] {"type", "name", "value", "id"},
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE, "id"},
         new String[] {
-          "radio", "result-handling", ResultHandling.DISPLAY.toString(), "resHandlingDisplay"
+          INPUT_RADIO, "result-handling", ResultHandling.DISPLAY.toString(), "resHandlingDisplay"
         });
     insertForm.addChild(
-        "label",
+        TAG_LABEL,
         new String[] {"for"},
         new String[] {"resHandlingDisplay"},
         ContentFilterToadlet.l10n("displayResultLabel"));
     insertForm.addChild("br");
     insertForm.addChild(
-        "input",
-        new String[] {"type", "name", "value", "id"},
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE, "id"},
         new String[] {
-          "radio", "result-handling", ResultHandling.SAVE.toString(), "resHandlingSave"
+          INPUT_RADIO, "result-handling", ResultHandling.SAVE.toString(), "resHandlingSave"
         });
     insertForm.addChild(
-        "label",
+        TAG_LABEL,
         new String[] {"for"},
         new String[] {"resHandlingSave"},
         ContentFilterToadlet.l10n("saveResultLabel"));
@@ -253,7 +364,9 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
     // mime type
     insertForm.addChild("#", ContentFilterToadlet.l10n("mimeTypeLabel") + ": ");
     insertForm.addChild(
-        "input", new String[] {"type", "name", "value"}, new String[] {"text", "mime-type", ""});
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {"text", "mime-type", ""});
     insertForm.addChild("br");
     insertForm.addChild("#", ContentFilterToadlet.l10n("mimeTypeText"));
     insertForm.addChild("br");
@@ -264,10 +377,10 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
       insertForm.addChild(
           "#", NodeL10n.getBase().getString("QueueToadlet.insertFileBrowseLabel") + ": ");
       insertForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
+          TAG_INPUT,
+          new String[] {"type", "name", ATTR_VALUE},
           new String[] {
-            "submit",
+            INPUT_SUBMIT,
             "filter-local",
             NodeL10n.getBase().getString("QueueToadlet.insertFileBrowseButton") + "..."
           });
@@ -275,26 +388,34 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
     }
     insertForm.addChild("#", NodeL10n.getBase().getString("QueueToadlet.insertFileLabel") + ": ");
     insertForm.addChild(
-        "input", new String[] {"type", "name", "value"}, new String[] {"file", "filename", ""});
-    insertForm.addChild("#", " \u00a0 ");
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
+        new String[] {"file", "filename", ""});
+    insertForm.addChild("#", NBSP);
 
     insertForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
+        TAG_INPUT,
+        new String[] {"type", "name", ATTR_VALUE},
         new String[] {
-          "submit", "filter-upload", ContentFilterToadlet.l10n("filterFileFilterLabel")
+          INPUT_SUBMIT, "filter-upload", ContentFilterToadlet.l10n("filterFileFilterLabel")
         });
     return insertBox;
   }
 
-  String l10n(String key) {
+  private static String l10n(String key) {
     return NodeL10n.getBase().getString("FileInsertWizardToadlet." + key);
   }
 
-  String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase().getString("FileInsertWizardToadlet." + key, pattern, value);
-  }
-
+  /**
+   * Indicates whether this toadlet should be exposed for the given context. Public gateway mode
+   * requires full access privileges; private deployments always allow access. The method performs
+   * no side effects, tolerates a {@code null} context during startup probing, and may be called
+   * repeatedly by routing logic without incurring additional checks beyond boolean evaluation.
+   *
+   * @param ctx current toadlet context carrying permission flags; may be {@code null} when called
+   *     during early routing.
+   * @return {@code true} when the endpoint is available for the caller, {@code false} otherwise.
+   */
   @Override
   public boolean isEnabled(ToadletContext ctx) {
     return (!container.publicGatewayMode()) || ((ctx != null) && ctx.isAllowedFullAccess());

--- a/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
@@ -1,0 +1,399 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class FileInsertWizardToadletTest {
+
+  @Mock HighLevelSimpleClient client;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  NodeClientCore core;
+
+  @Mock ToadletContainer container;
+
+  private FileInsertWizardToadlet toadlet;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    toadlet = new FileInsertWizardToadlet(client, core);
+    setContainer(toadlet, container);
+  }
+
+  @Test
+  void path_returnsConfiguredPath() {
+    assertEquals(FileInsertWizardToadlet.PATH, toadlet.path());
+  }
+
+  @Test
+  void isEnabled_whenGatewayDisallowed_returnsFalse() {
+    when(container.publicGatewayMode()).thenReturn(true);
+    assertFalse(toadlet.isEnabled(null));
+  }
+
+  @Test
+  void isEnabled_whenGatewayAndFullAccess_returnsTrue() {
+    when(container.publicGatewayMode()).thenReturn(true);
+    ToadletContext ctx = mock(ToadletContext.class);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+
+    assertTrue(toadlet.isEnabled(ctx));
+  }
+
+  @Test
+  void isEnabled_whenNotGateway_returnsTrue() {
+    when(container.publicGatewayMode()).thenReturn(false);
+    assertTrue(toadlet.isEnabled(null));
+  }
+
+  @Test
+  void handleMethodGET_whenLowThreat_prefersCanonicalRadio() throws Exception {
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(core.getNode().getSecurityLevels().getNetworkThreatLevel())
+        .thenReturn(NETWORK_THREAT_LEVEL.LOW);
+
+    PageHolder holder = new PageHolder();
+    PageMaker pageMaker = buildPageMaker(holder);
+    CapturingContext ctx = new CapturingContext(pageMaker, true, false);
+
+    toadlet.handleMethodGET(new URI("http://localhost/insertfile/"), mock(HTTPRequest.class), ctx);
+
+    HTMLNode chkInput = findById(holder.page.getContentNode(), "keytypeChk");
+    HTMLNode sskInput = findById(holder.page.getContentNode(), "keytypeSsk");
+
+    assertNotNull(chkInput);
+    assertNotNull(sskInput);
+    assertEquals("checked", chkInput.getAttribute("checked"));
+    assertNull(sskInput.getAttribute("checked"));
+  }
+
+  @Test
+  void handleMethodGET_afterRandomInsert_prefersSskRadio() throws Exception {
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(core.getNode().getSecurityLevels().getNetworkThreatLevel())
+        .thenReturn(NETWORK_THREAT_LEVEL.LOW);
+
+    PageHolder holder = new PageHolder();
+    PageMaker pageMaker = buildPageMaker(holder);
+    CapturingContext ctx = new CapturingContext(pageMaker, true, false);
+
+    toadlet.reportRandomInsert();
+
+    toadlet.handleMethodGET(new URI("http://localhost/insertfile/"), mock(HTTPRequest.class), ctx);
+
+    HTMLNode chkInput = findById(holder.page.getContentNode(), "keytypeChk");
+    HTMLNode sskInput = findById(holder.page.getContentNode(), "keytypeSsk");
+
+    assertNotNull(chkInput);
+    assertNotNull(sskInput);
+    assertNull(chkInput.getAttribute("checked"));
+    assertEquals("checked", sskInput.getAttribute("checked"));
+  }
+
+  @Test
+  void handleMethodGET_whenPublicGatewayAndNoFullAccess_sendsUnauthorized() throws Exception {
+    when(container.publicGatewayMode()).thenReturn(true);
+
+    PageHolder holder = new PageHolder();
+    PageMaker pageMaker = buildPageMaker(holder);
+    CapturingContext ctx = new CapturingContext(pageMaker, false, false);
+
+    toadlet.handleMethodGET(new URI("http://localhost/insertfile/"), mock(HTTPRequest.class), ctx);
+
+    assertEquals(403, ctx.getStatusCode());
+  }
+
+  private static void setContainer(FileInsertWizardToadlet toadlet, ToadletContainer container)
+      throws Exception {
+    Field field = Toadlet.class.getDeclaredField("container");
+    field.setAccessible(true);
+    field.set(toadlet, container);
+  }
+
+  private static HTMLNode findById(HTMLNode root, String id) {
+    if (id.equals(root.getAttribute("id"))) {
+      return root;
+    }
+    for (HTMLNode child : root.getChildren()) {
+      HTMLNode found = findById(child, id);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private static final class PageHolder {
+    PageNode page;
+  }
+
+  private static PageMaker buildPageMaker(PageHolder holder) {
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(pageMaker.getPageNode(anyString(), any(ToadletContext.class)))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode outer = new HTMLNode("div");
+              HTMLNode head = new HTMLNode("head");
+              HTMLNode content = new HTMLNode("div");
+              holder.page = new PageNode(outer, head, content);
+              return holder.page;
+            });
+    when(pageMaker.getInfobox(anyString(), anyString(), anyBoolean()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode outer = new HTMLNode("div");
+              HTMLNode content = outer.addChild("div");
+              return new InfoboxNode(outer, content);
+            });
+    when(pageMaker.getInfobox(anyString(), anyString(), any(HTMLNode.class), any(), anyBoolean()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(2);
+              HTMLNode outer = new HTMLNode("div");
+              HTMLNode content = outer.addChild("div");
+              InfoboxNode node = new InfoboxNode(outer, content);
+              parent.addChild(node.getOuterNode());
+              return node.getContentNode();
+            });
+    return pageMaker;
+  }
+
+  /**
+   * Captures response data while providing just enough context behaviour for the toadlet under
+   * test.
+   */
+  private static final class CapturingContext implements ToadletContext {
+
+    private final PageMaker pageMaker;
+    private final boolean fullAccess;
+    private final boolean advanced;
+    private final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    private int statusCode = -1;
+
+    CapturingContext(PageMaker pageMaker, boolean fullAccess, boolean advanced) {
+      this.pageMaker = pageMaker;
+      this.fullAccess = fullAccess;
+      this.advanced = advanced;
+    }
+
+    @Override
+    public void sendReplyHeaders(
+        int code, String desc, MultiValueTable<String, String> mvt, String mimeType, long length) {
+      this.statusCode = code;
+    }
+
+    @Override
+    public void sendReplyHeaders(
+        int code,
+        String desc,
+        MultiValueTable<String, String> mvt,
+        String mimeType,
+        long length,
+        boolean forceDisableJavascript) {
+      this.statusCode = code;
+    }
+
+    @Override
+    public void sendReplyHeaders(
+        int code,
+        String desc,
+        MultiValueTable<String, String> mvt,
+        String mimeType,
+        long length,
+        java.util.Date mTime) {
+      this.statusCode = code;
+    }
+
+    @Override
+    public void sendReplyHeadersStatic(
+        int code,
+        String desc,
+        MultiValueTable<String, String> mvt,
+        String mimeType,
+        long length,
+        java.util.Date mTime) {
+      this.statusCode = code;
+    }
+
+    @Override
+    public void sendReplyHeadersFProxy(
+        int code, String desc, MultiValueTable<String, String> mvt, String mimeType, long length) {
+      this.statusCode = code;
+    }
+
+    @Override
+    public void writeData(byte[] data, int offset, int length) {
+      body.write(data, offset, length);
+    }
+
+    @Override
+    public void forceDisconnect() {
+      this.statusCode = -999; // signal forced disconnect for potential assertions
+    }
+
+    @Override
+    public void writeData(byte[] data) throws IOException {
+      body.write(data);
+    }
+
+    @Override
+    public void writeData(Bucket data) {
+      throw new UnsupportedOperationException("Bucket streaming not required in this test stub");
+    }
+
+    @Override
+    public PageMaker getPageMaker() {
+      return pageMaker;
+    }
+
+    @Override
+    public String getFormPassword() {
+      return "";
+    }
+
+    @Override
+    public boolean checkFormPassword(HTTPRequest request, String redirectTo) {
+      return true;
+    }
+
+    @Override
+    public boolean checkFormPassword(HTTPRequest request) {
+      return true;
+    }
+
+    @Override
+    public boolean hasFormPassword(HTTPRequest request) {
+      return true;
+    }
+
+    @Override
+    public boolean checkFullAccess(Toadlet toadlet) {
+      return fullAccess;
+    }
+
+    @Override
+    public network.crypta.node.useralerts.UserAlertManager getAlertManager() {
+      UserAlertManager manager = mock(UserAlertManager.class);
+      when(manager.createSummary()).thenReturn(new HTMLNode("div"));
+      when(manager.createSummary(true)).thenReturn(new HTMLNode("div"));
+      return manager;
+    }
+
+    @Override
+    public network.crypta.clients.http.bookmark.BookmarkManager getBookmarkManager() {
+      return null;
+    }
+
+    @Override
+    public BucketFactory getBucketFactory() {
+      return null;
+    }
+
+    @Override
+    public MultiValueTable<String, String> getHeaders() {
+      return new MultiValueTable<>();
+    }
+
+    @Override
+    public ReceivedCookie getCookie(URI domain, URI path, String name) {
+      return null;
+    }
+
+    @Override
+    public void setCookie(Cookie newCookie) {
+      // Intentionally no-op for tests; cookie propagation is irrelevant for current scenarios.
+    }
+
+    @Override
+    public HTMLNode addFormChild(HTMLNode parentNode, String target, String id) {
+      HTMLNode form = new HTMLNode("form");
+      form.addAttribute("action", target);
+      form.addAttribute("id", id);
+      form.addAttribute("name", id);
+      parentNode.addChild(form);
+      return form;
+    }
+
+    @Override
+    public boolean isAllowedFullAccess() {
+      return fullAccess;
+    }
+
+    @Override
+    public boolean isAdvancedModeEnabled() {
+      return advanced;
+    }
+
+    @Override
+    public boolean doRobots() {
+      return false;
+    }
+
+    @Override
+    public ToadletContainer getContainer() {
+      return null;
+    }
+
+    @Override
+    public boolean disableProgressPage() {
+      return false;
+    }
+
+    @Override
+    public Toadlet activeToadlet() {
+      return null;
+    }
+
+    @Override
+    public String getUniqueId() {
+      return "id";
+    }
+
+    @Override
+    public URI getUri() {
+      return URI.create("http://localhost/");
+    }
+
+    @Override
+    public FProxyFetchInProgress.REFILTER_POLICY getReFilterPolicy() {
+      return FProxyFetchInProgress.REFILTER_POLICY.ACCEPT_OLD;
+    }
+
+    int getStatusCode() {
+      return statusCode;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- apply spotless formatting to FileInsertWizardToadlet and its test
- extract small helpers and constants to reduce duplication while keeping behavior unchanged
- refresh test stubs (deep stubs + helper builders) so the wizard rendering assertions remain stable

## Testing
- not run (format-only change)