### PR TITLE
Improve FProxy redirect safety and documentation

### DIFF
--- a/src/main/java/network/crypta/client/async/USKManager.java
+++ b/src/main/java/network/crypta/client/async/USKManager.java
@@ -118,8 +118,8 @@ public class USKManager {
   public USKManager(NodeClientCore core) {
     HighLevelSimpleClient client =
         core.makeClient(RequestStarter.UPDATE_PRIORITY_CLASS, false, false);
-    client.setMaxIntermediateLength(FProxyToadlet.MAX_LENGTH_NO_PROGRESS);
-    client.setMaxLength(FProxyToadlet.MAX_LENGTH_NO_PROGRESS);
+    client.setMaxIntermediateLength(FProxyToadlet.getMaxLengthNoProgress());
+    client.setMaxLength(FProxyToadlet.getMaxLengthNoProgress());
     backgroundFetchContext = client.getFetchContext();
     backgroundFetchContext.setFollowRedirects(false);
     backgroundFetchContextIgnoreDBR =

--- a/src/main/java/network/crypta/client/filter/M3UFilter.java
+++ b/src/main/java/network/crypta/client/filter/M3UFilter.java
@@ -49,7 +49,7 @@ public class M3UFilter implements ContentDataFilter {
   static final String BAD_URI_REPLACEMENT = "#bad-uri-removed";
 
   // pass-through for most files accessed via a playlist, likely through an external
-  // palyer. See FProxyToadlet.MAX_LENGTH_NO_PROGRESS for the default. This value must
+  // player. See FProxyToadlet.maxLengthNoProgress for the default. This value must
   // be synchronized with the test data!
 
   // Future: Add parsing of ext-comments to allow for gapless playback.

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -1,0 +1,349 @@
+package network.crypta.clients.http;
+
+import static network.crypta.node.updater.UpdaterPathsKt.CORE_UPDATE_PATH;
+
+import java.util.Arrays;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ajaxpush.DismissAlertToadlet;
+import network.crypta.clients.http.ajaxpush.LogWritebackToadlet;
+import network.crypta.clients.http.ajaxpush.PushDataToadlet;
+import network.crypta.clients.http.ajaxpush.PushFailoverToadlet;
+import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
+import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
+import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
+import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
+import network.crypta.config.Config;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClientBuilder;
+import network.crypta.node.RequestStarter;
+import network.crypta.node.updater.CoreActionToadlet;
+
+final class FProxyRegistrar {
+
+  private FProxyRegistrar() {}
+
+  static void maybeCreateFProxyEtc(
+      NodeClientCore core, Node node, Config config, SimpleToadletServer server) {
+
+    HighLevelSimpleClient client =
+        core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
+
+    FProxyToadlet.random = new byte[32];
+    core.getRandom().nextBytes(FProxyToadlet.random);
+
+    FProxyFetchTracker fetchTracker =
+        new FProxyFetchTracker(
+            core.getClientContext(),
+            client.getFetchContext(),
+            new RequestClientBuilder().realTime().build());
+
+    FProxyToadlet fproxy = new FProxyToadlet(client, core, fetchTracker);
+    core.setFProxy(fproxy);
+
+    server.registerMenu(
+        "/", FProxyToadlet.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing", null);
+    server.registerMenu(
+        FProxyToadlet.DOWNLOADS_PATH,
+        FProxyToadlet.CATEGORY_QUEUE,
+        "FProxyToadlet.categoryTitleQueue",
+        null);
+    server.registerMenu(
+        FProxyToadlet.FRIENDS_PATH,
+        FProxyToadlet.CATEGORY_FRIENDS,
+        "FProxyToadlet.categoryTitleFriends",
+        null);
+    server.registerMenu(
+        "/chat/", "FProxyToadlet.categoryChat", "FProxyToadlet.categoryTitleChat", null);
+    server.registerMenu(
+        "/alerts/", FProxyToadlet.CATEGORY_STATUS, "FProxyToadlet.categoryTitleStatus", null);
+    server.registerMenu(
+        "/seclevels/", FProxyToadlet.CATEGORY_CONFIG, "FProxyToadlet.categoryTitleConfig", null);
+
+    server.register(
+        fproxy,
+        FProxyToadlet.CATEGORY_BROWSING,
+        "/",
+        false,
+        "FProxyToadlet.welcomeTitle",
+        "FProxyToadlet.welcome",
+        false,
+        null);
+
+    DecodeToadlet decodeKeywordURL = new DecodeToadlet(client, core);
+    server.register(decodeKeywordURL, null, "/decode/", true, false);
+
+    InsertFreesiteToadlet siteinsert = new InsertFreesiteToadlet(client);
+    server.register(
+        siteinsert,
+        FProxyToadlet.CATEGORY_BROWSING,
+        "/insertsite/",
+        true,
+        "FProxyToadlet.insertFreesiteTitle",
+        "FProxyToadlet.insertFreesite",
+        false,
+        null);
+
+    UserAlertsToadlet alerts = new UserAlertsToadlet(client);
+    server.register(
+        alerts,
+        FProxyToadlet.CATEGORY_STATUS,
+        "/alerts/",
+        true,
+        "FProxyToadlet.alertsTitle",
+        "FProxyToadlet.alerts",
+        true,
+        null);
+
+    QueueToadlet downloadToadlet = new QueueToadlet(core, core.getFCPServer(), client, false);
+    server.register(
+        downloadToadlet,
+        FProxyToadlet.CATEGORY_QUEUE,
+        FProxyToadlet.DOWNLOADS_PATH,
+        true,
+        "FProxyToadlet.downloadsTitle",
+        "FProxyToadlet.downloads",
+        false,
+        downloadToadlet);
+    LocalDownloadDirectoryToadlet localDownloadDirectoryToadlet =
+        new LocalDownloadDirectoryToadlet(core, client, FProxyToadlet.DOWNLOADS_PATH);
+    server.register(
+        localDownloadDirectoryToadlet, null, localDownloadDirectoryToadlet.path(), true, false);
+    QueueToadlet uploadToadlet = new QueueToadlet(core, core.getFCPServer(), client, true);
+    server.register(
+        uploadToadlet,
+        FProxyToadlet.CATEGORY_QUEUE,
+        "/uploads/",
+        true,
+        "FProxyToadlet.uploadsTitle",
+        "FProxyToadlet.uploads",
+        false,
+        uploadToadlet);
+
+    FileInsertWizardToadlet fiw = new FileInsertWizardToadlet(client, core);
+    server.register(
+        fiw,
+        FProxyToadlet.CATEGORY_QUEUE,
+        FileInsertWizardToadlet.PATH,
+        true,
+        "FProxyToadlet.uploadFileWizardTitle",
+        "FProxyToadlet.uploadFileWizard",
+        false,
+        fiw);
+    uploadToadlet.setFIW(fiw);
+
+    LocalFileInsertToadlet localFileInsertToadlet = new LocalFileInsertToadlet(core, client);
+    server.register(localFileInsertToadlet, null, LocalFileInsertToadlet.PATH, true, false);
+
+    ContentFilterToadlet contentFilterToadlet = new ContentFilterToadlet(client, core);
+    server.register(
+        contentFilterToadlet,
+        FProxyToadlet.CATEGORY_QUEUE,
+        ContentFilterToadlet.CONTENT_FILTER_PATH,
+        true,
+        "FProxyToadlet.filterFileTitle",
+        "FProxyToadlet.filterFile",
+        false,
+        contentFilterToadlet);
+
+    LocalFileFilterToadlet localFileFilterToadlet = new LocalFileFilterToadlet(core, client);
+    server.register(localFileFilterToadlet, null, LocalFileFilterToadlet.PATH, true, false);
+
+    SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(client, node);
+    server.register(symlinkToadlet, null, "/sl/", true, false);
+
+    SecurityLevelsToadlet seclevels = new SecurityLevelsToadlet(client, node, core);
+    server.register(
+        seclevels,
+        FProxyToadlet.CATEGORY_CONFIG,
+        "/seclevels/",
+        true,
+        "FProxyToadlet.seclevelsTitle",
+        "FProxyToadlet.seclevels",
+        true,
+        null);
+
+    if (node.getPluginManager().isEnabled()) {
+      PproxyToadlet pproxy = new PproxyToadlet(client, node);
+      server.register(
+          pproxy,
+          FProxyToadlet.CATEGORY_CONFIG,
+          "/plugins/",
+          true,
+          "FProxyToadlet.pluginsTitle",
+          "FProxyToadlet.plugins",
+          true,
+          null);
+    }
+
+    SubConfig[] sc = config.getConfigs();
+    Arrays.sort(sc);
+
+    for (SubConfig cfg : sc) {
+      String prefix = cfg.getPrefix();
+      if (prefix.equals("security-levels") || prefix.equals("pluginmanager")) continue;
+      LocalDirectoryConfigToadlet localDirectoryConfigToadlet =
+          new LocalDirectoryConfigToadlet(core, client, FProxyToadlet.CONFIG_PATH + prefix);
+      ConfigToadlet configtoadlet =
+          new ConfigToadlet(localDirectoryConfigToadlet.path(), client, config, cfg, node, core);
+      server.register(
+          configtoadlet,
+          FProxyToadlet.CATEGORY_CONFIG,
+          FProxyToadlet.CONFIG_PATH + prefix,
+          true,
+          "ConfigToadlet." + prefix,
+          "ConfigToadlet.title." + prefix,
+          true,
+          configtoadlet);
+      server.register(
+          localDirectoryConfigToadlet, null, localDirectoryConfigToadlet.path(), true, false);
+    }
+
+    WelcomeToadlet welcometoadlet = new WelcomeToadlet(client, node);
+    server.register(welcometoadlet, null, FProxyToadlet.WELCOME_PATH, true, false);
+
+    ExternalLinkToadlet externalLinkToadlet = new ExternalLinkToadlet(client, node);
+    server.register(externalLinkToadlet, null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false);
+
+    CoreActionToadlet coreActionToadlet = new CoreActionToadlet(client, node);
+    server.register(coreActionToadlet, null, CORE_UPDATE_PATH, true, false);
+
+    DarknetConnectionsToadlet friendsToadlet = new DarknetConnectionsToadlet(node, core, client);
+    server.register(
+        friendsToadlet,
+        FProxyToadlet.CATEGORY_FRIENDS,
+        FProxyToadlet.FRIENDS_PATH,
+        true,
+        "FProxyToadlet.friendsTitle",
+        "FProxyToadlet.friends",
+        true,
+        null);
+
+    DarknetAddRefToadlet addRefToadlet = new DarknetAddRefToadlet(node, client, friendsToadlet);
+    server.register(
+        addRefToadlet,
+        FProxyToadlet.CATEGORY_FRIENDS,
+        "/addfriend/",
+        true,
+        "FProxyToadlet.addFriendTitle",
+        "FProxyToadlet.addFriend",
+        true,
+        null);
+
+    OpennetConnectionsToadlet opennetToadlet = new OpennetConnectionsToadlet(node, core, client);
+    server.register(
+        opennetToadlet,
+        FProxyToadlet.CATEGORY_STATUS,
+        "/strangers/",
+        true,
+        "FProxyToadlet.opennetTitle",
+        "FProxyToadlet.opennet",
+        true,
+        opennetToadlet);
+
+    ChatForumsToadlet chatForumsToadlet = new ChatForumsToadlet(client, node.getPluginManager());
+    server.register(
+        chatForumsToadlet,
+        "FProxyToadlet.categoryChat",
+        "/chat/",
+        true,
+        "FProxyToadlet.chatForumsTitle",
+        "FProxyToadlet.chatForums",
+        true,
+        chatForumsToadlet);
+
+    N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(node, core, client);
+    server.register(n2ntmToadlet, null, "/send_n2ntm/", true, true);
+    LocalFileN2NMToadlet localFileN2NMToadlet = new LocalFileN2NMToadlet(core, client);
+    server.register(localFileN2NMToadlet, null, LocalFileN2NMToadlet.PATH, true, false);
+
+    BookmarkEditorToadlet bookmarkEditorToadlet = new BookmarkEditorToadlet(client, core);
+    server.register(bookmarkEditorToadlet, null, "/bookmarkEditor/", true, false);
+
+    BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(client);
+    server.register(browserTestToadlet, null, "/test/", true, false);
+
+    StatisticsToadlet statisticsToadlet = new StatisticsToadlet(node, core, client);
+    server.register(
+        statisticsToadlet,
+        FProxyToadlet.CATEGORY_STATUS,
+        "/stats/",
+        true,
+        "FProxyToadlet.statsTitle",
+        "FProxyToadlet.stats",
+        true,
+        null);
+
+    DiagnosticToadlet diagnosticToadlet = new DiagnosticToadlet(node, core.getFCPServer(), client);
+    server.register(
+        diagnosticToadlet,
+        FProxyToadlet.CATEGORY_STATUS,
+        "/diagnostic/",
+        true,
+        "FProxyToadlet.diagnosticTitle",
+        "FProxyToadlet.diagnostic",
+        true,
+        null);
+
+    ConnectivityToadlet connectivityToadlet = new ConnectivityToadlet(client, node);
+    server.register(
+        connectivityToadlet,
+        FProxyToadlet.CATEGORY_STATUS,
+        "/connectivity/",
+        true,
+        "ConnectivityToadlet.connectivityTitle",
+        "ConnectivityToadlet.connectivity",
+        true,
+        null);
+
+    TranslationToadlet translationToadlet = new TranslationToadlet(client, core);
+    server.register(
+        translationToadlet,
+        FProxyToadlet.CATEGORY_CONFIG,
+        TranslationToadlet.TOADLET_URL,
+        true,
+        "TranslationToadlet.title",
+        "TranslationToadlet.titleLong",
+        true,
+        null);
+
+    FirstTimeWizardToadlet firstTimeWizardToadlet = new FirstTimeWizardToadlet(client, node, core);
+    server.register(firstTimeWizardToadlet, null, FirstTimeWizardToadlet.TOADLET_URL, true, false);
+
+    FirstTimeWizardNewToadlet firstTimeWizardNewToadlet =
+        new FirstTimeWizardNewToadlet(client, core, config);
+    server.register(
+        firstTimeWizardNewToadlet, null, FirstTimeWizardNewToadlet.TOADLET_URL, true, false);
+
+    SimpleHelpToadlet simpleHelpToadlet = new SimpleHelpToadlet(client, core);
+    server.register(simpleHelpToadlet, null, "/help/", true, false);
+
+    PushDataToadlet pushDataToadlet = new PushDataToadlet(client);
+    server.register(pushDataToadlet, null, pushDataToadlet.path(), true, false);
+
+    PushNotificationToadlet pushNotificationToadlet = new PushNotificationToadlet(client);
+    server.register(pushNotificationToadlet, null, pushNotificationToadlet.path(), true, false);
+
+    PushKeepaliveToadlet pushKeepaliveToadlet = new PushKeepaliveToadlet(client);
+    server.register(pushKeepaliveToadlet, null, pushKeepaliveToadlet.path(), true, false);
+
+    PushFailoverToadlet pushFailoverToadlet = new PushFailoverToadlet(client);
+    server.register(pushFailoverToadlet, null, pushFailoverToadlet.path(), true, false);
+
+    PushTesterToadlet pushTesterToadlet = new PushTesterToadlet(client);
+    server.register(pushTesterToadlet, null, pushTesterToadlet.path(), true, false);
+
+    PushLeavingToadlet pushLeavingToadlet = new PushLeavingToadlet(client);
+    server.register(pushLeavingToadlet, null, pushLeavingToadlet.path(), true, false);
+
+    ImageCreatorToadlet imageCreatorToadlet = new ImageCreatorToadlet(client);
+    server.register(imageCreatorToadlet, null, imageCreatorToadlet.path(), true, false);
+
+    LogWritebackToadlet logWritebackToadlet = new LogWritebackToadlet(client);
+    server.register(logWritebackToadlet, null, logWritebackToadlet.path(), true, false);
+
+    DismissAlertToadlet dismissAlertToadlet = new DismissAlertToadlet(client);
+    server.register(dismissAlertToadlet, null, dismissAlertToadlet.path(), true, false);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -20,10 +20,49 @@ import network.crypta.node.RequestClientBuilder;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.updater.CoreActionToadlet;
 
+/**
+ * Registers every FProxy-facing toadlet and menu entry exposed by the Crypta node.
+ *
+ * <p>This helper centralizes the wiring of the HTTP user interface: it constructs shared
+ * client-side helpers, instantiates each toadlet, assigns menu categories, and publishes them on
+ * the {@link SimpleToadletServer}. Callers invoke it once during node startup to ensure all public
+ * endpoints—browsing, queue management, configuration, alerts, and update actions—are available
+ * before handling requests. The registrar is intentionally package-private and stateless; it relies
+ * on the provided {@link NodeClientCore}, {@link Node}, and {@link Config} instances for runtime
+ * settings, threat posture, and plugin availability.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Creating a shared {@link HighLevelSimpleClient} and fetch tracker used by toadlets.
+ *   <li>Registering navigation menus under canonical categories for consistent UI grouping.
+ *   <li>Instantiating functional toadlets for downloads, uploads, security, plugins, chat, stats,
+ *       connectivity, first-time wizard flows, and core updates.
+ * </ul>
+ *
+ * <p>Thread-safety: registration is expected to run on a single startup thread; no internal state
+ * is retained after setup. Mutability is limited to injecting constructed toadlets into the server.
+ */
 final class FProxyRegistrar {
 
   private FProxyRegistrar() {}
 
+  /**
+   * Builds and registers the full FProxy toadlet set if the environment supports it.
+   *
+   * <p>The method seeds shared randomness, prepares a high-level client with interactive priority,
+   * wires a {@link FProxyFetchTracker}, and then registers every relevant toadlet with the provided
+   * server. Registration order aligns with menu placement: browsing first, followed by queue
+   * handlers, configuration, status/alerts, chat, and maintenance endpoints. Plugin-backed toadlets
+   * are added conditionally based on the node’s plugin manager. This method must be called exactly
+   * once during startup; it performs no deduplication and assumes the server is empty.
+   *
+   * @param core node client core supplying security levels, download directories, and RNG access;
+   *     must be initialized and non-null.
+   * @param node running node instance providing plugin manager and transport data; never null.
+   * @param config composite configuration used to enumerate sub-configs for dynamic toadlets.
+   * @param server toadlet server that exposes HTTP endpoints; expected to be in registration phase.
+   */
   static void maybeCreateFProxyEtc(
       NodeClientCore core, Node node, Config config, SimpleToadletServer server) {
 

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -65,6 +65,35 @@ import network.crypta.support.io.NoFreeBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Serves as the primary HTTP toadlet for Crypta’s Freenet proxy, mapping incoming browser
+ * navigation and download requests onto fetch operations inside the node. It routes GET/POST
+ * traffic for the root path, progress pages, configuration shortcuts, and large-file workflows
+ * while enforcing the node’s security posture and content-filtering rules.
+ *
+ * <p>The toadlet orchestrates request parsing, fetch context preparation, inline prefetch hooks,
+ * and progressive rendering so that interactive users receive timely feedback even when data is
+ * delayed. It respects gateway restrictions, threat levels, and MIME overrides while keeping
+ * downloads and inline views within configured size limits. Typical usage is a single instance
+ * created at startup and registered with the toadlet container.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Deriving user-visible URLs that encode size, retry, and filter preferences.
+ *   <li>Dispatching fetches with optional WebPush progress updates and rendering interim pages.
+ *   <li>Applying safety checks for dangerous RSS sniffing and content-type enforcement.
+ *   <li>Redirecting legacy paths and serving small static endpoints such as Atom feeds.
+ * </ul>
+ *
+ * <p>The class is not thread-safe; a single instance is reused by the container with per-request
+ * state kept in {@link GetRequestWorkflow}. It is immutable aside from static size limits that may
+ * be tuned at runtime by trusted code.
+ *
+ * @see Toadlet
+ * @see QueueToadlet
+ * @see FProxyFetchTracker
+ */
 public final class FProxyToadlet extends Toadlet implements RequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(FProxyToadlet.class);
 
@@ -160,6 +189,14 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       (2 * 1024 * 1024) * 11 / 10; // 2MiB plus a bit due to buggy inserts
 
   static final URI welcome;
+
+  /**
+   * Default scheduling priority applied to user-facing FProxy fetches.
+   *
+   * <p>The value mirrors {@link RequestStarter#INTERACTIVE_PRIORITY_CLASS} so that progress pages,
+   * inline views, and interactive downloads are treated as latency-sensitive work relative to
+   * background tasks.
+   */
   public static final short PRIORITY = RequestStarter.INTERACTIVE_PRIORITY_CLASS;
 
   static {
@@ -175,22 +212,67 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
   // Prefetch support uses a fixed upper bound; adjust here if configuration is added.
   static final int MAX_PREFETCH = 50;
 
+  /**
+   * Returns the maximum payload length, in bytes, allowed when a progress page is available.
+   *
+   * <p>This limit controls how large a response can be streamed while the browser displays a
+   * progress UI. It includes a small safety margin to accommodate inserts that slightly exceed the
+   * configured ceiling due to encoding overhead.
+   *
+   * @return maximum response size in bytes when progress feedback is enabled.
+   */
   public static long getMaxLengthWithProgress() {
     return maxLengthWithProgress;
   }
 
+  /**
+   * Sets the maximum payload length, in bytes, permitted when progress feedback is presented.
+   *
+   * <p>Callers should provide a positive value that reflects available memory and user experience
+   * goals; values are applied globally for subsequent requests. No synchronization is performed, so
+   * concurrent updates should be avoided.
+   *
+   * @param length new allowed size in bytes for progress-enabled transfers.
+   */
   public static void setMaxLengthWithProgress(long length) {
     maxLengthWithProgress = length;
   }
 
+  /**
+   * Returns the maximum payload length, in bytes, allowed when no progress page is sent.
+   *
+   * <p>This smaller ceiling is used for plain downloads and programmatic clients that cannot render
+   * progress UI, reducing resource usage for synchronous responses.
+   *
+   * @return maximum response size in bytes when progress feedback is disabled.
+   */
   public static long getMaxLengthNoProgress() {
     return maxLengthNoProgress;
   }
 
+  /**
+   * Sets the maximum payload length, in bytes, for transfers without progress rendering.
+   *
+   * <p>Use this to cap synchronous or programmatic fetches; the value should remain conservative to
+   * prevent accidental memory pressure when clients bypass the progress page workflow.
+   *
+   * @param length new allowed size in bytes for non-progress transfers.
+   */
   public static void setMaxLengthNoProgress(long length) {
     maxLengthNoProgress = length;
   }
 
+  /**
+   * Creates a toadlet bound to the given client and node services.
+   *
+   * <p>The constructor wires the high-level client with size limits suitable for non-progress
+   * transfers and caches references to the node core, client context, and fetch tracker. Instances
+   * are expected to be registered once with the container and reused across requests.
+   *
+   * @param client high-level fetch client used to perform HTTP-facing retrievals.
+   * @param core node core providing configuration, security levels, and download paths.
+   * @param tracker shared fetch tracker coordinating progress reporting and reuse.
+   */
   public FProxyToadlet(
       final HighLevelSimpleClient client, NodeClientCore core, FProxyFetchTracker tracker) {
     super(client);
@@ -206,6 +288,19 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     return true;
   }
 
+  /**
+   * Handles POST requests to the toadlet entry point, redirecting to the welcome page when
+   * applicable.
+   *
+   * <p>The method currently supports only root and servlet-prefixed paths, converting them into a
+   * temporary redirect toward the welcome workflow. Validation is defensive: it rejects null inputs
+   * and leaves other POST targets untouched.
+   *
+   * @param uri incoming request URI whose path determines redirect handling.
+   * @param req parsed HTTP request object supplying parameters and headers.
+   * @param ctx toadlet context for issuing redirects and access checks.
+   * @throws RedirectException if the request should be redirected to another path.
+   */
   public void handleMethodPOST(URI uri, HTTPRequest req, ToadletContext ctx)
       throws RedirectException {
     Objects.requireNonNull(req, "request");
@@ -417,16 +512,24 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
         || (ctx.getContainer().publicGatewayMode() && !ctx.isAllowedFullAccess());
   }
 
+  /**
+   * Resolves a localized string within the FProxy domain.
+   *
+   * @param msg localization key suffix to be prefixed with {@code FProxyToadlet.}.
+   * @return resolved localized text, or a placeholder if no translation exists.
+   */
   public static String l10n(String msg) {
     return NodeL10n.getBase().getString(L10N_PREFIX + msg);
   }
 
   /**
-   * Does the first 512 bytes of the data contain anything that Firefox might regard as RSS? This is
-   * a horrible evil hack; we shouldn't be doing blacklisting, we should be doing whitelisting.
-   * REDFLAG Expect future security issues!
+   * Checks whether the first 512 bytes resemble an RSS document as detected by Firefox’s sniffer.
+   * This blacklist-style probe is a defensive workaround used before applying stricter MIME
+   * handling, and may be removed once a whitelist is available. REDFLAG: expect future tightening.
    *
-   * @throws IOException
+   * @param data bucket containing the fetched payload; only the first 512 bytes are inspected.
+   * @return {@code true} when the leading bytes match Firefox’s RSS sniffing heuristics.
+   * @throws IOException if the bucket stream cannot be read fully or is unexpectedly truncated.
    */
   private static boolean isSniffedAsFeed(Bucket data) throws IOException {
     int sz = (int) Math.min(data.size(), 512);
@@ -1714,6 +1817,14 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     }
   }
 
+  /**
+   * Returns a localized string using the FProxy prefix with pattern substitution.
+   *
+   * @param key localization key suffix combined with the {@code FProxyToadlet.} prefix.
+   * @param pattern placeholder names expected by the localization bundle.
+   * @param value replacement values matched positionally to {@code pattern}.
+   * @return localized text after substitutions, preserving bundle formatting rules.
+   */
   public static String l10n(String key, String[] pattern, String[] value) {
     return NodeL10n.getBase().getString(L10N_PREFIX + key, pattern, value);
   }

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static network.crypta.node.updater.UpdaterPathsKt.CORE_UPDATE_PATH;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -19,6 +18,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.FetchContext;
@@ -32,25 +32,15 @@ import network.crypta.client.filter.FilterMIMEType;
 import network.crypta.client.filter.FoundURICallback;
 import network.crypta.client.filter.PushingTagReplacerCallback;
 import network.crypta.client.filter.UnsafeContentTypeException;
-import network.crypta.clients.http.ajaxpush.DismissAlertToadlet;
-import network.crypta.clients.http.ajaxpush.LogWritebackToadlet;
-import network.crypta.clients.http.ajaxpush.PushDataToadlet;
-import network.crypta.clients.http.ajaxpush.PushFailoverToadlet;
-import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
-import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
-import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
-import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
 import network.crypta.clients.http.updateableelements.ProgressBarElement;
 import network.crypta.clients.http.updateableelements.ProgressInfoElement;
 import network.crypta.clients.http.utils.UriFilterProxyHeaderParser;
-import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.SHA256;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestClientBuilder;
@@ -78,10 +68,70 @@ import org.slf4j.LoggerFactory;
 public final class FProxyToadlet extends Toadlet implements RequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(FProxyToadlet.class);
 
-  private static byte[] random;
+  private static final String L10N_PREFIX = "FProxyToadlet.";
+  private static final String CLASS_ATTRIBUTE = "class";
+  private static final String INFOBOX_HEADER_CLASS = "infobox-header";
+  private static final String INFOBOX_CONTENT_CLASS = "infobox-content";
+  private static final String INFOBOX_ERROR_CLASS = "infobox infobox-error";
+  private static final String INFOBOX_INFORMATION_CLASS = "infobox infobox-information";
+  private static final String HEADER_X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+  private static final String NOSNIFF = "nosniff";
+  private static final String TAG_INPUT = "input";
+  private static final String ATTR_TYPE = "type";
+  private static final String ATTR_NAME = "name";
+  private static final String ATTR_VALUE = "value";
+  private static final String ATTR_TITLE = "title";
+  private static final String TYPE_HIDDEN = "hidden";
+  private static final String TYPE_SUBMIT = "submit";
+  private static final String PARAM_FILTER_DATA = "filterData";
+  private static final String PARAM_MAX_SIZE = "max-size";
+  private static final String PARAM_FORCE = "force";
+  private static final String PARAM_FORCED_DOWNLOAD = "forcedownload";
+  private static final String DEFAULT_DOWNLOADS_PATH = defaultPath("downloads");
+  private static final String DEFAULT_FRIENDS_PATH = defaultPath("friends");
+  private static final String DEFAULT_CONFIG_PATH = defaultPath("config");
+  private static final String DEFAULT_WELCOME_PATH = defaultPath("welcome");
+
+  static final String DOWNLOADS_PATH =
+      normalizedPath(System.getProperty("crypta.fproxy.downloadsPath", DEFAULT_DOWNLOADS_PATH));
+  static final String FRIENDS_PATH =
+      normalizedPath(System.getProperty("crypta.fproxy.friendsPath", DEFAULT_FRIENDS_PATH));
+  static final String CONFIG_PATH =
+      normalizedPath(System.getProperty("crypta.fproxy.configPath", DEFAULT_CONFIG_PATH));
+  static final String WELCOME_PATH =
+      normalizedPath(System.getProperty("crypta.fproxy.welcomePath", DEFAULT_WELCOME_PATH));
+
+  private static final String CONFIG_NODE_PATH = CONFIG_PATH + "node";
+  private static final String OBSOLETED_MESSAGE_KEY = "obsoleted";
+  private static final String GO_BACK_TO_PREV_KEY = "goBackToPrev";
+  private static final String TOADLET_HOMEPAGE_KEY = "Toadlet.homepage";
+  private static final String ABORT_TO_HOMEPAGE_KEY = "abortToHomepage";
+  private static final String OPEN_WITH_KEY_EXPLORER_KEY = L10N_PREFIX + "openWithKeyExplorer";
+  static final String CATEGORY_BROWSING = L10N_PREFIX + "categoryBrowsing";
+  static final String CATEGORY_QUEUE = L10N_PREFIX + "categoryQueue";
+  static final String CATEGORY_FRIENDS = L10N_PREFIX + "categoryFriends";
+  static final String CATEGORY_STATUS = L10N_PREFIX + "categoryStatus";
+  static final String CATEGORY_CONFIG = L10N_PREFIX + "categoryConfig";
+
+  static byte[] random;
   final NodeClientCore core;
   final ClientContext context;
   final FProxyFetchTracker fetchTracker;
+
+  private static String defaultPath(String segment) {
+    return "/" + segment + "/";
+  }
+
+  private static String normalizedPath(String path) {
+    String normalized = path;
+    if (!normalized.startsWith("/")) {
+      normalized = "/" + normalized;
+    }
+    if (!normalized.endsWith("/")) {
+      normalized = normalized + "/";
+    }
+    return normalized;
+  }
 
   static final Set<String> prefetchAllowedTypes =
       new HashSet<>(
@@ -99,14 +149,14 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
   private static final long FORCE_GRAIN_INTERVAL = HOURS.toMillis(1);
 
   /** Maximum size for transparent pass-through. See config passthroughMaxSizeProgress */
-  public static long MAX_LENGTH_WITH_PROGRESS =
+  private static long maxLengthWithProgress =
       (100 * 1024 * 1024)
           * 11
           / 10; // 100MiB plus a bit due to buggy inserts, because our Windows installer is >70 MiB
 
   // nowadays
 
-  public static long MAX_LENGTH_NO_PROGRESS =
+  private static long maxLengthNoProgress =
       (2 * 1024 * 1024) * 11 / 10; // 2MiB plus a bit due to buggy inserts
 
   static final URI welcome;
@@ -114,22 +164,38 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
   static {
     try {
-      welcome = new URI("/welcome/");
+      welcome = new URI(WELCOME_PATH);
     } catch (URISyntaxException e) {
-      throw new Error("Broken URI constructor: " + e, e);
+      throw new IllegalStateException("Broken URI constructor: " + e, e);
     }
   }
 
   // Legacy logMINOR removed; use LOG.isDebugEnabled() directly.
 
-  // FIXME make this configurable (or get rid of prefetch support)
+  // Prefetch support uses a fixed upper bound; adjust here if configuration is added.
   static final int MAX_PREFETCH = 50;
+
+  public static long getMaxLengthWithProgress() {
+    return maxLengthWithProgress;
+  }
+
+  public static void setMaxLengthWithProgress(long length) {
+    maxLengthWithProgress = length;
+  }
+
+  public static long getMaxLengthNoProgress() {
+    return maxLengthNoProgress;
+  }
+
+  public static void setMaxLengthNoProgress(long length) {
+    maxLengthNoProgress = length;
+  }
 
   public FProxyToadlet(
       final HighLevelSimpleClient client, NodeClientCore core, FProxyFetchTracker tracker) {
     super(client);
-    client.setMaxLength(MAX_LENGTH_NO_PROGRESS);
-    client.setMaxIntermediateLength(MAX_LENGTH_NO_PROGRESS);
+    client.setMaxLength(getMaxLengthNoProgress());
+    client.setMaxIntermediateLength(getMaxLengthNoProgress());
     this.core = core;
     this.context = core.getClientContext();
     fetchTracker = tracker;
@@ -141,242 +207,16 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
   }
 
   public void handleMethodPOST(URI uri, HTTPRequest req, ToadletContext ctx)
-      throws ToadletContextClosedException, IOException, RedirectException {
+      throws RedirectException {
+    Objects.requireNonNull(req, "request");
+    Objects.requireNonNull(ctx, "context");
     String ks = uri.getPath();
 
     if (ks.equals("/") || ks.startsWith("/servlet/")) {
       try {
-        throw new RedirectException("/welcome/");
+        throw new RedirectException(WELCOME_PATH);
       } catch (URISyntaxException e) {
         // HUH!?!
-      }
-    }
-  }
-
-  private void handleDownload(
-      ToadletContext context,
-      Bucket data,
-      BucketFactory bucketFactory,
-      String mimeType,
-      String requestedMimeType,
-      String forceString,
-      boolean forceDownload,
-      String basePath,
-      FreenetURI key,
-      String extras,
-      String referrer,
-      boolean downloadLink,
-      ToadletContext ctx,
-      NodeClientCore core,
-      boolean dontFreeData,
-      String maybeCharset)
-      throws ToadletContextClosedException, IOException {
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "handleDownload(data.size={}, mimeType={}, requestedMimeType={}, forceDownload={},"
-              + " basePath={}, key={})",
-          data.size(),
-          mimeType,
-          requestedMimeType,
-          forceDownload,
-          basePath,
-          key);
-    String extrasNoMime =
-        extras; // extras will not include MIME type to start with - REDFLAG maybe it should be an
-    // array
-    if (requestedMimeType != null) {
-      if (!requestedMimeType.equals(mimeType)) {
-        if (extras == null) extras = "";
-        extras = extras + "&type=" + requestedMimeType;
-      }
-    }
-    long size = data.size();
-
-    long now = System.currentTimeMillis();
-    boolean force = false;
-    if (forceString != null) {
-      if (forceString.equals(getForceValue(key, now))
-          || forceString.equals(getForceValue(key, now - FORCE_GRAIN_INTERVAL))) force = true;
-    }
-
-    if ((!force) && (!forceDownload)) {
-      // Horrible hack needed for GWT as it relies on document.write() which is not supported in
-      // xhtml
-      if (mimeType.compareTo("application/xhtml+xml") == 0) {
-        mimeType = "text/html";
-      }
-      if (isSniffedAsFeed(data) && !(mimeType.startsWith("application/rss+xml"))) {
-        PageNode page = context.getPageMaker().getPageNode(l10n("dangerousRSSTitle"), context);
-        HTMLNode contentNode = page.getContentNode();
-
-        HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-alert");
-        infobox.addChild("div", "class", "infobox-header", l10n("dangerousRSSSubtitle"));
-        HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
-        infoboxContent.addChild(
-            "#",
-            NodeL10n.getBase()
-                .getString(
-                    "FProxyToadlet.dangerousRSS", new String[] {"type"}, new String[] {mimeType}));
-        infoboxContent.addChild("p", l10n("options"));
-        HTMLNode optionList = infoboxContent.addChild("ul");
-        HTMLNode option = optionList.addChild("li");
-
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                option,
-                "FProxyToadlet.openPossRSSAsPlainText",
-                new String[] {"link", "bold"},
-                new HTMLNode[] {
-                  HTMLNode.link(
-                      basePath
-                          + key.toString()
-                          + "?type=text/plain&force="
-                          + getForceValue(key, now)
-                          + extrasNoMime),
-                  HTMLNode.STRONG
-                });
-        // 	FIXME: is this safe? See bug #131
-        option = optionList.addChild("li");
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                option,
-                "FProxyToadlet.openPossRSSForceDisk",
-                new String[] {"link", "bold"},
-                new HTMLNode[] {
-                  HTMLNode.link(basePath + key + "?forcedownload" + extras), HTMLNode.STRONG
-                });
-        boolean mimeRSS =
-            mimeType.startsWith("application/xml+rss")
-                || mimeType.startsWith("text/xml"); /* blergh! */
-        if (!(mimeRSS || mimeType.startsWith("text/plain"))) {
-          option = optionList.addChild("li");
-          NodeL10n.getBase()
-              .addL10nSubstitution(
-                  option,
-                  "FProxyToadlet.openRSSForce",
-                  new String[] {"link", "bold", "mime"},
-                  new HTMLNode[] {
-                    HTMLNode.link(basePath + key + "?force=" + getForceValue(key, now) + extras),
-                    HTMLNode.STRONG,
-                    HTMLNode.text(mimeType)
-                  });
-        }
-        option = optionList.addChild("li");
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                option,
-                "FProxyToadlet.openRSSAsRSS",
-                new String[] {"link", "bold"},
-                new HTMLNode[] {
-                  HTMLNode.link(
-                      basePath
-                          + key
-                          + "?type=application/xml+rss&force="
-                          + getForceValue(key, now)
-                          + extrasNoMime),
-                  HTMLNode.STRONG
-                });
-        addDownloadOptions(
-            ctx,
-            optionList,
-            key,
-            mimeType,
-            true,
-            false,
-            core); // FIXME Or false, false? Or true, true? We don't have filter for rss/atom
-        // anyway, so it will be useless - only more confusion and clicking for user.
-        // When we *will* have one, we can just get rid of this warning page.
-        if (referrer != null) {
-          option = optionList.addChild("li");
-          NodeL10n.getBase()
-              .addL10nSubstitution(
-                  option,
-                  "FProxyToadlet.backToReferrer",
-                  new String[] {"link"},
-                  new HTMLNode[] {HTMLNode.link(referrer)});
-        }
-        option = optionList.addChild("li");
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                option,
-                "FProxyToadlet.backToFProxy",
-                new String[] {"link"},
-                new HTMLNode[] {HTMLNode.link("/")});
-
-        byte[] pageBytes = page.generate().getBytes(StandardCharsets.UTF_8);
-        context.sendReplyHeaders(
-            200, "OK", new MultiValueTable<>(), "text/html; charset=utf-8", pageBytes.length);
-        context.writeData(pageBytes);
-        return;
-      }
-    }
-
-    if (forceDownload) {
-      MultiValueTable<String, String> headers = new MultiValueTable<>(4);
-      headers.put(
-          "Content-Disposition", "attachment; filename=\"" + key.getPreferredFilename() + '"');
-      headers.put("Cache-Control", "private");
-      headers.put("Content-Transfer-Encoding", "binary");
-      headers.put("X-Content-Type-Options", "nosniff");
-      // really the above should be enough, but ...
-      // was application/x-msdownload, but some unix browsers offer to open that in Wine as default!
-      // it is important that this type not be understandable, but application/octet-stream doesn't
-      // work.
-      // see http://onjava.com/pub/a/onjava/excerpt/jebp_3/index3.html
-      // Testing on FF3.5.1 shows that application/x-force-download wants to run it in wine,
-      // whereas application/force-download wants to save it.
-      context.sendReplyHeadersFProxy(200, "OK", headers, "application/force-download", size);
-      context.writeData(data);
-    } else {
-      // Send the data, intact
-      MultiValueTable<String, String> hdr = context.getHeaders();
-
-      /*
-       * Firefox and its derivatives may use the MIME type implied by the filename extension for
-       * plain text, unless a Content-Encoding is specified.
-       *
-       * See https://developer.mozilla.org/en-US/docs/Mozilla/How_Mozilla_determines_MIME_Types#HTTP
-       */
-      MultiValueTable<String, String> retHdr = MultiValueTable.from("Content-Encoding", "identity");
-
-      String rangeStr = hdr.getFirst("range");
-      // was a range request
-      if (rangeStr != null) {
-
-        long[] range;
-        try {
-          range = parseRange(rangeStr);
-        } catch (HTTPRangeException e) {
-          ctx.sendReplyHeaders(416, "Requested Range Not Satisfiable", null, null, 0);
-          return;
-        }
-        if (range[1] == -1 || range[1] >= size) {
-          range[1] = size - 1;
-        }
-        Bucket tmpRange = bucketFactory.makeBucket(range[1] - range[0]);
-        try (InputStream is = data.getInputStream();
-            OutputStream os = tmpRange.getOutputStream()) {
-          if (range[0] > 0) FileUtil.skipFully(is, range[0]);
-          FileUtil.copy(is, os, range[1] - range[0] + 1);
-          // FIXME catch IOException here and tell the user there is a problem instead of just
-          // closing the connection.
-          // Currently there is no way to tell the difference between an IOE caused by the
-          // connection to the client and an internal one, we just close the connection in both
-          // cases.
-          // Resources will be closed automatically by try-with-resources
-        }
-        retHdr.put("Content-Range", "bytes " + range[0] + "-" + range[1] + "/" + size);
-        retHdr.put("X-Content-Type-Options", "nosniff");
-        context.sendReplyHeadersFProxy(206, "Partial content", retHdr, mimeType, tmpRange.size());
-        context.writeData(tmpRange);
-      } else {
-        retHdr.put("X-Content-Type-Options", "nosniff");
-        if (container.enableCachingForChkAndSskKeys() && (key.isCHK() || key.isSSK())) {
-          context.sendReplyHeadersStatic(200, "OK", retHdr, mimeType, size, new Date());
-        } else {
-          context.sendReplyHeadersFProxy(200, "OK", retHdr, mimeType, size);
-        }
-        context.writeData(data);
       }
     }
   }
@@ -393,10 +233,21 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       NodeClientCore core) {
     PHYSICAL_THREAT_LEVEL threatLevel = core.getNode().getSecurityLevels().getPhysicalThreatLevel();
     NETWORK_THREAT_LEVEL netLevel = core.getNode().getSecurityLevels().getNetworkThreatLevel();
+    boolean filterChecked = shouldEnableFilter(mimeType, disableFiltration, threatLevel, netLevel);
+
+    addDownloadToDiskOption(ctx, optionList, key, mimeType, filterChecked, dontShowFilter, core);
+    addDirectFetchOption(ctx, optionList, key, mimeType, filterChecked, dontShowFilter, core);
+  }
+
+  private static boolean shouldEnableFilter(
+      String mimeType,
+      boolean disableFiltration,
+      PHYSICAL_THREAT_LEVEL threatLevel,
+      NETWORK_THREAT_LEVEL netLevel) {
     boolean filterChecked =
-        !(((threatLevel == PHYSICAL_THREAT_LEVEL.LOW && netLevel == NETWORK_THREAT_LEVEL.LOW))
+        !((threatLevel == PHYSICAL_THREAT_LEVEL.LOW && netLevel == NETWORK_THREAT_LEVEL.LOW)
             || disableFiltration);
-    if ((filterChecked)
+    if (filterChecked
         && mimeType != null
         && !mimeType.equals("application/octet-stream")
         && !mimeType.isEmpty()) {
@@ -405,123 +256,134 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
           && !(threatLevel == PHYSICAL_THREAT_LEVEL.HIGH
               || threatLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM
               || netLevel == NETWORK_THREAT_LEVEL.HIGH
-              || netLevel == NETWORK_THREAT_LEVEL.MAXIMUM)) filterChecked = false;
+              || netLevel == NETWORK_THREAT_LEVEL.MAXIMUM)) {
+        filterChecked = false;
+      }
     }
-    // Display FProxy option to download to disk if the user isn't at maximum physical threat level
-    // and hasn't disabled downloading to disk.
-    if (threatLevel != PHYSICAL_THREAT_LEVEL.MAXIMUM && !isDownloadDisabledOrUnsafe(ctx, core)) {
-      HTMLNode option = optionList.addChild("li");
-      HTMLNode optionForm = ctx.addFormChild(option, "/downloads/", "tooBigQueueForm");
+    return filterChecked;
+  }
+
+  private static void addDownloadToDiskOption(
+      ToadletContext ctx,
+      HTMLNode optionList,
+      FreenetURI key,
+      String mimeType,
+      boolean filterChecked,
+      boolean dontShowFilter,
+      NodeClientCore core) {
+    PHYSICAL_THREAT_LEVEL threatLevel = core.getNode().getSecurityLevels().getPhysicalThreatLevel();
+    if (threatLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM || isDownloadDisabledOrUnsafe(ctx, core)) {
+      return;
+    }
+    HTMLNode option = optionList.addChild("li");
+    HTMLNode optionForm = ctx.addFormChild(option, DOWNLOADS_PATH, "tooBigQueueForm");
+    optionForm.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {TYPE_HIDDEN, "key", key.toString()});
+    optionForm.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {TYPE_HIDDEN, "return-type", "disk"});
+    optionForm.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {TYPE_HIDDEN, "persistence", "forever"});
+    if (mimeType != null && !mimeType.isEmpty()) {
       optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "key", key.toString()});
-      optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "return-type", "disk"});
-      optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "persistence", "forever"});
-      if (mimeType != null && !mimeType.isEmpty()) {
-        optionForm.addChild(
-            "input",
-            new String[] {"type", "name", "value"},
-            new String[] {"hidden", "type", mimeType});
-      }
-      optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"submit", "download", l10n("downloadInBackgroundToDiskButton")});
-      String downloadLocation = core.getDownloadsDir().getAbsolutePath();
-      // If the download directory isn't allowed, yet downloading is, at least one directory must
-      // have been explicitly defined, so take the first one.
-      if (!core.allowDownloadTo(core.getDownloadsDir())) {
-        downloadLocation = core.getAllowedDownloadDirs()[0].getAbsolutePath();
-      }
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {TYPE_HIDDEN, "type", mimeType});
+    }
+    optionForm.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {TYPE_SUBMIT, "download", l10n("downloadInBackgroundToDiskButton")});
+    String downloadLocation = core.getDownloadsDir().getAbsolutePath();
+    if (!core.allowDownloadTo(core.getDownloadsDir())) {
+      downloadLocation = core.getAllowedDownloadDirs()[0].getAbsolutePath();
+    }
+    NodeL10n.getBase()
+        .addL10nSubstitution(
+            optionForm,
+            "FProxyToadlet.downloadInBackgroundToDisk",
+            new String[] {"dir", "page"},
+            new HTMLNode[] {
+              new HTMLNode(
+                  TAG_INPUT,
+                  new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE, "maxlength", "size"},
+                  new String[] {
+                    "text",
+                    "path",
+                    downloadLocation,
+                    Integer.toString(QueueToadlet.MAX_FILENAME_LENGTH),
+                    String.valueOf(downloadLocation.length())
+                  }),
+              DOWNLOADS_LINK
+            });
+    optionForm.addChild("#", " ");
+    NodeL10n.getBase()
+        .addL10nSubstitution(
+            optionForm,
+            "FProxyToadlet.downloadToDiskWarningNotFiltered",
+            new String[] {"bold"},
+            new HTMLNode[] {HTMLNode.STRONG});
+    optionForm.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {
+          TYPE_SUBMIT,
+          "select-location",
+          NodeL10n.getBase().getString("QueueToadlet.browseToChange") + "..."
+        });
+    if (!dontShowFilter) {
+      addFilterControl(optionForm, filterChecked);
+    }
+    if (threatLevel == PHYSICAL_THREAT_LEVEL.HIGH) {
+      optionForm.addChild("br");
       NodeL10n.getBase()
           .addL10nSubstitution(
               optionForm,
-              "FProxyToadlet.downloadInBackgroundToDisk",
-              new String[] {"dir", "page"},
-              new HTMLNode[] {
-                new HTMLNode(
-                    "input",
-                    new String[] {"type", "name", "value", "maxlength", "size"},
-                    new String[] {
-                      "text",
-                      "path",
-                      downloadLocation,
-                      Integer.toString(QueueToadlet.MAX_FILENAME_LENGTH),
-                      String.valueOf(downloadLocation.length())
-                    }),
-                DOWNLOADS_LINK
-              });
-      optionForm.addChild("#", " ");
-      NodeL10n.getBase()
-          .addL10nSubstitution(
-              optionForm,
-              "FProxyToadlet.downloadToDiskWarningNotFiltered",
+              "FProxyToadlet.downloadToDiskSecurityWarning",
               new String[] {"bold"},
               new HTMLNode[] {HTMLNode.STRONG});
-      optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {
-            "submit",
-            "select-location",
-            NodeL10n.getBase().getString("QueueToadlet.browseToChange") + "..."
-          });
-      if (!dontShowFilter) {
-        HTMLNode filterControl = optionForm.addChild("div", l10n("filterData"));
-        HTMLNode f =
-            filterControl.addChild(
-                "input",
-                new String[] {"type", "name", "value"},
-                new String[] {"checkbox", "filterData", "filterData"});
-        if (filterChecked) f.addAttribute("checked", "checked");
-        filterControl.addChild("div", l10n("filterDataMessage"));
-      }
-      if (threatLevel == PHYSICAL_THREAT_LEVEL.HIGH) {
-        optionForm.addChild("br");
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                optionForm,
-                "FProxyToadlet.downloadToDiskSecurityWarning",
-                new String[] {"bold"},
-                new HTMLNode[] {HTMLNode.STRONG});
-        // optionForm.addChild("#", l10n("downloadToDiskSecurityWarning") + " ");
-      }
     }
