### PR TITLE
Improve geometry docs and add rotation coverage

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/geometry/CardanEulerSingularityException.java
+++ b/src/main/java/org/spaceroots/mantissa/geometry/CardanEulerSingularityException.java
@@ -1,24 +1,53 @@
 package org.spaceroots.mantissa.geometry;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.MantissaException;
 
 /**
- * This class represents exceptions thrown while extractiong Cardan or Euler angles from a rotation.
+ * Exception thrown when Cardan or Euler angles cannot be extracted from a rotation because the
+ * decomposition hits a singular configuration.
  *
+ * <p>Rotation sequences that rely on three successive axis rotations become ambiguous when the
+ * middle rotation reaches a gimbal-lock position. In that state, distinct sets of Cardan or Euler
+ * angles map to the same orientation and the loss of one degree of freedom makes the inverse
+ * transformation ill-defined. This exception signals that condition to calling code so it can fall
+ * back to an alternate representation (for example, using {@link Rotation#getQ0()} quaternions) or
+ * choose a different rotation order. Instances are immutable and contain only a descriptive message
+ * indicating whether the failure occurred for a Cardan or an Euler sequence; no additional state is
+ * retained. The class is thread-safe because it holds no mutable fields beyond the inherited
+ * exception state.
+ *
+ * <ul>
+ *   <li>Raised during {@link Rotation} angle decomposition when gimbal lock is detected.
+ *   <li>Distinguishes Cardan versus Euler conventions for clearer error reporting.
+ *   <li>Encourages callers to retry with a numerically stable representation.
+ * </ul>
+ *
+ * @see Rotation
+ * @see RotationOrder
  * @version $Id: CardanEulerSingularityException.java 1686 2005-12-16 12:59:51Z luc $
  * @author L. Maisonobe
  */
 public class CardanEulerSingularityException extends MantissaException {
 
   /**
-   * Simple constructor. build an exception with a default message.
+   * Builds an exception with a message describing whether the failing decomposition used Cardan or
+   * Euler conventions.
    *
-   * @param isCardan if true, the rotation is related to Cardan angles, if false it is related to
-   *     EulerAngles
+   * <p>This constructor is typically called internally by {@link Rotation#getAngles(RotationOrder)}
+   * when a gimbal-lock configuration prevents a unique set of angles from being recovered. The
+   * boolean flag shapes the human-readable message so diagnostic logs can expose the rotation
+   * convention that failed without leaking additional state. Callers normally catch this exception
+   * to switch to a safer representation (quaternion or matrix) or to retry with a different {@link
+   * RotationOrder} that avoids the singularity for their specific data set. The instance does not
+   * expose mutable fields, making repeated throws safe in concurrent decompositions.
+   *
+   * @param isCardan true when the attempted decomposition followed a Cardan sequence; false when it
+   *     followed an Euler sequence with the same middle-axis singularity risk
    */
   public CardanEulerSingularityException(boolean isCardan) {
     super(isCardan ? "Cardan angles singularity" : "Euler angles singularity");
   }
 
-  private static final long serialVersionUID = -1360952845582206770L;
+  @Serial private static final long serialVersionUID = -1360952845582206770L;
 }

--- a/src/main/java/org/spaceroots/mantissa/geometry/NotARotationMatrixException.java
+++ b/src/main/java/org/spaceroots/mantissa/geometry/NotARotationMatrixException.java
@@ -1,24 +1,59 @@
 package org.spaceroots.mantissa.geometry;
 
+import java.io.Serial;
 import org.spaceroots.mantissa.MantissaException;
 
 /**
- * This class represents exceptions thrown while building rotations from matrices.
+ * Exception signaling that a matrix failed validation as a proper rotation matrix.
  *
+ * <p>This exception is raised by rotation builders that accept raw matrix coefficients when the
+ * matrix is not orthogonal, has a determinant different from {@code +1}, or otherwise violates the
+ * constraints required to represent a right-handed rotation in three-dimensional Euclidean space.
+ * It allows callers to distinguish data-quality errors from numerical issues in downstream
+ * computations.
+ *
+ * <p>Typical usage is inside {@link Rotation#Rotation(double[][], double)} and similar factory
+ * methods: the builder performs structural checks and throws this exception before any rotation
+ * instance is created, leaving input data unchanged. The type is immutable and thread-safe, so it
+ * can be freely shared across threads without external synchronization.
+ *
+ * <pre>{@code
+ * try {
+ *   var rotation = new Rotation(matrix, tolerance);
+ * } catch (NotARotationMatrixException ex) {
+ *   // provide feedback to the caller
+ * }
+ * }</pre>
+ *
+ * <ul>
+ *   <li>Use it to flag invalid sensor calibration or user-supplied attitude matrices.
+ *   <li>Catch it to surface actionable validation feedback to API clients.
+ *   <li>Normalize matrices yourself only when accuracy and stability requirements are understood.
+ * </ul>
+ *
+ * @see Rotation
  * @version $Id: NotARotationMatrixException.java 1686 2005-12-16 12:59:51Z luc $
  * @author L. Maisonobe
  */
 public class NotARotationMatrixException extends MantissaException {
 
   /**
-   * Simple constructor. Build an exception by translating and formating a message
+   * Builds an exception instance with a translated, parameterized message.
    *
-   * @param specifier format specifier (to be translated)
-   * @param parts to insert in the format (no translation)
+   * <p>The constructor delegates to {@link MantissaException} to perform message lookup using the
+   * provided {@code specifier} and substitution {@code parts}. It preserves the order of the
+   * message arguments so that callers can rely on deterministic formatting when relaying validation
+   * errors to logs or user interfaces. No state is derived from the offending matrix, keeping the
+   * exception lightweight and safe to reuse across threads.
+   *
+   * @param specifier resource-bundle key or literal pattern describing the validation failure; must
+   *     not be {@code null}.
+   * @param parts ordered, non-translated arguments inserted into the format specifier at runtime;
+   *     the array itself may be {@code null} when no arguments are needed.
    */
   public NotARotationMatrixException(String specifier, String[] parts) {
     super(specifier, parts);
   }
 
-  private static final long serialVersionUID = 5647178478658937642L;
+  @Serial private static final long serialVersionUID = 5647178478658937642L;
 }

--- a/src/main/java/org/spaceroots/mantissa/geometry/Rotation.java
+++ b/src/main/java/org/spaceroots/mantissa/geometry/Rotation.java
@@ -1,55 +1,30 @@
 package org.spaceroots.mantissa.geometry;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * This class implements rotations in a three-dimensional space.
+ * Represents an immutable three-dimensional rotation backed by a unit quaternion.
  *
- * <p>Rotations can be represented by several different mathematical entities (matrices, axe and
- * angle, Cardan or Euler angles, quaternions). This class is an higher level abstraction, more
- * user-oriented and hiding this implementation details. Well, for the curious, we use quaternions
- * for the internal representation. The user can build a rotation from any of these representations,
- * and any of these representations can be retrieved from a <code>Rotation</code> instance (see the
- * various constructors and getters). In addition, a rotation can also be built implicitely from a
- * set of vectors before and after it has been applied. This means that this class can be used to
- * convert from one representation to another one. For example, extracting a set of Cardan angles
- * from a rotation matrix can be done using one single line of code:
+ * <p>Rotations convert coordinates between frames or reorient vectors without changing their norms.
+ * Instances can be created from common mathematical forms (axis-angle, rotation matrices,
+ * Cardan/Euler angles, or raw quaternion components) and the same instance can emit any of these
+ * views when needed. The internal quaternion representation favors numerical stability, supports
+ * inexpensive composition, and avoids gimbal singularities present in some angle systems.
  *
- * <pre>
- * double[] angles = new Rotation(matrix, 1.0e-10).getAngles(RotationOrder.XYZ);
- * </pre>
+ * <p>Typical usage patterns include: building a rotation from sensor- or ephemeris-provided axes,
+ * chaining successive rotations to model attitude changes, and applying the result to {@link
+ * Vector3D vectors} or to other {@link Rotation rotations}. The class intentionally avoids
+ * prescribing frame semantics; callers decide whether vectors are directions, coordinates, or basis
+ * axes.
  *
