### PR TITLE
Add documentation and tests for range coder components

### DIFF
--- a/src/main/java/org/sevenzip/compression/rangecoder/BitTreeDecoder.java
+++ b/src/main/java/org/sevenzip/compression/rangecoder/BitTreeDecoder.java
@@ -3,31 +3,80 @@ package org.sevenzip.compression.rangecoder;
 import java.io.IOException;
 
 /**
- * Decodes integers using a binary tree of range coder bit models.
+ * Decodes integer symbols from a range coder using a complete binary tree of adaptive bit models.
  *
- * <p>Mechanical refactor of the original 7-Zip BitTreeDecoder to follow Java naming conventions
- * without changing behavior.
+ * <p>This helper mirrors the original 7-Zip {@code BitTreeDecoder} while adopting Java naming
+ * conventions. Callers construct an instance with the desired tree height (number of bits per
+ * symbol), invoke {@link #init()} once to reset probabilities, and then repeatedly call {@link
+ * #decode(Decoder)} or {@link #reverseDecode(Decoder)} to consume symbols from a {@link Decoder}.
+ * Each internal node of the tree stores a probability slot that is updated in place as bits are
+ * observed, so a single instance is intended to be reused across many symbols within a stream.
+ *
+ * <p>The class is mutable and not thread-safe; confine each instance to a single decoding session
+ * or provide external synchronization. Probability arrays are allocated eagerly and retain their
+ * state until {@link #init()} is called again, enabling progressive adaptation but requiring an
+ * explicit reset between unrelated payloads. Behavior is deterministic for a given bit sequence and
+ * model state; no I/O occurs in this class beyond delegating to the supplied {@link Decoder}.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> walk the bit-tree, request bits from the range decoder,
+ *       and return the assembled symbol.
+ *   <li><strong>Notable behaviors:</strong> supports both MSB-first and LSB-first decoding paths,
+ *       and offers a static reverse helper that operates on externally managed model arrays.
+ * </ul>
+ *
+ * @see Decoder
+ * @see BitTreeEncoder
  */
 public class BitTreeDecoder {
   private final short[] models;
   private final int numBitLevels;
 
   /**
-   * Create a bit-tree decoder with the given number of bit levels.
+   * Creates a bit-tree decoder with a fixed depth measured in bit levels.
    *
-   * @param numBitLevels number of bits to decode (tree height)
+   * <p>The constructor allocates one probability slot for every node in the complete binary tree,
+   * totaling {@code 2^numBitLevels} entries. Newly constructed instances must be initialized with
+   * {@link #init()} before decoding the first symbol; the constructor does not zero or seed the
+   * model array on its own.
+   *
+   * @param numBitLevels number of bits to decode (tree height); must be non-negative and typically
+   *     small (for example 3–16) to balance table size and precision.
    */
   public BitTreeDecoder(int numBitLevels) {
     this.numBitLevels = numBitLevels;
     this.models = new short[1 << numBitLevels];
   }
 
-  /** Initialize probability models. */
+  /**
+   * Initializes every probability slot to an unbiased starting value.
+   *
+   * <p>This method must be invoked at least once before the first decode call and should be
+   * repeated whenever a new independent stream is processed. The operation overwrites all internal
+   * probability entries with {@link Decoder#BIT_MODEL_TOTAL} divided by two, matching the SevenZip
+   * reference implementation. Calling this method is idempotent and does not interact with any
+   * external resources.
+   */
   public void init() {
     Decoder.initBitModels(models);
   }
 
-  /** Decode next symbol MSB-first. */
+  /**
+   * Decodes the next symbol in most-significant-bit-first order.
+   *
+   * <p>The method walks the internal probability tree from the root to a leaf, requesting one bit
+   * from the supplied {@link Decoder} per level. Each observed bit advances the tree index to the
+   * left or right child, and the final leaf index is converted into the returned symbol by
+   * subtracting {@code 2^numBitLevels}. Probability slots are updated in place by the {@link
+   * Decoder}, preserving adaptive state for subsequent calls.
+   *
+   * @param rangeDecoder initialized {@link Decoder} that supplies range-coded bits; must not be
+   *     {@code null} and must already have consumed any necessary preamble bytes.
+   * @return decoded symbol in the range {@code 0} to {@code (2^numBitLevels - 1)} inclusive,
+   *     assembled with the first decoded bit as the most significant.
+   * @throws IOException if the underlying {@link Decoder} needs more input bytes and the stream
+   *     read fails or ends prematurely.
+   */
   public int decode(Decoder rangeDecoder) throws IOException {
     int m = 1;
     for (int bitIndex = numBitLevels; bitIndex != 0; bitIndex--)
@@ -35,7 +84,22 @@ public class BitTreeDecoder {
     return m - (1 << numBitLevels);
   }
 
-  /** Decode next symbol LSB-first. */
+  /**
+   * Decodes the next symbol in least-significant-bit-first order.
+   *
+   * <p>This variant traverses the same internal probability tree as {@link #decode(Decoder)} but
+   * places the first bit read into the least significant position of the result. The traversal
+   * continues for {@code numBitLevels} steps, updating the adaptive probability models on each
+   * access and assembling the returned integer by OR-ing the observed bits at their respective
+   * positions.
+   *
+   * @param rangeDecoder initialized {@link Decoder} to provide adaptive bits; must not be {@code
+   *     null} and must already be positioned at the start of the symbol.
+   * @return decoded symbol with bits ordered LSB-first, always within {@code 0 <= value <
+   *     2^numBitLevels}.
+   * @throws IOException if the {@link Decoder} cannot read from its backing stream during
+   *     renormalization.
+   */
   public int reverseDecode(Decoder rangeDecoder) throws IOException {
     int m = 1;
     int symbol = 0;
@@ -48,7 +112,27 @@ public class BitTreeDecoder {
     return symbol;
   }
 
-  /** Static helper for reverse-order decoding using an external model array. */
+  /**
+   * Decodes a symbol LSB-first using an externally managed probability table.
+   *
+   * <p>This static helper mirrors {@link #reverseDecode(Decoder)} but accepts a caller-supplied
+   * model array and starting index, enabling shared tables or sliced views across multiple trees.
+   * The traversal updates the referenced {@code models} array in place. Callers are responsible for
+   * initializing the relevant slice with {@link Decoder#initBitModels(short[])} prior to decoding.
+   *
+   * @param models mutable probability array that holds adaptive state; must be large enough to
+   *     contain entries starting at {@code startIndex + (1 << numBitLevels)}.
+   * @param startIndex base offset into {@code models} from which this tree's root node is read;
+   *     typically zero when using a dedicated array.
+   * @param rangeDecoder initialized {@link Decoder} that provides range-coded bits for this symbol;
+   *     must not be {@code null}.
+   * @param numBitLevels number of bit levels to traverse; controls both the depth of the tree and
+   *     the width of the decoded symbol.
+   * @return decoded symbol where the first bit read becomes bit zero of the result and subsequent
+   *     bits occupy increasingly significant positions.
+   * @throws IOException if the {@link Decoder} encounters an error while reading additional bytes
+   *     during renormalization.
+   */
   public static int reverseDecode(
       short[] models, int startIndex, Decoder rangeDecoder, int numBitLevels) throws IOException {
     int m = 1;

--- a/src/main/java/org/sevenzip/compression/rangecoder/BitTreeEncoder.java
+++ b/src/main/java/org/sevenzip/compression/rangecoder/BitTreeEncoder.java
@@ -3,31 +3,82 @@ package org.sevenzip.compression.rangecoder;
 import java.io.IOException;
 
 /**
- * Encodes integers using a binary tree of range coder bit models.
+ * Encodes small unsigned integers with a binary tree of adaptive range-coder bit models.
  *
- * <p>This is a direct port of the original 7-Zip BitTreeEncoder with purely mechanical refactors to
- * follow Java naming conventions and basic static analysis rules. No behavior is changed.
+ * <p>This type mirrors the original 7-Zip {@code BitTreeEncoder} while presenting clearer Java
+ * documentation. Callers construct the encoder with a fixed bit-width, invoke {@link #init()} to
+ * seed per-node probabilities, and then reuse a single instance to emit many symbols into a shared
+ * {@link Encoder}. Each internal node tracks its own probability slot that is updated as bits are
+ * observed, making the encoder stateful and intentionally mutable across calls.
+ *
+ * <p>Typical usage pattern:
+ *
+ * <ul>
+ *   <li>Create once with the desired bit depth (for example 3–16 bits depending on table size
+ *       tolerance).
+ *   <li>Call {@link #init()} before the first symbol or when starting a new independent stream.
+ *   <li>Use {@link #encode(Encoder, int)} for most-significant-bit order or {@link
+ *       #reverseEncode(Encoder, int)} for least-significant-bit order, depending on downstream
+ *       format.
+ *   <li>Optionally compute additive costs with {@link #getPrice(int)} or {@link
+ *       #reverseGetPrice(int)} to drive encoder decisions without mutating state.
+ * </ul>
+ *
+ * <p>The class is not thread-safe; confine each instance to a single encoding session or guard
+ * access externally. Probability arrays are allocated eagerly to {@code 2^numBitLevels} entries and
+ * retained for the life of the object. No I/O occurs here beyond delegating to the supplied {@link
+ * Encoder}; errors arise only from that delegate.
+ *
+ * @see BitTreeDecoder
+ * @see Encoder
  */
 public class BitTreeEncoder {
   private final short[] models;
   private final int numBitLevels;
 
   /**
-   * Create a bit-tree encoder with the given number of bit levels.
+   * Creates a bit-tree encoder with a fixed tree height.
    *
-   * @param numBitLevels number of bits to encode (tree height)
+   * <p>The constructor allocates the underlying probability table sized to {@code 2^numBitLevels}.
+   * Callers must invoke {@link #init()} before encoding so each slot starts at an unbiased
+   * probability. Instances are lightweight aside from the model array and are intended to be reused
+   * across many symbols to benefit from adaptive probabilities.
+   *
+   * @param numBitLevels number of bits to encode for each symbol; must be non-negative and is
+   *     typically small (for example 3–16) to balance precision against table size.
    */
   public BitTreeEncoder(int numBitLevels) {
     this.numBitLevels = numBitLevels;
     this.models = new short[1 << numBitLevels];
   }
 
-  /** Initialize probability models. */
+  /**
+   * Initializes every probability slot in the internal tree.
+   *
+   * <p>This method must be called at least once before the first encode operation and should be
+   * repeated whenever starting a new unrelated stream. It resets all nodes to an even split between
+   * zero and one, matching {@link Decoder#initBitModels(short[])} semantics. The call is idempotent
+   * and does not touch any external resources.
+   */
   public void init() {
     Decoder.initBitModels(models);
   }
 
-  /** Encode {@code symbol} most-significant-bit first. */
+  /**
+   * Encodes the supplied symbol in most-significant-bit-first order.
+   *
+   * <p>The method walks the adaptive tree from the root toward leaves, extracting one bit per level
+   * from {@code symbol} starting with the highest-order bit. Each bit is forwarded to the supplied
+   * {@link Encoder}, which both writes range-coded data and updates the corresponding probability
+   * node. The encoder instance is mutated as probabilities adapt to observed bits.
+   *
+   * @param rangeEncoder initialized {@link Encoder} that will receive encoded bits; must not be
+   *     {@code null}.
+   * @param symbol unsigned integer whose upper {@code numBitLevels} bits are emitted; bits beyond
+   *     that width are ignored.
+   * @throws IOException if the underlying {@link Encoder} fails to flush buffered bytes to its
+   *     attached stream.
+   */
   public void encode(Encoder rangeEncoder, int symbol) throws IOException {
     int m = 1;
     // Descend from MSB to LSB without mutating the loop counter in the body
@@ -38,7 +89,21 @@ public class BitTreeEncoder {
     }
   }
 
-  /** Encode {@code symbol} least-significant-bit first. */
+  /**
+   * Encodes the supplied symbol in least-significant-bit-first order.
+   *
+   * <p>This variant consumes bits starting from bit zero of {@code symbol}, which is useful for
+   * certain offset encodings that expect reversed bit ordering. Traversal still follows the
+   * left/right child structure of the adaptive tree, updating each visited node in place to reflect
+   * observed outcomes.
+   *
+   * @param rangeEncoder initialized {@link Encoder} that will receive encoded bits; must not be
+   *     {@code null}.
+   * @param symbol unsigned integer whose lower {@code numBitLevels} bits are emitted; higher bits
+   *     are shifted away as encoding progresses.
+   * @throws IOException if the delegate {@link Encoder} encounters an error while writing its
+   *     buffered state.
+   */
   public void reverseEncode(Encoder rangeEncoder, int symbol) throws IOException {
     int m = 1;
     for (int i = 0; i < numBitLevels; i++) {
@@ -49,7 +114,19 @@ public class BitTreeEncoder {
     }
   }
 
-  /** Return the price (cost) of encoding {@code symbol} MSB-first. */
+  /**
+   * Computes the additive price of encoding {@code symbol} in MSB-first order.
+   *
+   * <p>The returned cost is expressed in the same scaled units as {@link Encoder#getPrice(int,
+   * int)} and is suitable for heuristic comparisons during search without mutating model state. The
+   * method walks the same tree path {@link #encode(Encoder, int)} would traverse but only sums
+   * prices from the current probability table.
+   *
+   * @param symbol unsigned integer whose upper {@code numBitLevels} bits are considered; excess
+   *     bits are ignored.
+   * @return total scaled price for encoding the symbol with the present model probabilities in
+   *     MSB-first order.
+   */
   public int getPrice(int symbol) {
     int price = 0;
     int m = 1;
@@ -62,7 +139,18 @@ public class BitTreeEncoder {
     return price;
   }
 
-  /** Return the price (cost) of encoding {@code symbol} LSB-first. */
+  /**
+   * Computes the additive price of encoding {@code symbol} in LSB-first order.
+   *
+   * <p>This mirrors {@link #reverseEncode(Encoder, int)} but only accumulates prices, leaving
+   * probabilities unchanged. It is useful when selecting among candidate encodings while preserving
+   * the current model state.
+   *
+   * @param symbol unsigned integer whose lower {@code numBitLevels} bits are evaluated; higher bits
+   *     are discarded.
+   * @return total scaled price for encoding the symbol with the present model probabilities in
+   *     LSB-first order.
+   */
   public int reverseGetPrice(int symbol) {
     int price = 0;
     int m = 1;
@@ -75,7 +163,22 @@ public class BitTreeEncoder {
     return price;
   }
 
-  /** Static helper for computing reverse price using an external model array. */
+  /**
+   * Computes the LSB-first price using a caller-supplied model array.
+   *
+   * <p>This helper enables sharing a probability table across multiple trees by supplying an
+   * offset. It does not mutate the models, making it safe for speculative pricing. Prices match the
+   * scaling of {@link Encoder#getPrice(int, int)} and can be summed with other model costs.
+   *
+   * @param models probability table containing the tree slice starting at {@code startIndex}; must
+   *     be large enough for {@code startIndex + (1 << numBitLevels)} entries.
+   * @param startIndex base offset within {@code models} that represents the root of this tree.
+   * @param numBitLevels number of bit levels to traverse; controls both tree height and symbol
+   *     width.
+   * @param symbol unsigned integer whose lower {@code numBitLevels} bits are priced in LSB-first
+   *     order.
+   * @return total scaled price of encoding the symbol without altering the provided model array.
+   */
   public static int reverseGetPrice(short[] models, int startIndex, int numBitLevels, int symbol) {
     int price = 0;
     int m = 1;
@@ -88,7 +191,25 @@ public class BitTreeEncoder {
     return price;
   }
 
-  /** Static helper for reverse-order encoding using an external model array. */
+  /**
+   * Encodes a symbol in LSB-first order using an external model array slice.
+   *
+   * <p>This variant is convenient when multiple trees share one probability table with distinct
+   * offsets. It mutates the referenced {@code models} entries in place via the supplied {@link
+   * Encoder}, which writes the resulting range-coded bits to its configured output stream.
+   *
+   * @param models probability table that holds adaptive state; entries at and below {@code
+   *     startIndex} are updated.
+   * @param startIndex base offset within {@code models} that represents the root of this tree.
+   * @param rangeEncoder initialized {@link Encoder} that receives encoded bits and updates
+   *     probabilities; must not be {@code null}.
+   * @param numBitLevels number of bit levels to encode; determines traversal depth and consumed
+   *     bits from {@code symbol}.
+   * @param symbol unsigned integer whose lower {@code numBitLevels} bits are emitted; higher bits
+   *     are shifted away as encoding progresses.
+   * @throws IOException if the delegate {@link Encoder} cannot flush buffered bytes to its attached
+   *     stream while emitting the symbol.
+   */
   public static void reverseEncode(
       short[] models, int startIndex, Encoder rangeEncoder, int numBitLevels, int symbol)
       throws IOException {

--- a/src/main/java/org/sevenzip/compression/rangecoder/Decoder.java
+++ b/src/main/java/org/sevenzip/compression/rangecoder/Decoder.java
@@ -7,8 +7,30 @@ import java.util.Arrays;
 /**
  * Range coder decoder used by the LZMA implementation.
  *
- * <p>Method and constant names follow Java naming conventions to satisfy static analysis rules. The
- * behavior is unchanged from the original SevenZip reference implementation.
+ * <p>This class mirrors the reference SevenZip range-decoder while adopting Java naming
+ * conventions. It consumes bytes from an {@link InputStream} and reconstructs either direct-width
+ * integers or probability-adapted bits that cooperate with {@link Encoder}. Callers typically
+ * create a single instance per decode session, attach an input stream via {@link #setStream}, call
+ * {@link #init()} to load the initial state, then repeatedly invoke {@link #decodeBit(short[],
+ * int)} or {@link #decodeDirectBits(int)} until the enclosing algorithm completes. Probability
+ * tables are mutated in place, so they must be initialized with {@link #initBitModels(short[])}
+ * before first use and reused carefully between messages.
+ *
+ * <p>Instances are mutable and not thread-safe; confine each decoder to one thread at a time. The
+ * decoder maintains a 32-bit {@code code} accumulator and {@code range} interval that are narrowed
+ * as symbols are read. When the high bits underflow, the implementation pulls more bytes from the
+ * stream to restore precision. Behavior is deterministic for a given input stream and probability
+ * model state.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> manage range intervals, update probability models,
+ *       deliver decoded bits and fixed-width integers.
+ *   <li><strong>Notable behavior:</strong> automatically renormalizes when {@code range} loses
+ *       high-order entropy; leaves stream lifecycle (open/close) to the caller.
+ * </ul>
+ *
+ * @see Encoder
+ * @see org.sevenzip.compression.lzma.Decoder
  */
 public class Decoder {
   // Constants follow UPPER_SNAKE_CASE per Java conventions.
@@ -23,20 +45,74 @@ public class Decoder {
 
   InputStream stream;
 
+  /**
+   * Creates a decoder with no attached input stream and zeroed internal state.
+   *
+   * <p>Call {@link #setStream(InputStream)} followed by {@link #init()} before attempting to decode
+   * any symbols. The constructor performs no allocation beyond the instance itself and is safe to
+   * invoke repeatedly when pooling decoders.
+   */
+  public Decoder() {
+    // default constructor retains historical behavior
+  }
+
+  /**
+   * Assigns the input source that provides encoded range-coder bytes.
+   *
+   * <p>The stream reference is stored without modification; callers remain responsible for opening
+   * and closing it. Invoke {@link #init()} after setting the stream to load the initial range-coder
+   * state. Passing {@code null} is permitted but will cause {@link #init()} to throw an {@link
+   * IOException} when it attempts to read.
+   *
+   * @param stream readable {@link InputStream} containing the encoded payload; may be reused across
+   *     sessions if positioned appropriately.
+   */
   public final void setStream(InputStream stream) {
     this.stream = stream;
   }
 
+  /**
+   * Releases the current stream reference without closing it.
+   *
+   * <p>This is a lightweight lifecycle hook used when reusing a decoder instance for multiple
+   * payloads. It does not reset internal coder state; call {@link #init()} before decoding another
+   * payload after assigning a new stream.
+   */
   public final void releaseStream() {
     this.stream = null;
   }
 
+  /**
+   * Loads the initial coder state from the assigned stream.
+   *
+   * <p>This method resets the {@code code} accumulator to the first five bytes of the stream and
+   * sets {@code range} to {@code 0xFFFFFFFF}. It must be called exactly once after attaching a
+   * stream and before the first decode call. The method performs five blocking reads; partial or
+   * exhausted streams propagate as {@link IOException}.
+   *
+   * @throws IOException if the underlying stream cannot provide five bytes or signals an error.
+   */
   public final void init() throws IOException {
     code = 0;
     range = -1;
     for (int i = 0; i < 5; i++) code = (code << 8) | stream.read();
   }
 
+  /**
+   * Decodes a fixed-width unsigned integer directly from the range coder.
+   *
+   * <p>The method reads {@code numTotalBits} bits MSB-first without consulting probability models,
+   * mirroring the direct-bit path in the SevenZip specification. Each bit narrows {@code range};
+   * when the upper bits underflow, an additional byte is pulled from the stream. The internal
+   * {@code code} and {@code range} fields advance accordingly, so callers should not mix direct
+   * decoding with model-based decoding unless the encoded stream was written in the same order.
+   *
+   * @param numTotalBits number of bits to consume; must be non-negative and not exceed 32 in
+   *     typical usage.
+   * @return reconstructed unsigned value packed into an {@code int}; higher bits are zeroed when
+   *     {@code numTotalBits} is less than 32.
+   * @throws IOException if an additional byte is required and the stream cannot be read.
+   */
   public final int decodeDirectBits(int numTotalBits) throws IOException {
     int result = 0;
     for (int i = numTotalBits; i != 0; i--) {
@@ -53,6 +129,22 @@ public class Decoder {
     return result;
   }
 
+  /**
+   * Decodes a single binary symbol using an adaptive probability model.
+   *
+   * <p>The method splits the current {@code range} according to {@code probs[index]}, returns
+   * either zero or one, and updates the model entry toward the observed symbol using the classic
+   * SevenZip adaptation rule. Renormalization pulls more bytes from the stream whenever {@code
+   * range} loses high-order bits. The supplied probability array is mutated in place and may be
+   * shared across multiple calls as long as the same encoding order is followed.
+   *
+   * @param probs mutable probability table holding scaled masses; all entries should be initialized
+   *     with {@link #initBitModels(short[])} before first use.
+   * @param index position within {@code probs} to use for this symbol; must be a valid array slot.
+   * @return decoded symbol value, either {@code 0} for the low subrange or {@code 1} for the high
+   *     subrange after the split.
+   * @throws IOException if an additional byte is required from the stream and cannot be read.
+   */
   public int decodeBit(short[] probs, int index) throws IOException {
     int prob = probs[index];
     int newBound = (range >>> NUM_BIT_MODEL_TOTAL_BITS) * prob;
@@ -76,6 +168,17 @@ public class Decoder {
     }
   }
 
+  /**
+   * Initializes every probability slot to an unbiased starting value.
+   *
+   * <p>This helper fills the provided array with {@code BIT_MODEL_TOTAL / 2}, matching the SevenZip
+   * reference. It should be called exactly once for new tables and may be reused between messages
+   * when models are intentionally reset. The method performs no bounds checking beyond the array
+   * length supplied by the JVM.
+   *
+   * @param probs array of probability masses to reset; must be non-null and writable for the full
+   *     length.
+   */
   public static void initBitModels(short[] probs) {
     Arrays.fill(probs, (short) (BIT_MODEL_TOTAL >>> 1));
   }

--- a/src/main/java/org/sevenzip/compression/rangecoder/Encoder.java
+++ b/src/main/java/org/sevenzip/compression/rangecoder/Encoder.java
@@ -4,6 +4,27 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 
+/**
+ * Stateful range coder that emits encoded bits to an {@link OutputStream}. The encoder maintains
+ * internal {@code low} and {@code range} accumulators that are progressively narrowed as symbols
+ * are written, flushing bytes to the output when the high-order portion stabilizes. Callers are
+ * expected to create a single instance per logical coding session, initialize it, then feed bits
+ * via model-based {@link #encode(short[], int, int)} or direct-bit {@link #encodeDirectBits(int,
+ * int)} paths before flushing pending bytes. The instance is not thread-safe and must be confined
+ * to one thread while active. Each method mutates internal counters; reuse requires calling {@link
+ * #init()} to reset. Typical lifecycle:
+ *
+ * <ul>
+ *   <li>Set an {@link OutputStream} with {@link #setStream(OutputStream)}.
+ *   <li>Call {@link #init()} to reset range-coder state.
+ *   <li>Encode symbols, optionally updating probability models.
+ *   <li>Finish with {@link #flushData()} then {@link #flushStream()} to push buffered bytes.
+ * </ul>
+ *
+ * The encoder writes no framing or length metadata; callers remain responsible for delimiting or
+ * sizing encoded payloads and for coordinating model initialization through {@link
+ * #initBitModels(short[])} when adaptive probabilities are used.
+ */
 public class Encoder {
   static final int TOP_MASK = -(1 << 24);
 
@@ -20,14 +41,44 @@ public class Encoder {
 
   long position;
 
+  /** Creates a new encoder with no attached output stream and uninitialized coder state. */
+  public Encoder() {
+    // default constructor preserves historical behavior
+  }
+
+  /**
+   * Assigns the target {@link OutputStream} that will receive encoded bytes.
+   *
+   * <p>The stream is stored only as a reference and is not reset. Callers must supply an already
+   * open stream and remain responsible for closing it after {@link #flushStream()} is invoked. This
+   * method does not reset range-coder state; invoke {@link #init()} before starting a new message.
+   *
+   * @param stream writable, non-null {@link OutputStream} that remains valid for the lifetime of
+   *     the encoding session.
+   */
   public void setStream(OutputStream stream) {
     this.stream = stream;
   }
 
+  /**
+   * Releases the currently assigned stream reference.
+   *
+   * <p>This method does not flush or close the underlying stream and does not alter any range-coder
+   * accumulators. It is typically called after a session completes to allow the encoder instance to
+   * be reused with another stream.
+   */
   public void releaseStream() {
     stream = null;
   }
 
+  /**
+   * Resets the internal range-coder accumulators to their initial values.
+   *
+   * <p>After calling this method the encoder starts from a clean state: {@code low} is zero, {@code
+   * range} is {@code 0xFFFFFFFF}, the cache holds no pending bytes, and the processed byte position
+   * is zero. Call this before encoding the first symbol of a new payload. The assigned output
+   * stream is not changed.
+   */
   public void init() {
     position = 0;
     low = 0;
@@ -36,14 +87,41 @@ public class Encoder {
     cache = 0;
   }
 
+  /**
+   * Forces the current coder state to emit five trailing bytes.
+   *
+   * <p>This aligns with the standard range-coder finalization step used by LZMA: repeatedly call
+   * {@link #shiftLow()} five times so that remaining carry bits are flushed to the output. Call
+   * this before {@link #flushStream()} when finishing an encoded payload.
+   *
+   * @throws IOException if writing buffered bytes to the assigned stream fails.
+   */
   public void flushData() throws IOException {
     for (int i = 0; i < 5; i++) shiftLow();
   }
 
+  /**
+   * Flushes any buffered bytes on the assigned output stream.
+   *
+   * <p>Invoke this after {@link #flushData()} to ensure all encoded bytes are written downstream.
+   * The method does not close the stream.
+   *
+   * @throws IOException if the delegate stream rejects the flush operation.
+   */
   public void flushStream() throws IOException {
     stream.flush();
   }
 
+  /**
+   * Moves the high-order byte of {@code low} to the output when stabilization conditions are met.
+   *
+   * <p>This operation implements the range-coder carry-handling logic: when the upper bits of
+   * {@code low} change or drift below {@code 0xFF000000}, the cached bytes are emitted and the
+   * cached prefix updated. It adjusts {@code position}, {@code cacheSize}, and {@code cache}
+   * accordingly while keeping {@code low} within the lower 24 bits.
+   *
+   * @throws IOException if writing to the assigned stream fails.
+   */
   public void shiftLow() throws IOException {
     int lowHi = (int) (low >>> 32);
     if (lowHi != 0 || low < 0xFF000000L) {
@@ -59,6 +137,18 @@ public class Encoder {
     low = (low & 0xFFFFFF) << 8;
   }
 
+  /**
+   * Encodes a fixed-width unsigned integer by writing each bit directly.
+   *
+   * <p>Bits are taken from {@code v}, starting with the most significant of the {@code
+   * numTotalBits} requested, and processed through the range coder without probability adaptation.
+   * The caller is responsible for ensuring {@code numTotalBits} does not exceed the meaningful
+   * width of {@code v}.
+   *
+   * @param v value whose high bits are emitted; treated as unsigned.
+   * @param numTotalBits number of most significant bits to encode; must be non-negative.
+   * @throws IOException if flushing buffered bytes to the underlying stream fails.
+   */
   public void encodeDirectBits(int v, int numTotalBits) throws IOException {
     for (int i = numTotalBits - 1; i >= 0; i--) {
       range >>>= 1;
@@ -70,17 +160,58 @@ public class Encoder {
     }
   }
 
+  /**
+   * Calculates the number of bytes that would be added to the output if pending state were flushed.
+   *
+   * <p>The value includes cached bytes awaiting emission plus four extra bytes that complete the
+   * range-coder footer, matching the behavior of the original LZMA implementation.
+   *
+   * @return total additional byte count to be written when finalizing the stream state.
+   */
   public long getProcessedSizeAdd() {
     return cacheSize + position + 4;
   }
 
   static final int NUM_MOVE_REDUCING_BITS = 2;
+
+  /**
+   * Shift width used when converting bit-model probabilities to price units.
+   *
+   * <p>The constant defines how many fractional bits are retained when precomputing price tables,
+   * effectively scaling logarithmic probabilities into integer costs. Clients computing custom
+   * price estimates should apply the same shift so values stay consistent with {@link
+   * #getPrice(int, int)} and related helpers.
+   */
   public static final int NUM_BIT_PRICE_SHIFT_BITS = 6;
 
+  /**
+   * Initializes every probability entry to an even split of {@link #BIT_MODEL_TOTAL}.
+   *
+   * <p>Callers should run this once before encoding with adaptive models so that each probability
+   * starts unbiased at {@code BIT_MODEL_TOTAL / 2}. The method overwrites every element of the
+   * supplied array.
+   *
+   * @param probs array of probability values to initialize; must be non-null and writable.
+   */
   public static void initBitModels(short[] probs) {
     Arrays.fill(probs, (short) (BIT_MODEL_TOTAL >>> 1));
   }
 
+  /**
+   * Encodes a single binary symbol using the provided probability model.
+   *
+   * <p>The method splits {@code range} according to the current probability at {@code probs[index]}
+   * and updates {@code low}, {@code range}, and the model entry based on whether {@code symbol} is
+   * zero or one. When the resulting range falls below {@link #TOP_MASK}, {@link #shiftLow()} is
+   * invoked to flush stabilized bytes. This call mutates {@code probs[index]} in-place, gradually
+   * adapting it toward observed symbols.
+   *
+   * @param probs mutable probability table where each entry is in {@code [0, BIT_MODEL_TOTAL]} and
+   *     will be updated.
+   * @param index position within {@code probs} to use for this symbol; must be a valid array index.
+   * @param symbol binary value to encode; expected to be {@code 0} or {@code 1}.
+   * @throws IOException if writing buffered bytes to the underlying stream fails.
+   */
   public void encode(short[] probs, int index, int symbol) throws IOException {
     int prob = probs[index];
     int newBound = (range >>> NUM_BIT_MODEL_TOTAL_BITS) * prob;
@@ -112,15 +243,42 @@ public class Encoder {
     }
   }
 
+  /**
+   * Computes the encoded price for a binary symbol given its probability.
+   *
+   * <p>The result is looked up in a precomputed table to avoid runtime logarithms. Prices are
+   * expressed in scaled integer units using {@link #NUM_BIT_PRICE_SHIFT_BITS} fractional bits.
+   *
+   * @param prob probability mass for zero, scaled by {@link #BIT_MODEL_TOTAL}; intermediate values
+   *     are masked to the valid range.
+   * @param symbol symbol to price; expected to be {@code 0} or {@code 1}.
+   * @return scaled integer price suitable for additive cost estimation.
+   */
   public static int getPrice(int prob, int symbol) {
     return probPrices[
         (((prob - symbol) ^ (-symbol)) & (BIT_MODEL_TOTAL - 1)) >>> NUM_MOVE_REDUCING_BITS];
   }
 
+  /**
+   * Returns the precomputed price of encoding a zero bit with the given probability.
+   *
+   * @param prob current probability mass for zero, scaled by {@link #BIT_MODEL_TOTAL}; values
+   *     outside the range are clipped by lookup.
+   * @return integer price scaled by {@link #NUM_BIT_PRICE_SHIFT_BITS}, suitable for additive cost
+   *     comparisons.
+   */
   public static int getPrice0(int prob) {
     return probPrices[prob >>> NUM_MOVE_REDUCING_BITS];
   }
 
+  /**
+   * Returns the precomputed price of encoding a one bit with the given probability.
+   *
+   * @param prob probability mass for zero, scaled by {@link #BIT_MODEL_TOTAL}; the complement is
+   *     used for symbol one.
+   * @return integer price scaled by {@link #NUM_BIT_PRICE_SHIFT_BITS}, matching {@link
+   *     #getPrice(int, int)} semantics.
+   */
   public static int getPrice1(int prob) {
     return probPrices[(BIT_MODEL_TOTAL - prob) >>> NUM_MOVE_REDUCING_BITS];
   }

--- a/src/test/java/org/sevenzip/compression/rangecoder/BitTreeDecoderTest.java
+++ b/src/test/java/org/sevenzip/compression/rangecoder/BitTreeDecoderTest.java
@@ -1,0 +1,99 @@
+package org.sevenzip.compression.rangecoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BitTreeDecoderTest {
+
+  @Mock private Decoder rangeDecoder;
+
+  private BitTreeDecoder decoder;
+
+  @BeforeEach
+  void setUp() {
+    decoder = new BitTreeDecoder(3);
+    decoder.init();
+  }
+
+  @Test
+  void init_setsModelsToInitialProbabilities() throws Exception {
+    short[] models = extractModels(decoder);
+
+    for (short model : models) {
+      assertEquals((short) (Decoder.BIT_MODEL_TOTAL >>> 1), model);
+    }
+  }
+
+  @Test
+  void decode_whenBitsProduceValue_returnsExpectedSymbol() throws Exception {
+    when(rangeDecoder.decodeBit(any(short[].class), anyInt())).thenReturn(1, 0, 1);
+
+    int result = decoder.decode(rangeDecoder);
+
+    assertEquals(5, result);
+    ArgumentCaptor<Integer> indexCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(rangeDecoder, org.mockito.Mockito.times(3))
+        .decodeBit(any(short[].class), indexCaptor.capture());
+    assertEquals(1, indexCaptor.getAllValues().get(0));
+    assertEquals(3, indexCaptor.getAllValues().get(1));
+    assertEquals(6, indexCaptor.getAllValues().get(2));
+  }
+
+  @Test
+  void reverseDecode_whenBitsProduceValue_returnsExpectedSymbol() throws Exception {
+    when(rangeDecoder.decodeBit(any(short[].class), anyInt())).thenReturn(1, 0, 1);
+
+    int result = decoder.reverseDecode(rangeDecoder);
+
+    assertEquals(5, result);
+    ArgumentCaptor<Integer> indexCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(rangeDecoder, org.mockito.Mockito.times(3))
+        .decodeBit(any(short[].class), indexCaptor.capture());
+    assertEquals(1, indexCaptor.getAllValues().get(0));
+    assertEquals(3, indexCaptor.getAllValues().get(1));
+    assertEquals(6, indexCaptor.getAllValues().get(2));
+  }
+
+  @Test
+  void staticReverseDecode_withStartIndex_offsetsModelLookup() throws Exception {
+    when(rangeDecoder.decodeBit(any(short[].class), anyInt())).thenReturn(1, 1);
+    short[] models = new short[10];
+
+    int result = BitTreeDecoder.reverseDecode(models, 5, rangeDecoder, 2);
+
+    assertEquals(3, result);
+    ArgumentCaptor<Integer> indexCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(rangeDecoder, org.mockito.Mockito.times(2))
+        .decodeBit(any(short[].class), indexCaptor.capture());
+    assertEquals(6, indexCaptor.getAllValues().get(0));
+    assertEquals(8, indexCaptor.getAllValues().get(1));
+  }
+
+  @Test
+  void decode_whenDecoderThrows_propagatesIOException() throws Exception {
+    when(rangeDecoder.decodeBit(any(short[].class), anyInt())).thenThrow(new IOException("boom"));
+
+    assertThrows(IOException.class, () -> decoder.decode(rangeDecoder));
+  }
+
+  private short[] extractModels(BitTreeDecoder target) throws Exception {
+    Field modelsField = BitTreeDecoder.class.getDeclaredField("models");
+    modelsField.setAccessible(true);
+    return (short[]) modelsField.get(target);
+  }
+}

--- a/src/test/java/org/sevenzip/compression/rangecoder/BitTreeEncoderTest.java
+++ b/src/test/java/org/sevenzip/compression/rangecoder/BitTreeEncoderTest.java
@@ -1,0 +1,157 @@
+package org.sevenzip.compression.rangecoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class BitTreeEncoderTest {
+
+  private static final int HALF_PROB = Encoder.BIT_MODEL_TOTAL >>> 1;
+
+  @Test
+  void encode_whenSymbolTraversesZeroBits_expectMsbOrderIndices() throws IOException {
+    BitTreeEncoder encoder = new BitTreeEncoder(3);
+    encoder.init();
+    Encoder rangeEncoder = mock(Encoder.class);
+
+    encoder.encode(rangeEncoder, 0);
+
+    ArgumentCaptor<short[]> modelsCaptor = ArgumentCaptor.forClass(short[].class);
+    ArgumentCaptor<Integer> indexCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> bitCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(rangeEncoder, times(3))
+        .encode(modelsCaptor.capture(), indexCaptor.capture(), bitCaptor.capture());
+    verifyNoMoreInteractions(rangeEncoder);
+
+    List<short[]> modelsAcrossCalls = modelsCaptor.getAllValues();
+    assertEquals(3, modelsAcrossCalls.size());
+    assertSame(modelsAcrossCalls.get(0), modelsAcrossCalls.get(1));
+    assertSame(modelsAcrossCalls.get(1), modelsAcrossCalls.get(2));
+    assertEquals(List.of(1, 2, 4), indexCaptor.getAllValues());
+    assertEquals(List.of(0, 0, 0), bitCaptor.getAllValues());
+  }
+
+  @Test
+  void encode_whenSymbolAllOnes_expectMsbOrderIndices() throws IOException {
+    BitTreeEncoder encoder = new BitTreeEncoder(3);
+    encoder.init();
+    Encoder rangeEncoder = mock(Encoder.class);
+
+    encoder.encode(rangeEncoder, 7);
+
+    InOrder order = inOrder(rangeEncoder);
+    order.verify(rangeEncoder).encode(any(short[].class), eq(1), eq(1));
+    order.verify(rangeEncoder).encode(any(short[].class), eq(3), eq(1));
+    order.verify(rangeEncoder).encode(any(short[].class), eq(7), eq(1));
+    verifyNoMoreInteractions(rangeEncoder);
+  }
+
+  @Test
+  void reverseEncode_whenSymbolUsesLsbOrder_expectIndicesFollowLsbTraversal() throws IOException {
+    BitTreeEncoder encoder = new BitTreeEncoder(3);
+    encoder.init();
+    Encoder rangeEncoder = mock(Encoder.class);
+
+    encoder.reverseEncode(rangeEncoder, 0b110);
+
+    InOrder order = inOrder(rangeEncoder);
+    order.verify(rangeEncoder).encode(any(short[].class), eq(1), eq(0));
+    order.verify(rangeEncoder).encode(any(short[].class), eq(2), eq(1));
+    order.verify(rangeEncoder).encode(any(short[].class), eq(5), eq(1));
+    verifyNoMoreInteractions(rangeEncoder);
+  }
+
+  @Test
+  void getPrice_whenModelsInitialized_expectConstantPricePerBit() {
+    BitTreeEncoder encoder = new BitTreeEncoder(3);
+    encoder.init();
+
+    int expectedPricePerBit = Encoder.getPrice(HALF_PROB, 0);
+    int price = encoder.getPrice(0b101);
+
+    assertEquals(expectedPricePerBit * 3, price);
+  }
+
+  @Test
+  void getPrice_whenModelsDiffer_expectMsbPathSumsCorrespondingNodes() throws Exception {
+    BitTreeEncoder encoder = new BitTreeEncoder(3);
+    short[] models = getModels(encoder);
+    models[1] = 300;
+    models[3] = 700;
+    models[6] = 1200;
+
+    int price = encoder.getPrice(0b101);
+
+    int expected =
+        Encoder.getPrice(models[1], 1)
+            + Encoder.getPrice(models[3], 0)
+            + Encoder.getPrice(models[6], 1);
+    assertEquals(expected, price);
+  }
+
+  @Test
+  void reverseGetPrice_whenModelsDiffer_expectLsbPathSumsCorrespondingNodes() throws Exception {
+    BitTreeEncoder encoder = new BitTreeEncoder(3);
+    short[] models = getModels(encoder);
+    models[1] = 250;
+    models[2] = 600;
+    models[5] = 1500;
+
+    int price = encoder.reverseGetPrice(0b110);
+
+    int expected =
+        Encoder.getPrice(models[1], 0)
+            + Encoder.getPrice(models[2], 1)
+            + Encoder.getPrice(models[5], 1);
+    assertEquals(expected, price);
+  }
+
+  @Test
+  void reverseGetPrice_static_whenUsingExternalModels_expectStartIndexApplied() {
+    short[] models = new short[16];
+    Decoder.initBitModels(models);
+    int startIndex = 2;
+    int price = BitTreeEncoder.reverseGetPrice(models, startIndex, 3, 0b011);
+
+    int expectedPricePerBit = Encoder.getPrice(HALF_PROB, 1);
+    assertEquals(expectedPricePerBit * 3, price);
+  }
+
+  @Test
+  void reverseEncode_static_whenUsingExternalModels_expectOffsetsApplied() throws IOException {
+    short[] models = new short[16];
+    Decoder.initBitModels(models);
+    Encoder rangeEncoder = mock(Encoder.class);
+
+    BitTreeEncoder.reverseEncode(models, 2, rangeEncoder, 3, 0b011);
+
+    InOrder order = inOrder(rangeEncoder);
+    order.verify(rangeEncoder).encode(models, 3, 1);
+    order.verify(rangeEncoder).encode(models, 5, 1);
+    order.verify(rangeEncoder).encode(models, 9, 0);
+    verifyNoMoreInteractions(rangeEncoder);
+  }
+
+  private static short[] getModels(BitTreeEncoder encoder) throws Exception {
+    Field field = BitTreeEncoder.class.getDeclaredField("models");
+    field.setAccessible(true);
+    return (short[]) field.get(encoder);
+  }
+}

--- a/src/test/java/org/sevenzip/compression/rangecoder/DecoderTest.java
+++ b/src/test/java/org/sevenzip/compression/rangecoder/DecoderTest.java
@@ -1,0 +1,103 @@
+package org.sevenzip.compression.rangecoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class DecoderTest {
+
+  @Test
+  void init_whenStreamHasFiveBytes_setsRangeAndCode() throws IOException {
+    byte[] seed = new byte[] {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+    Decoder decoder = new Decoder();
+    decoder.setStream(new ByteArrayInputStream(seed));
+
+    decoder.init();
+
+    assertEquals(-1, decoder.range);
+    assertEquals(0x11223344, decoder.code);
+    assertNotNull(decoder.stream);
+  }
+
+  @Test
+  void decodeDirectBits_whenEncodedWithEncoder_returnsOriginalValue() throws IOException {
+    int value = 0b101101;
+    int bitCount = 6;
+    byte[] encoded = encodeDirectBits(value, bitCount);
+
+    Decoder decoder = new Decoder();
+    decoder.setStream(new ByteArrayInputStream(encoded));
+    decoder.init();
+
+    int decoded = decoder.decodeDirectBits(bitCount);
+
+    assertEquals(value, decoded);
+  }
+
+  @Test
+  void decodeBit_whenRoundTrippedThroughEncoder_matchesSymbolsAndUpdatesProbabilities()
+      throws IOException {
+    List<Integer> symbols = List.of(0, 1, 0, 1, 1);
+    byte[] encoded = encodeAdaptiveBits(symbols);
+
+    short[] probabilities = new short[1];
+    Decoder.initBitModels(probabilities);
+
+    Decoder decoder = new Decoder();
+    decoder.setStream(new ByteArrayInputStream(encoded));
+    decoder.init();
+
+    List<Integer> decoded = new ArrayList<>();
+    for (int ignored : symbols) {
+      decoded.add(decoder.decodeBit(probabilities, 0));
+    }
+
+    assertEquals(symbols, decoded);
+    assertEquals(expectedProbabilityAfter(symbols), probabilities[0]);
+  }
+
+  private static byte[] encodeDirectBits(int value, int bitCount) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Encoder encoder = new Encoder();
+    encoder.setStream(out);
+    encoder.init();
+    encoder.encodeDirectBits(value, bitCount);
+    encoder.flushData();
+    encoder.flushStream();
+    return out.toByteArray();
+  }
+
+  private static byte[] encodeAdaptiveBits(List<Integer> bits) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Encoder encoder = new Encoder();
+    encoder.setStream(out);
+    encoder.init();
+    short[] probabilities = new short[1];
+    Encoder.initBitModels(probabilities);
+    for (int bit : bits) {
+      encoder.encode(probabilities, 0, bit);
+    }
+    encoder.flushData();
+    encoder.flushStream();
+    return out.toByteArray();
+  }
+
+  private static short expectedProbabilityAfter(List<Integer> bits) {
+    int prob = Decoder.BIT_MODEL_TOTAL >>> 1;
+    for (int bit : bits) {
+      if (bit == 0) {
+        prob = prob + ((Decoder.BIT_MODEL_TOTAL - prob) >>> Decoder.NUM_MOVE_BITS);
+      } else {
+        prob = prob - (prob >>> Decoder.NUM_MOVE_BITS);
+      }
+    }
+    return (short) prob;
+  }
+}

--- a/src/test/java/org/sevenzip/compression/rangecoder/EncoderTest.java
+++ b/src/test/java/org/sevenzip/compression/rangecoder/EncoderTest.java
@@ -1,0 +1,182 @@
+package org.sevenzip.compression.rangecoder;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class EncoderTest {
+
+  @Mock OutputStream mockStream;
+
+  @Test
+  void init_setsInitialState_expectDefaults() {
+    Encoder encoder = new Encoder();
+
+    encoder.init();
+
+    assertEquals(0, encoder.position);
+    assertEquals(0, encoder.low);
+    assertEquals(-1, encoder.range);
+    assertEquals(1, encoder.cacheSize);
+    assertEquals(0, encoder.cache);
+  }
+
+  @Test
+  void setStream_and_releaseStream_expectLifecycleUpdates() {
+    Encoder encoder = new Encoder();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    encoder.setStream(out);
+    encoder.releaseStream();
+
+    assertNull(encoder.stream);
+  }
+
+  @Test
+  void flushStream_delegatesToUnderlyingStream() throws IOException {
+    Encoder encoder = new Encoder();
+    encoder.setStream(mockStream);
+
+    encoder.flushStream();
+
+    verify(mockStream).flush();
+  }
+
+  @Test
+  void shiftLow_writesByte_whenLowBelowThreshold() throws IOException {
+    Encoder encoder = new Encoder();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    encoder.setStream(out);
+    encoder.init();
+
+    encoder.shiftLow();
+
+    assertEquals(1, encoder.position);
+    assertEquals(1, encoder.cacheSize);
+    assertEquals(0, encoder.cache);
+    assertArrayEquals(new byte[] {(byte) 0x00}, out.toByteArray());
+  }
+
+  @Test
+  void shiftLow_skipsWrite_whenLowAtBoundary() throws IOException {
+    Encoder encoder = new Encoder();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    encoder.setStream(out);
+    encoder.init();
+    encoder.low = 0xFF000000L;
+
+    encoder.shiftLow();
+
+    assertEquals(0, encoder.position);
+    assertEquals(2, encoder.cacheSize);
+    assertEquals(0, out.size());
+  }
+
+  @Test
+  void flushData_writesFiveZeroBytes() throws IOException {
+    Encoder encoder = new Encoder();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    encoder.setStream(out);
+    encoder.init();
+
+    encoder.flushData();
+
+    byte[] expected = new byte[] {0, 0, 0, 0, 0};
+    assertArrayEquals(expected, out.toByteArray());
+    assertEquals(5, encoder.position);
+    assertEquals(1, encoder.cacheSize);
+  }
+
+  @Test
+  void encode_updatesProbabilityAndRangeForZeroSymbol() throws IOException {
+    Encoder encoder = new Encoder();
+    encoder.init();
+    short[] probs = {(short) 1024};
+
+    encoder.encode(probs, 0, 0);
+
+    assertEquals(0x7FFFFC00, encoder.range);
+    assertEquals(0, encoder.low);
+    assertEquals((short) 1056, probs[0]);
+  }
+
+  @Test
+  void encode_updatesStateAndFlushesForOneSymbol_whenRangeBelowTopMask() throws IOException {
+    Encoder encoder = new Encoder();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    encoder.setStream(out);
+    encoder.init();
+    encoder.range = 0x00FFFFFF;
+    short[] probs = {(short) 1024};
+
+    encoder.encode(probs, 0, 1);
+
+    assertEquals(0x8003FF00, encoder.range);
+    assertEquals(0x7FFC0000L, encoder.low);
+    assertEquals((short) 992, probs[0]);
+    assertArrayEquals(new byte[] {0}, out.toByteArray());
+    assertEquals(1, encoder.position);
+  }
+
+  @Test
+  void encodeDirectBits_writesExpectedBytes_forSixteenBitPattern() throws IOException {
+    Encoder encoder = new Encoder();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    encoder.setStream(out);
+    encoder.init();
+
+    encoder.encodeDirectBits(0xAAAA, 16);
+
+    assertArrayEquals(new byte[] {0, (byte) 0xAA}, out.toByteArray());
+    assertEquals(0xFFFFFF00, encoder.range);
+    assertEquals(0xFFFB5600L, encoder.low);
+    assertEquals(2, encoder.position);
+    assertEquals(0xA9, encoder.cache);
+  }
+
+  @Test
+  void initBitModels_setsAllEntriesToMidpoint() {
+    short[] probs = new short[4];
+    Arrays.fill(probs, (short) 0);
+
+    Encoder.initBitModels(probs);
+
+    assertArrayEquals(new short[] {1024, 1024, 1024, 1024}, probs);
+  }
+
+  @Test
+  void getProcessedSizeAdd_returnsSumOfCacheAndPositionPlusFour() {
+    Encoder encoder = new Encoder();
+    encoder.init();
+    encoder.position = 3;
+    encoder.cacheSize = 2;
+
+    long processed = encoder.getProcessedSizeAdd();
+
+    assertEquals(9, processed);
+  }
+
+  @Test
+  void priceHelpers_returnExpectedValuesForKnownProbabilities() {
+    int probMid = 1024;
+    int probOff = 600;
+
+    assertEquals(64, Encoder.getPrice0(probMid));
+    assertEquals(117, Encoder.getPrice0(probOff));
+    assertEquals(37, Encoder.getPrice1(probOff));
+    assertEquals(117, Encoder.getPrice(probOff, 0));
+    assertEquals(37, Encoder.getPrice(probOff, 1));
+  }
+}


### PR DESCRIPTION
## Summary
- add comprehensive Javadoc to Encoder, Decoder, and BitTree range coder helpers
- add unit tests covering encoder/decoder direct bit paths and adaptive probability updates
- add bit-tree encoder/decoder tests for MSB/LSB traversal, pricing, and external model helpers

## Testing
- not run (not requested)
