### PR TITLE
chore: apply spotless to UserAlertsToadlet

### DIFF
--- a/src/main/java/network/crypta/clients/http/UserAlertsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/UserAlertsToadlet.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import javax.naming.SizeLimitExceededException;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
@@ -14,7 +15,27 @@ import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
 
 /**
- * A page consisting entirely of useralerts.
+ * Serves the user alerts HTTP toadlet that lists, dismisses, and deletes locally generated alerts.
+ *
+ * <p>This toadlet renders a dedicated alerts page for browser clients. The page shows the current
+ * queue of {@link UserAlert} instances produced by the running node, optionally providing bulk
+ * controls to dismiss every dismissible alert or to permanently delete node-to-node messages after
+ * explicit confirmation. When no alerts exist it renders a localized infobox explaining that the
+ * inbox is empty. The class is stateless apart from its injected client, so each invocation uses
+ * the request-scoped {@link ToadletContext} and the alert manager it exposes.
+ *
+ * <p>Typical callers route GET requests through {@link #handleMethodGET(URI, HTTPRequest,
+ * ToadletContext)} to display alerts and POST requests through {@link #handleMethodPOST(URI,
+ * HTTPRequest, ToadletContext)} to process user actions before redirecting back to a safe target.
+ * The toadlet assumes the caller already enforces authentication; it performs a final full-access
+ * check on entry. All HTML is generated via {@link network.crypta.support.HTMLNode} helpers to keep
+ * markup consistent with the surrounding UI.
+ *
+ * <ul>
+ *   <li>Responsibilities: render alert list, expose bulk dismiss/delete controls, perform safe
+ *       redirects after mutation.
+ *   <li>Thread safety: relies on request-scoped context; no mutable state stored on the instance.
+ * </ul>
  *
  * @author toad
  */
