### PR TITLE
Refactor SecurityLevelsToadlet workflow and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.wizardsteps.PageHelper;
 import network.crypta.clients.http.wizardsteps.WizardL10n;
@@ -26,14 +26,86 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The security levels page.
+ * Renders and processes the security levels configuration page exposed over the HTTP client UI.
  *
- * @author Matthew Toseland <toad@amphibian.dyndns.org> (0xE43DA450)
+ * <p>This toadlet orchestrates the full workflow for selecting network and physical threat levels,
+ * prompting for master passwords when high-security modes require them, and rendering
+ * confirmation/rollback screens before persisting changes. It collaborates with {@link
+ * SecurityLevels} to translate user choices into durable node settings, and delegates HTML
+ * construction to the surrounding {@code ToadletContext}. The class assumes callers gate access
+ * through {@link ToadletContext#checkFullAccess(Toadlet)} so it can operate on administrative data.
+ *
+ * <p>Lifecycle highlights:
+ *
+ * <ul>
+ *   <li>Reads form submissions and routes between threat-level updates and password management.
+ *   <li>Generates confirmation pages when sensitive changes occur, preserving user-provided form
+ *       values so the follow-up submission remains deterministic.
+ *   <li>Persists configuration changes via {@link NodeClientCore#storeConfig()} only after
+ *       successful validation.
+ *   <li>Surfaces localized guidance and warnings to steer users away from insecure downgrades.
+ * </ul>
+ *
+ * <p>Thread safety: instances are created per toadlet and rely on the servlet-style dispatching of
+ * the surrounding framework; no internal synchronization is performed. Mutability is limited to
+ * request-scoped helpers and stored {@link Node} references. Use a distinct instance per request
+ * handler or ensure external serialization if reused.
+ *
+ * @author Matthew Toseland {@literal <}toad@amphibian.dyndns.org{@literal >} (0xE43DA450)
+ * @see SecurityLevels
+ * @see NodeClientCore
  */
 public class SecurityLevelsToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(SecurityLevelsToadlet.class);
 
+  /**
+   * Maximum number of characters accepted for password inputs across all security pages. Inputs
+   * longer than this limit are truncated by {@link HTTPRequest#getPartAsStringFailsafe(String,
+   * int)}, preventing excessively large payloads while still accommodating passphrases. The value
+   * is expressed in UTF-16 code units as delivered by the servlet request, not bytes.
+   */
   public static final int MAX_PASSWORD_LENGTH = 1024;
+
+  private static final String PARAM_SECLEVELS = "seclevels";
+  private static final String PARAM_NETWORK_THREAT_LEVEL = "security-levels.networkThreatLevel";
+  private static final String PARAM_NETWORK_THREAT_LEVEL_CONFIRM =
+      "security-levels.networkThreatLevel.confirm";
+  private static final String PARAM_NETWORK_THREAT_LEVEL_TRY_CONFIRM =
+      "security-levels.networkThreatLevel.tryConfirm";
+  private static final String PARAM_PHYSICAL_THREAT_LEVEL = "security-levels.physicalThreatLevel";
+  private static final String PARAM_MASTER_PASSWORD = "masterPassword";
+  private static final String PARAM_CONFIRM_MASTER_PASSWORD = "confirmMasterPassword";
+  private static final String PARAM_OLD_PASSWORD = "oldPassword";
+  private static final String ATTR_CLASS = "class";
+  private static final String ATTR_TYPE = "type";
+  private static final String ATTR_NAME = "name";
+  private static final String ATTR_VALUE = "value";
+  private static final String ATTR_ID = "id";
+  private static final String ATTR_CHECKED = "checked";
+  private static final String TAG_INPUT = "input";
+  private static final String TAG_DIV = "div";
+  private static final String TAG_LABEL = "label";
+  private static final String CLASS_CONFIG = "config";
+  private static final String CLASS_INFOBOX_CONTENT = "infobox-content";
+  private static final String INPUT_HIDDEN = "hidden";
+  private static final String INPUT_RADIO = "radio";
+  private static final String INPUT_PASSWORD = "password";
+  private static final String INPUT_SUBMIT = "submit";
+  private static final String INFOBOX_ERROR = "infobox-error";
+  private static final String PASSWORD_PAGE_TITLE_KEY = "passwordPageTitle";
+  private static final String PASSWORD_WRONG_TITLE_KEY = "passwordWrongTitle";
+  private static final String PASSWORD_FOR_DECRYPT_TITLE_KEY = "passwordForDecryptTitle";
+  private static final String PASSWORD_NOT_ZERO_LENGTH_KEY = "passwordNotZeroLength";
+  private static final String PARAM_REDIRECT = "redirect";
+  private static final String HEADER_LOCATION = "Location";
+  private static final String STATUS_FOUND = "Found";
+  private static final String PASSWORD_BOX_NAME = "passwordBox";
+  private static final String PASSWORD_ERROR_CLASS = "password-error";
+  private static final String MASTER_PASSWORD_FORM = "masterPasswordForm";
+  private static final String CANT_DELETE_PASSWORD_FILE_TITLE_KEY = "cantDeletePasswordFileTitle";
+  private static final String SET_PASSWORD_TITLE_KEY = "setPasswordTitle";
+  private static final String CONFIRM_PASSWORD_BOX_ID = "confirmPasswordBox";
+  private static final String PASSWORD_FILE_CORRUPTED_TITLE_KEY = "passwordFileCorruptedTitle";
   private final NodeClientCore core;
   private final Node node;
 
@@ -45,419 +117,556 @@ public class SecurityLevelsToadlet extends Toadlet {
     this.node = node;
   }
 
+  private static final class SecurityChangeState {
+    HTMLNode pageNode;
+    HTMLNode formNode;
+    boolean changedAnything;
+
+    boolean hasConfirmPage() {
+      return pageNode != null;
+    }
+  }
+
+  /**
+   * Handles POST submissions for the security levels page and dispatches them to specialized
+   * handlers. The method enforces full-access checks, routes master password updates separately
+   * from threat-level changes, and persists configuration only after successful validation. When a
+   * request does not match any known handler it redirects the client back to the main security
+   * levels view to maintain a predictable user path.
+   *
+   * @param uri request URI, retained for consistency with the toadlet contract and null-checked.
+   * @param request HTTP request carrying form parts such as security level selections and
+   *     password-related fields.
+   * @param ctx toadlet context responsible for authorization, page building, and response output.
+   * @throws ToadletContextClosedException if the client disconnects before the response completes.
+   * @throws IOException if an I/O error occurs while writing HTML content or redirect headers.
+   */
   public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
-      throws ToadletContextClosedException, IOException, RedirectException {
-    if (!ctx.checkFullAccess(this)) return;
-
-    if (request.isPartSet("seclevels")) {
-      // Handle the security level changes.
-      HTMLNode pageNode = null;
-      HTMLNode content = null;
-      HTMLNode ul = null;
-      HTMLNode formNode = null;
-      boolean changedAnything = false;
-      String configName = "security-levels.networkThreatLevel";
-      String confirm = "security-levels.networkThreatLevel.confirm";
-      String tryConfirm = "security-levels.networkThreatLevel.tryConfirm";
-      String networkThreatLevel = request.getPartAsStringFailsafe(configName, 128);
-      NETWORK_THREAT_LEVEL newThreatLevel =
-          SecurityLevels.parseNetworkThreatLevel(networkThreatLevel);
-      if (newThreatLevel != null) {
-        if (newThreatLevel != node.getSecurityLevels().getNetworkThreatLevel()) {
-          if (!request.isPartSet(confirm) && !request.isPartSet(tryConfirm)) {
-            HTMLNode warning = node.getSecurityLevels().getConfirmWarning(newThreatLevel, confirm);
-            if (warning != null) {
-              PageNode page =
-                  ctx.getPageMaker()
-                      .getPageNode(NodeL10n.getBase().getString("ConfigToadlet.fullTitle"), ctx);
-              pageNode = page.getOuterNode();
-              content = page.getContentNode();
-              formNode = ctx.addFormChild(content, ".", "configFormSecLevels");
-              ul = formNode.addChild("ul", "class", "config");
-              HTMLNode seclevelGroup = ul.addChild("li");
-
-              seclevelGroup.addChild(
-                  "input",
-                  new String[] {"type", "name", "value"},
-                  new String[] {"hidden", configName, networkThreatLevel});
-              HTMLNode infobox =
-                  seclevelGroup.addChild("div", "class", "infobox infobox-information");
-              infobox.addChild(
-                  "div",
-                  "class",
-                  "infobox-header",
-                  l10nSec(
-                      "networkThreatLevelConfirmTitle",
-                      "mode",
-                      SecurityLevels.localisedName(newThreatLevel)));
-              HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
-              infoboxContent.addChild(warning);
-              infoboxContent.addChild(
-                  "input",
-                  new String[] {"type", "name", "value"},
-                  new String[] {"hidden", tryConfirm, "on"});
-            } else {
-              // Apply immediately, no confirm needed.
-              node.getSecurityLevels().setThreatLevel(newThreatLevel);
-              changedAnything = true;
-            }
-          } else if (request.isPartSet(confirm)) {
-            // Apply immediately, user confirmed it.
-            node.getSecurityLevels().setThreatLevel(newThreatLevel);
-            changedAnything = true;
-          }
-        }
-      }
-
-      configName = "security-levels.physicalThreatLevel";
-      confirm = "security-levels.physicalThreatLevel.confirm";
-      tryConfirm = "security-levels.physicalThreatLevel.tryConfirm";
-      String physicalThreatLevel = request.getPartAsStringFailsafe(configName, 128);
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel =
-          SecurityLevels.parsePhysicalThreatLevel(physicalThreatLevel);
-      PHYSICAL_THREAT_LEVEL oldPhysicalLevel =
-          core.getNode().getSecurityLevels().getPhysicalThreatLevel();
-      if (LOG.isDebugEnabled())
-        LOG.debug(
-            "New physical threat level: "
-                + newPhysicalLevel
-                + " old = "
-                + node.getSecurityLevels().getPhysicalThreatLevel());
-      if (newPhysicalLevel != null) {
-        if (newPhysicalLevel == oldPhysicalLevel
-            && newPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH) {
-          String password = request.getPartAsStringFailsafe("masterPassword", MAX_PASSWORD_LENGTH);
-          String oldPassword = request.getPartAsStringFailsafe("oldPassword", MAX_PASSWORD_LENGTH);
-          String confirmPassword =
-              request.getPartAsStringFailsafe("confirmMasterPassword", MAX_PASSWORD_LENGTH);
-          if (!oldPassword.isEmpty()
-              && !confirmPassword.isEmpty()
-              && !password.isEmpty()
-              && password.equals(confirmPassword)) {
-            try {
-              core.getNode().changeMasterPassword(oldPassword, password, false);
-            } catch (MasterKeysWrongPasswordException e) {
-              sendChangePasswordForm(ctx, true, false, newPhysicalLevel.name());
-              return;
-            } catch (MasterKeysFileSizeException e) {
-              sendPasswordFileCorruptedPage(e.isTooBig(), ctx, false, true);
-              if (changedAnything) core.storeConfig();
-              return;
-            } catch (AlreadySetPasswordException e) {
-              sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
-              if (changedAnything) core.storeConfig();
-              return;
-            }
-          } else if (!password.isEmpty() || !oldPassword.isEmpty() || !confirmPassword.isEmpty()) {
-            sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
-            if (changedAnything) core.storeConfig();
-            return;
-          }
-        }
-        if (newPhysicalLevel != oldPhysicalLevel) {
-          // No confirmation for changes to physical threat level.
-          if (newPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH
-              && node.getSecurityLevels().getPhysicalThreatLevel() != newPhysicalLevel) {
-            // Check for password
-            String password =
-                request.getPartAsStringFailsafe("masterPassword", MAX_PASSWORD_LENGTH);
-            String confirmPassword =
-                request.getPartAsStringFailsafe("confirmMasterPassword", MAX_PASSWORD_LENGTH);
-            if (!password.isEmpty()
-                && !confirmPassword.isEmpty()
-                && password.equals(confirmPassword)) {
-              try {
-                if (oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.NORMAL
-                    || oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.LOW)
-                  core.getNode().changeMasterPassword("", password, false);
-                else core.getNode().setMasterPassword(password, false);
-              } catch (AlreadySetPasswordException e) {
-                sendChangePasswordForm(ctx, false, false, newPhysicalLevel.name());
-                return;
-              } catch (MasterKeysWrongPasswordException e) {
-                System.err.println("Wrong password!");
-                PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
-                HTMLNode contentNode = page.getContentNode();
-
-                content =
-                    ctx.getPageMaker()
-                        .getInfobox(
-                            "infobox-error",
-                            l10nSec("passwordWrongTitle"),
-                            contentNode,
-                            "wrong-password",
-                            true)
-                        .addChild("div", "class", "infobox-content");
-                SecurityLevelsToadlet.generatePasswordFormPage(
-                    true,
-                    ctx.getContainer(),
-                    content,
-                    false,
-                    false,
-                    true,
-                    newPhysicalLevel.name(),
-                    null);
-                addBackToSeclevelsLink(content);
-                writeHTMLReply(ctx, 200, "OK", page.generate());
-                if (changedAnything) core.storeConfig();
-                return;
-              } catch (MasterKeysFileSizeException e) {
-                sendPasswordFileCorruptedPage(e.isTooBig(), ctx, false, true);
-                if (changedAnything) core.storeConfig();
-                return;
-              }
-            } else {
-              if (password.isEmpty() || confirmPassword.isEmpty()) {
-                sendPasswordPage(ctx, true, newPhysicalLevel.name());
-              } else {
-                sendPasswordPageMismatch(ctx, newPhysicalLevel.name());
-              }
-              if (changedAnything) core.storeConfig();
-              return;
-            }
-          }
-          if ((newPhysicalLevel == PHYSICAL_THREAT_LEVEL.LOW
-                  || newPhysicalLevel == PHYSICAL_THREAT_LEVEL.NORMAL)
-              && oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH) {
-            // Check for password
-            String password =
-                request.getPartAsStringFailsafe(
-                    "masterPassword", SecurityLevelsToadlet.MAX_PASSWORD_LENGTH);
-            if (!password.isEmpty()) {
-              // This is actually the OLD password ...
-              try {
-                core.getNode().changeMasterPassword(password, "", false);
-              } catch (IOException e) {
-                if (!core.getNode().getMasterPasswordFile().exists()) {
-                  // Ok.
-                  System.out.println(
-                      "Master password file no longer exists, assuming this is deliberate");
-                } else {
-                  System.err.println(
-                      "Cannot change password as cannot write new passwords file: " + e);
-                  e.printStackTrace();
-                  String msg =
-                      "<html><head><title>"
-                          + l10nSec("cantWriteNewMasterKeysFileTitle")
-                          + "</title></head><body><h1>"
-                          + l10nSec("cantWriteNewMasterKeysFileTitle")
-                          + "</h1><p>"
-                          + l10nSec("cantWriteNewMasterKeysFile")
-                          + "<pre>";
-                  StringWriter sw = new StringWriter();
-                  PrintWriter pw = new PrintWriter(sw);
-                  e.printStackTrace(pw);
-                  pw.flush();
-                  msg = msg + sw + "</pre></body></html>";
-                  writeHTMLReply(ctx, 500, "Internal Error", msg);
-                  if (changedAnything) core.storeConfig();
-                  return;
-                }
-              } catch (MasterKeysWrongPasswordException e) {
-                System.err.println("Wrong password!");
-                PageNode page =
-                    ctx.getPageMaker().getPageNode(l10nSec("passwordForDecryptTitle"), ctx);
-                HTMLNode contentNode = page.getContentNode();
-
-                content =
-                    ctx.getPageMaker()
-                        .getInfobox(
-                            "infobox-error",
-                            l10nSec("passwordWrongTitle"),
-                            contentNode,
-                            "wrong-password",
-                            true)
-                        .addChild("div", "class", "infobox-content");
-
-                SecurityLevelsToadlet.generatePasswordFormPage(
-                    true,
-                    ctx.getContainer(),
-                    content,
-                    false,
-                    true,
-                    false,
-                    newPhysicalLevel.name(),
-                    null);
-
-                addBackToSeclevelsLink(content);
-
-                writeHTMLReply(ctx, 200, "OK", page.generate());
-                if (changedAnything) core.storeConfig();
-                return;
-              } catch (MasterKeysFileSizeException e) {
-                sendPasswordFileCorruptedPage(e.isTooBig(), ctx, false, true);
-                if (changedAnything) core.storeConfig();
-                return;
-              } catch (AlreadySetPasswordException e) {
-                sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
-                if (changedAnything) core.storeConfig();
-                return;
-              }
-            } else if (core.getNode().getMasterPasswordFile().exists()) {
-              // We need the old password
-              PageNode page =
-                  ctx.getPageMaker().getPageNode(l10nSec("passwordForDecryptTitle"), ctx);
-              HTMLNode contentNode = page.getContentNode();
-
-              content =
-                  ctx.getPageMaker()
-                      .getInfobox(
-                          "infobox-error",
-                          l10nSec("passwordForDecryptTitle"),
-                          contentNode,
-                          "password-prompt",
-                          false)
-                      .addChild("div", "class", "infobox-content");
-
-              if (password.isEmpty()) {
-                content.addChild("p", l10nSec("passwordNotZeroLength"));
-              }
-
-              SecurityLevelsToadlet.generatePasswordFormPage(
-                  false,
-                  ctx.getContainer(),
-                  content,
-                  false,
-                  true,
-                  false,
-                  newPhysicalLevel.name(),
-                  null);
-
-              addBackToSeclevelsLink(content);
-
-              writeHTMLReply(ctx, 200, "OK", page.generate());
-              if (changedAnything) core.storeConfig();
-              return;
-            }
-          }
-          if (newPhysicalLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM) {
-            try {
-              core.getNode().killMasterKeysFile();
-            } catch (IOException e) {
-              sendCantDeleteMasterKeysFile(ctx, newPhysicalLevel.name());
-              return;
-            }
-          }
-          node.getSecurityLevels().setThreatLevel(newPhysicalLevel);
-          changedAnything = true;
-        }
-      }
-
-      if (changedAnything) core.storeConfig();
-
-      if (pageNode != null) {
-        formNode.addChild(
-            "input",
-            new String[] {"type", "name", "value"},
-            new String[] {"hidden", "seclevels", "on"});
-        formNode.addChild(
-            "input", new String[] {"type", "value"}, new String[] {"submit", l10n("apply")});
-        formNode.addChild(
-            "input", new String[] {"type", "value"}, new String[] {"reset", l10n("undo")});
-        writeHTMLReply(ctx, 200, "OK", pageNode.generate());
-        return;
-      } else {
-        MultiValueTable<String, String> headers = MultiValueTable.from("Location", "/seclevels/");
-        ctx.sendReplyHeaders(302, "Found", headers, null, 0);
-        return;
-      }
-    } else {
-
-      if (request.isPartSet("masterPassword")) {
-        String masterPassword = request.getPartAsStringFailsafe("masterPassword", 1024);
-        if (masterPassword.isEmpty()) {
-          sendPasswordPage(ctx, true, null);
-          return;
-        }
-        System.err.println("Setting master password");
-        try {
-          node.setMasterPassword(masterPassword, false);
-        } catch (AlreadySetPasswordException e) {
-          System.err.println("Already set master password");
-          LOG.error("Already set master password");
-          MultiValueTable<String, String> headers = MultiValueTable.from("Location", "/");
-          ctx.sendReplyHeaders(302, "Found", headers, null, 0);
-          return;
-        } catch (MasterKeysWrongPasswordException e) {
-          sendPasswordFormPage(true, ctx);
-          return;
-        } catch (MasterKeysFileSizeException e) {
-          sendPasswordFileCorruptedPage(e.isTooBig(), ctx, false, false);
-          return;
-        }
-        MultiValueTable<String, String> headers = new MultiValueTable<>();
-        if (request.isPartSet("redirect")) {
-          String to = request.getPartAsStringFailsafe("redirect", 100);
-          if (to.startsWith("/")) {
-            headers.put("Location", to);
-            ctx.sendReplyHeaders(302, "Found", headers, null, 0);
-            return;
-          }
-        }
-        headers.put("Location", "/");
-        ctx.sendReplyHeaders(302, "Found", headers, null, 0);
-        return;
-      }
-
-      try {
-        throw new RedirectException("/seclevels/");
-      } catch (URISyntaxException e) {
-        // Impossible
-      }
+      throws ToadletContextClosedException, IOException {
+    Objects.requireNonNull(uri);
+    if (!ctx.checkFullAccess(this)) {
+      return;
     }
 
-    MultiValueTable<String, String> headers = MultiValueTable.from("Location", "/");
-    ctx.sendReplyHeaders(302, "Found", headers, null, 0);
+    if (request.isPartSet(PARAM_SECLEVELS)) {
+      handleSecurityLevelsPost(request, ctx);
+    } else if (request.isPartSet(PARAM_MASTER_PASSWORD)) {
+      handleMasterPasswordPost(request, ctx);
+    } else {
+      redirectToSeclevels(ctx);
+    }
+  }
+
+  private void handleSecurityLevelsPost(HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    SecurityChangeState state = new SecurityChangeState();
+
+    processNetworkThreatLevel(request, ctx, state);
+
+    if (processPhysicalThreatLevel(request, ctx, state)) {
+      return;
+    }
+
+    if (state.changedAnything) {
+      core.storeConfig();
+    }
+
+    if (state.hasConfirmPage()) {
+      finalizeConfirmationPage(ctx, state);
+    } else {
+      redirectToSeclevels(ctx);
+    }
+  }
+
+  private void processNetworkThreatLevel(
+      HTTPRequest request, ToadletContext ctx, SecurityChangeState state) {
+    String networkThreatLevel = request.getPartAsStringFailsafe(PARAM_NETWORK_THREAT_LEVEL, 128);
+    NETWORK_THREAT_LEVEL newThreatLevel =
+        SecurityLevels.parseNetworkThreatLevel(networkThreatLevel);
+    NETWORK_THREAT_LEVEL currentLevel = node.getSecurityLevels().getNetworkThreatLevel();
+
+    if (newThreatLevel == null || newThreatLevel == currentLevel) {
+      return;
+    }
+
+    if (request.isPartSet(PARAM_NETWORK_THREAT_LEVEL_CONFIRM)) {
+      node.getSecurityLevels().setThreatLevel(newThreatLevel);
+      state.changedAnything = true;
+      return;
+    }
+
+    HTMLNode warning =
+        node.getSecurityLevels()
+            .getConfirmWarning(newThreatLevel, PARAM_NETWORK_THREAT_LEVEL_CONFIRM);
+    if (warning == null) {
+      node.getSecurityLevels().setThreatLevel(newThreatLevel);
+      state.changedAnything = true;
+      return;
+    }
+
+    buildNetworkConfirmPage(networkThreatLevel, newThreatLevel, ctx, state, warning);
+  }
+
+  private void buildNetworkConfirmPage(
+      String networkThreatLevel,
+      NETWORK_THREAT_LEVEL newThreatLevel,
+      ToadletContext ctx,
+      SecurityChangeState state,
+      HTMLNode warning) {
+    PageNode page =
+        ctx.getPageMaker()
+            .getPageNode(NodeL10n.getBase().getString("ConfigToadlet.fullTitle"), ctx);
+    state.pageNode = page.getOuterNode();
+    HTMLNode content = page.getContentNode();
+    state.formNode = ctx.addFormChild(content, ".", "configFormSecLevels");
+    HTMLNode ul = state.formNode.addChild("ul", ATTR_CLASS, CLASS_CONFIG);
+    HTMLNode seclevelGroup = ul.addChild("li");
+
+    seclevelGroup.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {INPUT_HIDDEN, PARAM_NETWORK_THREAT_LEVEL, networkThreatLevel});
+    HTMLNode infobox = seclevelGroup.addChild(TAG_DIV, ATTR_CLASS, "infobox infobox-information");
+    infobox.addChild(
+        TAG_DIV,
+        ATTR_CLASS,
+        "infobox-header",
+        l10nSec(
+            "networkThreatLevelConfirmTitle",
+            "mode",
+            SecurityLevels.localisedName(newThreatLevel)));
+    HTMLNode infoboxContent = infobox.addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
+    infoboxContent.addChild(warning);
+    infoboxContent.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {INPUT_HIDDEN, PARAM_NETWORK_THREAT_LEVEL_TRY_CONFIRM, "on"});
+  }
+
+  private boolean processPhysicalThreatLevel(
+      HTTPRequest request, ToadletContext ctx, SecurityChangeState state)
+      throws ToadletContextClosedException, IOException {
+    String physicalThreatLevel = request.getPartAsStringFailsafe(PARAM_PHYSICAL_THREAT_LEVEL, 128);
+    PHYSICAL_THREAT_LEVEL newPhysicalLevel =
+        SecurityLevels.parsePhysicalThreatLevel(physicalThreatLevel);
+    PHYSICAL_THREAT_LEVEL oldPhysicalLevel =
+        core.getNode().getSecurityLevels().getPhysicalThreatLevel();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "New physical threat level: {} old = {}",
+          newPhysicalLevel,
+          node.getSecurityLevels().getPhysicalThreatLevel());
+    }
+
+    if (newPhysicalLevel == null) {
+      return false;
+    }
+
+    if (isSameHighThreatLevel(newPhysicalLevel, oldPhysicalLevel)) {
+      return handlePasswordChangeWhileHigh(request, ctx, state, newPhysicalLevel);
+    }
+
+    if (newPhysicalLevel == oldPhysicalLevel) {
+      return false;
+    }
+
+    if (newPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH
+        && handleUpgradeToHigh(request, ctx, state, oldPhysicalLevel, newPhysicalLevel)) {
+      return true;
+    }
+
+    if (isDowngradeFromHigh(newPhysicalLevel, oldPhysicalLevel)
+        && handleDowngradeFromHigh(request, ctx, state, newPhysicalLevel)) {
+      return true;
+    }
+
+    if (newPhysicalLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM
+        && handleMaximumLevel(ctx, newPhysicalLevel)) {
+      return true;
+    }
+
+    node.getSecurityLevels().setThreatLevel(newPhysicalLevel);
+    state.changedAnything = true;
+    return false;
+  }
+
+  private boolean handlePasswordChangeWhileHigh(
+      HTTPRequest request,
+      ToadletContext ctx,
+      SecurityChangeState state,
+      PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      throws ToadletContextClosedException, IOException {
+
+    String password = request.getPartAsStringFailsafe(PARAM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
+    String oldPassword = request.getPartAsStringFailsafe(PARAM_OLD_PASSWORD, MAX_PASSWORD_LENGTH);
+    String confirmPassword =
+        request.getPartAsStringFailsafe(PARAM_CONFIRM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
+    if (!oldPassword.isEmpty()
+        && !confirmPassword.isEmpty()
+        && !password.isEmpty()
+        && password.equals(confirmPassword)) {
+      try {
+        core.getNode().changeMasterPassword(oldPassword, password, false);
+      } catch (MasterKeysWrongPasswordException e) {
+        sendChangePasswordForm(ctx, true, false, newPhysicalLevel.name());
+        storeConfigIfChanged(state);
+        return true;
+      } catch (MasterKeysFileSizeException e) {
+        sendPasswordFileCorruptedPage(ctx);
+        storeConfigIfChanged(state);
+        return true;
+      } catch (AlreadySetPasswordException e) {
+        sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
+        storeConfigIfChanged(state);
+        return true;
+      }
+    } else if (!password.isEmpty() || !oldPassword.isEmpty() || !confirmPassword.isEmpty()) {
+      sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
+      storeConfigIfChanged(state);
+      return true;
+    }
+    return false;
+  }
+
+  private boolean applyDowngradePasswordChange(
+      String password,
+      ToadletContext ctx,
+      SecurityChangeState state,
+      PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      throws ToadletContextClosedException, IOException {
+    try {
+      core.getNode().changeMasterPassword(password, "", false);
+    } catch (IOException e) {
+      if (!core.getNode().getMasterPasswordFile().exists()) {
+        LOG.info("Master password file no longer exists, assuming this is deliberate");
+      } else {
+        LOG.error("Cannot change password as cannot write new passwords file", e);
+        String msg =
+            "<html><head><title>"
+                + l10nSec("cantWriteNewMasterKeysFileTitle")
+                + "</title></head><body><h1>"
+                + l10nSec("cantWriteNewMasterKeysFileTitle")
+                + "</h1><p>"
+                + l10nSec("cantWriteNewMasterKeysFile")
+                + "<pre>";
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        pw.flush();
+        msg = msg + sw + "</pre></body></html>";
+        writeHTMLReply(ctx, 500, "Internal Error", msg);
+        storeConfigIfChanged(state);
+        return true;
+      }
+    } catch (MasterKeysWrongPasswordException e) {
+      LOG.warn("Wrong password supplied when downgrading from HIGH", e);
+      sendWrongPasswordResponse(
+          ctx, PASSWORD_FOR_DECRYPT_TITLE_KEY, true, false, newPhysicalLevel.name());
+      storeConfigIfChanged(state);
+      return true;
+    } catch (MasterKeysFileSizeException e) {
+      sendPasswordFileCorruptedPage(ctx);
+      storeConfigIfChanged(state);
+      return true;
+    } catch (AlreadySetPasswordException e) {
+      sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
+      storeConfigIfChanged(state);
+      return true;
+    }
+    return false;
+  }
+
+  private boolean handleUpgradeToHigh(
+      HTTPRequest request,
+      ToadletContext ctx,
+      SecurityChangeState state,
+      PHYSICAL_THREAT_LEVEL oldPhysicalLevel,
+      PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      throws ToadletContextClosedException, IOException {
+    String password = request.getPartAsStringFailsafe(PARAM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
+    String confirmPassword =
+        request.getPartAsStringFailsafe(PARAM_CONFIRM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
+    if (!passwordsMatch(password, confirmPassword)) {
+      return handleUpgradePasswordMismatch(ctx, state, newPhysicalLevel, password, confirmPassword);
+    }
+    return applyUpgradePassword(oldPhysicalLevel, newPhysicalLevel, password, ctx, state);
+  }
+
+  private boolean passwordsMatch(String password, String confirmPassword) {
+    return !password.isEmpty() && !confirmPassword.isEmpty() && password.equals(confirmPassword);
+  }
+
+  private boolean handleUpgradePasswordMismatch(
+      ToadletContext ctx,
+      SecurityChangeState state,
+      PHYSICAL_THREAT_LEVEL newPhysicalLevel,
+      String password,
+      String confirmPassword)
+      throws ToadletContextClosedException, IOException {
+    if (password.isEmpty() || confirmPassword.isEmpty()) {
+      sendPasswordPage(ctx, newPhysicalLevel.name());
+    } else {
+      sendPasswordPageMismatch(ctx, newPhysicalLevel.name());
+    }
+    storeConfigIfChanged(state);
+    return true;
+  }
+
+  private boolean applyUpgradePassword(
+      PHYSICAL_THREAT_LEVEL oldPhysicalLevel,
+      PHYSICAL_THREAT_LEVEL newPhysicalLevel,
+      String password,
+      ToadletContext ctx,
+      SecurityChangeState state)
+      throws ToadletContextClosedException, IOException {
+    try {
+      if (oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.NORMAL
+          || oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.LOW) {
+        core.getNode().changeMasterPassword("", password, false);
+      } else {
+        core.getNode().setMasterPassword(password, false);
+      }
+    } catch (AlreadySetPasswordException e) {
+      sendChangePasswordForm(ctx, false, false, newPhysicalLevel.name());
+      storeConfigIfChanged(state);
+      return true;
+    } catch (MasterKeysWrongPasswordException e) {
+      LOG.warn("Wrong password supplied when upgrading to HIGH", e);
+      sendWrongPasswordResponse(ctx, PASSWORD_PAGE_TITLE_KEY, false, true, newPhysicalLevel.name());
+      storeConfigIfChanged(state);
+      return true;
+    } catch (MasterKeysFileSizeException e) {
+      sendPasswordFileCorruptedPage(ctx);
+      storeConfigIfChanged(state);
+      return true;
+    }
+    return false;
+  }
+
+  private boolean handleDowngradeFromHigh(
+      HTTPRequest request,
+      ToadletContext ctx,
+      SecurityChangeState state,
+      PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      throws ToadletContextClosedException, IOException {
+    String password = request.getPartAsStringFailsafe(PARAM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
+    if (!password.isEmpty()) {
+      return applyDowngradePasswordChange(password, ctx, state, newPhysicalLevel);
+    } else if (core.getNode().getMasterPasswordFile().exists()) {
+      PageNode page = ctx.getPageMaker().getPageNode(l10nSec(PASSWORD_FOR_DECRYPT_TITLE_KEY), ctx);
+      HTMLNode contentNode = page.getContentNode();
+
+      HTMLNode content =
+          ctx.getPageMaker()
+              .getInfobox(
+                  INFOBOX_ERROR,
+                  l10nSec(PASSWORD_FOR_DECRYPT_TITLE_KEY),
+                  contentNode,
+                  "password-prompt",
+                  false)
+              .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
+      content.addChild("p", l10nSec(PASSWORD_NOT_ZERO_LENGTH_KEY));
+
+      SecurityLevelsToadlet.generatePasswordFormPage(
+          false, ctx.getContainer(), content, false, true, false, newPhysicalLevel.name(), null);
+
+      addBackToSeclevelsLink(content);
+
+      writeHTMLReply(ctx, 200, "OK", page.generate());
+      storeConfigIfChanged(state);
+      return true;
+    }
+    return false;
+  }
+
+  private void sendWrongPasswordResponse(
+      ToadletContext ctx,
+      String pageTitleKey,
+      boolean forDowngrade,
+      boolean forUpgrade,
+      String physicalLevel)
+      throws ToadletContextClosedException, IOException {
+    PageNode page = ctx.getPageMaker().getPageNode(l10nSec(pageTitleKey), ctx);
+    HTMLNode contentNode = page.getContentNode();
+
+    HTMLNode content =
+        ctx.getPageMaker()
+            .getInfobox(
+                INFOBOX_ERROR,
+                l10nSec(PASSWORD_WRONG_TITLE_KEY),
+                contentNode,
+                "wrong-password",
+                true)
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
+    SecurityLevelsToadlet.generatePasswordFormPage(
+        true, ctx.getContainer(), content, false, forDowngrade, forUpgrade, physicalLevel, null);
+    addBackToSeclevelsLink(content);
+    writeHTMLReply(ctx, 200, "OK", page.generate());
+  }
+
+  private boolean handleMaximumLevel(ToadletContext ctx, PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      throws ToadletContextClosedException, IOException {
+    try {
+      core.getNode().killMasterKeysFile();
+    } catch (IOException e) {
+      sendCantDeleteMasterKeysFile(ctx, newPhysicalLevel.name());
+      return true;
+    }
+    return false;
+  }
+
+  private void handleMasterPasswordPost(HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    String masterPassword =
+        request.getPartAsStringFailsafe(PARAM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
+    if (masterPassword.isEmpty()) {
+      sendPasswordPage(ctx, null);
+      return;
+    }
+    LOG.info("Setting master password");
+    try {
+      node.setMasterPassword(masterPassword, false);
+    } catch (AlreadySetPasswordException e) {
+      LOG.error("Already set master password");
+      redirectToRoot(ctx);
+      return;
+    } catch (MasterKeysWrongPasswordException e) {
+      sendPasswordFormPage(ctx);
+      return;
+    } catch (MasterKeysFileSizeException e) {
+      sendPasswordFileCorruptedPage(ctx);
+      return;
+    }
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    if (request.isPartSet(PARAM_REDIRECT)) {
+      String to = request.getPartAsStringFailsafe(PARAM_REDIRECT, 100);
+      if (to.startsWith("/")) {
+        headers.put(HEADER_LOCATION, to);
+        ctx.sendReplyHeaders(302, STATUS_FOUND, headers, null, 0);
+        return;
+      }
+    }
+    redirectToRoot(ctx);
+  }
+
+  private void finalizeConfirmationPage(ToadletContext ctx, SecurityChangeState state)
+      throws ToadletContextClosedException, IOException {
+    state.formNode.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {INPUT_HIDDEN, PARAM_SECLEVELS, "on"});
+    state.formNode.addChild(
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_VALUE},
+        new String[] {INPUT_SUBMIT, l10n("apply")});
+    state.formNode.addChild(
+        TAG_INPUT, new String[] {ATTR_TYPE, ATTR_VALUE}, new String[] {"reset", l10n("undo")});
+    writeHTMLReply(ctx, 200, "OK", state.pageNode.generate());
+  }
+
+  private void redirectToSeclevels(ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    MultiValueTable<String, String> headers = MultiValueTable.from(HEADER_LOCATION, PATH);
+    ctx.sendReplyHeaders(302, STATUS_FOUND, headers, null, 0);
+  }
+
+  private void redirectToRoot(ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    MultiValueTable<String, String> headers = MultiValueTable.from(HEADER_LOCATION, "/");
+    ctx.sendReplyHeaders(302, STATUS_FOUND, headers, null, 0);
+  }
+
+  private void storeConfigIfChanged(SecurityChangeState state) {
+    if (state.changedAnything) {
+      core.storeConfig();
+    }
+  }
+
+  private boolean isDowngradeFromHigh(
+      PHYSICAL_THREAT_LEVEL newPhysicalLevel, PHYSICAL_THREAT_LEVEL oldPhysicalLevel) {
+    return (newPhysicalLevel == PHYSICAL_THREAT_LEVEL.LOW
+            || newPhysicalLevel == PHYSICAL_THREAT_LEVEL.NORMAL)
+        && oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH;
+  }
+
+  private boolean isSameHighThreatLevel(
+      PHYSICAL_THREAT_LEVEL newPhysicalLevel, PHYSICAL_THREAT_LEVEL oldPhysicalLevel) {
+    return newPhysicalLevel == oldPhysicalLevel && newPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH;
   }
 
   private void sendCantDeleteMasterKeysFile(ToadletContext ctx, String physicalSecurityLevel)
       throws ToadletContextClosedException, IOException {
     HTMLNode pageNode =
         sendCantDeleteMasterKeysFileInner(
-            ctx, node.getMasterPasswordFile().getPath(), false, physicalSecurityLevel, this.node);
+            ctx, node.getMasterPasswordFile().getPath(), false, physicalSecurityLevel);
     writeHTMLReply(ctx, 200, "OK", pageNode.generate());
   }
 
+  /**
+   * Adds an inline infobox to the first-time wizard when the node cannot delete the master password
+   * file. The helper wires the error message into the wizard page, preserves the selected physical
+   * threat level, and emits a retry form so users can resolve filesystem permissions without
+   * abandoning the setup flow.
+   *
+   * @param helper wizard helper that supplies localization and form creation utilities.
+   * @param filename absolute path to the password file that failed to delete; displayed verbatim to
+   *     aid troubleshooting.
+   * @param physicalSecurityLevel textual representation of the chosen physical threat level that
+   *     should persist across retries.
+   */
   public static void sendCantDeleteMasterKeysFileInner(
       PageHelper helper, String filename, String physicalSecurityLevel) {
-    HTMLNode contentNode = helper.getPageContent(l10nSec("cantDeletePasswordFileTitle"));
+    HTMLNode contentNode = helper.getPageContent(l10nSec(CANT_DELETE_PASSWORD_FILE_TITLE_KEY));
     HTMLNode content =
         helper
             .getInfobox(
-                "infobox-error",
-                l10nSec("cantDeletePasswordFileTitle"),
+                INFOBOX_ERROR,
+                l10nSec(CANT_DELETE_PASSWORD_FILE_TITLE_KEY),
                 contentNode,
-                "password-error",
+                PASSWORD_ERROR_CLASS,
                 true)
-            .addChild("div", "class", "infobox-content");
-    HTMLNode form = helper.addFormChild(content, "/wizard/", "masterPasswordForm");
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
+    HTMLNode form = helper.addFormChild(content, "/wizard/", MASTER_PASSWORD_FORM);
     sendCantDeleteMasterKeysFileInner(content, form, filename, physicalSecurityLevel);
   }
 
+  /**
+   * Constructs a full error page explaining that the master password file could not be deleted and
+   * provides a retry action. It uses the supplied context to build a localized page shell, embeds
+   * an infobox describing the failure, and returns the outer HTML node so callers can serialize the
+   * page themselves. When invoked from the wizard flow the generated form posts to the wizard; in
+   * other contexts it posts back to this toadlet while keeping the chosen physical threat level.
+   *
+   * @param ctx toadlet context used for page construction and localization; must be non-null.
+   * @param filename absolute path to the password file that failed deletion; shown to the user.
+   * @param forFirstTimeWizard whether the retry form should target the first-time wizard handler.
+   * @param physicalSecurityLevel current physical threat level label persisted across submissions.
+   * @return outer HTML node containing the fully prepared page for immediate rendering.
+   */
   public static HTMLNode sendCantDeleteMasterKeysFileInner(
       ToadletContext ctx,
       String filename,
       boolean forFirstTimeWizard,
-      String physicalSecurityLevel,
-      Node node) {
-    PageNode page = ctx.getPageMaker().getPageNode(l10nSec("cantDeletePasswordFileTitle"), ctx);
+      String physicalSecurityLevel) {
+    PageNode page =
+        ctx.getPageMaker().getPageNode(l10nSec(CANT_DELETE_PASSWORD_FILE_TITLE_KEY), ctx);
     HTMLNode pageNode = page.getOuterNode();
     HTMLNode contentNode = page.getContentNode();
 
     HTMLNode content =
         ctx.getPageMaker()
             .getInfobox(
-                "infobox-error",
-                l10nSec("cantDeletePasswordFileTitle"),
+                INFOBOX_ERROR,
+                l10nSec(CANT_DELETE_PASSWORD_FILE_TITLE_KEY),
                 contentNode,
-                "password-error",
+                PASSWORD_ERROR_CLASS,
                 true)
-            .addChild("div", "class", "infobox-content");
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
 
     HTMLNode form =
         forFirstTimeWizard
-            ? ctx.addFormChild(content, "/wizard/", "masterPasswordForm")
-            : ctx.addFormChild(content, "/seclevels/", "masterPasswordForm");
+            ? ctx.addFormChild(content, "/wizard/", MASTER_PASSWORD_FORM)
+            : ctx.addFormChild(content, PATH, MASTER_PASSWORD_FORM);
 
     sendCantDeleteMasterKeysFileInner(content, form, filename, physicalSecurityLevel);
     return pageNode;
@@ -466,27 +675,36 @@ public class SecurityLevelsToadlet extends Toadlet {
   private static void sendCantDeleteMasterKeysFileInner(
       HTMLNode content, HTMLNode form, String filename, String physicalSecurityLevel) {
     form.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"hidden", "security-levels.physicalThreatLevel", physicalSecurityLevel});
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {INPUT_HIDDEN, PARAM_PHYSICAL_THREAT_LEVEL, physicalSecurityLevel});
     form.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"hidden", "seclevels", "true"});
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {INPUT_HIDDEN, PARAM_SECLEVELS, "true"});
 
     form.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"submit", "tryAgain", l10nSec("cantDeletePasswordFileButton")});
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {INPUT_SUBMIT, "tryAgain", l10nSec("cantDeletePasswordFileButton")});
 
     content.addChild("p", l10nSec("cantDeletePasswordFile", "filename", filename));
   }
 
   /**
-   * Send a form asking the user to change the password.
+   * Sends a form requesting a master password change when the node already operates at high
+   * physical threat level. The form highlights empty or incorrect passwords when indicated,
+   * preserves the current physical threat level through hidden fields, and links back to the
+   * security levels page. Configuration is not persisted here; callers remain responsible for
+   * saving after successful submission.
    *
-   * @throws IOException
-   * @throws ToadletContextClosedException
+   * @param ctx toadlet context used to construct the page and write the response.
+   * @param wrongPassword whether the previous attempt failed validation and should show an error.
+   * @param emptyPassword whether the previous submission omitted a password and requires a prompt.
+   * @param physicalSecurityLevel selected physical threat level to retain across form posts.
+   * @throws IOException if an error occurs while generating or sending the HTML response body.
+   * @throws ToadletContextClosedException if the client connection closes before the reply finishes
+   *     sending.
    */
   private void sendChangePasswordForm(
       ToadletContext ctx,
@@ -502,15 +720,11 @@ public class SecurityLevelsToadlet extends Toadlet {
     HTMLNode content =
         ctx.getPageMaker()
             .getInfobox(
-                "infobox-error",
-                l10nSec("changePasswordTitle"),
-                contentNode,
-                "password-change",
-                true)
-            .addChild("div", "class", "infobox-content");
+                INFOBOX_ERROR, l10nSec("changePasswordTitle"), contentNode, "password-change", true)
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
 
     if (emptyPassword) {
-      content.addChild("p", l10nSec("passwordNotZeroLength"));
+      content.addChild("p", l10nSec(PASSWORD_NOT_ZERO_LENGTH_KEY));
     }
 
     if (wrongPassword) {
@@ -523,35 +737,37 @@ public class SecurityLevelsToadlet extends Toadlet {
 
     if (physicalSecurityLevel != null) {
       form.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "security-levels.physicalThreatLevel", physicalSecurityLevel});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {INPUT_HIDDEN, PARAM_PHYSICAL_THREAT_LEVEL, physicalSecurityLevel});
       form.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "seclevels", "true"});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {INPUT_HIDDEN, PARAM_SECLEVELS, "true"});
     }
     addBackToSeclevelsLink(content);
 
     writeHTMLReply(ctx, 200, "OK", page.generate());
   }
 
