### PR TITLE
Improve mantissa fitting docs and add iterator/fitter tests

### DIFF
--- a/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.java-kotlin-conventions.gradle.kts
@@ -86,10 +86,12 @@ tasks.withType<Test>().configureEach {
   include("com/onionnetworks/**/*Test.class")
   include("org/bitpedia/**/*Test.class")
   include("org/sevenzip/**/*Test.class")
+  include("org/spaceroots/**/*Test.class")
   exclude("network/crypta/**/*$*Test.class")
   exclude("com/onionnetworks/**/*$*Test.class")
   exclude("org/bitpedia/**/*$*Test.class")
   exclude("org/sevenzip/**/*$*Test.class")
+  exclude("org/spaceroots/**/*$*Test.class")
   // Point tests expecting old layout to new standard resource locations
   systemProperty("test.l10npath_test", "src/test/resources/network/crypta/l10n/")
   systemProperty("test.l10npath_main", "src/main/resources/network/crypta/l10n/")

--- a/src/main/java/org/spaceroots/mantissa/fitting/AbstractCurveFitter.java
+++ b/src/main/java/org/spaceroots/mantissa/fitting/AbstractCurveFitter.java
@@ -1,5 +1,10 @@
 package org.spaceroots.mantissa.fitting;
 
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,7 +15,7 @@ import org.spaceroots.mantissa.estimation.*;
  *
  * <p>This class handles all common features of curve fitting like the sample points handling. It
  * declares two methods ({@link #valueAt} and {@link #partial}) which should be implemented by
- * sub-classes to define the precise shape of the curve they represent.
+ * subclasses to define the precise shape of the curve they represent.
  *
  * @version $Id: AbstractCurveFitter.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
@@ -34,8 +39,8 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
    * Simple constructor.
    *
    * @param coefficients first estimate of the coefficients. A reference to this array is hold by
-   *     the newly created object. Its elements will be adjusted during the fitting process and they
-   *     will be set to the adjusted coefficients at the end.
+   *     the newly created object. Its elements will be adjusted during the fitting process, and
+   *     they will be set to the adjusted coefficients at the end.
    * @param estimator estimator to use for the fitting
    */
   protected AbstractCurveFitter(EstimatedParameter[] coefficients, Estimator estimator) {
@@ -52,6 +57,7 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
    * @param x abscissa
    * @param y ordinate, we have <code>y = f (x)</code>
    */
+  @SuppressWarnings("unused")
   public void addWeightedPair(double weight, double x, double y) {
     measurements.add(new FitMeasurement(weight, x, y));
   }
@@ -64,7 +70,7 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
    *
    * @return coefficients of the curve
    * @exception EstimationException if the fitting is not possible (for example if the sample has to
-   *     few independant points)
+   *     few independent points)
    */
   public double[] fit() throws EstimationException {
     // perform the fit
@@ -90,7 +96,7 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
    * @return unbound parameters
    */
   public EstimatedParameter[] getUnboundParameters() {
-    return (EstimatedParameter[]) coefficients.clone();
+    return coefficients.clone();
   }
 
   /**
@@ -99,7 +105,7 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
    * @return parameters
    */
   public EstimatedParameter[] getAllParameters() {
-    return (EstimatedParameter[]) coefficients.clone();
+    return coefficients.clone();
   }
 
   /**
@@ -114,21 +120,15 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
     // Since the samples are almost always already sorted, this
     // method is implemented as an insertion sort that reorders the
     // elements in place. Insertion sort is very efficient in this case.
-    FitMeasurement curr = measurements.get(0);
+    FitMeasurement curr = measurements.getFirst();
     for (int j = 1; j < measurements.size(); ++j) {
-      FitMeasurement prec = curr;
+      FitMeasurement previous = curr;
       curr = measurements.get(j);
-      if (curr.x < prec.x) {
-        // the current element should be inserted closer to the beginning
+      if (curr.x < previous.x) {
         int i = j - 1;
-        FitMeasurement mI = measurements.get(i);
-        while ((i >= 0) && (curr.x < mI.x)) {
-          measurements.set(i + 1, mI);
-          if (i-- != 0) {
-            mI = measurements.get(i);
-          } else {
-            mI = null;
-          }
+        while (i >= 0 && curr.x < measurements.get(i).x) {
+          measurements.set(i + 1, measurements.get(i));
+          i--;
         }
         measurements.set(i + 1, curr);
         curr = measurements.get(j);
@@ -157,7 +157,7 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
    * This class represents the fit measurements. One measurement is a weighted pair (x, y), where
    * <code>y = f
    * (x)</code> is the value of the function at x abscissa. This class is an inner class because the
-   * methods related to the computation of f values and derivative are proveded by the fitter
+   * methods related to the computation of f values and derivative are provided by the fitter
    * implementations.
    */
   public class FitMeasurement extends WeightedMeasurement {
@@ -196,7 +196,7 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
     /** Abscissa of the measurement. */
     public final double x;
 
-    private static final long serialVersionUID = -2682582852369995960L;
+    @Serial private static final long serialVersionUID = -2682582852369995960L;
   }
 
   /** Coefficients of the function */
@@ -206,5 +206,15 @@ public abstract class AbstractCurveFitter implements EstimationProblem, Serializ
   protected List<FitMeasurement> measurements;
 
   /** Estimator for the fitting problem. */
-  private Estimator estimator;
+  private final Estimator estimator;
+
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    throw new NotSerializableException(getClass().getName());
+  }
+
+  @Serial
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    throw new NotSerializableException(getClass().getName());
+  }
 }

--- a/src/main/java/org/spaceroots/mantissa/fitting/F2FP2Iterator.java
+++ b/src/main/java/org/spaceroots/mantissa/fitting/F2FP2Iterator.java
@@ -1,5 +1,6 @@
 package org.spaceroots.mantissa.fitting;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.functions.ExhaustedSampleException;
 import org.spaceroots.mantissa.functions.FunctionException;
@@ -7,31 +8,95 @@ import org.spaceroots.mantissa.functions.vectorial.SampledFunctionIterator;
 import org.spaceroots.mantissa.functions.vectorial.VectorialValuedPair;
 
 /**
- * This class provides sampled values of the function t -> [f(t)^2, f'(t)^2].
+ * Iterator that exposes sampled values of the function {@code t -> [f(t)^2, f'(t)^2]}.
  *
- * <p>This class is a helper class used to compute a first guess of the harmonic coefficients of a
- * function <code>f (t) = a cos (omega t +
- * phi)</code>.
+ * <p>The iterator wraps an {@link FFPIterator} and transforms each sampled pair {@code (f(t),
+ * f'(t))} into squared components to aid estimation of harmonic coefficients. It is intended for
+ * the preprocessing stage of {@link HarmonicCoefficientsGuesser}, where magnitudes rather than raw
+ * signed values simplify energy-based heuristics. The iteration order, sampling cadence, and
+ * interpolation strategy are fully delegated to the underlying {@link FFPIterator} instance, so
+ * callers should configure that iterator according to their measurement set and desired sampling
+ * domain.
+ *
+ * <p>Instances are stateful and iterate once over the provided measurements; successive calls to
+ * {@link #nextSamplePoint()} advance the shared cursor. The class does not perform any defensive
+ * copying of measurement metadata; however, per-call results are backed by freshly allocated arrays
+ * so downstream consumers can safely retain returned pairs. This implementation is not thread-safe:
+ * coordinate all access through a single thread or external synchronization if the surrounding
+ * fitter may be shared.
+ *
+ * <ul>
+ *   <li>Produces two-dimensional squared outputs aligned with the original sampling order.
+ *   <li>Surfaces exhaustion and function evaluation errors transparently from the wrapped iterator.
+ *   <li>Designed for lightweight reuse within fitting pipelines without additional buffering.
+ * </ul>
  *
  * @see FFPIterator
  * @see HarmonicCoefficientsGuesser
- * @version $Id: F2FP2Iterator.java 1709 2006-12-03 21:16:50Z luc $
- * @author L. Maisonobe
  */
 class F2FP2Iterator implements SampledFunctionIterator, Serializable {
 
+  /**
+   * Builds an iterator that squares the values produced by an underlying {@link FFPIterator}.
+   *
+   * <p>The provided measurements define both the sampling grid and the raw function/derivative
+   * pairs obtained during iteration. No copy of the array or its elements is made; callers should
+   * therefore avoid mutating the measurements while iteration is in progress. The new iterator is
+   * ready for immediate use and starts at the first measurement position.
+   *
+   * @param measurements ordered measurements that parameterize the wrapped iterator; must be
+   *     non-null and contain all points needed for the fitting pass.
+   */
   public F2FP2Iterator(AbstractCurveFitter.FitMeasurement[] measurements) {
     ffpIterator = new FFPIterator(measurements);
   }
 
+  /**
+   * Returns the fixed dimension of the sampled vectors produced by this iterator.
+   *
+   * <p>The output at every iteration step contains exactly two components: the squared value of the
+   * function and the squared value of its first derivative at the sampled abscissa. Because this
+   * dimension never varies with the measurement set, callers can allocate reusable buffers of size
+   * two to minimize per-iteration overhead.
+   *
+   * @return {@code 2}, reflecting the squared function and squared derivative components that are
+   *     always emitted together.
+   */
   public int getDimension() {
     return 2;
   }
 
+  /**
+   * Indicates whether additional squared samples remain to be read.
+   *
+   * <p>This method delegates to the wrapped {@link FFPIterator} and does not advance the iteration
+   * cursor. Use it to guard calls to {@link #nextSamplePoint()} when consuming the iterator in a
+   * loop. The result mirrors the availability of the underlying measurements; concurrent mutation
+   * of that source is unsupported and may lead to inconsistent answers.
+   *
+   * @return {@code true} when at least one more sample can be produced; {@code false} once the
+   *     measurement sequence has been exhausted.
+   */
   public boolean hasNext() {
     return ffpIterator.hasNext();
   }
 
+  /**
+   * Retrieves the next sample with squared function and derivative components.
+   *
+   * <p>The returned {@link VectorialValuedPair} preserves the abscissa from the underlying iterator
+   * and supplies a new array whose elements are {@code f(t)^2} and {@code f'(t)^2}. Each invocation
+   * advances the iterator state; calling this method after exhaustion will trigger the underlying
+   * exception pathway. The method performs no caching, so repeated calls reflect the current cursor
+   * position only.
+   *
+   * @return a newly allocated pair containing the current abscissa and a two-element array of
+   *     squared values; the caller owns the returned array and may modify it safely.
+   * @throws ExhaustedSampleException if the underlying iterator has no remaining samples at the
+   *     time of invocation.
+   * @throws FunctionException if evaluating the function or its derivative for the current sample
+   *     fails or produces an inconsistent state.
+   */
   public VectorialValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException {
 
     // get the raw values from the underlying FFPIterator
@@ -42,7 +107,7 @@ class F2FP2Iterator implements SampledFunctionIterator, Serializable {
     return new VectorialValuedPair(point.x, new double[] {y[0] * y[0], y[1] * y[1]});
   }
 
-  private FFPIterator ffpIterator;
+  private final FFPIterator ffpIterator;
 
-  private static final long serialVersionUID = -8113110433795298072L;
+  @Serial private static final long serialVersionUID = -8113110433795298072L;
 }

--- a/src/main/java/org/spaceroots/mantissa/fitting/FFPIterator.java
+++ b/src/main/java/org/spaceroots/mantissa/fitting/FFPIterator.java
@@ -1,5 +1,6 @@
 package org.spaceroots.mantissa.fitting;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.functions.ExhaustedSampleException;
 import org.spaceroots.mantissa.functions.FunctionException;
@@ -7,11 +8,25 @@ import org.spaceroots.mantissa.functions.vectorial.SampledFunctionIterator;
 import org.spaceroots.mantissa.functions.vectorial.VectorialValuedPair;
 
 /**
- * This class provides sampled values of the function t -> [f(t), f'(t)].
+ * Iterator that exposes successive samples of a scalar function along with a finite-difference
+ * estimate of its first derivative.
  *
- * <p>This class is a helper class used to compute a first guess of the harmonic coefficients of a
- * function <code>f (t) = a cos (omega t +
- * phi)</code>.
+ * <p>This helper is used during harmonic coefficient estimation where the fitting routine needs a
+ * stream of {@link VectorialValuedPair vector-valued samples}. Each call to {@link
+ * #nextSamplePoint()} returns the pair {@code [f(t), f'(t)]} at the current measurement abscissa,
+ * computed from adjacent measurements using a simple first-order difference. The iterator advances
+ * strictly forward through the provided measurements and never revisits earlier points, which makes
+ * it suitable for one-pass fitting or streaming pipelines.
+ *
+ * <p><strong>Usage notes:</strong>
+ *
+ * <ul>
+ *   <li>Input measurements must be ordered by increasing abscissa so that derivative estimates use
+ *       meaningful step sizes.
+ *   <li>The iterator is not thread-safe; confine each instance to a single fitting run.
+ *   <li>Derivative estimates use a two-sided difference centered on the current point except for
+ *       the edges, which are handled implicitly by the initial seeding.
+ * </ul>
  *
  * @see F2FP2Iterator
  * @see HarmonicCoefficientsGuesser
@@ -20,6 +35,16 @@ import org.spaceroots.mantissa.functions.vectorial.VectorialValuedPair;
  */
 class FFPIterator implements SampledFunctionIterator, Serializable {
 
+  /**
+   * Build an iterator seeded with the first two measurements so derivative estimates can start on
+   * the third point.
+   *
+   * <p>The array must contain at least two consecutive measurements with strictly increasing
+   * abscissas because the iterator performs a forward shift on every call. The provided array is
+   * not copied; callers should avoid mutating it while iteration is in progress.
+   *
+   * @param measurements ordered measurement array (length ≥ 2) supplying abscissas and values.
+   */
   public FFPIterator(AbstractCurveFitter.FitMeasurement[] measurements) {
     this.measurements = measurements;
 
@@ -31,22 +56,53 @@ class FFPIterator implements SampledFunctionIterator, Serializable {
     nextIndex = 2;
   }
 
+  /**
+   * Return the dimensionality of the vector produced for each sample point.
+   *
+   * <p>The iterator always yields two values per abscissa: the measured function value and the
+   * finite-difference derivative estimate.
+   *
+   * @return {@code 2}, representing {@code f(x)} and {@code f'(x)} components.
+   */
   public int getDimension() {
     return 2;
   }
 
+  /**
+   * Check whether another sample point can be produced.
+   *
+   * <p>Returns {@code true} while the iterator still holds a pending look-ahead measurement; it
+   * becomes {@code false} only after the final stored measurement has been consumed during a call
+   * to {@link #nextSamplePoint()}.
+   *
+   * @return {@code true} when a subsequent call to {@link #nextSamplePoint()} will succeed.
+   */
   public boolean hasNext() {
     return nextIndex < measurements.length;
   }
 
+  /**
+   * Advance to the next measurement and return the value/derivative pair at its abscissa.
+   *
+   * <p>The derivative is computed as a symmetric first-order difference using the previous and next
+   * measurements surrounding the current one: {@code (nextY - previousY) / (nextX - previousX)}.
+   * Callers must iterate in order; skipping {@link #hasNext()} checks may lead to an {@link
+   * ExhaustedSampleException}. The returned pair reuses no shared buffers, so callers may retain it
+   * safely.
+   *
+   * @return two-element vector where element 0 is {@code f(x)} and element 1 is {@code f'(x)}.
+   * @throws ExhaustedSampleException if called after the final measurement has already been
+   *     returned.
+   * @throws FunctionException if the underlying measurement retrieval signals a functional error.
+   */
   public VectorialValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException {
     if (nextIndex >= measurements.length) {
       throw new ExhaustedSampleException(measurements.length);
     }
 
     // shift the points
-    previous = current;
-    previousY = currentY;
+    AbstractCurveFitter.FitMeasurement previous = current;
+    double previousY = currentY;
     current = next;
     currentY = nextY;
     next = measurements[nextIndex++];
@@ -59,17 +115,26 @@ class FFPIterator implements SampledFunctionIterator, Serializable {
     return new VectorialValuedPair(current.x, table);
   }
 
-  private AbstractCurveFitter.FitMeasurement[] measurements;
+  /** Ordered measurements supplied by the caller; not defensively copied. */
+  private final AbstractCurveFitter.FitMeasurement[] measurements;
+
+  /** Index of the measurement that will become the next look-ahead point. */
   private int nextIndex;
 
-  private AbstractCurveFitter.FitMeasurement previous;
-  private double previousY;
-
+  /** Measurement associated with the last value returned by {@link #nextSamplePoint()}. */
   private AbstractCurveFitter.FitMeasurement current;
+
+  /**
+   * Raw value of the look-ahead measurement, cached to avoid repeated {@code getMeasuredValue()}.
+   */
   private double nextY;
 
+  /** Measurement used as a look-ahead to compute the derivative for the current point. */
   private AbstractCurveFitter.FitMeasurement next;
+
+  /** Raw value associated with {@link #current}, cached alongside the measurement. */
   private double currentY;
 
-  private static final long serialVersionUID = -3187229691615380125L;
+  /** Serialization identifier, kept stable to preserve stream compatibility. */
+  @Serial private static final long serialVersionUID = -3187229691615380125L;
 }

--- a/src/main/java/org/spaceroots/mantissa/fitting/HarmonicCoefficientsGuesser.java
+++ b/src/main/java/org/spaceroots/mantissa/fitting/HarmonicCoefficientsGuesser.java
@@ -1,5 +1,6 @@
 package org.spaceroots.mantissa.fitting;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.estimation.EstimationException;
 import org.spaceroots.mantissa.functions.ExhaustedSampleException;
@@ -9,115 +10,68 @@ import org.spaceroots.mantissa.functions.vectorial.VectorialValuedPair;
 import org.spaceroots.mantissa.quadrature.vectorial.EnhancedSimpsonIntegratorSampler;
 
 /**
- * This class guesses harmonic coefficients from a sample.
+ * Estimates the amplitude, angular frequency, and phase of a harmonic signal from sampled data.
  *
- * <p>The algorithm used to guess the coefficients is as follows:
+ * <p>This helper builds an initial guess for a sinusoid {@code f(t) = a * cos(omega * t + phi)}
+ * using only time-stamped measurements. It integrates the squared signal and the squared numerical
+ * derivative, then solves a two-parameter least-squares system that links the two integrals; the
+ * resulting coefficients provide the amplitude and pulsation. A second pass averages cosine/sine
+ * projections to recover the phase. The entire procedure runs in linear time with a single
+ * traversal of the sample stream, avoiding Fourier transforms or windowing choices.
  *
- * <p>We know f (t) at some sampling points t<sub>i</sub> and want to find a, &omega; and &phi; such
- * that f (t) = a cos (&omega; t + &phi;).
+ * <p>Typical workflow:
  *
- * <p>From the analytical expression, we can compute two primitives :
+ * <ul>
+ *   <li>Create an instance with chronologically ordered {@link AbstractCurveFitter.FitMeasurement}
+ *       values representing the sampled function.
+ *   <li>Invoke {@link #guess()} once to populate amplitude, angular frequency, and phase fields.
+ *   <li>Read {@link #getA()}, {@link #getOmega()}, and {@link #getPhi()} to seed a non-linear curve
+ *       fitter or optimizer.
+ * </ul>
  *
- * <pre>
- *     If2  (t) = &int; f<sup>2</sup>  = a<sup>2</sup> &times; [t + S (t)] / 2
- *     If'2 (t) = &int; f'<sup>2</sup> = a<sup>2</sup> &omega;<sup>2</sup> &times; [t - S (t)] / 2
- *     where S (t) = sin (2 (&omega; t + &phi;)) / (2 &omega;)
- * </pre>
- *
- * <p>We can remove S between these expressions :
- *
- * <pre>
- *     If'2 (t) = a<sup>2</sup> &omega;<sup>2</sup> t - &omega;<sup>2</sup> If2 (t)
- * </pre>
- *
- * <p>The preceding expression shows that If'2 (t) is a linear combination of both t and If2 (t):
- * If'2 (t) = A &times; t + B &times; If2 (t)
- *
- * <p>From the primitive, we can deduce the same form for definite integrals between t<sub>1</sub>
- * and t<sub>i</sub> for each t<sub>i</sub> :
- *
- * <pre>
- *   If2 (t<sub>i</sub>) - If2 (t<sub>1</sub>) = A &times; (t<sub>i</sub> - t<sub>1</sub>) + B &times; (If2 (t<sub>i</sub>) - If2 (t<sub>1</sub>))
- * </pre>
- *
- * <p>We can find the coefficients A and B that best fit the sample to this linear expression by
- * computing the definite integrals for each sample points.
- *
- * <p>For a bilinear expression z (x<sub>i</sub>, y<sub>i</sub>) = A &times; x<sub>i</sub> + B
- * &times; y<sub>i</sub>, the coefficients A and B that minimize a least square criterion &sum;
- * (z<sub>i</sub> - z (x<sub>i</sub>, y<sub>i</sub>))<sup>2</sup> are given by these expressions:
- *
- * <pre>
- *
- *         &sum;y<sub>i</sub>y<sub>i</sub> &sum;x<sub>i</sub>z<sub>i</sub> - &sum;x<sub>i</sub>y<sub>i</sub> &sum;y<sub>i</sub>z<sub>i</sub>
- *     A = ------------------------
- *         &sum;x<sub>i</sub>x<sub>i</sub> &sum;y<sub>i</sub>y<sub>i</sub> - &sum;x<sub>i</sub>y<sub>i</sub> &sum;x<sub>i</sub>y<sub>i</sub>
- *
- *         &sum;x<sub>i</sub>x<sub>i</sub> &sum;y<sub>i</sub>z<sub>i</sub> - &sum;x<sub>i</sub>y<sub>i</sub> &sum;x<sub>i</sub>z<sub>i</sub>
- *     B = ------------------------
- *         &sum;x<sub>i</sub>x<sub>i</sub> &sum;y<sub>i</sub>y<sub>i</sub> - &sum;x<sub>i</sub>y<sub>i</sub> &sum;x<sub>i</sub>y<sub>i</sub>
- * </pre>
- *
- * <p>In fact, we can assume both a and &omega; are positive and compute them directly, knowing that
- * A = a<sup>2</sup> &omega;<sup>2</sup> and that B = - &omega;<sup>2</sup>. The complete algorithm
- * is therefore:
- *
- * <pre>
- *
- * for each t<sub>i</sub> from t<sub>1</sub> to t<sub>n-1</sub>, compute:
- *   f  (t<sub>i</sub>)
- *   f' (t<sub>i</sub>) = (f (t<sub>i+1</sub>) - f(t<sub>i-1</sub>)) / (t<sub>i+1</sub> - t<sub>i-1</sub>)
- *   x<sub>i</sub> = t<sub>i</sub> - t<sub>1</sub>
- *   y<sub>i</sub> = &int; f<sup>2</sup> from t<sub>1</sub> to t<sub>i</sub>
- *   z<sub>i</sub> = &int; f'<sup>2</sup> from t<sub>1</sub> to t<sub>i</sub>
- *   update the sums &sum;x<sub>i</sub>x<sub>i</sub>, &sum;y<sub>i</sub>y<sub>i</sub>, &sum;x<sub>i</sub>y<sub>i</sub>, &sum;x<sub>i</sub>z<sub>i</sub> and &sum;y<sub>i</sub>z<sub>i</sub>
- * end for
- *
- *            |--------------------------
- *         \  | &sum;y<sub>i</sub>y<sub>i</sub> &sum;x<sub>i</sub>z<sub>i</sub> - &sum;x<sub>i</sub>y<sub>i</sub> &sum;y<sub>i</sub>z<sub>i</sub>
- * a     =  \ | ------------------------
- *           \| &sum;x<sub>i</sub>y<sub>i</sub> &sum;x<sub>i</sub>z<sub>i</sub> - &sum;x<sub>i</sub>x<sub>i</sub> &sum;y<sub>i</sub>z<sub>i</sub>
- *
- *
- *            |--------------------------
- *         \  | &sum;x<sub>i</sub>y<sub>i</sub> &sum;x<sub>i</sub>z<sub>i</sub> - &sum;x<sub>i</sub>x<sub>i</sub> &sum;y<sub>i</sub>z<sub>i</sub>
- * &omega;     =  \ | ------------------------
- *           \| &sum;x<sub>i</sub>x<sub>i</sub> &sum;y<sub>i</sub>y<sub>i</sub> - &sum;x<sub>i</sub>y<sub>i</sub> &sum;x<sub>i</sub>y<sub>i</sub>
- *
- * </pre>
- *
- * <p>Once we know &omega;, we can compute:
- *
- * <pre>
- *    fc = &omega; f (t) cos (&omega; t) - f' (t) sin (&omega; t)
- *    fs = &omega; f (t) sin (&omega; t) + f' (t) cos (&omega; t)
- * </pre>
- *
- * <p>It appears that <code>fc = a &omega; cos (&phi;)</code> and <code>fs = -a &omega; sin (&phi;)
- * </code>, so we can use these expressions to compute &phi;. The best estimate over the sample is
- * given by averaging these expressions.
- *
- * <p>Since integrals and means are involved in the preceding estimations, these operations run in
- * O(n) time, where n is the number of measurements.
+ * <p>The instance retains intermediate sums and therefore is not thread-safe. Estimates assume a
+ * single dominant harmonic component and may degrade with heavy noise or multiple tones; use a
+ * downstream fitter to refine the result. When {@link #guess()} has not been executed, getter
+ * methods return {@code Double.NaN} to signal the absence of a computed estimate.
  *
  * @version $Id: HarmonicCoefficientsGuesser.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
+ * @see AbstractCurveFitter
  */
 public class HarmonicCoefficientsGuesser implements Serializable {
 
+  /**
+   * Construct a guesser bound to the provided measurements.
+   *
+   * <p>The array is defensively cloned so subsequent user modifications do not alter the internal
+   * state. Measurements are expected to describe the sampled function in chronological order so the
+   * Simpson sampler can compute finite differences for the derivative term. All coefficient fields
+   * are initialized to {@code Double.NaN}; they remain in that state until {@link #guess()} is
+   * executed successfully. Supplying fewer than three points will cause estimation to fail because
+   * the derivative approximation requires neighboring values.
+   *
+   * @param measurements sequentially ordered sample points of the observed harmonic signal; the
+   *     array is cloned and must not be {@code null}.
+   */
   public HarmonicCoefficientsGuesser(AbstractCurveFitter.FitMeasurement[] measurements) {
-    this.measurements = (AbstractCurveFitter.FitMeasurement[]) measurements.clone();
+    this.measurements = measurements.clone();
     a = Double.NaN;
     omega = Double.NaN;
   }
 
   /**
-   * Estimate a first guess of the coefficients.
+   * Compute initial amplitude, angular frequency, and phase estimates from the stored sample set.
    *
-   * @exception ExhaustedSampleException if the sample is exhausted.
-   * @exception FunctionException if the integrator throws one.
-   * @exception EstimationException if the sample is too short or if the first guess cannot be
-   *     computed (when the elements under the square roots are negative).
+   * <p>The method first solves a least-squares system on squared integrals to infer the amplitude
+   * and angular frequency, then averages cosine/sine projections to deduce the phase. All results
+   * are cached inside this instance and replace any previous estimate, so repeated calls recompute
+   * the same values for unchanged input. Callers should invoke this method before reading any
+   * getter; otherwise the getters will return {@code Double.NaN} to indicate that no estimate was
+   * produced.
+   *
+   * @throws ExhaustedSampleException if the sampler runs out of points before finishing.
+   * @throws FunctionException if the underlying numerical integrator reports an evaluation error.
+   * @throws EstimationException if the sample is too short or leads to negative square roots.
    */
   public void guess() throws ExhaustedSampleException, FunctionException, EstimationException {
     guessAOmega();
@@ -127,10 +81,10 @@ public class HarmonicCoefficientsGuesser implements Serializable {
   /**
    * Estimate a first guess of the a and &omega; coefficients.
    *
-   * @exception ExhaustedSampleException if the sample is exhausted.
-   * @exception FunctionException if the integrator throws one.
-   * @exception EstimationException if the sample is too short or if the first guess cannot be
-   *     computed (when the elements under the square roots are negative).
+   * @throws ExhaustedSampleException if the sample is exhausted.
+   * @throws FunctionException if the integrator throws one.
+   * @throws EstimationException if the sample is too short or if the first guess cannot be computed
+   *     (when the elements under the square roots are negative).
    */
   private void guessAOmega()
       throws ExhaustedSampleException, FunctionException, EstimationException {
@@ -181,8 +135,8 @@ public class HarmonicCoefficientsGuesser implements Serializable {
   /**
    * Estimate a first guess of the &phi; coefficient.
    *
-   * @exception ExhaustedSampleException if the sample is exhausted.
-   * @exception FunctionException if the sampler throws one.
+   * @throws ExhaustedSampleException if the sample is exhausted.
+   * @throws FunctionException if the sampler throws one.
    */
   private void guessPhi() throws ExhaustedSampleException, FunctionException {
 
@@ -204,22 +158,65 @@ public class HarmonicCoefficientsGuesser implements Serializable {
     phi = Math.atan2(-fsMean, fcMean);
   }
 
+  /**
+   * Return the estimated angular frequency in the sample time unit.
+   *
+   * <p>The value is computed during {@link #guess()} from the least-squares relation between the
+   * squared signal integral and the squared derivative integral. It is always non-negative and
+   * reflects the original time base; rescaling input timestamps scales this number accordingly. If
+   * no estimate has been produced because {@link #guess()} failed or has not been invoked, the
+   * method yields {@code Double.NaN} to signal the missing value.
+   *
+   * @return angular frequency estimate in radians per input time unit, or {@code Double.NaN} when
+   *     the estimate is unavailable.
+   */
   public double getOmega() {
     return omega;
   }
 
+  /**
+   * Return the estimated signal amplitude.
+   *
+   * <p>This value is inferred during {@link #guess()} by combining the linear regression results
+   * that link squared integrals of the function and its derivative. The amplitude is computed as a
+   * positive magnitude; noise or degenerate samples may still produce {@code Double.NaN} when the
+   * estimation path fails. Prior to a successful {@link #guess()} invocation, the amplitude remains
+   * unset and therefore returns {@code Double.NaN}.
+   *
+   * @return positive amplitude estimate consistent with the sampled signal, or {@code Double.NaN}
+   *     when no estimate is available.
+   */
   public double getA() {
     return a;
   }
 
+  /**
+   * Return the estimated phase shift of the signal.
+   *
+   * <p>The value is produced by averaging cosine and sine projections of the measurements after the
+   * angular frequency has been inferred. The result follows the standard {@link Math#atan2(double,
+   * double)} range, typically between {@code -Math.PI} and {@code Math.PI}. If {@link #guess()} has
+   * not been executed, the method returns {@code Double.NaN} to indicate the absence of a phase
+   * estimate.
+   *
+   * @return phase estimate in radians using the measurement time base, or {@code Double.NaN} when
+   *     guessing has not succeeded.
+   */
   public double getPhi() {
     return phi;
   }
 
-  private AbstractCurveFitter.FitMeasurement[] measurements;
+  /** Immutable copy of the sampled measurements used to derive all coefficients. */
+  private final AbstractCurveFitter.FitMeasurement[] measurements;
+
+  /** Latest amplitude estimate; remains {@code Double.NaN} until {@link #guess()} succeeds. */
   private double a;
+
+  /** Latest angular frequency estimate expressed in the input time unit. */
   private double omega;
+
+  /** Latest phase estimate returned by {@link #getPhi()}. */
   private double phi;
 
-  private static final long serialVersionUID = 2400399048702758814L;
+  @Serial private static final long serialVersionUID = 2400399048702758814L;
 }

--- a/src/main/java/org/spaceroots/mantissa/fitting/HarmonicFitter.java
+++ b/src/main/java/org/spaceroots/mantissa/fitting/HarmonicFitter.java
@@ -1,31 +1,51 @@
 package org.spaceroots.mantissa.fitting;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.estimation.EstimatedParameter;
 import org.spaceroots.mantissa.estimation.EstimationException;
 import org.spaceroots.mantissa.estimation.Estimator;
-import org.spaceroots.mantissa.estimation.GaussNewtonEstimator;
 import org.spaceroots.mantissa.functions.ExhaustedSampleException;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This class implements a curve fitting specialized for sinusoids.
+ * Curve fitter for single-frequency harmonic signals.
  *
- * <p>Harmonic fitting is a very simple case of curve fitting. The estimated coefficients are the
- * amplitude a, the pulsation omega and the phase phi: <code>f (t) = a cos (omega t + phi)</code>.
- * They are searched by a least square estimator initialized with a rough guess based on integrals.
+ * <p>Provides least-squares estimation of amplitude {@code a}, pulsation {@code omega}, and phase
+ * {@code phi} for the model {@code f(t) = a cos(omega t + phi)}. Instances manage three {@link
+ * EstimatedParameter} coefficients and delegate iterative solving to an injected {@link Estimator}.
+ * When constructed without an initial vector, the fitter derives a first guess from sorted sample
+ * points using {@link HarmonicCoefficientsGuesser}, which expects at least four measurements with
+ * varied abscissae.
  *
- * <p>This class <emph>is by no means optimized</emph>, neither versus space nor versus time
- * performance.
+ * <p>The class stores measurements in insertion order and performs a defensive sort before
+ * computing guesses to stabilize the integral-based heuristic. The fitter mutates the shared
+ * coefficient objects during estimation; callers may reuse the instance across runs provided they
+ * supply fresh measurements or reset estimates as needed. The implementation is not synchronized
+ * and should be confined to a single thread per instance.
  *
- * @version $Id: HarmonicFitter.java 1709 2006-12-03 21:16:50Z luc $
+ * <ul>
+ *   <li>Responsibilities: coefficient priming, delegate setup, and harmonic value/gradient helpers.
+ *   <li>Limitations: optimized neither for memory nor for real-time execution.
+ * </ul>
+ *
+ * @see AbstractCurveFitter
+ * @see HarmonicCoefficientsGuesser
  * @author L. Maisonobe
+ * @version $Id: HarmonicFitter.java 1709 2006-12-03 21:16:50Z luc $
  */
 public class HarmonicFitter extends AbstractCurveFitter {
 
   /**
-   * Simple constructor.
+   * Creates a fitter that will compute its own initial coefficient guess.
    *
-   * @param estimator estimator to use for the fitting
+   * <p>Constructs a three-parameter harmonic fitter and seeds the parameters with neutral starting
+   * values ({@code a=2π}, {@code omega=0}, {@code phi=0}). The instance records that a heuristic
+   * first guess is still required; the next call to {@link #fit()} will sort the accumulated
+   * measurements, derive an initial estimate via {@link HarmonicCoefficientsGuesser}, and then
+   * launch the delegated estimator.
+   *
+   * @param estimator least-squares estimator driving iterations; must accept three parameters and
+   *     produce updated estimates
    */
   public HarmonicFitter(Estimator estimator) {
     super(3, estimator);
@@ -36,14 +56,18 @@ public class HarmonicFitter extends AbstractCurveFitter {
   }
 
   /**
-   * Simple constructor.
+   * Creates a fitter using caller-provided coefficient estimates.
    *
-   * <p>This constructor can be used when a first estimate of the coefficients is already known.
+   * <p>Use this constructor when the caller already holds an amplitude, pulsation, and phase
+   * estimate that should seed the solver. The provided array is retained and mutated directly by
+   * the fitter, so subsequent calls to {@link #fit()} will update the same objects. Because an
+   * initial vector is present, no heuristic guessing is performed unless the caller resets the
+   * {@code firstGuessNeeded} flag manually.
    *
-   * @param coefficients first estimate of the coefficients. A reference to this array is hold by
-   *     the newly created object. Its elements will be adjusted during the fitting process and they
-   *     will be set to the adjusted coefficients at the end.
-   * @param estimator estimator to use for the fitting
+   * @param coefficients mutable parameter array ordered as {@code a}, {@code omega}, {@code phi};
+   *     must contain three non-null entries ready for adjustment
+   * @param estimator estimator to iterate the least-squares problem; configured for three
+   *     parameters
    */
   public HarmonicFitter(EstimatedParameter[] coefficients, Estimator estimator) {
     super(coefficients, estimator);
@@ -51,61 +75,21 @@ public class HarmonicFitter extends AbstractCurveFitter {
   }
 
   /**
-   * Simple constructor.
+   * Performs harmonic least-squares estimation using the configured estimator.
    *
-   * @param maxIterations maximum number of iterations allowed
-   * @param convergence criterion threshold below which we do not need to improve the criterion
-   *     anymore
-   * @param steadyStateThreshold steady state detection threshold, the problem has reached a steady
-   *     state (read converged) if <code>Math.abs (Jn - Jn-1) < Jn * convergence</code>, where
-   *     <code>Jn</code> and <code>Jn-1</code> are the current and preceding criterion value (square
-   *     sum of the weighted residuals of considered measurements).
-   * @param epsilon threshold under which the matrix of the linearized problem is considered
-   *     singular (see {@link org.spaceroots.mantissa.linalg.SquareMatrix#solve(
-   *     org.spaceroots.mantissa.linalg.Matrix,double) SquareMatrix.solve}).
-   * @deprecated replaced by {@link #HarmonicFitter(Estimator)} as of version 7.0
+   * <p>When a first guess is required, the method validates that at least four measurements are
+   * present, sorts them to stabilize the heuristic, and delegates initial value computation to
+   * {@link HarmonicCoefficientsGuesser}. It then invokes the superclass implementation, which
+   * forwards the prepared parameters and measurements to the injected {@link Estimator}. After a
+   * successful call, {@code firstGuessNeeded} is cleared so subsequent invocations reuse the
+   * current estimates unless measurements or coefficients are reset by the caller.
+   *
+   * @return array containing the updated estimates ordered as {@code a}, {@code omega}, {@code
+   *     phi}; the array is managed by the fitter
+   * @throws EstimationException if fewer than four measurements are available or if guessing or
+   *     estimation fails inside the delegate
    */
-  @Deprecated
-  public HarmonicFitter(
-      int maxIterations, double convergence, double steadyStateThreshold, double epsilon) {
-    this(new GaussNewtonEstimator(maxIterations, convergence, steadyStateThreshold, epsilon));
-  }
-
-  /**
-   * Simple constructor.
-   *
-   * <p>This constructor can be used when a first estimate of the coefficients is already known.
-   *
-   * @param coefficients first estimate of the coefficients. A reference to this array is hold by
-   *     the newly created object. Its elements will be adjusted during the fitting process and they
-   *     will be set to the adjusted coefficients at the end.
-   * @param maxIterations maximum number of iterations allowed
-   * @param convergence criterion threshold below which we do not need to improve the criterion
-   *     anymore
-   * @param steadyStateThreshold steady state detection threshold, the problem has reached a steady
-   *     state (read converged) if <code>Math.abs (Jn - Jn-1) < Jn * convergence</code>, where
-   *     <code>Jn</code> and <code>Jn-1</code> are the current and preceding criterion value (square
-   *     sum of the weighted residuals of considered measurements).
-   * @param epsilon threshold under which the matrix of the linearized problem is considered
-   *     singular (see {@link org.spaceroots.mantissa.linalg.SquareMatrix#solve(
-   *     org.spaceroots.mantissa.linalg.Matrix,double) SquareMatrix.solve}).
-   * @deprecated replaced by {@link #HarmonicFitter(EstimatedParameter[], Estimator)} as of version
-   *     7.0
-   */
-  @Deprecated
-  public HarmonicFitter(
-      EstimatedParameter[] coefficients,
-      int maxIterations,
-      double convergence,
-      double steadyStateThreshold,
-      double epsilon) {
-    this(
-        coefficients,
-        new GaussNewtonEstimator(
-            maxIterations, convergence,
-            steadyStateThreshold, epsilon));
-  }
-
+  @Override
   public double[] fit() throws EstimationException {
     if (firstGuessNeeded) {
       if (measurements.size() < 4) {
@@ -123,9 +107,7 @@ public class HarmonicFitter extends AbstractCurveFitter {
         coefficients[0].setEstimate(guesser.getA());
         coefficients[1].setEstimate(guesser.getOmega());
         coefficients[2].setEstimate(guesser.getPhi());
-      } catch (ExhaustedSampleException e) {
-        throw new EstimationException(e);
-      } catch (FunctionException e) {
+      } catch (ExhaustedSampleException | FunctionException e) {
         throw new EstimationException(e);
       }
 
@@ -136,30 +118,41 @@ public class HarmonicFitter extends AbstractCurveFitter {
   }
 
   /**
-   * Get the current amplitude coefficient estimate. Get a, where <code>
-   * f (t) = a cos (omega t + phi)</code>
+   * Get the current amplitude coefficient estimate.
    *
-   * @return current amplitude coefficient estimate
+   * <p>Returns the latest in-memory value of {@code a} used by the fitter. Before the first solve
+   * it reflects the constructor seed; after {@link #fit()} completes it contains the optimized
+   * amplitude corresponding to the most recent measurement set. Callers may read it between
+   * iterations to monitor convergence or after solving to persist the result.
+   *
+   * @return current amplitude estimate as a double; value is mutable and owned by the fitter
    */
   public double getAmplitude() {
     return coefficients[0].getEstimate();
   }
 
   /**
-   * Get the current pulsation coefficient estimate. Get omega, where <code>
-   * f (t) = a cos (omega t + phi)</code>
+   * Get the current pulsation coefficient estimate.
    *
-   * @return current pulsation coefficient estimate
+   * <p>Exposes the stored {@code omega} value representing angular frequency. Prior to solving it
+   * matches the initial seed; after {@link #fit()} the value is whatever the estimator last
+   * computed. The returned primitive is a snapshot, while the underlying {@link EstimatedParameter}
+   * remains mutable for subsequent runs.
+   *
+   * @return present pulsation estimate in radians per unit abscissa; snapshot of mutable state
    */
   public double getPulsation() {
     return coefficients[1].getEstimate();
   }
 
   /**
-   * Get the current phase coefficient estimate. Get phi, where <code>f (t) = a cos (omega t + phi)
-   * </code>
+   * Get the current phase coefficient estimate.
    *
-   * @return current phase coefficient estimate
+   * <p>Returns the {@code phi} parameter representing phase offset applied to the cosine model. It
+   * may be the seed value or an optimized result depending on whether {@link #fit()} has run. The
+   * number is not normalized; callers may wrap it to {@code [-π, π]} or another range if desired.
+   *
+   * @return present phase estimate in radians; snapshot that may change on subsequent fits
    */
   public double getPhase() {
     return coefficients[2].getEstimate();
@@ -168,8 +161,13 @@ public class HarmonicFitter extends AbstractCurveFitter {
   /**
    * Get the value of the function at x according to the current parameters value.
    *
-   * @param x abscissa at which the theoretical value is requested
-   * @return theoretical value at x
+   * <p>Evaluates {@code f(x) = a cos(omega x + phi)} using the fitter's current estimates without
+   * modifying them. This helper is useful for inspecting residuals, plotting predicted curves, or
+   * building custom merit functions prior to solving. It performs no validation of the estimates
+   * and assumes they represent a consistent harmonic parameterization.
+   *
+   * @param x abscissa at which the theoretical value is requested; any real value is accepted
+   * @return computed model value at {@code x} based on the latest coefficient estimates
    */
   public double valueAt(double x) {
     double a = coefficients[0].getEstimate();
@@ -181,9 +179,16 @@ public class HarmonicFitter extends AbstractCurveFitter {
   /**
    * Get the derivative of the function at x with respect to parameter p.
    *
-   * @param x abscissa at which the partial derivative is requested
-   * @param p parameter with respect to which the derivative is requested
-   * @return partial derivative
+   * <p>Computes the partial derivative of {@code f(x)} with respect to one of the harmonic
+   * parameters while holding the others constant. The method relies on identity checks against the
+   * internally stored {@link EstimatedParameter} instances; callers should pass the same objects
+   * obtained from the fitter rather than newly created parameter instances.
+   *
+   * @param x abscissa at which the partial derivative is requested; accepts any finite value
+   * @param p parameter with respect to which the derivative is requested; must be one of the
+   *     fitter's internal coefficient objects
+   * @return partial derivative value for the requested parameter at {@code x}; based on current
+   *     estimates
    */
   public double partial(double x, EstimatedParameter p) {
     double a = coefficients[0].getEstimate();
@@ -191,15 +196,18 @@ public class HarmonicFitter extends AbstractCurveFitter {
     double phi = coefficients[2].getEstimate();
     if (p == coefficients[0]) {
       return Math.cos(omega * x + phi);
-    } else if (p == coefficients[1]) {
-      return -a * x * Math.sin(omega * x + phi);
     } else {
-      return -a * Math.sin(omega * x + phi);
+      double v = Math.sin(omega * x + phi);
+      if (p == coefficients[1]) {
+        return -a * x * v;
+      } else {
+        return -a * v;
+      }
     }
   }
 
   /** Indicator of the need to compute a first guess of the coefficients. */
   private boolean firstGuessNeeded;
 
-  private static final long serialVersionUID = -8722683066277473450L;
+  @Serial private static final long serialVersionUID = -8722683066277473450L;
 }

--- a/src/main/java/org/spaceroots/mantissa/fitting/PolynomialCoefficient.java
+++ b/src/main/java/org/spaceroots/mantissa/fitting/PolynomialCoefficient.java
@@ -1,11 +1,23 @@
 package org.spaceroots.mantissa.fitting;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.estimation.EstimatedParameter;
 
 /**
- * This class represents a polynomial coefficient.
+ * Immutable parameter wrapper that represents a single polynomial coefficient estimated during a
+ * curve fit.
  *
- * <p>Each coefficient is uniquely defined by its degree.
+ * <p>Each instance binds together the numeric estimate managed by {@link
+ * org.spaceroots.mantissa.estimation.Estimator} infrastructure and the monomial degree it applies
+ * to. The coefficient name is derived from its degree (for example {@code a0}, {@code a1}, etc.) so
+ * that estimators and callers can address parameters deterministically even when the fitter creates
+ * them lazily. Objects are small, thread-safe after construction, and intended to be stored in the
+ * coefficients array managed by {@link PolynomialFitter}. They do not mutate their identifying
+ * degree, but their inherited estimate value changes as the underlying optimizer iterates.
+ *
+ * <p>Typical usage pairs a {@link PolynomialCoefficient} with each term of a polynomial model prior
+ * to invoking the fitting process. Callers pass the instances to a fitter, inspect estimated values
+ * after convergence, and may serialize them if needed.
  *
  * @see PolynomialFitter
  * @version $Id: PolynomialCoefficient.java 1666 2005-12-15 16:37:55Z luc $
@@ -13,12 +25,36 @@ import org.spaceroots.mantissa.estimation.EstimatedParameter;
  */
 public class PolynomialCoefficient extends EstimatedParameter {
 
+  /**
+   * Create a coefficient placeholder for the specified monomial degree.
+   *
+   * <p>The newly created parameter is named {@code a<degree>} and initialized with an estimate of
+   * zero, allowing estimators to refine its value during optimization. The instance is typically
+   * placed into the coefficients array of a {@link PolynomialFitter} immediately after creation.
+   *
+   * @param degree non-negative exponent of the monomial this coefficient multiplies; used to derive
+   *     both the parameter name and the associated partial derivative during fitting.
+   */
   public PolynomialCoefficient(int degree) {
     super("a" + degree, 0.0);
     this.degree = degree;
   }
 
-  public final int degree;
+  /** Degree of the monomial this coefficient scales; fixed for the lifetime of the instance. */
+  private final int degree;
 
-  private static final long serialVersionUID = 5775845068390259552L;
+  /**
+   * Get the monomial degree that identifies this coefficient.
+   *
+   * <p>The returned value is the exponent used both for naming (for example {@code a2}) and for
+   * computing partial derivatives during polynomial fitting. It never changes after construction
+   * and can be safely cached by callers.
+   *
+   * @return immutable, non-negative degree associated with this coefficient instance.
+   */
+  public int getDegree() {
+    return degree;
+  }
+
+  @Serial private static final long serialVersionUID = 5775845068390259552L;
 }

--- a/src/main/java/org/spaceroots/mantissa/fitting/PolynomialFitter.java
+++ b/src/main/java/org/spaceroots/mantissa/fitting/PolynomialFitter.java
@@ -1,16 +1,33 @@
 package org.spaceroots.mantissa.fitting;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.estimation.EstimatedParameter;
 import org.spaceroots.mantissa.estimation.Estimator;
-import org.spaceroots.mantissa.estimation.GaussNewtonEstimator;
 
 /**
  * This class implements a curve fitting specialized for polynomials.
  *
- * <p>Polynomial fitting is a very simple case of curve fitting. The estimated coefficients are the
- * polynom coefficients. They are searched by a least square estimator.
+ * <p>The fitter wires {@link PolynomialCoefficient} instances into an {@link Estimator} so the
+ * regression problem can be solved with the same least-squares machinery used by other curve
+ * fitters. Each coefficient acts as an {@link org.spaceroots.mantissa.estimation.EstimatedParameter
+ * EstimatedParameter}, allowing callers to configure constraints, convergence thresholds, or
+ * weighting at the estimator level rather than inside this class. The design therefore keeps the
+ * fitter lightweight while still supporting robust solvers such as Gauss-Newton or Levenberg
+ * Marquardt.
  *
- * <p>This class <emph>is by no means optimized</emph>, neither in space nor in time performance.
+ * <p>Typical usage builds the fitter with a degree, registers sample points via {@link
+ * AbstractCurveFitter#addWeightedPair(double, double, double)}, and delegates the solve phase to
+ * the estimator. The fitter stores coefficients in increasing degree order and evaluates
+ * polynomials with Horner’s scheme, making the evaluation stable for modest degrees but still
+ * sensitive to ill-conditioned data. Instances are mutable and not thread-safe; create one fitter
+ * per concurrent regression to avoid parameter interference.
+ *
+ * <ul>
+ *   <li>Supports dense polynomials via the degree-based constructor.
+ *   <li>Supports sparse or pre-seeded polynomials by passing an explicit coefficient array.
+ *   <li>Exposes coefficients as estimated parameters so advanced estimators can apply bounds or
+ *       correlations.
+ * </ul>
  *
  * @see PolynomialCoefficient
  * @version $Id: PolynomialFitter.java 1709 2006-12-03 21:16:50Z luc $
@@ -19,15 +36,16 @@ import org.spaceroots.mantissa.estimation.GaussNewtonEstimator;
 public class PolynomialFitter extends AbstractCurveFitter {
 
   /**
-   * Simple constructor.
+   * Creates a fitter for a dense polynomial of the given degree.
    *
-   * <p>The polynomial fitter built this way are complete polynoms, ie. a n-degree polynom has n+1
-   * coefficients. In order to build fitter for sparse polynoms (for example <code>a x^20 - b
-   * x^30</code>, on should first build the coefficients array and provide it to {@link
-   * #PolynomialFitter(PolynomialCoefficient[], int, double, double, double)}.
+   * <p>The fitter will own a contiguous coefficient vector sized {@code degree + 1}, one parameter
+   * per monomial from constant term to the highest degree. Use this constructor when every degree
+   * up to the maximum should be estimated. For sparse polynomials where only select degrees are
+   * present, prefer {@link #PolynomialFitter(PolynomialCoefficient[], Estimator)} with an
+   * explicitly prepared array.
    *
-   * @param degree maximal degree of the polynom
-   * @param estimator estimator to use for the fitting
+   * @param degree maximal degree of the polynomial; negative values are not supported
+   * @param estimator estimator to use for the fitting; must accept one parameter per coefficient
    */
   public PolynomialFitter(int degree, Estimator estimator) {
     super(degree + 1, estimator);
@@ -37,100 +55,32 @@ public class PolynomialFitter extends AbstractCurveFitter {
   }
 
   /**
-   * Simple constructor.
+   * Creates a fitter backed by an existing array of coefficient parameters.
    *
-   * <p>This constructor can be used either when a first estimate of the coefficients is already
-   * known (which is of little interest because the fit cost is the same whether a first guess is
-   * known or not) or when one needs to handle sparse polynoms like <code>a
-   * x^20 - b x^30</code>.
+   * <p>Use this variant to seed the optimizer with prior estimates or to fit sparse polynomials by
+   * supplying only the degrees that matter. The fitter keeps a direct reference to the provided
+   * array, so subsequent fitting rounds update the same {@link PolynomialCoefficient} instances in
+   * place. Callers must ensure the array ordering matches increasing degree, starting at zero, to
+   * keep evaluation consistent with {@link #valueAt(double)}.
    *
-   * @param coefficients first estimate of the coefficients. A reference to this array is hold by
-   *     the newly created object. Its elements will be adjusted during the fitting process and they
-   *     will be set to the adjusted coefficients at the end.
-   * @param estimator estimator to use for the fitting
+   * @param coefficients first estimate of the coefficients; array is stored and mutated in place
+   * @param estimator estimator to use for the fitting; drives the optimization iterations
    */
   public PolynomialFitter(PolynomialCoefficient[] coefficients, Estimator estimator) {
     super(coefficients, estimator);
   }
 
   /**
-   * Simple constructor.
+   * Computes the polynomial value at the supplied abscissa using current estimates.
    *
-   * <p>The polynomial fitter built this way are complete polynoms, ie. a n-degree polynom has n+1
-   * coefficients. In order to build fitter for sparse polynoms (for example <code>a x^20 - b
-   * x^30</code>, on should first build the coefficients array and provide it to {@link
-   * #PolynomialFitter(PolynomialCoefficient[], int, double, double, double)}.
+   * <p>The evaluation uses Horner’s rule to reduce numerical error and minimize multiplications.
+   * Coefficients are applied from the highest degree down to the constant term, reflecting the
+   * current state of the estimator. Because coefficients are mutable during fitting, repeated calls
+   * within an iteration reflect incremental optimizer updates. Inputs of large magnitude may still
+   * amplify rounding error for high-degree polynomials; rescale data if stability is critical.
    *
-   * @param degree maximal degree of the polynom
-   * @param maxIterations maximum number of iterations allowed
-   * @param convergence criterion threshold below which we do not need to improve the criterion
-   *     anymore
-   * @param steadyStateThreshold steady state detection threshold, the problem has reached a steady
-   *     state (read converged) if <code>Math.abs (Jn - Jn-1) < Jn * convergence</code>, where
-   *     <code>Jn</code> and <code>Jn-1</code> are the current and preceding criterion value (square
-   *     sum of the weighted residuals of considered measurements).
-   * @param epsilon threshold under which the matrix of the linearized problem is considered
-   *     singular (see {@link org.spaceroots.mantissa.linalg.SquareMatrix#solve(
-   *     org.spaceroots.mantissa.linalg.Matrix,double) SquareMatrix.solve}).
-   * @deprecated replaced by {@link #PolynomialFitter(int,Estimator)} as of version 7.0
-   */
-  @Deprecated
-  public PolynomialFitter(
-      int degree,
-      int maxIterations,
-      double convergence,
-      double steadyStateThreshold,
-      double epsilon) {
-    this(
-        degree,
-        new GaussNewtonEstimator(
-            maxIterations, steadyStateThreshold,
-            convergence, epsilon));
-  }
-
-  /**
-   * Simple constructor.
-   *
-   * <p>This constructor can be used either when a first estimate of the coefficients is already
-   * known (which is of little interest because the fit cost is the same whether a first guess is
-   * known or not) or when one needs to handle sparse polynoms like <code>a
-   * x^20 - b x^30</code>.
-   *
-   * @param coefficients first estimate of the coefficients. A reference to this array is hold by
-   *     the newly created object. Its elements will be adjusted during the fitting process and they
-   *     will be set to the adjusted coefficients at the end.
-   * @param maxIterations maximum number of iterations allowed
-   * @param convergence criterion threshold below which we do not need to improve the criterion
-   *     anymore
-   * @param steadyStateThreshold steady state detection threshold, the problem has reached a steady
-   *     state (read converged) if <code>Math.abs (Jn - Jn-1) < Jn * convergence</code>, where
-   *     <code>Jn</code> and <code>Jn-1</code> are the current and preceding criterion value (square
-   *     sum of the weighted residuals of considered measurements).
-   * @param epsilon threshold under which the matrix of the linearized problem is considered
-   *     singular (see {@link org.spaceroots.mantissa.linalg.SquareMatrix#solve(
-   *     org.spaceroots.mantissa.linalg.Matrix,double) SquareMatrix.solve}).
-   * @deprecated replaced by {@link #PolynomialFitter(PolynomialCoefficient[], Estimator)} as of
-   *     version 7.0
-   */
-  @Deprecated
-  public PolynomialFitter(
-      PolynomialCoefficient[] coefficients,
-      int maxIterations,
-      double convergence,
-      double steadyStateThreshold,
-      double epsilon) {
-    this(
-        coefficients,
-        new GaussNewtonEstimator(
-            maxIterations, steadyStateThreshold,
-            convergence, epsilon));
-  }
-
-  /**
-   * Get the value of the function at x according to the current parameters value.
-   *
-   * @param x abscissa at which the theoretical value is requested
-   * @return theoretical value at x
+   * @param x abscissa at which the theoretical value is requested; any finite double is accepted
+   * @return polynomial value at {@code x}; caller owns the primitive result and may reuse it freely
    */
   public double valueAt(double x) {
     double y = coefficients[coefficients.length - 1].getEstimate();
@@ -141,18 +91,27 @@ public class PolynomialFitter extends AbstractCurveFitter {
   }
 
   /**
-   * Get the derivative of the function at x with respect to parameter p.
+   * Computes the partial derivative of the polynomial with respect to a coefficient.
    *
-   * @param x abscissa at which the partial derivative is requested
-   * @param p parameter with respect to which the derivative is requested
-   * @return partial derivative
+   * <p>Each {@link PolynomialCoefficient} corresponds to the monomial {@code x^degree}; therefore
+   * the derivative of the polynomial value with respect to that coefficient is simply {@code
+   * x^degree}. This helper exposes that value so estimators can populate Jacobian entries without
+   * reconstructing the polynomial. Parameters belonging to other models are rejected to avoid
+   * silently mis-shaping the Jacobian.
+   *
+   * @param x abscissa at which the partial derivative is requested; must be finite for usefulness
+   * @param p parameter with respect to which the derivative is requested; must be a known {@link
+   *     PolynomialCoefficient}
+   * @return partial derivative value {@code x^degree} for the provided coefficient
+   * @throws IllegalArgumentException if {@code p} is not a {@link PolynomialCoefficient} managed by
+   *     this fitter
    */
   public double partial(double x, EstimatedParameter p) {
-    if (p instanceof PolynomialCoefficient) {
-      return Math.pow(x, ((PolynomialCoefficient) p).getDegree());
+    if (p instanceof PolynomialCoefficient coefficient) {
+      return Math.pow(x, coefficient.getDegree());
     }
-    throw new RuntimeException("internal error");
+    throw new IllegalArgumentException("internal error");
   }
 
-  private static final long serialVersionUID = -744904084649890769L;
+  @Serial private static final long serialVersionUID = -744904084649890769L;
 }

--- a/src/main/java/org/spaceroots/mantissa/fitting/PolynomialFitter.java
+++ b/src/main/java/org/spaceroots/mantissa/fitting/PolynomialFitter.java
@@ -149,7 +149,7 @@ public class PolynomialFitter extends AbstractCurveFitter {
    */
   public double partial(double x, EstimatedParameter p) {
     if (p instanceof PolynomialCoefficient) {
-      return Math.pow(x, ((PolynomialCoefficient) p).degree);
+      return Math.pow(x, ((PolynomialCoefficient) p).getDegree());
     }
     throw new RuntimeException("internal error");
   }

--- a/src/test/java/org/spaceroots/mantissa/fitting/F2FP2IteratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/fitting/F2FP2IteratorTest.java
@@ -1,0 +1,127 @@
+package org.spaceroots.mantissa.fitting;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.spaceroots.mantissa.estimation.EstimatedParameter;
+import org.spaceroots.mantissa.estimation.EstimationProblem;
+import org.spaceroots.mantissa.estimation.Estimator;
+import org.spaceroots.mantissa.fitting.AbstractCurveFitter.FitMeasurement;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.vectorial.VectorialValuedPair;
+
+@SuppressWarnings("java:S100")
+class F2FP2IteratorTest {
+
+  private static final double EPS = 1.0e-12;
+  private static final DummyCurveFitter FITTER = new DummyCurveFitter();
+
+  @Test
+  void getDimension_whenCalled_returnsTwo() {
+    // Arrange
+    F2FP2Iterator iterator = new F2FP2Iterator(sampleThreePoints());
+
+    // Act
+    int dimension = iterator.getDimension();
+
+    // Assert
+    assertEquals(2, dimension);
+  }
+
+  @Test
+  void nextSamplePoint_withThreeMeasurements_returnsSquaredValueAndDerivative()
+      throws ExhaustedSampleException, FunctionException {
+    // Arrange
+    F2FP2Iterator iterator = new F2FP2Iterator(sampleThreePoints());
+
+    // Act
+    VectorialValuedPair point = iterator.nextSamplePoint();
+
+    // Assert
+    assertEquals(1.0, point.x, EPS);
+    assertArrayEquals(new double[] {4.0, 4.0}, point.y, EPS);
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void nextSamplePoint_withFourMeasurements_stepsThroughSequence()
+      throws ExhaustedSampleException, FunctionException {
+    // Arrange
+    FitMeasurement[] measurements =
+        new FitMeasurement[] {
+          measurement(0.0, 1.0),
+          measurement(1.0, 3.0),
+          measurement(2.0, 5.0),
+          measurement(4.0, 11.0)
+        };
+    F2FP2Iterator iterator = new F2FP2Iterator(measurements);
+
+    // Act
+    VectorialValuedPair first = iterator.nextSamplePoint();
+    VectorialValuedPair second = iterator.nextSamplePoint();
+
+    // Assert
+    assertFalse(iterator.hasNext());
+    assertEquals(1.0, first.x, EPS);
+    assertArrayEquals(new double[] {9.0, 4.0}, first.y, EPS);
+    assertEquals(2.0, second.x, EPS);
+    assertArrayEquals(new double[] {25.0, 7.111111111111111}, second.y, EPS);
+  }
+
+  @Test
+  void nextSamplePoint_whenExhausted_throwsExhaustedSampleException() {
+    // Arrange
+    F2FP2Iterator iterator = new F2FP2Iterator(sampleTwoPoints());
+
+    // Act + Assert
+    assertFalse(iterator.hasNext());
+    assertThrows(ExhaustedSampleException.class, iterator::nextSamplePoint);
+  }
+
+  private static FitMeasurement[] sampleThreePoints() {
+    return new FitMeasurement[] {
+      measurement(0.0, 1.0), measurement(1.0, 2.0), measurement(2.0, 5.0)
+    };
+  }
+
+  private static FitMeasurement[] sampleTwoPoints() {
+    return new FitMeasurement[] {measurement(0.0, 1.0), measurement(1.0, 2.0)};
+  }
+
+  private static FitMeasurement measurement(double x, double y) {
+    return FITTER.new FitMeasurement(1.0, x, y);
+  }
+
+  private static class DummyCurveFitter extends AbstractCurveFitter {
+    DummyCurveFitter() {
+      super(1, new NoOpEstimator());
+    }
+
+    @Override
+    public double valueAt(double x) {
+      return 0.0;
+    }
+
+    @Override
+    public double partial(double x, EstimatedParameter p) {
+      return 0.0;
+    }
+  }
+
+  private static class NoOpEstimator implements Estimator {
+
+    @Override
+    public void estimate(EstimationProblem problem) {
+      // no-op for tests
+    }
+
+    @Override
+    public double getRMS(EstimationProblem problem) {
+      return 0.0;
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/fitting/FFPIteratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/fitting/FFPIteratorTest.java
@@ -1,0 +1,136 @@
+package org.spaceroots.mantissa.fitting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.spaceroots.mantissa.estimation.EstimatedParameter;
+import org.spaceroots.mantissa.estimation.EstimationProblem;
+import org.spaceroots.mantissa.estimation.Estimator;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+import org.spaceroots.mantissa.functions.vectorial.VectorialValuedPair;
+
+@SuppressWarnings("java:S100")
+class FFPIteratorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void nextSamplePoint_whenThreeMeasurements_returnsValueAndCentralDerivative()
+      throws FunctionException, ExhaustedSampleException {
+
+    FitMeasurementFactory factory = new FitMeasurementFactory();
+    AbstractCurveFitter.FitMeasurement[] measurements = {
+      factory.create(0.0, 0.0), factory.create(1.0, 1.0), factory.create(2.0, 4.0)
+    };
+
+    FFPIterator iterator = new FFPIterator(measurements);
+
+    assertTrue(iterator.hasNext());
+
+    VectorialValuedPair pair = iterator.nextSamplePoint();
+
+    assertFalse(iterator.hasNext());
+    assertEquals(1.0, pair.x, EPS);
+    assertEquals(1.0, pair.y[0], EPS);
+    assertEquals(2.0, pair.y[1], EPS);
+  }
+
+  @Test
+  void nextSamplePoint_multipleCalls_progressesAndUpdatesDerivative()
+      throws FunctionException, ExhaustedSampleException {
+
+    FitMeasurementFactory factory = new FitMeasurementFactory();
+    AbstractCurveFitter.FitMeasurement[] measurements = {
+      factory.create(0.0, 0.0),
+      factory.create(1.0, 2.0),
+      factory.create(2.0, 4.0),
+      factory.create(3.0, 8.0)
+    };
+
+    FFPIterator iterator = new FFPIterator(measurements);
+
+    VectorialValuedPair first = iterator.nextSamplePoint();
+    assertTrue(iterator.hasNext());
+    assertEquals(1.0, first.x, EPS);
+    assertEquals(2.0, first.y[0], EPS);
+    assertEquals(2.0, first.y[1], EPS);
+
+    VectorialValuedPair second = iterator.nextSamplePoint();
+    assertFalse(iterator.hasNext());
+    assertEquals(2.0, second.x, EPS);
+    assertEquals(4.0, second.y[0], EPS);
+    assertEquals(3.0, second.y[1], EPS);
+  }
+
+  @Test
+  void nextSamplePoint_whenNoSamplesLeft_throwsExhaustedSampleException()
+      throws FunctionException, ExhaustedSampleException {
+
+    FitMeasurementFactory factory = new FitMeasurementFactory();
+    AbstractCurveFitter.FitMeasurement[] measurements = {
+      factory.create(0.0, 0.0),
+      factory.create(1.0, 1.0),
+      factory.create(2.0, 2.0),
+      factory.create(3.0, 3.0)
+    };
+
+    FFPIterator iterator = new FFPIterator(measurements);
+
+    iterator.nextSamplePoint();
+    iterator.nextSamplePoint();
+
+    assertFalse(iterator.hasNext());
+    assertThrows(ExhaustedSampleException.class, iterator::nextSamplePoint);
+  }
+
+  @Test
+  void nextSamplePoint_whenInsufficientMeasurements_throwsImmediately() {
+    FitMeasurementFactory factory = new FitMeasurementFactory();
+    AbstractCurveFitter.FitMeasurement[] measurements = {
+      factory.create(0.0, 0.0), factory.create(1.0, 1.0)
+    };
+
+    FFPIterator iterator = new FFPIterator(measurements);
+
+    assertFalse(iterator.hasNext());
+    assertThrows(ExhaustedSampleException.class, iterator::nextSamplePoint);
+  }
+
+  private static final class FitMeasurementFactory extends AbstractCurveFitter {
+
+    FitMeasurementFactory() {
+      super(0, new DummyEstimator());
+    }
+
+    AbstractCurveFitter.FitMeasurement create(double x, double y) {
+      return new FitMeasurement(1.0, x, y);
+    }
+
+    @Override
+    public double valueAt(double x) {
+      return 0.0;
+    }
+
+    @Override
+    public double partial(double x, EstimatedParameter p) {
+      return 0.0;
+    }
+  }
+
+  private static final class DummyEstimator implements Estimator {
+
+    @Override
+    public void estimate(EstimationProblem problem) {
+      // No-op: test iterator does not rely on parameter estimation.
+    }
+
+    @Override
+    public double getRMS(EstimationProblem problem) {
+      return 0.0;
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/fitting/HarmonicCoefficientsGuesserTest.java
+++ b/src/test/java/org/spaceroots/mantissa/fitting/HarmonicCoefficientsGuesserTest.java
@@ -1,0 +1,128 @@
+package org.spaceroots.mantissa.fitting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.spaceroots.mantissa.estimation.EstimatedParameter;
+import org.spaceroots.mantissa.estimation.EstimationException;
+import org.spaceroots.mantissa.estimation.EstimationProblem;
+import org.spaceroots.mantissa.estimation.Estimator;
+import org.spaceroots.mantissa.fitting.AbstractCurveFitter.FitMeasurement;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+
+@SuppressWarnings("java:S100")
+class HarmonicCoefficientsGuesserTest {
+
+  private static final double AMPLITUDE = 2.5;
+  private static final double OMEGA = 1.7;
+  private static final double PHI = 0.4;
+  private static final double STEP = 0.2;
+  private static final DummyCurveFitter FITTER = new DummyCurveFitter();
+
+  @Test
+  void guess_whenGivenCleanCosine_returnsCloseCoefficients()
+      throws ExhaustedSampleException,
+          EstimationException,
+          org.spaceroots.mantissa.functions.FunctionException {
+    // Arrange
+    FitMeasurement[] measurements = cosineSample();
+    HarmonicCoefficientsGuesser guesser = new HarmonicCoefficientsGuesser(measurements);
+
+    // Act
+    guesser.guess();
+
+    // Assert
+    assertEquals(AMPLITUDE, guesser.getA(), 1.0e-6);
+    assertEquals(OMEGA, guesser.getOmega(), 5.0e-2);
+    double angleError =
+        Math.atan2(Math.sin(PHI - guesser.getPhi()), Math.cos(PHI - guesser.getPhi()));
+    assertEquals(0.0, angleError, 1.0e-1);
+    assertTrue(rootMeanSquareError(measurements, guesser) < 1.0e-1);
+  }
+
+  @Test
+  void guess_whenSampleHasTooFewPoints_throwsExhaustedSampleException() {
+    // Arrange
+    FitMeasurement[] measurements =
+        new FitMeasurement[] {measurement(0.0, 0.0), measurement(1.0, 1.0)};
+    HarmonicCoefficientsGuesser guesser = new HarmonicCoefficientsGuesser(measurements);
+
+    // Act + Assert
+    assertThrows(ExhaustedSampleException.class, guesser::guess);
+  }
+
+  @Test
+  void guess_whenSquaredTermsAreNegative_throwsEstimationException() {
+    // Arrange
+    FitMeasurement[] measurements =
+        new FitMeasurement[] {
+          measurement(0.0, 0.0),
+          measurement(1.0, 1.0),
+          measurement(2.0, -2.0),
+          measurement(3.0, 3.0),
+          measurement(4.0, -4.0),
+          measurement(5.0, 5.0)
+        };
+    HarmonicCoefficientsGuesser guesser = new HarmonicCoefficientsGuesser(measurements);
+
+    // Act + Assert
+    assertThrows(EstimationException.class, guesser::guess);
+  }
+
+  private static FitMeasurement[] cosineSample() {
+    FitMeasurement[] sample = new FitMeasurement[25];
+    for (int i = 0; i < sample.length; i++) {
+      double x = i * STEP;
+      double y = AMPLITUDE * Math.cos(OMEGA * x + PHI);
+      sample[i] = measurement(x, y);
+    }
+    return sample;
+  }
+
+  private static FitMeasurement measurement(double x, double y) {
+    return FITTER.new FitMeasurement(1.0, x, y);
+  }
+
+  private static double rootMeanSquareError(
+      FitMeasurement[] measurements, HarmonicCoefficientsGuesser guesser) {
+    double sum = 0.0;
+    for (FitMeasurement measurement : measurements) {
+      double predicted =
+          guesser.getA() * Math.cos(guesser.getOmega() * measurement.x + guesser.getPhi());
+      double error = predicted - measurement.getMeasuredValue();
+      sum += error * error;
+    }
+    return Math.sqrt(sum / measurements.length);
+  }
+
+  private static class DummyCurveFitter extends AbstractCurveFitter {
+    DummyCurveFitter() {
+      super(1, new NoOpEstimator());
+    }
+
+    @Override
+    public double valueAt(double x) {
+      return 0.0;
+    }
+
+    @Override
+    public double partial(double x, EstimatedParameter p) {
+      return 0.0;
+    }
+  }
+
+  private static class NoOpEstimator implements Estimator {
+
+    @Override
+    public void estimate(EstimationProblem problem) {
+      // no-op for tests
+    }
+
+    @Override
+    public double getRMS(EstimationProblem problem) {
+      return 0.0;
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/fitting/HarmonicFitterTest.java
+++ b/src/test/java/org/spaceroots/mantissa/fitting/HarmonicFitterTest.java
@@ -1,0 +1,158 @@
+package org.spaceroots.mantissa.fitting;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.estimation.EstimatedParameter;
+import org.spaceroots.mantissa.estimation.EstimationException;
+import org.spaceroots.mantissa.estimation.Estimator;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class HarmonicFitterTest {
+
+  @Mock private Estimator estimator;
+
+  @Test
+  void constructor_withEstimator_initializesDefaultCoefficients() {
+    HarmonicFitter fitter = new HarmonicFitter(estimator);
+
+    assertEquals(2.0 * Math.PI, fitter.getAmplitude(), 1.0e-12);
+    assertEquals(0.0, fitter.getPulsation(), 1.0e-12);
+    assertEquals(0.0, fitter.getPhase(), 1.0e-12);
+  }
+
+  @Test
+  void fit_withTooFewMeasurements_throwsEstimationException() throws EstimationException {
+    HarmonicFitter fitter = new HarmonicFitter(estimator);
+    fitter.addWeightedPair(1.0, 0.0, 1.0);
+    fitter.addWeightedPair(1.0, 1.0, 0.5);
+    fitter.addWeightedPair(1.0, 2.0, -0.5);
+
+    assertThrows(EstimationException.class, fitter::fit);
+    verify(estimator, never()).estimate(fitter);
+  }
+
+  @Test
+  void fit_whenFirstGuessNeeded_sortsMeasurementsAndInvokesEstimator() throws EstimationException {
+    TrackingHarmonicFitter fitter = new TrackingHarmonicFitter(estimator);
+    // Unsorted sample of f(t) = 1.5 * cos(2 * t + 0.3)
+    double[] times = {1.0, 0.0, 1.6, 0.4, 0.8, 1.2, 0.2, 1.4, 0.6};
+    for (double t : times) {
+      fitter.addWeightedPair(1.0, t, 1.5 * Math.cos(2.0 * t + 0.3));
+    }
+    doNothing().when(estimator).estimate(fitter);
+
+    double[] result = fitter.fit();
+
+    assertTrue(fitter.sortCalled);
+    assertFalse(Double.isNaN(fitter.getAmplitude()));
+    assertFalse(Double.isNaN(fitter.getPulsation()));
+    assertFalse(Double.isNaN(fitter.getPhase()));
+    assertEquals(fitter.getAmplitude(), result[0], 1.0e-12);
+    assertEquals(fitter.getPulsation(), result[1], 1.0e-12);
+    assertEquals(fitter.getPhase(), result[2], 1.0e-12);
+    verify(estimator).estimate(fitter);
+
+    double[] sortedXs = new double[] {0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6};
+    double[] actualXs = new double[fitter.getMeasurements().length];
+    for (int i = 0; i < actualXs.length; i++) {
+      actualXs[i] = ((AbstractCurveFitter.FitMeasurement) fitter.getMeasurements()[i]).x;
+    }
+    assertArrayEquals(sortedXs, actualXs, 1.0e-12);
+  }
+
+  @Test
+  void fit_whenFirstGuessNotNeeded_usesProvidedCoefficients() throws EstimationException {
+    EstimatedParameter[] coefficients = new EstimatedParameter[3];
+    coefficients[0] = new EstimatedParameter("a", 5.0);
+    coefficients[1] = new EstimatedParameter("omega", 3.0);
+    coefficients[2] = new EstimatedParameter("phi", 1.0);
+    HarmonicFitter fitter = new HarmonicFitter(coefficients, estimator);
+    fitter.addWeightedPair(1.0, 1.0, 0.0);
+    doNothing().when(estimator).estimate(fitter);
+
+    double[] result = fitter.fit();
+
+    assertArrayEquals(new double[] {5.0, 3.0, 1.0}, result, 1.0e-12);
+    verify(estimator).estimate(fitter);
+  }
+
+  @Test
+  void valueAt_withCurrentEstimates_returnsExpectedValue() {
+    EstimatedParameter[] coefficients = new EstimatedParameter[3];
+    coefficients[0] = new EstimatedParameter("a", 3.0);
+    coefficients[1] = new EstimatedParameter("omega", 2.0);
+    coefficients[2] = new EstimatedParameter("phi", 0.5);
+    HarmonicFitter fitter = new HarmonicFitter(coefficients, estimator);
+
+    double result = fitter.valueAt(0.75);
+
+    assertEquals(3.0 * Math.cos(2.0 * 0.75 + 0.5), result, 1.0e-12);
+  }
+
+  @Test
+  void partial_withAmplitudeParameter_returnsCosineDerivative() {
+    HarmonicFitter fitter = new HarmonicFitter(estimator);
+    EstimatedParameter amplitude = fitter.getAllParameters()[0];
+
+    double derivative = fitter.partial(0.3, amplitude);
+
+    assertEquals(Math.cos(fitter.getPulsation() * 0.3 + fitter.getPhase()), derivative, 1.0e-12);
+  }
+
+  @Test
+  void partial_withPulsationParameter_returnsPulsationDerivative() {
+    HarmonicFitter fitter = new HarmonicFitter(estimator);
+    EstimatedParameter pulsation = fitter.getAllParameters()[1];
+    fitter.getAllParameters()[0].setEstimate(4.0);
+    fitter.getAllParameters()[1].setEstimate(1.5);
+    fitter.getAllParameters()[2].setEstimate(0.25);
+
+    double derivative = fitter.partial(0.5, pulsation);
+
+    double expected =
+        -fitter.getAmplitude() * 0.5 * Math.sin(fitter.getPulsation() * 0.5 + fitter.getPhase());
+    assertEquals(expected, derivative, 1.0e-12);
+  }
+
+  @Test
+  void partial_withPhaseParameter_returnsPhaseDerivative() {
+    HarmonicFitter fitter = new HarmonicFitter(estimator);
+    EstimatedParameter phase = fitter.getAllParameters()[2];
+    fitter.getAllParameters()[0].setEstimate(2.5);
+    fitter.getAllParameters()[1].setEstimate(1.2);
+    fitter.getAllParameters()[2].setEstimate(0.3);
+
+    double derivative = fitter.partial(1.1, phase);
+
+    double expected =
+        -fitter.getAmplitude() * Math.sin(fitter.getPulsation() * 1.1 + fitter.getPhase());
+    assertEquals(expected, derivative, 1.0e-12);
+  }
+
+  private static final class TrackingHarmonicFitter extends HarmonicFitter {
+
+    private boolean sortCalled;
+
+    private TrackingHarmonicFitter(Estimator estimator) {
+      super(estimator);
+    }
+
+    @Override
+    protected void sortMeasurements() {
+      sortCalled = true;
+      super.sortMeasurements();
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/fitting/PolynomialCoefficientTest.java
+++ b/src/test/java/org/spaceroots/mantissa/fitting/PolynomialCoefficientTest.java
@@ -1,0 +1,68 @@
+package org.spaceroots.mantissa.fitting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class PolynomialCoefficientTest {
+
+  @Test
+  void constructor_whenDegreeProvided_setsNameEstimateDegreeAndUnbound() {
+    PolynomialCoefficient coefficient = new PolynomialCoefficient(3);
+
+    assertEquals("a3", coefficient.getName());
+    assertEquals(0.0, coefficient.getEstimate());
+    assertEquals(3, coefficient.getDegree());
+    assertFalse(coefficient.isBound());
+  }
+
+  @Test
+  void setEstimate_whenUpdated_changesEstimateOnly() {
+    PolynomialCoefficient coefficient = new PolynomialCoefficient(2);
+
+    coefficient.setEstimate(4.5);
+
+    assertEquals(4.5, coefficient.getEstimate());
+    assertEquals(2, coefficient.getDegree());
+    assertEquals("a2", coefficient.getName());
+  }
+
+  @Test
+  void setBound_whenFlagToggled_updatesBoundStatus() {
+    PolynomialCoefficient coefficient = new PolynomialCoefficient(1);
+
+    coefficient.setBound(true);
+
+    assertTrue(coefficient.isBound());
+  }
+
+  @Test
+  void serialization_whenRoundTripped_preservesAllFields() throws Exception {
+    PolynomialCoefficient original = new PolynomialCoefficient(7);
+    original.setEstimate(1.25);
+    original.setBound(true);
+
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(buffer)) {
+      out.writeObject(original);
+    }
+
+    PolynomialCoefficient restored;
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+      restored = (PolynomialCoefficient) in.readObject();
+    }
+
+    assertEquals("a7", restored.getName());
+    assertEquals(7, restored.getDegree());
+    assertEquals(1.25, restored.getEstimate());
+    assertTrue(restored.isBound());
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/fitting/PolynomialFitterTest.java
+++ b/src/test/java/org/spaceroots/mantissa/fitting/PolynomialFitterTest.java
@@ -1,0 +1,106 @@
+package org.spaceroots.mantissa.fitting;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.estimation.EstimatedParameter;
+import org.spaceroots.mantissa.estimation.EstimationException;
+import org.spaceroots.mantissa.estimation.EstimationProblem;
+import org.spaceroots.mantissa.estimation.Estimator;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class PolynomialFitterTest {
+
+  @Mock private Estimator estimator;
+
+  @Test
+  void constructor_whenDegreeGiven_createsSequentialCoefficients() {
+    PolynomialFitter fitter = new PolynomialFitter(2, estimator);
+
+    EstimatedParameter[] parameters = fitter.getAllParameters();
+
+    assertEquals(3, parameters.length);
+    assertEquals("a0", parameters[0].getName());
+    assertEquals("a1", parameters[1].getName());
+    assertEquals("a2", parameters[2].getName());
+  }
+
+  @Test
+  void valueAt_whenCoefficientsSet_returnsPolynomialValue() {
+    PolynomialFitter fitter = new PolynomialFitter(2, estimator);
+    EstimatedParameter[] parameters = fitter.getAllParameters();
+    parameters[0].setEstimate(1.0);
+    parameters[1].setEstimate(2.0);
+    parameters[2].setEstimate(3.0);
+
+    double result = fitter.valueAt(2.0);
+
+    assertEquals(17.0, result);
+  }
+
+  @Test
+  void partial_whenPolynomialCoefficient_returnsPowerOfX() {
+    PolynomialCoefficient coefficient = new PolynomialCoefficient(2);
+    PolynomialFitter fitter =
+        new PolynomialFitter(new PolynomialCoefficient[] {coefficient}, estimator);
+
+    double result = fitter.partial(3.0, coefficient);
+
+    assertEquals(9.0, result);
+  }
+
+  @Test
+  void partial_whenNonPolynomialCoefficient_throwsIllegalArgumentException() {
+    PolynomialFitter fitter = new PolynomialFitter(1, estimator);
+    EstimatedParameter unrelated = new EstimatedParameter("p", 0.0);
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> fitter.partial(1.0, unrelated));
+
+    assertEquals("internal error", ex.getMessage());
+  }
+
+  @Test
+  void fit_whenEstimatorAdjustsValues_returnsAdjustedCoefficients() throws EstimationException {
+    PolynomialFitter fitter = new PolynomialFitter(1, estimator);
+    doAnswer(
+            invocation -> {
+              EstimationProblem problem = invocation.getArgument(0);
+              for (EstimatedParameter parameter : problem.getAllParameters()) {
+                parameter.setEstimate(parameter.getName().equals("a0") ? 1.5 : -0.5);
+              }
+              return null;
+            })
+        .when(estimator)
+        .estimate(fitter);
+
+    double[] fitted = fitter.fit();
+
+    verify(estimator).estimate(fitter);
+    assertArrayEquals(new double[] {1.5, -0.5}, fitted);
+  }
+
+  @Test
+  void fit_whenEstimatorFails_propagatesException() throws EstimationException {
+    PolynomialFitter fitter = new PolynomialFitter(0, estimator);
+    EstimationException failure = new EstimationException("failure");
+    doAnswer(
+            invocation -> {
+              throw failure;
+            })
+        .when(estimator)
+        .estimate(fitter);
+
+    EstimationException thrown = assertThrows(EstimationException.class, fitter::fit);
+
+    assertEquals(failure, thrown);
+  }
+}


### PR DESCRIPTION
## Summary
- Harden mantissa fitting classes with clearer Javadoc, immutable fields, and serialization safeguards
- Clarify polynomial coefficient handling and remove deprecated constructors from harmonic/polynomial fitters
- Add JUnit coverage for mantissa iterators, harmonic coefficient guessing, and polynomial fitter behavior; enable spaceroots tests in Gradle

## Testing
- Not run (not requested)