### PR TITLE
docs: clarify freesite insert toadlet

### DIFF
--- a/src/main/java/network/crypta/clients/http/InsertFreesiteToadlet.java
+++ b/src/main/java/network/crypta/clients/http/InsertFreesiteToadlet.java
@@ -7,13 +7,57 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
-/** This is just documentation, it will be replaced with a plugin wizard eventually. */
+/**
+ * Renders the informational page that guides users through inserting a freesite into Crypta via the
+ * browser interface. The toadlet builds a static set of localized instructions, curated links to
+ * helper tools (jSite, FlogHelper, Thingamablog), and direct pointers to on-network tutorials that
+ * explain freesite publishing. It does not perform any network I/O itself; instead it acts purely
+ * as a documentation surface so users can choose the workflow that fits their experience level.
+ *
+ * <p>Usage pattern:
+ *
+ * <ul>
+ *   <li>The containing {@link ToadletContainer} routes {@code GET /insertsite/} to this instance.
+ *   <li>{@link #handleMethodGET(URI, HTTPRequest, ToadletContext)} builds a {@link PageNode}, adds
+ *       alert summaries, and emits a single HTML reply.
+ *   <li>No mutable state is retained between invocations; the class is safe for reuse across
+ *       requests as long as callers provide a fresh {@link ToadletContext}.
+ * </ul>
+ *
+ * <p>Thread-safety: instances are stateless and rely on the provided context for per-request data,
+ * so they are safe to use concurrently when the container hands each request its own context. The
+ * localization and link content is fixed at compile time, which avoids runtime variability and
+ * keeps the rendered HTML deterministic for testing.
+ */
 public class InsertFreesiteToadlet extends Toadlet {
 
+  /**
+   * Create a new freesite help toadlet bound to the shared high-level client.
+   *
+   * @param client non-null helper used by the base {@link Toadlet}; retained for parity with other
+   *     toadlets even though this class performs only static rendering
+   */
   protected InsertFreesiteToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Handle {@code GET /insertsite/} by emitting a localized help page that explains how to publish
+   * a freesite. The method assembles a {@link PageNode}, injects the current alert summary, builds
+   * an infobox with helper links (plugins page, jSite downloads, on-network tutorials, and
+   * Thingamablog), and returns a 200 OK HTML response via {@link #writeHTMLReply(ToadletContext,
+   * int, String, String)}. No request parameters are inspected and no state is modified.
+   *
+   * @param uri resolved request URI; used only for signature parity and may be {@code null} in
+   *     tests
+   * @param req HTTP request wrapper; not read by this implementation but must be non-null to comply
+   *     with the dispatch contract
+   * @param ctx active request context providing page construction utilities and output streams;
+   *     must be open and non-null
+   * @throws ToadletContextClosedException if the client disconnects before headers or body are
+   *     written
+   * @throws IOException if header emission or HTML streaming fails while writing the reply
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);
@@ -81,10 +125,21 @@ public class InsertFreesiteToadlet extends Toadlet {
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
   }
 
+  /**
+   * Localized string helper scoped to this toadlet.
+   *
+   * @param string suffix key appended to {@code InsertFreesiteToadlet.} in the localization bundle
+   * @return resolved localization value or the key itself if missing; never {@code null}
+   */
   private static String l10n(String string) {
     return NodeL10n.getBase().getString("InsertFreesiteToadlet." + string);
   }
 
+  /**
+   * Return the mount path used by the toadlet container to route freesite help requests.
+   *
+   * @return absolute path {@code "/insertsite/"}; stable for bookmarks and menu entries
+   */
   @Override
   public String path() {
     return "/insertsite/";

--- a/src/test/java/network/crypta/clients/http/InsertFreesiteToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/InsertFreesiteToadletTest.java
@@ -1,0 +1,116 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class InsertFreesiteToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
+  @Mock private UserAlertManager alertManager;
+  @Mock private PageMaker pageMaker;
+
+  private InsertFreesiteToadlet toadlet;
+
+  @BeforeEach
+  void setUp() {
+    // Ensure localization base is initialized for deterministic string lookups.
+    new NodeL10n();
+    toadlet = new InsertFreesiteToadlet(client);
+  }
+
+  @Test
+  void path_whenCalled_returnsMountPath() {
+    assertEquals("/insertsite/", toadlet.path());
+  }
+
+  @Test
+  void handleMethodGET_whenCalled_buildsAndWritesHtmlPage() throws Exception {
+    HTMLNode outer = new HTMLNode("div");
+    HTMLNode head = outer.addChild("head");
+    HTMLNode content = outer.addChild("div", "id", "content");
+    PageNode pageNode = new PageNode(outer, head, content);
+
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(alertManager.createSummary()).thenReturn(new HTMLNode("summary"));
+
+    when(pageMaker.getPageNode(anyString(), eq(ctx))).thenReturn(pageNode);
+    when(pageMaker.getInfobox(anyString(), anyString(), eq(content), anyString(), anyBoolean()))
+        .thenAnswer(
+            invocation -> {
+              String category = invocation.getArgument(0);
+              String header = invocation.getArgument(1);
+              HTMLNode parent = invocation.getArgument(2);
+              String title = invocation.getArgument(3);
+              boolean isUnique = invocation.getArgument(4);
+
+              HTMLNode infobox =
+                  new HTMLNode("div", "class", "infobox " + (category == null ? "" : category));
+              if (isUnique && title != null) {
+                infobox.addAttribute("id", title);
+              }
+              infobox.addChild("div", "class", "infobox-header").addChild("#", header);
+              HTMLNode contentNode = infobox.addChild("div", "class", "infobox-content");
+              parent.addChild(infobox);
+              return contentNode;
+            });
+
+    doNothing().when(ctx).sendReplyHeaders(eq(200), eq("OK"), isNull(), anyString(), anyLong());
+    doNothing().when(ctx).writeData(any(byte[].class), anyInt(), anyInt());
+
+    toadlet.handleMethodGET(new URI("http://localhost/insertsite/"), request, ctx);
+
+    ArgumentCaptor<Long> lengthCaptor = ArgumentCaptor.forClass(Long.class);
+    verify(ctx)
+        .sendReplyHeaders(
+            eq(200), eq("OK"), isNull(), eq("text/html; charset=utf-8"), lengthCaptor.capture());
+
+    ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> writtenLengthCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(ctx)
+        .writeData(dataCaptor.capture(), offsetCaptor.capture(), writtenLengthCaptor.capture());
+
+    String body = new String(dataCaptor.getValue(), StandardCharsets.UTF_8);
+
+    assertEquals(0, offsetCaptor.getValue());
+    assertEquals(dataCaptor.getValue().length, writtenLengthCaptor.getValue());
+    assertEquals(dataCaptor.getValue().length, lengthCaptor.getValue());
+
+    assertTrue(body.contains("Publish!"));
+    assertTrue(body.contains("Freesite HOWTO"));
+    assertTrue(body.contains("/plugins/"));
+    assertTrue(body.contains("/jSite-15/"));
+    assertTrue(body.contains("thingamablog.zip"));
+    assertTrue(body.contains("freesite-insert"));
+    assertTrue(body.contains("<summary"));
+  }
+}


### PR DESCRIPTION
## Summary
- expand KDoc on InsertFreesiteToadlet to document behavior, usage, and path
- add coverage for InsertFreesiteToadlet GET rendering and path helper
- update freesite help expectations to current jSite download link

## Testing
- ./gradlew --parallel test --tests '*InsertFreesiteToadletTest'
- ./gradlew spotlessApply