### PR TITLE
Add documentation and tests for FileUtil utilities

### DIFF
--- a/src/main/java/com/onionnetworks/util/FileUtil.java
+++ b/src/main/java/com/onionnetworks/util/FileUtil.java
@@ -5,7 +5,38 @@ import java.net.URL;
 import java.util.BitSet;
 import java.util.StringTokenizer;
 
+/**
+ * Utility helpers for safe file handling inside Crypta/Onion-based directories.
+ *
+ * <p>This class provides sanitization, path construction, and small convenience helpers around
+ * {@link File} so callers can create or reference files without leaking unsafe characters or
+ * accidentally writing outside the expected working tree. All methods are static and side-effect
+ * free beyond the explicit filesystem interactions they perform. The helpers focus on predictable
+ * behavior for user-provided paths, ensure idempotent directory creation, and centralize decisions
+ * about where temporary and persistent files should live within a user's home directory.
+ *
+ * <p>Thread-safety: the class maintains no mutable static state beyond an immutable lookup table of
+ * safe characters, so methods can be invoked concurrently. File creation helpers are defensive
+ * against normal race conditions where multiple threads attempt to create the same file or
+ * directory. Callers should still synchronize higher-level workflows when they require stronger
+ * atomicity than the file system provides.
+ *
+ * <ul>
+ *   <li>Responsibilities: sanitize user-visible names, build .onion-scoped paths, create
+ *       directories/files, and perform reliable stream skipping.
+ *   <li>Notable behaviors: avoids absolute paths in {@link #safeOnionFile(String)}, falls back to
+ *       safe defaults for empty filenames, and prefers the user's home temp space to system-wide
+ *       temp when available.
+ * </ul>
+ *
+ * @see #safeOnionFile(String)
+ * @see #createTempFile(File)
+ */
 public class FileUtil {
+
+  private FileUtil() {
+    throw new IllegalStateException("Utility class");
+  }
 
   // safe characters for file name sanitization
   static BitSet safeChars = new BitSet(256);
@@ -29,8 +60,20 @@ public class FileUtil {
     safeChars.set('.');
   }
 
-  public static final String sanitizeFileName(String name) {
-    StringBuffer result = new StringBuffer();
+  /**
+   * Removes characters not considered safe for local filesystem names and collapses duplicate dots.
+   *
+   * <p>The resulting string contains only letters, digits, dash, underscore, space, and period
+   * characters. Consecutive periods are reduced to a single period to avoid hidden or parent path
+   * semantics on some platforms. The method is deterministic and does not attempt locale-specific
+   * normalization.
+   *
+   * @param name input filename fragment to sanitize; null values are not permitted
+   * @return sanitized filename containing only safe characters; may be empty if all characters were
+   *     removed
+   */
+  public static String sanitizeFileName(String name) {
+    StringBuilder result = new StringBuilder();
     for (int i = 0; i < name.length(); i++) {
       char c = name.charAt(i);
       // squish multiple '.'s into a single one.
@@ -44,35 +87,61 @@ public class FileUtil {
     return result.toString();
   }
 
-  public static final String pickSafeFileName(URL url) {
+  /**
+   * Derives a sanitized filename from a URL, defaulting to {@code index.html} when empty.
+   *
+   * <p>This helper extracts the last path component from the URL, runs it through {@link
+   * #sanitizeFileName(String)}, and substitutes a predictable fallback when the sanitized result is
+   * blank. It is intended for saving fetched resources without exposing raw URL content directly to
+   * the filesystem.
+   *
+   * @param url source URL whose last path segment will be used as the basis for the filename; must
+   *     not be null
+   * @return non-empty sanitized filename safe for local storage, using {@code index.html} when the
+   *     sanitized component would otherwise be empty
+   */
+  public static String pickSafeFileName(URL url) {
     String name = sanitizeFileName(new File(url.getFile()).getName());
-    if (name == null || name.equals("")) {
+    if (name.isEmpty()) {
       name = "index.html";
     }
     return name;
   }
 
   /**
-   * Creates a file in the .onion directory after scrubbing every directory and filename for unsafe
-   * chracters.
+   * Creates a file beneath the user's {@code .onion} directory after sanitizing every path segment.
    *
-   * @param rel the relative path to clean and put in .onion
-   * @return File object that's name safe
-   * @throws IllegalArgumentException if path isn't relative or if any path element (including the
-   *     filename) is "" after sanitization.
+   * <p>The provided path must be relative; absolute inputs are rejected to avoid writing outside
+   * the sandboxed area. Each segment is sanitized with {@link #sanitizeFileName(String)}, and empty
+   * results trigger an {@link IllegalArgumentException} to prevent ambiguous or collapsed paths.
+   * The helper ensures the target file exists, creating missing parent directories and the file
+   * itself when needed. File creation is tolerant of concurrent callers that race to create the
+   * same path.
+   *
+   * <pre>{@code
+   * // Example: place a downloaded resource under .onion/cache
+   * File cached = FileUtil.safeOnionFile("cache/page.dat");
+   * }</pre>
+   *
+   * @param rel relative path (using platform separators) to sanitize and place under {@code .onion}
+   *     ; must not be absolute or resolve to empty segments after cleaning
+   * @return existing or newly created file located under the user's {@code .onion} directory
+   * @throws IllegalArgumentException if the supplied path is absolute or collapses to an empty
+   *     segment after sanitization
+   * @throws IllegalStateException if filesystem creation fails after sanitization and validation
    */
   public static File safeOnionFile(String rel) {
     if ((new File(rel)).isAbsolute()) {
       throw new IllegalArgumentException(rel + " isn't relative");
     }
-    StringBuffer safe = new StringBuffer();
+    StringBuilder safe = new StringBuilder();
     for (StringTokenizer st = new StringTokenizer(rel, File.separator); st.hasMoreTokens(); ) {
       String tok = sanitizeFileName(st.nextToken());
-      if (tok == null || "".equals(tok)) {
-        throw new IllegalArgumentException("collapsed elemnt");
+      if (tok.isEmpty()) {
+        throw new IllegalArgumentException("collapsed element");
       }
-      if (safe == null) {
-        safe = new StringBuffer(tok);
+      if (safe.isEmpty()) {
+        safe.append(tok);
       } else {
         safe.append(File.separator).append(tok);
       }
@@ -89,75 +158,95 @@ public class FileUtil {
     return result;
   }
 
+  /**
+   * Ensures the target file and its parent directories exist, tolerating concurrent creators.
+   *
+   * <p>If parents do not exist they are created. When the file already exists, the method returns
+   * immediately without modifying timestamps. If creation is attempted and {@link
+   * File#createNewFile()} returns {@code false} because another thread or process created the file
+   * in the interim, the method treats that as success. Only failures to create parents or the file
+   * itself result in an {@link IOException}.
+   *
+   * @param f absolute or relative file reference to materialize on disk; must not be null
+   * @throws IOException if parent directories cannot be created or the file cannot be created and
+   *     does not already exist afterwards
+   */
   public static void ensureExists(File f) throws IOException {
-    if (!f.getParentFile().exists()) {
-      if (!f.getParentFile().mkdirs()) {
-        throw new IOException("Couldn't create parent dirs: " + f);
-      }
+    File parent = f.getParentFile();
+    if (parent != null && !parent.exists() && !parent.mkdirs()) {
+      throw new IOException("Couldn't create parent dirs: " + f);
     }
 
-    if (!f.exists()) {
-      f.createNewFile();
+    if (f.exists()) {
+      return;
+    }
+
+    if (!f.createNewFile()) {
+      if (f.exists()) {
+        return; // another thread/process created it
+      }
+      throw new IOException("Couldn't create file: " + f);
     }
   }
 
   /**
-   * Get the .onion directory off of the user's home directory. Created if it doesn't exist
+   * Returns the user's {@code .onion} directory, creating it on demand when possible.
    *
-   * @return File to onion networks directory, null on failure to create
+   * <p>The directory lives directly under the current user's home. If the home property is absent
+   * or directory creation fails, the method returns {@code null} to signal callers that persistence
+   * is unavailable. The returned {@link File} may already exist or may be newly created.
+   *
+   * @return {@link File} pointing to the {@code .onion} directory when resolvable; {@code null} if
+   *     the home directory is missing or the folder cannot be created
    */
   public static File getOnionDir() {
     String s = System.getProperty("user.home");
-    // If they don't have a home directory, then null ("java.io.tmpdir")
-    // will be used.
     if (s == null) {
-      // System.out.println("user.home was null");
       return null;
     }
     File f = new File(s, ".onion"); // FIX hardcoded name.
-    // System.out.println(f);
-    // check if exists
-    if (!f.exists()) {
-      // System.out.println("doesn't exist");
-      // make dirs
-      if (!f.mkdirs()) {
-        // System.out.println("mkdirs failed");
-        // fall back to system temp dir.
-        return null;
-      }
+    if (!f.exists() && !f.mkdirs()) {
+      return null;
     }
     return f;
   }
 
   /**
-   * Create a temp directory off of the onion directory, we do this instead of the system temp
-   * directory because the user probably has more disk space in their home directory.
+   * Provides a temp directory under {@code .onion}, preferring user space over system temp.
+   *
+   * <p>The directory name is {@code tmp}. If it does not exist, this method attempts to create it
+   * and returns {@code null} on failure. Callers can use this path for temporary files that should
+   * remain co-located with other per-user Crypta data instead of system-wide temp locations.
+   *
+   * @return {@link File} pointing to {@code .onion/tmp} when available; {@code null} if creation
+   *     fails or the base directory is unavailable
    */
-  public static final File getUserTempDir() {
+  public static File getUserTempDir() {
 
     File f = new File(getOnionDir(), "tmp"); // FIX hardcoded name
-    // System.out.println(f);
-    // check if exists
-    if (!f.exists()) {
-      // System.out.println("doesn't exist");
-      // make dirs
-      if (!f.mkdirs()) {
-        // System.out.println("mkdirs failed");
-        // fall back to system temp dir.
-        return null;
-      }
+    if (!f.exists() && !f.mkdirs()) {
+      return null;
     }
     return f;
   }
 
   /**
-   * Create a temporary file in the same directory as f and with a similar name. If f is null, then
-   * a randomly named file will be created in either the user temp directory or the system temp
-   * directory.
+   * Creates a temporary file near a reference file, with fallbacks to user and system temp spaces.
+   *
+   * <p>When {@code f} is non-null, the temp file is placed alongside it using a prefix derived from
+   * its name (extended to at least three characters). When {@code f} is null, the method prefers
+   * the user temp directory returned by {@link #getUserTempDir()}, falling back to the system temp
+   * directory if needed. If any creation attempt fails, the method retries in progressively broader
+   * locations before ultimately throwing.
+   *
+   * @param f reference file whose directory and name will influence the temp location; may be null
+   *     to request automatic placement
+   * @return newly created temporary {@link File} that already exists on disk and is writable by the
+   *     current process
+   * @throws IOException if all attempts to create the temporary file fail across preferred
+   *     directories
    */
-  public static final File createTempFile(File f) throws IOException {
-    // FIX unit test for relative file
-    // FIX the file names are hardcoded
+  public static File createTempFile(File f) throws IOException {
     File parent;
     String name;
     if (f == null) {
@@ -188,6 +277,19 @@ public class FileUtil {
     }
   }
 
+  /**
+   * Skips exactly {@code count} bytes from the input stream, blocking until satisfied or EOF.
+   *
+   * <p>This method repeatedly calls {@link InputStream#skip(long)} and, when necessary, falls back
+   * to buffered reads to guarantee forward progress. It throws {@link EOFException} if the stream
+   * ends before the requested number of bytes are consumed. The input stream is not closed.
+   *
+   * @param is input stream to advance; must support blocking reads; not closed by this method
+   * @param count number of bytes to skip; must be non-negative and typically small enough to fit in
+   *     memory for intermediary buffers
+   * @throws EOFException if the stream ends before the requested byte count is skipped
+   * @throws IOException if underlying stream operations fail while skipping or reading
+   */
   public static void skipFully(InputStream is, long count) throws IOException {
 
     byte[] b = null;

--- a/src/test/java/com/onionnetworks/util/FileUtilTest.java
+++ b/src/test/java/com/onionnetworks/util/FileUtilTest.java
@@ -1,0 +1,320 @@
+package com.onionnetworks.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class FileUtilTest {
+
+  private String originalUserHome;
+
+  @BeforeEach
+  void rememberUserHome() {
+    originalUserHome = System.getProperty("user.home");
+  }
+
+  @AfterEach
+  void restoreUserHome() {
+    if (originalUserHome != null) {
+      System.setProperty("user.home", originalUserHome);
+    } else {
+      System.clearProperty("user.home");
+    }
+  }
+
+  // sanitizeFileName --------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("sanitizeFileName_whenUnsafeCharacters_expectStrippedAndDotsCollapsed")
+  void sanitizeFileName_whenUnsafeCharacters_expectStrippedAndDotsCollapsed() {
+    // Arrange
+    String input = "a..b/c?d";
+
+    // Act
+    String sanitized = FileUtil.sanitizeFileName(input);
+
+    // Assert
+    assertEquals("a.bcd", sanitized);
+  }
+
+  @Test
+  @DisplayName("sanitizeFileName_whenNoSafeCharacters_expectEmptyString")
+  void sanitizeFileName_whenNoSafeCharacters_expectEmptyString() {
+    // Arrange
+    String input = "<>*";
+
+    // Act
+    String sanitized = FileUtil.sanitizeFileName(input);
+
+    // Assert
+    assertEquals("", sanitized);
+  }
+
+  // pickSafeFileName --------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("pickSafeFileName_whenSanitizedEmpty_expectIndexHtml")
+  void pickSafeFileName_whenSanitizedEmpty_expectIndexHtml() throws Exception {
+    // Arrange
+    URL url = new URI("http", "example.com", "/", null).toURL();
+
+    // Act
+    String name = FileUtil.pickSafeFileName(url);
+
+    // Assert
+    assertEquals("index.html", name);
+  }
+
+  @Test
+  @DisplayName("pickSafeFileName_whenValidName_expectSanitizedName")
+  void pickSafeFileName_whenValidName_expectSanitizedName() throws Exception {
+    // Arrange
+    URL url = new URI("http", "example.com", "/some-file.txt", null).toURL();
+
+    // Act
+    String name = FileUtil.pickSafeFileName(url);
+
+    // Assert
+    assertEquals("some-file.txt", name);
+  }
+
+  // safeOnionFile -----------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("safeOnionFile_whenAbsolutePathProvided_expectIllegalArgument")
+  void safeOnionFile_whenAbsolutePathProvided_expectIllegalArgument(@TempDir Path tmp) {
+    // Arrange
+    System.setProperty("user.home", tmp.toString());
+    String absolute = tmp.resolve("abs.txt").toAbsolutePath().toString();
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> FileUtil.safeOnionFile(absolute));
+  }
+
+  @Test
+  @DisplayName("safeOnionFile_whenElementCollapsesAfterSanitize_expectIllegalArgument")
+  void safeOnionFile_whenElementCollapsesAfterSanitize_expectIllegalArgument(@TempDir Path tmp) {
+    // Arrange
+    System.setProperty("user.home", tmp.toString());
+    String rel = "dir" + File.separator + "***";
+
+    // Act + Assert
+    assertThrows(IllegalArgumentException.class, () -> FileUtil.safeOnionFile(rel));
+  }
+
+  @Test
+  @DisplayName("safeOnionFile_whenRelativePath_expectFileCreatedUnderOnionDir")
+  void safeOnionFile_whenRelativePath_expectFileCreatedUnderOnionDir(@TempDir Path tmp) {
+    // Arrange
+    System.setProperty("user.home", tmp.toString());
+    String rel = "data" + File.separator + "file?.txt";
+    File expected =
+        tmp.resolve(".onion").resolve("data").resolve("file.txt").toAbsolutePath().toFile();
+
+    // Act
+    File created = FileUtil.safeOnionFile(rel);
+
+    // Assert
+    assertEquals(expected, created.getAbsoluteFile());
+    assertTrue(created.exists(), "safeOnionFile should create the file");
+  }
+
+  // ensureExists ------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("ensureExists_whenParentsMissing_expectParentsAndFileCreated")
+  void ensureExists_whenParentsMissing_expectParentsAndFileCreated(@TempDir Path tmp)
+      throws IOException {
+    // Arrange
+    File target =
+        tmp.resolve("nested").resolve("deep").resolve("file.bin").toAbsolutePath().toFile();
+
+    // Act
+    FileUtil.ensureExists(target);
+
+    // Assert
+    assertTrue(target.exists());
+    assertTrue(target.getParentFile().exists());
+  }
+
+  // getOnionDir / getUserTempDir -------------------------------------------------------------
+
+  @Test
+  @DisplayName("getOnionDir_whenUserHomeNull_expectNull")
+  void getOnionDir_whenUserHomeNull_expectNull() {
+    // Arrange
+    System.clearProperty("user.home");
+
+    // Act
+    File onionDir = FileUtil.getOnionDir();
+
+    // Assert
+    assertNull(onionDir);
+  }
+
+  @Test
+  @DisplayName("getOnionDir_whenUserHomeSet_expectDirectoryCreated")
+  void getOnionDir_whenUserHomeSet_expectDirectoryCreated(@TempDir Path tmp) {
+    // Arrange
+    System.setProperty("user.home", tmp.toString());
+
+    // Act
+    File onionDir = FileUtil.getOnionDir();
+
+    // Assert
+    assertNotNull(onionDir);
+    assertTrue(onionDir.exists());
+    assertEquals(tmp.resolve(".onion").toFile().getAbsolutePath(), onionDir.getAbsolutePath());
+  }
+
+  @Test
+  @DisplayName("getUserTempDir_whenOnionDirPresent_expectTmpSubDirectoryCreated")
+  void getUserTempDir_whenOnionDirPresent_expectTmpSubDirectoryCreated(@TempDir Path tmp) {
+    // Arrange
+    System.setProperty("user.home", tmp.toString());
+
+    // Act
+    File userTmp = FileUtil.getUserTempDir();
+
+    // Assert
+    assertNotNull(userTmp);
+    assertEquals(tmp.resolve(".onion").resolve("tmp").toFile(), userTmp.getAbsoluteFile());
+    assertTrue(userTmp.exists());
+  }
+
+  // createTempFile ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("createTempFile_whenNullFile_usesUserTempDirAndOnionPrefix")
+  void createTempFile_whenNullFile_usesUserTempDirAndOnionPrefix(@TempDir Path tmp)
+      throws IOException {
+    // Arrange
+    System.setProperty("user.home", tmp.toString());
+    File expectedParent = tmp.resolve(".onion").resolve("tmp").toFile();
+
+    // Act
+    File temp = FileUtil.createTempFile(null);
+
+    // Assert
+    assertTrue(temp.exists());
+    assertEquals(expectedParent.getAbsoluteFile(), temp.getParentFile().getAbsoluteFile());
+    assertTrue(temp.getName().startsWith("onion"));
+  }
+
+  @Test
+  @DisplayName("createTempFile_whenShortNameProvided_expectNameExtendedToThreeChars")
+  void createTempFile_whenShortNameProvided_expectNameExtendedToThreeChars(@TempDir Path tmp)
+      throws IOException {
+    // Arrange
+    File requested = tmp.resolve("ab").toFile();
+
+    // Act
+    File temp = FileUtil.createTempFile(requested);
+
+    // Assert
+    assertTrue(temp.exists());
+    assertEquals(tmp.toFile().getAbsoluteFile(), temp.getParentFile().getAbsoluteFile());
+    assertTrue(temp.getName().startsWith("abonion"));
+  }
+
+  // skipFully --------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("skipFully_whenSkipReturnsZeroThenReadProgresses_expectSuccess")
+  void skipFully_whenSkipReturnsZeroThenReadProgresses_expectSuccess() throws Exception {
+    // Arrange
+    try (InputStream stream = new SkipZeroThenReadStream(new byte[] {1, 2, 3})) {
+      // Act + Assert
+      assertDoesNotThrow(() -> FileUtil.skipFully(stream, 3));
+    }
+  }
+
+  @Test
+  @DisplayName("skipFully_whenEndOfStreamReached_expectEOFException")
+  void skipFully_whenEndOfStreamReached_expectEOFException() throws Exception {
+    // Arrange
+    try (InputStream stream =
+        new InputStream() {
+          @Override
+          public int read(byte @NotNull [] b, int off, int len) {
+            return -1;
+          }
+
+          @Override
+          public long skip(long n) {
+            return 0;
+          }
+
+          @Override
+          public int read() {
+            return -1;
+          }
+        }) {
+
+      // Act + Assert
+      assertThrows(EOFException.class, () -> FileUtil.skipFully(stream, 1));
+    }
+  }
+
+  // helpers ----------------------------------------------------------------------------------
+
+  private static class SkipZeroThenReadStream extends InputStream {
+
+    private final byte[] data;
+    private int index = 0;
+    private boolean skipCalled = false;
+
+    private SkipZeroThenReadStream(byte[] data) {
+      this.data = data;
+    }
+
+    @Override
+    public long skip(long n) {
+      if (!skipCalled) {
+        skipCalled = true;
+        return 0;
+      }
+      int remaining = data.length - index;
+      int toSkip = (int) Math.min(n, remaining);
+      index += toSkip;
+      return toSkip;
+    }
+
+    @Override
+    public int read(byte @NotNull [] b, int off, int len) {
+      if (index >= data.length) {
+        return -1;
+      }
+      int toCopy = Math.min(len, data.length - index);
+      System.arraycopy(data, index, b, off, toCopy);
+      index += toCopy;
+      return toCopy;
+    }
+
+    @Override
+    public int read() {
+      if (index >= data.length) {
+        return -1;
+      }
+      return data[index++] & 0xFF;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand FileUtil Javadocs and tighten parameter handling for file safety helpers
- add comprehensive JUnit 6 coverage for sanitizeFileName, pickSafeFileName, safeOnionFile, ensureExists, temp helpers, and skipFully
- minor refactors to improve null/empty checks and concurrency-safe file creation

## Testing
- not run (doc/tests only)