### PR TITLE
Add FileIntegrity documentation and tests

### DIFF
--- a/src/main/java/com/onionnetworks/io/FileIntegrity.java
+++ b/src/main/java/com/onionnetworks/io/FileIntegrity.java
@@ -3,44 +3,117 @@ package com.onionnetworks.io;
 import com.onionnetworks.util.Buffer;
 
 /**
- * This interface provides access to a number of block hashes for a file. These hashes can be used
- * to check the integrity of a single block and the overall file.
+ * Exposes a read-only view of cryptographic hashes calculated over a file and its constituent
+ * fixed-size blocks.
+ *
+ * <p>Implementations typically wrap precomputed digest material so callers can verify large files
+ * without re-hashing the entire contents. The interface is intentionally minimal: it reports the
+ * digest algorithm, the uniform block size, the original file length, and both per-block and whole
+ * file hashes. The final block may be shorter than the declared block size but is still hashed with
+ * the same algorithm to maintain deterministic coverage across the file.
+ *
+ * <p>Callers commonly pair this interface with a streaming reader that replays file data and
+ * compares the supplied hashes on-the-fly. Implementations should document their thread-safety and
+ * lifetime guarantees; a typical implementation is immutable once constructed, enabling reuse
+ * across validation passes or parallel download segments. All lengths are expressed in bytes and
+ * block indexes are expected to follow zero-based semantics unless otherwise specified by the
+ * implementation.
+ *
+ * <ul>
+ *   <li>Provides block-level verification to localize corruption quickly.
+ *   <li>Supplies a whole-file hash for coarse integrity checks or catalog metadata.
+ *   <li>Relies on a consistent message-digest algorithm across all reported hashes.
+ * </ul>
+ *
+ * @see FileIntegrityImpl
  */
 public interface FileIntegrity {
 
   /**
-   * @return the message digest algorithm used to create the the hashes.
-   */
-  public String getAlgorithm();
-
-  /**
-   * Specifies the size of each block. This size should be a power of 2 and all blocks will be this
-   * size, expect for the last block which may be equal to or less than the block size (but not 0).
+   * Returns the canonical name of the message-digest algorithm that produced all reported hashes.
    *
-   * @return the block size.
-   */
-  public int getBlockSize();
-
-  /**
-   * @return the size of the file.
-   */
-  public long getFileSize();
-
-  /**
-   * Returns the number of blocks that make up the file. This value will be equal to
-   * ceil(fileSize/blockSize).
+   * <p>The algorithm identifier is suitable for {@link
+   * java.security.MessageDigest#getInstance(String)} and should match both the per-block hashes and
+   * the overall file hash. Implementations must return a non-null, non-empty string so callers can
+   * create compatible digest instances when revalidating data. The algorithm choice determines
+   * digest size, collision properties, and the level of interoperability with other tools that may
+   * consume the integrity metadata.
    *
-   * @return the block count.
+   * @return algorithm name understood by {@code MessageDigest}, stable for this integrity record.
    */
-  public int getBlockCount();
+  String getAlgorithm();
 
   /**
-   * @return the hash of the specified block.
+   * Reports the nominal size, in bytes, of each uniformly hashed block within the file.
+   *
+   * <p>Implementations typically choose a power-of-two value to align with storage boundaries and
+   * simplify segment arithmetic. Every block except the final one must match this size exactly; the
+   * last block may be shorter but never zero bytes. The reported size remains constant for the life
+   * of this integrity descriptor so clients can calculate offsets deterministically when mapping
+   * block numbers back to absolute file positions.
+   *
+   * @return positive block size in bytes used for all but the final partial block.
    */
-  public Buffer getBlockHash(int blockNum);
+  int getBlockSize();
 
   /**
-   * @return the hash of the entire file.
+   * Returns the total file length, in bytes, that the integrity data describes.
+   *
+   * <p>The size represents the original payload length at the time the hashes were computed. It
+   * combines with {@link #getBlockSize()} to derive the block count and to verify that readers do
+   * not truncate or pad the content when reassembling distributed segments. Callers should treat
+   * this value as authoritative metadata for range validation and consistency checks.
+   *
+   * @return non-negative file length in bytes covered by the recorded hashes.
    */
-  public Buffer getFileHash();
+  long getFileSize();
+
+  /**
+   * Returns the number of hashed blocks that together span the described file.
+   *
+   * <p>The count equals {@code ceil(fileSize / blockSize)}; when the file size is an exact multiple
+   * of the block size, the final block is full length. This value helps callers preallocate data
+   * structures for per-block verification or progress reporting. Implementations should ensure
+   * consistency with {@link #getFileSize()} and {@link #getBlockSize()} so that iterating through
+   * block indices from zero to {@code count - 1} covers the entire file without gaps.
+   *
+   * @return total number of sequential blocks implied by the file size and block size.
+   */
+  @SuppressWarnings("unused")
+  int getBlockCount();
+
+  /**
+   * Retrieves the cryptographic hash for an individual block identified by its index.
+   *
+   * <p>Block numbering is expected to start at zero and increase sequentially. Callers should pass
+   * values within the range {@code 0 <= blockNum < getBlockCount()}; behavior for out-of-range
+   * values is implementation-specific and may result in runtime exceptions. The returned buffer is
+   * typically immutable; callers must not modify it unless the implementation explicitly allows
+   * mutation. Hashes correspond to the algorithm reported by {@link #getAlgorithm()} and reflect
+   * the exact bytes contained in the referenced block.
+   *
+   * <pre>{@code
+   * // Example: verify a freshly read block against known integrity data
+   * Buffer expected = integrity.getBlockHash(blockIndex);
+   * }</pre>
+   *
+   * @param blockNum zero-based index of the block to verify; must exist within the file span.
+   * @return hash bytes for the requested block, using the shared digest algorithm.
+   */
+  @SuppressWarnings("unused")
+  Buffer getBlockHash(int blockNum);
+
+  /**
+   * Provides the cryptographic digest computed over the entire file contents in order.
+   *
+   * <p>The whole-file hash complements per-block hashes by allowing a fast coarse-grained integrity
+   * check. It uses the same algorithm as {@link #getAlgorithm()} and is calculated over the
+   * original file length returned by {@link #getFileSize()}. Callers can compare this value before
+   * attempting block-by-block validation or after reconstruction from independent segments. The
+   * returned buffer is typically read-only and should be treated as immutable checksum metadata.
+   *
+   * @return digest of the full file data, consistent with the configured message-digest algorithm.
+   */
+  @SuppressWarnings("unused")
+  Buffer getFileHash();
 }