-  private void sendPasswordPage(ToadletContext ctx, boolean emptyPassword, String threatlevel)
+  private void sendPasswordPage(ToadletContext ctx, String threatlevel)
       throws ToadletContextClosedException, IOException {
 
     // Must set a password!
-    PageNode page = ctx.getPageMaker().getPageNode(l10nSec("setPasswordTitle"), ctx);
+    PageNode page = ctx.getPageMaker().getPageNode(l10nSec(SET_PASSWORD_TITLE_KEY), ctx);
     HTMLNode contentNode = page.getContentNode();
 
     HTMLNode content =
         ctx.getPageMaker()
             .getInfobox(
-                "infobox-error", l10nSec("setPasswordTitle"), contentNode, "password-prompt", false)
-            .addChild("div", "class", "infobox-content");
+                INFOBOX_ERROR,
+                l10nSec(SET_PASSWORD_TITLE_KEY),
+                contentNode,
+                "password-prompt",
+                false)
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
 
-    if (emptyPassword) {
-      content.addChild("p", l10nSec("passwordNotZeroLength"));
-    }
+    content.addChild("p", l10nSec(PASSWORD_NOT_ZERO_LENGTH_KEY));
 
     SecurityLevelsToadlet.generatePasswordFormPage(
         false, ctx.getContainer(), content, false, false, true, threatlevel, null);