+  }
 
-    // Display fetch option if not at low physical security or the user has disabled downloading to
-    // disk.
+  private static void addDirectFetchOption(
+      ToadletContext ctx,
+      HTMLNode optionList,
+      FreenetURI key,
+      String mimeType,
+      boolean filterChecked,
+      boolean dontShowFilter,
+      NodeClientCore core) {
+    PHYSICAL_THREAT_LEVEL threatLevel = core.getNode().getSecurityLevels().getPhysicalThreatLevel();
     if (threatLevel != PHYSICAL_THREAT_LEVEL.LOW || isDownloadDisabledOrUnsafe(ctx, core)) {
       HTMLNode option = optionList.addChild("li");
-      HTMLNode optionForm = ctx.addFormChild(option, "/downloads/", "tooBigQueueForm");
+      HTMLNode optionForm = ctx.addFormChild(option, DOWNLOADS_PATH, "tooBigQueueForm");
       optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "key", key.toString()});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {TYPE_HIDDEN, "key", key.toString()});
       optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "return-type", "direct"});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {TYPE_HIDDEN, "return-type", "direct"});
       optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "persistence", "forever"});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {TYPE_HIDDEN, "persistence", "forever"});
       if (mimeType != null && !mimeType.isEmpty()) {
         optionForm.addChild(
-            "input",
-            new String[] {"type", "name", "value"},
-            new String[] {"hidden", "type", mimeType});
+            TAG_INPUT,
+            new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+            new String[] {TYPE_HIDDEN, "type", mimeType});
       }
       optionForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"submit", "download", l10n("downloadInBackgroundToTempSpaceButton")});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {TYPE_SUBMIT, "download", l10n("downloadInBackgroundToTempSpaceButton")});
       NodeL10n.getBase()
           .addL10nSubstitution(
               optionForm,
@@ -529,16 +391,22 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
               new String[] {"page", "bold"},
               new HTMLNode[] {DOWNLOADS_LINK, HTMLNode.STRONG});
       if (!dontShowFilter) {
-        HTMLNode filterControl = optionForm.addChild("div", l10n("filterData"));
-        HTMLNode f =
-            filterControl.addChild(
-                "input",
-                new String[] {"type", "name", "value"},
-                new String[] {"checkbox", "filterData", "filterData"});
-        if (filterChecked) f.addAttribute("checked", "checked");
-        filterControl.addChild("div", l10n("filterDataMessage"));
+        addFilterControl(optionForm, filterChecked);
       }
     }
