### PR TITLE
docs: clarify ExceptionRAF failure behavior

### DIFF
--- a/src/main/java/com/onionnetworks/io/ExceptionRAF.java
+++ b/src/main/java/com/onionnetworks/io/ExceptionRAF.java
@@ -2,36 +2,157 @@ package com.onionnetworks.io;
 
 import java.io.*;
 
+/**
+ * {@link RAF} variant that always throws a pre-supplied {@link IOException} for read/write-style
+ * operations.
+ *
+ * <p>This wrapper is designed for tests and failure-injection scenarios where callers must observe
+ * deterministic I/O failures without touching the filesystem. It stores the provided exception and
+ * rethrows it from all mutating and positioning methods, letting higher-level components validate
+ * error-handling branches while keeping state isolated. The mode string is retained so {@link
+ * #getMode()} continues to behave like a normal {@code RAF} instance even though no file backing
+ * exists. Instances are synchronized in the same manner as {@code RAF}, enabling safe reuse across
+ * threads when simulating concurrent failures. Because the class never opens or owns a physical
+ * file descriptor, it is effectively immutable after construction except for inherited metadata
+ * fields.
+ *
+ * <ul>
+ *   <li>Injects the same {@link IOException} into every operation that would touch disk.
+ *   <li>Preserves {@code mode} for compatibility with code paths that inspect access intent.
+ *   <li>Useful for unit tests that must confirm retry, logging, or cleanup logic on persistent
+ *       failure.
+ * </ul>
+ *
+ * @see RAF
+ */
 public class ExceptionRAF extends RAF {
 
   IOException e;
 
+  /**
+   * Creates a throwing wrapper that reports the supplied exception for I/O actions.
+   *
+   * <p>The constructor does not open any file. Instead, it records the exception to replay on each
+   * subsequent operation and saves the provided mode so callers that query {@link #getMode()} see a
+   * consistent value. Use this when a component depends on {@code RAF}-like semantics but the test
+   * harness needs predictable failure injection without altering the filesystem.
+   *
+   * @param e exception instance that will be thrown by all I/O-related methods; must not be {@code
+   *     null} and should already carry the desired message and cause chain.
+   * @param mode access mode string (for example {@code "r"} or {@code "rw"}) retained for API
+   *     compatibility even though no file is opened; null or malformed values propagate via {@link
+   *     #getMode()} unchanged.
+   */
   public ExceptionRAF(IOException e, String mode) {
     this.e = e;
-    // FIX, this is rediculous, but check the mode.
+    // FIX, this is ridiculous, but check the mode.
     this.mode = mode;
     // This is so getMode() calls will succeed.
   }
 
-  public void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
+  /**
+   * Always throws the injected exception instead of writing data.
+   *
+   * <p>The method mirrors {@link RAF#seekAndWrite(long, byte[], int, int)} in signature and
+   * synchronization but immediately rethrows the stored exception to simulate a failure at a known
+   * offset. Callers should treat this as a deterministic I/O error and avoid assuming that the file
+   * position or contents changed.
+   *
+   * @param pos absolute position that would have been written; retained only for signature
+   *     compatibility and not validated.
+   * @param b buffer that would have supplied data; must not be {@code null} when upstream code
+   *     enforces argument validation.
+   * @param off start index within {@code b}; preserved for API parity but unused in this
+   *     implementation.
+   * @param len number of bytes requested; ignored because the exception is thrown unconditionally.
+   * @throws IOException always the same instance provided to the constructor to model write
+   *     failure.
+   */
+  @Override
+  public synchronized void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
     throw e;
   }
 
