### PR TITLE
Refactor first time wizard flow and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
@@ -33,34 +33,125 @@ import network.crypta.support.api.HTTPRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A first time wizard aimed to ease the configuration of the node. */
+/**
+ * HTTP toadlet that guides a first-time user through configuring a Crypta node. The wizard
+ * sequences a fixed set of UI steps, persists choices across page transitions, and applies
+ * side-effecting actions (such as enabling UPnP or auto-update) only when the relevant presets or
+ * form controls are chosen. It is intentionally self-contained so the launcher and embedded HTTP UI
+ * can share identical onboarding logic.
+ *
+ * <p>The toadlet coordinates several step handlers, each responsible for rendering and validating a
+ * portion of the workflow. Requests are stateless; the wizard rebuilds its flow from submitted form
+ * parameters and redirects between steps instead of maintaining server-side session state. All
+ * mutations funnel through the injected {@link NodeClientCore} instance, so external callers can
+ * rely on consistent authorization and threading policies enforced by the core.
+ *
+ * <p>Concurrency: requests for the same user are serialized by the HTTP layer, but the class does
+ * not assume single-threaded execution. All I/O and plugin manipulations are delegated to {@link
+ * NodeClientCore#getNode()} executors or configuration APIs, preserving thread safety. Callers
+ * should treat instances as request-safe but not share mutable wizard state beyond the persisted
+ * form parameters. Typical usage is to register this toadlet at {@link #TOADLET_URL} so the user is
+ * redirected there after first launch.
+ */
 public class FirstTimeWizardToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(FirstTimeWizardToadlet.class);
   private final NodeClientCore core;
   private final EnumMap<WIZARD_STEP, Step> steps;
   private final MISC stepMISC;
-  private final SECURITY_NETWORK stepSECURITY_NETWORK;
-  private final SECURITY_PHYSICAL stepSECURITY_PHYSICAL;
+  private final SECURITY_NETWORK stepSecurityNetwork;
+  private final SECURITY_PHYSICAL stepSecurityPhysical;
 
   // Legacy Logger threshold callbacks removed; use LOG.isDebugEnabled() directly.
 
+  /**
+   * Enumerates every screen in the first-time wizard. The ordering matches the forward navigation
+   * flow when no preset is selected; preset-specific shortcuts may skip some steps. Consumers
+   * should not reorder entries because the wizard uses ordinal switching and explicit mappings to
+   * compute redirects, back-links, and preset behavior.
+   */
   public enum WIZARD_STEP {
+    /**
+     * Landing page that introduces the wizard, summarizes the flow, and offers either preset
+     * buttons or a manual setup path so the user can choose their comfort level before any settings
+     * are touched.
+     */
     WELCOME,
+    /**
+     * Browser warning step that cautions users about supported browsers, highlights the limits of
+     * incognito mode, and prepares them for network-related redirects used in later steps.
+     */
     BROWSER_WARNING,
+    /**
+     * Miscellaneous settings step where users decide on auto-update behavior and utility plugin
+     * enablement, applying those choices immediately so downstream steps can show accurate current
+     * state.
+     */
     MISC,
+    /**
+     * Step asking whether the node should join opennet or remain darknet-only; this choice
+     * influences later defaults for threat levels and determines whether certain steps can be
+     * skipped.
+     */
     OPENNET,
+    /**
+     * Security step that collects the desired network threat level, optionally prefilled by
+     * presets, and writes the selection so routing and connection policies can be tuned before the
+     * node starts serving traffic.
+     */
     SECURITY_NETWORK,
+    /**
+     * Physical security step for local risk posture; may be skipped for preset-driven quick paths.
+     */
     SECURITY_PHYSICAL,
+    /**
+     * Optional node name selection presented mainly for darknet mode to aid peer identification;
+     * the wizard bypasses this when opennet is enabled because a public node name is unnecessary.
+     */
     NAME_SELECTION,
+    /**
+     * Datastore sizing step that recommends or accepts a custom store size based on disk
+     * heuristics, ensuring background storage tasks start with a sensible capacity ceiling.
+     */
     DATASTORE_SIZE,
+    /**
+     * Bandwidth step capturing overall link speed selections; the values seed later caps and guide
+     * defaults for rate shaping and monthly allotments.
+     */
     BANDWIDTH,
+    /**
+     * Monthly bandwidth cap step allowing users to constrain transfer volume over a billing cycle.
+     */
     BANDWIDTH_MONTHLY,
+    /**
+     * Upload/download rate step for finer grained throughput control in steady-state operation,
+     * applied after the base bandwidth step to let users tune regular vs. bursty traffic.
+     */
     BANDWIDTH_RATE,
+    /**
+     * Terminal pseudo-step that redirects the user to the home page once onboarding is done and the
+     * node is ready for regular use.
+     */
     COMPLETE // Redirects to front page
   }
 