+  }
+
+  private static void addFilterControl(HTMLNode optionForm, boolean filterChecked) {
+    HTMLNode filterControl = optionForm.addChild("div", l10n(PARAM_FILTER_DATA));
+    HTMLNode f =
+        filterControl.addChild(
+            TAG_INPUT,
+            new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+            new String[] {"checkbox", PARAM_FILTER_DATA, PARAM_FILTER_DATA});
+    if (filterChecked) {
+      f.addAttribute("checked", "checked");
+    }
+    filterControl.addChild("div", l10n("filterDataMessage"));
   }
 
   static boolean isDownloadDisabledOrUnsafe(ToadletContext ctx, NodeClientCore core) {
@@ -550,7 +418,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
   }
 
   public static String l10n(String msg) {
-    return NodeL10n.getBase().getString("FProxyToadlet." + msg);
+    return NodeL10n.getBase().getString(L10N_PREFIX + msg);
   }
 
   /**
@@ -565,7 +433,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     if (sz == 0) return false;
     try (DataInputStream is = new DataInputStream(data.getInputStream())) {
       byte[] buf = new byte[sz];
-      // FIXME Fortunately firefox doesn't detect RSS in UTF16 etc ... yet
+      // Firefox currently doesn't detect RSS in UTF16 etc.
       is.readFully(buf);
       return RssSniffer.isSniffedAsFeed(buf);
     }
@@ -581,938 +449,1260 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
   private void innerHandleMethodGET(
       URI uri, HTTPRequest httprequest, ToadletContext ctx, int recursion)
       throws ToadletContextClosedException, IOException, RedirectException {
+    new GetRequestWorkflow(uri, httprequest, ctx, recursion).execute();
+  }
 
-    String ks = uri.getPath();
+  private final class GetRequestWorkflow {
+    private final URI uri;
+    private final HTTPRequest httprequest;
+    private final ToadletContext ctx;
+    private final int recursion;
 
-    MultiValueTable<String, String> headers = ctx.getHeaders();
-    final String ua = headers.getFirst("user-agent");
-    final String accept = headers.getFirst("accept");
-    if (LOG.isDebugEnabled()) LOG.debug("UA = {} accept = {}", ua, accept);
-    final boolean canSendProgress =
-        isBrowser(ua)
-            && !ctx.disableProgressPage()
-            && (accept == null || accept.contains("text/html"))
-            && !httprequest.isParameterSet("forcedownload");
+    private String ks;
+    private String ua;
+    private String accept;
+    private boolean canSendProgress;
+    private long defaultMaxSize;
+    private int maxRetries;
+    private boolean restricted;
+    private boolean overrideSize;
+    private long maxSize;
+    private long maxSizeDownload;
+    private FreenetURI key;
+    private FetchContext fctx;
+    private String requestedMimeType;
+    private String forceString;
+    private String referer;
+    private Bucket data;
+    private String mimeType;
+    private FetchException fetchException;
+    private FProxyFetchResult fetchResult;
+    private boolean forceDownloadRequested;
 
-    long defaultMaxSize = canSendProgress ? MAX_LENGTH_WITH_PROGRESS : MAX_LENGTH_NO_PROGRESS;
+    GetRequestWorkflow(URI uri, HTTPRequest httprequest, ToadletContext ctx, int recursion) {
+      this.uri = uri;
+      this.httprequest = httprequest;
+      this.ctx = ctx;
+      this.recursion = recursion;
+    }
 
-    // max-retries
-    // Less than -1 = use default.
-    // 0 = one try only, don't retry
-    // 1 = two tries
-    // 2 = three tries
-    // 3 or more = GO INTO COOLDOWN EVERY 3 TRIES! TAKES *MUCH* LONGER!!! STRONGLY NOT
-    // RECOMMENDED!!!
-    int maxRetries = httprequest.getIntParam("max-retries", -2);
+    void execute() throws ToadletContextClosedException, IOException, RedirectException {
+      initializeRequestMetadata();
+      if (handleStaticPaths()) return;
+      if (!validateRangeHeader()) return;
+      if (!parseFreenetUri()) return;
+      prepareFetchContext();
+      performFetchWithProgress();
+      finishResponse();
+    }
 
-    long maxSize;
-    long maxSizeDownload;
+    private void initializeRequestMetadata() {
+      ks = uri.getPath();
+      MultiValueTable<String, String> headers = ctx.getHeaders();
+      ua = headers.getFirst("user-agent");
+      accept = headers.getFirst("accept");
+      if (LOG.isDebugEnabled()) LOG.debug("UA = {} accept = {}", ua, accept);
+      forceDownloadRequested = httprequest.isParameterSet(PARAM_FORCED_DOWNLOAD);
+      canSendProgress =
+          isBrowser(ua)
+              && !ctx.disableProgressPage()
+              && (accept == null || accept.contains("text/html"))
+              && !forceDownloadRequested;
 
-    boolean restricted = (container.publicGatewayMode() && !ctx.isAllowedFullAccess());
-
-    boolean overrideSize = false;
-    maxSize = defaultMaxSize;
-    maxSizeDownload = MAX_LENGTH_WITH_PROGRESS;
-    if (!restricted) {
-      if (httprequest.isParameterSet("max-size")) {
-        maxSize = maxSizeDownload = httprequest.getLongParam("max-size", defaultMaxSize);
+      defaultMaxSize = canSendProgress ? getMaxLengthWithProgress() : getMaxLengthNoProgress();
+      maxRetries = httprequest.getIntParam("max-retries", -2);
+      restricted = (container.publicGatewayMode() && !ctx.isAllowedFullAccess());
+      overrideSize = false;
+      maxSize = defaultMaxSize;
+      maxSizeDownload = getMaxLengthWithProgress();
+      if (!restricted && httprequest.isParameterSet(PARAM_MAX_SIZE)) {
+        maxSize = maxSizeDownload = httprequest.getLongParam(PARAM_MAX_SIZE, defaultMaxSize);
         overrideSize = true;
       }
     }
 
-    if (ks.equals("/")) {
-      if (httprequest.isParameterSet("key")) {
-        String k = httprequest.getParam("key");
-        FreenetURI newURI;
-        try {
-          newURI = new FreenetURI(k);
-        } catch (MalformedURLException e) {
-          LOG.info("Invalid key: {} for {}", e.toString(), k, e);
-          sendErrorPage(
-              ctx,
-              404,
-              l10n("notFoundTitle"),
-              NodeL10n.getBase()
-                  .getString(
-                      "FProxyToadlet.invalidKeyWithReason",
-                      new String[] {"reason"},
-                      new String[] {e.toString()}));
-          return;
-        }
+    private boolean handleStaticPaths()
+        throws ToadletContextClosedException, IOException, RedirectException {
+      if (ks.equals("/")) {
+        handleRootWithoutKey();
+        return true;
+      }
+      if (ks.equals("/favicon.ico")) return redirectTo(StaticToadlet.ROOT_URL + "favicon.ico");
+      if (ks.equals("/favicon.svg")) return redirectTo(StaticToadlet.ROOT_URL + "favicon.svg");
+      if (ks.startsWith("/feed/") || ks.equals("/feed")) return handleFeedRequest();
+      if (ks.equals("/robots.txt") && ctx.doRobots()) {
+        writeTextReply(ctx, 200, "Ok", "User-agent: *\nDisallow: /");
+        return true;
+      }
+      if (ks.startsWith("/darknet/") || ks.equals("/darknet")) {
+        writePermanentRedirect(ctx, OBSOLETED_MESSAGE_KEY, FRIENDS_PATH);
+        return true;
+      }
+      if (ks.startsWith("/opennet/") || ks.equals("/opennet")) {
+        writePermanentRedirect(ctx, OBSOLETED_MESSAGE_KEY, "/strangers/");
+        return true;
+      }
+      if (ks.startsWith("/queue/")) {
+        writePermanentRedirect(ctx, OBSOLETED_MESSAGE_KEY, DOWNLOADS_PATH);
+        return true;
+      }
+      if (ks.startsWith(CONFIG_PATH)) {
+        writePermanentRedirect(ctx, OBSOLETED_MESSAGE_KEY, CONFIG_NODE_PATH);
+        return true;
+      }
+      if (ks.startsWith("/")) ks = ks.substring(1);
+      return false;
+    }
 
-        if (LOG.isDebugEnabled()) LOG.debug("Redirecting to Crypta URI: {}", newURI);
-        String requestedMimeType = httprequest.getParam("type");
-        String location =
-            getLink(
-                newURI,
-                requestedMimeType,
-                maxSize,
-                httprequest.getParam("force", null),
-                httprequest.isParameterSet("forcedownload"),
-                maxRetries,
-                overrideSize);
-        writeTemporaryRedirect(ctx, null, location);
+    private void handleRootWithoutKey()
+        throws RedirectException, ToadletContextClosedException, IOException {
+      if (!httprequest.isParameterSet("key")) {
+        redirectToWelcome();
         return;
       }
 
-      /*
-       * Redirect to the welcome page because no key was specified.
-       */
+      String keyParam = httprequest.getParam("key");
+      try {
+        FreenetURI newURI = new FreenetURI(keyParam);
+        if (LOG.isDebugEnabled()) LOG.debug("Redirecting to Crypta URI: {}", newURI);
+        String requestedMime = httprequest.getParam("type");
+        String location =
+            getLink(
+                newURI,
+                requestedMime,
+                maxSize,
+                httprequest.getParam(PARAM_FORCE, null),
+                httprequest.isParameterSet(PARAM_FORCED_DOWNLOAD),
+                maxRetries,
+                overrideSize);
+        writeTemporaryRedirect(ctx, null, location);
+      } catch (MalformedURLException e) {
+        LOG.info("Invalid key: {} for {}", e, keyParam, e);
+        sendErrorPage(
+            ctx,
+            404,
+            l10n("notFoundTitle"),
+            NodeL10n.getBase()
+                .getString(
+                    "FProxyToadlet.invalidKeyWithReason",
+                    new String[] {"reason"},
+                    new String[] {e.toString()}));
+      }
+    }
+
+    private boolean redirectTo(String target) throws RedirectException {
+      try {
+        throw new RedirectException(target);
+      } catch (URISyntaxException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    private void redirectToWelcome()
+        throws RedirectException, IOException, ToadletContextClosedException {
       try {
         throw new RedirectException(
             new URI(null, null, null, -1, welcome.getPath(), uri.getQuery(), uri.getFragment()));
       } catch (URISyntaxException e) {
-        /*
-         * This shouldn't happen because all the inputs to the URI constructor come from getters
-         * of existing URIs.
-         */
-        LOG.error("Unexpected syntax error in URI: {}", e.toString());
+        LOG.error("Unexpected syntax error in URI: {}", e.getMessage(), e);
         writeTemporaryRedirect(
             ctx, "Internal error. Please check logs and report.", WelcomeToadlet.PATH);
-        return;
       }
-    } else if (ks.equals("/favicon.ico")) {
-      try {
-        throw new RedirectException(StaticToadlet.ROOT_URL + "favicon.ico");
-      } catch (URISyntaxException e) {
-        throw new Error(e);
-      }
-    } else if (ks.equals("/favicon.svg")) {
-      try {
-        throw new RedirectException(StaticToadlet.ROOT_URL + "favicon.svg");
-      } catch (URISyntaxException e) {
-        throw new Error(e);
-      }
-    } else if (ks.startsWith("/feed/") || ks.equals("/feed")) {
+    }
+
+    private boolean handleFeedRequest() throws ToadletContextClosedException, IOException {
       String schemeHostAndPort = getSchemeHostAndPort(ctx);
       String atom = ctx.getAlertManager().getAtom(schemeHostAndPort);
       byte[] buf = atom.getBytes(StandardCharsets.UTF_8);
       ctx.sendReplyHeadersFProxy(200, "OK", null, "application/atom+xml", buf.length);
       ctx.writeData(buf, 0, buf.length);
-      return;
-    } else if (ks.equals("/robots.txt") && ctx.doRobots()) {
-      this.writeTextReply(ctx, 200, "Ok", "User-agent: *\nDisallow: /");
-      return;
-    } else if (ks.startsWith("/darknet/")
-        || ks.equals("/darknet")) { // TODO (pre-build 1045 url format) remove when obsolete
-      writePermanentRedirect(ctx, "obsoleted", "/friends/");
-      return;
-    } else if (ks.startsWith("/opennet/")
-        || ks.equals("/opennet")) { // TODO (pre-build 1045 url format) remove when obsolete
-      writePermanentRedirect(ctx, "obsoleted", "/strangers/");
-      return;
-    } else if (ks.startsWith("/queue/")) {
-      writePermanentRedirect(ctx, "obsoleted", "/downloads/");
-      return;
-    } else if (ks.startsWith("/config/")) {
-      writePermanentRedirect(ctx, "obsoleted", "/config/node");
-      return;
+      return true;
     }
 
-    if (ks.startsWith("/")) ks = ks.substring(1);
-
-    // first check of httprange before get
-    // only valid number format is checked here
-    String rangeStr = ctx.getHeaders().getFirst("range");
-    if (rangeStr != null) {
+    private boolean validateRangeHeader() throws ToadletContextClosedException, IOException {
+      String rangeStr = ctx.getHeaders().getFirst("range");
+      if (rangeStr == null) return true;
       try {
         parseRange(rangeStr);
+        return true;
       } catch (HTTPRangeException e) {
         LOG.info("Invalid Range Header: {}", rangeStr, e);
         ctx.sendReplyHeaders(416, "Requested Range Not Satisfiable", null, null, 0);
-        return;
+        return false;
       }
     }
 
-    FreenetURI key;
-    try {
-      key = new FreenetURI(ks);
-    } catch (MalformedURLException e) {
-      PageNode page = ctx.getPageMaker().getPageNode(l10n("invalidKeyTitle"), ctx);
-      HTMLNode contentNode = page.getContentNode();
+    private boolean parseFreenetUri() throws ToadletContextClosedException, IOException {
+      try {
+        key = new FreenetURI(ks);
+        return true;
+      } catch (MalformedURLException e) {
+        PageNode page = ctx.getPageMaker().getPageNode(l10n("invalidKeyTitle"), ctx);
+        HTMLNode contentNode = page.getContentNode();
 
-      HTMLNode errorInfobox = contentNode.addChild("div", "class", "infobox infobox-error");
-      errorInfobox.addChild(
-          "div",
-          "class",
-          "infobox-header",
-          NodeL10n.getBase()
-              .getString(
-                  "FProxyToadlet.invalidKeyWithReason",
-                  new String[] {"reason"},
-                  new String[] {e.toString()}));
-      HTMLNode errorContent = errorInfobox.addChild("div", "class", "infobox-content");
-      errorContent.addChild("#", l10n("expectedKeyButGot"));
-      errorContent.addChild("code", ks);
-      errorContent.addChild("br");
-      errorContent.addChild(ctx.getPageMaker().createBackLink(ctx, l10n("goBack")));
-      errorContent.addChild("br");
-      addHomepageLink(errorContent);
+        HTMLNode errorInfobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_ERROR_CLASS);
+        errorInfobox.addChild(
+            "div",
+            CLASS_ATTRIBUTE,
+            INFOBOX_HEADER_CLASS,
+            NodeL10n.getBase()
+                .getString(
+                    "FProxyToadlet.invalidKeyWithReason",
+                    new String[] {"reason"},
+                    new String[] {e.toString()}));
+        HTMLNode errorContent =
+            errorInfobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+        errorContent.addChild("#", l10n("expectedKeyButGot"));
+        errorContent.addChild("code", ks);
+        errorContent.addChild("br");
+        errorContent.addChild(ctx.getPageMaker().createBackLink(ctx, l10n("goBack")));
+        errorContent.addChild("br");
+        addHomepageLink(errorContent);
 
-      this.writeHTMLReply(ctx, 400, l10n("invalidKeyTitle"), page.generate());
-      return;
+        writeHTMLReply(ctx, 400, l10n("invalidKeyTitle"), page.generate());
+        return false;
+      }
     }
 
-    FetchContext fctx = getFetchContext(maxSize, getSchemeHostAndPort(ctx));
-    // max-size=-1 => use default
-    maxSize = fctx.getMaxOutputLength();
-
-    // We should run the ContentFilter by default
-    String forceString = httprequest.getParam("force");
-    long now = System.currentTimeMillis();
-    boolean force = false;
-    if (forceString != null) {
-      if (forceString.equals(getForceValue(key, now))
-          || forceString.equals(getForceValue(key, now - FORCE_GRAIN_INTERVAL))) force = true;
-    }
-    if (restricted) maxRetries = -2;
-    if (maxRetries >= -1) {
-      fctx.setMaxNonSplitfileRetries(maxRetries);
-      fctx.setMaxSplitfileBlockRetries(maxRetries);
-    }
-    if (!force && !httprequest.isParameterSet("forcedownload")) fctx.setFilterData(true);
-    else if (LOG.isDebugEnabled()) LOG.debug("Content filter disabled via request parameter");
-    // Load the fetch context with the callbacks needed for web-pushing, if enabled
-    if (container.enableInlinePrefetch()) {
-      fctx.setPrefetchHook(
-          new FoundURICallback() {
-
-            final List<FreenetURI> uris = new ArrayList<>();
-
-            @Override
-            public void foundURI(FreenetURI uri) {
-              // Ignore
-            }
-
-            @Override
-            public void foundURI(FreenetURI uri, boolean inline) {
-              if (!inline) return;
-              if (LOG.isDebugEnabled()) LOG.debug("Prefetching {}", uri);
-              synchronized (this) {
-                if (uris.size() < MAX_PREFETCH)
-                  // FIXME Maybe we should do this randomly, but since it's a DoS protection (in an
-                  // obscure feature), if so we should do it in constant space!
-                  uris.add(uri);
-              }
-            }
-
-            @Override
-            public void onText(String text, String type, URI baseURI) {
-              // Ignore
-            }
-
-            @Override
-            public void onFinishedPage() {
-              core.getNode()
-                  .getExecutor()
-                  .execute(
-                      () -> {
-                        for (FreenetURI uri1 : uris) {
-                          client.prefetch(
-                              uri1, SECONDS.toMillis(60), 512 * 1024, prefetchAllowedTypes);
-                        }
-                      });
-            }
-          });
-    }
-    if (container.isFProxyWebPushingEnabled())
-      fctx.setTagReplacer(
-          new PushingTagReplacerCallback(core.getFProxy().fetchTracker, defaultMaxSize, ctx));
-
-    String requestedMimeType = httprequest.getParam("type", null);
-    fctx.setOverrideMIME(requestedMimeType);
-    String override =
-        (requestedMimeType == null) ? "" : "?type=" + URLEncoder.encode(requestedMimeType, true);
-    String maybeCharset =
-        httprequest.isParameterSet("maybecharset")
-            ? httprequest.getParam("maybecharset", null)
-            : null;
-    fctx.setCharset(maybeCharset);
-    if (override.isEmpty() && maybeCharset != null)
-      override = "?maybecharset=" + URLEncoder.encode(maybeCharset, true);
-    // No point passing ?force= across a redirect, since the key will change.
-    // However, there is every point in passing ?forcedownload.
-    if (httprequest.isParameterSet("forcedownload")) {
-      if (override.isEmpty()) override = "?forcedownload";
-      else override = override + "&forcedownload";
+    private void prepareFetchContext() {
+      fctx = getFetchContext(maxSize, getSchemeHostAndPort(ctx));
+      maxSize = fctx.getMaxOutputLength();
+      configureForceSettings();
+      configureMimeOverrides();
+      referer = sanitizeReferer(ctx);
     }
 
-    Bucket data = null;
-    String mimeType = null;
-    String referer = sanitizeReferer(ctx);
-    FetchException fe = null;
-
-    FProxyFetchResult fr = null;
-
-    FProxyFetchWaiter fetch = null;
-    try {
-      fetch = fetchTracker.makeFetcher(key, maxSize, fctx, ctx.getReFilterPolicy());
-    } catch (FetchException e) {
-      fe = e;
+    private void configureForceSettings() {
+      forceString = httprequest.getParam(PARAM_FORCE);
+      long now = System.currentTimeMillis();
+      boolean force =
+          forceString != null
+              && (forceString.equals(getForceValue(key, now))
+                  || forceString.equals(getForceValue(key, now - FORCE_GRAIN_INTERVAL)));
+      if (restricted) maxRetries = -2;
+      if (maxRetries >= -1) {
+        fctx.setMaxNonSplitfileRetries(maxRetries);
+        fctx.setMaxSplitfileBlockRetries(maxRetries);
+      }
+      if (!force && !forceDownloadRequested) fctx.setFilterData(true);
+      else if (LOG.isDebugEnabled()) LOG.debug("Content filter disabled via request parameter");
+      if (container.enableInlinePrefetch()) {
+        fctx.setPrefetchHook(createPrefetchHook());
+      }
+      if (container.isFProxyWebPushingEnabled()) {
+        fctx.setTagReplacer(
+            new PushingTagReplacerCallback(core.getFProxy().fetchTracker, defaultMaxSize, ctx));
+      }
     }
-    if (fetch != null)
-      while (true) {
-        fr = fetch.getResult(!canSendProgress);
-        if (fr.hasData()) {
 
-          if (fr.getFetchCount() > 1
-              && !fr.hasWaited()
-              && key.isUSK()
-              && context.uskManager.lookupKnownGood(USK.create(key)) > key.getSuggestedEdition()) {
+    private void configureMimeOverrides() {
+      requestedMimeType = httprequest.getParam("type", null);
+      fctx.setOverrideMIME(requestedMimeType);
+      String maybeCharset =
+          httprequest.isParameterSet("maybecharset")
+              ? httprequest.getParam("maybecharset", null)
+              : null;
+      fctx.setCharset(maybeCharset);
+    }
+
+    private FoundURICallback createPrefetchHook() {
+      return new FoundURICallback() {
+
+        final List<FreenetURI> uris = new ArrayList<>();
+
+        @Override
+        public void foundURI(FreenetURI uri) {
+          // Ignore
+        }
+
+        @Override
+        public void foundURI(FreenetURI uri, boolean inline) {
+          if (!inline) return;
+          if (LOG.isDebugEnabled()) LOG.debug("Prefetching {}", uri);
+          synchronized (this) {
+            if (uris.size() < MAX_PREFETCH) uris.add(uri);
+          }
+        }
+
+        @Override
+        public void onText(String text, String type, URI baseURI) {
+          // Ignore
+        }
+
+        @Override
+        public void onFinishedPage() {
+          core.getNode()
+              .getExecutor()
+              .execute(
+                  () -> {
+                    for (FreenetURI uri1 : uris) {
+                      client.prefetch(
+                          uri1, SECONDS.toMillis(60), 512L * 1024, prefetchAllowedTypes);
+                    }
+                  });
+        }
+      };
+    }
+
+    private void performFetchWithProgress() throws ToadletContextClosedException, IOException {
+      try {
+        fetchContent();
+      } catch (FetchException e) {
+        fetchException = e;
+      }
+    }
+
+    private void fetchContent() throws FetchException, ToadletContextClosedException, IOException {
+      FProxyFetchWaiter fetch =
+          fetchTracker.makeFetcher(key, maxSize, fctx, ctx.getReFilterPolicy());
+      boolean waitingForFetch = true;
+      while (waitingForFetch && fetch != null) {
+        fetchResult = fetch.getResult(!canSendProgress);
+        if (fetchResult.hasData()) {
+          if (shouldRefetchLaterEdition(fetchResult, key)) {
             LOG.info("Loading later edition...");
             fetch.progress.requestImmediateCancel();
-            fr = null;
-            fetch = null;
-            try {
-              fetch = fetchTracker.makeFetcher(key, maxSize, fctx, ctx.getReFilterPolicy());
-            } catch (FetchException e) {
-              fe = e;
-            }
-            if (fetch == null) break;
-            continue;
-          }
-
-          if (LOG.isDebugEnabled()) LOG.debug("Found data");
-          data = new NoFreeBucket(fr.data);
-          mimeType = fr.mimeType;
-          fetch.close(); // Not waiting any more, but still locked the results until sent
-          break;
-        } else if (fr.failed != null) {
-          if (LOG.isDebugEnabled()) LOG.debug("Request failed");
-          fe = fr.failed;
-          fetch.close(); // Not waiting any more, but still locked the results until sent
-          break;
-        } else if (canSendProgress) {
-          if (LOG.isDebugEnabled()) LOG.debug("Still in progress");
-          // Still in progress
-          boolean isJsEnabled =
-              ctx.getContainer().isFProxyJavascriptEnabled()
-                  && ua != null
-                  && !ua.contains("AppleWebKit/");
-          boolean isWebPushingEnabled = false;
-          PageNode page = ctx.getPageMaker().getPageNode(l10n("fetchingPageTitle"), ctx);
-          String location =
-              getLink(
-                  key,
-                  requestedMimeType,
-                  maxSize,
-                  httprequest.getParam("force", null),
-                  httprequest.isParameterSet("forcedownload"),
-                  maxRetries,
-                  overrideSize);
-          HTMLNode headNode = page.getHeadNode();
-          if (isJsEnabled) {
-            // If the user has enabled javascript, we add a <noscript> http refresh(if he has
-            // disabled it in the browser)
-            headNode
-                .addChild("noscript")
-                .addChild("meta", "http-equiv", "Refresh")
-                .addAttribute("content", "2;URL=" + location);
-            // If pushing is disabled, but js is enabled, then we add the original progresspage.js
-            if (!(isWebPushingEnabled = ctx.getContainer().isFProxyWebPushingEnabled())) {
-              HTMLNode scriptNode = headNode.addChild("script", "//abc");
-              scriptNode.addAttribute("type", "text/javascript");
-              scriptNode.addAttribute("src", "/static/js/progresspage.js");
-            }
+            fetchResult.close();
+            fetch = fetchTracker.makeFetcher(key, maxSize, fctx, ctx.getReFilterPolicy());
+            waitingForFetch = fetch != null;
           } else {
-            // If he disabled it, we just put the http refresh meta, without the noscript
-            headNode
-                .addChild("meta", "http-equiv", "Refresh")
-                .addAttribute("content", "2;URL=" + location);
+            cacheFetcherData(fetch);
+            waitingForFetch = false;
           }
-          HTMLNode contentNode = page.getContentNode();
-          HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-information");
-          infobox.addChild("div", "class", "infobox-header", l10n("fetchingPageBox"));
-          HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
-          infoboxContent.addAttribute("id", "infoContent");
-          infoboxContent.addChild(
-              new ProgressInfoElement(
-                  fetchTracker,
-                  key,
-                  fctx,
-                  maxSize,
-                  ctx.isAdvancedModeEnabled(),
-                  ctx,
-                  isWebPushingEnabled));
+        } else if (fetchResult.failed != null) {
+          fetchException = fetchResult.failed;
+          fetch.close();
+          waitingForFetch = false;
+        } else if (canSendProgress) {
+          renderProgressPage(fetch);
+          return;
+        } else {
+          fetchResult.close();
+        }
+      }
+    }
 
-          HTMLNode table = infoboxContent.addChild("table", "border", "0");
-          HTMLNode progressCell = table.addChild("tr").addChild("td", "class", "request-progress");
-          if (fr.totalBlocks <= 0)
-            progressCell.addChild("#", NodeL10n.getBase().getString("QueueToadlet.unknown"));
-          else {
-            progressCell.addChild(
-                new ProgressBarElement(fetchTracker, key, fctx, maxSize, ctx, isWebPushingEnabled));
+    private void cacheFetcherData(FProxyFetchWaiter fetch) {
+      if (LOG.isDebugEnabled()) LOG.debug("Found data");
+      data = new NoFreeBucket(fetchResult.data);
+      mimeType = fetchResult.mimeType;
+      fetch.close();
+    }
+
+    private void renderProgressPage(FProxyFetchWaiter fetch)
+        throws ToadletContextClosedException, IOException {
+      boolean isJsEnabled =
+          ctx.getContainer().isFProxyJavascriptEnabled()
+              && ua != null
+              && !ua.contains("AppleWebKit/");
+      boolean isWebPushingEnabled = false;
+      PageNode page = ctx.getPageMaker().getPageNode(l10n("fetchingPageTitle"), ctx);
+      String location =
+          getLink(
+              key,
+              requestedMimeType,
+              maxSize,
+              httprequest.getParam(PARAM_FORCE, null),
+              httprequest.isParameterSet(PARAM_FORCED_DOWNLOAD),
+              maxRetries,
+              overrideSize);
+      HTMLNode headNode = page.getHeadNode();
+      if (isJsEnabled) {
+        isWebPushingEnabled = ctx.getContainer().isFProxyWebPushingEnabled();
+        headNode
+            .addChild("noscript")
+            .addChild("meta", "http-equiv", "Refresh")
+            .addAttribute("content", "2;URL=" + location);
+        if (!isWebPushingEnabled) {
+          HTMLNode scriptNode = headNode.addChild("script", "//abc");
+          scriptNode.addAttribute("type", "text/javascript");
+          scriptNode.addAttribute("src", "/static/js/progresspage.js");
+        }
+      } else {
+        headNode
+            .addChild("meta", "http-equiv", "Refresh")
+            .addAttribute("content", "2;URL=" + location);
+      }
+      HTMLNode contentNode = page.getContentNode();
+      HTMLNode infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_INFORMATION_CLASS);
+      infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, l10n("fetchingPageBox"));
+      HTMLNode infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+      infoboxContent.addAttribute("id", "infoContent");
+      infoboxContent.addChild(
+          new ProgressInfoElement(
+              fetchTracker,
+              key,
+              fctx,
+              maxSize,
+              ctx.isAdvancedModeEnabled(),
+              ctx,
+              isWebPushingEnabled));
+
+      HTMLNode table = infoboxContent.addChild("table", "border", "0");
+      HTMLNode progressCell =
+          table.addChild("tr").addChild("td", CLASS_ATTRIBUTE, "request-progress");
+      if (fetchResult.totalBlocks <= 0)
+        progressCell.addChild("#", NodeL10n.getBase().getString("QueueToadlet.unknown"));
+      else {
+        progressCell.addChild(
+            new ProgressBarElement(fetchTracker, key, fctx, maxSize, ctx, isWebPushingEnabled));
+      }
+
+      infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_INFORMATION_CLASS);
+      infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, l10n("fetchingPageOptions"));
+      infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+
+      HTMLNode optionList = infoboxContent.addChild("ul");
+      optionList.addChild("li").addChild("p", l10n("progressOptionZero"));
+
+      addDownloadOptions(ctx, optionList, key, mimeType, false, false, core);
+
+      optionList
+          .addChild("li")
+          .addChild(ctx.getPageMaker().createBackLink(ctx, l10n(GO_BACK_TO_PREV_KEY)));
+      optionList
+          .addChild("li")
+          .addChild(
+              "a",
+              new String[] {"href", ATTR_TITLE},
+              new String[] {"/", NodeL10n.getBase().getString(TOADLET_HOMEPAGE_KEY)},
+              l10n(ABORT_TO_HOMEPAGE_KEY));
+
+      MultiValueTable<String, String> retHeaders = new MultiValueTable<>();
+      writeHTMLReply(ctx, 200, "OK", retHeaders, page.generate());
+      fetchResult.close();
+      fetch.close();
+    }
+
+    private void finishResponse()
+        throws ToadletContextClosedException, IOException, RedirectException {
+      try {
+        if (LOG.isDebugEnabled()) LOG.debug("FProxy fetching {} ({})", key, maxSize);
+        ensureDataIsAvailable();
+        sendDownloadResponse();
+      } catch (FetchException e) {
+        handleFetchException(e);
+      } catch (SocketException e) {
+        if ("Broken pipe".equals(e.getMessage())) {
+          if (LOG.isDebugEnabled()) LOG.debug("Caught {} while handling GET", e.getMessage(), e);
+        } else {
+          LOG.info("Caught {}", e.getMessage(), e);
+        }
+        throw e;
+      } catch (Exception t) {
+        writeInternalError(t, ctx);
+      } finally {
+        if (fetchResult == null && data != null) data.free();
+        if (fetchResult != null) fetchResult.close();
+      }
+    }
+
+    private void ensureDataIsAvailable() throws FetchException {
+      if (data == null && fetchException == null) {
+        reuseInProgressFetch();
+      }
+      if (data == null && fetchException == null) {
+        FetchResult result =
+            fetch(key, maxSize, new RequestClientBuilder().realTime().build(), fctx);
+        data = result.asBucket();
+        mimeType = result.getMimeType();
+      } else if (fetchException != null) {
+        throw fetchException;
+      }
+    }
+
+    private void sendDownloadResponse() throws ToadletContextClosedException, IOException {
+      handleDownload(data, "&max-size=" + maxSizeDownload);
+    }
+
+    private void handleDownload(Bucket data, String extras)
+        throws ToadletContextClosedException, IOException {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "handleDownload(data.size={}, mimeType={}, requestedMimeType={}, forceDownload={},"
+                + " basePath={}, key={})",
+            data.size(),
+            mimeType,
+            requestedMimeType,
+            forceDownloadRequested,
+            "/",
+            key);
+      }
+      String extrasNoMime = extras;
+      String updatedExtras = appendRequestedMimeType(extras, requestedMimeType, mimeType);
+      long size = data.size();
+
+      long now = System.currentTimeMillis();
+      boolean force = isForceRequested(forceString, key, now);
+
+      if (!force && !forceDownloadRequested) {
+        mimeType = adjustMimeForBrowserWorkarounds(mimeType);
+        if (handleDangerousRss(data, mimeType, now, extrasNoMime, updatedExtras, referer)) {
+          return;
+        }
+      }
+
+      if (forceDownloadRequested) {
+        sendForcedDownload(ctx, data, key, size);
+        return;
+      }
+
+      sendRangeOrFullResponse(ctx, ctx.getBucketFactory(), mimeType, key, ctx, data, size);
+    }
+
+    private String adjustMimeForBrowserWorkarounds(String mimeType) {
+      if ("application/xhtml+xml".equals(mimeType)) {
+        return "text/html";
+      }
+      return mimeType;
+    }
+
+    private boolean handleDangerousRss(
+        Bucket data, String mimeType, long now, String extrasNoMime, String extras, String referrer)
+        throws IOException, ToadletContextClosedException {
+      if (!isSniffedAsFeed(data) || mimeType.startsWith("application/rss+xml")) {
+        return false;
+      }
+      PageNode page = ctx.getPageMaker().getPageNode(l10n("dangerousRSSTitle"), ctx);
+      HTMLNode contentNode = page.getContentNode();
+
+      HTMLNode infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, "infobox infobox-alert");
+      infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, l10n("dangerousRSSSubtitle"));
+      HTMLNode infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+      infoboxContent.addChild(
+          "#",
+          NodeL10n.getBase()
+              .getString(
+                  "FProxyToadlet.dangerousRSS", new String[] {"type"}, new String[] {mimeType}));
+      infoboxContent.addChild("p", l10n("options"));
+      HTMLNode optionList = infoboxContent.addChild("ul");
+      HTMLNode option = optionList.addChild("li");
+
+      NodeL10n.getBase()
+          .addL10nSubstitution(
+              option,
+              "FProxyToadlet.openPossRSSAsPlainText",
+              new String[] {"link", "bold"},
+              new HTMLNode[] {
+                HTMLNode.link(
+                    "/"
+                        + key.toString()
+                        + "?type=text/plain&force="
+                        + getForceValue(key, now)
+                        + extrasNoMime),
+                HTMLNode.STRONG
+              });
+      option = optionList.addChild("li");
+      NodeL10n.getBase()
+          .addL10nSubstitution(
+              option,
+              "FProxyToadlet.openPossRSSForceDisk",
+              new String[] {"link", "bold"},
+              new HTMLNode[] {
+                HTMLNode.link("/" + key.toString() + "?forcedownload" + extras), HTMLNode.STRONG
+              });
+      boolean mimeRss =
+          mimeType.startsWith("application/xml+rss") || mimeType.startsWith("text/xml");
+      if (!(mimeRss || mimeType.startsWith("text/plain"))) {
+        option = optionList.addChild("li");
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                "FProxyToadlet.openRSSForce",
+                new String[] {"link", "bold", "mime"},
+                new HTMLNode[] {
+                  HTMLNode.link(
+                      "/" + key.toString() + "?force=" + getForceValue(key, now) + extras),
+                  HTMLNode.STRONG,
+                  HTMLNode.text(mimeType)
+                });
+      }
+      option = optionList.addChild("li");
+      NodeL10n.getBase()
+          .addL10nSubstitution(
+              option,
+              "FProxyToadlet.openRSSAsRSS",
+              new String[] {"link", "bold"},
+              new HTMLNode[] {
+                HTMLNode.link(
+                    "/"
+                        + key.toString()
+                        + "?type=application/xml+rss&force="
+                        + getForceValue(key, now)
+                        + extrasNoMime),
+                HTMLNode.STRONG
+              });
+      addDownloadOptions(ctx, optionList, key, mimeType, true, false, core);
+      if (referrer != null) {
+        option = optionList.addChild("li");
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                "FProxyToadlet.backToReferrer",
+                new String[] {"link"},
+                new HTMLNode[] {HTMLNode.link(referrer)});
+      }
+      option = optionList.addChild("li");
+      NodeL10n.getBase()
+          .addL10nSubstitution(
+              option,
+              "FProxyToadlet.backToFProxy",
+              new String[] {"link"},
+              new HTMLNode[] {HTMLNode.link("/")});
+
+      byte[] pageBytes = page.generate().getBytes(StandardCharsets.UTF_8);
+      ctx.sendReplyHeaders(
+          200, "OK", new MultiValueTable<>(), "text/html; charset=utf-8", pageBytes.length);
+      ctx.writeData(pageBytes);
+      return true;
+    }
+
+    private String appendRequestedMimeType(
+        String extras, String requestedMimeType, String mimeType) {
+      String updatedExtras = extras;
+      if (requestedMimeType != null && !requestedMimeType.equals(mimeType)) {
+        if (updatedExtras == null) {
+          updatedExtras = "";
+        }
+        updatedExtras = updatedExtras + "&type=" + requestedMimeType;
+      }
+      return updatedExtras;
+    }
+
+    private boolean isForceRequested(String forceString, FreenetURI key, long now) {
+      if (forceString == null) {
+        return false;
+      }
+      return forceString.equals(getForceValue(key, now))
+          || forceString.equals(getForceValue(key, now - FORCE_GRAIN_INTERVAL));
+    }
+
+    private void sendForcedDownload(ToadletContext context, Bucket data, FreenetURI key, long size)
+        throws ToadletContextClosedException, IOException {
+      MultiValueTable<String, String> headers = new MultiValueTable<>(4);
+      headers.put(
+          "Content-Disposition", "attachment; filename=\"" + key.getPreferredFilename() + '\"');
+      headers.put("Cache-Control", "private");
+      headers.put("Content-Transfer-Encoding", "binary");
+      headers.put(HEADER_X_CONTENT_TYPE_OPTIONS, NOSNIFF);
+      context.sendReplyHeadersFProxy(200, "OK", headers, "application/force-download", size);
+      context.writeData(data);
+    }
+
+    private void sendRangeOrFullResponse(
+        ToadletContext context,
+        BucketFactory bucketFactory,
+        String mimeType,
+        FreenetURI key,
+        ToadletContext ctx,
+        Bucket data,
+        long size)
+        throws ToadletContextClosedException, IOException {
+      MultiValueTable<String, String> hdr = context.getHeaders();
+
+      /*
+       * Firefox and its derivatives may use the MIME type implied by the filename extension for
+       * plain text, unless a Content-Encoding is specified.
+       *
+       * See https://developer.mozilla.org/en-US/docs/Mozilla/How_Mozilla_determines_MIME_Types#HTTP
+       */
+      MultiValueTable<String, String> retHdr = MultiValueTable.from("Content-Encoding", "identity");
+
+      String rangeStr = hdr.getFirst("range");
+      if (rangeStr != null) {
+        long[] range;
+        try {
+          range = parseRange(rangeStr);
+        } catch (HTTPRangeException e) {
+          ctx.sendReplyHeaders(416, "Requested Range Not Satisfiable", null, null, 0);
+          return;
+        }
+        if (range[1] == -1 || range[1] >= size) {
+          range[1] = size - 1;
+        }
+        Bucket tmpRange = bucketFactory.makeBucket(range[1] - range[0]);
+        try (InputStream is = data.getInputStream();
+            OutputStream os = tmpRange.getOutputStream()) {
+          if (range[0] > 0) {
+            FileUtil.skipFully(is, range[0]);
           }
+          FileUtil.copy(is, os, range[1] - range[0] + 1);
+        }
+        retHdr.put("Content-Range", "bytes " + range[0] + "-" + range[1] + "/" + size);
+        retHdr.put(HEADER_X_CONTENT_TYPE_OPTIONS, NOSNIFF);
+        context.sendReplyHeadersFProxy(206, "Partial content", retHdr, mimeType, tmpRange.size());
+        context.writeData(tmpRange);
+        return;
+      }
 
-          infobox = contentNode.addChild("div", "class", "infobox infobox-information");
-          infobox.addChild("div", "class", "infobox-header", l10n("fetchingPageOptions"));
-          infoboxContent = infobox.addChild("div", "class", "infobox-content");
+      retHdr.put(HEADER_X_CONTENT_TYPE_OPTIONS, NOSNIFF);
+      if (container.enableCachingForChkAndSskKeys() && (key.isCHK() || key.isSSK())) {
+        context.sendReplyHeadersStatic(200, "OK", retHdr, mimeType, size, new Date());
+      } else {
+        context.sendReplyHeadersFProxy(200, "OK", retHdr, mimeType, size);
+      }
+      context.writeData(data);
+    }
 
