### PR TITLE
Fix reflective dispatch synchronization and add tests

### DIFF
--- a/src/main/java/com/onionnetworks/util/InvokingDispatch.java
+++ b/src/main/java/com/onionnetworks/util/InvokingDispatch.java
@@ -1,46 +1,177 @@
 package com.onionnetworks.util;
 
-import java.util.*;
+import java.io.Serial;
+import java.util.EventListener;
+import java.util.EventObject;
+import java.util.Objects;
 
+/**
+ * Dispatches {@link Runnable} instances through {@link ReflectiveEventDispatch} while providing
+ * synchronous and asynchronous invocation helpers.
+ *
+ * <p>This dispatcher registers itself as a listener for an internal {@link InvokeEvent} and routes
+ * events to the {@link #invoke(InvokeEvent)} handler. Clients submit work with {@link
+ * #invokeLater(Runnable)} to enqueue execution without blocking, or with {@link
+ * #invokeAndWait(Runnable)} when they must wait for completion. Each submitted task is wrapped in
+ * an event carrying a per-invocation monitor so the caller can block without interfering with other
+ * requests.
+ *
+ * <p>The class is thread-safe for concurrent submissions: every {@link InvokeEvent} owns its own
+ * lock and completion flag, and the dispatch logic synchronizes on that lock only for the lifetime
+ * of the event. Execution order follows the underlying {@link ReflectiveEventDispatch} mechanics,
+ * so long-running tasks may delay later ones; callers should choose between the async and sync
+ * entry points accordingly. Typical usage is to share a single {@code InvokingDispatch} instance
+ * across components that need to schedule work onto a dedicated dispatch thread.
+ *
+ * <ul>
+ *   <li>Asynchronous: {@link #invokeLater(Runnable)} enqueues and returns immediately.
+ *   <li>Synchronous: {@link #invokeAndWait(Runnable)} blocks until the runnable completes or the
+ *       thread is interrupted.
+ *   <li>Handler: {@link #invoke(InvokeEvent)} performs execution and signals completion.
+ * </ul>
+ *
+ * @see ReflectiveEventDispatch
+ */
 public class InvokingDispatch extends ReflectiveEventDispatch implements EventListener {
 
-  public static final String INVOKE = "invoke";
+  /** Event name used to identify invoke requests within the reflective dispatch machinery. */
+  public static final String INVOKE_EVENT_NAME = "invoke";
 
+  /**
+   * Creates a new dispatcher and registers it to listen for its own invoke events, enabling
+   * subsequent calls to {@link #invokeLater(Runnable)} and {@link #invokeAndWait(Runnable)}.
+   */
   public InvokingDispatch() {
     super();
-    addListener(this, this, INVOKE);
+    addListener(this, this, INVOKE_EVENT_NAME);
   }
 
   // can't be inner class unless we create a public interface for invoke()
+  /**
+   * Handles an {@link InvokeEvent} by running the enclosed task and waking any waiting threads.
+   *
+   * <p>Execution occurs on the dispatch thread managed by {@link ReflectiveEventDispatch}. The
+   * method marks the event as completed and notifies all waiters on the event's lock so callers of
+   * {@link #invokeAndWait(Runnable)} can resume. The runnable is executed exactly once per event.
+   *
+   * @param ev event carrying the runnable and completion monitor; must not be {@code null}.
+   */
   public void invoke(InvokeEvent ev) {
     ev.getRunnable().run();
-    synchronized (ev) {
-      ev.notifyAll();
+    synchronized (ev.getLock()) {
+      ev.markCompleted();
+      ev.getLock().notifyAll();
     }
   }
 
+  /**
+   * Enqueues a runnable for execution on the dispatch thread without blocking the caller.
+   *
+   * <p>The runnable is wrapped in an {@link InvokeEvent} and fired through the reflective dispatch.
+   * Callers should prefer this method for fire-and-forget tasks or when they do not need to observe
+   * completion.
+   *
+   * @param r runnable to execute; must be non-null and ready for single invocation.
+   */
   public void invokeLater(Runnable r) {
-    fire(new InvokeEvent(this, r), INVOKE);
+    fire(new InvokeEvent(this, r), INVOKE_EVENT_NAME);
   }
 
+  /**
+   * Submits a runnable to the dispatch thread and blocks until it completes or the thread is
+   * interrupted.
+   *
+   * <p>The caller waits on a per-event lock so different submissions do not interfere with one
+   * another. If the current thread is interrupted while waiting, the method throws {@link
+   * InterruptedException} and leaves the interrupt status cleared. The runnable still executes
+   * unless dispatching is interrupted upstream.
+   *
+   * <pre>{@code
+   * InvokingDispatch dispatch = new InvokingDispatch();
+   * dispatch.invokeAndWait(() -> performWork());
+   * }</pre>
+   *
+   * @param r runnable to execute; must be non-null and safe to run exactly once.
+   * @throws InterruptedException if the calling thread is interrupted while waiting for completion.
+   */
   public void invokeAndWait(Runnable r) throws InterruptedException {
     InvokeEvent ev = new InvokeEvent(this, r);
-    synchronized (ev) {
-      fire(ev, INVOKE);
-      ev.wait();
+    Object lock = ev.getLock();
+    synchronized (lock) {
+      fire(ev, INVOKE_EVENT_NAME);
+      while (!ev.isCompleted()) {
+        lock.wait();
+      }
     }
   }
 
-  public class InvokeEvent extends EventObject {
-    Runnable r;
+  /**
+   * Event envelope that transports a {@link Runnable} and carries completion state for synchronous
+   * callers.
+   *
+   * <p>Each instance owns a dedicated lock object used by {@link InvokingDispatch} to coordinate
+   * wait/notify interactions. The completion flag advances from {@code false} to {@code true} when
+   * {@link #markCompleted()} is called by the dispatcher after the runnable finishes. Instances are
+   * single-use and not thread-safe beyond the guarded access provided by {@link
+   * InvokingDispatch#invokeAndWait(Runnable)}.
+   */
+  public static class InvokeEvent extends EventObject {
+    @Serial private static final long serialVersionUID = 1L;
 
+    /** Task to run on the dispatch thread; supplied by the creator and never mutated. */
+    private final transient Runnable runnable;
+
+    /** Per-event monitor used to coordinate waiting callers and completion notification. */
+    private final transient Object lock = new Object();
+
+    /** Tracks whether the runnable has finished executing; guarded by {@link #lock}. */
+    private boolean completed;
+
+    /**
+     * Creates a new invoke event carrying the specified runnable and source reference.
+     *
+     * @param source originator of the event, passed to {@link EventObject}; must be non-null.
+     * @param r runnable to execute when dispatched; must be non-null.
+     */
     public InvokeEvent(Object source, Runnable r) {
       super(source);
-      this.r = r;
+      this.runnable = Objects.requireNonNull(r);
     }
 
+    /**
+     * Returns the runnable associated with this event.
+     *
+     * @return runnable to be executed; never {@code null} and intended for a single run.
+     */
     public Runnable getRunnable() {
-      return r;
+      return runnable;
+    }
+
+    /**
+     * Returns the lock object used for coordinating wait/notify between dispatcher and callers.
+     *
+     * @return dedicated monitor for this event; callers should synchronize before waiting.
+     */
+    public Object getLock() {
+      return lock;
+    }
+
+    /**
+     * Indicates whether the runnable has completed execution.
+     *
+     * @return {@code true} after {@link #markCompleted()} is called; {@code false} otherwise.
+     */
+    public boolean isCompleted() {
+      return completed;
+    }
+
+    /**
+     * Marks this event as completed after the runnable finishes. Callers should synchronize on
+     * {@link #getLock()} when invoking this method to ensure the completion flag is visible to
+     * waiting threads.
+     */
+    public void markCompleted() {
+      this.completed = true;
     }
   }
 }

--- a/src/main/java/com/onionnetworks/util/ReflectiveEventDispatch.java
+++ b/src/main/java/com/onionnetworks/util/ReflectiveEventDispatch.java
@@ -1,20 +1,50 @@
 package com.onionnetworks.util;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.EventListener;
+import java.util.EventObject;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Dispatches {@link java.util.EventObject} instances to registered {@link EventListener}s by
  * reflectively invoking a named method on each listener. Uses an internal queue and background
  * thread to process events asynchronously.
  *
- * <p>This version adds generics to internal collections to avoid unchecked operations.
+ * <p>The dispatcher maintains a daemon thread that repeatedly removes queued {@code EventObject}
+ * instances, looks up listeners that registered interest in the originating event source and the
+ * supplied method name, and invokes that method with the event as its sole argument. Listener look-
+ * * ups and queue mutations are synchronized on the dispatcher instance, allowing multiple producer
+ * threads to submit events while the consumer thread drains the queue. Method lookups are cached to
+ * avoid repeated reflective discovery, but execution order remains FIFO for submitted events. When
+ * no listeners are registered for a given method name and source, the event is silently skipped.
  *
+ * <p>Use this class when you need a lightweight, per-source event bus without committing to a
+ * broader framework. Typical usage registers listeners tied to a particular publisher object and
+ * calls {@link #fire(EventObject, String)} whenever a state change occurs. The dispatcher remains
+ * mutable throughout its lifetime: you may add or remove listeners at any time, adjust the thread
+ * priority, or install a custom {@link ExceptionHandler} to capture reflective failures. The class
+ * is not intended for high-throughput scenarios; the single-threaded consumer ensures predictable
+ * ordering but limits parallel delivery.
+ *
+ * <ul>
+ *   <li>Queues events for asynchronous delivery on a dedicated daemon thread.
+ *   <li>Matches listeners by exact event source instance and method name.
+ *   <li>Caches reflective lookups to minimize per-event overhead.
+ *   <li>Falls back to logging when no {@link ExceptionHandler} is configured.
+ * </ul>
+ *
+ * @see ExceptionHandler
  * @author Justin Chapweske
  */
 public class ReflectiveEventDispatch implements Runnable {
 
-  public static final int DEFAULT_WARNING_TIME = 10;
+  private static final Logger LOGGER = Logger.getLogger(ReflectiveEventDispatch.class.getName());
 
   private final Thread thread;
   private final Map<Tuple, Method> methodCache = new HashMap<>();
@@ -23,54 +53,139 @@ public class ReflectiveEventDispatch implements Runnable {
   private final LinkedList<Object> eventQueue = new LinkedList<>();
   private ExceptionHandler handler;
 
+  /**
+   * Creates and starts a new dispatcher instance with a dedicated daemon thread.
+   *
+   * <p>The constructor immediately creates the internal queue, spawns the dispatch thread, and
+   * begins processing any events that are enqueued. Callers can adjust the thread priority or
+   * register an {@link ExceptionHandler} after construction; no additional initialization steps are
+   * required.
+   */
   public ReflectiveEventDispatch() {
     thread = new Thread(this, "Reflective Dispatch#" + hashCode());
     thread.setDaemon(true);
     thread.start();
   }
 
+  /**
+   * Updates the priority of the background dispatch thread.
+   *
+   * <p>Invoking this method after construction allows callers to align the dispatch thread's
+   * scheduling priority with surrounding application threads. The priority change takes effect
+   * immediately for subsequent scheduling decisions made by the JVM, and it does not interrupt any
+   * in-flight dispatch work.
+   *
+   * @param priority new thread priority in the platform-dependent {@link Thread} range; values
+   *     outside the allowed range are subject to JVM clamping.
+   */
   public void setPriority(int priority) {
     thread.setPriority(priority);
   }
 
+  /**
+   * Registers an exception handler that receives failures raised during listener invocation.
+   *
+   * <p>When set, the handler is invoked with an {@link ExceptionEvent} every time reflective
+   * invocation of a listener method throws an exception. Passing {@code null} restores the default
+   * behavior, which logs the exception at {@link Level#SEVERE}. The handler runs on the dispatch
+   * thread, so heavy processing may delay subsequent event delivery.
+   *
+   * @param h handler invoked for dispatch-time exceptions; may be {@code null} to disable custom
+   *     handling.
+   */
   public void setExceptionHandler(ExceptionHandler h) {
     handler = h;
   }
 
-  /** Adds a listener for a single method name for events originating from the provided source. */
+  /**
+   * Adds a listener for a single method name for events originating from the provided source.
+   *
+   * <p>This overload is a convenience wrapper around {@link #addListener(Object, EventListener,
+   * String[])}, registering the listener for exactly one method name. The registration is tied to
+   * the specific source instance; events fired from other sources are not delivered to this
+   * listener. Duplicate registrations for the same source and method name are idempotent because
+   * listeners are stored in a {@link Set}.
+   *
+   * @param source event source instance that must equal {@link EventObject#getSource()} for the
+   *     listener to be notified; must not be {@code null}.
+   * @param el listener object that exposes a public method named {@code methodName} accepting the
+   *     event type; must not be {@code null}.
+   * @param methodName name of the listener method to invoke; compared literally and case-sensitive.
+   */
   public synchronized void addListener(Object source, EventListener el, String methodName) {
     this.addListener(source, el, new String[] {methodName});
   }
 
-  /** Adds a listener for multiple method names for events originating from the provided source. */
+  /**
+   * Adds a listener for multiple method names for events originating from the provided source.
+   *
+   * <p>Each supplied method name is recorded against the given source instance. When {@link
+   * #fire(EventObject, String)} is later called with a matching source and method name, the
+   * corresponding method on the listener is invoked reflectively. Listener lookups are synchronized
+   * and thread-safe; registrations may occur while the dispatcher is actively delivering other
+   * events. Method names are kept as-is and must match the actual public listener method signature.
+   *
+   * <pre>{@code
+   * dispatcher.addListener(source, listener, new String[] {"onSave", "onClose"});
+   * dispatcher.fire(new EventObject(source), "onSave");
+   * }</pre>
+   *
+   * @param source event source instance that must match {@link EventObject#getSource()} during
+   *     dispatch for delivery to occur.
+   * @param el listener instance exposing public methods named in {@code methodNames} that accept a
+   *     single {@link EventObject} subtype argument.
+   * @param methodNames array of method names to register; entries must be non-null and
+   *     case-sensitive.
+   */
   public synchronized void addListener(Object source, EventListener el, String[] methodNames) {
-    Map<String, Set<EventListener>> hm = listeners.get(source);
-    if (hm == null) {
-      hm = new HashMap<>();
-      listeners.put(source, hm);
-    }
+    Map<String, Set<EventListener>> hm = listeners.computeIfAbsent(source, k -> new HashMap<>());
 
-    for (int i = 0; i < methodNames.length; i++) {
-      Set<EventListener> set = hm.get(methodNames[i]);
-      if (set == null) {
-        set = new HashSet<>();
-        hm.put(methodNames[i], set);
-      }
-      set.add(el);
+    for (String methodName : methodNames) {
+      hm.computeIfAbsent(methodName, k -> new HashSet<>()).add(el);
     }
   }
 
+  /**
+   * Removes a single listener registration for the provided source and method name.
+   *
+   * <p>This convenience overload delegates to {@link #removeListener(Object, EventListener,
+   * String[])}. Removal is synchronized with dispatch activity, ensuring that no additional events
+   * for the specified method and source are delivered to the listener once the call completes.
+   *
+   * @param source event source used during registration; must not be {@code null}.
+   * @param el listener instance to deregister for the specified method name.
+   * @param methodName method name previously registered for {@code el}; must have been added or an
+   *     exception is thrown.
+   * @throws IllegalArgumentException if the listener was not registered for the method name and
+   *     source.
+   */
   public synchronized void removeListener(Object source, EventListener el, String methodName) {
     this.removeListener(source, el, new String[] {methodName});
   }
 
+  /**
+   * Removes a listener registration for multiple method names tied to the specified source.
+   *
+   * <p>Each provided method name is removed independently. If the source or listener were not
+   * previously registered for any of the names, this method throws {@link IllegalArgumentException}
+   * to indicate a programming error. Removal is synchronized with dispatching to ensure no new
+   * deliveries occur for removed mappings after this call returns.
+   *
+   * @param source event source whose registrations should be removed; must be the exact object used
+   *     during {@link #addListener(Object, EventListener, String[])}.
+   * @param el listener instance previously registered for the given method names and source.
+   * @param methodNames method names to deregister for {@code el}; names must have been registered
+   *     or an exception is thrown.
+   * @throws IllegalArgumentException if the source or listener was not registered for any provided
+   *     method name.
+   */
   public synchronized void removeListener(Object source, EventListener el, String[] methodNames) {
     Map<String, Set<EventListener>> hm = listeners.get(source);
     if (hm == null) {
       throw new IllegalArgumentException("Listener not registered.");
     }
-    for (int i = 0; i < methodNames.length; i++) {
-      Set<EventListener> set = hm.get(methodNames[i]);
+    for (String methodName : methodNames) {
+      Set<EventListener> set = hm.get(methodName);
       if (set == null || !set.contains(el)) {
         throw new IllegalArgumentException("Listener not registered.");
       }
@@ -79,89 +194,115 @@ public class ReflectiveEventDispatch implements Runnable {
     }
   }
 
-  /** Queues an event for asynchronous dispatch to listeners of the given method. */
+  /**
+   * Queues an event for asynchronous dispatch to listeners of the given method.
+   *
+   * <p>The event is appended to the tail of the queue and delivered in FIFO order by the dispatcher
+   * thread. Delivery occurs only when the event's source equals the {@code source} used during
+   * listener registration and when the {@code methodName} matches one of the listener's registered
+   * method names. This method returns immediately; it does not wait for completion or surface
+   * listener exceptions.
+   *
+   * @param ev event instance to deliver; its {@link EventObject#getSource()} must match a
+   *     registered source for delivery to occur.
+   * @param methodName name of the listener method to target; compared literally and case-sensitive
+   *     against registered names.
+   */
   public synchronized void fire(EventObject ev, String methodName) {
     eventQueue.add(new Tuple(ev, methodName));
     this.notifyAll();
   }
 
-  /** Signals the dispatch thread to stop after processing queued events. */
+  /**
+   * Signals the dispatch thread to stop after processing queued events.
+   *
+   * <p>A sentinel object is placed on the queue; once encountered, the dispatch loop exits after
+   * completing any prior work. Events enqueued after this call may or may not be processed
+   * depending on timing, so callers should stop submitting new events before invoking this method.
+   * The method is idempotent but does not interrupt a listener currently executing.
+   */
   public synchronized void close() {
     // Place this on the queue to signify that we are done.
     eventQueue.add(this);
     this.notifyAll();
   }
 
+  /**
+   * Main dispatch loop executed by the internal daemon thread.
+   *
+   * <p>The loop waits for queued events, exits when {@link #close()} enqueues the sentinel marker,
+   * and otherwise delegates each unit of work to {@link #dispatch(DispatchWork)}. It preserves the
+   * order in which events were queued and performs listener invocation on the same dedicated thread
+   * to simplify synchronization concerns for clients. Applications typically never call this method
+   * directly because it is invoked automatically when the dispatcher is constructed.
+   */
   public void run() {
-    boolean done = false;
+    while (true) {
+      DispatchWork work;
+      try {
+        work = takeNextWork();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+      if (work == null) {
+        return;
+      }
+      dispatch(work);
+    }
+  }
 
-    while (!done) {
-      EventObject ev = null;
-      String methodName = null;
-      Set<EventListener> set = null;
-      synchronized (this) {
-        if (eventQueue.isEmpty()) {
-          try {
-            this.wait();
-          } catch (InterruptedException e) {
-            done = true;
-          }
-          continue;
+  private DispatchWork takeNextWork() throws InterruptedException {
+    synchronized (this) {
+      while (true) {
+        while (eventQueue.isEmpty()) {
+          this.wait();
         }
         Object obj = eventQueue.removeFirst();
         if (obj == this) {
-          // If this is on the queue, it is time to close.
-          done = true;
+          return null;
+        }
+        Tuple tuple = (Tuple) obj;
+        EventObject event = (EventObject) tuple.getLeft();
+        String methodName = (String) tuple.getRight();
+        Map<String, Set<EventListener>> hm = listeners.get(event.getSource());
+        Set<EventListener> set = hm == null ? null : hm.get(methodName);
+        if (set == null || set.isEmpty()) {
           continue;
         }
-        Tuple t = (Tuple) obj;
-        ev = (EventObject) t.getLeft();
-        methodName = (String) t.getRight();
-        Map<String, Set<EventListener>> hm = listeners.get(ev.getSource());
-        if (hm == null) {
-          continue;
-        }
-        set = hm.get(methodName);
-        if (set == null) {
-          continue;
-        }
-        // Make a copy incase its modified while we're doing the shit.
-        set = new HashSet<>(set);
-      }
-
-      for (EventListener el : set) {
-        // Get the method and invoke it, passing the event.
-        // long t1 = System.currentTimeMillis();
-        try {
-          final Class elc = el.getClass();
-          final Class evc = ev.getClass();
-
-          // Cache the method because getPublicMethod is very
-          // expensive to invoke.
-          Tuple cacheKey = new Tuple(elc, new Tuple(methodName, evc));
-          Method m = methodCache.get(cacheKey);
-          if (m == null) {
-            final Class ca[] = new Class[] {evc};
-            // This version of getMethod supports subclasses as
-            // parameter types.
-            m = Util.getPublicMethod(elc, methodName, ca);
-            methodCache.put(cacheKey, m);
-          }
-          final Object oa[] = new Object[] {ev};
-          m.invoke(el, oa);
-        } catch (Throwable t) {
-          if (handler != null) {
-            handler.handleException(new ExceptionEvent(this, t));
-          } else {
-            t.printStackTrace();
-          }
-        }
-        // long t2 = System.currentTimeMillis()-t1;
-        // if (t2 > DEFAULT_WARNING_TIME) {
-        //    System.out.println(el+"."+methodName+"("+ev+") took"+
-        //                       " too long: "+t2+" millis");
-        // }
+        return new DispatchWork(event, methodName, new HashSet<>(set));
       }
     }
   }
+
+  private void dispatch(DispatchWork work) {
+    for (EventListener el : work.listeners()) {
+      try {
+        Class<? extends EventListener> listenerClass = el.getClass();
+        Class<? extends EventObject> eventClass = work.event().getClass();
+
+        Tuple cacheKey = new Tuple(listenerClass, new Tuple(work.methodName(), eventClass));
+        Method method = methodCache.get(cacheKey);
+        if (method == null) {
+          Class<?>[] parameterTypes = new Class<?>[] {eventClass};
+          method = Util.getPublicMethod(listenerClass, work.methodName(), parameterTypes);
+          methodCache.put(cacheKey, method);
+        }
+        Object[] args = new Object[] {work.event()};
+        method.invoke(el, args);
+      } catch (Exception e) {
+        handleDispatchException(e);
+      }
+    }
+  }
+
+  private void handleDispatchException(Exception exception) {
+    if (handler != null) {
+      handler.handleException(new ExceptionEvent(this, exception));
+    } else {
+      LOGGER.log(Level.SEVERE, "Exception while dispatching event", exception);
+    }
+  }
+
+  private record DispatchWork(EventObject event, String methodName, Set<EventListener> listeners) {}
 }

--- a/src/test/java/com/onionnetworks/util/InvokingDispatchTest.java
+++ b/src/test/java/com/onionnetworks/util/InvokingDispatchTest.java
@@ -1,0 +1,100 @@
+package com.onionnetworks.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class InvokingDispatchTest {
+
+  private static final long AWAIT_TIMEOUT_MS = 750L;
+
+  private InvokingDispatch dispatch;
+
+  @BeforeEach
+  void setUp() {
+    dispatch = new InvokingDispatch();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    closeAndJoinDispatch();
+  }
+
+  @Test
+  void invokeLater_whenRunnableProvided_executesRunnable() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+
+    dispatch.invokeLater(latch::countDown);
+
+    assertTrue(latch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  void invokeAndWait_whenRunnableCompletes_returnsAfterExecution() throws Exception {
+    AtomicBoolean executed = new AtomicBoolean(false);
+
+    dispatch.invokeAndWait(() -> executed.set(true));
+
+    assertTrue(executed.get());
+  }
+
+  @Test
+  void invokeAndWait_blocksUntilRunnableFinishes() throws Exception {
+    CountDownLatch runStarted = new CountDownLatch(1);
+    CountDownLatch allowFinish = new CountDownLatch(1);
+    AtomicBoolean timedOutAwaitingFinish = new AtomicBoolean(false);
+    AtomicBoolean returned = new AtomicBoolean(false);
+
+    Thread caller =
+        new Thread(
+            () -> {
+              try {
+                dispatch.invokeAndWait(
+                    () -> {
+                      runStarted.countDown();
+                      try {
+                        boolean awaited =
+                            allowFinish.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                        if (!awaited) {
+                          timedOutAwaitingFinish.set(true);
+                        }
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                      }
+                    });
+                returned.set(true);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            },
+            "invokeAndWait-caller");
+
+    caller.start();
+
+    assertTrue(runStarted.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    assertTrue(caller.isAlive());
+
+    allowFinish.countDown();
+    caller.join(AWAIT_TIMEOUT_MS);
+
+    assertTrue(returned.get());
+    assertFalse(timedOutAwaitingFinish.get());
+    assertFalse(caller.isAlive());
+  }
+
+  private void closeAndJoinDispatch() throws Exception {
+    dispatch.close();
+    Field field = ReflectiveEventDispatch.class.getDeclaredField("thread");
+    field.setAccessible(true);
+    Thread thread = (Thread) field.get(dispatch);
+    thread.join(AWAIT_TIMEOUT_MS);
+  }
+}

--- a/src/test/java/com/onionnetworks/util/ReflectiveEventDispatchTest.java
+++ b/src/test/java/com/onionnetworks/util/ReflectiveEventDispatchTest.java
@@ -1,0 +1,190 @@
+package com.onionnetworks.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.EventListener;
+import java.util.EventObject;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ReflectiveEventDispatchTest {
+
+  private static final long AWAIT_TIMEOUT_MS = 750L;
+
+  private ReflectiveEventDispatch dispatch;
+
+  @Mock private ExceptionHandler exceptionHandler;
+
+  @BeforeEach
+  void setUp() {
+    dispatch = new ReflectiveEventDispatch();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    closeAndJoinDispatch();
+  }
+
+  @Test
+  void fire_whenListenerRegistered_invokesMethod() throws Exception {
+    Object source = new Object();
+    RecordingListener listener = new RecordingListener();
+
+    dispatch.addListener(source, listener, "onEvent");
+
+    EventObject event = new EventObject(source);
+    dispatch.fire(event, "onEvent");
+
+    assertTrue(listener.await());
+    assertSame(event, listener.lastEvent.get());
+  }
+
+  @Test
+  void fire_withSubclassEvent_invokesListenerExpectingSuperclass() throws Exception {
+    Object source = new Object();
+    SuperTypeListener listener = new SuperTypeListener();
+
+    dispatch.addListener(source, listener, "handleAny");
+
+    EventObject event = new CustomEvent(source);
+    dispatch.fire(event, "handleAny");
+
+    assertTrue(listener.await());
+    assertSame(event, listener.lastEvent.get());
+  }
+
+  @Test
+  void removeListener_whenNotRegistered_throwsException() {
+    EventListener listener = new EventListener() {};
+    Object source = new Object();
+
+    assertThrows(
+        IllegalArgumentException.class, () -> dispatch.removeListener(source, listener, "missing"));
+  }
+
+  @Test
+  void removeListener_whenMethodNotRegistered_throwsException() {
+    Object source = new Object();
+    EventListener listener = new EventListener() {};
+    dispatch.addListener(source, listener, "onEvent");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> dispatch.removeListener(source, listener, "otherMethod"));
+  }
+
+  @Test
+  void fire_afterListenerRemoved_doesNotInvoke() throws Exception {
+    Object source = new Object();
+    RecordingListener listener = new RecordingListener();
+    dispatch.addListener(source, listener, "onEvent");
+    dispatch.removeListener(source, listener, "onEvent");
+
+    dispatch.fire(new EventObject(source), "onEvent");
+
+    assertFalse(listener.await());
+  }
+
+  @Test
+  void fire_whenListenerThrows_routesExceptionToHandler() throws Exception {
+    Object source = new Object();
+    IllegalStateException failure = new IllegalStateException("boom");
+
+    ThrowingListener listener = new ThrowingListener(failure);
+    CountDownLatch handlerLatch = new CountDownLatch(1);
+    AtomicReference<ExceptionEvent> captured = new AtomicReference<>();
+
+    doAnswer(
+            invocation -> {
+              captured.set(invocation.getArgument(0));
+              handlerLatch.countDown();
+              return null;
+            })
+        .when(exceptionHandler)
+        .handleException(any());
+    dispatch.setExceptionHandler(exceptionHandler);
+    dispatch.addListener(source, listener, "onEvent");
+
+    dispatch.fire(new EventObject(source), "onEvent");
+
+    assertTrue(handlerLatch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    ExceptionEvent event = captured.get();
+    assertSame(dispatch, event.getSource());
+    assertInstanceOf(InvocationTargetException.class, event.getException());
+    assertSame(failure, event.getException().getCause());
+  }
+
+  private void closeAndJoinDispatch() throws Exception {
+    dispatch.close();
+    Field field = ReflectiveEventDispatch.class.getDeclaredField("thread");
+    field.setAccessible(true);
+    Thread thread = (Thread) field.get(dispatch);
+    thread.join(AWAIT_TIMEOUT_MS);
+  }
+
+  private static final class CustomEvent extends EventObject {
+    CustomEvent(Object source) {
+      super(source);
+    }
+  }
+
+  public static final class RecordingListener implements EventListener {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<EventObject> lastEvent = new AtomicReference<>();
+
+    @SuppressWarnings("unused")
+    public void onEvent(EventObject ev) {
+      lastEvent.set(ev);
+      latch.countDown();
+    }
+
+    boolean await() throws InterruptedException {
+      return latch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  public static final class SuperTypeListener implements EventListener {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<EventObject> lastEvent = new AtomicReference<>();
+
+    @SuppressWarnings("unused")
+    public void handleAny(EventObject ev) {
+      lastEvent.set(ev);
+      latch.countDown();
+    }
+
+    boolean await() throws InterruptedException {
+      return latch.await(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  public static final class ThrowingListener implements EventListener {
+    private final RuntimeException toThrow;
+
+    ThrowingListener(RuntimeException toThrow) {
+      this.toThrow = toThrow;
+    }
+
+    @SuppressWarnings("unused")
+    public void onEvent(EventObject ev) {
+      throw toThrow;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor `ReflectiveEventDispatch` to separate queue draining from listener invocation, cache lookups safely, and improve exception routing/logging
- harden `InvokingDispatch` synchronization with per-event locks/completion flags and clear event naming
- add focused unit tests for both dispatchers covering listener invocation, removal, superclass handling, and exception propagation

## Testing
- Not run (not requested)
