### PR TITLE
Improve estimation docs and refine LM solver behavior

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -86,10 +86,12 @@ tasks.withType<Test>().configureEach {
   include("com/onionnetworks/**/*Test.class")
   include("org/bitpedia/**/*Test.class")
   include("org/sevenzip/**/*Test.class")
+  include("org/spaceroots/**/*Test.class")
   exclude("network/crypta/**/*$*Test.class")
   exclude("com/onionnetworks/**/*$*Test.class")
   exclude("org/bitpedia/**/*$*Test.class")
   exclude("org/sevenzip/**/*$*Test.class")
+  exclude("org/spaceroots/**/*$*Test.class")
   // Point tests expecting old layout to new standard resource locations
   systemProperty("test.l10npath_test", "src/test/resources/network/crypta/l10n/")
   systemProperty("test.l10npath_main", "src/main/resources/network/crypta/l10n/")

--- a/src/main/java/org/spaceroots/mantissa/estimation/EstimatedParameter.java
+++ b/src/main/java/org/spaceroots/mantissa/estimation/EstimatedParameter.java
@@ -1,14 +1,29 @@
 package org.spaceroots.mantissa.estimation;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * This class represent the estimated parameters of an estimation problem.
+ * Represents a single parameter that participates in an estimation problem.
  *
- * <p>The parameters of an estimation problem have a name, a value and a bound flag. The value of
- * bound parameters is considered trusted and the solvers should not adjust them. On the other hand,
- * the solvers should adjust the value of unbounds parameters until they satisfy convergence
- * criterions specific to each solver.
+ * <p>An {@code EstimatedParameter} carries three pieces of state: a stable textual name, the
+ * current numeric estimate of its value, and a flag telling solvers whether the value should be
+ * kept fixed during optimization. Instances are intentionally lightweight and mutable so that
+ * iterative algorithms can update the value in place rather than copying large arrays of parameters
+ * on each iteration. The name remains constant for the life of the instance, allowing higher-level
+ * code to correlate results with human-readable identifiers.
+ *
+ * <p>Typical usage is to create one instance per unknown, pass it to an estimation problem
+ * implementation, and let a solver adjust unbound parameters until its convergence criteria are
+ * met. Bound parameters act like constants supplied to the solver; toggling the bound flag allows
+ * callers to switch between “fixed” and “free” behavior without creating a new object.
+ *
+ * <ul>
+ *   <li>Mutable: the estimate and bound flag may change between solver iterations.
+ *   <li>Not thread-safe: callers should confine instances to a single thread or provide external
+ *       synchronization.
+ *   <li>Serializable: parameter sets can be persisted alongside other estimation artifacts.
+ * </ul>
  *
  * @version $Id: EstimatedParameter.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
@@ -16,11 +31,17 @@ import java.io.Serializable;
 public class EstimatedParameter implements Serializable {
 
   /**
-   * Simple constructor. Build an instance from a first estimate of the parameter, initially
-   * considered unbound.
+   * Builds a parameter with an initial estimate and marks it as unbound.
    *
-   * @param name name of the parameter
-   * @param firstEstimate first estimate of the parameter
+   * <p>Use this variant when the parameter should be free to change during solver iterations. The
+   * provided name is preserved exactly for later reporting; callers should avoid {@code null} or
+   * empty strings to keep diagnostics meaningful. The numeric estimate is stored as-is, including
+   * {@link Double#NaN} or infinities, so callers should supply values that match downstream solver
+   * expectations.
+   *
+   * @param name descriptive, non-{@code null} identifier used in logs and result summaries.
+   * @param firstEstimate initial numeric value supplied to the estimation algorithm; may be any
+   *     {@code double} representable value.
    */
   public EstimatedParameter(String name, double firstEstimate) {
     this.name = name;
@@ -29,11 +50,18 @@ public class EstimatedParameter implements Serializable {
   }
 
   /**
-   * Simple constructor. Build an instance from a first estimate of the parameter and a bound flag
+   * Builds a parameter with an initial estimate and explicit bound state.
    *
-   * @param name name of the parameter
-   * @param firstEstimate first estimate of the parameter
-   * @param bound flag, should be true if the parameter is bound
+   * <p>Choose this overload when the caller already knows whether the parameter should remain fixed
+   * or adjustable. A bound parameter communicates to solvers that the value is trusted input and
+   * must not be altered, while an unbound parameter participates in optimization. The constructor
+   * does not validate the estimate; solvers decide how to treat special values.
+   *
+   * @param name descriptive, non-{@code null} identifier used in logs and result summaries.
+   * @param firstEstimate initial numeric value supplied to the estimation algorithm; may be any
+   *     {@code double} representable value.
+   * @param bound {@code true} to freeze the parameter during estimation, {@code false} to allow
+   *     solver-driven updates.
    */
   public EstimatedParameter(String name, double firstEstimate, boolean bound) {
     this.name = name;
@@ -42,9 +70,15 @@ public class EstimatedParameter implements Serializable {
   }
 
   /**
-   * Copy constructor. Build a copy of a parameter
+   * Copy constructor that duplicates the current state of another parameter.
    *
-   * @param parameter instance to copy
+   * <p>The new instance receives the same name reference, estimate value, and bound flag as the
+   * source. Subsequent changes to either instance do not affect the other, making this suitable for
+   * snapshotting solver state or branching hypothetical scenarios without mutating the original
+   * parameter.
+   *
+   * @param parameter existing parameter whose name, estimate, and bound flag are cloned; must not
+   *     be {@code null}.
    */
   public EstimatedParameter(EstimatedParameter parameter) {
     name = parameter.name;
@@ -53,59 +87,102 @@ public class EstimatedParameter implements Serializable {
   }
 
   /**
-   * Set a new estimated value for the parameter.
+   * Replaces the current numeric estimate.
    *
-   * @param estimate new estimate for the parameter
+   * <p>The new value is stored verbatim; no validation or normalization is performed. Solvers may
+   * call this repeatedly during iterative optimization, and client code can also use it to inject
+   * externally computed updates. Supplying {@link Double#NaN} or infinite values is permitted but
+   * may cause downstream algorithms to reject the parameter or fail to converge.
+   *
+   * @param estimate updated numeric value representing the latest guess for this parameter; any
+   *     {@code double} value is accepted.
    */
   public void setEstimate(double estimate) {
     this.estimate = estimate;
   }
 
   /**
-   * Get the current estimate of the parameter
+   * Returns the current numeric estimate for this parameter.
    *
-   * @return current estimate
+   * <p>This method is idempotent and threadsafe only to the extent that callers avoid concurrent
+   * mutation of the same instance. Returned values are the last ones provided to the constructor or
+   * {@link #setEstimate(double)} and may include {@link Double#NaN} or infinities if previously
+   * set.
+   *
+   * @return the stored estimate value; never modified by this accessor and may be {@link
+   *     Double#NaN} if set accordingly.
    */
   public double getEstimate() {
     return estimate;
   }
 
   /**
-   * get the name of the parameter
+   * Provides the stable name associated with this parameter.
    *
-   * @return parameter name
+   * <p>The name is set at construction and never changed, enabling callers to label solver outputs
+   * and diagnostics reliably. The returned reference is the original string; callers should avoid
+   * mutating it if a mutable implementation is used.
+   *
+   * @return immutable identifier string that was supplied at construction time.
    */
   public String getName() {
     return name;
   }
 
   /**
-   * Set the bound flag of the parameter
+   * Updates the bound flag that signals whether solvers may alter this parameter.
    *
-   * @param bound this flag should be set to true if the parameter is bound (i.e. if it should not
-   *     be adjusted by the solver).
+   * <p>Setting the flag to {@code true} indicates the estimate should remain fixed and treated as a
+   * trusted input. Setting it to {@code false} allows solvers to modify the estimate during
+   * optimization. This method performs no synchronization; callers coordinating multithreaded
+   * access must guard the instance externally.
+   *
+   * @param bound {@code true} to freeze the value for solver runs, {@code false} to mark it
+   *     adjustable.
    */
   public void setBound(boolean bound) {
     this.bound = bound;
   }
 
   /**
-   * Check if the parameter is bound
+   * Indicates whether the parameter is currently marked as bound.
    *
-   * @return true if the parameter is bound
+   * <p>A bound parameter communicates to estimation algorithms that its value should be left
+   * untouched. The flag can change over the life of the instance via {@link #setBound(boolean)}; no
+   * thread-safety guarantees are provided.
+   *
+   * @return {@code true} when the bound flag is set, meaning the parameter should not be altered by
+   *     solvers.
    */
   public boolean isBound() {
     return bound;
   }
 
-  /** Name of the parameter */
-  private String name;
+  /**
+   * Immutable, human-readable name that identifies this parameter within an estimation problem.
+   *
+   * <p>The value is provided during construction and used in logs, debug output, and result
+   * reporting to correlate numeric estimates with domain concepts. It is never changed after
+   * creation.
+   */
+  private final String name;
 
-  /** Current value of the parameter */
+  /**
+   * Mutable numeric value holding the latest estimate for this parameter.
+   *
+   * <p>This field is protected to support direct access from closely related subclasses that add
+   * domain-specific semantics. External callers should prefer {@link #getEstimate()} and {@link
+   * #setEstimate(double)} for clarity and future compatibility.
+   */
   protected double estimate;
 
-  /** Indicator for bound parameters (ie parameters that should not be estimated) */
+  /**
+   * Flag indicating whether this parameter should remain fixed during estimation runs.
+   *
+   * <p>When {@code true}, solvers are expected to leave {@link #estimate} untouched. The flag is
+   * mutable and may be toggled between successive solver invocations.
+   */
   private boolean bound;
 
-  private static final long serialVersionUID = -555440800213416949L;
+  @Serial private static final long serialVersionUID = -555440800213416949L;
 }

--- a/src/main/java/org/spaceroots/mantissa/estimation/EstimationException.java
+++ b/src/main/java/org/spaceroots/mantissa/estimation/EstimationException.java
@@ -1,9 +1,30 @@
 package org.spaceroots.mantissa.estimation;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.MantissaException;
 
 /**
- * This class represents exceptions thrown by the estimation solvers.
+ * Exception type signaled when an estimation process cannot continue.
+ *
+ * <p>This domain-specific subclass of {@link MantissaException} is raised by estimation solvers
+ * when they encounter conditions that prevent producing a reliable result. Typical triggers include
+ * inconsistent problem definitions, divergence detected by the optimizer, or numerical issues such
+ * as ill-conditioned matrices. Library callers are expected to catch this exception to surface
+ * actionable feedback to users or to retry with adjusted parameters rather than masking the failure
+ * as a generic {@link RuntimeException}.
+ *
+ * <p>Instances are effectively immutable after construction; no mutable state beyond the captured
+ * message and cause is retained. They are therefore safe to share across threads once created, even
+ * though creation is usually scoped to a single failing computation. The superclass provides the
+ * localization and formatting support, so messages can be prepared in a user-facing language while
+ * still conveying the original technical context.
+ *
+ * <ul>
+ *   <li>Responsibility: represent estimation-related failures with optional localization support.
+ *   <li>Typical flow: created inside solvers, propagated to clients, logged or displayed with full
+ *       context.
+ *   <li>Thread-safety: immutable contents permit safe reporting from background worker threads.
+ * </ul>
  *
  * @version $Id: EstimationException.java 1681 2005-12-16 11:13:28Z luc $
  * @author L. Maisonobe
@@ -11,32 +32,59 @@ import org.spaceroots.mantissa.MantissaException;
 public class EstimationException extends MantissaException {
 
   /**
-   * Simple constructor. Build an exception by translating the specified message
+   * Creates an exception with a plain, already translated message.
    *
-   * @param message message to translate
+   * <p>Use this constructor when the caller already holds a user-facing description of the problem
+   * and no additional formatting is required. The message is forwarded to the base class, which may
+   * apply any configured localization or resource-bundle lookup while preserving the supplied text.
+   * The resulting exception can be thrown directly or wrapped inside higher-level error handling
+   * that performs retries or user notifications. Because the message is captured verbatim, prefer
+   * concise wording that identifies the failing operation and any relevant input values.
+   *
+   * @param message human-readable explanation describing estimation failure scenario
    */
   public EstimationException(String message) {
     super(message);
   }
 
   /**
-   * Simple constructor. Build an exception by translating and formating a message
+   * Creates an exception whose message is built from a specifier and parts.
    *
-   * @param specifier format specifier (to be translated)
-   * @param parts to insert in the format (no translation)
+   * <p>This variant supports parameterized, potentially localized messages handled by {@link
+   * MantissaException}. The {@code specifier} is looked up and translated by the underlying message
+   * infrastructure, and the provided {@code parts} are inserted without translation. This is useful
+   * when solver errors need to include dynamic values such as iteration counts or residual norms
+   * while keeping the outer template managed centrally. Ensure that the parts array matches the
+   * placeholders expected by the specifier to avoid malformed output.
+   *
+   * <pre>{@code
+   * // Example: combine a translated template with dynamic values
+   * throw new EstimationException("estimation.residual.too.large",
+   *     new String[] {String.valueOf(residual)});
+   * }</pre>
+   *
+   * @param specifier format specifier translated by the Mantissa message framework
+   * @param parts ordered insertion values, kept as literals without translation
    */
   public EstimationException(String specifier, String[] parts) {
     super(specifier, parts);
   }
 
   /**
-   * Simple constructor. Build an exception from a cause
+   * Creates an exception that wraps an underlying cause.
    *
-   * @param cause cause of this exception
+   * <p>Choose this constructor when another exception triggered the estimation failure and that
+   * original context must be preserved. The cause is attached using standard exception chaining so
+   * stack traces remain intact. Callers may add a localized message later using higher-level error
+   * handlers, or they can rethrow this instance directly to signal that the solver aborted due to a
+   * downstream error such as I/O, invalid input preparation, or arithmetic overflow. The cause must
+   * be non-null to retain a meaningful diagnostic chain.
+   *
+   * @param cause originating exception that forced the estimation process to abort
    */
   public EstimationException(Throwable cause) {
     super(cause);
   }
 
-  private static final long serialVersionUID = 1613719630569355278L;
+  @Serial private static final long serialVersionUID = 1613719630569355278L;
 }

--- a/src/main/java/org/spaceroots/mantissa/estimation/EstimationProblem.java
+++ b/src/main/java/org/spaceroots/mantissa/estimation/EstimationProblem.java
@@ -1,18 +1,30 @@
 package org.spaceroots.mantissa.estimation;
 
 /**
- * This interface represents an estimation problem.
+ * Defines the contract for an estimation problem consumed by numerical estimators.
  *
- * <p>This interface should be implemented by all real estimation problems before they can be
- * handled by the estimators through the {@link Estimator#estimate Estimator.estimate} method.
+ * <p>An estimation problem groups a set of adjustable parameters and a collection of weighted
+ * measurements describing how well a proposed parameter vector matches observed reality. Concrete
+ * implementations typically assemble immutable model metadata at construction time, then expose
+ * mutable parameter state to the solver so it can iterate toward a minimum residual. The estimator
+ * drives the life-cycle: it repeatedly queries the problem for the current measurements and free
+ * parameters, updates parameter estimates based on residuals, and may re-evaluate model predictions
+ * between iterations.
  *
- * <p>An estimation problem, as seen by a solver is a set of parameters and a set of measurements.
- * The parameters are adjusted during the estimation through the {@link #getUnboundParameters
- * getUnboundParameters} and {@link EstimatedParameter#setEstimate EstimatedParameter.setEstimate}
- * methods. The measurements both have a measured value which is generally fixed at construction and
- * a theoretical value which depends on the model and hence varies as the parameters are adjusted.
- * The purpose of the solver is to reduce the residual between these values, it can retrieve the
- * measurements through the {@link #getMeasurements getMeasurements} method.
+ * <p>Typical usage follows this sequence: a client builds an {@code EstimationProblem} carrying the
+ * model-specific {@link EstimatedParameter} instances and {@link WeightedMeasurement} entries,
+ * passes it to {@link Estimator#estimate(EstimationProblem)}, and lets the estimator perform the
+ * optimization loop. Implementations should keep array ordering stable so solvers can cache
+ * intermediate state, and should document whether returned arrays are defensive copies or
+ * live-backed. This interface itself is agnostic to concurrency; unless an implementation states
+ * otherwise, callers should treat instances as not thread-safe and confine access to the estimating
+ * thread.
+ *
+ * <ul>
+ *   <li>Provides read access to all parameters, whether currently bound or free.
+ *   <li>Separates unbound parameters so solvers know which elements may be updated.
+ *   <li>Supplies weighted measurements used to compute residuals and drive corrections.
+ * </ul>
  *
  * @see Estimator
  * @see WeightedMeasurement
@@ -21,23 +33,48 @@ package org.spaceroots.mantissa.estimation;
  */
 public interface EstimationProblem {
   /**
-   * Get the measurements of an estimation problem.
+   * Returns the weighted measurements contributing to the objective being minimized.
    *
-   * @return measurements
+   * <p>The returned array represents the complete measurement set known to the problem at the
+   * moment of the call. Implementations are encouraged to preserve element ordering across calls so
+   * estimators can reuse residual caches or Jacobians. Unless otherwise documented, callers should
+   * treat both the array structure and the contained measurement instances as read-only to avoid
+   * invalidating the solver’s internal state. Measurement objects typically carry a fixed observed
+   * value and a model-computed theoretical value; the theoretical portion will be recomputed by the
+   * solver as parameters change, so callers do not need to trigger refreshes manually.
+   *
+   * @return an array of {@link WeightedMeasurement} instances, never {@code null}; element order is
+   *     stable per implementation contract and should not be mutated by callers
    */
-  public WeightedMeasurement[] getMeasurements();
+  WeightedMeasurement[] getMeasurements();
 
   /**
-   * Get the unbound parameters of the problem.
+   * Returns parameters that are currently free to vary during estimation.
    *
-   * @return unbound parameters
+   * <p>The array lists only the subset of parameters the solver is allowed to modify while seeking
+   * a solution. Implementations should ensure each entry is also present in the full parameter set
+   * returned by {@link #getAllParameters()} so solvers can correlate derivatives and constraints.
+   * Callers must not replace or remove elements from the returned array unless the implementation
+   * explicitly supports such modifications; most solvers expect structural stability and will write
+   * updated estimates via {@link EstimatedParameter#setEstimate(double)} on the existing objects.
+   *
+   * @return an array of adjustable {@link EstimatedParameter} objects representing free variables;
+   *     array and entries are expected to be non-null and reused across iterations
    */
-  public EstimatedParameter[] getUnboundParameters();
+  EstimatedParameter[] getUnboundParameters();
 
   /**
-   * Get all the parameters of the problem.
+   * Returns all parameters that describe the model, including bound and unbound ones.
    *
-   * @return parameters
+   * <p>This view allows callers to examine every parameter contributing to the model, even if some
+   * are held fixed during the current solve. The ordering should be consistent with the unbound
+   * subset so derivative arrays and constraint matrices can be indexed predictably. Implementations
+   * may include derived or informational parameters; solvers should only alter those that also
+   * appear in {@link #getUnboundParameters()}. Unless otherwise stated, treat the array as a live
+   * view owned by the problem to avoid desynchronizing parameter state from the underlying model.
+   *
+   * @return an array containing every {@link EstimatedParameter} instance known to the problem,
+   *     typically non-null with stable ordering; callers should avoid structural mutation
    */
-  public EstimatedParameter[] getAllParameters();
+  EstimatedParameter[] getAllParameters();
 }

--- a/src/main/java/org/spaceroots/mantissa/estimation/Estimator.java
+++ b/src/main/java/org/spaceroots/mantissa/estimation/Estimator.java
@@ -1,13 +1,27 @@
 package org.spaceroots.mantissa.estimation;
 
 /**
- * This interface represents solvers for estimation problems.
+ * Strategy interface for solvers that adjust model parameters to fit measured data.
  *
- * <p>The classes which are devoted to solve estimation problems should implement this interface.
- * The problems which can be handled should implement the {@link EstimationProblem} interface which
- * gather all the information needed by the solver.
+ * <p>Implementations orchestrate the life cycle of an {@link EstimationProblem}, driving iterations
+ * that refine parameter values until a stopping criterion is met or a failure condition is reached.
+ * The contract is deliberately minimal so algorithms such as least-squares, Kalman filtering, or
+ * other domain-specific estimators can plug in while exposing a consistent entry point to callers.
+ * Clients typically create a problem instance that carries parameters, measurements, and residual
+ * computation hooks, then pass it to an {@code Estimator} implementation to perform the solve step.
  *
- * <p>The interface is composed only of the {@link #estimate estimate} method.
+ * <p>Responsibility highlights:
+ *
+ * <ul>
+ *   <li>Runs an estimation routine over the supplied problem and updates its parameters in place.
+ *   <li>Provides access to quality metrics, such as the Root Mean Square (RMS) of residuals.
+ *   <li>Leaves algorithm-specific policy decisions (tolerances, iteration caps, damping) to
+ *       implementations.
+ * </ul>
+ *
+ * <p>Unless otherwise documented by a concrete implementation, instances are not guaranteed to be
+ * thread-safe. Callers should avoid sharing a single estimator across concurrent solve operations
+ * or protect access externally.
  *
  * @see EstimationProblem
  * @version $Id: Estimator.java 1677 2005-12-16 11:10:48Z luc $
@@ -16,26 +30,44 @@ package org.spaceroots.mantissa.estimation;
 public interface Estimator {
 
   /**
-   * Solve an estimation problem.
+   * Solve the supplied estimation problem until convergence or an unrecoverable error occurs.
    *
-   * <p>The method should set the parameters of the problem to several trial values until it reaches
-   * convergence. If this method returns normally (i.e. without throwing an exception), then the
-   * best estimate of the parameters can be retrieved from the problem itself, through the {@link
-   * EstimationProblem#getAllParameters EstimationProblem.getAllParameters} method.
+   * <p>The method drives the iterative loop that probes candidate parameter sets, evaluates
+   * residuals, and applies the algorithm-specific update rule. When the call returns normally, the
+   * {@link EstimationProblem} instance is expected to hold its best-known parameter estimates,
+   * which callers can inspect via {@link EstimationProblem#getAllParameters()}. Implementations may
+   * stop early when tolerances are met, a maximum iteration count is exceeded, or a numerical issue
+   * is detected. No internal synchronization is implied; callers should supply a distinct problem
+   * per thread or synchronize externally.
    *
-   * @param problem estimation problem to solve
-   * @exception EstimationException if the problem cannot be solved
+   * <pre>{@code
+   * EstimationProblem problem = ...; // populate measurements and initial parameters
+   * estimator.estimate(problem);
+   * var params = problem.getAllParameters();
+   * }</pre>
+   *
+   * @param problem estimation problem that provides parameters, measurements, and residual model;
+   *     must be non-null and initialized before invocation
+   * @throws EstimationException if convergence cannot be reached or the problem definition is
+   *     inconsistent
    */
-  public void estimate(EstimationProblem problem) throws EstimationException;
+  void estimate(EstimationProblem problem) throws EstimationException;
 
   /**
-   * Get the Root Mean Square value. Get the Root Mean Square value, i.e. the root of the arithmetic
-   * mean of the square of all weighted residuals. This is related to the criterion that is
-   * minimized by the estimator as follows: if <em>c</em> if the criterion, and <em>n</em> is the
-   * number of measurements, the the RMS is <em>sqrt (c/n)</em>.
+   * Compute the Root Mean Square (RMS) of the weighted residuals for a problem.
    *
-   * @param problem estimation problem
-   * @return RMS value
+   * <p>The RMS is the square root of the arithmetic mean of squared, weighted residual values
+   * produced by the most recent estimation pass. It mirrors the minimized criterion: given
+   * criterion {@code c} and {@code n} measurements, RMS equals {@code sqrt(c / n)}. Implementations
+   * should rely on the residuals stored in the provided problem and must not modify its state.
+   * Calling this method before a solve may yield stale or undefined values, depending on the
+   * underlying implementation.
+   *
+   * @param problem estimation problem whose current residuals are used to compute the RMS; must
+   *     match the problem previously processed by the estimator
+   * @return RMS value as a non-negative double; specific implementations may return {@code NaN}
+   *     when residuals are unavailable
    */
-  public double getRMS(EstimationProblem problem);
+  @SuppressWarnings("unused")
+  double getRMS(EstimationProblem problem);
 }

--- a/src/main/java/org/spaceroots/mantissa/estimation/GaussNewtonEstimator.java
+++ b/src/main/java/org/spaceroots/mantissa/estimation/GaussNewtonEstimator.java
@@ -1,5 +1,6 @@
 package org.spaceroots.mantissa.estimation;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.linalg.GeneralMatrix;
 import org.spaceroots.mantissa.linalg.Matrix;
@@ -7,10 +8,24 @@ import org.spaceroots.mantissa.linalg.SingularMatrixException;
 import org.spaceroots.mantissa.linalg.SymetricalMatrix;
 
 /**
- * This class implements a solver for estimation problems.
+ * Gauss-Newton implementation of a weighted least squares estimator.
  *
- * <p>This class solves estimation problems using a weighted least squares criterion on the
- * measurement residuals. It uses a Gauss-Newton algorithm.
+ * <p>The estimator iteratively refines a set of {@link EstimatedParameter estimated parameters} so
+ * that the weighted residuals of the provided {@link WeightedMeasurement measurements} are
+ * minimized in the least squares sense. It follows the classical Gauss-Newton scheme: linearize the
+ * model around the current parameters, solve the normal equations, and update the parameters.
+ * Convergence is governed by configurable thresholds that balance numerical stability against
+ * runtime cost. The class is mutable during an estimation run but not thread-safe; callers should
+ * isolate instances per estimation session or provide external synchronization if shared. Typical
+ * usage builds an instance with problem-specific tolerances, calls {@link
+ * #estimate(EstimationProblem)} repeatedly for different problems, and inspects derived metrics
+ * such as {@link #getRMS(EstimationProblem)} to judge fit quality.
+ *
+ * <ul>
+ *   <li>Iterative nonlinear least squares with Gauss-Newton updates
+ *   <li>Configurable iteration cap, steady-state detection, and singularity guard
+ *   <li>Convenience path for fully linear problems via {@link #linearEstimate(EstimationProblem)}
+ * </ul>
  *
  * @version $Id: GaussNewtonEstimator.java 1678 2005-12-16 11:11:40Z luc $
  * @author L. Maisonobe
@@ -18,32 +33,21 @@ import org.spaceroots.mantissa.linalg.SymetricalMatrix;
 public class GaussNewtonEstimator implements Estimator, Serializable {
 
   /**
-   * Simple constructor.
+   * Build an estimator with explicit convergence and stability thresholds.
    *
-   * <p>This constructor build an estimator and store its convergence characteristics.
+   * <p>The constructor captures the stopping rules used by every subsequent estimation run. An
+   * iteration stops early when the criterion falls under the {@code convergence} floor or when two
+   * consecutive criteria differ by less than {@code steadyStateThreshold} times the current value
+   * ({@code Math.abs(Jn - JnMinus1) &lt; Jn * steadyStateThreshold}). A failure to satisfy either
+   * rule within {@code maxIterations} iterations results in an {@link EstimationException} during
+   * execution. The {@code epsilon} parameter defines the minimal pivot magnitude accepted by the
+   * linear solver; values below it are treated as singular to avoid unstable updates. Choose
+   * thresholds based on measurement noise level and acceptable runtime.
    *
-   * <p>An estimator is considered to have converged whenever either the criterion goes below a
-   * physical threshold under which improvements are considered useless or when the algorithm is
-   * unable to improve it (even if it is still high). The first condition that is met stops the
-   * iterations.
-   *
-   * <p>The fact an estimator has converged does not mean that the model accurately fits the
-   * measurements. It only means no better solution can be found, it does not mean this one is good.
-   * Such an analysis is left to the caller.
-   *
-   * <p>If neither conditions are fulfilled before a given number of iterations, the algorithm is
-   * considered to have failed and an {@link EstimationException} is thrown.
-   *
-   * @param maxIterations maximum number of iterations allowed
-   * @param convergence criterion threshold below which we do not need to improve the criterion
-   *     anymore
-   * @param steadyStateThreshold steady state detection threshold, the problem has converged has
-   *     reached a steady state if <code>Math.abs (Jn - Jn-1) < Jn * convergence</code>, where
-   *     <code>Jn</code> and <code>Jn-1</code> are the current and preceding criterion value (square
-   *     sum of the weighted residuals of considered measurements).
-   * @param epsilon threshold under which the matrix of the linearized problem is considered
-   *     singular (see {@link org.spaceroots.mantissa.linalg.SquareMatrix#solve(Matrix,double)
-   *     SquareMatrix.solve}).
+   * @param maxIterations maximum number of Gauss-Newton iterations permitted before failure
+   * @param convergence absolute criterion floor; values below stop further refinements
+   * @param steadyStateThreshold relative change limit detecting stalled improvement between steps
+   * @param epsilon smallest allowed diagonal pivot before the normal matrix is considered singular
    */
   public GaussNewtonEstimator(
       int maxIterations, double convergence, double steadyStateThreshold, double epsilon) {
@@ -54,25 +58,30 @@ public class GaussNewtonEstimator implements Estimator, Serializable {
   }
 
   /**
-   * Solve an estimation problem using a least squares criterion.
+   * Solve an estimation problem using iterative Gauss-Newton updates.
    *
-   * <p>This method set the unbound parameters of the given problem starting from their current
-   * values through several iterations. At each step, the unbound parameters are changed in order to
-   * minimize a weighted least square criterion based on the measurements of the problem.
+   * <p>The method starts from the current estimates stored in the {@code problem} and repeatedly
+   * linearizes the model, solves the associated normal equations, and shifts the parameters toward
+   * the least squares minimum. Iterations end when either the criterion falls below the configured
+   * {@code convergence} floor or changes less than {@code steadyStateThreshold} relative to its
+   * current value, indicating steady state. Failure to satisfy these conditions within {@code
+   * maxIterations} steps triggers an {@link EstimationException}. Parameter arrays and measurement
+   * collections provided by the problem instance are mutated in place.
    *
-   * <p>The iterations are stopped either when the criterion goes below a physical threshold under
-   * which improvement are considered useless or when the algorithm is unable to improve it (even if
-   * it is still high). The first condition that is met stops the iterations. If the convergence it
-   * nos reached before the maximum number of iterations, an {@link EstimationException} is thrown.
+   * <p>The routine is not thread-safe and assumes the problem is consistent across iterations. The
+   * caller should ensure residuals and partial derivatives are recomputed on each invocation of
+   * {@link WeightedMeasurement} accessors.
    *
-   * @param problem estimation problem to solve
-   * @exception EstimationException if the problem cannot be solved
+   * @param problem estimation problem supplying measurements and adjustable parameters; must be
+   *     non-null and return consistent residuals for each iteration
+   * @exception EstimationException if convergence fails or the linear subproblem becomes singular
    * @see EstimationProblem
    */
   public void estimate(EstimationProblem problem) throws EstimationException {
     int iterations = 0;
-    double previous = 0.0;
-    double current = 0.0;
+    double previous = evaluateCriterion(problem);
+    double current;
+    double difference;
 
     // iterate until convergence is reached
     do {
@@ -85,25 +94,27 @@ public class GaussNewtonEstimator implements Estimator, Serializable {
       // perform one iteration
       linearEstimate(problem);
 
-      previous = current;
       current = evaluateCriterion(problem);
+      difference = Math.abs(previous - current);
+      previous = current;
 
     } while ((iterations < 2)
-        || (Math.abs(previous - current) > (current * steadyStateThreshold)
-            && (Math.abs(current) > convergence)));
+        || (difference > (current * steadyStateThreshold) && (Math.abs(current) > convergence)));
   }
 
   /**
-   * Estimate the solution of a linear least square problem.
+   * Perform one linearized Gauss-Newton step or solve a purely linear problem.
    *
-   * <p>The Gauss-Newton algorithm is iterative. Each iteration consist in solving a linearized
-   * least square problem. Several iterations are needed for general problems since the
-   * linearization is only an approximation of the problem behaviour. However, for linear problems
-   * one iteration is enough to get the solution. This method is provided in the public interface in
-   * order to handle more efficiently these linear problems.
+   * <p>The routine constructs the normal matrix and right-hand side from the measurement residuals
+   * and partial derivatives, solves the resulting linear system, and applies the increment to each
+   * unbound parameter. For a truly linear model this single call completes the estimation; for
+   * nonlinear models it represents one iteration of {@link #estimate(EstimationProblem)}. The
+   * method relies on {@link WeightedMeasurement} to provide up-to-date residuals and partials at
+   * the current parameter values.
    *
-   * @param problem estimation problem to solve
-   * @exception EstimationException if the problem cannot be solved
+   * @param problem estimation problem whose measurements define residuals and Jacobian entries; it
+   *     must expose unbound parameters that can be updated in place
+   * @exception EstimationException if the normal matrix is singular or the solver cannot progress
    */
   public void linearEstimate(EstimationProblem problem) throws EstimationException {
 
@@ -113,16 +124,16 @@ public class GaussNewtonEstimator implements Estimator, Serializable {
     // build the linear problem
     GeneralMatrix b = new GeneralMatrix(parameters.length, 1);
     SymetricalMatrix a = new SymetricalMatrix(parameters.length);
-    for (int i = 0; i < measurements.length; ++i) {
-      if (!measurements[i].isIgnored()) {
-        double weight = measurements[i].getWeight();
-        double residual = measurements[i].getResidual();
+    for (WeightedMeasurement measurement : measurements) {
+      if (!measurement.isIgnored()) {
+        double weight = measurement.getWeight();
+        double residual = measurement.getResidual();
 
         // compute the normal equation
         double[] grad = new double[parameters.length];
         Matrix bDecrement = new GeneralMatrix(parameters.length, 1);
         for (int j = 0; j < parameters.length; ++j) {
-          grad[j] = measurements[i].getPartial(parameters[j]);
+          grad[j] = measurement.getPartial(parameters[j]);
           bDecrement.setElement(j, 0, weight * residual * grad[j]);
         }
 
@@ -151,22 +162,26 @@ public class GaussNewtonEstimator implements Estimator, Serializable {
     double criterion = 0.0;
     WeightedMeasurement[] measurements = problem.getMeasurements();
 
-    for (int i = 0; i < measurements.length; ++i) {
-      double residual = measurements[i].getResidual();
-      criterion += measurements[i].getWeight() * residual * residual;
+    for (WeightedMeasurement measurement : measurements) {
+      double residual = measurement.getResidual();
+      criterion += measurement.getWeight() * residual * residual;
     }
 
     return criterion;
   }
 
   /**
-   * Get the Root Mean Square value. Get the Root Mean Square value, i.e. the root of the arithmetic
-   * mean of the square of all weighted residuals. This is related to the criterion that is
-   * minimized by the estimator as follows: if <em>c</em> if the criterion, and <em>n</em> is the
-   * number of measurements, then the RMS is <em>sqrt (c/n)</em>.
+   * Compute the root-mean-square of the weighted residuals for a problem.
    *
-   * @param problem estimation problem
-   * @return RMS value
+   * <p>The RMS equals {@code sqrt(criterion / n)} where {@code criterion} is the sum of weighted
+   * squared residuals across the measurements and {@code n} is their count. It provides a
+   * normalized measure of fit quality that is directly comparable across problems with different
+   * numbers of measurements. The method does not alter the problem or the estimator state and can
+   * be invoked between iterations to monitor convergence progress.
+   *
+   * @param problem estimation problem supplying residuals and weights; must be consistent with the
+   *     most recent parameter estimates
+   * @return RMS value derived from current residuals; {@code Double.NaN} is never returned
    */
   public double getRMS(EstimationProblem problem) {
     double criterion = evaluateCriterion(problem);
@@ -174,10 +189,29 @@ public class GaussNewtonEstimator implements Estimator, Serializable {
     return Math.sqrt(criterion / n);
   }
 
-  private int maxIterations;
-  private double steadyStateThreshold;
-  private double convergence;
-  private double epsilon;
+  /**
+   * Maximum count of Gauss-Newton iterations permitted for any estimation run. Exceeding this cap
+   * indicates the algorithm stalled or diverged and results in an {@link EstimationException}.
+   */
+  private final int maxIterations;
 
-  private static final long serialVersionUID = -7606628156644194170L;
+  /**
+   * Relative threshold used to detect steady-state behaviour between successive criteria values.
+   * When the absolute delta falls below this fraction of the current criterion, iterations stop.
+   */
+  private final double steadyStateThreshold;
+
+  /**
+   * Absolute criterion floor that short-circuits further refinement once reached, representing the
+   * minimum useful objective value given measurement noise and model fidelity.
+   */
+  private final double convergence;
+
+  /**
+   * Pivot magnitude cutoff passed to the linear solver; smaller values flag the normal matrix as
+   * numerically singular to prevent unstable parameter updates.
+   */
+  private final double epsilon;
+
+  @Serial private static final long serialVersionUID = -7606628156644194170L;
 }

--- a/src/main/java/org/spaceroots/mantissa/estimation/LevenbergMarquardtEstimator.java
+++ b/src/main/java/org/spaceroots/mantissa/estimation/LevenbergMarquardtEstimator.java
@@ -1,86 +1,71 @@
 package org.spaceroots.mantissa.estimation;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 
 /**
- * This class solves a least squares problem.
+ * Levenberg-Marquardt implementation for weighted nonlinear least-squares problems.
  *
- * <p>This implementation <em>should</em> work even for over-determined systems (i.e. systems having
- * more variables than equations). Over-determined systems are solved by ignoring the variables
- * which have the smallest impact according to their jacobian column norm. Only the rank of the
- * matrix and some loop bounds are changed to implement this. This feature has undergone only basic
- * testing for now and should still be considered experimental.
+ * <p>This estimator wraps a trust-region variant of the classical Levenberg-Marquardt algorithm as
+ * translated from MINPACK's {@code lmder}. Clients configure step-size and convergence tolerances,
+ * provide an {@link EstimationProblem}, and invoke {@link #estimate(EstimationProblem)} to mutate
+ * the supplied {@link EstimatedParameter} instances until the weighted residual norm cannot be
+ * reduced further. The implementation supports over-determined systems by discarding the least
+ * influential columns (measured by Jacobian norms), while keeping the QR decomposition rank aware.
  *
- * <p>The resolution engine is a simple translation of the MINPACK <a
- * href="http://www.netlib.org/minpack/lmder.f">lmder</a> routine with minor changes. The changes
- * include the over-determined resolution and the Q.R. decomposition which has been rewritten
- * following the algorithm described in the P. Lascaux and R. Theodor book <i>Analyse
- * num&eacute;rique matricielle appliqu&eacute;e &agrave; l'art de l'ing&eacute;nieur</i>, Masson
- * 1986. The redistribution policy for MINPACK is available <a
- * href="http://www.netlib.org/minpack/disclaimer">here</a>, for convenience, it is reproduced
- * below.
+ * <p>The solver is stateful and not thread-safe: create a fresh instance per concurrent solve. A
+ * typical call sequence is:
  *
- * <table border="0" width="80%" cellpadding="10" align="center" bgcolor="#E0E0E0">
- * <tr><td>
- *    Minpack Copyright Notice (1999) University of Chicago.
- *    All rights reserved
- * </td></tr>
- * <tr><td>
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * <ol>
- *  <li>Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.</li>
- * <li>Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.</li>
- * <li>The end-user documentation included with the redistribution, if any,
- *     must include the following acknowledgment:
- *     <code>This product includes software developed by the University of
- *           Chicago, as Operator of Argonne National Laboratory.</code>
- *     Alternately, this acknowledgment may appear in the software itself,
- *     if and wherever such third-party acknowledgments normally appear.</li>
- * <li><strong>WARRANTY DISCLAIMER. THE SOFTWARE IS SUPPLIED "AS IS"
- *     WITHOUT WARRANTY OF ANY KIND. THE COPYRIGHT HOLDER, THE
- *     UNITED STATES, THE UNITED STATES DEPARTMENT OF ENERGY, AND
- *     THEIR EMPLOYEES: (1) DISCLAIM ANY WARRANTIES, EXPRESS OR
- *     IMPLIED, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES
- *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE
- *     OR NON-INFRINGEMENT, (2) DO NOT ASSUME ANY LEGAL LIABILITY
- *     OR RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS, OR
- *     USEFULNESS OF THE SOFTWARE, (3) DO NOT REPRESENT THAT USE OF
- *     THE SOFTWARE WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS, (4)
- *     DO NOT WARRANT THAT THE SOFTWARE WILL FUNCTION
- *     UNINTERRUPTED, THAT IT IS ERROR-FREE OR THAT ANY ERRORS WILL
- *     BE CORRECTED.</strong></li>
- * <li><strong>LIMITATION OF LIABILITY. IN NO EVENT WILL THE COPYRIGHT
- *     HOLDER, THE UNITED STATES, THE UNITED STATES DEPARTMENT OF
- *     ENERGY, OR THEIR EMPLOYEES: BE LIABLE FOR ANY INDIRECT,
- *     INCIDENTAL, CONSEQUENTIAL, SPECIAL OR PUNITIVE DAMAGES OF
- *     ANY KIND OR NATURE, INCLUDING BUT NOT LIMITED TO LOSS OF
- *     PROFITS OR LOSS OF DATA, FOR ANY REASON WHATSOEVER, WHETHER
- *     SUCH LIABILITY IS ASSERTED ON THE BASIS OF CONTRACT, TORT
- *     (INCLUDING NEGLIGENCE OR STRICT LIABILITY), OR OTHERWISE,
- *     EVEN IF ANY OF SAID PARTIES HAS BEEN WARNED OF THE
- *     POSSIBILITY OF SUCH LOSS OR DAMAGES.</strong></li>
- * <ol></td></tr>
- * </table>
+ * <ul>
+ *   <li>Construct the estimator, optionally overriding default tolerances.
+ *   <li>Populate measurements and parameters inside an {@code EstimationProblem}.
+ *   <li>Call {@link #estimate(EstimationProblem)}; afterward inspect {@link #getCostEvaluations()}
+ *       and {@link #getJacobianEvaluations()}.
+ * </ul>
+ *
+ * <p>Numerical behavior mirrors MINPACK closely: damping is adjusted to balance Gauss-Newton and
+ * gradient-descent steps; orthogonality, parameter relative change, and cost relative change govern
+ * termination. No internal synchronization is performed, and the class mutates the parameter
+ * objects supplied by the problem, so callers should copy inputs when reuse is required.
+ *
+ * <p><strong>MINPACK copyright notice (1999) University of Chicago. All rights reserved.</strong>
+ * Redistribution of this translated work follows the original conditions:
+ *
+ * <ul>
+ *   <li>Source redistributions must retain the copyright notice, conditions, and disclaimer.
+ *   <li>Binary redistributions must reproduce the same notices in accompanying materials.
+ *   <li>End-user documentation must acknowledge “This product includes software developed by the
+ *       University of Chicago, as Operator of Argonne National Laboratory,” unless such credit
+ *       already appears in customary locations.
+ *   <li><strong>Warranty disclaimer:</strong> the software is provided “as is” without any express
+ *       or implied warranties, including merchantability, fitness, title, or non-infringement.
+ *   <li><strong>Limitation of liability:</strong> the copyright holder and contributing agencies
+ *       are not liable for direct or indirect damages, including lost profits or data, even if
+ *       advised of the possibility.
+ * </ul>
  *
  * @author Argonne National Laboratory. MINPACK project. March 1980 (original fortran)
  * @author Burton S. Garbow (original fortran)
  * @author Kenneth E. Hillstrom (original fortran)
  * @author Jorge J. More (original fortran)
  * @author Luc Maisonobe (Java translation)
+ * @see EstimationProblem
+ * @see EstimatedParameter
  */
 public class LevenbergMarquardtEstimator implements Serializable, Estimator {
 
   /**
-   * Build an estimator for least squares problems.
+   * Create an estimator with conservative, convergence-friendly defaults.
    *
-   * <p>The default values for the algorithm settings are:
+   * <p>The constructor seeds all trust-region and tolerance settings with values that favor
+   * stability over speed. These defaults mirror the upstream MINPACK recommendations and should be
+   * suitable for most small to medium non-linear least-squares problems. Callers may override any
+   * parameter through the corresponding setter before invoking {@link #estimate(EstimationProblem)}
+   * to match the conditioning and noise level of their data. Instances are reusable across multiple
+   * problems but hold mutable state, so allocate a new estimator for concurrent runs.
+   *
+   * <p>The default values are:
    *
    * <ul>
    *   <li>{@link #setInitialStepBoundFactor initial step bound factor}: 100.0
@@ -100,86 +85,125 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
   }
 
   /**
-   * Set the positive input variable used in determining the initial step bound. This bound is set
-   * to the product of initialStepBoundFactor and the euclidean norm of diag*x if nonzero, or else
-   * to initialStepBoundFactor itself. In most cases factor should lie in the interval (0.1, 100.0).
-   * 100.0 is a generally recommended value
+   * Set the scaling applied to the initial trust-region radius.
    *
-   * @param initialStepBoundFactor initial step bound factor
-   * @see #estimate
+   * <p>The first Levenberg-Marquardt step bound is computed as {@code factor * ||diag * x||} when
+   * the weighted parameters have a non-zero norm, or simply {@code factor} when all starting values
+   * are zero. Larger factors encourage exploratory steps; smaller factors constrain the initial
+   * move and can help ill-conditioned or highly non-linear problems. MINPACK recommends values
+   * between 0.1 and 100, with 100 remaining the historical default.
+   *
+   * @param initialStepBoundFactor initial step scaling factor, positive, typically between 0.1 and
+   *     100
+   * @see #estimate(EstimationProblem)
    */
   public void setInitialStepBoundFactor(double initialStepBoundFactor) {
     this.initialStepBoundFactor = initialStepBoundFactor;
   }
 
   /**
-   * Set the maximal number of cost evaluations.
+   * Set an upper bound on objective function evaluations.
    *
-   * @param maxCostEval maximal number of cost evaluations
-   * @see #estimate
+   * <p>The algorithm counts every call used to compute residuals and their weighted norm. When the
+   * counter reaches this limit, {@link #estimate(EstimationProblem)} aborts with an {@link
+   * EstimationException}. Increase the value when working with large systems or loose tolerances,
+   * and decrease it to force faster failure on divergent models.
+   *
+   * @param maxCostEval maximal number of cost evaluations permitted before aborting the solving
+   * @see #estimate(EstimationProblem)
    */
   public void setMaxCostEval(int maxCostEval) {
     this.maxCostEval = maxCostEval;
   }
 
   /**
-   * Set the desired relative error in the sum of squares.
+   * Set the stopping threshold on relative change of the cost.
    *
-   * @param costRelativeTolerance desired relative error in the sum of squares
-   * @see #estimate
+   * <p>Iterations halt when the actual and predicted reductions in the weighted sum of squared
+   * residuals both fall below this tolerance (scaled by the current cost). Tight values demand more
+   * precise fits but can trigger numerical noise; relaxed values allow earlier termination.
+   *
+   * @param costRelativeTolerance desired relative error on summed squares, positive and near
+   *     machine precision
+   * @see #estimate(EstimationProblem)
    */
   public void setCostRelativeTolerance(double costRelativeTolerance) {
     this.costRelativeTolerance = costRelativeTolerance;
   }
 
   /**
-   * Set the desired relative error in the approximate solution parameters.
+   * Set the stopping threshold on relative parameter changes.
    *
-   * @param parRelativeTolerance desired relative error in the approximate solution parameters
-   * @see #estimate
+   * <p>When the trust-region radius shrinks below this tolerance multiplied by the current
+   * parameter norm, the algorithm considers the solution stable and stops. Use smaller values to
+   * chase tighter parameter accuracy, or larger values to accept coarser solutions and reduce
+   * runtime.
+   *
+   * @param parRelativeTolerance desired relative error on parameters, positive and typically small
+   * @see #estimate(EstimationProblem)
    */
   public void setParRelativeTolerance(double parRelativeTolerance) {
     this.parRelativeTolerance = parRelativeTolerance;
   }
 
   /**
-   * Set the desired max cosine on the orthogonality.
+   * Set the maximum acceptable cosine between the residual vector and the Jacobian columns.
    *
-   * @param orthoTolerance desired max cosine on the orthogonality between the function vector and
-   *     the columns of the jacobian
-   * @see #estimate
+   * <p>The value controls the orthogonality termination criterion: when the gradient is nearly
+   * orthogonal to the residuals, further iterations are unlikely to reduce the cost. Values close
+   * to zero demand strong orthogonality; larger values tolerate less alignment and may stop
+   * earlier.
+   *
+   * @param orthoTolerance desired max cosine between residuals and Jacobian columns, usually small
+   *     and positive
+   * @see #estimate(EstimationProblem)
    */
   public void setOrthoTolerance(double orthoTolerance) {
     this.orthoTolerance = orthoTolerance;
   }
 
   /**
-   * Get the number of cost evaluations.
+   * Get the number of cost evaluations performed in the current solve.
    *
-   * @return number of cost evaluations
+   * <p>The counter resets to zero each time {@link #estimate(EstimationProblem)} starts and
+   * increases every time weighted residuals are recomputed. It is useful for diagnostics and to
+   * confirm whether a stop was triggered by {@link #setMaxCostEval(int)}.
+   *
+   * @return count of cost function evaluations executed since the last call to {@code estimate}
    */
   public int getCostEvaluations() {
     return costEvaluations;
   }
 
   /**
-   * Get the number of jacobian evaluations.
+   * Get the number of Jacobian evaluations performed in the current solve.
    *
-   * @return number of jacobian evaluations
+   * <p>The counter resets to zero when {@link #estimate(EstimationProblem)} begins and increments
+   * each time the Jacobian matrix is rebuilt. Expensive models can use this to monitor derivative
+   * cost or to tune evaluation limits.
+   *
+   * @return count of Jacobian evaluations executed since the last call to {@code estimate}
    */
   public int getJacobianEvaluations() {
     return jacobianEvaluations;
+  }
+
+  private static final class IterationState {
+    private double delta;
+    private double xNorm;
+    private boolean firstIteration = true;
   }
 
   /** Update the jacobian matrix. */
   private void updateJacobian() {
     ++jacobianEvaluations;
     Arrays.fill(jacobian, 0);
-    for (int i = 0, index = 0; i < rows; i++) {
+    for (int i = 0; i < rows; i++) {
       WeightedMeasurement wm = measurements[i];
       double factor = -Math.sqrt(wm.getWeight());
+      int rowStart = i * cols;
       for (int j = 0; j < cols; ++j) {
-        jacobian[index++] = factor * wm.getPartial(parameters[j]);
+        jacobian[rowStart + j] = factor * wm.getPartial(parameters[j]);
       }
     }
   }
@@ -188,7 +212,7 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
   private void updateResidualsAndCost() {
     ++costEvaluations;
     cost = 0;
-    for (int i = 0, index = 0; i < rows; i++, index += cols) {
+    for (int i = 0; i < rows; i++) {
       WeightedMeasurement wm = measurements[i];
       double residual = wm.getResidual();
       residuals[i] = Math.sqrt(wm.getWeight()) * residual;
@@ -198,53 +222,57 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
   }
 
   /**
-   * Get the Root Mean Square value. Get the Root Mean Square value, i.e. the root of the arithmetic
-   * mean of the square of all weighted residuals. This is related to the criterion that is
-   * minimized by the estimator as follows: if <em>c</em> if the criterion, and <em>n</em> is the
-   * number of measurements, then the RMS is <em>sqrt (c/n)</em>.
+   * Compute the root-mean-square (RMS) of the weighted residuals for a problem.
    *
-   * @param problem estimation problem
-   * @return RMS value
+   * <p>The RMS equals {@code sqrt(sum(weight_i * residual_i^2) / n)} where {@code n} is the number
+   * of measurements. It mirrors the criterion minimized by the estimator, scaled by the number of
+   * observations, and can be used to compare fit quality across problems with different sizes.
+   *
+   * @param problem estimation problem providing weighted residuals; must not be {@code null}
+   * @return non-negative RMS of the current residuals, computed without altering the estimator
    */
   public double getRMS(EstimationProblem problem) {
     WeightedMeasurement[] wm = problem.getMeasurements();
     double criterion = 0;
-    for (int i = 0; i < wm.length; ++i) {
-      double residual = wm[i].getResidual();
-      criterion += wm[i].getWeight() * residual * residual;
+    for (WeightedMeasurement weightedMeasurement : wm) {
+      double residual = weightedMeasurement.getResidual();
+      criterion += weightedMeasurement.getWeight() * residual * residual;
     }
     return Math.sqrt(criterion / wm.length);
   }
 
   /**
-   * Solve an estimation problem using the Levenberg-Marquardt algorithm.
+   * Solve an {@link EstimationProblem} using the MINPACK-style Levenberg-Marquardt routine.
    *
-   * <p>The algorithm used is a modified Levenberg-Marquardt one, based on the MINPACK <a
-   * href="http://www.netlib.org/minpack/lmder.f">lmder</a> routine. The algorithm settings must
-   * have been set up before this method is called with the {@link #setInitialStepBoundFactor},
-   * {@link #setMaxCostEval}, {@link #setCostRelativeTolerance}, {@link #setParRelativeTolerance}
-   * and {@link #setOrthoTolerance} methods. If these methods have not been called, the default
-   * values set up by the {@link #LevenbergMarquardtEstimator() constructor} will be used.
+   * <p>The method mutates the {@link EstimatedParameter} instances owned by the supplied problem in
+   * place, iteratively updating them until the trust-region criteria signal convergence or a
+   * termination condition is met. It balances Gauss-Newton and gradient-descent behavior through a
+   * dynamically adjusted damping factor, employs QR with column pivoting to handle rank deficiency,
+   * and stops when any of the configured tolerances indicate diminishing returns. Over-determined
+   * systems are supported by truncating low-impact columns while preserving consistent cost and
+   * gradient calculations.
    *
-   * <p>The authors of the original fortran function are:
+   * <p>Typical usage:
    *
-   * <ul>
-   *   <li>Argonne National Laboratory. MINPACK project. March 1980
-   *   <li>Burton S. Garbow
-   *   <li>Kenneth E. Hillstrom
-   *   <li>Jorge J. More
-   * </ul>
+   * <pre>{@code
+   * LevenbergMarquardtEstimator solver = new LevenbergMarquardtEstimator();
+   * solver.setMaxCostEval(2000);
+   * solver.estimate(problem);
+   * double rms = solver.getRMS(problem);
+   * }</pre>
    *
-   * <p>Luc Maisonobe did the Java translation.
+   * <p>The authors of the original Fortran function are Argonne National Laboratory (MINPACK, March
+   * 1980), Burton S. Garbow, Kenneth E. Hillstrom, and Jorge J. More. Luc Maisonobe produced the
+   * Java translation on which this implementation is based.
    *
-   * @param problem estimation problem to solve
-   * @exception EstimationException if convergence cannot be reached with the specified algorithm
-   *     settings or if there are more variables than equations
-   * @see #setInitialStepBoundFactor
-   * @see #setMaxCostEval
-   * @see #setCostRelativeTolerance
-   * @see #setParRelativeTolerance
-   * @see #setOrthoTolerance
+   * @param problem estimation problem with measurements and initial parameter guesses; never null
+   * @throws EstimationException if convergence fails, evaluations exceed limits, or the system
+   *     violates solver assumptions
+   * @see #setInitialStepBoundFactor(double)
+   * @see #setMaxCostEval(int)
+   * @see #setCostRelativeTolerance(double)
+   * @see #setParRelativeTolerance(double)
+   * @see #setOrthoTolerance(double)
    */
   public void estimate(EstimationProblem problem) throws EstimationException {
 
@@ -265,7 +293,8 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
     residuals = new double[rows];
 
     // local variables
-    double delta = 0, xNorm = 0;
+    double delta = 0;
+    double xNorm = 0;
     double[] diag = new double[cols];
     double[] oldX = new double[cols];
     double[] oldRes = new double[rows];
@@ -276,208 +305,317 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
     // evaluate the function at the starting point and calculate its norm
     updateResidualsAndCost();
 
-    // outer loop
     lmPar = 0;
     costEvaluations = 0;
     jacobianEvaluations = 0;
-    boolean firstIteration = true;
+    IterationState state = new IterationState();
+    state.delta = delta;
+    state.xNorm = xNorm;
+
+    runOuterIterations(diag, oldX, oldRes, work1, work2, work3, state);
+  }
+
+  private void runOuterIterations(
+      double[] diag,
+      double[] oldX,
+      double[] oldRes,
+      double[] work1,
+      double[] work2,
+      double[] work3,
+      IterationState state)
+      throws EstimationException {
     while (costEvaluations < maxCostEval) {
-
-      // compute the Q.R. decomposition of the jacobian matrix
-      updateJacobian();
-      qrDecomposition();
-
-      // compute Qt.res
-      qTy(residuals);
-
-      // now we don't need Q anymore,
-      // so let jacobian contain the R matrix with its diagonal elements
-      for (int k = 0; k < solvedCols; ++k) {
-        int pk = permutation[k];
-        jacobian[k * cols + pk] = diagR[pk];
+      prepareJacobian();
+      if (state.firstIteration) {
+        initializeScale(diag, state);
       }
 
-      if (firstIteration) {
-
-        // scale the variables according to the norms of the columns
-        // of the initial jacobian
-        xNorm = 0;
-        for (int k = 0; k < cols; ++k) {
-          double dk = jacNorm[k];
-          if (dk == 0) {
-            dk = 1.0;
-          }
-          double xk = dk * parameters[k].getEstimate();
-          xNorm += xk * xk;
-          diag[k] = dk;
-        }
-        xNorm = Math.sqrt(xNorm);
-
-        // initialize the step bound delta
-        delta = (xNorm == 0) ? initialStepBoundFactor : (initialStepBoundFactor * xNorm);
-      }
-
-      // check orthogonality between function vector and jacobian columns
-      double maxCosine = 0;
-      if (cost != 0) {
-        for (int j = 0; j < solvedCols; ++j) {
-          int pj = permutation[j];
-          double s = jacNorm[pj];
-          if (s != 0) {
-            double sum = 0;
-            for (int i = 0, index = pj; i <= j; ++i, index += cols) {
-              sum += jacobian[index] * residuals[i];
-            }
-            maxCosine = Math.max(maxCosine, Math.abs(sum) / (s * cost));
-          }
-        }
-      }
-      if (maxCosine <= orthoTolerance) {
+      double maxCosine = computeMaxCosine();
+      if (isOrthogonal(maxCosine)) {
         return;
       }
 
-      // rescale if necessary
-      for (int j = 0; j < cols; ++j) {
-        diag[j] = Math.max(diag[j], jacNorm[j]);
-      }
-
-      // inner loop
-      for (double ratio = 0; ratio < 1.0e-4; ) {
-
-        // save the state
-        for (int j = 0; j < solvedCols; ++j) {
-          int pj = permutation[j];
-          oldX[pj] = parameters[pj].getEstimate();
-        }
-        double previousCost = cost;
-        double[] tmpVec = residuals;
-        residuals = oldRes;
-        oldRes = tmpVec;
-
-        // determine the Levenberg-Marquardt parameter
-        determineLMParameter(oldRes, delta, diag, work1, work2, work3);
-
-        // compute the new point and the norm of the evolution direction
-        double lmNorm = 0;
-        for (int j = 0; j < solvedCols; ++j) {
-          int pj = permutation[j];
-          lmDir[pj] = -lmDir[pj];
-          parameters[pj].setEstimate(oldX[pj] + lmDir[pj]);
-          double s = diag[pj] * lmDir[pj];
-          lmNorm += s * s;
-        }
-        lmNorm = Math.sqrt(lmNorm);
-
-        // on the first iteration, adjust the initial step bound.
-        if (firstIteration) {
-          delta = Math.min(delta, lmNorm);
-        }
-
-        // evaluate the function at x + p and calculate its norm
-        updateResidualsAndCost();
-
-        // compute the scaled actual reduction
-        double actRed = -1.0;
-        if (0.1 * cost < previousCost) {
-          double r = cost / previousCost;
-          actRed = 1.0 - r * r;
-        }
-
-        // compute the scaled predicted reduction
-        // and the scaled directional derivative
-        for (int j = 0; j < solvedCols; ++j) {
-          int pj = permutation[j];
-          double dirJ = lmDir[pj];
-          work1[j] = 0;
-          for (int i = 0, index = pj; i <= j; ++i, index += cols) {
-            work1[i] += jacobian[index] * dirJ;
-          }
-        }
-        double coeff1 = 0;
-        for (int j = 0; j < solvedCols; ++j) {
-          coeff1 += work1[j] * work1[j];
-        }
-        double pc2 = previousCost * previousCost;
-        coeff1 = coeff1 / pc2;
-        double coeff2 = lmPar * lmNorm * lmNorm / pc2;
-        double preRed = coeff1 + 2 * coeff2;
-        double dirDer = -(coeff1 + coeff2);
-
-        // ratio of the actual to the predicted reduction
-        ratio = (preRed == 0) ? 0 : (actRed / preRed);
-
-        // update the step bound
-        if (ratio <= 0.25) {
-          double tmp = (actRed < 0) ? (0.5 * dirDer / (dirDer + 0.5 * actRed)) : 0.5;
-          if ((0.1 * cost >= previousCost) || (tmp < 0.1)) {
-            tmp = 0.1;
-          }
-          delta = tmp * Math.min(delta, 10.0 * lmNorm);
-          lmPar /= tmp;
-        } else if ((lmPar == 0) || (ratio >= 0.75)) {
-          delta = 2 * lmNorm;
-          lmPar *= 0.5;
-        }
-
-        // test for successful iteration.
-        if (ratio >= 1.0e-4) {
-          // successful iteration, update the norm
-          firstIteration = false;
-          xNorm = 0;
-          for (int k = 0; k < cols; ++k) {
-            double xK = diag[k] * parameters[k].getEstimate();
-            xNorm += xK * xK;
-          }
-          xNorm = Math.sqrt(xNorm);
-        } else {
-          // failed iteration, reset the previous values
-          cost = previousCost;
-          for (int j = 0; j < solvedCols; ++j) {
-            int pj = permutation[j];
-            parameters[pj].setEstimate(oldX[pj]);
-          }
-          tmpVec = residuals;
-          residuals = oldRes;
-          oldRes = tmpVec;
-        }
-
-        // tests for convergence.
-        if (((Math.abs(actRed) <= costRelativeTolerance)
-                && (preRed <= costRelativeTolerance)
-                && (ratio <= 2.0))
-            || (delta <= parRelativeTolerance * xNorm)) {
-          return;
-        }
-
-        // tests for termination and stringent tolerances
-        // (2.2204e-16 is the machine epsilon for IEEE754)
-        if (costEvaluations >= maxCostEval) {
-          break;
-        }
-        if ((Math.abs(actRed) <= 2.2204e-16) && (preRed <= 2.2204e-16) && (ratio <= 2.0)) {
-          throw new EstimationException(
-              "cost relative tolerance is too small ({0}),"
-                  + " no further reduction in the"
-                  + " sum of squares is possible",
-              new String[] {Double.toString(costRelativeTolerance)});
-        } else if (delta <= 2.2204e-16 * xNorm) {
-          throw new EstimationException(
-              "parameters relative tolerance is too small"
-                  + " ({0}), no further improvement in"
-                  + " the approximate solution is possible",
-              new String[] {Double.toString(parRelativeTolerance)});
-        } else if (maxCosine <= 2.2204e-16) {
-          throw new EstimationException(
-              "orthogonality tolerance is too small ({0}),"
-                  + " solution is orthogonal to the jacobian",
-              new String[] {Double.toString(orthoTolerance)});
-        }
+      rescaleDiagonal(diag);
+      InnerLoopResult result =
+          performInnerLoop(diag, oldX, oldRes, work1, work2, work3, state, maxCosine);
+      oldRes = result.oldResiduals;
+      if (result.converged) {
+        return;
       }
     }
 
     throw new EstimationException(
         "maximal number of evaluations exceeded ({0})",
         new String[] {Integer.toString(maxCostEval)});
+  }
+
+  private void prepareJacobian() {
+    updateJacobian();
+    qrDecomposition();
+    qTy(residuals);
+    for (int k = 0; k < solvedCols; ++k) {
+      int pk = permutation[k];
+      jacobian[k * cols + pk] = diagR[pk];
+    }
+  }
+
+  private void initializeScale(double[] diag, IterationState state) {
+    state.xNorm = 0;
+    for (int k = 0; k < cols; ++k) {
+      double dk = jacNorm[k];
+      if (dk == 0) {
+        dk = 1.0;
+      }
+      double xk = dk * parameters[k].getEstimate();
+      state.xNorm += xk * xk;
+      diag[k] = dk;
+    }
+    state.xNorm = Math.sqrt(state.xNorm);
+    state.delta =
+        (state.xNorm == 0) ? initialStepBoundFactor : (initialStepBoundFactor * state.xNorm);
+  }
+
+  private double computeMaxCosine() {
+    double maxCosine = 0;
+    if (cost != 0) {
+      for (int j = 0; j < solvedCols; ++j) {
+        int pj = permutation[j];
+        double s = jacNorm[pj];
+        if (s != 0) {
+          double sum = 0;
+          for (int i = 0, index = pj; i <= j; ++i, index += cols) {
+            sum += jacobian[index] * residuals[i];
+          }
+          maxCosine = Math.max(maxCosine, Math.abs(sum) / (s * cost));
+        }
+      }
+    }
+    return maxCosine;
+  }
+
+  private boolean isOrthogonal(double maxCosine) {
+    return maxCosine <= orthoTolerance;
+  }
+
+  private void rescaleDiagonal(double[] diag) {
+    for (int j = 0; j < cols; ++j) {
+      diag[j] = Math.max(diag[j], jacNorm[j]);
+    }
+  }
+
+  private InnerLoopResult performInnerLoop(
+      double[] diag,
+      double[] oldX,
+      double[] oldRes,
+      double[] work1,
+      double[] work2,
+      double[] work3,
+      IterationState state,
+      double maxCosine)
+      throws EstimationException {
+    double ratio = 0;
+    double[] localOldRes = oldRes;
+    while (ratio < 1.0e-4) {
+      saveCurrentPoint(oldX);
+      double previousCost = cost;
+      double[] tmpVec = residuals;
+      residuals = localOldRes;
+      localOldRes = tmpVec;
+
+      determineLMParameter(localOldRes, state.delta, diag, work1, work2, work3);
+
+      double lmNorm = computeLmNorm(diag, oldX);
+      adjustDeltaOnFirstIteration(state, lmNorm);
+
+      updateResidualsAndCost();
+
+      double actRed = computeActualReduction(previousCost);
+      PredictedReduction predicted = computeScaledPredictedReduction(previousCost, work1, lmNorm);
+      ratio = predicted.preRed == 0 ? 0 : (actRed / predicted.preRed);
+
+      updateStepBound(state, lmNorm, ratio, actRed, predicted.dirDer, previousCost);
+
+      if (ratio >= 1.0e-4) {
+        updateNorm(state, diag);
+      } else {
+        localOldRes = rollbackIteration(oldX, localOldRes, previousCost);
+      }
+
+      if (hasConverged(actRed, predicted.preRed, ratio, state)) {
+        return new InnerLoopResult(true, localOldRes);
+      }
+      if (handleTightTolerances(state, maxCosine, actRed, predicted.preRed, ratio)) {
+        return new InnerLoopResult(false, localOldRes);
+      }
+    }
+    return new InnerLoopResult(false, localOldRes);
+  }
+
+  private void saveCurrentPoint(double[] oldX) {
+    for (int j = 0; j < solvedCols; ++j) {
+      int pj = permutation[j];
+      oldX[pj] = parameters[pj].getEstimate();
+    }
+  }
+
+  private double computeLmNorm(double[] diag, double[] oldX) {
+    double lmNorm = 0;
+    for (int j = 0; j < solvedCols; ++j) {
+      int pj = permutation[j];
+      lmDir[pj] = -lmDir[pj];
+      parameters[pj].setEstimate(oldX[pj] + lmDir[pj]);
+      double s = diag[pj] * lmDir[pj];
+      lmNorm += s * s;
+    }
+    return Math.sqrt(lmNorm);
+  }
+
+  private void adjustDeltaOnFirstIteration(IterationState state, double lmNorm) {
+    if (state.firstIteration) {
+      state.delta = Math.min(state.delta, lmNorm);
+    }
+  }
+
+  private double computeActualReduction(double previousCost) {
+    if (0.1 * cost >= previousCost) {
+      return -1.0;
+    }
+    double r = cost / previousCost;
+    return 1.0 - r * r;
+  }
+
+  private PredictedReduction computeScaledPredictedReduction(
+      double previousCost, double[] work1, double lmNorm) {
+    for (int j = 0; j < solvedCols; ++j) {
+      int pj = permutation[j];
+      double dirJ = lmDir[pj];
+      work1[j] = 0;
+      for (int i = 0, index = pj; i <= j; ++i, index += cols) {
+        work1[i] += jacobian[index] * dirJ;
+      }
+    }
+    double coeff1 = 0;
+    for (int j = 0; j < solvedCols; ++j) {
+      coeff1 += work1[j] * work1[j];
+    }
+    double pc2 = previousCost * previousCost;
+    coeff1 = coeff1 / pc2;
+    double coeff2 = lmPar * lmNorm * lmNorm / pc2;
+    double preRed = coeff1 + 2 * coeff2;
+    double dirDer = -(coeff1 + coeff2);
+    return new PredictedReduction(preRed, dirDer);
+  }
+
+  private void updateStepBound(
+      IterationState state,
+      double lmNorm,
+      double ratio,
+      double actRed,
+      double dirDer,
+      double previousCost) {
+    if (ratio <= 0.25) {
+      double tmp = (actRed < 0) ? (0.5 * dirDer / (dirDer + 0.5 * actRed)) : 0.5;
+      if ((0.1 * cost >= previousCost) || (tmp < 0.1)) {
+        tmp = 0.1;
+      }
+      state.delta = tmp * Math.min(state.delta, 10.0 * lmNorm);
+      lmPar /= tmp;
+    } else if ((lmPar == 0) || (ratio >= 0.75)) {
+      state.delta = 2 * lmNorm;
+      lmPar *= 0.5;
+    }
+  }
+
+  private void updateNorm(IterationState state, double[] diag) {
+    state.firstIteration = false;
+    state.xNorm = 0;
+    for (int k = 0; k < cols; ++k) {
+      double xK = diag[k] * parameters[k].getEstimate();
+      state.xNorm += xK * xK;
+    }
+    state.xNorm = Math.sqrt(state.xNorm);
+  }
+
+  private double[] rollbackIteration(double[] oldX, double[] oldRes, double previousCost) {
+    cost = previousCost;
+    for (int j = 0; j < solvedCols; ++j) {
+      int pj = permutation[j];
+      parameters[pj].setEstimate(oldX[pj]);
+    }
+    double[] tmpVec = residuals;
+    residuals = oldRes;
+    return tmpVec;
+  }
+
+  private boolean hasConverged(double actRed, double preRed, double ratio, IterationState state) {
+    return ((Math.abs(actRed) <= costRelativeTolerance)
+            && (preRed <= costRelativeTolerance)
+            && (ratio <= 2.0))
+        || (state.delta <= parRelativeTolerance * state.xNorm);
+  }
+
+  private boolean handleTightTolerances(
+      IterationState state, double maxCosine, double actRed, double preRed, double ratio)
+      throws EstimationException {
+    if (costEvaluations >= maxCostEval) {
+      return true;
+    }
+    if ((Math.abs(actRed) <= 2.2204e-16) && (preRed <= 2.2204e-16) && (ratio <= 2.0)) {
+      throw new EstimationException(
+          "cost relative tolerance is too small ({0}),"
+              + " no further reduction in the"
+              + " sum of squares is possible",
+          new String[] {Double.toString(costRelativeTolerance)});
+    }
+    if (state.delta <= 2.2204e-16 * state.xNorm) {
+      throw new EstimationException(
+          "parameters relative tolerance is too small"
+              + " ({0}), no further improvement in"
+              + " the approximate solution is possible",
+          new String[] {Double.toString(parRelativeTolerance)});
+    }
+    if (maxCosine <= 2.2204e-16) {
+      throw new EstimationException(
+          "orthogonality tolerance is too small ({0})," + " solution is orthogonal to the jacobian",
+          new String[] {Double.toString(orthoTolerance)});
+    }
+    return false;
+  }
+
+  private static final class ParameterBounds {
+    private double parl;
+    private double paru;
+    private double gNorm;
+  }
+
+  private static final class ColumnSelection {
+    private final int columnIndex;
+    private final double norm2;
+
+    private ColumnSelection(int columnIndex, double norm2) {
+      this.columnIndex = columnIndex;
+      this.norm2 = norm2;
+    }
+  }
+
+  private static final class PredictedReduction {
+    private final double preRed;
+    private final double dirDer;
+
+    private PredictedReduction(double preRed, double dirDer) {
+      this.preRed = preRed;
+      this.dirDer = dirDer;
+    }
+  }
+
+  private static final class InnerLoopResult {
+    private final boolean converged;
+    private final double[] oldResiduals;
+
+    private InnerLoopResult(boolean converged, double[] oldResiduals) {
+      this.converged = converged;
+      this.oldResiduals = oldResiduals;
+    }
   }
 
   /**
@@ -509,8 +647,25 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
   private void determineLMParameter(
       double[] qy, double delta, double[] diag, double[] work1, double[] work2, double[] work3) {
 
-    // compute and store in x the gauss-newton direction, if the
-    // jacobian is rank-deficient, obtain a least squares solution
+    computeGaussNewtonDirection(qy);
+    double dxNorm = computeDxNorm(diag, work1);
+    double fp = dxNorm - delta;
+    if (fp <= 0.1 * delta) {
+      lmPar = 0;
+      return;
+    }
+
+    ParameterBounds bounds = computeParameterBounds(fp, delta, diag, work1, qy, dxNorm);
+
+    lmPar = Math.clamp(lmPar, bounds.parl, bounds.paru);
+    if (lmPar == 0) {
+      lmPar = bounds.gNorm / dxNorm;
+    }
+
+    refineLmParameter(qy, delta, diag, work1, work2, work3, bounds, fp);
+  }
+
+  private void computeGaussNewtonDirection(double[] qy) {
     for (int j = 0; j < rank; ++j) {
       lmDir[permutation[j]] = qy[j];
     }
@@ -525,9 +680,9 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
       }
       lmDir[pk] = ypk;
     }
+  }
 
-    // evaluate the function at the origin, and test
-    // for acceptance of the Gauss-Newton direction
+  private double computeDxNorm(double[] diag, double[] work1) {
     double dxNorm = 0;
     for (int j = 0; j < solvedCols; ++j) {
       int pj = permutation[j];
@@ -535,23 +690,18 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
       work1[pj] = s;
       dxNorm += s * s;
     }
-    dxNorm = Math.sqrt(dxNorm);
-    double fp = dxNorm - delta;
-    if (fp <= 0.1 * delta) {
-      lmPar = 0;
-      return;
-    }
+    return Math.sqrt(dxNorm);
+  }
 
-    // if the jacobian is not rank deficient, the Newton step provides
-    // a lower bound, parl, for the zero of the function,
-    // otherwise set this bound to zero
-    double sum2, parl = 0;
+  private ParameterBounds computeParameterBounds(
+      double fp, double delta, double[] diag, double[] work1, double[] qy, double dxNorm) {
+    ParameterBounds bounds = new ParameterBounds();
     if (rank == solvedCols) {
       for (int j = 0; j < solvedCols; ++j) {
         int pj = permutation[j];
         work1[pj] *= diag[pj] / dxNorm;
       }
-      sum2 = 0;
+      double sum2 = 0;
       for (int j = 0; j < solvedCols; ++j) {
         int pj = permutation[j];
         double sum = 0;
@@ -562,11 +712,10 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
         work1[pj] = s;
         sum2 += s * s;
       }
-      parl = fp / (delta * sum2);
+      bounds.parl = fp / (delta * sum2);
     }
 
-    // calculate an upper bound, paru, for the zero of the function
-    sum2 = 0;
+    double sum2 = 0;
     for (int j = 0; j < solvedCols; ++j) {
       int pj = permutation[j];
       double sum = 0;
@@ -576,80 +725,106 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
       sum /= diag[pj];
       sum2 += sum * sum;
     }
-    double gNorm = Math.sqrt(sum2);
-    double paru = gNorm / delta;
-    if (paru == 0) {
-      // 2.2251e-308 is the smallest positive real for IEE754
-      paru = 2.2251e-308 / Math.min(delta, 0.1);
+    bounds.gNorm = Math.sqrt(sum2);
+    bounds.paru = bounds.gNorm / delta;
+    if (bounds.paru == 0) {
+      bounds.paru = 2.2251e-308 / Math.min(delta, 0.1);
     }
+    return bounds;
+  }
 
-    // if the input par lies outside of the interval (parl,paru),
-    // set par to the closer endpoint
-    lmPar = Math.min(paru, Math.max(lmPar, parl));
-    if (lmPar == 0) {
-      lmPar = gNorm / dxNorm;
-    }
-
+  private void refineLmParameter(
+      double[] qy,
+      double delta,
+      double[] diag,
+      double[] work1,
+      double[] work2,
+      double[] work3,
+      ParameterBounds bounds,
+      double fp) {
+    double localDxNorm;
+    double localFp = fp;
     for (int countdown = 10; countdown >= 0; --countdown) {
-
-      // evaluate the function at the current value of lmPar
-      if (lmPar == 0) {
-        lmPar = Math.max(2.2251e-308, 0.001 * paru);
-      }
+      ensurePositiveLmPar(bounds);
       double sPar = Math.sqrt(lmPar);
-      for (int j = 0; j < solvedCols; ++j) {
-        int pj = permutation[j];
-        work1[pj] = sPar * diag[pj];
-      }
+      prepareScaledDirection(diag, work1, sPar);
       determineLMDirection(qy, work1, work2, work3);
 
-      dxNorm = 0;
-      for (int j = 0; j < solvedCols; ++j) {
-        int pj = permutation[j];
-        double s = diag[pj] * lmDir[pj];
-        work3[pj] = s;
-        dxNorm += s * s;
-      }
-      dxNorm = Math.sqrt(dxNorm);
-      double previousFP = fp;
-      fp = dxNorm - delta;
+      localDxNorm = computeDxNormForRefinement(diag, work3);
+      double previousFP = localFp;
+      localFp = localDxNorm - delta;
 
-      // if the function is small enough, accept the current value
-      // of lmPar, also test for the exceptional cases where parl is zero
-      if ((Math.abs(fp) <= 0.1 * delta)
-          || ((parl == 0) && (fp <= previousFP) && (previousFP < 0))) {
+      if (isFunctionSmallEnough(bounds, delta, localFp, previousFP)) {
         return;
       }
 
-      // compute the Newton correction
-      for (int j = 0; j < solvedCols; ++j) {
-        int pj = permutation[j];
-        work1[pj] = work3[pj] * diag[pj] / dxNorm;
-      }
-      for (int j = 0; j < solvedCols; ++j) {
-        int pj = permutation[j];
-        work1[pj] /= work2[j];
-        double tmp = work1[pj];
-        for (int i = j + 1; i < solvedCols; ++i) {
-          work1[permutation[i]] -= jacobian[i * cols + pj] * tmp;
-        }
-      }
-      sum2 = 0;
-      for (int j = 0; j < solvedCols; ++j) {
-        double s = work1[permutation[j]];
-        sum2 += s * s;
-      }
-      double correction = fp / (delta * sum2);
+      adjustWorkForCorrection(diag, work1, work2, work3, localDxNorm);
+      double correction = computeCorrectionMagnitude(delta, localFp, work1);
+      updateParameterBounds(bounds, localFp);
+      lmPar = Math.max(bounds.parl, lmPar + correction);
+    }
+  }
 
-      // depending on the sign of the function, update parl or paru.
-      if (fp > 0) {
-        parl = Math.max(parl, lmPar);
-      } else if (fp < 0) {
-        paru = Math.min(paru, lmPar);
-      }
+  private void ensurePositiveLmPar(ParameterBounds bounds) {
+    if (lmPar == 0) {
+      lmPar = Math.max(2.2251e-308, 0.001 * bounds.paru);
+    }
+  }
 
-      // compute an improved estimate for lmPar
-      lmPar = Math.max(parl, lmPar + correction);
+  private void prepareScaledDirection(double[] diag, double[] work1, double sPar) {
+    for (int j = 0; j < solvedCols; ++j) {
+      int pj = permutation[j];
+      work1[pj] = sPar * diag[pj];
+    }
+  }
+
+  private double computeDxNormForRefinement(double[] diag, double[] work3) {
+    double localDxNorm = 0;
+    for (int j = 0; j < solvedCols; ++j) {
+      int pj = permutation[j];
+      double s = diag[pj] * lmDir[pj];
+      work3[pj] = s;
+      localDxNorm += s * s;
+    }
+    return Math.sqrt(localDxNorm);
+  }
+
+  private boolean isFunctionSmallEnough(
+      ParameterBounds bounds, double delta, double localFp, double previousFP) {
+    return (Math.abs(localFp) <= 0.1 * delta)
+        || ((bounds.parl == 0) && (localFp <= previousFP) && (previousFP < 0));
+  }
+
+  private void adjustWorkForCorrection(
+      double[] diag, double[] work1, double[] work2, double[] work3, double localDxNorm) {
+    for (int j = 0; j < solvedCols; ++j) {
+      int pj = permutation[j];
+      work1[pj] = work3[pj] * diag[pj] / localDxNorm;
+    }
+    for (int j = 0; j < solvedCols; ++j) {
+      int pj = permutation[j];
+      work1[pj] /= work2[j];
+      double tmp = work1[pj];
+      for (int i = j + 1; i < solvedCols; ++i) {
+        work1[permutation[i]] -= jacobian[i * cols + pj] * tmp;
+      }
+    }
+  }
+
+  private double computeCorrectionMagnitude(double delta, double localFp, double[] work1) {
+    double sum2 = 0;
+    for (int j = 0; j < solvedCols; ++j) {
+      double s = work1[permutation[j]];
+      sum2 += s * s;
+    }
+    return localFp / (delta * sum2);
+  }
+
+  private void updateParameterBounds(ParameterBounds bounds, double localFp) {
+    if (localFp > 0) {
+      bounds.parl = Math.max(bounds.parl, lmPar);
+    } else if (localFp < 0) {
+      bounds.paru = Math.min(bounds.paru, lmPar);
     }
   }
 
@@ -678,9 +853,16 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
    * @param work work array
    */
   private void determineLMDirection(double[] qy, double[] diag, double[] lmDiag, double[] work) {
+    copyRAndQty(qy, work);
+    applyGivensRotations(diag, lmDiag, work);
+    int nSing = detectSingularSystem(lmDiag, work);
+    if (nSing > 0) {
+      solveUpperTriangular(lmDiag, work, nSing);
+    }
+    permuteDirection(work);
+  }
 
-    // copy R and Qty to preserve input and initialize s
-    //  in particular, save the diagonal elements of R in lmDir
+  private void copyRAndQty(double[] qy, double[] work) {
     for (int j = 0; j < solvedCols; ++j) {
       int pj = permutation[j];
       for (int i = j + 1; i < solvedCols; ++i) {
@@ -689,68 +871,62 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
       lmDir[j] = diagR[pj];
       work[j] = qy[j];
     }
+  }
 
-    // eliminate the diagonal matrix d using a Givens rotation
+  private void applyGivensRotations(double[] diag, double[] lmDiag, double[] work) {
     for (int j = 0; j < solvedCols; ++j) {
-
-      // prepare the row of d to be eliminated, locating the
-      // diagonal element using p from the Q.R. factorization
       int pj = permutation[j];
-      double dpj = diag[pj];
-      if (dpj != 0) {
-        Arrays.fill(lmDiag, j + 1, lmDiag.length, 0);
-      }
-      lmDiag[j] = dpj;
-
-      //  the transformations to eliminate the row of d
-      // modify only a single element of Qty
-      // beyond the first n, which is initially zero.
+      prepareLmDiag(diag, lmDiag, j, pj);
       double qtbpj = 0;
       for (int k = j; k < solvedCols; ++k) {
-        int pk = permutation[k];
-
-        // determine a Givens rotation which eliminates the
-        // appropriate element in the current row of d
         if (lmDiag[k] != 0) {
-
-          double sin, cos;
-          double rkk = jacobian[k * cols + pk];
-          if (Math.abs(rkk) < Math.abs(lmDiag[k])) {
-            double cotan = rkk / lmDiag[k];
-            sin = 1.0 / Math.sqrt(1.0 + cotan * cotan);
-            cos = sin * cotan;
-          } else {
-            double tan = lmDiag[k] / rkk;
-            cos = 1.0 / Math.sqrt(1.0 + tan * tan);
-            sin = cos * tan;
-          }
-
-          // compute the modified diagonal element of R and
-          // the modified element of (Qty,0)
-          jacobian[k * cols + pk] = cos * rkk + sin * lmDiag[k];
-          double temp = cos * work[k] + sin * qtbpj;
-          qtbpj = -sin * work[k] + cos * qtbpj;
-          work[k] = temp;
-
-          // accumulate the tranformation in the row of s
-          for (int i = k + 1; i < solvedCols; ++i) {
-            double rik = jacobian[i * cols + pk];
-            temp = cos * rik + sin * lmDiag[i];
-            lmDiag[i] = -sin * rik + cos * lmDiag[i];
-            jacobian[i * cols + pk] = temp;
-          }
+          qtbpj = applySingleRotation(lmDiag, work, k, qtbpj);
         }
       }
-
-      // store the diagonal element of s and restore
-      // the corresponding diagonal element of R
       int index = j * cols + permutation[j];
       lmDiag[j] = jacobian[index];
       jacobian[index] = lmDir[j];
     }
+  }
 
-    // solve the triangular system for z, if the system is
-    // singular, then obtain a least squares solution
+  private void prepareLmDiag(double[] diag, double[] lmDiag, int j, int pj) {
+    double dpj = diag[pj];
+    if (dpj != 0) {
+      Arrays.fill(lmDiag, j + 1, lmDiag.length, 0);
+    }
+    lmDiag[j] = dpj;
+  }
+
+  private double applySingleRotation(double[] lmDiag, double[] work, int k, double qtbpj) {
+    int pk = permutation[k];
+    double sin;
+    double cos;
+    double rkk = jacobian[k * cols + pk];
+    if (Math.abs(rkk) < Math.abs(lmDiag[k])) {
+      double cotan = rkk / lmDiag[k];
+      sin = 1.0 / Math.sqrt(1.0 + cotan * cotan);
+      cos = sin * cotan;
+    } else {
+      double tan = lmDiag[k] / rkk;
+      cos = 1.0 / Math.sqrt(1.0 + tan * tan);
+      sin = cos * tan;
+    }
+
+    jacobian[k * cols + pk] = cos * rkk + sin * lmDiag[k];
+    double temp = cos * work[k] + sin * qtbpj;
+    qtbpj = -sin * work[k] + cos * qtbpj;
+    work[k] = temp;
+
+    for (int i = k + 1; i < solvedCols; ++i) {
+      double rik = jacobian[i * cols + pk];
+      temp = cos * rik + sin * lmDiag[i];
+      lmDiag[i] = -sin * rik + cos * lmDiag[i];
+      jacobian[i * cols + pk] = temp;
+    }
+    return qtbpj;
+  }
+
+  private int detectSingularSystem(double[] lmDiag, double[] work) {
     int nSing = solvedCols;
     for (int j = 0; j < solvedCols; ++j) {
       if ((lmDiag[j] == 0) && (nSing == solvedCols)) {
@@ -760,18 +936,21 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
         work[j] = 0;
       }
     }
-    if (nSing > 0) {
-      for (int j = nSing - 1; j >= 0; --j) {
-        int pj = permutation[j];
-        double sum = 0;
-        for (int i = j + 1; i < nSing; ++i) {
-          sum += jacobian[i * cols + pj] * work[i];
-        }
-        work[j] = (work[j] - sum) / lmDiag[j];
-      }
-    }
+    return nSing;
+  }
 
-    // permute the components of z back to components of lmDir
+  private void solveUpperTriangular(double[] lmDiag, double[] work, int nSing) {
+    for (int j = nSing - 1; j >= 0; --j) {
+      int pj = permutation[j];
+      double sum = 0;
+      for (int i = j + 1; i < nSing; ++i) {
+        sum += jacobian[i * cols + pj] * work[i];
+      }
+      work[j] = (work[j] - sum) / lmDiag[j];
+    }
+  }
+
+  private void permuteDirection(double[] work) {
     for (int j = 0; j < lmDir.length; ++j) {
       lmDir[permutation[j]] = work[j];
     }
@@ -803,70 +982,77 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
    * matrix are therefore also in non-increasing absolute values order.
    */
   private void qrDecomposition() {
-
-    // initializations
+    initializeColumnNorms();
     for (int k = 0; k < cols; ++k) {
-      permutation[k] = k;
-      double norm2 = 0;
-      for (int index = k; index < jacobian.length; index += cols) {
-        double akk = jacobian[index];
-        norm2 += akk * akk;
-      }
-      jacNorm[k] = Math.sqrt(norm2);
-    }
-
-    // transform the matrix column after column
-    for (int k = 0; k < cols; ++k) {
-
-      // select the column with the greatest norm on active components
-      int nextColumn = -1;
-      double ak2 = Double.NEGATIVE_INFINITY;
-      for (int i = k; i < cols; ++i) {
-        double norm2 = 0;
-        int iDiag = k * cols + permutation[i];
-        for (int index = iDiag; index < jacobian.length; index += cols) {
-          double aki = jacobian[index];
-          norm2 += aki * aki;
-        }
-        if (norm2 > ak2) {
-          nextColumn = i;
-          ak2 = norm2;
-        }
-      }
-      if (ak2 == 0) {
+      ColumnSelection selection = selectNextColumn(k);
+      if (selection.norm2 == 0) {
         rank = k;
         return;
       }
-      int pk = permutation[nextColumn];
-      permutation[nextColumn] = permutation[k];
-      permutation[k] = pk;
+      pivotPermutation(k, selection.columnIndex);
+      performHouseholder(k, permutation[k], selection.norm2);
+    }
+    rank = solvedCols;
+  }
 
-      // choose alpha such that Hk.u = alpha ek
-      int kDiag = k * cols + pk;
-      double akk = jacobian[kDiag];
-      double alpha = (akk > 0) ? -Math.sqrt(ak2) : Math.sqrt(ak2);
-      double betak = 1.0 / (ak2 - akk * alpha);
-      beta[pk] = betak;
+  private void initializeColumnNorms() {
+    for (int k = 0; k < cols; ++k) {
+      permutation[k] = k;
+      jacNorm[k] = Math.sqrt(columnNormSquared(k, k));
+    }
+  }
 
-      // transform the current column
-      diagR[pk] = alpha;
-      jacobian[kDiag] -= alpha;
-
-      // transform the remaining columns
-      for (int dk = cols - 1 - k; dk > 0; --dk) {
-        int dkp = permutation[k + dk] - pk;
-        double gamma = 0;
-        for (int index = kDiag; index < jacobian.length; index += cols) {
-          gamma += jacobian[index] * jacobian[index + dkp];
-        }
-        gamma *= betak;
-        for (int index = kDiag; index < jacobian.length; index += cols) {
-          jacobian[index + dkp] -= gamma * jacobian[index];
-        }
+  private ColumnSelection selectNextColumn(int k) {
+    ColumnSelection selection = new ColumnSelection(-1, Double.NEGATIVE_INFINITY);
+    for (int i = k; i < cols; ++i) {
+      double norm2 = columnNormSquared(k, permutation[i]);
+      if (norm2 > selection.norm2) {
+        selection = new ColumnSelection(i, norm2);
       }
     }
+    return selection;
+  }
 
-    rank = solvedCols;
+  private double columnNormSquared(int startRow, int columnPermutationIndex) {
+    double norm2 = 0;
+    int iDiag = startRow * cols + columnPermutationIndex;
+    for (int index = iDiag; index < jacobian.length; index += cols) {
+      double aki = jacobian[index];
+      norm2 += aki * aki;
+    }
+    return norm2;
+  }
+
+  private void pivotPermutation(int k, int nextColumn) {
+    int pk = permutation[nextColumn];
+    permutation[nextColumn] = permutation[k];
+    permutation[k] = pk;
+  }
+
+  private void performHouseholder(int k, int pk, double ak2) {
+    int kDiag = k * cols + pk;
+    double akk = jacobian[kDiag];
+    double alpha = (akk > 0) ? -Math.sqrt(ak2) : Math.sqrt(ak2);
+    double betak = 1.0 / (ak2 - akk * alpha);
+    beta[pk] = betak;
+
+    diagR[pk] = alpha;
+    jacobian[kDiag] -= alpha;
+    applyHouseholderToRemainingColumns(k, pk, kDiag, betak);
+  }
+
+  private void applyHouseholderToRemainingColumns(int k, int pk, int kDiag, double betak) {
+    for (int dk = cols - 1 - k; dk > 0; --dk) {
+      int dkp = permutation[k + dk] - pk;
+      double gamma = 0;
+      for (int index = kDiag; index < jacobian.length; index += cols) {
+        gamma += jacobian[index] * jacobian[index + dkp];
+      }
+      gamma *= betak;
+      for (int index = kDiag; index < jacobian.length; index += cols) {
+        jacobian[index + dkp] -= gamma * jacobian[index];
+      }
+    }
   }
 
   /**
@@ -968,5 +1154,5 @@ public class LevenbergMarquardtEstimator implements Serializable, Estimator {
    */
   private double orthoTolerance;
 
-  private static final long serialVersionUID = 5387476316105068340L;
+  @Serial private static final long serialVersionUID = 5387476316105068340L;
 }

--- a/src/main/java/org/spaceroots/mantissa/estimation/WeightedMeasurement.java
+++ b/src/main/java/org/spaceroots/mantissa/estimation/WeightedMeasurement.java
@@ -3,22 +3,29 @@ package org.spaceroots.mantissa.estimation;
 import java.io.Serializable;
 
 /**
- * This class represents measurements in estimation problems.
+ * Weighted scalar measurement participating in a least-squares estimation run.
  *
- * <p>This abstract class implements all the methods needed to handle measurements in a general way.
- * It defines neither the {@link #getTheoreticalValue getTheoreticalValue} nor the {@link
- * #getPartial getPartial} methods, which should be defined by sub-classes according to the specific
- * problem.
+ * <p>This abstract type encapsulates the shared metadata needed by an estimation solver while
+ * delegating model-specific details to subclasses. Each measurement carries an immutable weight
+ * that scales its contribution to the cost function and a measured value that represents the raw
+ * observation. Subclasses provide the link to the model by implementing {@link
+ * #getTheoreticalValue()} and {@link #getPartial(EstimatedParameter)}, both of which must evaluate
+ * the current parameter estimate maintained by the solver and supplied through {@link
+ * EstimationProblem#getAllParameters()} or by direct access when the measurement is an inner class.
  *
- * <p>The {@link #getTheoreticalValue getTheoreticalValue} and {@link #getPartial getPartial}
- * methods must always use the current estimate of the parameters set by the solver in the problem.
- * These parameters can be retrieved through the {@link EstimationProblem#getAllParameters
- * EstimationProblem.getAllParameters} method if the measurements are independant of the problem, or
- * directly if they are implemented as inner classes of the problem.
+ * <p>Instances can be marked as ignored via {@link #setIgnored(boolean)} to temporarily exclude bad
+ * or outlying measurements without altering the surrounding problem definition. The ignore flag is
+ * mutable, but the weight and measured value are fixed after construction so residuals remain
+ * consistent across iterations. This class is deliberately lightweight and thread-hostile:
+ * instances are expected to be confined to the solver thread that owns the current parameter vector
+ * rather than shared concurrently.
  *
- * <p>The instances for which the <code>ignored</code> flag is set through the {@link #setIgnored
- * setIgnored} method are ignored by the solvers. This can be used to reject wrong measurements at
- * some steps of the estimation.
+ * <ul>
+ *   <li>Responsibilities: store observed value, expose residual and partial derivatives, convey
+ *       per-measurement weighting.
+ *   <li>Notable behaviors: optional exclusion via an ignore flag; residual computed lazily from
+ *       theoretical value.
+ * </ul>
  *
  * @see EstimationProblem
  * @version $Id: WeightedMeasurement.java 1679 2005-12-16 11:12:23Z luc $
@@ -27,106 +34,160 @@ import java.io.Serializable;
 public abstract class WeightedMeasurement implements Serializable {
 
   /**
-   * Simple constructor. Build a measurement with the given parameters, and set its ignore flag to
-   * false.
+   * Build a measurement with a fixed weight and observed value, initially considered valid.
    *
-   * @param weight weight of the measurement in the least squares problem (two common choices are
-   *     either to use 1.0 for all measurements, or to use a value proportional to the inverse of
-   *     the variance of the measurement type)
-   * @param measuredValue measured value
+   * <p>This constructor is convenient for the common case where all measurements start included in
+   * the optimization. The {@code weight} scales the contribution of the residual to the global cost
+   * (use 1.0 for uniform influence or the inverse of the expected variance for heteroscedastic
+   * data). The {@code measuredValue} is stored verbatim and later compared to the theoretical value
+   * returned by {@link #getTheoreticalValue()} to compute residuals. The ignore flag defaults to
+   * {@code false} so solvers will consume the measurement unless it is explicitly toggled later.
+   *
+   * @param weight positive scaling factor for this measurement within the least-squares objective;
+   *     values near zero effectively down-weight outliers.
+   * @param measuredValue raw observed quantity expressed in the same units as the theoretical
+   *     counterpart computed by the model.
    */
-  public WeightedMeasurement(double weight, double measuredValue) {
+  protected WeightedMeasurement(double weight, double measuredValue) {
     this.weight = weight;
     this.measuredValue = measuredValue;
     ignored = false;
   }
 
   /**
-   * Simple constructor. Build a measurement with the given parameters
+   * Build a measurement with explicit weight, observed value, and initial ignore policy.
    *
-   * @param weight weight of the measurement in the least squares problem
-   * @param measuredValue measured value
-   * @param ignored true if the measurement should be ignored
+   * <p>Use this constructor when some observations should start excluded (for example, points
+   * flagged during preprocessing) while still keeping their data available for later inclusion. The
+   * {@code weight} and {@code measuredValue} behave identically to the single-argument constructor,
+   * but the {@code ignored} flag immediately controls whether the solver should skip the
+   * measurement. Downstream code may toggle the flag via {@link #setIgnored(boolean)} to re-enable
+   * or suppress the measurement as iterative filters converge.
+   *
+   * @param weight positive scaling factor that modulates how much this measurement contributes to
+   *     the accumulated chi-square error term.
+   * @param measuredValue raw observed quantity expressed in the domain expected by the model; it is
+   *     never modified after construction.
+   * @param ignored whether the measurement is initially excluded from solver computations; {@code
+   *     true} keeps it silent until explicitly re-enabled.
    */
-  public WeightedMeasurement(double weight, double measuredValue, boolean ignored) {
+  protected WeightedMeasurement(double weight, double measuredValue, boolean ignored) {
     this.weight = weight;
     this.measuredValue = measuredValue;
     this.ignored = ignored;
   }
 
   /**
-   * Get the weight of the measurement in the least squares problem
+   * Return the scalar weight applied to this measurement in the least-squares objective.
    *
-   * @return weight
+   * <p>The weight is immutable after construction. Larger values make the residual associated with
+   * this measurement influence parameter updates more strongly, while smaller values down-weight it
+   * relative to other observations. Callers typically pick weights consistent with the inverse
+   * variance of the measurement noise model.
+   *
+   * @return immutable weight scaling factor; callers must not assume any specific normalization.
    */
   public double getWeight() {
     return weight;
   }
 
   /**
-   * Get the measured value
+   * Return the raw measured value captured for this observation.
    *
-   * @return measured value
+   * <p>The value is stored exactly as provided to the constructor and is never normalized or
+   * altered by the solver. It should be expressed in the same units and reference frame as the
+   * theoretical value computed by {@link #getTheoreticalValue()} to avoid bias in residuals.
+   *
+   * @return immutable measured value retained for residual computation and reporting.
    */
   public double getMeasuredValue() {
     return measuredValue;
   }
 
   /**
-   * Get the residual for this measurement The residual is the measured value minus the theoretical
-   * value.
+   * Compute the residual between the observed and theoretical values.
    *
-   * @return residual
+   * <p>The residual equals {@code measuredValue - getTheoreticalValue()}. It is evaluated lazily
+   * using the current parameter estimates held by the solver, so repeated calls may produce
+   * different values as iterations progress. The method performs no bounds checking; callers should
+   * ensure the underlying model remains numerically stable for the current parameter set.
+   *
+   * @return signed residual in the same units as the measurement; positive values indicate the
+   *     observation exceeds the model prediction.
    */
   public double getResidual() {
     return measuredValue - getTheoreticalValue();
   }
 
   /**
-   * Get the theoretical value expected for this measurement
+   * Compute the theoretical value predicted by the model for the current parameters.
    *
-   * <p>The theoretical value is the value expected for this measurement if the model and its
-   * parameter were all perfectly known.
+   * <p>Implementations must read the most recent parameter estimates supplied by the solver so the
+   * returned value reflects the solver's current iterate. The method should avoid side effects and
+   * be deterministic for a fixed parameter vector because solvers may invoke it repeatedly while
+   * assembling residuals and Jacobians. Implementations are responsible for any domain checks
+   * needed to keep the model well-defined.
    *
-   * <p>The value must be computed using the current estimate of the parameters set by the solver in
-   * the problem.
-   *
-   * @return theoretical value
+   * @return model-predicted value expressed in the same units as {@link #getMeasuredValue()}, ready
+   *     for residual computation.
    */
   public abstract double getTheoreticalValue();
 
   /**
-   * Get the partial derivative of the {@link #getTheoreticalValue theoretical value} according to
-   * the parameter.
+   * Return the partial derivative of the theoretical value with respect to a parameter.
    *
-   * <p>The value must be computed using the current estimate of the parameters set by the solver in
-   * the problem.
+   * <p>The derivative must be evaluated at the current parameter estimate managed by the solver.
+   * Implementations should return zero for parameters that do not influence the measurement and
+   * should be careful to keep derivative calculations numerically stable for ill-conditioned
+   * models. Solvers typically build a Jacobian matrix by calling this method for each parameter
+   * referenced by the measurement.
    *
-   * @param parameter parameter against which the partial derivative should be computed
-   * @return partial derivative of the {@link #getTheoreticalValue theoretical value}
+   * @param parameter parameter whose influence on the theoretical value is being differentiated;
+   *     must refer to a parameter known to the surrounding {@link EstimationProblem}.
+   * @return partial derivative value; positive numbers indicate the theoretical value increases
+   *     when the parameter grows.
    */
   public abstract double getPartial(EstimatedParameter parameter);
 
   /**
-   * Set the ignore flag to the specified value Setting the ignore flag to true allow to reject
-   * wrong measurements, which sometimes can be detected only rather late.
+   * Update the ignore flag to include or exclude this measurement from solver computations.
    *
-   * @param ignored value for the ignore flag
+   * <p>Setting {@code ignored} to {@code true} removes the measurement from subsequent residual and
+   * Jacobian calculations, which is useful for discarding late-detected outliers without altering
+   * the problem structure. The flag can be flipped back to {@code false} if a measurement is
+   * rehabilitated after additional validation steps. The method is not synchronized; callers should
+   * coordinate access if measurements are shared across threads.
+   *
+   * @param ignored {@code true} to skip this measurement in solver iterations; {@code false} to
+   *     reinstate it.
    */
   public void setIgnored(boolean ignored) {
     this.ignored = ignored;
   }
 
   /**
-   * Check if this measurement should be ignored
+   * Indicate whether this measurement is currently excluded from solver processing.
    *
-   * @return true if the measurement should be ignored
+   * <p>The return value reflects the most recent call to {@link #setIgnored(boolean)} or the
+   * constructor initialization. Solvers typically inspect this flag before consuming the
+   * measurement; callers may also use it for reporting or diagnostics.
+   *
+   * @return {@code true} when the measurement is flagged as ignored and therefore omitted from cost
+   *     and Jacobian assembly; {@code false} otherwise.
    */
   public boolean isIgnored() {
     return ignored;
   }
 
+  /** Immutable weight applied to this measurement in the global least-squares objective. */
   private final double weight;
+
+  /** Observed scalar value against which the model prediction is compared. */
   private final double measuredValue;
+
+  /**
+   * Mutable flag controlling whether the measurement participates in solver calculations; toggled
+   * through {@link #setIgnored(boolean)}.
+   */
   private boolean ignored;
 }

--- a/src/test/java/org/spaceroots/mantissa/estimation/EstimatedParameterTest.java
+++ b/src/test/java/org/spaceroots/mantissa/estimation/EstimatedParameterTest.java
@@ -1,0 +1,74 @@
+package org.spaceroots.mantissa.estimation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class EstimatedParameterTest {
+
+  @Test
+  void constructor_whenBoundNotProvided_setsUnboundByDefault() {
+    EstimatedParameter parameter = new EstimatedParameter("alpha", 1.5);
+
+    assertEquals("alpha", parameter.getName());
+    assertEquals(1.5, parameter.getEstimate());
+    assertFalse(parameter.isBound());
+  }
+
+  @Test
+  void constructor_whenBoundFlagProvided_setsFieldsAccordingly() {
+    EstimatedParameter parameter = new EstimatedParameter("beta", -2.0, true);
+
+    assertEquals("beta", parameter.getName());
+    assertEquals(-2.0, parameter.getEstimate());
+    assertTrue(parameter.isBound());
+  }
+
+  @Test
+  void setEstimate_whenCalled_updatesValue() {
+    EstimatedParameter parameter = new EstimatedParameter("gamma", 0.0);
+
+    parameter.setEstimate(42.0);
+
+    assertEquals(42.0, parameter.getEstimate());
+  }
+
+  @Test
+  void setEstimate_whenUsingNaN_preservesValue() {
+    EstimatedParameter parameter = new EstimatedParameter("delta", 5.0);
+
+    parameter.setEstimate(Double.NaN);
+
+    assertTrue(Double.isNaN(parameter.getEstimate()));
+  }
+
+  @Test
+  void setBound_whenToggled_changesFlag() {
+    EstimatedParameter parameter = new EstimatedParameter("epsilon", 3.0, false);
+
+    parameter.setBound(true);
+    assertTrue(parameter.isBound());
+
+    parameter.setBound(false);
+    assertFalse(parameter.isBound());
+  }
+
+  @Test
+  void copyConstructor_whenModified_doesNotAffectOriginalInstance() {
+    EstimatedParameter original = new EstimatedParameter("zeta", 7.0, true);
+    EstimatedParameter copy = new EstimatedParameter(original);
+
+    copy.setEstimate(8.0);
+    copy.setBound(false);
+
+    assertEquals("zeta", copy.getName());
+    assertEquals("zeta", original.getName());
+    assertEquals(7.0, original.getEstimate());
+    assertTrue(original.isBound());
+    assertEquals(8.0, copy.getEstimate());
+    assertFalse(copy.isBound());
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/estimation/GaussNewtonEstimatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/estimation/GaussNewtonEstimatorTest.java
@@ -1,0 +1,161 @@
+package org.spaceroots.mantissa.estimation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class GaussNewtonEstimatorTest {
+
+  @Test
+  void linearEstimate_whenLinearSystemExact_updatesParametersToLeastSquaresSolution()
+      throws EstimationException {
+    EstimatedParameter p0 = new EstimatedParameter("p0", 0.0);
+    EstimatedParameter p1 = new EstimatedParameter("p1", 0.0);
+    LinearProblem problem =
+        new LinearProblem(
+            new EstimatedParameter[] {p0, p1},
+            new LinearMeasurement(1.0, 7.0, new double[] {1.0, 2.0}, false, p0, p1),
+            new LinearMeasurement(1.0, 3.0, new double[] {2.0, -1.0}, false, p0, p1));
+
+    GaussNewtonEstimator estimator = new GaussNewtonEstimator(5, 1.0e-12, 1.0e-8, 1.0e-12);
+
+    estimator.linearEstimate(problem);
+
+    assertEquals(2.6, p0.getEstimate(), 1.0e-12);
+    assertEquals(2.2, p1.getEstimate(), 1.0e-12);
+  }
+
+  @Test
+  void linearEstimate_whenMeasurementIgnored_doesNotAffectUpdate() throws EstimationException {
+    EstimatedParameter p0 = new EstimatedParameter("p0", 0.0);
+    EstimatedParameter p1 = new EstimatedParameter("p1", 0.0);
+    LinearMeasurement informative1 =
+        new LinearMeasurement(1.0, 7.0, new double[] {1.0, 2.0}, false, p0, p1);
+    LinearMeasurement informative2 =
+        new LinearMeasurement(1.0, 3.0, new double[] {2.0, -1.0}, false, p0, p1);
+    LinearMeasurement ignored =
+        new LinearMeasurement(1.0, 100.0, new double[] {10.0, 0.0}, true, p0, p1);
+    LinearProblem problem =
+        new LinearProblem(new EstimatedParameter[] {p0, p1}, informative1, informative2, ignored);
+
+    GaussNewtonEstimator estimator = new GaussNewtonEstimator(5, 1.0e-12, 1.0e-8, 1.0e-12);
+
+    estimator.linearEstimate(problem);
+
+    assertEquals(2.6, p0.getEstimate(), 1.0e-12);
+    assertEquals(2.2, p1.getEstimate(), 1.0e-12);
+  }
+
+  @Test
+  void linearEstimate_whenMatrixSingular_throwsEstimationException() {
+    EstimatedParameter p0 = new EstimatedParameter("p0", 1.0);
+    LinearMeasurement singular = new LinearMeasurement(1.0, 5.0, new double[] {0.0}, false, p0);
+    LinearProblem problem = new LinearProblem(new EstimatedParameter[] {p0}, singular);
+
+    GaussNewtonEstimator estimator = new GaussNewtonEstimator(3, 1.0e-12, 1.0e-8, 1.0e-12);
+
+    assertThrows(EstimationException.class, () -> estimator.linearEstimate(problem));
+  }
+
+  @Test
+  void estimate_whenConvergesWithinMaxIterations_updatesParameters() throws EstimationException {
+    EstimatedParameter p0 = new EstimatedParameter("p0", 0.0);
+    EstimatedParameter p1 = new EstimatedParameter("p1", 0.0);
+    LinearProblem problem =
+        new LinearProblem(
+            new EstimatedParameter[] {p0, p1},
+            new LinearMeasurement(1.0, 7.0, new double[] {1.0, 2.0}, false, p0, p1),
+            new LinearMeasurement(1.0, 3.0, new double[] {2.0, -1.0}, false, p0, p1));
+
+    GaussNewtonEstimator estimator = new GaussNewtonEstimator(10, 1.0e-15, 1.0e-12, 1.0e-12);
+
+    estimator.estimate(problem);
+
+    assertEquals(2.6, p0.getEstimate(), 1.0e-10);
+    assertEquals(2.2, p1.getEstimate(), 1.0e-10);
+  }
+
+  @Test
+  void getRMS_whenResidualsPresent_computesRootMeanSquare() {
+    EstimatedParameter p0 = new EstimatedParameter("p0", 2.0);
+    EstimatedParameter p1 = new EstimatedParameter("p1", 4.0);
+
+    LinearMeasurement m1 =
+        new LinearMeasurement(2.0, 5.0, new double[] {1.0, 0.0}, false, p0, p1); // residual = 3
+    LinearMeasurement m2 =
+        new LinearMeasurement(1.0, 3.0, new double[] {0.0, 1.0}, false, p0, p1); // residual = -1
+    LinearProblem problem = new LinearProblem(new EstimatedParameter[] {p0, p1}, m1, m2);
+
+    GaussNewtonEstimator estimator = new GaussNewtonEstimator(3, 1.0e-12, 1.0e-8, 1.0e-12);
+
+    double rms = estimator.getRMS(problem);
+
+    assertEquals(Math.sqrt(19.0 / 2.0), rms, 1.0e-12);
+  }
+
+  private static final class LinearProblem implements EstimationProblem {
+    private final EstimatedParameter[] parameters;
+    private final WeightedMeasurement[] measurements;
+
+    LinearProblem(EstimatedParameter[] parameters, WeightedMeasurement... measurements) {
+      this.parameters = parameters;
+      this.measurements = measurements;
+    }
+
+    @Override
+    public WeightedMeasurement[] getMeasurements() {
+      return measurements;
+    }
+
+    @Override
+    public EstimatedParameter[] getUnboundParameters() {
+      return parameters;
+    }
+
+    @Override
+    public EstimatedParameter[] getAllParameters() {
+      return Arrays.copyOf(parameters, parameters.length);
+    }
+  }
+
+  private static final class LinearMeasurement extends WeightedMeasurement {
+    private final EstimatedParameter[] parameters;
+    private final double[] coefficients;
+
+    LinearMeasurement(
+        double weight,
+        double measuredValue,
+        double[] coefficients,
+        boolean ignored,
+        EstimatedParameter... parameters) {
+      super(weight, measuredValue, ignored);
+      this.parameters = parameters;
+      this.coefficients = coefficients;
+    }
+
+    @Override
+    public double getTheoreticalValue() {
+      double value = 0.0;
+      for (int i = 0; i < parameters.length; i++) {
+        value += coefficients[i] * parameters[i].getEstimate();
+      }
+      return value;
+    }
+
+    @Override
+    public double getPartial(EstimatedParameter parameter) {
+      for (int i = 0; i < parameters.length; i++) {
+        if (parameters[i] == parameter) {
+          return coefficients[i];
+        }
+      }
+      return 0.0;
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/estimation/LevenbergMarquardtEstimatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/estimation/LevenbergMarquardtEstimatorTest.java
@@ -1,0 +1,140 @@
+package org.spaceroots.mantissa.estimation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class LevenbergMarquardtEstimatorTest {
+
+  @Mock private WeightedMeasurement firstMeasurement;
+
+  @Mock private WeightedMeasurement secondMeasurement;
+
+  @Test
+  void getRMS_whenTwoMeasurements_returnsExpectedRootMeanSquare() {
+    when(firstMeasurement.getResidual()).thenReturn(3.0);
+    when(firstMeasurement.getWeight()).thenReturn(2.0);
+    when(secondMeasurement.getResidual()).thenReturn(-1.0);
+    when(secondMeasurement.getWeight()).thenReturn(4.0);
+
+    EstimationProblem problem =
+        new EstimationProblem() {
+          @Override
+          public WeightedMeasurement[] getMeasurements() {
+            return new WeightedMeasurement[] {firstMeasurement, secondMeasurement};
+          }
+
+          @Override
+          public EstimatedParameter[] getUnboundParameters() {
+            return new EstimatedParameter[0];
+          }
+
+          @Override
+          public EstimatedParameter[] getAllParameters() {
+            return getUnboundParameters();
+          }
+        };
+
+    LevenbergMarquardtEstimator estimator = new LevenbergMarquardtEstimator();
+
+    double rms = estimator.getRMS(problem);
+
+    // sqrt((2*9 + 4*1)/2) = sqrt(11) ≈ 3.31662
+    assertEquals(Math.sqrt(11.0), rms, 1.0e-12);
+  }
+
+  @Test
+  void estimate_whenLinearModel_convergesAndUpdatesParameter() throws EstimationException {
+    double trueSlope = 2.0;
+    LinearProblem problem = new LinearProblem(trueSlope, 0.1);
+    LevenbergMarquardtEstimator estimator = new LevenbergMarquardtEstimator();
+
+    estimator.estimate(problem);
+
+    assertEquals(trueSlope, problem.parameter.getEstimate(), 1.0e-6);
+    assertTrue(estimator.getCostEvaluations() > 0, "cost evaluations should be recorded");
+    assertTrue(estimator.getJacobianEvaluations() > 0, "jacobian evaluations should be recorded");
+  }
+
+  @Test
+  void estimate_whenMaxEvaluationsIsZero_throwsEstimationException() {
+    LinearProblem problem = new LinearProblem(1.0, 0.0);
+    LevenbergMarquardtEstimator estimator = new LevenbergMarquardtEstimator();
+    estimator.setMaxCostEval(0);
+
+    EstimationException exception =
+        assertThrows(EstimationException.class, () -> estimator.estimate(problem));
+
+    assertTrue(
+        exception.getMessage().contains("maximal number of evaluations exceeded"),
+        "exception message should mention evaluation limit");
+  }
+
+  private static final class LinearProblem implements EstimationProblem {
+
+    private final LinearMeasurement[] measurements;
+    private final EstimatedParameter parameter;
+
+    LinearProblem(double trueSlope, double initialEstimate) {
+      parameter = new EstimatedParameter("slope", initialEstimate);
+      measurements =
+          new LinearMeasurement[] {
+            new LinearMeasurement(1.0, 1.0, trueSlope, parameter),
+            new LinearMeasurement(1.0, 2.0, trueSlope, parameter),
+            new LinearMeasurement(1.0, 3.0, trueSlope, parameter)
+          };
+    }
+
+    @Override
+    public WeightedMeasurement[] getMeasurements() {
+      return measurements;
+    }
+
+    @Override
+    public EstimatedParameter[] getUnboundParameters() {
+      return new EstimatedParameter[] {parameter};
+    }
+
+    @Override
+    public EstimatedParameter[] getAllParameters() {
+      return getUnboundParameters();
+    }
+  }
+
+  private static final class LinearMeasurement extends WeightedMeasurement {
+
+    private final double x;
+    private final double trueSlope;
+    private final EstimatedParameter parameter;
+
+    LinearMeasurement(double weight, double x, double trueSlope, EstimatedParameter parameter) {
+      super(weight, trueSlope * x);
+      this.x = x;
+      this.trueSlope = trueSlope;
+      this.parameter = parameter;
+    }
+
+    @Override
+    public double getTheoreticalValue() {
+      return parameter.getEstimate() * x;
+    }
+
+    @Override
+    public double getPartial(EstimatedParameter parameter) {
+      return this.parameter == parameter ? x : 0.0;
+    }
+
+    @Override
+    public double getResidual() {
+      return (trueSlope * x) - getTheoreticalValue();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand Javadoc across estimation interfaces and helpers for clearer solver contracts
- add unit coverage for EstimatedParameter, GaussNewtonEstimator, and LevenbergMarquardtEstimator
- refactor Levenberg-Marquardt internals for readability and safer parameter updates while preserving MINPACK behavior

## Testing
- not run (not requested)