-          HTMLNode optionList = infoboxContent.addChild("ul");
-          optionList.addChild("li").addChild("p", l10n("progressOptionZero"));
+    private void reuseInProgressFetch() {
+      boolean needsFetch = true;
+      FProxyFetchInProgress progress = fetchTracker.getFetchInProgress(key, maxSize, fctx);
+      if (progress == null) {
+        return;
+      }
+      FProxyFetchWaiter waiter = null;
+      FProxyFetchResult result = null;
+      try {
+        waiter = progress.getWaiter();
+        result = waiter.getResult(false);
+        if (result.failed == null && result.data != null) {
+          mimeType = result.mimeType;
+          try {
+            data = ctx.getBucketFactory().makeBucket(result.data.size());
+            BucketTools.copy(result.data, data);
+            needsFetch = false;
+          } catch (IOException e) {
+            LOG.warn("Failed to reuse in-progress fetch result: {}", e.getMessage(), e);
+            data = null;
+          }
+        }
+      } finally {
+        if (waiter != null) {
+          progress.close(waiter);
+        }
+        if (result != null) {
+          progress.close(result);
+        }
+      }
+      if (needsFetch) {
+        data = null;
+      }
+    }
 
-          addDownloadOptions(ctx, optionList, key, mimeType, false, false, core);
+    private void handleFetchException(FetchException e)
+        throws ToadletContextClosedException, IOException, RedirectException {
+      String msg = e.getMessage();
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Failed to fetch {} : {}", uri, e.getMessage(), e);
+      }
+      if (e.newURI != null) {
+        handleRedirectException(e);
+        return;
+      }
+      if (e.mode == FetchExceptionMode.TOO_BIG) {
+        handleTooBigException(e);
+        return;
+      }
+      handleGenericFetchException(e, msg);
+    }
 
