### PR TITLE
Refine startup toadlet handling

### DIFF
--- a/src/main/java/network/crypta/clients/http/StartupToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StartupToadlet.java
@@ -7,17 +7,72 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
-/** Toadlet for "Freenet is starting up" page. */
+/**
+ * Serves the transient "Freenet is starting up" status page during node boot.
+ *
+ * <p>This toadlet responds on the root path while the node is still initializing, replacing the
+ * normal UI with a lightweight progress page that refreshes automatically until the full interface
+ * is ready. It delegates static assets to {@link StaticToadlet} when the requested path is under
+ * the shared static prefix so images and styles remain available even before startup completes. The
+ * handler always forces the HTTP connection to close to avoid keep-alive issues with incomplete
+ * initialization.
+ *
+ * <p>The page shows an entropy warning until the PRNG reports readiness via {@link
+ * #setIsPRNGReady()}; this guards against low-entropy environments during early boot. A
+ * meta-refresh controls the retry cadence instead of HTTP headers, keeping behavior consistent
+ * across intermediaries. The class is thread-safe for the readiness flag because the field is
+ * {@code volatile}, and it assumes the surrounding {@link Toadlet} infrastructure provides any
+ * broader synchronization needed for request handling.
+ *
+ * <ul>
+ *   <li>Responsibilities: render startup status, surface entropy readiness, proxy static assets.
+ *   <li>Lifecycle: active only during bootstrap, replaced by the normal UI when the node is ready.
+ *   <li>Concurrency: stateless per request; readiness flag may be set from background threads.
+ * </ul>
+ */
 public class StartupToadlet extends Toadlet {
 
   private final StaticToadlet staticToadlet;
   private volatile boolean isPRNGReady = false;
 
+  /**
+   * Creates a startup toadlet that can optionally delegate static content during bootstrap.
+   *
+   * <p>The provided {@link StaticToadlet} is used only when the incoming request path begins with
+   * {@link StaticToadlet#ROOT_URL}, allowing shared CSS or images to load while the main UI waits
+   * for initialization. Callers typically wire this from the HTTP router at node startup and keep
+   * it registered until the normal UI replaces the startup handler.
+   *
+   * @param staticToadlet optional handler for static resources; may be {@code null} if delegation
+   *     is not needed during startup.
+   */
   public StartupToadlet(StaticToadlet staticToadlet) {
     super(null);
     this.staticToadlet = staticToadlet;
   }
 
+  /**
+   * Handles GET requests for the startup page and delegates static assets when appropriate.
+   *
+   * <p>The method forces the connection to close to avoid HTTP pipelining during initialization,
+   * then serves either delegated static content or a minimal status page that refreshes every
+   * second. The status page embeds an entropy warning until {@link #setIsPRNGReady()} is invoked,
+   * displays a short startup message, and optionally links wrapper logs for troubleshooting. The
+   * response uses status {@code 503} with an HTML body so clients retry naturally without relying
+   * on HTTP {@code Retry-After} headers.
+   *
+   * <pre>{@code
+   * // Example: invoked by the HTTP server during bootstrap
+   * startupToadlet.handleMethodGET(uri, request, context);
+   * }</pre>
+   *
+   * @param uri request URI already parsed by the HTTP layer; path guides static delegation.
+   * @param req inbound HTTP request containing parameters and headers; must not be {@code null}.
+   * @param ctx toadlet context providing page builders and reply helpers; must be open for writes.
+   * @throws ToadletContextClosedException if the context has been closed before writing the reply.
+   * @throws IOException if page generation or output streaming fails while sending the response.
+   * @throws RedirectException if the handler requests a redirect instead of rendering the page.
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     // If we don't disconnect we will have pipelining issues
@@ -61,15 +116,34 @@ public class StartupToadlet extends Toadlet {
 
       WelcomeToadlet.maybeDisplayWrapperLogfile(ctx, contentNode);
 
-      // TODO: send a Retry-After header ?
+      // Retry cadence is controlled via meta refresh rather than HTTP header.
       writeHTMLReply(ctx, 503, desc, page.generate());
     }
   }
 
+  /**
+   * Marks the node's pseudo-random number generator as ready to suppress entropy warnings.
+   *
+   * <p>This flag is intended to be invoked by whichever component monitors entropy availability
+   * during startup (for example, once a secure PRNG has seeded). Because the field is {@code
+   * volatile}, updates become visible to subsequent HTTP requests without additional
+   * synchronization. Callers should set this only once the PRNG is genuinely usable to avoid
+   * misleading the startup page about entropy quality.
+   */
   public void setIsPRNGReady() {
     isPRNGReady = true;
   }
 
+  /**
+   * Returns the URL path served by this toadlet while the node is starting up.
+   *
+   * <p>The startup handler is registered on the root path so it intercepts all incoming requests
+   * until the main UI replaces it after initialization completes. Keeping the path fixed ensures
+   * clients that attempt to reach {@code /} receive a consistent status page rather than a socket
+   * error during the transition. The string is immutable and safe to cache by routing layers.
+   *
+   * @return the literal root path {@code "/"} used to register the startup toadlet.
+   */
   @Override
   public String path() {
     return "/";

--- a/src/test/java/network/crypta/clients/http/StartupToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/StartupToadletTest.java
@@ -1,0 +1,219 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.clients.http.PageMaker.RenderParameters;
+import network.crypta.l10n.BaseL10n;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class StartupToadletTest {
+
+  private static final String HTML_REPLY = "<html>generated</html>";
+
+  @Test
+  void handleMethodGET_withStaticPath_delegatesToStaticToadlet()
+      throws IOException, RedirectException, ToadletContextClosedException {
+    StaticToadlet staticToadlet = mock(StaticToadlet.class);
+    StartupToadlet toadlet = new StartupToadlet(staticToadlet);
+    ToadletContext ctx = mock(ToadletContext.class);
+    HTTPRequest req = mock(HTTPRequest.class);
+    URI uri = URI.create(StaticToadlet.ROOT_URL + "file.css");
+
+    toadlet.handleMethodGET(uri, req, ctx);
+
+    InOrder inOrder = inOrder(ctx, staticToadlet);
+    inOrder.verify(ctx).forceDisconnect();
+    inOrder.verify(staticToadlet).handleMethodGET(uri, req, ctx);
+    verifyNoMoreInteractions(staticToadlet);
+  }
+
+  @Test
+  void handleMethodGET_whenNotStaticAndPrngNotReady_rendersErrorAndRefresh()
+      throws IOException, RedirectException, ToadletContextClosedException {
+    ToadletContext ctx = mock(ToadletContext.class);
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+
+    HTMLNode headNode = new HTMLNode("head");
+    HTMLNode contentNode = new HTMLNode("div");
+    PageNode pageNode = mock(PageNode.class);
+    when(pageNode.getHeadNode()).thenReturn(headNode);
+    when(pageNode.getContentNode()).thenReturn(contentNode);
+    when(pageNode.generate()).thenReturn(HTML_REPLY);
+
+    BaseL10n l10n = mock(BaseL10n.class);
+    when(l10n.getString(anyString())).thenAnswer(inv -> inv.getArgument(0));
+    when(l10n.getString("StartupToadlet.title")).thenReturn("Startup Title");
+    when(l10n.getString("StartupToadlet.entropyErrorTitle")).thenReturn("Entropy Error");
+    when(l10n.getString("StartupToadlet.entropyErrorContent")).thenReturn("Need Entropy");
+    when(l10n.getString("StartupToadlet.isStartingUp")).thenReturn("Starting Up");
+
+    try (MockedStatic<NodeL10n> nodeL10n = org.mockito.Mockito.mockStatic(NodeL10n.class);
+        MockedStatic<WelcomeToadlet> welcomeToadlet =
+            org.mockito.Mockito.mockStatic(WelcomeToadlet.class)) {
+      nodeL10n.when(NodeL10n::getBase).thenReturn(l10n);
+
+      when(pageMaker.getPageNode(eq("Startup Title"), eq(ctx), any(RenderParameters.class)))
+          .thenReturn(pageNode);
+
+      AtomicReference<HTMLNode> prngInfobox = new AtomicReference<>();
+      AtomicReference<HTMLNode> statusInfobox = new AtomicReference<>();
+      org.mockito.Mockito.doAnswer(
+              invocation -> {
+                String header = invocation.getArgument(1);
+                HTMLNode parent = invocation.getArgument(2);
+                HTMLNode box = new HTMLNode("div");
+                parent.addChild(box);
+                if ("Entropy Error".equals(header)) {
+                  prngInfobox.set(box);
+                }
+                if ("Startup Title".equals(header)) {
+                  statusInfobox.set(box);
+                }
+                return box;
+              })
+          .when(pageMaker)
+          .getInfobox(anyString(), anyString(), eq(contentNode), isNull(), eq(true));
+
+      StartupToadlet toadlet = new StartupToadlet(null);
+
+      toadlet.handleMethodGET(URI.create("/"), mock(HTTPRequest.class), ctx);
+
+      verify(ctx).forceDisconnect();
+      verify(pageMaker).getPageNode(eq("Startup Title"), eq(ctx), any(RenderParameters.class));
+
+      assertTrue(
+          headNode.getChildren().stream()
+              .anyMatch(
+                  child ->
+                      "meta".equals(child.getName())
+                          && "refresh".equals(child.getAttribute("http-equiv"))
+                          && "1; url=".equals(child.getAttribute("content"))),
+          "Meta refresh tag should be present");
+
+      HTMLNode prngBox = prngInfobox.get();
+      assertTrue(
+          prngBox.getChildren().stream()
+              .anyMatch(
+                  node -> "#".equals(node.getName()) && "Need Entropy".equals(node.getContent())));
+
+      HTMLNode statusBox = statusInfobox.get();
+      assertTrue(
+          statusBox.getChildren().stream()
+              .anyMatch(
+                  node -> "#".equals(node.getName()) && "Starting Up".equals(node.getContent())));
+
+      welcomeToadlet.verify(() -> WelcomeToadlet.maybeDisplayWrapperLogfile(ctx, contentNode));
+
+      int expectedLength = HTML_REPLY.getBytes(StandardCharsets.UTF_8).length;
+      verify(ctx)
+          .sendReplyHeaders(
+              eq(503),
+              eq("Startup Title"),
+              isNull(),
+              eq("text/html; charset=utf-8"),
+              eq((long) expectedLength));
+
+      ArgumentCaptor<byte[]> bodyCaptor = ArgumentCaptor.forClass(byte[].class);
+      ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<Integer> lengthCaptor = ArgumentCaptor.forClass(Integer.class);
+      verify(ctx).writeData(bodyCaptor.capture(), offsetCaptor.capture(), lengthCaptor.capture());
+
+      assertEquals(HTML_REPLY, new String(bodyCaptor.getValue(), StandardCharsets.UTF_8));
+      assertEquals(0, offsetCaptor.getValue());
+      assertEquals(expectedLength, lengthCaptor.getValue());
+    }
+  }
+
+  @Test
+  void handleMethodGET_whenPrngReady_skipsEntropyInfobox()
+      throws IOException, RedirectException, ToadletContextClosedException {
+    ToadletContext ctx = mock(ToadletContext.class);
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+
+    HTMLNode headNode = new HTMLNode("head");
+    HTMLNode contentNode = new HTMLNode("div");
+    PageNode pageNode = mock(PageNode.class);
+    when(pageNode.getHeadNode()).thenReturn(headNode);
+    when(pageNode.getContentNode()).thenReturn(contentNode);
+    when(pageNode.generate()).thenReturn(HTML_REPLY);
+
+    BaseL10n l10n = mock(BaseL10n.class);
+    when(l10n.getString(anyString())).thenAnswer(inv -> inv.getArgument(0));
+    when(l10n.getString("StartupToadlet.title")).thenReturn("Startup Title");
+    when(l10n.getString("StartupToadlet.isStartingUp")).thenReturn("Starting Up");
+
+    try (MockedStatic<NodeL10n> nodeL10n = org.mockito.Mockito.mockStatic(NodeL10n.class);
+        MockedStatic<WelcomeToadlet> welcomeToadlet =
+            org.mockito.Mockito.mockStatic(WelcomeToadlet.class)) {
+      nodeL10n.when(NodeL10n::getBase).thenReturn(l10n);
+
+      when(pageMaker.getPageNode(eq("Startup Title"), eq(ctx), any(RenderParameters.class)))
+          .thenReturn(pageNode);
+
+      org.mockito.Mockito.doAnswer(
+              invocation -> {
+                HTMLNode parent = invocation.getArgument(2);
+                HTMLNode box = new HTMLNode("div");
+                parent.addChild(box);
+                return box;
+              })
+          .when(pageMaker)
+          .getInfobox(anyString(), anyString(), eq(contentNode), isNull(), eq(true));
+
+      StartupToadlet toadlet = new StartupToadlet(null);
+      toadlet.setIsPRNGReady();
+
+      toadlet.handleMethodGET(URI.create("/"), mock(HTTPRequest.class), ctx);
+
+      verify(pageMaker, never())
+          .getInfobox(
+              eq("infobox-error"),
+              eq("StartupToadlet.entropyErrorTitle"),
+              any(),
+              any(),
+              anyBoolean());
+      assertFalse(
+          contentNode.getChildren().stream()
+              .flatMap(node -> node.getChildren().stream())
+              .anyMatch(child -> "Need Entropy".equals(child.getContent())),
+          "Entropy infobox should be skipped when PRNG is ready");
+
+      welcomeToadlet.verify(() -> WelcomeToadlet.maybeDisplayWrapperLogfile(ctx, contentNode));
+    }
+  }
+
+  @Test
+  void path_returnsRoot() {
+    StartupToadlet toadlet = new StartupToadlet(null);
+    assertEquals("/", toadlet.path());
+  }
+}


### PR DESCRIPTION
## Summary
- expand StartupToadlet docs and clarify behavior around bootstrap handling and static delegation
- keep startup responses closing connections and retrying via meta refresh instead of headers
- add unit coverage for static delegation, entropy warning display, and PRNG-ready path handling

## Testing
- Not run (not requested)
