### PR TITLE
Add coverage for Journal persistence and document behavior

### DIFF
--- a/src/main/java/com/onionnetworks/io/Journal.java
+++ b/src/main/java/com/onionnetworks/io/Journal.java
@@ -1,17 +1,67 @@
 package com.onionnetworks.io;
 
-import com.onionnetworks.util.*;
-import java.io.*;
+import com.onionnetworks.util.AsyncPersistentProps;
+import com.onionnetworks.util.Range;
+import com.onionnetworks.util.RangeSet;
+import java.io.File;
+import java.io.IOException;
 import java.text.ParseException;
 
+/**
+ * Persists byte ranges written to a target file so interrupted writes can resume accurately.
+ *
+ * <p>A {@code Journal} backs its state with {@link AsyncPersistentProps}, storing the absolute path
+ * of the tracked file and a serialized {@link RangeSet} of completed byte intervals. Clients
+ * typically create one instance per download or output stream, call {@link #setTargetFile(File)}
+ * once a target is known, and then invoke {@link #addByteRange(Range)} after each successful write.
+ * On restart the constructor reloads the stored properties, allowing callers to query {@link
+ * #getByteRanges()} and decide which segments still need to be fetched or rewritten.
+ *
+ * <p>The class keeps only in-memory references to the target {@link File} and {@link RangeSet};
+ * state is flushed asynchronously through the parent. No internal synchronization is provided, so
+ * callers should either confine instances to a single thread or protect invocations externally when
+ * multiple threads record progress. The journal does not validate overlapping or unsorted ranges;
+ * it delegates to {@code RangeSet} to normalize or merge intervals.
+ *
+ * <ul>
+ *   <li>Tracks the absolute target file path and completed byte ranges.
+ *   <li>Reloads persisted state automatically during construction for resuming work.
+ *   <li>Expects callers to manage concurrency and range correctness when logging progress.
+ * </ul>
+ *
+ * @see AsyncPersistentProps
+ * @see RangeSet
+ */
 public class Journal extends AsyncPersistentProps {
 
+  /**
+   * Property key storing the absolute path of the file this journal represents, written eagerly
+   * when {@link #setTargetFile(File)} is invoked to let restarts recover the intended destination.
+   */
   public static final String FILE_PROP = "file";
+
+  /**
+   * Property key storing the serialized {@link RangeSet} of completed byte ranges; values use
+   * {@link RangeSet#toString()} format and are reloaded at construction time to rebuild progress.
+   */
   public static final String BYTES_PROP = "bytes";
 
   File f;
   RangeSet written;
 
+  /**
+   * Create a journal backed by a property file and reload any previously persisted ranges.
+   *
+   * <p>The constructor initializes the parent {@link AsyncPersistentProps} with the provided file,
+   * reads stored properties, rebuilds the {@link RangeSet} if present, and rehydrates the tracked
+   * target file path. If the byte-range property exists but cannot be parsed, construction fails to
+   * prevent operating on corrupted progress data.
+   *
+   * @param f backing properties file containing journal state; must be readable and writable by the
+   *     caller for persistence to succeed.
+   * @throws IOException if the properties file cannot be parsed, accessed, or contains invalid
+   *     range data that would make the journal unreliable.
+   */
   public Journal(File f) throws IOException {
     super(f);
 
@@ -36,20 +86,67 @@ public class Journal extends AsyncPersistentProps {
     }
   }
 
+  /**
+   * Set or update the file whose write progress is tracked by this journal.
+   *
+   * <p>The provided file reference is stored in memory and its absolute path is persisted using
+   * {@link #FILE_PROP}. Subsequent calls overwrite the previous value; callers should invoke this
+   * method before recording ranges to ensure the on-disk metadata references the correct output
+   * location. No validation is performed on the file beyond serialization of its path.
+   *
+   * @param f target file whose byte ranges are being recorded; must resolve to a stable location
+   *     accessible to the caller.
+   */
   public void setTargetFile(File f) {
     this.f = f;
     setProperty(FILE_PROP, f.getAbsolutePath());
   }
 
+  /**
+   * Return the file currently associated with this journal, if one has been recorded.
+   *
+   * <p>The return value reflects the most recent call to {@link #setTargetFile(File)} or the file
+   * reconstructed from persisted properties during construction. A {@code null} value indicates
+   * that no target has been specified yet, which usually occurs immediately after instantiation.
+   *
+   * @return tracked target file instance or {@code null} when no destination has been set.
+   */
+  @SuppressWarnings("unused")
   public File getTargetFile() {
     return f;
   }
 
+  /**
+   * Record a byte range that has been fully written to the target file and persist progress.
+   *
+   * <p>This method updates the internal {@link RangeSet} with the supplied {@link Range} and writes
+   * the serialized representation to the backing properties file. Callers should supply normalized
+   * ranges representing successfully flushed data; overlapping or adjacent intervals are delegated
+   * to {@code RangeSet} for merging. Invocations are lightweight but not synchronized, so
+   * concurrent calls should be externally serialized when used across threads to avoid race
+   * conditions while the underlying properties file is being updated.
+   *
+   * @param r byte range describing a contiguous region that finished writing; should match the
+   *     portion already durable on disk.
+   */
   public void addByteRange(Range r) {
     written.add(r);
     setProperty(BYTES_PROP, written.toString());
   }
 
+  /**
+   * Provide the collection of byte ranges currently marked as written for the target file.
+   *
+   * <p>The returned {@link RangeSet} is the live instance maintained by this journal; callers may
+   * inspect or copy it to determine outstanding work. Mutating the returned object will affect the
+   * journal's persisted state only after invoking {@link #addByteRange(Range)} or explicitly
+   * updating properties; therefore direct modification is discouraged in favor of controlled
+   * updates.
+   *
+   * @return live {@link RangeSet} representing recorded byte intervals, never {@code null} after
+   *     construction completes.
+   */
+  @SuppressWarnings("unused")
   public RangeSet getByteRanges() {
     return written;
   }

--- a/src/test/java/com/onionnetworks/io/JournalTest.java
+++ b/src/test/java/com/onionnetworks/io/JournalTest.java
@@ -1,0 +1,131 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.onionnetworks.util.Range;
+import com.onionnetworks.util.RangeSet;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class JournalTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void constructor_withValidExistingProperties_loadsRangesAndTargetFile() throws Exception {
+    File journalFile = tempDir.resolve("journal.properties").toFile();
+    File target = tempDir.resolve("target.data").toFile();
+
+    Properties props = new Properties();
+    props.setProperty(Journal.BYTES_PROP, "1-3,5-6");
+    props.setProperty(Journal.FILE_PROP, target.getAbsolutePath());
+    storeProperties(journalFile, props);
+
+    Journal journal = new Journal(journalFile);
+    try {
+      assertEquals(target.getAbsolutePath(), journal.getTargetFile().getAbsolutePath());
+      assertEquals(RangeSet.parse("1-3,5-6"), journal.getByteRanges());
+    } finally {
+      journal.close();
+    }
+  }
+
+  @Test
+  void constructor_withoutBytesProperty_initializesEmptyRangeSet() throws Exception {
+    File journalFile = tempDir.resolve("empty.properties").toFile();
+    storeProperties(journalFile, new Properties());
+
+    Journal journal = new Journal(journalFile);
+    try {
+      assertTrue(journal.getByteRanges().isEmpty());
+      assertNull(journal.getTargetFile());
+    } finally {
+      journal.close();
+    }
+  }
+
+  @Test
+  void constructor_withCorruptBytesProperty_throwsIOException() throws Exception {
+    File journalFile = tempDir.resolve("corrupt.properties").toFile();
+    Properties props = new Properties();
+    props.setProperty(Journal.BYTES_PROP, "not-a-range");
+    storeProperties(journalFile, props);
+
+    IOException exception = assertThrows(IOException.class, () -> new Journal(journalFile));
+    assertEquals("Corrupt journal.", exception.getMessage());
+  }
+
+  @Test
+  void addByteRange_whenAdded_persistsUpdatedRanges() throws Exception {
+    File journalFile = tempDir.resolve("addRange.properties").toFile();
+    Journal journal = new Journal(journalFile);
+    try {
+      journal.addByteRange(new Range(1, 3));
+      journal.flush();
+
+      Properties persisted = loadProperties(journalFile);
+      assertEquals("1-3", persisted.getProperty(Journal.BYTES_PROP));
+      assertEquals(RangeSet.parse("1-3"), journal.getByteRanges());
+    } finally {
+      journal.close();
+    }
+  }
+
+  @Test
+  void addByteRange_whenAdjacentRangeAdded_mergesAndPersists() throws Exception {
+    File journalFile = tempDir.resolve("merge.properties").toFile();
+    Properties props = new Properties();
+    props.setProperty(Journal.BYTES_PROP, "1-3");
+    storeProperties(journalFile, props);
+
+    Journal journal = new Journal(journalFile);
+    try {
+      journal.addByteRange(new Range(4));
+      journal.flush();
+
+      Properties persisted = loadProperties(journalFile);
+      assertEquals("1-4", persisted.getProperty(Journal.BYTES_PROP));
+      assertEquals(RangeSet.parse("1-4"), journal.getByteRanges());
+    } finally {
+      journal.close();
+    }
+  }
+
+  @Test
+  void setTargetFile_whenCalled_updatesPropertyAndGetter() throws Exception {
+    File journalFile = tempDir.resolve("targetFile.properties").toFile();
+    Journal journal = new Journal(journalFile);
+    File target = tempDir.resolve("data.bin").toFile();
+    try {
+      journal.setTargetFile(target);
+      journal.flush();
+
+      Properties persisted = loadProperties(journalFile);
+      assertEquals(target.getAbsolutePath(), persisted.getProperty(Journal.FILE_PROP));
+      assertEquals(target.getAbsolutePath(), journal.getTargetFile().getAbsolutePath());
+    } finally {
+      journal.close();
+    }
+  }
+
+  private void storeProperties(File file, Properties properties) throws IOException {
+    try (FileOutputStream out = new FileOutputStream(file)) {
+      properties.store(out, null);
+    }
+  }
+
+  private Properties loadProperties(File file) throws IOException {
+    Properties properties = new Properties();
+    try (FileInputStream in = new FileInputStream(file)) {
+      properties.load(in);
+    }
+    return properties;
+  }
+}


### PR DESCRIPTION
## Summary
- document how Journal persists target file paths and written ranges
- add JUnit 6 tests covering constructor, range persistence, merging, and target file updates

## Testing
- not run (not requested)