### PR TITLE
Add docs and tests for SevenZip LZ windows

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -85,9 +85,11 @@ tasks.withType<Test>().configureEach {
   include("network/crypta/**/*Test.class")
   include("com/onionnetworks/**/*Test.class")
   include("org/bitpedia/**/*Test.class")
+  include("org/sevenzip/**/*Test.class")
   exclude("network/crypta/**/*$*Test.class")
   exclude("com/onionnetworks/**/*$*Test.class")
   exclude("org/bitpedia/**/*$*Test.class")
+  exclude("org/sevenzip/**/*$*Test.class")
   // Point tests expecting old layout to new standard resource locations
   systemProperty("test.l10npath_test", "src/test/resources/network/crypta/l10n/")
   systemProperty("test.l10npath_main", "src/main/resources/network/crypta/l10n/")

--- a/src/main/java/org/sevenzip/compression/lz/BinTree.java
+++ b/src/main/java/org/sevenzip/compression/lz/BinTree.java
@@ -1,10 +1,54 @@
-// LZ.BinTree
-
 package org.sevenzip.compression.lz;
 
 import java.io.IOException;
 
+/**
+ * Binary-tree based match finder used by the LZMA encoder to discover repeated byte sequences
+ * efficiently. The structure extends {@link InWindow} to reuse buffered sliding-window semantics
+ * and augments it with hash buckets and a binary tree that tracks recent positions. Clients
+ * typically configure the finder with {@link #setType(int)} and {@link #createMatchFinder(int, int,
+ * int, int)}, attach an input stream through the {@link InWindow} API, and then alternate calls to
+ * {@link #getMatches(int[])} and {@link #skip(int)} while the encoder advances. Instances are
+ * mutable, not thread-safe, and should be confined to a single compression pipeline.
+ *
+ * <p>Responsibilities include maintaining cyclic buffers that hold left/right child links,
+ * computing rolling hashes for fast candidate retrieval, and normalizing stored offsets when
+ * indexes grow large. The finder limits traversal depth via {@code cutValue} to bound worst-case
+ * cost even on adversarial data. Invariants: {@code pos} always reflects the current window index,
+ * {@code cyclicBufferPos} remains within {@code [0, cyclicBufferSize)}, and hash tables never store
+ * negative values.
+ *
+ * <p>Notable behaviors:
+ *
+ * <ul>
+ *   <li>Supports two hash configurations: short direct matches (2 bytes) or full hash arrays (3–4
+ *       bytes) for longer lookups.
+ *   <li>Automatically normalizes stored positions near {@link #K_MAX_VAL_FOR_NORMALIZE} to prevent
+ *       integer overflow while preserving relative distances.
+ *   <li>Separates match discovery ({@link #getMatches(int[])}) from state advancement ({@link
+ *       #skip(int)}) so encoders can probe or fast-forward selectively.
+ * </ul>
+ *
+ * @see InWindow
+ */
 public class BinTree extends InWindow {
+
+  /**
+   * Creates a new, uninitialized match finder with default hash configuration. Callers must choose
+   * a hash type via {@link #setType(int)}, size buffers through {@link #createMatchFinder(int, int,
+   * int, int)}, and attach a stream on the {@link InWindow} API before collecting matches. This
+   * constructor performs no allocation beyond the superclass and is intentionally lightweight so
+   * the encoder can instantiate multiple finders when experimenting with settings.
+   *
+   * <p>This body is intentionally empty because all configuration happens through subsequent
+   * setters and the inherited window wiring; construction itself must stay side effect free for
+   * reuse by different encoder setups.
+   */
+  public BinTree() {
+    // Intentionally empty: setup is deferred to setter-style methods to keep construction side
+    // effect free.
+  }
+
   int cyclicBufferPos;
   int cyclicBufferSize = 0;
   int matchMaxLen;
@@ -30,6 +74,19 @@ public class BinTree extends InWindow {
   int kMinMatchCheck = 4;
   int kFixHashSize = K_HASH2_SIZE + K_HASH3_SIZE;
 
+  /**
+   * Configures the hash strategy based on the number of bytes to hash for initial candidate
+   * selection.
+   *
+   * <p>Values greater than two enable full hash arrays with three- and four-byte signatures,
+   * favoring accuracy at the cost of memory. Values of two or less switch to a lightweight mode
+   * that relies on direct-byte comparisons with minimal hash tables, suitable for tiny dictionaries
+   * or constrained environments. Must be invoked before {@link #createMatchFinder(int, int, int,
+   * int)} so that buffer sizing matches the chosen strategy.
+   *
+   * @param numHashBytes number of leading bytes used to build hash keys; must be positive and
+   *     typically 2–4 depending on match finder variant.
+   */
   public void setType(int numHashBytes) {
     hashArray = (numHashBytes > 2);
     if (hashArray) {
@@ -43,6 +100,18 @@ public class BinTree extends InWindow {
     }
   }
 
+  /**
+   * Resets internal buffers and hash tables, then primes the window by delegating to {@link
+   * InWindow#init()}.
+   *
+   * <p>After initialization the current position is zero, all hash and tree links are cleared to
+   * {@link #K_EMPTY_HASH_VALUE}, and offsets are adjusted via {@link #reduceOffsets(int)} to keep
+   * indices aligned. Callers must set the input stream on the inherited API before invoking this
+   * method. Subsequent calls to {@link #getMatches(int[])} or {@link #skip(int)} assume this setup
+   * has completed successfully.
+   *
+   * @throws IOException if the underlying stream cannot be read while priming the window buffer.
+   */
   @Override
   public void init() throws IOException {
     super.init();
@@ -51,6 +120,20 @@ public class BinTree extends InWindow {
     reduceOffsets(-1);
   }
 
+  /**
+   * Advances the current position by one byte, updating the cyclic buffer pointer and normalizing
+   * offsets when necessary.
+   *
+   * <p>This method increments {@code pos}, slides the cyclic pointer with wrap-around, and
+   * delegates to {@link InWindow#movePos()} to shift or refill the underlying window. When the
+   * absolute position reaches {@link #K_MAX_VAL_FOR_NORMALIZE}, stored offsets are compacted
+   * through {@link #normalize()} to avoid integer overflow while preserving match distances.
+   * Callers should use this in lockstep with match collection or skipping to keep the tree
+   * consistent.
+   *
+   * @throws IOException if additional data must be read from the stream during the move and the
+   *     read fails.
+   */
   @Override
   public void movePos() throws IOException {
     if (++cyclicBufferPos >= cyclicBufferSize) cyclicBufferPos = 0;
@@ -58,6 +141,24 @@ public class BinTree extends InWindow {
     if (pos == K_MAX_VAL_FOR_NORMALIZE) normalize();
   }
 
+  /**
+   * Allocates and wires all buffers required for binary-tree match finding given the chosen
+   * dictionary and lookahead sizes.
+   *
+   * <p>The method sizes the cyclic buffer, hash arrays, and window reservation based on the history
+   * size and match length limits. It also derives {@code cutValue}, which caps tree traversal depth
+   * to balance speed and match quality. Call this exactly once after {@link #setType(int)} and
+   * before {@link #init()} so the inherited window knows its keep-before/after sizes.
+   *
+   * @param historySize maximum backward distance (dictionary size) in bytes that matches may span;
+   *     must be positive and not exceed {@link #K_MAX_VAL_FOR_NORMALIZE} minus a small margin.
+   * @param keepAddBufferBefore extra bytes kept before the current position to tolerate backward
+   *     lookups beyond {@code historySize}; often zero in typical LZMA usage.
+   * @param matchMaxLen maximum match length to report; governs buffer sizing and traversal cut-off;
+   *     must be at least the encoder's fast-bytes setting.
+   * @param keepAddBufferAfter additional lookahead bytes preserved after the current position to
+   *     reduce refills during long matches; non-negative.
+   */
   public void createMatchFinder(
       int historySize, int keepAddBufferBefore, int matchMaxLen, int keepAddBufferAfter) {
     if (historySize > K_MAX_VAL_FOR_NORMALIZE - 256) return;
@@ -98,6 +199,23 @@ public class BinTree extends InWindow {
     }
   }
 
+  /**
+   * Collects match candidates at the current position and writes alternating length/distance pairs
+   * into the supplied buffer.
+   *
+   * <p>The method hashes the current prefix, probes recent positions via the binary tree, and
+   * returns the number of integers written (twice the number of matches). Each even index contains
+   * a match length, and the subsequent odd index holds the backward distance minus one. When
+   * lookahead is insufficient the method advances the position and returns zero. Tree traversal is
+   * bounded by {@code cutValue} to prevent excessive scanning. The caller owns the {@code
+   * distances} array and must size it to at least {@code 2 * matchMaxLen}.
+   *
+   * @param distances target array that receives length and distance pairs; must be non-null and
+   *     large enough for all potential matches.
+   * @return count of integers stored in {@code distances}; zero when no match is recorded due to
+   *     insufficient lookahead or empty history.
+   * @throws IOException if advancing the position triggers a window refill that fails.
+   */
   public int getMatches(int[] distances) throws IOException {
     int lenLimit;
     if (pos + matchMaxLen <= streamPos) lenLimit = matchMaxLen;
@@ -154,6 +272,19 @@ public class BinTree extends InWindow {
     return offset;
   }
 
+  /**
+   * Advances the match finder state by the requested number of positions without emitting matches.
+   *
+   * <p>Useful when the encoder selects a literal or already knows the distance to use. The method
+   * repeats internal hashing and tree maintenance for each skipped byte to keep structures in sync,
+   * but discards any collected matches. Traversal depth obeys {@code cutValue} to maintain bounded
+   * complexity. Negative values are not allowed; zero is a no-op aside from boundary checks.
+   *
+   * @param num number of positions to advance; must be non-negative and typically small relative to
+   *     the dictionary size.
+   * @throws IOException if window movement while skipping requires reading from the stream and the
+   *     read fails.
+   */
   public void skip(int num) throws IOException {
     do {
       int lenLimit;

--- a/src/main/java/org/sevenzip/compression/lz/InWindow.java
+++ b/src/main/java/org/sevenzip/compression/lz/InWindow.java
@@ -5,9 +5,36 @@ package org.sevenzip.compression.lz;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Sliding window reader that maintains an in-memory buffer backed by a sequential {@link
+ * InputStream}. The window supports efficient byte lookups and backward distance comparisons needed
+ * by LZ-style encoders without repeatedly reading from the underlying stream. Clients configure
+ * keep-size bands around the current position, initialize the buffer, then advance with {@link
+ * #movePos()} while querying bytes via {@link #getIndexByte(int)} or match lengths via {@link
+ * #getMatchLen(int, int, int)}. The buffer slides forward automatically when the current position
+ * approaches the end of the safe area, copying preserved bytes and fetching fresh data from the
+ * stream. Instances are mutable and not thread-safe; callers should confine each instance to a
+ * single encoding workflow. Typical usage: create the window with target sizes, attach an input
+ * stream, call {@link #init()}, then iterate move/inspect operations until no bytes remain.
+ */
 public class InWindow {
+
+  /**
+   * Creates a new, uninitialized window. The buffer is allocated later via {@link #create(int, int,
+   * int)} and populated by {@link #init()} once a stream has been set.
+   */
+  public InWindow() {
+    // Intentionally empty: buffer allocation and stream wiring are deferred to create()/init().
+  }
+
   // pointer to buffer with data
+  /**
+   * Backing array that stores the current sliding window contents. The buffer length is determined
+   * by {@link #create(int, int, int)} and reused across moves; callers should treat its contents as
+   * owned by this instance and avoid external mutations while the window is in use.
+   */
   protected byte[] bufferBase;
+
   InputStream stream;
   int posLimit; // offset (from buffer) of first byte when new block reading must be done
 
@@ -16,17 +43,45 @@ public class InWindow {
 
   int pointerToLastSafePosition;
 
+  /**
+   * Offset into {@link #bufferBase} where the active window currently begins. The value shifts when
+   * blocks are moved to keep headroom for future reads and remains non-negative while the buffer is
+   * valid.
+   */
   protected int bufferOffset;
 
   // Size of allocated memory block
+  /**
+   * Total size, in bytes, of the allocated buffer. This equals {@code keepSizeBefore +
+   * keepSizeAfter + keepSizeReserv} from the most recent {@link #create(int, int, int)} call and is
+   * used to cap sliding and read operations.
+   */
   protected int blockSize;
+
   // offset (from buffer) of current byte
+  /**
+   * Current logical position within the sliding window, expressed relative to {@link #bufferBase}
+   * and adjusted by {@link #bufferOffset}. It advances monotonically via {@link #movePos()} during
+   * a read session.
+   */
   protected int pos;
+
   int keepSizeBefore; // how many BYTEs must be kept in buffer before pos
   int keepSizeAfter; // how many BYTEs must be kept buffer after pos
+
   // offset (from buffer) of first not read byte from Stream
+  /**
+   * Index in {@link #bufferBase} where the next unread byte from the stream would be placed. The
+   * value grows with successful reads and shrinks when offsets are reduced after a block move.
+   */
   protected int streamPos;
 
+  /**
+   * Relocates buffered data toward the start of the array when the current position approaches the
+   * end of the safe region. The method preserves {@code keepSizeBefore} bytes before the current
+   * position, shifts the active window, and updates {@link #bufferOffset}. No bytes are read from
+   * the stream during this operation.
+   */
   public void moveBlock() {
     int offset = bufferOffset + pos - keepSizeBefore;
     // we need one additional byte, since MovePos moves on 1 byte.
@@ -39,6 +94,15 @@ public class InWindow {
     bufferOffset -= offset;
   }
 
+  /**
+   * Fills the buffer with additional bytes from the attached {@link InputStream} until either the
+   * post-position keep area is satisfied or the stream ends. The method respects the configured
+   * block size, updates {@link #posLimit}, and marks {@link #streamEndWasReached} when no more data
+   * is available.
+   *
+   * @throws IOException if the underlying stream read fails or is interrupted while populating the
+   *     buffer.
+   */
   public void readBlock() throws IOException {
     if (streamEndWasReached) return;
     while (true) {
@@ -63,6 +127,18 @@ public class InWindow {
     bufferBase = null;
   }
 
+  /**
+   * Allocates or reuses the internal buffer with bands sized for look-behind and look-ahead
+   * preservation. Existing buffers are discarded if their size differs from the requested total.
+   * The caller must subsequently provide a stream and call {@link #init()} before reading.
+   *
+   * @param keepSizeBefore number of bytes before the current position that must remain available
+   *     for back-reference comparisons; must be non-negative.
+   * @param keepSizeAfter number of bytes after the current position to retain for look-ahead during
+   *     matching; must be non-negative.
+   * @param keepSizeReserv additional reserved capacity to reduce frequent moves during long runs;
+   *     must be non-negative.
+   */
   public void create(int keepSizeBefore, int keepSizeAfter, int keepSizeReserv) {
     this.keepSizeBefore = keepSizeBefore;
     this.keepSizeAfter = keepSizeAfter;
@@ -75,14 +151,33 @@ public class InWindow {
     pointerToLastSafePosition = blockSize - keepSizeAfter;
   }
 
+  /**
+   * Assigns the input source that supplies bytes for subsequent {@link #readBlock()} operations.
+   * This method does not advance or read from the stream; clients typically set the stream, then
+   * call {@link #init()} to populate the buffer.
+   *
+   * @param stream input source providing sequential bytes; must not be {@code null} for reading to
+   *     succeed.
+   */
   public void setStream(InputStream stream) {
     this.stream = stream;
   }
 
+  /**
+   * Clears the reference to the current input stream. No buffering state is reset; callers can use
+   * this as a cleanup step after finishing reads or before attaching a different stream instance.
+   */
   public void releaseStream() {
     stream = null;
   }
 
+  /**
+   * Resets buffer pointers and populates the window with an initial read from the configured
+   * stream. After initialization, {@link #pos} is zero, the stream position reflects the number of
+   * bytes read, and {@link #posLimit} is set to the earliest point where further reads are needed.
+   *
+   * @throws IOException if reading from the configured stream fails during initialization.
+   */
   public void init() throws IOException {
     bufferOffset = 0;
     pos = 0;
@@ -91,6 +186,14 @@ public class InWindow {
     readBlock();
   }
 
+  /**
+   * Advances the current position by one byte, sliding the window when necessary and pulling more
+   * data from the stream. If the movement approaches the last safe position, the buffer content is
+   * shifted via {@link #moveBlock()} before additional bytes are read.
+   *
+   * @throws IOException if the underlying stream cannot supply bytes while filling the buffer after
+   *     the move.
+   */
   public void movePos() throws IOException {
     pos++;
     if (pos > posLimit) {
@@ -100,10 +203,33 @@ public class InWindow {
     }
   }
 
+  /**
+   * Returns the byte located at a relative offset from the current position within the buffer.
+   * Callers should ensure the requested index remains within the available window bounds to avoid
+   * undefined behavior.
+   *
+   * @param index zero-based offset from the current position; may be negative for look-behind
+   *     access and should not exceed the number of buffered bytes ahead.
+   * @return byte value stored at {@code pos + index} inside the active buffer window.
+   */
   public byte getIndexByte(int index) {
     return bufferBase[bufferOffset + pos + index];
   }
 
+  /**
+   * Computes the length of the longest match between data at the current position and data at a
+   * prior distance. The search respects the provided limit and clamps to the end-of-stream boundary
+   * if the stream is exhausted. Matching stops on the first differing byte.
+   *
+   * @param index offset from the current position where comparison starts; may be zero or positive
+   *     depending on caller needs.
+   * @param distance backward distance, in bytes, from the comparison start to the reference
+   *     position; must be non-negative.
+   * @param limit maximum number of bytes to compare; adjusted internally when past the end of the
+   *     stream.
+   * @return number of consecutive bytes that match between the two regions, never exceeding the
+   *     provided limit.
+   */
   public int getMatchLen(int index, int distance, int limit) {
     if (streamEndWasReached && (pos + index) + limit > streamPos) limit = streamPos - (pos + index);
     distance++;
@@ -117,10 +243,26 @@ public class InWindow {
     return i;
   }
 
+  /**
+   * Reports how many buffered bytes remain available from the current position to the end of the
+   * data read so far. The count shrinks as the caller advances and grows when additional data is
+   * read from the stream.
+   *
+   * @return non-negative number of bytes that can be consumed without triggering another stream
+   *     read.
+   */
   public int getNumAvailableBytes() {
     return streamPos - pos;
   }
 
+  /**
+   * Decrements all internal position trackers by the supplied value to reflect a logical shift in
+   * buffer indexing. This is typically used after a move to realign absolute offsets while keeping
+   * buffer contents intact.
+   *
+   * @param subValue number of bytes to subtract from buffer-related offsets; must be non-negative
+   *     and should not exceed current pointer values.
+   */
   public void reduceOffsets(int subValue) {
     bufferOffset += subValue;
     posLimit -= subValue;

--- a/src/main/java/org/sevenzip/compression/lz/OutWindow.java
+++ b/src/main/java/org/sevenzip/compression/lz/OutWindow.java
@@ -1,10 +1,29 @@
-// LZ.OutWindow
-
 package org.sevenzip.compression.lz;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * Sliding output buffer used by the LZ decoder to materialize decompressed bytes while reusing a
+ * fixed-size window.
+ *
+ * <p>The window maintains an in-memory ring buffer that mirrors LZ77-style back-references. Clients
+ * typically call {@link #create(int)} to size the buffer, {@link #setStream(OutputStream)} to
+ * attach a destination, and then interleave {@link #putByte(byte)}, {@link #copyBlock(int, int)},
+ * and {@link #flush()} as decoded symbols arrive. The window advances automatically, wrapping at
+ * the configured size so distance references resolve correctly even across flush boundaries.
+ *
+ * <p>State is mutable and not thread-safe; callers should confine each instance to a single
+ * decoding pipeline. Reusing the same instance across streams is supported through {@link
+ * #init(boolean)} and {@link #releaseStream()}, enabling long-running decoders to amortize buffer
+ * allocation while still emitting bytes promptly to the underlying {@link OutputStream}.
+ *
+ * <ul>
+ *   <li>Maintains positional invariants for distance-based copies.
+ *   <li>Flushes lazily when the window fills to minimize write calls.
+ *   <li>Requires explicit lifecycle coordination by the decoder that drives it.
+ * </ul>
+ */
 public class OutWindow {
   byte[] buffer;
   int pos;
@@ -12,6 +31,31 @@ public class OutWindow {
   int streamPos;
   OutputStream stream;
 
+  /**
+   * Creates a new out window with no stream attached and zeroed cursors.
+   *
+   * <p>The constructor leaves allocation deferred until {@link #create(int)} is called, ensuring
+   * that callers can select an appropriate window size before any buffer is allocated. The initial
+   * state has all indices at zero and {@code stream} set to {@code null}, making the instance ready
+   * for configuration within a decoder pipeline.
+   */
+  public OutWindow() {
+    // No-op: buffer allocation and cursor resets are deferred to create(int) to let callers choose
+    // the correct window size for their decoding parameters.
+  }
+
+  /**
+   * Allocates or reuses the backing buffer and resets write positions to the start of the window.
+   *
+   * <p>If the existing buffer size differs from {@code windowSize}, a new array is allocated;
+   * otherwise the current buffer is reused. After calling this method, both the current position
+   * and the last-flushed pointer are set to zero so the next writes begin at the start of the ring.
+   * The caller is responsible for ensuring a compatible size with any subsequent distance
+   * references.
+   *
+   * @param windowSize desired window capacity in bytes; must be positive and consistent with LZ
+   *     distance limits.
+   */
   public void create(int windowSize) {
     if (buffer == null || this.windowSize != windowSize) buffer = new byte[windowSize];
     this.windowSize = windowSize;
@@ -19,16 +63,46 @@ public class OutWindow {
     streamPos = 0;
   }
 
+  /**
+   * Attaches the destination stream, flushing and detaching any previously assigned stream first.
+   *
+   * <p>The method preserves buffered data by invoking {@link #releaseStream()} before switching the
+   * target. After a successful call the window continues writing from its current position, and
+   * callers should ensure {@link #create(int)} has been invoked to define buffer capacity prior to
+   * writing. The provided stream must remain open for the duration of subsequent writes.
+   *
+   * @param stream output target that receives flushed window contents; must not be {@code null}.
+   * @throws IOException if flushing the prior stream fails while detaching it.
+   */
   public void setStream(OutputStream stream) throws IOException {
     releaseStream();
     this.stream = stream;
   }
 
+  /**
+   * Flushes any pending bytes to the current stream and detaches it from this window.
+   *
+   * <p>The method is idempotent with respect to multiple invocations and leaves the buffer contents
+   * intact so decoding can resume after a new stream is attached. No attempt is made to close the
+   * underlying stream; ownership remains with the caller.
+   *
+   * @throws IOException if the buffered data cannot be written to the current stream.
+   */
   public void releaseStream() throws IOException {
     flush();
     stream = null;
   }
 
+  /**
+   * Resets window positions optionally preserving already buffered data for solid decoding phases.
+   *
+   * <p>When {@code solid} is {@code false}, both the last-flushed marker and the current write
+   * position are reset to zero, effectively discarding positional history for subsequent
+   * back-references. When {@code solid} is {@code true}, positions remain unchanged, allowing
+   * multipart compressed streams to share the same window state.
+   *
+   * @param solid whether to retain the current window content and positional history across calls.
+   */
   public void init(boolean solid) {
     if (!solid) {
       streamPos = 0;
@@ -36,6 +110,16 @@ public class OutWindow {
     }
   }
 
+  /**
+   * Writes any bytes accumulated since the last flush to the attached stream and updates pointers.
+   *
+   * <p>If no new bytes were written, the method returns immediately. When data is present, it
+   * writes the contiguous range between {@code streamPos} and {@code pos}. If the write boundary
+   * coincides with the end of the ring buffer, the current position is wrapped to zero to keep
+   * subsequent inserts in range.
+   *
+   * @throws IOException if the write to the underlying stream fails.
+   */
   public void flush() throws IOException {
     int size = pos - streamPos;
     if (size == 0) return;
@@ -44,6 +128,21 @@ public class OutWindow {
     streamPos = pos;
   }
 
+  /**
+   * Copies a previously emitted sequence from the window into the current position, flushing as
+   * needed.
+   *
+   * <p>The method calculates a source pointer at {@code distance + 1} bytes before the current
+   * position, wrapping around the ring buffer when negative. Bytes are copied one by one for {@code
+   * len} iterations, flushing the window whenever the write cursor reaches the configured capacity.
+   * Callers must ensure that {@code distance} does not exceed the initialized window size; no
+   * explicit validation is performed here.
+   *
+   * @param distance zero-based distance from the byte immediately before the current position; must
+   *     be less than the window size to remain valid.
+   * @param len number of bytes to duplicate from the calculated source region into the window.
+   * @throws IOException if a flush triggered during copying cannot write to the stream.
+   */
   public void copyBlock(int distance, int len) throws IOException {
     int srcPos = pos - distance - 1;
     if (srcPos < 0) srcPos += windowSize;
@@ -54,11 +153,32 @@ public class OutWindow {
     }
   }
 
+  /**
+   * Appends a single byte to the window and flushes automatically when the buffer fills.
+   *
+   * <p>The byte is written at the current cursor position and the position advances by one.
+   * Reaching the end of the window triggers an implicit {@link #flush()} so the stream receives the
+   * buffered data promptly while keeping the ring indices valid for future distance references.
+   *
+   * @param b value to store at the current position; all byte values are accepted as-is.
+   * @throws IOException if the automatic flush fails to write to the underlying stream.
+   */
   public void putByte(byte b) throws IOException {
     buffer[pos++] = b;
     if (pos >= windowSize) flush();
   }
 
+  /**
+   * Retrieves a previously written byte by distance without modifying window state.
+   *
+   * <p>The method computes a source position {@code distance + 1} bytes behind the current cursor,
+   * wrapping around the ring buffer if necessary. The buffer contents are left unchanged so callers
+   * can perform lookups while constructing new output without affecting subsequent writes.
+   *
+   * @param distance zero-based distance from the prior byte; must be within the current window.
+   * @return byte value located at the resolved position; ownership remains with the internal
+   *     buffer.
+   */
   public byte getByte(int distance) {
     int srcPos = pos - distance - 1;
     if (srcPos < 0) srcPos += windowSize;

--- a/src/test/java/org/sevenzip/compression/lz/BinTreeTest.java
+++ b/src/test/java/org/sevenzip/compression/lz/BinTreeTest.java
@@ -1,0 +1,135 @@
+package org.sevenzip.compression.lz;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BinTreeTest {
+
+  @Test
+  void setType_whenNumHashBytesLessOrEqualTo2_setsDirectMatchParams() {
+    BinTree binTree = new BinTree();
+
+    binTree.setType(2);
+
+    assertAll(
+        () -> assertFalse(binTree.hashArray),
+        () -> assertEquals(2, binTree.kNumHashDirectBytes),
+        () -> assertEquals(3, binTree.kMinMatchCheck),
+        () -> assertEquals(0, binTree.kFixHashSize));
+  }
+
+  @Test
+  void setType_whenNumHashBytesGreaterThan2_enablesHashArrayAndDefaults() {
+    BinTree binTree = new BinTree();
+
+    binTree.setType(4);
+
+    assertAll(
+        () -> assertTrue(binTree.hashArray),
+        () -> assertEquals(0, binTree.kNumHashDirectBytes),
+        () -> assertEquals(4, binTree.kMinMatchCheck),
+        () -> assertEquals(BinTree.K_HASH2_SIZE + BinTree.K_HASH3_SIZE, binTree.kFixHashSize));
+  }
+
+  @Test
+  void normalizeLinks_whenValuesBelowOrEqualSubValue_clearsAndShifts() {
+    BinTree binTree = new BinTree();
+    int[] values = {5, 6, 3};
+
+    binTree.normalizeLinks(values, values.length, 5);
+
+    assertArrayEquals(new int[] {0, 1, 0}, values);
+  }
+
+  @Test
+  void normalize_whenOffsetsExceedCyclicBuffer_adjustsStateAndArrays() {
+    BinTree binTree = new BinTree();
+    binTree.cyclicBufferSize = 4;
+    binTree.pos = 10;
+    binTree.bufferOffset = 0;
+    binTree.posLimit = 12;
+    binTree.streamPos = 13;
+    binTree.son = new int[] {6, 7, 8, 5, 12, 1, 9, 6};
+    binTree.hashSizeSum = 4;
+    binTree.hash = new int[] {10, 4, 7, 6};
+
+    binTree.normalize();
+
+    assertAll(
+        () -> assertArrayEquals(new int[] {0, 1, 2, 0, 6, 0, 3, 0}, binTree.son),
+        () -> assertArrayEquals(new int[] {4, 0, 1, 0}, binTree.hash),
+        () -> assertEquals(4, binTree.pos),
+        () -> assertEquals(6, binTree.bufferOffset),
+        () -> assertEquals(6, binTree.posLimit),
+        () -> assertEquals(7, binTree.streamPos));
+  }
+
+  @Test
+  void getMatches_whenLookaheadInsufficient_returnsZeroAndAdvancesPosition() throws IOException {
+    BinTree binTree = new BinTree();
+    binTree.setType(4);
+    binTree.createMatchFinder(8, 0, 16, 1);
+    binTree.setStream(new ByteArrayInputStream(new byte[] {1, 2}));
+    binTree.init();
+    int[] distances = new int[4];
+
+    int result = binTree.getMatches(distances);
+
+    assertAll(() -> assertEquals(0, result), () -> assertEquals(2, binTree.pos));
+  }
+
+  @Test
+  void getMatches_whenPatternRepeats_returnsLongestMatchAndDistance() throws IOException {
+    BinTree binTree = new BinTree();
+    binTree.setType(4);
+    binTree.createMatchFinder(16, 0, 6, 1);
+    binTree.setStream(new ByteArrayInputStream("abcabcabc".getBytes(StandardCharsets.US_ASCII)));
+    binTree.init();
+    int[] scratch = new int[20];
+    for (int i = 0; i < 3; i++) {
+      binTree.getMatches(scratch);
+    }
+    int[] distances = new int[20];
+
+    int offset = binTree.getMatches(distances);
+
+    boolean foundLongestRepeat = false;
+    for (int i = 0; i < offset; i += 2) {
+      if (distances[i] == 6 && distances[i + 1] == 2) {
+        foundLongestRepeat = true;
+        break;
+      }
+    }
+    final boolean longestRepeatDetected = foundLongestRepeat;
+
+    assertAll(
+        () -> assertTrue(offset >= 2),
+        () -> assertTrue(longestRepeatDetected),
+        () -> assertEquals(5, binTree.pos));
+  }
+
+  @Test
+  void skip_whenAdvancingMultiplePositions_updatesInternalPosition() throws IOException {
+    BinTree binTree = new BinTree();
+    binTree.setType(4);
+    binTree.createMatchFinder(8, 0, 4, 1);
+    binTree.setStream(new ByteArrayInputStream("aaaaaa".getBytes(StandardCharsets.US_ASCII)));
+    binTree.init();
+
+    binTree.skip(2);
+
+    assertEquals(3, binTree.pos);
+  }
+}

--- a/src/test/java/org/sevenzip/compression/lz/InWindowTest.java
+++ b/src/test/java/org/sevenzip/compression/lz/InWindowTest.java
@@ -1,0 +1,114 @@
+package org.sevenzip.compression.lz;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class InWindowTest {
+
+  @Test
+  void create_setsBufferSizeAndSafePosition() {
+    InWindow window = new InWindow();
+
+    window.create(2, 3, 4);
+
+    assertEquals(2, window.keepSizeBefore);
+    assertEquals(3, window.keepSizeAfter);
+    assertNotNull(window.bufferBase);
+    assertEquals(9, window.bufferBase.length);
+    assertEquals(6, window.pointerToLastSafePosition);
+  }
+
+  @Test
+  void init_whenStreamHasData_readsInitialBlockAndSetsLimits() throws Exception {
+    byte[] data = new byte[] {10, 20, 30, 40};
+    InWindow window = prepareWindow(data, 1, 1, 2);
+
+    assertEquals(0, window.pos);
+    assertEquals(0, window.bufferOffset);
+    assertEquals(data.length, window.streamPos);
+    assertEquals(window.streamPos - window.keepSizeAfter, window.posLimit);
+    assertFalse(window.streamEndWasReached);
+    assertArrayEquals(
+        data,
+        Arrays.copyOfRange(
+            window.bufferBase, window.bufferOffset, window.bufferOffset + window.streamPos));
+  }
+
+  @Test
+  void movePos_whenCrossingPosLimit_loadsAdditionalBytes() throws Exception {
+    byte[] data = new byte[] {0, 1, 2, 3, 4, 5, 6, 7};
+    InWindow window = prepareWindow(data, 1, 2, 3);
+    int initialStreamPos = window.streamPos;
+
+    int safetyCounter = 0;
+    while (window.streamPos == initialStreamPos && safetyCounter < data.length * 2) {
+      window.movePos();
+      safetyCounter++;
+    }
+
+    assertTrue(window.streamPos > initialStreamPos, "Expected additional bytes to be read");
+    assertEquals(data.length - window.pos, window.getNumAvailableBytes());
+  }
+
+  @Test
+  void movePos_whenBufferNearLimit_preservesCurrentByteAfterMoveBlock() throws Exception {
+    byte[] data = new byte[] {0, 1, 2, 3, 4, 5, 6, 7};
+    InWindow window = prepareWindow(data, 2, 2, 2);
+
+    while (window.pos < 5) {
+      window.movePos();
+    }
+
+    assertEquals(5, window.pos);
+    assertEquals(5, window.getIndexByte(0));
+  }
+
+  @Test
+  void getMatchLen_whenStreamEnded_clampsLimitAndReturnsMatchLength() throws Exception {
+    byte[] data = "abcabc".getBytes();
+    InWindow window = prepareWindow(data, 3, 1, 3);
+
+    for (int i = 0; i < 3; i++) {
+      window.movePos();
+    }
+
+    int matchLength = window.getMatchLen(0, 2, 10);
+
+    assertTrue(window.streamEndWasReached);
+    assertEquals(3, matchLength);
+  }
+
+  @Test
+  void reduceOffsets_adjustsInternalPointersConsistently() {
+    InWindow window = new InWindow();
+    window.bufferOffset = 5;
+    window.posLimit = 9;
+    window.pos = 7;
+    window.streamPos = 10;
+
+    window.reduceOffsets(3);
+
+    assertEquals(8, window.bufferOffset);
+    assertEquals(6, window.posLimit);
+    assertEquals(4, window.pos);
+    assertEquals(7, window.streamPos);
+  }
+
+  private InWindow prepareWindow(byte[] data, int keepBefore, int keepAfter, int keepReserve)
+      throws IOException {
+    InWindow window = new InWindow();
+    window.create(keepBefore, keepAfter, keepReserve);
+    window.setStream(new ByteArrayInputStream(data));
+    window.init();
+    return window;
+  }
+}

--- a/src/test/java/org/sevenzip/compression/lz/OutWindowTest.java
+++ b/src/test/java/org/sevenzip/compression/lz/OutWindowTest.java
@@ -1,0 +1,108 @@
+package org.sevenzip.compression.lz;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class OutWindowTest {
+
+  @Test
+  void create_whenCalled_setsWindowSizeAndResetsPositions() {
+    OutWindow window = new OutWindow();
+
+    window.create(4);
+
+    assertNotNull(window.buffer);
+    assertEquals(4, window.buffer.length);
+    assertEquals(0, window.pos);
+    assertEquals(0, window.streamPos);
+  }
+
+  @Test
+  void putByte_whenWindowFills_flushesToStreamAndResetsPositions() throws IOException {
+    OutWindow window = new OutWindow();
+    window.create(2);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    window.setStream(output);
+
+    window.putByte((byte) 0x11);
+    window.putByte((byte) 0x22); // triggers flush because windowSize reached
+
+    assertArrayEquals(new byte[] {(byte) 0x11, (byte) 0x22}, output.toByteArray());
+    assertEquals(0, window.pos);
+    assertEquals(0, window.streamPos);
+  }
+
+  @Test
+  void flush_whenNoPendingData_writesNothing() throws IOException {
+    OutWindow window = new OutWindow();
+    window.create(3);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    window.setStream(output);
+
+    window.flush();
+
+    assertEquals(0, output.size());
+    assertEquals(0, window.pos);
+    assertEquals(0, window.streamPos);
+  }
+
+  @Test
+  void releaseStream_whenPendingData_flushesAndClearsStream() throws IOException {
+    OutWindow window = new OutWindow();
+    window.create(3);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    window.setStream(output);
+
+    window.putByte((byte) 'x');
+    window.releaseStream();
+
+    assertArrayEquals(new byte[] {(byte) 'x'}, output.toByteArray());
+    assertNull(window.stream);
+  }
+
+  @Test
+  void copyBlock_whenDistanceWrapsAround_repeatsDataCorrectly() throws IOException {
+    OutWindow window = new OutWindow();
+    window.create(5);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    window.setStream(output);
+
+    window.putByte((byte) 1);
+    window.putByte((byte) 2);
+    window.putByte((byte) 3);
+    window.putByte((byte) 4);
+    window.putByte((byte) 5); // triggers flush, resets pos to 0
+
+    window.copyBlock(1, 3); // wraps source position to index 3
+    window.flush();
+
+    assertArrayEquals(new byte[] {1, 2, 3, 4, 5, 4, 5, 4}, output.toByteArray());
+    assertEquals(3, window.pos);
+    assertEquals(3, window.streamPos);
+  }
+
+  @Test
+  void getByte_whenDistanceWraps_returnsExpectedByte() throws IOException {
+    OutWindow window = new OutWindow();
+    window.create(3);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    window.setStream(output);
+
+    window.putByte((byte) 10);
+    window.putByte((byte) 11);
+    window.putByte((byte) 12); // triggers flush, pos resets to 0
+
+    byte value = window.getByte(1);
+
+    assertEquals(11, value);
+    assertEquals(0, window.pos);
+    assertEquals(0, window.streamPos);
+  }
+}


### PR DESCRIPTION
## Summary
- document BinTree, InWindow, and OutWindow with detailed lifecycle and invariants
- enable org.sevenzip test suite in the shared Gradle test includes
- add JUnit 6 coverage for BinTree match finder plus InWindow/OutWindow sliding window behaviors

## Testing
- not run (not requested)
