### PR TITLE
Improve ArrayUtils hex helpers and add coverage

### DIFF
--- a/src/main/java/org/bitpedia/util/ArrayUtils.java
+++ b/src/main/java/org/bitpedia/util/ArrayUtils.java
@@ -5,16 +5,76 @@
  */
 package org.bitpedia.util;
 
+/**
+ * Utility methods for converting byte values and ranges into lowercase hexadecimal strings.
+ *
+ * <p>This helper centralizes common encoding routines used by legacy Bitpedia code that relies on
+ * compact, deterministic hex output for logging, identifiers, and serialization. Methods here do
+ * not mutate shared state, allocate only local buffers, and avoid additional dependencies so they
+ * remain safe to call from performance-sensitive or security-sensitive paths. Callers are expected
+ * to pass valid offsets and lengths; the methods assume pre-validated input to keep the
+ * implementation lightweight. Output always uses lowercase characters and zero-pads single-digit
+ * values to two hex digits to preserve fixed-width formatting.
+ *
+ * <ul>
+ *   <li>Stateless and thread-safe because all data is local to each invocation.
+ *   <li>Best suited for small buffers and identifiers where readability matters more than
+ *       streaming.
+ *   <li>Intentionally minimal API surface to preserve backward compatibility with existing
+ *       consumers.
+ * </ul>
+ *
+ * @see #byteToHex(byte)
+ * @see #byteArrayToHex(byte[], int, int)
+ */
 public class ArrayUtils {
 
+  /**
+   * Prevents instantiation because this class only provides static utility methods and maintains no
+   * state.
+   */
+  private ArrayUtils() {}
+
+  /**
+   * Converts a single byte to a two-character, zero-padded lowercase hexadecimal string.
+   *
+   * <p>The byte is treated as an unsigned value in the range {@code 0} to {@code 255}. The result
+   * always contains exactly two characters so that callers can safely concatenate multiple outputs
+   * without additional padding logic. No allocation other than the internal string creation is
+   * performed, making the method suitable for frequent use in logging or simple serialization
+   * tasks.
+   *
+   * @param b the byte value to convert; interpreted unsigned so values map to {@code 00}–{@code ff}
+   *     deterministically
+   * @return a two-character lowercase hexadecimal representation of the supplied byte, never {@code
+   *     null} or empty
+   */
   public static String byteToHex(byte b) {
 
     return Integer.toString((b & 0xFF) + 0x100, 16).substring(1);
   }
 
+  /**
+   * Converts a contiguous range of a byte array into a lowercase hexadecimal string.
+   *
+   * <p>The slice defined by {@code offset} and {@code len} is copied into a newly allocated string
+   * whose length is exactly {@code len * 2}. Callers must supply bounds that fall within the array;
+   * this method performs no explicit range checks and will propagate any resulting {@link
+   * ArrayIndexOutOfBoundsException}. An empty range produces an empty string, which callers can use
+   * as a safe sentinel value. The method is thread-safe because it uses only local variables and
+   * does not mutate the provided array.
+   *
+   * @param b the source byte array holding the data to encode; must not be {@code null}
+   * @param offset zero-based starting index of the first byte to encode; must be within the array
+   *     bounds
+   * @param len number of bytes to encode starting at {@code offset}; must be non-negative and
+   *     selected so {@code offset + len} does not exceed {@code b.length}
+   * @return a lowercase hexadecimal string representing the requested slice; length equals {@code
+   *     len * 2}
+   */
   public static String byteArrayToHex(byte[] b, int offset, int len) {
 
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
 
     for (int i = offset; i < offset + len; i++) {
       buf.append(byteToHex(b[i]));

--- a/src/test/java/org/bitpedia/util/ArrayUtilsTest.java
+++ b/src/test/java/org/bitpedia/util/ArrayUtilsTest.java
@@ -1,0 +1,76 @@
+package org.bitpedia.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@SuppressWarnings("java:S100")
+class ArrayUtilsTest {
+
+  @ParameterizedTest
+  @CsvSource({"0,00", "1,01", "15,0f", "16,10", "127,7f", "-1,ff", "-128,80"})
+  @DisplayName("byteToHex returns two lowercase hex chars for any byte value")
+  void byteToHex_whenAnyByte_expectTwoDigitLowercase(int value, String expected) {
+    // Arrange
+    byte input = (byte) value;
+
+    // Act
+    String result = ArrayUtils.byteToHex(input);
+
+    // Assert
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void byteArrayToHex_whenSliceRequested_returnsConcatenatedHex() {
+    // Arrange
+    byte[] data = new byte[] {0x00, 0x01, 0x0F, 0x10, (byte) 0xAB};
+
+    // Act
+    String result = ArrayUtils.byteArrayToHex(data, 1, 3);
+
+    // Assert
+    assertEquals("010f10", result);
+  }
+
+  @Test
+  void byteArrayToHex_whenLengthIsZero_returnsEmptyString() {
+    // Arrange
+    byte[] data = new byte[] {0x01, 0x02};
+
+    // Act
+    String result = ArrayUtils.byteArrayToHex(data, 0, 0);
+
+    // Assert
+    assertEquals("", result);
+  }
+
+  @Test
+  void byteArrayToHex_whenOffsetNegative_throwsException() {
+    // Arrange
+    byte[] data = new byte[] {0x01, 0x02};
+
+    // Act + Assert
+    assertThrows(
+        ArrayIndexOutOfBoundsException.class, () -> ArrayUtils.byteArrayToHex(data, -1, 1));
+  }
+
+  @Test
+  void byteArrayToHex_whenOffsetBeyondArray_throwsException() {
+    // Arrange
+    byte[] data = new byte[] {0x01, 0x02};
+
+    // Act + Assert
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ArrayUtils.byteArrayToHex(data, 2, 1));
+  }
+
+  @Test
+  void byteArrayToHex_whenArrayIsNull_throwsNullPointerException() {
+    // Act + Assert
+    assertThrows(NullPointerException.class, () -> ArrayUtils.byteArrayToHex(null, 0, 1));
+  }
+}


### PR DESCRIPTION
## Summary
- add Javadoc and defensive static utility shape to ArrayUtils
- switch hex builder to StringBuilder and keep fixed-width lowercase output
- add JUnit coverage for byteToHex and byteArrayToHex slices and edge cases

## Testing
- not run (not requested)
