### PR TITLE
fix: harden ID3 tag parsing

### DIFF
--- a/src/main/java/org/bitpedia/collider/core/Id3Handler.java
+++ b/src/main/java/org/bitpedia/collider/core/Id3Handler.java
@@ -5,14 +5,41 @@
  */
 package org.bitpedia.collider.core;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 
+/**
+ * Utility reader for ID3 metadata embedded in audio files.
+ *
+ * <p>This helper parses the ID3v1 footer and ID3v2.2/ID3v2.3 headers directly from a {@code
+ * RandomAccessFile}, exposing only the small immutable {@link Id3Info} snapshot that callers
+ * typically need for cataloging or display. It performs size validation, gracefully stops on
+ * malformed frames, and combines v2 data with the older v1 footer so legacy tags are still honored.
+ * The class contains only static methods and state-free helper types, making it safe to invoke from
+ * multiple threads as long as each caller supplies its own open file handle.
+ *
+ * <p>Typical usage reads v2 tags first and falls back to v1 if necessary:
+ *
+ * <pre>{@code
+ * Id3Handler.Id3Info info = Id3Handler.readId3Tags("/path/to/song.mp3");
+ * if (info != null) {
+ *   System.out.println(info.title);
+ * }
+ * }</pre>
+ *
+ * <ul>
+ *   <li>Supports ID3v2.2 and ID3v2.3 text frames plus the ID3v1 footer.
+ *   <li>Leaves the file otherwise untouched; only reads bytes from supplied streams.
+ *   <li>Does not normalize character encodings beyond stripping the leading encoding byte.
+ *   <li>Thread-safe through immutability and absence of shared mutable state.
+ * </ul>
+ */
 public class Id3Handler {
 
   private static final int SUPPORTED_VERSION_2_2 = 2;
   private static final int SUPPORTED_VERSION_2_3 = 3;
+  private static final int FRAME_HEADER_V23_SIZE = 10;
+  private static final int FRAME_HEADER_V22_SIZE = 6;
 
   private static final String[] genres = {
     "Blues",
@@ -165,6 +192,15 @@ public class Id3Handler {
     "SynthPop"
   };
 
+  /**
+   * Data holder for an ID3v1 footer parsed from the last 128 bytes of a file.
+   *
+   * <p>Instances are populated by {@link #readFromFile(RandomAccessFile)} and hold raw field values
+   * exactly as encoded in the tag. Text values may contain padding spaces; callers can invoke
+   * {@link #trimFields()} to remove trailing whitespace while preserving null values. All fields
+   * are mutable to mirror the permissive legacy tag structure and are intended for short-lived use
+   * during metadata extraction.
+   */
   public static class Id3v1 {
 
     String id;
@@ -175,6 +211,17 @@ public class Id3Handler {
     String comment;
     int track;
     int genre;
+
+    /**
+     * Creates an empty container for ID3v1 field values read from a file.
+     *
+     * <p>No normalization or validation is performed during construction; fields are populated by
+     * {@link #readFromFile(RandomAccessFile)} or manual assignment before presentation to callers.
+     */
+    public Id3v1() {
+      // Intentionally empty; fields are populated after construction by readFromFile or direct
+      // assignment.
+    }
 
     static Id3v1 readFromFile(RandomAccessFile f) {
 
@@ -203,6 +250,14 @@ public class Id3Handler {
       }
     }
 
+    /**
+     * Removes leading and trailing whitespace from all text fields in place.
+     *
+     * <p>The operation skips null fields and leaves numeric fields unchanged. Use this after
+     * reading a tag when human-readable presentation is desired and the trailing padding added by
+     * ID3v1 encoders should be suppressed. The method is idempotent and safe to call multiple times
+     * on the same instance.
+     */
     public void trimFields() {
 
       if (null != title) title = title.trim();
@@ -212,6 +267,14 @@ public class Id3Handler {
     }
   }
 
+  /**
+   * Parsed ID3v2 header information for the tag block at the start of a file.
+   *
+   * <p>The header stores the raw version numbers, flags, and sync-safe size bytes that bound the
+   * subsequent frame sequence. Instances are produced by {@link #readFromFile(RandomAccessFile)}
+   * and consumed internally to drive frame parsing. The class performs no validation beyond simple
+   * byte extraction, leaving semantic checks to the caller.
+   */
   public static class Id3Header {
 
     String tag;
@@ -219,6 +282,16 @@ public class Id3Handler {
     int versionRevision;
     int flags;
     int[] size = new int[4];
+
+    /**
+     * Builds an empty header that will be filled from the start of an ID3v2 tag block.
+     *
+     * <p>All fields remain zero until {@link #readFromFile(RandomAccessFile)} populates them;
+     * callers typically do not instantiate this type directly outside parsing utilities.
+     */
+    public Id3Header() {
+      // Intentionally empty; header bytes are assigned during stream parsing.
+    }
 
     static Id3Header readFromFile(RandomAccessFile f) {
 
@@ -243,11 +316,24 @@ public class Id3Handler {
     }
   }
 
+  /**
+   * Frame header representation for ID3v2.3 tags.
+   *
+   * <p>Holds the four-character frame identifier, the frame size read from the stream, and the raw
+   * flags field. A header is considered valid only when the associated frame size is sensible for
+   * the containing file; this class does not enforce those rules itself. Instances are constructed
+   * on demand during sequential parsing and discarded once a frame is consumed.
+   */
   public static class FrameHeaderv23 {
 
     String tag;
     int size;
     int flags;
+
+    /** Constructs a placeholder for a single ID3v2.3 frame header before parsing stream bytes. */
+    public FrameHeaderv23() {
+      // Intentionally empty; values are set from the frame stream when parsing.
+    }
 
     static FrameHeaderv23 readFromFile(RandomAccessFile f) {
 
@@ -267,19 +353,27 @@ public class Id3Handler {
       }
     }
 
-    static int getHeaderSize() {
-      return 10;
-    }
-
     int getFrameSize() {
       return size;
     }
   }
 
+  /**
+   * Frame header representation for ID3v2.2 tags.
+   *
+   * <p>Stores the three-character frame identifier along with the three-byte size field encoded in
+   * big-endian order. Parsing is deliberately minimal and defers bounds checking to callers. Each
+   * header instance is typically short-lived and paired with a single frame read.
+   */
   public static class FrameHeaderv22 {
 
     String tag;
     byte[] size = new byte[3];
+
+    /** Constructs an empty representation of an ID3v2.2 frame header prior to parsing. */
+    public FrameHeaderv22() {
+      // Intentionally empty; populated immediately after construction while reading a frame.
+    }
 
     static FrameHeaderv22 readFromFile(RandomAccessFile f) {
 
@@ -297,10 +391,6 @@ public class Id3Handler {
       }
     }
 
-    static int getHeaderSize() {
-      return 6;
-    }
-
     int getFrameSize() {
 
       int b1 = size[0] >= 0 ? size[0] : size[0] + 256;
@@ -311,6 +401,15 @@ public class Id3Handler {
     }
   }
 
+  /**
+   * Consolidated view of the metadata fields extracted from ID3 tags.
+   *
+   * <p>The container aggregates artist, album, title, genre, year, encoder, and track number in a
+   * format suitable for upstream cataloging logic. All fields are nullable to reflect optional tag
+   * presence; callers may freely combine v2 and v1 data by passing a partially populated instance
+   * to {@link #readId3v1Tags(String, Id3Info)} for backfilling. Instances are mutable and intended
+   * for transient use rather than long-term caching.
+   */
   public static class Id3Info {
     String artist;
     String album;
@@ -319,25 +418,32 @@ public class Id3Handler {
     String year;
     String encoder;
     String trackNumber;
+
+    /** Creates an initially blank metadata aggregate suitable for progressive backfilling. */
+    public Id3Info() {
+      // Intentionally empty; fields are assigned progressively as tags are discovered.
+    }
   }
 
-  private static void handleFramev23(String tag, byte[] data, int ofs, int len, Id3Info info) {
+  private static final int TEXT_DATA_OFFSET = 1;
+
+  private static void handleFramev23(String tag, byte[] data, int len, Id3Info info) {
 
     if ((null == data) || (0 == data.length)) {
       return;
     }
 
     if ("TIT2".equals(tag)) {
-      info.title = new String(data, ofs, len);
+      info.title = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TALB".equals(tag)) {
-      info.album = new String(data, ofs, len);
+      info.album = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TPE1".equals(tag)) {
-      info.artist = new String(data, ofs, len);
+      info.artist = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TYER".equals(tag)) {
-      info.year = new String(data, ofs, len);
+      info.year = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TCON".equals(tag)) {
 
-      String genreName = new String(data, ofs, len);
+      String genreName = new String(data, TEXT_DATA_OFFSET, len);
       for (int i = 0; i < genres.length; i++) {
 
         if (genres[i].equals(genreName)) {
@@ -345,59 +451,44 @@ public class Id3Handler {
         }
       }
     } else if ("TRCK".equals(tag)) {
-      info.trackNumber = new String(data, ofs, len);
+      info.trackNumber = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TSSE".equals(tag)) {
-      info.encoder = new String(data, ofs, len);
+      info.encoder = new String(data, TEXT_DATA_OFFSET, len);
     }
   }
 
-  private static void handleFramev22(String tag, byte[] data, int ofs, int len, Id3Info info) {
+  private static void handleFramev22(String tag, byte[] data, int len, Id3Info info) {
 
     if ((null == data) || (0 == data.length)) return;
 
     if ("TT2".equals(tag)) {
-      info.title = new String(data, ofs, len);
+      info.title = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TAL".equals(tag)) {
-      info.album = new String(data, ofs, len);
+      info.album = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TP1".equals(tag)) {
-      info.artist = new String(data, ofs, len);
+      info.artist = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TYE".equals(tag)) {
-      info.year = new String(data, ofs, len);
+      info.year = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TSI".equals(tag)) {
-      info.genre = new String(data, ofs, len);
+      info.genre = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TRK".equals(tag)) {
-      info.trackNumber = new String(data, ofs, len);
+      info.trackNumber = new String(data, TEXT_DATA_OFFSET, len);
     } else if ("TSS".equals(tag)) {
-      info.encoder = new String(data, ofs, len);
+      info.encoder = new String(data, TEXT_DATA_OFFSET, len);
     }
   }
 
   private static Id3Info readId3v2Tags(String fileName) {
 
-    RandomAccessFile f = null;
-    try {
-      f = new RandomAccessFile(fileName, "r");
+    try (RandomAccessFile f = new RandomAccessFile(fileName, "r")) {
       long fileSize = f.length();
 
       Id3Header head = Id3Header.readFromFile(f);
-      if (null == head) {
+      if (isInvalidHeader(head)) {
         return null;
       }
 
-      if (!"ID3".equals(head.tag)) {
-        return null;
-      }
-
-      if ((SUPPORTED_VERSION_2_2 != head.versionMajor)
-          && (SUPPORTED_VERSION_2_3 != head.versionMajor)) {
-        return null;
-      }
-
-      long size =
-          (head.size[3] & 0x7F)
-              | ((head.size[2] & 0x7F) << 7)
-              | ((head.size[1] & 0x7F) << 14)
-              | ((head.size[0] & 0x7F) << 21);
+      long size = calculateTagSize(head.size);
       if (fileSize < size) {
         return null;
       }
@@ -409,123 +500,178 @@ public class Id3Handler {
       }
 
       Id3Info info = new Id3Info();
-      int frameSize = 0;
       while (size > 0) {
 
-        FrameHeaderv22 framev22 = null;
-        FrameHeaderv23 framev23 = null;
-
-        if (SUPPORTED_VERSION_2_2 == head.versionMajor) {
-
-          framev22 = FrameHeaderv22.readFromFile(f);
-          if (null == framev22) {
-            return null;
-          }
-
-          frameSize = framev22.getFrameSize();
+        int processedSize = processFrame(f, head.versionMajor, info, fileSize);
+        if (processedSize < 0) {
+          return null;
         }
-
-        if (SUPPORTED_VERSION_2_3 == head.versionMajor) {
-
-          framev23 = FrameHeaderv23.readFromFile(f);
-          if (null == framev23) {
-            return null;
-          }
-
-          frameSize = framev23.getFrameSize();
-        }
-
-        // If the frame size is funky, skip it and move on
-        if ((0 == frameSize) || (fileSize < frameSize)) {
+        if (processedSize == 0) {
           break;
         }
 
-        byte[] frameData = new byte[frameSize];
-        int read = f.read(frameData);
-        if (read != frameSize) {
-          return null;
-        }
-
-        if (SUPPORTED_VERSION_2_2 == head.versionMajor) {
-          handleFramev22(framev22.tag, frameData, 1, frameSize - 1, info);
-        } else {
-          handleFramev23(framev23.tag, frameData, 1, frameSize - 1, info);
-        }
-
-        size -=
-            (SUPPORTED_VERSION_2_3 == head.versionMajor
-                    ? FrameHeaderv23.getHeaderSize()
-                    : FrameHeaderv22.getHeaderSize())
-                + frameSize;
+        size -= getHeaderSize(head.versionMajor) + processedSize;
       }
 
       return info;
 
     } catch (Exception e) {
       return null;
-    } finally {
-      try {
-        f.close();
-      } catch (Exception e) {
-      }
     }
   }
 
   private static Id3Info readId3v1Tags(String fileName, Id3Info info) {
 
-    RandomAccessFile f = null;
-    try {
-      f = new RandomAccessFile(fileName, "r");
+    try (RandomAccessFile f = new RandomAccessFile(fileName, "r")) {
       Id3v1 id3 = Id3v1.readFromFile(f);
       if ((null == id3) || (!"TAG".equals(id3.id))) {
         return info;
       }
 
-      if (null == info) {
-        info = new Id3Info();
-      }
+      Id3Info target = (null == info) ? new Id3Info() : info;
+      populateFromId3v1(id3, target);
 
-      id3.trimFields();
-      if ((null != id3.artist) && (0 < id3.artist.length())) {
-        info.artist = id3.artist;
-      }
-      if ((null != id3.album) && (0 < id3.album.length())) {
-        info.album = id3.album;
-      }
-      if ((null != id3.title) && (0 < id3.title.length())) {
-        info.title = id3.title;
-      }
-      if ((null != id3.year) && (0 < id3.year.length())) {
-        try {
-          int intYear = Integer.parseInt(id3.year);
-          if ((1000 <= intYear) && (intYear < 3000)) {
-            info.year = id3.year;
-          }
-        } catch (Exception e) {
-        }
-      }
-
-      if (0 != id3.track) {
-        info.trackNumber = Integer.toString(id3.track);
-      }
-
-      if (255 != id3.genre) {
-        info.genre = Integer.toString(id3.genre);
-      }
-
+      return target;
+    } catch (IOException e) {
       return info;
-    } catch (FileNotFoundException e) {
-      return info;
-    } finally {
+    }
+  }
+
+  /**
+   * Reads ID3 metadata from the supplied file path, combining v2 and v1 sources.
+   *
+   * <p>The method first attempts to parse an ID3v2.2 or ID3v2.3 header from the start of the file;
+   * when present and well-formed, it processes frames until the declared tag size is exhausted or a
+   * malformed frame is encountered. It then looks for an ID3v1 footer and merges any missing fields
+   * such as title or track number. No bytes are written and the file is closed automatically via a
+   * try-with-resources block. Callers should treat a {@code null} result as an indication that no
+   * usable tag data was found.
+   *
+   * @param fileName absolute or relative path to the audio file to inspect; must reference a file
+   *     readable by the current process.
+   * @return populated {@link Id3Info} when at least one supported tag is present; {@code null} when
+   *     parsing fails or no metadata is available.
+   */
+  public static Id3Info readId3Tags(String fileName) {
+
+    return readId3v1Tags(fileName, readId3v2Tags(fileName));
+  }
+
+  private static long calculateTagSize(int[] sizeBytes) {
+    return (sizeBytes[3] & 0x7F)
+        | ((sizeBytes[2] & 0x7F) << 7)
+        | ((sizeBytes[1] & 0x7F) << 14)
+        | ((sizeBytes[0] & 0x7F) << 21);
+  }
+
+  private static boolean isInvalidHeader(Id3Header head) {
+    if (null == head) {
+      return true;
+    }
+    if (!"ID3".equals(head.tag)) {
+      return true;
+    }
+    return (SUPPORTED_VERSION_2_2 != head.versionMajor)
+        && (SUPPORTED_VERSION_2_3 != head.versionMajor);
+  }
+
+  private static int processFrame(RandomAccessFile f, int version, Id3Info info, long fileSize)
+      throws IOException {
+    if (SUPPORTED_VERSION_2_2 == version) {
+      return readAndHandleFrameV22(f, info, fileSize);
+    }
+    return readAndHandleFrameV23(f, info, fileSize);
+  }
+
+  private static int readAndHandleFrameV22(RandomAccessFile f, Id3Info info, long fileSize)
+      throws IOException {
+    FrameHeaderv22 frame = FrameHeaderv22.readFromFile(f);
+    if (null == frame) {
+      return -1;
+    }
+    int frameSize = frame.getFrameSize();
+    if (isInvalidFrameSize(frameSize, fileSize)) {
+      return 0;
+    }
+    byte[] frameData = readFrameData(f, frameSize);
+    if (null == frameData) {
+      return -1;
+    }
+    handleFramev22(frame.tag, frameData, frameSize - 1, info);
+    return frameSize;
+  }
+
+  private static int readAndHandleFrameV23(RandomAccessFile f, Id3Info info, long fileSize)
+      throws IOException {
+    FrameHeaderv23 frame = FrameHeaderv23.readFromFile(f);
+    if (null == frame) {
+      return -1;
+    }
+    int frameSize = frame.getFrameSize();
+    if (isInvalidFrameSize(frameSize, fileSize)) {
+      return 0;
+    }
+    byte[] frameData = readFrameData(f, frameSize);
+    if (null == frameData) {
+      return -1;
+    }
+    handleFramev23(frame.tag, frameData, frameSize - 1, info);
+    return frameSize;
+  }
+
+  private static boolean isInvalidFrameSize(int frameSize, long fileSize) {
+    return (0 == frameSize) || (fileSize < frameSize);
+  }
+
+  private static byte[] readFrameData(RandomAccessFile f, int frameSize) throws IOException {
+    byte[] frameData = new byte[frameSize];
+    int read = f.read(frameData);
+    return read == frameSize ? frameData : null;
+  }
+
+  private static int getHeaderSize(int version) {
+    return SUPPORTED_VERSION_2_3 == version ? FRAME_HEADER_V23_SIZE : FRAME_HEADER_V22_SIZE;
+  }
+
+  private static void populateFromId3v1(Id3v1 id3, Id3Info target) {
+    id3.trimFields();
+    if (hasText(id3.artist)) {
+      target.artist = id3.artist;
+    }
+    if (hasText(id3.album)) {
+      target.album = id3.album;
+    }
+    if (hasText(id3.title)) {
+      target.title = id3.title;
+    }
+    copyValidYear(id3, target);
+    if (0 != id3.track) {
+      target.trackNumber = Integer.toString(id3.track);
+    }
+
+    if (255 != id3.genre) {
+      target.genre = Integer.toString(id3.genre);
+    }
+  }
+
+  private static void copyValidYear(Id3v1 id3, Id3Info target) {
+    if (hasText(id3.year)) {
       try {
-        f.close();
-      } catch (Exception e) {
+        int intYear = Integer.parseInt(id3.year);
+        if ((1000 <= intYear) && (intYear < 3000)) {
+          target.year = id3.year;
+        }
+      } catch (NumberFormatException ignored) {
+        // Intentionally ignore invalid year formats to preserve original behavior.
       }
     }
   }
 
-  public static Id3Info readId3Tags(String fileName) {
+  private static boolean hasText(String value) {
+    return (null != value) && !value.trim().isEmpty();
+  }
 
-    return readId3v1Tags(fileName, readId3v2Tags(fileName));
+  private Id3Handler() {
+    throw new IllegalStateException("Utility class");
   }
 }

--- a/src/test/java/org/bitpedia/collider/core/Id3HandlerTest.java
+++ b/src/test/java/org/bitpedia/collider/core/Id3HandlerTest.java
@@ -1,0 +1,203 @@
+package org.bitpedia.collider.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class Id3HandlerTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void readId3Tags_whenFileHasV23Frames_populatesAllKnownFields() throws IOException {
+    Path file = createV23File(tempDir);
+
+    Id3Handler.Id3Info info = Id3Handler.readId3Tags(file.toString());
+
+    assertEquals("Title V23", info.title);
+    assertEquals("Album V23", info.album);
+    assertEquals("Artist V23", info.artist);
+    assertEquals("2024", info.year);
+    assertEquals("8", info.genre); // Jazz is index 8 in the static genre list
+    assertEquals("7", info.trackNumber);
+    assertEquals("JUnit Encoder", info.encoder);
+  }
+
+  @Test
+  void readId3Tags_whenFileHasV22Frames_populatesFieldsFromV22() throws IOException {
+    Path file = createV22File(tempDir);
+
+    Id3Handler.Id3Info info = Id3Handler.readId3Tags(file.toString());
+
+    assertEquals("Title V22", info.title);
+    assertEquals("Album V22", info.album);
+    assertEquals("Artist V22", info.artist);
+    assertEquals("1999", info.year);
+    assertEquals("CustomGenre", info.genre);
+    assertEquals("12", info.trackNumber);
+    assertEquals("EncoderV22", info.encoder);
+  }
+
+  @Test
+  void readId3Tags_whenV2Unsupported_usesId3v1Fallback() throws IOException {
+    Path file = createUnsupportedV2WithV1Tag(tempDir);
+
+    Id3Handler.Id3Info info = Id3Handler.readId3Tags(file.toString());
+
+    assertEquals("V1 Title", info.title);
+    assertEquals("V1 Artist", info.artist);
+    assertEquals("V1 Album", info.album);
+    assertEquals("2010", info.year);
+    assertEquals("5", info.trackNumber);
+    assertEquals("13", info.genre);
+  }
+
+  @Test
+  void readId3Tags_whenNoTagsPresent_returnsNull() throws IOException {
+    Path file = Files.write(tempDir.resolve("plain.bin"), new byte[] {0x01, 0x02, 0x03});
+
+    Id3Handler.Id3Info info = Id3Handler.readId3Tags(file.toString());
+
+    assertNull(info);
+  }
+
+  private static Path createV23File(Path dir) throws IOException {
+    ByteArrayOutputStream frames = new ByteArrayOutputStream();
+    writeV23Frame(frames, "TIT2", "Title V23");
+    writeV23Frame(frames, "TALB", "Album V23");
+    writeV23Frame(frames, "TPE1", "Artist V23");
+    writeV23Frame(frames, "TYER", "2024");
+    writeV23Frame(frames, "TCON", "Jazz");
+    writeV23Frame(frames, "TRCK", "7");
+    writeV23Frame(frames, "TSSE", "JUnit Encoder");
+
+    int tagBodySize = frames.size(); // includes frame headers and bodies
+
+    ByteArrayOutputStream file = new ByteArrayOutputStream();
+    DataOutputStream header = new DataOutputStream(file);
+    header.write("ID3".getBytes(StandardCharsets.ISO_8859_1));
+    header.writeByte(3); // version major
+    header.writeByte(0); // version revision
+    header.writeByte(0); // flags
+    header.write(toSynchsafe(tagBodySize));
+    file.write(frames.toByteArray());
+
+    Path path = dir.resolve("id3v23.mp3");
+    Files.write(path, file.toByteArray());
+    return path;
+  }
+
+  private static Path createV22File(Path dir) throws IOException {
+    ByteArrayOutputStream frames = new ByteArrayOutputStream();
+    writeV22Frame(frames, "TT2", "Title V22");
+    writeV22Frame(frames, "TAL", "Album V22");
+    writeV22Frame(frames, "TP1", "Artist V22");
+    writeV22Frame(frames, "TYE", "1999");
+    writeV22Frame(frames, "TSI", "CustomGenre");
+    writeV22Frame(frames, "TRK", "12");
+    writeV22Frame(frames, "TSS", "EncoderV22");
+
+    int tagBodySize = frames.size();
+
+    ByteArrayOutputStream file = new ByteArrayOutputStream();
+    DataOutputStream header = new DataOutputStream(file);
+    header.write("ID3".getBytes(StandardCharsets.ISO_8859_1));
+    header.writeByte(2); // version major
+    header.writeByte(0); // version revision
+    header.writeByte(0); // flags
+    header.write(toSynchsafe(tagBodySize));
+    file.write(frames.toByteArray());
+
+    Path path = dir.resolve("id3v22.mp3");
+    Files.write(path, file.toByteArray());
+    return path;
+  }
+
+  private static Path createUnsupportedV2WithV1Tag(Path dir) throws IOException {
+    ByteArrayOutputStream file = new ByteArrayOutputStream();
+    DataOutputStream header = new DataOutputStream(file);
+    header.write("ID3".getBytes(StandardCharsets.ISO_8859_1));
+    header.writeByte(4); // unsupported version major
+    header.writeByte(0);
+    header.writeByte(0);
+    header.write(new byte[] {0, 0, 0, 0}); // zero size
+
+    file.write(createId3v1Tag());
+
+    Path path = dir.resolve("id3v1.mp3");
+    Files.write(path, file.toByteArray());
+    return path;
+  }
+
+  private static void writeV23Frame(ByteArrayOutputStream frames, String tag, String value)
+      throws IOException {
+    byte[] valueBytes = value.getBytes(StandardCharsets.ISO_8859_1);
+    byte[] frameData = new byte[valueBytes.length + 1]; // first byte = text encoding
+    System.arraycopy(valueBytes, 0, frameData, 1, valueBytes.length);
+
+    DataOutputStream out = new DataOutputStream(frames);
+    out.write(tag.getBytes(StandardCharsets.ISO_8859_1));
+    out.writeInt(frameData.length);
+    out.writeShort(0); // flags
+    out.write(frameData);
+  }
+
+  private static void writeV22Frame(ByteArrayOutputStream frames, String tag, String value)
+      throws IOException {
+    byte[] valueBytes = value.getBytes(StandardCharsets.ISO_8859_1);
+    byte[] frameData = new byte[valueBytes.length + 1];
+    System.arraycopy(valueBytes, 0, frameData, 1, valueBytes.length);
+
+    frames.write(tag.getBytes(StandardCharsets.ISO_8859_1));
+    int len = frameData.length;
+    frames.write(new byte[] {(byte) ((len >> 16) & 0xFF), (byte) ((len >> 8) & 0xFF), (byte) len});
+    frames.write(frameData);
+  }
+
+  private static byte[] toSynchsafe(int size) {
+    return new byte[] {
+      (byte) ((size >> 21) & 0x7F),
+      (byte) ((size >> 14) & 0x7F),
+      (byte) ((size >> 7) & 0x7F),
+      (byte) (size & 0x7F)
+    };
+  }
+
+  private static byte[] createId3v1Tag() {
+    String title = "V1 Title";
+    String artist = "V1 Artist";
+    String album = "V1 Album";
+    String year = "2010";
+    int track = 5;
+    int genre = 13;
+    byte[] buf = new byte[128];
+    fillField(buf, 0, 3, "TAG");
+    fillField(buf, 3, 30, title);
+    fillField(buf, 33, 30, artist);
+    fillField(buf, 63, 30, album);
+    fillField(buf, 93, 4, year);
+    fillField(buf, 97, 28, ""); // comment
+    buf[125] = 0; // separator indicating track number present
+    buf[126] = (byte) track;
+    buf[127] = (byte) genre;
+    return buf;
+  }
+
+  private static void fillField(byte[] buf, int start, int length, String value) {
+    byte[] valueBytes = value.getBytes(StandardCharsets.ISO_8859_1);
+    int copyLength = Math.min(valueBytes.length, length);
+    System.arraycopy(valueBytes, 0, buf, start, copyLength);
+    for (int i = start + copyLength; i < start + length; i++) {
+      buf[i] = ' ';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor Id3Handler to validate headers, bound frame reads, and centralize frame handling for v2.2/v2.3 with safer fallbacks
- add comprehensive Javadoc and guard rails plus small utility helpers for tag size/frame parsing
- add Id3HandlerTest covering v2.3, v2.2, unsupported v2 with v1 fallback, and no-tag scenarios

## Testing
- not run (not requested)
