### PR TITLE
Improve Md4Handler docs and tests

### DIFF
--- a/src/main/java/org/bitpedia/collider/core/Md4Handler.java
+++ b/src/main/java/org/bitpedia/collider/core/Md4Handler.java
@@ -9,6 +9,33 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 
+/**
+ * Incremental MD4 message-digest calculator used by collider utilities.
+ *
+ * <p>This handler exposes a minimal streaming-style API that mirrors classic digest interfaces:
+ * call {@link #analyzeInit()} to reset the state, feed arbitrary-sized byte chunks through one of
+ * the {@code analyzeUpdate} overloads, and finish with {@link #analyzeFinal()} to obtain the
+ * 16-byte digest. Internally it maintains the four-word MD4 state, a byte buffer for partial
+ * blocks, and a 64-bit bit-count tracker, all stored in reusable arrays to avoid allocations during
+ * normal operation. The implementation intentionally follows the original specification rather than
+ * relying on {@code java.security.MessageDigest}, keeping behavior predictable across runtime
+ * environments.
+ *
+ * <p>Instances are mutable and <strong>not</strong> thread-safe; callers must serialize access or
+ * create separate handlers per thread. Typical lifecycle is short-lived: construct, initialize,
+ * stream data, finalize, then discard or reuse after another {@link #analyzeInit()} call. Because
+ * padding and length encoding are applied only in {@link #analyzeFinal()}, callers should avoid
+ * reusing the same instance without reinitializing. Performance is optimized for correctness and
+ * simplicity over vectorized speedups.
+ *
+ * <ul>
+ *   <li>Maintains internal little-endian transforms for MD4 processing.
+ *   <li>Supports arbitrary input lengths; buffering handles non-aligned tails.
+ *   <li>Returns digests in standard 16-byte little-endian word order.
+ * </ul>
+ *
+ * @see java.security.MessageDigest
+ */
 public class Md4Handler {
 
   // Constants for MD4Transform routine.
@@ -24,10 +51,11 @@ public class Md4Handler {
   private static final int S32 = 9;
   private static final int S33 = 11;
   private static final int S34 = 15;
+  private static final int BLOCK_LENGTH = 64;
 
-  private static byte P0 = -128; // 0x80
+  private static final byte P0 = -128; // 0x80
 
-  private static byte[] PADDING = {
+  private static final byte[] PADDING = {
     P0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
   };
@@ -36,15 +64,15 @@ public class Md4Handler {
   private int[] count; /* number of bits, modulo 2^64 (lsb first) */
   private byte[] buffer;
 
-  private static int F(int x, int y, int z) {
+  private static int f(int x, int y, int z) {
     return (((x) & (y)) | ((~x) & (z)));
   }
 
-  private static int G(int x, int y, int z) {
+  private static int g(int x, int y, int z) {
     return (((x) & (y)) | ((x) & (z)) | ((y) & (z)));
   }
 
-  private static int H(int x, int y, int z) {
+  private static int h(int x, int y, int z) {
     return ((x) ^ (y) ^ (z));
   }
 
@@ -52,19 +80,34 @@ public class Md4Handler {
     return (((x) << (n)) | ((x) >>> (32 - (n))));
   }
 
-  private static int FF(int a, int b, int c, int d, int x, int s) {
-    a += F(b, c, d) + x;
+  private static int ff(int a, int b, int c, int d, int x, int s) {
+    a += f(b, c, d) + x;
     return rotateLeft(a, s);
   }
 
-  private static int GG(int a, int b, int c, int d, int x, int s) {
-    a += G(b, c, d) + x + 0x5a827999;
+  private static int gg(int a, int b, int c, int d, int x, int s) {
+    a += g(b, c, d) + x + 0x5a827999;
     return rotateLeft(a, s);
   }
 
-  private static int HH(int a, int b, int c, int d, int x, int s) {
-    a += H(b, c, d) + x + 0x6ed9eba1;
+  private static int hh(int a, int b, int c, int d, int x, int s) {
+    a += h(b, c, d) + x + 0x6ed9eba1;
     return rotateLeft(a, s);
+  }
+
+  /**
+   * Creates a new handler with uninitialized digest state arrays.
+   *
+   * <p>The constructor allocates the internal buffers but leaves the MD4 state in an undefined
+   * configuration until {@link #analyzeInit()} is invoked. Constructing a handler is inexpensive
+   * and side effect free; callers may cache a single instance and reuse it across multiple digest
+   * runs as long as each run starts with a fresh initialization step. No external resources or
+   * platform facilities are consulted during construction, so creation is deterministic and
+   * suitable for use in tests or deterministic pipelines.
+   */
+  public Md4Handler() {
+    // Constructor intentionally empty; state is allocated here but seeded later in analyzeInit() to
+    // allow reuse between digests without reallocation.
   }
 
   /* Encodes input (int[]) into output (byte[]).
@@ -80,74 +123,77 @@ public class Md4Handler {
 
   /* Decodes input (unsigned char) into output (w32).
    * Assumes len is a multiple of 4. */
-  private static void decode(int[] output, byte[] input, int ofs, int len) {
+  private static void decode(int[] output, byte[] input, int ofs) {
 
-    ByteBuffer buf = ByteBuffer.wrap(input, ofs, len);
+    ByteBuffer buf = ByteBuffer.wrap(input, ofs, BLOCK_LENGTH);
     buf.order(ByteOrder.LITTLE_ENDIAN);
     IntBuffer intBuf = buf.asIntBuffer();
-    intBuf.get(output, 0, len / 4);
+    intBuf.get(output, 0, BLOCK_LENGTH / 4);
   }
 
   private static void md4Transform(int[] state, byte[] block, int ofs) {
 
-    int a = state[0], b = state[1], c = state[2], d = state[3];
+    int a = state[0];
+    int b = state[1];
+    int c = state[2];
+    int d = state[3];
     int[] x = new int[16];
 
-    decode(x, block, ofs, 64);
+    decode(x, block, ofs);
 
     /* Round 1 */
-    a = FF(a, b, c, d, x[0], S11); /* 1 */
-    d = FF(d, a, b, c, x[1], S12); /* 2 */
-    c = FF(c, d, a, b, x[2], S13); /* 3 */
-    b = FF(b, c, d, a, x[3], S14); /* 4 */
-    a = FF(a, b, c, d, x[4], S11); /* 5 */
-    d = FF(d, a, b, c, x[5], S12); /* 6 */
-    c = FF(c, d, a, b, x[6], S13); /* 7 */
-    b = FF(b, c, d, a, x[7], S14); /* 8 */
-    a = FF(a, b, c, d, x[8], S11); /* 9 */
-    d = FF(d, a, b, c, x[9], S12); /* 10 */
-    c = FF(c, d, a, b, x[10], S13); /* 11 */
-    b = FF(b, c, d, a, x[11], S14); /* 12 */
-    a = FF(a, b, c, d, x[12], S11); /* 13 */
-    d = FF(d, a, b, c, x[13], S12); /* 14 */
-    c = FF(c, d, a, b, x[14], S13); /* 15 */
-    b = FF(b, c, d, a, x[15], S14); /* 16 */
+    a = ff(a, b, c, d, x[0], S11); /* 1 */
+    d = ff(d, a, b, c, x[1], S12); /* 2 */
+    c = ff(c, d, a, b, x[2], S13); /* 3 */
+    b = ff(b, c, d, a, x[3], S14); /* 4 */
+    a = ff(a, b, c, d, x[4], S11); /* 5 */
+    d = ff(d, a, b, c, x[5], S12); /* 6 */
+    c = ff(c, d, a, b, x[6], S13); /* 7 */
+    b = ff(b, c, d, a, x[7], S14); /* 8 */
+    a = ff(a, b, c, d, x[8], S11); /* 9 */
+    d = ff(d, a, b, c, x[9], S12); /* 10 */
+    c = ff(c, d, a, b, x[10], S13); /* 11 */
+    b = ff(b, c, d, a, x[11], S14); /* 12 */
+    a = ff(a, b, c, d, x[12], S11); /* 13 */
+    d = ff(d, a, b, c, x[13], S12); /* 14 */
+    c = ff(c, d, a, b, x[14], S13); /* 15 */
+    b = ff(b, c, d, a, x[15], S14); /* 16 */
 
     /* Round 2 */
-    a = GG(a, b, c, d, x[0], S21); /* 17 */
-    d = GG(d, a, b, c, x[4], S22); /* 18 */
-    c = GG(c, d, a, b, x[8], S23); /* 19 */
-    b = GG(b, c, d, a, x[12], S24); /* 20 */
-    a = GG(a, b, c, d, x[1], S21); /* 21 */
-    d = GG(d, a, b, c, x[5], S22); /* 22 */
-    c = GG(c, d, a, b, x[9], S23); /* 23 */
-    b = GG(b, c, d, a, x[13], S24); /* 24 */
-    a = GG(a, b, c, d, x[2], S21); /* 25 */
-    d = GG(d, a, b, c, x[6], S22); /* 26 */
-    c = GG(c, d, a, b, x[10], S23); /* 27 */
-    b = GG(b, c, d, a, x[14], S24); /* 28 */
-    a = GG(a, b, c, d, x[3], S21); /* 29 */
-    d = GG(d, a, b, c, x[7], S22); /* 30 */
-    c = GG(c, d, a, b, x[11], S23); /* 31 */
-    b = GG(b, c, d, a, x[15], S24); /* 32 */
+    a = gg(a, b, c, d, x[0], S21); /* 17 */
+    d = gg(d, a, b, c, x[4], S22); /* 18 */
+    c = gg(c, d, a, b, x[8], S23); /* 19 */
+    b = gg(b, c, d, a, x[12], S24); /* 20 */
+    a = gg(a, b, c, d, x[1], S21); /* 21 */
+    d = gg(d, a, b, c, x[5], S22); /* 22 */
+    c = gg(c, d, a, b, x[9], S23); /* 23 */
+    b = gg(b, c, d, a, x[13], S24); /* 24 */
+    a = gg(a, b, c, d, x[2], S21); /* 25 */
+    d = gg(d, a, b, c, x[6], S22); /* 26 */
+    c = gg(c, d, a, b, x[10], S23); /* 27 */
+    b = gg(b, c, d, a, x[14], S24); /* 28 */
+    a = gg(a, b, c, d, x[3], S21); /* 29 */
+    d = gg(d, a, b, c, x[7], S22); /* 30 */
+    c = gg(c, d, a, b, x[11], S23); /* 31 */
+    b = gg(b, c, d, a, x[15], S24); /* 32 */
 
     /* Round 3 */
-    a = HH(a, b, c, d, x[0], S31); /* 33 */
-    d = HH(d, a, b, c, x[8], S32); /* 34 */
-    c = HH(c, d, a, b, x[4], S33); /* 35 */
-    b = HH(b, c, d, a, x[12], S34); /* 36 */
-    a = HH(a, b, c, d, x[2], S31); /* 37 */
-    d = HH(d, a, b, c, x[10], S32); /* 38 */
-    c = HH(c, d, a, b, x[6], S33); /* 39 */
-    b = HH(b, c, d, a, x[14], S34); /* 40 */
-    a = HH(a, b, c, d, x[1], S31); /* 41 */
-    d = HH(d, a, b, c, x[9], S32); /* 42 */
-    c = HH(c, d, a, b, x[5], S33); /* 43 */
-    b = HH(b, c, d, a, x[13], S34); /* 44 */
-    a = HH(a, b, c, d, x[3], S31); /* 45 */
-    d = HH(d, a, b, c, x[11], S32); /* 46 */
-    c = HH(c, d, a, b, x[7], S33); /* 47 */
-    b = HH(b, c, d, a, x[15], S34); /* 48 */
+    a = hh(a, b, c, d, x[0], S31); /* 33 */
+    d = hh(d, a, b, c, x[8], S32); /* 34 */
+    c = hh(c, d, a, b, x[4], S33); /* 35 */
+    b = hh(b, c, d, a, x[12], S34); /* 36 */
+    a = hh(a, b, c, d, x[2], S31); /* 37 */
+    d = hh(d, a, b, c, x[10], S32); /* 38 */
+    c = hh(c, d, a, b, x[6], S33); /* 39 */
+    b = hh(b, c, d, a, x[14], S34); /* 40 */
+    a = hh(a, b, c, d, x[1], S31); /* 41 */
+    d = hh(d, a, b, c, x[9], S32); /* 42 */
+    c = hh(c, d, a, b, x[5], S33); /* 43 */
+    b = hh(b, c, d, a, x[13], S34); /* 44 */
+    a = hh(a, b, c, d, x[3], S31); /* 45 */
+    d = hh(d, a, b, c, x[11], S32); /* 46 */
+    c = hh(c, d, a, b, x[7], S33); /* 47 */
+    b = hh(b, c, d, a, x[15], S34); /* 48 */
 
     state[0] += a;
     state[1] += b;
@@ -155,6 +201,15 @@ public class Md4Handler {
     state[3] += d;
   }
 
+  /**
+   * Initializes the MD4 state for a new digest computation.
+   *
+   * <p>This method resets the bit counters, primes the four-word state with the MD4 initial
+   * constants, and clears the working buffer. It must be called before supplying any input via the
+   * {@code analyzeUpdate} overloads; reusing an instance across multiple digests requires invoking
+   * this method between runs. The operation is idempotent with respect to newly created instances
+   * and performs no I/O. Thread safety is the caller's responsibility.
+   */
   public void analyzeInit() {
 
     count = new int[] {0, 0};
@@ -162,15 +217,41 @@ public class Md4Handler {
     buffer = new byte[64];
   }
 
+  /**
+   * Updates the digest with a contiguous range of bytes starting at offset zero.
+   *
+   * <p>This convenience overload delegates to {@link #analyzeUpdate(byte[], int, int)} using a zero
+   * offset. Callers should ensure that {@code inputLen} does not exceed the available bytes in
+   * {@code input}. The method preserves the existing state prepared by {@link #analyzeInit()} and
+   * may be called repeatedly to stream large inputs in manageable chunks.
+   *
+   * @param input input buffer supplying first bytes to digest; must be non-null.
+   * @param inputLen number of bytes from start to process; must fit the buffer.
+   */
   public void analyzeUpdate(byte[] input, int inputLen) {
 
     analyzeUpdate(input, 0, inputLen);
   }
 
+  /**
+   * Streams a slice of input bytes into the ongoing MD4 computation.
+   *
+   * <p>The method updates the internal bit-count tracker, absorbs complete 64-byte blocks through
+   * the MD4 transform, and retains any remaining tail bytes in the working buffer for the next
+   * call. Offsets and lengths are interpreted exactly as provided; the caller is responsible for
+   * ensuring bounds safety on {@code input}. Because state is mutated in place, concurrent calls on
+   * the same instance are unsupported. Invoking this method without first calling {@link
+   * #analyzeInit()} leaves the digest state undefined.
+   *
+   * @param input source buffer containing bytes to digest; must be non-null.
+   * @param ofs zero-based offset where processing begins within the input array.
+   * @param inputLen number of bytes to process starting at {@code ofs}; ensure bounds.
+   */
   public void analyzeUpdate(byte[] input, int ofs, int inputLen) {
 
     /* Compute number of bytes mod 64 */
-    int i = 0, index = ((count[0] >> 3) & 0x3F);
+    int i;
+    int index = ((count[0] >> 3) & 0x3F);
     /* Update number of bits */
     count[0] += inputLen << 3;
     if (count[0] < (inputLen << 3)) {
@@ -198,6 +279,17 @@ public class Md4Handler {
     System.arraycopy(input, i + ofs, buffer, index, inputLen - i);
   }
 
+  /**
+   * Completes the digest computation and returns the 16-byte MD4 hash.
+   *
+   * <p>The method applies MD4 padding, appends the total message length in bits, and processes any
+   * remaining buffered data before serializing the state words into the output array. After
+   * completion the internal state reflects the finalized digest; callers should invoke {@link
+   * #analyzeInit()} before reusing the instance for a new message. The returned array is a fresh
+   * copy owned by the caller and can be modified without affecting handler state.
+   *
+   * @return newly allocated 16-byte array containing the MD4 digest in little-endian word order.
+   */
   public byte[] analyzeFinal() {
 
     byte[] bits = new byte[8];

--- a/src/test/java/org/bitpedia/collider/core/Md4HandlerTest.java
+++ b/src/test/java/org/bitpedia/collider/core/Md4HandlerTest.java
@@ -1,0 +1,87 @@
+package org.bitpedia.collider.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class Md4HandlerTest {
+
+  private Md4Handler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new Md4Handler();
+    handler.analyzeInit();
+  }
+
+  @Test
+  void analyzeFinal_whenNoInput_returnsMd4OfEmptyString() {
+    byte[] digest = handler.analyzeFinal();
+
+    assertEquals("31d6cfe0d16ae931b73c59d7e0c089c0", toHex(digest));
+  }
+
+  @Test
+  void analyzeUpdate_whenSingleChunk_returnsMd4OfAbc() {
+    byte[] data = "abc".getBytes(StandardCharsets.US_ASCII);
+
+    handler.analyzeUpdate(data, data.length);
+    byte[] digest = handler.analyzeFinal();
+
+    assertEquals("a448017aaf21d8525fc10ae87aa6729d", toHex(digest));
+  }
+
+  @Test
+  void analyzeUpdate_whenMultipleChunks_returnsMd4OfMessageDigest() {
+    handler.analyzeUpdate("message ".getBytes(StandardCharsets.US_ASCII), 8);
+    handler.analyzeUpdate("digest".getBytes(StandardCharsets.US_ASCII), 6);
+
+    byte[] digest = handler.analyzeFinal();
+
+    assertEquals("d9130a8164549fe818874806e1c7014b", toHex(digest));
+  }
+
+  @Test
+  void analyzeUpdate_withOffsetUsesSpecifiedRange() {
+    byte[] data = "xxabczz".getBytes(StandardCharsets.US_ASCII);
+
+    handler.analyzeUpdate(data, 2, 3);
+    byte[] digest = handler.analyzeFinal();
+
+    assertEquals("a448017aaf21d8525fc10ae87aa6729d", toHex(digest));
+  }
+
+  @Test
+  void analyzeUpdate_whenLengthExceedsSingleBlock_processesAllBlocks() {
+    String message =
+        "12345678901234567890123456789012345678901234567890123456789012345678901234567890";
+    byte[] data = message.getBytes(StandardCharsets.US_ASCII);
+
+    handler.analyzeUpdate(data, data.length);
+    byte[] digest = handler.analyzeFinal();
+
+    assertEquals("e33b4ddc9c38f2199c3e7b164fcc0536", toHex(digest));
+  }
+
+  @Test
+  void analyzeFinal_whenInputRequiresExtendedPadding_usesCorrectDigest() {
+    String message = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    byte[] data = message.getBytes(StandardCharsets.US_ASCII);
+
+    handler.analyzeUpdate(data, data.length);
+    byte[] digest = handler.analyzeFinal();
+
+    assertEquals("043f8582f241db351ce627e153e7f0e4", toHex(digest));
+  }
+
+  private static String toHex(byte[] bytes) {
+    StringBuilder builder = new StringBuilder(bytes.length * 2);
+    for (byte value : bytes) {
+      builder.append(String.format("%02x", value));
+    }
+    return builder.toString();
+  }
+}


### PR DESCRIPTION
## Summary
- document Md4Handler with detailed KDoc and modernized helper naming/constants
- add streaming MD4 unit tests covering empty input, chunked updates, offsets, and long messages

## Testing
- ./gradlew spotlessApply