### PR TITLE
Improve FiniteInputStream docs and tests

### DIFF
--- a/src/main/java/com/onionnetworks/io/FiniteInputStream.java
+++ b/src/main/java/com/onionnetworks/io/FiniteInputStream.java
@@ -1,26 +1,56 @@
 package com.onionnetworks.io;
 
-import java.io.*;
-import java.net.*;
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * This class provides a FilterInputStream that only allows a finite number of bytes to be read,
- * even if the actual InputStream is much longer. This is useful for demultiplexing operations where
- * there may be a number of sub-InputStreams available in a parent InputStream.
+ * Fixed-length {@link InputStream} wrapper that exposes only a bounded slice of a parent stream.
  *
- * <p>Once the specified number of bytes have been read, a -1 will be returned. If the underlying
- * inputstream returns a -1 before the specified number of bytes have been read, an EOFException
- * will be thrown. If one does NOT close() the FiniteInputStream, the parent InputStream can still
- * be used to read additional data. Calling close() on the FiniteInputStream will close the parent
- * InputStream.
+ * <p>This stream enforces a byte budget supplied at construction time, allowing callers to treat a
+ * shared multiplexed stream as a sequence of independent finite segments. It keeps internal state
+ * of remaining bytes and stops returning data once the limit reaches zero, while optionally
+ * allowing the underlying stream to continue serving subsequent consumers. Closing this wrapper
+ * closes the parent stream; leaving it open lets callers advance the parent manually after the
+ * bounded read completes.
+ *
+ * <p>Typical usage reads or skips exactly the advertised payload length when parsing framed
+ * messages, attachments, or encrypted blobs whose size is known up front. The class is not
+ * thread-safe; each instance should be confined to a single reader. Read and skip operations
+ * decrement the remaining byte counter atomically relative to this instance and will raise an
+ * {@link java.io.EOFException} if the parent stream ends before the limit is satisfied.
+ *
+ * <ul>
+ *   <li>Enforces a strict byte quota with predictable EOF semantics.
+ *   <li>Allows continued access to the parent stream after the quota is consumed.
+ *   <li>Prefers clarity over buffering: no additional buffering is added beyond the parent.
+ * </ul>
  */
 public class FiniteInputStream extends FilterInputStream {
 
+  /**
+   * Remaining byte budget, in bytes, still permitted to flow through this view. Updated after every
+   * successful read or skip, this value should never become negative and mirrors the quota
+   * originally supplied to the constructor. State is local to the instance and is not synchronized
+   * for cross-thread visibility.
+   */
   protected long left;
 
   /**
-   * @param is The parent InputStream to read from.
-   * @param count the total number of bytes to allow to be read from the parent.
+   * Create a new bounded view onto an existing stream.
+   *
+   * <p>The wrapper maintains its own counter of bytes remaining and enforces an immediate end of
+   * stream once the quota is depleted. Passing a null stream triggers a {@link
+   * NullPointerException}; a negative {@code count} triggers an {@link IllegalArgumentException}.
+   * If {@code count} is zero, reads immediately return {@code -1} while leaving the parent stream
+   * untouched for subsequent consumers.
+   *
+   * @param is the parent {@link InputStream} that supplies bytes; must not be {@code null}.
+   * @param count total number of bytes this wrapper will expose before reporting end of stream.
+   * @throws NullPointerException if {@code is} is {@code null}.
+   * @throws IllegalArgumentException if {@code count} is negative.
    */
   public FiniteInputStream(InputStream is, long count) {
     super(is);
@@ -33,7 +63,19 @@ public class FiniteInputStream extends FilterInputStream {
     left = count;
   }
 
-  /** wraps read(byte[],int,int) to read a single byte. */
+  /**
+   * Reads a single byte while honoring the configured byte budget.
+   *
+   * <p>The method delegates to {@link #read(byte[], int, int)} so it inherits the same
+   * end-of-stream and early-EOF semantics. Once the remaining byte count reaches zero, this method
+   * returns {@code -1} immediately. If the parent stream ends prematurely, the propagated {@link
+   * EOFException} surfaces through the declared {@link IOException}.
+   *
+   * @return unsigned byte value in the range {@code 0..255}, or {@code -1} when the quota is
+   *     exhausted.
+   * @throws IOException if an I/O error occurs or the parent stream ends before the quota is met.
+   */
+  @Override
   public int read() throws IOException {
     byte[] b = new byte[1];
     if (read(b, 0, 1) == -1) {
@@ -43,15 +85,26 @@ public class FiniteInputStream extends FilterInputStream {
   }
 
   /**
-   * Read some bytes. This will read no more total bytes from the parent than the count specified in
-   * the constructor.
+   * Reads up to {@code len} bytes into the provided buffer without exceeding the remaining quota.
    *
-   * @return The number of bytes read, or -1 if the specified number of bytes for the
-   *     FiniteInputStream have been read.
-   * @throws EOFException If the parent stream unexpectantly ends before the <code>count</code>
-   *     bytes have been read.
+   * <p>The method truncates the requested length to the current {@code left} value so that callers
+   * never consume more than the advertised finite segment. When no bytes remain, it returns {@code
+   * -1}. If the underlying stream signals end-of-file before the quota is satisfied, an {@link
+   * EOFException} is thrown to highlight the truncated payload. Successful reads decrement the
+   * internal counter by the number of bytes delivered.
+   *
+   * @param b destination buffer that receives the data; must be writable at the specified range.
+   * @param off zero-based offset in {@code b} where bytes are written; must be within bounds.
+   * @param len requested maximum number of bytes to read; values above the remaining quota are
+   *     clamped.
+   * @return number of bytes read into {@code b}, or {@code -1} when the quota reaches zero before
+   *     the call.
+   * @throws EOFException if the parent stream ends before the requested finite section is fully
+   *     consumed.
+   * @throws IOException if an I/O error occurs while reading from the underlying stream.
    */
-  public int read(byte[] b, int off, int len) throws IOException {
+  @Override
+  public int read(byte @NotNull [] b, int off, int len) throws IOException {
     // check the len so that a 0 len returns a 0 result
     if (left == 0 && len > 0) {
       return -1;
@@ -69,12 +122,38 @@ public class FiniteInputStream extends FilterInputStream {
     return c;
   }
 
+  /**
+   * Skips up to {@code n} bytes while decrementing the remaining quota accordingly.
+   *
+   * <p>The skip length is clamped to the number of bytes still available so that the quota is never
+   * exceeded. The returned value reflects the actual number of bytes skipped, which may be smaller
+   * when the parent stream cannot advance as far as requested. The internal counter tracks the
+   * skipped amount exactly, keeping subsequent reads in sync with the finite view.
+   *
+   * @param n maximum number of bytes to skip; negative values are treated as zero by the underlying
+   *     stream.
+   * @return actual number of bytes skipped, never exceeding the remaining quota at call time.
+   * @throws IOException if the underlying stream reports an I/O error during the skip operation.
+   */
+  @Override
   public long skip(long n) throws IOException {
     long result = in.skip(Math.min(n, left));
     left -= result;
     return result;
   }
 
+  /**
+   * Reports the number of bytes that can be read without blocking, bounded by the remaining quota.
+   *
+   * <p>The returned value is the smaller of the parent stream's {@link InputStream#available()}
+   * result and the remaining byte budget, ensuring callers do not assume access beyond the finite
+   * segment. The value may change with subsequent reads or skips and should be treated as an
+   * estimate.
+   *
+   * @return non-negative byte count that can be read immediately, limited by the quota.
+   * @throws IOException if the underlying stream cannot report availability due to an I/O issue.
+   */
+  @Override
   public int available() throws IOException {
     // (int) cast is safe because in.available must be an int and thus
     // smaller than overflow.

--- a/src/test/java/com/onionnetworks/io/FiniteInputStreamTest.java
+++ b/src/test/java/com/onionnetworks/io/FiniteInputStreamTest.java
@@ -1,0 +1,139 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class FiniteInputStreamTest {
+
+  @Test
+  void constructor_whenInputStreamNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, FiniteInputStreamTest::createStreamWithNullParent);
+  }
+
+  @Test
+  void constructor_whenCountNegative_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class, FiniteInputStreamTest::createStreamWithNegativeCount);
+  }
+
+  private static void createStreamWithNullParent() throws IOException {
+    //noinspection EmptyTryBlock
+    try (FiniteInputStream ignored = new FiniteInputStream(null, 1)) {
+      // no-op
+    }
+  }
+
+  private static void createStreamWithNegativeCount() throws IOException {
+    //noinspection EmptyTryBlock
+    try (FiniteInputStream ignored =
+        new FiniteInputStream(new ByteArrayInputStream(new byte[0]), -1)) {
+      // no-op
+    }
+  }
+
+  @Test
+  void read_whenWithinLimit_returnsBytesUntilLimitThenMinusOne() throws IOException {
+    byte[] source = new byte[] {10, 20, 30, 40};
+
+    try (FiniteInputStream stream = new FiniteInputStream(new ByteArrayInputStream(source), 3)) {
+      byte[] buffer = new byte[2];
+
+      int firstRead = stream.read(buffer, 0, buffer.length);
+      assertEquals(2, firstRead);
+      assertArrayEquals(new byte[] {10, 20}, buffer);
+
+      int secondRead = stream.read(buffer, 0, buffer.length);
+      assertEquals(1, secondRead);
+      assertEquals(30, buffer[0]);
+
+      int end = stream.read(buffer, 0, 1);
+      assertEquals(-1, end);
+    }
+  }
+
+  @Test
+  void read_whenUnderlyingEndsEarly_throwsEOFException() throws IOException {
+    byte[] source = new byte[] {1, 2};
+
+    try (FiniteInputStream stream = new FiniteInputStream(new ByteArrayInputStream(source), 3)) {
+      byte[] buffer = new byte[2];
+      int read = stream.read(buffer, 0, buffer.length);
+      assertEquals(2, read);
+
+      assertThrows(EOFException.class, () -> stream.read(new byte[1], 0, 1));
+    }
+  }
+
+  @Test
+  void read_whenCountZero_returnsMinusOneWithoutReadingParent() throws IOException {
+    InputStream parent = mock(InputStream.class);
+
+    try (FiniteInputStream stream = new FiniteInputStream(parent, 0)) {
+      int result = stream.read();
+
+      assertEquals(-1, result);
+      verifyNoInteractions(parent);
+    }
+  }
+
+  @Test
+  void readZeroLength_whenNoBytesLeft_returnsZero() throws IOException {
+    try (FiniteInputStream stream =
+        new FiniteInputStream(new ByteArrayInputStream(new byte[] {5, 6}), 0)) {
+      int result = stream.read(new byte[1], 0, 0);
+
+      assertEquals(0, result);
+    }
+  }
+
+  @Test
+  void skip_whenRequestExceedsRemaining_skipsOnlyRemainingBytes() throws IOException {
+    try (FiniteInputStream stream =
+        new FiniteInputStream(new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5}), 3)) {
+      long skipped = stream.skip(10);
+
+      assertEquals(3L, skipped);
+      assertEquals(-1, stream.read());
+    }
+  }
+
+  @Test
+  void available_afterPartialRead_reflectsRemainingBytes() throws IOException {
+    try (FiniteInputStream stream =
+        new FiniteInputStream(new ByteArrayInputStream(new byte[] {9, 8, 7, 6, 5}), 4)) {
+      int initial = stream.available();
+      assertEquals(4, initial);
+
+      byte[] buffer = new byte[2];
+      int read = stream.read(buffer, 0, buffer.length);
+      assertEquals(2, read);
+
+      int after = stream.available();
+      assertEquals(2, after);
+    }
+  }
+
+  @Test
+  void read_whenSingleByteAvailable_returnsUnsignedByteValue() throws IOException {
+    try (FiniteInputStream stream =
+        new FiniteInputStream(new ByteArrayInputStream(new byte[] {(byte) 0xFF}), 1)) {
+      int value = stream.read();
+      assertEquals(255, value);
+
+      assertEquals(-1, stream.read());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add thorough Javadoc/KDoc-style documentation to FiniteInputStream and enforce null/negative guardrails
- improve skip/available semantics documentation and annotations
- add comprehensive FiniteInputStream tests covering constructor validation, read semantics, skip and available behavior

## Testing
- ./gradlew spotlessApply
- (not run) ./gradlew --parallel test