@@ -565,6 +781,19 @@ public class SecurityLevelsToadlet extends Toadlet {
     content.addChild("p").addChild("a", "href", PATH, l10nSec("backToSecurityLevels"));
   }
 
+  /**
+   * Renders the current security levels page for HTTP GET requests. It injects any accumulated
+   * alerts, displays network and physical threat options with localized guidance, and ensures the
+   * appropriate password prompts are visible based on the node state. The page is generated through
+   * the shared page maker to preserve consistent layout and theming across the UI.
+   *
+   * @param uri incoming request URI; retained for compatibility with the toadlet interface.
+   * @param req HTTP request object supplying parameters used to pre-fill form fields when needed.
+   * @param ctx toadlet context that validates full access and writes the completed page to the
+   *     client.
+   * @throws ToadletContextClosedException if the response output stream is closed prematurely.
+   * @throws IOException if output generation fails during HTML serialization or transmission.
+   */
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     if (!ctx.checkFullAccess(this)) return;
@@ -582,111 +811,121 @@ public class SecurityLevelsToadlet extends Toadlet {
   }
 
   private void drawSecurityLevelsPage(HTMLNode contentNode, ToadletContext ctx) {
-    HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-normal");
-    infobox.addChild("div", "class", "infobox-header", l10nSec("title"));
-    HTMLNode configNode = infobox.addChild("div", "class", "infobox-content");
-    HTMLNode formNode = ctx.addFormChild(configNode, ".", "configFormSecLevels");
-    // Network security level
-    formNode.addChild("div", "class", "configprefix", l10nSec("networkThreatLevelShort"));
-    HTMLNode ul = formNode.addChild("ul", "class", "config");
+    HTMLNode formNode = createSeclevelsForm(contentNode, ctx);
+
+    NETWORK_THREAT_LEVEL networkLevel = node.getSecurityLevels().getNetworkThreatLevel();
+    addNetworkThreatSection(formNode, networkLevel);
+
+    PHYSICAL_THREAT_LEVEL physicalLevel = node.getSecurityLevels().getPhysicalThreatLevel();
+    addPhysicalThreatSection(formNode, physicalLevel);
+
+    addFormButtons(formNode);
+  }
+
+  private HTMLNode createSeclevelsForm(HTMLNode contentNode, ToadletContext ctx) {
+    HTMLNode infobox = contentNode.addChild(TAG_DIV, ATTR_CLASS, "infobox infobox-normal");
+    infobox.addChild(TAG_DIV, ATTR_CLASS, "infobox-header", l10nSec("title"));
+    HTMLNode configNode = infobox.addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
+    return ctx.addFormChild(configNode, ".", "configFormSecLevels");
+  }
+
+  private void addNetworkThreatSection(
+      HTMLNode formNode, NETWORK_THREAT_LEVEL currentNetworkLevel) {
+    formNode.addChild(TAG_DIV, ATTR_CLASS, "configprefix", l10nSec("networkThreatLevelShort"));
+    HTMLNode ul = formNode.addChild("ul", ATTR_CLASS, CLASS_CONFIG);
     HTMLNode seclevelGroup = ul.addChild("li");
     seclevelGroup.addChild("#", l10nSec("networkThreatLevel.opennetIntro"));
 
-    NETWORK_THREAT_LEVEL networkLevel = node.getSecurityLevels().getNetworkThreatLevel();
+    addNetworkGroup(
+        seclevelGroup,
+        "networkThreatLevel.opennetLabel",
+        "networkThreatLevel.opennetExplain",
+        NETWORK_THREAT_LEVEL.getOpennetValues(),
+        currentNetworkLevel,
+        "opennetDiv",
+        false);
 
-    HTMLNode p = seclevelGroup.addChild("p");
-    p.addChild("b", l10nSec("networkThreatLevel.opennetLabel"));
-    p.addChild("#", ": " + l10nSec("networkThreatLevel.opennetExplain"));
-    HTMLNode div = seclevelGroup.addChild("div", "class", "opennetDiv");
+    addNetworkGroup(
+        seclevelGroup,
+        "networkThreatLevel.darknetLabel",
+        "networkThreatLevel.darknetExplain",
+        NETWORK_THREAT_LEVEL.getDarknetValues(),
+        currentNetworkLevel,
+        "darknetDiv",
+        true);
 
-    String controlName = "security-levels.networkThreatLevel";
-    for (NETWORK_THREAT_LEVEL level : NETWORK_THREAT_LEVEL.getOpennetValues()) {
-      HTMLNode input;
-      if (level == networkLevel) {
-        input =
-            div.addChild("p")
-                .addChild(
-                    "input",
-                    new String[] {"type", "checked", "name", "value", "id"},
-                    new String[] {
-                      "radio", "on", controlName, level.name(), controlName + level.name()
-                    });
-      } else {
-        input =
-            div.addChild("p")
-                .addChild(
-                    "input",
-                    new String[] {"type", "name", "value", "id"},
-                    new String[] {"radio", controlName, level.name(), controlName + level.name()});
-      }
-      input
-          .addChild("label", new String[] {"for"}, new String[] {controlName + level.name()})
-          .addChild("b", l10nSec("networkThreatLevel.name." + level));
-      input.addChild("#", ": ");
-      NodeL10n.getBase()
-          .addL10nSubstitution(
-              input,
-              "SecurityLevels.networkThreatLevel.choice." + level,
-              new String[] {"bold"},
-              new HTMLNode[] {HTMLNode.STRONG});
-      HTMLNode inner = input.addChild("p").addChild("i");
+    seclevelGroup.addChild("p").addChild("b", l10nSec("networkThreatLevel.opennetFriendsWarning"));
+  }
 
-      NodeL10n.getBase()
-          .addL10nSubstitution(
-              inner,
-              "SecurityLevels.networkThreatLevel.desc." + level,
-              new String[] {"bold"},
-              new HTMLNode[] {HTMLNode.STRONG});
+  private void addNetworkGroup(
+      HTMLNode seclevelGroup,
+      String labelKey,
+      String explainKey,
+      NETWORK_THREAT_LEVEL[] levels,
+      NETWORK_THREAT_LEVEL currentNetworkLevel,
+      String cssClass,
+      boolean includeLink) {
+    HTMLNode paragraph = seclevelGroup.addChild("p");
+    paragraph.addChild("b", l10nSec(labelKey));
+    paragraph.addChild("#", ": " + l10nSec(explainKey));
+    HTMLNode container = seclevelGroup.addChild(TAG_DIV, ATTR_CLASS, cssClass);
+
+    for (NETWORK_THREAT_LEVEL level : levels) {
+      addNetworkLevelOption(container, currentNetworkLevel, level, includeLink);
     }
+  }
 
-    p = seclevelGroup.addChild("p");
-    p.addChild("b", l10nSec("networkThreatLevel.darknetLabel"));
-    p.addChild("#", ": " + l10nSec("networkThreatLevel.darknetExplain"));
-    div = seclevelGroup.addChild("div", "class", "darknetDiv");
+  private void addNetworkLevelOption(
+      HTMLNode container,
+      NETWORK_THREAT_LEVEL currentNetworkLevel,
+      NETWORK_THREAT_LEVEL level,
+      boolean includeLink) {
+    String inputId = PARAM_NETWORK_THREAT_LEVEL + level.name();
+    HTMLNode input =
+        addRadioInput(
+            container.addChild("p"),
+            PARAM_NETWORK_THREAT_LEVEL,
+            level.name(),
+            level == currentNetworkLevel,
+            inputId);
+    input
+        .addChild(TAG_LABEL, new String[] {"for"}, new String[] {inputId})
+        .addChild("b", l10nSec("networkThreatLevel.name." + level));
+    input.addChild("#", ": ");
+    addNetworkDescriptions(input, level, includeLink);
+  }
 
-    for (NETWORK_THREAT_LEVEL level : NETWORK_THREAT_LEVEL.getDarknetValues()) {
-      HTMLNode input;
-      if (level == networkLevel) {
-        input =
-            div.addChild("p")
-                .addChild(
-                    "input",
-                    new String[] {"type", "checked", "name", "value", "id"},
-                    new String[] {
-                      "radio", "on", controlName, level.name(), controlName + level.name()
-                    });
-      } else {
-        input =
-            div.addChild("p")
-                .addChild(
-                    "input",
-                    new String[] {"type", "name", "value", "id"},
-                    new String[] {"radio", controlName, level.name(), controlName + level.name()});
-      }
-      input
-          .addChild("label", new String[] {"for"}, new String[] {controlName + level.name()})
-          .addChild("b", l10nSec("networkThreatLevel.name." + level));
-      input.addChild("#", ": ");
-      NodeL10n.getBase()
-          .addL10nSubstitution(
-              input,
-              "SecurityLevels.networkThreatLevel.choice." + level,
-              new String[] {"bold"},
-              new HTMLNode[] {HTMLNode.STRONG});
-      HTMLNode inner = input.addChild("p").addChild("i");
+  private void addNetworkDescriptions(
+      HTMLNode input, NETWORK_THREAT_LEVEL level, boolean includeLink) {
+    NodeL10n.getBase()
+        .addL10nSubstitution(
+            input,
+            "SecurityLevels.networkThreatLevel.choice." + level,
+            new String[] {"bold"},
+            new HTMLNode[] {HTMLNode.STRONG});
+    HTMLNode inner = input.addChild("p").addChild("i");
+    if (includeLink) {
       NodeL10n.getBase()
           .addL10nSubstitution(
               inner,
               "SecurityLevels.networkThreatLevel.desc." + level,
               new String[] {"bold", "link"},
               new HTMLNode[] {HTMLNode.STRONG, HTMLNode.link("/wizard/?step=OPENNET")});
+    } else {
+      NodeL10n.getBase()
+          .addL10nSubstitution(
+              inner,
+              "SecurityLevels.networkThreatLevel.desc." + level,
+              new String[] {"bold"},
+              new HTMLNode[] {HTMLNode.STRONG});
     }
-    seclevelGroup.addChild("p").addChild("b", l10nSec("networkThreatLevel.opennetFriendsWarning"));
+  }
 
-    // Physical security level
-    formNode.addChild("div", "class", "configprefix", l10nSec("physicalThreatLevelShort"));
-    ul = formNode.addChild("ul", "class", "config");
-    seclevelGroup = ul.addChild("li");
+  private void addPhysicalThreatSection(
+      HTMLNode formNode, PHYSICAL_THREAT_LEVEL currentPhysicalLevel) {
+    formNode.addChild(TAG_DIV, ATTR_CLASS, "configprefix", l10nSec("physicalThreatLevelShort"));
+    HTMLNode ul = formNode.addChild("ul", ATTR_CLASS, CLASS_CONFIG);
+    HTMLNode seclevelGroup = ul.addChild("li");
     seclevelGroup.addChild("#", l10nSec("physicalThreatLevel"));
 
     NodeL10n.getBase()
@@ -712,108 +951,126 @@ public class SecurityLevelsToadlet extends Toadlet {
       swapWarning.addChild("#", " " + WizardL10n.l10nSec("physicalThreatLevelSwapfileWindows"));
     }
 
-    PHYSICAL_THREAT_LEVEL physicalLevel = node.getSecurityLevels().getPhysicalThreatLevel();
-
-    controlName = "security-levels.physicalThreatLevel";
     for (PHYSICAL_THREAT_LEVEL level : PHYSICAL_THREAT_LEVEL.values()) {
-      HTMLNode input;
-      if (level == physicalLevel) {
-        input =
-            seclevelGroup
-                .addChild("p")
-                .addChild(
-                    "input",
-                    new String[] {"type", "checked", "name", "value", "id"},
-                    new String[] {
-                      "radio", "on", controlName, level.name(), controlName + level.name()
-                    });
+      addPhysicalLevelOption(seclevelGroup, currentPhysicalLevel, level);
+    }
+  }
+
+  private void addPhysicalLevelOption(
+      HTMLNode seclevelGroup,
+      PHYSICAL_THREAT_LEVEL currentPhysicalLevel,
+      PHYSICAL_THREAT_LEVEL level) {
+    String inputId = PARAM_PHYSICAL_THREAT_LEVEL + level.name();
+    HTMLNode input =
+        addRadioInput(
+            seclevelGroup.addChild("p"),
+            PARAM_PHYSICAL_THREAT_LEVEL,
+            level.name(),
+            level == currentPhysicalLevel,
+            inputId);
+    input
+        .addChild(TAG_LABEL, new String[] {"for"}, new String[] {inputId})
+        .addChild("b", l10nSec("physicalThreatLevel.name." + level));
+    input.addChild("#", ": ");
+    NodeL10n.getBase()
+        .addL10nSubstitution(
+            input,
+            "SecurityLevels.physicalThreatLevel.choice." + level,
+            new String[] {"bold"},
+            new HTMLNode[] {HTMLNode.STRONG});
+    HTMLNode inner = input.addChild("p").addChild("i");
+    NodeL10n.getBase()
+        .addL10nSubstitution(
+            inner,
+            "SecurityLevels.physicalThreatLevel.desc." + level,
+            new String[] {"bold"},
+            new HTMLNode[] {HTMLNode.STRONG});
+    if (level == PHYSICAL_THREAT_LEVEL.MAXIMUM && node.hasDatabase()) {
+      inner.addChild("b", " " + l10nSec("warningMaximumWillDeleteQueue"));
+    }
+    if (level == PHYSICAL_THREAT_LEVEL.HIGH) {
+      if (currentPhysicalLevel == level) {
+        addPasswordChangeForm(inner);
       } else {
-        input =
-            seclevelGroup
-                .addChild("p")
-                .addChild(
-                    "input",
-                    new String[] {"type", "name", "value", "id"},
-                    new String[] {"radio", controlName, level.name(), controlName + level.name()});
-      }
-      input
-          .addChild("label", new String[] {"for"}, new String[] {controlName + level.name()})
-          .addChild("b", l10nSec("physicalThreatLevel.name." + level));
-      input.addChild("#", ": ");
-      NodeL10n.getBase()
-          .addL10nSubstitution(
-              input,
-              "SecurityLevels.physicalThreatLevel.choice." + level,
-              new String[] {"bold"},
-              new HTMLNode[] {HTMLNode.STRONG});
-      HTMLNode inner = input.addChild("p").addChild("i");
-      NodeL10n.getBase()
-          .addL10nSubstitution(
-              inner,
-              "SecurityLevels.physicalThreatLevel.desc." + level,
-              new String[] {"bold"},
-              new HTMLNode[] {HTMLNode.STRONG});
-      if (level == PHYSICAL_THREAT_LEVEL.MAXIMUM && node.hasDatabase()) {
-        inner.addChild("b", " " + l10nSec("warningMaximumWillDeleteQueue"));
-      }
-      if (level == PHYSICAL_THREAT_LEVEL.HIGH) {
-        if (physicalLevel == level) {
-          addPasswordChangeForm(inner);
-        } else {
-          p = inner.addChild("p", l10nSec("setPassword"));
-          generatePasswordConfirmationForm(inner);
-        }
+        inner.addChild("p", l10nSec("setPassword"));
+        generatePasswordConfirmationForm(inner);
       }
     }
+  }
 
-    // FIXME implement the rest, it should be very similar to the above.
+  private HTMLNode addRadioInput(
+      HTMLNode parent, String controlName, String value, boolean checked, String inputId) {
+    String[] attributes =
+        checked
+            ? new String[] {ATTR_TYPE, ATTR_CHECKED, ATTR_NAME, ATTR_VALUE, ATTR_ID}
+            : new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE, ATTR_ID};
+    String[] values =
+        checked
+            ? new String[] {INPUT_RADIO, "on", controlName, value, inputId}
+            : new String[] {INPUT_RADIO, controlName, value, inputId};
+    return parent.addChild(TAG_INPUT, attributes, values);
+  }
 
+  private void addFormButtons(HTMLNode formNode) {
     formNode.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"hidden", "seclevels", "on"});
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {INPUT_HIDDEN, PARAM_SECLEVELS, "on"});
     formNode.addChild(
-        "input", new String[] {"type", "value"}, new String[] {"submit", l10n("apply")});
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_VALUE},
+        new String[] {INPUT_SUBMIT, l10n("apply")});
     formNode.addChild(
-        "input", new String[] {"type", "value"}, new String[] {"reset", l10n("undo")});
+        TAG_INPUT, new String[] {ATTR_TYPE, ATTR_VALUE}, new String[] {"reset", l10n("undo")});
   }
 
   private void addPasswordChangeForm(HTMLNode inner) {
     HTMLNode table = inner.addChild("table", "border", "0");
     HTMLNode row = table.addChild("tr");
     HTMLNode cell = row.addChild("td");
-    cell.addChild("label", "for", "oldPasswordBox", l10nSec("oldPasswordLabel"));
+    cell.addChild(TAG_LABEL, "for", "oldPasswordBox", l10nSec("oldPasswordLabel"));
     cell = row.addChild("td");
     cell.addChild(
-        "input",
-        new String[] {"id", "type", "name", "size"},
-        new String[] {"oldPasswordBox", "password", "oldPassword", "100"});
-    row = table.addChild("tr");
+        TAG_INPUT,
+        new String[] {"id", ATTR_TYPE, ATTR_NAME, "size"},
+        new String[] {"oldPasswordBox", INPUT_PASSWORD, PARAM_OLD_PASSWORD, "100"});
+    table.addChild("tr");
     row = table.addChild("tr");
     cell = row.addChild("td");