-          optionList
-              .addChild("li")
-              .addChild(ctx.getPageMaker().createBackLink(ctx, l10n("goBackToPrev")));
+    private void handleRedirectException(FetchException e)
+        throws ToadletContextClosedException, IOException, RedirectException {
+      if (accept != null
+          && (accept.startsWith("text/css") || accept.startsWith("image/"))
+          && recursion + 1 < MAX_RECURSION) {
+        followRedirectRecursively(e);
+        return;
+      }
+      Toadlet.writePermanentRedirect(
+          ctx,
+          e.getMessage(),
+          getLink(
+              e.newURI,
+              requestedMimeType,
+              maxSize,
+              httprequest.getParam(PARAM_FORCE, null),
+              httprequest.isParameterSet(PARAM_FORCED_DOWNLOAD),
+              maxRetries,
+              overrideSize));
+    }
+
+    private void followRedirectRecursively(FetchException e)
+        throws RedirectException, ToadletContextClosedException, IOException {
+      String link =
+          getLink(
+              e.newURI,
+              requestedMimeType,
+              maxSize,
+              httprequest.getParam(PARAM_FORCE, null),
+              httprequest.isParameterSet(PARAM_FORCED_DOWNLOAD),
+              maxRetries,
+              overrideSize);
+      try {
+        URI redirected = new URI(link);
+        innerHandleMethodGET(redirected, httprequest, ctx, recursion + 1);
+      } catch (URISyntaxException e1) {
+        LOG.error("Caught {} parsing new link {}", e1.getMessage(), link, e1);
+      }
+    }
+
+    private void handleTooBigException(FetchException e)
+        throws ToadletContextClosedException, IOException {
+      PageNode page = ctx.getPageMaker().getPageNode(l10n("fileInformationTitle"), ctx);
+      HTMLNode contentNode = page.getContentNode();
+
+      HTMLNode infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_INFORMATION_CLASS);
+      infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, l10n("largeFile"));
+      HTMLNode infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+      HTMLNode fileInformationList = infoboxContent.addChild("ul");
+      HTMLNode option = fileInformationList.addChild("li");
+      option.addChild("#", (l10n("filenameLabel") + ' '));
+      option.addChild("a", "href", '/' + key.toString(), getFilename(key, e.getExpectedMimeType()));
+
+      String mime = writeSizeAndMIME(fileInformationList, e);
+
+      infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_INFORMATION_CLASS);
+      infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, l10n("explanationTitle"));
+      infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+      infoboxContent.addChild("#", l10n("largeFileExplanationAndOptions"));
+      HTMLNode optionList = infoboxContent.addChild("ul");
+      if (!restricted) {
+        addLargeFileFetchForm(e, optionList, mime);
+      }
+
+      optionList
+          .addChild("li")
+          .addChild(
+              "a",
+              new String[] {"href", ATTR_TITLE},
+              new String[] {"/", NodeL10n.getBase().getString(TOADLET_HOMEPAGE_KEY)},
+              l10n(ABORT_TO_HOMEPAGE_KEY));
+      optionList
+          .addChild("li")
+          .addChild(ctx.getPageMaker().createBackLink(ctx, l10n(GO_BACK_TO_PREV_KEY)));
+
+      writeHTMLReply(ctx, 200, "OK", page.generate());
+    }
+
+    private void addLargeFileFetchForm(FetchException e, HTMLNode optionList, String mime) {
+      HTMLNode option = optionList.addChild("li");
+      HTMLNode optionForm =
+          option.addChild(
+              "form",
+              new String[] {"action", "method"},
+              new String[] {'/' + key.toString(), "get"});
+      optionForm.addChild(
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {
+            TYPE_HIDDEN,
+            PARAM_MAX_SIZE,
+            String.valueOf(e.getExpectedSize() == -1 ? Long.MAX_VALUE : e.getExpectedSize() * 2)
+          });
+      if (requestedMimeType != null)
+        optionForm.addChild(
+            TAG_INPUT,
+            new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+            new String[] {TYPE_HIDDEN, "type", requestedMimeType});
+      if (maxRetries >= -1)
+        optionForm.addChild(
+            TAG_INPUT,
+            new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+            new String[] {TYPE_HIDDEN, "max-retries", Integer.toString(maxRetries)});
+      optionForm.addChild(
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {TYPE_SUBMIT, "fetch", l10n("fetchLargeFileAnywayAndDisplayButton")});
+      optionForm.addChild("#", " - " + l10n("fetchLargeFileAnywayAndDisplay"));
+      addDownloadOptions(ctx, optionList, key, mime, false, false, core);
+    }
+
+    private void handleGenericFetchException(FetchException e, String msg)
+        throws ToadletContextClosedException, IOException {
+      PageNode page = ctx.getPageMaker().getPageNode(e.getShortMessage(), ctx);
+      HTMLNode contentNode = page.getContentNode();
+
+      HTMLNode infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_ERROR_CLASS);
+      infobox.addChild(
+          "div",
+          CLASS_ATTRIBUTE,
+          INFOBOX_HEADER_CLASS,
+          l10n("errorWithReason", "error", e.getShortMessage()));
+      HTMLNode infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+      HTMLNode fileInformationList = infoboxContent.addChild("ul");
+      HTMLNode option = fileInformationList.addChild("li");
+      option.addChild("#", (l10n("filenameLabel") + ' '));
+      option.addChild("a", "href", '/' + key.toString(), getFilename(key, e.getExpectedMimeType()));
+
+      String mime = writeSizeAndMIME(fileInformationList, e);
+      UnsafeContentTypeException filterException = null;
+      if (e.getCause() instanceof UnsafeContentTypeException cause) {
+        filterException = cause;
+      }
+      addFetchExplanationSection(contentNode, msg, e, filterException);
+      addFetchOptionsSection(contentNode, mime, filterException, e);
+
+      writeHTMLReply(
+          ctx,
+          (e.mode == FetchExceptionMode.NOT_IN_ARCHIVE) ? 404 : 500,
+          "Internal Error",
+          page.generate());
+    }
+
+    private void addFetchExplanationSection(
+        HTMLNode contentNode,
+        String msg,
+        FetchException e,
+        UnsafeContentTypeException filterException) {
+      HTMLNode infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_ERROR_CLASS);
+      infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, l10n("explanationTitle"));
+      HTMLNode infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+      if (filterException == null) infoboxContent.addChild("p", l10n("unableToRetrieve"));
+      else infoboxContent.addChild("p", l10n("unableToSafelyDisplay"));
+      if (e.isFatal() && filterException == null)
+        infoboxContent.addChild("p", l10n("errorIsFatal"));
+      infoboxContent.addChild("p", msg);
+      if (filterException != null && filterException.details() != null) {
+        HTMLNode detailList = infoboxContent.addChild("ul");
+        for (String detail : filterException.details()) {
+          detailList.addChild("li", detail);
+        }
+      }
+      if (e.errorCodes != null) {
+        infoboxContent.addChild("p").addChild("pre").addChild("#", e.errorCodes.toVerboseString());
+      }
+    }
+
+    private void addFetchOptionsSection(
+        HTMLNode contentNode,
+        String mime,
+        UnsafeContentTypeException filterException,
+        FetchException e) {
+      HTMLNode infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_ERROR_CLASS);
+      infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, l10n("options"));
+      HTMLNode infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+
+      HTMLNode optionList = infoboxContent.addChild("ul");
+      appendPluginOptions(optionList, e);
+      if (filterException != null) {
+        addFilterRecoveryOptions(optionList, mime, e);
+      }
+      addRetryAndAbortOptions(optionList, e);
+    }
+
+    private void appendPluginOptions(HTMLNode optionList, FetchException e) {
+      PluginInfoWrapper keyUtil;
+      if (!(e.mode == FetchExceptionMode.NOT_IN_ARCHIVE
+          || e.mode == FetchExceptionMode.NOT_ENOUGH_PATH_COMPONENTS)) {
+        return;
+      }
+      if ((keyUtil =
+              core.getNode()
+                  .getPluginManager()
+                  .getPluginInfoByClassName("plugins.KeyUtils.KeyUtilsPlugin"))
+          != null) {
+        appendKeyUtilsOptions(optionList, keyUtil);
+        return;
+      }
+      if ((keyUtil =
+              core.getNode()
+                  .getPluginManager()
+                  .getPluginInfoByClassName("plugins.KeyExplorer.KeyExplorer"))
+          != null) {
+        appendKeyExplorerOptions(optionList, keyUtil);
+      }
+    }
+
+    private void appendKeyUtilsOptions(HTMLNode optionList, PluginInfoWrapper keyUtil) {
+      HTMLNode option = optionList.addChild("li");
+      if (keyUtil.getPluginLongVersion() < 5010)
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                OPEN_WITH_KEY_EXPLORER_KEY,
+                new String[] {"link"},
+                new HTMLNode[] {HTMLNode.link("/KeyUtils/?automf=true&key=" + key.toString())});
+      else {
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                OPEN_WITH_KEY_EXPLORER_KEY,
+                new String[] {"link"},
+                new HTMLNode[] {HTMLNode.link("/KeyUtils/?key=" + key.toString())});
+        option = optionList.addChild("li");
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                "FProxyToadlet.openWithSiteExplorer",
+                new String[] {"link"},
+                new HTMLNode[] {HTMLNode.link("/KeyUtils/Site?key=" + key.toString())});
+      }
+    }
+
+    private void appendKeyExplorerOptions(HTMLNode optionList, PluginInfoWrapper keyUtil) {
+      HTMLNode option = optionList.addChild("li");
+      if (keyUtil.getPluginLongVersion() > 4999)
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                OPEN_WITH_KEY_EXPLORER_KEY,
+                new String[] {"link"},
+                new HTMLNode[] {HTMLNode.link("/KeyExplorer/?automf=true&key=" + key.toString())});
+      else
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                OPEN_WITH_KEY_EXPLORER_KEY,
+                new String[] {"link"},
+                new HTMLNode[] {
+                  HTMLNode.link("/plugins/plugins.KeyExplorer.KeyExplorer/?key=" + key.toString())
+                });
+    }
+
+    private void addFilterRecoveryOptions(HTMLNode optionList, String mime, FetchException e) {
+      if ((mime.equals("application/x-freenet-index"))
+          && (core.getNode()
+              .getPluginManager()
+              .isPluginLoaded("plugins.ThawIndexBrowser.ThawIndexBrowser"))) {
+        HTMLNode option = optionList.addChild("li");
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                "FProxyToadlet.openAsThawIndex",
+                new String[] {"link"},
+                new HTMLNode[] {
+                  HTMLNode.link(
+                      "/plugins/plugins.ThawIndexBrowser.ThawIndexBrowser/?key=" + key.toString())
+                });
+      }
+      HTMLNode option = optionList.addChild("li");
+      try {
+        MediaType textMediaType = new MediaType("text/plain");
+        textMediaType.setParameter(
+            "charset",
+            (e.getExpectedMimeType() != null)
+                ? MediaType.getCharsetRobust(e.getExpectedMimeType())
+                : null);
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                "FProxyToadlet.openAsText",
+                new String[] {"link"},
+                new HTMLNode[] {
+                  HTMLNode.link(
+                      getLink(
+                          key,
+                          textMediaType.toString(),
+                          maxSize,
+                          null,
+                          false,
+                          maxRetries,
+                          overrideSize))
+                });
+      } catch (MalformedURLException ex) {
+        LOG.error("Failed to build text/plain media type: {}", ex.getMessage(), ex);
+      }
+      option = optionList.addChild("li");
+      NodeL10n.getBase()
+          .addL10nSubstitution(
+              option,
+              "FProxyToadlet.openForceDisk",
+              new String[] {"link"},
+              new HTMLNode[] {
+                HTMLNode.link(getLink(key, mime, maxSize, null, true, maxRetries, overrideSize))
+              });
+      if (!(mime.equals("application/octet-stream")
+          || mime.equals("application/x-msdownload")
+          || !DefaultMIMETypes.isPlausibleMIMEType(mime))) {
+        option = optionList.addChild("li");
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                option,
+                "FProxyToadlet.openForce",
+                new String[] {"link", "mime"},
+                new HTMLNode[] {
+                  HTMLNode.link(
+                      getLink(
+                          key,
+                          mime,
+                          maxSize,
+                          getForceValue(key, System.currentTimeMillis()),
+                          false,
+                          maxRetries,
+                          overrideSize)),
+                  HTMLNode.text(HTMLEncoder.encode(mime))
+                });
+      }
+    }
+
+    private void addRetryAndAbortOptions(HTMLNode optionList, FetchException e) {
+      if ((!e.isFatal() || e.getCause() instanceof UnsafeContentTypeException)
+          && (ctx.isAllowedFullAccess() || !container.publicGatewayMode())) {
+        addDownloadOptions(
+            ctx,
+            optionList,
+            key,
+            mimeType,
+            e.getCause() instanceof UnsafeContentTypeException,
+            e.getCause() instanceof UnsafeContentTypeException,
+            core);
+        if (!(e.getCause() instanceof UnsafeContentTypeException)) {
           optionList
               .addChild("li")
               .addChild(
                   "a",
-                  new String[] {"href", "title"},
-                  new String[] {"/", NodeL10n.getBase().getString("Toadlet.homepage")},
-                  l10n("abortToHomepage"));
-
-          MultiValueTable<String, String> retHeaders = new MultiValueTable<>();
-          // retHeaders.put("Refresh", "2; url="+location);
-          writeHTMLReply(ctx, 200, "OK", retHeaders, page.generate());
-          fr.close();
-          fetch.close();
-          return;
-        } else if (fr != null) fr.close();
+                  "href",
+                  getLink(
+                      key,
+                      requestedMimeType,
+                      maxSize,
+                      httprequest.getParam(PARAM_FORCE, null),
+                      httprequest.isParameterSet(PARAM_FORCED_DOWNLOAD),
+                      maxRetries,
+                      overrideSize))
+              .addChild("#", l10n("retryNow"));
+        }
       }