+  /**
+   * Preset bundles that adjust wizard defaults. Presets primarily change threat level, UPnP, and
+   * auto-update settings while skipping intermediate screens to reduce friction. When no preset is
+   * selected the wizard executes the full manual flow and defers side effects until explicit form
+   * submission.
+   */
   public enum WIZARD_PRESET {
+    /**
+     * Low-security preset favoring convenience: enables opennet, UPnP, and auto-update while
+     * keeping physical safeguards at normal levels. Intended for users who prioritize ease of use
+     * and faster onboarding over restrictive defaults.
+     */
     LOW,
+    /**
+     * High-security preset favoring privacy: disables opennet, tightens network threat levels, and
+     * avoids convenience plugins unless manually re-enabled. Suited to users who want to minimize
+     * attack surface even if it requires more manual setup.
+     */
     HIGH
   }
 
@@ -87,13 +178,18 @@ public class FirstTimeWizardToadlet extends Toadlet {
     stepMISC = new MISC(core, config);
     steps.put(WIZARD_STEP.MISC, stepMISC);
 
-    stepSECURITY_NETWORK = new SECURITY_NETWORK(core);
-    steps.put(WIZARD_STEP.SECURITY_NETWORK, stepSECURITY_NETWORK);
+    stepSecurityNetwork = new SECURITY_NETWORK(core);
+    steps.put(WIZARD_STEP.SECURITY_NETWORK, stepSecurityNetwork);
 
-    stepSECURITY_PHYSICAL = new SECURITY_PHYSICAL(core);
-    steps.put(WIZARD_STEP.SECURITY_PHYSICAL, stepSECURITY_PHYSICAL);
+    stepSecurityPhysical = new SECURITY_PHYSICAL(core);
+    steps.put(WIZARD_STEP.SECURITY_PHYSICAL, stepSecurityPhysical);
   }
 
+  /**
+   * Base path where the wizard toadlet is mounted. External callers can redirect users here after
+   * startup; the toadlet uses this constant when building internal step URLs to keep routing
+   * consistent across deployments.
+   */
   public static final String TOADLET_URL = "/wizard/";
 
   private void addWizardConfiguration(Config configuration) {
@@ -153,12 +249,30 @@ public class FirstTimeWizardToadlet extends Toadlet {
     };
   }
 
+  /**
+   * Processes HTTP GET requests by rendering the requested wizard step or redirecting when guard
+   * conditions require skipping ahead. The method validates access rights, normalizes the step
+   * parameter, applies preset-driven shortcuts, and ensures required parameters such as opennet
+   * flags are present before continuing. Responses are generated synchronously; any failure while
+   * producing HTML results in a redirect to the internal error page so users are not left on a
+   * partial screen.
+   *
+   * @param uri request URI provided by the toadlet dispatcher; currently used only for context
+   *     logging and may be relative or absolute.
+   * @param request HTTP request containing query parameters that identify the current step and
+   *     persisted wizard fields; must not be {@code null}.
+   * @param ctx toadlet context responsible for permissions and response writing; expected to be a
+   *     live connection.
+   * @throws ToadletContextClosedException if the client disconnects while the response is being
+   *     written.
+   * @throws IOException if HTML generation or redirect writing fails.
+   */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     if (!ctx.checkFullAccess(this)) return;
 
     // Read the current step from the URL parameter, defaulting to the welcome page if unset or
