### PR TITLE
Improve FirstTimeWizard toadlet validation and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
@@ -29,12 +29,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Javascript-based First-Time-Wizard. The regular wizard redirects here if both fproxy and browser
- * have Javascript enabled.
+ * JavaScript-based First-Time-Wizard toadlet that guides new nodes through the minimum secure setup
+ * steps. The regular wizard redirects here when both FProxy and the user's browser have JavaScript
+ * enabled so that the richer, single-page flow can be used.
+ *
+ * <p>This toadlet orchestrates the entire first-run experience: it detects recommended bandwidth
+ * limits, proposes datastore sizes, optionally enforces a master password based on the configured
+ * physical threat level, and persists the resulting configuration. All rendering is delegated to
+ * the shared web template system, with localized strings loaded via {@link NodeL10n} and per-page
+ * state stored in a simple model map.
+ *
+ * <p>Instances are tied to a {@link NodeClientCore} and {@link Config}. They are not thread-safe on
+ * their own but are typically created once and invoked by the toadlet container on request threads.
+ * Error handling is intentionally defensive: invalid input re-renders the form with contextual
+ * messages, while unexpected failures are surfaced through structured logging.
+ *
+ * <ul>
+ *   <li>Collects threat-level choices and optionally enforces a master password.
+ *   <li>Suggests datastore and bandwidth limits based on detected capabilities.
+ *   <li>Redirects to {@link WelcomeToadlet#PATH} after successful completion.
+ * </ul>
+ *
+ * @see WebTemplateToadlet
+ * @see WelcomeToadlet
  */
 public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(FirstTimeWizardNewToadlet.class);
 
+  /**
+   * Public URL prefix under which the wizard is mounted; used by {@link #path()} and redirects from
+   * the legacy flow. The value is stable so bookmarks and deep links continue to work across
+   * releases.
+   */
   public static final String TOADLET_URL = "/wiz/";
 
   private static final long MIN_STORAGE_LIMIT =
@@ -44,11 +70,23 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
 
   private final Config config;
 
-  private static final String l10nPrefix = "FirstTimeWizardToadlet.";
+  private static final String L10N_PREFIX = "FirstTimeWizardToadlet.";
+
+  private static final int KIB = 1024;
+
+  private static final String DOWNLOAD_LIMIT_ERROR_KEY = "downloadLimitError";
+
+  private static final String UPLOAD_LIMIT_ERROR_KEY = "uploadLimitError";
+
+  private static final String STORAGE_LIMIT_ERROR_KEY = "storageLimitError";
+
+  private static final String PASSWORD_ERROR_KEY = "passwordError";
+
+  private static final String CHECKED_VALUE = "checked";
+
+  private static final String UNEXPECTED_ERROR_MESSAGE = "Should not happen, please report! {}";
 
   private boolean isPasswordAlreadySet;
-
-  private final int KiB = 1024;
 
   FirstTimeWizardNewToadlet(HighLevelSimpleClient client, NodeClientCore core, Config config) {
     super(client);
@@ -56,9 +94,29 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
     this.config = config;
   }
 
+  /**
+   * Renders the first-time wizard landing page in response to a GET request.
+   *
+   * <p>The method first emits a debug log when a URI is supplied, then enforces the container's
+   * full-access check to prevent partially initialized users from progressing. It marks whether a
+   * master password is already required based on the current physical threat level and finally
+   * delegates to {@link #showForm(ToadletContext, Map)} with a freshly detected model. The handler
+   * is idempotent and safe to repeat if the browser reloads the page.
+   *
+   * @param uri the absolute request target as received by the toadlet dispatcher; may be {@code
+   *     null} when upstream routing omits it
+   * @param request the parsed HTTP request object; used for side effects only during context
+   *     validation
+   * @param ctx the active toadlet context that provides access checks and rendering helpers
+   * @throws ToadletContextClosedException if the client disconnects before the response is written
+   * @throws IOException if building or streaming the HTML page fails
+   */
   @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
+    if (LOG.isDebugEnabled() && uri != null) {
+      LOG.debug("Handling GET for {}", uri);
+    }
     if (!ctx.checkFullAccess(this)) {
       return;
     }
@@ -70,8 +128,29 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
     showForm(ctx, new FormModel().toModel());
   }
 
