### PR TITLE
Refactor HTTPRequestImpl parsing and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/HTTPRequestImpl.java
+++ b/src/main/java/network/crypta/clients/http/HTTPRequestImpl.java
@@ -33,10 +33,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Used for passing all HTTP request information to the FredPlugin that handles the request. It
- * parses the query string and has several methods for accessing the request parameter values.
+ * Concrete {@link HTTPRequest} implementation that parses URIs, headers, and multipart bodies into
+ * accessible parameters and buckets for plugin handlers.
  *
- * @author nacktschneck
+ * <p>This class is created by the toadlet layer to expose request data to plugins and other
+ * components that expect the stable {@code HTTPRequest} API. It accepts either a pre-parsed {@link
+ * URI} or discrete path/query inputs, extracts query parameters into a multimap, and—when a body is
+ * present—parses {@code application/x-www-form-urlencoded} payloads or {@code multipart/form-data}
+ * uploads into {@link Bucket} instances. Parsed form fields are preserved in insertion order, and
+ * uploaded file bodies are stored in {@link RandomAccessBucket} instances supplied by the provided
+ * {@link BucketFactory}. The object is intentionally mutable for the duration of request handling
+ * but should be treated as confined to a single request-processing thread; it does not perform
+ * internal synchronization.
+ *
+ * <p>Typical usage: create an instance inside request dispatch, read scalar parameters via {@link
+ * #getParam(String)} or {@link #getIntParam(String)}, access uploaded files through {@link
+ * #getUploadedFile(String)}, and finally call {@link #freeParts()} once processing is complete to
+ * release bucket resources. Callers should not modify the returned buckets directly unless they
+ * fully own their lifecycle.
  */
 public class HTTPRequestImpl implements HTTPRequest {
   private static final Logger LOG = LoggerFactory.getLogger(HTTPRequestImpl.class);
@@ -73,13 +87,19 @@ public class HTTPRequestImpl implements HTTPRequest {
   // Legacy Logger threshold callbacks removed; use LOG.isDebugEnabled() directly for minor logs.
 
   /**
-   * Create a new HTTPRequest for the given URI and parse its request parameters.
+   * Builds a request wrapper for a URI that contains only a query string (no entity body).
    *
-   * @param uri the URI being requested
+   * <p>The constructor immediately parses the raw query into parameter lists so callers can read
+   * values through the convenience accessors. Use this overload when the transport layer already
+   * provided a complete {@link URI} and no payload needs to be streamed.
+   *
+   * @param uri the absolute or path-only URI being requested; must not be {@code null}
+   * @param method HTTP method name as received on the wire (for example, {@code "GET"} or {@code
+   *     "HEAD"})
    */
   public HTTPRequestImpl(URI uri, String method) {
     this.uri = uri;
-    this.parseRequestParameters(uri.getRawQuery(), true, false);
+    this.parseRequestParameters(uri.getRawQuery(), false);
     this.data = null;
     this.parts = null;
     this.bucketfactory = null;
@@ -87,11 +107,20 @@ public class HTTPRequestImpl implements HTTPRequest {
   }
 
   /**
-   * Creates a new HTTPRequest for the given path and url-encoded query string
+   * Builds a request from discrete path and query components, decoding neither at construction
+   * time.
    *
-   * @param path i.e. /test/test.html
-   * @param encodedQueryString a=some+text&b=abc%40def.de
-   * @throws URISyntaxException if the URI is invalid
+   * <p>This overload is useful for tests or callers that already separated the path from the query
+   * string. The constructor assembles the components into a {@link URI}, parses the query portion
+   * into parameters, and records the method verb. No body data is expected; multipart parsing will
+   * not be attempted.
+   *
+   * @param path request path such as {@code "/test/test.html"}; should be URL-encoded if it was
+   *     encoded on the wire
+   * @param encodedQueryString URL-encoded query content like {@code "a=some+text&b=abc%40def.de"};
+   *     may be {@code null} or empty to indicate no parameters
+   * @param method HTTP method name that triggered the request
+   * @throws URISyntaxException if the concatenated path and query cannot form a valid URI
    */
   public HTTPRequestImpl(String path, String encodedQueryString, String method)
       throws URISyntaxException {
@@ -104,22 +133,29 @@ public class HTTPRequestImpl implements HTTPRequest {
       this.uri = new URI(path);
     }
     this.method = method;
-    this.parseRequestParameters(uri.getRawQuery(), true, false);
+    this.parseRequestParameters(uri.getRawQuery(), false);
   }
 
   /**
-   * Creates a new HTTPRequest for the given URI and data.
+   * Builds a request that includes headers and an optional entity body, enabling multipart parsing.
    *
-   * @param uri The URI being requested
-   * @param h Client headers
-   * @param d The data
-   * @param ctx The toadlet context (for headers and bucket factory)
-   * @throws URISyntaxException if the URI is invalid
+   * <p>The constructor stores caller-supplied headers and bucket factory from the {@link
+   * ToadletContext}, parses query parameters, and, when a body is present, attempts to extract form
+   * fields or uploaded files depending on the detected {@code Content-Type}. Uploaded parts are
+   * materialized as {@link RandomAccessBucket} instances owned by this request until {@link
+   * #freeParts()} is called. Errors during multipart parsing are logged but do not abort
+   * construction so that callers can fall back to alternative handling.
+   *
+   * @param uri the target URI as received over HTTP; must be syntactically valid
+   * @param d bucket containing the raw request body; may be {@code null} when no payload is present
+   * @param ctx toadlet context supplying request headers and a {@link BucketFactory} for allocating
+   *     part buckets
+   * @param method HTTP method name such as {@code "POST"}; stored verbatim for later retrieval
    */
   public HTTPRequestImpl(URI uri, Bucket d, ToadletContext ctx, String method) {
     this.uri = uri;
     this.headers = ctx.getHeaders();
-    this.parseRequestParameters(uri.getRawQuery(), true, false);
+    this.parseRequestParameters(uri.getRawQuery(), false);
     this.data = d;
     this.parts = new HashMap<>();
     this.bucketfactory = ctx.getBucketFactory();
@@ -128,21 +164,35 @@ public class HTTPRequestImpl implements HTTPRequest {
       try {
         this.parseMultiPartData();
       } catch (IOException ioe) {
-        LOG.error("Temporary files error ? Could not parse: {}", ioe.toString(), ioe);
+        LOG.error("Temporary files error ? Could not parse: {}", ioe, ioe);
       }
     }
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getPath()
+  /**
+   * Returns the decoded request path component without query or fragment parts.
+   *
+   * <p>The value is derived directly from the stored {@link URI} and therefore reflects any
+   * normalization or encoding that occurred upstream. Callers can rely on this method to be side
+   * effect free; it does not mutate internal state and can be invoked multiple times during request
+   * processing.
+   *
+   * @return absolute or relative path portion of the request URI, never {@code null} but possibly
+   *     empty for edge-case URIs
    */
   @Override
   public String getPath() {
     return this.uri.getPath();
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#hasParameters()
+  /**
+   * Reports whether any query or body parameters have been parsed for this request.
+   *
+   * <p>The method inspects the internal parameter multimap populated during construction or
+   * multipart parsing. It does not trigger additional parsing work, making it inexpensive to call
+   * in routing logic that needs to short-circuit when no form data is present.
+   *
+   * @return {@code true} when at least one parameter name is recorded; {@code false} otherwise
    */
   @Override
   public boolean hasParameters() {
@@ -150,9 +200,14 @@ public class HTTPRequestImpl implements HTTPRequest {
   }
 
   /**
-   * Returns the names of all parameters.
+   * Returns a live view of all parameter names currently stored on the request.
    *
-   * @return The names of all parameters
+   * <p>The returned collection reflects both query parameters and URL-encoded form fields that were
+   * parsed at construction time. The collection is backed by the internal map, so later additions
+   * or removals to that map are observable. Callers should not mutate the map itself, but iterating
+   * the key set is safe for typical read scenarios.
+   *
+   * @return collection of parameter names; iteration order follows insertion order from the parser
    */
   @Override
   public Collection<String> getParameterNames() {
@@ -165,14 +220,12 @@ public class HTTPRequestImpl implements HTTPRequest {
    * Because they rely on the parameter map to be filled.
    *
    * @param queryString the query string in its raw form (not yet url-decoded)
-   * @param doUrlDecoding TODO
    */
-  private void parseRequestParameters(String queryString, boolean doUrlDecoding, boolean asParts) {
+  private void parseRequestParameters(String queryString, boolean asParts) {
 
-    if (LOG.isDebugEnabled())
-      LOG.debug("queryString is {} , doUrlDecoding={}", queryString, doUrlDecoding);
+    if (LOG.isDebugEnabled()) LOG.debug("queryString is {} , doUrlDecoding=true", queryString);
 
-    Map<String, List<String>> parameters = parseUriParameters(queryString, doUrlDecoding);
+    Map<String, List<String>> parameters = parseUriParameters(queryString, true);
 
     if (asParts) {
       for (Entry<String, List<String>> parameterValues : parameters.entrySet()) {
@@ -215,90 +268,91 @@ public class HTTPRequestImpl implements HTTPRequest {
    * @return the list of all values for this parameter that were parsed so far.
    */
   private List<String> getParameterValueList(String name) {
-    List<String> values = this.parameterNameValuesMap.get(name);
-    if (values == null) {
-      values = new LinkedList<>();
-      this.parameterNameValuesMap.put(name, values);
-    }
-    return values;
+    return parameterNameValuesMap.computeIfAbsent(name, ignored -> new LinkedList<>());
   }
 
   /**
-   * Parses the parameters from the given query string, optionally decoding the parameters using
-   * UTF-8.
+   * Parses a {@code name=value&...} query string into a multimap of parameter names to value lists.
    *
-   * @param queryString The query string to decode
-   * @param doUrlDecoding {@code true} to decode the parameter names and values
-   * @return The decoded parameters
+   * <p>This utility performs minimal allocation while preserving duplicate keys in the order they
+   * are encountered. When {@code doUrlDecoding} is {@code true}, both names and values are decoded
+   * with UTF-8 using {@link URLDecoder}. Tokens lacking an {@code '='} character are treated as
+   * keys with an empty value. The method never returns {@code null}; absent or empty input produces
+   * an empty map.
+   *
+   * @param queryString raw query portion as received on the wire; may be {@code null} or empty
+   * @param doUrlDecoding whether to URL-decode names and values using UTF-8 before storing them
+   * @return mutable map from parameter name to list of values in encounter order; the caller owns
+   *     the returned structure
    */
   public static Map<String, List<String>> parseUriParameters(
       String queryString, boolean doUrlDecoding) {
     if (LOG.isDebugEnabled())
       LOG.debug("queryString is {} , doUrlDecoding={}", queryString, doUrlDecoding);
 
-    /* create result map. */
     Map<String, List<String>> parameters = new HashMap<>();
-
-    // nothing to do if there was no query string in the URI
     if ((queryString == null) || queryString.isEmpty()) {
       return parameters;
     }
 
-    // iterate over all tokens in the query string (separated by &)
     StringTokenizer tokenizer = new StringTokenizer(queryString, "&");
     while (tokenizer.hasMoreTokens()) {
       String nameValueToken = tokenizer.nextToken();
-
       if (LOG.isDebugEnabled()) LOG.debug("Token: {}", nameValueToken);
-
-      // a token can be either a name, or a name value pair...
-      String name = null;
-      String value = "";
-      int indexOfEqualsChar = nameValueToken.indexOf('=');
-      if (indexOfEqualsChar < 0) {
-        // ...it's only a name, so the value stays emptys
-        name = nameValueToken;
-        if (LOG.isDebugEnabled()) LOG.debug("Name: {}", name);
-      } else if (indexOfEqualsChar == nameValueToken.length() - 1) {
-        // ...it's a name with an empty value, so remove the '='
-        // character
-        name = nameValueToken.substring(0, indexOfEqualsChar);
-        if (LOG.isDebugEnabled()) LOG.debug("Name: {}", name);
-      } else {
-        // ...it's a name value pair, split into name and value
-        name = nameValueToken.substring(0, indexOfEqualsChar);
-        value = nameValueToken.substring(indexOfEqualsChar + 1);
-        if (LOG.isDebugEnabled()) LOG.debug("Name: {} Value: {}", name, value);
-      }
-
-      // url-decode the name and value
-      if (doUrlDecoding) {
-        name = URLDecoder.decode(name, StandardCharsets.UTF_8);
-        value = URLDecoder.decode(value, StandardCharsets.UTF_8);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Decoded name: {}", name);
-          LOG.debug("Decoded value: {}", value);
-        }
-      }
-
-      List<String> values = parameters.get(name);
-      if (values == null) {
-        values = new ArrayList<>();
-        parameters.put(name, values);
-      }
-      values.add(value);
+      ParameterNameValue parsedToken = parseNameValueToken(nameValueToken, doUrlDecoding);
+      parameters
+          .computeIfAbsent(parsedToken.name(), ignored -> new ArrayList<>())
+          .add(parsedToken.value());
     }
 
     return parameters;
   }
 
+  private static ParameterNameValue parseNameValueToken(
+      String nameValueToken, boolean doUrlDecoding) {
+    String name;
+    String value = "";
+    int indexOfEqualsChar = nameValueToken.indexOf('=');
+    if (indexOfEqualsChar < 0) {
+      name = nameValueToken;
+      if (LOG.isDebugEnabled()) LOG.debug("Name: {}", name);
+    } else if (indexOfEqualsChar == nameValueToken.length() - 1) {
+      name = nameValueToken.substring(0, indexOfEqualsChar);
+      if (LOG.isDebugEnabled()) LOG.debug("Name: {}", name);
+    } else {
+      name = nameValueToken.substring(0, indexOfEqualsChar);
+      value = nameValueToken.substring(indexOfEqualsChar + 1);
+      if (LOG.isDebugEnabled()) LOG.debug("Name: {} Value: {}", name, value);
+    }
+
+    if (doUrlDecoding) {
+      name = URLDecoder.decode(name, StandardCharsets.UTF_8);
+      value = URLDecoder.decode(value, StandardCharsets.UTF_8);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Decoded name: {}", name);
+        LOG.debug("Decoded value: {}", value);
+      }
+    }
+    return new ParameterNameValue(name, value);
+  }
+
+  private record ParameterNameValue(String name, String value) {}
+
   /**
-   * Creates a query string from the given parameters.
+   * Builds a URL query string from a multimap of parameter names to values.
    *
-   * @param parameterValues The parameters to create a query string from
-   * @param doUrlEncoding {@code true} if encoding for HTTP headers, {@code false} to only encode
-   *     unsafe characters
-   * @return The query string
+   * <p>Each entry in {@code parameterValues} results in one token per value, joined with {@code
+   * '&'} and encoded via {@link URLEncoder#encode(String, boolean)}. Names and values are appended
+   * in map iteration order, and empty collections are serialized as an empty string. The method
+   * does not prepend a leading question mark, allowing callers to embed the string in broader URLs
+   * as needed.
+   *
+   * @param parameterValues map of parameter names to one or more values; null keys or values are
+   *     not supported and should be filtered by the caller
+   * @param doUrlEncoding {@code true} to perform full header-safe encoding; {@code false} to encode
+   *     only unsafe characters
+   * @return a newly constructed query string without a leading {@code '?';} may be empty when the
+   *     input map has no entries
    */
   public static String createQueryString(
       Map<String, List<String>> parameterValues, boolean doUrlEncoding) {
@@ -316,24 +370,47 @@ public class HTTPRequestImpl implements HTTPRequest {
     return queryString.toString();
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#isParameterSet(java.lang.String)
+  /**
+   * Indicates whether a parameter with the given name has been parsed.
+   *
+   * <p>The lookup checks the internal multimap exactly as populated by query parsing or URL-encoded
+   * bodies. It does not inspect multipart parts; use {@link #isPartSet(String)} for that purpose.
+   *
+   * @param name parameter name to test; comparison is case-sensitive
+   * @return {@code true} when the parameter map contains the name, even if its value list is empty
    */
   @Override
   public boolean isParameterSet(String name) {
     return this.parameterNameValuesMap.containsKey(name);
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getParam(java.lang.String)
+  /**
+   * Returns the first value of the named parameter or an empty string when absent.
+   *
+   * <p>This convenience method delegates to {@link #getParam(String, String)} with an empty
+   * default, making it suitable for optional text fields. It performs no trimming or type
+   * conversion; use typed helpers such as {@link #getIntParam(String)} when numeric coercion is
+   * required.
+   *
+   * @param name parameter name to look up; case-sensitive
+   * @return first parsed value or {@code ""} when the parameter is unset or empty
    */
   @Override
   public String getParam(String name) {
     return this.getParam(name, "");
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getParam(java.lang.String, java.lang.String)
+  /**
+   * Returns the first value of the named parameter, falling back to a caller-supplied default.
+   *
+   * <p>The method is tolerant of missing or blank parameters: when the parameter does not exist or
+   * its first value is the empty string, the provided {@code defaultValue} is returned unchanged.
+   * Subsequent values in the list are ignored by design; callers needing all entries should call
+   * {@link #getMultipleParam(String)} instead.
+   *
+   * @param name parameter name to retrieve; case-sensitive and expected to be URL-decoded
+   * @param defaultValue value returned when no usable parameter is present; may be {@code null}
+   * @return the first non-empty parameter value or {@code defaultValue} when no value is available
    */
   @Override
   public String getParam(String name, String defaultValue) {
@@ -344,16 +421,32 @@ public class HTTPRequestImpl implements HTTPRequest {
     return value;
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getIntParam(java.lang.String)
+  /**
+   * Parses the named parameter as an integer, returning {@code 0} on failure.
+   *
+   * <p>The method delegates to {@link #getIntParam(String, int)} with a default of {@code 0}. It is
+   * resilient to missing parameters and {@link NumberFormatException}s, making it useful for
+   * optional numeric inputs such as pagination offsets.
+   *
+   * @param name parameter name to parse
+   * @return parsed integer value or {@code 0} when absent or invalid
    */
   @Override
   public int getIntParam(String name) {
     return this.getIntParam(name, 0);
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getIntParam(java.lang.String, int)
+  /**
+   * Parses the named parameter as an integer with a caller-supplied fallback.
+   *
+   * <p>If the parameter is missing, {@code null}, or cannot be parsed as base-10, the provided
+   * {@code defaultValue} is returned. Overflow and format errors are caught and suppressed. This
+   * method reads only query or URL-encoded body parameters; multipart values are accessible through
+   * {@link #getIntPart(String, int)}.
+   *
+   * @param name parameter name to parse
+   * @param defaultValue value to return when parsing is not possible
+   * @return parsed integer or {@code defaultValue} on absence or parse failure
    */
   @Override
   public int getIntParam(String name, int defaultValue) {
@@ -361,6 +454,9 @@ public class HTTPRequestImpl implements HTTPRequest {
       return defaultValue;
     }
     String value = this.getParameterValue(name);
+    if (value == null) {
+      return defaultValue;
+    }
     try {
       return Integer.parseInt(value);
     } catch (NumberFormatException e) {
@@ -368,15 +464,25 @@ public class HTTPRequestImpl implements HTTPRequest {
     }
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getIntPart(java.lang.String, int)
+  /**
+   * Parses a multipart form field as an integer with a default fallback.
+   *
+   * <p>The lookup is performed against {@link #parts}, which contains multipart form fields and
+   * file uploads. The method reads the part content as UTF-8 text, then attempts integer parsing.
+   * When the part is missing or unparseable, {@code defaultValue} is returned. Binary file uploads
+   * are not appropriate inputs for this helper.
+   *
+   * @param name multipart field name to parse; must match the {@code name} attribute of the form
+   *     input
+   * @param defaultValue value returned when the part is absent or cannot be parsed
+   * @return parsed integer value or {@code defaultValue} if the part is missing or invalid
    */
   @Override
   public int getIntPart(String name, int defaultValue) {
     if (!this.isPartSet(name)) {
       return defaultValue;
     }
-    String value = this.getPartAsString(name, 32);
+    String value = this.getPartAsStringFailsafe(name, 32);
     try {
       return Integer.parseInt(value);
     } catch (NumberFormatException e) {
@@ -384,10 +490,17 @@ public class HTTPRequestImpl implements HTTPRequest {
     }
   }
 
-  // TODO: add similar methods for long, boolean etc.
+  // Additional helpers (long, boolean, etc.) can be added when required.
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getMultipleParam(java.lang.String)
+  /**
+   * Returns all values associated with a parameter name as an array.
+   *
+   * <p>The values come from query or URL-encoded body parsing and preserve encounter order. Missing
+   * parameters yield an empty array rather than {@code null}. The returned array is a shallow copy,
+   * so callers may modify it without affecting the underlying request state.
+   *
+   * @param name parameter name whose values should be returned
+   * @return array of parameter values in encounter order; never {@code null}
    */
   @Override
   public String[] getMultipleParam(String name) {
@@ -397,8 +510,15 @@ public class HTTPRequestImpl implements HTTPRequest {
     return values;
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getMultipleIntParam(java.lang.String)
+  /**
+   * Returns all parseable integer values for the given parameter name.
+   *
+   * <p>Each raw string is parsed individually; values that cannot be converted are silently
+   * skipped. The resulting array therefore contains only successful parses and may be shorter than
+   * the number of supplied values. Order is preserved for all successfully parsed entries.
+   *
+   * @param name parameter name to read
+   * @return array of integers parsed from the parameter values; empty when none are parseable
    */
   @Override
   public int[] getMultipleIntParam(String name) {
@@ -406,9 +526,9 @@ public class HTTPRequestImpl implements HTTPRequest {
 
     // try parsing all values and put the valid Integers in a new list
     List<Integer> intValueList = new ArrayList<>();
-    for (int i = 0; i < valueList.size(); i++) {
+    for (String s : valueList) {
       try {
-        intValueList.add(Integer.valueOf(valueList.get(i)));
+        intValueList.add(Integer.valueOf(s));
       } catch (Exception e) {
         // ignore invalid parameter values
       }
@@ -422,7 +542,7 @@ public class HTTPRequestImpl implements HTTPRequest {
     return values;
   }
 
-  // TODO: add similar methods for multiple long, boolean etc.
+  // Additional helpers for other primitive types can be added when required.
 
   /**
    * Parse submitted data from a bucket. Note that if this is application/x-www-form-urlencoded, it
@@ -430,142 +550,255 @@ public class HTTPRequestImpl implements HTTPRequest {
    * buckets.
    */
   private void parseMultiPartData() throws IOException {
-    if (data == null) return;
-    String ctype = this.headers.getFirst("content-type");
-    if (ctype == null) return;
-    if (LOG.isDebugEnabled()) LOG.debug("Uploaded content-type: {}", ctype);
-    String[] ctypeparts = ctype.split(";");
-    if (ctypeparts[0].equalsIgnoreCase("application/x-www-form-urlencoded")) {
-      // Completely different encoding, but easy to handle
-      if (data.size() > 1024 * 1024) throw new IOException("Too big");
-      byte[] buf = BucketTools.toByteArray(data);
-      String s = new String(buf, StandardCharsets.US_ASCII);
-      parseRequestParameters(s, true, true);
-    }
-    if (!ctypeparts[0].trim().equalsIgnoreCase("multipart/form-data") || (ctypeparts.length < 2))
+    if (data == null) {
       return;
-
-    String boundary = null;
-    for (String ctypepart : ctypeparts) {
-      String[] subparts = ctypepart.split("=");
-      if ((subparts.length == 2) && subparts[0].trim().equalsIgnoreCase("boundary"))
-        boundary = subparts[1];
     }
 
-    if ((boundary == null) || boundary.isEmpty()) return;
-    if (boundary.charAt(0) == '"') boundary = boundary.substring(1);
-    if (boundary.charAt(boundary.length() - 1) == '"')
-      boundary = boundary.substring(0, boundary.length() - 1);
+    String contentTypeHeader = this.headers.getFirst("content-type");
+    if (contentTypeHeader == null) {
+      return;
+    }
 
-    boundary = "--" + boundary;
+    if (LOG.isDebugEnabled()) LOG.debug("Uploaded content-type: {}", contentTypeHeader);
+
+    String[] contentTypeParts = contentTypeHeader.split(";");
+    if (isUrlEncoded(contentTypeParts)) {
+      parseUrlEncodedBody();
+      return;
+    }
+
+    if (!isMultipartFormData(contentTypeParts)) {
+      return;
+    }
+
+    String boundary = extractBoundary(contentTypeParts);
+    if ((boundary == null) || boundary.isEmpty()) {
+      return;
+    }
+
+    processMultipartBody(boundary);
+  }
+
+  private boolean isUrlEncoded(String[] contentTypeParts) {
+    return contentTypeParts.length > 0
+        && contentTypeParts[0].equalsIgnoreCase("application/x-www-form-urlencoded");
+  }
+
+  private void parseUrlEncodedBody() throws IOException {
+    if (data.size() > 1024 * 1024) throw new IOException("Too big");
+    byte[] buf = BucketTools.toByteArray(data);
+    String body = new String(buf, StandardCharsets.US_ASCII);
+    parseRequestParameters(body, true);
+  }
+
+  private boolean isMultipartFormData(String[] contentTypeParts) {
+    return contentTypeParts.length >= 2
+        && contentTypeParts[0].trim().equalsIgnoreCase("multipart/form-data");
+  }
+
+  private String extractBoundary(String[] contentTypeParts) {
+    String boundary = null;
+    for (String contentTypePart : contentTypeParts) {
+      String[] subparts = contentTypePart.split("=");
+      if ((subparts.length == 2) && subparts[0].trim().equalsIgnoreCase("boundary")) {
+        boundary = subparts[1];
+      }
+    }
+    return boundary;
+  }
+
+  private void processMultipartBody(String rawBoundary) throws IOException {
+    String boundary = normalizeBoundary(rawBoundary);
 
     if (LOG.isDebugEnabled()) LOG.debug("Boundary is: {}", boundary);
 
     try (InputStream is = this.data.getInputStream();
         LineReadingInputStream lis = new LineReadingInputStream(is)) {
 
-      String line;
-      line = lis.readLine(100, 100, false); // really it's US-ASCII, but ISO-8859-1 is close enough.
-      while ((is.available() > 0) && !line.equals(boundary)) {
-        line = lis.readLine(100, 100, false);
+      if (!advanceToFirstBoundary(is, lis, boundary)) {
+        return;
       }
 
-      boundary = "\r\n" + boundary;
+      readMultipartParts(is, lis, "\r\n" + boundary);
+    }
+  }
 
-      RandomAccessBucket filedata = null;
-      String name = null;
-      String filename = null;
-      String contentType = null;
+  private String normalizeBoundary(String boundary) {
+    String normalized = boundary;
+    if (!normalized.isEmpty() && normalized.charAt(0) == '"') {
+      normalized = normalized.substring(1);
+    }
+    if (!normalized.isEmpty() && normalized.charAt(normalized.length() - 1) == '"') {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return "--" + normalized;
+  }
 
-      try {
-        while (is.available() > 0) {
-          name = null;
-          filename = null;
-          contentType = null;
-          // chomp headers
-          while ((line =
-                  lis.readLine(
-                      200, 200, true)) /* should be UTF-8 as we told the browser to send UTF-8 */
-              != null) {
-            if (line.isEmpty()) break;
+  private boolean advanceToFirstBoundary(
+      InputStream is, LineReadingInputStream lis, String boundary) throws IOException {
+    String line = lis.readLine(100, 100, false); // really it's US-ASCII, but ISO-8859-1 is close.
+    while ((is.available() > 0) && (line != null) && !line.equals(boundary)) {
+      line = lis.readLine(100, 100, false);
+    }
+    return boundary.equals(line);
+  }
 
-            String[] lineparts = line.split(":");
-            if (lineparts == null || lineparts.length == 0) continue;
-            String hdrname = lineparts[0].trim();
+  private void readMultipartParts(
+      InputStream is, LineReadingInputStream lis, String boundaryWithPrefix) throws IOException {
+    boolean finished = false;
+    while (!finished && is.available() > 0) {
+      PartMetadata metadata = readPartMetadata(lis);
+      if (metadata.name() != null) {
+        RandomAccessBucket filedata = this.bucketfactory.makeBucket(is.available());
+        writePartData(is, boundaryWithPrefix, filedata);
 
-            if (hdrname.equalsIgnoreCase("Content-Disposition")) {
-              if (lineparts.length < 2) continue;
-              String[] valueparts = lineparts[1].split(";");
-
-              for (int i = 0; i < valueparts.length; i++) {
-                String[] subparts = valueparts[i].split("=");
-                if (subparts.length != 2) continue;
-                String fieldname = subparts[0].trim();
-                String value = subparts[1].trim();
-                if (value.startsWith("\"") && value.endsWith("\""))
-                  value = value.substring(1, value.length() - 1);
-                if (fieldname.equalsIgnoreCase("name")) name = value;
-                else if (fieldname.equalsIgnoreCase("filename")) filename = value;
-              }
-            } else if (hdrname.equalsIgnoreCase("Content-Type")) {
-              contentType = lineparts[1].trim();
-              if (LOG.isDebugEnabled()) LOG.debug("Parsed type: {}", contentType);
-            } else {
-              // Do nothing, irrelevant header
-            }
-          }
-
-          if (name == null) continue;
-
-          // we should be at the data now. Start reading it in, checking for the
-          // boundary string
-
-          // we can only give an upper bound for the size of the bucket
-          filedata = this.bucketfactory.makeBucket(is.available());
-          try (OutputStream bucketos = filedata.getOutputStream()) {
-            // buffer characters that match the boundary so far
-            // FIXME use whatever charset was used
-            byte[] bbound =
-                boundary.getBytes(
-                    StandardCharsets.UTF_8); // ISO-8859-1? boundary should be in US-ASCII
-            int offset = 0;
-            while ((is.available() > 0) && (offset < bbound.length)) {
-              byte b = (byte) is.read();
-
-              if (b == bbound[offset]) offset++;
-              else if ((b != bbound[offset]) && (offset > 0)) {
-                // offset bytes matched, but no more
-                // write the bytes that matched, then the non-matching byte
-                bucketos.write(bbound, 0, offset);
-                offset = 0;
-                if (b == bbound[0]) offset = 1;
-                else bucketos.write(b);
-              } else bucketos.write(b);
-            }
-          }
-
-          parts.put(name, filedata);
-          if (LOG.isDebugEnabled())
-            LOG.debug("Name = {} length = {} filename = {}", name, filedata.size(), filename);
-          if (filename != null)
-            uploadedFiles.put(name, new HTTPUploadedFileImpl(filename, contentType, filedata));
+        parts.put(metadata.name(), filedata);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              "Name = {} length = {} filename = {}",
+              metadata.name(),
+              filedata.size(),
+              metadata.filename());
         }
-      } catch (IOException e) {
-        LOG.error("Error parsing multipart data: {}", e.toString(), e);
+        if (metadata.filename() != null) {
+          uploadedFiles.put(
+              metadata.name(),
+              new HTTPUploadedFileImpl(metadata.filename(), metadata.contentType(), filedata));
+        }
+      }
+
+      // Consume the remainder of the boundary line (e.g., trailing CRLF or "--") so the next
+      // metadata read starts at the following headers, and detect the closing boundary.
+      String boundarySuffix = lis.readLine(200, 200, false);
+      if (boundarySuffix == null || boundarySuffix.startsWith("--")) {
+        finished = true; // reached the final boundary
       }
     }
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getUploadedFile(java.lang.String)
+  private PartMetadata readPartMetadata(LineReadingInputStream lis) throws IOException {
+    MutablePartMetadata metadata = new MutablePartMetadata();
+    String line;
+
+    while ((line = lis.readLine(200, 200, true)) != null) { // should be UTF-8
+      if (line.isEmpty()) {
+        break;
+      }
+
+      Header header = parseHeader(line);
+      if (header != null) {
+        if (header.name().equalsIgnoreCase("Content-Disposition")) {
+          parseContentDisposition(header.value(), metadata);
+        } else if (header.name().equalsIgnoreCase("Content-Type")) {
+          metadata.contentType = header.value();
+          if (LOG.isDebugEnabled()) LOG.debug("Parsed type: {}", metadata.contentType);
+        }
+      }
+    }
+
+    return metadata.toImmutable();
+  }
+
+  private Header parseHeader(String line) {
+    String[] lineparts = line.split(":", 2);
+    if (lineparts.length < 2) {
+      return null;
+    }
+    return new Header(lineparts[0].trim(), lineparts[1].trim());
+  }
+
+  private void parseContentDisposition(String headerValue, MutablePartMetadata metadata) {
+    String[] valueparts = headerValue.split(";");
+    for (String valuepart : valueparts) {
+      String[] subparts = valuepart.split("=", 2);
+      if (subparts.length != 2) {
+        continue;
+      }
+      String fieldname = subparts[0].trim();
+      String value = stripWrappingQuotes(subparts[1].trim());
+      if (fieldname.equalsIgnoreCase("name")) {
+        metadata.name = value;
+      } else if (fieldname.equalsIgnoreCase("filename")) {
+        metadata.filename = value;
+      }
+    }
+  }
+
+  private String stripWrappingQuotes(String value) {
+    if (value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2) {
+      return value.substring(1, value.length() - 1);
+    }
+    return value;
+  }
+
+  private void writePartData(InputStream is, String boundaryWithPrefix, RandomAccessBucket filedata)
+      throws IOException {
+    byte[] boundaryBytes = boundaryWithPrefix.getBytes(StandardCharsets.UTF_8);
+    try (OutputStream bucketos = filedata.getOutputStream()) {
+      int offset = 0;
+      int read;
+      while ((read = is.read()) != -1) {
+        byte b = (byte) read;
+
+        if (b == boundaryBytes[offset]) {
+          offset++;
+          if (offset == boundaryBytes.length) {
+            break;
+          }
+        } else if (offset > 0) {
+          bucketos.write(boundaryBytes, 0, offset);
+          offset = (boundaryBytes[0] == b) ? 1 : 0;
+          if (offset == 0) {
+            bucketos.write(b);
+          }
+        } else {
+          bucketos.write(b);
+        }
+      }
+    }
+  }
+
+  private record PartMetadata(String name, String filename, String contentType) {}
+
+  private record Header(String name, String value) {}
+
+  private static final class MutablePartMetadata {
+    private String name;
+    private String filename;
+    private String contentType;
+
+    private PartMetadata toImmutable() {
+      return new PartMetadata(name, filename, contentType);
+    }
+  }
+
+  /**
+   * Retrieves the uploaded file metadata and payload for the named multipart field.
+   *
+   * <p>The returned {@link HTTPUploadedFile} encapsulates the original filename, content type, and
+   * a {@link Bucket} containing the file data. The object is backed by internal buckets managed by
+   * this request and remains valid until {@link #freeParts()} is invoked. If the field name refers
+   * to a regular form value rather than a file upload, this method returns {@code null}.
+   *
+   * @param name multipart field name corresponding to the file input element
+   * @return uploaded file wrapper or {@code null} when no file part exists for the given name
    */
   @Override
   public HTTPUploadedFile getUploadedFile(String name) {
     return uploadedFiles.get(name);
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getPart(java.lang.String)
+  /**
+   * Retrieves the bucket for a multipart field or file by name.
+   *
+   * <p>The returned {@link RandomAccessBucket} contains the raw bytes of the part body and remains
+   * owned by this request instance. Callers should avoid freeing or modifying the bucket unless
+   * they fully control the lifecycle. Invoking this method after {@link #freeParts()} results in an
+   * {@link IllegalStateException}.
+   *
+   * @param name multipart field name to look up
+   * @return bucket containing the part data, or {@code null} if the field is absent
+   * @throws IllegalStateException if the parts have already been freed
    */
   @Override
   public RandomAccessBucket getPart(String name) {
@@ -573,8 +806,15 @@ public class HTTPRequestImpl implements HTTPRequest {
     return this.parts.get(name);
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#isPartSet(java.lang.String)
+  /**
+   * Indicates whether a multipart part with the given name exists.
+   *
+   * <p>Unlike {@link #isParameterSet(String)}, this method inspects only multipart/form-data parts.
+   * It throws an exception if parts were already freed to avoid silent misuse.
+   *
+   * @param name multipart field name to test
+   * @return {@code true} when a part with the name has been parsed; {@code false} otherwise
+   * @throws IllegalStateException if {@link #freeParts()} was already called
    */
   @Override
   public boolean isPartSet(String name) {
@@ -584,12 +824,37 @@ public class HTTPRequestImpl implements HTTPRequest {
     return this.parts.containsKey(name);
   }
 
+  /**
+   * Returns the part content as a UTF-8 string, truncated to {@code maxlength} bytes if necessary.
+   *
+   * <p>When the part is absent, an empty array is returned and the conversion yields an empty
+   * string. The method is lenient and does not throw on length overflow; callers needing strict
+   * enforcement should use {@link #getPartAsStringThrowing(String, int)}.
+   *
+   * @param name multipart field name
+   * @param maxlength maximum number of bytes to read before truncation
+   * @return UTF-8 decoded string, possibly empty when the part is missing
+   * @throws IllegalStateException if called after {@link #freeParts()}
+   */
   @Override
-  @Deprecated
   public String getPartAsString(String name, int maxlength) {
     return new String(getPartAsBytes(name, maxlength), StandardCharsets.UTF_8);
   }
 
+  /**
+   * Returns the part content as a UTF-8 string, enforcing presence and maximum length.
+   *
+   * <p>This variant throws {@link NoSuchElementException} when the part is missing and {@link
+   * SizeLimitExceededException} when the part size exceeds {@code maxLength}. It is useful for
+   * handlers that must differentiate between absent inputs and oversized submissions.
+   *
+   * @param name multipart field name
+   * @param maxLength maximum allowable part size in bytes
+   * @return decoded UTF-8 string representing the part content
+   * @throws NoSuchElementException if the named part does not exist
+   * @throws SizeLimitExceededException if the part size exceeds {@code maxLength}
+   * @throws IllegalStateException if the parts have already been freed
+   */
   @Override
   public String getPartAsStringThrowing(String name, int maxLength)
       throws NoSuchElementException, SizeLimitExceededException {
@@ -603,6 +868,18 @@ public class HTTPRequestImpl implements HTTPRequest {
     return getPartAsLimitedString(part, maxLength);
   }
 
+  /**
+   * Returns the part content as a UTF-8 string, gracefully handling missing parts or size limits.
+   *
+   * <p>If the part is absent, an empty string is returned. When the part exceeds {@code maxLength},
+   * the content is truncated to the provided limit rather than throwing an exception, making this
+   * helper suitable for UI echo or logging of small previews.
+   *
+   * @param name multipart field name
+   * @param maxLength maximum number of bytes to read from the part
+   * @return decoded UTF-8 string, possibly empty, truncated to {@code maxLength} bytes
+   * @throws IllegalStateException if called after {@link #freeParts()}
+   */
   @Override
   public String getPartAsStringFailsafe(String name, int maxLength) {
     if (freedParts) throw new IllegalStateException("Already freed");
@@ -614,11 +891,19 @@ public class HTTPRequestImpl implements HTTPRequest {
     return new String(getPartAsLimitedBytes(part, maxLength), StandardCharsets.UTF_8);
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getPartAsString(java.lang.String, int)
+  /**
+   * Returns the part content as a byte array, truncating when necessary.
+   *
+   * <p>This method reads up to {@code maxlength} bytes and returns them in a newly allocated array.
+   * Missing parts yield an empty array. Use {@link #getPartAsBytesThrowing(String, int)} to enforce
+   * strict size limits.
+   *
+   * @param name multipart field name
+   * @param maxlength maximum number of bytes to read
+   * @return byte array containing up to {@code maxlength} bytes; empty when part is absent
+   * @throws IllegalStateException if invoked after {@link #freeParts()}
    */
   @Override
-  @Deprecated
   public byte[] getPartAsBytes(String name, int maxlength) {
     if (freedParts) throw new IllegalStateException("Already freed");
     Bucket part = this.parts.get(name);
@@ -637,6 +922,20 @@ public class HTTPRequestImpl implements HTTPRequest {
     }
   }
 
+  /**
+   * Returns the part content as bytes, throwing on absence or excessive size.
+   *
+   * <p>This variant is suitable for security-sensitive handlers that must reject missing or
+   * oversized inputs. It reads the entire part and enforces {@code maxLength} strictly, throwing
+   * {@link SizeLimitExceededException} when the limit is exceeded.
+   *
+   * @param name multipart field name to read
+   * @param maxLength maximum allowed part size in bytes
+   * @return byte array containing the full part content
+   * @throws NoSuchElementException if the part is not present
+   * @throws SizeLimitExceededException if the part exceeds {@code maxLength}
+   * @throws IllegalStateException if called after {@link #freeParts()}
+   */
   @Override
   public byte[] getPartAsBytesThrowing(String name, int maxLength)
       throws NoSuchElementException, SizeLimitExceededException {
@@ -650,6 +949,18 @@ public class HTTPRequestImpl implements HTTPRequest {
     return getPartAsLimitedBytes(part, maxLength);
   }
 
+  /**
+   * Returns the part content as bytes, tolerating missing parts and truncating on demand.
+   *
+   * <p>When the part is absent, the method returns an empty array. If the part size exceeds {@code
+   * maxLength}, only the first {@code maxLength} bytes are returned, making this helper useful for
+   * previewing or hashing without strict enforcement.
+   *
+   * @param name multipart field name to read
+   * @param maxLength maximum number of bytes to include in the result
+   * @return byte array (possibly empty) with up to {@code maxLength} bytes from the part
+   * @throws IllegalStateException if parts have been freed
+   */
   @Override
   public byte[] getPartAsBytesFailsafe(String name, int maxLength) {
     if (freedParts) throw new IllegalStateException("Already freed");
@@ -669,8 +980,13 @@ public class HTTPRequestImpl implements HTTPRequest {
     }
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#freeParts()
+  /**
+   * Releases resources associated with parsed multipart parts.
+   *
+   * <p>The method iterates over all stored part buckets and invokes {@link Bucket#free()} on each,
+   * then clears internal maps and marks the request as freed to prevent accidental reuse. Callers
+   * should invoke this exactly once after they are done reading any multipart data. Subsequent
+   * calls to part accessors will throw {@link IllegalStateException}.
    */
   @Override
   public void freeParts() {
@@ -684,8 +1000,16 @@ public class HTTPRequestImpl implements HTTPRequest {
     // Do not free data. Caller is responsible for that.
   }
 
-  /* (non-Javadoc)
-   * @see freenet.clients.http.HTTPRequest#getLongParam(java.lang.String, long)
+  /**
+   * Parses a parameter as a {@code long}, returning a default on failure.
+   *
+   * <p>The method uses {@link Fields#parseLong(String)} to support decimal and size-suffix formats
+   * recognized elsewhere in the codebase. When the parameter is missing or malformed, the supplied
+   * {@code defaultValue} is returned without throwing.
+   *
+   * @param name parameter name to parse
+   * @param defaultValue value returned when parsing fails or the parameter is absent
+   * @return parsed {@code long} value or {@code defaultValue} on error
    */
   @Override
   public long getLongParam(String name, long defaultValue) {
@@ -703,8 +1027,10 @@ public class HTTPRequestImpl implements HTTPRequest {
   /**
    * Container for uploaded files in HTTP POST requests.
    *
-   * @author David 'Bombe' Roden &lt;bombe@freenetproject.org&gt;
-   * @version $Id$
+   * <p>Instances wrap the filename, content type, and backing {@link Bucket} created during
+   * multipart parsing. The bucket is owned by the enclosing {@link HTTPRequestImpl} and remains
+   * valid until {@link HTTPRequestImpl#freeParts()} is invoked. Callers should treat this class as
+   * a lightweight data carrier rather than a full file abstraction.
    */
   public static class HTTPUploadedFileImpl implements HTTPUploadedFile {
 
@@ -718,11 +1044,15 @@ public class HTTPRequestImpl implements HTTPRequest {
     private final Bucket data;
 
     /**
-     * Creates a new file with the specified filename, content type, and data.
+     * Creates a new uploaded file wrapper backed by the provided bucket.
      *
-     * @param filename The name of the file
-     * @param contentType The content type of the file
-     * @param data The data of the file
+     * <p>The constructor performs no validation beyond assignment. The {@code data} bucket is not
+     * copied, so callers must ensure it remains valid for the duration of use.
+     *
+     * @param filename original filename supplied by the client; may be empty but not {@code null}
+     * @param contentType MIME type declared for the upload; may be {@code null} when unspecified
+     * @param data bucket containing the file contents; ownership is retained by the enclosing
+     *     request
      */
     public HTTPUploadedFileImpl(String filename, String contentType, Bucket data) {
       this.filename = filename;
@@ -730,24 +1060,30 @@ public class HTTPRequestImpl implements HTTPRequest {
       this.data = data;
     }
 
-    /* (non-Javadoc)
-     * @see freenet.clients.http.HTTPUploadedFile#getContentType()
+    /**
+     * Returns the MIME content type declared for the uploaded file.
+     *
+     * @return content type string as provided in the multipart headers; may be {@code null}
      */
     @Override
     public String getContentType() {
       return contentType;
     }
 
-    /* (non-Javadoc)
-     * @see freenet.clients.http.HTTPUploadedFile#getData()
+    /**
+     * Returns the bucket containing the file data.
+     *
+     * @return {@link Bucket} with the uploaded bytes; callers must not free it directly
      */
     @Override
     public Bucket getData() {
       return data;
     }
 
-    /* (non-Javadoc)
-     * @see freenet.clients.http.HTTPUploadedFile#getFilename()
+    /**
+     * Returns the filename reported by the client for this upload.
+     *
+     * @return original filename; may be empty but never {@code null}
      */
     @Override
     public String getFilename() {
@@ -755,27 +1091,63 @@ public class HTTPRequestImpl implements HTTPRequest {
     }
   }
 
+  /**
+   * Returns the HTTP method name exactly as supplied when the request was constructed.
+   *
+   * @return method token such as {@code "GET"}, {@code "POST"}, or any custom verb
+   */
   @Override
   public String getMethod() {
     return method;
   }
 
+  /**
+   * Returns the raw body bucket as supplied at construction time.
+   *
+   * <p>The bucket may represent a streaming or in-memory payload depending on the transport layer.
+   * Callers should not free it unless they own the overall request lifecycle.
+   *
+   * @return bucket containing the unparsed request body; may be {@code null} for bodyless methods
+   */
   @Override
   public Bucket getRawData() {
     return data;
   }
 
+  /**
+   * Returns the first header value for the given lower-case header name.
+   *
+   * <p>Header lookup is case-sensitive and expects names to be pre-normalized to lower case to
+   * avoid ambiguity. When the header is missing, {@code null} is returned. An {@link
+   * IllegalArgumentException} is thrown if the supplied name is not lower-case, enforcing a
+   * consistent convention across the codebase.
+   *
+   * @param name lower-case header name to retrieve
+   * @return first matching header value or {@code null} when absent
+   * @throws IllegalArgumentException if {@code name} contains any upper-case characters
+   */
   @Override
   public String getHeader(String name) {
-    assert (name.equals(name.toLowerCase()));
+    if (!name.equals(name.toLowerCase())) {
+      throw new IllegalArgumentException("Header name must be lower-case");
+    }
     return this.headers.getFirst(name.toLowerCase());
   }
 
+  /**
+   * Returns the Content-Length header parsed as an integer, or {@code -1} when absent.
+   *
+   * <p>The method assumes the header was already validated by upstream parsing and therefore does
+   * not catch {@link NumberFormatException}. It is intended for internal consumers that trust
+   * request normalization.
+   *
+   * @return content length in bytes, or {@code -1} if no header was supplied
+   */
   @Override
   public int getContentLength() {
     String slen = headers.getFirst("content-length");
     if (slen == null) return -1;
-    // it is already parsed, so NumberFormatException can not happens here
+    // it is already parsed, so NumberFormatException can not happen here
     return Integer.parseInt(slen);
   }
 
@@ -785,12 +1157,29 @@ public class HTTPRequestImpl implements HTTPRequest {
     return parts.keySet().toArray(new String[0]);
   }
 
+  /**
+   * Indicates whether the request was marked as incognito by a query parameter.
+   *
+   * <p>The method checks for a parameter named {@code incognito} and returns its boolean value
+   * using {@link Boolean#parseBoolean(String)} semantics, defaulting to {@code false} when missing.
+   *
+   * @return {@code true} when the {@code incognito} parameter is present and set to a truthy value
+   */
   @Override
   public boolean isIncognito() {
     if (isParameterSet("incognito")) return Boolean.parseBoolean(getParam("incognito"));
     return false;
   }
 
+  /**
+   * Heuristically determines whether the User-Agent header indicates Google Chrome.
+   *
+   * <p>The method performs a substring search for {@code "Chrome"} in the {@code user-agent}
+   * header. It is intentionally simple and may produce false positives for Chromium-based browsers;
+   * callers should use it only for coarse feature hints.
+   *
+   * @return {@code true} if the user-agent contains {@code "Chrome"}; {@code false} otherwise
+   */
   @Override
   public boolean isChrome() {
     String ua = getHeader("user-agent");

--- a/src/test/java/network/crypta/clients/http/HTTPRequestImplTest.java
+++ b/src/test/java/network/crypta/clients/http/HTTPRequestImplTest.java
@@ -1,0 +1,446 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import javax.naming.SizeLimitExceededException;
+import network.crypta.clients.http.HTTPRequestImpl.HTTPUploadedFileImpl;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class HTTPRequestImplTest {
+
+  @Mock private BucketFactory bucketFactory;
+
+  @Test
+  void parseUriParameters_whenNullOrEmpty_returnsEmptyMap() {
+    Map<String, List<String>> nullResult = HTTPRequestImpl.parseUriParameters(null, true);
+    Map<String, List<String>> emptyResult = HTTPRequestImpl.parseUriParameters("", true);
+
+    assertTrue(nullResult.isEmpty());
+    assertTrue(emptyResult.isEmpty());
+  }
+
+  @Test
+  void parseUriParameters_whenMixedTokens_decodesAndGroupsValues() {
+    Map<String, List<String>> result =
+        HTTPRequestImpl.parseUriParameters("a=one&b=two+three&b=abc%40def.de&lonely&empty=", true);
+
+    assertEquals(List.of("one"), result.get("a"));
+    assertEquals(List.of("two three", "abc@def.de"), result.get("b"));
+    assertEquals(List.of(""), result.get("lonely"));
+    assertEquals(List.of(""), result.get("empty"));
+  }
+
+  @Test
+  void createQueryString_whenEncodingEnabled_encodesKeysAndValues() {
+    Map<String, List<String>> params = new LinkedHashMap<>();
+    params.put("sp ace", List.of("1+2", "ä"));
+    params.put("safe", List.of("ok"));
+
+    String query = HTTPRequestImpl.createQueryString(params, true);
+
+    assertEquals("sp%20ace=1%2b2&sp%20ace=%c3%a4&safe=ok", query);
+  }
+
+  @Test
+  void constructor_withPathAndQuery_parsesParameters() throws URISyntaxException {
+    HTTPRequestImpl request = new HTTPRequestImpl("/test/path", "a=1&b=two", "GET");
+
+    assertEquals("/test/path", request.getPath());
+    assertTrue(request.hasParameters());
+    assertTrue(request.isParameterSet("a"));
+    assertEquals("1", request.getParam("a"));
+    assertEquals("default", request.getParam("missing", "default"));
+    assertEquals(2, request.getIntParam("b", 2));
+    assertEquals(0, request.getIntParam("c", 0));
+  }
+
+  @Test
+  void getMultipleIntParam_whenMixedValidity_returnsOnlyParsableValues() throws URISyntaxException {
+    HTTPRequestImpl request = new HTTPRequestImpl("/m", "n=1&n=bad&n=3", "GET");
+
+    assertArrayEquals(new int[] {1, 3}, request.getMultipleIntParam("n"));
+  }
+
+  @Test
+  void getLongParam_whenInvalid_fallsBackToDefault() throws URISyntaxException {
+    HTTPRequestImpl request = new HTTPRequestImpl("/m", "value=notalong", "GET");
+
+    assertEquals(42L, request.getLongParam("value", 42L));
+  }
+
+  @Test
+  void isIncognito_whenFlagPresent_parsesBooleanValue() throws URISyntaxException {
+    HTTPRequestImpl request = new HTTPRequestImpl("/m", "incognito=true", "GET");
+
+    assertTrue(request.isIncognito());
+  }
+
+  @Test
+  void isChrome_whenUserAgentContainsChrome_returnsTrue() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    headers.put("user-agent", "Mozilla Chrome Something");
+    HTTPRequestImpl request =
+        new HTTPRequestImpl(new URI("/m"), new DummyBucket(""), buildContext(headers), "POST");
+
+    assertTrue(request.isChrome());
+  }
+
+  @Test
+  void getContentLength_withHeader_returnsParsedValue() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    headers.put("content-type", "application/x-www-form-urlencoded");
+    headers.put("content-length", "11");
+    HTTPRequestImpl request =
+        new HTTPRequestImpl(
+            new URI("/m"), new DummyBucket("a=1&b=2"), buildContext(headers), "POST");
+
+    assertEquals(11, request.getContentLength());
+  }
+
+  @Test
+  void parts_whenUrlEncodedBody_areAvailableAsPartBuckets() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    headers.put("content-type", "application/x-www-form-urlencoded");
+    DummyBucket body = new DummyBucket("partValue=hello");
+    HTTPRequestImpl request =
+        new HTTPRequestImpl(new URI("/upload"), body, buildContext(headers), "POST");
+
+    assertTrue(request.isPartSet("partValue"));
+    assertArrayEquals(new String[] {"partValue"}, request.getParts());
+    assertEquals("hello", request.getPartAsStringThrowing("partValue", 32));
+  }
+
+  @Test
+  void getPartAsStringThrowing_whenMissingPart_throwsNoSuchElement() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    headers.put("content-type", "application/x-www-form-urlencoded");
+    HTTPRequestImpl request =
+        new HTTPRequestImpl(
+            new URI("/upload"), new DummyBucket("one=1"), buildContext(headers), "POST");
+
+    assertThrows(
+        NoSuchElementException.class, () -> request.getPartAsStringThrowing("missing", 10));
+  }
+
+  @Test
+  void getPartAsBytesThrowing_whenTooLarge_throwsSizeLimitExceeded() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    headers.put("content-type", "application/x-www-form-urlencoded");
+    HTTPRequestImpl request =
+        new HTTPRequestImpl(
+            new URI("/upload"), new DummyBucket("big=12345"), buildContext(headers), "POST");
+
+    assertThrows(SizeLimitExceededException.class, () -> request.getPartAsBytesThrowing("big", 3));
+  }
+
+  @Test
+  void freeParts_marksAsFreed_andSubsequentAccessThrows() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    headers.put("content-type", "application/x-www-form-urlencoded");
+    HTTPRequestImpl request =
+        new HTTPRequestImpl(
+            new URI("/upload"), new DummyBucket("p=v"), buildContext(headers), "POST");
+
+    request.freeParts();
+
+    assertThrows(IllegalStateException.class, () -> request.isPartSet("p"));
+    assertThrows(IllegalStateException.class, () -> request.getPart("p"));
+  }
+
+  @Test
+  void uploadedFileImpl_exposesProvidedData() {
+    DummyBucket data = new DummyBucket("file");
+    HTTPUploadedFileImpl file = new HTTPUploadedFileImpl("name.txt", "text/plain", data);
+
+    assertEquals("name.txt", file.getFilename());
+    assertEquals("text/plain", file.getContentType());
+    assertEquals(data, file.getData());
+  }
+
+  private ToadletContext buildContext(MultiValueTable<String, String> headers) {
+    return new ToadletContext() {
+      @Override
+      public MultiValueTable<String, String> getHeaders() {
+        return headers;
+      }
+
+      @Override
+      public BucketFactory getBucketFactory() {
+        return bucketFactory;
+      }
+
+      // --- Unused methods below ---
+      @Override
+      public void sendReplyHeaders(
+          int code,
+          String desc,
+          MultiValueTable<String, String> mvt,
+          String mimeType,
+          long length) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void sendReplyHeaders(
+          int code,
+          String desc,
+          MultiValueTable<String, String> mvt,
+          String mimeType,
+          long length,
+          boolean forceDisableJavascript) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void sendReplyHeaders(
+          int code,
+          String desc,
+          MultiValueTable<String, String> mvt,
+          String mimeType,
+          long length,
+          java.util.Date mTime) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void sendReplyHeadersStatic(
+          int code,
+          String desc,
+          MultiValueTable<String, String> mvt,
+          String mimeType,
+          long length,
+          java.util.Date mTime) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void sendReplyHeadersFProxy(
+          int code,
+          String desc,
+          MultiValueTable<String, String> mvt,
+          String mimeType,
+          long length) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void writeData(byte[] data, int offset, int length) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void forceDisconnect() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void writeData(byte[] data) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void writeData(Bucket data) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public PageMaker getPageMaker() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public String getFormPassword() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean checkFormPassword(
+          network.crypta.support.api.HTTPRequest request, String redirectTo) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean checkFormPassword(network.crypta.support.api.HTTPRequest request) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean hasFormPassword(network.crypta.support.api.HTTPRequest request) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean checkFullAccess(Toadlet toadlet) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public network.crypta.node.useralerts.UserAlertManager getAlertManager() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public network.crypta.clients.http.bookmark.BookmarkManager getBookmarkManager() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public FProxyFetchInProgress.REFILTER_POLICY getReFilterPolicy() {
+        return FProxyFetchInProgress.REFILTER_POLICY.ACCEPT_OLD;
+      }
+
+      @Override
+      public network.crypta.clients.http.ReceivedCookie getCookie(
+          URI domain, URI path, String name) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setCookie(network.crypta.clients.http.Cookie newCookie) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public URI getUri() {
+        return URI.create("/");
+      }
+
+      @Override
+      public String getUniqueId() {
+        return "test-id";
+      }
+
+      @Override
+      public Toadlet activeToadlet() {
+        return null;
+      }
+
+      @Override
+      public ToadletContainer getContainer() {
+        return null;
+      }
+
+      @Override
+      public boolean disableProgressPage() {
+        return false;
+      }
+
+      @Override
+      public boolean doRobots() {
+        return false;
+      }
+
+      @Override
+      public boolean isAdvancedModeEnabled() {
+        return false;
+      }
+
+      @Override
+      public boolean isAllowedFullAccess() {
+        return false;
+      }
+
+      @Override
+      public network.crypta.support.HTMLNode addFormChild(
+          network.crypta.support.HTMLNode parentNode, String target, String id) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Minimal in-memory Bucket suitable for exercising the parsing code paths without involving
+   * filesystem IO.
+   */
+  private static final class DummyBucket implements RandomAccessBucket {
+    private final byte[] data;
+
+    DummyBucket(String content) {
+      this.data = content.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public java.io.OutputStream getOutputStream() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.io.OutputStream getOutputStreamUnbuffered() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.io.InputStream getInputStream() {
+      return new java.io.ByteArrayInputStream(data);
+    }
+
+    @Override
+    public java.io.InputStream getInputStreamUnbuffered() {
+      return getInputStream();
+    }
+
+    @Override
+    public String getName() {
+      return "Dummy";
+    }
+
+    @Override
+    public long size() {
+      return data.length;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return true;
+    }
+
+    @Override
+    public void setReadOnly() {
+      // already read-only
+    }
+
+    @Override
+    public void free() {
+      // nothing to free
+    }
+
+    @Override
+    public RandomAccessBucket createShadow() {
+      return this;
+    }
+
+    @Override
+    public void onResume(network.crypta.client.async.ClientContext context) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeTo(java.io.DataOutputStream dos) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public network.crypta.support.api.LockableRandomAccessBuffer toRandomAccessBuffer() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor HTTPRequestImpl to streamline query/part parsing, add structured helpers, and tighten header handling
- add unit coverage for parameter parsing, multipart parts, incognito/chrome detection, and uploaded file wrapper

## Testing
- Not run (not requested)
