### PR TITLE
Refine RAF wrappers and expand coverage

### DIFF
--- a/src/main/java/com/onionnetworks/io/AuditableRaf.java
+++ b/src/main/java/com/onionnetworks/io/AuditableRaf.java
@@ -2,27 +2,121 @@ package com.onionnetworks.io;
 
 import java.io.*;
 
+/**
+ * AuditableRaf decorates a {@link RAF} while attaching audit context to write calls.
+ *
+ * <p>It centralizes the notion of a default audit URI so callers can route write operations through
+ * overloaded {@link #seekAndWrite(long, byte[], int, int)} without repeating provenance hints.
+ * Implementations add whatever logging, checkpointing, or integrity recording is required while
+ * still relying on the base {@link FilterRAF} for actual file I/O.
+ *
+ * <p>The wrapper holds a mutable default URI that must be set before parameterless write routing;
+ * subclass implementations perform the audit-aware write in {@link #seekAndWrite(String, long,
+ * byte[], int, int)}. Methods are synchronized to serialize access and make it easy to share one
+ * instance among worker threads without leaking partial state changes. Implementors should document
+ * any additional concurrency guarantees or buffering they add.
+ *
+ * <ul>
+ *   <li>Maintains an optional default audit identifier for positional writes.
+ *   <li>Delegates low-level I/O to the wrapped {@link RAF} while enabling auditing hooks.
+ *   <li>Synchronizes access so callers can reuse a single wrapper safely across threads.
+ * </ul>
+ */
 public abstract class AuditableRaf extends FilterRAF {
 
+  /**
+   * Default audit URI applied when callers omit an explicit identifier.
+   *
+   * <p>The value is mutable and may be {@code null} until initialized through either constructor or
+   * {@link #setDefaultUri(String)}. It is read within synchronized methods to ensure callers see
+   * the latest configured audit context before routing writes through the delegate {@link RAF}.
+   */
   protected String defaultUri;
 
-  public AuditableRaf(RAF raf) {
+  /**
+   * Creates an auditable wrapper without an initial default URI.
+   *
+   * <p>This constructor keeps the default audit URI unset so callers must explicitly provide one
+   * later via {@link #setDefaultUri(String)} before using {@link #seekAndWrite(long, byte[], int,
+   * int)}. It is useful when the audit context is negotiated lazily or depends on information not
+   * available at instantiation time. The wrapped {@link RAF} is stored as the delegate but no
+   * additional buffering or positioning occurs here.
+   *
+   * @param raf underlying random-access file instance that receives delegated operations
+   */
+  @SuppressWarnings("unused")
+  protected AuditableRaf(RAF raf) {
     this(raf, null);
   }
 
-  public AuditableRaf(RAF raf, String defaultUri) {
+  /**
+   * Creates an auditable wrapper with an eager default audit URI.
+   *
+   * <p>Use this constructor when the audit provenance is known upfront, allowing {@link
+   * #seekAndWrite(long, byte[], int, int)} to route immediately through the configured URI. The
+   * provided identifier is stored verbatim; subclasses may still override interpretation inside
+   * {@link #seekAndWrite(String, long, byte[], int, int)}. As with the other constructor, no cursor
+   * movement or write occurs; only the delegate reference and URI are captured for later
+   * synchronized operations.
+   *
+   * @param raf underlying random-access file instance that receives delegated operations
+   * @param defaultUri audit identifier used when callers omit an explicit URI
+   */
+  protected AuditableRaf(RAF raf, String defaultUri) {
     super(raf);
     this.defaultUri = defaultUri;
   }
 
+  /**
+   * Returns the currently configured audit URI used by convenience writes.
+   *
+   * <p>The value represents the identifier automatically applied when {@link #seekAndWrite(long,
+   * byte[], int, int)} is invoked. Callers may read it to confirm whether initialization occurred
+   * or to log changes before updating. The method is synchronized, so the returned reference
+   * reflects the most recently set value when multiple threads share this instance.
+   *
+   * @return current default audit URI or null if none has been configured
+   */
+  @SuppressWarnings("unused")
   public synchronized String getDefaultUri() {
     return defaultUri;
   }
 
+  /**
+   * Sets or replaces the audit URI applied by convenience write calls.
+   *
+   * <p>Invoking this method updates the shared default used by {@link #seekAndWrite(long, byte[],
+   * int, int)}, enabling callers to switch audit streams without reconstructing the wrapper.
+   * Passing {@code null} clears the value and will cause subsequent calls to the convenience write
+   * method to throw {@link IllegalStateException}. Synchronization ensures updates are visible to
+   * threads performing concurrent writes, though subclasses may add stronger publication rules if
+   * required.
+   *
+   * @param uri new audit URI to apply to subsequent delegated write calls
+   */
+  @SuppressWarnings("unused")
   public synchronized void setDefaultUri(String uri) {
     this.defaultUri = uri;
   }
 
+  /**
+   * Writes bytes at a position using the configured default audit URI.
+   *
+   * <p>This convenience overload routes the write through {@link #seekAndWrite(String, long,
+   * byte[], int, int)} after verifying that a default URI has been provided. It synchronizes on the
+   * instance, reusing the delegate cursor semantics defined by {@link FilterRAF}. Callers must set
+   * the URI before invoking this method or else an {@link IllegalStateException} is thrown to
+   * prevent unaudited writes. Parameters follow standard {@link java.io.RandomAccessFile}
+   * semantics; bounds checks remain the caller's responsibility.
+   *
+   * @param pos absolute byte offset within the file where writing begins
+   * @param b source buffer containing data to copy into the file
+   * @param off start index within the buffer for the data segment
+   * @param len number of bytes to write from the provided buffer slice
+   * @throws IOException if the underlying RAF reports an I/O problem during write
+   * @throws IllegalStateException if no default URI has been configured for auditing
+   */
+  @Override
   public synchronized void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
     if (defaultUri == null) {
       throw new IllegalStateException("defaultUri is null");
@@ -30,6 +124,24 @@ public abstract class AuditableRaf extends FilterRAF {
     seekAndWrite(defaultUri, pos, b, off, len);
   }
 
+  /**
+   * Performs an audit-aware positional write with an explicit audit URI.
+   *
+   * <p>Subclasses implement this hook to record provenance, checksums, or journaling while
+   * delegating actual I/O to the wrapped {@link RAF}. The provided URI identifies the logical
+   * stream or object being mutated and should be treated as non-null by implementors. Calls are
+   * synchronized by the caller, but implementations should still avoid long-running blocking to
+   * keep write latency predictable. The semantics should mirror {@link
+   * java.io.RandomAccessFile#seek(long)} followed by {@link java.io.RandomAccessFile#write(byte[],
+   * int, int)} with any additional auditing layered on top.
+   *
+   * @param uri identifier that tags the audited write operation for tracking
+   * @param pos absolute byte offset within the file where writing begins
+   * @param b source buffer containing data to copy into the file
+   * @param off start index within the buffer for the data segment
+   * @param len number of bytes to write from the provided buffer slice
+   * @throws IOException if delegate RAF encounters an I/O failure during write
+   */
   public abstract void seekAndWrite(String uri, long pos, byte[] b, int off, int len)
       throws IOException;
 }

--- a/src/main/java/com/onionnetworks/io/BlockingRAF.java
+++ b/src/main/java/com/onionnetworks/io/BlockingRAF.java
@@ -7,9 +7,32 @@ import com.onionnetworks.util.Tuple;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
+/**
+ * Random-access file wrapper that intentionally blocks readers until requested ranges become
+ * available. The wrapper collects pending read requests, writes arriving data directly into the
+ * caller-provided buffers when possible, and coordinates with writers using intrinsic locking and
+ * {@link Object#wait()} / {@link Object#notifyAll()} to avoid busy waiting.
+ *
+ * <p>Use this class when a consumer thread must wait for producers to append data to a shared
+ * random-access file without polling. A typical flow is:
+ *
+ * <ol>
+ *   <li>Reader calls {@link #seekAndRead(long, byte[], int, int)}; the call blocks and registers
+ *       its desired range.
+ *   <li>Writer calls {@link #seekAndWrite(long, byte[], int, int)}; data is copied into any waiting
+ *       buffers and the write is persisted to the delegate {@link RAF}.
+ *   <li>Reader wakes when its start position is written, returning the number of bytes now
+ *       available.
+ * </ol>
+ *
+ * <p>State is guarded by the instance monitor; methods are synchronized to preserve invariants
+ * around {@code written} ranges and the {@code buffers} registry. The class is mutable and not
+ * thread-safe outside its own synchronization. Exceptions set via {@link
+ * #setException(IOException)} are propagated to readers and writers to fail fast. Closing or
+ * switching to read-only mode wakes blocked threads so they can react promptly.
+ */
 public class BlockingRAF extends FilterRAF {
 
   RangeSet written = new RangeSet();
@@ -20,10 +43,31 @@ public class BlockingRAF extends FilterRAF {
   // each other.
   Map<Object, Tuple> buffers = new HashMap<>();
 
+  /**
+   * Creates a blocking wrapper around the supplied random-access file.
+   *
+   * @param raf delegate {@link RAF} instance that performs the actual I/O; must be non-null and
+   *     already configured with the desired mode.
+   */
   public BlockingRAF(RAF raf) {
     super(raf);
   }
 
+  /**
+   * Writes data to the delegate and wakes any blocked readers whose requested ranges intersect the
+   * write. The written range is recorded so subsequent reads can bypass blocking.
+   *
+   * @param pos absolute position in the underlying file where the write begins; zero-based and
+   *     non-negative.
+   * @param b source byte array containing the data to write; must not be null.
+   * @param off offset within {@code b} to start reading bytes from; must satisfy {@code 0 <= off <=
+   *     b.length}.
+   * @param len number of bytes to write from the array; zero is allowed and results in no range
+   *     tracking.
+   * @throws IOException if the delegate refuses the write, an exception was set via {@link
+   *     #setException(IOException)}, or the RAF is closed.
+   */
+  @Override
   public synchronized void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
     // exception
     if (e != null) {
@@ -51,8 +95,7 @@ public class BlockingRAF extends FilterRAF {
 
     Range r = new Range(pos, pos + len - 1);
 
-    for (Iterator<Map.Entry<Object, Tuple>> it = buffers.entrySet().iterator(); it.hasNext(); ) {
-      Map.Entry<Object, Tuple> entry = it.next();
+    for (Map.Entry<Object, Tuple> entry : buffers.entrySet()) {
       Tuple t = entry.getValue();
       Range r2 = (Range) t.getLeft();
       Buffer buf = (Buffer) t.getRight();
@@ -77,11 +120,38 @@ public class BlockingRAF extends FilterRAF {
     }
   }
 
+  /**
+   * Unsupported operation in this wrapper; always throws an {@link IOException}. Use {@link
+   * #seekAndRead(long, byte[], int, int)} instead for partial reads that coordinate with the
+   * blocking semantics.
+   *
+   * @param pos absolute position to read from; ignored because the method always fails.
+   * @param b destination buffer that would have received data; ignored in this implementation.
+   * @param off offset into {@code b}; ignored because the call fails.
+   * @param len number of bytes requested; ignored because the call fails.
+   * @throws IOException unconditionally, to signal that full reads are not supported by this class.
+   */
+  @Override
   public synchronized void seekAndReadFully(long pos, byte[] b, int off, int len)
       throws IOException {
     throw new IOException("unsupported operation");
   }
 
+  /**
+   * Attempts to read a range of bytes, blocking until the requested start position becomes
+   * available or an exceptional condition occurs. When the data arrives while blocked, bytes are
+   * copied directly into the caller's buffer without an intermediate allocation.
+   *
+   * @param pos absolute position in the file to begin reading; must be non-negative.
+   * @param b destination array supplied by the caller to receive data; must not be null.
+   * @param off offset into {@code b} where bytes are stored; must be within the array bounds.
+   * @param len maximum number of bytes to read; zero yields an immediate return of zero.
+   * @return the number of bytes made available starting at {@code pos}; equals the written segment
+   *     length when direct write occurs.
+   * @throws IOException if the RAF is closed, set to read-only during the wait, or an exception was
+   *     injected with {@link #setException(IOException)}.
+   */
+  @Override
   public synchronized int seekAndRead(long pos, byte[] b, int off, int len) throws IOException {
 
     // Will the bytes be written directly to the buffer?
@@ -93,54 +163,21 @@ public class BlockingRAF extends FilterRAF {
     // for direct write.
     Object key = new Object();
 
-    while (!isClosed() && e == null && !getMode().equals("r") && len != 0) {
+    while (shouldBlock(len)) {
 
       if (r == null) {
-        // This is the range we are interested in.
         r = new Range(pos, pos + len - 1);
       }
 
-      // Get the ranges in common.
-      RangeSet rs = new RangeSet();
-      rs.add(r);
-      RangeSet avail = written.intersect(rs);
-      Range first = null;
-      if (!avail.isEmpty()) {
-        first = (Range) avail.iterator().next();
-      }
+      Range first = firstAvailableRange(r);
 
       if (written.contains(pos)) {
-
-        if (directWrite) {
-          // The data was written directly to the buffer.
-          return (int) first.size();
-        } else {
-          // (int) cast is safe because size() can't be larger than
-          // len
-          return delegateRaf.seekAndRead(pos, b, off, (int) first.size());
-        }
-      } else {
-
-        // The data will be written directly to the buffer.
-        directWrite = true;
-
-        if (first != null) {
-          // Change the range of interest to only include bytes which
-          // have yet to be written.
-          r = new Range(pos, first.getMin() - 1);
-        }
-
-        // Make the buffer available to be written to.
-        buffers.put(key, new Tuple(r, new Buffer(b, off, len)));
-
-        try {
-          this.wait();
-        } catch (InterruptedException ie) {
-          throw new InterruptedIOException(ie.getMessage());
-        } finally {
-          buffers.remove(key);
-        }
+        return readAvailable(directWrite, first, pos, b, off);
       }
+
+      directWrite = true;
+      r = pendingRange(pos, r, first);
+      waitForData(key, pos, r, b, off, len);
     }
 
     // exception
@@ -168,18 +205,88 @@ public class BlockingRAF extends FilterRAF {
     throw new IllegalStateException("Method should have already " + "returned.");
   }
 
+  /**
+   * Switches the underlying RAF to read-only mode and unblocks any waiting threads so they can
+   * resume using delegate reads. Readers still pending will wake and delegate to the underlying RAF
+   * on their next iteration.
+   *
+   * @throws IOException if the delegate fails to enter read-only mode.
+   */
+  @Override
   public synchronized void setReadOnly() throws IOException {
     delegateRaf.setReadOnly();
     this.notifyAll();
   }
 
+  /**
+   * Records an exception that will be thrown by future read or write attempts and wakes any blocked
+   * threads so they observe it promptly. The stored exception remains until another call replaces
+   * it or the RAF is closed.
+   *
+   * @param e exception to surface to waiting or subsequent operations; must not be null to avoid
+   *     masking the intended failure signal.
+   */
   public synchronized void setException(IOException e) {
     this.e = e;
     this.notifyAll();
   }
 
+  /**
+   * Closes the underlying RAF and wakes all blocked threads. Further reads or writes will fail with
+   * an {@link IOException}.
+   *
+   * @throws IOException if the delegate refuses to close.
+   */
+  @Override
   public synchronized void close() throws IOException {
     delegateRaf.close();
     this.notifyAll();
+  }
+
+  private Range firstAvailableRange(Range range) {
+    RangeSet requested = new RangeSet();
+    requested.add(range);
+    RangeSet available = written.intersect(requested);
+    return available.isEmpty() ? null : available.iterator().next();
+  }
+
+  private boolean shouldBlock(int len) {
+    return !isClosed() && e == null && !getMode().equals("r") && len != 0;
+  }
+
+  private int readAvailable(boolean directWrite, Range first, long pos, byte[] b, int off)
+      throws IOException {
+    if (directWrite) {
+      return (int) first.size();
+    }
+    return delegateRaf.seekAndRead(pos, b, off, (int) first.size());
+  }
+
+  private Range pendingRange(long pos, Range currentRange, Range firstAvailable) {
+    if (firstAvailable == null) {
+      return currentRange;
+    }
+    return new Range(pos, firstAvailable.getMin() - 1);
+  }
+
+  private synchronized void waitForData(
+      Object key, long startPos, Range range, byte[] b, int off, int len)
+      throws InterruptedIOException {
+    boolean wasEmpty = buffers.isEmpty();
+    buffers.put(key, new Tuple(range, new Buffer(b, off, len)));
+    if (wasEmpty) {
+      // Wake up any waiters (e.g., tests) that need to know a buffer was registered.
+      this.notifyAll();
+    }
+    try {
+      while (shouldBlock(len) && !written.contains(startPos)) {
+        this.wait();
+      }
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new InterruptedIOException(ie.getMessage());
+    } finally {
+      buffers.remove(key);
+    }
   }
 }

--- a/src/main/java/com/onionnetworks/io/BlockingRAF.java
+++ b/src/main/java/com/onionnetworks/io/BlockingRAF.java
@@ -30,7 +30,7 @@ public class BlockingRAF extends FilterRAF {
       throw e;
     }
 
-    _raf.seekAndWrite(pos, b, off, len);
+    delegateRaf.seekAndWrite(pos, b, off, len);
 
     // call this after seekAndWrite() to allow exceptions to be thrown, if
     // there are any.
@@ -117,7 +117,7 @@ public class BlockingRAF extends FilterRAF {
         } else {
           // (int) cast is safe because size() can't be larger than
           // len
-          return _raf.seekAndRead(pos, b, off, (int) first.size());
+          return delegateRaf.seekAndRead(pos, b, off, (int) first.size());
         }
       } else {
 
@@ -151,7 +151,7 @@ public class BlockingRAF extends FilterRAF {
     // We only block during r/w mode.  For read-only we use the
     // normal behavior.
     if (getMode().equals("r")) {
-      return _raf.seekAndRead(pos, b, off, len);
+      return delegateRaf.seekAndRead(pos, b, off, len);
     }
 
     // RAF closed
@@ -169,7 +169,7 @@ public class BlockingRAF extends FilterRAF {
   }
 
   public synchronized void setReadOnly() throws IOException {
-    _raf.setReadOnly();
+    delegateRaf.setReadOnly();
     this.notifyAll();
   }
 
@@ -179,7 +179,7 @@ public class BlockingRAF extends FilterRAF {
   }
 
   public synchronized void close() throws IOException {
-    _raf.close();
+    delegateRaf.close();
     this.notifyAll();
   }
 }

--- a/src/main/java/com/onionnetworks/io/CommitRaf.java
+++ b/src/main/java/com/onionnetworks/io/CommitRaf.java
@@ -38,7 +38,7 @@ public class CommitRaf extends FilterRAF {
       }
     }
 
-    _raf.seekAndWrite(pos, b, off, len);
+    delegateRaf.seekAndWrite(pos, b, off, len);
 
     // call this after seekAndWrite() to allow exceptions to be thrown, if
     // there are any.
@@ -117,7 +117,7 @@ public class CommitRaf extends FilterRAF {
       if (getMode().equals("r")
           && (length() == 0 || committed.equals(new RangeSet(new Range(0, length() - 1))))) {
 
-        return _raf.seekAndRead(pos, b, off, len);
+        return delegateRaf.seekAndRead(pos, b, off, len);
       }
 
       if (r == null) {
@@ -142,7 +142,7 @@ public class CommitRaf extends FilterRAF {
         } else {
           // (int) cast is safe because size() can't be larger than
           // len
-          return _raf.seekAndRead(pos, b, off, (int) first.size());
+          return delegateRaf.seekAndRead(pos, b, off, (int) first.size());
         }
       } else {
 
@@ -193,7 +193,7 @@ public class CommitRaf extends FilterRAF {
   }
 
   public synchronized void close() throws IOException {
-    _raf.close();
+    delegateRaf.close();
     this.notifyAll();
   }
 }

--- a/src/main/java/com/onionnetworks/io/CommitRaf.java
+++ b/src/main/java/com/onionnetworks/io/CommitRaf.java
@@ -3,9 +3,34 @@ package com.onionnetworks.io;
 import com.onionnetworks.util.*;
 import java.io.*;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
+/**
+ * Random-access file wrapper that defers visibility of written bytes until callers explicitly
+ * commit the corresponding ranges.
+ *
+ * <p>This wrapper coordinates producers writing into an underlying {@link RAF} and consumers that
+ * must block until those bytes are marked committed. Reads short-circuit to the delegate when the
+ * file is read-only and fully committed; otherwise they wait, optionally receiving data already
+ * resident in memory through temporary buffers. Writes are rejected whenever they overlap any range
+ * that has been committed previously, ensuring immutability once data is exposed.
+ *
+ * <p>Use {@code CommitRaf} for multipart downloads, transactional persistence, or any workflow
+ * where exposing partially written data would be unsafe. Instances synchronize all public
+ * operations, so a single wrapper can safely coordinate multiple reader and writer threads without
+ * additional locks. Committed regions are tracked in-memory via {@link RangeSet}, and exceptions
+ * injected through {@link #setException(IOException)} are propagated to subsequent callers before
+ * any I/O takes place.
+ *
+ * <ul>
+ *   <li>Writes fail if they overlap any committed byte.
+ *   <li>Reads block until their starting position is committed.
+ *   <li>Closing cascades to the delegate {@link RAF} and wakes blocked threads.
+ * </ul>
+ *
+ * @see Range
+ * @see RangeSet
+ */
 public class CommitRaf extends FilterRAF {
 
   RangeSet committed = new RangeSet();
@@ -16,10 +41,36 @@ public class CommitRaf extends FilterRAF {
   // each other.
   Map<Object, Tuple> buffers = new HashMap<>();
 
+  /**
+   * Creates a commit-aware wrapper around the provided random-access file.
+   *
+   * <p>The wrapper shares the delegate; it does not duplicate file descriptors and will close the
+   * delegate when {@link #close()} is invoked. Use a single instance per file when coordinating
+   * multithreaded producers and consumers that rely on explicit commit semantics rather than
+   * immediate visibility. All operations are synchronized on this instance, simplifying external
+   * locking requirements while maintaining serialized access to the delegate.
+   *
+   * @param raf underlying {@link RAF} providing persistent storage and positioning semantics
+   */
   public CommitRaf(RAF raf) {
     super(raf);
   }
 
+  /**
+   * Writes bytes to the delegate and updates any blocked readers once the data is present.
+   *
+   * <p>A write is rejected if any byte in the target range has already been committed, preserving
+   * immutability of committed data. A zero-length write is allowed and is used to surface any
+   * pending exception without altering file contents. After a successful write, any waiting reader
+   * buffers intersecting the written range are filled directly, avoiding an immediate disk read.
+   *
+   * @param pos absolute file position at which to begin writing, zero or greater
+   * @param b source buffer containing the data to write; must not be {@code null}
+   * @param off starting offset within {@code b} from which bytes are consumed
+   * @param len number of bytes to write; zero triggers exception propagation without I/O
+   * @throws IOException if an injected exception is pending or the range overlaps committed bytes
+   */
+  @Override
   public synchronized void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
     // exception
     if (e != null) {
@@ -49,11 +100,29 @@ public class CommitRaf extends FilterRAF {
     fillBlockedBuffers(pos, b, off, len);
   }
 
+  /**
+   * Marks the supplied range as committed and notifies any waiting threads.
+   *
+   * <p>Once committed, bytes in the specified range become immutable to future writes and eligible
+   * for readers that were blocked waiting for visibility. Ranges are merged with existing committed
+   * regions, and the method wakes all waiters so they can recheck their conditions.
+   *
+   * @param r contiguous byte range that has finished writing and is now immutable
+   */
   public synchronized void commit(Range r) {
     committed.add(r);
     this.notifyAll();
   }
 
+  /**
+   * Commits all ranges contained in the provided set and awakens waiting threads.
+   *
+   * <p>Each range is merged into the internal committed set, expanding the visible portion of the
+   * file for readers. The operation is atomic with respect to the synchronized monitor, ensuring
+   * that notifications occur after the ranges are recorded.
+   *
+   * @param rs collection of ranges that are fully written and ready for readers
+   */
   public synchronized void commit(RangeSet rs) {
     committed.add(rs);
     this.notifyAll();
@@ -67,8 +136,7 @@ public class CommitRaf extends FilterRAF {
     Range r = new Range(pos, pos + len - 1);
 
     // Iterate through the blocked readers and fill their buffers.
-    for (Iterator<Map.Entry<Object, Tuple>> it = buffers.entrySet().iterator(); it.hasNext(); ) {
-      Map.Entry<Object, Tuple> entry = it.next();
+    for (Map.Entry<Object, Tuple> entry : buffers.entrySet()) {
       Tuple t = entry.getValue();
       Range r2 = (Range) t.getLeft();
       Buffer buf = (Buffer) t.getRight();
@@ -93,11 +161,49 @@ public class CommitRaf extends FilterRAF {
     }
   }
 
+  /**
+   * Unsupported convenience method for reading an exact byte count.
+   *
+   * <p>This wrapper relies on commit-tracking semantics that are incompatible with a traditional
+   * "read fully" contract. Callers should instead invoke {@link #seekAndRead(long, byte[], int,
+   * int)} and handle partial reads and blocking behavior. This method always throws to prevent
+   * accidental misuse that could mask blocked reads or uncommitted regions.
+   *
+   * @param pos absolute position to begin reading
+   * @param b destination buffer to receive data
+   * @param off offset within {@code b} where bytes should be written
+   * @param len exact number of bytes requested by the caller
+   * @throws IOException always thrown to signal the operation is not supported here
+   */
+  @Override
   public synchronized void seekAndReadFully(long pos, byte[] b, int off, int len)
       throws IOException {
     throw new IOException("unsupported operation");
   }
 
+  /**
+   * Reads from the delegate, blocking if necessary until the requested position becomes committed.
+   *
+   * <p>When the file is read-only and fully committed, reads are delegated directly. Otherwise, the
+   * call waits until the starting position is marked committed, optionally having data copied
+   * directly into the provided buffer if a concurrent write satisfies part of the range. The method
+   * returns as soon as a contiguous committed region beginning at {@code pos} is available, so the
+   * byte count may be smaller than {@code len}. Pending exceptions or closure are surfaced before
+   * any data is returned.
+   *
+   * <pre>{@code
+   * // Example: block until the first kilobyte is committed
+   * int read = raf.seekAndRead(0, buffer, 0, 1024);
+   * }</pre>
+   *
+   * @param pos absolute position from which to read
+   * @param b destination buffer that will receive committed data
+   * @param off offset within {@code b} where bytes should be placed
+   * @param len maximum number of bytes requested; method may return fewer
+   * @return number of bytes transferred from the underlying {@link RAF} or in-memory buffers
+   * @throws IOException if a pending exception exists, the wrapper is closed, or the delegate fails
+   */
+  @Override
   public synchronized int seekAndRead(long pos, byte[] b, int off, int len) throws IOException {
 
     // Will the bytes be written directly to the buffer?
@@ -111,63 +217,117 @@ public class CommitRaf extends FilterRAF {
 
     while (!isClosed() && e == null && len != 0) {
 
-      // If the file is read-only and the whole thing is commited, then
-      // we read directly from the underlying Raf.  This is so that -1's
-      // get returned at EOF when the file is completedly committed.
-      if (getMode().equals("r")
-          && (length() == 0 || committed.equals(new RangeSet(new Range(0, length() - 1))))) {
+      if (isReadOnlyAndFullyCommitted()) {
 
         return delegateRaf.seekAndRead(pos, b, off, len);
       }
 
-      if (r == null) {
-        // This is the range we are interested in.
-        r = new Range(pos, pos + len - 1);
-      }
+      r = initRangeIfNeeded(r, pos, len);
 
-      // Get the ranges in common.
-      RangeSet rs = new RangeSet();
-      rs.add(r);
-      RangeSet avail = committed.intersect(rs);
-      Range first = null;
-      if (!avail.isEmpty()) {
-        first = (Range) avail.iterator().next();
-      }
+      Range first = firstCommittedOverlap(r);
 
       if (committed.contains(pos)) {
 
-        if (directWrite) {
-          // The data was written directly to the buffer.
-          return (int) first.size();
-        } else {
-          // (int) cast is safe because size() can't be larger than
-          // len
-          return delegateRaf.seekAndRead(pos, b, off, (int) first.size());
-        }
-      } else {
-
-        // The data will be written directly to the buffer.
-        directWrite = true;
-
-        if (first != null) {
-          // Change the range of interest to only include bytes which
-          // have yet to be committed.
-          r = new Range(pos, first.getMin() - 1);
-        }
-
-        // Make the buffer available to be written to.
-        buffers.put(key, new Tuple(r, new Buffer(b, off, len)));
-
-        try {
-          this.wait();
-        } catch (InterruptedException ie) {
-          throw new InterruptedIOException(ie.getMessage());
-        } finally {
-          buffers.remove(key);
-        }
+        return readCommittedBytes(pos, b, off, directWrite, first);
       }
+
+      // The data will be written directly to the buffer.
+      directWrite = true;
+      r = pendingPortionRange(pos, r, first);
+      waitForCommit(key, r, b, off, len, pos);
     }
 
+    return finalizeRead(len);
+  }
+
+  /**
+   * Injects an exception that will be rethrown by subsequent read or write attempts.
+   *
+   * <p>Use this to propagate fatal upstream failures to threads currently blocked on commit
+   * notifications. The stored exception is returned on the very next operation, after which normal
+   * commit checks are skipped. All waiting threads are notified so they can observe the new state.
+   *
+   * @param e exception to propagate to future callers; must not be cleared once set
+   */
+  public synchronized void setException(IOException e) {
+    this.e = e;
+    this.notifyAll();
+  }
+
+  /**
+   * Closes the underlying {@link RAF} and wakes any waiting threads.
+   *
+   * <p>Readers blocked waiting for commits will receive a closure signal and throw an {@link
+   * IOException}. The delegate is closed first, and the monitor notification allows threads to exit
+   * promptly rather than remain blocked indefinitely.
+   *
+   * @throws IOException if closing the delegate random-access file fails
+   */
+  @Override
+  public synchronized void close() throws IOException {
+    delegateRaf.close();
+    this.notifyAll();
+  }
+
+  private boolean isReadOnlyAndFullyCommitted() throws IOException {
+    return getMode().equals("r")
+        && (length() == 0 || committed.equals(new RangeSet(new Range(0, length() - 1))));
+  }
+
+  private Range initRangeIfNeeded(Range current, long pos, int len) {
+    if (current != null) {
+      return current;
+    }
+    return new Range(pos, pos + len - 1);
+  }
+
+  private Range firstCommittedOverlap(Range interestedRange) {
+    RangeSet rs = new RangeSet();
+    rs.add(interestedRange);
+    RangeSet avail = committed.intersect(rs);
+    if (avail.isEmpty()) {
+      return null;
+    }
+    return avail.iterator().next();
+  }
+
+  private int readCommittedBytes(long pos, byte[] b, int off, boolean directWrite, Range first)
+      throws IOException {
+    if (directWrite) {
+      // The data was written directly to the buffer.
+      return (int) first.size();
+    }
+    return delegateRaf.seekAndRead(pos, b, off, (int) first.size());
+  }
+
+  private Range pendingPortionRange(long pos, Range interestedRange, Range firstOverlap) {
+    if (firstOverlap == null) {
+      return interestedRange;
+    }
+    // Change the range of interest to only include bytes which
+    // have yet to be committed.
+    return new Range(pos, firstOverlap.getMin() - 1);
+  }
+
+  private synchronized void waitForCommit(
+      Object key, Range interestedRange, byte[] b, int off, int len, long pos)
+      throws InterruptedIOException {
+    // Make the buffer available to be written to.
+    buffers.put(key, new Tuple(interestedRange, new Buffer(b, off, len)));
+
+    try {
+      while (!isClosed() && e == null && !committed.contains(pos)) {
+        this.wait();
+      }
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new InterruptedIOException(ie.getMessage());
+    } finally {
+      buffers.remove(key);
+    }
+  }
+
+  private int finalizeRead(int len) throws IOException {
     // exception
     if (e != null) {
       throw e;
@@ -185,15 +345,5 @@ public class CommitRaf extends FilterRAF {
 
     // This should never happen.
     throw new IllegalStateException("Method should have already " + "returned.");
-  }
-
-  public synchronized void setException(IOException e) {
-    this.e = e;
-    this.notifyAll();
-  }
-
-  public synchronized void close() throws IOException {
-    delegateRaf.close();
-    this.notifyAll();
   }
 }

--- a/src/main/java/com/onionnetworks/io/FilterRAF.java
+++ b/src/main/java/com/onionnetworks/io/FilterRAF.java
@@ -1,66 +1,269 @@
 package com.onionnetworks.io;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 
+/**
+ * Abstract decorator that forwards every {@link RAF} operation to another instance while allowing
+ * subclasses to insert filtering, journaling, or synchronization policies around the delegated
+ * calls.
+ *
+ * <p>Use this base when you need to wrap an existing random-access file with cross-cutting
+ * behavior—such as journaling, commit tracking, or blocking semantics—without reimplementing the
+ * underlying cursor and file-lifecycle logic. Each public method remains synchronized so that a
+ * single {@code FilterRAF} can safely coordinate concurrent callers; subclasses are expected to
+ * honor that contract and avoid leaking the delegate in an inconsistent state. The delegated
+ * instance is supplied during construction and kept for the lifetime of the wrapper; closing the
+ * wrapper closes the delegate. Callers typically subclass this type, override a subset of methods
+ * to add pre-/post-processing, and otherwise rely on the default pass-through behavior to preserve
+ * semantics and positioning.
+ *
+ * <ul>
+ *   <li>Delegates all file operations to a provided {@link RAF}.
+ *   <li>Maintains synchronized access so cursor movements remain serialized.
+ *   <li>Intended for layered behaviors such as journaling or commit-aware reads.
+ * </ul>
+ */
 public abstract class FilterRAF extends RAF {
 
-  protected final RAF _raf;
+  /**
+   * Target {@link RAF} that receives all delegated calls; never {@code null} after construction and
+   * closed when this wrapper is closed.
+   */
+  protected final RAF delegateRaf;
 
-  public FilterRAF(RAF raf) {
-    this._raf = raf;
+  /**
+   * Creates a new filtered view that forwards to the supplied random-access file wrapper.
+   *
+   * <p>No ownership transfer occurs beyond delegation: subclasses may add state, but callers should
+   * assume that closing this wrapper closes the provided delegate as well. The wrapper does not
+   * change the delegate's mode or length; it simply intercepts calls so that subclasses can enforce
+   * additional invariants or record-keeping.
+   *
+   * @param raf non-null {@link RAF} to delegate all operations to; must already be open and in the
+   *     desired access mode for the lifetime of this wrapper.
+   */
+  protected FilterRAF(RAF raf) {
+    this.delegateRaf = raf;
   }
 
+  /**
+   * Writes a slice of the provided buffer at the given absolute position, forwarding directly to
+   * the delegate.
+   *
+   * <p>The call retains the synchronization guarantees of {@link RAF#seekAndWrite(long, byte[],
+   * int, int)} so subclasses can safely layer additional bookkeeping without interleaving cursor
+   * movement. No buffering or retries are performed; any checked exception from the delegate is
+   * propagated unchanged.
+   *
+   * @param pos zero-based offset where writing begins; negative values are invalid and delegated
+   *     calls will fail accordingly.
+   * @param b source byte array containing data to write; must remain valid for the duration of the
+   *     call and obey the offset and length bounds.
+   * @param off starting index within {@code b} from which bytes are taken; must be non-negative and
+   *     allow {@code len} bytes to fit within the array.
+   * @param len number of bytes to write from the buffer slice; may be zero to perform a no-op that
+   *     still validates arguments.
+   * @throws IOException if the delegate cannot seek or write at the requested position or if the
+   *     underlying file handle rejects the operation.
+   */
+  @Override
   public synchronized void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
-    _raf.seekAndWrite(pos, b, off, len);
+    delegateRaf.seekAndWrite(pos, b, off, len);
   }
 
+  /**
+   * Reads up to {@code len} bytes from the delegate starting at the specified absolute position.
+   *
+   * <p>The method keeps the synchronized, cursor-serializing semantics of the base implementation
+   * and performs no additional buffering or translation. Subclasses can override to apply filtering
+   * before or after delegation but should preserve the return contract of returning the number of
+   * bytes read or {@code -1} on end of file.
+   *
+   * @param pos absolute offset to seek before reading; must be non-negative to avoid delegate
+   *     errors.
+   * @param b destination buffer that receives data; must have capacity for the requested slice and
+   *     remain mutable for the duration of the call.
+   * @param off starting index in {@code b} where read bytes are placed; must satisfy array bounds
+   *     constraints.
+   * @param len maximum number of bytes to read; negative values are invalid and will surface as
+   *     delegate failures.
+   * @return count of bytes actually read, or {@code -1} if positioned at end of file before any
+   *     data is read; never larger than {@code len}.
+   * @throws IOException if seeking or reading fails in the delegate, including when the file is
+   *     closed or not open for reading.
+   */
+  @Override
   public synchronized int seekAndRead(long pos, byte[] b, int off, int len) throws IOException {
 
-    return _raf.seekAndRead(pos, b, off, len);
+    return delegateRaf.seekAndRead(pos, b, off, len);
   }
 
+  /**
+   * Reads exactly {@code len} bytes from the delegate beginning at the provided absolute offset.
+   *
+   * <p>This pass-through keeps the blocking behavior of {@link RAF#seekAndReadFully(long, byte[],
+   * int, int)}: it loops until the buffer slice is filled or an {@link IOException} is raised. It
+   * is suitable for callers expecting fixed-length records and needing deterministic completion or
+   * failure semantics.
+   *
+   * @param pos absolute file position at which reading starts; must be non-negative and within the
+   *     addressable range of the underlying file.
+   * @param b destination byte array that will hold all requested bytes; must not be {@code null}
+   *     and should be sized appropriately for the offset and length.
+   * @param off index in {@code b} where storage begins; must allow the subsequent {@code len} bytes
+   *     to fit without exceeding array bounds.
+   * @param len number of bytes to read; must be positive for meaningful work, though zero is
+   *     permitted as a no-op validation pass.
+   * @throws IOException if insufficient data is available, the delegate cannot seek, or any I/O
+   *     error occurs while filling the buffer slice.
+   */
+  @Override
   public synchronized void seekAndReadFully(long pos, byte[] b, int off, int len)
       throws IOException {
-    _raf.seekAndReadFully(pos, b, off, len);
+    delegateRaf.seekAndReadFully(pos, b, off, len);
   }
 
+  /**
+   * Renames the underlying file to the requested destination using the delegate's move semantics.
+   *
+   * <p>Callers can rely on the delegate to close and reopen the underlying handle as needed. This
+   * wrapper performs no additional checks beyond serialization; subclasses may override to track
+   * journal entries or to enforce policy before deferring to the delegate.
+   *
+   * @param destFile target path for the rename operation; must refer to a writable location or the
+   *     delegate will signal failure.
+   * @throws IOException if the delegate encounters an error while closing, copying, or reopening
+   *     the file during the rename process.
+   */
+  @Override
   public synchronized void renameTo(File destFile) throws IOException {
-    _raf.renameTo(destFile);
+    delegateRaf.renameTo(destFile);
   }
 
+  /**
+   * Returns the access mode string currently used by the delegate random-access file.
+   *
+   * <p>The value is whatever the delegate reports; this wrapper does not alter or cache it. Typical
+   * results include {@code "r"} for read-only access and {@code "rw"} for read/write access.
+   *
+   * @return non-null mode string describing the delegate's current open mode.
+   */
+  @Override
   public synchronized String getMode() {
-    return _raf.getMode();
+    return delegateRaf.getMode();
   }
 
+  /**
+   * Indicates whether the delegate has already been closed.
+   *
+   * <p>This is a pass-through convenience that preserves synchronized visibility. Subclasses should
+   * respect the delegate's closed state when layering additional behavior.
+   *
+   * @return {@code true} if the delegate reports a closed state; otherwise {@code false}.
+   */
+  @Override
   public synchronized boolean isClosed() {
-    return _raf.isClosed();
+    return delegateRaf.isClosed();
   }
 
+  /**
+   * Exposes the current {@link File} that backs the delegated random-access handle.
+   *
+   * <p>The reference reflects any renames performed by the delegate. Mutating the returned {@code
+   * File} does not affect this wrapper; callers should treat it as a snapshot and avoid external
+   * deletion that would violate the delegate's lifecycle.
+   *
+   * @return non-null {@link File} pointing to the delegate's current on-disk location.
+   */
+  @Override
   public synchronized File getFile() {
-    return _raf.getFile();
+    return delegateRaf.getFile();
   }
 
+  /**
+   * Reopens the delegate in read-only mode when supported, preventing further writes.
+   *
+   * <p>The method defers to the delegate to perform any necessary handle recreation. It remains
+   * synchronized to serialize mode changes with concurrent reads and writes.
+   *
+   * @throws IOException if the delegate cannot transition to read-only access or the underlying
+   *     file system rejects the change.
+   */
+  @Override
   public synchronized void setReadOnly() throws IOException {
-    _raf.setReadOnly();
+    delegateRaf.setReadOnly();
   }
 
+  /**
+   * Marks the delegate for deletion when the stream is closed.
+   *
+   * <p>Only the delegate's internal flag is updated; no deletion occurs until {@link #close()} is
+   * invoked. Subclasses may override to coordinate journal cleanup before deferring here.
+   */
+  @Override
   public synchronized void deleteOnClose() {
-    _raf.deleteOnClose();
+    delegateRaf.deleteOnClose();
   }
 
+  /**
+   * Truncates or extends the underlying file to the specified length using the delegate.
+   *
+   * <p>Extending fills new bytes with zeros per platform behavior; truncating discards excess
+   * content. Synchronization ensures length mutations serialize with other cursor-based operations
+   * invoked through this wrapper.
+   *
+   * @param len new file size in bytes; must be zero or positive, otherwise the delegate will raise
+   *     an {@link IOException}.
+   * @throws IOException if the delegate cannot adjust the length due to filesystem constraints or a
+   *     closed handle.
+   */
+  @Override
   public synchronized void setLength(long len) throws IOException {
-    _raf.setLength(len);
+    delegateRaf.setLength(len);
   }
 
+  /**
+   * Returns the current size of the underlying file in bytes.
+   *
+   * <p>This is a direct delegate call and therefore reflects any concurrent mutations performed
+   * through other wrappers sharing the same {@link RAF}. The value is obtained under the same
+   * synchronization used for other operations.
+   *
+   * @return non-negative file length in bytes as reported by the delegate.
+   * @throws IOException if the delegate cannot query the length, such as when the handle is closed
+   *     or the filesystem reports an error.
+   */
+  @Override
   public synchronized long length() throws IOException {
-    return _raf.length();
+    return delegateRaf.length();
   }
 
+  /**
+   * Closes this wrapper and the underlying delegate, releasing any system resources held by the
+   * random-access file.
+   *
+   * <p>Subclasses may extend to flush metadata before deferring to the delegate. After this call
+   * returns, subsequent operations on the wrapper should be considered invalid and may throw
+   * exceptions.
+   *
+   * @throws IOException if closing the delegate fails or the filesystem rejects final operations
+   *     performed during close.
+   */
+  @Override
   public synchronized void close() throws IOException {
-    _raf.close();
+    delegateRaf.close();
   }
 
+  /**
+   * Returns the delegate's {@link Object#toString()} representation, preserving existing debug
+   * output semantics.
+   *
+   * @return non-null string produced by the underlying delegate's {@code toString()}
+   *     implementation.
+   */
+  @Override
   public String toString() {
-    return _raf.toString();
+    return delegateRaf.toString();
   }
 }

--- a/src/main/java/com/onionnetworks/io/JournalingRAF.java
+++ b/src/main/java/com/onionnetworks/io/JournalingRAF.java
@@ -1,14 +1,54 @@
 package com.onionnetworks.io;
 
 import com.onionnetworks.util.*;
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+/**
+ * Random-access file wrapper that journals written byte ranges for crash-aware recovery.
+ *
+ * <p>This decorator pairs a mutable {@link RAF} with a persistent {@link Journal} that records
+ * every region successfully written through {@link #seekAndWrite(long, byte[], int, int)}. The
+ * journal captures both the destination file and the set of completed byte ranges so that callers
+ * can resume or verify partially written files after an unexpected shutdown. All operations remain
+ * synchronized via {@link FilterRAF}, providing serialized cursor movement and predictable journal
+ * updates when multiple threads share the same instance. The journal may be deleted when writes are
+ * finished, allowing long-lived readers to operate without auxiliary metadata once durability is
+ * established.
+ *
+ * <ul>
+ *   <li>Tracks the underlying file path so journal consumers can locate the target data.
+ *   <li>Records each successfully written byte span to support resumable downloads or rebuilds.
+ *   <li>Flushes and deletes the journal during mode transitions to keep metadata consistent.
+ * </ul>
+ *
+ * @see Journal
+ * @see Range
+ */
 public class JournalingRAF extends FilterRAF {
+
+  private static final Logger LOGGER = Logger.getLogger(JournalingRAF.class.getName());
 
   Journal journal;
 
-  public JournalingRAF(RAF raf, Journal journal) throws IOException {
+  /**
+   * Creates a journaling wrapper around an existing random-access file and persistent journal.
+   *
+   * <p>The constructor rejects read-only delegates because journaling applies only to writable
+   * files. It stores the supplied {@link Journal} and immediately records the delegate's current
+   * path so consumers of the journal can locate the target file even if future renames occur. The
+   * wrapper does not take ownership of any existing journal contents beyond continuing to append
+   * byte ranges as writes succeed.
+   *
+   * @param raf underlying random-access file wrapper to decorate for journaling.
+   * @param journal persistent journal storing byte ranges and target file metadata.
+   * @throws IllegalStateException if the provided RAF is open in read-only mode.
+   */
+  public JournalingRAF(RAF raf, Journal journal) {
     super(raf);
     if (raf.getMode().equals("r")) {
       throw new IllegalStateException("Can't create a journal for a " + "read-only file.");
@@ -20,17 +60,47 @@ public class JournalingRAF extends FilterRAF {
     journal.setTargetFile(raf.getFile());
   }
 
+  /**
+   * Writes bytes at an absolute position and records the written span in the journal.
+   *
+   * <p>The method first delegates the write to the underlying {@link RAF}, then adds the inclusive
+   * byte range to the journal if journaling is active. Recording occurs only after a successful
+   * delegate write, so the journal reflects data that has actually reached the file handle. The
+   * call remains synchronized to serialize pointer movement and journal updates across threads. If
+   * the process terminates before the journal is flushed, callers may need to reconcile partially
+   * recorded progress when resuming.
+   *
+   * @param pos absolute byte offset where writing begins; must be zero or positive.
+   * @param b source buffer containing bytes to write; must remain unchanged during call.
+   * @param off starting index within buffer; must allow requested length to fit.
+   * @param len number of bytes to write from buffer slice; zero allowed.
+   * @throws IOException if the delegate cannot seek or write at provided position.
+   */
+  @Override
   public synchronized void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
     super.seekAndWrite(pos, b, off, len);
     // FIX flush problem, what if it crashes before data is persisted?
 
     if (journal != null) {
       // can be null from deleteJournal
-      // Update the journal..
+      // Update the journal.
       journal.addByteRange(new Range(pos, pos + len - 1));
     }
   }
 
+  /**
+   * Renames the underlying file and updates the journal to track the new path.
+   *
+   * <p>The delegate performs the actual rename and may fall back to alternative strategies when a
+   * direct move fails. After the delegate completes, the journal's target file reference is
+   * refreshed using the delegate's current path to ensure future recovery uses the correct
+   * location. The journal is flushed immediately after updating to minimize divergence if the
+   * process terminates between the rename and subsequent writes.
+   *
+   * @param newFile destination file path for the rename operation; must be writable by the caller.
+   * @throws IOException if the delegate fails to rename or reopen the file handle.
+   */
+  @Override
   public synchronized void renameTo(File newFile) throws IOException {
     super.renameTo(newFile);
     // Update the file location.
@@ -47,12 +117,35 @@ public class JournalingRAF extends FilterRAF {
     }
   }
 
+  /**
+   * Transitions the delegate to read-only mode and removes the associated journal.
+   *
+   * <p>After deferring to the delegate to enforce read-only semantics, the method deletes the
+   * journal because no further writes will occur. This keeps metadata size bounded and prevents
+   * stale recovery state from being misinterpreted later. The call is synchronized, preserving the
+   * serialized ordering of mode changes relative to concurrent reads or pending journal updates.
+   *
+   * @throws IOException if the delegate cannot change to read-only access.
+   */
+  @Override
   public synchronized void setReadOnly() throws IOException {
     super.setReadOnly();
     // done writing, delete the journal
     deleteJournal();
   }
 
+  /**
+   * Closes the delegate and then closes any active journal.
+   *
+   * <p>The delegate is closed first to ensure file-system resources are released before the journal
+   * attempts to flush or close its own backing file. If a journal exists, it is closed even when
+   * the delegate close succeeds, allowing recovery consumers to observe a consistent snapshot of
+   * completed writes. The method is synchronized to avoid races with concurrent write or rename
+   * operations.
+   *
+   * @throws IOException if closing the delegate or the journal encounters an I/O error.
+   */
+  @Override
   public synchronized void close() throws IOException {
     super.close();
 
@@ -62,20 +155,38 @@ public class JournalingRAF extends FilterRAF {
     }
   }
 
+  /**
+   * Marks both the delegate and the journal for deletion when the stream closes.
+   *
+   * <p>The request is forwarded to the delegate so the underlying data file is removed on close.
+   * The journal is immediately deleted to prevent future recovery attempts from referencing a file
+   * scheduled for removal. Because no delete occurs until {@link #close()} runs, callers can still
+   * use the instance for further writes before shutdown if desired.
+   */
+  @Override
   public synchronized void deleteOnClose() {
     super.deleteOnClose();
     deleteJournal();
   }
 
   private void deleteJournal() {
+    if (journal == null) {
+      return;
+    }
     File file = journal.getFile();
     try {
       journal.close();
     } catch (IOException e) {
-      e.printStackTrace();
+      LOGGER.log(Level.WARNING, "Failed to close journal before deletion", e);
     }
     // FIX maybe throw exception on failed delete?
-    file.delete();
+    try {
+      Files.delete(file.toPath());
+    } catch (NoSuchFileException e) {
+      // already deleted; nothing further to do
+    } catch (IOException e) {
+      LOGGER.log(Level.WARNING, e, () -> "Failed to delete journal file: " + file);
+    }
     journal = null;
   }
 }

--- a/src/main/java/com/onionnetworks/io/JournalingRAF.java
+++ b/src/main/java/com/onionnetworks/io/JournalingRAF.java
@@ -37,9 +37,9 @@ public class JournalingRAF extends FilterRAF {
 
     // Can be null from deleteJournal()
     if (journal != null) {
-      // Use _raf.getFile() because renameTo() may have failed and was
+      // Use delegateRaf.getFile() because renameTo() may have failed and was
       // forced to fall back.
-      journal.setTargetFile(_raf.getFile());
+      journal.setTargetFile(delegateRaf.getFile());
 
       // flush here because it is important that the journal stay in
       // sync on this operation.

--- a/src/main/java/com/onionnetworks/io/LazyRenameRAF.java
+++ b/src/main/java/com/onionnetworks/io/LazyRenameRAF.java
@@ -3,11 +3,42 @@ package com.onionnetworks.io;
 import com.onionnetworks.util.*;
 import java.io.*;
 
+/**
+ * RandomAccessFile wrapper that defers the final rename of a writable file until it is sealed as
+ * read-only. This wrapper is intended for workflows that need to write data to a temporary
+ * location, confirm persistence, and only then expose the file at its long-lived destination. By
+ * delegating all I/O to an underlying {@link RAF} while staging the destination path, the class
+ * helps avoid consumers observing partially written content and makes {@link File#deleteOnExit()}
+ * safer for temporary artifacts. Instances synchronize mutating operations, so rename and read-only
+ * transitions occur in a serialized order on the same object, but callers should still coordinate
+ * access when sharing instances across threads. Typical usage writes to the wrapper, invokes {@link
+ * #renameTo(File)} to register the final target, and completes with {@link #setReadOnly()}, which
+ * performs the last hop to the destination.
+ *
+ * <ul>
+ *   <li>Keeps the original file hidden under a temporary sibling until sealed.
+ *   <li>Preserves compatibility with read-only wrappers by renaming immediately when opened in read
+ *       mode.
+ *   <li>Relies on {@link FileUtil#createTempFile(File)} to place temporary files alongside the
+ *       destination when possible.
+ * </ul>
+ */
 public class LazyRenameRAF extends FilterRAF {
 
   File destFile;
 
-  public LazyRenameRAF(RAF raf) throws IOException {
+  /**
+   * Creates a lazy-renaming wrapper around the provided random-access file. The underlying file
+   * must be opened for reading and writing; otherwise an {@link IllegalStateException} is thrown to
+   * prevent constructing an unusable wrapper. Callers typically write data through this instance,
+   * register a destination via {@link #renameTo(File)}, and finish with {@link #setReadOnly()} to
+   * move the data into place.
+   *
+   * @param raf delegate random-access file that backs all I/O for this wrapper
+   * @throws IllegalStateException if the delegate is opened in read-only mode and cannot be renamed
+   *     lazily
+   */
+  public LazyRenameRAF(RAF raf) {
     super(raf);
 
     if (getMode().equals("r")) {
@@ -20,10 +51,17 @@ public class LazyRenameRAF extends FilterRAF {
   // will revert to its previous state, no harm done.
   // document that it will create a temp file in the same directory.
   /**
-   * If the current location and the newFile are different, it is guarenteed that the file will be
-   * moved to some new location, even if it isn't the final destination. This is to allow the safe
-   * setting of deleteOnExit for locations that are intended to be temporary.
+   * Registers a final destination and moves the backing file to a temporary sibling until the file
+   * is sealed. When opened in read-only mode the rename happens immediately. In writable mode this
+   * method first records the destination, then renames the current file to a temporary path in the
+   * same directory (or a fallback temp location) so that the future {@link #setReadOnly()} call can
+   * atomically promote the file into place. Callers should invoke this only after all writes are
+   * complete; repeated calls overwrite the previously staged destination.
+   *
+   * @param newFile target path for the final file; must reference a writable directory
+   * @throws IOException if the delegate rename or temporary file creation fails on the filesystem
    */
+  @Override
   public synchronized void renameTo(File newFile) throws IOException {
     // FIX figure out the proper semantics for this temporary same-directory
     // file.
@@ -47,6 +85,18 @@ public class LazyRenameRAF extends FilterRAF {
 
   // This should at least by in read-only mode when it bombs, should
   // FIX parent.setReadOnly to revert as well.
+  /**
+   * Marks the underlying file read-only and performs the deferred rename when applicable. In
+   * writable mode this final step migrates the temporary file created by {@link #renameTo(File)} to
+   * the recorded destination, ensuring consumers only see a fully written, sealed artifact. When no
+   * destination has been staged the method leaves the file in its current location after enforcing
+   * read-only status. Subsequent write attempts through the delegate are expected to fail according
+   * to the {@link RAF} implementation.
+   *
+   * @throws IOException if the delegate cannot be marked read-only or the final rename operation
+   *     fails after sealing
+   */
+  @Override
   public synchronized void setReadOnly() throws IOException {
     delegateRaf.setReadOnly();
     if (destFile != null) {

--- a/src/main/java/com/onionnetworks/io/LazyRenameRAF.java
+++ b/src/main/java/com/onionnetworks/io/LazyRenameRAF.java
@@ -34,23 +34,23 @@ public class LazyRenameRAF extends FilterRAF {
     this.destFile = newFile;
 
     if (getMode().equals("r")) {
-      _raf.renameTo(destFile);
+      delegateRaf.renameTo(destFile);
     } else {
       // create a temp file in the same directory as destFile, if
       // destFile is null, then try to create a temp file in the
       // user temp directory, then fall back to the system temp dir.
       File newTemp = FileUtil.createTempFile(destFile);
 
-      _raf.renameTo(newTemp);
+      delegateRaf.renameTo(newTemp);
     }
   }
 
   // This should at least by in read-only mode when it bombs, should
   // FIX parent.setReadOnly to revert as well.
   public synchronized void setReadOnly() throws IOException {
-    _raf.setReadOnly();
+    delegateRaf.setReadOnly();
     if (destFile != null) {
-      _raf.renameTo(destFile);
+      delegateRaf.renameTo(destFile);
     }
   }
 }

--- a/src/main/java/com/onionnetworks/io/TempRaf.java
+++ b/src/main/java/com/onionnetworks/io/TempRaf.java
@@ -4,67 +4,185 @@ import com.onionnetworks.util.*;
 import java.io.*;
 
 /**
+ * Temporary {@link RAF}-backed random access file that lives in a scratch location until a keep
+ * policy decides whether it should be removed or preserved.
+ *
+ * <p>The class creates or wraps an underlying temporary file and forwards all random access
+ * operations to a {@link FilterRAF} delegate while tracking whether the file has been renamed. Use
+ * it to stage writes safely: callers can write to the temporary path, atomically rename to the
+ * final destination, and rely on deterministic cleanup on close. When no rename occurs—or when a
+ * rename happens but writing has not been finalized—the keep policy can delete the scratch file to
+ * avoid littering disks after partial operations or failures.
+ *
+ * <p>Lifecycle considerations include synchronized {@link #renameTo(File)} and {@link #close()}
+ * methods that guard the rename flag and cleanup logic; other I/O operations are delegated and may
+ * follow the concurrency guarantees of the wrapped {@link RAF}. Keep policies control deletion or
+ * retention, with {@link #DEFAULT_KEEP_POLICY} mapping to {@link #NEVER}. Choose stricter policies
+ * for short-lived staging buffers, and {@link #ALWAYS} when the temporary file must outlive the
+ * wrapper.
+ *
+ * <ul>
+ *   <li>Staging workflow: write to the temporary path, optionally call {@link #renameTo(File)},
+ *       then close.
+ *   <li>Cleanup behavior: enforced on {@link #close()} based on the keep policy and rename status.
+ *   <li>Threading: rename and close are synchronized; other methods inherit delegate semantics.
+ * </ul>
+ *
  * @author Justin Chapweske (justin@chapweske.com)
  */
 public class TempRaf extends FilterRAF {
 
+  /**
+   * Keep policy that always removes the temporary file during {@link #close()}, regardless of
+   * rename status or access mode, ensuring scratch data never persists beyond the wrapper.
+   */
   public static final int NEVER = 0;
+
+  /**
+   * Keep policy that removes the temporary file on {@link #close()} unless the file has been
+   * renamed and the RAF is currently opened in read-only mode, indicating writing has completed.
+   */
   public static final int RENAMED_AND_DONE_WRITING = 1;
+
+  /**
+   * Keep policy that removes the temporary file unless {@link #renameTo(File)} was called before
+   * {@link #close()}, enabling callers to persist only when an explicit rename occurs.
+   */
   public static final int RENAMED = 2;
+
+  /**
+   * Keep policy that never removes the temporary file, preserving the underlying data even when no
+   * rename occurs; suited to callers that manage cleanup manually or reuse the file elsewhere.
+   */
   public static final int ALWAYS = 3;
 
+  /** Default keep policy; identical to {@link #NEVER} for conservative automatic cleanup. */
   public static final int DEFAULT_KEEP_POLICY = 0;
 
   int keepPolicy;
-  boolean renamed = false;
+  boolean renamedFlag = false;
 
+  /**
+   * Create a temporary RAF using {@link #DEFAULT_KEEP_POLICY} and a scratch file allocated via
+   * {@link FileUtil#createTempFile(File)}.
+   *
+   * <p>This convenience constructor chooses the safest cleanup behavior by deleting the temporary
+   * file on {@link #close()} even if a rename occurred. The underlying file is created in the user
+   * or system temporary directory with read/write access. Use this when callers simply need short-
+   * * lived staging storage without coordinating explicit retention.
+   *
+   * @throws IOException if the temporary file cannot be created or opened for random access I/O.
+   */
+  @SuppressWarnings("unused")
   public TempRaf() throws IOException {
     this(DEFAULT_KEEP_POLICY);
   }
 
+  /**
+   * Create a temporary RAF that cleans up according to a caller-provided keep policy.
+   *
+   * <p>The constructor allocates a new scratch file, opens it in read/write mode, and installs the
+   * supplied keep policy so {@link #close()} can decide whether to delete or retain the file. Use
+   * {@link #RENAMED} or {@link #RENAMED_AND_DONE_WRITING} when you want deletion only if a rename
+   * does not occur; use {@link #ALWAYS} to opt out of automatic cleanup.
+   *
+   * <pre>{@code
+   * try (TempRaf raf = new TempRaf(TempRaf.RENAMED)) {
+   *   // write, then persist explicitly
+   *   raf.renameTo(new File("target.bin"));
+   * }
+   * }</pre>
+   *
+   * @param keepPolicy deletion strategy constant such as {@link #NEVER} or {@link #RENAMED}.
+   * @throws IOException if the temporary file cannot be created or opened for random access I/O.
+   */
   public TempRaf(int keepPolicy) throws IOException {
     // Create a temp file in the user temp dir, or failing that, the
     // system temp dir.
     this(new RAF(FileUtil.createTempFile(null), "rw"), keepPolicy);
   }
 
+  /**
+   * Wrap an existing {@link RAF} using {@link #DEFAULT_KEEP_POLICY} so the temporary file is
+   * removed on {@link #close()} regardless of subsequent renames.
+   *
+   * <p>Use this overload when an external component has already provisioned a suitable scratch
+   * file, but the caller still wants deterministic cleanup semantics enforced by this wrapper.
+   *
+   * @param raf underlying random access file to wrap; must reference a temporary file path.
+   */
+  @SuppressWarnings("unused")
   public TempRaf(RAF raf) {
     this(raf, DEFAULT_KEEP_POLICY);
   }
 
+  /**
+   * Wrap an existing {@link RAF} and apply a specific keep policy to govern cleanup on close.
+   *
+   * <p>The constructor delegates to the superclass with the provided RAF, records the keep policy,
+   * and registers a JVM shutdown hook via {@link File#deleteOnExit()} unless deletion is disabled
+   * by {@link #ALWAYS}. This ensures that temporary files do not linger after abrupt termination.
+   *
+   * @param raf underlying random access file that represents the temporary storage location.
+   * @param keepPolicy deletion strategy constant controlling cleanup when {@link #close()} runs.
+   */
   public TempRaf(RAF raf, int keepPolicy) {
     super(raf);
     if (keepPolicy != ALWAYS) {
-      // clean up in case of forcable shutdown.
+      // clean up in case of force shutdown.
       raf.getFile().deleteOnExit();
     }
 
     this.keepPolicy = keepPolicy;
   }
 
+  /**
+   * Rename the underlying temporary file to a caller-specified destination and record that a rename
+   * occurred for subsequent cleanup decisions.
+   *
+   * <p>The rename flag allows {@link #close()} to distinguish between temporary files that were
+   * staged but never persisted and those intentionally promoted to a final location. The method is
+   * synchronized to serialize concurrent rename attempts with closing.
+   *
+   * @param newFile destination file path to which the temporary file should be moved.
+   * @throws IOException if the delegate rename fails or the target cannot be written or replaced.
+   */
+  @Override
   public synchronized void renameTo(File newFile) throws IOException {
-    renamed = true;
+    renamedFlag = true;
     super.renameTo(newFile);
   }
 
+  /**
+   * Close the wrapped RAF and delete the temporary file according to the configured keep policy.
+   *
+   * <p>The method evaluates {@link #keepPolicy} and {@link #renamedFlag}: {@link #NEVER} always
+   * removes the file; {@link #RENAMED} removes it unless a rename occurred; {@link
+   * #RENAMED_AND_DONE_WRITING} removes it unless renamed while in read-only mode; {@link #ALWAYS}
+   * never deletes. The logic runs before delegating to {@link FilterRAF#close()}, and the method is
+   * synchronized to avoid races with {@link #renameTo(File)}.
+   *
+   * @throws IOException if closing the delegate RAF fails or underlying I/O errors occur.
+   */
+  @Override
   public synchronized void close() throws IOException {
 
     // keep as a switch statement for readability.
     switch (keepPolicy) {
-      case ALWAYS:
-        break;
       case NEVER:
         deleteOnClose();
         break;
       case RENAMED:
-        if (!renamed) {
+        if (!renamedFlag) {
           deleteOnClose();
         }
         break;
       case RENAMED_AND_DONE_WRITING:
-        if (!renamed || !getMode().equals("r")) {
+        if (!renamedFlag || !getMode().equals("r")) {
           deleteOnClose();
         }
+        break;
+      default:
         break;
     }
 

--- a/src/main/java/com/onionnetworks/io/WriteCommitRaf.java
+++ b/src/main/java/com/onionnetworks/io/WriteCommitRaf.java
@@ -2,19 +2,71 @@ package com.onionnetworks.io;
 
 import com.onionnetworks.util.*;
 import java.io.*;
-import java.util.*;
 
 /**
- * This raf commits its bytes the first time they are written.
+ * Random-access wrapper that commits each written region as soon as the write succeeds.
+ *
+ * <p>{@code WriteCommitRaf} builds on {@link CommitRaf} by automatically marking bytes committed
+ * immediately after they are persisted to the delegate {@link RAF}. This makes new data visible to
+ * readers without requiring the caller to invoke {@link #commit(Range)} manually, while still
+ * preserving the underlying guarantees that committed ranges become immutable and unblock waiting
+ * readers. Zero-length writes are allowed so pending exceptions surface consistently, but only
+ * nonzero writes trigger commits. When the file transitions to read-only mode, the wrapper commits
+ * the entire length so consumers can read to end-of-file without coordinating additional commit
+ * calls.
+ *
+ * <p>Use this class when producers do not need fine-grained transaction boundaries and prefer that
+ * durability implies visibility. All public operations synchronize on the instance, mirroring the
+ * thread-safety model of {@code CommitRaf}. Writes that overlap any previously committed byte are
+ * still rejected by the superclass, ensuring immutability once data is exposed. The automatic
+ * commit path is therefore best suited to append-heavy or forward-only write patterns where each
+ * region becomes readable immediately after it is written.
+ *
+ * <ul>
+ *   <li>Automatic commit of every successful nonzero write.
+ *   <li>Full-file commit when switching to read-only mode.
+ *   <li>Retains {@code CommitRaf}'s blocking read semantics and overlap checks.
+ * </ul>
  *
  * @author Justin Chapweske
+ * @see CommitRaf
+ * @see Range
  */
 public class WriteCommitRaf extends CommitRaf {
 
+  /**
+   * Creates an auto-committing wrapper around the provided random-access file.
+   *
+   * <p>The wrapper delegates all I/O to the supplied {@link RAF} while automatically committing any
+   * bytes written through {@link #seekAndWrite(long, byte[], int, int)}. Because the superclass
+   * enforces range immutability after commit, callers typically provide a fresh, writable {@code
+   * RAF} and perform writes in ascending order to avoid overlap violations. The constructor does
+   * not modify the delegate's state; closing this wrapper cascades to the same underlying handle,
+   * so it should not be shared elsewhere once wrapped.
+   *
+   * @param raf underlying {@link RAF} that persists data and maintains file positioning
+   */
   public WriteCommitRaf(RAF raf) {
     super(raf);
   }
 
+  /**
+   * Writes bytes at the given position and immediately commits the affected range.
+   *
+   * <p>The method delegates the actual write to the underlying {@link RAF} via the superclass,
+   * which also rejects attempts that overlap committed regions or surface pending exceptions. A
+   * zero-length invocation performs no I/O but still allows deferred errors to propagate from the
+   * delegate. After a successful nonzero write, the newly written range is marked committed so
+   * blocked readers can proceed without an explicit commit call from the caller. All arguments are
+   * validated by the superclass, and operations are synchronized to serialize concurrent access.
+   *
+   * @param pos absolute byte offset at which writing begins; must be zero or positive
+   * @param b source buffer containing data to persist; must not be {@code null}
+   * @param off starting offset within {@code b} from which bytes are read
+   * @param len number of bytes to write; zero performs error propagation only
+   * @throws IOException if the delegate fails, the range overlaps committed data, or closure occurs
+   */
+  @Override
   public synchronized void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
     super.seekAndWrite(pos, b, off, len);
     // Allow 0 length write to allow exceptions to be thrown.
@@ -23,6 +75,19 @@ public class WriteCommitRaf extends CommitRaf {
     }
   }
 
+  /**
+   * Switches the wrapper into read-only mode and commits all existing bytes.
+   *
+   * <p>Calling this method signals that no further writes will occur. The superclass flips the
+   * internal read-only flag and propagates the state to the delegate, after which this override
+   * commits the entire file range if the file is nonempty. Committing here ensures that readers
+   * waiting on visibility can progress to end-of-file without the caller issuing additional commit
+   * operations. Invocations are synchronized and may throw if the delegate cannot honor the
+   * read-only transition.
+   *
+   * @throws IOException if the delegate fails while entering read-only mode or is already closed
+   */
+  @Override
   public synchronized void setReadOnly() throws IOException {
     // When we switch to read-only, we commit the whole file.
     super.setReadOnly();

--- a/src/main/java/com/onionnetworks/io/WriteOnceRaf.java
+++ b/src/main/java/com/onionnetworks/io/WriteOnceRaf.java
@@ -5,19 +5,70 @@ import java.io.*;
 import java.util.*;
 
 /**
- * This Raf only allows a byte position to be written once. Any duplicate bytes are discarded.
+ * Enforces write-once semantics on a delegated random-access file.
  *
- * @author Justin Chapweske
+ * <p>WriteOnceRaf tracks which byte positions have not yet been persisted and only forwards the
+ * initial write for each position to the underlying {@link RAF}. Subsequent attempts to write the
+ * same offsets are silently ignored, making it suitable for assembling sparse or chunked payloads
+ * where duplicate arrivals are possible. The class extends {@link WriteCommitRaf}, so callers
+ * retain the normal commit/flush behavior provided by the parent implementation.
+ *
+ * <p>Use this wrapper when the producer may retry individual chunks or when concurrent download
+ * sources could send overlapping data. The instance keeps a range set of unwritten bytes and
+ * removes ranges as they are committed, avoiding unnecessary I/O and preserving the first-write
+ * policy. It does not attempt to resequence or compact writes; callers are responsible for seeking
+ * to the correct offsets and for managing any higher-level integrity checks.
+ *
+ * <p>Thread safety is limited to method-level synchronization on this instance. External
+ * synchronization is still recommended if multiple threads share the same {@code RAF}, especially
+ * if other operations bypass this wrapper. Writes are permanent for this object's lifetime; there
+ * is no API to reset or reopen positions once they have been consumed.
+ *
+ * <ul>
+ *   <li>Responsibilities: gate duplicate writes; delegate storage and commits to {@link RAF}.
+ *   <li>Notable behavior: zero-length writes still pass through to allow upstream validation.
+ * </ul>
+ *
+ * @see WriteCommitRaf
+ * @see com.onionnetworks.util.RangeSet
  */
 public class WriteOnceRaf extends WriteCommitRaf {
 
   // This range set contains all possible unwritten bytes.
   RangeSet unwritten = new RangeSet().complement();
 
+  /**
+   * Creates a write-once wrapper over the provided random-access file handle.
+   *
+   * <p>The underlying {@link RAF} is expected to represent the full target file and should already
+   * be positioned or resized as needed by the caller. The constructor initializes the internal set
+   * of unwritten bytes to include the entire addressable range, so the first write to any offset
+   * will be forwarded while all subsequent writes to the same offset are ignored.
+   *
+   * @param raf backing random-access file receiving first write per position; must be non-null.
+   */
   public WriteOnceRaf(RAF raf) {
     super(raf);
   }
 
+  /**
+   * Writes data while discarding any bytes that have already been written previously.
+   *
+   * <p>The method examines the requested span and forwards only the still-unwritten subranges to
+   * the underlying {@link RAF}. It keeps the original offset and length semantics, so callers may
+   * supply buffers containing both new and duplicate bytes without pre-filtering. A zero-length
+   * request is delegated to the superclass to surface any validation exceptions. The call is
+   * synchronized to keep the tracked unwritten ranges consistent across overlapping writes;
+   * nevertheless, sharing the same instance across threads still requires external coordination to
+   * avoid conflicting seek operations.
+   *
+   * @param pos zero-based file offset for the first byte; must be non-negative.
+   * @param b source buffer holding candidate bytes; duplicates are skipped during forwarding.
+   * @param off start index within {@code b} to read; obeys standard array bounds.
+   * @param len count of bytes to attempt; zero-length calls only validate arguments.
+   * @throws IOException if delegated write fails or underlying {@link RAF} reports an I/O error.
+   */
+  @Override
   public synchronized void seekAndWrite(long pos, byte[] b, int off, int len) throws IOException {
     if (len == 0) {
       // Do 0 length write to allow exceptions to be thrown.
@@ -26,8 +77,8 @@ public class WriteOnceRaf extends WriteCommitRaf {
     }
 
     Range r = new Range(pos, pos + len - 1);
-    for (Iterator it = unwritten.intersect(new RangeSet(r)).iterator(); it.hasNext(); ) {
-      Range r2 = (Range) it.next();
+    for (Iterator<Range> it = unwritten.intersect(new RangeSet(r)).iterator(); it.hasNext(); ) {
+      Range r2 = it.next();
       // (int) casts are safe because they will never be larger than len
       super.seekAndWrite(r2.getMin(), b, off + (int) (r2.getMin() - pos), (int) r2.size());
       unwritten.remove(r2);

--- a/src/test/java/com/onionnetworks/io/BlockingRAFTest.java
+++ b/src/test/java/com/onionnetworks/io/BlockingRAFTest.java
@@ -1,0 +1,232 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BlockingRAFTest {
+
+  private static final long WAIT_TIMEOUT_MILLIS = 1_000L;
+
+  @Mock private RAF delegateRaf;
+
+  private BlockingRAF blockingRaf;
+
+  @BeforeEach
+  void setUp() {
+    blockingRaf = new BlockingRAF(delegateRaf);
+    lenient().when(delegateRaf.getMode()).thenReturn("rw");
+    lenient().when(delegateRaf.isClosed()).thenReturn(false);
+  }
+
+  @Test
+  void seekAndReadFully_alwaysThrowsUnsupportedOperationException() {
+    IOException ex =
+        assertThrows(IOException.class, () -> blockingRaf.seekAndReadFully(0L, new byte[1], 0, 1));
+
+    assertEquals("unsupported operation", ex.getMessage());
+  }
+
+  @Test
+  void seekAndWrite_whenExceptionPreviouslySet_rethrowsAndSkipsDelegate() throws Exception {
+    IOException failure = new IOException("boom");
+    blockingRaf.setException(failure);
+
+    IOException thrown =
+        assertThrows(IOException.class, () -> blockingRaf.seekAndWrite(0L, new byte[0], 0, 0));
+
+    assertSame(failure, thrown);
+    verify(delegateRaf, never()).seekAndWrite(anyLong(), any(), anyInt(), anyInt());
+  }
+
+  @Test
+  void seekAndWrite_withZeroLength_doesNotRecordWrittenRange() throws Exception {
+    byte[] data = new byte[0];
+
+    blockingRaf.seekAndWrite(5L, data, 0, 0);
+
+    verify(delegateRaf).seekAndWrite(5L, data, 0, 0);
+    assertTrue(blockingRaf.written.isEmpty());
+  }
+
+  @Test
+  void seekAndRead_whenRangeAlreadyWritten_delegatesToUnderlyingRaf() throws Exception {
+    byte[] source = new byte[] {1, 2, 3, 4};
+    byte[] dest = new byte[4];
+    blockingRaf.seekAndWrite(10L, source, 0, source.length);
+    when(delegateRaf.seekAndRead(10L, dest, 0, 4)).thenReturn(4);
+
+    int read = blockingRaf.seekAndRead(10L, dest, 0, 4);
+
+    assertEquals(4, read);
+    verify(delegateRaf).seekAndRead(10L, dest, 0, 4);
+  }
+
+  @Test
+  void seekAndRead_whenDataArrivesAfterBlocking_writesDirectlyToCallerBuffer() throws Exception {
+    byte[] dest = new byte[4];
+    byte[] source = new byte[] {9, 8, 7, 6};
+    AtomicInteger bytesRead = new AtomicInteger(-1);
+    AtomicReference<Exception> thrown = new AtomicReference<>();
+
+    Thread reader =
+        new Thread(
+            () -> {
+              try {
+                bytesRead.set(blockingRaf.seekAndRead(20L, dest, 0, dest.length));
+              } catch (Exception e) {
+                thrown.set(e);
+              }
+            });
+
+    reader.start();
+    waitForBuffersToBeRegistered();
+
+    blockingRaf.seekAndWrite(20L, source, 0, source.length);
+
+    reader.join(WAIT_TIMEOUT_MILLIS);
+    assertFalse(reader.isAlive(), "reader thread should complete");
+    assertNotEquals(-1, bytesRead.get());
+    if (thrown.get() != null) {
+      throw thrown.get();
+    }
+
+    assertEquals(source.length, bytesRead.get());
+    assertArrayEquals(source, Arrays.copyOf(dest, source.length));
+  }
+
+  @Test
+  void seekAndRead_whenModeSwitchesToReadOnly_unblocksAndDelegatesToRead() throws Exception {
+    AtomicReference<String> mode = new AtomicReference<>("rw");
+    when(delegateRaf.getMode()).thenAnswer(inv -> mode.get());
+    when(delegateRaf.seekAndRead(anyLong(), any(), anyInt(), anyInt())).thenReturn(0);
+
+    byte[] dest = new byte[3];
+    AtomicInteger bytesRead = new AtomicInteger(-1);
+    AtomicReference<Exception> thrown = new AtomicReference<>();
+
+    Thread reader =
+        new Thread(
+            () -> {
+              try {
+                bytesRead.set(blockingRaf.seekAndRead(0L, dest, 0, dest.length));
+              } catch (Exception e) {
+                thrown.set(e);
+              }
+            });
+
+    reader.start();
+    waitForBuffersToBeRegistered();
+
+    mode.set("r");
+    blockingRaf.setReadOnly();
+
+    reader.join(WAIT_TIMEOUT_MILLIS);
+    assertFalse(reader.isAlive(), "reader thread should complete");
+    if (thrown.get() != null) {
+      throw thrown.get();
+    }
+
+    assertEquals(0, bytesRead.get());
+    verify(delegateRaf).setReadOnly();
+    verify(delegateRaf).seekAndRead(0L, dest, 0, dest.length);
+  }
+
+  @Test
+  void seekAndRead_whenExceptionSetDuringWait_throwsSameException() throws Exception {
+    AtomicReference<Exception> thrown = new AtomicReference<>();
+
+    Thread reader =
+        new Thread(
+            () -> {
+              try {
+                blockingRaf.seekAndRead(0L, new byte[2], 0, 2);
+              } catch (Exception e) {
+                thrown.set(e);
+              }
+            });
+
+    reader.start();
+    waitForBuffersToBeRegistered();
+
+    IOException expected = new IOException("forced");
+    blockingRaf.setException(expected);
+
+    reader.join(WAIT_TIMEOUT_MILLIS);
+    assertFalse(reader.isAlive(), "reader thread should complete");
+    assertSame(expected, thrown.get());
+  }
+
+  @Test
+  void seekAndRead_whenThreadInterruptedWhileWaiting_wrapsInInterruptedIOException() {
+    AtomicReference<Exception> thrown = new AtomicReference<>();
+
+    Thread reader =
+        new Thread(
+            () -> {
+              try {
+                blockingRaf.seekAndRead(0L, new byte[1], 0, 1);
+              } catch (Exception e) {
+                thrown.set(e);
+              }
+            });
+
+    reader.start();
+    waitForBuffersToBeRegistered();
+
+    reader.interrupt();
+
+    assertTimeoutPreemptively(
+        Duration.ofMillis(WAIT_TIMEOUT_MILLIS),
+        () -> {
+          reader.join();
+          assertInstanceOf(InterruptedIOException.class, thrown.get());
+        });
+  }
+
+  private void waitForBuffersToBeRegistered() {
+    final BlockingRAF raf = blockingRaf;
+    long deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MILLIS;
+    synchronized (raf) {
+      while (raf.buffers.isEmpty()) {
+        long remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0) {
+          throw new AssertionError("Reader thread did not block as expected");
+        }
+        try {
+          raf.wait(remaining);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("Interrupted while waiting for buffers", e);
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/com/onionnetworks/io/CommitRafTest.java
+++ b/src/test/java/com/onionnetworks/io/CommitRafTest.java
@@ -1,0 +1,191 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.onionnetworks.util.Range;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class CommitRafTest {
+
+  @Mock RAF delegate;
+
+  private CommitRaf commitRaf;
+  private ExecutorService executor;
+
+  @BeforeEach
+  void setUp() {
+    commitRaf = new CommitRaf(delegate);
+    executor = Executors.newSingleThreadExecutor();
+  }
+
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+  }
+
+  @Test
+  void seekAndWrite_whenExceptionSet_expectIOException() throws Exception {
+    IOException failure = new IOException("boom");
+    commitRaf.setException(failure);
+
+    IOException thrown =
+        assertThrows(IOException.class, () -> commitRaf.seekAndWrite(0, new byte[1], 0, 1));
+
+    assertSame(failure, thrown);
+    verify(delegate, never()).seekAndWrite(anyLong(), any(), anyInt(), anyInt());
+  }
+
+  @Test
+  void seekAndWrite_whenRangeAlreadyCommitted_expectIOException() throws Exception {
+    commitRaf.commit(new Range(5, 10));
+
+    assertThrows(IOException.class, () -> commitRaf.seekAndWrite(7, new byte[4], 0, 2));
+
+    verify(delegate, never()).seekAndWrite(anyLong(), any(), anyInt(), anyInt());
+  }
+
+  @Test
+  void seekAndWrite_withZeroLength_delegatesAndReturnsImmediately() throws Exception {
+    commitRaf.seekAndWrite(3, new byte[0], 0, 0);
+
+    verify(delegate).seekAndWrite(3L, new byte[0], 0, 0);
+  }
+
+  @Test
+  void seekAndRead_whenFullyCommittedAndReadOnly_delegatesToUnderlyingRaf() throws Exception {
+    when(delegate.getMode()).thenReturn("r");
+    when(delegate.length()).thenReturn(4L);
+    when(delegate.seekAndRead(anyLong(), any(), anyInt(), anyInt())).thenReturn(4);
+    when(delegate.isClosed()).thenReturn(false);
+    byte[] target = new byte[4];
+    commitRaf.commit(new Range(0, 3));
+
+    int read = commitRaf.seekAndRead(0, target, 0, 4);
+
+    assertEquals(4, read);
+    verify(delegate).seekAndRead(0L, target, 0, 4);
+  }
+
+  @Test
+  void seekAndRead_waitsForCommit_andReturnsDirectWriteBytes() throws Exception {
+    when(delegate.getMode()).thenReturn("rw");
+    when(delegate.isClosed()).thenReturn(false);
+    doAnswer(invocation -> null).when(delegate).seekAndWrite(anyLong(), any(), anyInt(), anyInt());
+
+    byte[] target = new byte[4];
+    Future<Integer> result =
+        executor.submit(() -> commitRaf.seekAndRead(0, target, 0, target.length));
+
+    assertTrue(waitForBufferRegistration());
+
+    byte[] data = new byte[] {1, 2, 3, 4};
+    commitRaf.seekAndWrite(0, data, 0, data.length);
+    commitRaf.commit(new Range(0, data.length - 1));
+
+    assertEquals(data.length, getWithTimeout(result));
+    assertArrayEquals(data, target);
+    verify(delegate, never()).seekAndRead(anyLong(), any(), anyInt(), anyInt());
+  }
+
+  @Test
+  void seekAndRead_whenExceptionSetWhileWaiting_throwsOriginalException() throws Exception {
+    when(delegate.getMode()).thenReturn("rw");
+    when(delegate.isClosed()).thenReturn(false);
+
+    byte[] target = new byte[2];
+    Future<Integer> result =
+        executor.submit(() -> commitRaf.seekAndRead(0, target, 0, target.length));
+
+    assertTrue(waitForBufferRegistration());
+
+    IOException failure = new IOException("injected");
+    commitRaf.setException(failure);
+
+    ExecutionException ex = assertThrows(ExecutionException.class, () -> getWithTimeout(result));
+    assertSame(failure, ex.getCause());
+    verify(delegate, never()).seekAndRead(anyLong(), any(), anyInt(), anyInt());
+  }
+
+  @Test
+  void seekAndRead_whenClosedWhileWaiting_throwsClosedIOException() throws Exception {
+    AtomicBoolean closed = new AtomicBoolean(false);
+    when(delegate.getMode()).thenReturn("rw");
+    when(delegate.isClosed()).thenAnswer(invocation -> closed.get());
+    doAnswer(
+            invocation -> {
+              closed.set(true);
+              return null;
+            })
+        .when(delegate)
+        .close();
+
+    byte[] target = new byte[3];
+    Future<Integer> result =
+        executor.submit(() -> commitRaf.seekAndRead(0, target, 0, target.length));
+
+    assertTrue(waitForBufferRegistration());
+
+    commitRaf.close();
+
+    ExecutionException ex = assertThrows(ExecutionException.class, () -> getWithTimeout(result));
+    assertInstanceOf(IOException.class, ex.getCause());
+    assertEquals("RAF closed", ex.getCause().getMessage());
+  }
+
+  @Test
+  void seekAndRead_whenLengthIsZero_returnsZeroWithoutWaiting() throws Exception {
+    int read = commitRaf.seekAndRead(0, new byte[0], 0, 0);
+
+    assertEquals(0, read);
+    assertTrue(commitRaf.buffers.isEmpty());
+  }
+
+  private boolean waitForBufferRegistration() throws InterruptedException {
+    CommitRaf rafRef = this.commitRaf;
+    long deadline = System.currentTimeMillis() + 1_000;
+    while (System.currentTimeMillis() < deadline) {
+      synchronized (rafRef) {
+        if (!rafRef.buffers.isEmpty()) {
+          return true;
+        }
+        long remaining = deadline - System.currentTimeMillis();
+        if (remaining > 0) {
+          rafRef.wait(Math.min(remaining, 50));
+        }
+      }
+    }
+    return false;
+  }
+
+  private int getWithTimeout(Future<Integer> future)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return future.get(1, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/com/onionnetworks/io/JournalingRAFTest.java
+++ b/src/test/java/com/onionnetworks/io/JournalingRAFTest.java
@@ -1,0 +1,147 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.onionnetworks.util.Range;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class JournalingRAFTest {
+
+  @TempDir Path tempDir;
+
+  @Mock RAF delegateRaf;
+
+  @Mock Journal journal;
+
+  private File defaultFile;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    defaultFile = Files.createFile(tempDir.resolve("default.dat")).toFile();
+  }
+
+  @Test
+  void constructor_whenModeReadOnly_throwsIllegalStateException() {
+    when(delegateRaf.getMode()).thenReturn("r");
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> new JournalingRAF(delegateRaf, journal));
+
+    assertEquals("Can't create a journal for a read-only file.", ex.getMessage());
+    verify(journal, never()).setTargetFile(any());
+  }
+
+  @Test
+  void constructor_whenWritable_setsInitialTargetFile() throws Exception {
+    JournalingRAF raf = newJournalingRaf(defaultFile);
+
+    verify(journal).setTargetFile(defaultFile);
+    // keep the instance reachable for further operations if needed
+    raf.close();
+  }
+
+  @Test
+  void seekAndWrite_whenCalled_recordsRangeAndDelegates() throws Exception {
+    try (JournalingRAF raf = newJournalingRaf(defaultFile)) {
+      byte[] data = new byte[] {1, 2, 3, 4};
+
+      raf.seekAndWrite(5L, data, 1, 2);
+
+      verify(delegateRaf).seekAndWrite(5L, data, 1, 2);
+      ArgumentCaptor<Range> rangeCaptor = ArgumentCaptor.forClass(Range.class);
+      verify(journal).addByteRange(rangeCaptor.capture());
+      assertEquals(new Range(5L, 6L), rangeCaptor.getValue());
+    }
+  }
+
+  @Test
+  void renameTo_whenDelegateRenames_updatesJournalTargetAndFlushes() throws Exception {
+    File dest = tempDir.resolve("renamed.dat").toFile();
+    File original = defaultFile;
+    when(delegateRaf.getMode()).thenReturn("rw");
+    when(delegateRaf.getFile()).thenReturn(original, dest);
+    try (JournalingRAF raf = new JournalingRAF(delegateRaf, journal)) {
+      raf.renameTo(dest);
+
+      verify(delegateRaf).renameTo(dest);
+      verify(journal).setTargetFile(dest);
+      verify(journal).flush();
+    }
+  }
+
+  @Test
+  void setReadOnly_whenInvoked_deletesJournalAndPreventsFurtherJournalClose() throws Exception {
+    File journalFile = Files.createFile(tempDir.resolve("journal.props")).toFile();
+    when(journal.getFile()).thenReturn(journalFile);
+    JournalingRAF raf = newJournalingRaf(defaultFile);
+
+    raf.setReadOnly();
+    raf.close();
+
+    assertFalse(journalFile.exists());
+    verify(delegateRaf).setReadOnly();
+    verify(journal, times(1)).close();
+  }
+
+  @Test
+  void deleteOnClose_whenInvoked_closesJournalAndDeletesFileImmediately() throws Exception {
+    File journalFile = Files.createFile(tempDir.resolve("delete.props")).toFile();
+    when(journal.getFile()).thenReturn(journalFile);
+    try (JournalingRAF raf = newJournalingRaf(defaultFile)) {
+      raf.deleteOnClose();
+
+      assertFalse(journalFile.exists());
+      verify(delegateRaf).deleteOnClose();
+      verify(journal).close();
+    }
+  }
+
+  @Test
+  void close_whenJournalPresent_closesDelegateAndJournal() throws Exception {
+    JournalingRAF raf = newJournalingRaf(defaultFile);
+
+    raf.close();
+
+    verify(delegateRaf).close();
+    verify(journal).close();
+  }
+
+  @Test
+  void seekAndWrite_afterJournalRemoved_stillDelegatesWithoutRecordingRange() throws Exception {
+    File journalFile = Files.createFile(tempDir.resolve("removed.props")).toFile();
+    when(journal.getFile()).thenReturn(journalFile);
+    try (JournalingRAF raf = newJournalingRaf(defaultFile)) {
+      raf.deleteOnClose();
+
+      byte[] data = new byte[] {9};
+      raf.seekAndWrite(0L, data, 0, 1);
+
+      verify(delegateRaf).seekAndWrite(0L, data, 0, 1);
+      verify(journal, never()).addByteRange(any());
+    }
+  }
+
+  private JournalingRAF newJournalingRaf(File initialFile) throws Exception {
+    when(delegateRaf.getMode()).thenReturn("rw");
+    when(delegateRaf.getFile()).thenReturn(initialFile);
+    return new JournalingRAF(delegateRaf, journal);
+  }
+}

--- a/src/test/java/com/onionnetworks/io/LazyRenameRAFTest.java
+++ b/src/test/java/com/onionnetworks/io/LazyRenameRAFTest.java
@@ -1,0 +1,104 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class LazyRenameRAFTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void constructor_whenModeReadOnly_throwsIllegalStateException() throws IOException {
+    Path file = Files.createTempFile(tempDir, "lazy-raf-", ".dat");
+    Files.write(file, new byte[] {1, 2, 3});
+
+    try (RAF readOnly = new RAF(file.toFile(), "r")) {
+      assertThrows(IllegalStateException.class, () -> new LazyRenameRAF(readOnly));
+    }
+  }
+
+  @Test
+  void renameTo_whenReadWriteMode_usesTempFileAndKeepsDestPending() throws IOException {
+    Path source = Files.createTempFile(tempDir, "lazy-raf-", ".dat");
+    byte[] data = new byte[] {10, 20, 30, 40};
+    RAF raf = new RAF(source.toFile(), "rw");
+
+    try (LazyRenameRAF lazy = new LazyRenameRAF(raf)) {
+      lazy.seekAndWrite(0, data, 0, data.length);
+      Path destination = tempDir.resolve("final-destination.dat");
+
+      lazy.renameTo(destination.toFile());
+
+      File tempLocation = lazy.getFile();
+      assertFalse(
+          Files.exists(destination),
+          "Final destination should not exist until setReadOnly is called");
+      assertEquals(destination.getParent(), tempLocation.getParentFile().toPath());
+      assertTrue(Files.exists(tempLocation.toPath()), "Intermediate temp file must exist");
+      assertArrayEquals(data, Files.readAllBytes(tempLocation.toPath()));
+    }
+  }
+
+  @Test
+  void setReadOnly_afterRename_movesTempToDestination() throws IOException {
+    Path source = Files.createTempFile(tempDir, "lazy-raf-", ".dat");
+    byte[] data = new byte[] {5, 6, 7};
+    RAF raf = new RAF(source.toFile(), "rw");
+
+    try (LazyRenameRAF lazy = new LazyRenameRAF(raf)) {
+      lazy.seekAndWrite(0, data, 0, data.length);
+      Path destination = tempDir.resolve("final-readonly.dat");
+      lazy.renameTo(destination.toFile());
+
+      File tempLocation = lazy.getFile();
+      lazy.setReadOnly();
+
+      assertTrue(
+          Files.exists(destination), "Destination should exist after setReadOnly promotes it");
+      assertFalse(
+          Files.exists(tempLocation.toPath()),
+          "Temporary staging file should be moved to destination");
+      assertArrayEquals(data, Files.readAllBytes(destination));
+      assertEquals(
+          destination.toFile().getCanonicalFile(),
+          lazy.getFile().getCanonicalFile(),
+          "RAF should now point to destination");
+    }
+  }
+
+  @Test
+  void renameTo_afterSetReadOnly_movesDirectlyToDestination() throws IOException {
+    Path source = Files.createTempFile(tempDir, "lazy-raf-", ".dat");
+    byte[] data = new byte[] {42, 43, 44, 45};
+    RAF raf = new RAF(source.toFile(), "rw");
+
+    try (LazyRenameRAF lazy = new LazyRenameRAF(raf)) {
+      lazy.seekAndWrite(0, data, 0, data.length);
+      lazy.setReadOnly();
+
+      Path destination = tempDir.resolve("direct-move.dat");
+      lazy.renameTo(destination.toFile());
+
+      assertTrue(
+          Files.exists(destination),
+          "Destination should be created immediately when already read-only");
+      assertFalse(Files.exists(source), "Original file should no longer exist after direct rename");
+      assertArrayEquals(data, Files.readAllBytes(destination));
+      assertEquals(
+          destination.toFile().getCanonicalFile(),
+          lazy.getFile().getCanonicalFile(),
+          "RAF should track the final destination");
+    }
+  }
+}

--- a/src/test/java/com/onionnetworks/io/TempRafTest.java
+++ b/src/test/java/com/onionnetworks/io/TempRafTest.java
@@ -1,0 +1,101 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class TempRafTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void close_whenKeepPolicyNever_deletesFile() throws IOException {
+    Path file = Files.createTempFile(tempDir, "tempraf-", ".dat");
+
+    try (TempRaf tempRaf = new TempRaf(new RAF(file.toFile(), "rw"), TempRaf.NEVER)) {
+      tempRaf.seekAndWrite(0, new byte[] {1, 2, 3}, 0, 3);
+    }
+
+    assertFalse(Files.exists(file), "Temporary file should be removed when keepPolicy=NEVER");
+  }
+
+  @Test
+  void close_whenKeepPolicyAlways_keepsFile() throws IOException {
+    Path file = Files.createTempFile(tempDir, "tempraf-", ".dat");
+
+    try (TempRaf tempRaf = new TempRaf(new RAF(file.toFile(), "rw"), TempRaf.ALWAYS)) {
+      tempRaf.seekAndWrite(0, new byte[] {4, 5, 6, 7}, 0, 4);
+    }
+
+    assertTrue(Files.exists(file), "File should persist when keepPolicy=ALWAYS");
+    assertTrue(Files.size(file) > 0, "File contents should remain intact after close");
+  }
+
+  @Test
+  void close_whenKeepPolicyRenamedWithoutRename_deletesFile() throws IOException {
+    Path file = Files.createTempFile(tempDir, "tempraf-", ".dat");
+
+    try (TempRaf tempRaf = new TempRaf(new RAF(file.toFile(), "rw"), TempRaf.RENAMED)) {
+      tempRaf.seekAndWrite(0, new byte[] {8}, 0, 1);
+    }
+
+    assertFalse(
+        Files.exists(file), "File should be deleted when keepPolicy=RENAMED and no rename occurs");
+  }
+
+  @Test
+  void close_whenKeepPolicyRenamedWithRename_keepsRenamedFile() throws IOException {
+    Path original = Files.createTempFile(tempDir, "tempraf-", ".dat");
+    Path renamed = tempDir.resolve("renamed-file.dat");
+
+    try (TempRaf tempRaf = new TempRaf(new RAF(original.toFile(), "rw"), TempRaf.RENAMED)) {
+      tempRaf.seekAndWrite(0, new byte[] {9, 10}, 0, 2);
+      tempRaf.renameTo(renamed.toFile());
+    }
+
+    assertFalse(Files.exists(original), "Original file should be moved during rename");
+    assertTrue(Files.exists(renamed), "Renamed file should persist with keepPolicy=RENAMED");
+  }
+
+  @Test
+  void close_whenKeepPolicyRenamedAndDoneWritingWithoutReadOnly_deletesFile() throws IOException {
+    Path original = Files.createTempFile(tempDir, "tempraf-", ".dat");
+    Path renamed = tempDir.resolve("renamed-during-write.dat");
+
+    try (TempRaf tempRaf =
+        new TempRaf(new RAF(original.toFile(), "rw"), TempRaf.RENAMED_AND_DONE_WRITING)) {
+      tempRaf.seekAndWrite(0, new byte[] {11}, 0, 1);
+      tempRaf.renameTo(renamed.toFile());
+    }
+
+    assertFalse(Files.exists(original), "Original file should be removed after rename");
+    assertFalse(
+        Files.exists(renamed),
+        "Renamed file should be deleted when not switched to read-only after rename");
+  }
+
+  @Test
+  void close_whenKeepPolicyRenamedAndDoneWritingWithReadOnly_keepsRenamedFile() throws IOException {
+    Path original = Files.createTempFile(tempDir, "tempraf-", ".dat");
+    Path renamed = tempDir.resolve("renamed-final.dat");
+
+    try (TempRaf tempRaf =
+        new TempRaf(new RAF(original.toFile(), "rw"), TempRaf.RENAMED_AND_DONE_WRITING)) {
+      tempRaf.seekAndWrite(0, new byte[] {12, 13}, 0, 2);
+      tempRaf.renameTo(renamed.toFile());
+      tempRaf.setReadOnly();
+    }
+
+    assertFalse(Files.exists(original), "Original file should not remain after rename");
+    assertTrue(
+        Files.exists(renamed),
+        "Renamed file should persist when set to read-only after rename with"
+            + " keepPolicy=RENAMED_AND_DONE_WRITING");
+  }
+}

--- a/src/test/java/com/onionnetworks/io/WriteCommitRafTest.java
+++ b/src/test/java/com/onionnetworks/io/WriteCommitRafTest.java
@@ -1,0 +1,74 @@
+package com.onionnetworks.io;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.onionnetworks.util.Range;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class WriteCommitRafTest {
+
+  @Mock RAF delegate;
+
+  private WriteCommitRaf writeCommitRaf;
+
+  @BeforeEach
+  void setUp() {
+    writeCommitRaf = spy(new WriteCommitRaf(delegate));
+  }
+
+  @Test
+  void seekAndWrite_whenBytesWritten_commitsRange() throws Exception {
+    byte[] data = new byte[] {1, 2, 3};
+
+    writeCommitRaf.seekAndWrite(5, data, 0, data.length);
+
+    InOrder order = inOrder(delegate, writeCommitRaf);
+    order.verify(delegate).seekAndWrite(5L, data, 0, data.length);
+    order.verify(writeCommitRaf).commit(new Range(5, 7));
+  }
+
+  @Test
+  void seekAndWrite_whenZeroLength_doesNotCommitRange() throws Exception {
+    byte[] data = new byte[0];
+
+    writeCommitRaf.seekAndWrite(2, data, 0, 0);
+
+    verify(delegate).seekAndWrite(2L, data, 0, 0);
+    verify(writeCommitRaf, never()).commit(any(Range.class));
+  }
+
+  @Test
+  void setReadOnly_whenFileHasData_commitsFullLength() throws Exception {
+    when(delegate.length()).thenReturn(8L);
+
+    writeCommitRaf.setReadOnly();
+
+    InOrder order = inOrder(delegate, writeCommitRaf);
+    order.verify(delegate).setReadOnly();
+    order.verify(delegate).length();
+    order.verify(writeCommitRaf).commit(new Range(0, 7));
+  }
+
+  @Test
+  void setReadOnly_whenFileIsEmpty_skipsCommit() throws Exception {
+    when(delegate.length()).thenReturn(0L);
+
+    writeCommitRaf.setReadOnly();
+
+    verify(delegate).setReadOnly();
+    verify(delegate).length();
+    verify(writeCommitRaf, never()).commit(any(Range.class));
+  }
+}

--- a/src/test/java/com/onionnetworks/io/WriteOnceRafTest.java
+++ b/src/test/java/com/onionnetworks/io/WriteOnceRafTest.java
@@ -1,0 +1,93 @@
+package com.onionnetworks.io;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class WriteOnceRafTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void seekAndWrite_whenFirstWrite_writesAllBytesOnce() throws Exception {
+    Path file = tempDir.resolve("first-write.dat");
+    byte[] data = "hello".getBytes(StandardCharsets.US_ASCII);
+
+    try (WriteOnceRaf raf = new WriteOnceRaf(new RAF(file.toFile(), "rw"))) {
+      raf.seekAndWrite(0, data, 0, data.length);
+
+      byte[] buffer = new byte[data.length];
+      int read = raf.seekAndRead(0, buffer, 0, buffer.length);
+      assertEquals(data.length, read);
+      assertArrayEquals(data, buffer);
+    }
+
+    assertArrayEquals(data, Files.readAllBytes(file));
+  }
+
+  @Test
+  void seekAndWrite_whenOverlappingWrite_skipsPreviouslyWrittenBytes() throws Exception {
+    Path file = tempDir.resolve("overlap-write.dat");
+    byte[] initial = "abcd".getBytes(StandardCharsets.US_ASCII);
+    byte[] overlapping = "wxyz".getBytes(StandardCharsets.US_ASCII);
+
+    try (WriteOnceRaf raf = new WriteOnceRaf(new RAF(file.toFile(), "rw"))) {
+      raf.seekAndWrite(0, initial, 0, initial.length);
+      raf.seekAndWrite(2, overlapping, 0, overlapping.length);
+    }
+
+    assertEquals(6, Files.size(file));
+    assertArrayEquals("abcdyz".getBytes(StandardCharsets.US_ASCII), Files.readAllBytes(file));
+  }
+
+  @Test
+  void seekAndWrite_whenEntireRangeAlreadyWritten_keepsOriginalData() throws Exception {
+    Path file = tempDir.resolve("duplicate-write.dat");
+    byte[] initial = "foo".getBytes(StandardCharsets.US_ASCII);
+    byte[] duplicate = "bar".getBytes(StandardCharsets.US_ASCII);
+
+    try (WriteOnceRaf raf = new WriteOnceRaf(new RAF(file.toFile(), "rw"))) {
+      raf.seekAndWrite(0, initial, 0, initial.length);
+      raf.seekAndWrite(0, duplicate, 0, duplicate.length);
+    }
+
+    assertEquals(initial.length, Files.size(file));
+    assertArrayEquals(initial, Files.readAllBytes(file));
+  }
+
+  @Test
+  void seekAndWrite_whenBridgingGap_writesOnlyUnwrittenMiddleSection() throws Exception {
+    Path file = tempDir.resolve("gap-bridge.dat");
+    byte[] prefix = "AB".getBytes(StandardCharsets.US_ASCII);
+    byte[] suffix = "CD".getBytes(StandardCharsets.US_ASCII);
+    byte[] bridge = "XYZ".getBytes(StandardCharsets.US_ASCII);
+
+    try (WriteOnceRaf raf = new WriteOnceRaf(new RAF(file.toFile(), "rw"))) {
+      raf.seekAndWrite(0, prefix, 0, prefix.length); // positions 0-1
+      raf.seekAndWrite(3, suffix, 0, suffix.length); // positions 3-4, leaves a hole at 2
+      raf.seekAndWrite(1, bridge, 0, bridge.length); // only unwritten index 2 should be filled
+    }
+
+    assertEquals(5, Files.size(file));
+    assertArrayEquals("ABYCD".getBytes(StandardCharsets.US_ASCII), Files.readAllBytes(file));
+  }
+
+  @Test
+  void seekAndWrite_whenLengthIsZero_leavesFileUnchanged() throws Exception {
+    Path file = tempDir.resolve("zero-length.dat");
+    byte[] data = "ignored".getBytes(StandardCharsets.US_ASCII);
+
+    try (WriteOnceRaf raf = new WriteOnceRaf(new RAF(file.toFile(), "rw"))) {
+      raf.seekAndWrite(0, data, 0, 0);
+    }
+
+    assertEquals(0, Files.size(file));
+    assertArrayEquals(new byte[0], Files.readAllBytes(file));
+  }
+}


### PR DESCRIPTION
## Summary
- refactor FilterRAF and related RAF wrappers for clearer delegation names and richer Javadoc
- stabilize BlockingRAF coordination and improve JournalingRAF cleanup/logging behavior
- add focused tests for CommitRaf, WriteCommitRaf, WriteOnceRaf, LazyRenameRAF, TempRaf, and blocking/journaling flows

## Testing
- Not run (not requested)