### PR TITLE
Refactor toadlet context handling and add tests

### DIFF
--- a/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -25,9 +25,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.TimeZone;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
-import network.crypta.clients.http.annotation.AllowData;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.crypt.SSL;
 import network.crypta.l10n.NodeL10n;
@@ -49,14 +48,40 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * ToadletContext implementation, including all the icky HTTP parsing etc. An actual ToadletContext
- * object represents a request, after we have parsed the headers. It provides methods to send
- * replies.
+ * Concrete {@link ToadletContext} that encapsulates a single HTTP request lifecycle and the
+ * response tools exposed to toadlets. The instance is created once the request line and headers
+ * have been parsed and stays bound to that socket conversation until the handler decides whether to
+ * keep the connection alive.
+ *
+ * <p>Typical usage flows from {@link #handle(Socket, ToadletContainer, PageMaker, UserAlertManager,
+ * BookmarkManager)}: the container builds a {@code ToadletContextImpl}, passes it to the selected
+ * toadlet, and the toadlet invokes convenience helpers such as {@link #sendReplyHeaders(int,
+ * String, MultiValueTable, String, long)} or {@link #writeData(Bucket)}. The context tracks
+ * cookies, form-password validation, CSP/HSTS headers, and other protocol details so individual
+ * toadlets can focus on rendering content.
+ *
+ * <p>The object is not thread-safe and is intended for single-request, single-thread use. Once
+ * {@link #close()} or {@link #forceDisconnect()} flips the internal state, further writes throw
+ * {@link ToadletContextClosedException}. Callers should treat instances as short-lived and avoid
+ * retaining references beyond the handling path.
+ *
+ * <ul>
+ *   <li>Responsibilities: header parsing, policy enforcement, cookie parsing/setting, and reply
+ *       header generation.
+ *   <li>Networking: wraps a single socket output stream; connection reuse obeys HTTP/1.0 and
+ *       keep-alive hints.
+ *   <li>Security: injects strict CSP/HSTS headers and enforces form-password checks when required
+ *       by toadlets.
+ * </ul>
  *
  * @author root
+ * @see ToadletContext
  */
 public class ToadletContextImpl implements ToadletContext {
   private static final Logger LOG = LoggerFactory.getLogger(ToadletContextImpl.class);
+  private static final String HTML_TITLE_PREFIX = "<html><head><title>";
+  private static final String BAD_REQUEST = "Bad Request";
+  private static final String CONNECTION_HEADER = "connection";
 
   private static final Class<?>[] HANDLE_PARAMETERS =
       new Class<?>[] {URI.class, HTTPRequest.class, ToadletContext.class};
@@ -80,7 +105,7 @@ public class ToadletContextImpl implements ToadletContext {
   private final BookmarkManager bookmarkManager;
   private final InetAddress remoteAddr;
   private Exception firstReplySendingException;
-  private volatile Toadlet activeToadlet;
+  private final AtomicReference<Toadlet> activeToadlet = new AtomicReference<>();
 
   /** The unique id of the request */
   private final String uniqueId;
@@ -97,6 +122,34 @@ public class ToadletContextImpl implements ToadletContext {
 
   private boolean shouldDisconnect;
 
+  /**
+   * Builds a per-request context wrapping the client socket, parsed headers, and supporting
+   * collaborators. The context owns the socket output stream and carries helpers for cookie
+   * handling, form-password validation, and reply generation. Instances are expected to be
+   * short-lived; callers should create one per request and avoid reuse across threads or
+   * connections. The constructor does not validate the supplied headers or URI beyond storing them;
+   * those are assumed to be pre-parsed by the caller.
+   *
+   * @param sock Client socket already accepted by the server loop and ready for I/O on the current
+   *     thread.
+   * @param headers Parsed HTTP request headers in a multi-value table, preserving repeated fields
+   *     as delivered by the client.
+   * @param bf Bucket factory used for request bodies and outgoing payload buffering during this
+   *     context's lifetime.
+   * @param pageMaker Shared page renderer and localization helper used when toadlets generate HTML
+   *     responses or redirects.
+   * @param container Owning toadlet container controlling policy decisions such as Javascript
+   *     enablement, access control, and persistent-connection support.
+   * @param userAlertManager Manager used to route user-facing alerts originating from toadlet
+   *     handlers during request processing.
+   * @param bookmarkManager Bookmark subsystem entry point used by toadlets that need access to
+   *     bookmark data scoped to this HTTP interaction.
+   * @param uri Fully parsed and normalized request URI associated with the incoming HTTP request
+   *     line.
+   * @param uniqueID Monotonic identifier supplied by the container to correlate logs and responses
+   *     across asynchronous callbacks.
+   * @throws IOException If the socket output stream cannot be obtained for subsequent replies.
+   */
   public ToadletContextImpl(
       Socket sock,
       MultiValueTable<String, String> headers,
@@ -121,8 +174,8 @@ public class ToadletContextImpl implements ToadletContext {
     this.container = container;
     this.userAlertManager = userAlertManager;
     this.bookmarkManager = bookmarkManager;
-    // Generate an unique id
-    uniqueId = String.valueOf(ThreadLocalRandom.current().nextDouble());
+    // Generate a unique id
+    uniqueId = String.valueOf(uniqueID);
   }
 
   private void close() {
@@ -132,6 +185,9 @@ public class ToadletContextImpl implements ToadletContext {
   private void sendMethodNotAllowed(String method, boolean shouldDisconnect)
       throws ToadletContextClosedException, IOException {
     if (closed) throw new ToadletContextClosedException();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Method not allowed: {}", method);
+    }
     MultiValueTable<String, String> mvt = MultiValueTable.from("Allow", "GET, PUT");
     sendError(
         sockOutputStream,
@@ -146,9 +202,10 @@ public class ToadletContextImpl implements ToadletContext {
     return NodeL10n.getBase().getString("ToadletContextImpl." + key);
   }
 
-  private static String l10n(String key, String pattern, String value) {
+  private static String l10nParseError(String value) {
     return NodeL10n.getBase()
-        .getString("ToadletContextImpl." + key, new String[] {pattern}, new String[] {value});
+        .getString(
+            "ToadletContextImpl.parseErrorWithError", new String[] {"error"}, new String[] {value});
   }
 
   /**
@@ -167,7 +224,7 @@ public class ToadletContextImpl implements ToadletContext {
         os,
         code,
         httpReason,
-        "<html><head><title>" + message + "</title></head><body><h1>" + message + "</h1></body>",
+        HTML_TITLE_PREFIX + message + "</title></head><body><h1>" + message + "</h1></body>",
         shouldDisconnect,
         mvt);
   }
@@ -180,7 +237,7 @@ public class ToadletContextImpl implements ToadletContext {
    * @param httpReason The HTTP reason string for the HTTP status code. Do not make stuff up, use
    *     the official reason string, or some browsers may break.
    * @param htmlMessage The HTML string to send.
-   * @param disconnect Whether to disconnect from the client afterwards.
+   * @param disconnect Whether to disconnect from the client afterward.
    * @param mvt Any additional headers.
    * @throws IOException If we could not send the error message.
    */
@@ -214,28 +271,61 @@ public class ToadletContextImpl implements ToadletContext {
     sendError(sockOutputStream, 404, "Not Found", l10n("noSuchToadlet"), shouldDisconnect, null);
   }
 
-  private static void sendURIParseError(OutputStream os, boolean shouldDisconnect, Throwable e)
-      throws IOException {
+  private static void sendURIParseError(OutputStream os, Throwable e) throws IOException {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw);
     e.printStackTrace(pw);
     pw.close();
     String message =
-        "<html><head><title>"
+        HTML_TITLE_PREFIX
             + l10n("uriParseErrorTitle")
             + "</title></head><body><p>"
             + HTMLEncoder.encode(e.getMessage())
             + "</p><pre>\n"
             + sw;
-    sendHTMLError(os, 400, "Bad Request", message, shouldDisconnect, null);
+    sendHTMLError(os, 400, BAD_REQUEST, message, true, null);
   }
 
+  /**
+   * Sends HTTP response headers for a reply with a known payload length. This convenience overload
+   * keeps scripting enabled according to container policy and assumes no modification time for
+   * caching. Callers typically use it when streaming simple bodies where chunking is unnecessary
+   * and connection reuse is allowed. The method must be called before writing any response bytes
+   * and only once per context instance; subsequent attempts raise an error to prevent malformed
+   * responses.
+   *
+   * @param code HTTP status code to emit toward the client connection.
+   * @param desc Human-readable reason phrase paired with the status code for logging and clients.
+   * @param mvt Additional headers to merge into the response; may be {@code null} for none.
+   * @param mimeType MIME type string; {@code null} sends no content-type header.
+   * @param length Exact number of response bytes that will follow; {@code -1} omits the header.
+   * @throws ToadletContextClosedException If the context has already been closed for further
+   *     output.
+   * @throws IOException If writing to the underlying socket output stream fails.
+   */
   public void sendReplyHeaders(
       int code, String desc, MultiValueTable<String, String> mvt, String mimeType, long length)
       throws ToadletContextClosedException, IOException {
     sendReplyHeaders(code, desc, mvt, mimeType, length, false);
   }
 
+  /**
+   * Sends HTTP response headers with optional suppression of inline JavaScript. Use this overload
+   * when a caller wants to ensure a hardened response (e.g., error pages) even if global JavaScript
+   * support is enabled in the container. The method computes CSP and connection headers based on
+   * the provided arguments and the container configuration, deferring to keep-alive if permitted.
+   *
+   * @param code HTTP status code to emit toward the client connection.
+   * @param desc Human-readable reason phrase paired with the status code for logging and clients.
+   * @param mvt Additional headers to merge into the response; may be {@code null} for none.
+   * @param mimeType MIME type string; {@code null} sends no content-type header.
+   * @param length Exact number of response bytes that will follow; {@code -1} omits the header.
+   * @param forceDisableJavascript When {@code true}, disables script allowances regardless of
+   *     container settings.
+   * @throws ToadletContextClosedException If the context has already been closed for further
+   *     output.
+   * @throws IOException If writing to the underlying socket output stream fails.
+   */
   public void sendReplyHeaders(
       int code,
       String desc,
@@ -245,9 +335,24 @@ public class ToadletContextImpl implements ToadletContext {
       boolean forceDisableJavascript)
       throws ToadletContextClosedException, IOException {
     boolean enableJavascript = (!forceDisableJavascript) && container.isFProxyJavascriptEnabled();
-    sendReplyHeaders(code, desc, mvt, mimeType, length, null, false, false, enableJavascript);
+    sendReplyHeaders(code, desc, mvt, mimeType, length, null, false, enableJavascript);
   }
 
+  /**
+   * Sends response headers for static content with a known last-modified timestamp. Unlike the
+   * streaming variant, this method always enables cache-related headers based on {@code mTime} so
+   * user agents can perform conditional requests and reuse cached assets. It leaves scripting and
+   * framing disabled to align with typical static resource expectations.
+   *
+   * @param replyCode HTTP status code to emit for the static response payload.
+   * @param replyDescription Reason phrase to accompany the status code for client readability.
+   * @param mvt Additional headers to merge into the response; may be {@code null} for none.
+   * @param mimeType MIME type string; {@code null} sends no content-type header.
+   * @param contentLength Exact number of bytes that will be written after the headers.
+   * @param mTime Last-modified timestamp used to set caching headers; must be non-null.
+   * @throws ToadletContextClosedException If the context is already closed and cannot send data.
+   * @throws IOException If the socket output stream rejects the header bytes.
+   */
   public void sendReplyHeadersStatic(
       int replyCode,
       String replyDescription,
@@ -258,9 +363,26 @@ public class ToadletContextImpl implements ToadletContext {
       throws ToadletContextClosedException, IOException {
     if (mTime == null) throw new IllegalArgumentException();
     sendReplyHeaders(
-        replyCode, replyDescription, mvt, mimeType, contentLength, mTime, false, false, false);
+        replyCode, replyDescription, mvt, mimeType, contentLength, mTime, false, false);
   }
 
+  /**
+   * Sends response headers for FProxy pages, enabling script support when both web pushing and
+   * JavaScript are permitted by the container. The method is intended for HTML responses rendered
+   * by the gateway UI, where richer interactivity is required and framing may be allowed based on
+   * the container's CSP policy. It mirrors {@link #sendReplyHeaders(int, String, MultiValueTable,
+   * String, long)} but narrows semantics to the FProxy context for clarity and auditing.
+   *
+   * @param replyCode HTTP status code to emit toward the client connection.
+   * @param replyDescription Human-readable reason phrase paired with the status code for logging
+   *     and clients.
+   * @param mvt Additional headers to merge into the response; may be {@code null} for none.
+   * @param mimeType MIME type string; {@code null} sends no content-type header.
+   * @param contentLength Exact number of response bytes that will follow the header block.
+   * @throws ToadletContextClosedException If the context has already been closed for further
+   *     output.
+   * @throws IOException If writing to the underlying socket output stream fails.
+   */
   @Override
   public void sendReplyHeadersFProxy(
       int replyCode,
@@ -273,15 +395,7 @@ public class ToadletContextImpl implements ToadletContext {
     enableJavascript =
         container.isFProxyWebPushingEnabled() && container.isFProxyJavascriptEnabled();
     sendReplyHeaders(
-        replyCode,
-        replyDescription,
-        mvt,
-        mimeType,
-        contentLength,
-        null,
-        false,
-        true,
-        enableJavascript);
+        replyCode, replyDescription, mvt, mimeType, contentLength, null, true, enableJavascript);
   }
 
   private void sendReplyHeaders(
@@ -291,7 +405,6 @@ public class ToadletContextImpl implements ToadletContext {
       String mimeType,
       long contentLength,
       Date mTime,
-      boolean isOutlinkConfirmationPage,
       boolean allowFrames,
       boolean enableJavascript)
       throws ToadletContextClosedException, IOException {
@@ -305,7 +418,8 @@ public class ToadletContextImpl implements ToadletContext {
       mvt = new MultiValueTable<>();
     }
     if (replyCookies != null) {
-      // We do NOT use "set-cookie2" even though we should according though RFC2965 - Firefox 3.0.14
+      // We do NOT use "set-cookie2" even though we should, according though RFC2965 - Firefox
+      // 3.0.14
       // ignores it for me!
 
       for (Cookie cookie : replyCookies) {
@@ -316,11 +430,11 @@ public class ToadletContextImpl implements ToadletContext {
     }
 
     if (container.isSSL()) {
-      String HSTS = SSL.getHSTSHeader();
-      if (!HSTS.isEmpty() && !mvt.containsKey("strict-transport-security")) {
+      String hsts = SSL.getHSTSHeader();
+      if (!hsts.isEmpty() && !mvt.containsKey("strict-transport-security")) {
         // SSL enabled, set strict-transport-security so that the user agent upgrade future requests
         // to SSL.
-        mvt.put("strict-transport-security", HSTS);
+        mvt.put("strict-transport-security", hsts);
       }
     }
     sendReplyHeaders(
@@ -336,28 +450,75 @@ public class ToadletContextImpl implements ToadletContext {
         allowFrames);
   }
 
+  /**
+   * Returns the page maker responsible for rendering localized HTML responses. Callers typically
+   * use it to assemble templated UI fragments after access checks have passed. The reference is
+   * shared with other contexts but should be treated as read-mostly; heavy mutations belong in the
+   * container wiring. It also centralizes consistent branding and error layout so individual
+   * toadlets can remain lightweight and focus on data retrieval and validation.
+   *
+   * @return PageMaker instance configured for the current node environment and localization
+   *     settings.
+   */
   @Override
   public PageMaker getPageMaker() {
     return pagemaker;
   }
 
+  /**
+   * Retrieves the configured form password string used to protect POST endpoints from CSRF and
+   * cross-user invocation. The value is opaque to callers and should be compared using
+   * constant-time checks, as implemented by {@link #hasFormPassword(HTTPRequest)}. Do not expose it
+   * to logs. The password may be rotated between requests by container policy, so callers must
+   * fetch it anew for each validation rather than caching it across contexts.
+   *
+   * @return Form password for this node; never {@code null} but may be empty in permissive modes.
+   */
   @Override
   public String getFormPassword() {
     return container.getFormPassword();
   }
 
+  /**
+   * Validates that the supplied request carries the correct form password, redirecting to the root
+   * path on failure. This helper centralizes CSRF enforcement for POST handlers and ensures callers
+   * do not accidentally leak response bodies before verifying credentials. When validation fails
+   * the caller should stop processing and rely on the redirect that was already emitted.
+   *
+   * @param request HTTP request object containing parsed parameters and body parts for validation.
+   * @return {@code true} when the form password matches the configured value; {@code false} after a
+   *     redirect has been sent to the client.
+   * @throws ToadletContextClosedException If the context is already closed before the redirect is
+   *     written.
+   * @throws IOException If header transmission fails while issuing the redirect response.
+   */
   @Override
   public boolean checkFormPassword(HTTPRequest request)
       throws ToadletContextClosedException, IOException {
     return checkFormPassword(request, "/");
   }
 
+  /**
+   * Validates that the supplied request carries the correct form password, redirecting to a caller
+   * provided location on failure. This variant is useful when a toadlet wants to return the user to
+   * a specific page rather than the root. The method does not throw when authentication fails; it
+   * simply returns {@code false} after writing headers.
+   *
+   * @param request HTTP request object containing parsed parameters and body parts for validation.
+   * @param redirectTo Absolute or relative path where unauthenticated clients should be redirected.
+   * @return {@code true} when the form password matches the configured value; {@code false} after a
+   *     redirect has been sent to the target location.
+   * @throws ToadletContextClosedException If the context is already closed before the redirect is
+   *     written.
+   * @throws IOException If header transmission fails while issuing the redirect response.
+   */
   @Override
   public boolean checkFormPassword(HTTPRequest request, String redirectTo)
       throws ToadletContextClosedException, IOException {
     if (!hasFormPassword(request)) {
-      MultiValueTable<String, String> headers = MultiValueTable.from("Location", redirectTo);
-      sendReplyHeaders(302, "Found", headers, null, 0);
+      MultiValueTable<String, String> redirectHeaders =
+          MultiValueTable.from("Location", redirectTo);
+      sendReplyHeaders(302, "Found", redirectHeaders, null, 0);
       return false;
     } else {
       return true;
@@ -365,6 +526,16 @@ public class ToadletContextImpl implements ToadletContext {
   }
 
   /**
+   * Checks whether the current client holds full-access permissions for the requested resource. If
+   * access is denied, the target toadlet is asked to emit its unauthorized page and processing
+   * stops. Use this early in request handling to prevent partially rendered responses that might
+   * leak privileged information.
+   *
+   * @param toadlet Target toadlet that can render an unauthorized response when access fails.
+   * @return {@code true} when full access is permitted by the container policy; {@code false} after
+   *     the toadlet has produced an unauthorized page.
+   * @throws ToadletContextClosedException If the context has already been closed during handling.
+   * @throws IOException If the unauthorized page cannot be written to the client socket.
    * @see ToadletContext#checkFullAccess(Toadlet)
    */
   @Override
@@ -378,8 +549,17 @@ public class ToadletContextImpl implements ToadletContext {
     }
   }
 
+  /**
+   * Performs a constant-time comparison between the supplied {@code formPassword} parameter and the
+   * node's configured secret. Logging remains conservative to avoid exposing mismatched values.
+   * This method does not send responses and can be used by callers that want to enforce their own
+   * error handling flow.
+   *
+   * @param request HTTP request containing a potential {@code formPassword} parameter to verify.
+   * @return {@code true} when the provided parameter matches exactly; {@code false} otherwise.
+   */
   @Override
-  public boolean hasFormPassword(HTTPRequest request) throws IOException {
+  public boolean hasFormPassword(HTTPRequest request) {
     String pass = request.getPartAsStringFailsafe("formPassword", 32);
     byte[] inputBytes = pass.getBytes(StandardCharsets.UTF_8);
     byte[] compareBytes = getFormPassword().getBytes(StandardCharsets.UTF_8);
@@ -389,16 +569,44 @@ public class ToadletContextImpl implements ToadletContext {
     } else return true;
   }
 
+  /**
+   * Returns the alert manager that can surface user-facing notifications triggered during this
+   * request. Handlers can publish warnings or informational alerts without re-creating alert
+   * infrastructure, ensuring consistent presentation across the web UI. The manager handles
+   * queuing, deduplication, and localization concerns so individual toadlets can raise alerts
+   * without worrying about display semantics or thread confinement.
+   *
+   * @return Shared {@link UserAlertManager} instance used by the container for UI alerts.
+   */
   @Override
   public UserAlertManager getAlertManager() {
     return userAlertManager;
   }
 
+  /**
+   * Provides access to the bookmark subsystem so toadlets can read or modify stored bookmarks while
+   * servicing this request. The returned manager is shared across requests and should be treated as
+   * a service dependency rather than a per-request object. It offers persistence, validation, and
+   * localization support so individual handlers can focus on user flows rather than storage
+   * details.
+   *
+   * @return Bookmark manager configured for the running node; never {@code null}.
+   */
   @Override
   public BookmarkManager getBookmarkManager() {
     return bookmarkManager;
   }
 
+  /**
+   * Returns a view of the request headers as a multi-value table. Callers can inspect fields such
+   * as {@code user-agent}, cookies, or conditional headers to tailor responses. The table reflects
+   * the parsed input and should not be mutated unless the caller intends to shadow values during
+   * response generation. Iteration preserves all repeated fields, enabling accurate parsing of
+   * headers such as {@code cookie} or {@code accept-language} that legitimately appear multiple
+   * times.
+   *
+   * @return Request headers keyed by lower-cased field names with all received values preserved.
+   */
   @Override
   public MultiValueTable<String, String> getHeaders() {
     return headers;
@@ -419,37 +627,31 @@ public class ToadletContextImpl implements ToadletContext {
     }
   }
 
+  /**
+   * Looks up a previously received cookie by name after parsing all {@code Cookie} headers. Domain
+   * and path arguments are currently unused but retained for interface compatibility. Invalid
+   * cookies are skipped with logging so a malformed entry does not prevent other cookies from being
+   * resolved.
+   *
+   * @param domain Ignored domain hint; callers should pass the request host for future use.
+   * @param path Ignored path hint; callers should pass the request path for future use.
+   * @param name Case-insensitive cookie name to retrieve from the parsed collection.
+   * @return Matching {@link ReceivedCookie} or {@code null} when absent or parsing produced no
+   *     cookies.
+   * @throws ParseException If cookie headers cannot be parsed into structured values.
+   */
   @Override
   public ReceivedCookie getCookie(URI domain, URI path, String name) throws ParseException {
     parseCookies();
 
-    if (cookies == null) // There are no cookies.
-    return null;
+    if (cookies == null) { // There are no cookies.
+      return null;
+    }
 
     name = name.toLowerCase();
 
-    // String stringDomain = domain==null ? null : domain.toString().toLowerCase();
-    // String stringPath = path.toString();
-
-    // RFC2965: Two cookies are equal if name and domain are equal with case-insensitive comparison
-    // and path is equal with case-sensitive comparison.
-    // getName() / getDomain() returns lowercase and getPath() returns the original path.
-
-    // UNFORTUNATELY firefox will ONLY give us the name and the value of the cookie, so we ignore
-    // everything else.
-
     for (ReceivedCookie cookie : cookies) {
       try {
-        // if(stringDomain != null) {
-        //	URI cookieDomain = cookie.getDomain();
-        //
-        //	if(cookieDomain==null || !stringDomain.equals(cookieDomain.toString()))
-        //		continue;
-        // }
-        //
-        // if(cookie.getPath().toString().equals(stringPath) && cookie.getName().equals(name))
-        //	return cookie;
-
         if (cookie.getName().equals(name)) return cookie;
       } catch (RuntimeException e) {
         LOG.error("Error in cookie", e);
@@ -459,6 +661,18 @@ public class ToadletContextImpl implements ToadletContext {
     return null;
   }
 
+  /**
+   * Registers a cookie to be sent with the response. Added cookies are encoded during header
+   * emission; callers may invoke this multiple times to queue several {@code Set-Cookie} fields. A
+   * cookie added here remains pending until the next call to one of the {@code sendReplyHeaders*}
+   * helpers, which serializes the collection in insertion order. Because the context is tied to a
+   * single request and not thread-safe, callers should add cookies before handing control to any
+   * asynchronous writers. Modifications after headers have been emitted are ignored because
+   * response state is then fixed by HTTP semantics.
+   *
+   * @param newCookie Cookie instance to serialize into the outbound headers; must not be {@code
+   *     null}.
+   */
   @Override
   public void setCookie(Cookie newCookie) {
     if (replyCookies == null) replyCookies = new ArrayList<>(4);
@@ -483,51 +697,22 @@ public class ToadletContextImpl implements ToadletContext {
     if (mvt == null) {
       mvt = new MultiValueTable<>();
     }
-    if (mimeType != null) {
-      if (mimeType.equalsIgnoreCase("text/html")) {
-        mvt.put("content-type", mimeType + "; charset=UTF-8");
-      } else {
-        mvt.put("content-type", mimeType);
-      }
-    }
+    addContentTypeHeader(mvt, mimeType);
     if (contentLength >= 0) {
       mvt.put("content-length", Long.toString(contentLength));
     }
 
-    // For privacy reasons, only static content may be cached
-    boolean allowCaching = mTime != null;
-
-    String expiresTime;
-    String cacheControl;
-    if (allowCaching) {
-      // use an expiry time of 30 day from now, about the frequency of Freenet releases
-      // Expires is needed for older browsers
-      expiresTime = TimeUtil.makeHTTPDate(System.currentTimeMillis() + DAYS.toMillis(30));
-      cacheControl = "public, max-age=" + 3600 * 24 * 30;
-    } else {
-      expiresTime = "Thu, 01 Jan 1970 00:00:00 GMT";
-      // no-cache for Internet Explorer, no-store for Firefox
-      cacheControl =
-          "private, max-age=0, must-revalidate, no-cache, no-store, post-check=0, pre-check=0";
-      mvt.put("pragma", "no-cache");
-    }
-    mvt.put("expires", expiresTime);
-    mvt.put("cache-control", cacheControl);
+    addCachingHeaders(mvt, mTime);
 
     String nowString = TimeUtil.makeHTTPDate(System.currentTimeMillis());
-    String lastModString;
-    if (mTime == null) {
-      lastModString = nowString;
-    } else {
-      lastModString = TimeUtil.makeHTTPDate(mTime.getTime());
-    }
+    String lastModString = mTime == null ? nowString : TimeUtil.makeHTTPDate(mTime.getTime());
 
     mvt.put("last-modified", lastModString);
     mvt.put("date", nowString);
     if (disconnect) {
-      mvt.put("connection", "close");
+      mvt.put(CONNECTION_HEADER, "close");
     } else {
-      mvt.put("connection", "keep-alive");
+      mvt.put(CONNECTION_HEADER, "keep-alive");
     }
     mvt.put("cross-origin-embedder-policy", "require-corp");
     mvt.put("cross-origin-opener-policy", "same-origin");
@@ -556,6 +741,34 @@ public class ToadletContextImpl implements ToadletContext {
     sockOutputStream.write(buf.toString().getBytes(StandardCharsets.US_ASCII));
   }
 
+  private static void addCachingHeaders(MultiValueTable<String, String> mvt, Date mTime) {
+    boolean allowCaching = mTime != null;
+    String expiresTime;
+    String cacheControl;
+    if (allowCaching) {
+      expiresTime = TimeUtil.makeHTTPDate(System.currentTimeMillis() + DAYS.toMillis(30));
+      cacheControl = "public, max-age=" + 3600 * 24 * 30;
+    } else {
+      expiresTime = "Thu, 01 Jan 1970 00:00:00 GMT";
+      cacheControl =
+          "private, max-age=0, must-revalidate, no-cache, no-store, post-check=0, pre-check=0";
+      mvt.put("pragma", "no-cache");
+    }
+    mvt.put("expires", expiresTime);
+    mvt.put("cache-control", cacheControl);
+  }
+
+  private static void addContentTypeHeader(MultiValueTable<String, String> mvt, String mimeType) {
+    if (mimeType == null) {
+      return;
+    }
+    if (mimeType.equalsIgnoreCase("text/html")) {
+      mvt.put("content-type", mimeType + "; charset=UTF-8");
+    } else {
+      mvt.put("content-type", mimeType);
+    }
+  }
+
   private static String generateCSP(boolean allowScripts, boolean allowFrames) {
     // allow access to blobs, because these are purely local
     // Use modern CSP tokens; remove deprecated "options inline-script".
@@ -571,31 +784,54 @@ public class ToadletContextImpl implements ToadletContext {
   }
 
   private static String generateRestrictedScriptSrc() {
-    // TODO: auto-generate these hashes from the path to the source file
+    // Note: auto-generate these hashes from the path to the source file
     String[] allowedScriptHashes =
         new String[] {
           "sha256-RY9OjosvFxocXEmcUqBJ2v1KByDRdUgnGHYSL3Qx/t8=" // freenet/clients/http/staticfiles/js/m3u-player.js
         };
-    if (allowedScriptHashes.length == 0) {
-      return "'none'";
-    } else {
-      StringJoiner stringJoiner = new StringJoiner("' '", "'", "'");
-      for (String source : allowedScriptHashes) {
-        stringJoiner.add(source);
-      }
-      return stringJoiner.toString();
+    StringJoiner stringJoiner = new StringJoiner("' '", "'", "'");
+    stringJoiner.setEmptyValue("'none'");
+    for (String source : allowedScriptHashes) {
+      stringJoiner.add(source);
     }
+    return stringJoiner.toString();
   }
 
-  static TimeZone TZ_UTC = TimeZone.getTimeZone("UTC");
+  private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
 
+  /**
+   * Parses an RFC 7231/RFC 1123 HTTP date string into a {@link Date} in UTC. The parser is strict
+   * with respect to the {@code EEE, dd MMM yyyy HH:mm:ss 'GMT'} pattern and locale, matching the
+   * formatting used by {@link TimeUtil#makeHTTPDate(long)}. Callers can rely on this utility when
+   * interpreting headers such as {@code If-Modified-Since} or {@code Last-Modified}. Invalid input
+   * results in a {@link ParseException}, allowing callers to surface clear client errors without
+   * silently accepting malformed dates.
+   *
+   * @param httpDate Raw HTTP date string, usually sourced from client request headers.
+   * @return Parsed {@link Date} instance in UTC representing the provided timestamp.
+   * @throws ParseException If the supplied string does not conform to the expected HTTP date
+   *     format.
+   */
   public static Date parseHTTPDate(String httpDate) throws ParseException {
     SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US);
-    sdf.setTimeZone(TZ_UTC);
+    sdf.setTimeZone(UTC_TIME_ZONE);
     return sdf.parse(httpDate);
   }
 
-  /** Handle an incoming connection. Blocking, obviously. */
+  /**
+   * Handles an incoming socket connection by reading the request line, headers, and optional body
+   * before dispatching to the appropriate toadlet. The loop continues to process pipelined requests
+   * while the client and container allow persistent connections. Errors are translated into HTTP
+   * responses where possible, with parsing and length violations mapped to {@code 400 Bad Request}
+   * and unexpected exceptions mapped to {@code 500 Internal Failure}. This method blocks on I/O and
+   * should be invoked from a dedicated worker thread per connection.
+   *
+   * @param sock Open client socket carrying the HTTP conversation for this handler thread.
+   * @param container Owning container that resolves toadlets and enforces policy decisions.
+   * @param pageMaker Shared page renderer used for error pages and UI responses.
+   * @param userAlertManager Manager used to emit user-facing alerts encountered during handling.
+   * @param bookmarkManager Bookmark subsystem reference available to toadlets for request handling.
+   */
   public static void handle(
       Socket sock,
       ToadletContainer container,
@@ -604,232 +840,22 @@ public class ToadletContextImpl implements ToadletContext {
       BookmarkManager bookmarkManager) {
     try (InputStream is = new BufferedInputStream(sock.getInputStream(), 4096);
         LineReadingInputStream lis = new LineReadingInputStream(is)) {
-      while (true) {
-        String firstLine = lis.readLine(32768, 128, false); // ISO-8859-1 or US-ASCII, _not_ UTF-8
-        if (firstLine == null) {
-          sock.close();
-          return;
-        } else if (firstLine.isEmpty()) {
-          continue;
-        }
-
-        if (LOG.isDebugEnabled()) LOG.debug("first line: {}", firstLine);
-
-        String[] split = firstLine.split(" ");
-
-        if (split.length != 3)
-          throw new ParseException(
-              "Could not parse request line (split.length=" + split.length + "): " + firstLine, -1);
-
-        if (!split[2].startsWith("HTTP/1."))
-          throw new ParseException("Unrecognized protocol " + split[2], -1);
-
-        URI uri;
-        try {
-          uri = URIPreEncoder.encodeURI(split[1]).normalize();
-          if (LOG.isDebugEnabled())
-            LOG.debug(
-                "URI: {} path {} host {} frag {} port {} query {} scheme {}",
-                uri,
-                uri.getPath(),
-                uri.getHost(),
-                uri.getFragment(),
-                uri.getPort(),
-                uri.getQuery(),
-                uri.getScheme());
-        } catch (URISyntaxException e) {
-          sendURIParseError(sock.getOutputStream(), true, e);
-          return;
-        }
-        String method = split[0];
-
-        MultiValueTable<String, String> headers = new MultiValueTable<>();
-
-        while (true) {
-          String line = lis.readLine(32768, 128, false); // ISO-8859 or US-ASCII, not UTF-8
-          if (line == null) {
-            sock.close();
-            return;
-          }
-          // System.out.println("Length="+line.length()+": "+line);
-          if (line.isEmpty()) break;
-          int index = line.indexOf(':');
-          if (index < 0) {
-            throw new ParseException("Missing ':' in request header field", -1);
-          }
-          String before = line.substring(0, index).toLowerCase();
-          String after = line.substring(index + 1);
-          after = after.trim();
-          headers.put(before, after);
-        }
-
-        boolean disconnect =
-            shouldDisconnectAfterHandled(split[2].equals("HTTP/1.0"), headers)
-                || !container.enablePersistentConnections();
-
-        boolean allowPost = container.allowPosts();
-        BucketFactory bf = container.getBucketFactory();
-
-        ToadletContextImpl ctx =
-            new ToadletContextImpl(
-                sock,
-                headers,
-                bf,
-                pageMaker,
-                container,
-                userAlertManager,
-                bookmarkManager,
-                uri,
-                container.generateUniqueID());
-        ctx.shouldDisconnect = disconnect;
-
-        /*
-         * copy the data into a bucket now,
-         * before we go into the redirect loop
-         */
-
-        Bucket data;
-
-        String slen = headers.getFirst("content-length");
-
-        if (METHODS_MUST_HAVE_DATA.contains(method)) {
-          // <method> must have data
-          if (slen == null) {
-            ctx.shouldDisconnect = true;
-            ctx.sendReplyHeaders(400, "Bad Request", null, null, -1);
-            return;
-          }
-        } else if (METHODS_CANNOT_HAVE_DATA.contains(method)) {
-          // <method> can not have data
-          if (slen != null) {
-            ctx.shouldDisconnect = true;
-            ctx.sendReplyHeaders(400, "Bad Request", null, null, -1);
-            return;
-          }
-        }
-
-        if (slen != null) {
-          long len;
-          try {
-            len = Integer.parseInt(slen);
-            if (len < 0) throw new NumberFormatException("content-length less than 0");
-          } catch (NumberFormatException e) {
-            ctx.shouldDisconnect = true;
-            ctx.sendReplyHeaders(400, "Bad Request", null, null, -1);
-            return;
-          }
-          if (allowPost && ((!container.publicGatewayMode()) || ctx.isAllowedFullAccess())) {
-            data = bf.makeBucket(len);
-            BucketTools.copyFrom(data, is, len);
-          } else {
-            FileUtil.skipFully(is, len);
-            if (method.equals("POST")) {
-              ctx.sendMethodNotAllowed("POST", true);
-            } else {
-              sendError(
-                  sock.getOutputStream(),
-                  403,
-                  "Forbidden",
-                  "Content not allowed in this configuration",
-                  true,
-                  null);
-            }
-            ctx.close();
-            return;
-          }
-        } else {
-          // we're not doing to use it, but we have to keep
-          // the compiler happy
-          data = null;
-        }
-
-        if (!container.enableExtendedMethodHandling()) {
-          if (!METHODS_RESTRICTED_MODE.contains(method)) {
-            sendError(
-                sock.getOutputStream(),
-                403,
-                "Forbidden",
-                "Method not allowed in this configuration",
-                true,
-                null);
-            return;
-          }
-        }
-
-        // Handle it.
-        try {
-          boolean redirect = true;
-          while (redirect) {
-            // don't go around the loop unless set explicitly
-            redirect = false;
-
-            Toadlet t;
-            try {
-              t = container.findToadlet(uri);
-            } catch (PermanentRedirectException e) {
-              Toadlet.writePermanentRedirect(ctx, "Found elsewhere", e.newuri.toASCIIString());
-              break;
-            }
-
-            if (t == null) {
-              ctx.sendNoToadletError(ctx.shouldDisconnect);
-              break;
-            }
-
-            // if the Toadlet does not support the method, we don't need to parse the data
-            // also due this pre check a 'NoSuchMethodException' should never appear
-            if (!(t.findSupportedMethods().contains(method))) {
-              ctx.sendMethodNotAllowed(method, ctx.shouldDisconnect);
-              break;
-            }
-
-            HTTPRequestImpl req = new HTTPRequestImpl(uri, data, ctx, method);
-
-            // require form password if it's a POST, unless the toadlet requests otherwise
-            if (method.equals("POST") && !t.allowPOSTWithoutPassword()) {
-              if (!ctx.checkFormPassword(req, t.path())) {
-                break;
-              }
-            }
-
-            if (ctx.isAllowedFullAccess()) {
-              ctx.getPageMaker().parseMode(req, container);
-            }
-
-            try {
-              callToadletMethod(t, method, uri, req, ctx, data, sock, redirect);
-            } catch (RedirectException re) {
-              uri = re.newuri;
-              redirect = true;
-            } finally {
-              req.freeParts();
-            }
-          }
-          if (ctx.shouldDisconnect) {
-            sock.close();
-            return;
-          }
-        } finally {
-          if (data != null) data.free();
-        }
+      boolean keepProcessing =
+          processRequest(sock, container, pageMaker, userAlertManager, bookmarkManager, is, lis);
+      while (keepProcessing) {
+        keepProcessing =
+            processRequest(sock, container, pageMaker, userAlertManager, bookmarkManager, is, lis);
       }
-
     } catch (ParseException e) {
       try {
         sendError(
-            sock.getOutputStream(),
-            400,
-            "Bad Request",
-            l10n("parseErrorWithError", "error", e.getMessage()),
-            true,
-            null);
+            sock.getOutputStream(), 400, BAD_REQUEST, l10nParseError(e.getMessage()), true, null);
       } catch (IOException e1) {
         // Ignore
       }
     } catch (TooLongException e) {
       try {
-        sendError(
-            sock.getOutputStream(), 400, "Bad Request", l10n("headersLineTooLong"), true, null);
+        sendError(sock.getOutputStream(), 400, BAD_REQUEST, l10n("headersLineTooLong"), true, null);
       } catch (IOException e1) {
         // Ignore
       }
@@ -837,11 +863,11 @@ public class ToadletContextImpl implements ToadletContext {
       // ignore and return
     } catch (ToadletContextClosedException e) {
       LOG.error("ToadletContextClosedException while handling connection!");
-    } catch (Throwable t) {
-      LOG.error("Caught error: {} handling socket", t.toString(), t);
+    } catch (Exception t) {
+      LOG.error("Caught error: {} handling socket", t, t);
       try {
         String msg =
-            "<html><head><title>"
+            HTML_TITLE_PREFIX
                 + NodeL10n.getBase().getString("Toadlet.internalErrorTitle")
                 + "</title></head><body><h1>"
                 + NodeL10n.getBase().getString("Toadlet.internalErrorPleaseReport")
@@ -870,6 +896,297 @@ public class ToadletContextImpl implements ToadletContext {
     }
   }
 
+  private static boolean processRequest(
+      Socket sock,
+      ToadletContainer container,
+      PageMaker pageMaker,
+      UserAlertManager userAlertManager,
+      BookmarkManager bookmarkManager,
+      InputStream is,
+      LineReadingInputStream lis)
+      throws IOException,
+          ParseException,
+          ToadletContextClosedException,
+          NoSuchMethodException,
+          IllegalAccessException,
+          ToadletInvocationException {
+    String firstLine = lis.readLine(32768, 128, false); // ISO-8859-1 or US-ASCII, _not_ UTF-8
+    if (firstLine == null) {
+      sock.close();
+      return false;
+    }
+    if (firstLine.isEmpty()) {
+      return true;
+    }
+    RequestLine requestLine = parseRequestLine(firstLine, sock);
+    if (requestLine == null) {
+      return false;
+    }
+
+    MultiValueTable<String, String> requestHeaders = readHeaders(lis, sock);
+    if (requestHeaders == null) {
+      return false;
+    }
+
+    boolean disconnect =
+        shouldDisconnectAfterHandled(requestLine.isHTTP10(), requestHeaders)
+            || !container.enablePersistentConnections();
+
+    BucketFactory bf = container.getBucketFactory();
+
+    ToadletContextImpl ctx =
+        new ToadletContextImpl(
+            sock,
+            requestHeaders,
+            bf,
+            pageMaker,
+            container,
+            userAlertManager,
+            bookmarkManager,
+            requestLine.uri,
+            container.generateUniqueID());
+    ctx.shouldDisconnect = disconnect;
+
+    DataReadResult dataResult =
+        readRequestData(
+            requestLine.method,
+            requestHeaders.getFirst("content-length"),
+            container.allowPosts(),
+            container,
+            ctx,
+            bf,
+            is);
+
+    if (!dataResult.continueProcessing) {
+      return false;
+    }
+
+    Bucket data = dataResult.data;
+    try {
+      if (!container.enableExtendedMethodHandling()
+          && !METHODS_RESTRICTED_MODE.contains(requestLine.method)) {
+        sendError(
+            sock.getOutputStream(),
+            403,
+            "Forbidden",
+            "Method not allowed in this configuration",
+            true,
+            null);
+        return false;
+      }
+
+      handleToadletRequests(container, requestLine.method, requestLine.uri, data, ctx, sock);
+      if (ctx.shouldDisconnect) {
+        sock.close();
+        return false;
+      }
+      return true;
+    } finally {
+      if (data != null) data.free();
+    }
+  }
+
+  private static RequestLine parseRequestLine(String firstLine, Socket sock)
+      throws IOException, ParseException {
+    if (LOG.isDebugEnabled()) LOG.debug("first line: {}", firstLine);
+
+    String[] split = firstLine.split(" ");
+
+    if (split.length != 3) {
+      throw new ParseException(
+          "Could not parse request line (split.length=" + split.length + "): " + firstLine, -1);
+    }
+
+    if (!split[2].startsWith("HTTP/1."))
+      throw new ParseException("Unrecognized protocol " + split[2], -1);
+
+    try {
+      URI uri = URIPreEncoder.encodeURI(split[1]).normalize();
+      if (LOG.isDebugEnabled())
+        LOG.debug(
+            "URI: {} path {} host {} frag {} port {} query {} scheme {}",
+            uri,
+            uri.getPath(),
+            uri.getHost(),
+            uri.getFragment(),
+            uri.getPort(),
+            uri.getQuery(),
+            uri.getScheme());
+      return new RequestLine(split[0], uri, split[2]);
+    } catch (URISyntaxException e) {
+      sendURIParseError(sock.getOutputStream(), e);
+      return null;
+    }
+  }
+
+  private static MultiValueTable<String, String> readHeaders(
+      LineReadingInputStream lis, Socket sock) throws IOException, ParseException {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    while (true) {
+      String line = lis.readLine(32768, 128, false); // ISO-8859 or US-ASCII, not UTF-8
+      if (line == null) {
+        sock.close();
+        return null;
+      }
+      if (line.isEmpty()) {
+        return headers;
+      }
+      int index = line.indexOf(':');
+      if (index < 0) {
+        throw new ParseException("Missing ':' in request header field", -1);
+      }
+      String before = line.substring(0, index).toLowerCase();
+      String after = line.substring(index + 1).trim();
+      headers.put(before, after);
+    }
+  }
+
+  private static DataReadResult readRequestData(
+      String method,
+      String contentLengthHeader,
+      boolean allowPost,
+      ToadletContainer container,
+      ToadletContextImpl ctx,
+      BucketFactory bf,
+      InputStream is)
+      throws IOException, ToadletContextClosedException {
+    boolean missingRequiredData =
+        METHODS_MUST_HAVE_DATA.contains(method) && contentLengthHeader == null;
+    boolean unexpectedData =
+        METHODS_CANNOT_HAVE_DATA.contains(method) && contentLengthHeader != null;
+    if (missingRequiredData || unexpectedData) {
+      ctx.shouldDisconnect = true;
+      ctx.sendReplyHeaders(400, BAD_REQUEST, null, null, -1);
+      return DataReadResult.stop();
+    }
+
+    if (contentLengthHeader == null) {
+      return DataReadResult.success(null);
+    }
+
+    long length;
+    try {
+      length = Integer.parseInt(contentLengthHeader);
+      if (length < 0) throw new NumberFormatException("content-length less than 0");
+    } catch (NumberFormatException e) {
+      ctx.shouldDisconnect = true;
+      ctx.sendReplyHeaders(400, BAD_REQUEST, null, null, -1);
+      return DataReadResult.stop();
+    }
+
+    if (allowPost && ((!container.publicGatewayMode()) || ctx.isAllowedFullAccess())) {
+      Bucket data = bf.makeBucket(length);
+      BucketTools.copyFrom(data, is, length);
+      return DataReadResult.success(data);
+    }
+
+    FileUtil.skipFully(is, length);
+    if ("POST".equals(method)) {
+      ctx.sendMethodNotAllowed("POST", true);
+    } else {
+      sendError(
+          ctx.sockOutputStream,
+          403,
+          "Forbidden",
+          "Content not allowed in this configuration",
+          true,
+          null);
+    }
+    ctx.close();
+    return DataReadResult.stop();
+  }
+
+  private static void handleToadletRequests(
+      ToadletContainer container,
+      String method,
+      URI uri,
+      Bucket data,
+      ToadletContextImpl ctx,
+      Socket sock)
+      throws IOException,
+          ToadletContextClosedException,
+          NoSuchMethodException,
+          IllegalAccessException,
+          ToadletInvocationException {
+    URI currentUri = uri;
+    boolean redirect;
+    do {
+      redirect = false;
+      FindToadletResult toadletResult = findToadlet(container, ctx, currentUri);
+      if (toadletResult.handled) {
+        return;
+      }
+      Toadlet toadlet = toadletResult.toadlet;
+      if (toadlet == null) {
+        ctx.sendNoToadletError(ctx.shouldDisconnect);
+        return;
+      }
+
+      if (!toadlet.findSupportedMethods().contains(method)) {
+        ctx.sendMethodNotAllowed(method, ctx.shouldDisconnect);
+        return;
+      }
+
+      HTTPRequestImpl req = new HTTPRequestImpl(currentUri, data, ctx, method);
+      try {
+        if (method.equals("POST")
+            && !toadlet.allowPOSTWithoutPassword()
+            && !ctx.checkFormPassword(req, toadlet.path())) {
+          return;
+        }
+
+        if (ctx.isAllowedFullAccess()) {
+          ctx.getPageMaker().parseMode(req, container);
+        }
+
+        try {
+          callToadletMethod(toadlet, method, currentUri, req, ctx, data, sock);
+        } catch (RedirectException re) {
+          currentUri = re.newuri;
+          redirect = true;
+        }
+      } finally {
+        req.freeParts();
+      }
+    } while (redirect);
+  }
+
+  private static FindToadletResult findToadlet(
+      ToadletContainer container, ToadletContextImpl ctx, URI uri)
+      throws IOException, ToadletContextClosedException {
+    try {
+      Toadlet toadlet = container.findToadlet(uri);
+      return new FindToadletResult(toadlet, false);
+    } catch (PermanentRedirectException e) {
+      Toadlet.writePermanentRedirect(ctx, "Found elsewhere", e.newuri.toASCIIString());
+      return new FindToadletResult(null, true);
+    }
+  }
+
+  private record DataReadResult(Bucket data, boolean continueProcessing) {
+    static DataReadResult success(Bucket data) {
+      return new DataReadResult(data, true);
+    }
+
+    static DataReadResult stop() {
+      return new DataReadResult(null, false);
+    }
+  }
+
+  private record RequestLine(String method, URI uri, String protocol) {
+    boolean isHTTP10() {
+      return "HTTP/1.0".equals(protocol);
+    }
+  }
+
+  private record FindToadletResult(Toadlet toadlet, boolean handled) {}
+
+  private static final class ToadletInvocationException extends Exception {
+    ToadletInvocationException(Throwable cause) {
+      super(cause);
+    }
+  }
+
   private static void callToadletMethod(
       Toadlet t,
       String method,
@@ -877,56 +1194,99 @@ public class ToadletContextImpl implements ToadletContext {
       HTTPRequestImpl req,
       ToadletContextImpl ctx,
       Bucket data,
-      Socket sock,
-      boolean methodIsConfigurable)
-      throws Throwable {
-    String methodName = Toadlet.HANDLE_METHOD_PREFIX + method;
+      Socket sock)
+      throws IOException,
+          RedirectException,
+          ToadletContextClosedException,
+          NoSuchMethodException,
+          IllegalAccessException,
+          ToadletInvocationException {
     if ("GET".equals(method)) {
-      // Short cut the common case.
-      if (data != null) {
-        sendError(sock.getOutputStream(), 400, "Bad Request", "Content not allowed", true, null);
-        ctx.close();
-        return;
-      }
-      ctx.setActiveToadlet(t);
-      t.handleMethodGET(uri, req, ctx);
+      handleGetRequest(t, uri, req, ctx, data, sock);
       return;
     }
+
+    Method reflectedMethod = resolveHandleMethod(t, method);
+    invokeToadletMethod(t, reflectedMethod, uri, req, ctx);
+  }
+
+  private static void invokeToadletMethod(
+      Toadlet toadlet, Method reflectedMethod, URI uri, HTTPRequestImpl req, ToadletContextImpl ctx)
+      throws IOException,
+          RedirectException,
+          ToadletContextClosedException,
+          ToadletInvocationException,
+          IllegalAccessException {
+    ctx.setActiveToadlet(toadlet);
     try {
-      Class<? extends Toadlet> c = t.getClass();
-      Method m = c.getMethod(methodName, HANDLE_PARAMETERS);
-      if (methodIsConfigurable) {
-        AllowData anno = m.getAnnotation(AllowData.class);
-        if (anno == null) {
-          if (data != null) {
-            sendError(
-                sock.getOutputStream(), 400, "Bad Request", "Content not allowed", true, null);
-            ctx.close();
-            return;
-          }
-        } else if (anno.value()) {
-          if (data == null) {
-            sendError(sock.getOutputStream(), 400, "Bad Request", "Missing Content", true, null);
-            ctx.close();
-            return;
-          }
-        }
-      }
-      ctx.setActiveToadlet(t);
-      Object[] arglist = new Object[] {uri, req, ctx};
-      m.invoke(t, arglist);
+      reflectedMethod.invoke(toadlet, uri, req, ctx);
     } catch (InvocationTargetException ite) {
-      throw ite.getCause();
+      handleInvocationCause(ite.getCause());
     }
+  }
+
+  private static void handleInvocationCause(Throwable cause)
+      throws IOException,
+          RedirectException,
+          ToadletContextClosedException,
+          ToadletInvocationException {
+    if (cause instanceof IOException io) {
+      throw io;
+    }
+    if (cause instanceof RedirectException redirect) {
+      throw redirect;
+    }
+    if (cause instanceof ToadletContextClosedException closed) {
+      throw closed;
+    }
+    if (cause instanceof RuntimeException runtime) {
+      throw runtime;
+    }
+    if (cause instanceof Error error) {
+      throw error;
+    }
+    throw new ToadletInvocationException(cause);
+  }
+
+  private static Method resolveHandleMethod(Toadlet toadlet, String method)
+      throws NoSuchMethodException {
+    Class<? extends Toadlet> clazz = toadlet.getClass();
+    String methodName = Toadlet.HANDLE_METHOD_PREFIX + method;
+    return clazz.getMethod(methodName, HANDLE_PARAMETERS);
+  }
+
+  private static void handleGetRequest(
+      Toadlet toadlet,
+      URI uri,
+      HTTPRequestImpl req,
+      ToadletContextImpl ctx,
+      Bucket data,
+      Socket sock)
+      throws IOException, ToadletContextClosedException, RedirectException {
+    if (data != null) {
+      sendError(sock.getOutputStream(), 400, BAD_REQUEST, "Content not allowed", true, null);
+      ctx.close();
+      return;
+    }
+    ctx.setActiveToadlet(toadlet);
+    toadlet.handleMethodGET(uri, req, ctx);
   }
 
   private void setActiveToadlet(Toadlet t) {
-    this.activeToadlet = t;
+    this.activeToadlet.set(t);
   }
 
+  /**
+   * Returns the toadlet currently handling this context, or {@code null} when none is active. The
+   * value is updated before invoking handler methods and can be used by logging or error handling
+   * code to attribute messages to the correct component. It reflects a best-effort reference and is
+   * not intended for long-term storage.
+   *
+   * @return Active {@link Toadlet} assigned to this context, or {@code null} before dispatch.
+   */
   @Override
   public Toadlet activeToadlet() {
-    return activeToadlet;
+    return activeToadlet.get();
   }
 
   /**
@@ -938,7 +1298,7 @@ public class ToadletContextImpl implements ToadletContext {
    */
   private static boolean shouldDisconnectAfterHandled(
       boolean isHTTP10, MultiValueTable<String, String> headers) {
-    String connection = headers.getFirst("connection");
+    String connection = headers.getFirst(CONNECTION_HEADER);
     if (connection != null) {
       if (connection.equalsIgnoreCase("close")) return true;
 
@@ -948,6 +1308,18 @@ public class ToadletContextImpl implements ToadletContext {
     return isHTTP10;
   }
 
+  /**
+   * Writes a portion of a byte array to the client, preserving any previously sent headers. Call
+   * this after emitting response headers and before finalizing the connection. The method performs
+   * no buffering beyond the socket stream, so callers may wish to chunk large payloads externally
+   * for back-pressure handling.
+   *
+   * @param data Byte array containing the content to transmit to the client.
+   * @param offset Offset within the array where the payload to send begins.
+   * @param length Number of bytes to write starting at {@code offset}; must not exceed array size.
+   * @throws ToadletContextClosedException If the context has been closed and cannot accept output.
+   * @throws IOException If the socket write fails or the connection drops mid-transfer.
+   */
   @Override
   public void writeData(byte[] data, int offset, int length)
       throws ToadletContextClosedException, IOException {
@@ -955,15 +1327,32 @@ public class ToadletContextImpl implements ToadletContext {
     sockOutputStream.write(data, offset, length);
   }
 
+  /**
+   * Writes an entire byte array as the response body following any previously sent headers. This is
+   * a thin convenience wrapper over the offset-based variant and does not perform additional
+   * validation beyond the closed-context check. Use it for small payloads that are already fully
+   * materialized in memory.
+   *
+   * @param data Byte array to write to the socket; must not be {@code null}.
+   * @throws ToadletContextClosedException If the context has been closed and cannot accept output.
+   * @throws IOException If the socket write fails or the connection drops mid-transfer.
+   */
   @Override
   public void writeData(byte[] data) throws ToadletContextClosedException, IOException {
     writeData(data, 0, data.length);
   }
 
   /**
-   * @param data The Bucket which contains the reply data. This function assumes ownership of the
-   *     Bucket, calling free() on it when done. If this behavior is undesired, callers can wrap
-   *     their Bucket in a NoFreeBucket.
+   * Streams the contents of the supplied {@link Bucket} to the client and then frees the bucket.
+   * Callers transfer ownership to the context; if the data must remain available afterward, wrap it
+   * in a {@link NoFreeBucket} before calling. The method copies until the bucket reports end-of-
+   * stream or the socket write fails, making it suitable for large payloads without loading the
+   * entire content into memory at once. It keeps the order of writes unchanged, allowing response
+   * bodies generated earlier to be piped directly.
+   *
+   * @param data Bucket containing the reply data to transfer; ownership passes to the context.
+   * @throws ToadletContextClosedException If the context has been closed and cannot accept output.
+   * @throws IOException If reading from the bucket or writing to the socket fails.
    * @see NoFreeBucket
    */
   @Override
@@ -973,56 +1362,146 @@ public class ToadletContextImpl implements ToadletContext {
     data.free();
   }
 
+  /**
+   * Provides the bucket factory configured for this node, enabling handlers to allocate temporary
+   * storage for request bodies or generated responses. The factory selection may incorporate
+   * quota-handling and disk preferences, so callers should prefer this accessor over creating
+   * buckets directly. Using the shared factory keeps allocation consistent with node-level storage
+   * policies such as maximum size limits or memory/disk balancing.
+   *
+   * @return {@link BucketFactory} suitable for allocating storage during request processing.
+   */
   @Override
   public BucketFactory getBucketFactory() {
     return bf;
   }
 
+  /**
+   * Adds a form element to the given parent node using container defaults. This is a pass-through
+   * to {@link ToadletContainer#addFormChild(HTMLNode, String, String)} and keeps form creation
+   * logic centralized. Callers should use it when emitting forms that need the container's action
+   * paths and hidden fields. It ensures consistent CSRF protection and localization across all
+   * request handlers.
+   *
+   * @param parentNode Parent HTML node to which the form child will be appended.
+   * @param target Target URL or path for form submission generated by the container.
+   * @param name Form name used for identification within the page.
+   * @return Newly created {@link HTMLNode} representing the form child.
+   */
   @Override
   public HTMLNode addFormChild(HTMLNode parentNode, String target, String name) {
     return container.addFormChild(parentNode, target, name);
   }
 
+  /**
+   * Determines whether the request originates from a client granted full access. The decision is
+   * delegated to the container and usually involves IP-based checks or session state. Use it to
+   * gate expensive operations or privileged views before processing user input. The result can vary
+   * between requests, so callers should check per-request rather than caching the answer globally.
+   *
+   * @return {@code true} when the container reports that the remote address has full access.
+   */
   @Override
   public boolean isAllowedFullAccess() {
     return container.isAllowedFullAccess(remoteAddr);
   }
 
+  /**
+   * Indicates whether the node is operating in advanced mode, which typically unlocks additional UI
+   * controls and diagnostic information. Toadlets can use this flag to tailor responses without
+   * duplicating configuration reads. Advanced mode often exposes extra logging hooks, expert forms,
+   * or maintenance endpoints that are hidden in the default mode for safety.
+   *
+   * @return {@code true} when advanced mode features should be enabled in responses.
+   */
   @Override
   public boolean isAdvancedModeEnabled() {
     return container.isAdvancedModeEnabled();
   }
 
+  /**
+   * Reports whether the server should expose a robots.txt response. This allows toadlets to
+   * suppress crawler-facing endpoints in deployments where indexing is undesirable. Use it to
+   * decide whether to inject robot tags or return 404/403 responses for robot probes.
+   *
+   * @return {@code true} when robots directives should be served for this node.
+   */
   @Override
   public boolean doRobots() {
     return container.doRobots();
   }
 
+  /**
+   * Requests that the underlying connection be closed after the current response. Callers can set
+   * this when they know further reuse is unsafe or when protocol errors have occurred. The flag is
+   * honored when headers are emitted next and complements automatic close behavior driven by {@code
+   * Connection: close} requests or HTTP/1.0 clients.
+   */
   @Override
   public void forceDisconnect() {
     this.shouldDisconnect = true;
   }
 
+  /**
+   * Returns the parent container that owns this context and governs policy decisions. Toadlets can
+   * consult it for configuration or helper methods beyond what the context exposes directly. The
+   * container is long-lived and centralizes shared services such as bucket factories, security
+   * checks, and localization helpers.
+   *
+   * @return Non-null {@link ToadletContainer} instance associated with this request.
+   */
   @Override
   public ToadletContainer getContainer() {
     return container;
   }
 
+  /**
+   * Indicates whether the progress page should be suppressed for this request. The container uses
+   * this to allow plugin-provided UIs to opt out of the standard progress feedback. Handlers can
+   * consult this flag when deciding whether to stream incremental progress updates or present a
+   * minimalist response.
+   *
+   * @return {@code true} when progress pages must be disabled for the caller.
+   */
   @Override
   public boolean disableProgressPage() {
     return container.disableProgressPage();
   }
 
+  /**
+   * Returns the unique identifier assigned to this request. The ID is a stringified long used for
+   * logging, correlation, and client-visible debugging. It remains stable for the lifetime of the
+   * context and is safe to include in client-visible diagnostics because it contains no sensitive
+   * data by itself.
+   *
+   * @return Unique request identifier supplied by the container at creation time.
+   */
   @Override
   public String getUniqueId() {
     return uniqueId;
   }
 
+  /**
+   * Returns the normalized request URI associated with this context. Callers should treat it as
+   * immutable and prefer cloning when modifications are required for redirects. The URI contains
+   * any query string provided by the client; callers should parse query parameters before mutation
+   * to avoid losing fidelity.
+   *
+   * @return Request {@link URI} as parsed from the incoming request line.
+   */
   @Override
   public URI getUri() {
     return uri;
   }
 
+  /**
+   * Exposes the current refilter policy chosen by FProxy for this request. Handlers can use the
+   * policy to decide whether to re-run content filters on cached data or forwarded responses. The
+   * value reflects container configuration and any per-request overrides captured when the context
+   * was created.
+   *
+   * @return {@link REFILTER_POLICY} indicating how the proxy should treat filtering behavior.
+   */
   @Override
   public REFILTER_POLICY getReFilterPolicy() {
     return container.getReFilterPolicy();

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -1,0 +1,264 @@
+package network.crypta.clients.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ToadletContextImplTest {
+
+  @Mock private BucketFactory bucketFactory;
+  @Mock private PageMaker pageMaker;
+  @Mock private ToadletContainer container;
+  @Mock private UserAlertManager alertManager;
+  @Mock private BookmarkManager bookmarkManager;
+  @Mock private HTTPRequest request;
+
+  private ByteArrayOutputStream outputStream;
+  private ToadletContextImpl context;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    outputStream = new ByteArrayOutputStream();
+    Socket socket = new FakeSocket(outputStream, InetAddress.getLoopbackAddress());
+
+    // Minimal stubbing used across tests
+    org.mockito.Mockito.when(container.getFormPassword()).thenReturn("secret");
+    org.mockito.Mockito.when(container.isFProxyJavascriptEnabled()).thenReturn(false);
+    org.mockito.Mockito.when(container.isSSL()).thenReturn(false);
+
+    context =
+        new ToadletContextImpl(
+            socket,
+            new MultiValueTable<>(),
+            bucketFactory,
+            pageMaker,
+            container,
+            alertManager,
+            bookmarkManager,
+            new URI("http://example.com/"),
+            1L);
+  }
+
+  @Test
+  void parseHTTPDate_whenValidString_parsesEpoch() throws Exception {
+    Date parsed = ToadletContextImpl.parseHTTPDate("Thu, 01 Jan 1970 00:00:00 GMT");
+    assertEquals(0L, parsed.getTime());
+  }
+
+  @Test
+  void parseHTTPDate_whenInvalid_throwsParseException() {
+    assertThrows(ParseException.class, () -> ToadletContextImpl.parseHTTPDate("not a date"));
+  }
+
+  @Test
+  void shouldDisconnectAfterHandled_withCloseHeader_returnsTrue() {
+    MultiValueTable<String, String> headers = MultiValueTable.from("connection", "close");
+    assertTrue(
+        invokeShouldDisconnectAfterHandled(false, headers),
+        "close header must force disconnect regardless of version");
+  }
+
+  @Test
+  void shouldDisconnectAfterHandled_http11WithoutHeader_returnsFalse() {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    assertFalse(invokeShouldDisconnectAfterHandled(false, headers));
+  }
+
+  @Test
+  void shouldDisconnectAfterHandled_http10WithoutHeader_returnsTrue() {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    assertTrue(invokeShouldDisconnectAfterHandled(true, headers));
+  }
+
+  @Test
+  void hasFormPassword_whenMatches_returnsTrue() {
+    org.mockito.Mockito.when(request.getPartAsStringFailsafe("formPassword", 32))
+        .thenReturn("secret");
+
+    assertTrue(context.hasFormPassword(request));
+  }
+
+  @Test
+  void hasFormPassword_whenMismatch_returnsFalse() {
+    org.mockito.Mockito.when(request.getPartAsStringFailsafe("formPassword", 32))
+        .thenReturn("wrong");
+
+    assertFalse(context.hasFormPassword(request));
+  }
+
+  @Test
+  void checkFormPassword_whenMissing_redirectsAndReturnsFalse() throws Exception {
+    org.mockito.Mockito.when(request.getPartAsStringFailsafe("formPassword", 32)).thenReturn("bad");
+
+    boolean result = context.checkFormPassword(request, "/redirect");
+
+    assertFalse(result);
+    Map<String, List<String>> headers = parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+    assertEquals("302", headers.get("__status").getFirst());
+    assertEquals("/redirect", headers.get("location").getFirst());
+  }
+
+  @Test
+  void sendReplyHeaders_withoutModifiedTime_setsNoCacheAndCsp() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+
+    ToadletContextImpl.sendReplyHeaders(
+        outputStream, 200, "OK", headers, "text/plain", 10, null, true, false, false);
+
+    Map<String, List<String>> parsed = parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+
+    assertEquals("200", parsed.get("__status").getFirst());
+    assertEquals("close", parsed.get("connection").getFirst());
+    assertEquals("text/plain", parsed.get("content-type").getFirst());
+    assertEquals("10", parsed.get("content-length").getFirst());
+    assertEquals("Thu, 01 Jan 1970 00:00:00 GMT", parsed.get("expires").getFirst());
+    assertTrue(parsed.get("cache-control").getFirst().contains("no-cache"));
+    assertEquals("DENY", parsed.get("x-frame-options").getFirst());
+    String csp = parsed.get("content-security-policy").getFirst();
+    assertTrue(csp.contains("frame-src 'none'"));
+    assertTrue(csp.contains("sha256-RY9OjosvFxocXEmcUqBJ2v1KByDRdUgnGHYSL3Qx/t8="));
+    String scriptDirective = getScriptDirective(csp);
+    assertFalse(
+        scriptDirective.contains("unsafe-inline"),
+        "inline scripts must be forbidden when disabled");
+  }
+
+  @Test
+  void sendReplyHeaders_withModifiedTime_allowsCachingAndScripts() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    Date modified = new Date(0L);
+
+    ToadletContextImpl.sendReplyHeaders(
+        outputStream, 200, "OK", headers, "text/html", 5, modified, false, true, true);
+
+    Map<String, List<String>> parsed = parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+
+    assertEquals("keep-alive", parsed.get("connection").getFirst());
+    assertEquals("text/html; charset=UTF-8", parsed.get("content-type").getFirst());
+    assertTrue(parsed.get("cache-control").getFirst().startsWith("public"));
+    assertEquals(
+        ToadletContextImpl.parseHTTPDate(parsed.get("last-modified").getFirst()).getTime(),
+        modified.getTime());
+    String csp = parsed.get("content-security-policy").getFirst();
+    assertTrue(csp.contains("frame-src 'self'"));
+    assertTrue(csp.contains("unsafe-inline"));
+    assertTrue(csp.contains("unsafe-eval"));
+  }
+
+  @Test
+  void sendReplyHeaders_whenCalledTwice_throwsIllegalState() throws Exception {
+    context.sendReplyHeaders(200, "OK", null, "text/plain", 0);
+
+    assertThrows(
+        IllegalStateException.class, () -> context.sendReplyHeaders(200, "OK", null, null, 0));
+  }
+
+  @Test
+  void writeData_whenClosed_throwsToadletContextClosedException() throws Exception {
+    java.lang.reflect.Field closedField = ToadletContextImpl.class.getDeclaredField("closed");
+    closedField.setAccessible(true);
+    closedField.set(context, true);
+
+    assertThrows(ToadletContextClosedException.class, () -> context.writeData(new byte[] {1, 2}));
+  }
+
+  private static boolean invokeShouldDisconnectAfterHandled(
+      boolean isHttp10, MultiValueTable<String, String> headers) {
+    try {
+      java.lang.reflect.Method m =
+          ToadletContextImpl.class.getDeclaredMethod(
+              "shouldDisconnectAfterHandled", boolean.class, MultiValueTable.class);
+      m.setAccessible(true);
+      return (boolean) m.invoke(null, isHttp10, headers);
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static Map<String, List<String>> parseHeaders(String raw) {
+    Map<String, List<String>> map = new LinkedHashMap<>();
+    String[] lines = raw.split("\\r?\\n");
+    if (lines.length == 0) return map;
+    String statusLine = lines[0];
+    String[] statusParts = statusLine.split(" ");
+    if (statusParts.length >= 2) {
+      map.put("__status", List.of(statusParts[1]));
+    }
+    for (int i = 1; i < lines.length; i++) {
+      String line = lines[i];
+      if (line.trim().isEmpty()) {
+        continue;
+      }
+      int idx = line.indexOf(':');
+      if (idx <= 0) continue;
+      String key = line.substring(0, idx).toLowerCase(Locale.ROOT);
+      String value = line.substring(idx + 1).trim();
+      map.computeIfAbsent(key, k -> new java.util.ArrayList<>()).add(value);
+    }
+    return map;
+  }
+
+  private static String getScriptDirective(String csp) {
+    final String prefix = "script-src";
+    for (String part : csp.split(";")) {
+      String trimmed = part.trim();
+      if (trimmed.startsWith(prefix)) {
+        return trimmed;
+      }
+    }
+    return "";
+  }
+
+  private static class FakeSocket extends Socket {
+    private final ByteArrayOutputStream os;
+    private final InetAddress inetAddress;
+
+    FakeSocket(ByteArrayOutputStream os, InetAddress inetAddress) {
+      this.os = os;
+      this.inetAddress = inetAddress;
+    }
+
+    @Override
+    public ByteArrayOutputStream getOutputStream() {
+      return os;
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+      return inetAddress;
+    }
+
+    @Override
+    public void close() {
+      // no-op for tests
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor ToadletContextImpl to clarify request lifecycle, error handling, and active toadlet tracking
- replace volatile tracking with AtomicReference and tighten header/URI parsing helpers
- add comprehensive unit tests covering form password checks, CSP/headers, and connection handling

## Testing
- not run (not requested)
