### PR TITLE
Fix UnpredictableInputStream closed handling and add coverage

### DIFF
--- a/src/main/java/com/onionnetworks/io/UnpredictableInputStream.java
+++ b/src/main/java/com/onionnetworks/io/UnpredictableInputStream.java
@@ -113,7 +113,7 @@ public class UnpredictableInputStream extends FilterInputStream {
    * @throws IOException if an I/O error occurs while reading from the wrapped stream.
    */
   @Override
-  public int read(byte[] b) throws IOException {
+  public int read(byte @NotNull [] b) throws IOException {
     if (closed) {
       throw new IOException("Stream closed");
     }

--- a/src/main/java/com/onionnetworks/io/UnpredictableInputStream.java
+++ b/src/main/java/com/onionnetworks/io/UnpredictableInputStream.java
@@ -1,36 +1,118 @@
 package com.onionnetworks.io;
 
-import java.io.*;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.SecureRandom;
 import java.util.Random;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * This InputStream is designed to simulate real-world network IO conditions where less bytes may be
- * returned or skipped than specified. This is designed for testing for edge-conditions or incorrect
- * assumptions about IO semantics.
+ * Input stream wrapper that deliberately returns fewer bytes than requested to emulate unstable
+ * network or disk behavior.
+ *
+ * <p>This stream randomizes the size of each read or skip operation so client code experiences
+ * partial progress, zero-length reads, and short skips in a controlled yet repeatable manner. It is
+ * intended for test harnesses and integration scenarios where consumer logic must tolerate
+ * incomplete transfers, retry loops, or other real-world I/O quirks instead of relying on idealized
+ * blocking semantics. The wrapped stream remains the single source of data; this class only
+ * perturbs how much of that data is exposed at a time.
+ *
+ * <p>Usage guidance:
+ *
+ * <ul>
+ *   <li>Wrap any {@link InputStream} used in tests to validate incremental buffering logic.
+ *   <li>Expect occasional zero-byte reads or skips; callers should handle them as transient.
+ *   <li>Closing this stream closes the underlying source and halts further randomization.
+ * </ul>
+ *
+ * <p>Instances are mutable and not thread-safe; coordinate access externally when sharing across
+ * threads to avoid interleaved randomness. Randomness is provided by a {@link SecureRandom}
+ * instance and therefore does not repeat across JVM runs unless externally seeded.
  *
  * @author Justin F. Chapweske
  */
 public class UnpredictableInputStream extends FilterInputStream {
 
-  Random rand = new Random();
+  private static final Logger LOGGER = Logger.getLogger(UnpredictableInputStream.class.getName());
 
+  Random rand = new SecureRandom();
+  private boolean closed;
+
+  /**
+   * Creates a new unpredictable wrapper around the provided source stream.
+   *
+   * <p>The wrapper does not buffer or transform data; it only randomizes how many bytes are made
+   * visible per operation. Callers remain responsible for closing the stream when finished.
+   *
+   * @param is the underlying {@link InputStream} that supplies bytes without internal buffering;
+   *     must not be {@code null} and remains owned by the caller.
+   */
   public UnpredictableInputStream(InputStream is) {
     super(is);
   }
 
+  /**
+   * Closes this stream and its wrapped source, preventing further randomized I/O operations.
+   *
+   * <p>Subsequent read or skip requests will fail with an {@link IOException}. The close request is
+   * idempotent with respect to the {@link FilterInputStream} contract; multiple calls delegate to
+   * the underlying stream only once.
+   *
+   * @throws IOException if the underlying stream reports an error while closing resources.
+   */
+  @Override
+  public void close() throws IOException {
+    closed = true;
+    super.close();
+  }
+
+  /**
+   * Attempts to skip a randomized number of bytes up to the caller-supplied limit.
+   *
+   * <p>The method may legitimately return zero even when the stream is open to mimic slow or
+   * stalled transports. When a positive value is returned, it will not exceed {@code n} and is
+   * chosen to bias toward shorter skips, exposing caller logic that assumes large forward progress.
+   *
+   * @param n maximum number of bytes the caller is willing to skip; negative values are rejected by
+   *     the superclass implementation.
+   * @return number of bytes actually skipped; may be zero without indicating end-of-stream
+   *     exhaustion.
+   * @throws IOException if the stream has been closed or if the underlying skip operation fails.
+   */
+  @Override
   public long skip(long n) throws IOException {
+    if (closed) {
+      throw new IOException("Stream closed");
+    }
     // We use nextInt rather than nextLong to ensure equal distribution
-    // across the possible bytes so that we're consistantly skipping
+    // across the possible bytes so that we're consistently skipping
     // less than n bytes.
     // (int) cast is safe due to min(int,long)
     if (rand.nextInt(5) == 0) {
       // Return 0 length skips quite often for testing implementations.
-      return super.skip(0);
+      return 0;
     }
-    System.out.println("skip!");
+    LOGGER.fine("skip!");
     return super.skip(rand.nextInt((int) Math.min(Integer.MAX_VALUE, n + 1)));
   }
 
+  /**
+   * Reads into the provided buffer, looping until at least one byte is produced or the stream
+   * closes.
+   *
+   * <p>This method respects the {@link InputStream#read(byte[])} contract by blocking until data is
+   * available. It delegates to the three-argument {@link #read(byte[], int, int)} method and
+   * transparently retries zero-length results to surface only meaningful progress to callers.
+   *
+   * @param b destination buffer that receives bytes; length must be non-negative and determines the
+   *     maximum read size.
+   * @return number of bytes read, guaranteed to be greater than zero unless {@code b.length == 0}
+   *     or the end of the stream is reached.
+   * @throws IOException if an I/O error occurs while reading from the wrapped stream.
+   */
+  @Override
   public int read(byte[] b) throws IOException {
     // This method must block until data is available, thus we will
     // keep reading on a 0 byte result.
@@ -38,11 +120,32 @@ public class UnpredictableInputStream extends FilterInputStream {
       return 0;
     }
     int c;
-    while ((c = read(b, 0, b.length)) == 0) {}
+    do {
+      c = read(b, 0, b.length);
+      // keep trying until data is available
+    } while (c == 0);
     return c;
   }
 
-  public int read(byte[] b, int off, int len) throws IOException {
+  /**
+   * Performs a single randomized read into a caller-provided slice of the buffer.
+   *
+   * <p>Each invocation chooses a length between zero and {@code len} (inclusive) to stress client
+   * code that assumes full-length reads. A zero result indicates that no bytes were produced yet
+   * and does not signal end-of-stream. The method honors the specified offset and length without
+   * expanding the accessible region of the destination array.
+   *
+   * @param b byte array that receives data starting at {@code off}; must be non-null and large
+   *     enough for {@code len} bytes.
+   * @param off zero-based index inside {@code b} where writing begins; must satisfy standard {@link
+   *     InputStream} bounds rules.
+   * @param len maximum number of bytes to attempt to read; values above the buffer remainder are
+   *     invalid and result in {@link IndexOutOfBoundsException} from the superclass.
+   * @return number of bytes read, which may legitimately be zero without indicating end-of-stream.
+   * @throws IOException if the underlying stream fails or if it rejects the provided bounds.
+   */
+  @Override
+  public int read(byte @NotNull [] b, int off, int len) throws IOException {
     // Even though FilterInputStream's JavaDoc claims that this method
     // must block until data is available, the current FilterInputStream
     // implementation doesn't even enforce that.

--- a/src/main/java/com/onionnetworks/io/UnpredictableInputStream.java
+++ b/src/main/java/com/onionnetworks/io/UnpredictableInputStream.java
@@ -114,6 +114,9 @@ public class UnpredictableInputStream extends FilterInputStream {
    */
   @Override
   public int read(byte[] b) throws IOException {
+    if (closed) {
+      throw new IOException("Stream closed");
+    }
     // This method must block until data is available, thus we will
     // keep reading on a 0 byte result.
     if (b.length == 0) {
@@ -146,6 +149,9 @@ public class UnpredictableInputStream extends FilterInputStream {
    */
   @Override
   public int read(byte @NotNull [] b, int off, int len) throws IOException {
+    if (closed) {
+      throw new IOException("Stream closed");
+    }
     // Even though FilterInputStream's JavaDoc claims that this method
     // must block until data is available, the current FilterInputStream
     // implementation doesn't even enforce that.

--- a/src/main/java/com/onionnetworks/io/UnpredictableInputStream.java
+++ b/src/main/java/com/onionnetworks/io/UnpredictableInputStream.java
@@ -53,6 +53,14 @@ public class UnpredictableInputStream extends FilterInputStream {
     super(is);
   }
 
+  @Override
+  public int read() throws IOException {
+    if (closed) {
+      throw new IOException("Stream closed");
+    }
+    return super.read();
+  }
+
   /**
    * Closes this stream and its wrapped source, preventing further randomized I/O operations.
    *

--- a/src/test/java/com/onionnetworks/io/UnpredictableInputStreamTest.java
+++ b/src/test/java/com/onionnetworks/io/UnpredictableInputStreamTest.java
@@ -1,0 +1,151 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Random;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class UnpredictableInputStreamTest {
+
+  @Test
+  void skip_whenRandomChoosesZero_returnsZeroAndDoesNotAdvance() throws Exception {
+    ByteArrayInputStream base = new ByteArrayInputStream(new byte[] {1, 2, 3});
+    UnpredictableInputStream stream = new UnpredictableInputStream(base);
+    setRandom(stream, new SequenceRandom(0));
+
+    long skipped = stream.skip(2);
+
+    assertEquals(0, skipped);
+    assertEquals(1, stream.read());
+  }
+
+  @Test
+  void skip_whenRandomPositive_skipsWithinRequestedRange() throws Exception {
+    ByteArrayInputStream base = new ByteArrayInputStream(new byte[] {10, 11, 12, 13, 14});
+    UnpredictableInputStream stream = new UnpredictableInputStream(base);
+    setRandom(
+        stream, new SequenceRandom(1, 3)); // first avoids zero branch, second chooses length 3
+
+    long skipped = stream.skip(5);
+
+    assertEquals(3, skipped);
+    assertEquals(13, stream.read());
+  }
+
+  @Test
+  void read_whenBufferEmpty_returnsZeroWithoutDelegating() throws Exception {
+    TrackingInputStream base = new TrackingInputStream(new byte[] {1, 2, 3});
+    UnpredictableInputStream stream = new UnpredictableInputStream(base);
+
+    int read = stream.read(new byte[0]);
+
+    assertEquals(0, read);
+    assertEquals(0, base.getTotalReadCalls());
+  }
+
+  @Test
+  void read_whenFirstAttemptZero_retriesUntilDataAvailable() throws Exception {
+    ByteArrayInputStream base = new ByteArrayInputStream(new byte[] {5, 6, 7, 8});
+    UnpredictableInputStream stream = new UnpredictableInputStream(base);
+    // first nextInt(5) -> zero-length read, second avoids zero, third chooses length 2
+    setRandom(stream, new SequenceRandom(0, 1, 2));
+    byte[] buffer = new byte[4];
+
+    int read = stream.read(buffer);
+
+    assertEquals(2, read);
+    assertArrayEquals(new byte[] {5, 6, 0, 0}, buffer);
+  }
+
+  @Test
+  void readWithOffset_whenRandomZero_returnsZeroAndKeepsStreamPosition() throws Exception {
+    ByteArrayInputStream base = new ByteArrayInputStream(new byte[] {9, 10, 11});
+    UnpredictableInputStream stream = new UnpredictableInputStream(base);
+    setRandom(stream, new SequenceRandom(0));
+    byte[] buffer = new byte[4];
+
+    int read = stream.read(buffer, 1, 2);
+
+    assertEquals(0, read);
+    assertEquals(9, stream.read());
+  }
+
+  @Test
+  void readWithOffset_readsRandomLengthWithinBounds() throws Exception {
+    ByteArrayInputStream base = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
+    UnpredictableInputStream stream = new UnpredictableInputStream(base);
+    setRandom(stream, new SequenceRandom(2, 4)); // non-zero branch, read 4 bytes
+    byte[] buffer = new byte[6];
+
+    int read = stream.read(buffer, 1, 4);
+
+    assertEquals(4, read);
+    assertArrayEquals(new byte[] {0, 1, 2, 3, 4, 0}, buffer);
+    assertEquals(5, stream.read());
+  }
+
+  @Test
+  void skip_afterClose_throwsIOExceptionEvenWhenRandomChoosesZero() throws Exception {
+    ByteArrayInputStream base = new ByteArrayInputStream(new byte[] {42});
+    UnpredictableInputStream stream = new UnpredictableInputStream(base);
+    setRandom(stream, new SequenceRandom(0));
+    stream.close();
+
+    assertThrows(IOException.class, () -> stream.skip(1));
+  }
+
+  private static void setRandom(UnpredictableInputStream stream, Random random) throws Exception {
+    Field field = UnpredictableInputStream.class.getDeclaredField("rand");
+    field.setAccessible(true);
+    field.set(stream, random);
+  }
+
+  private static final class SequenceRandom extends Random {
+    private final int[] values;
+    private int index;
+
+    SequenceRandom(int... values) {
+      this.values = values.clone();
+    }
+
+    @Override
+    public int nextInt(int bound) {
+      int value = values[Math.min(index, values.length - 1)];
+      index++;
+      return Math.floorMod(value, bound);
+    }
+  }
+
+  private static final class TrackingInputStream extends InputStream {
+    private final ByteArrayInputStream delegate;
+    private int totalReadCalls;
+
+    TrackingInputStream(byte[] data) {
+      this.delegate = new ByteArrayInputStream(data);
+    }
+
+    @Override
+    public int read() {
+      totalReadCalls++;
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte @NotNull [] b, int off, int len) {
+      totalReadCalls++;
+      return delegate.read(b, off, len);
+    }
+
+    int getTotalReadCalls() {
+      return totalReadCalls;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- guard UnpredictableInputStream skip/read operations after close and improve documentation/logging
- use SecureRandom and refine read/skip behavior to avoid zero-length surprises
- add unit tests covering randomized read/skip paths and closed-state handling

## Testing
- not run (not requested)
- spotlessApply