-    // invalid..
+    // invalid.
     WIZARD_STEP currentStep;
     try {
       currentStep = WIZARD_STEP.valueOf(request.getParam("step", WIZARD_STEP.WELCOME.toString()));
@@ -174,13 +288,11 @@ public class FirstTimeWizardToadlet extends Toadlet {
           ctx, "Skipping unneeded warning", persistFields.appendTo(TOADLET_URL + "?step=MISC"));
       return;
     } else if (currentStep == WIZARD_STEP.MISC && persistFields.isUsingPreset()) {
-      /*If using a preset, skip the miscellaneous page as both high and low security set those settings.
-       * This overrides the persistence fields.*/
       StringBuilder redirectBase = new StringBuilder(TOADLET_URL + "?step=");
       if (persistFields.preset == WIZARD_PRESET.HIGH) {
         redirectBase.append(
             "SECURITY_NETWORK&preset=HIGH&confirm=true&opennet=false&security-levels.networkThreatLevel=HIGH");
-      } else /*if (persistFields.preset == WIZARD_PRESET.LOW)*/ {
+      } else {
         redirectBase.append("DATASTORE_SIZE&preset=LOW&opennet=true");
       }
       // addPersistFields() is not used here because the fields are overridden.
@@ -210,144 +322,197 @@ public class FirstTimeWizardToadlet extends Toadlet {
   }
 
   /**
-   * @return whether wizard steps should log minor events.
+   * Indicates whether wizard components should emit minor debug-level events. This is a thin helper
+   * around the shared logger so step implementations do not repeat the {@link
+   * Logger#isDebugEnabled()} check. Returning {@code false} discourages verbose logging during
+   * normal operation, while a {@code true} value makes it safe to log granular state transitions
+   * that aid troubleshooting without changing behavior.
+   *
+   * @return {@code true} when debug logging is enabled and steps may log fine-grained progress;
+   *     otherwise {@code false} to minimize noise.
    */
   public static boolean shouldLogMinor() {
     return LOG.isDebugEnabled();
   }
 
+  /**
+   * Processes HTTP POST submissions for the wizard. The method normalizes the current step, routes
+   * preset button presses through {@link #handlePresetSelection(HTTPRequest, ToadletContext)}, and
+   * delegates form handling to the relevant step implementation. Redirect targets are calculated
+   * eagerly to keep clients on a consistent flow even when optional fields are missing. Any IO or
+   * context failures are surfaced immediately because partial application of wizard state is
+   * undesirable.
+   *
+   * @param uri request URI provided by the toadlet dispatcher; not inspected for routing logic.
+   * @param request HTTP request containing form fields submitted by the user; must include the
+   *     current step identifier.
+   * @param ctx toadlet context that mediates access checks and redirect writing; expected to remain
+   *     open for the duration of processing.
+   * @throws ToadletContextClosedException if the client disconnects before the redirect is sent.
+   * @throws IOException if redirect responses cannot be written or step handlers encounter IO
+   *     issues.
+   */
   public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
+    Objects.requireNonNull(uri, "uri");
     if (!ctx.checkFullAccess(this)) return;
 
-    WIZARD_STEP currentStep;
-    try {
-      // Attempt to parse the current step, defaulting to WELCOME if unspecified or invalid.
-      String currentValue = request.getPartAsStringFailsafe("step", 20);
-      currentStep =
-          currentValue.isEmpty() ? WIZARD_STEP.WELCOME : WIZARD_STEP.valueOf(currentValue);
-    } catch (IllegalArgumentException e) {
-      // Failed to parse enum value, default to welcome.
-      // TODO: Should this be an error page instead?
-      currentStep = WIZARD_STEP.WELCOME;
+    WIZARD_STEP currentStep = parseCurrentStep(request);
+    PersistFields persistFields = new PersistFields(request);
+
+    if (isPresetSelection(currentStep, request)) {
+      handlePresetSelection(request, ctx);
+      return;
     }
 
-    PersistFields persistFields = new PersistFields(request);
-    String redirectTarget;
+    RedirectResult redirectResult;
+    try {
+      redirectResult = determineRedirect(currentStep, persistFields, request);
+    } catch (IOException e) {
+      writeInternalError(ctx, e);
+      return;
+    }
 
-    if (currentStep.equals(WIZARD_STEP.WELCOME)
+    persistFields = redirectResult.persistFields;
+    super.writeTemporaryRedirect(
+        ctx, "Wizard redirect", stepURL(persistFields.appendTo(redirectResult.target)));
+  }
+
+  private WIZARD_STEP parseCurrentStep(HTTPRequest request) {
+    try {
+      String currentValue = request.getPartAsStringFailsafe("step", 20);
+      return currentValue.isEmpty() ? WIZARD_STEP.WELCOME : WIZARD_STEP.valueOf(currentValue);
+    } catch (IllegalArgumentException e) {
+      return WIZARD_STEP.WELCOME;
+    }
+  }
+
+  private boolean isPresetSelection(WIZARD_STEP currentStep, HTTPRequest request) {
+    return currentStep.equals(WIZARD_STEP.WELCOME)
         && (request.isPartSet("presetLow")
             || request.isPartSet("presetHigh")
-            || request.isPartSet("presetNone"))) {
-
-      /*Apply presets and UPnP is enabled first to allow it time to load (and thus enable
-      autodetection) before hitting the bandwidth page. This also effectively sets the preset field.*/
-      StringBuilder redirectTo =
-          new StringBuilder(TOADLET_URL + "?step=BROWSER_WARNING&incognito=");
-      redirectTo.append(request.getPartAsStringFailsafe("incognito", 5));
-
-      // Translate button name to preset value on the query string.
-      if (request.isPartSet("presetLow")) {
-        // Low security preset
-        stepMISC.setUPnP(loadUPnPPlugin);
-        stepMISC.setAutoUpdate(enableAutoUpdater);
-        redirectTo.append("&preset=LOW&opennet=true");
-        stepSECURITY_NETWORK.setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.LOW);
-        stepSECURITY_PHYSICAL.setThreatLevel(
-            SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, stepSECURITY_PHYSICAL.getCurrentLevel());
-      } else if (request.isPartSet("presetHigh")) {
-        // High security preset
-        stepMISC.setUPnP(loadUPnPPlugin);
-        stepMISC.setAutoUpdate(enableAutoUpdater);
-        redirectTo.append("&preset=HIGH&opennet=false");
-      }
-
-      super.writeTemporaryRedirect(ctx, "Wizard set preset", redirectTo.toString());
-      return;
-    } else if (request.isPartSet("back")) {
-      // User chose back, return to previous page, or cancel if single step.
-      if (request.isPartSet("singlestep")) {
-        redirectTarget = WIZARD_STEP.COMPLETE.name();
-      } else {
-        redirectTarget = getPreviousStep(currentStep, persistFields.preset).name();
-      }
-    } else {
-      try {
-        redirectTarget = steps.get(currentStep).postStep(request);
-        // Go to complete rather than go to next if single step.
-        if (request.isPartSet("singlestep") && !redirectTarget.startsWith(currentStep.name())) {
-          redirectTarget = WIZARD_STEP.COMPLETE.name();
-        }
-
-        // Opennet step can change the persisted value for opennet.
-        if (currentStep == WIZARD_STEP.OPENNET) {
-          try {
-            HTTPRequest newRequest = new HTTPRequestImpl(new URI(stepURL(redirectTarget)), "GET");
-            // Only continue if a value for opennet has been selected.
-            if (newRequest.isPartSet("opennet")) {
-              redirectTarget = WIZARD_STEP.SECURITY_NETWORK.name();
-              persistFields = new PersistFields(persistFields.preset, newRequest);
-            }
-          } catch (URISyntaxException e) {
-            LOG.error("Unexpected invalid query string from OPENNET step! {}", e.toString(), e);
-            redirectTarget = WIZARD_STEP.WELCOME.name();
-          }
-        }
-      } catch (IOException e) {
-        String title;
-        if (e.getMessage().equals("cantWriteNewMasterKeysFile")) {
-          // Recognized as being unable to write to the master keys file.
-          title = NodeL10n.getBase().getString("SecurityLevels.cantWriteNewMasterKeysFileTitle");
-        } else {
-          // Some other error.
-          title = NodeL10n.getBase().getString("Toadlet.internalErrorPleaseReport");
-        }
-
-        // Very loud error message, with descriptive title and header if possible.
-        StringBuilder msg =
-            new StringBuilder("<html><head><title>")
-                .append(title)
-                .append("</title></head><body><h1>")
-                .append(title)
-                .append("</h1><pre>");
-
-        // Print stack trace.
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        e.printStackTrace(pw);
-        pw.flush();
-        msg.append(sw).append("</pre>");
-
-        // Include internal exception if one exists.
-        Throwable internal = e.getCause();
-        if (internal != null) {
-          msg.append("<h1>")
-              .append(NodeL10n.getBase().getString("Toadlet.internalErrorPleaseReport"))
-              .append("</h1>")
-              .append("<pre>");
-
-          sw = new StringWriter();
-          pw = new PrintWriter(sw);
-          internal.printStackTrace(pw);
-          pw.flush();
-          msg.append(sw).append("</pre>");
-        }
-        msg.append("</body></html>");
-        writeHTMLReply(ctx, 500, "Internal Error", msg.toString());
-        return;
-      }
-    }
-    super.writeTemporaryRedirect(
-        ctx, "Wizard redirect", stepURL(persistFields.appendTo(redirectTarget)));
+            || request.isPartSet("presetNone"));
   }
