### PR TITLE
Refactor SimUtil logging and add tests

### DIFF
--- a/src/main/java/com/onionnetworks/util/SimUtil.java
+++ b/src/main/java/com/onionnetworks/util/SimUtil.java
@@ -1,37 +1,97 @@
 package com.onionnetworks.util;
 
-public class SimUtil {
+import java.util.Arrays;
+import java.util.StringJoiner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-  /**
-   * Prints a command to be redirected to a file, and run as a shell script for invoking the GNU
-   * plotutils "graph" command.
-   */
-  public static final void printGraphCommand(
-      String title, String x, String y, int[][] plots, String[] graphNames) {
-    System.out.println("#!/bin/sh");
-    System.out.println(
-        "# By default (no args) it will display it in X, " + "use $1=gif,png,for images");
-    System.out.println("if [ -n \"$1\" ]");
-    System.out.println("then type=$1");
-    System.out.println("else type=\"X\"");
-    System.out.println("fi");
+/**
+ * Miscellaneous simulation utilities used by the legacy Onion Networks tooling. The helper methods
+ * focus on printing small shell scripts for the GNU Plotutils {@code graph} command and on simple
+ * numeric helpers needed by those scripts. This class provides only static helpers and cannot be
+ * instantiated.
+ *
+ * <p>Typical usage is to call {@link #printGraphCommand(String, String, String, int[][], String[])}
+ * to emit a ready-to-run script to standard output, redirect that output to a file, and execute the
+ * file to visualize multiple plots. The median and swap helpers exist to support lightweight data
+ * massaging in the same code paths without pulling in additional dependencies.
+ *
+ * <p>The utilities are intentionally minimal and have no internal synchronization; callers must
+ * handle any required threading guarantees. Methods mutate the arrays that are passed in, so
+ * callers should supply defensive copies when necessary to preserve original inputs.
+ */
+public final class SimUtil {
 
-    System.out.print("echo \"");
-    for (int i = 0; i < plots.length; i++) {
-      for (int j = 0; j < plots[i].length; j++) {
-        System.out.print(plots[i][j] + " ");
-      }
-      System.out.println("\n"); // blank line
-    }
-    System.out.print(
-        "\" | graph -W .003 -C -T $type -L \"" + title + "\" -X \"" + x + "\" -Y \"" + y + "\"");
+  private static final Logger LOGGER = Logger.getLogger(SimUtil.class.getName());
+
+  private SimUtil() {
+    throw new IllegalStateException("Utility class");
   }
 
   /**
-   * Yes, this could be one line, but this really needs to be readable as an error in this method
-   * could really screw things up.
+   * Prints a shell script that feeds plot data to the Plotutils {@code graph} command. The script
+   * is written to standard output so callers can redirect it to a temporary file and execute it
+   * with a chosen output type. Each dataset in {@code plots} becomes one series; datasets are
+   * delimited by a blank line as expected by {@code graph}.
+   *
+   * @param title graph title text; used verbatim in the {@code -L} flag, may be empty but not null.
+   * @param x label for the X axis; supplied to {@code -X}, should describe units or scale.
+   * @param y label for the Y axis; supplied to {@code -Y}, should describe units or scale.
+   * @param plots two-dimensional array of series values; outer dimension selects the series, inner
+   *     elements are emitted as space-separated integers per line.
+   * @param graphNames optional descriptive names for debug logging; not used in the generated
+   *     script, can be {@code null} when not needed.
    */
-  public static final int getMedian(int[] data) {
+  @SuppressWarnings("java:S106")
+  public static void printGraphCommand(
+      String title, String x, String y, int[][] plots, String[] graphNames) {
+    String script = buildGraphCommandScript(title, x, y, plots);
+    System.out.print(script);
+    System.out.flush();
+    if (graphNames != null && LOGGER.isLoggable(Level.FINE)) {
+      LOGGER.log(Level.FINE, () -> "Graph names: " + Arrays.toString(graphNames));
+    }
+  }
+
+  private static String buildGraphCommandScript(String title, String x, String y, int[][] plots) {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append("#!/bin/sh")
+        .append(System.lineSeparator())
+        .append("# By default (no args) it will display it in X, use $1=gif,png,for images")
+        .append(System.lineSeparator())
+        .append("if [ -n \"$1\" ]")
+        .append(System.lineSeparator())
+        .append("then type=$1")
+        .append(System.lineSeparator())
+        .append("else type=\"X\"")
+        .append(System.lineSeparator())
+        .append("fi")
+        .append(System.lineSeparator())
+        .append("echo \"");
+    for (int[] plot : plots) {
+      for (int value : plot) {
+        builder.append(value).append(' ');
+      }
+      builder.append(System.lineSeparator()).append(System.lineSeparator());
+    }
+    builder.append("\" | graph -W .003 -C -T $type -L \"").append(title).append("\" -X \"");
+    builder.append(x).append("\" -Y \"").append(y).append('"');
+    return builder.toString();
+  }
+
+  /**
+   * Sorts the provided array in place using a simple bubble sort and returns the median element.
+   * The method logs the sorted contents at {@link Level#INFO} to aid debugging. Input arrays are
+   * expected to be non-empty; callers that require the lower median for even-length arrays must
+   * adjust after the call.
+   *
+   * @param data integer array to sort and examine; contents are reordered, not copied, and must be
+   *     non-null with at least one element.
+   * @return the element at {@code data.length / 2} after sorting; for even lengths this is the
+   *     upper middle value.
+   */
+  public static int getMedian(int[] data) {
     // do a stupid bubble sort then pick middle.
     // FIX, this sort doesn't have to suck.
     for (int i = 0; i < data.length - 1; i++) {
@@ -41,14 +101,30 @@ public class SimUtil {
         }
       }
     }
-    for (int i = 0; i < data.length; i++) {
-      System.err.print(data[i] + " ");
-    }
-    System.err.println();
+    LOGGER.log(Level.INFO, () -> joinValuesWithTrailingSpace(data));
     return data[data.length / 2];
   }
 
-  public static final void swap(int[] data, int posA, int posB) {
+  private static String joinValuesWithTrailingSpace(int[] data) {
+    StringJoiner joiner = new StringJoiner(" ", "", " ");
+    for (int value : data) {
+      joiner.add(Integer.toString(value));
+    }
+    return joiner.toString();
+  }
+
+  /**
+   * Exchanges two elements within the provided integer array. The operation is performed in place
+   * and is commonly used by the bubble sort inside {@link #getMedian(int[])} to reorder values.
+   *
+   * @param data target array whose elements will be swapped; must be non-null and large enough to
+   *     contain both indices.
+   * @param posA zero-based index of the first element to exchange; must satisfy {@code 0 <= posA <
+   *     data.length}.
+   * @param posB zero-based index of the second element to exchange; must satisfy {@code 0 <= posB <
+   *     data.length}.
+   */
+  public static void swap(int[] data, int posA, int posB) {
     int tmp = data[posA];
     data[posA] = data[posB];
     data[posB] = tmp;

--- a/src/test/java/com/onionnetworks/util/SimUtilTest.java
+++ b/src/test/java/com/onionnetworks/util/SimUtilTest.java
@@ -1,0 +1,149 @@
+package com.onionnetworks.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class SimUtilTest {
+
+  private Logger logger;
+  private Handler handler;
+  private PrintStream originalOut;
+  private ByteArrayOutputStream stdout;
+  private Level previousLevel;
+  private boolean previousUseParentHandlers;
+
+  @BeforeEach
+  void setUpLogger() {
+    logger = Logger.getLogger(SimUtil.class.getName());
+    previousUseParentHandlers = logger.getUseParentHandlers();
+    previousLevel = logger.getLevel();
+    logger.setUseParentHandlers(false);
+    logger.setLevel(Level.ALL);
+    TestLogHandler testHandler = new TestLogHandler();
+    logger.addHandler(testHandler);
+    handler = testHandler;
+
+    originalOut = System.out;
+    stdout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdout));
+  }
+
+  @AfterEach
+  void tearDownLogger() {
+    logger.removeHandler(handler);
+    logger.setUseParentHandlers(previousUseParentHandlers);
+    logger.setLevel(previousLevel);
+    System.setOut(originalOut);
+  }
+
+  @Test
+  void printGraphCommand_whenCalled_outputsExpectedScript() {
+    int[][] plots = {
+      {1, 2},
+      {3, 4}
+    };
+    String[] names = {"first", "second"};
+
+    SimUtil.printGraphCommand("Title", "X Axis", "Y Axis", plots, names);
+
+    String ls = System.lineSeparator();
+    String expected =
+        "#!/bin/sh"
+            + ls
+            + "# By default (no args) it will display it in X, use $1=gif,png,for images"
+            + ls
+            + "if [ -n \"$1\" ]"
+            + ls
+            + "then type=$1"
+            + ls
+            + "else type=\"X\""
+            + ls
+            + "fi"
+            + ls
+            + "echo \""
+            + "1 2 "
+            + ls
+            + ls
+            + "3 4 "
+            + ls
+            + ls
+            + "\" | graph -W .003 -C -T $type -L \"Title\" -X \"X Axis\" -Y \"Y Axis\"";
+
+    assertEquals(expected, stdout.toString());
+  }
+
+  @Test
+  void getMedian_whenUnsortedOddLength_returnsMedianAndSortsArray() {
+    int[] data = {5, 1, 3};
+
+    int median = SimUtil.getMedian(data);
+
+    assertEquals(3, median);
+    assertArrayEquals(new int[] {1, 3, 5}, data);
+    assertEquals("1 3 5 ", firstLogMessage());
+  }
+
+  @Test
+  void getMedian_whenEvenLength_returnsUpperMiddleValue() {
+    int[] data = {4, 1, 2, 3};
+
+    int median = SimUtil.getMedian(data);
+
+    assertEquals(3, median);
+    assertArrayEquals(new int[] {1, 2, 3, 4}, data);
+  }
+
+  @Test
+  void getMedian_whenEmptyArray_throwsArrayIndexOutOfBoundsException() {
+    int[] data = new int[0];
+
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> SimUtil.getMedian(data));
+  }
+
+  @Test
+  void swap_whenIndicesProvided_swapsValues() {
+    int[] data = {10, 20, 30};
+
+    SimUtil.swap(data, 0, 2);
+
+    assertArrayEquals(new int[] {30, 20, 10}, data);
+  }
+
+  private String firstLogMessage() {
+    return ((TestLogHandler) handler).records.getFirst().getMessage();
+  }
+
+  private static final class TestLogHandler extends Handler {
+
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord logRecord) {
+      records.add(logRecord);
+    }
+
+    @Override
+    public void flush() {
+      // No-op: in-memory log collection requires no flushing.
+    }
+
+    @Override
+    public void close() {
+      // No-op: nothing external to release in test handler.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor SimUtil to use Logger, add detailed Javadoc, and extract script-building helper
- replace stderr printing with structured logging and prevent instantiation
- add SimUtilTest coverage for graph script output, median sorting, and swap behavior

## Testing
- not run (not requested)