### PR TITLE
Add coverage and docs for SymlinkerToadlet redirects

### DIFF
--- a/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
+++ b/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
@@ -16,9 +16,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Symlinker Toadlet
+ * Toadlet that resolves short alias paths to other toadlet URLs via HTTP redirects.
  *
- * <p>Provide alias to other toadlet URLs by throwing {@link RedirectException}.
+ * <p>This toadlet keeps a synchronized in-memory map of aliases and redirects any request whose
+ * path starts with a known alias to the mapped target. It bootstraps from persisted configuration,
+ * seeds a couple of built-in plugin aliases, and can persist later edits on demand. Synchronization
+ * on the internal {@link Map} keeps link updates and lookups thread-safe. Callers typically create
+ * one instance per node, let it register its configuration, and rely on {@link
+ * #handleMethodGET(URI, HTTPRequest, ToadletContext)} to perform the resolution work.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Maintaining alias-to-target mappings loaded from persisted configuration values.
+ *   <li>Adding and removing aliases while optionally persisting the updated map.
+ *   <li>Resolving incoming requests and issuing redirects or localized 404 responses.
+ * </ul>
+ *
+ * <p>Instances are not immutable: callers should avoid external iteration over the alias map and
+ * rely on this class to coordinate updates. Redirect semantics preserve the original query string
+ * and fragment while replacing only the matched path prefix.
  */
 public class SymlinkerToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(SymlinkerToadlet.class);
@@ -27,6 +44,18 @@ public class SymlinkerToadlet extends Toadlet {
   private final Node node;
   SubConfig tslconfig;
 
+  /**
+   * Creates a new symlinker toadlet, registers its configuration, and seeds built-in aliases.
+   *
+   * <p>The constructor reads the {@code toadletsymlinker.symlinks} array from the node
+   * configuration, populates the in-memory map, and finalizes the configuration section to prevent
+   * external modifications. Two convenience aliases are added for the Librarian and TestGallery
+   * plugins. Construction is not thread-safe, but subsequent alias access is synchronized on the
+   * internal map.
+   *
+   * @param client high-level HTTP client used to write responses and redirects for requests.
+   * @param node node instance supplying configuration storage and persistence hooks for aliases.
+   */
   public SymlinkerToadlet(HighLevelSimpleClient client, final Node node) {
     super(client);
     this.node = node;
@@ -47,8 +76,6 @@ public class SymlinkerToadlet extends Toadlet {
 
           @Override
           public void set(String[] val) throws InvalidConfigValueException {
-            // if(storeDir.equals(new File(val))) return;
-            // FIXME
             throw new InvalidConfigValueException("Cannot set the plugins that's loaded.");
           }
 
@@ -72,23 +99,51 @@ public class SymlinkerToadlet extends Toadlet {
     addLink("/sl/gallery/", "/plugins/plugins.TestGallery/", false);
   }
 
+  /**
+   * Inserts or updates an alias mapping in memory and optionally persists it to disk.
+   *
+   * <p>The method acquires a monitor on the alias map, updates the mapping for {@code alias} to the
+   * provided {@code target}, and logs the operation. When {@code store} is {@code true}, the node's
+   * configuration is requested to persist current aliases. No validation or normalization of path
+   * components is performed; callers should pass canonical prefixes, including trailing slashes, to
+   * avoid ambiguous matches. The boolean return indicates whether the previous mapping value was
+   * identical to the alias string before replacement.
+   *
+   * @param alias request path prefix to match; typically starts and ends with a slash.
+   * @param target destination prefix that replaces the alias in constructed redirect paths.
+   * @param store whether to trigger immediate persistence of the modified alias map.
+   * @return {@code true} if the prior mapping value equaled the alias before being overwritten.
+   */
   public boolean addLink(String alias, String target, boolean store) {
     boolean ret;
     synchronized (linkMap) {
       ret = alias.equals(linkMap.put(alias, target));
-      LOG.info("Adding link: " + alias + " => " + target);
+      LOG.info("Adding link: {} => {}", alias, target);
     }
     if (store) node.getClientCore().storeConfig();
     return ret;
   }
 
+  /**
+   * Removes an existing alias mapping and optionally persists the change.
+   *
+   * <p>The method synchronizes on the alias map, deletes the mapping for {@code alias} when
+   * present, and logs the removal together with the previous target. No validation is performed on
+   * the alias format, and requesting persistence only affects configuration storage, not runtime
+   * behavior. Calls are idempotent with respect to non-existent aliases and return a boolean to
+   * signal whether removal occurred.
+   *
+   * @param alias path prefix identifying the mapping to delete from the symlinker.
+   * @param store whether to trigger configuration persistence after the removal attempt.
+   * @return {@code true} when a mapping existed and was removed; {@code false} otherwise.
+   */
   public boolean removeLink(String alias, boolean store) {
     boolean ret;
     synchronized (linkMap) {
       Object o;
       ret = (o = linkMap.remove(alias)) != null;
 
-      LOG.info("Removing link: " + alias + " => " + o);
+      LOG.info("Removing link: {} => {}", alias, o);
     }
     if (store) node.getClientCore().storeConfig();
     return ret;
@@ -105,11 +160,28 @@ public class SymlinkerToadlet extends Toadlet {
     return retarr;
   }
 
+  /**
+   * Handles GET requests by resolving configured aliases and issuing redirects or 404 responses.
+   *
+   * <p>The handler scans all registered aliases for a prefix match against the request path,
+   * choosing the last encountered match when multiple aliases overlap. When a mapping is found, it
+   * rewrites the path by replacing the alias with its target while preserving the original query
+   * string and fragment, then throws a {@link RedirectException} to redirect the client. If the
+   * path does not match any alias, the method writes a localized 404 response. URI syntax errors
+   * during redirect construction are logged and returned to the caller as an HTML body.
+   *
+   * @param uri incoming request URI whose path is inspected for alias prefixes.
+   * @param request HTTP request wrapper; currently unused but provided for interface compatibility.
+   * @param ctx toadlet context used for writing replies or signaling redirect responses.
+   * @throws ToadletContextClosedException when the context is already closed before replying.
+   * @throws IOException if writing a response fails due to I/O problems in the context.
+   * @throws RedirectException when a matching alias is found and the client should be redirected.
+   */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String path = uri.getPath();
-    String foundkey = null;
     String foundtarget = null;
+    String foundkey = null;
     synchronized (linkMap) {
       for (Map.Entry<String, String> entry : linkMap.entrySet()) {
         String key = entry.getKey();
@@ -120,28 +192,35 @@ public class SymlinkerToadlet extends Toadlet {
       }
     }
 
-    // TODO redirect to errorpage
-    if ((foundtarget == null) || (foundkey == null)) {
+    if (foundtarget == null) {
       writeTextReply(
           ctx, 404, "Not found", NodeL10n.getBase().getString("StaticToadlet.pathNotFound"));
       return;
     }
 
     path = foundtarget + path.substring(foundkey.length());
-    URI outuri = null;
+    URI outuri;
     try {
       outuri = new URI(null, null, path, uri.getQuery(), uri.getFragment());
     } catch (URISyntaxException e) {
-      // TODO Handle error somehow
+      LOG.warn("Failed to create redirect URI for path {}", path, e);
       writeHTMLReply(ctx, 200, "OK", e.getMessage());
       return;
     }
 
-    uri.getRawQuery();
-
     throw new RedirectException(outuri);
   }
 
+  /**
+   * Returns the base path under which this toadlet serves alias resolution requests.
+   *
+   * <p>The path is a fixed string {@code "/sl/"}; callers typically mount this toadlet at that
+   * location so that child paths such as {@code /sl/search/} can be redirected. The value is stable
+   * across process restarts and does not depend on configuration, making it suitable for wiring in
+   * the node's HTTP toadlet registry or in tests that assert routing behavior.
+   *
+   * @return constant base path string {@code "/sl/"} used to register the toadlet.
+   */
   @Override
   public String path() {
     return "/sl/";

--- a/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
@@ -130,23 +130,18 @@ class SymlinkerToadletTest {
   }
 
   @Test
-  void handleMethodGET_whenTargetContainsSpaces_returnsHtmlError() {
+  void handleMethodGET_whenTargetContainsSpaces_redirectsWithEncodedPath() throws Exception {
     when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
     SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
     toadlet.addLink("/bad/", "/target with space/", false);
 
-    assertDoesNotThrow(
-        () -> toadlet.handleMethodGET(new URI("http://localhost/bad/here"), request, ctx));
+    RedirectException redirect =
+        assertThrows(
+            RedirectException.class,
+            () -> toadlet.handleMethodGET(new URI("http://localhost/bad/here"), request, ctx));
 
-    verify(ctx)
-        .sendReplyHeaders(
-            org.mockito.ArgumentMatchers.eq(200),
-            org.mockito.ArgumentMatchers.eq("OK"),
-            isNull(),
-            org.mockito.ArgumentMatchers.eq("text/html; charset=utf-8"),
-            anyLong(),
-            org.mockito.ArgumentMatchers.eq(false));
-    verify(ctx).writeData(any(byte[].class), anyInt(), anyInt());
+    assertEquals("/target with space/here", redirect.getTarget().getPath());
+    assertEquals("/target%20with%20space/here", redirect.getTarget().getRawPath());
   }
 
   private SymlinkerToadlet createToadletWithConfigLinks(String... links) {

--- a/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
@@ -1,0 +1,150 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class SymlinkerToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private Node node;
+  @Mock private PersistentConfig persistentConfig;
+  @Mock private SubConfig subConfig;
+  @Mock private NodeClientCore nodeClientCore;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
+
+  @BeforeEach
+  void setUp() {
+    when(node.getConfig()).thenReturn(persistentConfig);
+    when(persistentConfig.createSubConfig("toadletsymlinker")).thenReturn(subConfig);
+
+    doNothing().when(subConfig).finishedInitialization();
+  }
+
+  @Test
+  void handleMethodGET_whenAliasMatches_redirectsWithOriginalQueryAndFragment() throws Exception {
+    SymlinkerToadlet toadlet = createToadletWithConfigLinks("/cfg/#/target/");
+
+    URI incoming = new URI("http://localhost/cfg/path?foo=bar#frag");
+
+    RedirectException redirect =
+        assertThrows(
+            RedirectException.class, () -> toadlet.handleMethodGET(incoming, request, ctx));
+
+    assertEquals("/target/path", redirect.getTarget().getPath());
+    assertEquals("foo=bar", redirect.getTarget().getQuery());
+    assertEquals("frag", redirect.getTarget().getFragment());
+  }
+
+  @Test
+  void addLink_whenStoreTrue_persistsAndRedirects() {
+    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+
+    boolean added = toadlet.addLink("/alias/", "/dest/", true);
+
+    assertFalse(added);
+    verify(nodeClientCore, times(1)).storeConfig();
+
+    RedirectException redirect =
+        assertThrows(
+            RedirectException.class,
+            () -> toadlet.handleMethodGET(new URI("http://x/alias/file"), request, ctx));
+
+    assertEquals("/dest/file", redirect.getTarget().getPath());
+  }
+
+  @Test
+  void removeLink_whenExistingAlias_returnsTrueAndPreventsRedirect() throws Exception {
+    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
+    when(node.getClientCore()).thenReturn(nodeClientCore);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+
+    toadlet.addLink("/remove/", "/kept/", false);
+    reset(nodeClientCore);
+
+    boolean removed = toadlet.removeLink("/remove/", true);
+
+    assertTrue(removed);
+    verify(nodeClientCore, times(1)).storeConfig();
+
+    assertDoesNotThrow(
+        () -> toadlet.handleMethodGET(new URI("http://localhost/remove/x"), request, ctx));
+
+    verify(ctx)
+        .sendReplyHeaders(
+            org.mockito.ArgumentMatchers.eq(404),
+            org.mockito.ArgumentMatchers.eq("Not found"),
+            isNull(),
+            org.mockito.ArgumentMatchers.eq("text/plain; charset=utf-8"),
+            anyLong(),
+            org.mockito.ArgumentMatchers.eq(true));
+    verify(ctx).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void handleMethodGET_whenNoMatchingAlias_sends404Response() throws Exception {
+    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+
+    assertDoesNotThrow(
+        () -> toadlet.handleMethodGET(new URI("http://localhost/unknown"), request, ctx));
+
+    verify(ctx)
+        .sendReplyHeaders(
+            org.mockito.ArgumentMatchers.eq(404),
+            org.mockito.ArgumentMatchers.eq("Not found"),
+            isNull(),
+            org.mockito.ArgumentMatchers.eq("text/plain; charset=utf-8"),
+            anyLong(),
+            org.mockito.ArgumentMatchers.eq(true));
+    verify(ctx).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void handleMethodGET_whenTargetContainsSpaces_redirectsWithJoinedPath() {
+    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+    toadlet.addLink("/bad/", "/target with space/", false);
+
+    RedirectException redirect =
+        assertThrows(
+            RedirectException.class,
+            () -> toadlet.handleMethodGET(new URI("http://localhost/bad/here"), request, ctx));
+
+    assertEquals("/target with space/here", redirect.getTarget().getPath());
+  }
+
+  private SymlinkerToadlet createToadletWithConfigLinks(String... links) {
+    when(subConfig.getStringArr("symlinks")).thenReturn(links);
+    return new SymlinkerToadlet(client, node);
+  }
+}

--- a/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
@@ -130,17 +130,23 @@ class SymlinkerToadletTest {
   }
 
   @Test
-  void handleMethodGET_whenTargetContainsSpaces_redirectsWithJoinedPath() {
+  void handleMethodGET_whenTargetContainsSpaces_returnsHtmlError() {
     when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
     SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
     toadlet.addLink("/bad/", "/target with space/", false);
 
-    RedirectException redirect =
-        assertThrows(
-            RedirectException.class,
-            () -> toadlet.handleMethodGET(new URI("http://localhost/bad/here"), request, ctx));
+    assertDoesNotThrow(
+        () -> toadlet.handleMethodGET(new URI("http://localhost/bad/here"), request, ctx));
 
-    assertEquals("/target with space/here", redirect.getTarget().getPath());
+    verify(ctx)
+        .sendReplyHeaders(
+            org.mockito.ArgumentMatchers.eq(200),
+            org.mockito.ArgumentMatchers.eq("OK"),
+            isNull(),
+            org.mockito.ArgumentMatchers.eq("text/html; charset=utf-8"),
+            anyLong(),
+            org.mockito.ArgumentMatchers.eq(false));
+    verify(ctx).writeData(any(byte[].class), anyInt(), anyInt());
   }
 
   private SymlinkerToadlet createToadletWithConfigLinks(String... links) {


### PR DESCRIPTION
## Summary
- expand SymlinkerToadlet KDoc and logging clarity
- add Mockito-based unit tests covering alias resolution, persistence, removals, and 404 responses

## Testing
- not run in this workspace
