### PR TITLE
Improve vectorial sampling docs and add iterator/sampler tests

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/functions/vectorial/BasicSampledFunctionIterator.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/vectorial/BasicSampledFunctionIterator.java
@@ -1,39 +1,101 @@
 package org.spaceroots.mantissa.functions.vectorial;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.functions.ExhaustedSampleException;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This class is a wrapper allowing to iterate over a SampledFunction.
+ * Iterator over a sampled function that exposes one vector point at a time.
  *
- * <p>The basic implementation of the iteration interface does not perform any transformation on the
- * sample, it only handles a loop over the underlying sampled function.
+ * <p>This iterator wraps a {@link SampledFunction} instance and provides a sequential, forward-only
+ * traversal over its ordered samples. It delegates all data access to the wrapped function while
+ * maintaining a simple cursor that starts at the first element and advances by one with each
+ * successful call to {@link #nextSamplePoint()}. The iterator does not perform any interpolation or
+ * transformation; it simply surfaces the stored sample pairs as-is, preserving their original
+ * abscissa ordering and dimensionality.
+ *
+ * <p>Use this class when client code needs to consume samples incrementally without pulling the
+ * entire dataset into memory or when coordinating sampling with external control flow such as
+ * streaming or batch processing. The iterator is mutable and not thread-safe; callers should create
+ * separate instances per consumer thread or guard access externally. The underlying sampled
+ * function is assumed to remain stable for the lifetime of the iterator; modifying the source while
+ * iterating may lead to inconsistent results.
+ *
+ * <ul>
+ *   <li>Stateful cursor advances strictly forward; random access is not supported.
+ *   <li>Dimension queries are delegated directly to the sampled function.
+ *   <li>Exhaustion is signaled via {@link ExhaustedSampleException} rather than returning null.
+ * </ul>
  *
  * @see SampledFunction
+ * @see SampledFunctionIterator
  * @version $Id: BasicSampledFunctionIterator.java 1686 2005-12-16 12:59:51Z luc $
  * @author L. Maisonobe
  */
 public class BasicSampledFunctionIterator implements SampledFunctionIterator, Serializable {
 
   /**
-   * Simple constructor. Build an instance from a SampledFunction
+   * Create an iterator bound to a sampled function.
    *
-   * @param function smapled function over which we want to iterate
+   * <p>The iterator keeps only a reference to the supplied function and initializes its internal
+   * cursor to the first sample. The function must define a stable ordering and size for all
+   * samples, as the iterator relies on these properties to detect exhaustion and to compute the
+   * next element index. The caller is responsible for ensuring the argument is non-null and remains
+   * valid for the duration of iteration.
+   *
+   * @param function sampled function providing ordered vector-valued samples; must not be null
    */
   public BasicSampledFunctionIterator(SampledFunction function) {
     this.function = function;
     next = 0;
   }
 
+  /**
+   * Get the dimension of the vector values produced by this iterator.
+   *
+   * <p>The dimension is obtained directly from the underlying sampled function and therefore
+   * reflects the shape of every returned {@link VectorialValuedPair}. The value is constant for the
+   * lifetime of the iterator and independent of the current cursor position. Clients may call this
+   * method repeatedly without side effects when sizing arrays or validating input/output buffers
+   * prior to pulling samples.
+   *
+   * @return number of components in each vector sample; always non-negative
+   */
   public int getDimension() {
     return function.getDimension();
   }
 
+  /**
+   * Test whether another sample is available.
+   *
+   * <p>This check compares the current cursor position with the size of the underlying sampled
+   * function. It performs no lookahead beyond this numeric comparison and does not modify iterator
+   * state. Callers should use this method to guard calls to {@link #nextSamplePoint()} in order to
+   * avoid {@link ExhaustedSampleException}. The result remains valid only until the next mutation
+   * of the iterator or the underlying sampled function.
+   *
+   * @return {@code true} when at least one more sample can be returned; otherwise {@code false}
+   */
   public boolean hasNext() {
     return next < function.size();
   }
 
+  /**
+   * Return the next sampled point from the underlying function.
+   *
+   * <p>The method retrieves the sample at the current cursor position, advances the cursor by one,
+   * and returns the retrieved {@link VectorialValuedPair}. If the iterator is already exhausted, an
+   * {@link ExhaustedSampleException} is thrown. Any problem encountered while accessing or
+   * computing the sample is reported via {@link FunctionException}. The returned pair reflects the
+   * exact state of the sampled function at the time of invocation; subsequent modifications to the
+   * source data are not reflected retroactively.
+   *
+   * @return vector-valued sample at the current cursor position before it is advanced
+   * @throws ExhaustedSampleException if the cursor has reached or exceeded the available sample
+   *     count
+   * @throws FunctionException if the sampled function cannot compute or deliver the requested point
+   */
   public VectorialValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException {
 
     if (next >= function.size()) {
@@ -50,5 +112,5 @@ public class BasicSampledFunctionIterator implements SampledFunctionIterator, Se
   /** Next sample element. */
   private int next;
 
-  private static final long serialVersionUID = -4386278658288500627L;
+  @Serial private static final long serialVersionUID = -4386278658288500627L;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/vectorial/ComputableFunction.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/vectorial/ComputableFunction.java
@@ -4,18 +4,28 @@ import java.io.Serializable;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This interface represents vectorial functions of one real variable.
+ * Interface for real-to-vector functions that can be evaluated on demand.
  *
- * <p>This interface should be implemented by all vectorial functions that can be evaluated at any
- * point. This does not imply that an explicit definition is available, a function given by an
- * implicit function that should be numerically solved for each point for example is considered a
- * computable function.
+ * <p>Implementations expose a consistent, finite vector dimension and provide deterministic
+ * evaluations at any real abscissa where the function is defined. The contract makes no assumption
+ * about how values are produced: implementations may rely on analytical formulas, interpolation,
+ * iterative solvers, or external data sources. The essential guarantee is that callers can request
+ * values individually, letting numerical algorithms pick their own sampling strategy without
+ * forcing a fixed grid.
  *
- * <p>The {@link ComputableFunctionSampler} class can be used to transform classes implementing this
- * interface into classes implementing the {@link SampledFunction} interface.
+ * <p>Typical usage patterns include:
  *
- * <p>Several numerical algorithms (Gauss-Legendre integrators for example) need to choose
- * themselves the evaluation points, so they can handle only objects that implement this interface.
+ * <ul>
+ *   <li>feeding integrators or optimizers that adaptively choose evaluation points;
+ *   <li>sampling into {@link SampledFunction} via {@link ComputableFunctionSampler};
+ *   <li>building higher-order operations (e.g., Jacobians) that compose multiple {@code
+ *       ComputableFunction} instances.
+ * </ul>
+ *
+ * <p>Implementations should document their domain restrictions, side effects, and thread-safety. A
+ * pure function may be safely shared across threads, whereas stateful or caching implementations
+ * might need external synchronization. Returned arrays are owned by the caller only if explicitly
+ * stated by the implementation; callers should defensively copy when retaining results.
  *
  * @see org.spaceroots.mantissa.quadrature.vectorial.ComputableFunctionIntegrator
  * @see SampledFunction
@@ -24,18 +34,38 @@ import org.spaceroots.mantissa.functions.FunctionException;
  */
 public interface ComputableFunction extends Serializable {
   /**
-   * Get the dimension of the vectorial values of the function.
+   * Get the dimension of vectors produced by {@link #valueAt(double)}.
    *
-   * @return dimension
+   * <p>The dimension is constant for a given function instance and represents the number of
+   * components present in every returned array. Algorithms may cache this value to pre-size buffers
+   * or to validate result shapes before proceeding with costly computations. Implementations should
+   * return a positive value; zero-dimensional functions are not supported by downstream numerical
+   * utilities in this package.
+   *
+   * @return strictly positive vector dimension, identical for all evaluations
    */
-  public int getDimension();
+  int getDimension();
 
   /**
-   * Get the value of the function at the specified abscissa.
+   * Evaluate the function at the specified abscissa and return the vector value.
    *
-   * @param x current abscissa
-   * @return function value
-   * @exception FunctionException if something goes wrong
+   * <p>The returned array length must always equal {@link #getDimension()}. Implementations may
+   * allocate a new array per call or reuse internal buffers; callers should copy the result if they
+   * retain it beyond the immediate scope. Inputs outside the supported domain should trigger a
+   * {@link FunctionException} rather than silently clipping or extrapolating unless the
+   * implementation explicitly documents such behavior. Implementations should be consistent with
+   * respect to thread-safety expectations described at the type level.
+   *
+   * <pre>{@code
+   * // Example: compute the value and inspect its first component
+   * ComputableFunction f = ...;
+   * double[] v = f.valueAt(0.25);
+   * double first = v[0];
+   * }</pre>
+   *
+   * @param x real abscissa at which the function must be evaluated
+   * @return new or reused array containing exactly getDimension() components
+   * @exception FunctionException if evaluation fails or the point is outside the domain
    */
-  public double[] valueAt(double x) throws FunctionException;
+  double[] valueAt(double x) throws FunctionException;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/vectorial/ComputableFunctionSampler.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/vectorial/ComputableFunctionSampler.java
@@ -1,28 +1,36 @@
 package org.spaceroots.mantissa.functions.vectorial;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This class is a wrapper allowing to sample a {@link ComputableFunction}.
+ * Sampler that exposes a regular grid view over a {@link ComputableFunction}.
  *
- * <p>The sample produced is a regular sample. It can be specified by several means :
+ * <p>Instances describe an evenly spaced sequence of abscissas and compute vector values lazily
+ * when callers request individual sample points. This is useful when algorithms need predictable
+ * spacing (for plotting, interpolation warm starts, quick previews) but the underlying function is
+ * defined in terms of on-demand evaluations. No point values are cached; repeated calls re-evaluate
+ * the function and therefore keep memory usage constant at the price of extra computation.
+ *
+ * <p>Construction supports several grid definitions:
  *
  * <ul>
- *   <li>from an initial point a step and a number of points
- *   <li>from a range and a number of points
- *   <li>from a range and a step between points.
+ *   <li>an origin, a constant step, and an explicit point count;
+ *   <li>a closed range and a desired point count (step inferred);
+ *   <li>a closed range and a desired step, with optional adjustment so the upper bound is exactly
+ *       included.
  * </ul>
  *
- * In the latter case, the step can optionaly be adjusted in order to have the last point exactly at
- * the upper bound of the range.
- *
- * <p>The sample points are computed on demand, they are not stored. This allow to use this method
- * for very large sample with little memory overhead. The drawback is that if the same sample points
- * are going to be requested several times, they will be recomputed each time. In this case, the
- * user should consider storing the points by some other means.
+ * <p>Callers typically obtain the expected size via {@link #size()}, inspect the vector length via
+ * {@link #getDimension()}, and iterate indices with {@link #samplePointAt(int)}. The class is
+ * immutable after construction, thread-safe for concurrent reads assuming the wrapped {@code
+ * ComputableFunction} itself is thread-safe, and produces defensive copies of returned ordinate
+ * arrays.
  *
  * @see ComputableFunction
+ * @see VectorialValuedPair
+ * @see SampledFunction
  * @version $Id: ComputableFunctionSampler.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
@@ -31,13 +39,15 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
   /**
    * Constructor.
    *
-   * <p>Build a sample from an {@link ComputableFunction}. Beware of the classical off-by-one
-   * problem ! If you want to have a sample like this : 0.0, 0.1, 0.2 ..., 1.0, then you should
-   * specify step = 0.1 and n = 11 (not n = 10).
+   * <p>Builds a sampler from a fixed origin, a constant step, and an explicit number of points. Use
+   * this when the grid is already known or derived from upstream constraints such as plot
+   * resolution. Beware of the common off-by-one pattern: a closed range {@code [0, 1]} with step
+   * {@code 0.1} requires {@code n == 11}.
    *
-   * @param begin beginning of the range (will be the abscissa of the first point)
-   * @param step step between points
-   * @param n number of points
+   * @param function underlying function to evaluate; must remain valid for every requested point.
+   * @param begin abscissa of the first grid point; any finite {@code double} is accepted.
+   * @param step positive spacing between successive points, in the same unit as {@code begin}.
+   * @param n total number of grid points to expose; must be positive to avoid empty samples.
    */
   public ComputableFunctionSampler(ComputableFunction function, double begin, double step, int n) {
     this.function = function;
@@ -49,8 +59,15 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
   /**
    * Constructor. Build a sample from an {@link ComputableFunction}.
    *
-   * @param range abscissa range (from <code>range [0]</code> to <code>range [1]</code>)
-   * @param n number of points
+   * <p>Creates a regular grid over a closed range by inferring a constant step from the desired
+   * number of points. The first point lies at {@code range[0]} and the last at {@code range[1]}},
+   * with linear interpolation in between.
+   *
+   * @param function underlying function to evaluate; must support every point in the supplied
+   *     range.
+   * @param range two-element array describing {@code [lower, upper]} abscissa bounds; indices 0 and
+   *     1 are read directly and are not copied.
+   * @param n number of points to produce across the range; must be at least 2 to span the bounds.
    */
   public ComputableFunctionSampler(ComputableFunction function, double[] range, int n) {
     this.function = function;
@@ -62,12 +79,17 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
   /**
    * Constructor. Build a sample from an {@link ComputableFunction}.
    *
-   * @param range abscissa range (from <code>range [0]</code> to <code>range [1]</code>)
-   * @param step step between points
-   * @param adjustStep if true, the step is reduced in order to have the last point of the sample
-   *     exactly at <code>range [1]</code>, if false the last point will be between <code>
-   *     range [1] -
-   * step</code> and <code>range [1]</code>
+   * <p>Creates a grid over a closed range using a preferred step size. When {@code adjustStep} is
+   * {@code true}, the sampler slightly shrinks the step so the final point lands exactly on the
+   * upper bound; otherwise the final point is the largest value that does not exceed the upper
+   * bound by more than one unadjusted step.
+   *
+   * @param function underlying function to evaluate; must accept every generated abscissa.
+   * @param range two-element array describing {@code [lower, upper]} abscissa bounds, read as-is.
+   * @param step preferred spacing between points; must be strictly positive to avoid infinite
+   *     loops.
+   * @param adjustStep whether to reduce the spacing so the last point equals {@code range[1]};
+   *     {@code false} keeps the original spacing even if the last point falls short of the bound.
    */
   public ComputableFunctionSampler(
       ComputableFunction function, double[] range, double step, boolean adjustStep) {
@@ -86,10 +108,33 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
     return n;
   }
 
+  /**
+   * Get the vector dimension produced by the wrapped function.
+   *
+   * <p>The returned value is forwarded from {@link ComputableFunction#getDimension()} without local
+   * caching; repeated calls therefore keep consistency with dynamic implementations but may incur
+   * repeated delegate lookups.
+   *
+   * @return strictly positive vector dimension consistent with all values produced by the sampler.
+   */
   public int getDimension() {
     return function.getDimension();
   }
 
+  /**
+   * Compute the sample point at a given grid index.
+   *
+   * <p>The abscissa is derived from the sampler definition ({@code begin + index * step}); the
+   * ordinate is the function value at that abscissa. The returned {@link VectorialValuedPair}
+   * defensively copies the ordinate array so callers can retain it safely.
+   *
+   * @param index zero-based index within the grid; must satisfy {@code 0 <= index < size()}.
+   * @return pair containing the abscissa and a fresh copy of the ordinate vector at that position.
+   * @throws ArrayIndexOutOfBoundsException if {@code index} is negative or greater than or equal to
+   *     {@link #size()}.
+   * @throws FunctionException if the underlying function rejects the computed abscissa or fails
+   *     during evaluation.
+   */
   public VectorialValuedPair samplePointAt(int index)
       throws ArrayIndexOutOfBoundsException, FunctionException {
 
@@ -102,16 +147,16 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
   }
 
   /** Underlying computable function. */
-  private ComputableFunction function;
+  private final ComputableFunction function;
 
   /** Beginning abscissa. */
-  private double begin;
+  private final double begin;
 
   /** Step between points. */
-  private double step;
+  private final double step;
 
   /** Total number of points. */
-  private int n;
+  private final int n;
 
-  private static final long serialVersionUID = 1368582688313212821L;
+  @Serial private static final long serialVersionUID = 1368582688313212821L;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/vectorial/SampledFunction.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/vectorial/SampledFunction.java
@@ -4,19 +4,37 @@ import java.io.Serializable;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This interface represent sampled vectorial functions.
+ * Interface for vector-valued functions represented only by sampled points.
  *
- * <p>A function sample is an ordered set of points of the form (x, y) where x is the abscissa of
- * the point and y is the function value at x. It is typically a function that has been computed by
- * external means or the result of measurements.
+ * <p>Implementations expose a finite, ordered sequence of {@code (x, y)} pairs where {@code x}
+ * denotes the abscissa of the sample and {@code y} holds the vectorial value evaluated at that
+ * abscissa. The interface is intended for data that already exists in discrete form, such as
+ * measurements produced by sensors, tabulated results from numerical simulations, or functions that
+ * are expensive to recompute analytically. Clients typically read samples sequentially to feed
+ * interpolators, resamplers, or numerical integrators.
  *
- * <p>The {@link ComputableFunctionSampler} class can be used to transform classes implementing the
- * {@link ComputableFunction} interface into classes implementing this interface.
+ * <p>Samples are treated as immutable for the lifetime of a {@code SampledFunction} instance; the
+ * ordering of indices is stable and spans {@link #size()} elements starting at zero.
+ * Implementations may perform lazy loading or compute values on demand, but they should guarantee
+ * that repeated accesses to the same index yield consistent coordinates. Unless specified otherwise
+ * by a concrete type, instances are not thread-safe for concurrent mutation of the underlying
+ * storage; concurrent read-only access to precomputed samples is generally safe when the
+ * implementation does not cache transient state.
+ *
+ * <p>Typical usage follows one of these patterns:
+ *
+ * <ul>
+ *   <li>Obtain metadata such as {@link #getDimension()} and {@link #size()} to plan processing.
+ *   <li>Iterate indices from {@code 0} to {@code size() - 1} and read each {@link
+ *       VectorialValuedPair} via {@link #samplePointAt(int)}.
+ *   <li>Wrap a {@link ComputableFunction} using {@link ComputableFunctionSampler} to capture a
+ *       dense sampling of an otherwise continuous function.
+ * </ul>
  *
  * <p>Sampled functions cannot be directly handled by integrators implementing the {@link
  * org.spaceroots.mantissa.quadrature.vectorial.SampledFunctionIntegrator
  * SampledFunctionIntegrator}. These integrators need a {@link SampledFunctionIterator} object to
- * iterate over the sample.
+ * iterate over the sample while preserving any invariants required by the underlying algorithm.
  *
  * @see SampledFunctionIterator
  * @see ComputableFunctionSampler
@@ -27,27 +45,59 @@ import org.spaceroots.mantissa.functions.FunctionException;
 public interface SampledFunction extends Serializable {
 
   /**
-   * Get the number of points in the sample.
+   * Return the number of sampled points available from this function.
    *
-   * @return number of points in the sample
+   * <p>The count includes every valid index starting at zero and ending at {@code size() - 1}.
+   * Implementations should keep this value stable for the lifetime of the instance so downstream
+   * consumers can preallocate buffers or schedule work without defensive checks. Large samples may
+   * reside on disk or stream from remote sources; callers should not assume the method is constant
+   * time, though most in-memory implementations will be fast. The returned size does not imply
+   * uniform spacing of abscissas or any particular ordering beyond the guarantee that indices are
+   * strictly increasing.
+   *
+   * @return total number of stored sample points, always non-negative and stable across calls
    */
-  public int size();
+  int size();
 
   /**
-   * Get the dimension of the vectorial values of the function.
+   * Get the dimension of the vectorial values stored in each sample point.
    *
-   * @return dimension
+   * <p>The dimension corresponds to the length of the vector component stored in {@link
+   * VectorialValuedPair#y}. A constant dimension across all indices is assumed; callers may rely on
+   * this to size arrays or matrices used for interpolation and integration. Returning a dimension
+   * of zero is permitted for purely scalar data represented with the vectorial container, but
+   * typical implementations return a positive value. The method must not perform expensive
+   * computations beyond reading readily available metadata.
+   *
+   * @return the number of elements in each sample vector component; usually a positive integer
    */
-  public int getDimension();
+  int getDimension();
 
   /**
-   * Get the abscissa and value of the sample at the specified index.
+   * Retrieve the abscissa and vector value stored at a given sample index.
    *
-   * @param index index in the sample, should be between 0 and {@link #size} - 1
-   * @return abscissa and value of the sample at the specified index
-   * @exception ArrayIndexOutOfBoundsException if the index is wrong
-   * @exception FunctionException if an eventual underlying function throws one
+   * <p>Indexing is zero-based and must fall within the inclusive range {@code 0} to {@code size() -
+   * 1}. The returned {@link VectorialValuedPair} should reflect the coordinates as stored by the
+   * implementation; callers should not mutate shared instances unless the concrete implementation
+   * documents that it returns defensive copies. Access may trigger lazy loading or evaluation of
+   * the underlying computable function, so repeated calls with the same index should be expected to
+   * return consistent results. This method is not inherently thread-safe; external synchronization
+   * is required if concurrent mutation of backing data is possible.
+   *
+   * <pre>{@code
+   * // Example: iterate through all samples
+   * for (int i = 0; i < sampled.size(); ++i) {
+   *   VectorialValuedPair point = sampled.samplePointAt(i);
+   *   process(point.getAbscissa(), point.getValue());
+   * }
+   * }</pre>
+   *
+   * @param index zero-based position of the desired sample; must be within bounds of the sequence
+   * @return pair containing the abscissa and associated vector value for the requested index
+   * @throws ArrayIndexOutOfBoundsException if the provided index is negative or not below {@link
+   *     #size()}
+   * @throws FunctionException if computation or deferred loading of the underlying function fails
    */
-  public VectorialValuedPair samplePointAt(int index)
+  VectorialValuedPair samplePointAt(int index)
       throws ArrayIndexOutOfBoundsException, FunctionException;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/vectorial/SampledFunctionIterator.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/vectorial/SampledFunctionIterator.java
@@ -4,34 +4,76 @@ import org.spaceroots.mantissa.functions.ExhaustedSampleException;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This interface provides iteration services over vectorial functions samples.
+ * Iterator over vector-valued function samples produced by {@link SampledFunction}.
+ *
+ * <p>Implementations walk through a sequence of sampled points, typically generated from a
+ * discretized or lazily evaluated vector function. The iterator exposes only read methods and
+ * advances in a single forward direction; callers are expected to loop with {@link #hasNext()} and
+ * {@link #nextSamplePoint()} until exhaustion. The dimensionality of each vector remains stable for
+ * the life of the iterator, enabling callers to allocate result buffers up front. Instances are
+ * stateful and generally not thread-safe; share them across threads only when external
+ * synchronization preserves iteration order.
+ *
+ * <ul>
+ *   <li>Expose the fixed dimension of every returned vector value.
+ *   <li>Report exhaustion without altering the underlying sample source.
+ *   <li>Propagate function evaluation failures via {@link FunctionException}.
+ * </ul>
+ *
+ * <pre>{@code
+ * SampledFunctionIterator it = sampledFunction.iterator();
+ * while (it.hasNext()) {
+ *   VectorialValuedPair pair = it.nextSamplePoint();
+ *   // consume pair.getX() and pair.getVector()
+ * }
+ * }</pre>
  *
  * @see SampledFunction
+ * @see VectorialValuedPair
  * @version $Id: SampledFunctionIterator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
 public interface SampledFunctionIterator {
 
   /**
-   * Get the dimension of the vectorial values of the function.
+   * Return the dimensionality of vectors yielded by this iterator.
    *
-   * @return dimension
+   * <p>The dimension is constant for all samples exposed by a given iterator instance and normally
+   * matches the output dimension of the originating {@link SampledFunction}. Callers often retrieve
+   * it once before iteration to allocate reusable arrays or matrices sized for each sample vector.
+   * Implementations should not perform expensive computations when answering this query; the value
+   * ought to be available without advancing the iteration cursor.
+   *
+   * @return number of components in each sample vector produced by this iterator
    */
-  public int getDimension();
+  int getDimension();
 
   /**
-   * Check if the iterator can provide another point.
+   * Determine whether another sample point is available.
    *
-   * @return true if the iterator can provide another point.
+   * <p>This predicate must not advance the iterator or trigger underlying function evaluation. A
+   * {@code true} value indicates that a subsequent call to {@link #nextSamplePoint()} is expected
+   * to succeed without throwing {@link ExhaustedSampleException}. Once it returns {@code false},
+   * the iterator is considered exhausted and further calls to this method should continue to return
+   * {@code false} consistently.
+   *
+   * @return {@code true} when at least one additional sample point can be retrieved safely
    */
-  public boolean hasNext();
+  boolean hasNext();
 
   /**
-   * Get the next point of a sampled function.
+   * Retrieve the next sampled point produced by the iterator.
    *
-   * @return the next point of the sampled function
-   * @exception ExhaustedSampleException if the sample has been exhausted
-   * @exception FunctionException if the underlying function throws one
+   * <p>The call advances the internal cursor and returns a {@link VectorialValuedPair} containing
+   * the sample abscissa alongside the vector-valued function output. Clients should typically guard
+   * calls with {@link #hasNext()} to avoid exhaustion errors. The returned pair is expected to be
+   * either a new immutable instance or an object whose contents will not be mutated by subsequent
+   * iterator operations, allowing immediate consumption by the caller. Repeated invocations
+   * progress strictly forward; no rewinding or look-ahead is implied.
+   *
+   * @return next available sample point with its abscissa and vector value components
+   * @throws ExhaustedSampleException if no further sample points remain for this iterator instance
+   * @throws FunctionException if evaluating the underlying function fails for the requested sample
    */
-  public VectorialValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException;
+  VectorialValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/vectorial/VectorialValuedPair.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/vectorial/VectorialValuedPair.java
@@ -1,37 +1,81 @@
 package org.spaceroots.mantissa.functions.vectorial;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * This class represents an (x, f(x)) pair for vectorial functions.
+ * Immutable pair capturing a single abscissa and the vectorial value of a function at that point.
  *
- * <p>A vectorial function is a function of one vectorial parameter x whose value is a vector. This
- * class is used has a simple immutable placeholder to contain both an abscissa and the value of the
- * function at this abscissa.
+ * <p>This value object travels between samplers, interpolators, and numerical integrators as a
+ * concise record of the relation {@code y = f(x)}. The constructor defensively clones the provided
+ * ordinate so later mutations of the caller's buffer do not alter the stored sample. Instances are
+ * serializable to allow caching sample sets, persisting intermediate results, or sending data
+ * across process boundaries without recomputation. Although the fields are {@code final}, callers
+ * should treat the exposed {@link #y} array as read-only to avoid surprising consumers that assume
+ * immutability.
+ *
+ * <p>Typical usage patterns include:
+ *
+ * <ul>
+ *   <li>Representing raw measurements returned by {@link SampledFunction} implementations.
+ *   <li>Holding interpolation results produced by {@link ComputableFunctionSampler}.
+ *   <li>Passing immutable coordinates into algorithms that iterate over sampled curves.
+ * </ul>
+ *
+ * <p>Instances carry no inherent units or scaling; responsibility for consistent dimensionality and
+ * axis ordering remains with the calling code. The class itself is thread-safe for concurrent read
+ * access, provided consumers do not mutate the shared ordinate array.
  *
  * @see SampledFunction
- * @see VectorialValuedPair
+ * @see SampledFunctionIterator
+ * @see ComputableFunctionSampler
  * @version $Id: VectorialValuedPair.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
 public class VectorialValuedPair implements Serializable {
 
   /**
-   * Simple constructor. Build an instance from its coordinates
+   * Create a pair from an abscissa and its associated vectorial value.
    *
-   * @param x abscissa
-   * @param y ordinate (value of the function)
+   * <p>The constructor performs a shallow clone of the supplied ordinate array to shield the stored
+   * sample from later in-place edits performed by the caller. The {@code x} coordinate accepts any
+   * finite real value; units are defined by the surrounding function or dataset. Passing a null
+   * array triggers a {@link NullPointerException} during cloning, and callers should ensure the
+   * array length matches the expected dimension of the enclosing {@link SampledFunction}.
+   *
+   * <pre>{@code
+   * // Example: build a point from computed values
+   * double[] value = evaluator.apply(input);
+   * VectorialValuedPair point = new VectorialValuedPair(input, value);
+   * }</pre>
+   *
+   * @param x abscissa coordinate representing the input position; any real value is accepted
+   * @param y vectorial value evaluated at the provided abscissa; must be non-null and is cloned to
+   *     preserve immutability of the stored sample
    */
   public VectorialValuedPair(double x, double[] y) {
     this.x = x;
-    this.y = (double[]) y.clone();
+    this.y = y.clone();
   }
 
-  /** Abscissa of the point. */
+  /**
+   * Abscissa coordinate associated with this sample point.
+   *
+   * <p>The value remains constant after construction and should be interpreted using the same units
+   * as the function that produced the sample. Callers may reuse the scalar freely because it is a
+   * primitive copied by value.
+   */
   public final double x;
 
-  /** Vectorial ordinate of the point, y = f (x). */
+  /**
+   * Vectorial ordinate capturing {@code y = f(x)} for this point.
+   *
+   * <p>The array reference is {@code final} but its contents are mutable; the constructor clones
+   * the original input so external modifications do not affect this instance. Consumers should
+   * still treat the array as read-only to maintain thread safety and semantic clarity when sharing
+   * instances across processing stages.
+   */
   public final double[] y;
 
-  private static final long serialVersionUID = -7397116933564410103L;
+  @Serial private static final long serialVersionUID = -7397116933564410103L;
 }

--- a/src/test/java/org/spaceroots/mantissa/functions/vectorial/BasicSampledFunctionIteratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/functions/vectorial/BasicSampledFunctionIteratorTest.java
@@ -1,0 +1,114 @@
+// package and imports
+package org.spaceroots.mantissa.functions.vectorial;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class BasicSampledFunctionIteratorTest {
+
+  @Mock private SampledFunction function;
+
+  @Test
+  void getDimension_whenDelegateReturnsValue_returnsSame() {
+    when(function.getDimension()).thenReturn(3);
+
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    assertEquals(3, iterator.getDimension());
+    verify(function, times(1)).getDimension();
+  }
+
+  @Test
+  void hasNext_whenSizePositiveAndNoIteration_returnsTrue() {
+    when(function.size()).thenReturn(2);
+
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    assertTrue(iterator.hasNext());
+    verify(function, times(1)).size();
+  }
+
+  @Test
+  void hasNext_afterConsumingAllSamples_returnsFalse() throws Exception {
+    when(function.size()).thenReturn(1);
+    VectorialValuedPair pair = new VectorialValuedPair(1.0, new double[] {2.0});
+    when(function.samplePointAt(0)).thenReturn(pair);
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    iterator.nextSamplePoint();
+
+    assertFalse(iterator.hasNext());
+    verify(function, times(2)).size();
+  }
+
+  @Test
+  void nextSamplePoint_whenIterating_returnsValuesSequentially() throws Exception {
+    when(function.size()).thenReturn(2);
+    VectorialValuedPair first = new VectorialValuedPair(0.5, new double[] {1.0, 2.0});
+    VectorialValuedPair second = new VectorialValuedPair(1.5, new double[] {-1.0, 3.0});
+    when(function.samplePointAt(0)).thenReturn(first);
+    when(function.samplePointAt(1)).thenReturn(second);
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    VectorialValuedPair firstResult = iterator.nextSamplePoint();
+    VectorialValuedPair secondResult = iterator.nextSamplePoint();
+
+    assertEquals(first.x, firstResult.x);
+    assertArrayEquals(first.y, firstResult.y);
+    assertEquals(second.x, secondResult.x);
+    assertArrayEquals(second.y, secondResult.y);
+    assertFalse(iterator.hasNext());
+
+    var order = inOrder(function);
+    order.verify(function).size();
+    order.verify(function).samplePointAt(0);
+    order.verify(function).size();
+    order.verify(function).samplePointAt(1);
+    order.verify(function).size();
+  }
+
+  @Test
+  void nextSamplePoint_whenExhausted_throwsExhaustedSampleException() throws Exception {
+    when(function.size()).thenReturn(1);
+    VectorialValuedPair pair = new VectorialValuedPair(2.0, new double[] {4.0});
+    when(function.samplePointAt(0)).thenReturn(pair);
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    iterator.nextSamplePoint();
+
+    assertThrows(ExhaustedSampleException.class, iterator::nextSamplePoint);
+    verify(function, times(3)).size();
+    verify(function, times(1)).samplePointAt(0);
+    verifyNoMoreInteractions(function);
+  }
+
+  @Test
+  void nextSamplePoint_whenDelegateThrowsFunctionException_propagatesAndAdvancesIndex()
+      throws Exception {
+    when(function.size()).thenReturn(1);
+    when(function.samplePointAt(0)).thenThrow(new FunctionException("boom"));
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    assertThrows(FunctionException.class, iterator::nextSamplePoint);
+    assertThrows(ExhaustedSampleException.class, iterator::nextSamplePoint);
+
+    verify(function, times(1)).samplePointAt(0);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/functions/vectorial/BasicSampledFunctionIteratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/functions/vectorial/BasicSampledFunctionIteratorTest.java
@@ -94,6 +94,7 @@ class BasicSampledFunctionIteratorTest {
     iterator.nextSamplePoint();
 
     assertThrows(ExhaustedSampleException.class, iterator::nextSamplePoint);
+    // size() is called once on the initial read and twice on the exhausted call (guard + message)
     verify(function, times(3)).size();
     verify(function, times(1)).samplePointAt(0);
     verifyNoMoreInteractions(function);

--- a/src/test/java/org/spaceroots/mantissa/functions/vectorial/ComputableFunctionSamplerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/functions/vectorial/ComputableFunctionSamplerTest.java
@@ -1,0 +1,112 @@
+package org.spaceroots.mantissa.functions.vectorial;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.FunctionException;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ComputableFunctionSamplerTest {
+
+  @Mock private ComputableFunction function;
+
+  @Test
+  void size_whenCreatedWithDirectParameters_returnsProvidedCount() {
+    ComputableFunctionSampler sampler = new ComputableFunctionSampler(function, 1.0, 0.5, 4);
+
+    assertEquals(4, sampler.size());
+  }
+
+  @Test
+  void samplePointAt_whenValidIndex_returnsPairWithComputedAbscissaAndClonedValue()
+      throws FunctionException {
+    double[] rawValue = new double[] {1.0, -2.0};
+    when(function.valueAt(1.5)).thenReturn(rawValue);
+    ComputableFunctionSampler sampler = new ComputableFunctionSampler(function, 1.0, 0.5, 4);
+
+    VectorialValuedPair pair = sampler.samplePointAt(1);
+
+    assertEquals(1.5, pair.x);
+    assertArrayEquals(rawValue, pair.y);
+    assertNotSame(rawValue, pair.y);
+  }
+
+  @Test
+  void getDimension_whenCalled_delegatesToUnderlyingFunction() {
+    when(function.getDimension()).thenReturn(3);
+    ComputableFunctionSampler sampler = new ComputableFunctionSampler(function, 0.0, 1.0, 2);
+
+    int dimension = sampler.getDimension();
+
+    assertEquals(3, dimension);
+    verify(function, times(1)).getDimension();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 3})
+  void samplePointAt_whenIndexOutOfBounds_throwsException(int index) {
+    ComputableFunctionSampler sampler = new ComputableFunctionSampler(function, 0.0, 1.0, 3);
+
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> sampler.samplePointAt(index));
+  }
+
+  @Test
+  void constructorWithRangeAndCount_whenSamplingLastPoint_hitsUpperBound()
+      throws FunctionException {
+    ArgumentCaptor<Double> xCaptor = ArgumentCaptor.forClass(Double.class);
+    when(function.valueAt(anyDouble())).thenReturn(new double[] {42.0});
+    ComputableFunctionSampler sampler =
+        new ComputableFunctionSampler(function, new double[] {2.0, 4.0}, 5);
+
+    sampler.samplePointAt(4);
+
+    verify(function).valueAt(xCaptor.capture());
+    assertEquals(4.0, xCaptor.getValue(), 1.0e-12);
+    assertEquals(5, sampler.size());
+  }
+
+  @Test
+  void
+      constructorWithRangeAndStepAdjustTrue_whenSamplingLastPoint_usesAdjustedStepToReachUpperBound()
+          throws FunctionException {
+    ArgumentCaptor<Double> xCaptor = ArgumentCaptor.forClass(Double.class);
+    when(function.valueAt(anyDouble())).thenReturn(new double[] {7.0});
+    ComputableFunctionSampler sampler =
+        new ComputableFunctionSampler(function, new double[] {0.0, 1.0}, 0.3, true);
+
+    sampler.samplePointAt(sampler.size() - 1);
+
+    verify(function).valueAt(xCaptor.capture());
+    assertEquals(1.0, xCaptor.getValue(), 1.0e-12);
+    assertEquals(4, sampler.size());
+  }
+
+  @Test
+  void constructorWithRangeAndStepAdjustFalse_whenSamplingLastPoint_keepsOriginalStep()
+      throws FunctionException {
+    ArgumentCaptor<Double> xCaptor = ArgumentCaptor.forClass(Double.class);
+    when(function.valueAt(anyDouble())).thenReturn(new double[] {3.0});
+    ComputableFunctionSampler sampler =
+        new ComputableFunctionSampler(function, new double[] {0.0, 1.0}, 0.3, false);
+
+    sampler.samplePointAt(sampler.size() - 1);
+
+    verify(function).valueAt(xCaptor.capture());
+    assertEquals(0.6, xCaptor.getValue(), 1.0e-12);
+    assertEquals(3, sampler.size());
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/functions/vectorial/VectorialValuedPairTest.java
+++ b/src/test/java/org/spaceroots/mantissa/functions/vectorial/VectorialValuedPairTest.java
@@ -1,0 +1,78 @@
+package org.spaceroots.mantissa.functions.vectorial;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class VectorialValuedPairTest {
+
+  @Test
+  void constructor_whenProvidedValues_copiesAbscissaAndOrdinate() {
+    double[] input = {1.0, -2.5, 3.3};
+
+    VectorialValuedPair pair = new VectorialValuedPair(4.2, input);
+
+    assertEquals(4.2, pair.x);
+    assertArrayEquals(input, pair.y);
+    assertNotSame(input, pair.y, "y should be defensively copied");
+  }
+
+  @Test
+  void constructor_whenInputArrayModified_doesNotAffectStored() {
+    double[] input = {5.0, 6.0};
+
+    VectorialValuedPair pair = new VectorialValuedPair(1.0, input);
+    input[0] = -99.0;
+
+    assertArrayEquals(new double[] {5.0, 6.0}, pair.y);
+  }
+
+  @Test
+  void constructor_whenEmptyArray_allowsCreation() {
+    double[] empty = {};
+
+    VectorialValuedPair pair = new VectorialValuedPair(0.0, empty);
+
+    assertEquals(0.0, pair.x);
+    assertArrayEquals(empty, pair.y);
+  }
+
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void constructor_whenNullArray_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new VectorialValuedPair(2.0, null));
+  }
+
+  @Test
+  void serialization_whenRoundTripped_preservesValuesAndIsolation()
+      throws IOException, ClassNotFoundException {
+    double[] input = {7.1, 8.2};
+    VectorialValuedPair original = new VectorialValuedPair(9.3, input);
+
+    byte[] serialized;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(original);
+      serialized = baos.toByteArray();
+    }
+
+    VectorialValuedPair restored;
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restored = (VectorialValuedPair) ois.readObject();
+    }
+
+    assertEquals(original.x, restored.x);
+    assertArrayEquals(original.y, restored.y);
+    assertNotSame(
+        original.y, restored.y, "Deserialization should create a separate array instance");
+  }
+}


### PR DESCRIPTION
## Summary
- expand Javadoc across vectorial sampling types (computable functions, sampled functions, iterators, pairs) to clarify contracts and usage
- refactor `BasicSampledFunctionIterator`/`ComputableFunctionSampler` for immutability tweaks and add thorough unit tests covering iteration, bounds, and defensive copies
- document `VectorialValuedPair` semantics and add serialization/immutability tests

## Testing
- not run (not requested)
