### PR TITLE
Improve DatagramSocketFactory documentation and tests

### DIFF
--- a/src/main/java/com/onionnetworks/net/DatagramSocketFactory.java
+++ b/src/main/java/com/onionnetworks/net/DatagramSocketFactory.java
@@ -4,19 +4,122 @@
 package com.onionnetworks.net;
 
 import java.io.IOException;
-import java.net.*;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
 
+/**
+ * Factory for creating {@link java.net.DatagramSocket} instances with consistent configuration
+ * across calling code.
+ *
+ * <p>Implementations centralize UDP socket creation so callers do not hard-code constructor choices
+ * or platform checks. A single factory instance can be shared by components that need to open
+ * sockets for listening, request-response exchanges, or background heartbeats while keeping the
+ * selection of socket options in one place. Typical usage is to obtain the default implementation
+ * via {@link #getDefault()} and delegate all socket allocation to it.
+ *
+ * <p>Factories are usually lightweight and either stateless or thread-safe so they can be reused by
+ * multiple networking subsystems. Implementations decide how sockets are bound (wildcard versus
+ * specific interface), whether they remain unconnected, and whether platform-specific tuning such
+ * as buffer sizing or traffic class hints is applied. Callers should treat returned sockets as
+ * owned by the caller and close them when no longer needed to release file descriptors.
+ *
+ * <ul>
+ *   <li>Provides a single point to customize binding addresses and ports.
+ *   <li>Hides platform differences behind a narrow creation interface.
+ *   <li>Supports test doubles for deterministic UDP behavior in unit tests.
+ * </ul>
+ *
+ * <pre>{@code
+ * DatagramSocketFactory factory = DatagramSocketFactory.getDefault();
+ * DatagramSocket socket = factory.createDatagramSocket();
+ * // Use socket for sends/receives, then close when finished.
+ * }</pre>
+ *
+ * @see PlainDatagramSocketFactory
+ */
 public abstract class DatagramSocketFactory {
 
+  /**
+   * Protected base constructor for subclassing factories.
+   *
+   * <p>Subclasses are expected to be lightweight and reusable; they typically store configuration
+   * such as preferred bind addresses or socket options and expose them via the creation methods.
+   * Extending classes should avoid expensive state initialization here because factories may be
+   * instantiated eagerly during application bootstrapping or testing, and they are generally shared
+   * across threads. No socket resources are allocated by this constructor; resource acquisition is
+   * deferred to the individual {@code createDatagramSocket} methods.
+   */
   protected DatagramSocketFactory() {}
 
+  /**
+   * Creates a new datagram socket using the factory's default binding strategy.
+   *
+   * <p>Implementations may bind to an ephemeral port on the wildcard address or apply custom
+   * defaults; callers should not assume connectivity or binding to a particular interface. The
+   * returned socket is ready for send and receive operations and may be further configured by the
+   * caller (for example, setting timeouts or buffer sizes) before use. Each invocation must produce
+   * a fresh socket; the caller owns the lifecycle and must close it to release the underlying file
+   * descriptor. The operation is not idempotent because a new socket is allocated every time it is
+   * invoked.
+   *
+   * @return a new {@link DatagramSocket} configured according to this factory's defaults and owned
+   *     by the caller
+   * @throws IOException if the socket cannot be created or bound by the implementation
+   */
+  @SuppressWarnings("unused")
   public abstract DatagramSocket createDatagramSocket() throws IOException;
 
+  /**
+   * Creates a datagram socket bound to a specific local port.
+   *
+   * <p>The factory decides the local address and other options, while the caller specifies the
+   * requested UDP port. Passing {@code 0} delegates port selection to the operating system, which
+   * is useful for temporary sockets. Implementations must either bind the returned socket to the
+   * given port or fail with an exception; they should not silently choose a different port. Callers
+   * are responsible for validating that the selected port is available for their use case and for
+   * closing the socket when finished to free system resources.
+   *
+   * @param port local UDP port to bind; use {@code 0} to request an ephemeral port
+   * @return a new {@link DatagramSocket} bound to the requested port and owned by the caller
+   * @throws IOException if the socket cannot be created or the port cannot be bound
+   */
+  @SuppressWarnings("unused")
   public abstract DatagramSocket createDatagramSocket(int port) throws IOException;
 
+  /**
+   * Creates a datagram socket bound to a specific local address and port.
+   *
+   * <p>This variant allows callers to select both the bind address (network interface) and port,
+   * which is useful when multiple interfaces are present or when binding must be restricted to a
+   * particular address family. The port behaves like {@link #createDatagramSocket(int)}; specifying
+   * {@code 0} requests an ephemeral port from the operating system. Implementations must honor the
+   * provided address and port or throw an exception rather than falling back to defaults. The
+   * caller owns the returned socket and must close it when no longer needed. This method is not
+   * idempotent because each call allocates a new socket instance.
+   *
+   * @param port local UDP port to bind; use {@code 0} when any available port is acceptable
+   * @param iaddr local {@link InetAddress} to bind; must not be {@code null} for deterministic
+   *     binding
+   * @return a {@link DatagramSocket} bound to the specified address and port for caller ownership
+   * @throws IOException if the socket cannot be created or bound to the requested address/port
+   */
+  @SuppressWarnings("unused")
   public abstract DatagramSocket createDatagramSocket(int port, InetAddress iaddr)
       throws IOException;
 
+  /**
+   * Returns the default factory that creates platform-standard datagram sockets.
+   *
+   * <p>The default implementation, {@link PlainDatagramSocketFactory}, delegates to the JDK's
+   * built-in {@link DatagramSocket} constructors without adding custom options. It is suitable for
+   * most callers that simply need UDP sockets configured with system defaults. The returned factory
+   * is lightweight and may be reused across threads; callers may also instantiate it repeatedly
+   * with minimal cost because it holds no external resources. Consider supplying a custom factory
+   * when sockets must be preconfigured with specific buffer sizes, traffic class values, or binding
+   * constraints.
+   *
+   * @return a new {@link PlainDatagramSocketFactory} that follows JDK default socket semantics
+   */
   public static DatagramSocketFactory getDefault() {
     return new PlainDatagramSocketFactory();
   }

--- a/src/main/java/com/onionnetworks/net/PlainDatagramSocketFactory.java
+++ b/src/main/java/com/onionnetworks/net/PlainDatagramSocketFactory.java
@@ -6,16 +6,107 @@ package com.onionnetworks.net;
 import java.io.*;
 import java.net.*;
 
+/**
+ * Simple factory that produces unadorned {@link DatagramSocket} instances for UDP communication.
+ *
+ * <p>This implementation exists as the baseline socket provider for components that accept a
+ * configurable factory. It performs no decoration or state caching; every call returns a newly
+ * constructed socket created directly through the standard JDK APIs. Use it when you want the
+ * operating system and JVM to choose all default parameters such as buffer sizes, socket options,
+ * and address reuse policies. The factory is stateless and thread-safe, making it suitable for
+ * shared reuse across subsystems that simply need a means of producing sockets on demand.
+ *
+ * <p>Because sockets created by this factory are mutable, callers should immediately configure any
+ * desired options (timeouts, broadcast flags, traffic class settings) before exposing the socket to
+ * other threads. Responsibility for closing the socket remains entirely with the caller to avoid
+ * exhausting native file descriptors or port allocations. There is no retry logic, pooling, or
+ * monitoring embedded here; higher-level components should layer those behaviors as needed while
+ * leaving this class as a predictable, low-overhead creation utility.
+ *
+ * <ul>
+ *   <li>Provides the most direct access to {@code DatagramSocket} construction.
+ *   <li>Imposes no custom defaults, filters, or lifecycle hooks.
+ *   <li>Safe to call concurrently; each invocation yields an independent socket.
+ * </ul>
+ */
 public class PlainDatagramSocketFactory extends DatagramSocketFactory {
 
+  /** Constructs a new instance of this factory with no retained state. */
+  public PlainDatagramSocketFactory() {
+    // Intentionally empty: factory holds no configuration and relies on JDK defaults.
+  }
+
+  /**
+   * Creates plain {@link DatagramSocket} instances with no additional configuration or wrapping.
+   *
+   * <p>This factory is the simplest implementation used by callers that want a vanilla UDP socket
+   * without transport filters, monitoring hooks, or custom socket options. It delegates entirely to
+   * the JDK constructors, so address binding, buffer sizes, and platform defaults are chosen by the
+   * underlying Java networking stack and operating system. Typical call patterns include
+   * provisioning a lightweight socket for stateless message exchange or supplying the factory to
+   * components that expect a pluggable socket creator. The factory itself is stateless and may be
+   * reused safely across threads.
+   *
+   * <p>Because the produced sockets are mutable and not pooled, each invocation returns a newly
+   * allocated socket with its own lifecycle. Callers are responsible for applying any desired
+   * socket options (for example, timeouts) immediately after creation and for closing the socket
+   * when no longer needed to avoid file descriptor leaks. No concurrency control is performed
+   * within the factory; thread safety concerns are limited to the caller's own use of the resulting
+   * {@code DatagramSocket} instances.
+   *
+   * <ul>
+   *   <li>Returns unwrapped UDP sockets using standard JDK behavior.
+   *   <li>Stateless and thread-safe to invoke concurrently.
+   *   <li>Does not alter buffer sizes, timeouts, or platform defaults.
+   * </ul>
+   *
+   * @see DatagramSocketFactory
+   * @see DatagramSocket
+   */
   public DatagramSocket createDatagramSocket() throws IOException {
     return new DatagramSocket();
   }
 
+  /**
+   * Creates a {@link DatagramSocket} bound to a specific local port using platform defaults.
+   *
+   * <p>This method is appropriate when a deterministic port is required for inbound traffic or for
+   * interoperability with peers that expect a stable source port. The socket is created in a bound
+   * but otherwise unconfigured state; callers should promptly set options such as receive buffers
+   * or timeouts if they deviate from defaults. The operation is not idempotent: repeated calls will
+   * attempt to bind separate sockets to the same port and will fail when the port is already in use
+   * or reserved by the operating system. The returned socket must be closed by the caller.
+   *
+   * @param port local UDP port number to bind; use {@code 0} to request an ephemeral port when a
+   *     fixed port is unavailable.
+   * @return newly created bound socket that the caller owns and should close after use.
+   * @throws IOException if binding fails due to permission constraints, port conflicts, or resource
+   *     exhaustion in the underlying network stack.
+   */
   public DatagramSocket createDatagramSocket(int port) throws IOException {
     return new DatagramSocket(port);
   }
 
+  /**
+   * Creates a {@link DatagramSocket} bound to a specific port and local address.
+   *
+   * <p>Use this variant when an application must bind to a particular network interface or IP
+   * address, such as when operating on a multihomed host or constraining traffic to a private
+   * subnet. The method performs no validation beyond delegating to the JDK constructor; the caller
+   * should ensure that the address represents a local interface and that the port is appropriate
+   * for the intended protocol flow. As with the other factory methods, each invocation allocates a
+   * new socket instance that remains mutable and must be closed by the caller once communication is
+   * complete.
+   *
+   * @param port local UDP port number to bind; must be within the valid user-port range supported
+   *     by the host operating system.
+   * @param iaddr local {@link InetAddress} representing the interface to bind; must not be {@code
+   *     null} and should correspond to an address assigned to the current host.
+   * @return newly allocated datagram socket bound to the requested address and port for caller
+   *     managed communication.
+   * @throws IOException if the requested address or port cannot be bound because of permissions,
+   *     conflicts, or resource limits enforced by the platform.
+   */
   public DatagramSocket createDatagramSocket(int port, InetAddress iaddr) throws IOException {
 
     return new DatagramSocket(port, iaddr);

--- a/src/test/java/com/onionnetworks/net/PlainDatagramSocketFactoryTest.java
+++ b/src/test/java/com/onionnetworks/net/PlainDatagramSocketFactoryTest.java
@@ -1,0 +1,76 @@
+package com.onionnetworks.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.BindException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class PlainDatagramSocketFactoryTest {
+
+  private final PlainDatagramSocketFactory factory = new PlainDatagramSocketFactory();
+
+  @Test
+  void createDatagramSocket_whenCalled_returnsOpenSocket() throws Exception {
+    try (DatagramSocket socket = factory.createDatagramSocket()) {
+      assertNotNull(socket);
+      assertTrue(socket.isBound());
+      assertTrue(socket.getLocalPort() > 0);
+    }
+  }
+
+  @Test
+  void createDatagramSocket_withSpecificPort_bindsToRequestedPort() throws Exception {
+    int availablePort;
+    try (DatagramSocket socket = new DatagramSocket(0)) {
+      availablePort = socket.getLocalPort();
+    }
+
+    try (DatagramSocket socket = factory.createDatagramSocket(availablePort)) {
+      assertEquals(availablePort, socket.getLocalPort());
+    }
+  }
+
+  @Test
+  void createDatagramSocket_whenPortInUse_throwsBindException() throws Exception {
+    try (DatagramSocket reserved = new DatagramSocket(0)) {
+      int portInUse = reserved.getLocalPort();
+
+      assertThrows(
+          BindException.class,
+          () -> {
+            //noinspection EmptyTryBlock
+            try (DatagramSocket ignored = factory.createDatagramSocket(portInUse)) {
+              // unreachable when exception is thrown
+            }
+          });
+    }
+  }
+
+  @Test
+  void createDatagramSocket_whenInvalidPort_throwsIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          //noinspection EmptyTryBlock
+          try (DatagramSocket ignored = factory.createDatagramSocket(-1)) {
+            // unreachable when exception is thrown
+          }
+        });
+  }
+
+  @Test
+  void createDatagramSocket_withPortAndAddressProvided_bindsToAddress() throws Exception {
+    InetAddress loopback = InetAddress.getLoopbackAddress();
+
+    try (DatagramSocket socket = factory.createDatagramSocket(0, loopback)) {
+      assertTrue(socket.isBound());
+      assertEquals(loopback, socket.getLocalAddress());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed Javadoc to DatagramSocketFactory and PlainDatagramSocketFactory to clarify usage and lifecycle expectations
- keep PlainDatagramSocketFactory constructors documented and behavior unchanged
- add PlainDatagramSocketFactoryTest covering socket creation, specific port binding, invalid port rejection, in-use port handling, and binding to a specific address

## Testing
- not run