### PR TITLE
Add PageNode head link tests and clarify Javadoc

### DIFF
--- a/src/main/java/network/crypta/clients/http/PageNode.java
+++ b/src/main/java/network/crypta/clients/http/PageNode.java
@@ -3,15 +3,36 @@ package network.crypta.clients.http;
 import network.crypta.support.HTMLNode;
 
 /**
- * PageNode is a wrapper similar to InfoboxNode for a whole page. Similarly, PageNode.outer is the
- * HTML for the whole page, PageNode.content is where you add content to the page, and headNode is
- * the <head> element so you can add headers. The title will already have been added.
+ * Represents a complete HTML page shell with convenient access to the document head and content
+ * sections.
+ *
+ * <p>PageNode mirrors {@link InfoboxNode} but targets full-page composition instead of a boxed
+ * fragment. The {@code outer} node holds the entire document markup, while {@code content} acts as
+ * the primary insertion point for user-visible body elements such as paragraphs, lists, or
+ * interactive widgets. The {@code headNode} references the document {@code <head>} so callers can
+ * register metadata, stylesheets, or preloads alongside an already-set title. Typical usage creates
+ * a PageNode, writes metadata through {@link #getHeadNode()} or {@link #addForwardLink(String,
+ * String, String, String)}, and then populates {@code content} with the rendered body before
+ * serialization.
+ *
+ * <p>Instances are mutable during construction; after the page is emitted, callers should avoid
+ * further mutation to prevent divergence between cached and streamed output. This class performs no
+ * synchronization and is not thread-safe; confine each instance to a single thread or coordinate
+ * external locking when building pages concurrently. The contained {@link HTMLNode} references are
+ * live and changes apply immediately to the output tree.
+ *
+ * <ul>
+ *   <li>Responsibilities: expose the head node, provide helpers for common link relations, and
+ *       inherit content management from {@link InfoboxNode}.
+ *   <li>Notable behaviors: does not deduplicate head entries and does not validate URLs or media
+ *       types.
+ * </ul>
  */
 public class PageNode extends InfoboxNode {
 
   /**
-   * Return the HTMLNode corresponding to the &lt;head&gt; tag, so we can add stuff to it, e.g.
-   * &lt;meta&gt; tags.
+   * Return the HTMLNode corresponding to the {@code <head>} tag, so we can add stuff to it, e.g.
+   * {@code <meta>} tags.
    */
   public final HTMLNode headNode;
 
@@ -20,14 +41,33 @@ public class PageNode extends InfoboxNode {
     this.headNode = head;
   }
 
+  /**
+   * Returns the live {@link HTMLNode} that represents the document {@code <head>} element.
+   *
+   * <p>Callers can attach metadata, preload hints, stylesheets, or other standard head children to
+   * this node before the enclosing page is rendered. The returned reference is mutable and updates
+   * apply immediately; it is not copied or wrapped. No validation or duplication checks are
+   * performed, so callers should avoid adding the same relationship multiple times unless intended.
+   * Use this accessor when helper methods such as {@link #addCustomStyleSheet(String)} are too
+   * restrictive or when precise control over ordering is required.
+   *
+   * @return mutable {@code HTMLNode} for the {@code <head>} element; never {@code null}
+   */
   public HTMLNode getHeadNode() {
     return headNode;
   }
 
   /**
-   * Adds a custom style sheet to the header of the page.
+   * Adds a custom style sheet link element to the page head for screen media.
    *
-   * @param customStyleSheet The URL of the custom style sheet
+   * <p>This is a convenience wrapper around {@link #addForwardLink(String, String, String, String)}
+   * that sets the relationship to {@code stylesheet}, declares the MIME type as {@code text/css},
+   * and targets the {@code screen} media attribute. The method performs no URL validation or
+   * deduplication, so callers should ensure the same stylesheet is not added repeatedly unless
+   * multiple identical declarations are acceptable to downstream consumers. Invoke this before
+   * serializing the page to ensure the link appears in the emitted head section.
+   *
+   * @param customStyleSheet absolute or relative URL pointing to the CSS resource; must be non-null
    */
   public void addCustomStyleSheet(String customStyleSheet) {
     addForwardLink("stylesheet", customStyleSheet, "text/css", "screen");
@@ -36,9 +76,15 @@ public class PageNode extends InfoboxNode {
   /**
    * Adds a document relationship forward link to the HTML document's HEAD node.
    *
-   * @param linkType The link type (e.g. "stylesheet" or "shortcut icon")
-   * @param href The link
+   * <p>This overload delegates to the four-argument variant while leaving {@code type} and {@code
+   * media} unspecified. Use it when only the relationship and target URL matter and the user agent
+   * can infer other attributes. The link is appended as a new {@code <link>} child under the
+   * existing head element without attempting to reorder or merge similar entries.
+   *
+   * @param linkType relationship value for the {@code rel} attribute; typically non-null
+   * @param href hyperlink reference that resolves to the related resource; absolute or relative
    */
+  @SuppressWarnings("unused")
   public void addForwardLink(String linkType, String href) {
     addForwardLink(linkType, href, null, null);
   }
@@ -46,10 +92,18 @@ public class PageNode extends InfoboxNode {
   /**
    * Adds a document relationship forward link to the HTML document's HEAD node.
    *
-   * @param linkType The link type (e.g. "stylesheet" or "shortcut icon")
-   * @param href The link
-   * @param type The type of the referenced data
-   * @param media The media for which this link is valid
+   * <p>The method constructs a new {@code <link>} element with {@code rel} and {@code href}
+   * attributes, then conditionally applies {@code type} and {@code media} when non-null. It does
+   * not canonicalize values, resolve URLs, or prevent duplicates, making it suitable for callers
+   * that need full control over link semantics or wish to emit multiple variants (for example,
+   * alternate stylesheets or icons). Invoke this helper prior to final rendering so the generated
+   * link appears in the document head in insertion order. The call is idempotent only when clients
+   * avoid passing identical combinations repeatedly.
+   *
+   * @param linkType relationship to the referenced document (e.g., {@code stylesheet})
+   * @param href destination URI for the linked resource; relative paths are permitted
+   * @param type optional MIME type describing the linked content; {@code null} skips the attribute
+   * @param media optional media descriptor such as {@code screen} or {@code print}; null omits it
    */
   public void addForwardLink(String linkType, String href, String type, String media) {
     HTMLNode linkNode =

--- a/src/test/java/network/crypta/clients/http/PageNodeTest.java
+++ b/src/test/java/network/crypta/clients/http/PageNodeTest.java
@@ -1,0 +1,111 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
+import java.util.Map;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class PageNodeTest {
+
+  @Test
+  void getHeadNode_whenCalled_returnsInjectedHeadNode() {
+    HTMLNode head = new HTMLNode("head");
+    PageNode pageNode = new PageNode(new HTMLNode("html"), head, new HTMLNode("div"));
+
+    HTMLNode result = pageNode.getHeadNode();
+
+    assertSame(head, result);
+  }
+
+  @Test
+  void addCustomStyleSheet_whenCalled_addsStylesheetLinkWithTypeAndMedia() {
+    PageNode pageNode = newPageNode();
+    String stylesheetUrl = "https://example.com/styles.css";
+
+    pageNode.addCustomStyleSheet(stylesheetUrl);
+
+    List<HTMLNode> children = pageNode.getHeadNode().getChildren();
+    assertEquals(1, children.size());
+
+    HTMLNode linkNode = children.getFirst();
+    Map<String, String> attributes = linkNode.getAttributes();
+    assertEquals("link", linkNode.getFirstTag());
+    assertEquals("stylesheet", attributes.get("rel"));
+    assertEquals(stylesheetUrl, attributes.get("href"));
+    assertEquals("text/css", attributes.get("type"));
+    assertEquals("screen", attributes.get("media"));
+  }
+
+  @Test
+  void addForwardLink_whenTypeAndMediaProvided_addsAllAttributes() {
+    PageNode pageNode = newPageNode();
+
+    pageNode.addForwardLink("shortcut icon", "/favicon.ico", "image/x-icon", "all");
+
+    HTMLNode linkNode = pageNode.getHeadNode().getChildren().getFirst();
+    Map<String, String> attributes = linkNode.getAttributes();
+
+    assertEquals("shortcut icon", attributes.get("rel"));
+    assertEquals("/favicon.ico", attributes.get("href"));
+    assertEquals("image/x-icon", attributes.get("type"));
+    assertEquals("all", attributes.get("media"));
+  }
+
+  @Test
+  void addForwardLink_whenTypeProvidedButMediaMissing_omitsMediaAttribute() {
+    PageNode pageNode = newPageNode();
+
+    pageNode.addForwardLink("prefetch", "/resource", "application/json", null);
+
+    HTMLNode linkNode = pageNode.getHeadNode().getChildren().getFirst();
+    Map<String, String> attributes = linkNode.getAttributes();
+
+    assertEquals("application/json", attributes.get("type"));
+    assertFalse(attributes.containsKey("media"));
+  }
+
+  @Test
+  void addForwardLink_whenMediaProvidedButTypeMissing_omitsTypeAttribute() {
+    PageNode pageNode = newPageNode();
+
+    pageNode.addForwardLink("stylesheet", "/print.css", null, "print");
+
+    HTMLNode linkNode = pageNode.getHeadNode().getChildren().getFirst();
+    Map<String, String> attributes = linkNode.getAttributes();
+
+    assertEquals("print", attributes.get("media"));
+    assertFalse(attributes.containsKey("type"));
+    assertEquals("stylesheet", attributes.get("rel"));
+    assertEquals("/print.css", attributes.get("href"));
+  }
+
+  @Test
+  void addForwardLink_whenTypeAndMediaMissing_addsOnlyRelAndHref() {
+    PageNode pageNode = newPageNode();
+
+    pageNode.addForwardLink("prefetch", "https://example.com/data", null, null);
+
+    HTMLNode linkNode = pageNode.getHeadNode().getChildren().getFirst();
+    Map<String, String> attributes = linkNode.getAttributes();
+
+    assertEquals(2, attributes.size());
+    assertEquals("prefetch", attributes.get("rel"));
+    assertEquals("https://example.com/data", attributes.get("href"));
+    assertFalse(attributes.containsKey("type"));
+    assertFalse(attributes.containsKey("media"));
+  }
+
+  private PageNode newPageNode() {
+    HTMLNode page = new HTMLNode("html");
+    HTMLNode head = new HTMLNode("head");
+    HTMLNode content = new HTMLNode("div");
+    page.addChild(head);
+    page.addChild(content);
+    return new PageNode(page, head, content);
+  }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering PageNode head accessors and link helpers
- expand PageNode Javadoc to document responsibilities, thread-safety expectations, and helper behaviors

## Testing
- not run (not requested)