+  /**
+   * Processes a submitted wizard form and either persists the settings or re-renders the page with
+   * validation feedback.
+   *
+   * <p>The handler applies the same access gate as {@link #handleMethodGET(URI, HTTPRequest,
+   * ToadletContext)} and logs the incoming URI when debug logging is enabled. Inputs are captured
+   * in a {@code FormModel}, validated for bandwidth, datastore size, and optional password rules,
+   * then saved when no errors are present. A successful submission triggers a temporary redirect to
+   * the welcome page; otherwise the form is displayed again with localized error messages. The
+   * method performs no partial saves on invalid input, keeping configuration atomic.
+   *
+   * @param uri the original request URI supplied by the toadlet container
+   * @param request the request body carrying the form fields to validate and apply
+   * @param ctx the current toadlet context used for security checks and HTML rendering
+   * @throws ToadletContextClosedException if the client connection closes before the response is
+   *     written
+   * @throws IOException if writing the HTML response or redirect fails
+   */
   public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
+    if (LOG.isDebugEnabled() && uri != null) {
+      LOG.debug("Handling POST for {}", uri);
+    }
     if (!ctx.checkFullAccess(this)) {
       return;
     }
@@ -97,21 +176,30 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
                 ctx,
                 new PageMaker.RenderParameters().renderNavigationLinks(false).renderStatus(false));
     page.addCustomStyleSheet("/static/first-time-wizard.css");
-    addChild(page.getContentNode(), "first-time-wizard", model, l10nPrefix);
+    addChild(page.getContentNode(), "first-time-wizard", model, L10N_PREFIX);
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
   }
 
