### PR TITLE
Add Ed2Handler tests and documentation

### DIFF
--- a/src/main/java/org/bitpedia/collider/core/Ed2Handler.java
+++ b/src/main/java/org/bitpedia/collider/core/Ed2Handler.java
@@ -5,6 +5,28 @@
  */
 package org.bitpedia.collider.core;
 
+/**
+ * Streaming calculator for the eD2k-style hash chain used in Bitzi-style workflows.
+ *
+ * <p>The handler partitions an incoming byte stream into fixed-size segments of {@link #EDSEG_SIZE}
+ * bytes (9,728,000 bytes). Each segment is hashed with {@link Md4Handler}; the resulting
+ * per-segment digests are then fed to a second {@code Md4Handler} that yields the final aggregate
+ * digest. This pattern matches the eDonkey/eMule verification model where chunks are validated
+ * independently and again in aggregate.
+ *
+ * <p>Usage is straightforward: call {@link #analyzeInit()}, feed data through {@link
+ * #analyzeUpdate(byte[], int, int)} in any chunking pattern, then finish with {@link
+ * #analyzeFinal()}. Instances are mutable and not thread-safe; restrict each instance to a single
+ * thread or synchronize externally when sharing.
+ *
+ * <ul>
+ *   <li>Maintains both per-segment and top-level {@code Md4Handler} instances.
+ *   <li>Ignores zero-length updates to avoid accidental counter drift.
+ *   <li>Processes input that crosses segment boundaries in one call.
+ * </ul>
+ *
+ * @see Md4Handler
+ */
 public class Ed2Handler {
 
   private static final int EDSEG_SIZE = 1024 * 9500;
@@ -13,6 +35,28 @@ public class Ed2Handler {
   private Md4Handler top; // the total file value
   private long nextPos;
 
+  /**
+   * Creates a new handler instance without initializing internal hash state.
+   *
+   * <p>Construction is deliberately lightweight; the segment and top-level {@link Md4Handler}
+   * instances are allocated during {@link #analyzeInit()} so callers can create objects early and
+   * initialize them only when a stream is ready to process. This constructor performs no I/O, does
+   * not allocate large buffers, and is safe to invoke repeatedly when preparing pools of hashers
+   * for concurrent workflows.
+   */
+  public Ed2Handler() {
+    // Constructor intentionally no-op; state is allocated lazily in analyzeInit() so callers can
+    // create instances early and initialize only when they are ready to stream data.
+  }
+
+  /**
+   * Resets the handler, preparing to consume a fresh byte stream.
+   *
+   * <p>This initializes both internal {@link Md4Handler} instances and clears the byte position
+   * counter so that subsequent calls to {@link #analyzeUpdate(byte[], int, int)} process input as
+   * if no previous data had been seen. Invoke this before starting a new file or when reusing an
+   * instance to avoid mixing state between different hash computations.
+   */
   public void analyzeInit() {
 
     nextPos = 0;
@@ -24,11 +68,35 @@ public class Ed2Handler {
     top.analyzeInit();
   }
 
+  /**
+   * Updates the current segment hash with the provided bytes starting at offset zero.
+   *
+   * <p>This is a convenience overload that forwards to {@link #analyzeUpdate(byte[], int, int)}
+   * with an offset of {@code 0}. The method treats a zero-length input as a no-op. When the call
+   * causes a segment boundary to be crossed, the method finalizes the current segment, feeds its
+   * digest into the top-level hash, and continues with the remaining data.
+   *
+   * @param input byte array containing the data to hash; must not be {@code null} and may be empty
+   * @param inputLen number of bytes from the start of {@code input} to consume for hashing
+   */
   public void analyzeUpdate(byte[] input, int inputLen) {
 
     analyzeUpdate(input, 0, inputLen);
   }
 
+  /**
+   * Streams a portion of the supplied buffer into the segment-oriented hash chain.
+   *
+   * <p>Bytes from {@code input} beginning at {@code ofs} are incorporated until {@code inputLen}
+   * bytes have been consumed. If the update stays within the current segment, only the segment hash
+   * is advanced. When the update reaches a segment boundary, the segment hash is finalized, its
+   * digest fed to the top-level hash, and processing continues with any remaining bytes in the same
+   * call. A zero-length update performs no work and leaves internal counters unchanged.
+   *
+   * @param input source buffer containing raw file data; must not be {@code null} and is read-only
+   * @param ofs zero-based offset within {@code input} where hashing begins; must satisfy bounds
+   * @param inputLen number of bytes to process starting at {@code ofs}; may be zero to signal noop
+   */
   public void analyzeUpdate(byte[] input, int ofs, int inputLen) {
 
     // first, do no harm
@@ -62,6 +130,16 @@ public class Ed2Handler {
     analyzeUpdate(input, ofs + firstLen, inputLen - firstLen);
   }
 
+  /**
+   * Finalizes the hash computation and returns the resulting digest.
+   *
+   * <p>If only a single segment of data was processed, this method returns the segment's MD4 digest
+   * directly. For multi-segment streams, it finalizes the current segment, feeds that digest into
+   * the top-level hash, and returns the MD4 digest of all segment digests. Calling this method
+   * multiple times without reinitializing will recompute based on the same buffered state.
+   *
+   * @return a 16-byte MD4 digest representing either the sole segment or the aggregate of segments
+   */
   public byte[] analyzeFinal() {
 
     if (nextPos <= EDSEG_SIZE) {

--- a/src/test/java/org/bitpedia/collider/core/Ed2HandlerTest.java
+++ b/src/test/java/org/bitpedia/collider/core/Ed2HandlerTest.java
@@ -1,0 +1,144 @@
+package org.bitpedia.collider.core;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class Ed2HandlerTest {
+
+  private static final int SEGMENT_SIZE = readSegmentSize();
+
+  @Test
+  void analyzeFinal_whenNoData_returnsMd4OfEmptyInput() {
+    Ed2Handler handler = new Ed2Handler();
+    handler.analyzeInit();
+
+    byte[] digest = handler.analyzeFinal();
+
+    assertArrayEquals(computeMd4(new byte[0], 0, 0), digest);
+  }
+
+  @Test
+  void analyzeFinal_whenSingleSegment_returnsMd4OfData() {
+    byte[] data = generateData(1024);
+    Ed2Handler handler = new Ed2Handler();
+    handler.analyzeInit();
+
+    handler.analyzeUpdate(data, data.length);
+    byte[] digest = handler.analyzeFinal();
+
+    assertArrayEquals(computeMd4(data, 0, data.length), digest);
+  }
+
+  @Test
+  void analyzeFinal_whenExactSegmentSize_returnsMd4OfData() {
+    byte[] data = generateData(SEGMENT_SIZE);
+    Ed2Handler handler = new Ed2Handler();
+    handler.analyzeInit();
+
+    handler.analyzeUpdate(data, data.length);
+    byte[] digest = handler.analyzeFinal();
+
+    assertArrayEquals(computeMd4(data, 0, data.length), digest);
+  }
+
+  @Test
+  void analyzeFinal_whenDataSpansTwoSegments_returnsMd4OfSegmentDigests() {
+    int totalLength = SEGMENT_SIZE + 1234;
+    byte[] data = generateData(totalLength);
+    Ed2Handler handler = new Ed2Handler();
+    handler.analyzeInit();
+
+    handler.analyzeUpdate(data, data.length);
+    byte[] digest = handler.analyzeFinal();
+
+    assertArrayEquals(computeEd2Expected(data), digest);
+  }
+
+  @Test
+  void analyzeUpdate_whenBoundaryCrossedInChunks_matchesSingleUpdate() {
+    int totalLength = SEGMENT_SIZE + 4321;
+    byte[] data = generateData(totalLength);
+
+    Ed2Handler singleUpdate = new Ed2Handler();
+    singleUpdate.analyzeInit();
+    singleUpdate.analyzeUpdate(data, data.length);
+    byte[] singleDigest = singleUpdate.analyzeFinal();
+
+    Ed2Handler chunked = new Ed2Handler();
+    chunked.analyzeInit();
+    int firstChunk = SEGMENT_SIZE - 10;
+    chunked.analyzeUpdate(data, 0, firstChunk);
+    chunked.analyzeUpdate(data, firstChunk, totalLength - firstChunk);
+    byte[] chunkedDigest = chunked.analyzeFinal();
+
+    assertArrayEquals(singleDigest, chunkedDigest);
+  }
+
+  @Test
+  void analyzeUpdate_whenZeroLengthInputProvided_digestUnaffected() {
+    byte[] data = generateData(4096);
+
+    Ed2Handler baseline = new Ed2Handler();
+    baseline.analyzeInit();
+    baseline.analyzeUpdate(data, data.length);
+    byte[] expected = baseline.analyzeFinal();
+
+    Ed2Handler withZeroUpdate = new Ed2Handler();
+    withZeroUpdate.analyzeInit();
+    withZeroUpdate.analyzeUpdate(data, 0, 2048);
+    withZeroUpdate.analyzeUpdate(new byte[0], 0);
+    withZeroUpdate.analyzeUpdate(data, 2048, data.length - 2048);
+    byte[] actual = withZeroUpdate.analyzeFinal();
+
+    assertArrayEquals(expected, actual);
+  }
+
+  private static int readSegmentSize() {
+    try {
+      Field field = Ed2Handler.class.getDeclaredField("EDSEG_SIZE");
+      field.setAccessible(true);
+      return field.getInt(null);
+    } catch (ReflectiveOperationException ex) {
+      throw new IllegalStateException("Unable to read segment size", ex);
+    }
+  }
+
+  private static byte[] computeEd2Expected(byte[] data) {
+    if (data.length <= SEGMENT_SIZE) {
+      return computeMd4(data, 0, data.length);
+    }
+
+    Md4Handler top = new Md4Handler();
+    top.analyzeInit();
+
+    int offset = 0;
+    while (offset < data.length) {
+      int len = Math.min(SEGMENT_SIZE, data.length - offset);
+      byte[] segmentDigest = computeMd4(data, offset, len);
+      top.analyzeUpdate(segmentDigest, segmentDigest.length);
+      offset += len;
+    }
+
+    return top.analyzeFinal();
+  }
+
+  private static byte[] computeMd4(byte[] data, int offset, int length) {
+    Md4Handler md4 = new Md4Handler();
+    md4.analyzeInit();
+    if (length > 0) {
+      md4.analyzeUpdate(data, offset, length);
+    }
+    return md4.analyzeFinal();
+  }
+
+  private static byte[] generateData(int length) {
+    byte[] data = new byte[length];
+    for (int i = 0; i < length; i++) {
+      data[i] = (byte) (i % 256);
+    }
+    return data;
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed Javadoc explaining Ed2Handler streaming MD4 chain behavior and lifecycle
- add JUnit 6 coverage for empty, single-segment, multi-segment, boundary-crossing, and zero-length update scenarios

## Testing
- ./gradlew spotlessApply
- not run: ./gradlew test