### PR TITLE
Add IntervalPusherManager tests and expand Javadoc

### DIFF
--- a/src/main/java/network/crypta/clients/http/IntervalPusherManager.java
+++ b/src/main/java/network/crypta/clients/http/IntervalPusherManager.java
@@ -6,7 +6,28 @@ import network.crypta.clients.http.updateableelements.BaseUpdateableElement;
 import network.crypta.clients.http.updateableelements.PushDataManager;
 import network.crypta.support.Ticker;
 
-/** This manager object will push elements at a fixed interval */
+/**
+ * Coordinates periodic push updates for registered HTTP updateable elements.
+ *
+ * <p>This manager acts as a lightweight scheduler that relies on a shared {@link Ticker} to run a
+ * refresher job every fixed interval (10 seconds). Clients create a single instance per HTTP
+ * context, register elements as they become visible to the UI, and allow the manager to keep those
+ * elements fresh without bespoke timers. The internal {@link CopyOnWriteArrayList} permits safe
+ * iteration from the refresher while callers add or remove elements concurrently. When the list is
+ * empty no further jobs are queued, so idle nodes avoid unnecessary wakeups. The manager is
+ * intentionally minimal: it delegates all data retrieval to {@link PushDataManager} and uses each
+ * element's updater identifier to trigger the appropriate push logic.
+ *
+ * <ul>
+ *   <li>Registers UI elements that expect recurring server pushes.
+ *   <li>Queues a timed job on first registration and requeues while elements exist.
+ *   <li>Stops rescheduling automatically once all elements are deregistered.
+ * </ul>
+ *
+ * @see Ticker
+ * @see PushDataManager
+ * @see BaseUpdateableElement
+ */
 public class IntervalPusherManager {
 
   /** The interval when the elements will be pushed */
@@ -40,10 +61,16 @@ public class IntervalPusherManager {
   private final List<BaseUpdateableElement> elements = new CopyOnWriteArrayList<>();
 
   /**
-   * Constructor
+   * Creates a manager that schedules update pushes with the supplied ticker.
    *
-   * @param ticker - The Ticker
-   * @param pushDataManager - The PushDataManager
+   * <p>The manager remains idle until the first element is registered. Afterward it maintains a
+   * single recurring job that requeues itself as long as at least one element stays registered.
+   * Callers should provide the shared {@link Ticker} instance used for other HTTP client timing
+   * tasks so updates align with the application's scheduling model. Neither parameter may be null;
+   * this class does not perform null checks beyond normal {@link NullPointerException} semantics.
+   *
+   * @param ticker non-null ticker that handles delayed job scheduling
+   * @param pushDataManager manager that performs element updates when jobs run
    */
   public IntervalPusherManager(Ticker ticker, PushDataManager pushDataManager) {
     this.ticker = ticker;
@@ -51,10 +78,19 @@ public class IntervalPusherManager {
   }
 
   /**
-   * Registers an element to be pushed at a fixed interval
+   * Registers an element to be pushed at a fixed interval.
    *
-   * @param element - The element
+   * <p>The element is appended to the internal {@link CopyOnWriteArrayList}, allowing concurrent
+   * registration even while a refresh cycle is iterating. If this call adds the first element, the
+   * manager immediately schedules the refresher job, which subsequently requeues itself every
+   * {@value #REFRESH_PERIOD} milliseconds while the list remains non-empty. Duplicate registrations
+   * are not deduplicated and result in multiple update calls. The element must expose a stable
+   * updater identifier because the manager forwards that value to {@link PushDataManager} without
+   * further validation.
+   *
+   * @param element element to track; must not be null
    */
+  @SuppressWarnings("unused")
   public void registerUpdateableElement(BaseUpdateableElement element) {
     boolean needsStart = elements.isEmpty();
     elements.add(element);
@@ -65,10 +101,17 @@ public class IntervalPusherManager {
   }
 
   /**
-   * Removes the element from interval pushing
+   * Removes the element from interval pushing.
    *
-   * @param element - The element to be removed
+   * <p>The element is removed from the internal copy-on-write list, which makes the operation safe
+   * to perform while a refresh iteration is in progress. If removal empties the list, the currently
+   * executing refresher (if any) completes its cycle but does not schedule a follow-up job, thereby
+   * stopping periodic updates until a new element is registered. The method tolerates removal of
+   * elements that were not previously registered; in that case it performs no work.
+   *
+   * @param element element to remove from recurring update schedule
    */
+  @SuppressWarnings("unused")
   public void deregisterUpdateableElement(BaseUpdateableElement element) {
     elements.remove(element);
   }

--- a/src/test/java/network/crypta/clients/http/IntervalPusherManagerTest.java
+++ b/src/test/java/network/crypta/clients/http/IntervalPusherManagerTest.java
@@ -1,0 +1,108 @@
+package network.crypta.clients.http;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import network.crypta.clients.http.updateableelements.BaseUpdateableElement;
+import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class IntervalPusherManagerTest {
+
+  private static final long REFRESH_PERIOD_MS = 10_000L;
+
+  @Mock private Ticker ticker;
+
+  @Mock private PushDataManager pushDataManager;
+
+  @Mock private BaseUpdateableElement firstElement;
+
+  @Mock private BaseUpdateableElement secondElement;
+
+  private IntervalPusherManager manager;
+
+  @BeforeEach
+  void setUp() {
+    manager = new IntervalPusherManager(ticker, pushDataManager);
+  }
+
+  @Test
+  void registerUpdateableElement_whenFirstElement_shouldScheduleRefresher() {
+    manager.registerUpdateableElement(firstElement);
+
+    verify(ticker)
+        .queueTimedJob(
+            any(Runnable.class), eq("Stats refresher"), eq(REFRESH_PERIOD_MS), eq(false), eq(true));
+  }
+
+  @Test
+  void registerUpdateableElement_whenAdditionalElement_shouldNotScheduleAgain() {
+    manager.registerUpdateableElement(firstElement);
+    clearInvocations(ticker);
+
+    manager.registerUpdateableElement(secondElement);
+
+    verify(ticker, never())
+        .queueTimedJob(any(Runnable.class), anyString(), anyLong(), anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  void refresherJob_whenRun_updatesElementsAndReschedules() {
+    when(firstElement.getUpdaterId(null)).thenReturn("first");
+    when(secondElement.getUpdaterId(null)).thenReturn("second");
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+
+    manager.registerUpdateableElement(firstElement);
+    manager.registerUpdateableElement(secondElement);
+
+    verify(ticker)
+        .queueTimedJob(
+            captor.capture(), eq("Stats refresher"), eq(REFRESH_PERIOD_MS), eq(false), eq(true));
+
+    Runnable refresher = captor.getValue();
+
+    refresher.run();
+
+    verify(pushDataManager).updateElement("first");
+    verify(pushDataManager).updateElement("second");
+    verify(ticker, times(2))
+        .queueTimedJob(
+            any(Runnable.class), eq("Stats refresher"), eq(REFRESH_PERIOD_MS), eq(false), eq(true));
+  }
+
+  @Test
+  void refresherJob_whenNoElements_doesNotReschedule() {
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    manager.registerUpdateableElement(firstElement);
+
+    verify(ticker)
+        .queueTimedJob(
+            captor.capture(), eq("Stats refresher"), eq(REFRESH_PERIOD_MS), eq(false), eq(true));
+
+    manager.deregisterUpdateableElement(firstElement);
+    clearInvocations(ticker, pushDataManager);
+
+    captor.getValue().run();
+
+    verifyNoInteractions(pushDataManager);
+    verify(ticker, never())
+        .queueTimedJob(any(Runnable.class), anyString(), anyLong(), anyBoolean(), anyBoolean());
+  }
+}


### PR DESCRIPTION
## Summary
- add thorough unit coverage for IntervalPusherManager scheduling and rescheduling behavior
- expand Javadoc with long-form documentation and concurrency notes for the HTTP interval pusher
- keep scheduling semantics unchanged while documenting expectations and edge cases

## Testing
- ./gradlew spotlessApply
- (no functional tests run; change is docs and new unit tests only)