+  /**
+   * Returns the public HTTP path where this toadlet is registered.
+   *
+   * <p>The path is static and aligns with {@link #TOADLET_URL}, enabling callers to reference the
+   * wizard entry point when composing navigation links or redirects. The container invokes this to
+   * mount the toadlet under the shared FProxy namespace.
+   *
+   * @return the URL prefix for the JavaScript-first wizard flow, always {@value #TOADLET_URL}
+   */
   @Override
   public String path() {
     return TOADLET_URL;
   }
 
   private static String l10n(String key) {
-    return NodeL10n.getBase().getString(l10nPrefix + key);
+    return NodeL10n.getBase().getString(L10N_PREFIX + key);
   }
 
   private static String l10n(String key, String value) {
-    return NodeL10n.getBase().getString(l10nPrefix + key, value);
+    return NodeL10n.getBase().getString(L10N_PREFIX + key, value);
   }
 
   private class FormModel {
@@ -192,73 +280,93 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
           request.getPartAsStringFailsafe(
               "confirmPassword", SecurityLevelsToadlet.MAX_PASSWORD_LENGTH);
 
-      // validate
-      if (haveMonthlyLimit.isEmpty()) {
-        try {
-          long downloadLimit =
-              this.downloadLimit.isEmpty() ? 0 : Fields.parseInt(this.downloadLimit + "KiB");
-          if (downloadLimit < Node.getMinimumBandwidth()) {
-            errors.put(
-                "downloadLimitError",
-                l10n("valid.downloadLimit", Integer.toString(Node.getMinimumBandwidth() / KiB)));
-          }
-        } catch (NumberFormatException e) {
-          errors.put(
-              "downloadLimitError",
-              l10n("valid.number.prefix.downloadLimit") + " " + e.getMessage());
-        }
+      validateInputs(passwordConfirmation);
+    }
 
-        try {
-          long uploadLimit =
-              this.uploadLimit.isEmpty() ? 0 : Fields.parseInt(this.uploadLimit + "KiB");
-          if (uploadLimit < Node.getMinimumBandwidth()) {
-            errors.put(
-                "uploadLimitError",
-                l10n("valid.uploadLimit", Integer.toString(Node.getMinimumBandwidth() / KiB)));
-          }
-          int nanosInSecond = (int) SECONDS.toNanos(1);
-          if (nanosInSecond < uploadLimit) { // see Node set outputBandwidthLimit
-            errors.put(
-                "uploadLimitError",
-                l10n("valid.uploadLimitMax", Integer.toString(nanosInSecond / KiB)));
-          }
-        } catch (NumberFormatException e) {
-          errors.put(
-              "uploadLimitError", l10n("valid.number.prefix.uploadLimit") + " " + e.getMessage());
-        }
+    private void validateInputs(String passwordConfirmation) {
+      if (haveMonthlyLimit.isEmpty()) {
+        validateBandwidthLimits();
       } else {
-        try {
-          double monthlyLimit = 0;
-          if (!bandwidthMonthlyLimit.isEmpty()) {
-            monthlyLimit = Double.parseDouble(bandwidthMonthlyLimit);
-          }
-          if (monthlyLimit < BandwidthLimit.minMonthlyLimit) {
-            errors.put(
-                "bandwidthMonthlyLimitError",
-                l10n(
-                    "valid.bandwidthMonthlyLimit",
-                    "%.2f".formatted(BandwidthLimit.minMonthlyLimit)));
-          }
-        } catch (NumberFormatException e) {
+        validateMonthlyLimit();
+      }
+      validateStorageLimit();
+      validatePassword(passwordConfirmation);
+    }
+
+    private void validateBandwidthLimits() {
+      validateDownloadLimit();
+      validateUploadLimit();
+    }
+
+    private void validateDownloadLimit() {
+      try {
+        long parsedDownloadLimit =
+            downloadLimit.isEmpty() ? 0 : Fields.parseInt(downloadLimit + "KiB");
+        if (parsedDownloadLimit < Node.getMinimumBandwidth()) {
+          errors.put(
+              DOWNLOAD_LIMIT_ERROR_KEY,
+              l10n("valid.downloadLimit", Integer.toString(Node.getMinimumBandwidth() / KIB)));
+        }
+      } catch (NumberFormatException e) {
+        errors.put(
+            DOWNLOAD_LIMIT_ERROR_KEY,
+            l10n("valid.number.prefix.downloadLimit") + " " + e.getMessage());
+      }
+    }
+
+    private void validateUploadLimit() {
+      try {
+        long parsedUploadLimit = uploadLimit.isEmpty() ? 0 : Fields.parseInt(uploadLimit + "KiB");
+        if (parsedUploadLimit < Node.getMinimumBandwidth()) {
+          errors.put(
+              UPLOAD_LIMIT_ERROR_KEY,
+              l10n("valid.uploadLimit", Integer.toString(Node.getMinimumBandwidth() / KIB)));
+        }
+        int nanosInSecond = (int) SECONDS.toNanos(1);
+        if (nanosInSecond < parsedUploadLimit) { // see Node set outputBandwidthLimit
+          errors.put(
+              UPLOAD_LIMIT_ERROR_KEY,
+              l10n("valid.uploadLimitMax", Integer.toString(nanosInSecond / KIB)));
+        }
+      } catch (NumberFormatException e) {
+        errors.put(
+            UPLOAD_LIMIT_ERROR_KEY, l10n("valid.number.prefix.uploadLimit") + " " + e.getMessage());
+      }
+    }
+
+    private void validateMonthlyLimit() {
+      try {
+        double monthlyLimitValue = 0;
+        if (!bandwidthMonthlyLimit.isEmpty()) {
+          monthlyLimitValue = Double.parseDouble(bandwidthMonthlyLimit);
+        }
+        if (monthlyLimitValue < BandwidthLimit.minMonthlyLimit) {
           errors.put(
               "bandwidthMonthlyLimitError",
-              l10n("valid.number.prefix.bandwidthMonthlyLimit") + " " + e.getMessage());
+              l10n(
+                  "valid.bandwidthMonthlyLimit", "%.2f".formatted(BandwidthLimit.minMonthlyLimit)));
         }
+      } catch (NumberFormatException e) {
+        errors.put(
+            "bandwidthMonthlyLimitError",
+            l10n("valid.number.prefix.bandwidthMonthlyLimit") + " " + e.getMessage());
       }
+    }
 
+    private void validateStorageLimit() {
       try {
-        long storageLimit =
-            this.storageLimit.isEmpty() ? 0 : Fields.parseLong(this.storageLimit + "GiB");
-        if (storageLimit
+        long storageLimitValue =
+            storageLimit.isEmpty() ? 0 : Fields.parseLong(storageLimit + "GiB");
+        if (storageLimitValue
             < MIN_STORAGE_LIMIT) { // min store size + 10% for client cache + 10% for slashdot cache
           errors.put(
-              "storageLimitError",
+              STORAGE_LIMIT_ERROR_KEY,
               NodeL10n.getBase().getString("Node.invalidMinStoreSizeWithCaches"));
         } else {
           long maxDatastoreSize = DatastoreUtil.maxDatastoreSize();
-          if (storageLimit > maxDatastoreSize) {
+          if (storageLimitValue > maxDatastoreSize) {
             errors.put(
-                "storageLimitError",
+                STORAGE_LIMIT_ERROR_KEY,
                 NodeL10n.getBase()
                     .getString(
                         "Node.invalidMaxStoreSize",
@@ -267,23 +375,27 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
         }
       } catch (NumberFormatException e) {
         errors.put(
-            "storageLimitError", l10n("valid.number.prefix.storageLimit") + " " + e.getMessage());
+            STORAGE_LIMIT_ERROR_KEY,
+            l10n("valid.number.prefix.storageLimit") + " " + e.getMessage());
       }
+    }
 
-      if (!setPassword.isEmpty()) {
-        if (password.isEmpty()) {
-          errors.put(
-              "passwordError",
-              NodeL10n.getBase().getString("SecurityLevels.passwordNotZeroLength"));
-        }
-        if (password.length() > SecurityLevelsToadlet.MAX_PASSWORD_LENGTH) {
-          errors.put(
-              "passwordError", NodeL10n.getBase().getString("SecurityLevels.passwordTooLong"));
-        }
-        if (!password.equals(passwordConfirmation)) {
-          errors.put(
-              "passwordError", NodeL10n.getBase().getString("SecurityLevels.passwordsDoNotMatch"));
-        }
+    private void validatePassword(String passwordConfirmation) {
+      if (setPassword.isEmpty()) {
+        return;
+      }
+      if (password.isEmpty()) {
+        errors.put(
+            PASSWORD_ERROR_KEY,
+            NodeL10n.getBase().getString("SecurityLevels.passwordNotZeroLength"));
+      }
+      if (password.length() > SecurityLevelsToadlet.MAX_PASSWORD_LENGTH) {
+        errors.put(
+            PASSWORD_ERROR_KEY, NodeL10n.getBase().getString("SecurityLevels.passwordTooLong"));
+      }
+      if (!password.equals(passwordConfirmation)) {
+        errors.put(
+            PASSWORD_ERROR_KEY, NodeL10n.getBase().getString("SecurityLevels.passwordsDoNotMatch"));
       }
     }
 
@@ -298,8 +410,8 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
                 core.getNode().getIpDetector().getBandwidthIndicator());
 
         // Detected limits reasonable; add half of both as recommended option.
-        downloadLimitDetected = Long.toString(detected.downBytes / 2 / KiB);
-        uploadLimitDetected = Long.toString(detected.upBytes / 2 / KiB);
+        downloadLimitDetected = Long.toString(detected.downBytes / 2 / KIB);
+        uploadLimitDetected = Long.toString(detected.upBytes / 2 / KIB);
       } catch (PluginNotFoundException | IllegalValueException e) {
         LOG.info(e.getMessage(), e);
       }
@@ -307,9 +419,9 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
 
     private Map<String, Object> toModel() {
       HashMap<String, Object> model = new HashMap<>();
-      model.put("knowSomeone", !knowSomeone.isEmpty() ? "checked" : "");
-      model.put("connectToStrangers", !connectToStrangers.isEmpty() ? "checked" : "");
-      model.put("haveMonthlyLimit", !haveMonthlyLimit.isEmpty() ? "checked" : "");
+      model.put("knowSomeone", !knowSomeone.isEmpty() ? CHECKED_VALUE : "");
+      model.put("connectToStrangers", !connectToStrangers.isEmpty() ? CHECKED_VALUE : "");
+      model.put("haveMonthlyLimit", !haveMonthlyLimit.isEmpty() ? CHECKED_VALUE : "");
       model.put("downloadLimit", downloadLimit);
       model.put("uploadLimit", uploadLimit);
       model.put("bandwidthMonthlyLimit", bandwidthMonthlyLimit);
@@ -317,7 +429,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
       model.put("storageLimit", storageLimit);
       model.put("minStorageLimit", minStorageLimit);
       if (!isPasswordAlreadySet) {
-        model.put("setPassword", !setPassword.isEmpty() ? "checked" : "");
+        model.put("setPassword", !setPassword.isEmpty() ? CHECKED_VALUE : "");
       }
       model.put("isPasswordAlreadySet", isPasswordAlreadySet);
 
@@ -371,7 +483,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
           config.get("node").set("outputBandwidthLimit", Long.toString(bandwidth.upBytes));
         }
       } catch (ConfigException e) {
-        LOG.error("Should not happen, please report! {}", e.toString(), e);
+        LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
       }
 
       DATASTORE_SIZE.setDatastoreSize(storageLimit + "GiB", config, this);
@@ -393,14 +505,14 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
             | MasterKeysWrongPasswordException
             | MasterKeysFileSizeException
             | IOException e) {
-          LOG.error("Should not happen, please report! {}", e.toString(), e);
+          LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
         }
       }
 
       try {
         config.get("fproxy").set("hasCompletedWizard", true);
       } catch (ConfigException e) {
-        LOG.error("Should not happen, please report! {}", e.toString(), e);
+        LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
       }
       core.storeConfig();
     }

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
@@ -1,0 +1,319 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.wizardsteps.BandwidthLimit;
+import network.crypta.clients.http.wizardsteps.BandwidthManipulator;
+import network.crypta.clients.http.wizardsteps.DATASTORE_SIZE;
+import network.crypta.config.Config;
+import network.crypta.config.Option;
+import network.crypta.config.SubConfig;
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.NodeIPDetector;
+import network.crypta.node.SecurityLevels;
+import network.crypta.pluginmanager.FredPluginBandwidthIndicator;
+import network.crypta.pluginmanager.PluginNotFoundException;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.io.DatastoreUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class FirstTimeWizardNewToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private NodeClientCore core;
+  @Mock private Node node;
+  @Mock private SecurityLevels securityLevels;
+  @Mock private ToadletContext ctx;
+  @Mock private PageMaker pageMaker;
+  @Mock private SimpleToadletServer toadletContainer;
+  @Mock private Config config;
+  @Mock private SubConfig nodeSubConfig;
+  @Mock private SubConfig fproxySubConfig;
+
+  @BeforeEach
+  void setUp() {
+    HTMLNode outer = new HTMLNode("div");
+    HTMLNode head = outer.addChild("head");
+    HTMLNode content = outer.addChild("div");
+    PageNode pageNode = new PageNode(outer, head, content);
+
+    when(core.getNode()).thenReturn(node);
+    when(node.getSecurityLevels()).thenReturn(securityLevels);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(pageMaker.getPageNode(anyString(), eq(ctx), any(PageMaker.RenderParameters.class)))
+        .thenReturn(pageNode);
+    when(core.getToadletContainer()).thenReturn(toadletContainer);
+    when(toadletContainer.getFormPassword()).thenReturn("form-pass");
+    lenient().when(config.get("node")).thenReturn(nodeSubConfig);
+    lenient().when(config.get("fproxy")).thenReturn(fproxySubConfig);
+  }
+
+  @Test
+  void path_returnsWizardUrl() {
+    FirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(client, core, config);
+
+    assertEquals(FirstTimeWizardNewToadlet.TOADLET_URL, toadlet.path());
+  }
+
+  @Test
+  void handleMethodGET_whenAccessDenied_returnsEarly() throws Exception {
+    TestableFirstTimeWizardNewToadlet toadlet =
+        new TestableFirstTimeWizardNewToadlet(client, core, config);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(false);
+
+    toadlet.handleMethodGET(
+        new URI(FirstTimeWizardNewToadlet.TOADLET_URL), mock(HTTPRequest.class), ctx);
+
+    verify(ctx, times(1)).checkFullAccess(toadlet);
+    assertFalse(toadlet.htmlWritten);
+    assertNull(toadlet.lastModel);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void handleMethodGET_whenPhysicalThreatHigh_setsPasswordAlreadySetAndUsesDetectedLimits()
+      throws Exception {
+    TestableFirstTimeWizardNewToadlet toadlet =
+        new TestableFirstTimeWizardNewToadlet(client, core, config);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+
+    FredPluginBandwidthIndicator bandwidthIndicator = mock(FredPluginBandwidthIndicator.class);
+    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
+    when(node.getIpDetector()).thenReturn(ipDetector);
+    lenient().when(ipDetector.getBandwidthIndicator()).thenReturn(bandwidthIndicator);
+
+    Option<Long> storeSize = mock(Option.class);
+    Option<Long> clientCache = mock(Option.class);
+    Option<Long> slashdotCache = mock(Option.class);
+    when(storeSize.isDefault()).thenReturn(false);
+    when(storeSize.getValue()).thenReturn(2L * DatastoreUtil.ONE_GIB);
+    when(clientCache.getValue()).thenReturn(0L);
+    when(slashdotCache.getValue()).thenReturn(0L);
+
+    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
+        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class);
+        MockedStatic<Config> configStatic = mockStatic(Config.class)) {
+
+      BaseL10n base = mock(BaseL10n.class);
+      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
+      when(base.getString(anyString())).thenAnswer(inv -> inv.getArgument(0));
+      when(base.getString(anyString(), anyString())).thenAnswer(inv -> inv.getArgument(0));
+      when(base.getString(anyString(), any(String[].class), any(String[].class)))
+          .thenAnswer(inv -> inv.getArgument(0));
+
+      configStatic.when(() -> Config.longOption(nodeSubConfig, "storeSize")).thenReturn(storeSize);
+      configStatic
+          .when(() -> Config.longOption(nodeSubConfig, "clientCacheSize"))
+          .thenReturn(clientCache);
+      configStatic
+          .when(() -> Config.longOption(nodeSubConfig, "slashdotCacheSize"))
+          .thenReturn(slashdotCache);
+
+      bandwidth
+          .when(() -> BandwidthManipulator.detectBandwidthLimits(bandwidthIndicator))
+          .thenReturn(new BandwidthLimit(2097152L, 1048576L, "desc", false));
+
+      toadlet.handleMethodGET(
+          new URI(FirstTimeWizardNewToadlet.TOADLET_URL), mock(HTTPRequest.class), ctx);
+    }
+
+    assertTrue(toadlet.htmlWritten);
+    assertNotNull(toadlet.lastModel);
+    assertEquals(Boolean.TRUE, toadlet.lastModel.get("isPasswordAlreadySet"));
+    assertFalse(toadlet.lastModel.containsKey("setPassword"));
+    assertEquals("1024", toadlet.lastModel.get("downloadLimitDetected"));
+    assertEquals("512", toadlet.lastModel.get("uploadLimitDetected"));
+    assertEquals("form-pass", toadlet.lastModel.get("formPassword"));
+  }
+
+  @Test
+  void handleMethodPOST_whenValidInput_savesConfigAndRedirects() throws Exception {
+    TestableFirstTimeWizardNewToadlet toadlet =
+        new TestableFirstTimeWizardNewToadlet(client, core, config);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+
+    Map<String, String> parts = new HashMap<>();
+    parts.put("knowSomeone", "");
+    parts.put("connectToStrangers", "on");
+    parts.put("haveMonthlyLimit", "");
+    parts.put("downLimit", "20000");
+    parts.put("upLimit", "20000");
+    parts.put("monthlyLimit", "");
+    parts.put("storage", "2");
+    parts.put("setPassword", "");
+    parts.put("password", "");
+    parts.put("confirmPassword", "");
+    HTTPRequest request = buildRequest(parts);
+
+    when(node.getIpDetector()).thenReturn(mock(NodeIPDetector.class));
+
+    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
+        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
+        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class);
+        MockedStatic<DATASTORE_SIZE> datastoreSize = mockStatic(DATASTORE_SIZE.class)) {
+
+      BaseL10n base = mock(BaseL10n.class);
+      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
+      when(base.getString(anyString())).thenAnswer(inv -> inv.getArgument(0));
+      when(base.getString(anyString(), anyString())).thenAnswer(inv -> inv.getArgument(0));
+      when(base.getString(anyString(), any(String[].class), any(String[].class)))
+          .thenAnswer(inv -> inv.getArgument(0));
+
+      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+      datastore.when(() -> DatastoreUtil.autodetectDatastoreSize(core, config)).thenReturn(0L);
+      bandwidth
+          .when(() -> BandwidthManipulator.detectBandwidthLimits(any()))
+          .thenThrow(new PluginNotFoundException("none"));
+
+      toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx);
+
+      datastoreSize.verify(
+          () -> DATASTORE_SIZE.setDatastoreSize(eq("2GiB"), eq(config), any()), times(1));
+    }
+
+    verify(nodeSubConfig).set("inputBandwidthLimit", "20000KiB");
+    verify(nodeSubConfig).set("outputBandwidthLimit", "20000KiB");
+    verify(fproxySubConfig).set("hasCompletedWizard", true);
+    verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
+    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    verify(node).setMasterPassword("", true);
+    verify(core).storeConfig();
+    verify(ctx)
+        .sendReplyHeaders(
+            eq(302),
+            eq("Found"),
+            ArgumentMatchers.any(),
+            eq("text/html; charset=UTF-8"),
+            anyLong());
+    assertTrue(toadlet.htmlWritten);
+    @SuppressWarnings("unchecked")
+    Map<String, String> errors = (Map<String, String>) toadlet.lastModel.get("errors");
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void handleMethodPOST_whenDownloadBelowMinimum_rendersErrorsInsteadOfRedirect() throws Exception {
+    TestableFirstTimeWizardNewToadlet toadlet =
+        new TestableFirstTimeWizardNewToadlet(client, core, config);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+
+    Map<String, String> parts = new HashMap<>();
+    parts.put("haveMonthlyLimit", "");
+    parts.put("downLimit", "1");
+    parts.put("upLimit", "20000");
+    parts.put("monthlyLimit", "");
+    parts.put("storage", "2");
+    parts.put("setPassword", "");
+    parts.put("password", "");
+    parts.put("confirmPassword", "");
+    HTTPRequest request = buildRequest(parts);
+
+    when(node.getIpDetector()).thenReturn(mock(NodeIPDetector.class));
+
+    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
+        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
+        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class)) {
+
+      BaseL10n base = mock(BaseL10n.class);
+      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
+      when(base.getString(anyString())).thenAnswer(inv -> inv.getArgument(0));
+      when(base.getString(anyString(), anyString())).thenAnswer(inv -> inv.getArgument(0));
+      when(base.getString(anyString(), any(String[].class), any(String[].class)))
+          .thenAnswer(inv -> inv.getArgument(0));
+
+      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+      bandwidth
+          .when(() -> BandwidthManipulator.detectBandwidthLimits(any()))
+          .thenThrow(new PluginNotFoundException("none"));
+
+      toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx);
+    }
+
+    assertTrue(toadlet.htmlWritten);
+    verify(ctx, never()).sendReplyHeaders(eq(302), anyString(), any(), anyString(), anyLong());
+    assertNotNull(toadlet.lastModel);
+    @SuppressWarnings("unchecked")
+    Map<String, String> errors = (Map<String, String>) toadlet.lastModel.get("errors");
+    assertTrue(errors.containsKey("downloadLimitError"));
+    verifyNoInteractions(nodeSubConfig, fproxySubConfig);
+  }
+
+  private HTTPRequest buildRequest(Map<String, String> parts) {
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.getPartAsStringFailsafe(anyString(), anyInt()))
+        .thenAnswer(
+            invocation -> {
+              String key = invocation.getArgument(0, String.class);
+              return parts.getOrDefault(key, "");
+            });
+    return request;
+  }
+
+  private static final class TestableFirstTimeWizardNewToadlet extends FirstTimeWizardNewToadlet {
+    Map<String, Object> lastModel;
+    boolean htmlWritten;
+    boolean redirected;
+    String redirectLocation;
+
+    TestableFirstTimeWizardNewToadlet(
+        HighLevelSimpleClient client, NodeClientCore core, Config config) {
+      super(client, core, config);
+    }
+
+    @Override
+    void addChild(
+        HTMLNode parent, String templateName, Map<String, Object> model, String l10nPrefix) {
+      this.lastModel = model;
+      parent.addChild("div", "id", templateName);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply) {
+      this.htmlWritten = true;
+    }
+
+    @Override
+    protected void writeTemporaryRedirect(ToadletContext ctx, String msg, String location) {
+      this.redirected = true;
+      this.redirectLocation = location;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor FirstTimeWizardNewToadlet for clearer logging, constants, and defensive validation
- add dedicated unit tests covering GET/POST flows and validation edge cases
- improve error key handling and model population for the JavaScript wizard

## Testing
- not run (not requested)
