### PR TITLE
Add InfoboxNode documentation and unit tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/InfoboxNode.java
+++ b/src/main/java/network/crypta/clients/http/InfoboxNode.java
@@ -3,21 +3,40 @@ package network.crypta.clients.http;
 import network.crypta.support.HTMLNode;
 
 /**
- * Represents a box (or a page, see PageNode). This is a bit of HTML for a box. We return the
- * "outer", which is the HTML for the whole box, so you can render it to HTML, or add it to another
- * HTMLNode, and we return the "content", which is the inside of the box, where you can add content.
+ * Lightweight wrapper that bundles an outer HTML container with the inner content region for a
+ * rendered infobox or page fragment. Typical usage builds the surrounding structural markup once
+ * (header, chrome, borders) and then hands the content node to callers so they can append user
+ * interface elements or textual content without needing to understand the container shape. The
+ * class is intentionally minimal: it stores the two relevant {@link HTMLNode} instances and
+ * delegates HTML generation to the outer node.
+ *
+ * <p>Use this type when building HTTP responses or templated page sections where you want to expose
+ * a safe place to insert body content while retaining control over the wrapping markup. The outer
+ * node normally represents the element added to a parent document, whereas the content node marks
+ * the interior where consumers can append children. Instances are mutable only through the
+ * contained {@link HTMLNode} objects; the references themselves are final, so the pairing remains
+ * stable after construction.
+ *
+ * <p>Thread-safety follows the underlying {@link HTMLNode} implementation: nodes are not
+ * thread-safe, and callers should confine instances to a single thread or apply their own
+ * synchronization when mutating child structures.
  *
  * @author toad
  */
 public class InfoboxNode {
 
   /**
-   * The top of the tree. Use this to add the box to a parent HTMLNode, or if it's a page, to render
-   * the whole page as HTML.
+   * Top-level container node for the infobox or page fragment. Add this node to a parent document
+   * or render it directly to produce complete HTML for the wrapper around the inner content. The
+   * reference is stable, but the underlying node remains mutable.
    */
   public final HTMLNode outer;
 
-  /** The inside of the box. Use this to add content inside the box. */
+  /**
+   * Content region inside the infobox. Callers can append additional HTML children here to populate
+   * the visible body of the box while leaving the outer markup unchanged. The node is mutable and
+   * shared with the {@link #outer} tree.
+   */
   public final HTMLNode content;
 
   InfoboxNode(HTMLNode box, HTMLNode content) {
@@ -28,15 +47,41 @@ public class InfoboxNode {
   /**
    * Calls {@link HTMLNode#generate()} on the {@link #getOuterNode() outer node} and returns the
    * generated HTML.
+   *
+   * <p>This method is a convenience that renders the full outer container along with any content
+   * appended to it. It does not perform defensive copying; repeated invocations reflect any
+   * mutations made to either the outer or content nodes between calls. Generation occurs entirely
+   * in memory and does not perform I/O.
+   *
+   * @return serialized HTML markup for the outer node and its current descendants; never {@code
+   *     null} but may be empty when no tags or text are present
    */
   public String generate() {
     return outer.generate();
   }
 
+  /**
+   * Returns the outer container node.
+   *
+   * <p>Use this handle when you need to attach the infobox to another {@link HTMLNode} or modify
+   * attributes on the wrapper element. The returned reference is the same instance supplied at
+   * construction time.
+   *
+   * @return live reference to the outer HTML node pairing this infobox with surrounding markup
+   */
   public HTMLNode getOuterNode() {
     return outer;
   }
 
+  /**
+   * Returns the inner content node.
+   *
+   * <p>Callers typically append children or text to this node to fill the box body. Changes are
+   * immediately reflected when {@link #generate()} is called on the infobox or directly on the
+   * outer node.
+   *
+   * @return live reference to the content node inside the infobox
+   */
   public HTMLNode getContentNode() {
     return content;
   }

--- a/src/test/java/network/crypta/clients/http/InfoboxNodeTest.java
+++ b/src/test/java/network/crypta/clients/http/InfoboxNodeTest.java
@@ -1,0 +1,60 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class InfoboxNodeTest {
+
+  @Mock private HTMLNode outerMock;
+
+  @Mock private HTMLNode contentMock;
+
+  @Test
+  void constructor_whenGivenNodes_preservesReferences() {
+    HTMLNode outer = new HTMLNode("div");
+    HTMLNode content = new HTMLNode("span");
+
+    InfoboxNode infoboxNode = new InfoboxNode(outer, content);
+
+    assertSame(outer, infoboxNode.getOuterNode());
+    assertSame(content, infoboxNode.getContentNode());
+    assertSame(outer, infoboxNode.outer);
+    assertSame(content, infoboxNode.content);
+  }
+
+  @Test
+  void generate_whenOuterNodeGeneratesHtml_returnsHtmlFromOuter() {
+    InfoboxNode infoboxNode = new InfoboxNode(outerMock, contentMock);
+    when(outerMock.generate()).thenReturn("<div>generated</div>");
+
+    String generated = infoboxNode.generate();
+
+    assertEquals("<div>generated</div>", generated);
+    verify(outerMock).generate();
+    verifyNoInteractions(contentMock);
+  }
+
+  @Test
+  void generate_whenOuterIsMutatedAfterConstruction_reflectsLatestStructure() {
+    HTMLNode outer = new HTMLNode("section");
+    HTMLNode content = new HTMLNode("div");
+    InfoboxNode infoboxNode = new InfoboxNode(outer, content);
+
+    outer.addChild("p", "first");
+    assertEquals("<section><p>first</p></section>", infoboxNode.generate());
+
+    outer.addChild("p", "second");
+    assertEquals("<section><p>first</p><p>second</p></section>", infoboxNode.generate());
+  }
+}


### PR DESCRIPTION
## Summary
- expand InfoboxNode Javadoc with doclint-clean, detailed API documentation
- add deterministic JUnit 6/Mockito tests covering constructor and generate delegation
- ensure HTML generation reflects live outer node mutations

## Testing
- ./gradlew test --tests 'network.crypta.clients.http.InfoboxNodeTest'