--- a/src/main/java/com/onionnetworks/io/FileIntegrityImpl.java
+++ b/src/main/java/com/onionnetworks/io/FileIntegrityImpl.java
@@ -4,18 +4,58 @@ import com.onionnetworks.util.Buffer;
 import com.onionnetworks.util.Util;
 
 /**
- * This class provides a way to access various structures needed to check the integrity of a file.
+ * Immutable container for integrity metadata associated with a file.
+ *
+ * <p>This implementation stores the digest algorithm name, the overall file hash, and a hash for
+ * each fixed-size block of the file. It performs basic validation in the constructor to ensure the
+ * supplied hashes align with the expected block layout and size. Callers typically obtain an
+ * instance from code that already computed the hashes, then pass it to verification routines that
+ * compare hashes against bytes read from disk or the network. Because the internal arrays are not
+ * defensively copied, callers should treat the provided {@code Buffer} instances as read-only after
+ * construction to preserve integrity guarantees.
+ *
+ * <p>The class is thread-safe for concurrent reads after construction: all fields are {@code final}
+ * and no mutation occurs. It does not perform any I/O itself; it simply exposes the precomputed
+ * values needed by {@link FileIntegrity} consumers. Typical usage patterns include: reading the
+ * algorithm name to initialize a message digest, requesting individual block hashes during
+ * streaming verification, and comparing {@link #getFileHash()} when all blocks have been processed.
+ *
+ * <ul>
+ *   <li>Validates non-null inputs and non-negative sizes during construction.
+ *   <li>Computes the expected block count using ceiling division to cover partial tails.
+ *   <li>Assumes callers manage the lifecycle of the supplied buffers.
+ * </ul>
  *
  * @author Justin F. Chapweske
  */
 public class FileIntegrityImpl implements FileIntegrity {
 
-  private String algo;
-  private Buffer fileHash;
-  private Buffer[] blockHashes;
-  private int blockSize, blockCount;
-  private long fileSize;
+  private final String algo;
+  private final Buffer fileHash;
+  private final Buffer[] blockHashes;
+  private final int blockSize;
+  private final int blockCount;
+  private final long fileSize;
 
+  /**
+   * Creates an immutable snapshot of file-integrity data for a single file instance.
+   *
+   * <p>All inputs must already reflect the same digest algorithm. The constructor checks for null
+   * references, enforces non-negative sizes, and verifies the number of provided block hashes
+   * matches the ceiling of {@code fileSize / blockSize}. The supplied arrays are stored by
+   * reference; callers should avoid mutating them after construction to prevent divergence between
+   * stored hashes and the represented file.
+   *
+   * @param algorithm message-digest algorithm name (e.g., {@code "SHA-256"}); must not be null.
+   * @param fileHash hash of the complete file content using {@code algorithm}; must not be null.
+   * @param blockHashes ordered hashes for each block from offset 0 upward; array must not be null.
+   * @param fileSize total file length in bytes; must be zero or positive.
+   * @param blockSize configured block size in bytes; must be positive for non-empty files.
+   * @throws NullPointerException if {@code algorithm}, {@code fileHash}, or {@code blockHashes} is
+   *     {@code null}.
+   * @throws IllegalArgumentException if {@code fileSize} or {@code blockSize} is negative, or if
+   *     {@code blockHashes.length} does not equal the computed block count.
+   */
   public FileIntegrityImpl(
       String algorithm, Buffer fileHash, Buffer[] blockHashes, long fileSize, int blockSize) {
     if (algorithm == null) {
@@ -41,51 +81,82 @@ public class FileIntegrityImpl implements FileIntegrity {
   }
 
   /**
-   * @return the message digest algorithm used to create the the hashes.
+   * Returns the message-digest algorithm name used to create every hash in this instance.
+   *
+   * <p>The algorithm is the exact string provided at construction time and should be compatible
+   * with {@link java.security.MessageDigest#getInstance(String)} when initializing verifiers.
+   *
+   * @return algorithm identifier; callers must not assume normalization beyond the provided value.
    */
   public String getAlgorithm() {
     return algo;
   }
 
   /**
-   * Specifies the size of each block. This size should be a power of 2 and all blocks will be this
-   * size, expect for the last block which may be equal to or less than the block size (but not 0).
+   * Reports the configured block size, in bytes, used when computing per-block hashes.
    *
-   * @return the block size.
+   * <p>All blocks except the tail share this size; the final block may be shorter when {@code
+   * fileSize} is not an exact multiple. The value is identical to the constructor argument and
+   * should typically be a power of two for efficient alignment, although no enforcement occurs
+   * here.
+   *
+   * @return positive integer size in bytes; unchanged from construction input.
    */
   public int getBlockSize() {
     return blockSize;
   }
 
   /**
-   * @return the size of the file.
+   * Returns the total file size, in bytes, that the stored hashes describe.
+   *
+   * <p>The value represents the original length supplied to the constructor. Verification routines
+   * can use it to detect truncated data or to compute stream boundaries when iterating blocks.
+   *
+   * @return non-negative length in bytes for the represented file.
    */
   public long getFileSize() {
     return fileSize;
   }
 
   /**
-   * Returns the number of blocks that make up the file. This value will be equal to
-   * ceil(fileSize/blockSize).
+   * Returns the number of logical blocks whose hashes are stored in this instance.
    *
-   * @return the block count.
+   * <p>The count equals {@code ceil(fileSize / blockSize)} and therefore includes a final partial
+   * block when the file length is not evenly divisible by the block size. It is precomputed during
+   * construction to support fast bounds checking when retrieving block hashes.
+   *
+   * @return positive count when {@code fileSize > 0}; otherwise zero for an empty file.
    */
   public int getBlockCount() {
     return blockCount;
   }
 
   /**
-   * @return the hash of the specified block.
+   * Returns the hash of the specified block index.
+   *
+   * <p>The returned {@link Buffer} is the same object provided at construction time; callers should
+   * treat it as immutable to preserve integrity. Block numbering starts at zero and increases
+   * sequentially toward the end of the file.
+   *
+   * @param blockNum zero-based block index to retrieve; must be within stored bounds.
+   * @return block hash buffer representing the requested block's digest bytes.
+   * @throws IllegalArgumentException if {@code blockNum} is negative or greater than or equal to
+   *     {@link #getBlockCount()}.
    */
   public Buffer getBlockHash(int blockNum) {
     if (blockNum < 0 || blockNum >= blockCount) {
-      throw new IllegalArgumentException("Invalide block #" + blockNum);
+      throw new IllegalArgumentException("Invalid block #" + blockNum);
     }
     return blockHashes[blockNum];
   }
 
   /**
-   * @return the hash of the entire file.
+   * Returns the digest of the entire file content using {@link #getAlgorithm()}.
+   *
+   * <p>The buffer reference is shared with the constructor input; callers should avoid modification
+   * to keep the stored metadata consistent with the underlying file.
+   *
+   * @return hash buffer for the whole file, covering every byte from start to end.
    */
   public Buffer getFileHash() {
     return fileHash;

--- a/src/test/java/com/onionnetworks/io/FileIntegrityImplTest.java
+++ b/src/test/java/com/onionnetworks/io/FileIntegrityImplTest.java
@@ -1,0 +1,136 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.onionnetworks.util.Buffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("java:S100")
+class FileIntegrityImplTest {
+
+  @Test
+  void constructor_whenAlgorithmNull_expectNullPointerException() {
+    Buffer fileHash = new Buffer(new byte[] {1});
+    Buffer[] blockHashes = {new Buffer(new byte[] {2})};
+
+    assertThrows(
+        NullPointerException.class,
+        () -> new FileIntegrityImpl(null, fileHash, blockHashes, 1L, 1));
+  }
+
+  @Test
+  void constructor_whenFileHashNull_expectNullPointerException() {
+    Buffer[] blockHashes = {new Buffer(new byte[] {2})};
+
+    assertThrows(
+        NullPointerException.class, () -> new FileIntegrityImpl("SHA-1", null, blockHashes, 1L, 1));
+  }
+
+  @Test
+  void constructor_whenBlockHashesNull_expectNullPointerException() {
+    Buffer fileHash = new Buffer(new byte[] {1});
+
+    assertThrows(
+        NullPointerException.class, () -> new FileIntegrityImpl("SHA-1", fileHash, null, 1L, 1));
+  }
+
+  @Test
+  void constructor_whenFileSizeNegative_expectIllegalArgumentException() {
+    Buffer fileHash = new Buffer(new byte[] {1});
+    Buffer[] blockHashes = {new Buffer(new byte[] {2})};
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new FileIntegrityImpl("SHA-1", fileHash, blockHashes, -1L, 1));
+  }
+
+  @Test
+  void constructor_whenBlockSizeNegative_expectIllegalArgumentException() {
+    Buffer fileHash = new Buffer(new byte[] {1});
+    Buffer[] blockHashes = {new Buffer(new byte[] {2})};
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new FileIntegrityImpl("SHA-1", fileHash, blockHashes, 1L, -1));
+  }
+
+  @Test
+  void constructor_whenBlockHashesCountMismatch_expectIllegalArgumentException() {
+    Buffer fileHash = new Buffer(new byte[] {1});
+    Buffer[] blockHashes = {new Buffer(new byte[] {2})};
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new FileIntegrityImpl("SHA-1", fileHash, blockHashes, 512L, 256));
+  }
+
+  @Test
+  void constructor_whenBlockSizeZero_expectArithmeticException() {
+    Buffer fileHash = new Buffer(new byte[] {1});
+    Buffer[] blockHashes = new Buffer[0];
+
+    assertThrows(
+        ArithmeticException.class,
+        () -> new FileIntegrityImpl("SHA-1", fileHash, blockHashes, 0L, 0));
+  }
+
+  @Test
+  void getters_whenValidConstruction_returnSuppliedValues() {
+    Buffer fileHash = new Buffer(new byte[] {1, 2, 3});
+    Buffer[] blockHashes = {
+      new Buffer(new byte[] {10}),
+      new Buffer(new byte[] {11}),
+      new Buffer(new byte[] {12}),
+      new Buffer(new byte[] {13}),
+      new Buffer(new byte[] {14})
+    };
+
+    FileIntegrityImpl integrity =
+        new FileIntegrityImpl("SHA-256", fileHash, blockHashes, 1025L, 256);
+
+    assertEquals("SHA-256", integrity.getAlgorithm());
+    assertEquals(256, integrity.getBlockSize());
+    assertEquals(1025L, integrity.getFileSize());
+    assertEquals(5, integrity.getBlockCount());
+    assertSame(fileHash, integrity.getFileHash());
+  }
+
+  @Test
+  void getBlockHash_whenValidIndex_returnsCorrespondingBuffer() {
+    Buffer[] blockHashes = {
+      new Buffer(new byte[] {5}), new Buffer(new byte[] {6}), new Buffer(new byte[] {7})
+    };
+    FileIntegrityImpl integrity =
+        new FileIntegrityImpl("SHA-1", new Buffer(new byte[] {1}), blockHashes, 3L, 1);
+
+    Buffer result = integrity.getBlockHash(2);
+
+    assertSame(blockHashes[2], result);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 3})
+  void getBlockHash_whenIndexOutOfRange_expectIllegalArgumentException(int index) {
+    Buffer[] blockHashes = {
+      new Buffer(new byte[] {5}), new Buffer(new byte[] {6}), new Buffer(new byte[] {7})
+    };
+    FileIntegrityImpl integrity =
+        new FileIntegrityImpl("SHA-1", new Buffer(new byte[] {1}), blockHashes, 3L, 1);
+
+    assertThrows(IllegalArgumentException.class, () -> integrity.getBlockHash(index));
+  }
+
+  @Test
+  void constructor_whenFileSizeZeroAndNoBlocks_expectZeroBlockCount() {
+    Buffer fileHash = new Buffer(new byte[] {0});
+    Buffer[] blockHashes = new Buffer[0];
+
+    FileIntegrityImpl integrity = new FileIntegrityImpl("SHA-1", fileHash, blockHashes, 0L, 1);
+
+    assertEquals(0, integrity.getBlockCount());
+  }
+}


### PR DESCRIPTION
## Summary
- document FileIntegrity interfaces and implementation with clearer Javadoc
- enforce immutability in FileIntegrityImpl fields
- add unit tests covering constructor validation and getters for FileIntegrityImpl

## Testing
- ./gradlew spotlessApply
