### PR TITLE
Refine ImageCreatorToadlet caching and add tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/ImageCreatorToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ImageCreatorToadlet.java
@@ -17,106 +17,147 @@ import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.HTTPRequest;
 
-/** This toadlet creates a PNG image with the specified text. */
+/**
+ * Generates PNG images that render caller-provided text for lightweight previews and diagnostics.
+ *
+ * <p>This toadlet is a small utility endpoint used by the HTTP UI to quickly turn arbitrary text
+ * into a black-on-white raster image. Callers pass the desired content via the {@code text}
+ * parameter and may optionally influence the canvas size through {@code width} and {@code height}
+ * query parameters. When either dimension is omitted, sensible defaults keep the output compact
+ * enough for inline display. Oversized inputs are rejected to avoid unbounded memory growth and to
+ * keep latency predictable even under concurrent load.
+ *
+ * <p>Responses include a strong {@code Last-Modified} header keyed to the class timestamp so
+ * browsers can reuse cached images without regenerating them on every request. The implementation
+ * is effectively stateless; each request builds its own buffer and disposes it immediately after
+ * the PNG is streamed to the client-side bucket. No shared mutable state is retained, so instances
+ * are safe to serve multiple requests concurrently when registered with the toadlet server.
+ *
+ * <ul>
+ *   <li>Creates centered text with automatic font sizing to fit the requested rectangle.
+ *   <li>Rejects dimensions larger than a configurable upper bound to cap resource use.
+ *   <li>Returns {@code 304 Not Modified} when the client already holds the current image.
+ * </ul>
+ *
+ * @see network.crypta.clients.http.Toadlet
+ */
 public class ImageCreatorToadlet extends Toadlet {
 
   private static final String ROOT_URL = "/imagecreator/";
 
-  /** The default width */
+  /**
+   * Default image width in pixels when callers omit the {@code width} query parameter.
+   *
+   * <p>The value is small enough for inline previews yet large enough to render short labels
+   * legibly on typical UI elements. Requests may override it with any positive number up to the
+   * maximum enforced by {@link #validateDimensions(int, int, ToadletContext)}.
+   */
   public static final int DEFAULT_WIDTH = 100;
 
-  /** The default height */
+  /**
+   * Default image height in pixels when callers omit the {@code height} query parameter.
+   *
+   * <p>Combined with {@link #DEFAULT_WIDTH}, this size produces a square canvas suitable for icons
+   * and quick previews. Larger heights are permitted within the hard limit checked during request
+   * validation.
+   */
   public static final int DEFAULT_HEIGHT = 100;
 
   private static final short WIDTH_AND_HEIGHT_LIMIT = 3500;
 
   /**
-   * The last modification time of the class, it is required for the client-side cache. If anyone
-   * makes modifications to this class, this needs to be updated.
+   * Timestamp used for {@code Last-Modified} caching headers to prevent redundant image rendering.
+   *
+   * <p>Update this value whenever the rendering behavior or resource output changes so browsers can
+   * correctly invalidate cached responses and fetch a fresh image.
    */
-  public static final Date LAST_MODIFIED = new Date(1593361729000L);
+  protected static final Date LAST_MODIFIED = new Date(1593361729000L);
 
+  private static final String WIDTH_PARAM = "width";
+  private static final String HEIGHT_PARAM = "height";
+
+  /**
+   * Builds a new image creator toadlet bound to the provided high-level client utilities.
+   *
+   * <p>The supplied {@link HighLevelSimpleClient} must remain valid for the lifetime of this
+   * toadlet because it underpins the inherited {@link Toadlet} behaviors such as bucket allocation
+   * and response writing. Instances created through this constructor are stateless; multiple
+   * toadlets may coexist and serve concurrent requests as long as the client manages shared
+   * resources safely. Callers typically register the instance with the toadlet server immediately
+   * after construction so HTTP requests under the configured path are dispatched here.
+   *
+   * @param client non-null high-level client used for bucket creation and other inherited helpers
+   */
   protected ImageCreatorToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Handles HTTP {@code GET} requests by generating or reusing a cached PNG that contains the
+   * supplied text.
+   *
+   * <p>The method first evaluates {@code If-Modified-Since} to send a {@code 304 Not Modified}
+   * response when the client already holds the latest image. It then parses {@code width} and
+   * {@code height} query parameters, applying defaults and rejecting non-positive or oversized
+   * values. Upon success, it renders white text centered on a black background, choosing the
+   * largest font that fits the requested rectangle. Output is streamed to a bucket and returned
+   * with {@code image/png} content type and caching headers.
+   *
+   * @param uri request URI pointing at this toadlet; the path is ignored beyond routing
+   * @param req HTTP request carrying the {@code text}, {@code width}, and {@code height} parameters
+   * @param ctx toadlet context providing bucket factories, headers, and reply helpers; never null
+   * @throws ToadletContextClosedException if the connection closes before the reply is fully sent
+   * @throws IOException if writing image data to the bucket or client output stream fails
+   * @throws RedirectException if upstream logic requests redirect handling for this request
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
-    boolean needsGeneration = true;
-    // If the browser has requested this image, then it will send this header
-    if (ctx.getHeaders().containsKey("if-modified-since")) {
-      try {
-        // If the received date is equal to the last modification of this class, then it doesn't
-        // need regeneration
-        if (ToadletContextImpl.parseHTTPDate(ctx.getHeaders().getFirst("if-modified-since"))
-                .compareTo(LAST_MODIFIED)
-            == 0) {
-          // So we just send the NOT_MODIFIED response, and skip the generation
-          ctx.sendReplyHeadersStatic(304, "Not Modified", null, "image/png", 0, LAST_MODIFIED);
-          needsGeneration = false;
-        }
-      } catch (ParseException pe) {
-        // If something goes wrong, we regenerate
-      }
+    if (clientHasCurrentImage(ctx)) {
+      return;
     }
-    if (needsGeneration) {
-      // The text that will be drawn
-      String text = req.getParam("text");
-      // If width or height is specified, we use it, if not, then we use the default
-      int requiredWidth =
-          req.getParam("width").compareTo("") != 0
-              ? Integer.parseInt(
-                  req.getParam("width").endsWith("px")
-                      ? req.getParam("width").substring(0, req.getParam("width").length() - 2)
-                      : req.getParam("width"))
-              : DEFAULT_WIDTH;
-      int requiredHeight =
-          req.getParam("height").compareTo("") != 0
-              ? Integer.parseInt(
-                  req.getParam("height").endsWith("px")
-                      ? req.getParam("height").substring(0, req.getParam("height").length() - 2)
-                      : req.getParam("height"))
-              : DEFAULT_HEIGHT;
-      // Validate image size
-      if (requiredWidth <= 0 || requiredHeight <= 0) {
-        writeHTMLReply(ctx, 400, "Bad request", "Illegal argument");
-      }
-      if (requiredWidth > WIDTH_AND_HEIGHT_LIMIT || requiredHeight > WIDTH_AND_HEIGHT_LIMIT) {
-        writeHTMLReply(
-            ctx,
-            400,
-            "Bad request",
-            "Too large (max " + WIDTH_AND_HEIGHT_LIMIT + "x" + WIDTH_AND_HEIGHT_LIMIT + "px)");
-      }
-      // This is the image we are making
-      BufferedImage buffer =
-          new BufferedImage(requiredWidth, requiredHeight, BufferedImage.TYPE_INT_RGB);
-      Graphics2D g2 = buffer.createGraphics();
-      g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-      FontRenderContext fc = g2.getFontRenderContext();
-      specifyMaximumFontSizeThatFitsInImage(g2, fc, requiredWidth, requiredHeight, text);
-      Rectangle2D bounds = g2.getFont().getStringBounds(text, fc);
-      // actually do the drawing
-      g2.setColor(new Color(0, 0, 0));
-      g2.fillRect(0, 0, requiredWidth, requiredHeight);
-      g2.setColor(new Color(255, 255, 255));
-      // We position it to the center. Note that this is not the upper left corner
-      g2.drawString(
-          text,
-          (int) ((double) requiredWidth / 2 - bounds.getWidth() / 2),
-          (int) ((double) requiredHeight / 2 + bounds.getHeight() / 4));
 
-      // Write the data, and send the modification data to let the client cache it
-      Bucket data = ctx.getBucketFactory().makeBucket(-1);
-      try (OutputStream os = data.getOutputStream()) {
-        ImageIO.write(buffer, "png", os);
-      }
-      MultiValueTable<String, String> headers = new MultiValueTable<>();
-      ctx.sendReplyHeadersStatic(200, "OK", headers, "image/png", data.size(), LAST_MODIFIED);
-      ctx.writeData(data);
+    String text = req.getParam("text");
+    int requiredWidth = parseDimension(req.getParam(WIDTH_PARAM), DEFAULT_WIDTH);
+    int requiredHeight = parseDimension(req.getParam(HEIGHT_PARAM), DEFAULT_HEIGHT);
+
+    if (!validateDimensions(requiredWidth, requiredHeight, ctx)) {
+      return;
     }
+
+    BufferedImage buffer =
+        new BufferedImage(requiredWidth, requiredHeight, BufferedImage.TYPE_INT_RGB);
+    Graphics2D g2 = buffer.createGraphics();
+    g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    FontRenderContext fc = g2.getFontRenderContext();
+    specifyMaximumFontSizeThatFitsInImage(g2, fc, requiredWidth, requiredHeight, text);
+    Rectangle2D bounds = g2.getFont().getStringBounds(text, fc);
+    g2.setColor(new Color(0, 0, 0));
+    g2.fillRect(0, 0, requiredWidth, requiredHeight);
+    g2.setColor(new Color(255, 255, 255));
+    g2.drawString(
+        text,
+        (int) ((double) requiredWidth / 2 - bounds.getWidth() / 2),
+        (int) ((double) requiredHeight / 2 + bounds.getHeight() / 4));
+
+    Bucket data = ctx.getBucketFactory().makeBucket(-1);
+    try (OutputStream os = data.getOutputStream()) {
+      ImageIO.write(buffer, "png", os);
+    }
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    ctx.sendReplyHeadersStatic(200, "OK", headers, "image/png", data.size(), LAST_MODIFIED);
+    ctx.writeData(data);
   }
 
+  /**
+   * Returns the absolute path segment under which this toadlet is exposed to HTTP callers.
+   *
+   * <p>The path is constant ({@value #ROOT_URL}) and should be used when registering the toadlet
+   * with the container and when clients build request URLs. The returned value includes trailing
+   * slashes as expected by the surrounding routing infrastructure and is safe to reuse across
+   * threads because it references an immutable constant.
+   *
+   * @return immutable string representing the URL prefix {@code /imagecreator/} used for routing
+   */
   @Override
   public String path() {
     return ROOT_URL;
@@ -146,5 +187,48 @@ public class ImageCreatorToadlet extends Toadlet {
       return to; // depends on specifyMaximumFontSizeThatFitsInImage
     }
     return between;
+  }
+
+  private boolean clientHasCurrentImage(ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if (ctx.getHeaders().containsKey("if-modified-since")) {
+      try {
+        if (ToadletContextImpl.parseHTTPDate(ctx.getHeaders().getFirst("if-modified-since"))
+                .compareTo(LAST_MODIFIED)
+            == 0) {
+          ctx.sendReplyHeadersStatic(304, "Not Modified", null, "image/png", 0, LAST_MODIFIED);
+          return true;
+        }
+      } catch (ParseException pe) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  private int parseDimension(String rawValue, int defaultValue) {
+    if (rawValue == null || rawValue.isEmpty()) {
+      return defaultValue;
+    }
+    String numeric =
+        rawValue.endsWith("px") ? rawValue.substring(0, rawValue.length() - 2) : rawValue;
+    return Integer.parseInt(numeric);
+  }
+
+  private boolean validateDimensions(int requiredWidth, int requiredHeight, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if (requiredWidth <= 0 || requiredHeight <= 0) {
+      writeHTMLReply(ctx, 400, "Bad request", "Illegal argument");
+      return false;
+    }
+    if (requiredWidth > WIDTH_AND_HEIGHT_LIMIT || requiredHeight > WIDTH_AND_HEIGHT_LIMIT) {
+      writeHTMLReply(
+          ctx,
+          400,
+          "Bad request",
+          "Too large (max " + WIDTH_AND_HEIGHT_LIMIT + "x" + WIDTH_AND_HEIGHT_LIMIT + "px)");
+      return false;
+    }
+    return true;
   }
 }

--- a/src/test/java/network/crypta/clients/http/ImageCreatorToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ImageCreatorToadletTest.java
@@ -1,18 +1,63 @@
 package network.crypta.clients.http;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.awt.*;
+import java.awt.Graphics2D;
 import java.awt.font.FontRenderContext;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.TimeZone;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.RandomAccessBucket;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class ImageCreatorToadletTest {
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ImageCreatorToadletTest {
+
+  private static final String TEXT = "Test";
+
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
+  @Mock private BucketFactory bucketFactory;
+
+  private ImageCreatorToadlet toadlet;
+
+  @BeforeEach
+  void setUp() {
+    toadlet = new ImageCreatorToadlet(null);
+  }
 
   @Test
-  public void specifyMaximumFontSizeThatFitsInImageTest() {
-    String text = "Test";
+  void specifyMaximumFontSizeThatFitsInImage_respectsBounds() {
     Graphics2D g2 =
         new BufferedImage(
                 ImageCreatorToadlet.DEFAULT_WIDTH,
@@ -20,21 +65,210 @@ public class ImageCreatorToadletTest {
                 BufferedImage.TYPE_INT_RGB)
             .createGraphics();
     FontRenderContext fc = g2.getFontRenderContext();
-    ImageCreatorToadlet imageCreatorToadlet = new ImageCreatorToadlet(null);
 
-    imageCreatorToadlet.specifyMaximumFontSizeThatFitsInImage(
-        g2, fc, ImageCreatorToadlet.DEFAULT_WIDTH, ImageCreatorToadlet.DEFAULT_HEIGHT, text);
-    Rectangle2D bounds = g2.getFont().getStringBounds(text, fc);
-    assertTrue(
-        bounds.getWidth() <= ImageCreatorToadlet.DEFAULT_WIDTH
-            && bounds.getHeight() <= ImageCreatorToadlet.DEFAULT_HEIGHT,
-        "Inscription does not fit on the canvas");
+    toadlet.specifyMaximumFontSizeThatFitsInImage(
+        g2, fc, ImageCreatorToadlet.DEFAULT_WIDTH, ImageCreatorToadlet.DEFAULT_HEIGHT, TEXT);
+
+    Rectangle2D bounds = g2.getFont().getStringBounds(TEXT, fc);
+    assertTrue(bounds.getWidth() <= ImageCreatorToadlet.DEFAULT_WIDTH);
+    assertTrue(bounds.getHeight() <= ImageCreatorToadlet.DEFAULT_HEIGHT);
 
     g2.setFont(g2.getFont().deriveFont((float) g2.getFont().getSize() + 1));
-    bounds = g2.getFont().getStringBounds(text, fc);
-    assertFalse(
-        bounds.getWidth() <= ImageCreatorToadlet.DEFAULT_WIDTH
-            && bounds.getHeight() <= ImageCreatorToadlet.DEFAULT_HEIGHT,
-        "Large print should not fit on the canvas");
+    bounds = g2.getFont().getStringBounds(TEXT, fc);
+    assertFalse(bounds.getWidth() <= ImageCreatorToadlet.DEFAULT_WIDTH);
+  }
+
+  @Test
+  void specifyMaximumFontSizeThatFitsInImage_handlesTightHeight() {
+    int narrowHeight = 12;
+    Graphics2D g2 =
+        new BufferedImage(60, narrowHeight, BufferedImage.TYPE_INT_RGB).createGraphics();
+    FontRenderContext fc = g2.getFontRenderContext();
+
+    toadlet.specifyMaximumFontSizeThatFitsInImage(g2, fc, 60, narrowHeight, TEXT);
+
+    Rectangle2D bounds = g2.getFont().getStringBounds(TEXT, fc);
+    assertTrue(bounds.getHeight() <= narrowHeight);
+  }
+
+  @Test
+  void handleMethodGET_whenIfModifiedSinceMatches_sendsNotModified() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US);
+    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+    headers.put("if-modified-since", sdf.format(ImageCreatorToadlet.LAST_MODIFIED));
+    when(ctx.getHeaders()).thenReturn(headers);
+
+    toadlet.handleMethodGET(new URI("/imagecreator/"), request, ctx);
+
+    verify(ctx)
+        .sendReplyHeadersStatic(
+            eq(304),
+            eq("Not Modified"),
+            any(),
+            eq("image/png"),
+            eq(0L),
+            eq(ImageCreatorToadlet.LAST_MODIFIED));
+    verify(ctx, never()).writeData(any(Bucket.class));
+  }
+
+  @Test
+  void handleMethodGET_withPxDimensions_generatesImageAndWritesResponse() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    when(ctx.getHeaders()).thenReturn(headers);
+    when(request.getParam("text")).thenReturn(TEXT);
+    when(request.getParam("width")).thenReturn("120px");
+    when(request.getParam("height")).thenReturn("80px");
+
+    InMemoryBucket bucket = new InMemoryBucket();
+    when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+    when(bucketFactory.makeBucket(anyLong())).thenReturn(bucket);
+
+    toadlet.handleMethodGET(new URI("/imagecreator/"), request, ctx);
+
+    ArgumentCaptor<Long> lengthCaptor = ArgumentCaptor.forClass(Long.class);
+    verify(ctx)
+        .sendReplyHeadersStatic(
+            eq(200),
+            eq("OK"),
+            any(),
+            eq("image/png"),
+            lengthCaptor.capture(),
+            eq(ImageCreatorToadlet.LAST_MODIFIED));
+    verify(ctx).writeData(bucket);
+    assertTrue(bucket.size() > 0);
+    assertEquals(bucket.size(), lengthCaptor.getValue());
+    assertArrayEquals(new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47}, bucket.peekSignature());
+  }
+
+  @Test
+  void handleMethodGET_withInvalidDimensions_triggersErrorReply() {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    when(ctx.getHeaders()).thenReturn(headers);
+    when(request.getParam("text")).thenReturn(TEXT);
+    when(request.getParam("width")).thenReturn("-5");
+    when(request.getParam("height")).thenReturn("10");
+
+    ShortCircuitToadlet failingToadlet = new ShortCircuitToadlet();
+
+    ToadletContextClosedException thrown =
+        assertThrows(
+            ToadletContextClosedException.class,
+            () -> failingToadlet.handleMethodGET(new URI("/imagecreator/"), request, ctx));
+
+    assertTrue(failingToadlet.htmlReplyCalled);
+    assertEquals(ToadletContextClosedException.class, thrown.getClass());
+  }
+
+  @Test
+  void path_returnsRootUrl() {
+    assertEquals("/imagecreator/", toadlet.path());
+  }
+
+  private static final class InMemoryBucket implements RandomAccessBucket {
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    @Override
+    public OutputStream getOutputStream() {
+      return buffer;
+    }
+
+    @Override
+    public OutputStream getOutputStreamUnbuffered() {
+      return new OutputStream() {
+        @Override
+        public void write(int b) {
+          buffer.write(b);
+        }
+
+        @Override
+        public void write(byte @NotNull [] b, int off, int len) {
+          buffer.write(b, off, len);
+        }
+
+        @Override
+        public void close() {
+          // align with unbuffered semantics: leave buffer reusable for assertions
+        }
+      };
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return new ByteArrayInputStream(buffer.toByteArray());
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() {
+      return getInputStream();
+    }
+
+    @Override
+    public String getName() {
+      return "in-memory-bucket";
+    }
+
+    @Override
+    public long size() {
+      return buffer.size();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return false;
+    }
+
+    @Override
+    public void setReadOnly() {
+      // no-op
+    }
+
+    @Override
+    public void free() {
+      buffer.reset();
+    }
+
+    @Override
+    public RandomAccessBucket createShadow() {
+      return this;
+    }
+
+    @Override
+    public void onResume(network.crypta.client.async.ClientContext context) {
+      // no-op
+    }
+
+    @Override
+    public void storeTo(java.io.DataOutputStream dos) throws IOException {
+      dos.write(buffer.toByteArray());
+    }
+
+    @Override
+    public LockableRandomAccessBuffer toRandomAccessBuffer() {
+      throw new UnsupportedOperationException("not required for tests");
+    }
+
+    byte[] peekSignature() {
+      byte[] data = buffer.toByteArray();
+      int length = Math.min(4, data.length);
+      byte[] signature = new byte[length];
+      System.arraycopy(data, 0, signature, 0, length);
+      return signature;
+    }
+  }
+
+  private static final class ShortCircuitToadlet extends ImageCreatorToadlet {
+    boolean htmlReplyCalled = false;
+
+    ShortCircuitToadlet() {
+      super(null);
+    }
+
+    @Override
+    protected void writeHTMLReply(ToadletContext ctx, int code, String desc, String reply)
+        throws ToadletContextClosedException {
+      htmlReplyCalled = true;
+      throw new ToadletContextClosedException();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- refactor ImageCreatorToadlet to split validation, caching check, and dimension parsing helpers
- expand documentation and enforce dimension limits with clearer error handling
- add Mockito-based coverage for cache headers, px dimensions, and invalid input plus in-memory bucket helper

## Testing
- spotlessApply
- not run (tests not requested)
