### PR TITLE
Improve SimpleToadletServer lifecycle and documentation

### DIFF
--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -1,15 +1,14 @@
 package network.crypta.clients.http;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.Random;
 import network.crypta.client.filter.HTMLFilter;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
@@ -48,9 +47,33 @@ import org.slf4j.LoggerFactory;
 import org.tanukisoftware.wrapper.WrapperManager;
 
 /**
- * The Toadlet (HTTP) Server
+ * The Toadlet (HTTP) Server.
  *
- * <p>Provide a HTTP server for FProxy
+ * <p>SimpleToadletServer owns the embedded HTTP listener that exposes FProxy and assorted control
+ * endpoints to browsers and local tools. It wires configuration callbacks, constructs the network
+ * interface, and manages registration of individual {@link Toadlet} handlers. Typical lifecycle:
+ * construct the server with the node configuration, call {@link #setCore(NodeClientCore)} once the
+ * node core becomes available, start the listener, and invoke {@link #finishStart()} after startup
+ * housekeeping completes. The server keeps track of theme selection, panic button visibility,
+ * gateway mode, and access controls. It also delegates bookmark management, push managers, and
+ * theme overrides to the core and supporting helper classes.
+ *
+ * <p>Concurrency: the network listener and request handling threads read shared state such as the
+ * {@link #core} reference, panic flags, and theme settings. The core reference is published through
+ * a volatile write in {@link #setCore(NodeClientCore)} so request threads see it once set.
+ * Mutability: most configuration is thread-safe via synchronized blocks or volatile fields; URL
+ * registration is guarded by the server monitor. Extended configuration callbacks are invoked on
+ * the configuration thread; request handlers run on the executor.
+ *
+ * <ul>
+ *   <li>Responsibilities: bind sockets, dispatch toadlets, surface configuration, and relay alerts.
+ *   <li>Notable behaviors: preserves startup toadlet until replaced; honours gateway/public mode;
+ *       mirrors theme changes to plugins; emits panic button state based on physical threat level.
+ * </ul>
+ *
+ * @see Toadlet
+ * @see NodeClientCore
+ * @see network.crypta.clients.http.FProxyToadlet
  */
 public final class SimpleToadletServer
     implements ToadletContainer, Runnable, LinkFilterExceptionProvider {
@@ -73,12 +96,18 @@ public final class SimpleToadletServer
     String name;
   }
 
+  private static final String FILENAME_KEY = "filename";
+  private static final String CSS_OVERRIDE_KEY = "CSSOverride";
+  private static final String PASSTHROUGH_MAX_SIZE_PROGRESS_KEY = "passthroughMaxSizeProgress";
+
   // Socket / Binding
   private final int port;
   private String bindTo;
   private final String allowedHosts;
   private NetworkInterface networkInterface;
   private boolean ssl = false;
+
+  /** Default TCP port used for the public FProxy listener when no override is supplied. */
   public static final int DEFAULT_FPROXY_PORT = 8888;
 
   // ACL
@@ -97,8 +126,10 @@ public final class SimpleToadletServer
   // Control
   private Thread myThread;
   private final PriorityAwareExecutor executor;
-  private final Random random;
+  private final SecureRandom random;
   private BucketFactory bf;
+
+  @SuppressWarnings("java:S3077")
   private volatile NodeClientCore core;
 
   // HTTP Option
@@ -109,10 +140,19 @@ public final class SimpleToadletServer
   private boolean enableExtendedMethodHandling;
   private boolean enableCachingForChkAndSskKeys;
 
-  // Something does not really belongs to here
+  // Something does not really belong to here
   static volatile boolean isPanicButtonToBeShown; // move to QueueToadlet ?
   static volatile boolean noConfirmPanic;
-  public BookmarkManager bookmarkManager; // move to WelcomeToadlet / BookmarkEditorToadlet ?
+
+  private static void setPanicButtonVisibility(boolean value) {
+    isPanicButtonToBeShown = value;
+  }
+
+  private static void setNoConfirmPanic(boolean value) {
+    noConfirmPanic = value;
+  }
+
+  private BookmarkManager bookmarkManager; // move to WelcomeToadlet / BookmarkEditorToadlet ?
   private volatile boolean fProxyJavascriptEnabled; // ugh?
   private volatile boolean fProxyWebPushingEnabled; // ugh?
   private volatile boolean fproxyHasCompletedWizard; // hmmm..
@@ -123,17 +163,13 @@ public final class SimpleToadletServer
 
   private boolean finishedStartup;
 
-  /**
-   * The PushDataManager handles all the pushing tasks
-   *
-   * @deprecated Use {@link #getPushDataManager()} instead of accessing this directly.
-   */
-  @Deprecated
-  /* It’s not the field that is deprecated but accessing it directly is. */
-  public PushDataManager pushDataManager;
+  private StartupToadlet startupToadlet;
+
+  /** The PushDataManager handles all the pushing tasks. */
+  private PushDataManager pushDataManager;
 
   /** The IntervalPusherManager handles interval pushing */
-  public IntervalPusherManager intervalPushManager;
+  private IntervalPusherManager intervalPushManager;
 
   // Legacy logMINOR removed; use LOG.isDebugEnabled() directly.
 
@@ -167,7 +203,7 @@ public final class SimpleToadletServer
     }
 
     @Override
-    public void set(Long val) throws InvalidConfigValueException {
+    public void set(Long val) {
       if (get().equals(val)) return;
       FProxyToadlet.setMaxLengthNoProgress(val);
     }
@@ -180,7 +216,7 @@ public final class SimpleToadletServer
     }
 
     @Override
-    public void set(Long val) throws InvalidConfigValueException {
+    public void set(Long val) {
       if (get().equals(val)) return;
       FProxyToadlet.setMaxLengthWithProgress(val);
     }
@@ -250,14 +286,14 @@ public final class SimpleToadletServer
     }
 
     @Override
-    public void set(String CSSName) throws InvalidConfigValueException {
-      if ((CSSName.indexOf(':') != -1) || (CSSName.indexOf('/') != -1))
+    public void set(String cssName) throws InvalidConfigValueException {
+      if ((cssName.indexOf(':') != -1) || (cssName.indexOf('/') != -1))
         throw new InvalidConfigValueException(l10n("illegalCSSName"));
-      cssTheme = THEME.themeFromName(CSSName);
+      cssTheme = THEME.themeFromName(cssName);
       pageMaker.setTheme(cssTheme);
-      NodeClientCore core = SimpleToadletServer.this.core;
-      if (core.getNode().getPluginManager() != null)
-        core.getNode().getPluginManager().setFProxyTheme(cssTheme);
+      NodeClientCore coreRef = SimpleToadletServer.this.core;
+      if (coreRef.getNode().getPluginManager() != null)
+        coreRef.getNode().getPluginManager().setFProxyTheme(cssTheme);
       fetchKeyBoxAboveBookmarks = cssTheme.fetchKeyBoxAboveBookmarks;
     }
 
@@ -275,17 +311,17 @@ public final class SimpleToadletServer
 
     @Override
     public void set(String val) throws InvalidConfigValueException {
-      NodeClientCore core = SimpleToadletServer.this.core;
-      if (core == null) return;
+      NodeClientCore coreRef = SimpleToadletServer.this.core;
+      if (coreRef == null) return;
       if (val.equals(get()) || val.isEmpty()) cssOverride = null;
       else {
         File tmp = new File(val.trim());
-        if (!core.allowUploadFrom(tmp))
+        if (!coreRef.allowUploadFrom(tmp))
           throw new InvalidConfigValueException(
-              l10n("cssOverrideNotInUploads", "filename", tmp.toString()));
+              l10n("cssOverrideNotInUploads", FILENAME_KEY, tmp.toString()));
         else if (!tmp.canRead() || !tmp.isFile())
           throw new InvalidConfigValueException(
-              l10n("cssOverrideCantRead", "filename", tmp.toString()));
+              l10n("cssOverrideCantRead", FILENAME_KEY, tmp.toString()));
         File parent = tmp.getParentFile();
         // Basic sanity check.
         // Prevents user from specifying root dir.
@@ -294,7 +330,7 @@ public final class SimpleToadletServer
         // Because of the .. check above, any malicious thing cannot break out of the dir anyway.
         if (parent.getParentFile() == null)
           throw new InvalidConfigValueException(
-              l10n("cssOverrideCantUseRootDir", "filename", parent.toString()));
+              l10n("cssOverrideCantUseRootDir", FILENAME_KEY, parent.toString()));
         cssOverride = tmp;
       }
       if (cssOverride == null) pageMaker.setOverride(null);
@@ -313,10 +349,11 @@ public final class SimpleToadletServer
     }
 
     @Override