-
-    try {
-      if (LOG.isDebugEnabled()) LOG.debug("FProxy fetching {} ({})", key, maxSize);
-      if (data == null && fe == null) {
-        boolean needsFetch = true;
-        // If we don't have the data, then check if an FProxyFetchInProgress has. It can happen when
-        // one FetchInProgress downloaded an image
-        // asynchronously, then loads it. This way a FetchInprogress will have the full image, and
-        // no need to block.
-        FProxyFetchInProgress progress = fetchTracker.getFetchInProgress(key, maxSize, fctx);
-        if (progress != null) {
-          FProxyFetchWaiter waiter = null;
-          FProxyFetchResult result = null;
-          try {
-            waiter = progress.getWaiter();
-            result = waiter.getResult(false);
-            if (result.failed == null && result.data != null) {
-              mimeType = result.mimeType;
-              data = result.data;
-              data = ctx.getBucketFactory().makeBucket(result.data.size());
-              BucketTools.copy(result.data, data);
-              needsFetch = false;
-            }
-          } finally {
-            if (waiter != null) {
-              progress.close(waiter);
-            }
-            if (result != null) {
-              progress.close(result);
-            }
-          }
-        }
-        if (needsFetch) {
-          // If we don't have the data, then we need to fetch it and block until it is available
-          FetchResult result =
-              fetch(key, maxSize, new RequestClientBuilder().realTime().build(), fctx);
-
-          // Now, is it safe?
-
-          data = result.asBucket();
-          mimeType = result.getMimeType();
-        }
-      } else if (fe != null) throw fe;
-
-      handleDownload(
-          ctx,
-          data,
-          ctx.getBucketFactory(),
-          mimeType,
-          requestedMimeType,
-          forceString,
-          httprequest.isParameterSet("forcedownload"),
-          "/",
-          key,
-          "&max-size=" + maxSizeDownload,
-          referer,
-          true,
-          ctx,
-          core,
-          fr != null,
-          maybeCharset);
-    } catch (FetchException e) {
-      // Handle exceptions thrown from the ContentFilter
-      String msg = e.getMessage();
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Failed to fetch {} : {}", uri, e.toString());
-      }
-      if (e.newURI != null) {
-        if (accept != null
-            && (accept.startsWith("text/css") || accept.startsWith("image/"))
-            && recursion++ < MAX_RECURSION) {
-          // If it's an image or a CSS fetch, auto-follow the redirect, up to a limit.
-          String link =
-              getLink(
-                  e.newURI,
-                  requestedMimeType,
-                  maxSize,
-                  httprequest.getParam("force", null),
-                  httprequest.isParameterSet("forcedownload"),
-                  maxRetries,
-                  overrideSize);
-          try {
-            uri = new URI(link);
-            innerHandleMethodGET(uri, httprequest, ctx, recursion);
-            return;
-          } catch (URISyntaxException e1) {
-            LOG.error("Caught {} parsing new link {}", e1.toString(), link, e1);
-          }
-        }
-        Toadlet.writePermanentRedirect(
-            ctx,
-            msg,
-            getLink(
-                e.newURI,
-                requestedMimeType,
-                maxSize,
-                httprequest.getParam("force", null),
-                httprequest.isParameterSet("forcedownload"),
-                maxRetries,
-                overrideSize));
-      } else if (e.mode == FetchExceptionMode.TOO_BIG) {
-        PageNode page = ctx.getPageMaker().getPageNode(l10n("fileInformationTitle"), ctx);
-        HTMLNode contentNode = page.getContentNode();
-
-        HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-information");
-        infobox.addChild("div", "class", "infobox-header", l10n("largeFile"));
-        HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
-        HTMLNode fileInformationList = infoboxContent.addChild("ul");
-        HTMLNode option = fileInformationList.addChild("li");
-        option.addChild("#", (l10n("filenameLabel") + ' '));
-        option.addChild(
-            "a", "href", '/' + key.toString(), getFilename(key, e.getExpectedMimeType()));
-
-        String mime = writeSizeAndMIME(fileInformationList, e);
-
-        infobox = contentNode.addChild("div", "class", "infobox infobox-information");
-        infobox.addChild("div", "class", "infobox-header", l10n("explanationTitle"));
-        infoboxContent = infobox.addChild("div", "class", "infobox-content");
-        infoboxContent.addChild("#", l10n("largeFileExplanationAndOptions"));
-        HTMLNode optionList = infoboxContent.addChild("ul");
-        // HTMLNode optionTable = infoboxContent.addChild("table", "border", "0");
-        if (!restricted) {
-          option = optionList.addChild("li");
-          HTMLNode optionForm =
-              option.addChild(
-                  "form",
-                  new String[] {"action", "method"},
-                  new String[] {'/' + key.toString(), "get"});
-          optionForm.addChild(
-              "input",
-              new String[] {"type", "name", "value"},
-              new String[] {
-                "hidden",
-                "max-size",
-                String.valueOf(e.getExpectedSize() == -1 ? Long.MAX_VALUE : e.getExpectedSize() * 2)
-              });
-          if (requestedMimeType != null)
-            optionForm.addChild(
-                "input",
-                new String[] {"type", "name", "value"},
-                new String[] {"hidden", "type", requestedMimeType});
-          if (maxRetries >= -1)
-            optionForm.addChild(
-                "input",
-                new String[] {"type", "name", "value"},
-                new String[] {"hidden", "max-retries", Integer.toString(maxRetries)});
-          optionForm.addChild(
-              "input",
-              new String[] {"type", "name", "value"},
-              new String[] {"submit", "fetch", l10n("fetchLargeFileAnywayAndDisplayButton")});
-          optionForm.addChild("#", " - " + l10n("fetchLargeFileAnywayAndDisplay"));
-          addDownloadOptions(ctx, optionList, key, mime, false, false, core);
-        }
-
-        // optionTable.addChild("tr").addChild("td", "colspan", "2").addChild("a", new String[] {
-        // "href", "title" }, new String[] { "/", NodeL10n.getBase().getString("Toadlet.homepage")
-        // }, l10n("abortToHomepage"));
-        optionList
-            .addChild("li")
-            .addChild(
-                "a",
-                new String[] {"href", "title"},
-                new String[] {"/", NodeL10n.getBase().getString("Toadlet.homepage")},
-                l10n("abortToHomepage"));
-
-        // option = optionTable.addChild("tr").addChild("td", "colspan", "2");
-        optionList
-            .addChild("li")
-            .addChild(ctx.getPageMaker().createBackLink(ctx, l10n("goBackToPrev")));
-
-        writeHTMLReply(ctx, 200, "OK", page.generate());
-      } else {
-        PageNode page = ctx.getPageMaker().getPageNode(e.getShortMessage(), ctx);
-        HTMLNode contentNode = page.getContentNode();
-
-        HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-error");
-        infobox.addChild(
-            "div",
-            "class",
-            "infobox-header",
-            l10n("errorWithReason", "error", e.getShortMessage()));
-        HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
-        HTMLNode fileInformationList = infoboxContent.addChild("ul");
-        HTMLNode option = fileInformationList.addChild("li");
-        option.addChild("#", (l10n("filenameLabel") + ' '));
-        option.addChild(
-            "a", "href", '/' + key.toString(), getFilename(key, e.getExpectedMimeType()));
-
-        String mime = writeSizeAndMIME(fileInformationList, e);
-        infobox = contentNode.addChild("div", "class", "infobox infobox-error");
-        infobox.addChild("div", "class", "infobox-header", l10n("explanationTitle"));
-        UnsafeContentTypeException filterException = null;
-        if (e.getCause() != null && e.getCause() instanceof UnsafeContentTypeException) {
-          filterException = (UnsafeContentTypeException) e.getCause();
-        }
-        infoboxContent = infobox.addChild("div", "class", "infobox-content");
-        if (filterException == null) infoboxContent.addChild("p", l10n("unableToRetrieve"));
-        else infoboxContent.addChild("p", l10n("unableToSafelyDisplay"));
-        if (e.isFatal() && filterException == null)
-          infoboxContent.addChild("p", l10n("errorIsFatal"));
-        infoboxContent.addChild("p", msg);
-        if (filterException != null) {
-          if (filterException.details() != null) {
-            HTMLNode detailList = infoboxContent.addChild("ul");
-            for (String detail : filterException.details()) {
-              detailList.addChild("li", detail);
-            }
-          }
-        }
-        if (e.errorCodes != null) {
-          infoboxContent
-              .addChild("p")
-              .addChild("pre")
-              .addChild("#", e.errorCodes.toVerboseString());
-        }
-
-        infobox = contentNode.addChild("div", "class", "infobox infobox-error");
-        infobox.addChild("div", "class", "infobox-header", l10n("options"));
-        infoboxContent = infobox.addChild("div", "class", "infobox-content");
-
-        HTMLNode optionList = infoboxContent.addChild("ul");
-
-        PluginInfoWrapper keyUtil;
-        if ((e.mode == FetchExceptionMode.NOT_IN_ARCHIVE
-            || e.mode == FetchExceptionMode.NOT_ENOUGH_PATH_COMPONENTS)) {
-          // first look for the newest version
-          if ((keyUtil =
-                  core.getNode()
-                      .getPluginManager()
-                      .getPluginInfoByClassName("plugins.KeyUtils.KeyUtilsPlugin"))
-              != null) {
-            option = optionList.addChild("li");
-            if (keyUtil.getPluginLongVersion() < 5010)
-              NodeL10n.getBase()
-                  .addL10nSubstitution(
-                      option,
-                      "FProxyToadlet.openWithKeyExplorer",
-                      new String[] {"link"},
-                      new HTMLNode[] {
-                        HTMLNode.link("/KeyUtils/?automf=true&key=" + key.toString())
-                      });
-            else {
-              NodeL10n.getBase()
-                  .addL10nSubstitution(
-                      option,
-                      "FProxyToadlet.openWithKeyExplorer",
-                      new String[] {"link"},
-                      new HTMLNode[] {HTMLNode.link("/KeyUtils/?key=" + key.toString())});
-              option = optionList.addChild("li");
-              NodeL10n.getBase()
-                  .addL10nSubstitution(
-                      option,
-                      "FProxyToadlet.openWithSiteExplorer",
-                      new String[] {"link"},
-                      new HTMLNode[] {HTMLNode.link("/KeyUtils/Site?key=" + key.toString())});
-            }
-          } else if ((keyUtil =
-                  core.getNode()
-                      .getPluginManager()
-                      .getPluginInfoByClassName("plugins.KeyExplorer.KeyExplorer"))
-              != null) {
-            option = optionList.addChild("li");
-            if (keyUtil.getPluginLongVersion() > 4999)
-              NodeL10n.getBase()
-                  .addL10nSubstitution(
-                      option,
-                      "FProxyToadlet.openWithKeyExplorer",
-                      new String[] {"link"},
-                      new HTMLNode[] {
-                        HTMLNode.link("/KeyExplorer/?automf=true&key=" + key.toString())
-                      });
-            else
-              NodeL10n.getBase()
-                  .addL10nSubstitution(
-                      option,
-                      "FProxyToadlet.openWithKeyExplorer",
-                      new String[] {"link"},
-                      new HTMLNode[] {
-                        HTMLNode.link(
-                            "/plugins/plugins.KeyExplorer.KeyExplorer/?key=" + key.toString())
-                      });
-          }
-        }
-        if (filterException != null) {
-          if ((mime.equals("application/x-freenet-index"))
-              && (core.getNode()
-                  .getPluginManager()
-                  .isPluginLoaded("plugins.ThawIndexBrowser.ThawIndexBrowser"))) {
-            option = optionList.addChild("li");
-            NodeL10n.getBase()
-                .addL10nSubstitution(
-                    option,
-                    "FProxyToadlet.openAsThawIndex",
-                    new String[] {"link"},
-                    new HTMLNode[] {
-                      HTMLNode.link(
-                          "/plugins/plugins.ThawIndexBrowser.ThawIndexBrowser/?key="
-                              + key.toString())
-                    });
-          }
-          option = optionList.addChild("li");
-          // FIXME: is this safe? See bug #131
-          MediaType textMediaType = new MediaType("text/plain");
-          textMediaType.setParameter(
-              "charset",
-              (e.getExpectedMimeType() != null)
-                  ? MediaType.getCharsetRobust(e.getExpectedMimeType())
-                  : null);
-          NodeL10n.getBase()
-              .addL10nSubstitution(
-                  option,
-                  "FProxyToadlet.openAsText",
-                  new String[] {"link"},
-                  new HTMLNode[] {
-                    HTMLNode.link(
-                        getLink(
-                            key,
-                            textMediaType.toString(),
-                            maxSize,
-                            null,
-                            false,
-                            maxRetries,
-                            overrideSize))
-                  });
-          option = optionList.addChild("li");
-          NodeL10n.getBase()
-              .addL10nSubstitution(
-                  option,
-                  "FProxyToadlet.openForceDisk",
-                  new String[] {"link"},
-                  new HTMLNode[] {
-                    HTMLNode.link(getLink(key, mime, maxSize, null, true, maxRetries, overrideSize))
-                  });
-          if (!(mime.equals("application/octet-stream")
-              || mime.equals("application/x-msdownload")
-              || !DefaultMIMETypes.isPlausibleMIMEType(mime))) {
-            option = optionList.addChild("li");
-            NodeL10n.getBase()
-                .addL10nSubstitution(
-                    option,
-                    "FProxyToadlet.openForce",
-                    new String[] {"link", "mime"},
-                    new HTMLNode[] {
-                      HTMLNode.link(
-                          getLink(
-                              key,
-                              mime,
-                              maxSize,
-                              getForceValue(key, now),
-                              false,
-                              maxRetries,
-                              overrideSize)),
-                      HTMLNode.text(HTMLEncoder.encode(mime))
-                    });
-          }
-        }
-
-        if ((!e.isFatal() || filterException != null)
-            && (ctx.isAllowedFullAccess() || !container.publicGatewayMode())) {
-          addDownloadOptions(
-              ctx,
-              optionList,
-              key,
-              mimeType,
-              filterException != null,
-              filterException != null,
-              core);
-          if (filterException == null)
-            optionList
-                .addChild("li")
-                .addChild(
-                    "a",
-                    "href",
-                    getLink(
-                        key,
-                        requestedMimeType,
-                        maxSize,
-                        httprequest.getParam("force", null),
-                        httprequest.isParameterSet("forcedownload"),
-                        maxRetries,
-                        overrideSize))
-                .addChild("#", l10n("retryNow"));
-        }
-
-        optionList
-            .addChild("li")
-            .addChild(
-                "a",
-                new String[] {"href", "title"},
-                new String[] {"/", NodeL10n.getBase().getString("Toadlet.homepage")},
-                l10n("abortToHomepage"));
-
-        optionList
-            .addChild("li")
-            .addChild(ctx.getPageMaker().createBackLink(ctx, l10n("goBackToPrev")));
-        this.writeHTMLReply(
-            ctx,
-            (e.mode == FetchExceptionMode.NOT_IN_ARCHIVE)
-                ? 404
-                : 500 /* close enough - FIXME probably should depend on status code */,
-            "Internal Error",
-            page.generate());
-      }
-    } catch (SocketException e) {
-      // Probably irrelevant
-      if (e.getMessage().equals("Broken pipe")) {
-        if (LOG.isDebugEnabled()) LOG.debug("Caught {} while handling GET", e.toString(), e);
-      } else {
-        LOG.info("Caught {}", e.toString());
-      }
-      throw e;
-    } catch (Throwable t) {
-      writeInternalError(t, ctx);
-    } finally {
-      if (fr == null && data != null) data.free();
-      if (fr != null) fr.close();
+      optionList
+          .addChild("li")
+          .addChild(
+              "a",
+              new String[] {"href", ATTR_TITLE},
+              new String[] {"/", NodeL10n.getBase().getString(TOADLET_HOMEPAGE_KEY)},
+              l10n(ABORT_TO_HOMEPAGE_KEY));
+      optionList
+          .addChild("li")
+          .addChild(ctx.getPageMaker().createBackLink(ctx, l10n(GO_BACK_TO_PREV_KEY)));
     }
