### PR TITLE
fix: improve N2NTM toadlet handling

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -292,7 +292,7 @@ final class FProxyRegistrar {
         true,
         chatForumsToadlet);
 
-    N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(node, core, client);
+    N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(node, core, client, "/friends/");
     server.register(n2ntmToadlet, null, "/send_n2ntm/", true, true);
     LocalFileN2NMToadlet localFileN2NMToadlet = new LocalFileN2NMToadlet(core, client);
     server.register(localFileN2NMToadlet, null, LocalFileN2NMToadlet.PATH, true, false);

--- a/src/main/java/network/crypta/clients/http/N2NTMToadlet.java
+++ b/src/main/java/network/crypta/clients/http/N2NTMToadlet.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
@@ -20,22 +21,87 @@ import network.crypta.support.api.HTTPUploadedFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Toadlet responsible for composing and sending node-to-node text messages (N2NTM) and optional
+ * file offers to trusted peers through the web interface.
+ *
+ * <p>The handler renders a form where users pick darknet friends, type a message, and, in advanced
+ * mode, attach either a local file or an uploaded payload. It enforces message length limits, caps
+ * attachments to the larger of 1&nbsp;MiB or five percent of the memory ceiling, and invokes {@link
+ * DarknetPeerNode#sendTextFeed(String)} plus the peer file-offer routine for each selected peer.
+ * The UI records per-peer statuses so queued, sent, or delayed outcomes stay visible alongside the
+ * original text.
+ *
+ * <p>State is limited to the embedded file browser toadlet and friends redirect path, so instances
+ * stay safe to reuse across concurrent requests when the backing {@link Node} and {@link
+ * HighLevelSimpleClient} are thread-safe. Use it when you need a simple web workflow that pairs
+ * short text with optional binary offers without exposing transport details.
+ */
 public class N2NTMToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(N2NTMToadlet.class);
 
+  private static final String L10N_PREFIX = "N2NTMToadlet.";
+  private static final String ATTR_CLASS = "class";
+  private static final String INFOBOX_CONTENT = "infobox-content";
+  private static final String ATTR_TITLE = "title";
+  private static final String ATTR_VALUE = "value";
+  private static final String RETURN_TO_FRIENDS = "returnToFriends";
+  private static final String FRIENDS = "friends";
+  private static final String N2NM_UPLOAD = "n2nm-upload";
+  private static final String INPUT_TAG = "input";
+  private static final long ONE_MEBIBYTE = 1024L * 1024L;
+  private static final int MESSAGE_HEAD_LIMIT = 1024;
+  private static final int MESSAGE_MAX_LENGTH = 1024 * 128;
+  private static final int MESSAGE_PART_LIMIT = 1024 * 1024;
+
   private final Node node;
   private final LocalFileN2NMToadlet browser;
+  private final String friendsPath;
 
-  protected N2NTMToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
+  /**
+   * Builds a new N2NTM toadlet wired to the supplied node services and localization context.
+   *
+   * @param n owning {@link Node} exposing darknet peers; keep reachable while this lives.
+   * @param core client core powering the file browser for attachment resolution; not {@code null}.
+   * @param client HTTP client for the base {@link Toadlet}; must outlive this instance.
+   * @param friendsPath path to the friends listing for redirects, typically with leading slash.
+   */
+  protected N2NTMToadlet(
+      Node n, NodeClientCore core, HighLevelSimpleClient client, String friendsPath) {
     super(client);
     browser = new LocalFileN2NMToadlet(core, client);
     this.node = n;
+    this.friendsPath = friendsPath;
   }
 
+  /**
+   * Returns the companion toadlet that renders the local file browser used for selecting
+   * attachments.
+   *
+   * @return file browser toadlet sharing the client core; keep lifecycle stable during requests.
+   */
   public Toadlet getBrowser() {
     return browser;
   }
 
+  /**
+   * Handles HTTP {@code GET} requests by rendering the message composition form or redirecting
+   * unqualified calls back to the friends list.
+   *
+   * <p>When a specific peer hash code is present, the method resolves it to a darknet peer, renders
+   * a pre-populated form targeting that peer, and responds with localized content. If the hash code
+   * cannot be resolved, an error infobox with navigation links is returned instead. Requests
+   * failing the full-access check receive no further processing. Calls without a peer selector are
+   * sent to the friends page, preserving the expected navigation flow.
+   *
+   * @param uri request URI used for logging and routing; may be {@code null}.
+   * @param request HTTP request wrapper providing parameters such as {@code peernode_hashcode}.
+   * @param ctx context supplying localization, access checks, and response helpers; keep it open.
+   * @throws ToadletContextClosedException if the response stream closes before writing completes.
+   * @throws IOException if writing the generated HTML fails.
+   * @throws RedirectException if a redirect is triggered by the underlying page maker.
+   */
+  @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
 
@@ -45,54 +111,47 @@ public class N2NTMToadlet extends Toadlet {
       PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessage"), ctx);
       HTMLNode contentNode = page.getContentNode();
 
-      String peernode_name = null;
-      String input_hashcode_string = request.getParam("peernode_hashcode");
-      int input_hashcode = -1;
+      String peerNodeName = null;
+      String inputHashcodeString = request.getParam("peernode_hashcode");
+      int inputHashcode = -1;
       try {
-        input_hashcode = Integer.parseInt(input_hashcode_string);
+        inputHashcode = Integer.parseInt(inputHashcodeString);
       } catch (NumberFormatException e) {
         // ignore here, handle below
       }
-      if (input_hashcode != -1) {
+      if (inputHashcode != -1) {
         DarknetPeerNode[] peerNodes = node.getDarknetConnections();
         for (DarknetPeerNode pn : peerNodes) {
-          int peer_hashcode = pn.hashCode();
-          if (peer_hashcode == input_hashcode) {
-            peernode_name = pn.getName();
+          int peerHashcode = pn.hashCode();
+          if (peerHashcode == inputHashcode) {
+            peerNodeName = pn.getName();
             break;
           }
         }
       }
-      if (peernode_name == null) {
+      if (peerNodeName == null) {
         contentNode.addChild(
-            createPeerInfobox(
-                "infobox-error",
+            createPeerNotFoundInfobox(
                 l10n("peerNotFoundTitle"),
-                l10n("peerNotFoundWithHash", "hash", input_hashcode_string)));
+                NodeL10n.getBase()
+                    .getString(
+                        L10N_PREFIX + "peerNotFoundWithHash",
+                        new String[] {"hash"},
+                        new String[] {inputHashcodeString})));
         this.writeHTMLReply(ctx, 200, "OK", page.generate());
         return;
       }
       HashMap<String, String> peers = new HashMap<>();
-      peers.put(input_hashcode_string, peernode_name);
+      peers.put(inputHashcodeString, peerNodeName);
       createN2NTMSendForm(ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
       this.writeHTMLReply(ctx, 200, "OK", page.generate());
       return;
     }
-    MultiValueTable<String, String> headers = MultiValueTable.from("Location", "/friends/");
-    ctx.sendReplyHeaders(302, "Found", headers, null, 0);
-  }
-
-  private String l10n(String key, String[] pattern, String[] value) {
-    return NodeL10n.getBase().getString("N2NTMToadlet." + key, pattern, value);
-  }
-
-  private String l10n(String key, String pattern, String value) {
-    return NodeL10n.getBase()
-        .getString("N2NTMToadlet." + key, new String[] {pattern}, new String[] {value});
+    sendFriendsRedirect(ctx);
   }
 
   private static String l10n(String key) {
-    return NodeL10n.getBase().getString("N2NTMToadlet." + key);
+    return NodeL10n.getBase().getString(L10N_PREFIX + key);
   }
 
   /*
@@ -100,202 +159,381 @@ public class N2NTMToadlet extends Toadlet {
    */
   private static long maxSize() {
     long memory = NodeStarter.getMemoryLimitBytes();
-    if (memory == Long.MAX_VALUE || memory <= 0) return 1024 * 1024;
+    if (memory == Long.MAX_VALUE || memory <= 0) return ONE_MEBIBYTE;
     long maxMem = Math.round(0.05 * memory);
-    return Math.max(maxMem, 1024 * 1024);
+    return Math.max(maxMem, ONE_MEBIBYTE);
   }
 
-  private static HTMLNode createPeerInfobox(String infoboxType, String header, String message) {
-    HTMLNode infobox = new HTMLNode("div", "class", "infobox " + infoboxType);
-    infobox.addChild("div", "class", "infobox-header", header);
-    HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
+  private HTMLNode createPeerNotFoundInfobox(String header, String message) {
+    HTMLNode infobox = new HTMLNode("div", ATTR_CLASS, "infobox infobox-error");
+    infobox.addChild("div", ATTR_CLASS, "infobox-header", header);
+    HTMLNode infoboxContent = infobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT);
     infoboxContent.addChild("#", message);
     HTMLNode list = infoboxContent.addChild("ul");
     Toadlet.addHomepageLink(list);
     list.addChild("li")
         .addChild(
             "a",
-            new String[] {"href", "title"},
-            new String[] {"/friends/", l10n("returnToFriends")},
-            l10n("friends"));
+            new String[] {"href", ATTR_TITLE},
+            new String[] {friendsPath, l10n(RETURN_TO_FRIENDS)},
+            l10n(FRIENDS));
     return infobox;
   }
 
+  /**
+   * Processes {@code POST} submissions for sending N2NTM messages or delegating to the local file
+   * browser.
+   *
+   * <p>This handler first enforces full-access permissions, then honors browse requests by issuing
+   * a redirect to the file browser toadlet. For send actions, it validates message length, resolves
+   * both uploaded and locally selected files subject to size caps, and attempts to deliver text and
+   * file offers to each chosen peer. Per-peer outcomes are rendered in a status table while the
+   * original message body is echoed for confirmation. Invalid inputs (oversized payloads,
+   * unreadable files, or missing peers) result in localized error infoboxes and do not mutate peer
+   * state.
+   *
+   * @param uri request URI logged for observability; may be {@code null} internally.
+   * @param request multipart HTTP request holding message text, peer selectors, and optional upload
+   *     parts.
+   * @param ctx active context used for access checks, page generation, and response dispatch; keep
+   *     it open while processing.
+   * @throws ToadletContextClosedException if the client disconnects while the response is being
+   *     written.
+   * @throws IOException if writing responses or reading uploads encounters an I/O failure.
+   * @throws RedirectException if the method triggers a redirect (e.g., browse delegation) during
+   *     processing.
+   */
   public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
 
     if (!ctx.checkFullAccess(this)) return;
 
-    // Browse button clicked. Redirect.
+    if (uri != null && LOG.isDebugEnabled()) {
+      LOG.debug("handleMethodPOST for {}", uri);
+    }
+
+    if (handleBrowseRedirect(request)) {
+      return;
+    }
+
+    if (isSendRequest(request)) {
+      processSendRequest(request, ctx);
+      return;
+    }
+    sendFriendsRedirect(ctx);
+  }
+
+  private boolean handleBrowseRedirect(HTTPRequest request) throws RedirectException {
     if (request.isPartSet("n2nm-browse")) {
       try {
         throw new RedirectException(LocalFileN2NMToadlet.PATH);
       } catch (URISyntaxException e) {
-        // Should be impossible because the browser is registered with .PATH.
+        LOG.error("Unexpected LocalFileN2NMToadlet path", e);
       }
-      return;
+      return true;
     }
+    return false;
+  }
 
-    if (request.isPartSet("n2nm-upload")
+  private boolean isSendRequest(HTTPRequest request) {
+    return request.isPartSet(N2NM_UPLOAD)
         || request.isPartSet(LocalFileBrowserToadlet.selectFile)
-        || request.isPartSet("send")) {
-      File filename = null;
-      String message = request.getPartAsStringFailsafe("message", 1024 * 1024);
-      message = message.trim();
-      String messageHead = message.substring(0, Math.min(message.length(), 1024));
-      if (message.length() > 1024 * 128) {
-        this.writeTextReply(ctx, 400, "Bad request", l10n("tooLong"));
-        return;
-      }
-      PageNode page = ctx.getPageMaker().getPageNode(l10n("processingSend"), ctx);
-      HTMLNode contentNode = page.getContentNode();
-      HTMLNode peerTableInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
-      DarknetPeerNode[] peerNodes = node.getDarknetConnections();
-      if (request.isPartSet(LocalFileBrowserToadlet.selectFile)) {
-        String fnam = request.getPartAsStringFailsafe("filename", 1024);
-        if (fnam != null && !fnam.isEmpty()) {
-          filename = new File(fnam);
-          if (!(filename.exists() && filename.canRead())) {
-            peerTableInfobox.addChild("#", l10n("noSuchFileOrCannotRead"));
-            Toadlet.addHomepageLink(peerTableInfobox);
-            this.writeHTMLReply(ctx, 400, "OK", page.generate());
-            return;
-          }
-        }
-      }
+        || request.isPartSet("send");
+  }
 
-      HTMLNode peerTable = peerTableInfobox.addChild("table", "class", "n2ntm-send-statuses");
-      HTMLNode peerTableHeaderRow = peerTable.addChild("tr");
-      peerTableHeaderRow.addChild("th", l10n("peerName"));
-      peerTableHeaderRow.addChild("th", l10n("sendStatus"));
-      for (DarknetPeerNode pn : peerNodes) {
-        if (request.isPartSet("node_" + pn.hashCode())) {
-          int status;
-
-          if (filename != null) {
-            try {
-              status = pn.sendFileOffer(filename, messageHead);
-            } catch (IOException e) {
-              peerTableInfobox.addChild("#", l10n("noSuchFileOrCannotRead"));
-              Toadlet.addHomepageLink(peerTableInfobox);
-              addUnsentMessageTextInfo(peerTableInfobox, message);
-              this.writeHTMLReply(ctx, 200, "OK", page.generate());
-              return;
-            }
-          } else if (request.isPartSet("n2nm-upload")) {
-            try {
-              HTTPUploadedFile file = request.getUploadedFile("n2nm-upload");
-              if (!file.getFilename().isEmpty()) {
-                long size = request.getUploadedFile("n2nm-upload").getData().size();
-                if (size > 0) {
-                  long limit = maxSize();
-                  if (size > limit) {
-                    peerTableInfobox.addChild(
-                        "#",
-                        l10n(
-                            "tooLarge",
-                            new String[] {"attempt", "limit"},
-                            new String[] {
-                              SizeUtil.formatSize(size, true), SizeUtil.formatSize(limit, true)
-                            }));
-                    HTMLNode list = peerTableInfobox.addChild("ul");
-                    Toadlet.addHomepageLink(list);
-                    list.addChild("li")
-                        .addChild(
-                            "a",
-                            new String[] {"href", "title"},
-                            new String[] {"/friends/", l10n("returnToFriends")},
-                            l10n("friends"));
-                    addUnsentMessageTextInfo(peerTableInfobox, message);
-                    this.writeHTMLReply(ctx, 200, "OK", page.generate());
-                    return;
-                  }
-                  status = pn.sendFileOffer(request.getUploadedFile("n2nm-upload"), messageHead);
-                }
-              }
-            } catch (IOException e) {
-              peerTableInfobox.addChild("#", l10n("uploadFailed"));
-              Toadlet.addHomepageLink(peerTableInfobox);
-              addUnsentMessageTextInfo(peerTableInfobox, message);
-              this.writeHTMLReply(ctx, 200, "OK", page.generate());
-              return;
-            }
-          }
-          status = pn.sendTextFeed(message);
-
-          String sendStatusShort;
-          String sendStatusLong;
-          String sendStatusClass;
-          if (status == PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF) {
-            sendStatusShort = l10n("delayedTitle");
-            sendStatusLong = l10n("delayed");
-            sendStatusClass = "n2ntm-send-delayed";
-            LOG.info("Sent N2NTM to '" + pn.getName() + "': " + message);
-          } else if (status == PeerManager.PEER_NODE_STATUS_CONNECTED) {
-            sendStatusShort = l10n("sentTitle");
-            sendStatusLong = l10n("sent");
-            sendStatusClass = "n2ntm-send-sent";
-            LOG.info("Sent N2NTM to '" + pn.getName() + "': " + message);
-          } else {
-            sendStatusShort = l10n("queuedTitle");
-            sendStatusLong = l10n("queued");
-            sendStatusClass = "n2ntm-send-queued";
-            LOG.info("Queued N2NTM to '" + pn.getName() + "': " + message);
-          }
-          HTMLNode peerRow = peerTable.addChild("tr");
-          peerRow.addChild("td", "class", "peer-name").addChild("#", pn.getName());
-          peerRow
-              .addChild("td", "class", sendStatusClass)
-              .addChild(
-                  "span",
-                  new String[] {"title", "style"},
-                  new String[] {sendStatusLong, "border-bottom: 1px dotted; cursor: help;"},
-                  sendStatusShort);
-        }
-      }
-      HTMLNode infoboxContent = peerTableInfobox.addChild("div", "class", "n2ntm-message-text");
-      infoboxContent.addChild("#", message);
-      HTMLNode list = peerTableInfobox.addChild("ul");
-      Toadlet.addHomepageLink(list);
-      list.addChild("li")
-          .addChild(
-              "a",
-              new String[] {"href", "title"},
-              new String[] {"/friends/", l10n("returnToFriends")},
-              l10n("friends"));
-      this.writeHTMLReply(ctx, 200, "OK", page.generate());
+  private void processSendRequest(HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    String message = request.getPartAsStringFailsafe("message", MESSAGE_PART_LIMIT).trim();
+    if (message.length() > MESSAGE_MAX_LENGTH) {
+      this.writeTextReply(ctx, 400, "Bad request", l10n("tooLong"));
       return;
     }
-    MultiValueTable<String, String> headers = MultiValueTable.from("Location", "/friends/");
+    String messageHead = message.substring(0, Math.min(message.length(), MESSAGE_HEAD_LIMIT));
+
+    PageNode page = ctx.getPageMaker().getPageNode(l10n("processingSend"), ctx);
+    HTMLNode contentNode = page.getContentNode();
+    HTMLNode peerTableInfobox = contentNode.addChild("div", ATTR_CLASS, "infobox infobox-normal");
+
+    FileResolution fileResolution = resolveSelectedFile(request, peerTableInfobox, page, ctx);
+    if (fileResolution.abortProcessing()) {
+      return;
+    }
+    File filename = fileResolution.file();
+
+    UploadResolution uploadResolution =
+        resolveUploadedFile(request, peerTableInfobox, page, ctx, message);
+    if (uploadResolution.abortProcessing()) {
+      return;
+    }
+    HTTPUploadedFile uploadedFile = uploadResolution.file();
+
+    DarknetPeerNode[] peerNodes = node.getDarknetConnections();
+
+    HTMLNode peerTable = peerTableInfobox.addChild("table", ATTR_CLASS, "n2ntm-send-statuses");
+    HTMLNode peerTableHeaderRow = peerTable.addChild("tr");
+    peerTableHeaderRow.addChild("th", l10n("peerName"));
+    peerTableHeaderRow.addChild("th", l10n("sendStatus"));
+
+    SendContext sendContext =
+        new SendContext(message, messageHead, filename, uploadedFile, peerTableInfobox, page, ctx);
+
+    boolean aborted = sendToSelectedPeers(request, peerNodes, peerTable, sendContext);
+    if (aborted) {
+      return;
+    }
+
+    HTMLNode infoboxContent = peerTableInfobox.addChild("div", ATTR_CLASS, "n2ntm-message-text");
+    infoboxContent.addChild("#", message);
+    HTMLNode list = peerTableInfobox.addChild("ul");
+    Toadlet.addHomepageLink(list);
+    list.addChild("li")
+        .addChild(
+            "a",
+            new String[] {"href", ATTR_TITLE},
+            new String[] {friendsPath, l10n(RETURN_TO_FRIENDS)},
+            l10n(FRIENDS));
+    this.writeHTMLReply(ctx, 200, "OK", page.generate());
+  }
+
+  private boolean sendToSelectedPeers(
+      HTTPRequest request, DarknetPeerNode[] peerNodes, HTMLNode peerTable, SendContext sendContext)
+      throws ToadletContextClosedException, IOException {
+    for (DarknetPeerNode pn : peerNodes) {
+      if (request.isPartSet("node_" + pn.hashCode())) {
+        if (sendFileOfferIfAny(pn, sendContext)) {
+          return true;
+        }
+        int status = pn.sendTextFeed(sendContext.message());
+        addPeerStatusRow(peerTable, pn, status, sendContext.message());
+      }
+    }
+    return false;
+  }
+
+  private boolean sendFileOfferIfAny(DarknetPeerNode pn, SendContext sendContext)
+      throws ToadletContextClosedException, IOException {
+    if (sendContext.filename() != null) {
+      try {
+        pn.sendFileOffer(sendContext.filename(), sendContext.messageHead());
+      } catch (IOException e) {
+        sendContext.peerTableInfobox().addChild("#", l10n("noSuchFileOrCannotRead"));
+        Toadlet.addHomepageLink(sendContext.peerTableInfobox());
+        addUnsentMessageTextInfo(sendContext.peerTableInfobox(), sendContext.message());
+        this.writeHTMLReply(sendContext.ctx(), 200, "OK", sendContext.page().generate());
+        return true;
+      }
+    } else if (hasUploadedContent(sendContext.uploadedFile())) {
+      try {
+        pn.sendFileOffer(sendContext.uploadedFile(), sendContext.messageHead());
+      } catch (IOException e) {
+        sendContext.peerTableInfobox().addChild("#", l10n("uploadFailed"));
+        Toadlet.addHomepageLink(sendContext.peerTableInfobox());
+        addUnsentMessageTextInfo(sendContext.peerTableInfobox(), sendContext.message());
+        this.writeHTMLReply(sendContext.ctx(), 200, "OK", sendContext.page().generate());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasUploadedContent(HTTPUploadedFile uploadedFile) {
+    return uploadedFile != null
+        && !uploadedFile.getFilename().isEmpty()
+        && uploadedFile.getData().size() > 0;
+  }
+
+  private void addPeerStatusRow(
+      HTMLNode peerTable, DarknetPeerNode pn, int status, String message) {
+    SendStatus sendStatus =
+        switch (status) {
+          case PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF ->
+              new SendStatus(l10n("delayedTitle"), l10n("delayed"), "n2ntm-send-delayed", "Sent");
+          case PeerManager.PEER_NODE_STATUS_CONNECTED ->
+              new SendStatus(l10n("sentTitle"), l10n("sent"), "n2ntm-send-sent", "Sent");
+          default ->
+              new SendStatus(l10n("queuedTitle"), l10n("queued"), "n2ntm-send-queued", "Queued");
+        };
+    LOG.info("{} N2NTM to '{}': {}", sendStatus.logPrefix(), pn.getName(), message);
+    HTMLNode peerRow = peerTable.addChild("tr");
+    peerRow.addChild("td", ATTR_CLASS, "peer-name").addChild("#", pn.getName());
+    peerRow
+        .addChild("td", ATTR_CLASS, sendStatus.cssClass())
+        .addChild(
+            "span",
+            new String[] {ATTR_TITLE, "style"},
+            new String[] {sendStatus.longLabel(), "border-bottom: 1px dotted; cursor: help;"},
+            sendStatus.shortLabel());
+  }
+
+  private FileResolution resolveSelectedFile(
+      HTTPRequest request, HTMLNode peerTableInfobox, PageNode page, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if (!request.isPartSet(LocalFileBrowserToadlet.selectFile)) {
+      return FileResolution.none();
+    }
+    String fnam = request.getPartAsStringFailsafe("filename", 1024);
+    if (fnam == null || fnam.isEmpty()) {
+      return FileResolution.none();
+    }
+    File filename = new File(fnam);
+    if (filename.exists() && filename.canRead()) {
+      return FileResolution.success(filename);
+    }
+    peerTableInfobox.addChild("#", l10n("noSuchFileOrCannotRead"));
+    Toadlet.addHomepageLink(peerTableInfobox);
+    this.writeHTMLReply(ctx, 400, "OK", page.generate());
+    return FileResolution.abort();
+  }
+
+  private UploadResolution resolveUploadedFile(
+      HTTPRequest request,
+      HTMLNode peerTableInfobox,
+      PageNode page,
+      ToadletContext ctx,
+      String message)
+      throws ToadletContextClosedException, IOException {
+    if (!request.isPartSet(N2NM_UPLOAD)) {
+      return UploadResolution.none();
+    }
+    try {
+      HTTPUploadedFile file = request.getUploadedFile(N2NM_UPLOAD);
+      if (!hasUploadedContent(file)) {
+        return UploadResolution.none();
+      }
+      long size = file.getData().size();
+      long limit = maxSize();
+      if (size > limit) {
+        peerTableInfobox.addChild(
+            "#",
+            NodeL10n.getBase()
+                .getString(
+                    L10N_PREFIX + "tooLarge",
+                    new String[] {"attempt", "limit"},
+                    new String[] {
+                      SizeUtil.formatSize(size, true), SizeUtil.formatSize(limit, true)
+                    }));
+        HTMLNode list = peerTableInfobox.addChild("ul");
+        Toadlet.addHomepageLink(list);
+        list.addChild("li")
+            .addChild(
+                "a",
+                new String[] {"href", ATTR_TITLE},
+                new String[] {friendsPath, l10n(RETURN_TO_FRIENDS)},
+                l10n(FRIENDS));
+        addUnsentMessageTextInfo(peerTableInfobox, message);
+        this.writeHTMLReply(ctx, 200, "OK", page.generate());
+        return UploadResolution.abort();
+      }
+      return UploadResolution.success(file);
+    } catch (IOException e) {
+      peerTableInfobox.addChild("#", l10n("uploadFailed"));
+      Toadlet.addHomepageLink(peerTableInfobox);
+      addUnsentMessageTextInfo(peerTableInfobox, message);
+      this.writeHTMLReply(ctx, 200, "OK", page.generate());
+      return UploadResolution.abort();
+    }
+  }
+
+  private void sendFriendsRedirect(ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    MultiValueTable<String, String> headers = MultiValueTable.from("Location", friendsPath);
     ctx.sendReplyHeaders(302, "Found", headers, null, 0);
   }
 
+  /**
+   * Appends a short explanatory paragraph and the original message body to a supplied HTML node so
+   * users can copy or retry sending.
+   *
+   * <p>The helper is used when sending fails due to validation or I/O issues and the UI needs to
+   * preserve the composed text. The message content is inserted verbatim under two {@code <p>}
+   * elements; callers should ensure the target node is properly escaped and not reused across
+   * concurrent responses.
+   *
+   * @param node parent {@link HTMLNode} that receives the explanatory paragraphs; not {@code null}.
+   * @param message message text that failed to send; inserted verbatim, may be empty.
+   */
   public static void addUnsentMessageTextInfo(HTMLNode node, String message) {
     node.addChild("p", l10n("unsentMessageText"));
     node.addChild("p", message);
   }
 
+  private record FileResolution(File file, boolean abortProcessing) {
+    static FileResolution success(File file) {
+      return new FileResolution(file, false);
+    }
+
+    static FileResolution abort() {
+      return new FileResolution(null, true);
+    }
+
+    static FileResolution none() {
+      return new FileResolution(null, false);
+    }
+  }
+
+  private record UploadResolution(HTTPUploadedFile file, boolean abortProcessing) {
+    static UploadResolution success(HTTPUploadedFile file) {
+      return new UploadResolution(file, false);
+    }
+
+    static UploadResolution abort() {
+      return new UploadResolution(null, true);
+    }
+
+    static UploadResolution none() {
+      return new UploadResolution(null, false);
+    }
+  }
+
+  private record SendContext(
+      String message,
+      String messageHead,
+      File filename,
+      HTTPUploadedFile uploadedFile,
+      HTMLNode peerTableInfobox,
+      PageNode page,
+      ToadletContext ctx) {}
+
+  private record SendStatus(
+      String shortLabel, String longLabel, String cssClass, String logPrefix) {}
+
+  /**
+   * Renders the N2NTM send form within the provided content node for the given set of peers.
+   *
+   * <p>The form lists target peers, inserts hidden inputs keyed by each peer hash code, and builds
+   * a textarea for composing the message body. When {@code advancedMode} is enabled and the caller
+   * has full access, the form also exposes controls for browsing local files and uploading
+   * attachments, including a localized size warning based on {@link #maxSize()}. Submit buttons are
+   * labeled for both browsing and sending so the same handler can route requests appropriately. The
+   * method assumes ownership of adding necessary line breaks and will not sanitize peer names;
+   * callers should only pass trusted values.
+   *
+   * @param advancedMode whether advanced UI elements (file browse/upload) should be shown to the
+   *     user.
+   * @param contentNode container node that receives the form and infobox; unique per response.
+   * @param ctx context generating form URLs and enforcing permissions; must match current request.
+   * @param peers map of peer hash codes to display names; pass only selected peers.
+   */
   public static void createN2NTMSendForm(
-      boolean advancedMode, HTMLNode contentNode, ToadletContext ctx, HashMap<String, String> peers)
-      throws ToadletContextClosedException, IOException {
+      boolean advancedMode, HTMLNode contentNode, ToadletContext ctx, Map<String, String> peers) {
     HTMLNode infobox =
         contentNode.addChild(
-            "div", new String[] {"class", "id"}, new String[] {"infobox", "n2nbox"});
-    infobox.addChild("div", "class", "infobox-header", l10n("sendMessage"));
-    HTMLNode messageTargets = infobox.addChild("div", "class", "infobox-content");
+            "div", new String[] {ATTR_CLASS, "id"}, new String[] {"infobox", "n2nbox"});
+    infobox.addChild("div", ATTR_CLASS, "infobox-header", l10n("sendMessage"));
+    HTMLNode messageTargets = infobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT);
     messageTargets.addChild("p", l10n("composingMessageLabel"));
     HTMLNode messageTargetList = messageTargets.addChild("ul");
     // Iterate peers
     for (String peer_name : peers.values()) {
       messageTargetList.addChild("li", peer_name);
     }
-    HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
+    HTMLNode infoboxContent = infobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT);
     HTMLNode messageForm = ctx.addFormChild(infoboxContent, "/send_n2ntm/", "sendN2NTMForm");
     // Iterate peers
     for (String peerNodeHash : peers.keySet()) {
       messageForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
+          INPUT_TAG,
+          new String[] {"type", "name", ATTR_VALUE},
           new String[] {"hidden", "node_" + peerNodeHash, "1"});
     }
     messageForm.addChild(
@@ -310,8 +548,8 @@ public class N2NTMToadlet extends Toadlet {
         messageForm.addChild(
             "#", NodeL10n.getBase().getString("QueueToadlet.insertFileBrowseLabel") + ": ");
         messageForm.addChild(
-            "input",
-            new String[] {"type", "name", "value"},
+            INPUT_TAG,
+            new String[] {"type", "name", ATTR_VALUE},
             new String[] {
               "submit",
               "n2nm-browse",
@@ -328,17 +566,22 @@ public class N2NTMToadlet extends Toadlet {
       messageForm.addChild(
           "#", NodeL10n.getBase().getString("QueueToadlet.insertFileLabel") + ": ");
       messageForm.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"file", "n2nm-upload", ""});
+          INPUT_TAG,
+          new String[] {"type", "name", ATTR_VALUE},
+          new String[] {"file", N2NM_UPLOAD, ""});
       messageForm.addChild("br");
     }
     messageForm.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
+        INPUT_TAG,
+        new String[] {"type", "name", ATTR_VALUE},
         new String[] {"submit", "send", l10n("sendMessageShort")});
   }
 
+  /**
+   * Returns the root HTTP path served by this toadlet.
+   *
+   * @return path string {@code /send_n2ntm/} for registration and form actions.
+   */
   @Override
   public String path() {
     return "/send_n2ntm/";

--- a/src/test/java/network/crypta/clients/http/N2NTMToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/N2NTMToadletTest.java
@@ -1,0 +1,240 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class N2NTMToadletTest {
+
+  @Mock private Node node;
+  @Mock private NodeClientCore core;
+  @Mock private HighLevelSimpleClient client;
+  @Mock private HTTPRequest request;
+  @Mock private ToadletContext ctx;
+
+  private N2NTMToadlet toadlet;
+
+  @BeforeAll
+  static void initL10n() {
+    // Ensure localization bundle is initialised once for predictable strings.
+    new NodeL10n();
+  }
+
+  @BeforeEach
+  void setUp() {
+    toadlet = new N2NTMToadlet(node, core, client, "/friends/");
+  }
+
+  @Test
+  void path_returnsConfiguredEndpoint() {
+    assertEquals("/send_n2ntm/", toadlet.path());
+  }
+
+  @Test
+  void getBrowser_returnsLocalFileToadlet() {
+    assertInstanceOf(LocalFileN2NMToadlet.class, toadlet.getBrowser());
+  }
+
+  @Test
+  void handleMethodGET_whenAccessDenied_abortsEarly() throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(false);
+
+    toadlet.handleMethodGET(new URI("http://localhost/send_n2ntm/"), request, ctx);
+
+    verify(ctx).checkFullAccess(toadlet);
+    verifyNoMoreInteractions(ctx);
+  }
+
+  @Test
+  void handleMethodGET_whenNoParam_redirectsToFriends() throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(request.isParameterSet("peernode_hashcode")).thenReturn(false);
+
+    toadlet.handleMethodGET(new URI("http://localhost/send_n2ntm/"), request, ctx);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(
+            (Class<MultiValueTable<String, String>>) (Class<?>) MultiValueTable.class);
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), eq(null), eq(0L));
+    assertEquals("/friends/", headersCaptor.getValue().getFirst("Location"));
+  }
+
+  @Test
+  void handleMethodGET_whenPeerMissing_showsErrorBox() throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(request.isParameterSet("peernode_hashcode")).thenReturn(true);
+    DarknetPeerNode peer = mock(DarknetPeerNode.class);
+    int peerHash = peer.hashCode();
+    String missingHash = String.valueOf(peerHash + 1);
+    when(request.getParam("peernode_hashcode")).thenReturn(missingHash);
+    when(node.getDarknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
+
+    PageMaker pageMaker = mock(PageMaker.class);
+    PageNode page = createPageNode();
+    doReturn(page).when(pageMaker).getPageNode(anyString(), any(ToadletContext.class));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    AtomicReference<String> html = new AtomicReference<>("");
+    N2NTMToadlet spyToadlet = spy(toadlet);
+    doAnswer(
+            invocation -> {
+              html.set(invocation.getArgument(3));
+              return null;
+            })
+        .when(spyToadlet)
+        .writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
+
+    spyToadlet.handleMethodGET(
+        new URI("http://localhost/send_n2ntm/?peernode_hashcode=1234"), request, ctx);
+
+    String generated = html.get();
+    assertTrue(generated.contains("infobox-error"));
+    assertTrue(generated.contains(missingHash));
+  }
+
+  @Test
+  void handleMethodGET_whenPeerFound_rendersSendForm() throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(request.isParameterSet("peernode_hashcode")).thenReturn(true);
+    DarknetPeerNode peer = mock(DarknetPeerNode.class);
+    int peerHash = peer.hashCode();
+    when(request.getParam("peernode_hashcode")).thenReturn(String.valueOf(peerHash));
+    when(peer.getName()).thenReturn("Alice");
+    when(node.getDarknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
+
+    PageMaker pageMaker = mock(PageMaker.class);
+    PageNode page = createPageNode();
+    doReturn(page).when(pageMaker).getPageNode(anyString(), any(ToadletContext.class));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(true);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.addFormChild(any(HTMLNode.class), eq("/send_n2ntm/"), eq("sendN2NTMForm")))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              HTMLNode form = new HTMLNode("form");
+              parent.addChild(form);
+              return form;
+            });
+
+    AtomicReference<String> html = new AtomicReference<>("");
+    N2NTMToadlet spyToadlet = spy(toadlet);
+    doAnswer(
+            invocation -> {
+              html.set(invocation.getArgument(3));
+              return null;
+            })
+        .when(spyToadlet)
+        .writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
+
+    spyToadlet.handleMethodGET(
+        new URI("http://localhost/send_n2ntm/?peernode_hashcode=42"), request, ctx);
+
+    String generated = html.get();
+    assertTrue(generated.contains("Alice"));
+    assertTrue(generated.contains("node_" + peerHash));
+    assertTrue(generated.contains("n2ntmtext"));
+  }
+
+  @Test
+  void handleMethodPOST_whenMessageTooLong_returnsBadRequest() throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(request.isPartSet(anyString())).thenReturn(false);
+    when(request.isPartSet("send")).thenReturn(true);
+
+    String oversizedMessage = "x".repeat(130 * 1024 + 1);
+    when(request.getPartAsStringFailsafe("message", 1024 * 1024)).thenReturn(oversizedMessage);
+
+    N2NTMToadlet spyToadlet = spy(toadlet);
+    AtomicReference<Integer> status = new AtomicReference<>(0);
+    doAnswer(
+            invocation -> {
+              status.set(invocation.getArgument(1));
+              return null;
+            })
+        .when(spyToadlet)
+        .writeTextReply(eq(ctx), anyInt(), anyString(), anyString());
+
+    spyToadlet.handleMethodPOST(new URI("http://localhost/send_n2ntm/"), request, ctx);
+
+    assertEquals(400, status.get());
+    verify(spyToadlet, times(1)).writeTextReply(eq(ctx), eq(400), eq("Bad request"), anyString());
+  }
+
+  @Test
+  void addUnsentMessageTextInfo_appendsMessage() {
+    HTMLNode root = new HTMLNode("div");
+    String message = "Pending message body";
+
+    N2NTMToadlet.addUnsentMessageTextInfo(root, message);
+
+    String html = root.generate();
+    assertTrue(html.contains(message));
+    assertTrue(html.contains("<p>"));
+  }
+
+  @Test
+  void createN2NTMSendForm_whenAdvanced_addsFileControls() {
+    HTMLNode contentNode = new HTMLNode("div");
+    HashMap<String, String> peers = new HashMap<>();
+    peers.put("7", "Bob");
+
+    when(ctx.addFormChild(any(HTMLNode.class), eq("/send_n2ntm/"), eq("sendN2NTMForm")))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              HTMLNode form = new HTMLNode("form");
+              parent.addChild(form);
+              return form;
+            });
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+
+    N2NTMToadlet.createN2NTMSendForm(true, contentNode, ctx, peers);
+
+    String html = contentNode.generate();
+    assertTrue(html.contains("Bob"));
+    assertTrue(html.contains("node_7"));
+    assertTrue(html.contains("n2nm-upload"));
+    assertTrue(html.contains("n2ntmtext"));
+  }
+
+  private PageNode createPageNode() {
+    HTMLNode outer = new HTMLNode("div");
+    HTMLNode content = outer.addChild("div");
+    HTMLNode head = new HTMLNode("head");
+    return new PageNode(outer, head, content);
+  }
+}


### PR DESCRIPTION
## Summary
- wire N2NTM toadlet with explicit friends redirect path and broaden docs
- refactor request handling for safer redirects, size checks, and per-peer status rendering
- add comprehensive unit tests for N2NTM toadlet GET/POST flows

## Testing
- gradlew spotlessApply