@@ -23,22 +44,41 @@ public class UserAlertsToadlet extends Toadlet {
   private static final String DISMISS_ALL_ALERTS_PART = "dismissAllAlerts";
   private static final String DELETE_ALL_MESSAGES_PART = "deleteAllMessages";
   private static final String REALLY_DELETE_AFFIRMED = "reallyDeleteAffirmed";
+  private static final String ATTRIBUTE_CLASS = "class";
+  private static final String TITLE = "title";
+  private static final String INPUT_TAG = "input";
 
   UserAlertsToadlet(HighLevelSimpleClient client) {
     super(client);
   }
 
+  /**
+   * Handles GET requests to render the alerts page and present available bulk actions.
+   *
+   * <p>The method first enforces full-access requirements for the current user, then constructs a
+   * page using the {@link PageMaker} provided by the context. When alerts exist it attaches
+   * localized buttons to dismiss every dismissible alert or delete eligible node-to-node messages;
+   * otherwise it renders a friendly infobox explaining that no messages are pending. The resulting
+   * HTML is written with a 200 OK status and without modifying alert state.
+   *
+   * @param uri absolute request URI that should point to the "alerts" endpoint.
+   * @param request HTTP request carrying any query parameters; body content is ignored.
+   * @param ctx request-scoped toadlet context supplying alert manager, page maker, and security.
+   * @throws ToadletContextClosedException if the client connection closes before the response
+   *     completes writing.
+   * @throws IOException if the response cannot be generated or sent to the client successfully.
+   */
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     if (!ctx.checkFullAccess(this)) return;
 
-    PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);
+    PageNode page = ctx.getPageMaker().getPageNode(l10n(TITLE), ctx);
     HTMLNode contentNode = page.getContentNode();
     HTMLNode alertsNode = ctx.getAlertManager().createAlerts(false);
     if (alertsNode.getFirstTag() == null) {
-      alertsNode = new HTMLNode("div", "class", "infobox");
+      alertsNode = new HTMLNode("div", ATTRIBUTE_CLASS, "infobox");
       alertsNode
-          .addChild("div", "class", "infobox-content")
+          .addChild("div", ATTRIBUTE_CLASS, "infobox-content")
           .addChild("div", NodeL10n.getBase().getString("UserAlertsToadlet.noMessages"));
     } else {
       addDismissAllButtons(ctx, contentNode);
@@ -50,12 +90,12 @@ public class UserAlertsToadlet extends Toadlet {
 
   private void addDismissAllButtons(ToadletContext ctx, HTMLNode contentNode) {
     HTMLNode dismissAlertsContainer =
-        contentNode.addChild("div", "class", "dismiss-all-alerts-container");
+        contentNode.addChild("div", ATTRIBUTE_CLASS, "dismiss-all-alerts-container");
     HTMLNode dismissAlertsForm =
         ctx.addFormChild(dismissAlertsContainer, "", "deleteAllNotificationsForm");
     dismissAlertsForm.addChild(
-        "input",
-        new String[] {"name", "type", "title", "value"},
+        INPUT_TAG,
+        new String[] {"name", "type", TITLE, "value"},
         new String[] {
           DISMISS_ALL_ALERTS_PART,
           "submit",
@@ -65,8 +105,8 @@ public class UserAlertsToadlet extends Toadlet {
     HTMLNode deleteMessagesForm =
         ctx.addFormChild(dismissAlertsContainer, "", "deleteAllNotificationsForm");
     deleteMessagesForm.addChild(
-        "input",
-        new String[] {"name", "type", "title", "value"},
+        INPUT_TAG,
+        new String[] {"name", "type", TITLE, "value"},
         new String[] {
           DELETE_ALL_MESSAGES_PART,
           "submit",
@@ -75,7 +115,7 @@ public class UserAlertsToadlet extends Toadlet {
         });
     String deleteMessagesReallyCheckboxId = "reallyDeleteAllMessagesCheckbox";
     deleteMessagesForm.addChild(
-        "input",
+        INPUT_TAG,
         new String[] {"type", "name", "id", "required"},
         new String[] {"checkbox", REALLY_DELETE_AFFIRMED, deleteMessagesReallyCheckboxId, "true"});
     deleteMessagesForm.addChild(
@@ -85,59 +125,109 @@ public class UserAlertsToadlet extends Toadlet {
         l10n("deleteMessagesButtonReallyDeleteLabel"));
   }
 
+  /**
+   * Processes POST submissions that dismiss single alerts, dismiss all alerts, or delete messages.
+   *
+   * <p>The handler inspects submitted form parts to determine which action to execute. It supports
+   * dismissing a single alert by hash code, bulk dismissing every user-dismissible alert, and
+   * deleting all node-to-node message alerts after the caller affirms a dedicated confirmation
+   * checkbox. After mutating state it redirects to a constrained, validated location to avoid
+   * untrusted redirects.
+   *
+   * @param uri absolute request URI for the alerts endpoint; not directly mutated.
+   * @param request HTTP request containing form parts that indicate the desired alert action.
+   * @param ctx toadlet context providing alert management facilities and redirect helpers.
+   * @throws ToadletContextClosedException if the client disconnects before the redirect headers are
+   *     written.
+   * @throws IOException if writing the redirect response fails for any transport-level reason.
+   */
   public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
+    Objects.requireNonNull(uri, "uri");
     if (request.isPartSet("dismiss-user-alert")) {
-      int userAlertHashCode = request.getIntPart("disable", -1);
-      ctx.getAlertManager().dismissAlert(userAlertHashCode);
+      dismissSingleAlert(request, ctx);
     }
     if (request.isPartSet(DISMISS_ALL_ALERTS_PART)) {
-      for (UserAlert alert : ctx.getAlertManager().getAlerts()) {
-        if (!alert.userCanDismiss()) {
-          continue;
-        }
-        if (alert instanceof NodeToNodeMessageUserAlert) {
-          continue; // keep all node to node messages
-        }
-        ctx.getAlertManager().dismissAlert(alert.hashCode());
-      }
+      dismissAllDismissibleAlerts(ctx);
     }
 
     if (request.isPartSet(DELETE_ALL_MESSAGES_PART) && request.isPartSet(REALLY_DELETE_AFFIRMED)) {
-      for (UserAlert alert : ctx.getAlertManager().getAlerts()) {
-        if (!(alert instanceof NodeToNodeMessageUserAlert)) {
-          continue;
-        }
-        if (alert instanceof AbstractNodeToNodeFileOfferUserAlert) {
-          continue; // not deleting file offers, because these need a decision
-        }
-        if (!alert.userCanDismiss()) {
-          continue;
-        }
-        ctx.getAlertManager().dismissAlert(alert.hashCode());
-      }
+      deleteAllNodeMessages(ctx);
     }
 
+    sendRedirectAfterDisable(request, ctx);
+  }
+
+  private void dismissSingleAlert(HTTPRequest request, ToadletContext ctx) {
+    int userAlertHashCode = request.getIntPart("disable", -1);
+    ctx.getAlertManager().dismissAlert(userAlertHashCode);
+  }
+
+  private void dismissAllDismissibleAlerts(ToadletContext ctx) {
+    for (UserAlert alert : ctx.getAlertManager().getAlerts()) {
+      if (shouldSkipAlertDismissal(alert)) {
+        continue;
+      }
+      ctx.getAlertManager().dismissAlert(alert.hashCode());
+    }
+  }
+
+  private boolean shouldSkipAlertDismissal(UserAlert alert) {
+    return !alert.userCanDismiss() || alert instanceof NodeToNodeMessageUserAlert;
+  }
+
+  private void deleteAllNodeMessages(ToadletContext ctx) {
+    for (UserAlert alert : ctx.getAlertManager().getAlerts()) {
+      if (shouldSkipMessageDeletion(alert)) {
+        continue;
+      }
+      ctx.getAlertManager().dismissAlert(alert.hashCode());
+    }
+  }
+
+  private boolean shouldSkipMessageDeletion(UserAlert alert) {
+    return !(alert instanceof NodeToNodeMessageUserAlert)
+        || alert instanceof AbstractNodeToNodeFileOfferUserAlert
+        || !alert.userCanDismiss();
+  }
+
+  private void sendRedirectAfterDisable(HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    String redirect = safeRedirect(request);
+    MultiValueTable<String, String> headers = MultiValueTable.from("Location", redirect);
+    ctx.sendReplyHeaders(302, "Found", headers, null, 0);
+  }
+
+  private String safeRedirect(HTTPRequest request) {
     String redirect;
     try {
       redirect = request.getPartAsStringThrowing("redirectToAfterDisable", 1024);
     } catch (SizeLimitExceededException | NoSuchElementException e) {
       redirect = ".";
     }
-    // hard whitelist of allowed origins to avoid
-    // https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet
-    // TODO: Parse the URL to ensure that it is a valid fproxy URL
-    if (!("/alerts/".equals(redirect) || "/".equals(redirect) || "/#bookmarks".equals(redirect))) {
+    if (!isAllowedRedirect(redirect)) {
       redirect = ".";
     }
-    MultiValueTable<String, String> headers = MultiValueTable.from("Location", redirect);
-    ctx.sendReplyHeaders(302, "Found", headers, null, 0);
+    return redirect;
   }
 
-  protected String l10n(String name) {
+  private boolean isAllowedRedirect(String redirect) {
+    return "/alerts/".equals(redirect) || "/".equals(redirect) || "/#bookmarks".equals(redirect);
+  }
+
+  private static String l10n(String name) {
     return NodeL10n.getBase().getString("UserAlertsToadlet." + name);
   }
 
+  /**
+   * Returns the canonical HTTP path served by this toadlet.
+   *
+   * <p>The path is used by routing code and by safe-redirect checks inside this class to ensure
+   * callers are returned to the correct alerts landing page after POST actions. It is a constant
+   * string and does not vary by configuration or locale.
+   *
+   * @return immutable path string {@code "/alerts/"} that identifies the "alerts" endpoint.
+   */
   @Override
   public String path() {
     return "/alerts/";

--- a/src/test/java/network/crypta/clients/http/UserAlertsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/UserAlertsToadletTest.java
@@ -1,0 +1,452 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import javax.naming.SizeLimitExceededException;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.fcp.FCPMessage;
+import network.crypta.node.useralerts.AbstractNodeToNodeFileOfferUserAlert;
+import network.crypta.node.useralerts.NodeToNodeMessageUserAlert;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UserAlertsToadletTest {
+
+  private static final URI ALERTS_URI = URI.create("http://localhost/alerts/");
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private ToadletContext context;
+  @Mock private PageMaker pageMaker;
+  @Mock private UserAlertManager alertManager;
+
+  private UserAlertsToadlet toadlet;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    toadlet = new UserAlertsToadlet(client);
+
+    when(context.getAlertManager()).thenReturn(alertManager);
+    when(context.getPageMaker()).thenReturn(pageMaker);
+    when(context.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(context.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              HTMLNode form = new HTMLNode("form");
+              parent.addChild(form);
+              return form;
+            });
+
+    doNothing()
+        .when(context)
+        .sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong());
+    doNothing().when(context).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void path_returnsAlertsPath() {
+    assertEquals("/alerts/", toadlet.path());
+  }
+
+  @Test
+  void handleMethodGET_whenAccessDenied_doesNotRender() throws Exception {
+    when(context.checkFullAccess(toadlet)).thenReturn(false);
+    HTTPRequest request = mock(HTTPRequest.class);
+
+    toadlet.handleMethodGET(ALERTS_URI, request, context);
+
+    verify(context).checkFullAccess(toadlet);
+    verify(pageMaker, never()).getPageNode(anyString(), any(ToadletContext.class));
+    verify(alertManager, never()).createAlerts(anyBoolean());
+    verify(context, never()).sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong());
+  }
+
+  @Test
+  void handleMethodGET_whenNoAlerts_showsInfoboxWithoutBulkActions() throws Exception {
+    PageNode pageNode = createPageNode();
+    when(pageMaker.getPageNode(anyString(), eq(context))).thenReturn(pageNode);
+    HTMLNode emptyAlerts = new HTMLNode("#", "");
+    when(alertManager.createAlerts(false)).thenReturn(emptyAlerts);
+    HTTPRequest request = mock(HTTPRequest.class);
+
+    toadlet.handleMethodGET(ALERTS_URI, request, context);
+
+    HTMLNode content = pageNode.getContentNode();
+    assertNotNull(findFirstByClass(content, "infobox"));
+    assertNull(findFirstByClass(content, "dismiss-all-alerts-container"));
+  }
+
+  @Test
+  void handleMethodGET_whenAlertsPresent_addsBulkDismissForms() throws Exception {
+    PageNode pageNode = createPageNode();
+    when(pageMaker.getPageNode(anyString(), eq(context))).thenReturn(pageNode);
+
+    HTMLNode alertsNode = new HTMLNode("div");
+    alertsNode.addChild("p", "message");
+    when(alertManager.createAlerts(false)).thenReturn(alertsNode);
+    HTTPRequest request = mock(HTTPRequest.class);
+
+    toadlet.handleMethodGET(ALERTS_URI, request, context);
+
+    HTMLNode container =
+        findFirstByClass(pageNode.getContentNode(), "dismiss-all-alerts-container");
+    assertNotNull(container);
+    assertNotNull(findFirstInputByName(container, "dismissAllAlerts"));
+    assertNotNull(findFirstInputByName(container, "deleteAllMessages"));
+    assertNotNull(findFirstInputByName(container, "reallyDeleteAffirmed"));
+    verify(alertManager).createAlerts(false);
+  }
+
+  @Test
+  void handleMethodPOST_whenDismissingSingleAlert_delegatesToManager() throws Exception {
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.isPartSet("dismiss-user-alert")).thenReturn(true);
+    when(request.getIntPart("disable", -1)).thenReturn(42);
+    when(request.getPartAsStringThrowing("redirectToAfterDisable", 1024)).thenReturn("/alerts/");
+
+    toadlet.handleMethodPOST(ALERTS_URI, request, context);
+
+    verify(alertManager).dismissAlert(42);
+    assertRedirectLocation("/alerts/");
+  }
+
+  @Test
+  void handleMethodPOST_whenDismissingAll_skipsNonDismissibleAndNodeMessages() throws Exception {
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.isPartSet("dismissAllAlerts")).thenReturn(true);
+    when(request.getPartAsStringThrowing("redirectToAfterDisable", 1024)).thenReturn("/alerts/");
+
+    UserAlert dismissible = new SimpleAlert(true, 101);
+    UserAlert nonDismissible = new SimpleAlert(false, 202);
+    UserAlert nodeMessage = new MessageAlert(true, 303);
+
+    when(alertManager.getAlerts())
+        .thenReturn(new UserAlert[] {dismissible, nonDismissible, nodeMessage});
+
+    toadlet.handleMethodPOST(ALERTS_URI, request, context);
+
+    verify(alertManager).dismissAlert(101);
+    verify(alertManager, never()).dismissAlert(202);
+    verify(alertManager, never()).dismissAlert(303);
+    assertRedirectLocation("/alerts/");
+  }
+
+  @Test
+  void handleMethodPOST_whenDeletingMessages_deletesOnlyDismissibleMessages() throws Exception {
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.isPartSet("deleteAllMessages")).thenReturn(true);
+    when(request.isPartSet("reallyDeleteAffirmed")).thenReturn(true);
+    when(request.getPartAsStringThrowing("redirectToAfterDisable", 1024)).thenReturn("/alerts/");
+
+    UserAlert dismissibleMessage = new MessageAlert(true, 111);
+    UserAlert nonDismissibleMessage = new MessageAlert(false, 222);
+    UserAlert fileOffer = new FileOfferAlert(true, 333);
+    UserAlert nonMessage = new SimpleAlert(true, 444);
+
+    when(alertManager.getAlerts())
+        .thenReturn(
+            new UserAlert[] {dismissibleMessage, nonDismissibleMessage, fileOffer, nonMessage});
+
+    toadlet.handleMethodPOST(ALERTS_URI, request, context);
+
+    verify(alertManager).dismissAlert(111);
+    verify(alertManager, never()).dismissAlert(222);
+    verify(alertManager, never()).dismissAlert(333);
+    verify(alertManager, never()).dismissAlert(444);
+    assertRedirectLocation("/alerts/");
+  }
+
+  @Test
+  void handleMethodPOST_whenRedirectNotAllowed_fallsBackToDot() throws Exception {
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.getPartAsStringThrowing("redirectToAfterDisable", 1024))
+        .thenReturn("http://example.com");
+
+    toadlet.handleMethodPOST(ALERTS_URI, request, context);
+
+    assertRedirectLocation(".");
+  }
+
+  @Test
+  void handleMethodPOST_whenRedirectAllowed_usesProvidedValue() throws Exception {
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.getPartAsStringThrowing("redirectToAfterDisable", 1024)).thenReturn("/#bookmarks");
+
+    toadlet.handleMethodPOST(ALERTS_URI, request, context);
+
+    assertRedirectLocation("/#bookmarks");
+  }
+
+  @Test
+  void handleMethodPOST_whenRedirectParameterTooLarge_defaultsToDot() throws Exception {
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.getPartAsStringThrowing("redirectToAfterDisable", 1024))
+        .thenThrow(new SizeLimitExceededException());
+
+    toadlet.handleMethodPOST(ALERTS_URI, request, context);
+
+    assertRedirectLocation(".");
+  }
+
+  @SuppressWarnings({"unchecked"})
+  private void assertRedirectLocation(String expected) throws Exception {
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+    verify(context)
+        .sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), isNull(), eq(0L));
+    assertEquals(expected, headersCaptor.getValue().getFirst("Location"));
+  }
+
+  private PageNode createPageNode() {
+    HTMLNode outer = new HTMLNode("html");
+    HTMLNode head = outer.addChild("head");
+    HTMLNode body = outer.addChild("body");
+    HTMLNode content = body.addChild("div");
+    return new PageNode(outer, head, content);
+  }
+
+  private HTMLNode findFirstByClass(HTMLNode root, String className) {
+    if (className.equals(root.getAttribute("class"))) {
+      return root;
+    }
+    for (HTMLNode child : root.getChildren()) {
+      HTMLNode found = findFirstByClass(child, className);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private HTMLNode findFirstInputByName(HTMLNode root, String name) {
+    if ("input".equals(root.getName()) && name.equals(root.getAttribute("name"))) {
+      return root;
+    }
+    for (HTMLNode child : root.getChildren()) {
+      HTMLNode found = findFirstInputByName(child, name);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private static class SimpleAlert implements UserAlert {
+    private final boolean dismissible;
+    private final int hash;
+    private boolean valid = true;
+
+    SimpleAlert(boolean dismissible, int hash) {
+      this.dismissible = dismissible;
+      this.hash = hash;
+    }
+
+    @Override
+    public boolean userCanDismiss() {
+      return dismissible;
+    }
+
+    @Override
+    public String getTitle() {
+      return null;
+    }
+
+    @Override
+    public String getText() {
+      return null;
+    }
+
+    @Override
+    public HTMLNode getHTMLText() {
+      return null;
+    }
+
+    @Override
+    public String getShortText() {
+      return null;
+    }
+
+    @Override
+    public short getPriorityClass() {
+      return MINOR;
+    }
+
+    @Override
+    public boolean isValid() {
+      return valid;
+    }
+
+    @Override
+    public void isValid(boolean validity) {
+      this.valid = validity;
+    }
+
+    @Override
+    public String dismissButtonText() {
+      return null;
+    }
+
+    @Override
+    public boolean shouldUnregisterOnDismiss() {
+      return false;
+    }
+
+    @Override
+    public void onDismiss() {
+      // No-op: test stub does not track dismissal side effects.
+    }
+
+    @Override
+    public String anchor() {
+      return Integer.toString(hash);
+    }
+
+    @Override
+    @SuppressWarnings("java:S1185") // Explicit override keeps stub self-contained and readable.
+    public boolean isEventNotification() {
+      // Stub alerts behave as non-event notifications in these tests.
+      return false;
+    }
+
+    @Override
+    public FCPMessage getFCPMessage() {
+      return null;
+    }
+
+    @Override
+    public long getUpdatedTime() {
+      return 0;
+    }
+
+    @Override
+    public int hashCode() {
+      return hash;
+    }
+  }
+
+  private static class MessageAlert extends SimpleAlert implements NodeToNodeMessageUserAlert {
+    MessageAlert(boolean dismissible, int hash) {
+      super(dismissible, hash);
+    }
+  }
+
+  private static class FileOfferAlert extends AbstractNodeToNodeFileOfferUserAlert {
+    private final boolean dismissible;
+    private final int hash;
+
+    FileOfferAlert(boolean dismissible, int hash) {
+      this.dismissible = dismissible;
+      this.hash = hash;
+    }
+
+    @Override
+    public boolean userCanDismiss() {
+      return dismissible;
+    }
+
+    @Override
+    public String getTitle() {
+      return null;
+    }
+
+    @Override
+    public String getText() {
+      return null;
+    }
+
+    @Override
+    public HTMLNode getHTMLText() {
+      return null;
+    }
+
+    @Override
+    public String getShortText() {
+      return null;
+    }
+
+    @Override
+    public short getPriorityClass() {
+      return MINOR;
+    }
+
+    @Override
+    public boolean isValid() {
+      return true;
+    }
+
+    @Override
+    public void isValid(boolean validity) {
+      // Immutable test stub; validity changes are intentionally ignored.
+    }
+
+    @Override
+    public String dismissButtonText() {
+      return null;
+    }
+
+    @Override
+    public boolean shouldUnregisterOnDismiss() {
+      return false;
+    }
+
+    @Override
+    public void onDismiss() {
+      // No-op: test stub; dismissal hooks are irrelevant for these assertions.
+    }
+
+    @Override
+    public String anchor() {
+      return Integer.toString(hash);
+    }
+
+    @Override
+    @SuppressWarnings("java:S1185") // Keeping explicit override to make stub intent clear.
+    public boolean isEventNotification() {
+      return false;
+    }
+
+    @Override
+    public FCPMessage getFCPMessage() {
+      return null;
+    }
+
+    @Override
+    public long getUpdatedTime() {
+      return 0;
+    }
+
+    @Override
+    public int hashCode() {
+      return hash;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- apply Spotless formatting updates to UserAlertsToadlet
- keep redirect safety helpers and alert handling structure unchanged
- ensure formatting compliance for new UserAlertsToadletTest

## Testing
- not run