-  }
 
-  private String getSchemeHostAndPort(ToadletContext ctx) {
-    // retrieve config from froxy
-    SubConfig fProxyConfig = core.getNode().getConfig().get("fproxy");
+    private boolean shouldRefetchLaterEdition(FProxyFetchResult result, FreenetURI key) {
+      try {
+        return result.getFetchCount() > 1
+            && !result.hasWaited()
+            && key.isUSK()
+            && context.uskManager.lookupKnownGood(USK.create(key)) > key.getSuggestedEdition();
+      } catch (MalformedURLException e) {
+        LOG.warn("Unable to create USK for {}", key, e);
+        return false;
+      }
+    }
 
-    Option<?> fProxyPort = fProxyConfig.getOption("port");
-    Option<?> fProxyBindTo = fProxyConfig.getOption("bindTo");
+    private String getSchemeHostAndPort(ToadletContext ctx) {
+      // retrieve config from froxy
+      SubConfig fProxyConfig = core.getNode().getConfig().get("fproxy");
 
-    // get uri host and headers
-    MultiValueTable<String, String> headers = ctx.getHeaders();
-    // TODO: parse the Forwarded header, too. Skipped here to reduce the scope.
-    String uriScheme = ctx.getUri().getScheme();
-    String uriHost = ctx.getUri().getHost();
+      Option<?> fProxyPort = fProxyConfig.getOption("port");
+      Option<?> fProxyBindTo = fProxyConfig.getOption("bindTo");
 
-    return UriFilterProxyHeaderParser.parse(fProxyPort, fProxyBindTo, uriScheme, uriHost, headers)
-        .toString();
-  }
+      // get uri host and headers
+      MultiValueTable<String, String> headers = ctx.getHeaders();
+      // Forwarded header parsing is handled by UriFilterProxyHeaderParser when present.
+      String uriScheme = ctx.getUri().getScheme();
+      String uriHost = ctx.getUri().getHost();
 
-  private boolean isBrowser(String ua) {
-    if (ua == null) return false;
-    return (ua.contains("Mozilla/") || ua.contains("Opera/"));
-  }
+      return UriFilterProxyHeaderParser.parse(fProxyPort, fProxyBindTo, uriScheme, uriHost, headers)
+          .toString();
+    }
 
-  private static String writeSizeAndMIME(HTMLNode fileInformationList, FetchException e) {
-    boolean finalized = e.finalizedSize();
-    long size = e.getExpectedSize();
-    String mime = e.getExpectedMimeType();
-    writeSizeAndMIME(fileInformationList, size, mime, finalized);
-    return mime;
-  }
+    private boolean isBrowser(String ua) {
+      if (ua == null) return false;
+      return (ua.contains("Mozilla/") || ua.contains("Opera/"));
+    }
 