+
+  private void handlePresetSelection(HTTPRequest request, ToadletContext ctx)
+      throws IOException, ToadletContextClosedException {
+    StringBuilder redirectTo = new StringBuilder(TOADLET_URL + "?step=BROWSER_WARNING&incognito=");
+    redirectTo.append(request.getPartAsStringFailsafe("incognito", 5));
+
+    boolean presetLow = request.isPartSet("presetLow");
+    boolean presetHigh = request.isPartSet("presetHigh");
+
+    if (presetLow) {
+      stepMISC.setUPnP(loadUPnPPlugin);
+      stepMISC.setAutoUpdate(enableAutoUpdater);
+      stepSecurityNetwork.setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.LOW);
+      stepSecurityPhysical.setThreatLevel(
+          SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, stepSecurityPhysical.getCurrentLevel());
+      redirectTo.append("&preset=LOW&opennet=true");
+    } else if (presetHigh) {
+      stepMISC.setUPnP(loadUPnPPlugin);
+      stepMISC.setAutoUpdate(enableAutoUpdater);
+      redirectTo.append("&preset=HIGH&opennet=false");
+    }
+
+    super.writeTemporaryRedirect(ctx, "Wizard set preset", redirectTo.toString());
+  }
+
+  private RedirectResult determineRedirect(
+      WIZARD_STEP currentStep, PersistFields persistFields, HTTPRequest request)
+      throws IOException {
+    if (request.isPartSet("back")) {
+      String redirectTarget =
+          request.isPartSet("singlestep")
+              ? WIZARD_STEP.COMPLETE.name()
+              : getPreviousStep(currentStep, persistFields.preset).name();
+      return new RedirectResult(redirectTarget, persistFields);
+    }
+
+    String redirectTarget = steps.get(currentStep).postStep(request);
+    if (request.isPartSet("singlestep") && !redirectTarget.startsWith(currentStep.name())) {
+      redirectTarget = WIZARD_STEP.COMPLETE.name();
+    }
+
+    if (currentStep == WIZARD_STEP.OPENNET) {
+      return adjustForOpenNet(redirectTarget, persistFields);
+    }
+
+    return new RedirectResult(redirectTarget, persistFields);
+  }
+
+  private RedirectResult adjustForOpenNet(String redirectTarget, PersistFields persistFields) {
+    try {
+      HTTPRequest newRequest = new HTTPRequestImpl(new URI(stepURL(redirectTarget)), "GET");
+      if (newRequest.isPartSet("opennet")) {
+        PersistFields updatedPersist = new PersistFields(persistFields.preset, newRequest);
+        return new RedirectResult(WIZARD_STEP.SECURITY_NETWORK.name(), updatedPersist);
+      }
+      return new RedirectResult(redirectTarget, persistFields);
+    } catch (URISyntaxException e) {
+      LOG.error("Unexpected invalid query string from OPENNET step! {}", e, e);
+      return new RedirectResult(WIZARD_STEP.WELCOME.name(), persistFields);
+    }
+  }
+
+  private void writeInternalError(ToadletContext ctx, IOException e)
+      throws IOException, ToadletContextClosedException {
+    String title;
+    if ("cantWriteNewMasterKeysFile".equals(e.getMessage())) {
+      title = NodeL10n.getBase().getString("SecurityLevels.cantWriteNewMasterKeysFileTitle");
+    } else {
+      title = NodeL10n.getBase().getString("Toadlet.internalErrorPleaseReport");
+    }
+
+    StringBuilder msg =
+        new StringBuilder("<html><head><title>")
+            .append(title)
+            .append("</title></head><body><h1>")
+            .append(title)
+            .append("</h1><pre>");
+
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    e.printStackTrace(pw);
+    pw.flush();
+    msg.append(sw).append("</pre>");
+
+    Throwable internal = e.getCause();
+    if (internal != null) {
+      msg.append("<h1>")
+          .append(NodeL10n.getBase().getString("Toadlet.internalErrorPleaseReport"))
+          .append("</h1>")
+          .append("<pre>");
+
+      sw = new StringWriter();
+      pw = new PrintWriter(sw);
+      internal.printStackTrace(pw);
+      pw.flush();
+      msg.append(sw).append("</pre>");
+    }
+    msg.append("</body></html>");
+    writeHTMLReply(ctx, 500, "Internal Error", msg.toString());
+  }
+
+  private record RedirectResult(String target, PersistFields persistFields) {}
 
   private String stepURL(String step) {
     return TOADLET_URL + "?step=" + step;
   }
 
