### PR TITLE
Improve function exception Javadocs

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/functions/ExhaustedSampleException.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/ExhaustedSampleException.java
@@ -1,9 +1,26 @@
 package org.spaceroots.mantissa.functions;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.MantissaException;
 
 /**
- * This class represents exceptions thrown by sample iterators.
+ * Exception indicating that a sample iterator has no more data to provide.
+ *
+ * <p>This exception is raised when a sampling routine exhausts the finite set of elements it
+ * exposes, such as while integrating or fitting a function using precomputed sample points. It
+ * enables callers to stop iteration cleanly instead of relying on sentinel values or null checks,
+ * which keeps sampling loops explicit and deterministic. Typical usage is to catch the exception at
+ * the boundary of the sampling algorithm and perform any final aggregation or logging before
+ * releasing resources.
+ *
+ * <p>The exception is immutable and carries the last known sample size to aid diagnostics without
+ * exposing mutable state. It is intended for single-threaded use of iterators but can safely be
+ * shared across threads as a passive data carrier because its content never changes.
+ *
+ * <ul>
+ *   <li>Signals premature iteration end when a requested sample index is out of bounds.
+ *   <li>Encourages explicit control flow for algorithms that depend on fixed-size datasets.
+ * </ul>
  *
  * @version $Id: ExhaustedSampleException.java 1686 2005-12-16 12:59:51Z luc $
  * @author L. Maisonobe
@@ -11,13 +28,20 @@ import org.spaceroots.mantissa.MantissaException;
 public class ExhaustedSampleException extends MantissaException {
 
   /**
-   * Simple constructor.
+   * Builds an exception instance that records the available sample size for diagnostics.
    *
-   * @param size size of the sample
+   * <p>Use this constructor when an iterator or sampler detects that the caller asked for an index
+   * beyond the available element count. The provided {@code size} is embedded in the message so
+   * higher layers can log or surface the limit encountered. Constructing the exception does not
+   * perform I/O or extra validation, keeping it safe to create inside tight loops while still
+   * preserving clear control flow around exhaustion events.
+   *
+   * @param size total elements available in the sample when exhaustion occurred; must be
+   *     non-negative
    */
   public ExhaustedSampleException(int size) {
     super("sample contains only {0} elements", new String[] {Integer.toString(size)});
   }
 
-  private static final long serialVersionUID = -1490493298938282440L;
+  @Serial private static final long serialVersionUID = -1490493298938282440L;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/FunctionException.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/FunctionException.java
@@ -1,9 +1,33 @@
 package org.spaceroots.mantissa.functions;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.MantissaException;
 
 /**
- * This class represents exceptions thrown by scalar functions.
+ * Signals failures that occur while evaluating or preparing scalar or vector functions.
+ *
+ * <p>The exception acts as the common transport for user-visible errors in the functions package.
+ * Callers typically throw it when an argument violates a domain constraint, when evaluation cannot
+ * converge, or when a lower-level numerical routine reports an unrecoverable problem. The class
+ * extends {@link MantissaException} so messages can be localized and parameterized without forcing
+ * callers to build formatted strings eagerly. Instances are immutable and therefore safe to share
+ * across threads once created.
+ *
+ * <p>Typical usage is to raise the exception close to the detection site, optionally supplying a
+ * cause so that diagnostic chains remain intact. Consumers can inspect the message parts inherited
+ * from {@code MantissaException} to build structured error reports without re-formatting raw text.
+ * Example:
+ *
+ * <pre>{@code
+ * // Example: wrap a numerical failure with a localized message key
+ * throw new FunctionException("function.non.convergent", new String[] {functionName});
+ * }</pre>
+ *
+ * <ul>
+ *   <li>Captures translated message specifiers and dynamic parts for deferred formatting.
+ *   <li>Provides constructors for raw messages or chained exceptions.
+ *   <li>Does not alter control flow semantics; it only enriches error reporting.
+ * </ul>
  *
  * @version $Id: FunctionException.java 1686 2005-12-16 12:59:51Z luc $
  * @author L. Maisonobe
@@ -11,32 +35,51 @@ import org.spaceroots.mantissa.MantissaException;
 public class FunctionException extends MantissaException {
 
   /**
-   * Simple constructor. Build an exception by translating and formating a message
+   * Builds an exception whose message is produced from a translated format string.
    *
-   * @param specifier format specifier (to be translated)
-   * @param parts to insert in the format (no translation)
+   * <p>Use this constructor when the message should be localized and composed lazily. The {@code
+   * specifier} is resolved by {@link MantissaException} against the configured translation
+   * resources, and {@code parts} are inserted verbatim into the resulting format. Neither argument
+   * is modified, and the resulting exception remains immutable after construction.
+   *
+   * @param specifier translation key or format specifier describing the error condition; must not
+   *     be {@code null} and should match a resource bundle entry.
+   * @param parts ordered substitution values inserted into the translated format; may be empty but
+   *     must not be {@code null} when formatting expects arguments.
    */
   public FunctionException(String specifier, String[] parts) {
     super(specifier, parts);
   }
 
   /**
-   * Simple constructor. Build an exception by translating the specified message
+   * Builds an exception from a single message that will be translated if possible.
    *
-   * @param message message to translate
+   * <p>This variant is convenient when the error text is already complete or when no dynamic parts
+   * are needed. The message is passed to {@link MantissaException}, which will attempt localization
+   * according to the project-wide resource configuration. The instance is immutable and thread-safe
+   * after construction.
+   *
+   * @param message human-readable error description or translation key; should be non-empty and
+   *     meaningful to the caller or user interface.
    */
   public FunctionException(String message) {
     super(message);
   }
 
   /**
-   * Simple constructor. Build an exception from a cause
+   * Builds an exception that wraps an underlying cause while preserving its stack trace.
    *
-   * @param cause cause of this exception
+   * <p>Select this constructor when an upstream component throws an exception that should propagate
+   * as a function-level failure. The cause is recorded for later inspection through standard
+   * exception chaining APIs, allowing diagnostics to retain full context. No message translation is
+   * performed unless the cause supplies one.
+   *
+   * @param cause originating throwable that triggered the failure; may be {@code null} when the
+   *     caller prefers to defer message creation to higher layers.
    */
   public FunctionException(Throwable cause) {
     super(cause);
   }
 
-  private static final long serialVersionUID = 1455885104381976115L;
+  @Serial private static final long serialVersionUID = 1455885104381976115L;
 }


### PR DESCRIPTION
## Summary
- expand FunctionException Javadoc with usage guidance and mark serialVersionUID with @Serial
- clarify ExhaustedSampleException intent/usage and annotate serialVersionUID with @Serial

## Testing
- Not run (docs-only changes)