### PR TITLE
docs: clarify ExceptionEvent behavior

### DIFF
--- a/src/main/java/com/onionnetworks/util/ExceptionEvent.java
+++ b/src/main/java/com/onionnetworks/util/ExceptionEvent.java
@@ -3,19 +3,57 @@ package com.onionnetworks.util;
 import java.util.EventObject;
 
 /**
- * This class encapsulates an Exception and a Source to be dispatched through the ExceptionHandler
- * class.
+ * Carries a {@link Throwable} captured by a component together with the source object that raised
+ * it so that listeners can react uniformly through an {@code ExceptionHandler} pipeline.
+ *
+ * <p>This event is created as soon as an exception needs to be propagated outside the immediate
+ * call site, keeping both the originating object (the {@code source}) and the original throwable
+ * instance intact. Consumers typically enqueue or broadcast the event rather than throwing it
+ * directly, allowing logging, user notification, or recovery workflows to be centralized. The class
+ * is deliberately lightweight: it stores only the given source and exception reference and performs
+ * no copying or wrapping, which means the lifecycle of the contained exception is managed entirely
+ * by the caller. Instances are immutable after construction and are safe to share across threads
+ * provided the referenced throwable itself is treated as immutable.
+ *
+ * <ul>
+ *   <li>Encapsulates exception details without altering stack traces or causes.
+ *   <li>Maintains the original event source to aid routing and diagnostics.
+ *   <li>Designed for asynchronous dispatch or observer-style handlers.
+ * </ul>
  *
  * @author Justin Chapweske
  */
 public class ExceptionEvent extends EventObject {
 
+  /**
+   * The original throwable instance associated with this event; stored exactly as supplied so
+   * handlers can inspect or rethrow it without losing stack trace or suppressed exception details.
+   */
   Throwable t;
 
   /**
-   * @param source The source of the event. This should probably be the object that caught the
-   *     exception.
-   * @param t The Throwable that is being fired.
+   * Creates a new event that binds the given source object to the supplied throwable for later
+   * dispatch to exception listeners.
+   *
+   * <p>The constructor performs no validation or wrapping; callers are expected to pass a source
+   * that meaningfully identifies the context where the failure originated. This makes it possible
+   * for downstream handlers to group, filter, or route events by subsystem while still having
+   * access to the complete throwable for logging or rethrowing. The same throwable reference is
+   * retained, so any additional suppression or detail messages added later will be visible to
+   * handlers that consume the event.
+   *
+   * <pre>{@code
+   * try {
+   *   service.execute();
+   * } catch (Throwable ex) {
+   *   dispatcher.fire(new ExceptionEvent(this, ex));
+   * }
+   * }</pre>
+   *
+   * @param source the object that observed or caught the exception; never {@code null} when used
+   *     with {@link EventObject} listeners.
+   * @param t the throwable being propagated; may be any checked or unchecked failure instance
+   *     produced by the source.
    */
   public ExceptionEvent(Object source, Throwable t) {
     super(source);
@@ -23,7 +61,16 @@ public class ExceptionEvent extends EventObject {
   }
 
   /**
-   * @return The Throwable being dispatched.
+   * Returns the throwable instance that this event carries for downstream handling.
+   *
+   * <p>The returned reference is the exact object supplied at construction time, allowing callers
+   * to inspect stack traces, causes, or custom fields without serialization or copying overhead.
+   * Callers should avoid mutating the throwable in ways that would confuse other listeners unless
+   * coordinated externally; otherwise this method is safe to call repeatedly and does not alter the
+   * stored state.
+   *
+   * @return the original throwable associated with this event; may be {@code null} if the creator
+   *     intentionally forwarded an absent failure.
    */
   public Throwable getException() {
     return t;

--- a/src/test/java/com/onionnetworks/util/ExceptionEventTest.java
+++ b/src/test/java/com/onionnetworks/util/ExceptionEventTest.java
@@ -1,0 +1,36 @@
+package com.onionnetworks.util;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class ExceptionEventTest {
+
+  @Test
+  void constructor_whenSourceAndThrowableProvided_expectStored() {
+    Object source = new Object();
+    IllegalArgumentException throwable = new IllegalArgumentException("boom");
+
+    ExceptionEvent event = new ExceptionEvent(source, throwable);
+
+    assertSame(source, event.getSource(), "Source should be stored by EventObject");
+    assertSame(throwable, event.getException(), "Throwable should be accessible via getException");
+  }
+
+  @Test
+  void constructor_whenSourceNull_expectIllegalArgumentException() {
+    RuntimeException throwable = new RuntimeException();
+
+    assertThrows(IllegalArgumentException.class, () -> new ExceptionEvent(null, throwable));
+  }
+
+  @Test
+  void getException_whenThrowableNull_expectReturnsNull() {
+    ExceptionEvent event = new ExceptionEvent(new Object(), null);
+
+    assertNull(event.getException());
+  }
+}


### PR DESCRIPTION
## Summary
- expand ExceptionEvent Javadoc to explain lifecycle and usage
- add focused unit tests for constructor and getException behavior

## Testing
- not run (doc/test-only change)