### PR TITLE
Add KzTreeHandler docs and test coverage

### DIFF
--- a/src/main/java/org/bitpedia/collider/core/KzTreeHandler.java
+++ b/src/main/java/org/bitpedia/collider/core/KzTreeHandler.java
@@ -5,6 +5,29 @@
  */
 package org.bitpedia.collider.core;
 
+/**
+ * Computes Kazaa-style hash trees over streaming content using MD5 digests.
+ *
+ * <p>The handler accumulates input in {@value #KZTREE_BLOCKSIZE}-byte leaves, hashes each leaf with
+ * MD5, and progressively composes parent nodes until a single root digest remains. Callers
+ * typically create an instance, invoke {@link #analyzeInit()}, feed data through {@link
+ * #analyzeUpdate(byte[], int, int)}, and finish with {@link #analyzeFinal()}. The instance is
+ * stateful and not thread-safe; reuse requires a fresh initialization before processing another
+ * payload. Zero-length inputs are handled by hashing an empty block, and single-block inputs are
+ * rehashed to align with the KZ tree specification.
+ *
+ * <p><strong>Responsibilities</strong>
+ *
+ * <ul>
+ *   <li>Maintain in-progress leaf and node stacks while streaming bytes.
+ *   <li>Produce deterministic MD5-based tree roots for content integrity checks.
+ *   <li>Ensure edge cases (partial leaves, odd generations, empty input) match legacy behavior.
+ * </ul>
+ *
+ * <p>Mutating operations update internal buffers; no defensive copies are kept aside from the final
+ * digest returned to the caller. Callers should synchronize externally when sharing an instance
+ * across threads.
+ */
 public class KzTreeHandler {
 
   /* MD5 hash result size, in bytes */
@@ -29,6 +52,22 @@ public class KzTreeHandler {
   private byte[] nodes; /* stack of interim node values */
   private int gen;
 
+  /** Creates a handler with empty state; invoke {@link #analyzeInit()} before supplying data. */
+  public KzTreeHandler() {
+    // Constructor intentionally empty; actual buffer allocation is deferred to analyzeInit to allow
+    // repeated reuse of the same instance without reallocating when callers prefer explicit reset.
+  }
+
+  /**
+   * Resets the handler so a new stream can be processed.
+   *
+   * <p>This method allocates fresh leaf and node buffers sized for the configured block and stack
+   * dimensions, and clears all counters used to track partially filled blocks and composed nodes.
+   * It must be invoked exactly once before feeding any bytes to {@link #analyzeUpdate(byte[], int,
+   * int)}, and should be called again before reusing the instance for a subsequent payload. The
+   * method performs no I/O and does not release prior buffers; repeated calls overwrite existing
+   * state in place.
+   */
   public void analyzeInit() {
 
     leaf = new byte[KZTREE_BLOCKSIZE];
@@ -40,6 +79,21 @@ public class KzTreeHandler {
     topIndex = 0;
   }
 
+  /**
+   * Feeds a segment of the source data into the tree builder.
+   *
+   * <p>The supplied {@code buffer} slice is appended to the current leaf until it reaches {@value
+   * #KZTREE_BLOCKSIZE} bytes, at which point the block is hashed and folded into the node stack.
+   * Larger segments are processed iteratively to avoid excessive copying. Callers may provide
+   * successive slices of any length; partial blocks are retained between calls. Input is treated as
+   * opaque bytes and is not modified.
+   *
+   * @param buffer contiguous array containing the next bytes to analyze; must not be {@code null}.
+   * @param ofs zero-based offset within {@code buffer} where consumption begins; must be within the
+   *     array bounds.
+   * @param len number of bytes from {@code buffer} to read starting at {@code ofs}; may be zero to
+   *     advance nothing.
+   */
   public void analyzeUpdate(byte[] buffer, int ofs, int len) {
 
     if (0 != index) {
@@ -73,8 +127,9 @@ public class KzTreeHandler {
     }
   }
 
-  /* A full KZTREE_BLOCKSIZE bytes have become available;
-   * hash those, and possibly composite together siblings. */
+  /**
+   * A full {@code KZTREE_BLOCKSIZE} bytes have become available; hash them and compose siblings.
+   */
   private void kztreeBlock() {
 
     byte[] md5 = Md5Handler.md5(leaf, index);
@@ -92,8 +147,7 @@ public class KzTreeHandler {
   private void kztreeCompose() {
 
     if (gen != ((gen >> 1) << 1)) { // compose of generation with odd population
-      // MD5 the only child in place
-      // MD5(ctx->top - MD5SIZE,MD5SIZE,ctx->top - MD5SIZE);
+      // Hash the only child in place to advance the tree level.
       byte[] childMd5 = Md5Handler.md5(nodes, topIndex - MD5_SIZE, MD5_SIZE);
       System.arraycopy(childMd5, 0, nodes, topIndex - MD5_SIZE, MD5_SIZE);
 
@@ -105,10 +159,27 @@ public class KzTreeHandler {
     topIndex -= MD5_SIZE; // update top ptr
   }
 
+  /**
+   * Completes hashing and returns the tree root digest.
+   *
+   * <p>This method finalizes any partially filled block, injects a synthetic empty block when the
+   * total length is zero, and composes remaining node generations until a single root remains. It
+   * also rehashes the lone block case to preserve legacy KZ tree semantics. The returned byte array
+   * is a new {@code MD5_SIZE}-length instance owned by the caller; internal buffers are left
+   * intact, allowing optional inspection after completion.
+   *
+   * @return 16-byte MD5 digest representing the root of the constructed hash tree; never {@code
+   *     null}.
+   */
   public byte[] analyzeFinal() {
 
     // do last partial block, if any
     if (0 < index) {
+      kztreeBlock();
+    }
+
+    if (0 == count) {
+      // for the zero-length input case, hash nothing.
       kztreeBlock();
     }
 
@@ -120,10 +191,6 @@ public class KzTreeHandler {
     if (1 == count) {
       // for the single block case, hash again
       kztreeCompose();
-    }
-    if (0 == count) {
-      // for the zero-length input case, hash nothing.
-      kztreeBlock();
     }
 
     byte[] digest = new byte[MD5_SIZE];

--- a/src/test/java/org/bitpedia/collider/core/KzTreeHandlerTest.java
+++ b/src/test/java/org/bitpedia/collider/core/KzTreeHandlerTest.java
@@ -1,0 +1,117 @@
+package org.bitpedia.collider.core;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class KzTreeHandlerTest {
+
+  private static final int BLOCK_SIZE = 32 * 1024;
+
+  @Test
+  void analyzeFinal_whenInputEmpty_returnsDoubleMd5OfEmpty() {
+    KzTreeHandler handler = new KzTreeHandler();
+    handler.analyzeInit();
+
+    byte[] digest = handler.analyzeFinal();
+
+    byte[] expected = md5(md5(new byte[0]));
+    assertArrayEquals(expected, digest);
+  }
+
+  @Test
+  void analyzeFinal_whenSingleShortBlock_returnsDoubleMd5OfData() {
+    byte[] data = "hello world".getBytes();
+    KzTreeHandler handler = new KzTreeHandler();
+    handler.analyzeInit();
+
+    handler.analyzeUpdate(data, 0, data.length);
+    byte[] digest = handler.analyzeFinal();
+
+    byte[] expected = md5(md5(data));
+    assertArrayEquals(expected, digest);
+  }
+
+  @Test
+  void analyzeFinal_whenTwoFullBlocks_combinesBlockDigests() {
+    byte[] block1 = filledBlock((byte) 0x11);
+    byte[] block2 = filledBlock((byte) 0x22);
+    KzTreeHandler handler = new KzTreeHandler();
+    handler.analyzeInit();
+
+    handler.analyzeUpdate(block1, 0, block1.length);
+    handler.analyzeUpdate(block2, 0, block2.length);
+    byte[] digest = handler.analyzeFinal();
+
+    byte[] expected = md5(concat(md5(block1), md5(block2))); // parent = MD5(child1||child2)
+    assertArrayEquals(expected, digest);
+  }
+
+  @Test
+  void analyzeFinal_whenThreeBlocks_usesOddComposeRule() {
+    byte[] block1 = filledBlock((byte) 0x33);
+    byte[] block2 = filledBlock((byte) 0x44);
+    byte[] block3 = filledBlock((byte) 0x55);
+    KzTreeHandler handler = new KzTreeHandler();
+    handler.analyzeInit();
+
+    handler.analyzeUpdate(block1, 0, block1.length);
+    handler.analyzeUpdate(block2, 0, block2.length);
+    handler.analyzeUpdate(block3, 0, block3.length);
+    byte[] digest = handler.analyzeFinal();
+
+    byte[] m1 = md5(block1);
+    byte[] m2 = md5(block2);
+    byte[] m3 = md5(block3);
+    byte[] parent12 = md5(concat(m1, m2));
+    byte[] hashedThird = md5(m3); // odd compose re-hashes the lone child
+    byte[] expectedRoot = md5(concat(parent12, hashedThird));
+
+    assertArrayEquals(expectedRoot, digest);
+  }
+
+  @Test
+  void analyzeUpdate_whenFedInChunks_matchesSinglePassDigest() {
+    byte[] data = new byte[BLOCK_SIZE + 17];
+    Arrays.fill(data, (byte) 0x7A);
+
+    KzTreeHandler streaming = new KzTreeHandler();
+    streaming.analyzeInit();
+    streaming.analyzeUpdate(data, 0, 10);
+    streaming.analyzeUpdate(data, 10, data.length - 10);
+    byte[] streamingDigest = streaming.analyzeFinal();
+
+    KzTreeHandler singlePass = new KzTreeHandler();
+    singlePass.analyzeInit();
+    singlePass.analyzeUpdate(data, 0, data.length);
+    byte[] singlePassDigest = singlePass.analyzeFinal();
+
+    assertArrayEquals(singlePassDigest, streamingDigest);
+  }
+
+  private static byte[] filledBlock(byte value) {
+    byte[] block = new byte[BLOCK_SIZE];
+    Arrays.fill(block, value);
+    return block;
+  }
+
+  private static byte[] concat(byte[] left, byte[] right) {
+    byte[] combined = new byte[left.length + right.length];
+    System.arraycopy(left, 0, combined, 0, left.length);
+    System.arraycopy(right, 0, combined, left.length, right.length);
+    return combined;
+  }
+
+  private static byte[] md5(byte[] data) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("MD5");
+      return digest.digest(data);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("MD5 algorithm missing", e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed Javadoc to KzTreeHandler covering streaming usage and edge cases
- clarify odd-generation compose comments and zero-length input handling
- introduce JUnit 6 tests for empty, single-block, multi-block, odd-compose, and chunked update scenarios

## Testing
- not run