### PR TITLE
Document RAFInputStream usage and add tests

### DIFF
--- a/src/main/java/com/onionnetworks/io/RAFInputStream.java
+++ b/src/main/java/com/onionnetworks/io/RAFInputStream.java
@@ -1,18 +1,69 @@
 package com.onionnetworks.io;
 
 import java.io.*;
-import java.net.*;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * InputStream view over a seekable {@link RAF} instance.
+ *
+ * <p>This stream adapts a random-access file abstraction to the {@link InputStream} contract so
+ * callers can consume data with familiar streaming methods while the underlying storage remains
+ * addressable by absolute position. It tracks a private cursor (`pos`) that advances only when a
+ * read completes successfully, and it never performs writes or resizes the backing file. The stream
+ * neither owns nor closes the provided {@link RAF}; closing this wrapper simply marks the adapter
+ * unusable so subsequent reads throw {@link EOFException}.
+ *
+ * <p>Typical usage is to hand an already-positioned {@link RAF} to this class and then issue
+ * sequential reads via {@link #read()}, {@link #read(byte[], int, int)}, or {@link #skip(long)}.
+ * The implementation clamps skips so the cursor never moves past the current end of file, making it
+ * safe to use with dynamically growing data where the caller wants a conservative view. Instances
+ * are not thread-safe; callers should synchronize externally if multiple threads might share the
+ * same adapter or its backing {@link RAF}.
+ *
+ * <ul>
+ *   <li>Maintains its own offset without mutating external state on the {@link RAF}.
+ *   <li>Ignores negative skips and treats end-of-file as a hard boundary for cursor movement.
+ *   <li>Delegates all byte retrieval to {@link RAF#seekAndRead(long, byte[], int, int)} to keep the
+ *       cursor consistent with random-access semantics.
+ * </ul>
+ *
+ * @see RAF
+ * @see InputStream
+ */
 public class RAFInputStream extends InputStream {
 
   RAF raf;
   long pos;
 
+  /**
+   * Create a new adapter that reads sequentially from the given random-access file while preserving
+   * the caller-managed file state.
+   *
+   * <p>The supplied {@link RAF} is not closed by this stream, and its existing file pointer or any
+   * external locks are left untouched. The adapter starts reading from offset zero and advances its
+   * internal cursor only after successful reads. Passing {@code null} yields a stream that behaves
+   * as if it were already closed and will raise {@link EOFException} on read attempts.
+   *
+   * @param raf non-null random-access source that provides seek-and-read capabilities; ownership
+   *     and lifecycle remain with the caller.
+   */
   public RAFInputStream(RAF raf) {
     this.raf = raf;
   }
 
-  /** wraps read(byte[],int,int) to read a single byte. */
+  /**
+   * Read a single unsigned byte from the current cursor position.
+   *
+   * <p>This method delegates to {@link #read(byte[], int, int)} with a one-byte buffer, ensuring
+   * the cursor advances by exactly one on success. If the adapter has been closed or the end of
+   * file is reached, it returns {@code -1} without altering the cursor. The returned value is
+   * promoted to an {@code int} in the range {@code 0..255} to match {@link InputStream}
+   * conventions.
+   *
+   * @return next byte as an unsigned integer or {@code -1} when no more data is available or the
+   *     stream has been closed.
+   * @throws IOException if an I/O failure occurs during delegation to the underlying {@link RAF}.
+   */
   public int read() throws IOException {
     byte[] b = new byte[1];
     if (read(b, 0, 1) == -1) {
@@ -21,7 +72,25 @@ public class RAFInputStream extends InputStream {
     return b[0] & 0xFF;
   }
 
-  public int read(byte[] b, int off, int len) throws IOException {
+  /**
+   * Read up to {@code len} bytes into the target buffer starting at {@code off}.
+   *
+   * <p>Data is retrieved by calling {@link RAF#seekAndRead(long, byte[], int, int)} at the current
+   * cursor. When at least one byte is obtained, the cursor advances by the exact count read; when
+   * {@code -1} is returned, the cursor stays unchanged and the caller can treat it as end-of-file.
+   * Negative lengths or offsets are not validated here; callers must supply ranges that fit the
+   * destination array.
+   *
+   * @param b destination array that must be non-null and large enough for {@code off + len} bytes.
+   * @param off zero-based index within {@code b} at which bytes begin to be written.
+   * @param len maximum number of bytes to attempt; zero yields an immediate {@code 0} result.
+   * @return number of bytes copied (may be less than {@code len}) or {@code -1} when no more data
+   *     can be read because the adapter has been closed or the end of file is reached.
+   * @throws EOFException if the adapter has been closed and cannot provide further data.
+   * @throws IOException if the underlying {@link RAF} signals a read failure or range error.
+   */
+  @Override
+  public int read(byte @NotNull [] b, int off, int len) throws IOException {
     if (raf == null) {
       throw new EOFException();
     }
@@ -32,6 +101,20 @@ public class RAFInputStream extends InputStream {
     return c;
   }
 
+  /**
+   * Advance the cursor by at most {@code n} bytes without reading data.
+   *
+   * <p>Skipping is bounded to the current file length so callers never observe the cursor
+   * surpassing the effective end of file. Negative skip requests are ignored and return {@code 0}.
+   * A positive skip that would overshoot the file length is truncated to the number of remaining
+   * bytes, making the operation idempotent at EOF.
+   *
+   * @param n number of bytes to attempt to skip; negative values are treated as zero.
+   * @return actual number of bytes the cursor advanced, never negative and never exceeding
+   *     remaining bytes in the file.
+   * @throws IOException if querying the underlying {@link RAF#length()} fails.
+   */
+  @Override
   public long skip(long n) throws IOException {
     // don't skip if n < 0
     if (n > 0) {
@@ -43,7 +126,19 @@ public class RAFInputStream extends InputStream {
     return 0;
   }
 
-  // This does not close the underlying RAF.
+  /**
+   * Mark this adapter as closed without touching the underlying {@link RAF}.
+   *
+   * <p>Closing sets the internal reference to {@code null}, causing subsequent reads to throw
+   * {@link EOFException} and skips to behave as if end-of-file were reached. The backing {@link
+   * RAF} remains open so callers that own it may continue to use it directly or wrap it again. This
+   * method is idempotent and safe to call multiple times; after the first call it has no additional
+   * effect.
+   *
+   * @throws IOException never thrown by this implementation but retained for {@link InputStream}
+   *     compatibility.
+   */
+  @Override
   public void close() throws IOException {
     raf = null;
   }

--- a/src/test/java/com/onionnetworks/io/RAFInputStreamTest.java
+++ b/src/test/java/com/onionnetworks/io/RAFInputStreamTest.java
@@ -1,0 +1,179 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.EOFException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class RAFInputStreamTest {
+
+  @Test
+  void read_whenDataAvailable_returnsUnsignedByteAndAdvancesPosition() throws Exception {
+    byte[] data = new byte[] {(byte) 0xFF};
+    RAF raf = mock(RAF.class);
+    doAnswer(invocation -> fillFromArray(invocation.getArgument(0), invocation, data))
+        .when(raf)
+        .seekAndRead(anyLong(), any(byte[].class), anyInt(), anyInt());
+
+    RAFInputStream stream = new RAFInputStream(raf);
+
+    int first = stream.read();
+    int second = stream.read();
+
+    assertEquals(255, first);
+    assertEquals(-1, second);
+
+    ArgumentCaptor<Long> positions = ArgumentCaptor.forClass(Long.class);
+    verify(raf, org.mockito.Mockito.times(2))
+        .seekAndRead(positions.capture(), any(byte[].class), anyInt(), anyInt());
+    assertEquals(0L, positions.getAllValues().get(0));
+    assertEquals(1L, positions.getAllValues().get(1));
+    verifyNoMoreInteractions(raf);
+  }
+
+  @Test
+  void read_whenUnderlyingSignalsEof_doesNotAdvancePosition() throws Exception {
+    byte[] data = new byte[] {1, 2};
+    RAF raf = mock(RAF.class);
+    doAnswer(invocation -> fillFromArray(invocation.getArgument(0), invocation, data))
+        .when(raf)
+        .seekAndRead(anyLong(), any(byte[].class), anyInt(), anyInt());
+
+    RAFInputStream stream = new RAFInputStream(raf);
+
+    byte[] buffer = new byte[2];
+    int read = stream.read(buffer, 0, 2);
+    assertEquals(2, read);
+    assertEquals(-1, stream.read(buffer, 0, 1));
+    assertEquals(-1, stream.read(buffer, 0, 1));
+
+    ArgumentCaptor<Long> positions = ArgumentCaptor.forClass(Long.class);
+    verify(raf, org.mockito.Mockito.times(3))
+        .seekAndRead(positions.capture(), any(byte[].class), anyInt(), anyInt());
+    assertEquals(0L, positions.getAllValues().get(0));
+    assertEquals(2L, positions.getAllValues().get(1));
+    assertEquals(2L, positions.getAllValues().get(2));
+    verifyNoMoreInteractions(raf);
+  }
+
+  @Test
+  void read_afterClose_throwsEOFException() throws Exception {
+    RAF raf = mock(RAF.class);
+    RAFInputStream stream = new RAFInputStream(raf);
+
+    stream.close();
+
+    assertThrows(EOFException.class, () -> stream.read(new byte[1], 0, 1));
+    verifyNoMoreInteractions(raf);
+  }
+
+  @Test
+  void skip_whenWithinFileLength_advancesPositionAndReturnsSkippedAmount() throws Exception {
+    RAF raf = mock(RAF.class);
+    doAnswer(
+            invocation -> {
+              byte[] buffer = invocation.getArgument(1);
+              int offset = invocation.getArgument(2);
+              buffer[offset] = 0x01;
+              return 1;
+            })
+        .when(raf)
+        .seekAndRead(anyLong(), any(byte[].class), anyInt(), anyInt());
+    doAnswer(invocation -> 10L).when(raf).length();
+
+    RAFInputStream stream = new RAFInputStream(raf);
+
+    long firstSkip = stream.skip(4);
+    long secondSkip = stream.skip(3);
+    int value = stream.read();
+
+    assertEquals(4L, firstSkip);
+    assertEquals(3L, secondSkip);
+    assertEquals(1, value);
+
+    ArgumentCaptor<Long> positions = ArgumentCaptor.forClass(Long.class);
+    verify(raf, org.mockito.Mockito.times(2)).length();
+    verify(raf).seekAndRead(positions.capture(), any(byte[].class), anyInt(), anyInt());
+    assertEquals(7L, positions.getValue());
+    verifyNoMoreInteractions(raf);
+  }
+
+  @Test
+  void skip_whenRequestExceedsFileLength_clampsToRemainingBytes() throws Exception {
+    RAF raf = mock(RAF.class);
+    org.mockito.Mockito.when(raf.length()).thenReturn(5L);
+    doAnswer(invocation -> -1)
+        .when(raf)
+        .seekAndRead(anyLong(), any(byte[].class), anyInt(), anyInt());
+
+    RAFInputStream stream = new RAFInputStream(raf);
+
+    long skipped = stream.skip(10);
+    long skippedAgain = stream.skip(1);
+    int result = stream.read();
+
+    assertEquals(5L, skipped);
+    assertEquals(0L, skippedAgain);
+    assertEquals(-1, result);
+
+    ArgumentCaptor<Long> positions = ArgumentCaptor.forClass(Long.class);
+    verify(raf, org.mockito.Mockito.times(2)).length();
+    verify(raf).seekAndRead(positions.capture(), any(byte[].class), anyInt(), anyInt());
+    assertEquals(5L, positions.getValue());
+    verifyNoMoreInteractions(raf);
+  }
+
+  @Test
+  void skip_whenNegative_doesNotChangePosition() throws Exception {
+    RAF raf = mock(RAF.class);
+    doAnswer(
+            invocation -> {
+              byte[] buffer = invocation.getArgument(1);
+              int offset = invocation.getArgument(2);
+              buffer[offset] = 0x01;
+              return 1;
+            })
+        .when(raf)
+        .seekAndRead(anyLong(), any(byte[].class), anyInt(), anyInt());
+
+    RAFInputStream stream = new RAFInputStream(raf);
+
+    //noinspection ConstantValue
+    long skipped = stream.skip(-3);
+    int value = stream.read();
+
+    assertEquals(0L, skipped);
+    assertEquals(1, value);
+
+    ArgumentCaptor<Long> positions = ArgumentCaptor.forClass(Long.class);
+    verify(raf).seekAndRead(positions.capture(), any(byte[].class), anyInt(), anyInt());
+    assertEquals(0L, positions.getValue());
+    verifyNoMoreInteractions(raf);
+  }
+
+  private Object fillFromArray(
+      long requestedPos, org.mockito.invocation.InvocationOnMock inv, byte[] data) {
+    byte[] buffer = inv.getArgument(1);
+    int offset = inv.getArgument(2);
+    int length = inv.getArgument(3);
+    if (requestedPos >= data.length) {
+      return -1;
+    }
+    int toRead = Math.min(length, data.length - (int) requestedPos);
+    System.arraycopy(data, (int) requestedPos, buffer, offset, toRead);
+    return toRead;
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed KDoc for RAFInputStream to clarify cursor semantics and ownership
- annotate read/skip/close overrides and improve null handling with explicit EOFException behavior
- add focused RAFInputStream tests covering read, eof handling, skip clamping, and closing

## Testing
- not run (docs/tests-only change)
