### PR TITLE
Harden StaticToadlet path handling and add coverage

### DIFF
--- a/src/main/java/network/crypta/clients/http/StaticToadlet.java
+++ b/src/main/java/network/crypta/clients/http/StaticToadlet.java
@@ -13,86 +13,247 @@ import network.crypta.support.api.Bucket;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.io.FileBucket;
 
-/** Static Toadlet. Serve up static files */
+/**
+ * Serves static assets bundled with the node as well as user-supplied override files.
+ *
+ * <p>This toadlet routes {@code /static/} requests either to classpath resources packaged inside
+ * the application JAR or to files located under the configurable override directory. It performs
+ * cautious path validation to prevent escaping the allowed roots, sets conservative cache headers
+ * so clients refresh modified assets quickly, and hands buckets to the {@link ToadletContext} for
+ * streaming without retaining ownership. Typical usage wires an instance into the HTTP server
+ * registry so that theme assets, icons, and HTML fragments can be fetched by browsers. The handler
+ * is stateless and thread-safe provided callers supply independent {@link ToadletContext} instances
+ * per request.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Normalize and validate incoming resource paths under {@link #ROOT_URL}.
+ *   <li>Map override requests to files while ensuring callers cannot traverse outside the override
+ *       base.
+ *   <li>Stream classpath resources from {@value #ROOT_PATH} with last-modified dates derived from
+ *       the hosting JAR or file.
+ * </ul>
+ *
+ * Clients should prefer this toadlet over ad-hoc file serving to keep consistent validation, cache
+ * behavior, and ownership semantics for buckets.
+ */
 public class StaticToadlet extends Toadlet {
   StaticToadlet() {
     super(null);
   }
 
+  private static final String KEY_PATH_NOT_FOUND_TITLE = "pathNotFoundTitle";
+  private static final String KEY_PATH_NOT_FOUND = "pathNotFound";
+  private static final String KEY_PATH_INVALID = "pathInvalidChars";
+
+  /**
+   * Base URL prefix under which static assets are exposed to HTTP clients.
+   *
+   * <p>Every request handled by this toadlet must start with this prefix; routing logic strips it
+   * before resolving resources. Keeping the prefix centralized makes it easy for callers to mount
+   * the toadlet under a different path without changing lookup behavior.
+   */
   public static final String ROOT_URL = "/static/";
+
+  /**
+   * Classpath location that contains packaged static resources resolved by {@link
+   * Class#getResource}.
+   *
+   * <p>Files beneath this directory are bundled inside the application JAR and accessed via the
+   * classloader, which allows the same asset set to be served in embedded, installed, or test
+   * environments without requiring filesystem layout assumptions.
+   */
   public static final String ROOT_PATH = "staticfiles/";
+
+  /**
+   * Path segment that designates user-supplied override files within the static namespace.
+   *
+   * <p>When a request path begins with this segment, the toadlet resolves it against the override
+   * directory so operators can customize themes or assets without repackaging the node. Traversal
+   * checks guard against escaping beyond the configured override root.
+   */
   public static final String OVERRIDE = "override/";
+
+  /**
+   * Fully qualified URL prefix that maps to the override directory for theme customization.
+   *
+   * <p>Combining {@link #ROOT_URL} with {@link #OVERRIDE} yields the externally visible path that
+   * administrators reference when providing custom files. Keeping it as a constant avoids
+   * hard-coded string concatenation throughout the codebase.
+   */
   public static final String OVERRIDE_URL = ROOT_URL + OVERRIDE;
 
+  /**
+   * Handles HTTP GET requests for static assets or override files.
+   *
+   * <p>The method validates that the requested path begins with {@link #ROOT_URL}, strips the
+   * prefix, rejects traversal attempts, and dispatches to either {@link #serveOverride(String,
+   * ToadletContext)} or {@link #serveClasspathResource(String, ToadletContext)}. It sets headers
+   * before streaming data and relies on the supplied {@link ToadletContext} to manage bucket
+   * lifetime. Callers should provide a distinct context per incoming connection to avoid
+   * cross-request interference.
+   *
+   * @param uri request URI under {@link #ROOT_URL}, expected non-null for routed GET calls.
+   * @param request request wrapper carrying headers and parameters; used only for validation.
+   * @param ctx response context that emits headers and streams bytes; must stay open while writing.
+   * @throws ToadletContextClosedException if the connection closes before headers or body finish.
+   * @throws IOException if filesystem lookups or streaming encounter low-level I/O failures.
+   */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    String path = uri.getPath();
+    String requestPath = uri.getPath();
 
-    if (!path.startsWith(ROOT_URL)) {
-      // we should never get any other path anyway
-      return;
+    if (!requestPath.startsWith(ROOT_URL)) {
+      return; // we should never get any other path anyway
     }
-    try {
-      path = path.substring(ROOT_URL.length());
-    } catch (IndexOutOfBoundsException ioobe) {
-      this.sendErrorPage(ctx, 404, l10n("pathNotFoundTitle"), l10n("pathNotFound"));
+
+    String path = stripRootPrefix(requestPath, ctx);
+    if (path == null) {
       return;
     }
 
-    // be very strict about what characters we allow in the path, since
-    if (!path.matches("^[A-Za-z0-9\\._\\/\\-]*$") || path.contains("..")) {
-      this.sendErrorPage(ctx, 404, l10n("pathNotFoundTitle"), l10n("pathInvalidChars"));
+    if (isInvalidPath(path)) {
+      sendPathInvalid(ctx);
       return;
     }
 
     if (path.startsWith(OVERRIDE)) {
-      File f = this.container.getOverrideFile();
-      if (f == null || (!f.exists()) || (f.isDirectory()) || (!f.isFile())) {
-        this.sendErrorPage(ctx, 404, l10n("pathNotFoundTitle"), l10n("pathInvalidChars"));
-        return;
-      }
-      f = f.getAbsoluteFile();
-      if (f == null || (!f.exists()) || (f.isDirectory()) || (!f.isFile())) {
-        this.sendErrorPage(ctx, 404, l10n("pathNotFoundTitle"), l10n("pathInvalidChars"));
-        return;
-      }
-      File parent = f.getParentFile();
-      // Basic sanity check.
-      // Prevents user from specifying root dir.
-      // They can still shoot themselves in the foot, but only when developing themes/using custom
-      // themes.
-      // Because of the .. check above, any malicious thing cannot break out of the dir anyway.
-      if (parent.getParentFile() == null) {
-        this.sendErrorPage(ctx, 404, l10n("pathNotFoundTitle"), l10n("pathInvalidChars"));
-        return;
-      }
-      File from = new File(parent, path.substring(OVERRIDE.length()));
-      if ((!from.exists()) && (!from.isFile())) {
-        this.sendErrorPage(ctx, 404, l10n("pathNotFoundTitle"), l10n("pathInvalidChars"));
-        return;
-      }
-      try {
-        FileBucket fb = new FileBucket(from, true, false, false, false);
-        ctx.sendReplyHeadersStatic(
-            200,
-            "OK",
-            null,
-            DefaultMIMETypes.guessMIMEType(path, false),
-            fb.size(),
-            new Date(
-                System.currentTimeMillis() - 1000)); // Already expired, we want it to reload it.
-        ctx.writeData(fb);
-        return;
-      } catch (IOException e) {
-        // Not strictly accurate but close enough
-        this.sendErrorPage(ctx, 404, l10n("pathNotFoundTitle"), l10n("pathNotFound"));
-        return;
-      }
+      serveOverride(path, ctx);
+      return;
     }
 
+    serveClasspathResource(path, ctx);
+  }
+
+  /**
+   * Try to find the modification time for a URL, or return null if not possible We usually load our
+   * resources from the JAR, or possibly from a file in some setups, so we check the modification
+   * time of the JAR for resources in a jar and the mtime for files.
+   */
+  private Date getUrlMTime(URL url) {
+    if (url == null) {
+      return null;
+    }
+    if (url.getProtocol().equals("jar")) {
+      File f = new File(url.getPath().substring(0, url.getPath().indexOf('!')));
+      return new Date(f.lastModified());
+    } else if (url.getProtocol().equals("file")) {
+      File f = new File(url.getPath());
+      return new Date(f.lastModified());
+    } else {
+      return null;
+    }
+  }
+
+  private static String l10n(String key) {
+    return NodeL10n.getBase().getString("StaticToadlet." + key);
+  }
+
+  /**
+   * Returns the root URL handled by this toadlet.
+   *
+   * <p>This value is used by the HTTP server wiring to route inbound requests to the correct
+   * handler and by clients that want to construct absolute paths to packaged assets. The value is
+   * immutable and reflects {@link #ROOT_URL}, keeping configuration centralized while allowing
+   * other components to compare or publish the mounted path reliably.
+   *
+   * @return canonical URL prefix served by this toadlet; never {@code null} or empty.
+   */
+  @Override
+  public String path() {
+    return ROOT_URL;
+  }
+
+  /**
+   * Do we have a specific static file? Note that override files are not supported here as it is a
+   * static method.
+   *
+   * <p>This helper checks only the packaged resources that ship with the application and does not
+   * consult the filesystem override directory. It is intended for callers that need to confirm an
+   * asset exists before attempting to embed links or references in generated pages. The lookup uses
+   * the classloader, so it remains reliable across different distribution formats, including shaded
+   * JARs and installed distributions where the working directory is not predictable.
+   *
+   * @param path relative path under {@link #ROOT_PATH} to check; traversal segments are disallowed.
+   * @return {@code true} when a matching classpath resource exists; {@code false} otherwise.
+   */
+  public static boolean haveFile(String path) {
+    URL url = StaticToadlet.class.getResource(ROOT_PATH + path);
+    return url != null;
+  }
+
+  private String stripRootPrefix(String path, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    try {
+      return path.substring(ROOT_URL.length());
+    } catch (IndexOutOfBoundsException ioobe) {
+      sendPathNotFound(ctx);
+      return null;
+    }
+  }
+
+  private boolean isInvalidPath(String path) {
+    return !path.matches("^[A-Za-z0-9._/\\-]*$") || path.contains("..");
+  }
+
+  @SuppressWarnings("java:S2095")
+  private void serveOverride(String path, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    File overrideFile = this.container.getOverrideFile();
+    if (isInvalidFile(overrideFile)) {
+      sendPathInvalid(ctx);
+      return;
+    }
+    File absoluteOverride = overrideFile.getAbsoluteFile();
+    if (isInvalidFile(absoluteOverride)) {
+      sendPathInvalid(ctx);
+      return;
+    }
+    File parent = absoluteOverride.getParentFile();
+    // Basic sanity check.
+    // Prevents user from specifying root dir.
+    // They can still shoot themselves in the foot, but only when developing themes/using custom
+    // themes.
+    // Because of the .. check above, any malicious thing cannot break out of the dir anyway.
+    if (parent.getParentFile() == null) {
+      sendPathInvalid(ctx);
+      return;
+    }
+    File from = new File(parent, path.substring(OVERRIDE.length()));
+    if ((!from.exists()) && (!from.isFile())) {
+      sendPathInvalid(ctx);
+      return;
+    }
+    // Do not use try-with-resources: ToadletContext assumes ownership of the bucket and will free
+    // it after sending the response. Closing it here could discard data before the send completes.
+    FileBucket fb = new FileBucket(from, true, false, false, false);
+    boolean handedOff = false;
+    try {
+      ctx.sendReplyHeadersStatic(
+          200,
+          "OK",
+          null,
+          DefaultMIMETypes.guessMIMEType(path, false),
+          fb.size(),
+          new Date(System.currentTimeMillis() - 1000)); // Already expired, we want it to reload it.
+      handedOff = true;
+      ctx.writeData(fb);
+    } catch (IOException e) {
+      // Not strictly accurate but close enough
+      sendPathNotFound(ctx);
+    } finally {
+      if (!handedOff) {
+        fb.free();
+      }
+    }
+  }
+
+  private void serveClasspathResource(String path, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
     InputStream strm = getClass().getResourceAsStream(ROOT_PATH + path);
     if (strm == null) {
-      this.sendErrorPage(ctx, 404, l10n("pathNotFoundTitle"), l10n("pathNotFound"));
+      sendPathNotFound(ctx);
       return;
     }
     Bucket data = ctx.getBucketFactory().makeBucket(strm.available());
@@ -115,40 +276,17 @@ public class StaticToadlet extends Toadlet {
     ctx.writeData(data);
   }
 
-  /**
-   * Try to find the modification time for a URL, or return null if not possible We usually load our
-   * resources from the JAR, or possibly from a file in some setups, so we check the modification
-   * time of the JAR for resources in a jar and the mtime for files.
-   */
-  private Date getUrlMTime(URL url) {
-    if (url.getProtocol().equals("jar")) {
-      File f = new File(url.getPath().substring(0, url.getPath().indexOf('!')));
-      return new Date(f.lastModified());
-    } else if (url.getProtocol().equals("file")) {
-      File f = new File(url.getPath());
-      return new Date(f.lastModified());
-    } else {
-      return null;
-    }
+  private void sendPathNotFound(ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    this.sendErrorPage(ctx, 404, l10n(KEY_PATH_NOT_FOUND_TITLE), l10n(KEY_PATH_NOT_FOUND));
   }
 
-  private String l10n(String key) {
-    return NodeL10n.getBase().getString("StaticToadlet." + key);
+  private void sendPathInvalid(ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    this.sendErrorPage(ctx, 404, l10n(KEY_PATH_NOT_FOUND_TITLE), l10n(KEY_PATH_INVALID));
   }
 
-  @Override
-  public String path() {
-    return ROOT_URL;
-  }
-
-  /**
-   * Do we have a specific static file? Note that override files are not supported here as it is a
-   * static method.
-   *
-   * @param The path to the file, relative to the staticfiles directory.
-   */
-  public static boolean haveFile(String path) {
-    URL url = StaticToadlet.class.getResource(ROOT_PATH + path);
-    return url != null;
+  private boolean isInvalidFile(File file) {
+    return file == null || !file.exists() || !file.isFile();
   }
 }

--- a/src/test/java/network/crypta/clients/http/StaticToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/StaticToadletTest.java
@@ -1,0 +1,281 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.Objects;
+import network.crypta.client.DefaultMIMETypes;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class StaticToadletTest {
+
+  @Mock private ToadletContext ctx;
+
+  @Test
+  void path_returnsRootUrl() {
+    StaticToadlet toadlet = new StaticToadlet();
+
+    assertEquals(StaticToadlet.ROOT_URL, toadlet.path());
+  }
+
+  @Test
+  void haveFile_whenResourceExists_returnsTrue() {
+    assertTrue(StaticToadlet.haveFile("base.css"));
+  }
+
+  @Test
+  void haveFile_whenResourceMissing_returnsFalse() {
+    assertFalse(StaticToadlet.haveFile("does-not-exist.unknown"));
+  }
+
+  @Test
+  void handleMethodGET_whenPathOutsideRoot_returnsWithoutInteraction() throws Exception {
+    TestStaticToadlet toadlet = new TestStaticToadlet();
+
+    toadlet.handleMethodGET(new URI("/other"), mock(HTTPRequest.class), ctx);
+
+    verifyNoInteractions(ctx);
+    assertNull(toadlet.lastError());
+  }
+
+  @Test
+  void handleMethodGET_whenPathHasInvalidCharacters_sendsErrorPage() throws Exception {
+    TestStaticToadlet toadlet = new TestStaticToadlet();
+
+    toadlet.handleMethodGET(new URI("/static/../file.css"), mock(HTTPRequest.class), ctx);
+
+    assertEquals(404, toadlet.lastError().status());
+    assertEquals(
+        NodeL10n.getBase().getString("StaticToadlet.pathNotFoundTitle"),
+        toadlet.lastError().desc());
+    assertEquals(
+        NodeL10n.getBase().getString("StaticToadlet.pathInvalidChars"),
+        toadlet.lastError().message());
+    verifyNoInteractions(ctx);
+  }
+
+  @Test
+  void handleMethodGET_whenResourceMissing_sendsNotFoundError() throws Exception {
+    TestStaticToadlet toadlet = new TestStaticToadlet();
+
+    toadlet.handleMethodGET(new URI("/static/missing.file"), mock(HTTPRequest.class), ctx);
+
+    assertEquals(404, toadlet.lastError().status());
+    assertEquals(
+        NodeL10n.getBase().getString("StaticToadlet.pathNotFound"), toadlet.lastError().message());
+    verifyNoInteractions(ctx);
+  }
+
+  @Test
+  void handleMethodGET_whenResourceExists_streamsFromClasspath() throws Exception {
+    URL resourceUrl =
+        Objects.requireNonNull(
+            StaticToadlet.class.getResource(StaticToadlet.ROOT_PATH + "base.css"));
+    Path resourcePath = Path.of(resourceUrl.toURI());
+    byte[] expectedBytes = Files.readAllBytes(resourcePath);
+    Date expectedMtime = new Date(resourcePath.toFile().lastModified());
+
+    InMemoryBucketFactory bucketFactory = new InMemoryBucketFactory();
+    when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+    doNothing()
+        .when(ctx)
+        .sendReplyHeadersStatic(
+            anyInt(), any(String.class), any(), any(String.class), anyLong(), any());
+    doNothing().when(ctx).writeData(any(RandomAccessBucket.class));
+
+    TestStaticToadlet toadlet = new TestStaticToadlet();
+
+    toadlet.handleMethodGET(new URI("/static/base.css"), mock(HTTPRequest.class), ctx);
+
+    RandomAccessBucket writtenBucket = bucketFactory.lastCreated;
+    assertEquals(expectedBytes.length, writtenBucket.size());
+
+    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+    ArgumentCaptor<Long> lengthCaptor = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<String> mimeCaptor = ArgumentCaptor.forClass(String.class);
+
+    verify(ctx)
+        .sendReplyHeadersStatic(
+            eq(200),
+            eq("OK"),
+            isNull(),
+            mimeCaptor.capture(),
+            lengthCaptor.capture(),
+            dateCaptor.capture());
+
+    assertEquals(DefaultMIMETypes.guessMIMEType("base.css", false), mimeCaptor.getValue());
+    assertEquals(expectedBytes.length, lengthCaptor.getValue());
+    assertEquals(expectedMtime, dateCaptor.getValue());
+    verify(ctx, times(1)).writeData(writtenBucket);
+  }
+
+  @Test
+  void handleMethodGET_whenOverrideFilePresent_servesFromOverride() throws Exception {
+    Path overrideDir = Files.createTempDirectory("static-toadlet-override");
+    Path parent = overrideDir.resolve("overrides");
+    Files.createDirectories(parent);
+    Path marker = parent.resolve("marker.txt");
+    Files.writeString(marker, "marker");
+    Path overrideFile = parent.resolve("custom.txt");
+    Files.writeString(overrideFile, "override-content");
+
+    ToadletContainer container = mock(ToadletContainer.class);
+    when(container.getOverrideFile()).thenReturn(marker.toFile());
+
+    TestStaticToadlet toadlet = new TestStaticToadlet();
+    toadlet.container = container;
+
+    doNothing()
+        .when(ctx)
+        .sendReplyHeadersStatic(
+            anyInt(), any(String.class), any(), any(String.class), anyLong(), any());
+    doNothing().when(ctx).writeData(any(Bucket.class));
+
+    toadlet.handleMethodGET(new URI("/static/override/custom.txt"), mock(HTTPRequest.class), ctx);
+
+    verify(container, times(1)).getOverrideFile();
+    verify(ctx)
+        .sendReplyHeadersStatic(
+            eq(200),
+            eq("OK"),
+            isNull(),
+            eq(DefaultMIMETypes.guessMIMEType("custom.txt", false)),
+            eq(overrideFile.toFile().length()),
+            any(Date.class));
+    verify(ctx).writeData(any(Bucket.class));
+    assertNull(toadlet.lastError());
+  }
+
+  private static final class TestStaticToadlet extends StaticToadlet {
+    private ErrorCall lastError;
+
+    @Override
+    protected void sendErrorPage(ToadletContext ctx, int code, String desc, String message) {
+      this.lastError = new ErrorCall(code, desc, message);
+    }
+
+    ErrorCall lastError() {
+      return lastError;
+    }
+  }
+
+  private record ErrorCall(int status, String desc, String message) {}
+
+  private static final class InMemoryBucketFactory implements BucketFactory {
+    private InMemoryRandomAccessBucket lastCreated;
+
+    @Override
+    public RandomAccessBucket makeBucket(long size) {
+      lastCreated = new InMemoryRandomAccessBucket();
+      return lastCreated;
+    }
+  }
+
+  private static final class InMemoryRandomAccessBucket implements RandomAccessBucket {
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    private boolean readOnly;
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+      if (readOnly) {
+        throw new IOException("Bucket is read only");
+      }
+      return buffer;
+    }
+
+    @Override
+    public OutputStream getOutputStreamUnbuffered() throws IOException {
+      return getOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return new ByteArrayInputStream(buffer.toByteArray());
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() {
+      return getInputStream();
+    }
+
+    @Override
+    public String getName() {
+      return "in-memory-bucket";
+    }
+
+    @Override
+    public long size() {
+      return buffer.size();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return readOnly;
+    }
+
+    @Override
+    public void setReadOnly() {
+      this.readOnly = true;
+    }
+
+    @Override
+    public void free() {
+      buffer.reset();
+    }
+
+    @Override
+    public RandomAccessBucket createShadow() {
+      return null;
+    }
+
+    @Override
+    public void onResume(network.crypta.client.async.ClientContext context) {
+      // No-op: test bucket does not persist across runs, resume lifecycle is irrelevant here.
+    }
+
+    @Override
+    public void storeTo(java.io.DataOutputStream dos) {
+      throw new UnsupportedOperationException("Not implemented for test bucket");
+    }
+
+    @Override
+    public LockableRandomAccessBuffer toRandomAccessBuffer() {
+      throw new UnsupportedOperationException("Not implemented for test bucket");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor StaticToadlet to centralize path validation, error handling, and override/classpath routing
- add comprehensive Mockito-based tests covering classpath resources, override files, and invalid path handling
- improve documentation and null-safety for static asset serving helpers

## Testing
- not run (not requested)