-    public void set(Boolean val) throws InvalidConfigValueException {
+    public void set(Boolean val) {
       if (get().equals(val)) return;
+      boolean startServer = Boolean.TRUE.equals(val);
       synchronized (SimpleToadletServer.this) {
-        if (val) {
+        if (startServer) {
           // Start it
           myThread = new Thread(SimpleToadletServer.this, "SimpleToadletServer");
         } else {
@@ -345,7 +382,7 @@ public final class SimpleToadletServer
     }
 
     @Override
-    public void set(Boolean val) throws InvalidConfigValueException {
+    public void set(Boolean val) {
       ts.setAdvancedMode(val);
     }
   }
@@ -364,7 +401,7 @@ public final class SimpleToadletServer
     }
 
     @Override
-    public void set(Boolean val) throws InvalidConfigValueException {
+    public void set(Boolean val) {
       if (get().equals(val)) return;
       ts.enableFProxyJavascript(val);
     }
@@ -384,7 +421,7 @@ public final class SimpleToadletServer
     }
 
     @Override
-    public void set(Boolean val) throws InvalidConfigValueException, NodeNeedRestartException {
+    public void set(Boolean val) {
       if (get().equals(val)) return;
       ts.enableFProxyWebPushing(val);
     }
@@ -392,7 +429,7 @@ public final class SimpleToadletServer
 
   private boolean haveCalledFProxy = false;
 
-  // FIXME factor this out to a global helper class somehow?
+  // Consider factoring this out to a shared helper class if it grows further.
 
   private class ReFilterCallback extends StringCallback implements EnumerableOptionCallback {
 
@@ -410,14 +447,24 @@ public final class SimpleToadletServer
     }
 
     @Override
-    public void set(String val) throws InvalidConfigValueException, NodeNeedRestartException {
+    public void set(String val) {
       refilterPolicy = REFILTER_POLICY.valueOf(val);
     }
   }
 
+  /**
+   * Builds the FProxy runtime structures once the core is ready.
+   *
+   * <p>Call this after {@link #setCore(NodeClientCore)} and before accepting requests to install
+   * bookmark handling, interval push scheduling, and UI registration against the active node. This
+   * method is idempotent; subsequent calls are ignored after the first successful invocation. It
+   * captures the current {@link #core} and {@link Node} references, wires the push managers to the
+   * shared {@link Ticker}, and delegates to {@link FProxyRegistrar} to create request handlers and
+   * configuration entries.
+   */
   public void createFproxy() {
-    NodeClientCore core = this.core;
-    Node node = core.getNode();
+    NodeClientCore coreRef = this.core;
+    Node node = coreRef.getNode();
     synchronized (this) {
       if (haveCalledFProxy) return;
       haveCalledFProxy = true;
@@ -425,28 +472,142 @@ public final class SimpleToadletServer
 
     pushDataManager = new PushDataManager(getTicker());
     intervalPushManager = new IntervalPusherManager(getTicker(), pushDataManager);
-    bookmarkManager = new BookmarkManager(core, publicGatewayMode());
-    FProxyRegistrar.maybeCreateFProxyEtc(core, node, node.getConfig(), this);
+    bookmarkManager = new BookmarkManager(coreRef, publicGatewayMode());
+    FProxyRegistrar.maybeCreateFProxyEtc(coreRef, node, node.getConfig(), this);
   }
 
+  /**
+   * Publishes the initialized node core to request handlers.
+   *
+   * <p>The core reference is written with volatile semantics so that listener threads see it after
+   * startup. Call this exactly once, immediately after the node finishes constructing its {@link
+   * NodeClientCore}, and before invoking {@link #createFproxy()} or {@link #start()}. Passing
+   * {@code null} is not supported and leaves the server unable to service requests.
+   *
+   * @param core fully constructed {@link NodeClientCore}; must not be {@code null}.
+   */
   public void setCore(NodeClientCore core) {
     this.core = core;
   }
 
-  /** Create a SimpleToadletServer, using the settings from the SubConfig (the fproxy.* config). */
+  /**
+   * Creates a SimpleToadletServer bound to the given FProxy configuration.
+   *
+   * <p>The constructor performs lightweight configuration registration, initializes option
+   * callbacks, and defers expensive wiring (core assignment, network listener startup) to later
+   * calls. It seeds random sources, sets the initial access control list, and records whether the
+   * server should start enabled. The {@link #core} is left {@code null}; callers must invoke {@link
+   * #setCore(NodeClientCore)} before servicing requests.
+   *
+   * @param fproxyConfig configuration subsection containing fproxy.* keys that drive listener
+   *     options, theme settings, limits, and ACLs; must be non-null.
+   * @param bucketFactory factory used to create buckets for request payload handling; callers may
+   *     later replace it via {@link #setBucketFactory(BucketFactory)}.
+   * @param executor executor that runs HTTP worker threads with priority awareness; ownership stays
+   *     with the caller.
+   * @param node parent {@link Node} providing global services such as logging and plugin access.
+   * @throws InvalidConfigValueException if any configuration entry is invalid or fails validation
+   *     during registration.
+   */
   public SimpleToadletServer(
       SubConfig fproxyConfig,
       BucketFactory bucketFactory,
       PriorityAwareExecutor executor,
       Node node)
-      throws IOException, InvalidConfigValueException {
+      throws InvalidConfigValueException {
 
     this.executor = executor;
     this.core = null; // setCore() will be called later.
-    this.random = new Random();
+    this.random = new SecureRandom();
 
+    int configItemOrder = registerInitialOptions(fproxyConfig);
+
+    boolean enabled = fproxyConfig.getBoolean("enabled");
+
+    configItemOrder = registerPanicAndGatewayOptions(fproxyConfig, configItemOrder);
+    publicGatewayMode = fproxyConfig.getBoolean("publicGatewayMode");
+    wasPublicGatewayMode = publicGatewayMode;
+
+    // This is OFF BY DEFAULT
+    // This is OFF BY DEFAULT because for example firefox has a limit of 2 persistent
+    // connections per server, but 8 non-persistent connections per server. We need 8 conns
+    // more than we need the efficiency gain of reusing connections - especially on first
+    // install.
+
+    configItemOrder = registerConnectionOptions(fproxyConfig, configItemOrder);
+    allowedFullAccess = new AllowedHosts(fproxyConfig.getString("allowedHostsFullAccess"));
+    configItemOrder = registerAccessOptions(fproxyConfig, configItemOrder);
+
+    configItemOrder = registerFilterAndLimitOptions(fproxyConfig, configItemOrder);
+
+    this.bf = bucketFactory;
+    port = fproxyConfig.getInt("port");
+    bindTo = fproxyConfig.getString("bindTo");
+    String cssName = fproxyConfig.getString("css");
+    if ((cssName.indexOf(':') != -1) || (cssName.indexOf('/') != -1))
+      throw new InvalidConfigValueException("CSS name must not contain slashes or colons!");
+    cssTheme = THEME.themeFromName(cssName);
+    pageMaker = new PageMaker(cssTheme, node);
+
+    if (!fproxyConfig.getOption(CSS_OVERRIDE_KEY).isDefault()) {
+      cssOverride = new File(fproxyConfig.getString(CSS_OVERRIDE_KEY));
+      pageMaker.setOverride(StaticToadlet.OVERRIDE_URL + cssOverride.getName());
+    } else {
+      cssOverride = null;
+      pageMaker.setOverride(null);
+    }
+
+    fproxyConfig.register(
+        "fetchKeyBoxAboveBookmarks",
+        cssTheme.fetchKeyBoxAboveBookmarks,
+        configItemOrder,
+        false,
+        false,
+        "SimpleToadletServer.fetchKeyBoxAboveBookmarks",
+        "SimpleToadletServer.fetchKeyBoxAboveBookmarksLong",
+        new BooleanCallback() {
+          @Override
+          public Boolean get() {
+            return fetchKeyBoxAboveBookmarks;
+          }
+
+          @Override
+          public void set(Boolean val) {
+            if (get().equals(val)) return;
+            fetchKeyBoxAboveBookmarks = val;
+          }
+        });
+    fetchKeyBoxAboveBookmarks = fproxyConfig.getBoolean("fetchKeyBoxAboveBookmarks");
+
+    this.advancedModeEnabled = fproxyConfig.getBoolean("advancedModeEnabled");
+    toadlets = new LinkedList<>();
+
+    if (SSL.available()) {
+      ssl = fproxyConfig.getBoolean("ssl");
+    }
+
+    this.allowedHosts = fproxyConfig.getString("allowedHosts");
+
+    if (!enabled) {
+      LOG.info("Not starting FProxy as it's disabled");
+    } else {
+      maybeGetNetworkInterface();
+      myThread = new Thread(this, "SimpleToadletServer");
+      myThread.setDaemon(true);
+    }
+
+    // Register static toadlet and startup toadlet
+
+    StaticToadlet statictoadlet = new StaticToadlet();
+    register(statictoadlet, null, "/static/", false, false);
+
+    // "Freenet is starting up..." page, to be removed at #removeStartupToadlet()
+    startupToadlet = new StartupToadlet(statictoadlet);
+    register(startupToadlet, null, "/", false, false);
+  }
+
+  private int registerInitialOptions(SubConfig fproxyConfig) {
     int configItemOrder = 0;
-
     fproxyConfig.register(
         "enabled",
         true,
@@ -456,8 +617,6 @@ public final class SimpleToadletServer
         "SimpleToadletServer.enabled",
         "SimpleToadletServer.enabledLong",
         new FProxyEnabledCallback());
-
-    boolean enabled = fproxyConfig.getBoolean("enabled");
 
     fproxyConfig.register(
         "ssl",
@@ -497,7 +656,7 @@ public final class SimpleToadletServer
         "SimpleToadletServer.cssNameLong",
         new FProxyCSSNameCallback());
     fproxyConfig.register(
-        "CSSOverride",
+        CSS_OVERRIDE_KEY,
         "",
         configItemOrder++,
         true,
@@ -521,8 +680,7 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
+          public void set(Boolean val) {
             sendAllThemes = val;
           }
         });
@@ -553,8 +711,7 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
+          public void set(Boolean val) {
             if (get().equals(val)) return;
             enableExtendedMethodHandling = val;
           }
@@ -592,8 +749,7 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
+          public void set(Boolean val) {
             if (get().equals(val)) return;
             fproxyHasCompletedWizard = val;
           }
@@ -614,8 +770,8 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
+          public void set(Boolean val) {
+            if (get().equals(val)) return;
             disableProgressPage = val;
           }
         });
@@ -624,7 +780,10 @@ public final class SimpleToadletServer
     fProxyWebPushingEnabled = fproxyConfig.getBoolean("webPushingEnabled");
     disableProgressPage = fproxyConfig.getBoolean("disableProgressPage");
     enableExtendedMethodHandling = fproxyConfig.getBoolean("enableExtendedMethodHandling");
+    return configItemOrder;
+  }
 
+  private int registerPanicAndGatewayOptions(SubConfig fproxyConfig, int configItemOrder) {
     fproxyConfig.register(
         "showPanicButton",
         false,
@@ -641,8 +800,11 @@ public final class SimpleToadletServer
 
           @Override
           public void set(Boolean value) {
-            if (value == SimpleToadletServer.isPanicButtonToBeShown) {
-            } else SimpleToadletServer.isPanicButtonToBeShown = value;
+            boolean newValue = Boolean.TRUE.equals(value);
+            if (newValue == SimpleToadletServer.isPanicButtonToBeShown) {
+              return;
+            }
+            setPanicButtonVisibility(newValue);
           }
         });
 
@@ -662,10 +824,12 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
-            if (val == SimpleToadletServer.noConfirmPanic) {
-            } else SimpleToadletServer.noConfirmPanic = val;
+          public void set(Boolean val) {
+            boolean newValue = Boolean.TRUE.equals(val);
+            if (newValue == SimpleToadletServer.noConfirmPanic) {
+              return;
+            }
+            setNoConfirmPanic(newValue);
           }
         });
 
@@ -685,20 +849,19 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
-            if (publicGatewayMode == val) return;
-            publicGatewayMode = val;
+          public void set(Boolean val) throws NodeNeedRestartException {
+            boolean newValue = Boolean.TRUE.equals(val);
+            if (publicGatewayMode == newValue) return;
+            publicGatewayMode = newValue;
             throw new NodeNeedRestartException(l10n("publicGatewayModeNeedsRestart"));
           }
         });
