### PR TITLE
Improve scalar sampling docs and add iterator coverage

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/functions/scalar/BasicSampledFunctionIterator.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/scalar/BasicSampledFunctionIterator.java
@@ -1,14 +1,32 @@
 package org.spaceroots.mantissa.functions.scalar;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.functions.ExhaustedSampleException;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This class is a simple wrapper allowing to iterate over a SampledFunction.
+ * Iterator over a scalar {@link SampledFunction}.
  *
- * <p>The basic implementation of the iteration interface does not perform any transformation on the
- * sample, it only handles a loop over the underlying sampled function.
+ * <p>This iterator provides a minimal, allocation-free way to traverse the discrete samples
+ * produced by a {@link SampledFunction}. It keeps only the next index internally and delegates
+ * every lookup to the underlying function, so consumers always observe the same values they would
+ * obtain when calling {@link SampledFunction#samplePointAt(int)} directly. Use this class when you
+ * need a sequential view of samples without copying them into a collection, or when you want a
+ * lightweight cursor that can be passed between components while preserving the function as the
+ * single source of truth.
+ *
+ * <p>Instances are mutable with respect to their internal cursor but thread-unsafe; a single
+ * instance must not be shared across threads without external synchronization. The iterator does
+ * not skip or filter values, and it stops exactly after {@link SampledFunction#size()} elements.
+ * Calls to {@link #nextSamplePoint()} advance the cursor, while {@link #hasNext()} leaves it
+ * unchanged, making the class suitable for simple while-loop traversal patterns.
+ *
+ * <ul>
+ *   <li>Responsibilities: maintain iteration state and delegate sampling.
+ *   <li>Notable behavior: throws {@link ExhaustedSampleException} once all samples are consumed.
+ *   <li>Performance: O(1) state, no buffering; each access is a single underlying lookup.
+ * </ul>
  *
  * @see SampledFunction
  * @version $Id: BasicSampledFunctionIterator.java 1686 2005-12-16 12:59:51Z luc $
@@ -23,19 +41,47 @@ public class BasicSampledFunctionIterator implements SampledFunctionIterator, Se
   private int next;
 
   /**
-   * Simple constructor. Build an instance from a SampledFunction
+   * Creates an iterator bound to the provided sampled function.
    *
-   * @param function smapled function over which we want to iterate
+   * <p>The iterator starts at the first sample (index {@code 0}) and progresses sequentially with
+   * each call to {@link #nextSamplePoint()}. The supplied function is retained by reference; its
+   * size and values are queried on demand, so later modifications of the function's backing data
+   * are visible through the iterator.
+   *
+   * @param function sampled function providing indexed scalar values; must be non-null
    */
   public BasicSampledFunctionIterator(SampledFunction function) {
     this.function = function;
     next = 0;
   }
 
+  /**
+   * Indicates whether another sample is available without advancing the cursor.
+   *
+   * <p>The check compares the current cursor position against {@link SampledFunction#size()} and
+   * therefore reflects any changes in the function's length between calls. It does not guard
+   * against concurrent modifications; callers should ensure consistent access if the underlying
+   * function can change in other threads.
+   *
+   * @return {@code true} when at least one sample remains to be returned
+   */
   public boolean hasNext() {
     return next < function.size();
   }
 
+  /**
+   * Returns the next sample point from the underlying function.
+   *
+   * <p>The method advances the internal cursor and requests the corresponding value from {@link
+   * SampledFunction#samplePointAt(int)}. If the iterator is already exhausted, it throws an {@link
+   * ExhaustedSampleException}. This method performs no caching; each call may re-evaluate the
+   * sample if the function computes values lazily.
+   *
+   * @return immutable pair containing the abscissa and sampled scalar value
+   * @throws ExhaustedSampleException if iteration is already exhausted when requesting another
+   *     sample
+   * @throws FunctionException if underlying sampled function fails to compute the sample value
+   */
   public ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException {
     if (next >= function.size()) {
       throw new ExhaustedSampleException(function.size());
@@ -45,5 +91,5 @@ public class BasicSampledFunctionIterator implements SampledFunctionIterator, Se
     return function.samplePointAt(current);
   }
 
-  private static final long serialVersionUID = -9106690005598356403L;
+  @Serial private static final long serialVersionUID = -9106690005598356403L;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/scalar/ComputableFunction.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/scalar/ComputableFunction.java
@@ -4,18 +4,28 @@ import java.io.Serializable;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This interface represents scalar functions of one real variable.
+ * Interface describing a scalar function of one real variable that can be evaluated on demand.
  *
- * <p>This interface should be implemented by all scalar functions that can be evaluated at any
- * point. This does not imply that an explicit definition is available, a function given by an
- * implicit function that should be numerically solved for each point for example is considered a
- * computable function.
+ * <p>Implementations represent mathematical functions that accept a single real-valued argument and
+ * return a real-valued result. The interface makes no assumptions about how the value is computed:
+ * it may be closed-form, approximated through interpolation, numerically solved from an implicit
+ * equation, or backed by a cached data set. Callers should treat the object as a pure function
+ * whose observable behavior is fully captured by successive {@link #valueAt(double)} evaluations.
+ * Whether instances are thread-safe or memoized depends on the concrete implementation; callers
+ * should consult specific subclasses when invoking from concurrent code or when reusing instances
+ * across multiple algorithms.
  *
- * <p>The {@link ComputableFunctionSampler} class can be used to transform classes implementing this
- * interface into classes implementing the {@link SampledFunction} interface.
+ * <p>Typical usage includes numerical integration, root finding, interpolation, or any algorithm
+ * that must adaptively evaluate a function at abscissas chosen at runtime. The companion {@link
+ * ComputableFunctionSampler} can wrap an implementation to produce a {@link SampledFunction} when
+ * discrete samples are required for plotting or tabulation.
  *
- * <p>Several numerical algorithms (Gauss-Legendre integrators for example) need to choose
- * themselves the evaluation points, so they can handle only objects that implement this interface.
+ * <ul>
+ *   <li>Responsibility: provide deterministic scalar values for supplied abscissas.
+ *   <li>Expectation: clearly document domain restrictions or discontinuities in concrete classes.
+ *   <li>Interoperability: usable with quadrature utilities such as {@link
+ *       org.spaceroots.mantissa.quadrature.scalar.ComputableFunctionIntegrator}.
+ * </ul>
  *
  * @see org.spaceroots.mantissa.quadrature.scalar.ComputableFunctionIntegrator
  * @see SampledFunction
@@ -25,11 +35,30 @@ import org.spaceroots.mantissa.functions.FunctionException;
 public interface ComputableFunction extends Serializable {
 
   /**
-   * Get the value of the function at the specified abscissa.
+   * Compute the value of the function at the supplied abscissa.
    *
-   * @param x current abscissa
-   * @return function value
-   * @exception FunctionException if something goes wrong
+   * <p>This operation must synchronously evaluate the current function for the exact argument
+   * provided and return the corresponding scalar result. Implementations may perform inexpensive
+   * analytic computations or expensive numerical procedures such as solving implicit equations or
+   * interpolating tabulated data; performance characteristics and domain constraints are therefore
+   * implementation specific. Callers should supply finite values within the supported domain and
+   * expect a deterministic result for the same input. Errors arising from invalid abscissas,
+   * convergence failures, or other evaluation issues are reported through {@link
+   * FunctionException}.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * ComputableFunction sine = x -> Math.sin(x);
+   * double peak = sine.valueAt(Math.PI / 2.0);
+   * }</pre>
+   *
+   * @param x abscissa where the function must be evaluated; implementations may reject NaN or
+   *     infinite values and can define narrower valid domains.
+   * @return scalar value produced for {@code x}; typically finite and reproducible for identical
+   *     arguments.
+   * @throws FunctionException if evaluation fails because the argument is outside the supported
+   *     domain or a numerical procedure cannot converge.
    */
-  public double valueAt(double x) throws FunctionException;
+  double valueAt(double x) throws FunctionException;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/scalar/ComputableFunctionSampler.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/scalar/ComputableFunctionSampler.java
@@ -1,55 +1,65 @@
 package org.spaceroots.mantissa.functions.scalar;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This class is a wrapper allowing to sample a {@link ComputableFunction}.
+ * Sampler that lazily evaluates a {@link ComputableFunction} on an evenly spaced grid of abscissas.
  *
- * <p>The sample produced is a regular sample. It can be specified by several means :
+ * <p>Instances capture a function reference together with the starting abscissa, the step between
+ * points, and the number of points to expose. They never cache computed values, so each call to
+ * {@link #samplePointAt(int)} recomputes the ordinate directly from the underlying function. This
+ * makes the sampler inexpensive in memory and suitable for large theoretical or streaming domains
+ * where retaining every sample would be prohibitive.
+ *
+ * <p>The sampler is immutable after construction; all coordinates are derived from the constructor
+ * arguments. Thread-safety therefore depends on the thread-safety of the supplied function because
+ * invocations are delegated without additional synchronization. Typical call flow is to construct
+ * the sampler with one of the provided factory-style constructors and iterate over indices until
+ * {@link #size()} to retrieve {@link ScalarValuedPair} instances.
  *
  * <ul>
- *   <li>from an initial point a step and a number of points
- *   <li>from a range and a number of points
- *   <li>from a range and a step between points.
+ *   <li>Support for fixed step and size starting at a specific abscissa.
+ *   <li>Support for deriving the step from a bounded range and desired sample count.
+ *   <li>Optional step adjustment to force the final point to coincide with the range upper bound.
  * </ul>
  *
- * In the latter case, the step can optionaly be adjusted in order to have the last point exactly at
- * the upper bound of the range.
- *
- * <p>The sample points are computed on demand, they are not stored. This allow to use this method
- * for very large sample with little memory overhead. The drawback is that if the same sample points
- * are going to be requested several times, they will be recomputed each time. In this case, the
- * user should consider storing the points by some other means.
- *
  * @see ComputableFunction
+ * @see ScalarValuedPair
+ * @see SampledFunction
  * @version $Id: ComputableFunctionSampler.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
 public class ComputableFunctionSampler implements SampledFunction, Serializable {
 
   /** Underlying computable function. */
-  private ComputableFunction function;
+  private final ComputableFunction function;
 
   /** Beginning abscissa. */
-  private double begin;
+  private final double begin;
 
   /** Step between points. */
-  private double step;
+  private final double step;
 
   /** Total number of points. */
-  private int n;
+  private final int n;
 
   /**
-   * Constructor.
+   * Creates a sampler starting at a fixed abscissa with a constant step size.
    *
-   * <p>Build a sample from an {@link ComputableFunction}. Beware of the classical off-by-one
-   * problem ! If you want to have a sample like this : 0.0, 0.1, 0.2 ..., 1.0, then you should
-   * specify step = 0.1 and n = 11 (not n = 10).
+   * <p>This constructor is convenient when callers already know the exact grid spacing and the
+   * precise number of points they want to expose. The sampler merely records the parameters and
+   * derives each abscissa as {@code begin + index * step}, leaving responsibility for meaningful
+   * values to the caller. Because points are recomputed on every access, this variant avoids any
+   * storage overhead but repeats evaluation work if indices are revisited. A common off-by-one
+   * pitfall is forgetting that both bounds count as points: to cover {@code 0.0} through {@code
+   * 1.0} with a step of {@code 0.1}, you must request {@code 11} points rather than {@code 10}.
    *
-   * @param begin beginning of the range (will be the abscissa of the first point)
-   * @param step step between points
-   * @param n number of points
+   * @param function computable function evaluated to produce each sampled ordinate; non-null.
+   * @param begin abscissa of the first sample point; often the range lower bound.
+   * @param step distance between successive abscissas; negative values yield descending grids.
+   * @param n total number of sample points generated; should be a positive integer.
    */
   public ComputableFunctionSampler(ComputableFunction function, double begin, double step, int n) {
     this.function = function;
@@ -59,10 +69,18 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
   }
 
   /**
-   * Constructor. Build a sample from an {@link ComputableFunction}.
+   * Creates a sampler spanning a closed range with evenly spaced points.
    *
-   * @param range abscissa range (from <code>range [0]</code> to <code>range [1]</code>)
-   * @param n number of points
+   * <p>The constructor derives the step size so that the first point matches {@code range[0]} and
+   * the final point matches {@code range[1]}, distributing {@code n} points linearly in between.
+   * The supplied range array is used directly; callers should pass a two-element array whose first
+   * entry is the lower bound and second entry is the upper bound. No validation is performed on the
+   * bounds or the count, so a non-positive {@code n} will lead to undefined behavior such as
+   * division by zero during step computation.
+   *
+   * @param function computable function evaluated to produce each sampled ordinate; non-null.
+   * @param range two-element array giving inclusive lower and upper abscissa bounds, in that order.
+   * @param n number of evenly distributed sample points; should be at least two.
    */
   public ComputableFunctionSampler(ComputableFunction function, double[] range, int n) {
     this.function = function;
@@ -72,14 +90,19 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
   }
 
   /**
-   * Constructor. Build a sample from an {@link ComputableFunction}.
+   * Creates a sampler across a range with an explicit step and optional adjustment.
    *
+   * <p>When {@code adjustStep} is {@code true}, the sampler reduces the provided step just enough
+   * to ensure the final abscissa coincides with {@code range[1]}, keeping the original direction of
+   * travel. When {@code adjustStep} is {@code false}, it uses the unmodified step and derives the
+   * number of points by flooring the division of the range length by the step, which means the last
+   * point may fall short of the upper bound. The range array is consumed as-is; callers should
+   * ensure the two entries represent the intended lower and upper bounds for consistent results.
+   *
+   * @param function computable function evaluated to produce each sampled ordinate; non-null.
    * @param range abscissa range (from <code>range [0]</code> to <code>range [1]</code>)
-   * @param step step between points
-   * @param adjustStep if true, the step is reduced in order to have the last point of the sample
-   *     exactly at <code>range [1]</code>, if false the last point will be between <code>
-   *     range [1] -
-   * step</code> and <code>range [1]</code>
+   * @param step nominal distance between successive abscissas before any optional adjustment.
+   * @param adjustStep if true, the step is reduced so the final point equals <code>range[1]</code>.
    */
   public ComputableFunctionSampler(
       ComputableFunction function, double[] range, double step, boolean adjustStep) {
@@ -94,10 +117,45 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
     }
   }
 
+  /**
+   * Returns the number of sample points defined for this sampler.
+   *
+   * <p>The value equals the count supplied at construction time (or derived from the provided
+   * range/step) and never changes afterward. It is useful for bounding iteration because valid
+   * indices run from {@code 0} inclusive to {@code size()} exclusive. This method performs no
+   * evaluation of the underlying function and therefore executes in constant time regardless of
+   * function complexity or external state.
+   *
+   * @return total number of sample points available from this sampler instance.
+   */
   public int size() {
     return n;
   }
 
+  /**
+   * Returns the sampled abscissa/ordinate pair at the specified zero-based index.
+   *
+   * <p>The method validates that {@code index} falls within the range {@code [0, size())}; if not,
+   * it throws an {@link ArrayIndexOutOfBoundsException}. For valid indices it computes the abscissa
+   * lazily and delegates evaluation of the ordinate to the wrapped {@link ComputableFunction}. No
+   * caching occurs, so repeated calls for the same index will re-evaluate the function each time.
+   * Callers should be prepared for exceptions emitted by the underlying function and account for
+   * any performance cost if the function is expensive.
+   *
+   * <pre>{@code
+   * // Example: iterate over all points
+   * for (int i = 0; i < sampler.size(); i++) {
+   *   ScalarValuedPair p = sampler.samplePointAt(i);
+   * }
+   * }</pre>
+   *
+   * @param index zero-based position of the desired point; must satisfy {@code 0 <= index <
+   *     size()}.
+   * @return sampled coordinate pair constructed on demand from the underlying function.
+   * @throws ArrayIndexOutOfBoundsException if the index is negative or greater than or equal to
+   *     {@link #size()}.
+   * @throws FunctionException if the wrapped function cannot compute the ordinate for the abscissa.
+   */
   public ScalarValuedPair samplePointAt(int index)
       throws ArrayIndexOutOfBoundsException, FunctionException {
 
@@ -109,5 +167,5 @@ public class ComputableFunctionSampler implements SampledFunction, Serializable 
     return new ScalarValuedPair(x, function.valueAt(x));
   }
 
-  private static final long serialVersionUID = -5127043442851795719L;
+  @Serial private static final long serialVersionUID = -5127043442851795719L;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/scalar/SampledFunction.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/scalar/SampledFunction.java
@@ -4,18 +4,31 @@ import java.io.Serializable;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This interface represent sampled scalar functions.
+ * Represents a finite scalar function known only through a discrete set of sampled points.
  *
- * <p>A function sample is an ordered set of points of the form (x, y) where x is the abscissa of
- * the point and y is the function value at x. It is typically a function that has been computed by
- * external means or the result of measurements.
+ * <p>A sampled function exposes an ordered sequence of (x, y) pairs where x is the abscissa and y
+ * is the corresponding scalar value. Implementations typically wrap data produced by measurement
+ * devices, numerical solvers, or other offline processes rather than computing values on demand.
+ * The interface focuses on predictable, read-only traversal of those samples so downstream
+ * algorithms can integrate, interpolate, or analyze them without coupling to the sampling origin.
  *
- * <p>The {@link ComputableFunctionSampler} class can be used to transform classes implementing the
- * {@link ComputableFunction} interface into classes implementing this interface.
+ * <p>Clients normally obtain an instance by collecting data directly or by converting a {@link
+ * ComputableFunction} through {@link ComputableFunctionSampler}, which evaluates the computable
+ * function at chosen abscissas. Consumers should treat the returned sample as immutable; most
+ * implementations fix the number of points and preserve the insertion order so callers can reason
+ * about iteration and indexing reliably.
  *
- * <p>Sampled functions cannot be directly handled by integrators implementing the {@link
- * org.spaceroots.mantissa.quadrature.scalar.SampledFunctionIntegrator SampledFunctionIntegrator}.
- * These integrators need a {@link SampledFunctionIterator} object to iterate over the sample.
+ * <p>Integrators such as {@link org.spaceroots.mantissa.quadrature.scalar.SampledFunctionIntegrator
+ * SampledFunctionIntegrator} operate through a {@link SampledFunctionIterator}, which adapts this
+ * interface for streaming access. Implementations are generally not thread-safe; if the underlying
+ * storage can be mutated or shared across threads, callers must coordinate external
+ * synchronization.
+ *
+ * <ul>
+ *   <li>Responsibility: expose the size and indexed access to sampled (x, y) pairs.
+ *   <li>Typical use: drive numeric integration, interpolation, or plotting loops.
+ *   <li>Lifetime: usually immutable once constructed; indices remain stable.
+ * </ul>
  *
  * @see SampledFunctionIterator
  * @see ComputableFunctionSampler
@@ -26,20 +39,39 @@ import org.spaceroots.mantissa.functions.FunctionException;
 public interface SampledFunction extends Serializable {
 
   /**
-   * Get the number of points in the sample.
+   * Return the number of points currently stored in the sample.
    *
-   * @return number of points in the sample
+   * <p>The count reflects the total number of abscissa/value pairs that the implementation exposes
+   * for indexed access. For most implementations this value is determined at construction time and
+   * does not change, allowing callers to preallocate buffers and bound iteration safely. Use this
+   * method before calling {@link #samplePointAt(int)} to avoid out-of-range access and to size any
+   * consumer loops. Implementations are expected to return non-negative values; an empty sample is
+   * represented by zero.
+   *
+   * @return non-negative number of abscissa/value points available in deterministic order
    */
-  public int size();
+  int size();
 
   /**
-   * Get the abscissa and value of the sample at the specified index.
+   * Get the abscissa and value pair located at the specified zero-based index.
    *
-   * @param index index in the sample, should be between 0 and {@link #size} - 1
-   * @return abscissa and value of the sample at the specified index
-   * @exception ArrayIndexOutOfBoundsException if the index is wrong
-   * @exception FunctionException if an eventual underlying function throws one
+   * <p>Indexed access enables random retrieval without forcing a full iteration. Callers should
+   * provide a valid index in the range {@code 0 <= index < size()}; the method signals misuse with
+   * {@link ArrayIndexOutOfBoundsException}. Implementations may fetch values from cached storage or
+   * lazily from an underlying function; in the latter case failures are reported through {@link
+   * FunctionException}. Retrieved pairs should be treated as snapshots of the sampling state at the
+   * time of the call.
+   *
+   * <pre>{@code
+   * SampledFunction f = sampler.sample();
+   * ScalarValuedPair first = f.samplePointAt(0);
+   * }</pre>
+   *
+   * @param index zero-based position within the sample; must be less than {@link #size()}
+   * @return immutable pair containing the abscissa and function value stored at the index
+   * @exception ArrayIndexOutOfBoundsException if index is negative or not strictly less than size()
+   * @exception FunctionException if computing or retrieving the stored value fails at runtime
    */
-  public ScalarValuedPair samplePointAt(int index)
+  ScalarValuedPair samplePointAt(int index)
       throws ArrayIndexOutOfBoundsException, FunctionException;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/scalar/SampledFunctionIterator.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/scalar/SampledFunctionIterator.java
@@ -4,27 +4,67 @@ import org.spaceroots.mantissa.functions.ExhaustedSampleException;
 import org.spaceroots.mantissa.functions.FunctionException;
 
 /**
- * This interface provides iteration services over scalar functions samples.
+ * Iterator that exposes successive samples of a scalar-valued function on a predefined support.
+ *
+ * <p>Implementations present function evaluations one point at a time, usually walking through a
+ * regular grid or a supplied collection of abscissae. Clients typically loop with {@link
+ * #hasNext()} followed by {@link #nextSamplePoint()} to stream data into downstream consumers
+ * without material inspection of the entire sample set. Most implementations are stateful and
+ * single-use: once a point has been returned it is considered consumed and will not be served
+ * again. Unless stated otherwise, instances are not thread-safe and should be confined to the
+ * thread performing the sampling.
+ *
+ * <p>This iterator is useful when the function values are expensive to compute or need to be
+ * generated lazily, such as when sampling numerical integrations, interpolated trajectories, or
+ * external data feeds. Clients can stop early based on convergence checks, propagate exceptions
+ * raised during function evaluation, or combine results with additional metadata carried by {@link
+ * ScalarValuedPair}.
+ *
+ * <ul>
+ *   <li>Provides forward-only access to ordered sample points.
+ *   <li>Propagates underlying computation failures through {@link FunctionException}.
+ *   <li>Signals depletion via {@link ExhaustedSampleException}.
+ * </ul>
  *
  * @see SampledFunction
+ * @see ScalarValuedPair
  * @version $Id: SampledFunctionIterator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
 public interface SampledFunctionIterator {
 
   /**
-   * Check if the iterator can provide another point.
+   * Check if another sampled point is available without advancing the iterator state.
    *
-   * @return true if the iterator can provide another point.
+   * <p>The method performs a non-consuming check: subsequent calls to {@link #nextSamplePoint()}
+   * will return the same next item until it is actually consumed. Typical callers use this in a
+   * loop to terminate gracefully when the sample stream runs out rather than relying on exception
+   * control flow. Implementations should keep this check inexpensive; repeated calls must not
+   * modify internal position or trigger new evaluations.
+   *
+   * @return true if another sample can be delivered on the next call to {@link #nextSamplePoint()}.
    */
-  public boolean hasNext();
+  boolean hasNext();
 
   /**
-   * Get the next point of a sampled function.
+   * Get the next available point of the sampled function.
    *
-   * @return the next point of the sampled function
-   * @exception ExhaustedSampleException if the sample has been exhausted
-   * @exception FunctionException if the underlying function throws one
+   * <p>Calling this method advances the iterator and returns the paired abscissa and ordinate
+   * encapsulated in a {@link ScalarValuedPair}. The method is typically invoked within a {@code
+   * while (iterator.hasNext())} loop and is expected to return promptly once computation completes.
+   * Implementations should document whether the returned pair is immutable; callers should avoid
+   * modifying mutable results to prevent surprising interactions with downstream processing.
+   *
+   * <pre>{@code
+   * while (iterator.hasNext()) {
+   *   ScalarValuedPair sample = iterator.nextSamplePoint();
+   *   process(sample);
+   * }
+   * }</pre>
+   *
+   * @return the next sampled abscissa/value pair; never null when the iterator has a next element
+   * @throws ExhaustedSampleException if the sample stream has been fully consumed
+   * @throws FunctionException if evaluating the underlying function fails for the next point
    */
-  public ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException;
+  ScalarValuedPair nextSamplePoint() throws ExhaustedSampleException, FunctionException;
 }

--- a/src/main/java/org/spaceroots/mantissa/functions/scalar/ScalarValuedPair.java
+++ b/src/main/java/org/spaceroots/mantissa/functions/scalar/ScalarValuedPair.java
@@ -1,15 +1,32 @@
 package org.spaceroots.mantissa.functions.scalar;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * This class represents an (x, f(x)) pair for scalar functions.
+ * Holder for a scalar function sample consisting of one abscissa and its scalar value.
  *
- * <p>A scalar function is a function of one scalar parameter x whose value is a scalar. This class
- * is used has a simple placeholder to contain both an abscissa and the value of the function at
- * this abscissa.
+ * <p>This mutable data object pairs a single input coordinate {@code x} with the corresponding
+ * function value {@code f(x)}. It is primarily used by sampling utilities that exchange lists or
+ * streams of measured points, letting algorithms keep the two scalars together without allocating a
+ * heavier structure. Instances carry no validation beyond basic storage, so callers remain
+ * responsible for domain checks, units, and numerical quality before persisting the pair or
+ * forwarding it to interpolators.
  *
- * @see SampledFunction
+ * <p>Typical usage is to create a pair when observing or computing a new sample, pass the object to
+ * a {@link SampledFunction} implementation, and later mutate the stored values if the sample is
+ * reused for iterative refinement. Because setters update the internal state directly, instances
+ * are not thread-safe; share immutable copies or external synchronization when the same object
+ * crosses threads. Equality and ordering are intentionally not defined here, leaving callers free
+ * to choose their own comparison strategies when sorting or deduplicating sample sets.
+ *
+ * <ul>
+ *   <li>Represents one scalar input/output pair used by sampling and interpolation code.
+ *   <li>Supports reuse through mutation while keeping a compact two-double footprint.
+ *   <li>Designed for simple transport; no invariants beyond holding the provided coordinates.
+ * </ul>
+ *
+ * @see org.spaceroots.mantissa.functions.scalar.SampledFunction
  * @see org.spaceroots.mantissa.functions.vectorial.VectorialValuedPair
  * @version $Id: ScalarValuedPair.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
@@ -17,10 +34,17 @@ import java.io.Serializable;
 public class ScalarValuedPair implements Serializable {
 
   /**
-   * Simple constructor. Build an instance from its coordinates
+   * Builds a new pair from the provided coordinates without applying any validation.
    *
-   * @param x abscissa
-   * @param y ordinate (value of the function)
+   * <p>The constructor simply records the supplied abscissa and ordinate so that downstream code
+   * can transport the sample as a cohesive unit. Use this when creating a fresh measurement or when
+   * transforming an existing sample into a mutable representation that may be adjusted during later
+   * processing stages. No bounds checking is performed; callers should ensure {@code x} and {@code
+   * y} reflect meaningful values for the surrounding algorithm, including finite ranges if required
+   * by later consumers.
+   *
+   * @param x abscissa coordinate to store, typically the function input value in domain units
+   * @param y ordinate value to store, representing {@code f(x)} as a finite scalar measurement
    */
   public ScalarValuedPair(double x, double y) {
     this.x = x;
@@ -28,9 +52,14 @@ public class ScalarValuedPair implements Serializable {
   }
 
   /**
-   * Copy-constructor.
+   * Copy-constructor that duplicates the coordinates from another pair instance.
    *
-   * @param p point to copy
+   * <p>This is a convenience for cloning when a caller needs an independent mutable copy of an
+   * existing sample. The coordinates are copied by value, so subsequent mutations on either
+   * instance do not affect the other. The source reference must not be {@code null}; passing {@code
+   * null} will result in a {@link NullPointerException} because the fields are accessed directly.
+   *
+   * @param p existing pair to duplicate; must be non-null and already contain meaningful values
    */
   public ScalarValuedPair(ScalarValuedPair p) {
     x = p.x;
@@ -38,36 +67,59 @@ public class ScalarValuedPair implements Serializable {
   }
 
   /**
-   * Getter for the abscissa.
+   * Returns the current abscissa stored in this pair.
    *
-   * @return value of the abscissa
+   * <p>The method performs no transformation; it simply exposes the latest value set through the
+   * constructor or {@link #setX(double)}. Because the class is mutable, the returned value may
+   * change over time if callers reuse the instance across iterations. Callers that require stable
+   * snapshots should either copy the value immediately or work with defensive copies of the pair.
+   *
+   * @return the abscissa currently associated with this sample, in the same units supplied earlier
    */
   public double getX() {
     return x;
   }
 
   /**
-   * Getter for the ordinate.
+   * Returns the current ordinate (function value) stored in this pair.
    *
-   * @return value of the ordinate
+   * <p>The ordinate reflects the last value supplied to the constructor or {@link #setY(double)}.
+   * It is intended to represent {@code f(x)} for the accompanying abscissa, but this class does not
+   * enforce any relationship between the two fields. The returned value is a direct primitive copy;
+   * further changes to the pair will not retroactively affect earlier callers that already consumed
+   * the primitive.
+   *
+   * @return the scalar ordinate representing the function output for the stored abscissa
    */
   public double getY() {
     return y;
   }
 
   /**
-   * Setter for the abscissa.
+   * Updates the abscissa associated with this pair.
    *
-   * @param x new value for the abscissa
+   * <p>Use this to reuse an existing {@code ScalarValuedPair} instance in iterative algorithms that
+   * recompute sample points without reallocating objects. The method overwrites the previous value
+   * immediately; there is no synchronization, so coordinate updates that cross threads should be
+   * guarded externally. Consider updating the ordinate as well to keep the pair semantically
+   * consistent if the function value changes alongside the abscissa.
+   *
+   * @param x new abscissa to store, using the same units as prior values for consistency
    */
   public void setX(double x) {
     this.x = x;
   }
 
   /**
-   * Setter for the ordinate.
+   * Updates the ordinate (function value) associated with this pair.
    *
-   * @param y new value for the ordinate
+   * <p>This mutator enables reusing a single instance while refining or correcting previously
+   * computed outputs. The assignment happens atomically on the field but offers no thread-safety
+   * guarantees; coordinate updates should be externally synchronized when visible to multiple
+   * threads. Ensure callers maintain meaningful pairing between {@code x} and {@code y} when
+   * updating the ordinate independently of the abscissa.
+   *
+   * @param y new function value to store, typically the result of evaluating {@code f(x)}
    */
   public void setY(double y) {
     this.y = y;
@@ -79,5 +131,5 @@ public class ScalarValuedPair implements Serializable {
   /** Scalar ordinate of the point, y = f (x). */
   private double y;
 
-  private static final long serialVersionUID = 1884346552569300794L;
+  @Serial private static final long serialVersionUID = 1884346552569300794L;
 }

--- a/src/test/java/org/spaceroots/mantissa/functions/scalar/BasicSampledFunctionIteratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/functions/scalar/BasicSampledFunctionIteratorTest.java
@@ -1,0 +1,107 @@
+package org.spaceroots.mantissa.functions.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.ExhaustedSampleException;
+import org.spaceroots.mantissa.functions.FunctionException;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class BasicSampledFunctionIteratorTest {
+
+  @Mock private SampledFunction function;
+
+  @Test
+  void hasNext_whenIteratorCreatedAndSizePositive_returnsTrue() {
+    // Arrange
+    when(function.size()).thenReturn(2);
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    // Act
+    boolean result = iterator.hasNext();
+
+    // Assert
+    assertTrue(result);
+  }
+
+  @Test
+  void hasNext_whenNoElements_returnsFalse() {
+    // Arrange
+    when(function.size()).thenReturn(0);
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    // Act
+    boolean result = iterator.hasNext();
+
+    // Assert
+    assertFalse(result);
+  }
+
+  @Test
+  void nextSamplePoint_whenCalledSequentially_returnsPointsAndAdvances() throws Exception {
+    // Arrange
+    when(function.size()).thenReturn(2);
+    when(function.samplePointAt(0)).thenReturn(new ScalarValuedPair(0.0, 1.0));
+    when(function.samplePointAt(1)).thenReturn(new ScalarValuedPair(2.0, 3.0));
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    // Act
+    ScalarValuedPair first = iterator.nextSamplePoint();
+    ScalarValuedPair second = iterator.nextSamplePoint();
+
+    // Assert
+    assertEquals(0.0, first.getX());
+    assertEquals(1.0, first.getY());
+    assertEquals(2.0, second.getX());
+    assertEquals(3.0, second.getY());
+    assertFalse(iterator.hasNext());
+    verify(function, times(1)).samplePointAt(0);
+    verify(function, times(1)).samplePointAt(1);
+  }
+
+  @Test
+  void nextSamplePoint_whenExhausted_throwsExhaustedSampleException() throws Exception {
+    // Arrange
+    when(function.size()).thenReturn(1);
+    when(function.samplePointAt(0)).thenReturn(new ScalarValuedPair(0.0, 0.0));
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    // Act
+    iterator.nextSamplePoint();
+
+    // Assert
+    assertThrows(ExhaustedSampleException.class, iterator::nextSamplePoint);
+    verify(function, times(1)).samplePointAt(0);
+    verify(function, never()).samplePointAt(1);
+  }
+
+  @Test
+  void nextSamplePoint_whenUnderlyingFunctionThrows_propagatesExceptionAndAdvancesIndex()
+      throws Exception {
+    // Arrange
+    when(function.size()).thenReturn(2);
+    when(function.samplePointAt(0)).thenReturn(new ScalarValuedPair(1.0, 1.5));
+    when(function.samplePointAt(1)).thenThrow(new FunctionException("failure"));
+    BasicSampledFunctionIterator iterator = new BasicSampledFunctionIterator(function);
+
+    // Act
+    iterator.nextSamplePoint();
+
+    // Assert
+    assertThrows(FunctionException.class, iterator::nextSamplePoint);
+    assertFalse(iterator.hasNext());
+    assertThrows(ExhaustedSampleException.class, iterator::nextSamplePoint);
+    verify(function, times(1)).samplePointAt(1);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/functions/scalar/ComputableFunctionSamplerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/functions/scalar/ComputableFunctionSamplerTest.java
@@ -1,0 +1,105 @@
+package org.spaceroots.mantissa.functions.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.spaceroots.mantissa.functions.FunctionException;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ComputableFunctionSamplerTest {
+
+  @Test
+  void size_whenConstructedWithExplicitValues_returnsProvidedCount() {
+    ComputableFunction function = mock(ComputableFunction.class);
+    ComputableFunctionSampler sampler = new ComputableFunctionSampler(function, 0.0, 0.5, 4);
+
+    int result = sampler.size();
+
+    assertEquals(4, result);
+  }
+
+  @Test
+  void samplePointAt_whenIndexWithinBounds_returnsPairAndDelegatesToFunction() throws Exception {
+    ComputableFunction function = mock(ComputableFunction.class);
+    when(function.valueAt(anyDouble()))
+        .thenAnswer(invocation -> 2.0 * (Double) invocation.getArgument(0));
+    ComputableFunctionSampler sampler = new ComputableFunctionSampler(function, 1.0, 0.5, 5);
+
+    ScalarValuedPair pair = sampler.samplePointAt(2);
+
+    assertEquals(2.0, pair.getX());
+    assertEquals(4.0, pair.getY());
+    verify(function, times(1)).valueAt(2.0);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 3})
+  void samplePointAt_whenIndexIsOutOfRange_throwsArrayIndexOutOfBoundsException(int invalidIndex) {
+    ComputableFunction function = mock(ComputableFunction.class);
+    ComputableFunctionSampler sampler = new ComputableFunctionSampler(function, 0.0, 1.0, 3);
+
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> sampler.samplePointAt(invalidIndex));
+  }
+
+  @Test
+  void constructorWithRangeAndCount_whenSamplingLastPoint_hitsUpperBound() throws Exception {
+    ComputableFunction function = mock(ComputableFunction.class);
+    when(function.valueAt(anyDouble())).thenAnswer(invocation -> invocation.getArgument(0));
+    ComputableFunctionSampler sampler =
+        new ComputableFunctionSampler(function, new double[] {2.0, 3.0}, 5);
+
+    ScalarValuedPair pair = sampler.samplePointAt(4);
+
+    assertEquals(3.0, pair.getX());
+    assertEquals(3.0, pair.getY());
+  }
+
+  @Test
+  void constructorWithRangeStepAdjustTrue_whenSamplingLastPoint_matchesUpperBound()
+      throws Exception {
+    ComputableFunction function = mock(ComputableFunction.class);
+    when(function.valueAt(anyDouble())).thenAnswer(invocation -> invocation.getArgument(0));
+    ComputableFunctionSampler sampler =
+        new ComputableFunctionSampler(function, new double[] {0.0, 1.0}, 0.3, true);
+
+    ScalarValuedPair pair = sampler.samplePointAt(sampler.size() - 1);
+
+    assertEquals(1.0, pair.getX(), 1e-12);
+    assertEquals(1.0, pair.getY(), 1e-12);
+  }
+
+  @Test
+  void constructorWithRangeStepAdjustFalse_whenSamplingLastPoint_respectsUnadjustedStep()
+      throws Exception {
+    ComputableFunction function = mock(ComputableFunction.class);
+    when(function.valueAt(anyDouble())).thenAnswer(invocation -> invocation.getArgument(0));
+    ComputableFunctionSampler sampler =
+        new ComputableFunctionSampler(function, new double[] {0.0, 1.0}, 0.3, false);
+
+    ScalarValuedPair pair = sampler.samplePointAt(sampler.size() - 1);
+
+    assertEquals(0.6, pair.getX(), 1e-12);
+    assertEquals(0.6, pair.getY(), 1e-12);
+    assertEquals(3, sampler.size());
+  }
+
+  @Test
+  void samplePointAt_whenFunctionThrows_propagatesFunctionException() throws Exception {
+    ComputableFunction function = mock(ComputableFunction.class);
+    when(function.valueAt(anyDouble())).thenThrow(new FunctionException("failure"));
+    ComputableFunctionSampler sampler = new ComputableFunctionSampler(function, 0.0, 1.0, 2);
+
+    assertThrows(FunctionException.class, () -> sampler.samplePointAt(0));
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/functions/scalar/ScalarValuedPairTest.java
+++ b/src/test/java/org/spaceroots/mantissa/functions/scalar/ScalarValuedPairTest.java
@@ -1,0 +1,90 @@
+package org.spaceroots.mantissa.functions.scalar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ScalarValuedPairTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void constructor_whenGivenValues_storeValues() {
+    ScalarValuedPair pair = new ScalarValuedPair(1.5, -2.0);
+
+    assertEquals(1.5, pair.getX(), EPS);
+    assertEquals(-2.0, pair.getY(), EPS);
+  }
+
+  @Test
+  void copyConstructor_whenSourceProvided_createsIndependentCopy() {
+    ScalarValuedPair original = new ScalarValuedPair(3.0, 4.0);
+
+    ScalarValuedPair copy = new ScalarValuedPair(original);
+    original.setX(5.0);
+    original.setY(6.0);
+
+    assertEquals(3.0, copy.getX(), EPS);
+    assertEquals(4.0, copy.getY(), EPS);
+    assertEquals(5.0, original.getX(), EPS);
+    assertEquals(6.0, original.getY(), EPS);
+  }
+
+  @Test
+  void setters_whenUpdated_overwriteValues() {
+    ScalarValuedPair pair = new ScalarValuedPair(0.0, 0.0);
+
+    pair.setX(-7.5);
+    pair.setY(9.25);
+
+    assertEquals(-7.5, pair.getX(), EPS);
+    assertEquals(9.25, pair.getY(), EPS);
+  }
+
+  @Test
+  void serialization_whenRoundTripped_preservesState() throws Exception {
+    ScalarValuedPair pair = new ScalarValuedPair(123.456, -654.321);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
+      oos.writeObject(pair);
+    }
+
+    ScalarValuedPair deserialized;
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+      deserialized = (ScalarValuedPair) ois.readObject();
+    }
+
+    assertEquals(pair.getX(), deserialized.getX(), EPS);
+    assertEquals(pair.getY(), deserialized.getY(), EPS);
+  }
+
+  @ParameterizedTest
+  @MethodSource("specialValuesProvider")
+  void constructor_whenSpecialDoubleValues_preservesValues(double x, double y) {
+    ScalarValuedPair pair = new ScalarValuedPair(x, y);
+
+    assertEquals(Double.doubleToLongBits(x), Double.doubleToLongBits(pair.getX()));
+    assertEquals(Double.doubleToLongBits(y), Double.doubleToLongBits(pair.getY()));
+  }
+
+  private static Stream<Arguments> specialValuesProvider() {
+    return Stream.of(
+        Arguments.of(Double.NaN, 1.0),
+        Arguments.of(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY),
+        Arguments.of(Double.MIN_VALUE, Double.MAX_VALUE));
+  }
+}


### PR DESCRIPTION
## Summary
- expand documentation for scalar sampling interfaces and pair holder
- make sampler fields final and add serial annotations for iterators/pairs
- add unit tests covering sampler, iterator, and scalar pair behaviors

## Testing
- not run (not requested)