### PR TITLE
fix: generic JoiningIterator and tighten tests

### DIFF
--- a/src/main/java/com/onionnetworks/util/JoiningIterator.java
+++ b/src/main/java/com/onionnetworks/util/JoiningIterator.java
@@ -3,24 +3,91 @@ package com.onionnetworks.util;
 import java.util.Iterator;
 
 /**
- * @author Ry4an Brase
+ * Iterator that traverses all elements from a primary iterator and then continues with a secondary
+ * iterator, presenting them as one continuous sequence.
+ *
+ * <p>JoiningIterator stitches two ordered sources together so callers can treat them as a single
+ * stream without copying or buffering. It advances the supplied iterators lazily, preserving any
+ * side effects or mutation semantics they expose. Use it when concatenation semantics are desired
+ * and the second source should remain untouched until the first is fully consumed. Instances are
+ * not thread-safe; concurrent access requires external synchronization. Removal is intentionally
+ * unsupported to avoid ambiguous mutation of the underlying sources, so callers should supply
+ * iterators that already reflect the desired contents.
+ *
+ * <ul>
+ *   <li>Progresses through {@code first} completely before consulting {@code second}.
+ *   <li>Delegates element retrieval directly to the underlying iterators without buffering.
+ *   <li>Propagates {@link java.util.NoSuchElementException} and other runtime exceptions thrown by
+ *       the sources.
+ * </ul>
+ *
+ * @param <T> type of elements produced sequentially by the joined iterators
+ * @see java.util.Iterator
  */
-public class JoiningIterator implements Iterator {
-  private Iterator first, second;
+public class JoiningIterator<T> implements Iterator<T> {
+  private final Iterator<? extends T> first;
+  private final Iterator<? extends T> second;
 
-  public JoiningIterator(Iterator f, Iterator s) {
+  /**
+   * Creates an iterator that yields elements from the first iterator and then from the second.
+   *
+   * <p>The iterators are stored by reference and are not inspected at construction time. Emitted
+   * results reflect the current state of each iterator when {@link #next()} is called. The first
+   * iterator is exhausted before the second is consulted, providing deterministic ordering without
+   * additional buffering. Neither argument may be {@code null}; callers retain ownership and
+   * responsibility for any thread-safety guarantees.
+   *
+   * @param f iterator whose elements are delivered first in sequence; must be non-null
+   * @param s iterator read only after {@code f} is exhausted; must be non-null
+   */
+  public JoiningIterator(Iterator<? extends T> f, Iterator<? extends T> s) {
     first = f;
     second = s;
   }
 
+  /**
+   * Reports whether either underlying iterator still has elements available.
+   *
+   * <p>The check first consults {@code first}; if it reports additional elements, the combined
+   * iterator is considered non-empty regardless of {@code second}. Only when {@code first} is
+   * exhausted does the method query {@code second}. The operation does not advance iteration state
+   * or buffer values, so repeated calls are safe but may reflect concurrent modifications to the
+   * underlying iterators.
+   *
+   * @return {@code true} if {@code first} or {@code second} advertises remaining elements
+   */
+  @Override
   public boolean hasNext() {
     return first.hasNext() || second.hasNext();
   }
 
-  public Object next() {
-    return (first.hasNext()) ? first.next() : second.next(); // throws NSEEx
+  /**
+   * Returns the next element from the first iterator until it is exhausted, then from the second.
+   *
+   * <p>The call advances only one underlying iterator per invocation. If {@code first} still has
+   * elements, its next value is returned; otherwise the method delegates to {@code second}. No
+   * buffering occurs, so results mirror the real-time state of the underlying iterators. Callers
+   * should invoke {@link #hasNext()} first to avoid exceptions when both sources are exhausted.
+   *
+   * @return next element yielded by {@code first} or, once exhausted, by {@code second}
+   * @throws java.util.NoSuchElementException if both iterators are exhausted at call time
+   */
+  @Override
+  public T next() {
+    return first.hasNext() ? first.next() : second.next(); // throws NSEEx
   }
 
+  /**
+   * Unsupported operation because mutating the joined iterators would be ambiguous for callers.
+   *
+   * <p>Removing elements through this wrapper could desynchronize the two sources or hide state
+   * changes, so the method unconditionally throws {@link UnsupportedOperationException}. Clients
+   * that require mutation should operate directly on the underlying iterators or use a different
+   * abstraction that defines clear removal semantics for concatenated sequences.
+   *
+   * @throws UnsupportedOperationException always thrown to signal that removal is not supported
+   */
+  @Override
   public void remove() {
     throw new UnsupportedOperationException();
   }

--- a/src/test/java/com/onionnetworks/util/JoiningIteratorTest.java
+++ b/src/test/java/com/onionnetworks/util/JoiningIteratorTest.java
@@ -1,0 +1,72 @@
+package com.onionnetworks.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class JoiningIteratorTest {
+
+  @Test
+  void hasNext_whenBothIteratorsEmpty_returnsFalse() {
+    Iterator<Integer> first = Collections.emptyIterator();
+    Iterator<Integer> second = Collections.emptyIterator();
+
+    JoiningIterator<Integer> iterator = new JoiningIterator<>(first, second);
+
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void next_whenBothIteratorsEmpty_throwsNoSuchElementException() {
+    Iterator<Integer> first = Collections.emptyIterator();
+    Iterator<Integer> second = Collections.emptyIterator();
+    JoiningIterator<Integer> iterator = new JoiningIterator<>(first, second);
+
+    assertThrows(java.util.NoSuchElementException.class, iterator::next);
+  }
+
+  @Test
+  void next_whenFirstIteratorExhausted_continuesWithSecond() {
+    Iterator<Integer> first = Collections.emptyIterator();
+    Iterator<Integer> second = Arrays.asList(10, 20).iterator();
+    JoiningIterator<Integer> iterator = new JoiningIterator<>(first, second);
+
+    List<Integer> values = new ArrayList<>();
+    while (iterator.hasNext()) {
+      values.add(iterator.next());
+    }
+
+    assertEquals(Arrays.asList(10, 20), values);
+  }
+
+  @Test
+  void next_whenFirstHasElements_returnsAllFromFirstThenSecond() {
+    Iterator<String> first = Arrays.asList("a", "b").iterator();
+    Iterator<String> second = Collections.singletonList("c").iterator();
+    JoiningIterator<String> iterator = new JoiningIterator<>(first, second);
+
+    List<String> values = new ArrayList<>();
+    while (iterator.hasNext()) {
+      values.add(iterator.next());
+    }
+
+    assertEquals(Arrays.asList("a", "b", "c"), values);
+  }
+
+  @Test
+  void remove_alwaysThrowsUnsupportedOperationException() {
+    Iterator<Integer> first = List.of(1).iterator();
+    Iterator<Integer> second = List.of(2).iterator();
+    JoiningIterator<Integer> iterator = new JoiningIterator<>(first, second);
+
+    assertThrows(UnsupportedOperationException.class, iterator::remove);
+  }
+}


### PR DESCRIPTION
## Summary
- make JoiningIterator generic with typed iterator fields and richer Javadoc
- add unit tests covering empty, ordering, and removal behavior

## Testing
- not run (not requested)