-  // FIXME: There really has to be a better way to find the previous step, but with an enum there's
-  // no decrement.
-  // FIXME: Would a set work better than an enum?
+  /**
+   * Computes the previous wizard step given the current position and any preset in effect. The
+   * method respects preset-specific jumps (for example, HIGH can skip directly from the security
+   * pages back to the welcome screen) while maintaining the default linear ordering for manual
+   * flows. {@code null} presets are treated as manual mode. This helper is side effect free and can
+   * be used by both server logic and template code when building back buttons.
+   *
+   * @param currentStep step for which the caller needs the previous page; must not be {@code null}.
+   * @param preset active preset that may change the navigation path; may be {@code null} to signal
+   *     manual setup.
+   * @return the step users should be sent to when navigating backward from {@code currentStep},
+   *     defaulting to {@link WIZARD_STEP#WELCOME} when unknown.
+   */
   public static WIZARD_STEP getPreviousStep(WIZARD_STEP currentStep, WIZARD_PRESET preset) {
 
     // Might be obvious, but still: No breaks needed in cases because their only contents are
@@ -356,49 +521,41 @@ public class FirstTimeWizardToadlet extends Toadlet {
     // First pages for the presets
     if (preset == WIZARD_PRESET.HIGH) {
       switch (currentStep) {
-        case SECURITY_NETWORK:
-        case SECURITY_PHYSICAL:
-          // Go back to the beginning from the warning or the physical security page.
+        case SECURITY_NETWORK, SECURITY_PHYSICAL:
           return WIZARD_STEP.WELCOME;
         default:
           // do nothing
       }
-    } else if (preset == WIZARD_PRESET.LOW) {
-      // do nothing
-      if (Objects.requireNonNull(currentStep)
-          == WIZARD_STEP.DATASTORE_SIZE) { // Go back to the beginning from the datastore page.
-        return WIZARD_STEP.WELCOME;
-      }
+    } else if (preset == WIZARD_PRESET.LOW
+        && Objects.requireNonNull(currentStep) == WIZARD_STEP.DATASTORE_SIZE) {
+      return WIZARD_STEP.WELCOME;
     }
 
     // Otherwise normal order.
-    switch (currentStep) {
-      case MISC:
-      case BROWSER_WARNING:
-        return WIZARD_STEP.WELCOME;
-      case OPENNET:
-        return WIZARD_STEP.MISC;
-      case SECURITY_NETWORK:
-        return WIZARD_STEP.OPENNET;
-      case SECURITY_PHYSICAL:
-        return WIZARD_STEP.SECURITY_NETWORK;
-      case NAME_SELECTION:
-        return WIZARD_STEP.SECURITY_PHYSICAL;
-      case DATASTORE_SIZE:
-        return WIZARD_STEP.NAME_SELECTION;
-      case BANDWIDTH:
-        return WIZARD_STEP.DATASTORE_SIZE;
-      case BANDWIDTH_MONTHLY:
-      case BANDWIDTH_RATE:
-        return WIZARD_STEP.BANDWIDTH;
-      default:
-        // do nothing
-    }
-
-    // Should be matched by this point, unknown step.
-    return WIZARD_STEP.WELCOME;
+    return switch (currentStep) {
+      case MISC, BROWSER_WARNING -> WIZARD_STEP.WELCOME;
+      case OPENNET -> WIZARD_STEP.MISC;
+      case SECURITY_NETWORK -> WIZARD_STEP.OPENNET;
+      case SECURITY_PHYSICAL -> WIZARD_STEP.SECURITY_NETWORK;
+      case NAME_SELECTION -> WIZARD_STEP.SECURITY_PHYSICAL;
+      case DATASTORE_SIZE -> WIZARD_STEP.NAME_SELECTION;
+      case BANDWIDTH -> WIZARD_STEP.DATASTORE_SIZE;
+      case BANDWIDTH_MONTHLY, BANDWIDTH_RATE -> WIZARD_STEP.BANDWIDTH;
+      default ->
+          // do nothing
+          // Should be matched by this point, unknown step.
+          WIZARD_STEP.WELCOME;
+    };
   }
 
+  /**
+   * {@inheritDoc} This implementation always returns {@link #TOADLET_URL}, ensuring the wizard is
+   * consistently mounted even when instantiated in different hosting environments. Downstream code
+   * should rely on this constant rather than duplicating path literals to avoid divergence between
+   * registration and redirect construction.
+   *
+   * @return canonical mount path for this toadlet, suitable for redirect targets and registration.
+   */
   @Override
   public String path() {
     return TOADLET_URL;

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
@@ -1,0 +1,218 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.EnumMap;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.FirstTimeWizardToadlet.WIZARD_PRESET;
+import network.crypta.clients.http.FirstTimeWizardToadlet.WIZARD_STEP;
+import network.crypta.clients.http.wizardsteps.MISC;
+import network.crypta.clients.http.wizardsteps.PageHelper;
+import network.crypta.clients.http.wizardsteps.SECURITY_NETWORK;
+import network.crypta.clients.http.wizardsteps.SECURITY_PHYSICAL;
+import network.crypta.clients.http.wizardsteps.Step;
+import network.crypta.config.PersistentConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.SecurityLevels;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class FirstTimeWizardToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private Node node;
+  @Mock private NodeClientCore core;
+  @Mock private ToadletContext ctx;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    PersistentConfig config = new PersistentConfig(null);
+    when(node.getConfig()).thenReturn(config);
+    when(core.getNode()).thenReturn(node);
+    when(ctx.checkFullAccess(any())).thenReturn(true);
+  }
+
+  @Test
+  void getPreviousStep_withHighPresetAtSecurityNetwork_returnsWelcome() {
+    WIZARD_STEP result =
+        FirstTimeWizardToadlet.getPreviousStep(WIZARD_STEP.SECURITY_NETWORK, WIZARD_PRESET.HIGH);
+
+    assertEquals(WIZARD_STEP.WELCOME, result);
+  }
+
+  @Test
+  void handleMethodGET_browserWarningWithIncognitoChrome_redirectsToMisc() throws Exception {
+    FirstTimeWizardToadlet toadlet = spy(new FirstTimeWizardToadlet(client, node, core));
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.hasParameters()).thenReturn(true);
+    when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
+        .thenReturn("BROWSER_WARNING");
+    when(request.getParam("opennet", "false")).thenReturn("false");
+    when(request.getParam("singlestep", "false")).thenReturn("false");
+    when(request.getParam("preset")).thenReturn("");
+    when(request.isChrome()).thenReturn(true);
+    when(request.isIncognito()).thenReturn(true);
+
+    ArgumentCaptor<String> locationCaptor = ArgumentCaptor.forClass(String.class);
+    doNothing()
+        .when(toadlet)
+        .writeTemporaryRedirect(eq(ctx), anyString(), locationCaptor.capture());
+
+    toadlet.handleMethodGET(new URI(FirstTimeWizardToadlet.TOADLET_URL), request, ctx);
+
+    verify(toadlet, times(1))
+        .writeTemporaryRedirect(eq(ctx), eq("Skipping unneeded warning"), anyString());
+    assertEquals("/wizard/?step=MISC&opennet=false", locationCaptor.getValue());
+  }
+
+  @Test
+  void handleMethodGET_securityNetworkWithoutOpennet_redirectsToOpenNet() throws Exception {
+    FirstTimeWizardToadlet toadlet = spy(new FirstTimeWizardToadlet(client, node, core));
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.hasParameters()).thenReturn(true);
+    when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
+        .thenReturn("SECURITY_NETWORK");
+    when(request.getParam("opennet", "false")).thenReturn("false");
+    when(request.getParam("singlestep", "false")).thenReturn("false");
+    when(request.getParam("preset")).thenReturn("");
+    when(request.isParameterSet("opennet")).thenReturn(false);
+
+    ArgumentCaptor<String> locationCaptor = ArgumentCaptor.forClass(String.class);
+    doNothing()
+        .when(toadlet)
+        .writeTemporaryRedirect(eq(ctx), anyString(), locationCaptor.capture());
+
+    toadlet.handleMethodGET(new URI(FirstTimeWizardToadlet.TOADLET_URL), request, ctx);
+
+    verify(toadlet, times(1))
+        .writeTemporaryRedirect(eq(ctx), eq("Need opennet choice"), anyString());
+    assertEquals("/wizard/?step=OPENNET&opennet=false", locationCaptor.getValue());
+  }
+
+  @Test
+  void handleMethodPOST_presetLow_setsThreatLevelsAndRedirects() throws Exception {
+    FirstTimeWizardToadlet toadlet = spy(new FirstTimeWizardToadlet(client, node, core));
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.hasParameters()).thenReturn(false);
+    when(request.getPartAsStringFailsafe("step", 20)).thenReturn("WELCOME");
+    when(request.getPartAsStringFailsafe("incognito", 5)).thenReturn("0");
+    when(request.getPartAsStringFailsafe("preset", 4)).thenReturn("LOW");
+    when(request.getPartAsStringFailsafe("opennet", 5)).thenReturn("false");
+    when(request.getPartAsStringFailsafe("singlestep", 5)).thenReturn("false");
+    when(request.isPartSet("presetLow")).thenReturn(true);
+    when(request.isPartSet("presetHigh")).thenReturn(false);
+    when(request.isPartSet("presetNone")).thenReturn(false);
+    when(request.isPartSet("back")).thenReturn(false);
+    when(request.isPartSet("singlestep")).thenReturn(false);
+
+    // Replace side-effecting steps with mocks to verify interactions.
+    MISC misc = mock(MISC.class);
+    SECURITY_NETWORK securityNetwork = mock(SECURITY_NETWORK.class);
+    SECURITY_PHYSICAL securityPhysical = mock(SECURITY_PHYSICAL.class);
+    when(securityPhysical.getCurrentLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    setField(toadlet, "stepMISC", misc);
+    setField(toadlet, "stepSecurityNetwork", securityNetwork);
+    setField(toadlet, "stepSecurityPhysical", securityPhysical);
+
+    ArgumentCaptor<String> locationCaptor = ArgumentCaptor.forClass(String.class);
+    doNothing()
+        .when(toadlet)
+        .writeTemporaryRedirect(eq(ctx), anyString(), locationCaptor.capture());
+
+    toadlet.handleMethodPOST(new URI(FirstTimeWizardToadlet.TOADLET_URL), request, ctx);
+
+    verify(misc).setUPnP(true);
+    verify(misc).setAutoUpdate(true);
+    verify(securityNetwork).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.LOW);
+    verify(securityPhysical)
+        .setThreatLevel(
+            SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL,
+            SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    assertEquals(
+        "/wizard/?step=BROWSER_WARNING&incognito=0&preset=LOW&opennet=true",
+        locationCaptor.getValue());
+  }
+
+  @Test
+  void handleMethodPOST_whenStepThrowsIOException_returnsInternalErrorPage() throws Exception {
+    FirstTimeWizardToadlet toadlet = spy(new FirstTimeWizardToadlet(client, node, core));
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.hasParameters()).thenReturn(false);
+    when(request.getPartAsStringFailsafe("step", 20)).thenReturn("MISC");
+    when(request.getPartAsStringFailsafe("preset", 4)).thenReturn("");
+    when(request.isPartSet(anyString())).thenReturn(false);
+
+    // Force current step handler to throw.
+    EnumMap<WIZARD_STEP, Step> steps = getSteps(toadlet);
+    Step failingStep =
+        new Step() {
+          @Override
+          public void getStep(HTTPRequest request, PageHelper helper) {
+            // no-op for this test
+          }
+
+          @Override
+          public String postStep(HTTPRequest request) throws IOException {
+            throw new IOException("cantWriteNewMasterKeysFile");
+          }
+        };
+    steps.put(WIZARD_STEP.MISC, failingStep);
+
+    ArgumentCaptor<Integer> codeCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+    doNothing()
+        .when(toadlet)
+        .writeHTMLReply(eq(ctx), codeCaptor.capture(), anyString(), bodyCaptor.capture());
+
+    toadlet.handleMethodPOST(new URI(FirstTimeWizardToadlet.TOADLET_URL), request, ctx);
+
+    assertEquals(500, codeCaptor.getValue());
+    assertTrue(bodyCaptor.getValue().contains("<html>"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private EnumMap<WIZARD_STEP, Step> getSteps(FirstTimeWizardToadlet toadlet) {
+    try {
+      Field field = FirstTimeWizardToadlet.class.getDeclaredField("steps");
+      field.setAccessible(true);
+      return (EnumMap<WIZARD_STEP, Step>) field.get(toadlet);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private void setField(Object target, String fieldName, Object value) {
+    try {
+      Field field = FirstTimeWizardToadlet.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- clarify the first-time wizard toadlet with richer documentation and renamed helpers
- refactor preset/back/redirect logic into smaller helpers and tighten error handling
- add unit coverage for navigation, preset handling, and internal error paths

## Testing
- ./gradlew spotlessApply
- Not run: other tests