-    wasPublicGatewayMode = publicGatewayMode = fproxyConfig.getBoolean("publicGatewayMode");
+    setPanicButtonVisibility(fproxyConfig.getBoolean("showPanicButton"));
+    setNoConfirmPanic(fproxyConfig.getBoolean("noConfirmPanic"));
+    return configItemOrder;
+  }
 
-    // This is OFF BY DEFAULT because for example firefox has a limit of 2 persistent
-    // connections per server, but 8 non-persistent connections per server. We need 8 conns
-    // more than we need the efficiency gain of reusing connections - especially on first
-    // install.
-
+  private int registerConnectionOptions(SubConfig fproxyConfig, int configItemOrder) {
     fproxyConfig.register(
         "enablePersistentConnections",
         false,
@@ -717,19 +880,13 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val) throws InvalidConfigValueException {
+          public void set(Boolean val) {
             synchronized (SimpleToadletServer.this) {
               enablePersistentConnections = val;
             }
           }
         });
     enablePersistentConnections = fproxyConfig.getBoolean("enablePersistentConnections");
-
-    // Off by default.
-    // I had hoped it would yield a significant performance boost to bootstrap performance
-    // on browsers with low numbers of simultaneous connections. Unfortunately the bottleneck
-    // appears to be that the node does very few local requests compared to external requests
-    // (for anonymity's sake).
 
     fproxyConfig.register(
         "enableInlinePrefetch",
@@ -749,7 +906,7 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val) throws InvalidConfigValueException {
+          public void set(Boolean val) {
             synchronized (SimpleToadletServer.this) {
               enableInlinePrefetch = val;
             }
@@ -773,8 +930,7 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
+          public void set(Boolean val) {
             enableActivelinks = val;
           }
         });
@@ -792,7 +948,7 @@ public final class SimpleToadletServer
         true);
     FProxyToadlet.setMaxLengthNoProgress(fproxyConfig.getLong("passthroughMaxSize"));
     fproxyConfig.register(
-        "passthroughMaxSizeProgress",
+        PASSTHROUGH_MAX_SIZE_PROGRESS_KEY,
         FProxyToadlet.getMaxLengthWithProgress(),
         configItemOrder++,
         true,
@@ -801,14 +957,12 @@ public final class SimpleToadletServer
         "SimpleToadletServer.passthroughMaxSizeProgressLong",
         new FProxyPassthruMaxSizeProgress(),
         true);
-    FProxyToadlet.setMaxLengthWithProgress(fproxyConfig.getLong("passthroughMaxSizeProgress"));
-    System.out.println(
-        "Set fproxy max length to "
-            + FProxyToadlet.getMaxLengthNoProgress()
-            + " and max length with progress to "
-            + FProxyToadlet.getMaxLengthWithProgress()
-            + " = "
-            + fproxyConfig.getLong("passthroughMaxSizeProgress"));
+    FProxyToadlet.setMaxLengthWithProgress(fproxyConfig.getLong(PASSTHROUGH_MAX_SIZE_PROGRESS_KEY));
+    LOG.info(
+        "Set fproxy max length to {} and max length with progress to {} = {}",
+        FProxyToadlet.getMaxLengthNoProgress(),
+        FProxyToadlet.getMaxLengthWithProgress(),
+        fproxyConfig.getLong(PASSTHROUGH_MAX_SIZE_PROGRESS_KEY));
 
     fproxyConfig.register(
         "enableCachingForChkAndSskKeys",
@@ -825,12 +979,15 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean value)
-              throws InvalidConfigValueException, NodeNeedRestartException {
+          public void set(Boolean value) {
             enableCachingForChkAndSskKeys = value;
           }
         });
     enableCachingForChkAndSskKeys = fproxyConfig.getBoolean("enableCachingForChkAndSskKeys");
+    return configItemOrder;
+  }
+
+  private int registerAccessOptions(SubConfig fproxyConfig, int configItemOrder) {
     fproxyConfig.register(
         "allowedHosts",
         "127.0.0.1,0:0:0:0:0:0:0:1",
@@ -864,7 +1021,6 @@ public final class SimpleToadletServer
             }
           }
         });
-    allowedFullAccess = new AllowedHosts(fproxyConfig.getString("allowedHostsFullAccess"));
     fproxyConfig.register(
         "doRobots",
         false,
@@ -880,13 +1036,15 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Boolean val) throws InvalidConfigValueException {
+          public void set(Boolean val) {
             doRobots = val;
           }
         });
     doRobots = fproxyConfig.getBoolean("doRobots");
+    return configItemOrder;
+  }
 
-    // We may not know what the overall thread limit is yet so just set it to 100.
+  private int registerFilterAndLimitOptions(SubConfig fproxyConfig, int configItemOrder) {
     fproxyConfig.register(
         "maxFproxyConnections",
         100,
@@ -931,11 +1089,10 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Integer val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
+          public void set(Integer val) throws InvalidConfigValueException {
             if (val < -1)
               throw new InvalidConfigValueException(
-                  "-1 = disabled, 0+ = set a minimum interval"); // FIXME l10n
+                  "-1 = disabled, 0+ = set a minimum interval"); // localization pending
             HTMLFilter.setMetaRefreshSamePageMinInterval(val);
           }
         },
@@ -959,11 +1116,10 @@ public final class SimpleToadletServer
           }
 
           @Override
-          public void set(Integer val)
-              throws InvalidConfigValueException, NodeNeedRestartException {
+          public void set(Integer val) throws InvalidConfigValueException {
             if (val < -1)
               throw new InvalidConfigValueException(
-                  "-1 = disabled, 0+ = set a minimum interval"); // FIXME l10n
+                  "-1 = disabled, 0+ = set a minimum interval"); // localization pending
             HTMLFilter.setMetaRefreshRedirectMinInterval(val);
           }
         },
@@ -1004,81 +1160,16 @@ public final class SimpleToadletServer
         new ReFilterCallback());
 
     this.refilterPolicy = REFILTER_POLICY.valueOf(fproxyConfig.getString("refilterPolicy"));
-
-    // Network seclevel not physical seclevel because bad filtering can cause network level
-    // anonymity breaches.
-    SimpleToadletServer.isPanicButtonToBeShown = fproxyConfig.getBoolean("showPanicButton");
-    SimpleToadletServer.noConfirmPanic = fproxyConfig.getBoolean("noConfirmPanic");
-
-    this.bf = bucketFactory;
-    port = fproxyConfig.getInt("port");
-    bindTo = fproxyConfig.getString("bindTo");
-    String cssName = fproxyConfig.getString("css");
-    if ((cssName.indexOf(':') != -1) || (cssName.indexOf('/') != -1))
-      throw new InvalidConfigValueException("CSS name must not contain slashes or colons!");
-    cssTheme = THEME.themeFromName(cssName);
-    pageMaker = new PageMaker(cssTheme, node);
-
-    if (!fproxyConfig.getOption("CSSOverride").isDefault()) {
-      cssOverride = new File(fproxyConfig.getString("CSSOverride"));
-      pageMaker.setOverride(StaticToadlet.OVERRIDE_URL + cssOverride.getName());
-    } else {
-      cssOverride = null;
-      pageMaker.setOverride(null);
-    }
-
-    fproxyConfig.register(
-        "fetchKeyBoxAboveBookmarks",
-        cssTheme.fetchKeyBoxAboveBookmarks,
-        configItemOrder++,
-        false,
-        false,
-        "SimpleToadletServer.fetchKeyBoxAboveBookmarks",
-        "SimpleToadletServer.fetchKeyBoxAboveBookmarksLong",
-        new BooleanCallback() {
-          @Override
-          public Boolean get() {
-            return fetchKeyBoxAboveBookmarks;
-          }
-
-          @Override
-          public void set(Boolean val) {
-            if (get().equals(val)) return;
-            fetchKeyBoxAboveBookmarks = val;
-          }
-        });
-    fetchKeyBoxAboveBookmarks = fproxyConfig.getBoolean("fetchKeyBoxAboveBookmarks");
-
-    this.advancedModeEnabled = fproxyConfig.getBoolean("advancedModeEnabled");
-    toadlets = new LinkedList<>();
-
-    if (SSL.available()) {
-      ssl = fproxyConfig.getBoolean("ssl");
-    }
-
-    this.allowedHosts = fproxyConfig.getString("allowedHosts");
-
-    if (!enabled) {
-      LOG.info("Not starting FProxy as it's disabled");
-      System.out.println("Not starting FProxy as it's disabled");
-    } else {
-      maybeGetNetworkInterface();
-      myThread = new Thread(this, "SimpleToadletServer");
-      myThread.setDaemon(true);
-    }
-
-    // Register static toadlet and startup toadlet
-
-    StaticToadlet statictoadlet = new StaticToadlet();
-    register(statictoadlet, null, "/static/", false, false);
-
-    // "Freenet is starting up..." page, to be removed at #removeStartupToadlet()
-    startupToadlet = new StartupToadlet(statictoadlet);
-    register(startupToadlet, null, "/", false, false);
+    return configItemOrder;
   }
 