-  private static void writeSizeAndMIME(
-      HTMLNode fileInformationList, long size, String mime, boolean finalized) {
-    if (size > 0) {
-      if (finalized) {
-        fileInformationList.addChild("li", (l10n("sizeLabel") + ' ') + SizeUtil.formatSize(size));
+    private String writeSizeAndMIME(HTMLNode fileInformationList, FetchException e) {
+      boolean finalized = e.finalizedSize();
+      long size = e.getExpectedSize();
+      String mime = e.getExpectedMimeType();
+      writeSizeAndMIME(fileInformationList, size, mime, finalized);
+      return mime;
+    }
+
+    private void writeSizeAndMIME(
+        HTMLNode fileInformationList, long size, String mime, boolean finalized) {
+      if (size > 0) {
+        if (finalized) {
+          fileInformationList.addChild("li", (l10n("sizeLabel") + ' ') + SizeUtil.formatSize(size));
+        } else {
+          fileInformationList.addChild(
+              "li", (l10n("sizeLabel") + ' ') + SizeUtil.formatSize(size) + l10n("mayChange"));
+        }
       } else {
+        fileInformationList.addChild("li", l10n("sizeUnknown"));
+      }
+      if (mime != null) {
         fileInformationList.addChild(
-            "li", (l10n("sizeLabel") + ' ') + SizeUtil.formatSize(size) + l10n("mayChange"));
+            "li",
+            NodeL10n.getBase()
+                .getString(
+                    L10N_PREFIX + (finalized ? "mimeType" : "expectedMimeType"),
+                    new String[] {"mime"},
+                    new String[] {mime}));
+      } else {
+        fileInformationList.addChild("li", l10n("unknownMIMEType"));
       }
-    } else {
-      fileInformationList.addChild("li", l10n("sizeUnknown"));
     }
-    if (mime != null) {
-      fileInformationList.addChild(
-          "li",
-          NodeL10n.getBase()
-              .getString(
-                  "FProxyToadlet." + (finalized ? "mimeType" : "expectedMimeType"),
-                  new String[] {"mime"},
-                  new String[] {mime}));
-    } else {
-      fileInformationList.addChild("li", l10n("unknownMIMEType"));
-    }
-  }
 
-  private String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase()
-        .getString("FProxyToadlet." + key, new String[] {pattern}, new String[] {value});
+    private String l10n(String key) {
+      return FProxyToadlet.l10n(key);
+    }
+
+    private String l10n(String key, String pattern, String value) {
+      return NodeL10n.getBase()
+          .getString(L10N_PREFIX + key, new String[] {pattern}, new String[] {value});
+    }
+
+    private String getLink(
+        FreenetURI uri,
+        String requestedMimeType,
+        long maxSize,
+        String force,
+        boolean forceDownload,
+        int maxRetries,
+        boolean appendMaxSize) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("/");
+      sb.append(uri.toASCIIString());
+      char c = '?';
+      if (requestedMimeType != null && !requestedMimeType.isEmpty()) {
+        sb.append(c).append("type=").append(URLEncoder.encode(requestedMimeType, false));
+        c = '&';
+      }
+      if (maxSize > 0 && appendMaxSize) {
+        sb.append(c).append("max-size=").append(maxSize);
+        c = '&';
+      }
+      if (force != null) {
+        sb.append(c).append("force=").append(force);
+        c = '&';
+      }
+      if (forceDownload) {
+        sb.append(c).append("forcedownload=true");
+        c = '&';
+      }
+      if (maxRetries >= -1) {
+        sb.append(c).append("max-retries=").append(maxRetries);
+      }
+      return sb.toString();
+    }
+
+    private String sanitizeReferer(ToadletContext ctx) {
+      // Similar logic exists in GenericFilterCallback; keep aligned if it changes.
+      String sanitizedReferer = ctx.getHeaders().getFirst("referer");
+      if (sanitizedReferer != null) {
+        try {
+          URI refererURI = new URI(URIPreEncoder.encode(sanitizedReferer));
+          String path = refererURI.getPath();
+          while (path.startsWith("/")) path = path.substring(1);
+          if (path.isEmpty()) return "/";
+          FreenetURI furi = new FreenetURI(path);
+          HTTPRequest req = new HTTPRequestImpl(refererURI, "GET");
+          String type = req.getParam("type");
+          sanitizedReferer = "/" + furi;
+          if (type != null && !type.isEmpty()) sanitizedReferer += "?type=" + type;
+        } catch (MalformedURLException e) {
+          sanitizedReferer = "/";
+          LOG.info("Caught MalformedURLException on the referer : {}", e.getMessage());
+        } catch (Exception t) {
+          LOG.error("Caught handling referrer: {} for {}", t.getMessage(), sanitizedReferer, t);
+          sanitizedReferer = null;
+        }
+      }
+      return sanitizedReferer;
+    }
   }
 
   public static String l10n(String key, String[] pattern, String[] value) {
-    return NodeL10n.getBase().getString("FProxyToadlet." + key, pattern, value);
-  }
-
-  private String getLink(
-      FreenetURI uri,
-      String requestedMimeType,
-      long maxSize,
-      String force,
-      boolean forceDownload,
-      int maxRetries,
-      boolean appendMaxSize) {
-    StringBuilder sb = new StringBuilder();
-    sb.append("/");
-    sb.append(uri.toASCIIString());
-    char c = '?';
-    if (requestedMimeType != null && !requestedMimeType.isEmpty()) {
-      sb.append(c).append("type=").append(URLEncoder.encode(requestedMimeType, false));
-      c = '&';
-    }
-    if (maxSize > 0 && appendMaxSize) {
-      sb.append(c).append("max-size=").append(maxSize);
-      c = '&';
-    }
-    if (force != null) {
-      sb.append(c).append("force=").append(force);
-      c = '&';
-    }
-    if (forceDownload) {
-      sb.append(c).append("forcedownload=true");
-      c = '&';
-    }
-    if (maxRetries >= -1) {
-      sb.append(c).append("max-retries=").append(maxRetries);
-      c = '&';
-    }
-    return sb.toString();
-  }
-
-  private String sanitizeReferer(ToadletContext ctx) {
-    // FIXME we do something similar in the GenericFilterCallback thingy?
-    String referer = ctx.getHeaders().getFirst("referer");
-    if (referer != null) {
-      try {
-        URI refererURI = new URI(URIPreEncoder.encode(referer));
-        String path = refererURI.getPath();
-        while (path.startsWith("/")) path = path.substring(1);
-        if (path.isEmpty()) return "/";
-        FreenetURI furi = new FreenetURI(path);
-        HTTPRequest req = new HTTPRequestImpl(refererURI, "GET");
-        String type = req.getParam("type");
-        referer = "/" + furi;
-        if (type != null && !type.isEmpty()) referer += "?type=" + type;
-      } catch (MalformedURLException e) {
-        referer = "/";
-        LOG.info("Caught MalformedURLException on the referer : {}", e.getMessage());
-      } catch (Throwable t) {
-        LOG.error("Caught handling referrer: {} for {}", t.toString(), referer, t);
-        referer = null;
-      }
-    }
-    return referer;
+    return NodeL10n.getBase().getString(L10N_PREFIX + key, pattern, value);
   }
 
   private static String getForceValue(FreenetURI key, long time) {
@@ -1523,332 +1713,10 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       bos.write(key.toString().getBytes(StandardCharsets.UTF_8));
       bos.write(Long.toString(time / FORCE_GRAIN_INTERVAL).getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
-      throw new Error(e);
+      throw new IllegalStateException(e);
     }
 
     return HexUtil.bytesToHex(SHA256.digest(bos.toByteArray()));
-  }
-
-  public static void maybeCreateFProxyEtc(
-      NodeClientCore core, Node node, Config config, SimpleToadletServer server)
-      throws IOException {
-
-    // FIXME how to change these on the fly when the interface language is changed?
-
-    HighLevelSimpleClient client =
-        core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
-
-    random = new byte[32];
-    core.getRandom().nextBytes(random);
-
-    FProxyFetchTracker fetchTracker =
-        new FProxyFetchTracker(
-            core.getClientContext(),
-            client.getFetchContext(),
-            new RequestClientBuilder().realTime().build());
-
-    FProxyToadlet fproxy = new FProxyToadlet(client, core, fetchTracker);
-    core.setFProxy(fproxy);
-
-    server.registerMenu(
-        "/", "FProxyToadlet.categoryBrowsing", "FProxyToadlet.categoryTitleBrowsing", null);
-    server.registerMenu(
-        "/downloads/", "FProxyToadlet.categoryQueue", "FProxyToadlet.categoryTitleQueue", null);
-    server.registerMenu(
-        "/friends/", "FProxyToadlet.categoryFriends", "FProxyToadlet.categoryTitleFriends", null);
-    server.registerMenu(
-        "/chat/", "FProxyToadlet.categoryChat", "FProxyToadlet.categoryTitleChat", null);
-    server.registerMenu(
-        "/alerts/", "FProxyToadlet.categoryStatus", "FProxyToadlet.categoryTitleStatus", null);
-    server.registerMenu(
-        "/seclevels/", "FProxyToadlet.categoryConfig", "FProxyToadlet.categoryTitleConfig", null);
-
-    server.register(
-        fproxy,
-        "FProxyToadlet.categoryBrowsing",
-        "/",
-        false,
-        "FProxyToadlet.welcomeTitle",
-        "FProxyToadlet.welcome",
-        false,
-        null);
-
-    DecodeToadlet decodeKeywordURL = new DecodeToadlet(client, core);
-    server.register(decodeKeywordURL, null, "/decode/", true, false);
-
-    InsertFreesiteToadlet siteinsert = new InsertFreesiteToadlet(client);
-    server.register(
-        siteinsert,
-        "FProxyToadlet.categoryBrowsing",
-        "/insertsite/",
-        true,
-        "FProxyToadlet.insertFreesiteTitle",
-        "FProxyToadlet.insertFreesite",
-        false,
-        null);
-
-    UserAlertsToadlet alerts = new UserAlertsToadlet(client);
-    server.register(
-        alerts,
-        "FProxyToadlet.categoryStatus",
-        "/alerts/",
-        true,
-        "FProxyToadlet.alertsTitle",
-        "FProxyToadlet.alerts",
-        true,
-        null);
-
-    QueueToadlet downloadToadlet = new QueueToadlet(core, core.getFCPServer(), client, false);
-    server.register(
-        downloadToadlet,
-        "FProxyToadlet.categoryQueue",
-        "/downloads/",
-        true,
-        "FProxyToadlet.downloadsTitle",
-        "FProxyToadlet.downloads",
-        false,
-        downloadToadlet);
-    LocalDownloadDirectoryToadlet localDownloadDirectoryToadlet =
-        new LocalDownloadDirectoryToadlet(core, client, "/downloads/");
-    server.register(
-        localDownloadDirectoryToadlet, null, localDownloadDirectoryToadlet.path(), true, false);
-    QueueToadlet uploadToadlet = new QueueToadlet(core, core.getFCPServer(), client, true);
-    server.register(
-        uploadToadlet,
-        "FProxyToadlet.categoryQueue",
-        "/uploads/",
-        true,
-        "FProxyToadlet.uploadsTitle",
-        "FProxyToadlet.uploads",
-        false,
-        uploadToadlet);
-
-    FileInsertWizardToadlet fiw = new FileInsertWizardToadlet(client, core);
-    server.register(
-        fiw,
-        "FProxyToadlet.categoryQueue",
-        FileInsertWizardToadlet.PATH,
-        true,
-        "FProxyToadlet.uploadFileWizardTitle",
-        "FProxyToadlet.uploadFileWizard",
-        false,
-        fiw);
-    uploadToadlet.setFIW(fiw);
-
-    LocalFileInsertToadlet localFileInsertToadlet = new LocalFileInsertToadlet(core, client);
-    server.register(localFileInsertToadlet, null, LocalFileInsertToadlet.PATH, true, false);
-
-    ContentFilterToadlet contentFilterToadlet = new ContentFilterToadlet(client, core);
-    server.register(
-        contentFilterToadlet,
-        "FProxyToadlet.categoryQueue",
-        ContentFilterToadlet.CONTENT_FILTER_PATH,
-        true,
-        "FProxyToadlet.filterFileTitle",
-        "FProxyToadlet.filterFile",
-        false,
-        contentFilterToadlet);
-
-    LocalFileFilterToadlet localFileFilterToadlet = new LocalFileFilterToadlet(core, client);
-    server.register(localFileFilterToadlet, null, LocalFileFilterToadlet.PATH, true, false);
-
-    SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(client, node);
-    server.register(symlinkToadlet, null, "/sl/", true, false);
-
-    SecurityLevelsToadlet seclevels = new SecurityLevelsToadlet(client, node, core);
-    server.register(
-        seclevels,
-        "FProxyToadlet.categoryConfig",
-        "/seclevels/",
-        true,
-        "FProxyToadlet.seclevelsTitle",
-        "FProxyToadlet.seclevels",
-        true,
-        null);
-
-    if (node.getPluginManager().isEnabled()) {
-      PproxyToadlet pproxy = new PproxyToadlet(client, node);
-      server.register(
-          pproxy,
-          "FProxyToadlet.categoryConfig",
-          "/plugins/",
-          true,
-          "FProxyToadlet.pluginsTitle",
-          "FProxyToadlet.plugins",
-          true,
-          null);
-    }
-
-    SubConfig[] sc = config.getConfigs();
-    Arrays.sort(sc);
-
-    for (SubConfig cfg : sc) {
-      String prefix = cfg.getPrefix();
-      if (prefix.equals("security-levels") || prefix.equals("pluginmanager")) continue;
-      LocalDirectoryConfigToadlet localDirectoryConfigToadlet =
-          new LocalDirectoryConfigToadlet(core, client, "/config/" + prefix);
-      ConfigToadlet configtoadlet =
-          new ConfigToadlet(localDirectoryConfigToadlet.path(), client, config, cfg, node, core);
-      server.register(
-          configtoadlet,
-          "FProxyToadlet.categoryConfig",
-          "/config/" + prefix,
-          true,
-          "ConfigToadlet." + prefix,
-          "ConfigToadlet.title." + prefix,
-          true,
-          configtoadlet);
-      server.register(
-          localDirectoryConfigToadlet, null, localDirectoryConfigToadlet.path(), true, false);
-    }
-
-    WelcomeToadlet welcometoadlet = new WelcomeToadlet(client, node);
-    server.register(welcometoadlet, null, "/welcome/", true, false);
-
-    ExternalLinkToadlet externalLinkToadlet = new ExternalLinkToadlet(client, node);
-    server.register(externalLinkToadlet, null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false);
-
-    // Core updater action endpoint (download/install)
-    network.crypta.node.updater.CoreActionToadlet coreActionToadlet =
-        new network.crypta.node.updater.CoreActionToadlet(client, node);
-    server.register(coreActionToadlet, null, CORE_UPDATE_PATH, true, false);
-
-    DarknetConnectionsToadlet friendsToadlet = new DarknetConnectionsToadlet(node, core, client);
-    server.register(
-        friendsToadlet,
-        "FProxyToadlet.categoryFriends",
-        "/friends/",
-        true,
-        "FProxyToadlet.friendsTitle",
-        "FProxyToadlet.friends",
-        true,
-        null);
-
-    DarknetAddRefToadlet addRefToadlet = new DarknetAddRefToadlet(node, client, friendsToadlet);
-    server.register(
-        addRefToadlet,
-        "FProxyToadlet.categoryFriends",
-        "/addfriend/",
-        true,
-        "FProxyToadlet.addFriendTitle",
-        "FProxyToadlet.addFriend",
-        true,
-        null);
-
-    OpennetConnectionsToadlet opennetToadlet = new OpennetConnectionsToadlet(node, core, client);
-    server.register(
-        opennetToadlet,
-        "FProxyToadlet.categoryStatus",
-        "/strangers/",
-        true,
-        "FProxyToadlet.opennetTitle",
-        "FProxyToadlet.opennet",
-        true,
-        opennetToadlet);
-
-    ChatForumsToadlet chatForumsToadlet = new ChatForumsToadlet(client, node.getPluginManager());
-    server.register(
-        chatForumsToadlet,
-        "FProxyToadlet.categoryChat",
-        "/chat/",
-        true,
-        "FProxyToadlet.chatForumsTitle",
-        "FProxyToadlet.chatForums",
-        true,
-        chatForumsToadlet);
-
-    N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(node, core, client);
-    server.register(n2ntmToadlet, null, "/send_n2ntm/", true, true);
-    LocalFileN2NMToadlet localFileN2NMToadlet = new LocalFileN2NMToadlet(core, client);
-    server.register(localFileN2NMToadlet, null, LocalFileN2NMToadlet.PATH, true, false);
-
-    BookmarkEditorToadlet bookmarkEditorToadlet = new BookmarkEditorToadlet(client, core);
-    server.register(bookmarkEditorToadlet, null, "/bookmarkEditor/", true, false);
-
-    BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(client);
-    server.register(browserTestToadlet, null, "/test/", true, false);
-
-    StatisticsToadlet statisticsToadlet = new StatisticsToadlet(node, core, client);
-    server.register(
-        statisticsToadlet,
-        "FProxyToadlet.categoryStatus",
-        "/stats/",
-        true,
-        "FProxyToadlet.statsTitle",
-        "FProxyToadlet.stats",
-        true,
-        null);
-
-    DiagnosticToadlet diagnosticToadlet = new DiagnosticToadlet(node, core.getFCPServer(), client);
-    server.register(
-        diagnosticToadlet,
-        "FProxyToadlet.categoryStatus",
-        "/diagnostic/",
-        true,
-        "FProxyToadlet.diagnosticTitle",
-        "FProxyToadlet.diagnostic",
-        true,
-        null);
-
-    ConnectivityToadlet connectivityToadlet = new ConnectivityToadlet(client, node);
-    server.register(
-        connectivityToadlet,
-        "FProxyToadlet.categoryStatus",
-        "/connectivity/",
-        true,
-        "ConnectivityToadlet.connectivityTitle",
-        "ConnectivityToadlet.connectivity",
-        true,
-        null);
-
-    TranslationToadlet translationToadlet = new TranslationToadlet(client, core);
-    server.register(
-        translationToadlet,
-        "FProxyToadlet.categoryConfig",
-        TranslationToadlet.TOADLET_URL,
-        true,
-        "TranslationToadlet.title",
-        "TranslationToadlet.titleLong",
-        true,
-        null);
-
-    FirstTimeWizardToadlet firstTimeWizardToadlet = new FirstTimeWizardToadlet(client, node, core);
-    server.register(firstTimeWizardToadlet, null, FirstTimeWizardToadlet.TOADLET_URL, true, false);
-
-    FirstTimeWizardNewToadlet firstTimeWizardNewToadlet =
-        new FirstTimeWizardNewToadlet(client, core, config);
-    server.register(
-        firstTimeWizardNewToadlet, null, FirstTimeWizardNewToadlet.TOADLET_URL, true, false);
-
-    SimpleHelpToadlet simpleHelpToadlet = new SimpleHelpToadlet(client, core);
-    server.register(simpleHelpToadlet, null, "/help/", true, false);
-
-    PushDataToadlet pushDataToadlet = new PushDataToadlet(client);
-    server.register(pushDataToadlet, null, pushDataToadlet.path(), true, false);
-
-    PushNotificationToadlet pushNotificationToadlet = new PushNotificationToadlet(client);
-    server.register(pushNotificationToadlet, null, pushNotificationToadlet.path(), true, false);
-
-    PushKeepaliveToadlet pushKeepaliveToadlet = new PushKeepaliveToadlet(client);
-    server.register(pushKeepaliveToadlet, null, pushKeepaliveToadlet.path(), true, false);
-
-    PushFailoverToadlet pushFailoverToadlet = new PushFailoverToadlet(client);
-    server.register(pushFailoverToadlet, null, pushFailoverToadlet.path(), true, false);
-
-    PushTesterToadlet pushTesterToadlet = new PushTesterToadlet(client);
-    server.register(pushTesterToadlet, null, pushTesterToadlet.path(), true, false);
-
-    PushLeavingToadlet pushLeavingToadlet = new PushLeavingToadlet(client);
-    server.register(pushLeavingToadlet, null, pushLeavingToadlet.path(), true, false);
-
-    ImageCreatorToadlet imageCreatorToadlet = new ImageCreatorToadlet(client);
-    server.register(imageCreatorToadlet, null, imageCreatorToadlet.path(), true, false);
-
-    LogWritebackToadlet logWritebackToadlet = new LogWritebackToadlet(client);
-    server.register(logWritebackToadlet, null, logWritebackToadlet.path(), true, false);
-
-    DismissAlertToadlet dismissAlertToadlet = new DismissAlertToadlet(client);
-    server.register(dismissAlertToadlet, null, dismissAlertToadlet.path(), true, false);
   }
 
   /**
@@ -1866,8 +1734,9 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     long[] result = new long[2];
     try {
       String[] units = hdrrange.split("=", 2);
-      // FIXME are MBytes and co valid? if so, we need to adjust the values and
-      // return always bytes
+      // If additional units (e.g. MBytes) should be supported, adjust parsing and normalize to
+      // bytes
+      // here.
       if (!"bytes".equals(units[0])) {
         throw new HTTPRangeException("Unknown unit, only 'bytes' supportet yet");
       }

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -523,12 +523,21 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
     private boolean handleStaticPaths()
         throws ToadletContextClosedException, IOException, RedirectException {
-      if (ks.equals("/")) {
-        handleRootWithoutKey();
-        return true;
+      switch (ks) {
+        case "/" -> {
+          handleRootWithoutKey();
+          return true;
+        }
+        case "/favicon.ico" -> {
+          return redirectTo(StaticToadlet.ROOT_URL + "favicon.ico");
+        }
+        case "/favicon.svg" -> {
+          return redirectTo(StaticToadlet.ROOT_URL + "favicon.svg");
+        }
+        default -> {
+          // fall through to additional path checks below
+        }
       }
-      if (ks.equals("/favicon.ico")) return redirectTo(StaticToadlet.ROOT_URL + "favicon.ico");
-      if (ks.equals("/favicon.svg")) return redirectTo(StaticToadlet.ROOT_URL + "favicon.svg");
       if (ks.startsWith("/feed/") || ks.equals("/feed")) return handleFeedRequest();
       if (ks.equals("/robots.txt") && ctx.doRobots()) {
         writeTextReply(ctx, 200, "Ok", "User-agent: *\nDisallow: /");
@@ -928,7 +937,6 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
             "/",
             key);
       }
-      String extrasNoMime = extras;
       String updatedExtras = appendRequestedMimeType(extras, requestedMimeType, mimeType);
       long size = data.size();
 
@@ -937,7 +945,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
       if (!force && !forceDownloadRequested) {
         mimeType = adjustMimeForBrowserWorkarounds(mimeType);
-        if (handleDangerousRss(data, mimeType, now, extrasNoMime, updatedExtras, referer)) {
+        if (handleDangerousRss(data, mimeType, now, extras, updatedExtras, referer)) {
           return;
         }
       }
@@ -958,7 +966,12 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     }
 
     private boolean handleDangerousRss(
-        Bucket data, String mimeType, long now, String extrasNoMime, String extras, String referrer)
+        Bucket data,
+        String mimeType,
+        long now,
+        String extras,
+        String updatedExtras,
+        String referrer)
         throws IOException, ToadletContextClosedException {
       if (!isSniffedAsFeed(data) || mimeType.startsWith("application/rss+xml")) {
         return false;
@@ -989,7 +1002,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
                         + key.toString()
                         + "?type=text/plain&force="
                         + getForceValue(key, now)
-                        + extrasNoMime),
+                        + extras),
                 HTMLNode.STRONG
               });
       option = optionList.addChild("li");
@@ -999,7 +1012,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
               "FProxyToadlet.openPossRSSForceDisk",
               new String[] {"link", "bold"},
               new HTMLNode[] {
-                HTMLNode.link("/" + key.toString() + "?forcedownload" + extras), HTMLNode.STRONG
+                HTMLNode.link("/" + key.toString() + "?forcedownload" + updatedExtras),
+                HTMLNode.STRONG
               });
       boolean mimeRss =
           mimeType.startsWith("application/xml+rss") || mimeType.startsWith("text/xml");
@@ -1012,7 +1026,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
                 new String[] {"link", "bold", "mime"},
                 new HTMLNode[] {
                   HTMLNode.link(
-                      "/" + key.toString() + "?force=" + getForceValue(key, now) + extras),
+                      "/" + key.toString() + "?force=" + getForceValue(key, now) + updatedExtras),
                   HTMLNode.STRONG,
                   HTMLNode.text(mimeType)
                 });
@@ -1029,7 +1043,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
                         + key.toString()
                         + "?type=application/xml+rss&force="
                         + getForceValue(key, now)
-                        + extrasNoMime),
+                        + extras),
                 HTMLNode.STRONG
               });
       addDownloadOptions(ctx, optionList, key, mimeType, true, false, core);
@@ -1198,17 +1212,18 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
     private void handleRedirectException(FetchException e)
         throws ToadletContextClosedException, IOException, RedirectException {
+      FreenetURI redirectUri = Objects.requireNonNull(e.newURI, "redirect URI is null");
       if (accept != null
           && (accept.startsWith("text/css") || accept.startsWith("image/"))
           && recursion + 1 < MAX_RECURSION) {
-        followRedirectRecursively(e);
+        followRedirectRecursively(redirectUri);
         return;
       }
       Toadlet.writePermanentRedirect(
           ctx,
           e.getMessage(),
           getLink(
-              e.newURI,
+              redirectUri,
               requestedMimeType,
               maxSize,
               httprequest.getParam(PARAM_FORCE, null),
@@ -1217,11 +1232,11 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
               overrideSize));
     }
 
-    private void followRedirectRecursively(FetchException e)
+    private void followRedirectRecursively(FreenetURI redirectUri)
         throws RedirectException, ToadletContextClosedException, IOException {
       String link =
           getLink(
-              e.newURI,
+              redirectUri,
               requestedMimeType,
               maxSize,
               httprequest.getParam(PARAM_FORCE, null),
@@ -1314,10 +1329,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
       HTMLNode infobox = contentNode.addChild("div", CLASS_ATTRIBUTE, INFOBOX_ERROR_CLASS);
       infobox.addChild(
-          "div",
-          CLASS_ATTRIBUTE,
-          INFOBOX_HEADER_CLASS,
-          l10n("errorWithReason", "error", e.getShortMessage()));
+          "div", CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, l10nErrorWithReason(e.getShortMessage()));
       HTMLNode infoboxContent = infobox.addChild("div", CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
       HTMLNode fileInformationList = infoboxContent.addChild("ul");
       HTMLNode option = fileInformationList.addChild("li");
@@ -1636,9 +1648,10 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       return FProxyToadlet.l10n(key);
     }
 
-    private String l10n(String key, String pattern, String value) {
+    private String l10nErrorWithReason(String errorMessage) {
       return NodeL10n.getBase()
-          .getString(L10N_PREFIX + key, new String[] {pattern}, new String[] {value});
+          .getString(
+              L10N_PREFIX + "errorWithReason", new String[] {"error"}, new String[] {errorMessage});
     }
 
     private String getLink(

--- a/src/main/java/network/crypta/clients/http/HTTPRangeException.java
+++ b/src/main/java/network/crypta/clients/http/HTTPRangeException.java
@@ -3,14 +3,36 @@ package network.crypta.clients.http;
 import java.io.Serial;
 import network.crypta.support.LightweightException;
 
-/** If thrown, something wrong with http range */
+/**
+ * Signals invalid or unsupported HTTP Range headers encountered while parsing client requests.
+ *
+ * <p>The exception is raised when range syntax is malformed (missing bounds, wrong units, negative
+ * offsets) or when offsets conflict with expected ordering. Callers typically surface this as a 416
+ * response or fall back to sending the entire resource. The class is lightweight and intended for
+ * control flow rather than detailed error reporting; it carries only a message or root cause.
+ *
+ * <p>Typical usage wraps the parsing routine: if {@link HTTPRangeException} is thrown, respond with
+ * an error status instead of attempting partial I/O. Instances are immutable and thread-safe.
+ */
 public class HTTPRangeException extends LightweightException {
   @Serial private static final long serialVersionUID = -1;
 
+  /**
+   * Creates a new range exception with the supplied root cause.
+   *
+   * @param cause underlying parsing or numeric error that triggered the range failure; must be
+   *     non-null for diagnostic clarity.
+   */
   public HTTPRangeException(Throwable cause) {
     super(cause);
   }
 
+  /**
+   * Creates a new range exception with a descriptive message.
+   *
+   * @param msg human-readable description of the invalid range condition; empty messages are
+   *     accepted but discouraged for troubleshooting.
+   */
   public HTTPRangeException(String msg) {
     super(msg);
   }

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -163,26 +163,26 @@ public final class SimpleToadletServer
   private static class FProxyPassthruMaxSizeNoProgress extends LongCallback {
     @Override
     public Long get() {
-      return FProxyToadlet.MAX_LENGTH_NO_PROGRESS;
+      return FProxyToadlet.getMaxLengthNoProgress();
     }
 
     @Override
     public void set(Long val) throws InvalidConfigValueException {
       if (get().equals(val)) return;
-      FProxyToadlet.MAX_LENGTH_NO_PROGRESS = val;
+      FProxyToadlet.setMaxLengthNoProgress(val);
     }
   }
 
   private static class FProxyPassthruMaxSizeProgress extends LongCallback {
     @Override
     public Long get() {
-      return FProxyToadlet.MAX_LENGTH_WITH_PROGRESS;
+      return FProxyToadlet.getMaxLengthWithProgress();
     }
 
     @Override
     public void set(Long val) throws InvalidConfigValueException {
       if (get().equals(val)) return;
-      FProxyToadlet.MAX_LENGTH_WITH_PROGRESS = val;
+      FProxyToadlet.setMaxLengthWithProgress(val);
     }
   }
 
@@ -426,13 +426,7 @@ public final class SimpleToadletServer
     pushDataManager = new PushDataManager(getTicker());
     intervalPushManager = new IntervalPusherManager(getTicker(), pushDataManager);
     bookmarkManager = new BookmarkManager(core, publicGatewayMode());
-    try {
-      FProxyToadlet.maybeCreateFProxyEtc(core, node, node.getConfig(), this);
-    } catch (IOException e) {
-      LOG.error("Could not start fproxy: {}", e.toString(), e);
-      System.err.println("Could not start fproxy:");
-      e.printStackTrace();
-    }
+    FProxyRegistrar.maybeCreateFProxyEtc(core, node, node.getConfig(), this);
   }
 
   public void setCore(NodeClientCore core) {
@@ -788,7 +782,7 @@ public final class SimpleToadletServer
 
     fproxyConfig.register(
         "passthroughMaxSize",
-        FProxyToadlet.MAX_LENGTH_NO_PROGRESS,
+        FProxyToadlet.getMaxLengthNoProgress(),
         configItemOrder++,
         true,
         false,
@@ -796,10 +790,10 @@ public final class SimpleToadletServer
         "SimpleToadletServer.passthroughMaxSizeLong",
         new FProxyPassthruMaxSizeNoProgress(),
         true);
-    FProxyToadlet.MAX_LENGTH_NO_PROGRESS = fproxyConfig.getLong("passthroughMaxSize");
+    FProxyToadlet.setMaxLengthNoProgress(fproxyConfig.getLong("passthroughMaxSize"));
     fproxyConfig.register(
         "passthroughMaxSizeProgress",
-        FProxyToadlet.MAX_LENGTH_WITH_PROGRESS,
+        FProxyToadlet.getMaxLengthWithProgress(),
         configItemOrder++,
         true,
         false,
@@ -807,12 +801,12 @@ public final class SimpleToadletServer
         "SimpleToadletServer.passthroughMaxSizeProgressLong",
         new FProxyPassthruMaxSizeProgress(),
         true);
-    FProxyToadlet.MAX_LENGTH_WITH_PROGRESS = fproxyConfig.getLong("passthroughMaxSizeProgress");
+    FProxyToadlet.setMaxLengthWithProgress(fproxyConfig.getLong("passthroughMaxSizeProgress"));
     System.out.println(
         "Set fproxy max length to "
-            + FProxyToadlet.MAX_LENGTH_NO_PROGRESS
+            + FProxyToadlet.getMaxLengthNoProgress()
             + " and max length with progress to "
-            + FProxyToadlet.MAX_LENGTH_WITH_PROGRESS
+            + FProxyToadlet.getMaxLengthWithProgress()
             + " = "
             + fproxyConfig.getLong("passthroughMaxSizeProgress"));
 

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -137,7 +137,7 @@ public class BookmarkManager implements RequestClient {
             .prefetch(
                 uri,
                 MINUTES.toMillis(60),
-                FProxyToadlet.MAX_LENGTH_WITH_PROGRESS,
+                FProxyToadlet.getMaxLengthWithProgress(),
                 null,
                 PRIORITY_PROGRESS);
         return;

--- a/src/test/java/network/crypta/clients/http/FProxyToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyToadletTest.java
@@ -1,0 +1,141 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.async.ClientContext;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FProxyToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+
+  @Mock private NodeClientCore core;
+
+  @Mock private FProxyFetchTracker fetchTracker;
+
+  @Mock private ClientContext clientContext;
+
+  @Test
+  void constructor_setsMaxLengthsOnClient() {
+    when(core.getClientContext()).thenReturn(clientContext);
+
+    new FProxyToadlet(client, core, fetchTracker);
+
+    verify(client).setMaxLength(FProxyToadlet.getMaxLengthNoProgress());
+    verify(client).setMaxIntermediateLength(FProxyToadlet.getMaxLengthNoProgress());
+  }
+
+  @Test
+  void allowPOSTWithoutPassword_alwaysReturnsTrue() {
+    FProxyToadlet toadlet = newFProxy();
+
+    assertTrue(toadlet.allowPOSTWithoutPassword());
+  }
+
+  @Test
+  void handleMethodPOST_rootPath_redirectsToWelcome() {
+    FProxyToadlet toadlet = newFProxy();
+    URI uri = URI.create("/");
+
+    RedirectException exception =
+        assertThrows(
+            RedirectException.class,
+            () ->
+                toadlet.handleMethodPOST(uri, mock(HTTPRequest.class), mock(ToadletContext.class)));
+
+    assertEquals(URI.create("/welcome/"), exception.getTarget());
+  }
+
+  @Test
+  void handleMethodPOST_servletPath_redirectsToWelcome() {
+    FProxyToadlet toadlet = newFProxy();
+    URI uri = URI.create("/servlet/sample");
+
+    RedirectException exception =
+        assertThrows(
+            RedirectException.class,
+            () ->
+                toadlet.handleMethodPOST(uri, mock(HTTPRequest.class), mock(ToadletContext.class)));
+
+    assertEquals(URI.create("/welcome/"), exception.getTarget());
+  }
+
+  @Test
+  void handleMethodPOST_otherPath_doesNothing() {
+    FProxyToadlet toadlet = newFProxy();
+    URI uri = URI.create("/other");
+
+    assertDoesNotThrow(
+        () -> toadlet.handleMethodPOST(uri, mock(HTTPRequest.class), mock(ToadletContext.class)));
+  }
+
+  @Test
+  void parseRange_withExplicitEnd_returnsBounds() throws Exception {
+    long[] result = invokeParseRange("bytes=0-499");
+
+    assertArrayEquals(new long[] {0L, 499L}, result);
+  }
+
+  @Test
+  void parseRange_withoutEnd_setsMinusOne() throws Exception {
+    long[] result = invokeParseRange("bytes=500-");
+
+    assertArrayEquals(new long[] {500L, -1L}, result);
+  }
+
+  @Test
+  void parseRange_withInvalidUnit_throwsException() {
+    assertThrows(HTTPRangeException.class, () -> invokeParseRange("items=0-10"));
+  }
+
+  @Test
+  void parseRange_whenFromExceedsTo_throwsException() {
+    assertThrows(HTTPRangeException.class, () -> invokeParseRange("bytes=10-5"));
+  }
+
+  @Test
+  void lifecycleFlags_returnExpectedValues() {
+    FProxyToadlet toadlet = newFProxy();
+
+    assertTrue(toadlet.realTimeFlag());
+    assertEquals("/", toadlet.path());
+    assertFalse(toadlet.persistent());
+  }
+
+  private FProxyToadlet newFProxy() {
+    when(core.getClientContext()).thenReturn(clientContext);
+    return new FProxyToadlet(client, core, fetchTracker);
+  }
+
+  private long[] invokeParseRange(String value) throws Exception {
+    Method parseRange = FProxyToadlet.class.getDeclaredMethod("parseRange", String.class);
+    parseRange.setAccessible(true);
+    try {
+      return (long[]) parseRange.invoke(null, value);
+    } catch (Exception e) {
+      if (e.getCause() != null && e.getCause() instanceof Exception cause) {
+        throw cause;
+      }
+
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- harden FProxyToadlet redirects (static path switch, null-safe redirect URI, RSS extras handling, localized error header helper)
- add detailed Javadoc for FProxy registrar/toadlet and HTTP range parsing
- introduce FProxyToadlet unit tests covering POST redirects and range parsing utilities

## Testing
- Not run (not requested)