-    cell.addChild("label", "for", "newPasswordBox", l10nSec("newPasswordLabel"));
+    cell.addChild(TAG_LABEL, "for", "newPasswordBox", l10nSec("newPasswordLabel"));
     cell = row.addChild("td");
     cell.addChild(
-        "input",
-        new String[] {"id", "type", "name", "size"},
-        new String[] {"newPasswordBox", "password", "masterPassword", "100"});
+        TAG_INPUT,
+        new String[] {"id", ATTR_TYPE, ATTR_NAME, "size"},
+        new String[] {"newPasswordBox", INPUT_PASSWORD, PARAM_MASTER_PASSWORD, "100"});
     row = table.addChild("tr");
     cell = row.addChild("td");
-    cell.addChild("label", "for", "confirmPasswordBox", l10nSec("confirmNewPasswordLabel"));
+    cell.addChild(TAG_LABEL, "for", CONFIRM_PASSWORD_BOX_ID, l10nSec("confirmNewPasswordLabel"));
     cell = row.addChild("td");
     cell.addChild(
-        "input",
-        new String[] {"id", "type", "name", "size"},
-        new String[] {"confirmPasswordBox", "password", "confirmMasterPassword", "100"});
+        TAG_INPUT,
+        new String[] {"id", ATTR_TYPE, ATTR_NAME, "size"},
+        new String[] {
+          CONFIRM_PASSWORD_BOX_ID, INPUT_PASSWORD, PARAM_CONFIRM_MASTER_PASSWORD, "100"
+        });
     HTMLNode p = inner.addChild("p");
     p.addChild(
-        "input",
-        new String[] {"type", "name", "value"},
-        new String[] {"submit", "changePassword", l10nSec("changePasswordButton")});
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+        new String[] {INPUT_SUBMIT, "changePassword", l10nSec("changePasswordButton")});
   }
 