-  public StartupToadlet startupToadlet;
-
+  /**
+   * Removes the temporary startup toadlet once the node is ready.
+   *
+   * <p>Calling this method unregisters the startup handler that served initial setup pages and
+   * clears its reference for garbage collection. It must only be invoked after {@link #setCore} and
+   * after startup has progressed far enough that the main toadlets are available.
+   */
   public void removeStartupToadlet() {
     // setCore() must have been called first. It is in fact called much earlier on.
     synchronized (this) {
@@ -1089,7 +1180,7 @@ public final class SimpleToadletServer
     }
   }
 
-  private void maybeGetNetworkInterface() throws IOException {
+  private void maybeGetNetworkInterface() {
     if (this.networkInterface != null) return;
     if (ssl) {
       this.networkInterface =
@@ -1110,25 +1201,38 @@ public final class SimpleToadletServer
     return wasPublicGatewayMode;
   }
 
+  /**
+   * Starts the HTTP listener thread if it has been initialized.
+   *
+   * <p>Callers should ensure {@link #setCore(NodeClientCore)} and {@link #createFproxy()} have
+   * completed before invoking this method. When {@link #myThread} is non-null, the network
+   * interface is lazily created and the thread is started, logging the bind address and port. This
+   * call is idempotent when {@link #myThread} is already {@code null} or the thread has previously
+   * been started.
+   */
   public void start() {
-    if (myThread != null)
-      try {
-        maybeGetNetworkInterface();
-        myThread.start();
-        LOG.info("Starting FProxy on {}:{}", bindTo, port);
-        System.out.println("Starting FProxy on " + bindTo + ':' + port);
-      } catch (IOException e) {
-        LOG.error("Could not bind network port for FProxy?", e);
-      }
+    if (myThread != null) {
+      maybeGetNetworkInterface();
+      myThread.start();
+      LOG.info("Starting FProxy on {}:{}", bindTo, port);
+    }
   }
 
+  /**
+   * Completes startup by wiring threat-level listeners and marking readiness.
+   *
+   * <p>This method should be called after {@link #start()} once the node finishes loading
+   * subsystems. It attaches listeners to network and physical threat level changes so the server
+   * can adjust refilter policies and panic button visibility in real time. When the wiring
+   * succeeds, {@link #finishedStartup} becomes true, allowing deferred operations to proceed.
+   */
   public void finishStart() {
     core.getNode()
         .getSecurityLevels()
         .addNetworkThreatLevelListener(
             (oldLevel, newLevel) -> {
               // At LOW, we do ACCEPT_OLD.
-              // Otherwise we do RE_FILTER.
+              // Otherwise, we do RE_FILTER.
               // But we don't change it unless it changes from LOW to not LOW.
               if (newLevel == NETWORK_THREAT_LEVEL.LOW && newLevel != oldLevel) {
                 refilterPolicy = REFILTER_POLICY.ACCEPT_OLD;
@@ -1141,9 +1245,9 @@ public final class SimpleToadletServer
         .addPhysicalThreatLevelListener(
             (oldLevel, newLevel) -> {
               if (newLevel != oldLevel && newLevel == PHYSICAL_THREAT_LEVEL.LOW) {
-                isPanicButtonToBeShown = false;
+                setPanicButtonVisibility(false);
               } else if (newLevel != oldLevel) {
-                isPanicButtonToBeShown = true;
+                setPanicButtonVisibility(true);
               }
             });
     synchronized (this) {
@@ -1192,6 +1296,18 @@ public final class SimpleToadletServer
     }
   }
 
+  /**
+   * Registers a navigation category contributed by a plugin.
+   *
+   * <p>The category is added to the page maker so plugin pages appear in the navigation menu with
+   * translated titles where available. Callers should supply stable identifiers; no synchronization
+   * beyond the internal {@link PageMaker} handling is required.
+   *
+   * @param link navigation link target, typically a path prefix owned by the plugin.
+   * @param name short category name shown in menus; should be unique within its level.
+   * @param title descriptive title used for tooltips or extended labels; may be {@code null}.
+   * @param plugin localization helper that translates the title/name for the current locale.
+   */
   public void registerMenu(String link, String name, String title, FredPluginL10n plugin) {
     pageMaker.addNavigationCategory(link, name, title, plugin);
   }
@@ -1208,13 +1324,20 @@ public final class SimpleToadletServer
         }
       }
     }
-    if (e != null && e.t == t) {
-      if (e.menu != null && e.name != null) {
-        pageMaker.removeNavigationLink(e.menu, e.name);
-      }
+    if (e != null && e.t == t && e.menu != null && e.name != null) {
+      pageMaker.removeNavigationLink(e.menu, e.name);
     }
   }
 
+  /**
+   * Returns the startup toadlet currently registered with the server.
+   *
+   * <p>The startup toadlet serves the initial wizard and bootstrap pages before the main interface
+   * becomes available. It may be removed via {@link #removeStartupToadlet()} once the node finishes
+   * initialization.
+   *
+   * @return startup toadlet instance or {@code null} if it has already been removed.
+   */
   public StartupToadlet getStartupToadlet() {
     return startupToadlet;
   }
@@ -1227,41 +1350,51 @@ public final class SimpleToadletServer
   @Override
   public Toadlet findToadlet(URI uri) throws PermanentRedirectException {
     String path = uri.getPath();
-
-    // Show the wizard until dismissed by the user (See bug #2624)
-    NodeClientCore core = this.core;
-    if (core != null && core.getNode() != null && !fproxyHasCompletedWizard) {
-      // If the user has not completed the wizard, only allow access to the wizard and static
-      // resources. Anything else redirects to the first page of the wizard.
-      if (!(path.startsWith(FirstTimeWizardToadlet.TOADLET_URL)
-          || path.startsWith(FirstTimeWizardNewToadlet.TOADLET_URL)
-          || path.startsWith(StaticToadlet.ROOT_URL)
-          || path.startsWith(ExternalLinkToadlet.EXTERNAL_LINK_PATH)
-          || path.equals("/favicon.ico")
-          || path.equals("/favicon.svg"))) {
-        try {
-          throw new PermanentRedirectException(
-              new URI(
-                  null, null, null, -1, FirstTimeWizardToadlet.TOADLET_URL, uri.getQuery(), null));
-        } catch (URISyntaxException e) {
-          throw new Error(e);
-        }
-      }
+    if (shouldRedirectToWizard(path)) {
+      throw new PermanentRedirectException(createWizardRedirectURI(uri));
     }
+    return findRegisteredToadlet(path);
+  }
 
+  private boolean shouldRedirectToWizard(String path) {
+    NodeClientCore coreLocal = this.core;
+    if (coreLocal == null || coreLocal.getNode() == null || fproxyHasCompletedWizard) {
+      return false;
+    }
+    return !isWizardPathAllowed(path);
+  }
+
+  private boolean isWizardPathAllowed(String path) {
+    return path.startsWith(FirstTimeWizardToadlet.TOADLET_URL)
+        || path.startsWith(FirstTimeWizardNewToadlet.TOADLET_URL)
+        || path.startsWith(StaticToadlet.ROOT_URL)
+        || path.startsWith(ExternalLinkToadlet.EXTERNAL_LINK_PATH)
+        || path.equals("/favicon.ico")
+        || path.equals("/favicon.svg");
+  }
+
+  private URI createWizardRedirectURI(URI uri) {
+    try {
+      return new URI(
+          null, null, null, -1, FirstTimeWizardToadlet.TOADLET_URL, uri.getQuery(), null);
+    } catch (URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private Toadlet findRegisteredToadlet(String path) throws PermanentRedirectException {
     synchronized (toadlets) {
       for (ToadletElement te : toadlets) {
         if (path.startsWith(te.prefix)) return te.t;
-        if (!te.prefix.isEmpty() && te.prefix.charAt(te.prefix.length() - 1) == '/') {
-          if (path.equals(te.prefix.substring(0, te.prefix.length() - 1))) {
-            URI newURI;
-            try {
-              newURI = new URI(te.prefix);
-            } catch (URISyntaxException e) {
-              throw new Error(e);
-            }
-            throw new PermanentRedirectException(newURI);
+        if (te.prefix.charAt(te.prefix.length() - 1) == '/'
+            && path.equals(te.prefix.substring(0, te.prefix.length() - 1))) {
+          URI newURI;
+          try {
+            newURI = new URI(te.prefix);
+          } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
           }
+          throw new PermanentRedirectException(newURI);
         }
       }
     }
@@ -1270,33 +1403,63 @@ public final class SimpleToadletServer
 
   @Override
   public void run() {
-    boolean finishedStartup = false;
+    boolean finishedStartupFlag = false;
     while (true) {
-      synchronized (this) {
-        while (fproxyConnections > maxFproxyConnections) {
-          try {
-            wait();
-          } catch (InterruptedException e) {
-            // Ignore
-          }
-        }
-        if ((!finishedStartup) && this.finishedStartup) finishedStartup = true;
-        if (myThread == null) return;
+      finishedStartupFlag = updateFinishedStartupFlag(finishedStartupFlag);
+      if (!acquireConnectionSlot()) {
+        return;
       }
       Socket conn = networkInterface.accept();
       if (WrapperManager.hasShutdownHookBeenTriggered()) return;
       if (conn == null) continue; // timeout
       if (LOG.isDebugEnabled()) LOG.debug("Accepted connection");
-      SocketHandler sh = new SocketHandler(conn, finishedStartup);
+      SocketHandler sh = new SocketHandler(conn, finishedStartupFlag);
       sh.start();
     }
   }
 
+  private boolean acquireConnectionSlot() {
+    synchronized (this) {
+      while (fproxyConnections > maxFproxyConnections) {
+        try {
+          wait();
+        } catch (InterruptedException ignored) {
+          Thread.currentThread().interrupt();
+          return false;
+        }
+      }
+      return myThread != null;
+    }
+  }
+
+  private boolean updateFinishedStartupFlag(boolean finishedStartupFlag) {
+    synchronized (this) {
+      if (!finishedStartupFlag && this.finishedStartup) {
+        return true;
+      }
+    }
+    return finishedStartupFlag;
+  }
+
+  /**
+   * Handles a single accepted HTTP socket connection.
+   *
+   * <p>A SocketHandler is created per connection and either executed on the configured executor
+   * (after startup) or on a temporary thread during early boot. It owns the socket lifetime, runs
+   * request processing via {@link ToadletContextImpl}, and decrements the active connection counter
+   * on completion. Instances are short-lived and not reused across requests.
+   */
   public class SocketHandler implements PrioRunnable {
 
     Socket sock;
     final boolean finishedStartup;
 
+    /**
+     * Creates a handler for a freshly accepted socket.
+     *
+     * @param conn connected client socket; ownership transfers to the handler.
+     * @param finishedStartup whether the node has finished startup and can use the shared executor.
+     */
     public SocketHandler(Socket conn, boolean finishedStartup) {
       this.sock = conn;
       this.finishedStartup = finishedStartup;
@@ -1316,10 +1479,8 @@ public final class SimpleToadletServer
       try {
         ToadletContextImpl.handle(
             sock, SimpleToadletServer.this, pageMaker, getUserAlertManager(), bookmarkManager);
-      } catch (Throwable t) {
-        System.err.println("Caught in SimpleToadletServer: " + t);
-        t.printStackTrace();
-        LOG.error("Caught in SimpleToadletServer: {}", t.toString(), t);
+      } catch (Exception t) {
+        LOG.error("Caught in SimpleToadletServer: {}", t, t);
       } finally {
         synchronized (SimpleToadletServer.this) {
           fproxyConnections--;
@@ -1340,12 +1501,30 @@ public final class SimpleToadletServer
     return this.cssTheme;
   }
 
+  /**
+   * Returns the user alert manager associated with the current core.
+   *
+   * <p>The alert manager surfaces node warnings and informational banners to the UI and handles
+   * their dismissal state. When the core has not yet been assigned this method returns {@code
+   * null}; callers should therefore wait until after {@link #setCore(NodeClientCore)} is invoked.
+   *
+   * @return active {@link UserAlertManager} from the core, or {@code null} when unavailable.
+   */
   public UserAlertManager getUserAlertManager() {
-    NodeClientCore core = this.core;
-    if (core == null) return null;
-    return core.getAlerts();
+    NodeClientCore coreRef = this.core;
+    if (coreRef == null) return null;
+    return coreRef.getAlerts();
   }
 
+  /**
+   * Overrides the current theme selection.
+   *
+   * <p>This setter is primarily used by configuration callbacks and assumes the provided theme has
+   * already been validated. It does not persist the change; callers must handle storage.
+   *
+   * @param theme new theme enumeration value to use for rendering pages.
+   */
+  @SuppressWarnings("unused")
   public void setCSSName(THEME theme) {
     this.cssTheme = theme;
   }
@@ -1374,6 +1553,16 @@ public final class SimpleToadletServer
     return this.fProxyJavascriptEnabled;
   }
 
+  /**
+   * Enables or disables JavaScript in FProxy pages.
+   *
+   * <p>The flag is stored as a volatile boolean and read by template rendering code to decide
+   * whether to include inline scripts. Callers are expected to persist the chosen value elsewhere.
+   * Changing this setting only affects newly rendered pages; already rendered responses are
+   * unchanged. The method is thread-safe and may be called from configuration UI handlers.
+   *
+   * @param b {@code true} to permit JavaScript, {@code false} to disable it across pages.
+   */
   public synchronized void enableFProxyJavascript(boolean b) {
     fProxyJavascriptEnabled = b;
   }
@@ -1383,6 +1572,16 @@ public final class SimpleToadletServer
     return this.fProxyWebPushingEnabled;
   }
 
+  /**
+   * Toggles push support for FProxy web interfaces.
+   *
+   * <p>When enabled, pages may initiate push data channels to deliver live updates. The flag is
+   * stored and read concurrently; synchronization guards writes. Existing connections will read the
+   * latest value on their next push attempt, so callers can flip this at runtime to triage load or
+   * feature issues without restarting the node.
+   *
+   * @param b {@code true} to enable pushing, {@code false} to disable it.
+   */
   public synchronized void enableFProxyWebPushing(boolean b) {
     fProxyWebPushingEnabled = b;
   }
@@ -1423,18 +1622,64 @@ public final class SimpleToadletServer
     return formNode;
   }
 
-  public void setBucketFactory(BucketFactory tempBucketFactory) {
+  /**
+   * Replaces the bucket factory used for incoming request handling.
+   *
+   * <p>Intended for controlled overrides or tests that need deterministic buffering behavior.
+   * Synchronization ensures the new factory becomes visible to concurrent worker threads. Does not
+   * retroactively alter buckets already allocated for in-flight requests.
+   *
+   * @param tempBucketFactory replacement {@link BucketFactory}; must not be {@code null}.
+   */
+  public synchronized void setBucketFactory(BucketFactory tempBucketFactory) {
     this.bf = tempBucketFactory;
   }
 
+  /**
+   * Indicates whether the HTTP listener is currently configured to run.
+   *
+   * <p>This mirrors whether the server thread was created at construction. It does not confirm the
+   * socket bind succeeded; callers should also observe logs for binding errors when transitioning
+   * to running state.
+   *
+   * @return {@code true} when the listener thread exists, {@code false} otherwise.
+   */
   public boolean isEnabled() {
     return myThread != null;
   }
 
-  public BookmarkManager getBookmarks() {
+  /**
+   * Returns the bookmark manager backing user bookmark operations.
+   *
+   * <p>The manager may be {@code null} before {@link #createFproxy()} wires the supporting
+   * components. Once available it manages storage, import/export, and UI synchronization for saved
+   * bookmarks. Callers should treat the reference as owned by the server.
+   *
+   * @return {@link BookmarkManager} instance or {@code null} when not yet available.
+   */
+  public BookmarkManager getBookmarkManager() {
     return bookmarkManager;
   }
 
+  /**
+   * Convenience alias for {@link #getBookmarkManager()}.
+   *
+   * <p>Provided for compatibility with older call sites that referenced the shorter name.
+   *
+   * @return bookmark manager instance or {@code null}.
+   */
+  public BookmarkManager getBookmarks() {
+    return getBookmarkManager();
+  }
+
+  /**
+   * Returns the URIs of all currently stored bookmarks.
+   *
+   * <p>The returned array is a snapshot; subsequent modifications to the bookmark store are not
+   * reflected. Callers should not mutate the array contents.
+   *
+   * @return array of {@link FreenetURI} entries; empty when no bookmarks exist.
+   */
   public FreenetURI[] getBookmarkURIs() {
     if (bookmarkManager == null) return new FreenetURI[0];
     return bookmarkManager.getBookmarkURIs();
@@ -1465,6 +1710,14 @@ public final class SimpleToadletServer
     return !(bf instanceof ArrayBucketFactory);
   }
 
+  /**
+   * Returns the bucket factory currently active for request bodies.
+   *
+   * <p>The factory is used to allocate buffers for uploads and other payloads. The method is
+   * synchronized to ensure callers see the latest factory after runtime swaps.
+   *
+   * @return non-null {@link BucketFactory} used to allocate request storage.
+   */
   @Override
   public synchronized BucketFactory getBucketFactory() {
     return bf;
@@ -1480,21 +1733,53 @@ public final class SimpleToadletServer
     return disableProgressPage;
   }
 
+  /**
+   * Returns the page maker responsible for building HTML responses.
+   *
+   * <p>PageMaker handles templating, navigation link management, and shared look-and-feel settings
+   * such as theme overrides.
+   *
+   * @return configured {@link PageMaker} instance.
+   */
   @Override
   public PageMaker getPageMaker() {
     return pageMaker;
   }
 
+  /**
+   * Provides the ticker used to schedule periodic tasks.
+   *
+   * <p>The ticker is shared across push managers and other time-based components. It is owned by
+   * the {@link Node} and exposed here for convenience.
+   *
+   * @return {@link Ticker} from the node; never {@code null} after the core is set.
+   */
   public Ticker getTicker() {
     return core.getNode().getTicker();
   }
 
+  /**
+   * Returns the currently bound node core.
+   *
+   * <p>Callers must not mutate the core state in ways that violate server invariants. The reference
+   * may change only through {@link #setCore(NodeClientCore)} during startup.
+   *
+   * @return {@link NodeClientCore} instance or {@code null} when unset.
+   */
   public NodeClientCore getCore() {
     return core;
   }
 
   private REFILTER_POLICY refilterPolicy;
 
+  /**
+   * Returns the active refilter policy applied to request processing.
+   *
+   * <p>The policy is updated in response to threat-level changes to balance usability with
+   * security. Caller should treat the value as read-only.
+   *
+   * @return current {@link REFILTER_POLICY} value.
+   */
   @Override
   public REFILTER_POLICY getReFilterPolicy() {
     return refilterPolicy;
@@ -1550,10 +1835,33 @@ public final class SimpleToadletServer
 
   @Override
   public long generateUniqueID() {
-    // FIXME increment a counter?
+    // Generates a unique ID per call; replace with a counter if sequential IDs are required.
     return random.nextLong();
   }
 
+  /**
+   * Returns the interval pusher manager coordinating scheduled push cycles.
+   *
+   * <p>Used by pages that need periodic server-initiated updates. Ownership remains with the
+   * server; callers should not attempt to shut it down directly.
+   *
+   * @return {@link IntervalPusherManager} instance, or {@code null} before {@link #createFproxy()}
+   *     runs.
+   */
+  @SuppressWarnings("unused")
+  public IntervalPusherManager getIntervalPushManager() {
+    return intervalPushManager;
+  }
+
+  /**
+   * Returns the push data manager handling ad-hoc push operations.
+   *
+   * <p>Supports one-off push transmissions triggered by toadlets. Like the interval manager, this
+   * object is created during {@link #createFproxy()} and owned by the server.
+   *
+   * @return {@link PushDataManager} instance or {@code null} if initialization has not yet created
+   *     one.
+   */
   public PushDataManager getPushDataManager() {
     return pushDataManager;
   }

--- a/src/main/java/network/crypta/clients/http/ToadletContainer.java
+++ b/src/main/java/network/crypta/clients/http/ToadletContainer.java
@@ -3,57 +3,73 @@ package network.crypta.clients.http;
 import java.io.File;
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.PageMaker.THEME;
 import network.crypta.pluginmanager.FredPluginL10n;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.BucketFactory;
 
-/** Interface for toadlet containers. Toadlets should register here. */
+/**
+ * Central contract for components that own and expose HTTP toadlets.
+ *
+ * <p>Implementations map incoming HTTP paths to {@link Toadlet} instances, inject shared UI
+ * services such as theme and page maker support, and surface policy toggles that affect request
+ * handling. A container typically sits directly behind the HTTP listener: it receives requests,
+ * resolves the target toadlet via {@link #findToadlet(URI)}, and provides helpers for rendering
+ * forms, enforcing authentication, and reporting node capabilities to callers.
+ *
+ * <p>Usage patterns usually involve registering toadlets at startup, optionally wiring them into a
+ * navigation menu, and then invoking the various getters from request-processing threads. State is
+ * expected to be long-lived and stable for the lifetime of the node; implementors should document
+ * whether registration or mode changes are thread-safe and whether they can occur after the HTTP
+ * server starts.
+ *
+ * <ul>
+ *   <li>Registration: associates path prefixes with handlers and optional menu entries.
+ *   <li>Presentation: exposes theme selection, page builder access, and generated form helpers.
+ *   <li>Policy: reports gateway/public access settings, caching behavior, and other feature flags.
+ * </ul>
+ *
+ * <p>See also {@link PageMaker} for templating support and {@link ToadletContext} for per-request
+ * execution context.
+ */
 public interface ToadletContainer {
 
   /**
-   * Register a Toadlet. All requests whose URL starts with the given prefix will be passed to this
-   * toadlet.
+   * Register a {@link Toadlet} without adding a navigation link.
    *
-   * @param t the toadlet to register
-   * @param menu the menu category to register a navigation link with with. It is most likely also a
-   *     l10n key, though that is irrelevant to this method.
-   * @param urlPrefix the prefix that the Toadlet will serve; should be a path like /foo/bar/baz,
-   *     most likely the string returned by the toadlet's path() method
-   * @param atFront If true, this Toadlet will take precedence over any other previously-registered
-   *     Toadlet whose urlPrefix also matches. Otherwise, the other matching Toadlet is used
-   *     instead.
-   * @param fullOnly Whether or not the navigation link is shown when the http client does not have
-   *     full security access. Note that passing false does not prevent the Toadlet from receiving
-   *     requests under urlPrefix, so Toadlet authors are advised to check for full access
-   *     themselves, possibly returning a 403 error code.
+   * <p>All incoming requests whose path begins with {@code urlPrefix} are routed to the supplied
+   * toadlet. The registration order controls precedence when prefixes overlap; placing a toadlet at
+   * the front allows it to shadow earlier registrations with the same prefix. This overload is
+   * useful for programmatic endpoints or internal hooks that do not need menu exposure but still
+   * need to be reachable through the HTTP surface.
+   *
+   * @param t the toadlet to register; must remain valid for the lifetime of the container
+   * @param menu menu category key that scopes navigation; ignored when no menu entry is created
+   * @param urlPrefix leading path segment (e.g., {@code /foo/bar}) used for handler resolution
+   * @param atFront whether this toadlet should win over earlier matching prefixes when resolving
+   * @param fullAccessOnly whether the link is hidden for reduced-permission clients; does not gate
+   *     dispatching, so handlers should still validate access before serving sensitive content
    */
   void register(Toadlet t, String menu, String urlPrefix, boolean atFront, boolean fullAccessOnly);
 
   /**
-   * Registers a Toadlet and optionally adds a navigation link to the menu. All requests whose URL
-   * starts with the given prefix will be given to this Toadlet. If either the menu or the name
-   * parameter is null, then no navigation link is be registered for the Toadlet and the title,
-   * fullOnly, cb, and l10n parameters are ignored.
+   * Register a {@link Toadlet} and, when possible, expose it in the navigation menu.
    *
-   * @param t the toadlet to register
-   * @param menu the menu category to register a navigation link with with. It is most likely also a
-   *     l10n key, though that is irrelevant to this method.
-   * @param urlPrefix the prefix that the Toadlet will serve; should be a path like /foo/bar/baz,
-   *     most likely the string returned by the toadlet's path() method
-   * @param atFront If true, this Toadlet will take precedence over any other previously-registered
-   *     Toadlet whose urlPrefix also matches. Otherwise, the other matching Toadlet is used
-   *     instead.
-   * @param name A l10n key used for the navigation link label.
-   * @param title A l10n key used for the navigation link tooltip.
-   * @param fullOnly Whether or not the navigation link is shown when the http client does not have
-   *     full security access. Note that passing false does not prevent the Toadlet from receiving
-   *     requests under urlPrefix, so Toadlet authors are advised to check for full access
-   *     themselves, possibly returning a 403 error code.
-   * @param cb A LinkEnabledCalback, allowing fine control of when the navigation link is visible
-   *     and when it isn't. Passing null means it is always visible.
+   * <p>This overload allows callers to provide localized menu metadata and a callback that
+   * dynamically governs link visibility. Menu and name values may be {@code null} to suppress menu
+   * creation while still routing traffic. The registration process does not duplicate toadlets or
+   * mutate them; ownership and lifecycle stay with the caller. Overlapping prefixes follow the same
+   * precedence rules as the simpler overload.
+   *
+   * @param t the toadlet to register; must safely handle concurrent requests once exposed
+   * @param menu menu grouping key; {@code null} skips menu creation even when other metadata exists
+   * @param urlPrefix leading path segment (e.g., {@code /foo/bar}) used for request routing
+   * @param atFront whether this toadlet should be prioritized over earlier registrations
+   * @param name localization key that renders the menu label when a link is created
+   * @param title localization key that renders the tooltip for the link when present
+   * @param fullOnly whether the menu link is visible only to clients with full access permissions
+   * @param cb optional callback that can enable or hide the link based on runtime state
    */
   void register(
       Toadlet t,
@@ -66,29 +82,24 @@ public interface ToadletContainer {
       LinkEnabledCallback cb);
 
   /**
-   * Registers a Toadlet and optionally adds a navigation link to the menu. All requests whose URL
-   * starts with the given prefix will be given to this Toadlet. If either the menu or the name
-   * parameter is null, then no navigation link is be registered for the Toadlet and the title,
-   * fullOnly, cb, and l10n parameters are ignored.
+   * Register a {@link Toadlet} with menu metadata and localization support.
    *
-   * @param t the toadlet to register
-   * @param menu the menu category to register a navigation link with with. It is most likely also a
-   *     l10n key, though that is irrelevant to this method.
-   * @param urlPrefix the prefix that the Toadlet will serve; should be a path like /foo/bar/baz,
-   *     most likely the string returned by the toadlet's path() method
-   * @param atFront If true, this Toadlet will take precedence over any other previously-registered
-   *     Toadlet whose urlPrefix also matches. Otherwise, the other matching Toadlet is used
-   *     instead.
-   * @param name A l10n key used for the navigation link label.
-   * @param title A l10n key used for the navigation link tooltip.
-   * @param fullOnly Whether or not the navigation link is shown when the http client does not have
-   *     full security access. Note that passing false does not prevent the Toadlet from receiving
-   *     requests under urlPrefix, so Toadlet authors are advised to check for full access
-   *     themselves, possibly returning a 403 error code.
-   * @param cb A LinkEnabledCalback, allowing fine control of when the navigation link is visible
-   *     and when it isn't. Passing null means it is always visible.
-   * @param l10n A FredPluginL10n instance for translating the name and title parameters. May be
-   *     null.
+   * <p>This variant mirrors {@link #register(Toadlet, String, String, boolean, String, String,
+   * boolean, LinkEnabledCallback)} while allowing localized strings to be resolved by the caller
+   * through a provided {@link FredPluginL10n}. Passing {@code null} for menu or name suppresses
+   * link creation and ignores presentation arguments. Implementations may cache translations or
+   * consult the callback for each render, so inputs should remain valid after registration.
+   *
+   * @param t the toadlet to register for the given prefix
+   * @param menu menu grouping key; {@code null} disables link creation regardless of other values
+   * @param urlPrefix leading path segment (e.g., {@code /foo/bar}) that this toadlet serves
+   * @param atFront whether this toadlet should override earlier registrations with matching
+   *     prefixes
+   * @param name localization key used for the visible link text when a menu entry is shown
+   * @param title localization key that supplies the link tooltip text where supported
+   * @param fullOnly whether the link is shown only to users with full access permissions enabled
+   * @param cb optional visibility callback consulted to decide whether the link is currently shown
+   * @param l10n optional localization provider used to resolve {@code name} and {@code title}
    */
   void register(
       Toadlet t,
@@ -101,85 +112,327 @@ public interface ToadletContainer {
       LinkEnabledCallback cb,
       FredPluginL10n l10n);
 
+  /**
+   * Remove a previously registered toadlet and any associated navigation link metadata.
+   *
+   * <p>After deregistration, new requests under the toadlet's prefix will no longer be dispatched
+   * to it. Implementations should be resilient when the toadlet was not registered and should avoid
+   * interrupting in-flight requests that are already being served.
+   *
+   * @param t the toadlet to unregister; ignored when the container does not track it
+   */
   void unregister(Toadlet t);
 
   /**
    * Find a Toadlet by URI.
    *
-   * @throws URISyntaxException
-   * @throws RedirectException
-   * @throws PermanentRedirectException
+   * <p>Resolvers should match the longest registered prefix and may return {@code null} when no
+   * toadlet is available. Implementations may perform redirects for canonicalization, and callers
+   * should be prepared to reissue requests when a permanent redirect is signaled.
+   *
+   * @param uri absolute or server-relative URI used to locate the target toadlet
+   * @return the registered toadlet for the given URI, or {@code null} when no mapping exists
+   * @throws PermanentRedirectException when the URI should be replaced by a different canonical
+   *     endpoint before retrying
    */
   Toadlet findToadlet(URI uri) throws PermanentRedirectException;
 
-  /** Get the name of the theme to be used by all the Toadlets */
+  /**
+   * Get the theme configured for all toadlets.
+   *
+   * <p>The theme guides page rendering choices such as colors and typography. Callers typically
+   * feed this value into {@link PageMaker} before building responses to ensure consistent
+   * presentation across the UI.
+   *
+   * @return the configured {@link THEME} for current responses
+   */
   THEME getTheme();
 
-  /** Get the form password */
+  /**
+   * Obtain the form password that protects sensitive POST submissions.
+   *
+   * <p>This value is commonly embedded into hidden fields by {@link #addFormChild(HTMLNode, String,
+   * String)} to mitigate cross-site or automated attacks. Implementations should return a stable
+   * token for the duration of a session or node lifetime.
+   *
+   * @return a non-empty password string that callers must echo with privileged form submissions
+   */
   String getFormPassword();
 
-  /** Is the given IP address allowed full access to the node? */
+  /**
+   * Determine whether the given remote address has full access rights.
+   *
+   * <p>Full access controls the visibility of administrative pages and queue views. Containers may
+   * evaluate static ACLs, authentication state, or connection-level properties. The check is purely
+   * advisory; toadlets should still verify permissions before serving sensitive resources.
+   *
+   * @param remoteAddr client address being evaluated; {@code null} is treated as unauthorized
+   * @return {@code true} when the address is considered fully trusted, {@code false} otherwise
+   */
   boolean isAllowedFullAccess(InetAddress remoteAddr);
 
-  /** Whether to tell spiders to go away */
+  /**
+   * Report whether the node should ask web crawlers not to index pages.
+   *
+   * <p>When {@code true}, toadlets can emit appropriate {@code robots} headers or meta tags to
+   * discourage indexing of private or ephemeral content.
+   *
+   * @return {@code true} when crawler directives should block indexing
+   */
   boolean doRobots();
 
+  /**
+   * Append a toadlet-aware form node to the supplied parent.
+   *
+   * <p>The helper constructs a form targeting the given path, injects the container's form
+   * password, and returns the newly created {@link HTMLNode}. Callers can then populate inputs or
+   * controls before rendering the document. Parent nodes are modified in place.
+   *
+   * @param parentNode HTML node that receives the new form as a child; must not be {@code null}
+   * @param target path that the form submits to, relative to the toadlet container
+   * @param name optional name attribute to set on the form for identification
+   * @return the created {@link HTMLNode} representing the form element
+   */
   HTMLNode addFormChild(HTMLNode parentNode, String target, String name);
 
+  /**
+   * Indicate whether persistent HTTP connections are allowed for served toadlets.
+   *
+   * <p>Persistent connections reduce handshake overhead for multiple requests but may be disabled
+   * when resource usage needs to be constrained or intermediaries misbehave. Callers that stream
+   * large responses or issue many small requests can check this flag to decide whether to advertise
+   * keep-alive semantics or to close sockets aggressively after each exchange.
+   *
+   * @return {@code true} when keep-alive connections may be used
+   */
   boolean enablePersistentConnections();
 
+  /**
+   * State whether inline prefetch of linked resources is permitted.
+   *
+   * <p>When enabled, toadlets may optimistically fetch resources referenced in a page to reduce
+   * perceived latency. Callers should honor this flag before initiating speculative fetches and may
+   * also throttle the number of speculative requests to avoid overwhelming constrained nodes.
+   *
+   * @return {@code true} when inline prefetching is enabled
+   */
   boolean enableInlinePrefetch();
 
+  /**
+   * State whether extended HTTP method handling is active.
+   *
+   * <p>Extended handling may include support for additional verbs or relaxed parsing. Toadlets that
+   * rely on non-GET/POST methods should consult this flag before advertising such capabilities and
+   * may need to degrade gracefully to safer subsets when the feature is disabled.
+   *
+   * @return {@code true} when extended method handling is enabled
+   */
   boolean enableExtendedMethodHandling();
 
+  /**
+   * State whether caching is allowed for CHK and SSK key responses.
+   *
+   * <p>Enabling caching lets callers reuse fetched content keyed by content hashes or signed keys.
+   * Disabled caching forces fresh retrieval to reduce stale data risk. Toadlets that expose cache
+   * headers or maintain local caches should synchronize their behavior with this policy flag.
+   *
+   * @return {@code true} when caching of CHK/SSK responses is permitted
+   */
   boolean enableCachingForChkAndSskKeys();
 
-  /** Get the BucketFactory */
+  /**
+   * Access the shared {@link BucketFactory} for creating temporary or persistent buckets.
+   *
+   * <p>Callers typically use the factory to stream request or response bodies without manually
+   * managing files. The returned factory should be thread-safe or otherwise safe for concurrent
+   * use.
+   *
+   * @return the bucket factory associated with this container
+   */
   BucketFactory getBucketFactory();
 
-  /** Can we deal with POSTs yet? */
+  /**
+   * Indicate whether POST requests are accepted.
+   *
+   * <p>Some deployments may temporarily disable POST handling during bootstrap or maintenance.
+   * Callers should avoid generating POST forms when this returns {@code false} and may want to
+   * redirect users toward read-only flows or explanatory status pages until POST support returns.
+   *
+   * @return {@code true} when POST handling is enabled
+   */
   boolean allowPosts();
 
   /**
    * Was public-gateway mode enabled on startup? (Changing it won't take effect until restart
    * because of bookmark-related issues). If so, users with full access will still be able to
-   * configure the node etc, but everyone else will not have access to the download queue or
+   * configure the node etc., but everyone else will not have access to the download queue or
    * anything else that might conceivably result in a DoS.
+   *
+   * @return {@code true} when public gateway restrictions are active for unauthenticated users
    */
   boolean publicGatewayMode();
 
+  /**
+   * State whether activelinks rendering support is enabled for outgoing pages.
+   *
+   * <p>When enabled, link rendering may include richer metadata or interactive behaviors. Toadlets
+   * that emit HTML should respect this flag when choosing link styles, tooltips, or progressive
+   * enhancements so the UI remains usable when the feature is disabled.
+   *
+   * @return {@code true} when activelinks support is enabled
+   */
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   boolean enableActivelinks();
 
+  /**
+   * State whether all themes are sent to the client instead of only the active one.
+   *
+   * <p>Sending all themes can simplify client-side theme switching at the cost of additional
+   * bandwidth. Static clients may prefer to receive only the active theme, while theme pickers can
+   * preload assets when this flag is {@code true} to deliver instant switches.
+   *
+   * @return {@code true} when all theme assets are provided to clients
+   */
   boolean sendAllThemes();
 
+  /**
+   * Determine whether FProxy JavaScript helpers are enabled in generated pages.
+   *
+   * <p>Disabling scripts can harden pages for highly restricted environments but may remove
+   * progressive enhancements or live status updates. Toadlets that rely on client-side behavior
+   * should degrade gracefully or emit compatibility warnings when scripts are disabled.
+   *
+   * @return {@code true} when JavaScript support is allowed in FProxy pages
+   */
   boolean isFProxyJavascriptEnabled();
 
+  /**
+   * Determine whether FProxy server push or WebSocket-style features are enabled.
+   *
+   * <p>When disabled, pages should fall back to polling or static updates to avoid relying on push
+   * channels. Implementations can also use this signal to avoid allocating long-lived connections
+   * when the operator prefers strictly request/response traffic.
+   *
+   * @return {@code true} when push-style updates are permitted
+   */
   boolean isFProxyWebPushingEnabled();
 
+  /**
+   * Indicate whether progress pages are disabled for downloads or other long-running operations.
+   *
+   * <p>Containers may suppress progress pages in kiosk or embedded modes where minimal output is
+   * desired. Toadlets that would normally stream progress should check this flag and emit succinct
+   * completion messages or status codes instead of interactive progress dashboards.
+   *
+   * @return {@code true} when progress pages are suppressed
+   */
   boolean disableProgressPage();
 
+  /**
+   * Obtain the page maker used to build HTML responses.
+   *
+   * <p>Callers can reuse the returned {@link PageMaker} to assemble pages consistent with the
+   * container's theme, localization, and layout conventions. The page maker may also embed common
+   * headers, navigation scaffolding, and security tokens so downstream code can focus on content.
+   *
+   * @return the shared {@link PageMaker} instance
+   */
   PageMaker getPageMaker();
 
+  /**
+   * Report whether advanced mode is currently enabled.
+   *
+   * <p>Advanced mode typically unlocks expert options or verbose diagnostics intended for trusted
+   * users. UI components can read this flag to conditionally render advanced controls and to avoid
+   * surprising novice users with experimental features when the mode is off.
+   *
+   * @return {@code true} when advanced mode features should be shown
+   */
   boolean isAdvancedModeEnabled();
 
+  /**
+   * Enable or disable advanced mode.
+   *
+   * <p>Implementations should persist the chosen state and notify interested components as needed.
+   * Callers are expected to gate privileged UI elements on this value rather than direct authority
+   * checks. Changing this flag may have immediate UI effects, so consumers should re-render any
+   * cached views after toggling.
+   *
+   * @param enabled {@code true} to expose advanced mode features; {@code false} to hide them
+   */
   void setAdvancedMode(boolean enabled);
 
+  /**
+   * Report whether the FProxy setup wizard has been completed.
+   *
+   * <p>Toadlets may use this to decide whether to reroute users to onboarding flows or to surface
+   * reminders about incomplete configuration. The result should remain stable across requests until
+   * the wizard runs to completion.
+   *
+   * @return {@code true} when the initial wizard has already run to completion
+   */
   boolean fproxyHasCompletedWizard();
 
   /**
-   * What to do when we find cached data on the global queue but it's already been filtered, and we
+   * What to do when we find cached data on the global queue, but it's already been filtered, and we
    * want a filtered copy.
+   *
+   * @return the refilter policy governing how cached filtered content is handled
    */
   REFILTER_POLICY getReFilterPolicy();
 
+  /**
+   * Retrieve a file that overrides defaults for this container.
+   *
+   * <p>Implementations may use this file to supply custom configuration or branding assets. The
+   * file may be absent when default settings are in effect, so callers should handle {@code null}
+   * defensively.
+   *
+   * @return override file path, or {@code null} when no override is configured
+   */
   File getOverrideFile();
 
+  /**
+   * Get the base URL that external clients should use to reach this container.
+   *
+   * <p>The URL typically includes protocol and host information and may reflect current SSL
+   * settings or public gateway mode. This value is suitable for constructing absolute links in
+   * email notifications or redirects.
+   *
+   * @return a canonical URL string for the container
+   */
   String getURL();
 
+  /**
+   * Get a base URL using an explicit host instead of the auto-detected one.
+   *
+   * <p>This is useful when constructing links for virtual hosting scenarios or behind proxies where
+   * the externally visible host differs from the local listener. Implementations should preserve
+   * the container's current scheme and port when composing the URL.
+   *
+   * @param host hostname to embed in the returned URL; must be a valid host token
+   * @return a URL string that points to this container using the supplied host
+   */
   String getURL(String host);
 
+  /**
+   * Determine whether the container is serving content over HTTPS.
+   *
+   * <p>Toadlets can use this information to decide whether to emit secure-only links or additional
+   * transport guidance.
+   *
+   * @return {@code true} when HTTPS is active for this container
+   */
   boolean isSSL();
 
-  /** Create a unique ID for a ToadletContext */
+  /**
+   * Create a container-scoped unique identifier suitable for {@link ToadletContext} instances.
+   *
+   * <p>IDs should be unique for the lifetime of the container and may be used for correlation or
+   * logging. Implementations should avoid expensive generation paths because this method may be
+   * called for every incoming request.
+   *
+   * @return a monotonically unique identifier for contextual correlation
+   */
   long generateUniqueID();
 }

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -1236,7 +1236,7 @@ public class Node implements TimeSkewDetectorCallback {
       fproxyConfig.finishedInitialization();
       toadlets.start();
       return toadlets;
-    } catch (IOException | InvalidConfigValueException e4) {
+    } catch (InvalidConfigValueException e4) {
       throw new NodeInitException(
           NodeInitException.EXIT_COULD_NOT_START_FPROXY, "Could not start FProxy: " + e4);
     }

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -1,0 +1,190 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.net.InetAddress;
+import java.net.URI;
+import network.crypta.config.Config;
+import network.crypta.config.SubConfig;
+import network.crypta.io.NetworkInterface;
+import network.crypta.io.SSLNetworkInterface;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.io.ArrayBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SimpleToadletServerTest {
+
+  @Test
+  void findToadlet_whenRegisteredPrefixMatches_returnsRegisteredToadlet() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    DummyToadlet toadlet = new DummyToadlet("/test/");
+
+    server.register(toadlet, null, "/test/", true, false);
+
+    Toadlet result = server.findToadlet(new URI("http://localhost/test/resource"));
+
+    assertSame(toadlet, result);
+  }
+
+  @Test
+  void findToadlet_whenMissingTrailingSlash_redirectsToNormalizedPrefix() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    DummyToadlet toadlet = new DummyToadlet("/redirect/");
+    server.register(toadlet, null, "/redirect/", true, false);
+
+    PermanentRedirectException ex =
+        assertThrows(
+            PermanentRedirectException.class,
+            () -> server.findToadlet(new URI("http://localhost/redirect")));
+
+    assertEquals("/redirect/", ex.newuri.getPath());
+  }
+
+  @Test
+  void findToadlet_whenWizardIncomplete_redirectsToWizard() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    Node node = mock(Node.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getNode()).thenReturn(node);
+    server.setCore(core);
+
+    PermanentRedirectException ex =
+        assertThrows(
+            PermanentRedirectException.class,
+            () -> server.findToadlet(new URI("http://localhost/hidden")));
+
+    assertEquals(FirstTimeWizardToadlet.TOADLET_URL, ex.newuri.getPath());
+  }
+
+  @Test
+  void isLinkExcepted_whenToadletDeclaresException_usesToadletDecision() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    ExceptedToadlet toadlet = new ExceptedToadlet("/except/");
+    server.register(toadlet, null, "/except/", true, false);
+
+    boolean result = server.isLinkExcepted(new URI("http://localhost/except/page"));
+
+    assertTrue(result);
+  }
+
+  @Test
+  void isLinkExcepted_whenNoExceptedToadlet_returnsFalse() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+
+    boolean result = server.isLinkExcepted(new URI("http://localhost/nowhere"));
+
+    assertFalse(result);
+  }
+
+  @Test
+  void addFormChild_whenCoreProvidesPassword_includesHiddenInput() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getFormPassword()).thenReturn("secret-token");
+    server.setCore(core);
+
+    HTMLNode parent = new HTMLNode("div");
+
+    HTMLNode form = server.addFormChild(parent, "/target", "form-id");
+
+    assertEquals("/target", form.getAttribute("action"));
+    HTMLNode inputNode =
+        form.getChildren().stream()
+            .filter(child -> "input".equals(child.getFirstTag()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals("hidden", inputNode.getAttribute("type"));
+    assertEquals("formPassword", inputNode.getAttribute("name"));
+    assertEquals("secret-token", inputNode.getAttribute("value"));
+  }
+
+  @Test
+  void getURL_whenHostProvided_buildsHttpUrlWithPort() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+
+    String url = server.getURL("example.com");
+
+    assertEquals("http://example.com:" + SimpleToadletServer.DEFAULT_FPROXY_PORT + "/", url);
+  }
+
+  @Test
+  void allowPosts_whenUsingArrayBucketFactory_returnsFalse() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    server.setBucketFactory(new ArrayBucketFactory());
+
+    assertFalse(server.allowPosts());
+  }
+
+  @Test
+  void isAllowedFullAccess_whenAddressMatchesAllowList_returnsTrue() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+
+    assertTrue(server.isAllowedFullAccess(InetAddress.getByName("127.0.0.1")));
+    assertFalse(server.isAllowedFullAccess(InetAddress.getByName("8.8.8.8")));
+  }
+
+  @SuppressWarnings({"resource", "MustBeClosedChecker"})
+  private SimpleToadletServer newServerWithDefaults() throws Exception {
+    Config rootConfig = new Config();
+    SubConfig config = rootConfig.createSubConfig("fproxy");
+    Node node = mock(Node.class);
+    BucketFactory bucketFactory = mock(BucketFactory.class);
+    PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
+
+    try (MockedStatic<NetworkInterface> netMock = mockStatic(NetworkInterface.class);
+        MockedStatic<SSLNetworkInterface> sslMock = mockStatic(SSLNetworkInterface.class)) {
+      NetworkInterface iface = mock(NetworkInterface.class);
+      netMock
+          .when(() -> NetworkInterface.create(anyInt(), any(), any(), any(), anyBoolean()))
+          .thenReturn(iface);
+      sslMock
+          .when(() -> SSLNetworkInterface.create(anyInt(), any(), any(), any(), anyBoolean()))
+          .thenReturn(iface);
+      return new SimpleToadletServer(config, bucketFactory, executor, node);
+    }
+  }
+
+  private static class DummyToadlet extends Toadlet {
+    private final String path;
+
+    DummyToadlet(String path) {
+      super(null);
+      this.path = path;
+    }
+
+    @Override
+    public void handleMethodGET(
+        URI uri, network.crypta.support.api.HTTPRequest request, ToadletContext ctx) {
+      // Intentionally no-op: tests only need a concrete Toadlet for registration/lookup behavior.
+    }
+
+    @Override
+    public String path() {
+      return path;
+    }
+  }
+
+  private static final class ExceptedToadlet extends DummyToadlet
+      implements LinkFilterExceptedToadlet {
+
+    ExceptedToadlet(String path) {
+      super(path);
+    }
+
+    @Override
+    public boolean isLinkExcepted(URI link) {
+      return link.getPath().startsWith(path());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor SimpleToadletServer lifecycle wiring, threading, and configuration callbacks; replace Random with SecureRandom and add richer Javadocs
- add focused SimpleToadletServer tests covering toadlet lookup, wizard redirect, ACL checks, form password injection, and bucket factory behavior
- clarify ToadletContainer contract with expanded documentation

## Testing
- ./gradlew spotlessApply
- not run: ./gradlew --parallel test (requested if needed)
