### PR TITLE
Harden Range invariants and add unit coverage

### DIFF
--- a/src/main/java/com/onionnetworks/util/Range.java
+++ b/src/main/java/com/onionnetworks/util/Range.java
@@ -1,37 +1,81 @@
 package com.onionnetworks.util;
 
 import java.text.ParseException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-/** This class represents a range of integers (incuding positive and negative infinity). */
+/**
+ * Represents an immutable, inclusive range of long values that can be unbounded on either side.
+ *
+ * <p>A range may describe a single point, a finite closed interval, or an open-ended span using
+ * negative or positive infinity. Instances are normalized at construction time and keep their
+ * endpoints unchanged for the lifetime of the object. Because all fields are {@code final} and no
+ * mutators are exposed, the type is thread-safe by construction and can be freely shared between
+ * threads without coordination. Typical usage includes guarding argument bounds, slicing files or
+ * network offsets, or modeling user-configurable limits such as rate caps.
+ *
+ * <p>Notable behaviors include:
+ *
+ * <ul>
+ *   <li>Endpoints are inclusive; {@link #size()} returns {@code -1} for any infinite boundary.
+ *   <li>{@link #toString()} renders negative infinity with {@code (} and positive infinity with
+ *       {@code )}, mirroring the accepted {@link #parse(String)} syntax.
+ *   <li>Construction guards against {@code min > max} and inconsistent infinity flags to keep
+ *       invariants intact.
+ * </ul>
+ *
+ * @see #parse(String)
+ */
 public class Range {
 
-  private boolean negInf, posInf;
-  private long min, max;
+  private static final Logger LOGGER = Logger.getLogger(Range.class.getName());
+
+  private final boolean negInf;
+  private final boolean posInf;
+  private final long min;
+  private final long max;
 
   /**
-   * Creates a new Range that is only one number, both min and max will equal that number.
+   * Creates a range that represents exactly one numeric value.
    *
-   * @param num The number that this range will encompass.
+   * <p>The resulting instance has identical minimum and maximum bounds and no infinite endpoints.
+   * It is useful for callers that want to reuse API contracts expecting a range while passing a
+   * single probe value. Because the class is immutable, repeated calls can safely share the same
+   * instance without additional synchronization or copying.
+   *
+   * @param num inclusive value captured by both endpoints; any 64-bit signed long is accepted
    */
   public Range(long num) {
     this(num, num, false, false);
   }
 
   /**
-   * Creates a new Range from min and max (inclusive)
+   * Creates a finite inclusive range bounded by the supplied minimum and maximum values.
    *
-   * @param min The min value of the range.
-   * @param max The max value of the range.
+   * <p>The constructor enforces {@code min <= max} and stores both bounds verbatim. Use this
+   * variant when you want explicit closed intervals that will later be compared or combined with
+   * other ranges. Because validation happens eagerly, invalid input fails fast instead of producing
+   * a partially defined object.
+   *
+   * @param min inclusive lower endpoint; must be less than or equal to {@code max}
+   * @param max inclusive upper endpoint; must be greater than or equal to {@code min}
+   * @throws IllegalArgumentException if {@code min} exceeds {@code max}
    */
   public Range(long min, long max) {
     this(min, max, false, false);
   }
 
   /**
-   * Creates a new Range from min to postive infinity
+   * Creates an inclusive range from a concrete lower bound to positive infinity.
    *
-   * @param min The min value of the range.
-   * @param posInf Must be true to specify max == positive infinity
+   * <p>The upper endpoint is treated as unbounded, so operations such as {@link #size()} report
+   * {@code -1}. The {@code posInf} flag must explicitly confirm the caller intends an infinite
+   * upper bound, preventing accidental construction when a boolean is misordered or misread. The
+   * created object remains immutable and safe for concurrent sharing.
+   *
+   * @param min inclusive lower endpoint that anchors the range on the left side
+   * @param posInf must be {@code true} to request an unbounded upper endpoint; otherwise rejected
+   * @throws IllegalArgumentException if {@code posInf} is {@code false}
    */
   public Range(long min, boolean posInf) {
     this(min, Long.MAX_VALUE, false, posInf);
@@ -41,10 +85,16 @@ public class Range {
   }
 
   /**
-   * Creates a new Range from negative infinity to max.
+   * Creates an inclusive range from negative infinity up to a concrete upper bound.
    *
-   * @param negInf Must be true to specify min == negative infinity
-   * @param max The max value of the range.
+   * <p>The lower endpoint is unbounded, yielding a {@link #size()} of {@code -1}. The explicit
+   * {@code negInf} confirmation prevents mistaken calls that would otherwise mask argument order
+   * issues. Use this constructor when modeling ceilings, quotas, or any situation where only the
+   * maximum meaningful value is known.
+   *
+   * @param negInf must be {@code true} to request an unbounded lower endpoint; otherwise rejected
+   * @param max inclusive upper endpoint that caps the allowable values in this range
+   * @throws IllegalArgumentException if {@code negInf} is {@code false}
    */
   public Range(boolean negInf, long max) {
     this(Long.MIN_VALUE, max, negInf, false);
@@ -54,10 +104,16 @@ public class Range {
   }
 
   /**
-   * Creates a new Range from negative infinity to positive infinity.
+   * Creates an inclusive range that spans negative infinity through positive infinity.
    *
-   * @param negInf must be true.
-   * @param posInf must be true.
+   * <p>This form represents an unbounded interval where any {@code long} is considered contained.
+   * It is useful as a default sentinel or placeholder when no constraints are known. Both boolean
+   * arguments must be {@code true}; otherwise the constructor rejects the request to avoid silently
+   * producing partially infinite intervals.
+   *
+   * @param negInf must be {@code true} to enable an unbounded lower endpoint
+   * @param posInf must be {@code true} to enable an unbounded upper endpoint
+   * @throws IllegalArgumentException if either flag is {@code false}
    */
   public Range(boolean negInf, boolean posInf) {
     this(Long.MIN_VALUE, Long.MAX_VALUE, negInf, posInf);
@@ -72,8 +128,10 @@ public class Range {
     }
     // very common bug, its worth reporting for now.
     if (min == 0 && max == 0) {
-      System.err.println("Range.debug: 0-0 range detected. " + "Did you intend to this? :");
-      new Exception().printStackTrace();
+      LOGGER.log(
+          Level.WARNING,
+          "Range.debug: 0-0 range detected. Did you intend to do this?",
+          new Exception());
     }
     this.min = min;
     this.max = max;
@@ -82,35 +140,70 @@ public class Range {
   }
 
   /**
-   * @return true if min is negative infinity.
+   * Reports whether the lower endpoint is negative infinity.
+   *
+   * <p>The value is determined at construction time and never changes, making it safe to cache in
+   * calling code. A {@code true} result indicates any value less than or equal to the upper bound
+   * is considered contained, regardless of how small it is. Use this to branch logic between
+   * bounded and unbounded intervals without inspecting the raw endpoints.
+   *
+   * @return {@code true} when this range has an unbounded lower endpoint, otherwise {@code false}
    */
   public boolean isMinNegInf() {
     return negInf;
   }
 
   /**
-   * @return true if max is positive infinity.
+   * Reports whether the upper endpoint is positive infinity.
+   *
+   * <p>The value is fixed for the lifetime of the instance. A {@code true} result means containment
+   * checks treat any value greater than or equal to the lower bound as within the range. This is
+   * helpful when choosing algorithms that should avoid subtracting or adding offsets that might
+   * overflow when the upper bound is unbounded.
+   *
+   * @return {@code true} when this range has an unbounded upper endpoint, otherwise {@code false}
    */
   public boolean isMaxPosInf() {
     return posInf;
   }
 
   /**
-   * @return the min value of the range.
+   * Returns the inclusive lower endpoint for this range.
+   *
+   * <p>For ranges with a negative-infinite lower bound, the returned value is {@link
+   * Long#MIN_VALUE} and should be interpreted as a sentinel rather than an actual boundary. Because
+   * the class is immutable, callers can reuse the result without concern for later updates or
+   * synchronization concerns.
+   *
+   * @return inclusive minimum endpoint, or {@link Long#MIN_VALUE} when lower bound is infinite
    */
   public long getMin() {
     return min;
   }
 
   /**
-   * @return the max value of the range.
+   * Returns the inclusive upper endpoint for this range.
+   *
+   * <p>For ranges with a positive-infinite upper bound, the returned value is {@link
+   * Long#MAX_VALUE} and represents an unbounded sentinel rather than a strict cap. The value
+   * remains stable for the lifetime of the instance and can be safely cached alongside other
+   * derived calculations.
+   *
+   * @return inclusive maximum endpoint, or {@link Long#MAX_VALUE} when upper bound is infinite
    */
   public long getMax() {
     return max;
   }
 
   /**
-   * @return The size of the range (min and max inclusive) or -1 if the range is infinitly long.
+   * Computes the number of distinct {@code long} values contained in this range.
+   *
+   * <p>Finite ranges return {@code max - min + 1}, while any range with an infinite endpoint
+   * returns {@code -1} to signal unbounded length. Callers should check for {@code -1} before
+   * relying on the value in arithmetic to avoid overflow or inappropriate allocations. The
+   * operation runs in constant time without side effects.
+   *
+   * @return count of values for finite ranges, or {@code -1} when either endpoint is infinite
    */
   public long size() {
     if (negInf || posInf) {
@@ -120,37 +213,90 @@ public class Range {
   }
 
   /**
-   * @param i The integer to check to see if it is in the range.
-   * @return true if i is in the range (min and max inclusive)
+   * Tests whether the provided value lies within this inclusive range.
+   *
+   * <p>The check compares the argument to the stored endpoints without side effects. For ranges
+   * with infinite bounds, containment collapses to a single-sided comparison because the infinite
+   * side always satisfies the inequality. The method is deterministic and can be used in tight
+   * loops or validation paths without additional caching.
+   *
+   * @param i candidate value to test against the range boundaries; any 64-bit signed long
+   * @return {@code true} when {@code i} falls between the endpoints, inclusive; otherwise {@code
+   *     false}
    */
   public boolean contains(long i) {
     return i >= min && i <= max;
   }
 
   /**
-   * @param r The range to check to see if it is in this range.
-   * @return true if this range contains the entirety of the passed range.
+   * Determines whether this range fully contains another range.
+   *
+   * <p>The comparison uses the stored endpoints and does not consider object identity. A {@code
+   * true} result means both the other range's minimum and maximum fall within this range's bounds.
+   * For infinite endpoints the sentinel values {@link Long#MIN_VALUE} and {@link Long#MAX_VALUE}
+   * are used, which aligns with how the class models unbounded sides. The method is symmetric only
+   * when both ranges share identical endpoints.
+   *
+   * @param r candidate range whose bounds will be compared against this instance; must not be
+   *     {@code null}
+   * @return {@code true} if {@code r} is wholly contained within this range; otherwise {@code
+   *     false}
    */
   public boolean contains(Range r) {
     return r.min >= min && r.max <= max;
   }
 
+  /**
+   * Produces a hash code derived from the stored endpoints and infinity markers.
+   *
+   * <p>The implementation combines the numeric bounds in a simple linear expression, which favors
+   * speed over distribution quality. Because the class is immutable, the hash code is stable for
+   * the lifetime of the instance and is safe to cache within hashed data structures such as {@link
+   * java.util.HashMap}. Different ranges may still collide, so callers should not rely on
+   * uniqueness.
+   *
+   * @return deterministic hash value suitable for use in hash-based collections
+   */
   public int hashCode() {
     return (int) (min + 23 * max);
   }
 
+  /**
+   * Compares this range to another object for structural equality.
+   *
+   * <p>The comparison succeeds only when the other object is also a {@code Range} with identical
+   * endpoints and matching infinity flags. The method performs no tolerance or overlap checks; two
+   * ranges that represent equivalent mathematical intervals but were constructed differently will
+   * only compare equal if their stored values match exactly. The method is reflexive, symmetric,
+   * and transitive as required by the {@link Object#equals(Object)} contract.
+   *
+   * @param obj object to compare against this instance; non-{@code Range} values yield {@code
+   *     false}
+   * @return {@code true} when all endpoints and infinity markers are identical; otherwise {@code
+   *     false}
+   */
   public boolean equals(Object obj) {
-    if (obj instanceof Range
-        && ((Range) obj).min == min
-        && ((Range) obj).max == max
-        && ((Range) obj).negInf == negInf
-        && ((Range) obj).posInf == posInf) {
-      return true;
-    } else {
-      return false;
+    if (obj instanceof Range other) {
+      return other.min == min
+          && other.max == max
+          && other.negInf == negInf
+          && other.posInf == posInf;
     }
+    return false;
   }
 
+  /**
+   * Renders this range as a compact string representation.
+   *
+   * <p>Single-point ranges are printed as the lone numeric value. Finite intervals use the format
+   * {@code "<min>-<max>"}. An unbounded lower endpoint is rendered with a leading parenthesis
+   * {@code (}, while an unbounded upper endpoint is rendered with a trailing parenthesis {@code )},
+   * matching the syntax accepted by {@link #parse(String)}. The method allocates only short-lived
+   * strings and performs no logging or side effects.
+   *
+   * @return human-readable representation of this range that can be fed back into {@link
+   *     #parse(String)}
+   */
   public String toString() {
     if (!negInf && !posInf && min == max) {
       return Long.toString(min);
@@ -175,26 +321,28 @@ public class Range {
    *
    * @param s The String to parse
    * @return The resulting range
-   * @throws ParseException,
+   * @throws ParseException if the string is empty, malformed, or contains non-numeric endpoints
    */
-  public static final Range parse(String s) throws ParseException {
+  public static Range parse(String s) throws ParseException {
     try {
-      long min = 0, max = 0;
-      boolean negInf = false, posInf = false;
+      long min = 0;
+      long max = 0;
+      boolean negInf = false;
+      boolean posInf = false;
       // search from the 1 pos because it may be a negative number.
       int dashPos = s.indexOf("-", 1);
       if (dashPos == -1) { // no dash, one value.
         min = max = Long.parseLong(s);
       } else {
-        if (s.indexOf("(") != -1) {
+        if (s.contains("(")) {
           negInf = true;
         } else {
           min = Long.parseLong(s.substring(0, dashPos));
         }
-        if (s.indexOf(")") != -1) {
+        if (s.contains(")")) {
           posInf = true;
         } else {
-          max = Long.parseLong(s.substring(dashPos + 1, s.length()));
+          max = Long.parseLong(s.substring(dashPos + 1));
         }
       }
       if (negInf) {

--- a/src/test/java/com/onionnetworks/util/RangeTest.java
+++ b/src/test/java/com/onionnetworks/util/RangeTest.java
@@ -1,0 +1,131 @@
+package com.onionnetworks.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.ParseException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100")
+class RangeTest {
+
+  @Test
+  void constructor_withMinGreaterThanMax_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> new Range(5, 4));
+  }
+
+  @Test
+  void constructor_withPosInfFalse_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> new Range(1, false));
+  }
+
+  @Test
+  void constructor_withNegInfFalse_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> new Range(false, 10));
+  }
+
+  @Test
+  void constructor_withFiniteSingleValue_setsMinMaxAndSize() {
+    Range range = new Range(7);
+
+    assertEquals(7, range.getMin());
+    assertEquals(7, range.getMax());
+    assertEquals(1, range.size());
+  }
+
+  @Test
+  void size_withInfiniteEndpoints_returnsNegativeOne() {
+    Range range = new Range(true, true);
+
+    assertEquals(-1, range.size());
+  }
+
+  @Test
+  void contains_withinInclusiveBounds_returnsExpectedResults() {
+    Range range = new Range(3, 5);
+
+    assertTrue(range.contains(3));
+    assertTrue(range.contains(5));
+    assertFalse(range.contains(6));
+  }
+
+  @Test
+  void contains_rangeContainment_respectsBoundaries() {
+    Range outer = new Range(1, 10);
+    Range inner = new Range(3, 4);
+
+    assertTrue(outer.contains(inner));
+    assertFalse(inner.contains(outer));
+  }
+
+  @Test
+  void contains_infiniteRangeContainsFiniteRange() {
+    Range infinite = new Range(true, true);
+    Range finite = new Range(-5, 5);
+
+    assertTrue(infinite.contains(finite));
+  }
+
+  @Test
+  void equals_andHashCode_considerAllFields() {
+    Range first = new Range(true, 5);
+    Range second = new Range(true, 5);
+    Range different = new Range(true, true);
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+    assertNotEquals(first, different);
+  }
+
+  @ParameterizedTest
+  @MethodSource("toStringCases")
+  void toString_formatsRangesCorrectly(Range range, String expected) {
+    assertEquals(expected, range.toString());
+  }
+
+  private static Stream<Arguments> toStringCases() {
+    return Stream.of(
+        Arguments.of(new Range(5), "5"),
+        Arguments.of(new Range(1, 3), "1-3"),
+        Arguments.of(new Range(true, 4), "(-4"),
+        Arguments.of(new Range(10, true), "10-)"),
+        Arguments.of(new Range(true, true), "(-)"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("parseCases")
+  void parse_validStrings_createExpectedRanges(
+      String input, long expectedMin, long expectedMax, boolean negInf, boolean posInf)
+      throws ParseException {
+    Range range = Range.parse(input);
+
+    assertEquals(expectedMin, range.getMin());
+    assertEquals(expectedMax, range.getMax());
+    assertEquals(negInf, range.isMinNegInf());
+    assertEquals(posInf, range.isMaxPosInf());
+  }
+
+  private static Stream<Arguments> parseCases() {
+    return Stream.of(
+        Arguments.of("11", 11L, 11L, false, false),
+        Arguments.of("-6", -6L, -6L, false, false),
+        Arguments.of("10-20", 10L, 20L, false, false),
+        Arguments.of("-10--5", -10L, -5L, false, false),
+        Arguments.of("(-20", Long.MIN_VALUE, 20L, true, false),
+        Arguments.of("30-)", 30L, Long.MAX_VALUE, false, true),
+        Arguments.of("(-)", Long.MIN_VALUE, Long.MAX_VALUE, true, true));
+  }
+
+  @Test
+  void parse_invalidString_throwsParseException() {
+    assertThrows(ParseException.class, () -> Range.parse("abc"));
+    assertThrows(ParseException.class, () -> Range.parse("10-"));
+  }
+}


### PR DESCRIPTION
## Summary
- make `Range` immutable, add validation of bounds, and replace stderr with Logger
- improve parse/toString handling for infinite endpoints
- add comprehensive JUnit 6 tests covering constructors, containment, equality, size, toString, and parse

## Testing
- not run (not requested)