-  public void seekAndReadFully(long pos, byte[] b, int off, int len) throws IOException {
+  /**
+   * Always throws the injected exception instead of reading data.
+   *
+   * <p>This method emulates {@link RAF#seekAndReadFully(long, byte[], int, int)} but never touches
+   * storage. It is primarily used in tests that must observe the behavior of callers when a
+   * guaranteed read failure occurs at a specific offset. No buffer mutations take place before the
+   * exception is propagated.
+   *
+   * @param pos absolute position that would have been read from; unused but preserved for signature
+   *     compatibility.
+   * @param b destination buffer that would have been populated; callers should not rely on its
+   *     contents changing.
+   * @param off starting offset within {@code b}; unused because no I/O occurs.
+   * @param len number of bytes requested for the read; ignored in this implementation.
+   * @throws IOException always the constructor-supplied instance to indicate read failure.
+   */
+  @Override
+  public synchronized void seekAndReadFully(long pos, byte[] b, int off, int len)
+      throws IOException {
     throw e;
   }
 
-  public void renameTo(File destFile) throws IOException {
+  /**
+   * Always throws the injected exception instead of renaming the file.
+   *
+   * <p>The call is synchronized to match {@link RAF#renameTo(File)} but short-circuits by
+   * rethrowing the stored exception. No filesystem interactions occur, making it suitable for
+   * verifying how callers handle move failures without altering disk state.
+   *
+   * @param destFile destination path that would have been used for the rename operation; value is
+   *     not examined.
+   * @throws IOException always the provided exception, representing a rename failure condition.
+   */
+  @Override
+  public synchronized void renameTo(File destFile) throws IOException {
     throw e;
   }
 
+  /**
+   * Always throws the injected exception instead of reopening in read-only mode.
+   *
+   * <p>This override preserves the synchronization and signature of {@link RAF#setReadOnly()} while
+   * guaranteeing a controlled failure. Callers should expect the mode to remain unchanged and no
+   * handles to be opened or closed.
+   *
+   * @throws IOException always the stored exception, simulating inability to change access mode.
+   */
+  @Override
   public synchronized void setReadOnly() throws IOException {
     throw e;
   }
 
+  /**
+   * Always throws the injected exception instead of resizing the underlying file.
+   *
+   * <p>The method keeps the synchronized contract of {@link RAF#setLength(long)} but immediately
+   * fails with the stored exception, allowing callers to validate error handling around resize
+   * paths without modifying the filesystem.
+   *
+   * @param len target length in bytes that would have been applied; ignored because no I/O occurs.
+   * @throws IOException always the constructor-supplied exception to model a resize failure.
+   */
+  @Override
   public synchronized void setLength(long len) throws IOException {
     throw e;
   }
 
-  public synchronized void close() throws IOException {}
+  /**
+   * Performs no action and does not throw, simulating a clean close on a failed handle.
+   *
+   * <p>Unlike other overrides, this method deliberately swallows the stored exception to mirror
+   * scenarios where cleanup must succeed even after earlier failures. It remains synchronized for
+   * consistency with {@link RAF#close()} but leaves internal state untouched and does not attempt
+   * to delete any backing file.
+   *
+   * @throws IOException never in this implementation, despite the signature matching the parent
+   *     class.
+   */
+  @Override
+  public synchronized void close() throws IOException {
+    // Intentionally no-op to simulate successful close without throwing the injected exception.
+  }
 }

--- a/src/test/java/com/onionnetworks/io/ExceptionRAFTest.java
+++ b/src/test/java/com/onionnetworks/io/ExceptionRAFTest.java
@@ -1,0 +1,93 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class ExceptionRAFTest {
+
+  @Test
+  void getMode_whenConstructed_returnsProvidedMode() throws IOException {
+    IOException ioException = new IOException("boom");
+    try (ExceptionRAF raf = new ExceptionRAF(ioException, "rw")) {
+      assertEquals("rw", raf.getMode());
+    }
+  }
+
+  @Test
+  void seekAndWrite_whenInvoked_throwsProvidedException() throws IOException {
+    IOException ioException = new IOException("write-error");
+    byte[] data = new byte[] {1, 2, 3};
+
+    try (ExceptionRAF raf = new ExceptionRAF(ioException, "rw")) {
+      IOException thrown =
+          assertThrows(IOException.class, () -> raf.seekAndWrite(0, data, 0, data.length));
+
+      assertSame(ioException, thrown);
+    }
+  }
+
+  @Test
+  void seekAndReadFully_whenInvoked_throwsProvidedException() throws IOException {
+    IOException ioException = new IOException("read-error");
+    byte[] buffer = new byte[4];
+
+    try (ExceptionRAF raf = new ExceptionRAF(ioException, "rw")) {
+      IOException thrown =
+          assertThrows(IOException.class, () -> raf.seekAndReadFully(0, buffer, 0, buffer.length));
+
+      assertSame(ioException, thrown);
+    }
+  }
+
+  @Test
+  void renameTo_whenInvoked_throwsProvidedException(@TempDir Path tempDir) throws IOException {
+    IOException ioException = new IOException("rename-error");
+    File destination = tempDir.resolve("dest.dat").toFile();
+
+    try (ExceptionRAF raf = new ExceptionRAF(ioException, "rw")) {
+      IOException thrown = assertThrows(IOException.class, () -> raf.renameTo(destination));
+
+      assertSame(ioException, thrown);
+    }
+  }
+
+  @Test
+  void setReadOnly_whenInvoked_throwsProvidedException() throws IOException {
+    IOException ioException = new IOException("readonly-error");
+
+    try (ExceptionRAF raf = new ExceptionRAF(ioException, "rw")) {
+      IOException thrown = assertThrows(IOException.class, raf::setReadOnly);
+
+      assertSame(ioException, thrown);
+    }
+  }
+
+  @Test
+  void setLength_whenInvoked_throwsProvidedException() throws IOException {
+    IOException ioException = new IOException("length-error");
+
+    try (ExceptionRAF raf = new ExceptionRAF(ioException, "rw")) {
+      IOException thrown = assertThrows(IOException.class, () -> raf.setLength(10L));
+
+      assertSame(ioException, thrown);
+    }
+  }
+
+  @Test
+  void close_whenInvoked_doesNotThrowAndLeavesClosedFlagFalse() throws IOException {
+    try (ExceptionRAF raf = new ExceptionRAF(new IOException("close-error"), "rw")) {
+      assertDoesNotThrow(raf::close);
+      assertFalse(raf.isClosed());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document ExceptionRAF to clarify deterministic failure injection semantics and mode retention
- keep close() a no-op and align Javadoc with synchronized overrides
- add ExceptionRAF tests using try-with-resources to assert injected IOExceptions and close behavior

## Testing
- ./gradlew spotlessApply
- Not run (not requested)