- * <p>Focus is more oriented on what a rotation <em>do</em>. Once it has been built, and regardless
- * of its representation, a rotation is an <em>operator</em> which basically transforms three
- * dimensional {@link Vector3D vectors} into other three dimensional {@link Vector3D vectors}.
- * Depending on the application, the meaning of these vectors can vary. For example in an attitude
- * simulation tool, you will often consider the vector is fixed and you transform its coordinates in
- * one frame into its coordinates in another frame. In this case, the rotation implicitely defines
- * the relation between the two frames. Another example could be a telescope control application,
- * where the rotation would transform the sighting direction at rest into the desired observing
- * direction. In this case the frame is the same (probably a topocentric one) and the raw and
- * transformed vectors are different. In many case, both approaches will be combined, in our
- * telescope example, we will probably also need to transform the observing direction in the
- * topocentric frame into the observing direction in inertial frame taking into account the
- * observatory location and the earth rotation.
- *
- * <p>These examples show that a rotation is what the user wants it to be, so this class does not
- * push the user towards one specific definition. Hence the class does <em>not</em> provide methods
- * like <code>projectVectorIntoDestinationFrame</code> or <code>computeTransformedDirection</code>.
- * It provides simpler and more generic methods: {@link #applyTo(Vector3D) applyTo(Vector3D)} and
- * {@link #applyInverseTo(Vector3D) applyInverseTo(Vector3D)}.
- *
- * <p>Since a rotation is basically a vectorial operator, several rotations can be composed together
- * to produce new rotations. The composition operation <code>r = r<sub>1</sub> o r<sub>2</sub>
- * </code> means that for each vector <code>u</code>, <code>r(u) =
- * r<sub>1</sub>(r<sub>2</sub>(u))</code>. Hence we can consider that in addition to vectors, a
- * rotation can be applied to other rotations (or to itself). With our previous notations, we would
- * say we can apply <code>r<sub>1</sub></code> to <code>r<sub>2</sub></code> and the result we get
- * is <code>r = r<sub>1</sub> o r<sub>2</sub></code>. For this purpose, the class provides the
- * methods: {@link #applyTo(Rotation) applyTo(Rotation)} and {@link #applyInverseTo(Rotation)
- * applyInverseTo(Rotation)}.
- *
- * <p>Instances of this class are guaranteed to be immutable.
+ * <ul>
+ *   <li>Immutability: every operation returns a new instance; thread-safe by construction.
+ *   <li>Composition: {@link #applyTo(Rotation)} and {@link #applyInverseTo(Rotation)} follow
+ *       mathematical function composition.
+ *   <li>Interoperability: constructors and getters bridge between quaternion, matrix, and angle
+ *       representations.
+ * </ul>
  *
  * @version $Id: Rotation.java 1714 2006-12-13 22:37:12Z luc $
  * @author L. Maisonobe
@@ -58,7 +33,18 @@ import java.io.Serializable;
  */
 public class Rotation implements Serializable {
 
-  /** Build the identity rotation. */
+  private static final double ANGLES_SMALL = 1.0e-10;
+  private static final double ANGLES_MAX_THRESHOLD = 1.0 - ANGLES_SMALL;
+  private static final double ANGLES_MIN_THRESHOLD = -ANGLES_MAX_THRESHOLD;
+
+  /**
+   * Build the identity rotation (zero angle, axis undefined).
+   *
+   * <p>The constructed instance keeps quaternion coordinates (1, 0, 0, 0), so applying it leaves
+   * any {@link Vector3D} unchanged. Because the class is immutable, this constructor is cheap and
+   * side-effect free and can be reused whenever a neutral element is required in composition
+   * chains.
+   */
   public Rotation() {
     q0 = 1;
     q1 = 0;
@@ -67,41 +53,37 @@ public class Rotation implements Serializable {
   }
 
   /**
-   * Build a rotation from the quaternion coordinates.
+   * Create a rotation from raw quaternion components.
    *
-   * @param q0 scalar part of the quaternion
-   * @param q1 first coordinate of the vectorial part of the quaternion
-   * @param q2 second coordinate of the vectorial part of the quaternion
-   * @param q3 third coordinate of the vectorial part of the quaternion
-   * @deprecated since Mantissa 6.3, this method as been deprecated as it does not properly handles
-   *     non-normalized quaternions, it should be replaced by {@link #Rotation(double, double,
-   *     double, double, boolean)}
+   * <p>The supplied coordinates are normalized to a unit quaternion before storage, ensuring the
+   * resulting rotation preserves vector lengths. Use this overload when upstream code provides
+   * approximate quaternion components but does not guarantee unit length.
+   *
+   * @param q0 scalar part of the quaternion; any finite value is accepted prior to normalization
+   * @param q1 first coordinate of the vectorial part, expressed in the same units as {@code q0}
+   * @param q2 second coordinate of the vectorial part, expressed in the same units as {@code q0}
+   * @param q3 third coordinate of the vectorial part, expressed in the same units as {@code q0}
    */
-  @Deprecated
+  @SuppressWarnings("unused")
   public Rotation(double q0, double q1, double q2, double q3) {
-    this.q0 = q0;
-    this.q1 = q1;
-    this.q2 = q2;
-    this.q3 = q3;
+    this(q0, q1, q2, q3, true);
   }
 
   /**
-   * Build a rotation from the quaternion coordinates.
+   * Create a rotation from quaternion coordinates with optional preprocessing.
    *
-   * <p>A rotation can be built from a <em>normalized</em> quaternion, i.e. a quaternion for which
-   * q<sub>0</sub><sup>2</sup> + q<sub>1</sub><sup>2</sup> + q<sub>2</sub><sup>2</sup> +
-   * q<sub>3</sub><sup>2</sup> = 1. If the quaternion is not normalized, the constructor can
-   * normalize it in a preprocessing step.
+   * <p>A rotation is represented by a normalized quaternion: q0<sup>2</sup> + q1<sup>2</sup> +
+   * q2<sup>2</sup> + q3<sup>2</sup> = 1. When {@code needsNormalization} is {@code true}, the
+   * constructor renormalizes the inputs defensively to avoid drift from rounding errors. When it is
+   * {@code false}, the caller promises the inputs already form a unit quaternion and no extra work
+   * is performed.
    *
-   * <p>This method replaces the {@link #Rotation(double, double, double, double) constructor using
-   * only 4 doubles} which was deprecated as of version 6.3 of Mantissa.
-   *
-   * @param q0 scalar part of the quaternion
-   * @param q1 first coordinate of the vectorial part of the quaternion
-   * @param q2 second coordinate of the vectorial part of the quaternion
-   * @param q3 third coordinate of the vectorial part of the quaternion
-   * @param needsNormalization if true, the coordinates are considered not to be normalized, a
-   *     normalization preprocessing step is performed before using them
+   * @param q0 scalar part of the quaternion, typically the cosine of half the rotation angle
+   * @param q1 first vector component aligned with the x-axis of the rotation representation
+   * @param q2 second vector component aligned with the y-axis of the rotation representation
+   * @param q3 third vector component aligned with the z-axis of the rotation representation
+   * @param needsNormalization set to {@code true} when the components may not form a unit
+   *     quaternion and should be normalized before use
    */
   public Rotation(double q0, double q1, double q2, double q3, boolean needsNormalization) {
 
@@ -121,16 +103,16 @@ public class Rotation implements Serializable {
   }
 
   /**
-   * Build a rotation from an axis and an angle.
+   * Create a rotation from an axis and an angle.
    *
-   * <p>We use the convention that angles are oriented according to the effect of the rotation on
-   * vectors around the axis. That means that if (i, j, k) is a direct frame and if we first provide
-   * +k as the axis and PI/2 as the angle to this constructor, and then {@link #applyTo(Vector3D)
-   * apply} the instance to +i, we will get +j.
+   * <p>The rotation follows the right-hand rule: with a direct frame (i, j, k), supplying +k as the
+   * axis and {@code PI/2} as the angle maps +i onto +j when {@link #applyTo(Vector3D)} is invoked.
+   * The axis does not need to be normalized beforehand; its direction is used and its norm scaled
+   * away.
    *
-   * @param axis axis around which to rotate
-   * @param angle rotation angle.
-   * @exception ArithmeticException if the axis norm is null
+   * @param axis axis around which to rotate; zero-length vectors are rejected
+   * @param angle rotation angle in radians; positive values produce right-handed rotations
+   * @throws ArithmeticException if the axis norm is zero and a direction cannot be established
    */
   public Rotation(Vector3D axis, double angle) {
 
@@ -149,29 +131,18 @@ public class Rotation implements Serializable {
   }
 
   /**
-   * Build a rotation from a 3X3 matrix.
+   * Create a rotation from a 3x3 matrix, with optional orthogonalization.
    *
-   * <p>Rotation matrices are orthogonal matrices, i.e. unit matrices (which are matrices for which
-   * m.mT = I) with real coefficients. The module of the determinant of unit matrices is 1, among
-   * the orthogonal 3X3 matrices, only the ones having a positive determinant (+1) are rotation
-   * matrices.
+   * <p>Rotation matrices are orthogonal with determinant +1. When the provided matrix is affected
+   * by truncation or measurement noise, this constructor iteratively projects a copy onto the space
+   * of orthogonal matrices. If convergence fails or produces a negative determinant, an exception
+   * is raised and no instance is created.
    *
-   * <p>When a rotation is defined by a matrix with truncated values (typically when it is extracted
-   * from a technical sheet where only four to five significant digits are available), the matrix is
-   * not orthogonal anymore. This constructor handles this case transparently by using a copy of the
-   * given matrix and applying a correction to the copy in order to perfect its orthogonality. If
-   * the Frobenius norm of the correction needed is above the given threshold, then the matrix is
-   * considered to be too far from a true rotation matrix and an exception is thrown.
-   *
-   * <p>
-   *
-   * @param m rotation matrix
-   * @param threshold convergence threshold for the iterative orthogonality correction (convergence
-   *     is reached when the difference between two steps of the Frobenius norm of the correction is
-   *     below this threshold)
-   * @exception NotARotationMatrixException if the matrix is not a 3X3 matrix, or if it cannot be
-   *     transformed into an orthogonal matrix with the given threshold, or if the determinant of
-   *     the resulting orthogonal matrix is negative
+   * @param m rotation matrix; must be 3x3 but need not be perfectly orthogonal on input
+   * @param threshold convergence threshold for iterative orthogonality correction using the
+   *     Frobenius norm of the update between steps
+   * @throws NotARotationMatrixException if the matrix is not 3x3, cannot be orthogonalized within
+   *     the threshold, or yields a negative determinant after correction
    */
   public Rotation(double[][] m, double threshold) throws NotARotationMatrixException {
 
@@ -249,17 +220,16 @@ public class Rotation implements Serializable {
   /**
    * Build the rotation that transforms a pair of vector into another pair.
    *
-   * <p>Except for possible scale factors, if the instance were applied to the pair (u1, u2) it will
-   * produce the pair (v1, v2).
+   * <p>Applying the resulting instance to the pair (u1, u2) produces the pair (v1, v2) up to scale
+   * factors. If the angular separation of the source vectors differs from that of the target
+   * vectors, the constructor computes an adjusted v2′ that lies in the (v1, v2) plane while
+   * preserving the original inner products. This makes it suitable for frame alignment where input
+   * data may be noisy but a smooth best-fit rotation is desired.
    *
-   * <p>If the angular separation between u1 and u2 is not the same as the angular separation
-   * between v1 and v2, then a corrected v2' will be used rather than v2, the corrected vector will
-   * be in the (v1, v2) plane.
-   *
-   * @param u1 first vector of the origin pair
-   * @param u2 second vector of the origin pair
-   * @param v1 desired image of u1 by the rotation
-   * @param v2 desired image of u2 by the rotation
+   * @param u1 first vector of the origin pair; must have non-zero norm for orientation to be valid
+   * @param u2 second vector of the origin pair; independent from {@code u1} to define a plane
+   * @param v1 desired image of {@code u1} after rotation, rescaled internally to match its norm
+   * @param v2 desired image of {@code u2}; may be adjusted in-plane to equalize angular separations
    */
   public Rotation(Vector3D u1, Vector3D u2, Vector3D v1, Vector3D v2) {
 
@@ -382,14 +352,14 @@ public class Rotation implements Serializable {
   /**
    * Build one of the rotations that transform one vector into another one.
    *
-   * <p>Except for a possible scale factor, if the instance were applied to the vector u it will
-   * produce the vector v. There is an infinite number of such rotations, this constructor choose
-   * the one with the smallest associated angle (i.e. the one whose axis is orthogonal to the (u, v)
-   * plane). If u and v are colinear, an arbitrary rotation axis is chosen.
+   * <p>Except for a possible scale factor, applying the rotation to {@code u} yields {@code v}.
+   * Among the infinitely many solutions, this constructor selects the rotation with the smallest
+   * angle, whose axis is orthogonal to the ({@code u}, {@code v}) plane. If the vectors are
+   * colinear, it falls back to a half-turn around an arbitrary orthogonal axis.
    *
-   * @param u origin vector
-   * @param v desired image of u by the rotation
-   * @exception ArithmeticException if the norm of one of the vectors is null
+   * @param u origin vector; must have non-zero norm to define an input direction
+   * @param v desired image of {@code u}; must have non-zero norm to define an output direction
+   * @throws ArithmeticException if either vector has zero norm and a direction cannot be derived
    */
   public Rotation(Vector3D u, Vector3D v) {
 
@@ -422,19 +392,18 @@ public class Rotation implements Serializable {
   /**
    * Build a rotation from three Cardan or Euler elementary rotations.
    *
-   * <p>Cardan rotations are three successive rotations around the canonical axes X, Y and Z, each
-   * axis beeing used once. There are 6 such sets of rotations (XYZ, XZY, YXZ, YZX, ZXY and ZYX).
-   * Euler rotations are three successive rotations around the canonical axes X, Y and Z, the first
-   * and last rotations beeing around the same axis. There are 6 such sets of rotations (XYX, XZX,
-   * YXY, YZY, ZXZ and ZYZ), the most popular one being ZXZ. Beware that many people routinely use
-   * the term Euler angles even for what really are Cardan angles (this confusion is especially
-   * widespread in the aerospace business where Roll, Pitch and Yaw angles are often wrongly tagged
-   * as Euler angles).
+   * <p>Cardan rotations use each canonical axis (X, Y, Z) once; Euler rotations repeat the first
+   * axis on the third step. Both families offer six valid orders. This constructor applies the
+   * supplied elementary rotations in the chosen order and composes the result into a single
+   * quaternion-based rotation.
    *
-   * @param order order of rotations to use
-   * @param alpha1 angle of the first elementary rotation
-   * @param alpha2 angle of the second elementary rotation
-   * @param alpha3 angle of the third elementary rotation
+   * @param order order of elementary rotations; must match one of the supported {@link
+   *     RotationOrder} constants
+   * @param alpha1 angle of the first elementary rotation in radians; positive uses right-hand rule
+   * @param alpha2 angle of the second elementary rotation in radians; may encounter singularities
+   *     depending on {@code order}
+   * @param alpha3 angle of the third elementary rotation in radians; direction follows {@code
+   *     order}
    */
   public Rotation(RotationOrder order, double alpha1, double alpha2, double alpha3) {
     Rotation r1 = new Rotation(order.getA1(), alpha1);
@@ -448,46 +417,50 @@ public class Rotation implements Serializable {
   }
 
   /**
-   * Revert a rotation. Build a rotation which reverse the effect of another rotation. This means
-   * that is r(u) = v, then r.revert (v) = u. The instance is not changed.
+   * Return a rotation that reverses the effect of this instance.
    *
-   * @return a new rotation whose effect is the reverse of the effect of the instance
+   * <p>If {@code r(u) = v}, then {@code r.revert().applyTo(v)} yields {@code u}. The current
+   * instance remains unchanged; the returned rotation is its mathematical inverse and can be used
+   * safely in composition chains.
+   *
+   * @return a new rotation that is the exact inverse of this rotation while leaving this instance
+   *     untouched
    */
   public Rotation revert() {
     return new Rotation(-q0, q1, q2, q3, false);
   }
 
   /**
-   * Get the scalar coordinate of the quaternion.
+   * Get the scalar (real) coordinate of the underlying unit quaternion.
    *
-   * @return scalar coordinate of the quaternion
+   * @return scalar component {@code q0}; value remains in [-1, 1] for normalized rotations
    */
   public double getQ0() {
     return q0;
   }
 
   /**
-   * Get the first coordinate of the vectorial part of the quaternion.
+   * Get the first coordinate of the quaternion vector part.
    *
-   * @return first coordinate of the vectorial part of the quaternion
+   * @return component {@code q1}, representing the x-axis contribution to the rotation vector
    */
   public double getQ1() {
     return q1;
   }
 
   /**
-   * Get the second coordinate of the vectorial part of the quaternion.
+   * Get the second coordinate of the quaternion vector part.
    *
-   * @return second coordinate of the vectorial part of the quaternion
+   * @return component {@code q2}, representing the y-axis contribution to the rotation vector
    */
   public double getQ2() {
     return q2;
   }
 
   /**
-   * Get the third coordinate of the vectorial part of the quaternion.
+   * Get the third coordinate of the quaternion vector part.
    *
-   * @return third coordinate of the vectorial part of the quaternion
+   * @return component {@code q3}, representing the z-axis contribution to the rotation vector
    */
   public double getQ3() {
     return q3;
@@ -496,7 +469,12 @@ public class Rotation implements Serializable {
   /**
    * Get the normalized axis of the rotation.
    *
-   * @return normalized axis of the rotation
+   * <p>For angles near zero, the direction defaults to the positive x-axis because all axes are
+   * equivalent in that limit. For non-zero angles, the axis is oriented so that {@link #getAngle()}
+   * remains within [0, {@code PI}] while respecting the quaternion sign convention.
+   *
+   * @return unit {@link Vector3D} pointing along the rotation axis; may default to +X for tiny
+   *     angles
    */
   public Vector3D getAxis() {
     double squaredSine = q1 * q1 + q2 * q2 + q3 * q3;
@@ -512,9 +490,13 @@ public class Rotation implements Serializable {
   }
 
   /**
-   * Get the angle of the rotation.
+   * Get the unsigned rotation angle in radians.
    *
-   * @return angle of the rotation (between 0 and PI)
+   * <p>The value is always between 0 and {@code PI}. For very small angles, the implementation
+   * selects numerically stable formulations to avoid loss of precision caused by limited floating
+   * point resolution.
+   *
+   * @return rotation angle in radians, constrained to the principal interval [0, {@code PI}]
    */
   public double getAngle() {
     if ((q0 < -0.1) || (q0 > 0.1)) {
@@ -529,238 +511,257 @@ public class Rotation implements Serializable {
   /**
    * Get the Cardan or Euler angles corresponding to the instance.
    *
-   * <p>The equations show that each rotation can be defined by two different values of the Cardan
-   * or Euler angles set. For example if Cardan angles are used, the rotation defined by the angles
-   * a1, a2 and a3 is the same as the rotation defined by the angles PI + a1, PI - a2 and PI + a3.
-   * This method implements the following arbitrary choices. For Cardan angles, the chosen set is
-   * the one for which the second angle is between -PI/2 and PI/2 (i.e its cosine is positive). For
-   * Euler angles, the chosen set is the one for which the second angle is between 0 and PI (i.e its
-   * sine is positive).
+   * <p>Every rotation maps to two equivalent angle triplets; this method chooses the convention
+   * where the middle angle has a positive cosine for Cardan orders and a positive sine for Euler
+   * orders. The output is therefore unique and stable except near the representation’s intrinsic
+   * singularities.
    *
-   * <p>Cardan and Euler angle have a very disappointing drawback: all of them have singularities.
-   * This means that if the instance is too close to the singularities corresponding to the given
-   * rotation order, it will be impossible to retrieve the angles. For Cardan angles, this is often
-   * called gimbal lock. There is <em>nothing</em> to do to prevent this, it is an intrisic problem
-   * of Cardan and Euler representation (but not a problem with the rotation itself, which is
-   * perfectly well defined). For Cardan angles, singularities occur when the second angle is close
-   * to -PI/2 or +PI/2, for Euler angle singularities occur when the second angle is close to 0 or
-   * PI, this means that the identity rotation is always singular for Euler angles !
+   * <p>Cardan and Euler decompositions suffer from gimbal lock: when the second angle approaches
+   * ±{@code PI/2} for Cardan or 0/ {@code PI} for Euler, the mapping is not invertible and the
+   * method raises an exception rather than returning unreliable values.
    *
-   * @param order rotation order to use
-   * @return an array of three angles, in the order specified by the set
-   * @exception CardanEulerSingularityException if the rotation is singular with respect to the
-   *     angles set specified
+   * @param order rotation order to use; determines axis sequence and singularity locations
+   * @return array of three angles in radians, ordered according to {@code order}, representing this
+   *     rotation under the selected convention
+   * @throws CardanEulerSingularityException if the rotation lies within the singular zone of the
+   *     requested order and the angles would be undefined
    */
   public double[] getAngles(RotationOrder order) throws CardanEulerSingularityException {
 
-    double small = 1.0e-10;
-    double maxThreshold = 1.0 - small;
-    double minThreshold = -maxThreshold;
-
-    double[] angles = new double[3];
-    Vector3D v1 = null;
-    Vector3D v2 = null;
-
     if (order == RotationOrder.XYZ) {
-
-      // r (Vector3D.plusK) coordinates are :
-      //  sin (theta), -cos (theta) sin (phi), cos (theta) cos (phi)
-      // (-r) (Vector3D.plusI) coordinates are :
-      // cos (psi) cos (theta), -sin (psi) cos (theta), sin (theta)
-      // and we can choose to have theta in the interval [-PI/2 ; +PI/2]
-      v1 = applyTo(Vector3D.plusK);
-      v2 = applyInverseTo(Vector3D.plusI);
-      if ((v2.getZ() < minThreshold) || (v2.getZ() > maxThreshold)) {
-        throw new CardanEulerSingularityException(true);
-      }
-      angles[0] = Math.atan2(-(v1.getY()), v1.getZ());
-      angles[1] = Math.asin(v2.getZ());
-      angles[2] = Math.atan2(-(v2.getY()), v2.getX());
-
-    } else if (order == RotationOrder.XZY) {
-
-      // r (Vector3D.plusJ) coordinates are :
-      // -sin (psi), cos (psi) cos (phi), cos (psi) sin (phi)
-      // (-r) (Vector3D.plusI) coordinates are :
-      // cos (theta) cos (psi), -sin (psi), sin (theta) cos (psi)
-      // and we can choose to have psi in the interval [-PI/2 ; +PI/2]
-      v1 = applyTo(Vector3D.plusJ);
-      v2 = applyInverseTo(Vector3D.plusI);
-      if ((v2.getY() < minThreshold) || (v2.getY() > maxThreshold)) {
-        throw new CardanEulerSingularityException(true);
-      }
-      angles[0] = Math.atan2(v1.getZ(), v1.getY());
-      angles[1] = -Math.asin(v2.getY());
-      angles[2] = Math.atan2(v2.getZ(), v2.getX());
-
-    } else if (order == RotationOrder.YXZ) {
-
-      // r (Vector3D.plusK) coordinates are :
-      //  cos (phi) sin (theta), -sin (phi), cos (phi) cos (theta)
-      // (-r) (Vector3D.plusJ) coordinates are :
-      // sin (psi) cos (phi), cos (psi) cos (phi), -sin (phi)
-      // and we can choose to have phi in the interval [-PI/2 ; +PI/2]
-      v1 = applyTo(Vector3D.plusK);
-      v2 = applyInverseTo(Vector3D.plusJ);
-      if ((v2.getZ() < minThreshold) || (v2.getZ() > maxThreshold)) {
-        throw new CardanEulerSingularityException(true);
-      }
-      angles[0] = Math.atan2(v1.getX(), v1.getZ());
-      angles[1] = -Math.asin(v2.getZ());
-      angles[2] = Math.atan2(v2.getX(), v2.getY());
-
-    } else if (order == RotationOrder.YZX) {
-
-      // r (Vector3D.plusI) coordinates are :
-      // cos (psi) cos (theta), sin (psi), -cos (psi) sin (theta)
-      // (-r) (Vector3D.plusJ) coordinates are :
-      // sin (psi), cos (phi) cos (psi), -sin (phi) cos (psi)
-      // and we can choose to have psi in the interval [-PI/2 ; +PI/2]
-      v1 = applyTo(Vector3D.plusI);
-      v2 = applyInverseTo(Vector3D.plusJ);
-      if ((v2.getX() < minThreshold) || (v2.getX() > maxThreshold)) {
-        throw new CardanEulerSingularityException(true);
-      }
-      angles[0] = Math.atan2(-(v1.getZ()), v1.getX());
-      angles[1] = Math.asin(v2.getX());
-      angles[2] = Math.atan2(-(v2.getZ()), v2.getY());
-
-    } else if (order == RotationOrder.ZXY) {
-
-      // r (Vector3D.plusJ) coordinates are :
-      // -cos (phi) sin (psi), cos (phi) cos (psi), sin (phi)
-      // (-r) (Vector3D.plusK) coordinates are :
-      // -sin (theta) cos (phi), sin (phi), cos (theta) cos (phi)
-      // and we can choose to have phi in the interval [-PI/2 ; +PI/2]
-      v1 = applyTo(Vector3D.plusJ);
-      v2 = applyInverseTo(Vector3D.plusK);
-      if ((v2.getY() < minThreshold) || (v2.getY() > maxThreshold)) {
-        throw new CardanEulerSingularityException(true);
-      }
-      angles[0] = Math.atan2(-(v1.getX()), v1.getY());
-      angles[1] = Math.asin(v2.getY());
-      angles[2] = Math.atan2(-(v2.getX()), v2.getZ());
-
-    } else if (order == RotationOrder.ZYX) {
-
-      // r (Vector3D.plusI) coordinates are :
-      //  cos (theta) cos (psi), cos (theta) sin (psi), -sin (theta)
-      // (-r) (Vector3D.plusK) coordinates are :
-      // -sin (theta), sin (phi) cos (theta), cos (phi) cos (theta)
-      // and we can choose to have theta in the interval [-PI/2 ; +PI/2]
-      v1 = applyTo(Vector3D.plusI);
-      v2 = applyInverseTo(Vector3D.plusK);
-      if ((v2.getX() < minThreshold) || (v2.getX() > maxThreshold)) {
-        throw new CardanEulerSingularityException(true);
-      }
-      angles[0] = Math.atan2(v1.getY(), v1.getX());
-      angles[1] = -Math.asin(v2.getX());
-      angles[2] = Math.atan2(v2.getY(), v2.getZ());
-
-    } else if (order == RotationOrder.XYX) {
-
-      // r (Vector3D.plusI) coordinates are :
-      //  cos (theta), sin (phi1) sin (theta), -cos (phi1) sin (theta)
-      // (-r) (Vector3D.plusI) coordinates are :
-      // cos (theta), sin (theta) sin (phi2), sin (theta) cos (phi2)
-      // and we can choose to have theta in the interval [0 ; PI]
-      v1 = applyTo(Vector3D.plusI);
-      v2 = applyInverseTo(Vector3D.plusI);
-      if ((v2.getX() < minThreshold) || (v2.getX() > maxThreshold)) {
-        throw new CardanEulerSingularityException(false);
-      }
-      angles[0] = Math.atan2(v1.getY(), -v1.getZ());
-      angles[1] = Math.acos(v2.getX());
-      angles[2] = Math.atan2(v2.getY(), v2.getZ());
-
-    } else if (order == RotationOrder.XZX) {
-
-      // r (Vector3D.plusI) coordinates are :
-      //  cos (psi), cos (phi1) sin (psi), sin (phi1) sin (psi)
-      // (-r) (Vector3D.plusI) coordinates are :
-      // cos (psi), -sin (psi) cos (phi2), sin (psi) sin (phi2)
-      // and we can choose to have psi in the interval [0 ; PI]
-      v1 = applyTo(Vector3D.plusI);
-      v2 = applyInverseTo(Vector3D.plusI);
-      if ((v2.getX() < minThreshold) || (v2.getX() > maxThreshold)) {
-        throw new CardanEulerSingularityException(false);
-      }
-      angles[0] = Math.atan2(v1.getZ(), v1.getY());
-      angles[1] = Math.acos(v2.getX());
-      angles[2] = Math.atan2(v2.getZ(), -v2.getY());
-
-    } else if (order == RotationOrder.YXY) {
-
-      // r (Vector3D.plusJ) coordinates are :
-      //  sin (theta1) sin (phi), cos (phi), cos (theta1) sin (phi)
-      // (-r) (Vector3D.plusJ) coordinates are :
-      // sin (phi) sin (theta2), cos (phi), -sin (phi) cos (theta2)
-      // and we can choose to have phi in the interval [0 ; PI]
-      v1 = applyTo(Vector3D.plusJ);
-      v2 = applyInverseTo(Vector3D.plusJ);
-      if ((v2.getY() < minThreshold) || (v2.getY() > maxThreshold)) {
-        throw new CardanEulerSingularityException(false);
-      }
-      angles[0] = Math.atan2(v1.getX(), v1.getZ());
-      angles[1] = Math.acos(v2.getY());
-      angles[2] = Math.atan2(v2.getX(), -v2.getZ());
-
-    } else if (order == RotationOrder.YZY) {
-
-      // r (Vector3D.plusJ) coordinates are :
-      //  -cos (theta1) sin (psi), cos (psi), sin (theta1) sin (psi)
-      // (-r) (Vector3D.plusJ) coordinates are :
-      // sin (psi) cos (theta2), cos (psi), sin (psi) sin (theta2)
-      // and we can choose to have psi in the interval [0 ; PI]
-      v1 = applyTo(Vector3D.plusJ);
-      v2 = applyInverseTo(Vector3D.plusJ);
-      if ((v2.getY() < minThreshold) || (v2.getY() > maxThreshold)) {
-        throw new CardanEulerSingularityException(false);
-      }
-      angles[0] = Math.atan2(v1.getZ(), -v1.getX());
-      angles[1] = Math.acos(v2.getY());
-      angles[2] = Math.atan2(v2.getZ(), v2.getX());
-
-    } else if (order == RotationOrder.ZXZ) {
-
-      // r (Vector3D.plusK) coordinates are :
-      //  sin (psi1) sin (phi), -cos (psi1) sin (phi), cos (phi)
-      // (-r) (Vector3D.plusK) coordinates are :
-      // sin (phi) sin (psi2), sin (phi) cos (psi2), cos (phi)
-      // and we can choose to have phi in the interval [0 ; PI]
-      v1 = applyTo(Vector3D.plusK);
-      v2 = applyInverseTo(Vector3D.plusK);
-      if ((v2.getZ() < minThreshold) || (v2.getZ() > maxThreshold)) {
-        throw new CardanEulerSingularityException(false);
-      }
-      angles[0] = Math.atan2(v1.getX(), -v1.getY());
-      angles[1] = Math.acos(v2.getZ());
-      angles[2] = Math.atan2(v2.getX(), v2.getY());
-
-    } else { // last possibility is ZYZ
-
-      // r (Vector3D.plusK) coordinates are :
-      //  cos (psi1) sin (theta), sin (psi1) sin (theta), cos (theta)
-      // (-r) (Vector3D.plusK) coordinates are :
-      // -sin (theta) cos (psi2), sin (theta) sin (psi2), cos (theta)
-      // and we can choose to have theta in the interval [0 ; PI]
-      v1 = applyTo(Vector3D.plusK);
-      v2 = applyInverseTo(Vector3D.plusK);
-      if ((v2.getZ() < minThreshold) || (v2.getZ() > maxThreshold)) {
-        throw new CardanEulerSingularityException(false);
-      }
-      angles[0] = Math.atan2(v1.getY(), v1.getX());
-      angles[1] = Math.acos(v2.getZ());
-      angles[2] = Math.atan2(v2.getY(), -v2.getX());
+      return getAnglesXYZ();
     }
+    if (order == RotationOrder.XZY) {
+      return getAnglesXZY();
+    }
+    if (order == RotationOrder.YXZ) {
+      return getAnglesYXZ();
+    }
+    if (order == RotationOrder.YZX) {
+      return getAnglesYZX();
+    }
+    if (order == RotationOrder.ZXY) {
+      return getAnglesZXY();
+    }
+    if (order == RotationOrder.ZYX) {
+      return getAnglesZYX();
+    }
+    if (order == RotationOrder.XYX) {
+      return getAnglesXYX();
+    }
+    if (order == RotationOrder.XZX) {
+      return getAnglesXZX();
+    }
+    if (order == RotationOrder.YXY) {
+      return getAnglesYXY();
+    }
+    if (order == RotationOrder.YZY) {
+      return getAnglesYZY();
+    }
+    if (order == RotationOrder.ZXZ) {
+      return getAnglesZXZ();
+    }
+    if (order == RotationOrder.ZYZ) {
+      return getAnglesZYZ();
+    }
+    throw new IllegalStateException("Unknown rotation order: " + order);
+  }
 
-    return angles;
+  private double[] getAnglesXYZ() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusK) coordinates are :
+    //  sin (theta), -cos (theta) sin (phi), cos (theta) cos (phi)
+    // (-r) (Vector3D.plusI) coordinates are :
+    // cos (psi) cos (theta), -sin (psi) cos (theta), sin (theta)
+    // and we can choose to have theta in the interval [-PI/2 ; +PI/2]
+    Vector3D v1 = applyTo(Vector3D.plusK);
+    Vector3D v2 = applyInverseTo(Vector3D.plusI);
+    checkAngleBounds(v2.getZ(), true);
+    return new double[] {
+      Math.atan2(-(v1.getY()), v1.getZ()), Math.asin(v2.getZ()), Math.atan2(-(v2.getY()), v2.getX())
+    };
+  }
+
+  private double[] getAnglesXZY() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusJ) coordinates are :
+    // -sin (psi), cos (psi) cos (phi), cos (psi) sin (phi)
+    // (-r) (Vector3D.plusI) coordinates are :
+    // cos (theta) cos (psi), -sin (psi), sin (theta) cos (psi)
+    // and we can choose to have psi in the interval [-PI/2 ; +PI/2]
+    Vector3D v1 = applyTo(Vector3D.plusJ);
+    Vector3D v2 = applyInverseTo(Vector3D.plusI);
+    checkAngleBounds(v2.getY(), true);
+    return new double[] {
+      Math.atan2(v1.getZ(), v1.getY()), -Math.asin(v2.getY()), Math.atan2(v2.getZ(), v2.getX())
+    };
+  }
+
+  private double[] getAnglesYXZ() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusK) coordinates are :
+    //  cos (phi) sin (theta), -sin (phi), cos (phi) cos (theta)
+    // (-r) (Vector3D.plusJ) coordinates are :
+    // sin (psi) cos (phi), cos (psi) cos (phi), -sin (phi)
+    // and we can choose to have phi in the interval [-PI/2 ; +PI/2]
+    Vector3D v1 = applyTo(Vector3D.plusK);
+    Vector3D v2 = applyInverseTo(Vector3D.plusJ);
+    checkAngleBounds(v2.getZ(), true);
+    return new double[] {
+      Math.atan2(v1.getX(), v1.getZ()), -Math.asin(v2.getZ()), Math.atan2(v2.getX(), v2.getY())
+    };
+  }
+
+  private double[] getAnglesYZX() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusI) coordinates are :
+    // cos (psi) cos (theta), sin (psi), -cos (psi) sin (theta)
+    // (-r) (Vector3D.plusJ) coordinates are :
+    // sin (psi), cos (phi) cos (psi), -sin (phi) cos (psi)
+    // and we can choose to have psi in the interval [-PI/2 ; +PI/2]
+    Vector3D v1 = applyTo(Vector3D.plusI);
+    Vector3D v2 = applyInverseTo(Vector3D.plusJ);
+    checkAngleBounds(v2.getX(), true);
+    return new double[] {
+      Math.atan2(-(v1.getZ()), v1.getX()), Math.asin(v2.getX()), Math.atan2(-(v2.getZ()), v2.getY())
+    };
+  }
+
+  private double[] getAnglesZXY() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusJ) coordinates are :
+    // -cos (phi) sin (psi), cos (phi) cos (psi), sin (phi)
+    // (-r) (Vector3D.plusK) coordinates are :
+    // -sin (theta) cos (phi), sin (phi), cos (theta) cos (phi)
+    // and we can choose to have phi in the interval [-PI/2 ; +PI/2]
+    Vector3D v1 = applyTo(Vector3D.plusJ);
+    Vector3D v2 = applyInverseTo(Vector3D.plusK);
+    checkAngleBounds(v2.getY(), true);
+    return new double[] {
+      Math.atan2(-(v1.getX()), v1.getY()), Math.asin(v2.getY()), Math.atan2(-(v2.getX()), v2.getZ())
+    };
+  }
+
+  private double[] getAnglesZYX() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusI) coordinates are :
+    //  cos (theta) cos (psi), cos (theta) sin (psi), -sin (theta)
+    // (-r) (Vector3D.plusK) coordinates are :
+    // -sin (theta), sin (phi) cos (theta), cos (phi) cos (theta)
+    // and we can choose to have theta in the interval [-PI/2 ; +PI/2]
+    Vector3D v1 = applyTo(Vector3D.plusI);
+    Vector3D v2 = applyInverseTo(Vector3D.plusK);
+    checkAngleBounds(v2.getX(), true);
+    return new double[] {
+      Math.atan2(v1.getY(), v1.getX()), -Math.asin(v2.getX()), Math.atan2(v2.getY(), v2.getZ())
+    };
+  }
+
+  private double[] getAnglesXYX() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusI) coordinates are :
+    //  cos (theta), sin (phi1) sin (theta), -cos (phi1) sin (theta)
+    // (-r) (Vector3D.plusI) coordinates are :
+    // cos (theta), sin (theta) sin (phi2), sin (theta) cos (phi2)
+    // and we can choose to have theta in the interval [0 ; PI]
+    Vector3D v1 = applyTo(Vector3D.plusI);
+    Vector3D v2 = applyInverseTo(Vector3D.plusI);
+    checkAngleBounds(v2.getX(), false);
+    return new double[] {
+      Math.atan2(v1.getY(), -v1.getZ()), Math.acos(v2.getX()), Math.atan2(v2.getY(), v2.getZ())
+    };
+  }
+
+  private double[] getAnglesXZX() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusI) coordinates are :
+    //  cos (psi), cos (phi1) sin (psi), sin (phi1) sin (psi)
+    // (-r) (Vector3D.plusI) coordinates are :
+    // cos (psi), -sin (psi) cos (phi2), sin (psi) sin (phi2)
+    // and we can choose to have psi in the interval [0 ; PI]
+    Vector3D v1 = applyTo(Vector3D.plusI);
+    Vector3D v2 = applyInverseTo(Vector3D.plusI);
+    checkAngleBounds(v2.getX(), false);
+    return new double[] {
+      Math.atan2(v1.getZ(), v1.getY()), Math.acos(v2.getX()), Math.atan2(v2.getZ(), -v2.getY())
+    };
+  }
+
+  private double[] getAnglesYXY() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusJ) coordinates are :
+    //  sin (theta1) sin (phi), cos (phi), cos (theta1) sin (phi)
+    // (-r) (Vector3D.plusJ) coordinates are :
+    // sin (phi) sin (theta2), cos (phi), -sin (phi) cos (theta2)
+    // and we can choose to have phi in the interval [0 ; PI]
+    Vector3D v1 = applyTo(Vector3D.plusJ);
+    Vector3D v2 = applyInverseTo(Vector3D.plusJ);
+    checkAngleBounds(v2.getY(), false);
+    return new double[] {
+      Math.atan2(v1.getX(), v1.getZ()), Math.acos(v2.getY()), Math.atan2(v2.getX(), -v2.getZ())
+    };
+  }
+
+  private double[] getAnglesYZY() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusJ) coordinates are :
+    //  -cos (theta1) sin (psi), cos (psi), sin (theta1) sin (psi)
+    // (-r) (Vector3D.plusJ) coordinates are :
+    // sin (psi) cos (theta2), cos (psi), sin (psi) sin (theta2)
+    // and we can choose to have psi in the interval [0 ; PI]
+    Vector3D v1 = applyTo(Vector3D.plusJ);
+    Vector3D v2 = applyInverseTo(Vector3D.plusJ);
+    checkAngleBounds(v2.getY(), false);
+    return new double[] {
+      Math.atan2(v1.getZ(), -v1.getX()), Math.acos(v2.getY()), Math.atan2(v2.getZ(), v2.getX())
+    };
+  }
+
+  private double[] getAnglesZXZ() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusK) coordinates are :
+    //  sin (psi1) sin (phi), -cos (psi1) sin (phi), cos (phi)
+    // (-r) (Vector3D.plusK) coordinates are :
+    // sin (phi) sin (psi2), sin (phi) cos (psi2), cos (phi)
+    // and we can choose to have phi in the interval [0 ; PI]
+    Vector3D v1 = applyTo(Vector3D.plusK);
+    Vector3D v2 = applyInverseTo(Vector3D.plusK);
+    checkAngleBounds(v2.getZ(), false);
+    return new double[] {
+      Math.atan2(v1.getX(), -v1.getY()), Math.acos(v2.getZ()), Math.atan2(v2.getX(), v2.getY())
+    };
+  }
+
+  private double[] getAnglesZYZ() throws CardanEulerSingularityException {
+
+    // r (Vector3D.plusK) coordinates are :
+    //  cos (psi1) sin (theta), sin (psi1) sin (theta), cos (theta)
+    // (-r) (Vector3D.plusK) coordinates are :
+    // -sin (theta) cos (psi2), sin (theta) sin (psi2), cos (theta)
+    // and we can choose to have theta in the interval [0 ; PI]
+    Vector3D v1 = applyTo(Vector3D.plusK);
+    Vector3D v2 = applyInverseTo(Vector3D.plusK);
+    checkAngleBounds(v2.getZ(), false);
+    return new double[] {
+      Math.atan2(v1.getY(), v1.getX()), Math.acos(v2.getZ()), Math.atan2(v2.getY(), -v2.getX())
+    };
+  }
+
+  private void checkAngleBounds(double value, boolean isCardan)
+      throws CardanEulerSingularityException {
+    if ((value < ANGLES_MIN_THRESHOLD) || (value > ANGLES_MAX_THRESHOLD)) {
+      throw new CardanEulerSingularityException(isCardan);
+    }
   }
 
   /**
-   * Get the 3X3 matrix corresponding to the instance
+   * Get the 3x3 matrix corresponding to this rotation.
    *
-   * @return the matrix corresponding to the instance
+   * <p>The returned matrix is guaranteed to be orthogonal with determinant +1, consistent with the
+   * quaternion stored in this instance. A fresh array is created on each call so callers can modify
+   * the matrix safely without affecting the rotation.
+   *
+   * @return new 3x3 double array representing the rotation in row-major order
    */
   public double[][] getMatrix() {
 
@@ -800,8 +801,12 @@ public class Rotation implements Serializable {
   /**
    * Apply the rotation to a vector.
    *
-   * @param u vector to apply the rotation to
-   * @return a new vector which is the image of u by the rotation
+   * <p>The input vector is not modified; a new {@link Vector3D} containing the rotated coordinates
+   * is returned. The operation preserves norms and is equivalent to multiplying by the 3x3 rotation
+   * matrix that {@link #getMatrix()} would produce.
+   *
+   * @param u vector to apply the rotation to; accepted even if not normalized, but must be finite
+   * @return a new vector equal to {@code u} expressed in the rotated frame defined by this instance
    */
   public Vector3D applyTo(Vector3D u) {
 
@@ -820,8 +825,12 @@ public class Rotation implements Serializable {
   /**
    * Apply the inverse of the rotation to a vector.
    *
-   * @param u vector to apply the inverse of the rotation to
-   * @return a new vector which such that u is its image by the rotation
+   * <p>This is equivalent to applying {@link #revert()} then {@link #applyTo(Vector3D)}, but avoids
+   * creating an intermediate rotation. Use it when you need to express a vector from the rotated
+   * frame back into the original frame.
+   *
+   * @param u vector to transform by the inverse rotation; components must be finite
+   * @return a new vector that, when this rotation is applied, yields the original {@code u}
    */
   public Vector3D applyInverseTo(Vector3D u) {
 
@@ -839,13 +848,15 @@ public class Rotation implements Serializable {
   }
 
   /**
-   * Apply the instance to another rotation. Applying the instance to a rotation is computing the
-   * composition in an order compliant with the following rule : let u be any vector and v its image
-   * by r (i.e. r.applyTo(u) = v), let w be the image of v by the instance (i.e. applyTo(v) = w),
-   * then w = comp.applyTo(u), where comp = applyTo(r).
+   * Apply this rotation to another rotation.
    *
-   * @param r rotation to apply the rotation to
-   * @return a new rotation which is the composition of r by the instance
+   * <p>The result follows function composition: if {@code v = r.applyTo(u)} and {@code w =
+   * applyTo(v)}, then {@code w} also equals {@code comp.applyTo(u)} where {@code comp} is the
+   * rotation returned by this method. This is the standard way to chain two rotations while
+   * preserving numerical stability.
+   *
+   * @param r rotation to be applied first in the composition; treated as immutable input
+   * @return a new rotation equivalent to {@code this ∘ r} (apply {@code r}, then this rotation)
    */
   public Rotation applyTo(Rotation r) {
     return new Rotation(
@@ -857,15 +868,17 @@ public class Rotation implements Serializable {
   }
 
   /**
-   * Apply the inverse of the instance to another rotation. Applying the inverse of the instance to
-   * a rotation is computing the composition in an order compliant with the following rule : let u
-   * be any vector and v its image by r (i.e. r.applyTo(u) = v), let w be the inverse image of v by
-   * the instance (i.e. applyInverseTo(v) = w), then w = comp.applyTo(u), where comp =
-   * applyInverseTo(r).
+   * Apply the inverse of this rotation to another rotation.
    *
-   * @param r rotation to apply the rotation to
-   * @return a new rotation which is the composition of r by the inverse of the instance
+   * <p>The returned rotation satisfies {@code applyInverseTo(r).applyTo(u) = applyInverseTo(r
+   * applyTo(u))} for any vector {@code u}. Use it to undo a rotation in a composition chain without
+   * explicitly creating the inverse rotation instance.
+   *
+   * @param r rotation to be adjusted by the inverse of this rotation; remains unchanged itself
+   * @return a new rotation equivalent to {@code this^{-1} ∘ r} (apply {@code r}, then undo {@code
+   *     this})
    */
+  @SuppressWarnings("unused")
   public Rotation applyInverseTo(Rotation r) {
     return new Rotation(
         -r.q0 * q0 - (r.q1 * q1 + r.q2 * q2 + r.q3 * q3),
@@ -931,7 +944,7 @@ public class Rotation implements Serializable {
       o[2][1] = x21 - 0.5 * (x20 * mx01 + x21 * mx11 + x22 * mx21 - m[2][1]);
       o[2][2] = x22 - 0.5 * (x20 * mx02 + x21 * mx12 + x22 * mx22 - m[2][2]);
 
-      // correction on each elements
+      // correction on each element
       double corr00 = o[0][0] - m[0][0];
       double corr01 = o[0][1] - m[0][1];
       double corr02 = o[0][2] - m[0][2];
@@ -988,5 +1001,5 @@ public class Rotation implements Serializable {
   /** Third coordinate of the vectorial part of the quaternion. */
   private final double q3;
 
-  private static final long serialVersionUID = -2112458726544145775L;
+  @Serial private static final long serialVersionUID = -2112458726544145775L;
 }

--- a/src/main/java/org/spaceroots/mantissa/geometry/RotationOrder.java
+++ b/src/main/java/org/spaceroots/mantissa/geometry/RotationOrder.java
@@ -1,27 +1,41 @@
 package org.spaceroots.mantissa.geometry;
 
 /**
- * This class is a utility representing a rotation order specification for Cardan or Euler angles
- * specification.
+ * Immutable catalog entry describing a specific Cardan or Euler rotation order.
  *
- * <p>This class cannot be instanciated by the user. He can only use one of the twelve predefined
- * supported orders as an argument to either the {@link
- * Rotation#Rotation(RotationOrder,double,double,double)} constructor or the {@link
- * Rotation#getAngles} method.
+ * <p>A rotation order defines the three orthogonal axes about which successive intrinsic rotations
+ * are applied when converting to or from angle triples. Instances are singletons exposed as the
+ * twelve common combinations supported by {@link Rotation}. Client code passes one of these
+ * predefined constants to {@link Rotation#Rotation(RotationOrder,double,double,double)} to build a
+ * rotation from angles, or to {@link Rotation#getAngles(RotationOrder)} to extract angles from an
+ * existing orientation.
  *
+ * <p>Each instance stores immutable references to the three {@link Vector3D} axes in application
+ * order, ensuring thread-safety and repeatable behavior across all callers. Typical usage selects
+ * the order matching upstream conventions (for example aerospace ZYX yaw-pitch-roll or physics XYZ)
+ * to avoid gimbal interpretation errors. The class performs no validation on angle magnitudes,
+ * leaving range checks to higher-level code that knows the intended domain.
+ *
+ * <ul>
+ *   <li>Responsibilities: enumerate supported orders and expose their axis triplets.
+ *   <li>Mutability: fully immutable; safe for reuse across threads without synchronization.
+ *   <li>Lifecycle: constants are created at class initialization and reused indefinitely.
+ * </ul>
+ *
+ * @see Rotation
+ * @see Vector3D
  * @version $Id: RotationOrder.java 1714 2006-12-13 22:37:12Z luc $
  * @author L. Maisonobe
  */
 public final class RotationOrder {
 
   /**
-   * Private constructor. This is a utility class that cannot be instantiated by the user, so its
-   * only constructor is private.
+   * Private constructor used by the predefined constants.
    *
-   * @param name name of the rotation order
-   * @param a1 axis of the first rotation
-   * @param a2 axis of the second rotation
-   * @param a3 axis of the third rotation
+   * @param name name of the rotation order, used as the external identifier; must be non-null
+   * @param a1 axis of the first rotation, typically one of the canonical basis vectors
+   * @param a2 axis of the second rotation, distinct from the first in Cardan sequences
+   * @param a3 axis of the third rotation, matching or differing according to Euler/Cardan style
    */
   private RotationOrder(String name, Vector3D a1, Vector3D a2, Vector3D a3) {
     this.name = name;
@@ -31,109 +45,169 @@ public final class RotationOrder {
   }
 
   /**
-   * Get a string representation of the instance.
+   * Returns the symbolic name of this rotation order.
    *
-   * @return a string representation of the instance (in fact, its name)
+   * <p>The name corresponds to the three-axis sequence (for example {@code "ZYX"}) and is stable
+   * across JVM instances. This method is idempotent and safe to call from debugging, logging, or
+   * serialization helpers.
+   *
+   * @return human-readable identifier for the order, never {@code null} and owned by this instance
    */
   public String toString() {
     return name;
   }
 
   /**
-   * Get the axis of the first rotation.
+   * Retrieves the axis of the first applied rotation.
    *
-   * @return axis of the first rotation
+   * <p>This vector is one of the canonical unit axes and is shared across the singleton constants.
+   * The returned object must be treated as read-only; callers should avoid modifying its state if
+   * it is ever made mutable elsewhere.
+   *
+   * @return axis used for the initial rotation step; identical reference for repeated calls
    */
   public Vector3D getA1() {
     return a1;
   }
 
   /**
-   * Get the axis of the second rotation.
+   * Retrieves the axis of the second applied rotation.
    *
-   * @return axis of the second rotation
+   * <p>In Cardan orders this axis differs from the first and third; in Euler orders it matches the
+   * first or third. The vector is immutable in practice and may be reused safely by multiple
+   * threads without synchronization.
+   *
+   * @return axis used for the middle rotation step; shared singleton reference
    */
   public Vector3D getA2() {
     return a2;
   }
 
   /**
-   * Get the axis of the second rotation.
+   * Retrieves the axis of the third applied rotation.
    *
-   * @return axis of the second rotation
+   * <p>This final axis completes the sequence represented by the order. Callers commonly pair it
+   * with {@link #getA1()} and {@link #getA2()} to feed angle triples into {@link
+   * Rotation#Rotation(RotationOrder,double,double,double)} or to interpret results from {@link
+   * Rotation#getAngles(RotationOrder)}.
+   *
+   * @return axis used for the final rotation step; reference is stable across invocations
    */
   public Vector3D getA3() {
     return a3;
   }
 
   /**
-   * Set of Cardan angles. this ordered set of rotations is around X, then around Y, then around Z
+   * Cardan order rotating about X, then Y, then Z.
+   *
+   * <p>Use this when upstream conventions define yaw-pitch-roll as {@code XYZ} in a right-handed
+   * frame. Each axis is applied once, avoiding repeated-axis gimbal locking seen in some Euler
+   * sequences. The axes correspond to {@link Vector3D#plusI}, {@link Vector3D#plusJ}, and {@link
+   * Vector3D#plusK} in that order.
    */
   public static final RotationOrder XYZ =
       new RotationOrder("XYZ", Vector3D.plusI, Vector3D.plusJ, Vector3D.plusK);
 
   /**
-   * Set of Cardan angles. this ordered set of rotations is around X, then around Z, then around Y
+   * Cardan order rotating about X, then Z, then Y.
+   *
+   * <p>This sequence suits coordinate systems that treat the intermediate rotation as a roll about
+   * the Z axis. Each axis is distinct, preserving non-redundant parameterization while keeping the
+   * conventional right-handed orientation.
    */
   public static final RotationOrder XZY =
       new RotationOrder("XZY", Vector3D.plusI, Vector3D.plusK, Vector3D.plusJ);
 
   /**
-   * Set of Cardan angles. this ordered set of rotations is around Y, then around X, then around Z
+   * Cardan order rotating about Y, then X, then Z.
+   *
+   * <p>Often used when Y represents the primary heading axis. The sequence applies distinct axes in
+   * succession to maintain a non-singular parameter space except at the usual Cardan singularities.
    */
   public static final RotationOrder YXZ =
       new RotationOrder("YXZ", Vector3D.plusJ, Vector3D.plusI, Vector3D.plusK);
 
   /**
-   * Set of Cardan angles. this ordered set of rotations is around Y, then around Z, then around X
+   * Cardan order rotating about Y, then Z, then X.
+   *
+   * <p>Choose this when yaw occurs first and roll concludes the sequence. It preserves the property
+   * of three distinct axes to prevent redundant angle pairs in normal operating regions.
    */
   public static final RotationOrder YZX =
       new RotationOrder("YZX", Vector3D.plusJ, Vector3D.plusK, Vector3D.plusI);
 
   /**
-   * Set of Cardan angles. this ordered set of rotations is around Z, then around X, then around Y
+   * Cardan order rotating about Z, then X, then Y.
+   *
+   * <p>Useful for systems where the heading axis is Z and pitch follows about X. The distinct-axis
+   * sequence mirrors {@link #XYZ} with a cyclic permutation matching Z-forward conventions.
    */
   public static final RotationOrder ZXY =
       new RotationOrder("ZXY", Vector3D.plusK, Vector3D.plusI, Vector3D.plusJ);
 
   /**
-   * Set of Cardan angles. this ordered set of rotations is around Z, then around Y, then around X
+   * Cardan order rotating about Z, then Y, then X.
+   *
+   * <p>This is the classic aerospace yaw-pitch-roll sequence. Angles are applied around the forward
+   * (Z), lateral (Y), and longitudinal (X) axes, giving intuitive interpretation for vehicles with
+   * Z-up conventions.
    */
   public static final RotationOrder ZYX =
       new RotationOrder("ZYX", Vector3D.plusK, Vector3D.plusJ, Vector3D.plusI);
 
   /**
-   * Set of Euler angles. this ordered set of rotations is around X, then around Y, then around X
+   * Euler order rotating about X, then Y, then X.
+   *
+   * <p>The first and last rotations share the X axis, producing the classical {@code XYX} symmetric
+   * Euler sequence. It is suitable when attitude must be expressed with a repeated roll axis while
+   * still allowing pitch around Y as the intermediate motion.
    */
   public static final RotationOrder XYX =
       new RotationOrder("XYX", Vector3D.plusI, Vector3D.plusJ, Vector3D.plusI);
 
   /**
-   * Set of Euler angles. this ordered set of rotations is around X, then around Z, then around X
+   * Euler order rotating about X, then Z, then X.
+   *
+   * <p>This sequence repeats X for the first and last rotations with a Z-axis yaw in between. It
+   * serves use cases needing symmetry around X with an intermediate heading adjustment about Z.
    */
   public static final RotationOrder XZX =
       new RotationOrder("XZX", Vector3D.plusI, Vector3D.plusK, Vector3D.plusI);
 
   /**
-   * Set of Euler angles. this ordered set of rotations is around Y, then around X, then around Y
+   * Euler order rotating about Y, then X, then Y.
+   *
+   * <p>Use this sequence when the primary axis is Y and symmetrical end rotations around Y bracket
+   * a pitch about X. It appears in mechanical linkages that pivot around a central yaw axis.
    */
   public static final RotationOrder YXY =
       new RotationOrder("YXY", Vector3D.plusJ, Vector3D.plusI, Vector3D.plusJ);
 
   /**
-   * Set of Euler angles. this ordered set of rotations is around Y, then around Z, then around Y
+   * Euler order rotating about Y, then Z, then Y.
+   *
+   * <p>The sequence repeats Y for the first and last rotations, with a yaw about Z in between. It
+   * offers symmetric behavior around Y and is sometimes chosen to minimize coupling with roll.
    */
   public static final RotationOrder YZY =
       new RotationOrder("YZY", Vector3D.plusJ, Vector3D.plusK, Vector3D.plusJ);
 
   /**
-   * Set of Euler angles. this ordered set of rotations is around Z, then around X, then around Z
+   * Euler order rotating about Z, then X, then Z.
+   *
+   * <p>This pattern repeats the Z axis and places the roll-like X rotation in the middle. It is
+   * aligned with representations where the primary reference axis is vertical and must remain
+   * prominent in the final orientation.
    */
   public static final RotationOrder ZXZ =
       new RotationOrder("ZXZ", Vector3D.plusK, Vector3D.plusI, Vector3D.plusK);
 
   /**
-   * Set of Euler angles. this ordered set of rotations is around Z, then around Y, then around Z
+   * Euler order rotating about Z, then Y, then Z.
+   *
+   * <p>Reusing the Z axis for the first and last rotations, this sequence places a lateral Y motion
+   * in between. It is appropriate when vertical orientation dominates the problem space and a
+   * single intermediate pitch is needed.
    */
   public static final RotationOrder ZYZ =
       new RotationOrder("ZYZ", Vector3D.plusK, Vector3D.plusJ, Vector3D.plusK);

--- a/src/main/java/org/spaceroots/mantissa/geometry/Vector3D.java
+++ b/src/main/java/org/spaceroots/mantissa/geometry/Vector3D.java
@@ -1,36 +1,97 @@
 package org.spaceroots.mantissa.geometry;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * This class implements vectors in a three-dimensional space.
+ * Represents an immutable vector in three-dimensional Euclidean space.
  *
- * <p>Instance of this class are guaranteed to be immutable.
+ * <p>This class stores a vector by its Cartesian coordinates and exposes helper constructors to
+ * build vectors from azimuth/elevation angles or from linear combinations of other vectors. All
+ * instances are immutable: every operation such as addition, scaling, or normalization returns a
+ * new {@code Vector3D} without modifying the source operands. This makes the class inherently
+ * thread-safe and well suited for sharing between computations or caching as constants.
  *
+ * <p>Typical usage patterns include building basis vectors, translating between spherical and
+ * Cartesian coordinates, computing angles and projections, and generating orthogonal reference
+ * frames for geometric algorithms. Consumers should prefer reusing the provided canonical vectors
+ * when possible to avoid redundant allocations.
+ *
+ * <p><strong>Notable behaviors:</strong>
+ *
+ * <ul>
+ *   <li>All accessors and operations avoid side effects; null norms trigger {@link
+ *       ArithmeticException} when normalization or angular separation is undefined.
+ *   <li>Methods that combine vectors attempt to preserve numerical stability by selecting formulas
+ *       appropriate to the input orientation.
+ *   <li>Serialization is supported via {@link Serializable}, enabling safe reuse in persisted
+ *       state.
+ * </ul>
+ *
+ * @see #crossProduct(Vector3D, Vector3D)
+ * @see #dotProduct(Vector3D, Vector3D)
+ * @see #orthogonal()
  * @version $Id: Vector3D.java 1716 2006-12-13 22:56:35Z luc $
  * @author L. Maisonobe
  */
 public class Vector3D implements Serializable {
 
-  /** First canonical vector (coordinates : 1, 0, 0). */
+  /**
+   * Unit vector pointing along the positive X axis (coordinates: 1, 0, 0).
+   *
+   * <p>This constant is reused to avoid repeated allocations when callers need a right-directed
+   * basis vector of length one. The instance is immutable and can be safely shared across threads
+   * without synchronization.
+   */
   public static final Vector3D plusI = new Vector3D(1, 0, 0);
 
-  /** Opposite of the first canonical vector (coordinates : -1, 0, 0). */
+  /**
+   * Unit vector pointing along the negative X axis (coordinates: -1, 0, 0).
+   *
+   * <p>Useful as a ready-made left-directed axis when constructing orthogonal frames or applying
+   * reflections. The vector length is exactly one and the instance is immutable.
+   */
   public static final Vector3D minusI = new Vector3D(-1, 0, 0);
 
-  /** Second canonical vector (coordinates : 0, 1, 0). */
+  /**
+   * Unit vector pointing along the positive Y axis (coordinates: 0, 1, 0).
+   *
+   * <p>Use this constant to represent the canonical forward/up axis in planar computations or as
+   * part of an orthonormal basis without additional object creation.
+   */
   public static final Vector3D plusJ = new Vector3D(0, 1, 0);
 
-  /** Opposite of the second canonical vector (coordinates : 0, -1, 0). */
+  /**
+   * Unit vector pointing along the negative Y axis (coordinates: 0, -1, 0).
+   *
+   * <p>This shared constant helps express down/backward directions and supports geometric
+   * operations that expect a unit vector with a negative Y component.
+   */
   public static final Vector3D minusJ = new Vector3D(0, -1, 0);
 
-  /** Third canonical vector (coordinates : 0, 0, 1). */
+  /**
+   * Unit vector pointing along the positive Z axis (coordinates: 0, 0, 1).
+   *
+   * <p>Frequently used as a vertical axis in right-handed coordinate systems. The immutable
+   * instance can be reused wherever a normalized Z basis vector is required.
+   */
   public static final Vector3D plusK = new Vector3D(0, 0, 1);
 
-  /** Opposite of the third canonical vector (coordinates : 0, 0, -1). */
+  /**
+   * Unit vector pointing along the negative Z axis (coordinates: 0, 0, -1).
+   *
+   * <p>Provides a prebuilt downward-facing axis with unit length. Sharing this constant avoids
+   * repeated construction in transformations or cross-product calculations.
+   */
   public static final Vector3D minusK = new Vector3D(0, 0, -1);
 
-  /** Simple constructor. Build a null vector. */
+  /**
+   * Creates a null vector with all coordinates set to zero.
+   *
+   * <p>The zero vector is often used as an origin reference or as a neutral element when summing
+   * multiple vectors. Because instances are immutable, the returned object can be reused safely
+   * wherever a shared zero vector is appropriate.
+   */
   public Vector3D() {
     x = 0;
     y = 0;
@@ -38,11 +99,15 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Simple constructor. Build a vector from its coordinates
+   * Builds a vector from explicit Cartesian coordinates.
    *
-   * @param x abscissa
-   * @param y ordinate
-   * @param z height
+   * <p>This constructor is the most direct way to represent a point or displacement in space.
+   * Values are stored as provided without range checks; callers remain responsible for supplying
+   * coordinates in the desired units.
+   *
+   * @param x abscissa value along the X axis; any finite double is accepted
+   * @param y ordinate value along the Y axis; any finite double is accepted
+   * @param z height value along the Z axis; any finite double is accepted
    * @see #getX()
    * @see #getY()
    * @see #getZ()
@@ -54,10 +119,16 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Simple constructor. Build a vector from its azimuthal coordinates
+   * Builds a unit-length vector from azimuth and elevation angles.
    *
-   * @param alpha azimuth (&alpha;) around Z (0 is +X, &pi;/2 is +Y, &pi; is -X and 3&pi;/2 is -Y)
-   * @param delta elevation (&delta;) above (XY) plane, from -&pi;/2 to +&pi;/2
+   * <p>The azimuth {@code alpha} is measured in radians around the Z axis where 0 corresponds to
+   * the positive X direction and {@code Math.PI / 2} points to the positive Y direction. The
+   * elevation {@code delta} is measured in radians above the XY plane in the range -{@code
+   * Math.PI}/2 to +{@code Math.PI}/2. The resulting vector has a norm of 1 unless the inputs
+   * contain infinities or NaN.
+   *
+   * @param alpha azimuth around the Z axis in radians; 0 is +X, {@code PI/2} is +Y
+   * @param delta elevation above the XY plane in radians; range [-{@code PI}/2, {@code PI}/2]
    * @see #getAlpha()
    * @see #getDelta()
    */
@@ -69,11 +140,14 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Multiplicative constructor Build a vector from another one and a scale factor. The vector built
-   * will be a * u
+   * Builds a vector by scaling another vector with a scalar factor.
    *
-   * @param a scale factor
-   * @param u base (unscaled) vector
+   * <p>The resulting vector equals {@code a * u}. Neither the input vector nor the factor is
+   * modified. Use this constructor when creating intermediate scaled values inside composite
+   * operations without exposing temporary setters.
+   *
+   * @param a scale factor applied multiplicatively to all coordinates of {@code u}
+   * @param u base vector to scale; must not be {@code null} and is left unchanged
    */
   public Vector3D(double a, Vector3D u) {
     this.x = a * u.x;
@@ -82,13 +156,15 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Linear constructor Build a vector from two other ones and corresponding scale factors. The
-   * vector built will be a1 * u1 + a2 * u2
+   * Builds a vector as a linear combination of two input vectors.
    *
-   * @param a1 first scale factor
-   * @param u1 first base (unscaled) vector
-   * @param a2 second scale factor
-   * @param u2 second base (unscaled) vector
+   * <p>The constructed vector equals {@code a1 * u1 + a2 * u2}. This is a convenience for
+   * expressing affine transforms or barycentric coordinates without mutating intermediate data.
+   *
+   * @param a1 scale factor applied to {@code u1}; finite double recommended
+   * @param u1 first base vector; treated as immutable input and not copied defensively
+   * @param a2 scale factor applied to {@code u2}; finite double recommended
+   * @param u2 second base vector; treated as immutable input and not copied defensively
    */
   public Vector3D(double a1, Vector3D u1, double a2, Vector3D u2) {
     this.x = a1 * u1.x + a2 * u2.x;
@@ -97,15 +173,18 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Linear constructor Build a vector from three other ones and corresponding scale factors. The
-   * vector built will be a1 * u1 + a2 * u2 + a3 * u3
+   * Builds a vector as a linear combination of three input vectors.
    *
-   * @param a1 first scale factor
-   * @param u1 first base (unscaled) vector
-   * @param a2 second scale factor
-   * @param u2 second base (unscaled) vector
-   * @param a3 third scale factor
-   * @param u3 third base (unscaled) vector
+   * <p>The resulting coordinates follow {@code a1 * u1 + a2 * u2 + a3 * u3} and are computed
+   * directly from the supplied factors. Inputs are assumed valid and are not normalized
+   * automatically.
+   *
+   * @param a1 scale factor applied to {@code u1}; finite double recommended
+   * @param u1 first base vector contributing to the linear combination
+   * @param a2 scale factor applied to {@code u2}; finite double recommended
+   * @param u2 second base vector contributing to the linear combination
+   * @param a3 scale factor applied to {@code u3}; finite double recommended
+   * @param u3 third base vector contributing to the linear combination
    */
   public Vector3D(double a1, Vector3D u1, double a2, Vector3D u2, double a3, Vector3D u3) {
     this.x = a1 * u1.x + a2 * u2.x + a3 * u3.x;
@@ -114,17 +193,20 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Linear constructor Build a vector from four other ones and corresponding scale factors. The
-   * vector built will be a1 * u1 + a2 * u2 + a3 * u3 + a4 * u4
+   * Builds a vector as a linear combination of four input vectors.
    *
-   * @param a1 first scale factor
-   * @param u1 first base (unscaled) vector
-   * @param a2 second scale factor
-   * @param u2 second base (unscaled) vector
-   * @param a3 third scale factor
-   * @param u3 third base (unscaled) vector
-   * @param a4 fourth scale factor
-   * @param u4 fourth base (unscaled) vector
+   * <p>The coordinates are computed as {@code a1 * u1 + a2 * u2 + a3 * u3 + a4 * u4}. No
+   * normalization or overflow guarding is performed; callers should ensure the provided
+   * coefficients match their numeric expectations.
+   *
+   * @param a1 scale factor applied to {@code u1}; finite double recommended
+   * @param u1 first base vector contributing to the linear combination
+   * @param a2 scale factor applied to {@code u2}; finite double recommended
+   * @param u2 second base vector contributing to the linear combination
+   * @param a3 scale factor applied to {@code u3}; finite double recommended
+   * @param u3 third base vector contributing to the linear combination
+   * @param a4 scale factor applied to {@code u4}; finite double recommended
+   * @param u4 fourth base vector contributing to the linear combination
    */
   public Vector3D(
       double a1,
@@ -141,9 +223,12 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Get the abscissa of the vector.
+   * Returns the abscissa component of the vector.
    *
-   * @return abscissa of the vector
+   * <p>The X coordinate is returned exactly as stored. No unit conversion or bounds checking is
+   * applied, making it safe for high-performance numeric routines.
+   *
+   * @return immutable X component value represented as a double
    * @see #Vector3D(double, double, double)
    */
   public double getX() {
@@ -151,9 +236,12 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Get the ordinate of the vector.
+   * Returns the ordinate component of the vector.
    *
-   * @return ordinate of the vector
+   * <p>The Y coordinate is provided without additional processing. Use this when projecting onto
+   * the XY plane or when computing planar distances.
+   *
+   * @return immutable Y component value represented as a double
    * @see #Vector3D(double, double, double)
    */
   public double getY() {
@@ -161,9 +249,12 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Get the height of the vector.
+   * Returns the height component of the vector.
    *
-   * @return height of the vector
+   * <p>The Z coordinate is delivered verbatim. This is typically used for vertical distances,
+   * elevation calculations, or cross-product inputs.
+   *
+   * @return immutable Z component value represented as a double
    * @see #Vector3D(double, double, double)
    */
   public double getZ() {
@@ -171,18 +262,26 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Get the norm for the vector.
+   * Computes the Euclidean norm of the vector.
    *
-   * @return euclidian norm for the vector
+   * <p>The norm is calculated as {@code sqrt(x^2 + y^2 + z^2)}. Results may be sensitive to
+   * floating-point overflow or underflow for extremely large or small coordinates, mirroring
+   * standard {@link Math#sqrt(double)} behavior.
+   *
+   * @return non-negative double representing the vector length; zero for the null vector
    */
   public double getNorm() {
     return Math.sqrt(x * x + y * y + z * z);
   }
 
   /**
-   * Get the azimuth of the vector.
+   * Returns the azimuth angle of the vector around the Z axis.
    *
-   * @return azimuth (&alpha;) of the vector, between -&pi; and +&pi;
+   * <p>The azimuth {@code alpha} is produced via {@link Math#atan2(double, double)} and lies in the
+   * range -{@code Math.PI} to +{@code Math.PI}. When both X and Y are zero, the result is platform
+   * dependent but follows {@code atan2(0, 0)} semantics.
+   *
+   * @return azimuth in radians measured from +X toward +Y; range [-{@code PI}, {@code PI}]
    * @see #Vector3D(double, double)
    */
   public double getAlpha() {
@@ -190,9 +289,14 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Get the elevation of the vector.
+   * Returns the elevation angle of the vector above the XY plane.
    *
-   * @return elevation (&delta;) of the vector, between -&pi;/2 and +&pi;/2
+   * <p>The elevation {@code delta} is computed as {@code asin(z / norm)} and therefore requires a
+   * non-zero norm. Values range from -{@code Math.PI}/2 to +{@code Math.PI}/2. For zero-length
+   * vectors, callers should handle the resulting {@link ArithmeticException} if the norm is checked
+   * before invocation.
+   *
+   * @return elevation in radians above the XY plane; range [-{@code PI}/2, {@code PI}/2]
    * @see #Vector3D(double, double)
    */
   public double getDelta() {
@@ -200,52 +304,68 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Add a vector to the instance.
+   * Produces a new vector equal to this vector plus the given vector.
    *
-   * @param v vector to add
-   * @return a new vector
+   * <p>Neither operand is modified. This method is convenient for chaining translations while
+   * preserving the immutability of the original vectors.
+   *
+   * @param v vector to add; expected non-null and interpreted in the same units
+   * @return new {@code Vector3D} representing the coordinate-wise sum
    */
   public Vector3D add(Vector3D v) {
     return new Vector3D(x + v.x, y + v.y, z + v.z);
   }
 
   /**
-   * Add a scaled vector to the instance.
+   * Produces a new vector equal to this vector plus a scaled vector.
    *
-   * @param factor scale factor to apply to v before adding it
-   * @param v vector to add
-   * @return a new vector
+   * <p>The supplied {@code factor} is applied to {@code v} before addition, enabling affine
+   * combinations without separate scaling calls.
+   *
+   * @param factor scale applied to {@code v} prior to addition; any finite double
+   * @param v vector to add after scaling; must use the same coordinate system
+   * @return new {@code Vector3D} containing the scaled sum
    */
   public Vector3D add(double factor, Vector3D v) {
     return new Vector3D(x + factor * v.x, y + factor * v.y, z + factor * v.z);
   }
 
   /**
-   * Subtract a vector from the instance.
+   * Produces a new vector equal to this vector minus the given vector.
    *
-   * @param v vector to subtract
-   * @return a new vector
+   * <p>Use this for computing displacements between positions or reversing a prior addition. The
+   * original vectors remain unchanged.
+   *
+   * @param v vector to subtract; must not be {@code null} and shares units with this vector
+   * @return new {@code Vector3D} representing the coordinate-wise difference
    */
   public Vector3D subtract(Vector3D v) {
     return new Vector3D(x - v.x, y - v.y, z - v.z);
   }
 
   /**
-   * Subtract a scaled vector from the instance.
+   * Produces a new vector equal to this vector minus a scaled vector.
    *
-   * @param factor scale factor to apply to v before subtracting it
-   * @param v vector to subtract
-   * @return a new vector
+   * <p>The {@code factor} scales {@code v} before subtraction, allowing weighted differences
+   * without temporary intermediate objects.
+   *
+   * @param factor scale applied to {@code v} prior to subtraction; any finite double
+   * @param v vector to subtract after scaling; must use the same coordinate system
+   * @return new {@code Vector3D} representing the scaled difference
    */
   public Vector3D subtract(double factor, Vector3D v) {
     return new Vector3D(x - factor * v.x, y - factor * v.y, z - factor * v.z);
   }
 
   /**
-   * Normalize the instance.
+   * Returns a normalized version of this vector.
    *
-   * @return a new normalized vector
-   * @exception ArithmeticException if the norm is null
+   * <p>The result has a norm of 1 while preserving direction. If the norm is zero, an {@link
+   * ArithmeticException} is thrown to signal the undefined operation. Because a new instance is
+   * created, the original vector remains unchanged and safe to reuse.
+   *
+   * @return normalized vector with unit length and identical direction
+   * @throws ArithmeticException if this vector has a zero norm and cannot be normalized
    */
   public Vector3D normalize() {
     double s = getNorm();
@@ -256,21 +376,21 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Get a vector orthogonal to the instance.
+   * Returns a normalized vector orthogonal to this vector.
    *
-   * <p>There are an infinite number of normalized vectors orthogonal to the instance. This method
-   * picks up one of them almost arbitrarily. It is useful when one needs to compute a reference
-   * frame with one of the axes in a predefined direction. The following example shows how to build
-   * a frame having the k axis aligned with the known vector u :
+   * <p>Because infinitely many orthogonal vectors exist, the implementation selects one
+   * deterministically based on the largest coordinate magnitude to maintain numerical stability.
+   * The returned vector always has unit length and is suitable for building local coordinate
+   * frames.
    *
-   * <pre><code>
-   *   Vector3D k = u.normalize();
-   *   Vector3D i = k.orthogonal();
-   *   Vector3D j = Vector3D.crossProduct(k, i);
-   * </code></pre>
+   * <pre>{@code
+   * Vector3D k = u.normalize();
+   * Vector3D i = k.orthogonal();
+   * Vector3D j = Vector3D.crossProduct(k, i);
+   * }</pre>
    *
-   * @return a new normalized vector orthogonal to the instance
-   * @exception ArithmeticException if the norm of the instance is null
+   * @return normalized vector orthogonal to this vector and suitable for basis construction
+   * @throws ArithmeticException if this vector has a zero norm and no direction exists
    */
   public Vector3D orthogonal() {
 
@@ -292,15 +412,16 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Compute the angular separation between two vectors.
+   * Computes the angular separation between two vectors in radians.
    *
-   * <p>This method computes the angular separation between two vectors using the dot product for
-   * well separated vectors and the cross product for almost aligned vectors. This allow to have a
-   * good accuracy in all cases, even for vectors very close to each other.
+   * <p>The method uses the dot product for well-separated vectors and switches to a sine-based
+   * calculation for nearly aligned vectors to maintain numeric accuracy. Inputs must both have
+   * non-zero norms; otherwise an {@link ArithmeticException} is raised.
    *
-   * @param v1 first vector
-   * @param v2 second vector
-   * @exception ArithmeticException if either vector has a null norm
+   * @param v1 first vector; must be non-null and have non-zero norm
+   * @param v2 second vector; must be non-null and have non-zero norm
+   * @return angle in radians between {@code v1} and {@code v2}; range [0, {@code PI}]
+   * @throws ArithmeticException if either vector has a zero norm and the angle is undefined
    */
   public static double angle(Vector3D v1, Vector3D v2) {
 
@@ -325,41 +446,53 @@ public class Vector3D implements Serializable {
   }
 
   /**
-   * Get the opposite of the instance.
+   * Returns a vector that is the additive inverse of this vector.
    *
-   * @return a new vector which is opposite to the instance
+   * <p>Each coordinate is negated, producing a vector pointing in the exact opposite direction with
+   * identical magnitude.
+   *
+   * @return new {@code Vector3D} representing the opposite of this vector
    */
   public Vector3D negate() {
     return new Vector3D(-x, -y, -z);
   }
 
   /**
-   * Multiply the instance by a scalar
+   * Returns a vector scaled by the provided scalar.
    *
-   * @param a scalar
-   * @return a new vector
+   * <p>The scaling applies uniformly to all coordinates. The original vector is left unchanged,
+   * preserving immutability and allowing safe reuse.
+   *
+   * @param a scalar multiplier applied to each coordinate; any finite double
+   * @return new {@code Vector3D} scaled version of this vector
    */
   public Vector3D multiply(double a) {
     return new Vector3D(a * x, a * y, a * z);
   }
 
   /**
-   * Compute the dot-product of two vectors.
+   * Computes the dot product of two vectors.
    *
-   * @param v1 first vector
-   * @param v2 second vector
-   * @return the dot product v1.v2
+   * <p>The dot product equals {@code v1.x * v2.x + v1.y * v2.y + v1.z * v2.z}. It is positive for
+   * acute angles, negative for obtuse angles, and zero for orthogonal vectors.
+   *
+   * @param v1 first operand; expected non-null and expressed in the same units as {@code v2}
+   * @param v2 second operand; expected non-null and expressed in the same units as {@code v1}
+   * @return scalar dot product value capturing directional similarity
    */
   public static double dotProduct(Vector3D v1, Vector3D v2) {
     return v1.x * v2.x + v1.y * v2.y + v1.z * v2.z;
   }
 
   /**
-   * Compute the cross-product of two vectors.
+   * Computes the cross product of two vectors.
    *
-   * @param v1 first vector
-   * @param v2 second vector
-   * @return the cross product v1 ^ v2 as a new Vector
+   * <p>The cross product yields a vector perpendicular to both inputs following the right-hand
+   * rule. Its magnitude equals the area of the parallelogram spanned by the operands.
+   *
+   * @param v1 first operand; expected non-null and expressed in the same units as {@code v2}
+   * @param v2 second operand; expected non-null and expressed in the same units as {@code v1}
+   * @return new {@code Vector3D} orthogonal to both inputs following the right-hand rule
    */
   public static Vector3D crossProduct(Vector3D v1, Vector3D v2) {
     return new Vector3D(
@@ -375,5 +508,5 @@ public class Vector3D implements Serializable {
   /** Height. */
   private final double z;
 
-  private static final long serialVersionUID = 7318440192750283659L;
+  @Serial private static final long serialVersionUID = 7318440192750283659L;
 }

--- a/src/test/java/org/spaceroots/mantissa/geometry/RotationOrderTest.java
+++ b/src/test/java/org/spaceroots/mantissa/geometry/RotationOrderTest.java
@@ -1,0 +1,53 @@
+package org.spaceroots.mantissa.geometry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("java:S100")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RotationOrderTest {
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("rotationOrdersProvider")
+  void getters_whenUsingPredefinedOrders_returnConfiguredAxes(
+      String name,
+      RotationOrder order,
+      Vector3D expectedA1,
+      Vector3D expectedA2,
+      Vector3D expectedA3) {
+    assertSame(expectedA1, order.getA1());
+    assertSame(expectedA2, order.getA2());
+    assertSame(expectedA3, order.getA3());
+    assertEquals(name, order.toString());
+  }
+
+  @Test
+  void toString_whenUsingDistinctOrders_returnsDistinctNames() {
+    assertEquals("XYZ", RotationOrder.XYZ.toString());
+    assertEquals("ZYZ", RotationOrder.ZYZ.toString());
+  }
+
+  private static Stream<Arguments> rotationOrdersProvider() {
+    return Stream.of(
+        Arguments.of("XYZ", RotationOrder.XYZ, Vector3D.plusI, Vector3D.plusJ, Vector3D.plusK),
+        Arguments.of("XZY", RotationOrder.XZY, Vector3D.plusI, Vector3D.plusK, Vector3D.plusJ),
+        Arguments.of("YXZ", RotationOrder.YXZ, Vector3D.plusJ, Vector3D.plusI, Vector3D.plusK),
+        Arguments.of("YZX", RotationOrder.YZX, Vector3D.plusJ, Vector3D.plusK, Vector3D.plusI),
+        Arguments.of("ZXY", RotationOrder.ZXY, Vector3D.plusK, Vector3D.plusI, Vector3D.plusJ),
+        Arguments.of("ZYX", RotationOrder.ZYX, Vector3D.plusK, Vector3D.plusJ, Vector3D.plusI),
+        Arguments.of("XYX", RotationOrder.XYX, Vector3D.plusI, Vector3D.plusJ, Vector3D.plusI),
+        Arguments.of("XZX", RotationOrder.XZX, Vector3D.plusI, Vector3D.plusK, Vector3D.plusI),
+        Arguments.of("YXY", RotationOrder.YXY, Vector3D.plusJ, Vector3D.plusI, Vector3D.plusJ),
+        Arguments.of("YZY", RotationOrder.YZY, Vector3D.plusJ, Vector3D.plusK, Vector3D.plusJ),
+        Arguments.of("ZXZ", RotationOrder.ZXZ, Vector3D.plusK, Vector3D.plusI, Vector3D.plusK),
+        Arguments.of("ZYZ", RotationOrder.ZYZ, Vector3D.plusK, Vector3D.plusJ, Vector3D.plusK));
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/geometry/RotationTest.java
+++ b/src/test/java/org/spaceroots/mantissa/geometry/RotationTest.java
@@ -1,0 +1,185 @@
+package org.spaceroots.mantissa.geometry;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class RotationTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void defaultConstructor_whenAppliedToVector_returnsSame() {
+    Rotation rotation = new Rotation();
+    Vector3D original = new Vector3D(1.25, -2.5, 3.75);
+
+    Vector3D result = rotation.applyTo(original);
+
+    assertAll(
+        () -> assertVectorEquals(original, result, EPS),
+        () -> assertEquals(0.0, rotation.getAngle(), EPS),
+        () -> assertVectorEquals(new Vector3D(1, 0, 0), rotation.getAxis(), EPS),
+        () ->
+            assertArrayEquals(
+                new double[] {
+                  1.0, 0.0, 0.0,
+                  0.0, 1.0, 0.0,
+                  0.0, 0.0, 1.0
+                },
+                flatten(rotation.getMatrix()),
+                EPS));
+  }
+
+  @Test
+  void axisAngleConstructor_withPiOverTwoAroundZ_rotatesXToY() {
+    Rotation rotation = new Rotation(Vector3D.plusK, Math.PI / 2.0);
+
+    Vector3D rotated = rotation.applyTo(Vector3D.plusI);
+
+    assertVectorEquals(Vector3D.plusJ, rotated, 1.0e-10);
+  }
+
+  @Test
+  void axisAngleConstructor_withZeroAxis_throwsArithmeticException() {
+    Vector3D zero = new Vector3D(0, 0, 0);
+
+    assertThrows(ArithmeticException.class, () -> new Rotation(zero, 1.0));
+  }
+
+  @Test
+  void quaternionConstructor_needsNormalization_normalizesInputs() {
+    Rotation rotation = new Rotation(2.0, 2.0, 0.0, 0.0, true);
+
+    double normSquared =
+        rotation.getQ0() * rotation.getQ0()
+            + rotation.getQ1() * rotation.getQ1()
+            + rotation.getQ2() * rotation.getQ2()
+            + rotation.getQ3() * rotation.getQ3();
+
+    assertEquals(1.0, normSquared, EPS);
+  }
+
+  @Test
+  void matrixConstructor_withImproperDeterminant_throwsNotARotationMatrixException() {
+    double[][] improper = {
+      {1.0, 0.0, 0.0},
+      {0.0, 1.0, 0.0},
+      {0.0, 0.0, -1.0}
+    };
+
+    assertThrows(NotARotationMatrixException.class, () -> new Rotation(improper, 1.0e-10));
+  }
+
+  @Test
+  void matrixConstructor_withValidMatrix_producesEquivalentRotation() throws Exception {
+    Rotation original = new Rotation(Vector3D.plusK, Math.PI / 3.0);
+    double[][] matrix = original.getMatrix();
+
+    Rotation rebuilt = new Rotation(matrix, 1.0e-12);
+    Vector3D sample = new Vector3D(0.3, -1.2, 0.9);
+
+    assertVectorEquals(original.applyTo(sample), rebuilt.applyTo(sample), 1.0e-12);
+  }
+
+  @Test
+  void applyInverseTo_whenAppliedToRotatedVector_returnsOriginal() {
+    Rotation rotation = new Rotation(new Vector3D(1, 1, 1), 0.75);
+    Vector3D base = new Vector3D(-2.0, 5.0, 0.5);
+
+    Vector3D rotated = rotation.applyTo(base);
+    Vector3D recovered = rotation.applyInverseTo(rotated);
+
+    assertVectorEquals(base, recovered, 1.0e-12);
+  }
+
+  @Test
+  void applyToRotation_composesRotationsConsistently() {
+    Rotation aroundX = new Rotation(Vector3D.plusI, Math.PI / 2.0);
+    Rotation aroundY = new Rotation(Vector3D.plusJ, Math.PI / 3.0);
+
+    Rotation composed = aroundX.applyTo(aroundY);
+    Vector3D probe = new Vector3D(0.2, 0.3, 0.4);
+
+    Vector3D sequential = aroundX.applyTo(aroundY.applyTo(probe));
+    Vector3D viaComposition = composed.applyTo(probe);
+
+    assertVectorEquals(sequential, viaComposition, 1.0e-12);
+  }
+
+  @Test
+  void getAngles_whenUsingXYZOrder_returnsOriginalAngles() throws Exception {
+    double a1 = 0.3;
+    double a2 = -0.4;
+    double a3 = 1.0;
+    Rotation rotation = new Rotation(RotationOrder.XYZ, a1, a2, a3);
+
+    double[] angles = rotation.getAngles(RotationOrder.XYZ);
+
+    assertArrayEquals(new double[] {a1, a2, a3}, angles, 1.0e-12);
+  }
+
+  @Test
+  void getAngles_whenEulerSequenceSingular_throwsCardanEulerSingularityException() {
+    Rotation identity = new Rotation();
+
+    assertThrows(
+        CardanEulerSingularityException.class, () -> identity.getAngles(RotationOrder.ZYZ));
+  }
+
+  @Test
+  void constructorWithTwoVectors_oppositeVectors_generatesPiRotation() {
+    Vector3D u = Vector3D.plusI;
+    Vector3D v = Vector3D.minusI;
+
+    Rotation rotation = new Rotation(u, v);
+
+    Vector3D result = rotation.applyTo(u);
+    assertVectorEquals(v, result, 1.0e-12);
+    assertEquals(Math.PI, rotation.getAngle(), 1.0e-12);
+  }
+
+  @Test
+  void revert_whenAppliedAfterRotation_recoversOriginalVector() {
+    Rotation rotation = new Rotation(Vector3D.plusJ, 0.9);
+    Rotation reverted = rotation.revert();
+    Vector3D source = new Vector3D(0.8, -0.6, 0.4);
+
+    Vector3D rotated = rotation.applyTo(source);
+    Vector3D recovered = reverted.applyTo(rotated);
+
+    assertVectorEquals(source, recovered, 1.0e-12);
+  }
+
+  @Test
+  void constructorWithVectorPairs_whenMappingOrthogonalBasis_alignsCorrectly() {
+    Vector3D u1 = Vector3D.plusI;
+    Vector3D u2 = Vector3D.plusJ;
+    Vector3D v1 = Vector3D.plusJ;
+    Vector3D v2 = Vector3D.minusI;
+
+    Rotation rotation = new Rotation(u1, u2, v1, v2);
+
+    assertAll(
+        () -> assertVectorEquals(v1, rotation.applyTo(u1), 1.0e-12),
+        () -> assertVectorEquals(v2, rotation.applyTo(u2), 1.0e-12));
+  }
+
+  private static double[] flatten(double[][] matrix) {
+    return new double[] {
+      matrix[0][0], matrix[0][1], matrix[0][2],
+      matrix[1][0], matrix[1][1], matrix[1][2],
+      matrix[2][0], matrix[2][1], matrix[2][2]
+    };
+  }
+
+  private static void assertVectorEquals(Vector3D expected, Vector3D actual, double epsilon) {
+    assertAll(
+        () -> assertEquals(expected.getX(), actual.getX(), epsilon),
+        () -> assertEquals(expected.getY(), actual.getY(), epsilon),
+        () -> assertEquals(expected.getZ(), actual.getZ(), epsilon));
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/geometry/Vector3DTest.java
+++ b/src/test/java/org/spaceroots/mantissa/geometry/Vector3DTest.java
@@ -1,0 +1,267 @@
+package org.spaceroots.mantissa.geometry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@SuppressWarnings("java:S100")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class Vector3DTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Test
+  void defaultConstructor_createsZeroVector() {
+    Vector3D vector = new Vector3D();
+
+    assertEquals(0.0, vector.getX(), EPS);
+    assertEquals(0.0, vector.getY(), EPS);
+    assertEquals(0.0, vector.getZ(), EPS);
+    assertEquals(0.0, vector.getNorm(), EPS);
+  }
+
+  @Test
+  void coordinateConstructor_setsFields() {
+    Vector3D vector = new Vector3D(1.5, -2.0, 3.25);
+
+    assertEquals(1.5, vector.getX(), EPS);
+    assertEquals(-2.0, vector.getY(), EPS);
+    assertEquals(3.25, vector.getZ(), EPS);
+  }
+
+  @Test
+  void sphericalConstructor_preservesAlphaAndDelta() {
+    double alpha = Math.PI / 3;
+    double delta = Math.PI / 6;
+
+    Vector3D vector = new Vector3D(alpha, delta);
+
+    assertEquals(alpha, vector.getAlpha(), EPS);
+    assertEquals(delta, vector.getDelta(), EPS);
+    assertEquals(1.0, vector.getNorm(), EPS);
+  }
+
+  @Test
+  void scaleConstructor_multipliesComponents() {
+    Vector3D base = new Vector3D(1, -2, 3);
+
+    Vector3D scaled = new Vector3D(2.5, base);
+
+    assertEquals(2.5, scaled.getX(), EPS);
+    assertEquals(-5.0, scaled.getY(), EPS);
+    assertEquals(7.5, scaled.getZ(), EPS);
+  }
+
+  @Test
+  void linearConstructor_twoVectors_combinesCorrectly() {
+    Vector3D result = new Vector3D(2, Vector3D.plusI, -3, Vector3D.minusJ);
+
+    assertEquals(2.0, result.getX(), EPS);
+    assertEquals(3.0, result.getY(), EPS);
+    assertEquals(0.0, result.getZ(), EPS);
+  }
+
+  @Test
+  void linearConstructor_threeVectors_combinesCorrectly() {
+    Vector3D result = new Vector3D(1, Vector3D.plusI, 2, Vector3D.plusJ, 3, Vector3D.plusK);
+
+    assertEquals(1.0, result.getX(), EPS);
+    assertEquals(2.0, result.getY(), EPS);
+    assertEquals(3.0, result.getZ(), EPS);
+  }
+
+  @Test
+  void linearConstructor_fourVectors_combinesCorrectly() {
+    Vector3D result =
+        new Vector3D(1, Vector3D.plusI, 1, Vector3D.plusJ, 1, Vector3D.plusK, -2, Vector3D.minusK);
+
+    assertEquals(1.0, result.getX(), EPS);
+    assertEquals(1.0, result.getY(), EPS);
+    assertEquals(3.0, result.getZ(), EPS);
+  }
+
+  @Test
+  void getAlpha_handlesAllQuadrants() {
+    Vector3D vector = new Vector3D(-1, 1, 0);
+
+    assertEquals(3 * Math.PI / 4, vector.getAlpha(), EPS);
+  }
+
+  @Test
+  void getDelta_reflectsElevation() {
+    Vector3D vector = new Vector3D(0, Math.sqrt(3), 1);
+
+    assertEquals(Math.PI / 6, vector.getDelta(), EPS);
+  }
+
+  @Test
+  void add_addsCoordinates() {
+    Vector3D sum = new Vector3D(1, 2, 3).add(new Vector3D(-2, 4, 1));
+
+    assertEquals(-1.0, sum.getX(), EPS);
+    assertEquals(6.0, sum.getY(), EPS);
+    assertEquals(4.0, sum.getZ(), EPS);
+  }
+
+  @Test
+  void add_withFactor_scalesBeforeAdding() {
+    Vector3D sum = new Vector3D(1, 1, 1).add(2, new Vector3D(0.5, -1, 3));
+
+    assertEquals(2.0, sum.getX(), EPS);
+    assertEquals(-1.0, sum.getY(), EPS);
+    assertEquals(7.0, sum.getZ(), EPS);
+  }
+
+  @Test
+  void subtract_subtractsCoordinates() {
+    Vector3D diff = new Vector3D(5, -2, 4).subtract(new Vector3D(1, 1, 6));
+
+    assertEquals(4.0, diff.getX(), EPS);
+    assertEquals(-3.0, diff.getY(), EPS);
+    assertEquals(-2.0, diff.getZ(), EPS);
+  }
+
+  @Test
+  void subtract_withFactor_scalesBeforeSubtracting() {
+    Vector3D diff = new Vector3D(1, 1, 1).subtract(3, new Vector3D(0.5, -1, 2));
+
+    assertEquals(-0.5, diff.getX(), EPS);
+    assertEquals(4.0, diff.getY(), EPS);
+    assertEquals(-5.0, diff.getZ(), EPS);
+  }
+
+  @Test
+  void multiply_scalesVector() {
+    Vector3D product = new Vector3D(-1, 2, -3).multiply(4);
+
+    assertEquals(-4.0, product.getX(), EPS);
+    assertEquals(8.0, product.getY(), EPS);
+    assertEquals(-12.0, product.getZ(), EPS);
+  }
+
+  @Test
+  void negate_invertsComponents() {
+    Vector3D negated = new Vector3D(1.2, -3.4, 5.6).negate();
+
+    assertEquals(-1.2, negated.getX(), EPS);
+    assertEquals(3.4, negated.getY(), EPS);
+    assertEquals(-5.6, negated.getZ(), EPS);
+  }
+
+  @Test
+  void normalize_returnsUnitVector() {
+    Vector3D vector = new Vector3D(2, 0, 0);
+
+    Vector3D normalized = vector.normalize();
+
+    assertEquals(1.0, normalized.getX(), EPS);
+    assertEquals(0.0, normalized.getY(), EPS);
+    assertEquals(0.0, normalized.getZ(), EPS);
+    assertEquals(1.0, normalized.getNorm(), EPS);
+  }
+
+  @Test
+  void normalize_zeroVector_throwsArithmeticException() {
+    Vector3D zero = new Vector3D();
+
+    assertThrows(ArithmeticException.class, zero::normalize);
+  }
+
+  @Test
+  void orthogonal_forSmallX_usesYZBranch() {
+    Vector3D vector = new Vector3D(0.1, 1, 0);
+
+    Vector3D orthogonal = vector.orthogonal();
+
+    assertTrue(Math.abs(Vector3D.dotProduct(vector, orthogonal)) < EPS);
+    assertEquals(1.0, orthogonal.getNorm(), EPS);
+  }
+
+  @Test
+  void orthogonal_forSmallY_usesXZBranch() {
+    Vector3D vector = new Vector3D(1, 0.1, 0);
+
+    Vector3D orthogonal = vector.orthogonal();
+
+    assertTrue(Math.abs(Vector3D.dotProduct(vector, orthogonal)) < EPS);
+    assertEquals(1.0, orthogonal.getNorm(), EPS);
+  }
+
+  @Test
+  void orthogonal_forLargeXY_usesXYBranch() {
+    Vector3D vector = new Vector3D(1, 1, 1);
+
+    Vector3D orthogonal = vector.orthogonal();
+
+    assertTrue(Math.abs(Vector3D.dotProduct(vector, orthogonal)) < EPS);
+    assertEquals(1.0, orthogonal.getNorm(), EPS);
+  }
+
+  @Test
+  void orthogonal_zeroVector_throwsArithmeticException() {
+    Vector3D zero = new Vector3D();
+
+    assertThrows(ArithmeticException.class, zero::orthogonal);
+  }
+
+  @Test
+  void angle_forPerpendicularVectors_returnsPiOver2() {
+    double angle = Vector3D.angle(Vector3D.plusI, Vector3D.plusJ);
+
+    assertEquals(Math.PI / 2, angle, EPS);
+  }
+
+  @Test
+  void angle_forAlmostAlignedVectors_returnsSmallAngle() {
+    Vector3D v1 = new Vector3D(1, 0, 0);
+    Vector3D v2 = new Vector3D(0.99999, 0, 0);
+
+    double angle = Vector3D.angle(v1, v2);
+
+    assertEquals(0.0, angle, 1.0e-6);
+  }
+
+  @Test
+  void angle_forAlmostOppositeVectors_returnsPi() {
+    Vector3D v1 = new Vector3D(1, 0, 0);
+    Vector3D v2 = new Vector3D(-0.99999, 0, 0);
+
+    double angle = Vector3D.angle(v1, v2);
+
+    assertEquals(Math.PI, angle, 1.0e-6);
+  }
+
+  @Test
+  void angle_withZeroNorm_throwsArithmeticException() {
+    Vector3D zero = new Vector3D();
+
+    assertThrows(ArithmeticException.class, () -> Vector3D.angle(zero, Vector3D.plusI));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1, 0, 0, 1", "0, 1, 0, 2", "0, 0, 1, 3", "3, 4, 5, 26"})
+  void dotProduct_calculatesExpectedValue(
+      double x2, double y2, double z2, double expectedDotProduct) {
+    Vector3D v1 = new Vector3D(1, 2, 3);
+    Vector3D v2 = new Vector3D(x2, y2, z2);
+
+    double dot = Vector3D.dotProduct(v1, v2);
+
+    assertEquals(expectedDotProduct, dot, EPS);
+  }
+
+  @Test
+  void crossProduct_followsRightHandRule() {
+    Vector3D cross = Vector3D.crossProduct(Vector3D.plusI, Vector3D.plusJ);
+
+    assertEquals(0.0, cross.getX(), EPS);
+    assertEquals(0.0, cross.getY(), EPS);
+    assertEquals(1.0, cross.getZ(), EPS);
+  }
+}


### PR DESCRIPTION
## Summary
- expand Rotation, RotationOrder, Vector3D, and related exception Javadocs for clearer usage and invariants
- refactor angle extraction helpers in Rotation for readability and add @Serial where appropriate
- add comprehensive unit tests for Rotation, RotationOrder, and Vector3D covering constructors, angle handling, and vector operations

## Testing
- not run (not requested)