-  static final String PATH = "/seclevels/";
+  private static final String PATH_PROPERTY = "network.crypta.seclevels.path";
+  static final String PATH = System.getProperty(PATH_PROPERTY, "/seclevels/");
 
+  /**
+   * Returns the routing path for this toadlet. The value comes from the {@code
+   * network.crypta.seclevels.path} system property when set, otherwise falls back to {@code
+   * /seclevels/}. Callers should treat the path as a stable identifier for hyperlink generation and
+   * redirect targets; it is not recalculated per request.
+   *
+   * @return canonical toadlet path, guaranteed non-null and suitable for HTTP routing.
+   */
   @Override
   public String path() {
     return PATH;
@@ -831,54 +1088,62 @@ public class SecurityLevelsToadlet extends Toadlet {
     return NodeL10n.getBase().getString("SecurityLevels." + key, pattern, value);
   }
 
-  void sendPasswordFileCorruptedPage(
-      boolean tooBig, ToadletContext ctx, boolean forSecLevels, boolean forFirstTimeWizard)
+  void sendPasswordFileCorruptedPage(ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    HTMLNode page =
-        sendPasswordFileCorruptedPageInner(
-            tooBig,
-            ctx,
-            forSecLevels,
-            forFirstTimeWizard,
-            node.getMasterPasswordFile().getPath(),
-            node);
+    HTMLNode page = sendPasswordFileCorruptedPageInner(ctx, node.getMasterPasswordFile().getPath());
     writeHTMLReply(ctx, 500, "Internal Server Error", page.generate());
   }
 
+  /**
+   * Embeds a corruption notice into the first-time wizard when the master password file cannot be
+   * parsed. The helper supplies localized strings and existing page scaffolding; this method
+   * appends an infobox that identifies the affected file and offers navigation links back to safer
+   * entry points so the user can decide whether to retry, reset, or exit the wizard.
+   *
+   * @param helper wizard helper responsible for adding content to the current wizard step.
+   * @param masterPasswordFile absolute path to the corrupted master password file displayed to the
+   *     user for clarity.
+   */
   public static void sendPasswordFileCorruptedPageInner(
       PageHelper helper, String masterPasswordFile) {
-    HTMLNode contentNode = helper.getPageContent(l10nSec("passwordFileCorruptedTitle"));
+    HTMLNode contentNode = helper.getPageContent(l10nSec(PASSWORD_FILE_CORRUPTED_TITLE_KEY));
     HTMLNode infoBox =
         helper
             .getInfobox(
-                "infobox-error",
-                l10nSec("passwordFileCorruptedTitle"),
+                INFOBOX_ERROR,
+                l10nSec(PASSWORD_FILE_CORRUPTED_TITLE_KEY),
                 contentNode,
-                "password-error",
+                PASSWORD_ERROR_CLASS,
                 false)
-            .addChild("div", "class", "infobox-content");
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
     sendPasswordFileCorruptedPageInner(infoBox, masterPasswordFile);
   }
 
+  /**
+   * Creates a standalone page warning that the master password file appears corrupted. The page is
+   * built through the provided context, includes localized text explaining the failure, and adds
+   * navigation back to the security levels view so administrators can choose an appropriate
+   * recovery path. This helper leaves HTTP status selection to the caller by returning the page
+   * node instead of writing the response directly.
+   *
+   * @param ctx toadlet context that provides localization and HTML helper utilities.
+   * @param masterPasswordFile absolute path to the corrupted file to display for diagnostic use.
+   * @return HTML node representing the fully composed page, ready for serialization.
+   */
   public static HTMLNode sendPasswordFileCorruptedPageInner(
-      boolean tooBig,
-      ToadletContext ctx,
-      boolean forSecLevels,
-      boolean forFirstTimeWizard,
-      String masterPasswordFile,
-      Node node) {
-    PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordFileCorruptedTitle"), ctx);
+      ToadletContext ctx, String masterPasswordFile) {
+    PageNode page = ctx.getPageMaker().getPageNode(l10nSec(PASSWORD_FILE_CORRUPTED_TITLE_KEY), ctx);
     HTMLNode pageNode = page.getOuterNode();
     HTMLNode contentNode = page.getContentNode();
     HTMLNode infoBox =
         ctx.getPageMaker()
             .getInfobox(
-                "infobox-error",
-                l10nSec("passwordFileCorruptedTitle"),
+                INFOBOX_ERROR,
+                l10nSec(PASSWORD_FILE_CORRUPTED_TITLE_KEY),
                 contentNode,
-                "password-error",
+                PASSWORD_ERROR_CLASS,
                 false)
-            .addChild("div", "class", "infobox-content");
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
     sendPasswordFileCorruptedPageInner(infoBox, masterPasswordFile);
     return pageNode;
   }
@@ -899,31 +1164,30 @@ public class SecurityLevelsToadlet extends Toadlet {
   }
 
   /**
-   * Send a page asking for the master password.
+   * Sends a retry page after the user entered a wrong master password. The page contains an error
+   * infobox, re-displays the password prompt, and links back to the home page to avoid dead ends.
+   * No configuration is changed here; it simply gives the user another chance to authenticate.
    *
-   * @param wasWrong If true, we want the master password because the user entered the wrong
-   *     password.
-   * @param ctx
-   * @throws IOException
-   * @throws ToadletContextClosedException
+   * @param ctx toadlet context used to localize strings, build the form, and emit the response.
+   * @throws IOException if HTML serialization or response writing fails.
+   * @throws ToadletContextClosedException if the connection closes before the response completes.
    */
-  private void sendPasswordFormPage(boolean wasWrong, ToadletContext ctx)
+  private void sendPasswordFormPage(ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
+    PageNode page = ctx.getPageMaker().getPageNode(l10nSec(PASSWORD_PAGE_TITLE_KEY), ctx);
     HTMLNode contentNode = page.getContentNode();
 
     HTMLNode content =
         ctx.getPageMaker()
             .getInfobox(
-                "infobox-error",
-                wasWrong ? l10nSec("passwordWrongTitle") : l10nSec("enterPasswordTitle"),
+                INFOBOX_ERROR,
+                l10nSec(PASSWORD_WRONG_TITLE_KEY),
                 contentNode,
-                "password-error",
+                PASSWORD_ERROR_CLASS,
                 false)
-            .addChild("div", "class", "infobox-content");
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
 
-    generatePasswordFormPage(
-        wasWrong, ctx.getContainer(), content, false, false, false, null, null);
+    generatePasswordFormPage(true, ctx.getContainer(), content, false, false, false, null, null);
 
     addHomepageLink(content);
 
@@ -931,21 +1195,30 @@ public class SecurityLevelsToadlet extends Toadlet {
   }
 
   /**
-   * Send a page asking for the master password.
+   * Sends a page prompting the user to provide or confirm the master password when upgrading
+   * security or when a mismatch occurred. It highlights mismatched entries, preserves the chosen
+   * threat level through hidden fields, and guides the user back to the security levels screen on
+   * completion.
    *
-   * @param ctx
-   * @throws IOException
-   * @throws ToadletContextClosedException
+   * @param ctx toadlet context used to construct localized content and deliver the HTML response.
+   * @param threatLevel name of the physical threat level currently being configured; may be null
+   *     when no specific level needs to be preserved.
+   * @throws IOException if an error occurs while generating or sending the HTML page.
+   * @throws ToadletContextClosedException if the client disconnects before the reply is sent.
    */
   private void sendPasswordPageMismatch(ToadletContext ctx, String threatLevel)
       throws ToadletContextClosedException, IOException {
-    PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
+    PageNode page = ctx.getPageMaker().getPageNode(l10nSec(PASSWORD_PAGE_TITLE_KEY), ctx);
     HTMLNode contentNode = page.getContentNode();
     HTMLNode content =
         ctx.getPageMaker()
             .getInfobox(
-                "infobox-error", l10nSec("setPasswordTitle"), contentNode, "password-error", false)
-            .addChild("div", "class", "infobox-content");
+                INFOBOX_ERROR,
+                l10nSec(SET_PASSWORD_TITLE_KEY),
+                contentNode,
+                PASSWORD_ERROR_CLASS,
+                false)
+            .addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
     content.addChild("p", l10nSec("passwordsDoNotMatch"));
     generatePasswordFormPage(
         false, ctx.getContainer(), content, false, false, true, threatLevel, null);
@@ -954,8 +1227,20 @@ public class SecurityLevelsToadlet extends Toadlet {
   }
 
   /**
-   * @param forFirstTimeWizard used to determine form target: wizard if in the wizard, this toadlet
-   *     if not.
+   * Renders the shared password form used throughout the wizard and security levels flows. This
+   * overload attaches the form to the supplied {@code content} node and directs submissions either
+   * to the first-time wizard or this toadlet, depending on the {@code forFirstTimeWizard} flag. It
+   * adds contextual messages for wrong passwords, downgrade decryption, or upgrade confirmation,
+   * and preserves physical threat level choices and optional redirect targets via hidden inputs.
+   *
+   * @param wasWrong {@code true} when the previous submission failed password validation.
+   * @param ctx container used to create the form element with the correct submission endpoint.
+   * @param content HTML node that receives explanatory text and the generated form structure.
+   * @param forFirstTimeWizard whether to post the form back into the first-time wizard sequence.
+   * @param forDowngrade indicates the prompt relates to decrypting data during a downgrade flow.
+   * @param forUpgrade indicates the prompt is part of an upgrade requiring password confirmation.
+   * @param physicalSecurityLevel current physical threat level name to persist across submissions.
+   * @param redirect optional path the client should be redirected to after successful submission.
    */
   public static void generatePasswordFormPage(
       boolean wasWrong,
@@ -969,7 +1254,7 @@ public class SecurityLevelsToadlet extends Toadlet {
 
     String postTo =
         forFirstTimeWizard ? FirstTimeWizardToadlet.TOADLET_URL : SecurityLevelsToadlet.PATH;
-    HTMLNode form = ctx.addFormChild(content, postTo, "masterPasswordForm");
+    HTMLNode form = ctx.addFormChild(content, postTo, MASTER_PASSWORD_FORM);
     generatePasswordFormPage(
         wasWrong, form, content, forDowngrade, forUpgrade, physicalSecurityLevel, redirect);
   }
@@ -978,23 +1263,40 @@ public class SecurityLevelsToadlet extends Toadlet {
     HTMLNode table = formNode.addChild("table", "border", "0");
     HTMLNode row = table.addChild("tr");
     HTMLNode cell = row.addChild("td");
-    cell.addChild("label", "for", "passwordBox", l10nSec("passwordLabel"));
+    cell.addChild(TAG_LABEL, "for", PASSWORD_BOX_NAME, l10nSec("passwordLabel"));
     cell = row.addChild("td");
     cell.addChild(
-        "input",
-        new String[] {"id", "type", "name", "size"},
-        new String[] {"passwordBox", "password", "masterPassword", "100"});
-    row = table.addChild("tr");
+        TAG_INPUT,
+        new String[] {"id", ATTR_TYPE, ATTR_NAME, "size"},
+        new String[] {PASSWORD_BOX_NAME, INPUT_PASSWORD, PARAM_MASTER_PASSWORD, "100"});
+    table.addChild("tr");
     row = table.addChild("tr");
     cell = row.addChild("td");
-    cell.addChild("label", "for", "confirmPasswordBox", l10nSec("confirmPasswordLabel"));
+    cell.addChild(TAG_LABEL, "for", CONFIRM_PASSWORD_BOX_ID, l10nSec("confirmPasswordLabel"));
     cell = row.addChild("td");
     cell.addChild(
-        "input",
-        new String[] {"id", "type", "name", "size"},
-        new String[] {"confirmPasswordBox", "password", "confirmMasterPassword", "100"});
+        TAG_INPUT,
+        new String[] {"id", ATTR_TYPE, ATTR_NAME, "size"},
+        new String[] {
+          CONFIRM_PASSWORD_BOX_ID, INPUT_PASSWORD, PARAM_CONFIRM_MASTER_PASSWORD, "100"
+        });
   }
 
+  /**
+   * Populates an existing form node with password controls and contextual messaging. The helper
+   * tailors the surrounding {@code content} node to reflect whether the caller is prompting for a
+   * downgrade decryption password, an upgrade confirmation, or a retry after failure. Hidden fields
+   * can retain the selected physical threat level and redirect target so follow-up requests remain
+   * consistent. Response writing remains the caller's responsibility.
+   *
+   * @param wasWrong {@code true} if the previous password attempt failed and the UI should warn.
+   * @param formNode form element that receives inputs, hidden fields, and the submit control.
+   * @param content container node used to display descriptive text adjacent to the form.
+   * @param forDowngrade indicates the prompt relates to decrypting data during a downgrade.
+   * @param forUpgrade indicates the prompt accompanies an upgrade requiring password confirmation.
+   * @param physicalSecurityLevel selected physical threat level to persist through submissions.
+   * @param redirect optional path to redirect the user to after a successful submission.
+   */
   public static void generatePasswordFormPage(
       boolean wasWrong,
       HTMLNode formNode,
@@ -1017,32 +1319,32 @@ public class SecurityLevelsToadlet extends Toadlet {
     if (forUpgrade) {
       generatePasswordConfirmationForm(formNode);
     } else {
-      formNode.addChild("label", "for", "passwordBox", l10nSec("passwordLabel"));
+      formNode.addChild(TAG_LABEL, "for", PASSWORD_BOX_NAME, l10nSec("passwordLabel"));
       formNode.addChild(
-          "input",
-          new String[] {"id", "type", "name", "size"},
-          new String[] {"passwordBox", "password", "masterPassword", "100"});
+          TAG_INPUT,
+          new String[] {"id", ATTR_TYPE, ATTR_NAME, "size"},
+          new String[] {PASSWORD_BOX_NAME, INPUT_PASSWORD, PARAM_MASTER_PASSWORD, "100"});
     }
 
     if (physicalSecurityLevel != null) {
       formNode.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "security-levels.physicalThreatLevel", physicalSecurityLevel});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {INPUT_HIDDEN, PARAM_PHYSICAL_THREAT_LEVEL, physicalSecurityLevel});
       formNode.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "seclevels", "true"});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {INPUT_HIDDEN, PARAM_SECLEVELS, "true"});
     }
     if (redirect != null) {
       formNode.addChild(
-          "input",
-          new String[] {"type", "name", "value"},
-          new String[] {"hidden", "redirect", redirect});
+          TAG_INPUT,
+          new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
+          new String[] {INPUT_HIDDEN, PARAM_REDIRECT, redirect});
     }
     formNode.addChild(
-        "input",
-        new String[] {"type", "value"},
-        new String[] {"submit", l10nSec("passwordSubmit")});
+        TAG_INPUT,
+        new String[] {ATTR_TYPE, ATTR_VALUE},
+        new String[] {INPUT_SUBMIT, l10nSec("passwordSubmit")});
   }
 }

