### PR TITLE
Improve LZMA docs and add encoder/decoder coverage

### DIFF
--- a/src/main/java/org/sevenzip/compression/lzma/Base.java
+++ b/src/main/java/org/sevenzip/compression/lzma/Base.java
@@ -2,29 +2,113 @@
 
 package org.sevenzip.compression.lzma;
 
+/**
+ * Provides shared constants and finite-state helper routines for the LZMA encoder/decoder state
+ * machine.
+ *
+ * <p>This type centralizes the numeric configuration for the reference implementation, including
+ * literal/match state encodings, distance slot geometry, and length bucket thresholds. Consumers
+ * typically read these values rather than copy literals so that encoder and decoder branches remain
+ * synchronized when tuning or upgrading the algorithm. The class is intentionally stateless and
+ * thread-safe; all members are {@code static} constants or pure functions. Typical usage patterns
+ * include selecting the next state after emitting a literal or match, determining whether a state
+ * is considered a literal state, and mapping a match length to the correct position-model bucket to
+ * drive probability model selection. Because the values mirror the original LZMA specification,
+ * they preserve binary compatibility with existing compressed streams while keeping the
+ * implementation straightforward to reason about across platforms.
+ *
+ * <ul>
+ *   <li>Responsibilities: expose canonical constants and state transition helpers.
+ *   <li>Mutability: immutable; safe to share across threads without coordination.
+ *   <li>Performance: helpers avoid branching depth and do not allocate.
+ * </ul>
+ */
 public class Base {
+  /**
+   * Count of remembered repetition distances used by the encoder/decoder; keeps track of the last
+   * four distances to accelerate repeated match detection. The value is fixed at four to mirror the
+   * reference LZMA design and should match associated probability models.
+   */
   public static final int NUM_REP_DISTANCES = 4;
+
+  /**
+   * Total number of possible finite states within the simplified LZMA state machine. States 0–6
+   * represent literal-emission contexts; states 7–11 represent various match/repetition contexts.
+   * Algorithms rely on this size to bound arrays and normalize state transitions.
+   */
   public static final int NUM_STATES = 12;
+
+  /**
+   * Initial state identifier assigned when a coder starts or is reset. Using zero guarantees entry
+   * into the literal branch until matches are observed, matching historical implementations and
+   * test vectors.
+   */
   public static final int STATE_INIT = 0;
 
-  /** Transition state for a literal (char) emission. */
+  /**
+   * Transition state for a literal (char) emission.
+   *
+   * <p>Determines the next finite-state index after emitting a literal. For low-index states (0–3)
+   * the machine returns to the initial literal state. For mid-range states (4–9) it advances toward
+   * match-oriented states to reflect observed patterns. For higher states it shifts toward the
+   * repetition branch. The function is pure and side effect free.
+   *
+   * @param index current state index, expected to be within {@code 0..NUM_STATES-1}; values outside
+   *     the range are accepted but mapped using the same arithmetic without validation.
+   * @return next state index after processing a literal; callers should reuse the result
+   *     immediately to maintain encoder/decoder alignment.
+   */
   public static int stateUpdateChar(int index) {
     if (index < 4) return 0;
     if (index < 10) return index - 3;
     return index - 6;
   }
 
-  /** Transition state for a match. */
+  /**
+   * Transition state for a match.
+   *
+   * <p>Advances the finite-state machine when a full match (non-repetition) token is emitted.
+   * States below seven move into the primary match state, while higher states move into an
+   * alternate match cluster, preserving legacy probability distributions.
+   *
+   * @param index current state index before emitting a match token; typically the previous state of
+   *     the LZMA coder.
+   * @return match state index {@code 7} for literal-dominated states or {@code 10} for
+   *     match-oriented states, preserving the original split.
+   */
   public static int stateUpdateMatch(int index) {
     return (index < 7 ? 7 : 10);
   }
 
-  /** Transition state for a repeated match. */
+  /**
+   * Transition state for a repeated match.
+   *
+   * <p>Used when reusing one of the recent distances tracked by the coder. States below seven move
+   * into repetition state {@code 8}; others move into repetition state {@code 11}. The logic
+   * mirrors the classic implementation and keeps repetition probabilities isolated from first-time
+   * matches.
+   *
+   * @param index state index prior to handling a repeated distance; expected within {@code
+   *     0..NUM_STATES-1} but not strictly validated.
+   * @return next repetition state index ({@code 8} or {@code 11}) suitable for immediate reuse by
+   *     the caller.
+   */
   public static int stateUpdateRep(int index) {
     return (index < 7 ? 8 : 11);
   }
 
-  /** Transition state for a short repeated match. */
+  /**
+   * Transition state for a short repeated match.
+   *
+   * <p>Short repetitions represent single-byte matches to a recent distance. Literal-weighted
+   * states transition to index {@code 9}; existing match-weighted states transition to index {@code
+   * 11}. This distinction helps maintain accurate probability models for very short repeats versus
+   * longer repetitions.
+   *
+   * @param index current state index prior to processing a short repetition token; typically
+   *     derived from the previous coding step.
+   * @return next state index ({@code 9} or {@code 11}) for continued coding after the short repeat.
+   */
   public static int stateUpdateShortRep(int index) {
     return (index < 7 ? 9 : 11);
   }
@@ -35,54 +119,186 @@ public class Base {
    * <p>Legacy LZMA semantics: states {@code 0..6} represent literal states and {@code 7..11}
    * represent match/repetition states. Some encoder/decoder branches depend on this exact split. Do
    * not invert this condition.
+   *
+   * @param index state index under evaluation; values under seven are considered literal, values
+   *     seven or above are treated as match-capable.
+   * @return {@code true} when the index denotes a literal state, otherwise {@code false}; callers
+   *     can branch encoder/decoder logic accordingly.
    */
   public static boolean isCharState(int index) {
     return index < 7;
   }
 
+  /**
+   * Number of bits used to encode the position slot for distance modeling. Six bits provide 64
+   * distinct slots, balancing precision and table size for typical LZMA distance coding.
+   */
   public static final int NUM_POS_SLOT_BITS = 6;
+
+  /**
+   * Minimum dictionary log size supported by the implementation. A value of zero represents a
+   * single-byte dictionary and serves mainly as a theoretical lower bound for validation paths.
+   */
   public static final int DIC_LOG_SIZE_MIN = 0;
+
   /*
    * Note: historical constants (kDicLogSizeMax, kDistTableSizeMax) were intentionally removed
    * as they are unused in this codebase.
    */
 
+  /**
+   * Number of bits dedicated to mapping match lengths to position-state buckets, primarily chosen
+   * for speed. Two bits create four buckets and keep lookup tables compact.
+   */
   public static final int NUM_LEN_TO_POS_STATES_BITS = 2; // it's for speed optimization
+
+  /**
+   * Total count of length-to-position states derived from {@link #NUM_LEN_TO_POS_STATES_BITS}. With
+   * two bits, four buckets are available for grouping match lengths when selecting probability
+   * models.
+   */
   public static final int NUM_LEN_TO_POS_STATES = 1 << NUM_LEN_TO_POS_STATES_BITS;
 
+  /**
+   * Minimum match length recognized by the coder. The LZMA format treats length values below two as
+   * literals; matches start at two bytes to maintain format compatibility.
+   */
   public static final int MATCH_MIN_LEN = 2;
 
-  /** Computes the length-to-position state bucket. */
+  /**
+   * Computes the length-to-position state bucket.
+   *
+   * <p>Maps a raw match length to one of the small number of position-state buckets used by
+   * distance models. Lengths shorter than {@link #MATCH_MIN_LEN} are normalized to zero after
+   * subtraction. Values exceeding the available buckets clamp to the last bucket to avoid array
+   * overflows.
+   *
+   * @param len match length expressed in bytes; should be at least {@link #MATCH_MIN_LEN} for
+   *     typical callers, though smaller values are accepted and treated as zero-length after
+   *     normalization.
+   * @return bucket index within {@link #NUM_LEN_TO_POS_STATES}; the maximum value is the last
+   *     bucket when the length exceeds the available range.
+   */
   public static int getLenToPosState(int len) {
     len -= MATCH_MIN_LEN;
     if (len < NUM_LEN_TO_POS_STATES) return len;
     return NUM_LEN_TO_POS_STATES - 1;
   }
 
+  /**
+   * Number of bits dedicated to the alignment portion of distance coding. Four bits allow sixteen
+   * alignment values, controlling fine-grained distance reconstruction during decoding.
+   */
   public static final int NUM_ALIGN_BITS = 4;
+
+  /**
+   * Size of the alignment lookup table, computed from {@link #NUM_ALIGN_BITS}. With four bits, the
+   * table contains sixteen entries and remains cache-friendly.
+   */
   public static final int ALIGN_TABLE_SIZE = 1 << NUM_ALIGN_BITS;
+
+  /**
+   * Bitmask used to extract the alignment portion from a coded distance value. It equals the
+   * alignment table size minus one, making it suitable for efficient bitwise masking operations.
+   */
   public static final int ALIGN_MASK = (ALIGN_TABLE_SIZE - 1);
 
+  /**
+   * Start index (inclusive) for position models that receive specialized treatment. Distances with
+   * slot indices below this value use simpler probability trees; larger distances rely on extended
+   * slot encoding.
+   */
   public static final int START_POS_MODEL_INDEX = 4;
+
+  /**
+   * End index (inclusive) for the base position models. Distances at or above this index transition
+   * to the full-distance modeling path, enabling broader range representation.
+   */
   public static final int END_POS_MODEL_INDEX = 14;
 
+  /**
+   * Total number of explicit distance values represented without additional bit trees, derived from
+   * the end position model index. Distances beyond this count require extra bits during coding.
+   */
   public static final int NUM_FULL_DISTANCES = 1 << (END_POS_MODEL_INDEX / 2);
 
+  /**
+   * Maximum bits allowed for literal position state selection during encoding, limiting how finely
+   * position-dependent literal contexts are partitioned.
+   */
   public static final int NUM_LIT_POS_STATES_BITS_ENCODING_MAX = 4;
+
+  /**
+   * Maximum number of bits used to derive literal contexts from preceding bytes. Eight bits support
+   * up to 256 distinct literal contexts, enabling nuanced probability modeling when memory permits.
+   */
   public static final int NUM_LIT_CONTEXT_BITS_MAX = 8;
 
+  /**
+   * Maximum bits for position states used by decoders, constraining table sizes and probability
+   * model allocations during runtime.
+   */
   public static final int NUM_POS_STATES_BITS_MAX = 4;
+
+  /**
+   * Maximum count of position states derived from {@link #NUM_POS_STATES_BITS_MAX}. With four bits
+   * the encoder/decoder can differentiate up to sixteen positions for context modeling.
+   */
   public static final int NUM_POS_STATES_MAX = (1 << NUM_POS_STATES_BITS_MAX);
+
+  /**
+   * Maximum bits for position states specifically during encoding, mirroring decoder constraints to
+   * keep model sizes consistent across the pipeline.
+   */
   public static final int NUM_POS_STATES_BITS_ENCODING_MAX = 4;
+
+  /**
+   * Maximum number of position states available to the encoder, computed from the encoding bit
+   * limit. Ensures symmetry with decoder expectations and bounds memory usage.
+   */
   public static final int NUM_POS_STATES_ENCODING_MAX = (1 << NUM_POS_STATES_BITS_ENCODING_MAX);
 
+  /**
+   * Number of bits allocated to the low-length probability subrange. Three bits yield eight symbols
+   * for short matches, enabling fast lookups for common short lengths.
+   */
   public static final int NUM_LOW_LEN_BITS = 3;
+
+  /**
+   * Number of bits allocated to the mid-length probability subrange. Also, three bits, providing
+   * eight symbols that fill the space between low and high length ranges.
+   */
   public static final int NUM_MID_LEN_BITS = 3;
+
+  /**
+   * Number of bits allocated to the high-length probability subrange. Eight bits allow 256 symbols
+   * to represent the remaining long match lengths beyond the low and mid-ranges.
+   */
   public static final int NUM_HIGH_LEN_BITS = 8;
+
+  /**
+   * Count of symbols in the low-length range, computed from {@link #NUM_LOW_LEN_BITS}. Provides a
+   * quick reference for allocating probability arrays for short matches.
+   */
   public static final int NUM_LOW_LEN_SYMBOLS = 1 << NUM_LOW_LEN_BITS;
+
+  /**
+   * Count of symbols in the mid-length range, computed from {@link #NUM_MID_LEN_BITS}. Mirrors the
+   * low-length calculation to keep middle ranges consistent in sizing and access patterns.
+   */
   public static final int NUM_MID_LEN_SYMBOLS = 1 << NUM_MID_LEN_BITS;
+
+  /**
+   * Total number of length symbols across low, mid, and high ranges. This figure drives allocation
+   * sizes for length probability models and defines the upper bound of decodable match lengths.
+   */
   public static final int NUM_LEN_SYMBOLS =
       NUM_LOW_LEN_SYMBOLS + NUM_MID_LEN_SYMBOLS + (1 << NUM_HIGH_LEN_BITS);
+
+  /**
+   * Maximum representable match length, derived from the minimum match length and total symbol
+   * count. Defines the highest length value the coder can emit without additional extensions.
+   */
   public static final int MATCH_MAX_LEN = MATCH_MIN_LEN + NUM_LEN_SYMBOLS - 1;
 
   private Base() {}

--- a/src/main/java/org/sevenzip/compression/lzma/Decoder.java
+++ b/src/main/java/org/sevenzip/compression/lzma/Decoder.java
@@ -8,6 +8,34 @@ import java.io.OutputStream;
 import org.sevenzip.compression.lz.OutWindow;
 import org.sevenzip.compression.rangecoder.BitTreeDecoder;
 
+/**
+ * Streaming LZMA decoder that materializes compressed input into an {@link OutWindow} backed output
+ * buffer.
+ *
+ * <p>The decoder drives the reference range-coder implementation and LZ-style repetition tracking
+ * to reconstruct bytes in order. Callers typically configure the instance once with {@link
+ * #setDecoderProperties(byte[])} and reuse it across streams by providing fresh input and output
+ * streams to {@link #code(InputStream, OutputStream, long)}. Internally the type manages
+ * probability models for literals, match lengths, and distances, along with a sliding window to
+ * satisfy back-references. The class is stateful and <strong>not</strong> thread-safe; confine each
+ * instance to a single decoding pipeline or provide external synchronization if shared.
+ *
+ * <p>Lifecycle expectations:
+ *
+ * <ul>
+ *   <li>Create an instance and configure properties (dictionary size and lc/lp/pb parameters).
+ *   <li>Invoke {@code code(...)} with an input stream positioned at the start of an LZMA payload
+ *       and an output stream ready to receive plain bytes.
+ *   <li>Repeat with new streams as needed; the decoder reinitializes internal models per call.
+ * </ul>
+ *
+ * <p>Performance considerations: buffer sizes follow the encoded dictionary; decoding proceeds
+ * byte-by-byte with frequent small range-coder updates. Avoid sharing the same {@link
+ * java.io.InputStream} or {@link java.io.OutputStream} across concurrent decodes. Errors surfaced
+ * as {@link IOException} indicate malformed input or I/O failures and leave the instance in an
+ * undefined state until reinitialized via a new {@link #code(InputStream, OutputStream, long)}
+ * call.
+ */
 public class Decoder {
   static class LenDecoder {
     short[] choice = new short[2];
@@ -129,6 +157,14 @@ public class Decoder {
 
   int posStateMask;
 
+  /**
+   * Creates a decoder with uninitialized models and window buffers sized on first configuration.
+   *
+   * <p>The constructor performs no I/O and allocates only constant-size probability structures; the
+   * dictionary buffer is deferred to the first successful {@link #setDecoderProperties(byte[])} or
+   * {@link #setDictionarySize(int)} call. Instances are mutable and should be configured before
+   * decoding to avoid validation failures.
+   */
   public Decoder() {
     for (int i = 0; i < Base.NUM_LEN_TO_POS_STATES; i++)
       posSlotDecoder[i] = new BitTreeDecoder(Base.NUM_POS_SLOT_BITS);
@@ -175,6 +211,35 @@ public class Decoder {
     rangeDecoder.init();
   }
 
+  /**
+   * Decodes a single LZMA stream from {@code inStream} into {@code outStream} until {@code outSize}
+   * bytes are produced or the stream signals end-of-data.
+   *
+   * <p>This method resets internal probability models, attaches the provided streams, and then
+   * iteratively emits literals or back-references according to the encoded payload. The operation
+   * is blocking and must not be called concurrently on the same instance. A negative {@code
+   * outSize} requests decoding until the end marker; non-negative values cap output length and
+   * allow early termination when the requested byte count is reached.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * Decoder decoder = new Decoder();
+   * decoder.setDecoderProperties(props);
+   * boolean ok = decoder.code(in, out, -1);
+   * }</pre>
+   *
+   * @param inStream source of compressed bytes; must be positioned at the beginning of the LZMA
+   *     stream and remain readable for the duration of decoding.
+   * @param outStream destination for decompressed bytes; must accept writes and remain open until
+   *     decoding completes, though it is not closed by this method.
+   * @param outSize number of bytes to decode, or a negative value to continue until the encoded end
+   *     marker; values are interpreted as a 64-bit signed length.
+   * @return {@code true} when decoding finishes without validation errors; {@code false} if the
+   *     input violates format invariants before reaching the requested length.
+   * @throws IOException if reading from {@code inStream} or writing to {@code outStream} fails, or
+   *     if model initialization cannot proceed due to upstream I/O errors.
+   */
   public boolean code(InputStream inStream, OutputStream outStream, long outSize)
       throws IOException {
     rangeDecoder.setStream(inStream);
@@ -313,6 +378,21 @@ public class Decoder {
     }
   }
 
+  /**
+   * Applies the lc/lp/pb parameters and dictionary size encoded in a five-byte LZMA properties
+   * header.
+   *
+   * <p>The method interprets the first byte as packed literal-context, literal-position, and
+   * position-state bits, then reads a little-endian 32-bit dictionary size from the remaining
+   * bytes. It initializes probability models and buffers accordingly. Callers should invoke this
+   * once per decoder configuration; repeated calls update the state and may reallocate the output
+   * window when dictionary sizes change.
+   *
+   * @param properties five-byte property block from the start of an LZMA stream; must contain
+   *     packed lc/lp/pb in the first byte followed by a 32-bit little-endian dictionary size.
+   * @return {@code true} when parameters are valid and internal structures are updated; {@code
+   *     false} when validation fails due to length or out-of-range values.
+   */
   public boolean setDecoderProperties(byte[] properties) {
     if (properties.length < 5) return false;
     int val = properties[0] & 0xFF;

--- a/src/main/java/org/sevenzip/compression/lzma/Encoder.java
+++ b/src/main/java/org/sevenzip/compression/lzma/Encoder.java
@@ -8,9 +8,44 @@ import org.sevenzip.ICodeProgress;
 import org.sevenzip.compression.lz.BinTree;
 import org.sevenzip.compression.rangecoder.BitTreeEncoder;
 
+/**
+ * Streaming LZMA encoder responsible for turning an {@link InputStream} into compressed bytes while
+ * tracking coder state, repetition distances, and price tables.
+ *
+ * <p>This implementation mirrors the reference LZMA algorithm and exposes the same tuning knobs
+ * used by command-line tools: dictionary size, fast-bytes limit, match-finder choice, and literal
+ * context settings. Callers typically configure the encoder, set input/output streams, and invoke
+ * {@link #code(InputStream, OutputStream, ICodeProgress)} to perform a full pass; lower-level entry
+ * points such as {@link #codeOneBlock(long[], long[], boolean[])} can be used by advanced
+ * orchestrators that want tighter progress control. Instances are stateful and not thread-safe; a
+ * new encoder should be created per logical compression job. The encoder retains internal buffers
+ * sized to the configured dictionary and fast-bytes window and updates probability models as bytes
+ * are written. Flushing emits end markers when requested, enabling decoders to detect stream
+ * termination reliably.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> manage match finding, price tables, range coding, and
+ *       repetition tracking during compression.
+ *   <li><strong>Mutability:</strong> heavily stateful; reuse only when resetting all tuning
+ *       parameters and streams.
+ *   <li><strong>Thread safety:</strong> not thread-safe; synchronize externally when sharing.
+ * </ul>
+ *
+ * @see org.sevenzip.compression.lzma.Decoder
+ * @see org.sevenzip.compression.rangecoder.Encoder
+ */
 public class Encoder {
   // Match finder type constants (BT2/BT4) in UPPER_SNAKE_CASE per conventions
+  /**
+   * Identifier for the binary-tree match finder using two-byte hashing. Use when memory is tight or
+   * ultra-fast initialization is preferred over match quality.
+   */
   public static final int MATCH_FINDER_TYPE_BT2 = 0;
+
+  /**
+   * Identifier for the binary-tree match finder using four-byte hashing. This is the default and
+   * offers better match quality at the cost of additional memory and preprocessing time.
+   */
   public static final int MATCH_FINDER_TYPE_BT4 = 1;
 
   static final int INFINITY_PRICE = 0xFFFFFFF;
@@ -706,6 +741,11 @@ public class Encoder {
     numFastBytesPrev = numFastBytes;
   }
 
+  /**
+   * Constructs a new encoder instance with default dictionary size, fast-bytes setting, and BT4
+   * match finder. Internal probability models and buffers are allocated lazily; {@link #create()}
+   * and {@link #setStreams(InputStream, OutputStream)} must be invoked before compression.
+   */
   public Encoder() {
     for (int i = 0; i < NUM_OPTS; i++) optimum[i] = new Optimal();
     for (int i = 0; i < Base.NUM_LEN_TO_POS_STATES; i++)
@@ -1227,6 +1267,25 @@ public class Encoder {
     return false;
   }
 
+  /**
+   * Compresses a single logical block using the currently configured streams and updates progress
+   * arrays in place.
+   *
+   * <p>This call advances internal position counters, emits literals or matches as needed, and
+   * stops when the encoder determines a flush point or detects the end of input. Callers typically
+   * loop on this method until {@code finished[0]} becomes {@code true}. The method expects the
+   * input and output arrays to be at least length one and will overwrite index {@code 0} on each
+   * invocation.
+   *
+   * @param inSize single-element array updated with total bytes consumed from the input stream in
+   *     this invocation; must be non-null and length ≥ 1.
+   * @param outSize single-element array receiving the encoded byte count written by the range
+   *     encoder; must be non-null and length ≥ 1.
+   * @param finished single-element boolean array set to {@code true} when the encoder finishes the
+   *     entire stream or reaches a flush condition; must be non-null and length ≥ 1.
+   * @throws IOException if reading from the input stream or writing encoded bytes fails at any
+   *     point during processing.
+   */
   public void codeOneBlock(long[] inSize, long[] outSize, boolean[] finished) throws IOException {
     inSize[0] = 0;
     outSize[0] = 0;
@@ -1303,6 +1362,25 @@ public class Encoder {
   long[] processedOutSize = new long[1];
   boolean[] finished = new boolean[1];
 
+  /**
+   * Compresses the entire {@link InputStream} to the provided {@link OutputStream}, reporting
+   * progress through an optional callback.
+   *
+   * <p>The method initializes internal match finders, iteratively calls {@link
+   * #codeOneBlock(long[], long[], boolean[])}, and guarantees that resources are released even when
+   * exceptions occur. Compression stops when the input is exhausted or the encoder emits an
+   * explicit end marker. The method is blocking and not thread-safe; invoke it from a dedicated
+   * worker thread when used in asynchronous systems.
+   *
+   * @param inStream source of uncompressed bytes; must remain readable for the duration of the
+   *     call; not closed by this method.
+   * @param outStream destination for encoded bytes; must accept streaming writes; flushed and
+   *     released when encoding completes.
+   * @param progress optional progress reporter notified with cumulative in/out sizes after each
+   *     block; may be {@code null} to disable callbacks.
+   * @throws IOException if the encoder cannot read from the input or write to the output stream at
+   *     any step of the compression loop.
+   */
   public void code(InputStream inStream, OutputStream outStream, ICodeProgress progress)
       throws IOException {
     needReleaseMFStream = false;
@@ -1321,9 +1399,26 @@ public class Encoder {
     }
   }
 
+  /**
+   * Byte length of the serialized LZMA property header emitted by {@link #writeCoderProperties}.
+   */
   public static final int PROP_SIZE = 5;
+
   byte[] properties = new byte[PROP_SIZE];
 
+  /**
+   * Writes the five-byte LZMA property header describing literal and dictionary configuration to
+   * the supplied stream.
+   *
+   * <p>The header encodes position state bits, literal position bits, literal context bits, and the
+   * dictionary size in little-endian order, matching the canonical 7-Zip LZMA header layout.
+   * Callers should invoke this before writing compressed data so decoders can reconstruct the same
+   * settings.
+   *
+   * @param outStream destination stream that receives the property bytes; must remain writable
+   *     throughout the call.
+   * @throws IOException if the property bytes cannot be written to the provided stream.
+   */
   public void writeCoderProperties(OutputStream outStream) throws IOException {
     properties[0] =
         (byte) ((posStateBits * 5 + numLiteralPosStateBits) * 9 + numLiteralContextBits);
@@ -1372,12 +1467,36 @@ public class Encoder {
     alignPriceCount = 0;
   }
 
+  /**
+   * Sets the encoder algorithm profile, trading speed for compression ratio.
+   *
+   * <p>Valid values are {@code 0} (fast), {@code 1} (normal), and {@code 2} (maximum). Values
+   * outside this range are ignored and the previous setting remains in effect. The choice affects
+   * internal heuristics only; stream format compatibility is unchanged.
+   *
+   * @param algorithm profile selector in the inclusive range {@code 0..2}; other values are
+   *     rejected without side effects.
+   * @return {@code true} when the value is accepted and recorded; {@code false} when rejected.
+   */
   public boolean setAlgorithm(int algorithm) {
     // Accept historical values 0..2 (0=fast, 1=normal, 2=max). Values outside this
     // range are rejected to match typical LZMA command-line expectations.
     return algorithm >= 0 && algorithm <= 2;
   }
 
+  /**
+   * Configures the dictionary size used by the match finder and probability models.
+   *
+   * <p>The supplied size must be between {@code 1 << Base.DIC_LOG_SIZE_MIN} and {@code 1 << 29}
+   * inclusive. Larger dictionaries generally improve compression for long inputs but consume more
+   * memory and initialization time. On success, the internal distance table size is recalculated to
+   * maintain pricing consistency.
+   *
+   * @param dictionarySize desired dictionary in bytes; must fall within the supported range or the
+   *     request is ignored.
+   * @return {@code true} when the size is accepted and internal tables are updated; {@code false}
+   *     when the value falls outside allowed bounds.
+   */
   public boolean setDictionarySize(int dictionarySize) {
     int kDicLogSizeMaxCompress = 29;
     if (dictionarySize < (1 << Base.DIC_LOG_SIZE_MIN)
@@ -1391,12 +1510,35 @@ public class Encoder {
     return true;
   }
 
+  /**
+   * Sets the fast-bytes threshold that bounds greedy match extension before falling back to the
+   * optimal parser.
+   *
+   * <p>Valid values are between {@code 5} and {@code Base.MATCH_MAX_LEN} inclusive. Lower values
+   * favor speed while higher values allow longer matches to be accepted eagerly. When the input is
+   * out of range, the prior configuration is preserved.
+   *
+   * @param numFastBytes maximum number of bytes for quick match processing; must be within the
+   *     allowed range to take effect.
+   * @return {@code true} if the value is recorded; {@code false} when rejected as invalid.
+   */
   public boolean setNumFastBytes(int numFastBytes) {
     if (numFastBytes < 5 || numFastBytes > Base.MATCH_MAX_LEN) return false;
     this.numFastBytes = numFastBytes;
     return true;
   }
 
+  /**
+   * Selects the match finder implementation used during compression.
+   *
+   * <p>Accepts {@link #MATCH_FINDER_TYPE_BT2} or {@link #MATCH_FINDER_TYPE_BT4}; values outside
+   * {@code 0..2} are rejected. Changing the match finder after creation discards any cached match
+   * finder state to ensure the new type is applied on the next {@link #create()} call.
+   *
+   * @param matchFinderIndex numeric identifier for the desired match finder; see constants for
+   *     supported values.
+   * @return {@code true} when the identifier is recognized and stored; {@code false} otherwise.
+   */
   public boolean setMatchFinder(int matchFinderIndex) {
     if (matchFinderIndex < 0 || matchFinderIndex > 2) return false;
     int matchFinderIndexPrev = matchFinderType;
@@ -1408,6 +1550,24 @@ public class Encoder {
     return true;
   }
 
+  /**
+   * Configures literal context bits (lc), literal position bits (lp), and position state bits (pb)
+   * that influence probability model selection.
+   *
+   * <p>Each value must be within the bounds defined by {@link Base#NUM_LIT_CONTEXT_BITS_MAX},
+   * {@link Base#NUM_LIT_POS_STATES_BITS_ENCODING_MAX}, and {@link
+   * Base#NUM_POS_STATES_BITS_ENCODING_MAX}. Accepted values update the corresponding masks used
+   * during encoding; invalid inputs are rejected without altering existing state.
+   *
+   * @param lc literal context bits in the inclusive range {@code 0..8}; higher values improve
+   *     textual compression at the cost of model size.
+   * @param lp literal position bits in the inclusive range {@code 0..4}; useful for data with
+   *     fixed-byte structures.
+   * @param pb position state bits in the inclusive range {@code 0..4}; affects match/literal
+   *     decision granularity.
+   * @return {@code true} when all values are valid and applied; {@code false} when any argument is
+   *     outside its supported range.
+   */
   public boolean setLcLpPb(int lc, int lp, int pb) {
     if (lp < 0
         || lp > Base.NUM_LIT_POS_STATES_BITS_ENCODING_MAX
@@ -1422,6 +1582,15 @@ public class Encoder {
     return true;
   }
 
+  /**
+   * Enables or disables writing an explicit end-of-stream marker after the final encoded symbol.
+   *
+   * <p>When enabled, decoders can reliably detect the end of the compressed stream even if the
+   * uncompressed size is unknown. Disabling the marker can be useful in container formats that
+   * convey length separately.
+   *
+   * @param endMarkerMode {@code true} to append the end marker; {@code false} to omit it.
+   */
   public void setEndMarkerMode(boolean endMarkerMode) {
     writeEndMark = endMarkerMode;
   }

--- a/src/test/java/org/sevenzip/compression/lzma/BaseTest.java
+++ b/src/test/java/org/sevenzip/compression/lzma/BaseTest.java
@@ -1,0 +1,131 @@
+package org.sevenzip.compression.lzma;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BaseTest {
+
+  @Nested
+  class StateUpdateChar {
+    static Stream<Arguments> cases() {
+      return Stream.of(
+          arguments(0, 0),
+          arguments(3, 0),
+          arguments(4, 1),
+          arguments(9, 6),
+          arguments(10, 4),
+          arguments(11, 5));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void stateUpdateChar_variousIndices_returnsExpectedState(int index, int expected) {
+      // Act
+      int result = Base.stateUpdateChar(index);
+
+      // Assert
+      assertEquals(expected, result);
+    }
+  }
+
+  @Nested
+  class StateUpdateMatch {
+    static Stream<Arguments> cases() {
+      return Stream.of(arguments(0, 7), arguments(6, 7), arguments(7, 10), arguments(11, 10));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void stateUpdateMatch_variousIndices_returnsExpectedState(int index, int expected) {
+      int result = Base.stateUpdateMatch(index);
+      assertEquals(expected, result);
+    }
+  }
+
+  @Nested
+  class StateUpdateRep {
+    static Stream<Arguments> cases() {
+      return Stream.of(arguments(0, 8), arguments(6, 8), arguments(7, 11), arguments(11, 11));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void stateUpdateRep_variousIndices_returnsExpectedState(int index, int expected) {
+      int result = Base.stateUpdateRep(index);
+      assertEquals(expected, result);
+    }
+  }
+
+  @Nested
+  class StateUpdateShortRep {
+    static Stream<Arguments> cases() {
+      return Stream.of(arguments(0, 9), arguments(6, 9), arguments(7, 11), arguments(11, 11));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void stateUpdateShortRep_variousIndices_returnsExpectedState(int index, int expected) {
+      int result = Base.stateUpdateShortRep(index);
+      assertEquals(expected, result);
+    }
+  }
+
+  @Nested
+  class IsCharState {
+    static Stream<Arguments> cases() {
+      return Stream.of(
+          arguments(0, true), arguments(6, true), arguments(7, false), arguments(11, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void isCharState_boundariesReflectLiteralVsMatchStates(int index, boolean expected) {
+      boolean result = Base.isCharState(index);
+      if (expected) {
+        assertTrue(result);
+      } else {
+        assertFalse(result);
+      }
+    }
+  }
+
+  @Nested
+  class GetLenToPosState {
+
+    static Stream<Arguments> cases() {
+      return Stream.of(
+          arguments(Base.MATCH_MIN_LEN, 0),
+          arguments(Base.MATCH_MIN_LEN + 1, 1),
+          arguments(Base.MATCH_MIN_LEN + Base.NUM_LEN_TO_POS_STATES - 1, 3),
+          arguments(
+              Base.MATCH_MIN_LEN + Base.NUM_LEN_TO_POS_STATES, Base.NUM_LEN_TO_POS_STATES - 1),
+          arguments(Base.MATCH_MIN_LEN + 20, Base.NUM_LEN_TO_POS_STATES - 1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void getLenToPosState_variousLengths_clampsAtMaxBucket(int length, int expected) {
+      int result = Base.getLenToPosState(length);
+      assertEquals(expected, result);
+    }
+
+    @Test
+    void getLenToPosState_whenLengthAtMinimum_returnsZero() {
+      int result = Base.getLenToPosState(Base.MATCH_MIN_LEN);
+      assertEquals(0, result);
+    }
+  }
+}

--- a/src/test/java/org/sevenzip/compression/lzma/DecoderTest.java
+++ b/src/test/java/org/sevenzip/compression/lzma/DecoderTest.java
@@ -1,0 +1,114 @@
+package org.sevenzip.compression.lzma;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class DecoderTest {
+
+  private static byte[] properties(int lc, int lp, int pb, int dictSize) {
+    int remainder = lp + pb * 5;
+    int val = lc + 9 * remainder;
+    byte[] props = new byte[5];
+    props[0] = (byte) val;
+    props[1] = (byte) (dictSize & 0xFF);
+    props[2] = (byte) ((dictSize >>> 8) & 0xFF);
+    props[3] = (byte) ((dictSize >>> 16) & 0xFF);
+    props[4] = (byte) ((dictSize >>> 24) & 0xFF);
+    return props;
+  }
+
+  @Test
+  void setDecoderProperties_whenTooShort_returnsFalse() {
+    Decoder decoder = new Decoder();
+
+    boolean result = decoder.setDecoderProperties(new byte[] {1, 2, 3, 4});
+
+    assertFalse(result);
+    assertEquals(-1, decoder.dictionarySize);
+    assertEquals(-1, decoder.dictionarySizeCheck);
+  }
+
+  @Test
+  void setDecoderProperties_whenPbExceedsLimit_returnsFalse() {
+    Decoder decoder = new Decoder();
+    // pb=5 exceeds Base.NUM_POS_STATES_BITS_MAX (4)
+    byte[] props = properties(0, 0, Base.NUM_POS_STATES_BITS_MAX + 1, 64);
+
+    boolean result = decoder.setDecoderProperties(props);
+
+    assertFalse(result);
+    assertEquals(-1, decoder.dictionarySize);
+    assertEquals(-1, decoder.dictionarySizeCheck);
+  }
+
+  @Test
+  void setDecoderProperties_withValidValues_initializesModels() {
+    Decoder decoder = new Decoder();
+    int dictSize = 8192;
+    byte[] props = properties(3, 1, 2, dictSize);
+
+    boolean result = decoder.setDecoderProperties(props);
+
+    assertTrue(result);
+    assertEquals(dictSize, decoder.dictionarySize);
+    assertEquals(dictSize, decoder.dictionarySizeCheck);
+    assertEquals(dictSize, (int) readObjectField(decoder.outWindow, "windowSize"));
+    assertEquals((1 << 2) - 1, decoder.posStateMask);
+    assertEquals(1 << 2, decoder.lenDecoder.numPosStates);
+    assertEquals(1 << (3 + 1), decoder.literalDecoder.coders.length);
+  }
+
+  @Test
+  void setDictionarySize_whenNegative_doesNotChangeExistingConfiguration() {
+    Decoder decoder = new Decoder();
+    decoder.setDictionarySize(4096);
+
+    boolean result = decoder.setDictionarySize(-5);
+
+    assertFalse(result);
+    assertEquals(4096, decoder.dictionarySize);
+    assertEquals(4096, (int) readObjectField(decoder.outWindow, "windowSize"));
+  }
+
+  @Test
+  void setLcLpPb_whenLcExceedsLimit_returnsFalse() {
+    Decoder decoder = new Decoder();
+
+    boolean result = decoder.setLcLpPb(Base.NUM_LIT_CONTEXT_BITS_MAX + 1, /* lp= */ 0, /* pb= */ 0);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void code_whenOutSizeZero_performsInitAndReturnsTrue() throws Exception {
+    Decoder decoder = new Decoder();
+    decoder.setDecoderProperties(properties(2, 0, 1, 4096));
+    ByteArrayInputStream in = new ByteArrayInputStream(new byte[10]);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    boolean result = decoder.code(in, out, 0);
+
+    assertTrue(result);
+    assertEquals(0, out.size());
+    assertNull(readObjectField(decoder.outWindow, "stream"));
+    assertNull(readObjectField(decoder.rangeDecoder, "stream"));
+  }
+
+  private static Object readObjectField(Object target, String fieldName) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.get(target);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to read field via reflection", e);
+    }
+  }
+}

--- a/src/test/java/org/sevenzip/compression/lzma/EncoderTest.java
+++ b/src/test/java/org/sevenzip/compression/lzma/EncoderTest.java
@@ -1,0 +1,187 @@
+package org.sevenzip.compression.lzma;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("java:S100")
+class EncoderTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 2})
+  void setAlgorithm_withinRange_returnsTrue(int algorithm) {
+    Encoder encoder = new Encoder();
+
+    assertTrue(encoder.setAlgorithm(algorithm));
+  }
+
+  @Test
+  void setAlgorithm_outOfRange_returnsFalse() {
+    Encoder encoder = new Encoder();
+
+    assertFalse(encoder.setAlgorithm(-1));
+    assertFalse(encoder.setAlgorithm(3));
+  }
+
+  @Test
+  void setDictionarySize_withinBounds_updatesDictionaryAndDistTable() {
+    Encoder encoder = new Encoder();
+    int newSize = 1 << 10;
+
+    boolean updated = encoder.setDictionarySize(newSize);
+
+    assertTrue(updated);
+    assertEquals(newSize, encoder.dictionarySize);
+    assertEquals(20, encoder.distTableSize);
+  }
+
+  @Test
+  void setDictionarySize_aboveMax_rejectedAndStateUnchanged() {
+    Encoder encoder = new Encoder();
+    int originalSize = encoder.dictionarySize;
+    int originalDistTable = encoder.distTableSize;
+
+    boolean updated = encoder.setDictionarySize(1 << 30);
+
+    assertFalse(updated);
+    assertEquals(originalSize, encoder.dictionarySize);
+    assertEquals(originalDistTable, encoder.distTableSize);
+  }
+
+  @Test
+  void setNumFastBytes_enforcesBounds() {
+    Encoder encoder = new Encoder();
+    int original = encoder.numFastBytes;
+
+    assertTrue(encoder.setNumFastBytes(16));
+    assertEquals(16, encoder.numFastBytes);
+
+    assertFalse(encoder.setNumFastBytes(4));
+    assertEquals(16, encoder.numFastBytes);
+
+    assertFalse(encoder.setNumFastBytes(Base.MATCH_MAX_LEN + 1));
+    assertEquals(16, encoder.numFastBytes);
+    // restore to original for isolation
+    assertTrue(encoder.setNumFastBytes(original));
+  }
+
+  @Test
+  void setMatchFinder_switchesTypeWhenValid() {
+    Encoder encoder = new Encoder();
+
+    boolean updated = encoder.setMatchFinder(Encoder.MATCH_FINDER_TYPE_BT2);
+
+    assertTrue(updated);
+    assertEquals(Encoder.MATCH_FINDER_TYPE_BT2, encoder.matchFinderType);
+    // matchFinder stays null until create() is called
+    assertNull(encoder.matchFinder);
+    assertEquals(-1, encoder.dictionarySizePrev);
+  }
+
+  @Test
+  void setMatchFinder_rejectsOutOfRangeValues() {
+    Encoder encoder = new Encoder();
+
+    boolean updated = encoder.setMatchFinder(5);
+
+    assertFalse(updated);
+    assertEquals(Encoder.MATCH_FINDER_TYPE_BT4, encoder.matchFinderType);
+  }
+
+  @Test
+  void setLcLpPb_updatesInternalMasks() {
+    Encoder encoder = new Encoder();
+
+    boolean updated = encoder.setLcLpPb(1, 2, 3);
+
+    assertTrue(updated);
+    assertEquals(1, encoder.numLiteralContextBits);
+    assertEquals(2, encoder.numLiteralPosStateBits);
+    assertEquals(3, encoder.posStateBits);
+    assertEquals((1 << 3) - 1, encoder.posStateMask);
+  }
+
+  @Test
+  void setLcLpPb_rejectsInvalidParameters() {
+    Encoder encoder = new Encoder();
+    int originalLc = encoder.numLiteralContextBits;
+    int originalLp = encoder.numLiteralPosStateBits;
+    int originalPb = encoder.posStateBits;
+    int originalMask = encoder.posStateMask;
+
+    boolean updated = encoder.setLcLpPb(Base.NUM_LIT_CONTEXT_BITS_MAX + 1, 0, 0);
+
+    assertFalse(updated);
+    assertEquals(originalLc, encoder.numLiteralContextBits);
+    assertEquals(originalLp, encoder.numLiteralPosStateBits);
+    assertEquals(originalPb, encoder.posStateBits);
+    assertEquals(originalMask, encoder.posStateMask);
+  }
+
+  @Test
+  void writeCoderProperties_emitsExpectedByteLayout() throws IOException {
+    Encoder encoder = new Encoder();
+    encoder.setLcLpPb(1, 2, 3);
+    encoder.setDictionarySize(0x00123456);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    encoder.writeCoderProperties(output);
+
+    byte[] props = output.toByteArray();
+    assertEquals(Encoder.PROP_SIZE, props.length);
+    assertArrayEquals(new byte[] {(byte) 0x9A, 0x56, 0x34, 0x12, 0x00}, props);
+  }
+
+  @Test
+  void setEndMarkerMode_togglesFlag() {
+    Encoder encoder = new Encoder();
+    assertFalse(encoder.writeEndMark);
+
+    encoder.setEndMarkerMode(true);
+
+    assertTrue(encoder.writeEndMark);
+  }
+
+  @Test
+  void literalEncoder_getSubCoder_returnsConsistentInstance() {
+    Encoder.LiteralEncoder literalEncoder = new Encoder.LiteralEncoder();
+    literalEncoder.create(1, 2);
+
+    Encoder.LiteralEncoder.Encoder2 coderA = literalEncoder.getSubCoder(3, (byte) 0x10);
+    Encoder.LiteralEncoder.Encoder2 coderB = literalEncoder.getSubCoder(3, (byte) 0x10);
+    Encoder.LiteralEncoder.Encoder2 coderC = literalEncoder.getSubCoder(2, (byte) 0x10);
+
+    assertSame(coderA, coderB);
+    assertNotSame(coderA, coderC);
+  }
+
+  @Test
+  void literalEncoder_getPrice_matchAndLiteralAgreeForSameBytes() {
+    Encoder.LiteralEncoder.Encoder2 coder = new Encoder.LiteralEncoder.Encoder2();
+    coder.init();
+    byte symbol = (byte) 0x5A;
+
+    int literalPrice = coder.getPrice(false, (byte) 0x00, symbol);
+    int matchedPrice = coder.getPrice(true, symbol, symbol);
+
+    assertEquals(literalPrice, matchedPrice);
+    assertTrue(matchedPrice > 0);
+  }
+
+  @Test
+  void lenPriceTableEncoder_updateTables_resetsCounters() {
+    Encoder.LenPriceTableEncoder lenPriceTableEncoder = new Encoder.LenPriceTableEncoder();
+    lenPriceTableEncoder.setTableSize(4);
+    lenPriceTableEncoder.init(4);
+
+    lenPriceTableEncoder.updateTables(4);
+
+    for (int posState = 0; posState < 4; posState++) {
+      assertEquals(4, lenPriceTableEncoder.counters[posState]);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document LZMA Base constants and encoder/decoder lifecycle for maintainability
- add focused Decoder/Encoder unit tests and Javadoc clarifications
- cover state transitions and length/position helpers to lock behavior down

## Testing
- not run (not requested)
