### PR TITLE
Docs: document LzmaAlone and add coverage

### DIFF
--- a/src/main/java/org/sevenzip/LzmaAlone.java
+++ b/src/main/java/org/sevenzip/LzmaAlone.java
@@ -3,16 +3,148 @@ package org.sevenzip;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 import org.sevenzip.compression.lzma.Decoder;
 import org.sevenzip.compression.lzma.Encoder;
 
+/**
+ * Standalone entry point for running LZMA compression, decompression, and micro-benchmarks from the
+ * command line. The class parses a small switch-based argument syntax, configures encoder or + *
+ * decoder instances, and streams data between files without loading them entirely into memory.
+ *
+ * <p>Typical usage is through {@link #main(String[])} by invoking the packaged jar with either
+ * encode ({@code e}), decode ({@code d}), or benchmark ({@code b}) modes, followed by optional
+ * tuning flags. The implementation favors deterministic behavior: it sets all tunables explicitly
+ * and relies on buffered streams to limit memory pressure on large inputs. Operations are
+ * synchronous and block until completion; no background threads are started.
+ *
+ * <p>Thread safety: this class maintains no shared mutable state beyond logger configuration and is
+ * intended to be used as a single-process tool. Creating multiple instances concurrently is not a
+ * supported pattern; prefer separate JVM invocations if parallel execution is required.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Parsing command-line switches into a {@link CommandLine} model.
+ *   <li>Configuring encoder/decoder instances and orchestrating streaming I/O.
+ *   <li>Printing user-facing help and reporting basic argument errors.
+ * </ul>
+ */
 public class LzmaAlone {
+
+  /**
+   * Constructs a new instance of the tool facade. Instantiation is rarely required because all
+   * primary entry points are static, but the constructor remains available for frameworks that rely
+   * on reflective creation.
+   */
+  public LzmaAlone() {
+    // Intentionally empty: provided for reflective construction in tooling that expects a public
+    // no-arg entry point.
+  }
+
+  private static final Logger LOGGER = Logger.getLogger(LzmaAlone.class.getName());
+
+  static {
+    Handler handler = new SystemOutHandler();
+    LOGGER.setUseParentHandlers(false);
+    LOGGER.addHandler(handler);
+    LOGGER.setLevel(Level.INFO);
+  }
+
+  static void setLogStream(PrintStream stream) {
+    SystemOutHandler.setLogStream(stream);
+  }
+
+  static PrintStream getLogStream() {
+    return SystemOutHandler.getLogStream();
+  }
+
+  private static final class SystemOutHandler extends Handler {
+    private static final AtomicReference<PrintStream> LOG_STREAM =
+        new AtomicReference<>(new PrintStream(new FileOutputStream(FileDescriptor.out)));
+    private final SimpleFormatter formatter = new SimpleFormatter();
+
+    SystemOutHandler() {
+      setLevel(Level.INFO);
+    }
+
+    @Override
+    public synchronized void publish(LogRecord logRecord) {
+      if (!isLoggable(logRecord)) {
+        return;
+      }
+      LOG_STREAM.get().print(formatter.format(logRecord));
+    }
+
+    @Override
+    public void flush() {
+      LOG_STREAM.get().flush();
+    }
+
+    @Override
+    public void close() {
+      // nothing to close; System.out is managed externally
+    }
+
+    static void setLogStream(PrintStream stream) {
+      LOG_STREAM.set(stream);
+    }
+
+    static PrintStream getLogStream() {
+      return LOG_STREAM.get();
+    }
+  }
+
+  /**
+   * Parsed command-line options for LZMA standalone invocations. This mutable holder captures the
+   * requested operation (encode, decode, benchmark), file paths, dictionary and match-finder
+   * parameters, and optional end-of-stream handling.
+   *
+   * <p>The parser is intentionally permissive: switches may precede positional arguments and are
+   * case-insensitive where appropriate. Fields are populated only after successful parsing; callers
+   * should always check the boolean result of {@link #parse(String[])} before reading values. The
+   * instance is not thread-safe and is meant to be confined to the parsing flow of a single
+   * invocation.
+   */
   public static class CommandLine {
+
+    /**
+     * Creates an empty command-line model with defaults matching the original LZMA SDK tool. Values
+     * remain unset until {@link #parse(String[])} completes successfully.
+     */
+    public CommandLine() {
+      // Intentionally empty: instances are populated via parse(String[]) after creation.
+    }
+
+    /**
+     * Mode constant for LZMA compression of the provided input file to the output file, producing a
+     * stream with embedded coder properties and optional end-of-stream marker suitable for later
+     * decoding by compatible tools.
+     */
     public static final int K_ENCODE = 0;
+
+    /**
+     * Mode constant for LZMA decompression of the provided input file to the output file; expects
+     * the input to begin with coder properties and an eight-byte size header emitted by encode
+     * runs.
+     */
     public static final int K_DECODE = 1;
+
+    /**
+     * Mode constant triggering the built-in benchmark, which runs several encode/decode passes
+     * against generated data to estimate throughput; the integer operand controls pass count and
+     * defaults to ten iterations when omitted.
+     */
     public static final int K_BENCHMARK = 2;
 
     private int command = -1;
@@ -65,6 +197,15 @@ public class LzmaAlone {
       return true;
     }
 
+    /**
+     * Parses the provided argument list into this instance, respecting both switch tokens (prefixed
+     * with {@code -}) and positional parameters.
+     *
+     * @param args full argument array as received by {@link LzmaAlone#main(String[])}, not null;
+     *     entries may include switches and up to two positional file paths depending on the mode.
+     * @return {@code true} when parsing succeeds and the command plus required operands are
+     *     populated; {@code false} when any token is invalid or required operands are missing.
+     */
     public boolean parse(String[] args) {
       ParseState state = new ParseState(true, 0);
       for (String s : args) {
@@ -144,7 +285,7 @@ public class LzmaAlone {
   }
 
   static void printHelp() {
-    System.out.println(
+    LOGGER.info(
         """
 
             Usage:  LZMA <e|d> [<switches>...] inputFile outputFile
@@ -162,8 +303,30 @@ public class LzmaAlone {
         """);
   }
 
+  /**
+   * Application entry point wiring the command-line interface to encoding, decoding, or benchmark
+   * flows. Invokes {@link CommandLine#parse(String[])} to interpret arguments and dispatches to the
+   * appropriate handler.
+   *
+   * <p>Expected usage patterns:
+   *
+   * <ul>
+   *   <li>{@code LzmaAlone e input.bin output.lzma} – compresses a file.
+   *   <li>{@code LzmaAlone d input.lzma output.bin} – decompresses a file.
+   *   <li>{@code LzmaAlone b 5} – runs five benchmark passes to gauge performance.
+   * </ul>
+   *
+   * When argument validation fails, the method prints guidance and exits without throwing. IO
+   * failures or unsupported option combinations propagate as runtime exceptions aligned with the
+   * underlying encoder/decoder.
+   *
+   * @param args raw command-line tokens defining the mode and file operands; may be empty to show
+   *     usage guidance.
+   * @throws Exception when IO operations, codec configuration, or benchmark execution fail; callers
+   *     rely on process exit handling for reporting.
+   */
   public static void main(String[] args) throws Exception {
-    System.out.println("\nLZMA (Java) 4.61  2008-11-23\n");
+    LOGGER.info("\nLZMA (Java) 4.61  2008-11-23\n");
 
     if (args.length < 1) {
       printHelp();
@@ -172,7 +335,7 @@ public class LzmaAlone {
 
     CommandLine params = new CommandLine();
     if (!params.parse(args)) {
-      System.out.println("\nIncorrect command");
+      LOGGER.info("\nIncorrect command");
       return;
     }
 

--- a/src/test/java/org/sevenzip/LzmaAloneTest.java
+++ b/src/test/java/org/sevenzip/LzmaAloneTest.java
@@ -1,0 +1,155 @@
+package org.sevenzip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("java:S100")
+class LzmaAloneTest {
+  private PrintStream originalOut;
+  private PrintStream originalLogStream;
+  private ByteArrayOutputStream capturedOut;
+
+  @BeforeEach
+  void setUp() {
+    originalOut = System.out;
+    originalLogStream = LzmaAlone.getLogStream();
+    capturedOut = new ByteArrayOutputStream();
+    LzmaAlone.setLogStream(new PrintStream(capturedOut));
+  }
+
+  @AfterEach
+  void tearDown() {
+    LzmaAlone.setLogStream(originalLogStream);
+    System.setOut(originalOut);
+  }
+
+  @Test
+  void parse_whenEncodeArgsProvided_setsCommandAndFiles() {
+    LzmaAlone.CommandLine cmd = new LzmaAlone.CommandLine();
+
+    boolean parsed = cmd.parse(new String[] {"e", "input.file", "output.file"});
+
+    assertTrue(parsed);
+    assertEquals(LzmaAlone.CommandLine.K_ENCODE, getIntField(cmd, "command"));
+    assertEquals("input.file", getStringField(cmd, "inFile"));
+    assertEquals("output.file", getStringField(cmd, "outFile"));
+  }
+
+  @Test
+  void parse_whenSwitchesProvided_updatesAllParameters() {
+    LzmaAlone.CommandLine cmd = new LzmaAlone.CommandLine();
+
+    boolean parsed =
+        cmd.parse(
+            new String[] {
+              "-d20", "-fb64", "-lc4", "-lp1", "-pb3", "-mfbt2", "-eos", "e", "input", "output"
+            });
+
+    assertTrue(parsed);
+    assertTrue(getBooleanField(cmd, "dictionarySizeIsDefined"));
+    assertEquals(1 << 20, getIntField(cmd, "dictionarySize"));
+    assertEquals(64, getIntField(cmd, "fb"));
+    assertEquals(4, getIntField(cmd, "lc"));
+    assertEquals(1, getIntField(cmd, "lp"));
+    assertEquals(3, getIntField(cmd, "pb"));
+    assertEquals(0, getIntField(cmd, "matchFinder"));
+    assertTrue(getBooleanField(cmd, "eos"));
+    assertEquals(LzmaAlone.CommandLine.K_ENCODE, getIntField(cmd, "command"));
+  }
+
+  @Test
+  void parseSwitch_whenMatchFinderUnknown_returnsFalse() {
+    LzmaAlone.CommandLine cmd = new LzmaAlone.CommandLine();
+
+    boolean parsed = cmd.parseSwitch("mfunknown");
+
+    assertFalse(parsed);
+    assertEquals(1, getIntField(cmd, "matchFinder")); // default remains unchanged
+  }
+
+  @Test
+  void parse_whenBenchmarkPassesInvalid_returnsFalse() {
+    LzmaAlone.CommandLine cmd = new LzmaAlone.CommandLine();
+
+    boolean parsed = cmd.parse(new String[] {"b", "0"});
+
+    assertFalse(parsed);
+  }
+
+  @Test
+  void main_whenArgsMissing_printsHelp() throws Exception {
+    System.setOut(new PrintStream(capturedOut));
+
+    LzmaAlone.main(new String[] {});
+
+    String output = capturedOut.toString(StandardCharsets.UTF_8);
+    assertTrue(output.contains("Usage:  LZMA <e|d> [<switches>...] inputFile outputFile"));
+  }
+
+  @Test
+  void main_whenDecodeWithTooShortInput_throws() throws Exception {
+    System.setOut(new PrintStream(capturedOut));
+    Path tempFile = Files.createTempFile("lzma-empty", ".lzma");
+    Path outFile = Files.createTempFile("lzma-empty-out", ".bin");
+    String[] decodeArgs = new String[] {"d", tempFile.toString(), outFile.toString()};
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> LzmaAlone.main(decodeArgs));
+
+    assertTrue(ex.getMessage().contains("input .lzma file is too short"));
+  }
+
+  @Test
+  void main_whenEncodeAndDecodeRoundTrip_preservesContent(@TempDir Path tempDir) throws Exception {
+    Path source = tempDir.resolve("source.txt");
+    Path encoded = tempDir.resolve("encoded.lzma");
+    Path decoded = tempDir.resolve("decoded.txt");
+    Files.writeString(source, "Crypta LZMA test payload", StandardCharsets.UTF_8);
+
+    System.setOut(new PrintStream(capturedOut));
+    LzmaAlone.main(new String[] {"e", source.toString(), encoded.toString()});
+    LzmaAlone.main(new String[] {"d", encoded.toString(), decoded.toString()});
+
+    byte[] original = Files.readAllBytes(source);
+    byte[] roundTripped = Files.readAllBytes(decoded);
+    assertEquals(
+        new String(original, StandardCharsets.UTF_8),
+        new String(roundTripped, StandardCharsets.UTF_8));
+    assertTrue(Files.size(encoded) > 0);
+  }
+
+  private static int getIntField(LzmaAlone.CommandLine cmd, String fieldName) {
+    return (int) readField(cmd, fieldName);
+  }
+
+  private static boolean getBooleanField(LzmaAlone.CommandLine cmd, String fieldName) {
+    return (boolean) readField(cmd, fieldName);
+  }
+
+  private static String getStringField(LzmaAlone.CommandLine cmd, String fieldName) {
+    return (String) readField(cmd, fieldName);
+  }
+
+  private static Object readField(LzmaAlone.CommandLine cmd, String fieldName) {
+    try {
+      Field field = LzmaAlone.CommandLine.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.get(cmd);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalStateException("Unable to read field " + fieldName, e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add comprehensive Javadoc for `LzmaAlone` CLI entry points and command parsing
- route console output through a logger with configurable stream and document constructors
- add `LzmaAloneTest` covering parsing, help output, decode error path, and encode/decode round-trip

## Testing
- ./gradlew test --tests org.sevenzip.LzmaAloneTest
- ./gradlew test