--- a/src/test/java/network/crypta/clients/http/SecurityLevelsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SecurityLevelsToadletTest.java
@@ -1,0 +1,200 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SecurityLevelsToadletTest {
+
+  @Test
+  void path_whenCalled_returnsSecurityLevelsPath() {
+    SecurityLevelsToadlet toadlet =
+        new SecurityLevelsToadlet(
+            mock(HighLevelSimpleClient.class), mock(Node.class), mock(NodeClientCore.class));
+
+    String result = toadlet.path();
+
+    assertEquals(SecurityLevelsToadlet.PATH, result);
+  }
+
+  @Test
+  void generatePasswordFormPage_whenUpgrade_addsConfirmationAndHiddenFields() {
+    HTMLNode content = new HTMLNode("div");
+    HTMLNode formNode = content.addChild("form");
+
+    SecurityLevelsToadlet.generatePasswordFormPage(
+        false, formNode, content, false, true, "HIGH", "/next");
+
+    assertFalse(findInputsByName(formNode, "masterPassword").isEmpty());
+    assertFalse(findInputsByName(formNode, "confirmMasterPassword").isEmpty());
+    assertEquals(
+        "HIGH",
+        findInputsByName(formNode, "security-levels.physicalThreatLevel")
+            .getFirst()
+            .getAttribute("value"));
+    assertEquals("true", findInputsByName(formNode, "seclevels").getFirst().getAttribute("value"));
+    assertEquals("/next", findInputsByName(formNode, "redirect").getFirst().getAttribute("value"));
+    assertFalse(findSubmitInputs(formNode).isEmpty());
+  }
+
+  @Test
+  void generatePasswordFormPage_whenDowngradeWithoutUpgrade_usesSinglePasswordField() {
+    HTMLNode content = new HTMLNode("div");
+    HTMLNode formNode = content.addChild("form");
+
+    SecurityLevelsToadlet.generatePasswordFormPage(
+        false, formNode, content, true, false, null, null);
+
+    assertEquals(1, findInputsByName(formNode, "masterPassword").size());
+    assertTrue(findInputsByName(formNode, "confirmMasterPassword").isEmpty());
+    assertTrue(findInputsByName(formNode, "security-levels.physicalThreatLevel").isEmpty());
+  }
+
+  @Test
+  void generatePasswordFormPage_whenFirstTimeWizard_postsToWizardUrl() {
+    ToadletContainer container = mock(ToadletContainer.class);
+    HTMLNode content = new HTMLNode("div");
+    when(container.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              String target = invocation.getArgument(1);
+              String id = invocation.getArgument(2);
+              HTMLNode form = parent.addChild("form");
+              form.addAttribute("target", target);
+              form.addAttribute("id", id);
+              return form;
+            });
+
+    SecurityLevelsToadlet.generatePasswordFormPage(
+        false, container, content, true, false, false, "LOW", null);
+
+    verify(container)
+        .addFormChild(content, FirstTimeWizardToadlet.TOADLET_URL, "masterPasswordForm");
+    HTMLNode form = findByTag(content, "form").getFirst();
+    assertEquals(
+        "LOW",
+        findInputsByName(form, "security-levels.physicalThreatLevel")
+            .getFirst()
+            .getAttribute("value"));
+    assertEquals("true", findInputsByName(form, "seclevels").getFirst().getAttribute("value"));
+    assertEquals(FirstTimeWizardToadlet.TOADLET_URL, form.getAttribute("target"));
+  }
+
+  @Test
+  void sendCantDeleteMasterKeysFileInner_whenCannotDelete_addsHiddenFieldsAndFilename() {
+    PageNode pageNode = simplePageNode();
+    ToadletContext ctx = contextStub(pageNode);
+
+    HTMLNode outer =
+        SecurityLevelsToadlet.sendCantDeleteMasterKeysFileInner(
+            ctx, "/tmp/master.keys", false, "HIGH");
+
+    HTMLNode form = findByTag(pageNode.getContentNode(), "form").getFirst();
+    assertEquals(
+        "HIGH",
+        findInputsByName(form, "security-levels.physicalThreatLevel")
+            .getFirst()
+            .getAttribute("value"));
+    assertEquals("true", findInputsByName(form, "seclevels").getFirst().getAttribute("value"));
+    assertFalse(findInputsByName(form, "tryAgain").isEmpty());
+    assertTrue(outer.generate().contains("/tmp/master.keys"));
+  }
+
+  @Test
+  void sendPasswordFileCorruptedPageInner_whenCalled_addsFilePathAndBackLink() {
+    PageNode pageNode = simplePageNode();
+    ToadletContext ctx = contextStub(pageNode);
+
+    SecurityLevelsToadlet.sendPasswordFileCorruptedPageInner(ctx, "/tmp/master.keys");
+
+    HTMLNode content = pageNode.getContentNode();
+    assertTrue(
+        findByTag(content, "p").stream()
+            .anyMatch(node -> node.generateChildren().contains("/tmp/master.keys")));
+    assertTrue(
+        findByTag(content, "a").stream()
+            .anyMatch(node -> SecurityLevelsToadlet.PATH.equals(node.getAttribute("href"))));
+  }
+
+  private PageNode simplePageNode() {
+    HTMLNode outer = new HTMLNode("html");
+    HTMLNode head = outer.addChild("head");
+    HTMLNode body = outer.addChild("body");
+    return new PageNode(outer, head, body);
+  }
+
+  private ToadletContext contextStub(PageNode pageNode) {
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(pageMaker.getPageNode(anyString(), any(ToadletContext.class))).thenReturn(pageNode);
+    when(pageMaker.getInfobox(
+            anyString(), anyString(), any(HTMLNode.class), anyString(), anyBoolean()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(2);
+              return parent.addChild("div");
+            });
+
+    ToadletContext ctx = mock(ToadletContext.class);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    lenient()
+        .when(ctx.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              String target = invocation.getArgument(1);
+              String id = invocation.getArgument(2);
+              HTMLNode form = parent.addChild("form");
+              form.addAttribute("target", target);
+              form.addAttribute("id", id);
+              return form;
+            });
+    return ctx;
+  }
+
+  private List<HTMLNode> findInputsByName(HTMLNode node, String name) {
+    return findByTag(node, "input").stream()
+        .filter(n -> name.equals(n.getAttribute("name")))
+        .toList();
+  }
+
+  private List<HTMLNode> findSubmitInputs(HTMLNode node) {
+    return findByTag(node, "input").stream()
+        .filter(n -> "submit".equals(n.getAttribute("type")))
+        .toList();
+  }
+
+  private List<HTMLNode> findByTag(HTMLNode node, String tag) {
+    List<HTMLNode> matches = new ArrayList<>();
+    collectByTag(node, tag, matches);
+    return matches;
+  }
+
+  private void collectByTag(HTMLNode node, String tag, List<HTMLNode> matches) {
+    if (tag.equals(node.getName())) {
+      matches.add(node);
+    }
+    for (HTMLNode child : node.getChildren()) {
+      collectByTag(child, tag, matches);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor SecurityLevelsToadlet POST handling into clearer helpers with constants and stronger null checks
- streamline password/confirmation flows and master password error handling with consistent UI elements
- add SecurityLevelsToadlet unit tests covering path resolution and password form generation/edge cases

## Testing
- not run (CI)