### PR TITLE
Improve step interpolator docs and coverage

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/AbstractStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/AbstractStepInterpolator.java
@@ -5,11 +5,29 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 /**
- * This abstract class represents an interpolator over the last step during an ODE integration.
+ * Base class for dense-output interpolators that reconstruct the ODE state between grid points.
  *
- * <p>The various ODE integrators provide objects extending this class to the step handlers. The
- * handlers can use these objects to retrieve the state vector at intermediate times between the
- * previous and the current grid points (dense output).
+ * <p>An {@code AbstractStepInterpolator} instance is created by an integrator after each accepted
+ * step and passed to {@link StepHandler step handlers}. Handlers call {@link #setInterpolatedTime}
+ * followed by {@link #getInterpolatedState()} to obtain intermediate states without forcing extra
+ * integration steps. The instance maintains the raw step endpoints, the integration direction, and
+ * a mutable interpolated state buffer reused across calls.
+ *
+ * <p>Lifecycle overview:
+ *
+ * <ul>
+ *   <li>{@link #reinitialize(double[], boolean)} prepares arrays and resets time markers.
+ *   <li>{@link #storeTime(double)} records the end of a step and snapshots the current state.
+ *   <li>{@link #setInterpolatedTime(double)} computes an intermediate state on demand.
+ *   <li>{@link #finalizeStep()} ensures any delayed evaluations happen once per step.
+ * </ul>
+ *
+ * Typical usage occurs within a single integration thread; instances are mutable and not thread
+ * safe. To keep a snapshot beyond the current handler invocation, call {@link #finalizeStep()},
+ * then {@link #copy()} to obtain an independent, deep-cloned interpolator. Copies inherit the
+ * integration direction and already-computed data but remain detached from subsequent integrator
+ * updates. Integrators are expected to progress monotonically in the {@linkplain #isForward()
+ * forward} direction indicated here.
  *
  * @see FirstOrderIntegrator
  * @see SecondOrderIntegrator
@@ -17,39 +35,44 @@ import java.io.ObjectOutput;
  * @version $Id: AbstractStepInterpolator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
-public abstract class AbstractStepInterpolator implements StepInterpolator, Cloneable {
+public abstract class AbstractStepInterpolator {
 
-  /** previous time */
+  /** Previous grid point time, i.e. the start of the current step, in integration units. */
   protected double previousTime;
 
-  /** current time */
+  /** Current grid point time recorded after the last accepted step. */
   protected double currentTime;
 
-  /** current time step */
+  /** Current step size, computed as {@code currentTime - previousTime}. */
   protected double h;
 
-  /** current state */
+  /** State vector at {@link #currentTime}; shared with the owning integrator. */
   protected double[] currentState;
 
-  /** interpolated time */
+  /** Time at which {@link #interpolatedState} has been computed. */
   protected double interpolatedTime;
 
-  /** interpolated state */
+  /**
+   * Working buffer holding the state corresponding to {@link #interpolatedTime}; reused across
+   * interpolations within the same step.
+   */
   protected double[] interpolatedState;
 
-  /** indicate if the step has been finalized or not. */
+  /** Indicates whether {@link #finalizeStep()} has already been executed for this step. */
   private boolean finalized;
 
-  /** integration direction. */
+  /** Integration direction flag; {@code true} when time increases during integration. */
   private boolean forward;
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * #reinitialize} method should be called before using the instance in order to initialize the
-   * internal arrays. This constructor is used only in order to delay the initialization in some
-   * cases. As an example, the {@link RungeKuttaFehlbergIntegrator} uses the prototyping design
-   * pattern to create the step interpolators by cloning an uninitialized model and latter
-   * initializing the copy.
+   * Simple constructor for deferred initialization.
+   *
+   * <p>The created instance carries no state arrays until {@link #reinitialize(double[], boolean)}
+   * is invoked. Integrators use this path when they need a prototype object to clone later (for
+   * example, {@link RungeKuttaFehlbergIntegrator}) or when the step size is unknown during
+   * construction. All time markers are initialized to {@link Double#NaN} so accidental use before
+   * reinitialization is easy to detect. The constructor performs no allocation, which keeps cloning
+   * inexpensive when integrators maintain internal pools of prototype interpolators.
    */
   protected AbstractStepInterpolator() {
     previousTime = Double.NaN;
@@ -63,10 +86,16 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   }
 
   /**
-   * Simple constructor.
+   * Simple constructor with immediate state binding.
    *
-   * @param y reference to the integrator array holding the state at the end of the step
-   * @param forward integration direction indicator
+   * <p>Use this when the integrator already has a state vector available for the end of the step
+   * and wants the interpolator to reference it directly. Because the array is not copied, any
+   * in-place updates performed by the integrator remain visible to subsequent interpolation
+   * requests, reducing memory churn but requiring callers to respect the integrator's ownership.
+   *
+   * @param y reference to the integrator-managed array holding the state at the end of the step;
+   *     the reference is stored, not copied
+   * @param forward integration direction indicator; {@code true} when time increases
    */
   protected AbstractStepInterpolator(double[] y, boolean forward) {
 
@@ -83,18 +112,17 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   }
 
   /**
-   * Copy constructor.
+   * Copy constructor creating a deep, detached interpolator.
    *
-   * <p>The copied interpolator should have been finalized before the copy, otherwise the copy will
-   * not be able to perform correctly any derivative computation and will throw a {@link
-   * NullPointerException} later. Since we don't want this constructor to throw the exceptions
-   * finalization may involve and since we don't want this method to modify the state of the copied
-   * interpolator, finalization is <strong>not</strong> done automatically, it remains under user
-   * control.
+   * <p>The source should already be {@link #finalizeStep() finalized}; otherwise derivative data
+   * may be missing and later interpolation attempts can raise a {@link NullPointerException}. To
+   * avoid side effects, this constructor never finalizes the source automatically. All array fields
+   * are deep-copied so the new instance can evolve independently while preserving the same step
+   * bounds, direction, and precomputed interpolated state. Each clone therefore serves as a durable
+   * snapshot that can survive beyond the lifetime of the integrator callback while the original
+   * continues to mutate with new step data.
    *
-   * <p>The copy is a deep copy: its arrays are separated from the original arrays of the instance.
-   *
-   * @param interpolator interpolator to copy from.
+   * @param interpolator interpolator to copy from; must describe a finalized step for safe use
    */
   protected AbstractStepInterpolator(AbstractStepInterpolator interpolator) {
 
@@ -104,8 +132,8 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
     interpolatedTime = interpolator.interpolatedTime;
 
     if (interpolator.currentState != null) {
-      currentState = (double[]) interpolator.currentState.clone();
-      interpolatedState = (double[]) interpolator.interpolatedState.clone();
+      currentState = interpolator.currentState.clone();
+      interpolatedState = interpolator.interpolatedState.clone();
     } else {
       currentState = null;
       interpolatedState = null;
@@ -116,10 +144,16 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   }
 
   /**
-   * Reinitialize the instance
+   * Reinitialize the instance for a new step.
    *
-   * @param y reference to the integrator array holding the state at the end of the step
-   * @param forward integration direction indicator
+   * <p>The method resets all time markers to {@link Double#NaN}, prepares a fresh {@link
+   * #interpolatedState} array sized to the provided state vector, clears the {@link #finalized}
+   * flag, and records the integration direction. Integrators invoke it when reusing an interpolator
+   * across steps or when cloning a prototype to avoid repeated allocations.
+   *
+   * @param y reference to the integrator array holding the state at the end of the step; reused as
+   *     {@link #currentState}
+   * @param forward integration direction indicator; affects {@link #isForward()}
    */
   protected void reinitialize(double[] y, boolean forward) {
 
@@ -136,42 +170,40 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   }
 
   /**
-   * Copy the instance.
+   * Create a deep copy of the instance.
    *
-   * <p>The copied interpolator should have been finalized before the copy, otherwise the copy will
-   * not be able to perform correctly any interpolation and will throw a {@link
-   * NullPointerException} later. Since we don't want this constructor to throw the exceptions
-   * finalization may involve and since we don't want this method to modify the state of the copied
-   * interpolator, finalization is <strong>not</strong> done automatically, it remains under user
-   * control.
+   * <p>Callers should invoke {@link #finalizeStep()} before copying so that any delayed derivative
+   * evaluations are captured; otherwise later calls that rely on those values may fail. The
+   * returned instance owns independent arrays but preserves the same step metadata and computed
+   * interpolation state, enabling safe storage of snapshots while the integrator continues. Copies
+   * are the only supported mechanism for retaining dense output beyond the duration of a step
+   * handler invocation.
    *
-   * <p>The copy is a deep copy: its arrays are separated from the original arrays of the instance.
-   *
-   * <p>This method has been redeclared as public instead of protected.
-   *
-   * @return a copy of the instance.
+   * @return a copy of this interpolator with detached arrays and identical step metadata
    */
-  public Object clone() {
-    try {
-      return super.clone();
-    } catch (CloneNotSupportedException cnse) {
-      // should never happen
-      return null;
-    }
-  }
+  public abstract AbstractStepInterpolator copy();
 
   /**
-   * Shift one step forward. Copy the current time into the previous time, hence preparing the
-   * interpolator for future calls to {@link #storeTime storeTime}
+   * Shift one step forward.
+   *
+   * <p>Copies {@link #currentTime} into {@link #previousTime}, preparing the instance for the next
+   * call to {@link #storeTime(double)}. This method does not modify state arrays. Integrators call
+   * it immediately after accepting a step so that subsequent calls to {@link #storeTime(double)}
+   * compute a consistent step size {@link #h}. It should never be used to skip finalization; doing
+   * so leaves the current step in an undefined state for dense output.
    */
   public void shift() {
     previousTime = currentTime;
   }
 
   /**
-   * Store the current step time.
+   * Store the current step time and snapshot the state.
    *
-   * @param t current time
+   * @param t current time at the end of the step; may be greater or smaller than {@link
+   *     #previousTime} depending on integration direction. The method also recomputes the step size
+   *     {@link #h}, resets the interpolated time to the grid point, clones the current state into
+   *     {@link #interpolatedState}, and clears the {@link #finalized} flag to allow deferred
+   *     evaluations on the new step.
    */
   public void storeTime(double t) {
 
@@ -187,7 +219,11 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   /**
    * Get the previous grid point time.
    *
-   * @return previous grid point time
+   * <p>The value corresponds to the start of the most recently accepted step and is initialized to
+   * {@link Double#NaN} until the first call to {@link #shift()}. Client code can use this as the
+   * lower bound when checking whether an interpolated time lies within the active step.
+   *
+   * @return previous grid point time marking the start of the current step
    */
   public double getPreviousTime() {
     return previousTime;
@@ -196,32 +232,47 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   /**
    * Get the current grid point time.
    *
-   * @return current grid point time
+   * <p>This represents the upper bound of the current step. When combined with {@link
+   * #getPreviousTime()}, it defines the domain over which interpolation is expected to be accurate.
+   * The value remains {@link Double#NaN} until {@link #storeTime(double)} has been invoked at least
+   * once.
+   *
+   * @return current grid point time stored by the most recent {@link #storeTime(double)} call
    */
   public double getCurrentTime() {
     return currentTime;
   }
 
   /**
-   * Get the time of the interpolated point. If {@link #setInterpolatedTime} has not been called, it
-   * returns the current grid point time.
+   * Get the time of the interpolated point.
    *
-   * @return interpolation point time
+   * <p>If {@link #setInterpolatedTime(double)} has not been called, it returns the current grid
+   * point time. Once an interpolated time has been set, this value tracks the timestamp for which
+   * {@link #getInterpolatedState()} will return a consistent snapshot, even if the request lies
+   * outside the nominal step interval. Callers can compare it with {@link #getPreviousTime()} and
+   * {@link #getCurrentTime()} to decide whether the current state represents interpolation or
+   * extrapolation.
+   *
+   * @return interpolation point time associated with the last computed state
    */
   public double getInterpolatedTime() {
     return interpolatedTime;
   }
 
   /**
-   * Set the time of the interpolated point.
+   * Set the time of the interpolated point and recompute the state.
    *
-   * <p>Setting the time outside of the current step is now allowed (it was not allowed up to
-   * version 5.4 of Mantissa), but should be used with care since the accuracy of the interpolator
-   * will probably be very poor far from this step. This allowance has been added to simplify
-   * implementation of search algorithms near the step endpoints.
+   * <p>Calling this method triggers {@link #computeInterpolatedState(double, double)} with the
+   * appropriate normalized abscissa. Values outside the current step are permitted to ease
+   * implementation of search algorithms near the step endpoints, but accuracy will degrade as the
+   * requested time moves away from the stored step. The interpolated state buffer is overwritten in
+   * place. The method may implicitly call {@link #finalizeStep()} if the interpolator defers some
+   * evaluations.
    *
-   * @param time time of the interpolated point
-   * @throws DerivativeException if this call induces an automatic step finalization that throws one
+   * @param time time of the interpolated point, expressed in the same units as the integration
+   *     variable; may lie outside the step bounds
+   * @throws DerivativeException if evaluating the user-provided derivatives fails during automatic
+   *     finalization or interpolation computations
    */
   public void setInterpolatedTime(double time) throws DerivativeException {
     interpolatedTime = time;
@@ -232,25 +283,34 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   /**
    * Check if the natural integration direction is forward.
    *
-   * <p>This method provides the integration direction as specified by the integrator itself, it
-   * avoid some nasty problems in degenerated cases like null steps due to cancellation at step
-   * initialization, step control or switching function triggering.
+   * <p>The flag reflects the integrator's intended direction, protecting clients from anomalies
+   * such as zero-length steps that could appear when switching functions or step control logic
+   * cancels movement. Consumers of dense output should prefer this accessor over inferring the
+   * direction from step endpoints because it is defined even before the first step is stored. The
+   * value remains constant for the lifetime of the interpolator instance and is copied verbatim
+   * when {@link #copy()} is invoked.
    *
-   * @return true if the integration variable (time) increases during integration
+   * @return {@code true} if the integration variable increases during integration; {@code false}
+   *     otherwise
    */
   public boolean isForward() {
     return forward;
   }
 
   /**
-   * Compute the state at the interpolated time. This is the main processing method that should be
-   * implemented by the derived classes to perform the interpolation.
+   * Compute the state at the interpolated time.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>Implementations fill {@link #interpolatedState} using the provided normalized abscissa and
+   * time offset. They may reuse cached stage derivatives and must leave the buffer fully populated
+   * when returning. No side effects outside this instance should be performed. Implementors should
+   * avoid allocating temporary arrays for performance reasons and are free to exploit symmetry when
+   * handling backward integration ({@code theta} outside the [0, 1] interval).
+   *
+   * @param theta normalized interpolation abscissa within the step (0 at {@link #previousTime}, 1
+   *     at {@link #currentTime}); may fall outside [0, 1] for extrapolation requests
+   * @param oneMinusThetaH time gap {@code currentTime - interpolatedTime}; sign matches integration
+   *     direction
+   * @throws DerivativeException if evaluating user derivatives during interpolation fails
    */
   protected abstract void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException;
@@ -258,43 +318,33 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   /**
    * Get the state vector of the interpolated point.
    *
-   * @return state vector at time {@link #getInterpolatedTime}
+   * <p>The returned array is a defensive copy; modifications will not affect the internal buffers.
+   * Repeated calls after different {@link #setInterpolatedTime(double)} values will return
+   * independent arrays reflecting each query, making it safe for callers to cache results without
+   * cloning again.
+   *
+   * @return cloned state vector corresponding to {@link #getInterpolatedTime()}, leaving the
+   *     internal buffer untouched
    */
   public double[] getInterpolatedState() {
-    return (double[]) interpolatedState.clone();
+    return interpolatedState.clone();
   }
 
   /**
    * Finalize the step.
    *
-   * <p>Some Runge-Kutta-Fehlberg integrators need fewer functions evaluations than their
-   * counterpart step interpolators. These interpolators should perform the last evaluations they
-   * need by themselves only if they need them. This method triggers these extra evaluations. It can
-   * be called directly by the user step handler and it is called automatically if {@link
-   * #setInterpolatedTime} is called.
+   * <p>Some interpolators defer expensive derivative evaluations until an interpolated state is
+   * requested. This method ensures such deferred work executes at most once per step by invoking
+   * {@link #doFinalize()} when needed and latching the {@link #finalized} flag. Handlers may call
+   * it explicitly before introducing side effects in the ODE equations, or rely on implicit calls
+   * from {@link #setInterpolatedTime(double)}.
    *
-   * <p>Once this method has been called, <strong>no</strong> other evaluation will be performed on
-   * this step. If there is a need to have some side effects between the step handler and the
-   * differential equations (for example update some data in the equations once the step has been
-   * done), it is advised to call this method explicitly from the step handler before these side
-   * effects are set up. If the step handler induces no side effect, then this method can safely be
-   * ignored, it will be called transparently as needed.
+   * <p><strong>Warning:</strong> the interpolator instance provided to {@link
+   * StepHandler#handleStep(StepInterpolator, boolean)} is only valid during that invocation. To
+   * reuse later, call {@code finalizeStep()}, then {@link #copy()} and store the copy instead of
+   * the transient original.
    *
-   * <p><strong>Warning</strong>: since the step interpolator provided to the step handler as a
-   * parameter of the {@link StepHandler#handleStep handleStep} is valid only for the duration of
-   * the {@link StepHandler#handleStep handleStep} call, one cannot simply store a reference and
-   * reuse it later. One should first finalize the instance, then copy this finalized instance into
-   * a new object that can be kept.
-   *
-   * <p>This method calls the protected {@link #doFinalize doFinalize} method if it has never been
-   * called during this step and set a flag indicating that it has been called once. It is the
-   * {@link #doFinalize doFinalize} method which should perform the evaluations. This wrapping
-   * prevents from calling {@link #doFinalize doFinalize} several times and hence evaluating the
-   * differential equations too often. Therefore, subclasses are not allowed not reimplement it,
-   * they should rather reimplement {@link #doFinalize doFinalize}.
-   *
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * @throws DerivativeException if user-supplied derivative computations fail during finalization
    */
   public final void finalizeStep() throws DerivativeException {
     if (!finalized) {
@@ -304,23 +354,27 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
   }
 
   /**
-   * Really finalize the step. The default implementation of this method does nothing.
+   * Perform implementation-specific finalization work.
    *
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The default implementation does nothing. Subclasses override this to trigger any additional
+   * derivative evaluations required by their interpolation formulae. Implementations must remain
+   * idempotent because {@link #finalizeStep()} guarantees single execution per step via a guard
+   * flag.
+   *
+   * @throws DerivativeException if user derivative evaluation fails during subclass finalization
    */
   protected void doFinalize() throws DerivativeException {}
 
-  public abstract void writeExternal(ObjectOutput out) throws IOException;
-
-  public abstract void readExternal(ObjectInput in) throws IOException;
-
   /**
-   * Save the base state of the instance. This method performs step finalization if it has not been
-   * done before.
+   * Save the base state of the instance.
    *
-   * @param out stream where to save the state
-   * @exception IOException in case of write error
+   * <p>Serializes dimensions, step bounds, direction, raw state, and interpolated time to the
+   * provided stream. The interpolated state itself is omitted because it can be recomputed. Invokes
+   * {@link #finalizeStep()} beforehand so deferred computations are included. Implementations that
+   * extend the serialized form should call this method first, then write subclass fields.
+   *
+   * @param out stream where to save the state; must remain open for the duration of the write
+   * @exception IOException if an I/O error occurs or finalization raises a derivative failure
    */
   protected void writeBaseExternal(ObjectOutput out) throws IOException {
 
@@ -330,8 +384,8 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
     out.writeDouble(h);
     out.writeBoolean(forward);
 
-    for (int i = 0; i < currentState.length; ++i) {
-      out.writeDouble(currentState[i]);
+    for (double v : currentState) {
+      out.writeDouble(v);
     }
 
     out.writeDouble(interpolatedTime);
@@ -343,21 +397,21 @@ public abstract class AbstractStepInterpolator implements StepInterpolator, Clon
     try {
       finalizeStep();
     } catch (DerivativeException e) {
-      IOException ioe = new IOException();
-      ioe.initCause(e);
-      throw ioe;
+      throw new IOException(e);
     }
   }
 
   /**
-   * Read the base state of the instance. This method does <strong>neither</strong> set the
-   * interpolated time nor state. It is up to the derived class to reset it properly calling the
-   * {@link #setInterpolatedTime} method later, once all rest of the object state has been set up
-   * properly.
+   * Read the base state of the instance.
    *
-   * @param in stream where to read the state from
-   * @return interpolated time be set later by the caller
-   * @exception IOException in case of read error
+   * <p>Restores dimensions, step bounds, direction, and raw state from the stream. The interpolated
+   * time and state remain unset; callers must later invoke {@link #setInterpolatedTime(double)}
+   * after completing subclass-specific deserialization. The method assumes the serialized format
+   * produced by {@link #writeBaseExternal(ObjectOutput)}.
+   *
+   * @param in stream where to read the state from; must supply data in the expected order
+   * @return interpolated time placeholder read from the stream, to be applied by the caller later
+   * @exception IOException if a read error occurs while reconstructing the base fields
    */
   protected double readBaseExternal(ObjectInput in) throws IOException {
 

--- a/src/main/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaStepInterpolator.java
@@ -1,21 +1,29 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
+
 /**
- * This class implements a step interpolator for the classical fourth order Runge-Kutta integrator.
+ * Dense-output interpolator tailored for the classical fourth-order Runge-Kutta scheme.
  *
- * <p>This interpolator allows to compute dense output inside the last step computed. The
- * interpolation equation is consistent with the integration scheme :
+ * <p>The interpolator reconstructs intermediate states inside the most recently completed
+ * integration step, making it possible to evaluate the continuous trajectory without reducing the
+ * solver step size. It applies the closed-form dense-output polynomial associated with the RK4
+ * tableau, using the already computed stage derivatives {@code y'_1} through {@code y'_4} to avoid
+ * any additional function calls. Clients typically obtain instances from {@link
+ * ClassicalRungeKuttaIntegrator} via the standard step handler API and invoke {@link
+ * #setInterpolatedTime(double)} to position the interpolation cursor within the step. The state
+ * returned by {@link #getInterpolatedState()} is immutable to callers but backed by internal
+ * buffers reused across calls; copy the array if retaining it beyond the current notification.
  *
- * <pre>
- *   y(t_n + theta h) = y (t_n + h)
- *                    + (1 - theta) (h/6) [ (-4 theta^2 + 5 theta - 1) y'_1
- *                                          +(4 theta^2 - 2 theta - 2) (y'_2 + y'_3)
- *                                          -(4 theta^2 +   theta + 1) y'_4
- *                                        ]
- * </pre>
+ * <p>Invariants and notable behaviors:
  *
- * where theta belongs to [0 ; 1] and where y'_1 to y'_4 are the four evaluations of the derivatives
- * already computed during the step.
+ * <ul>
+ *   <li>Interpolation is defined for {@code 0 ≤ theta ≤ 1}, where {@code theta} measures progress
+ *       from the previous grid point to the current one.
+ *   <li>Instances are reused by the integrator; {@link #copy()} provides an isolated snapshot when
+ *       step handlers need to preserve state across callbacks.
+ *   <li>The class is not thread-safe; use distinct instances per integrator thread.
+ * </ul>
  *
  * @see ClassicalRungeKuttaIntegrator
  * @version $Id: ClassicalRungeKuttaStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
@@ -25,39 +33,59 @@ class ClassicalRungeKuttaStepInterpolator extends RungeKuttaStepInterpolator
     implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * RungeKuttaStepInterpolator#reinitialize} method should be called before using the instance in
-   * order to initialize the internal arrays. This constructor is used only in order to delay the
-   * initialization in some cases. The {@link RungeKuttaIntegrator} class uses the prototyping
-   * design pattern to create the step interpolators by cloning an uninitialized model and latter
-   * initializing the copy.
+   * Simple constructor used by the integrator's prototype mechanism to create fresh interpolators.
+   * The instance starts in an uninitialized state; callers must invoke {@link
+   * RungeKuttaStepInterpolator#reinitialize(FirstOrderDifferentialEquations,double[],double[][],boolean)}
+   * before the first use so that the internal state buffers point to the step data managed by the
+   * integrator. This deferred initialization keeps allocation costs low when many interpolators are
+   * cloned for event or handler chains.
    */
   public ClassicalRungeKuttaStepInterpolator() {}
 
   /**
-   * Copy constructor.
+   * Copy constructor that performs a deep copy of all mutable interpolation buffers.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>The copied instance shares no arrays with the source, allowing step handlers to retain the
+   * duplicate safely after the integrator proceeds to the next step. Scalar configuration such as
+   * direction flags are copied verbatim.
+   *
+   * @param interpolator interpolator to copy from; must be already initialized for meaningful data.
    */
   public ClassicalRungeKuttaStepInterpolator(ClassicalRungeKuttaStepInterpolator interpolator) {
     super(interpolator);
   }
 
+  /**
+   * Create an independent clone of this interpolator with detached state arrays.
+   *
+   * <p>Use this method when a step handler needs to retain interpolation results beyond the current
+   * callback. The returned instance can be moved to different interpolation times without affecting
+   * the original, because all internal buffers are duplicated during cloning.
+   *
+   * @return a new {@code ClassicalRungeKuttaStepInterpolator} holding copies of the current state
+   *     arrays and configuration flags.
+   */
   @Override
   public ClassicalRungeKuttaStepInterpolator copy() {
     return new ClassicalRungeKuttaStepInterpolator(this);
   }
 
   /**
-   * Compute the state at the interpolated time. This is the main processing method that should be
-   * implemented by the derived classes to perform the interpolation.
+   * Compute the state vector corresponding to the current interpolated time within the step.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The implementation evaluates the dense-output polynomial associated with the RK4 tableau
+   * using the four stored derivative evaluations {@code yDotK}. The {@code theta} argument defines
+   * where the interpolation point lies between the previous grid point and the current one, while
+   * {@code oneMinusThetaH} supplies the precomputed time offset in seconds. The method overwrites
+   * the internal {@code interpolatedState} buffer; callers should access it via {@link
+   * #getInterpolatedState()} after invocation.
+   *
+   * @param theta normalized abscissa in {@code [0, 1]} representing progress across the current
+   *     integration step; values outside the range lead to extrapolation.
+   * @param oneMinusThetaH signed time gap between the interpolated instant and the current step end
+   *     time, typically {@code (1 - theta) * h} where {@code h} is the step size.
+   * @throws DerivativeException propagated if a user-supplied derivative function triggers it
+   *     during interpolation support logic in the parent class.
    */
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
@@ -77,5 +105,9 @@ class ClassicalRungeKuttaStepInterpolator extends RungeKuttaStepInterpolator
     }
   }
 
-  private static final long serialVersionUID = -6576285612589783992L;
+  /**
+   * Serialization version identifier preserving compatibility for persisted interpolator snapshots
+   * across library releases that retain the same field layout.
+   */
+  @Serial private static final long serialVersionUID = -6576285612589783992L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaStepInterpolator.java
@@ -21,7 +21,8 @@ package org.spaceroots.mantissa.ode;
  * @version $Id: ClassicalRungeKuttaStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
-class ClassicalRungeKuttaStepInterpolator extends RungeKuttaStepInterpolator {
+class ClassicalRungeKuttaStepInterpolator extends RungeKuttaStepInterpolator
+    implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -43,13 +44,8 @@ class ClassicalRungeKuttaStepInterpolator extends RungeKuttaStepInterpolator {
     super(interpolator);
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public ClassicalRungeKuttaStepInterpolator copy() {
     return new ClassicalRungeKuttaStepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/ContinuousOutputModel.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ContinuousOutputModel.java
@@ -81,7 +81,7 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
         throw new IllegalArgumentException("propagation direction mismatch");
       }
 
-      StepInterpolator lastInterpolator = steps.get(index);
+      StepInterpolator lastInterpolator = (StepInterpolator) steps.get(index);
       double current = lastInterpolator.getCurrentTime();
       double previous = lastInterpolator.getPreviousTime();
       double step = current - previous;
@@ -92,7 +92,7 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
     }
 
     for (AbstractStepInterpolator ai : model.steps) {
-      steps.add((AbstractStepInterpolator) ai.clone());
+      steps.add(ai.copy());
     }
 
     index = steps.size() - 1;
@@ -142,7 +142,7 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
     }
 
     ai.finalizeStep();
-    steps.add((AbstractStepInterpolator) ai.clone());
+    steps.add(ai.copy());
 
     if (isLast) {
       finalTime = ai.getCurrentTime();
@@ -196,11 +196,11 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
     try {
       // initialize the search with the complete steps table
       int iMin = 0;
-      StepInterpolator sMin = steps.get(iMin);
+      StepInterpolator sMin = (StepInterpolator) steps.get(iMin);
       double tMin = 0.5 * (sMin.getPreviousTime() + sMin.getCurrentTime());
 
       int iMax = steps.size() - 1;
-      StepInterpolator sMax = steps.get(iMax);
+      StepInterpolator sMax = (StepInterpolator) steps.get(iMax);
       double tMax = 0.5 * (sMax.getPreviousTime() + sMax.getCurrentTime());
 
       // handle points outside of the integration interval
@@ -220,7 +220,7 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
       while (iMax - iMin > 5) {
 
         // use the last estimated index as the splitting index
-        StepInterpolator si = steps.get(index);
+        StepInterpolator si = (StepInterpolator) steps.get(index);
         int location = locatePoint(time, si);
         if (location < 0) {
           iMax = index;
@@ -236,7 +236,7 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
 
         // compute a new estimate of the index in the reduced table slice
         int iMed = (iMin + iMax) / 2;
-        StepInterpolator sMed = steps.get(iMed);
+        StepInterpolator sMed = (StepInterpolator) steps.get(iMed);
         double tMed = 0.5 * (sMed.getPreviousTime() + sMed.getCurrentTime());
 
         if ((Math.abs(tMed - tMin) < 1e-6) || (Math.abs(tMax - tMed) < 1e-6)) {
@@ -270,11 +270,11 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
 
       // now the table slice is very small, we perform an iterative search
       index = iMin;
-      while ((index <= iMax) && (locatePoint(time, steps.get(index)) > 0)) {
+      while ((index <= iMax) && (locatePoint(time, (StepInterpolator) steps.get(index)) > 0)) {
         ++index;
       }
 
-      StepInterpolator si = steps.get(index);
+      StepInterpolator si = (StepInterpolator) steps.get(index);
 
       si.setInterpolatedTime(time);
 

--- a/src/main/java/org/spaceroots/mantissa/ode/DormandPrince54StepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DormandPrince54StepInterpolator.java
@@ -8,7 +8,8 @@ package org.spaceroots.mantissa.ode;
  * @version $Id: DormandPrince54StepInterpolator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
-class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator {
+class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator
+    implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -54,13 +55,8 @@ class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator {
     }
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public DormandPrince54StepInterpolator copy() {
     return new DormandPrince54StepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/DormandPrince54StepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DormandPrince54StepInterpolator.java
@@ -1,8 +1,31 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
+
 /**
- * This class represents an interpolator over the last step during an ODE integration for the 5(4)
- * Dormand-Prince integrator.
+ * Interpolator that provides dense output for a Dormand-Prince 5(4) Runge-Kutta step.
+ *
+ * <p>The instance is created by {@link DormandPrince54Integrator} and reused between successive
+ * steps so that intermediate states can be queried at arbitrary normalized positions inside the
+ * current step. The interpolator computes the Shampine dense-output polynomial once per step,
+ * caches its intermediate vectors, and exposes the interpolated state without altering the
+ * underlying integrator state. Instances are mutable and stateful: callers must invoke {@link
+ * #reinitialize(FirstOrderDifferentialEquations, double[], double[][], boolean)} and {@link
+ * #storeTime(double)} as the integrator progresses. No internal synchronization is provided; a
+ * single instance must be confined to the integration thread that owns it.
+ *
+ * <p>Typical usage links the interpolator lifetime to a single integration run. The integrator
+ * calls {@code reinitialize} when a step starts, {@code storeTime} when a step ends, and the client
+ * invokes {@code computeInterpolatedState} with a normalized abscissa to obtain a continuous view
+ * of the solution across the accepted step. The class assumes the step size and stage derivatives
+ * remain unchanged between these calls.
+ *
+ * <ul>
+ *   <li>Responsibility: assemble dense-output coefficients specific to the Dormand-Prince 5(4)
+ *       tableau.
+ *   <li>Behavior: lazily initializes and reuses interpolation vectors to limit allocations.
+ *   <li>Thread-safety: not thread-safe; intended for single-threaded integration pipelines.
+ * </ul>
  *
  * @see DormandPrince54Integrator
  * @version $Id: DormandPrince54StepInterpolator.java 1709 2006-12-03 21:16:50Z luc $
@@ -12,11 +35,14 @@ class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator
     implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * #reinitialize} method should be called before using the instance in order to initialize the
-   * internal arrays. This constructor is used only in order to delay the initialization in some
-   * cases. The {@link RungeKuttaFehlbergIntegrator} uses the prototyping design pattern to create
-   * the step interpolators by cloning an uninitialized model and latter initializing the copy.
+   * Create an uninitialized interpolator ready to be wired into an integrator.
+   *
+   * <p>The constructor intentionally leaves the internal interpolation vectors {@code null} so that
+   * allocation can be delayed until the owning integrator knows the problem dimension. Call {@link
+   * #reinitialize(FirstOrderDifferentialEquations, double[], double[][], boolean)} before
+   * requesting any interpolated state; otherwise the instance does not contain valid buffers. This
+   * pattern enables prototype-based creation, where the integrator clones a blank model for each
+   * integration run.
    */
   public DormandPrince54StepInterpolator() {
     super();
@@ -28,10 +54,15 @@ class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator
   }
 
   /**
-   * Copy constructor.
+   * Build a new interpolator by deeply copying another instance.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>All cached interpolation vectors are cloned so that the returned object evolves
+   * independently from {@code interpolator}. Scalar state such as the step size, direction flag,
+   * and stored times are propagated as well, mirroring the snapshot used by the parent integrator
+   * when it needs a safe duplicate for event detection or user callbacks.
+   *
+   * @param interpolator source interpolator providing the cached stage data and runtime state; may
+   *     be partially uninitialized when constructed by the integrator.
    */
   public DormandPrince54StepInterpolator(DormandPrince54StepInterpolator interpolator) {
 
@@ -47,10 +78,10 @@ class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator
 
     } else {
 
-      v1 = (double[]) interpolator.v1.clone();
-      v2 = (double[]) interpolator.v2.clone();
-      v3 = (double[]) interpolator.v3.clone();
-      v4 = (double[]) interpolator.v4.clone();
+      v1 = interpolator.v1.clone();
+      v2 = interpolator.v2.clone();
+      v3 = interpolator.v3.clone();
+      v4 = interpolator.v4.clone();
       vectorsInitialized = interpolator.vectorsInitialized;
     }
   }
@@ -61,13 +92,22 @@ class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator
   }
 
   /**
-   * Reinitialize the instance
+   * Reinitialize the interpolator for a new Dormand-Prince 5(4) step.
    *
-   * @param equations set of differential equations being integrated
-   * @param y reference to the integrator array holding the state at the end of the step
-   * @param yDotK reference to the integrator array holding all the intermediate slopes
-   * @param forward integration direction indicator
+   * <p>The method resets cached interpolation vectors and records references to the integrator
+   * arrays that hold the current step data. Array references are borrowed, not copied, so the
+   * caller must ensure they remain stable until the step is finalized. After calling this method,
+   * invoke {@link #storeTime(double)} for the step end time and call {@link
+   * #computeInterpolatedState(double, double)} to obtain dense output.
+   *
+   * @param equations set of differential equations defining {@code y'}; used only for dimension
+   *     consistency.
+   * @param y reference to the state vector at the end of the current step; must match dimension.
+   * @param yDotK stage derivatives for the step, indexed by stage then component; reused in-place.
+   * @param forward {@code true} if time increases during integration; influences interpolation
+   *     direction handling.
    */
+  @Override
   public void reinitialize(
       FirstOrderDifferentialEquations equations, double[] y, double[][] yDotK, boolean forward) {
     super.reinitialize(equations, y, yDotK, forward);
@@ -79,24 +119,39 @@ class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator
   }
 
   /**
-   * Store the current step time.
+   * Store the current step end time and clear cached interpolation vectors.
    *
-   * @param t current time
+   * <p>The integrator invokes this method once per accepted step to record the step boundary. Any
+   * previously computed interpolation vectors become invalid because the step size or slope data
+   * may have changed. Subsequent calls to {@link #computeInterpolatedState(double, double)} will
+   * lazily rebuild the vectors for the new step before returning an interpolated state.
+   *
+   * @param t current step end time in the integrator's time unit; reused for interpolation bounds.
    */
+  @Override
   public void storeTime(double t) {
     super.storeTime(t);
     vectorsInitialized = false;
   }
 
   /**
-   * Compute the state at the interpolated time.
+   * Compute the state vector at an interpolated point inside the current step.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The method lazily builds the dense-output polynomial coefficients for the Dormand-Prince
+   * 5(4) tableau the first time it is invoked after {@link #storeTime(double)}. It then evaluates
+   * the polynomial using the normalized position {@code theta} and the already-computed stage
+   * derivatives. Inputs are treated as dimensionless fractions of the current step: {@code theta}
+   * equals {@code 0} at the previous grid point and {@code 1} at the current one, while {@code
+   * oneMinusThetaH} conveys the scaled distance to the end of the step. No derivative evaluations
+   * occur inside this method; it strictly combines cached data.
+   *
+   * @param theta normalized interpolation abscissa in [0, 1]; values outside range extrapolate.
+   * @param oneMinusThetaH signed gap between the interpolated time and the current step end, in the
+   *     same units as the integrator step size.
+   * @throws DerivativeException if the parent integration infrastructure needs derivatives and
+   *     their evaluation fails or is refused by the user function.
    */
+  @Override
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
 
@@ -115,21 +170,21 @@ class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator
       for (int i = 0; i < interpolatedState.length; ++i) {
         v1[i] =
             h
-                * (a70 * yDotK[0][i]
-                    + a72 * yDotK[2][i]
-                    + a73 * yDotK[3][i]
-                    + a74 * yDotK[4][i]
-                    + a75 * yDotK[5][i]);
+                * (A70 * yDotK[0][i]
+                    + A72 * yDotK[2][i]
+                    + A73 * yDotK[3][i]
+                    + A74 * yDotK[4][i]
+                    + A75 * yDotK[5][i]);
         v2[i] = h * yDotK[0][i] - v1[i];
         v3[i] = v1[i] - v2[i] - h * yDotK[6][i];
         v4[i] =
             h
-                * (d0 * yDotK[0][i]
-                    + d2 * yDotK[2][i]
-                    + d3 * yDotK[3][i]
-                    + d4 * yDotK[4][i]
-                    + d5 * yDotK[5][i]
-                    + d6 * yDotK[6][i]);
+                * (D0 * yDotK[0][i]
+                    + D2 * yDotK[2][i]
+                    + D3 * yDotK[3][i]
+                    + D4 * yDotK[4][i]
+                    + D5 * yDotK[5][i]
+                    + D6 * yDotK[6][i]);
       }
 
       vectorsInitialized = true;
@@ -159,19 +214,19 @@ class DormandPrince54StepInterpolator extends RungeKuttaStepInterpolator
   private boolean vectorsInitialized;
 
   // last row of the Butcher-array internal weights, note that a71 is null
-  private static final double a70 = 35.0 / 384.0;
-  private static final double a72 = 500.0 / 1113.0;
-  private static final double a73 = 125.0 / 192.0;
-  private static final double a74 = -2187.0 / 6784.0;
-  private static final double a75 = 11.0 / 84.0;
+  private static final double A70 = 35.0 / 384.0;
+  private static final double A72 = 500.0 / 1113.0;
+  private static final double A73 = 125.0 / 192.0;
+  private static final double A74 = -2187.0 / 6784.0;
+  private static final double A75 = 11.0 / 84.0;
 
   // dense output of Shampine (1986), note that d1 is null
-  private static final double d0 = -12715105075.0 / 11282082432.0;
-  private static final double d2 = 87487479700.0 / 32700410799.0;
-  private static final double d3 = -10690763975.0 / 1880347072.0;
-  private static final double d4 = 701980252875.0 / 199316789632.0;
-  private static final double d5 = -1453857185.0 / 822651844.0;
-  private static final double d6 = 69997945.0 / 29380423.0;
+  private static final double D0 = -12715105075.0 / 11282082432.0;
+  private static final double D2 = 87487479700.0 / 32700410799.0;
+  private static final double D3 = -10690763975.0 / 1880347072.0;
+  private static final double D4 = 701980252875.0 / 199316789632.0;
+  private static final double D5 = -1453857185.0 / 822651844.0;
+  private static final double D6 = 69997945.0 / 29380423.0;
 
-  private static final long serialVersionUID = 4104157279605906956L;
+  @Serial private static final long serialVersionUID = 4104157279605906956L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/DormandPrince853StepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DormandPrince853StepInterpolator.java
@@ -12,7 +12,8 @@ import java.io.ObjectOutput;
  * @version $Id: DormandPrince853StepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
-class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator {
+class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
+    implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -68,13 +69,8 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator {
     yTmp = null;
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public DormandPrince853StepInterpolator copy() {
     return new DormandPrince853StepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/DormandPrince853StepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DormandPrince853StepInterpolator.java
@@ -3,10 +3,32 @@ package org.spaceroots.mantissa.ode;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serial;
 
 /**
- * This class represents an interpolator over the last step during an ODE integration for the 8(5,3)
- * Dormand-Prince integrator.
+ * Step interpolator for the Dormand–Prince 8(5,3) Runge-Kutta method.
+ *
+ * <p>This implementation reconstructs intermediate states inside the last accepted integration
+ * step, allowing dense output and precise event localization without re-running derivative
+ * evaluations. Instances are typically created as lightweight prototypes by {@link
+ * DormandPrince853Integrator} and are reinitialized per step with shared work arrays to minimize
+ * allocations. The interpolator assumes the owning integrator keeps the Butcher tableau weights and
+ * all stage derivatives consistent with the 8(5,3) scheme and that {@link #doFinalize()} is invoked
+ * before any interpolation after a step is stored.
+ *
+ * <p>Objects are mutable and reused; they hold transient state like cached slope vectors {@code v}
+ * and temporary buffers. They are not thread-safe and must stay confined to the integrator thread.
+ * Typical usage flow is: construct (or clone) → {@link
+ * #reinitialize(FirstOrderDifferentialEquations, double[], double[][], boolean)} → {@link
+ * #storeTime(double)} → (lazy) {@link #computeInterpolatedState(double, double)} whenever a handler
+ * requests intermediate values.
+ *
+ * <ul>
+ *   <li>Produces dense trajectories consistent with the Dormand–Prince error estimator.
+ *   <li>Performs up to three extra derivative evaluations to complete high-order interpolation
+ *       stages.
+ *   <li>Serializable to support restartable integrations with cached slopes.
+ * </ul>
  *
  * @see DormandPrince853Integrator
  * @version $Id: DormandPrince853StepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
@@ -16,11 +38,14 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
     implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * #reinitialize} method should be called before using the instance in order to initialize the
-   * internal arrays. This constructor is used only in order to delay the initialization in some
-   * cases. The {@link RungeKuttaFehlbergIntegrator} uses the prototyping design pattern to create
-   * the step interpolators by cloning an uninitialized model and latter initializing the copy.
+   * Simple constructor for prototype creation.
+   *
+   * <p>The instance starts without allocated work arrays because the dimension of the state vector
+   * is unknown at this point. It becomes usable only after a call to {@link
+   * #reinitialize(FirstOrderDifferentialEquations, double[], double[][], boolean)}, which allocates
+   * slope caches and temporary buffers based on the current problem size. Integrators create one
+   * prototype and then clone it per step to avoid repeatedly wiring new interpolators from scratch;
+   * the lazy setup keeps cloning cheap while deferring allocations until the first actual step.
    */
   public DormandPrince853StepInterpolator() {
     super();
@@ -31,10 +56,16 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
   }
 
   /**
-   * Copy constructor.
+   * Copy constructor that deep-copies cached slopes and vectors.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>The new instance duplicates the interpolation buffers and the three lazily evaluated slope
+   * arrays so that later mutations do not affect the source interpolator. If the source has not yet
+   * been initialized with a state vector, the clone remains uninitialized and will allocate its
+   * buffers during the next {@link #reinitialize(FirstOrderDifferentialEquations, double[],
+   * double[][], boolean)} call.
+   *
+   * @param interpolator interpolator to copy from; may be uninitialized, in which case the clone
+   *     also starts without allocated vectors but retains the same finalized-step status.
    */
   public DormandPrince853StepInterpolator(DormandPrince853StepInterpolator interpolator) {
 
@@ -69,27 +100,42 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
     yTmp = null;
   }
 
+  /**
+   * Create an independent copy of this interpolator.
+   *
+   * <p>The clone preserves the cached step data, interpolation vectors, and lazily computed stage
+   * derivatives so that it can provide identical dense output even after the original advances to
+   * another step. Callers typically clone before handing the interpolator to user code to avoid
+   * races with the integrator reusing the instance for subsequent steps. The copy remains mutable
+   * and should not be shared across threads.
+   *
+   * @return a new interpolator instance whose internal arrays are deep-copied from this one to
+   *     prevent shared mutable state between clones.
+   */
   @Override
   public DormandPrince853StepInterpolator copy() {
     return new DormandPrince853StepInterpolator(this);
   }
 
   /**
-   * Reinitialize the instance Some Runge-Kutta-Fehlberg integrators need fewer functions
-   * evaluations than their counterpart step interpolators. So the interpolator should perform the
-   * last evaluations they need by themselves. The {@link RungeKuttaFehlbergIntegrator
-   * RungeKuttaFehlbergIntegrator} abstract class calls this method in order to let the step
-   * interpolator perform the evaluations it needs. These evaluations will be performed during the
-   * call to <code>doFinalize</code> if any, i.e. only if the step handler either calls the {@link
-   * AbstractStepInterpolator#finalizeStep finalizeStep} method or the {@link
-   * AbstractStepInterpolator#getInterpolatedState getInterpolatedState} method (for an interpolator
-   * which needs a finalization) or if it clones the step interpolator.
+   * Reinitialize the interpolator with the data of the current step.
    *
-   * @param equations set of differential equations being integrated
-   * @param y reference to the integrator array holding the state at the end of the step
-   * @param yDotK reference to the integrator array holding all the intermediate slopes
-   * @param forward integration direction indicator
+   * <p>This method binds the shared state and slope arrays produced by the integrator to this
+   * interpolator, allocates per-dimension buffers, and resets the lazily computed interpolation
+   * vectors. It must be invoked once per accepted step before any call to {@link
+   * #computeInterpolatedState(double, double)}. Subsequent calls overwrite previous bindings and
+   * discard cached vectors to reflect the new step data.
+   *
+   * @param equations set of differential equations being integrated; never {@code null} and used
+   *     for any deferred derivative evaluations.
+   * @param y reference to the integrator array holding the state at the end of the step; contents
+   *     are read but not copied.
+   * @param yDotK reference to the integrator array holding all intermediate stage slopes from the
+   *     Dormand–Prince tableau; the array is reused directly.
+   * @param forward integration direction indicator; {@code true} for increasing time, {@code false}
+   *     for backward integration.
    */
+  @Override
   public void reinitialize(
       FirstOrderDifferentialEquations equations, double[] y, double[][] yDotK, boolean forward) {
 
@@ -113,25 +159,38 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
   }
 
   /**
-   * Store the current step time.
+   * Store the current step time and invalidate cached vectors.
    *
-   * @param t current time
+   * <p>Calling this resets the interpolation buffers so that subsequent calls to {@link
+   * #computeInterpolatedState(double, double)} will recompute the interpolation polynomials for the
+   * new step boundaries. Integrators call this once each time a step is accepted and before any
+   * dense output requests are served.
+   *
+   * @param t current time, expressed in the same units as the integrator independent variable.
    */
+  @Override
   public void storeTime(double t) {
     super.storeTime(t);
     vectorsInitialized = false;
   }
 
   /**
-   * Compute the state at the interpolated time. This is the main processing method that should be
-   * implemented by the derived classes to perform the interpolation.
+   * Compute the interpolated state inside the current step.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The method lazily builds high-order interpolation vectors the first time it is invoked after
+   * a step is stored, performing up to three additional derivative evaluations via {@link
+   * #doFinalize()} if they have not already been executed. Subsequent calls within the same step
+   * reuse the cached vectors. The interpolation uses the Dormand–Prince dense output coefficients
+   * and preserves the direction of integration for both forward and backward flows.
+   *
+   * @param theta normalized interpolation abscissa within the step; {@code 0} corresponds to the
+   *     start of the step and {@code 1} to its end.
+   * @param oneMinusThetaH time gap between the interpolated time and the current step end; computed
+   *     as {@code (1 - theta) * h} and may be negative for backward integration.
+   * @throws DerivativeException propagated if the user-supplied derivative function throws while
+   *     evaluating any of the deferred stages needed for interpolation.
    */
+  @Override
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
 
@@ -151,14 +210,14 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
       for (int i = 0; i < interpolatedState.length; ++i) {
         v[0][i] =
             h
-                * (b_01 * yDotK[0][i]
-                    + b_06 * yDotK[5][i]
-                    + b_07 * yDotK[6][i]
-                    + b_08 * yDotK[7][i]
-                    + b_09 * yDotK[8][i]
-                    + b_10 * yDotK[9][i]
-                    + b_11 * yDotK[10][i]
-                    + b_12 * yDotK[11][i]);
+                * (B_01 * yDotK[0][i]
+                    + B_06 * yDotK[5][i]
+                    + B_07 * yDotK[6][i]
+                    + B_08 * yDotK[7][i]
+                    + B_09 * yDotK[8][i]
+                    + B_10 * yDotK[9][i]
+                    + B_11 * yDotK[10][i]
+                    + B_12 * yDotK[11][i]);
         v[1][i] = h * yDotK[0][i] - v[0][i];
         v[2][i] = v[0][i] - v[1][i] - h * yDotK[12][i];
         for (int k = 0; k < d.length; ++k) {
@@ -202,11 +261,17 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
   }
 
   /**
-   * Really finalize the step. Perform the last 3 functions evaluations (k14, k15, k16)
+   * Complete the step by evaluating the remaining Dormand–Prince stages.
    *
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>This method computes the stage derivatives k14, k15, and k16 required only for dense output,
+   * not for the embedded error estimate. It reuses the shared work arrays and writes the results
+   * into {@code yDotKLast}. The method is invoked lazily by {@link
+   * #computeInterpolatedState(double, double)} when interpolation data are first needed.
+   *
+   * @throws DerivativeException propagated if the user-supplied differential equations object
+   *     throws during any of the additional derivative evaluations.
    */
+  @Override
   protected void doFinalize() throws DerivativeException {
 
     double s;
@@ -214,70 +279,74 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
     // k14
     for (int j = 0; j < currentState.length; ++j) {
       s =
-          k14_01 * yDotK[0][j]
-              + k14_06 * yDotK[5][j]
-              + k14_07 * yDotK[6][j]
-              + k14_08 * yDotK[7][j]
-              + k14_09 * yDotK[8][j]
-              + k14_10 * yDotK[9][j]
-              + k14_11 * yDotK[10][j]
-              + k14_12 * yDotK[11][j]
-              + k14_13 * yDotK[12][j];
+          K14_01 * yDotK[0][j]
+              + K14_06 * yDotK[5][j]
+              + K14_07 * yDotK[6][j]
+              + K14_08 * yDotK[7][j]
+              + K14_09 * yDotK[8][j]
+              + K14_10 * yDotK[9][j]
+              + K14_11 * yDotK[10][j]
+              + K14_12 * yDotK[11][j]
+              + K14_13 * yDotK[12][j];
       yTmp[j] = currentState[j] + h * s;
     }
-    equations.computeDerivatives(previousTime + c14 * h, yTmp, yDotKLast[0]);
+    equations.computeDerivatives(previousTime + C14 * h, yTmp, yDotKLast[0]);
 
     // k15
     for (int j = 0; j < currentState.length; ++j) {
       s =
-          k15_01 * yDotK[0][j]
-              + k15_06 * yDotK[5][j]
-              + k15_07 * yDotK[6][j]
-              + k15_08 * yDotK[7][j]
-              + k15_09 * yDotK[8][j]
-              + k15_10 * yDotK[9][j]
-              + k15_11 * yDotK[10][j]
-              + k15_12 * yDotK[11][j]
-              + k15_13 * yDotK[12][j]
-              + k15_14 * yDotKLast[0][j];
+          K15_01 * yDotK[0][j]
+              + K15_06 * yDotK[5][j]
+              + K15_07 * yDotK[6][j]
+              + K15_08 * yDotK[7][j]
+              + K15_09 * yDotK[8][j]
+              + K15_10 * yDotK[9][j]
+              + K15_11 * yDotK[10][j]
+              + K15_12 * yDotK[11][j]
+              + K15_13 * yDotK[12][j]
+              + K15_14 * yDotKLast[0][j];
       yTmp[j] = currentState[j] + h * s;
     }
-    equations.computeDerivatives(previousTime + c15 * h, yTmp, yDotKLast[1]);
+    equations.computeDerivatives(previousTime + C15 * h, yTmp, yDotKLast[1]);
 
     // k16
     for (int j = 0; j < currentState.length; ++j) {
       s =
-          k16_01 * yDotK[0][j]
-              + k16_06 * yDotK[5][j]
-              + k16_07 * yDotK[6][j]
-              + k16_08 * yDotK[7][j]
-              + k16_09 * yDotK[8][j]
-              + k16_10 * yDotK[9][j]
-              + k16_11 * yDotK[10][j]
-              + k16_12 * yDotK[11][j]
-              + k16_13 * yDotK[12][j]
-              + k16_14 * yDotKLast[0][j]
-              + k16_15 * yDotKLast[1][j];
+          K16_01 * yDotK[0][j]
+              + K16_06 * yDotK[5][j]
+              + K16_07 * yDotK[6][j]
+              + K16_08 * yDotK[7][j]
+              + K16_09 * yDotK[8][j]
+              + K16_10 * yDotK[9][j]
+              + K16_11 * yDotK[10][j]
+              + K16_12 * yDotK[11][j]
+              + K16_13 * yDotK[12][j]
+              + K16_14 * yDotKLast[0][j]
+              + K16_15 * yDotKLast[1][j];
       yTmp[j] = currentState[j] + h * s;
     }
-    equations.computeDerivatives(previousTime + c16 * h, yTmp, yDotKLast[2]);
+    equations.computeDerivatives(previousTime + C16 * h, yTmp, yDotKLast[2]);
   }
 
   /**
-   * Save the state of the instance.
+   * Save the state of the interpolator for serialization.
    *
-   * @param out stream where to save the state
-   * @exception IOException in case of write error
+   * <p>The method ensures deferred stages are computed, then writes the cached slopes and the base
+   * class data so that the interpolator can be restored later with identical interpolation
+   * capabilities. It preserves ordering so {@link #readExternal(ObjectInput)} can mirror the
+   * layout.
+   *
+   * @param out stream where to save the state; must remain open for the duration of the write.
+   * @exception IOException in case of write error while persisting slopes or delegated base state.
    */
+  @Override
   public void writeExternal(ObjectOutput out) throws IOException {
 
     try {
       // save the local attributes
       finalizeStep();
     } catch (DerivativeException e) {
-      IOException ioe = new IOException();
-      ioe.initCause(e);
-      throw ioe;
+      throw new IOException(e);
     }
     out.writeInt(currentState.length);
     for (int i = 0; i < currentState.length; ++i) {
@@ -291,11 +360,16 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
   }
 
   /**
-   * Read the state of the instance.
+   * Read the state of the interpolator from an external stream.
    *
-   * @param in stream where to read the state from
-   * @exception IOException in case of read error
+   * <p>All slope arrays and the base interpolator state are restored to allow dense output to
+   * resume exactly where a serialized integration left off. The method allocates necessary arrays
+   * based on the serialized dimension before delegating to the superclass for shared fields.
+   *
+   * @param in stream where to read the state from; the caller retains ownership of the stream.
+   * @exception IOException in case of read error or truncated data that prevent slope recovery.
    */
+  @Override
   public void readExternal(ObjectInput in) throws IOException {
 
     // read the local attributes
@@ -315,74 +389,153 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
     super.readExternal(in);
   }
 
-  /** Last evaluations. */
+  /** Cached stage derivatives k14, k15, and k16 computed lazily for dense output. */
   private double[][] yDotKLast;
 
-  /** Temporary state vector. */
+  /** Temporary state vector used when forming intermediate trial states for derivative calls. */
   private double[] yTmp;
 
-  /** Vectors for interpolation. */
+  /** Interpolation polynomial vectors built once per step and reused for subsequent queries. */
   private double[][] v;
 
-  /** Initialization indicator for the interpolation vectors. */
+  /** Flag indicating whether {@link #v} contains data consistent with the stored step. */
   private boolean vectorsInitialized;
 
   // external weights of the integrator,
   // note that b_02 through b_05 are null
-  private static double b_01 = 104257.0 / 1920240.0;
-  private static double b_06 = 3399327.0 / 763840.0;
-  private static double b_07 = 66578432.0 / 35198415.0;
-  private static double b_08 = -1674902723.0 / 288716400.0;
-  private static double b_09 = 54980371265625.0 / 176692375811392.0;
-  private static double b_10 = -734375.0 / 4826304.0;
-  private static double b_11 = 171414593.0 / 851261400.0;
-  private static double b_12 = 137909.0 / 3084480.0;
+  /** External weight {@code b1} from the Dormand–Prince 8(5,3) Butcher tableau. */
+  private static final double B_01 = 104257.0 / 1920240.0;
+
+  /** External weight {@code b6} used in the dense output polynomial. */
+  private static final double B_06 = 3399327.0 / 763840.0;
+
+  /** External weight {@code b7} scaling the seventh stage derivative. */
+  private static final double B_07 = 66578432.0 / 35198415.0;
+
+  /** External weight {@code b8} applied to the eighth stage derivative. */
+  private static final double B_08 = -1674902723.0 / 288716400.0;
+
+  /** External weight {@code b9} contributing to the principal solution estimate. */
+  private static final double B_09 = 54980371265625.0 / 176692375811392.0;
+
+  /** External weight {@code b10} for the tenth stage derivative. */
+  private static final double B_10 = -734375.0 / 4826304.0;
+
+  /** External weight {@code b11} for the eleventh stage derivative. */
+  private static final double B_11 = 171414593.0 / 851261400.0;
+
+  /** External weight {@code b12} involved in the twelfth stage combination. */
+  private static final double B_12 = 137909.0 / 3084480.0;
 
   // k14 for interpolation only
-  private static double c14 = 1.0 / 10.0;
+  /** Abscissa for the fourteenth stage used solely during dense output completion. */
+  private static final double C14 = 1.0 / 10.0;
 
-  private static double k14_01 = 13481885573.0 / 240030000000.0 - b_01;
-  private static double k14_06 = 0.0 - b_06;
-  private static double k14_07 = 139418837528.0 / 549975234375.0 - b_07;
-  private static double k14_08 = -11108320068443.0 / 45111937500000.0 - b_08;
-  private static double k14_09 = -1769651421925959.0 / 14249385146080000.0 - b_09;
-  private static double k14_10 = 57799439.0 / 377055000.0 - b_10;
-  private static double k14_11 = 793322643029.0 / 96734250000000.0 - b_11;
-  private static double k14_12 = 1458939311.0 / 192780000000.0 - b_12;
-  private static double k14_13 = -4149.0 / 500000.0;
+  /** Weight for yDotK[0] when constructing stage k14. */
+  private static final double K14_01 = 13481885573.0 / 240030000000.0 - B_01;
+
+  /** Weight for yDotK[5] when constructing stage k14. */
+  private static final double K14_06 = 0.0 - B_06;
+
+  /** Weight for yDotK[6] when constructing stage k14. */
+  private static final double K14_07 = 139418837528.0 / 549975234375.0 - B_07;
+
+  /** Weight for yDotK[7] when constructing stage k14. */
+  private static final double K14_08 = -11108320068443.0 / 45111937500000.0 - B_08;
+
+  /** Weight for yDotK[8] when constructing stage k14. */
+  private static final double K14_09 = -1769651421925959.0 / 14249385146080000.0 - B_09;
+
+  /** Weight for yDotK[9] when constructing stage k14. */
+  private static final double K14_10 = 57799439.0 / 377055000.0 - B_10;
+
+  /** Weight for yDotK[10] when constructing stage k14. */
+  private static final double K14_11 = 793322643029.0 / 96734250000000.0 - B_11;
+
+  /** Weight for yDotK[11] when constructing stage k14. */
+  private static final double K14_12 = 1458939311.0 / 192780000000.0 - B_12;
+
+  /** Weight for yDotK[12] when constructing stage k14. */
+  private static final double K14_13 = -4149.0 / 500000.0;
 
   // k15 for interpolation only
-  private static double c15 = 1.0 / 5.0;
+  /** Abscissa for the fifteenth stage used only for dense output reconstruction. */
+  private static final double C15 = 1.0 / 5.0;
 
-  private static double k15_01 = 1595561272731.0 / 50120273500000.0 - b_01;
-  private static double k15_06 = 975183916491.0 / 34457688031250.0 - b_06;
-  private static double k15_07 = 38492013932672.0 / 718912673015625.0 - b_07;
-  private static double k15_08 = -1114881286517557.0 / 20298710767500000.0 - b_08;
-  private static double k15_09 = 0.0 - b_09;
-  private static double k15_10 = 0.0 - b_10;
-  private static double k15_11 = -2538710946863.0 / 23431227861250000.0 - b_11;
-  private static double k15_12 = 8824659001.0 / 23066716781250.0 - b_12;
-  private static double k15_13 = -11518334563.0 / 33831184612500.0;
-  private static double k15_14 = 1912306948.0 / 13532473845.0;
+  /** Weight for yDotK[0] when constructing stage k15. */
+  private static final double K15_01 = 1595561272731.0 / 50120273500000.0 - B_01;
+
+  /** Weight for yDotK[5] when constructing stage k15. */
+  private static final double K15_06 = 975183916491.0 / 34457688031250.0 - B_06;
+
+  /** Weight for yDotK[6] when constructing stage k15. */
+  private static final double K15_07 = 38492013932672.0 / 718912673015625.0 - B_07;
+
+  /** Weight for yDotK[7] when constructing stage k15. */
+  private static final double K15_08 = -1114881286517557.0 / 20298710767500000.0 - B_08;
+
+  /** Weight for yDotK[8] when constructing stage k15. */
+  private static final double K15_09 = 0.0 - B_09;
+
+  /** Weight for yDotK[9] when constructing stage k15. */
+  private static final double K15_10 = 0.0 - B_10;
+
+  /** Weight for yDotK[10] when constructing stage k15. */
+  private static final double K15_11 = -2538710946863.0 / 23431227861250000.0 - B_11;
+
+  /** Weight for yDotK[11] when constructing stage k15. */
+  private static final double K15_12 = 8824659001.0 / 23066716781250.0 - B_12;
+
+  /** Weight for yDotK[12] when constructing stage k15. */
+  private static final double K15_13 = -11518334563.0 / 33831184612500.0;
+
+  /** Weight for yDotKLast[0] when constructing stage k15. */
+  private static final double K15_14 = 1912306948.0 / 13532473845.0;
 
   // k16 for interpolation only
-  private static double c16 = 7.0 / 9.0;
+  /** Abscissa for the sixteenth stage, evaluated solely for interpolation support. */
+  private static final double C16 = 7.0 / 9.0;
 
-  private static double k16_01 = -13613986967.0 / 31741908048.0 - b_01;
-  private static double k16_06 = -4755612631.0 / 1012344804.0 - b_06;
-  private static double k16_07 = 42939257944576.0 / 5588559685701.0 - b_07;
-  private static double k16_08 = 77881972900277.0 / 19140370552944.0 - b_08;
-  private static double k16_09 = 22719829234375.0 / 63689648654052.0 - b_09;
-  private static double k16_10 = 0.0 - b_10;
-  private static double k16_11 = 0.0 - b_11;
-  private static double k16_12 = 0.0 - b_12;
-  private static double k16_13 = -1199007803.0 / 857031517296.0;
-  private static double k16_14 = 157882067000.0 / 53564469831.0;
-  private static double k16_15 = -290468882375.0 / 31741908048.0;
+  /** Weight for yDotK[0] when constructing stage k16. */
+  private static final double K16_01 = -13613986967.0 / 31741908048.0 - B_01;
+
+  /** Weight for yDotK[5] when constructing stage k16. */
+  private static final double K16_06 = -4755612631.0 / 1012344804.0 - B_06;
+
+  /** Weight for yDotK[6] when constructing stage k16. */
+  private static final double K16_07 = 42939257944576.0 / 5588559685701.0 - B_07;
+
+  /** Weight for yDotK[7] when constructing stage k16. */
+  private static final double K16_08 = 77881972900277.0 / 19140370552944.0 - B_08;
+
+  /** Weight for yDotK[8] when constructing stage k16. */
+  private static final double K16_09 = 22719829234375.0 / 63689648654052.0 - B_09;
+
+  /** Weight for yDotK[9] when constructing stage k16. */
+  private static final double K16_10 = 0.0 - B_10;
+
+  /** Weight for yDotK[10] when constructing stage k16. */
+  private static final double K16_11 = 0.0 - B_11;
+
+  /** Weight for yDotK[11] when constructing stage k16. */
+  private static final double K16_12 = 0.0 - B_12;
+
+  /** Weight for yDotK[12] when constructing stage k16. */
+  private static final double K16_13 = -1199007803.0 / 857031517296.0;
+
+  /** Weight for yDotKLast[0] when constructing stage k16. */
+  private static final double K16_14 = 157882067000.0 / 53564469831.0;
+
+  /** Weight for yDotKLast[1] when constructing stage k16. */
+  private static final double K16_15 = -290468882375.0 / 31741908048.0;
 
   // interpolation weights
   // (beware that only the non-null values are in the table)
-  private static double[][] d = {
+  /**
+   * Dense-output weight matrix {@code d[k][j]} that combines base and additional stages into the
+   * interpolation polynomial coefficients.
+   */
+  private static final double[][] d = {
     {
       -17751989329.0 / 2106076560.0,
       4272954039.0 / 7539864640.0,
@@ -441,5 +594,6 @@ class DormandPrince853StepInterpolator extends RungeKuttaStepInterpolator
     }
   };
 
-  private static final long serialVersionUID = 4165537490327432186L;
+  /** Serialization identifier preserving stream compatibility across versions. */
+  @Serial private static final long serialVersionUID = 4165537490327432186L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/DummyStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DummyStepInterpolator.java
@@ -16,7 +16,7 @@ import java.io.ObjectOutput;
  * @version $Id: DummyStepInterpolator.java 1721 2007-10-07 20:21:25Z luc $
  * @author L. Maisonobe
  */
-public class DummyStepInterpolator extends AbstractStepInterpolator {
+public class DummyStepInterpolator extends AbstractStepInterpolator implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -38,6 +38,20 @@ public class DummyStepInterpolator extends AbstractStepInterpolator {
    */
   protected DummyStepInterpolator(double[] y, boolean forward) {
     super(y, forward);
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param interpolator interpolator to copy from
+   */
+  protected DummyStepInterpolator(DummyStepInterpolator interpolator) {
+    super(interpolator);
+  }
+
+  @Override
+  public DummyStepInterpolator copy() {
+    return new DummyStepInterpolator(this);
   }
 
   /**

--- a/src/main/java/org/spaceroots/mantissa/ode/DummyStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DummyStepInterpolator.java
@@ -3,14 +3,30 @@ package org.spaceroots.mantissa.ode;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serial;
 
 /**
- * This class is a step interpolator that does nothing.
+ * Step interpolator that returns the end-of-step state without computing a curve.
  *
- * <p>This class is used when the {@link StepHandler "step handler"} set up by the user does not
- * need step interpolation. It does not recompute the state when {@link
- * AbstractStepInterpolator#setInterpolatedTime setInterpolatedTime} is called. This implies the
- * interpolated state is always the state at the end of the current step.
+ * <p>This lightweight implementation exists for callers that register a {@link StepHandler step
+ * handler} but never request intermediate evaluations between the solver grid points. The
+ * interpolated state is always copied from the already known end-of-step state when {@link
+ * AbstractStepInterpolator#setInterpolatedTime(double)} is invoked, so no additional derivative
+ * evaluations or polynomial reconstruction are performed. It is therefore useful for performance
+ * sensitive integrations, for prototype creation through the cloning pattern, or whenever the
+ * consumer is satisfied with fixed-step output.
+ *
+ * <p>The instance mirrors the lifecycle of {@link AbstractStepInterpolator}: it starts empty, must
+ * be {@link AbstractStepInterpolator#reinitialize(double[], boolean) reinitialized} before use, and
+ * is reused by the integrator across steps. The class is not thread-safe and relies on the mutable
+ * arrays provided by the owning integrator; copies made through {@link #copy()} detach the backing
+ * state snapshot at the time of cloning.
+ *
+ * <ul>
+ *   <li>Responsibility: expose the last computed state without interpolation math.
+ *   <li>Trade-off: minimal overhead, but no intermediate times can be synthesized.
+ *   <li>Serialization: supports externalization of the base interpolator state for checkpointing.
+ * </ul>
  *
  * @see StepHandler
  * @version $Id: DummyStepInterpolator.java 1721 2007-10-07 20:21:25Z luc $
@@ -19,61 +35,109 @@ import java.io.ObjectOutput;
 public class DummyStepInterpolator extends AbstractStepInterpolator implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * AbstractStepInterpolator#reinitialize} method should be called before using the instance in
-   * order to initialize the internal arrays. This constructor is used only in order to delay the
-   * initialization in some cases. As an example, the {@link RungeKuttaFehlbergIntegrator} uses the
-   * prototyping design pattern to create the step interpolators by cloning an uninitialized model
-   * and latter initializing the copy.
+   * Create an uninitialized interpolator ready for delayed setup.
+   *
+   * <p>The newly created instance contains no allocated state arrays. Callers are expected to
+   * supply step end values via {@link AbstractStepInterpolator#reinitialize(double[], boolean)}
+   * before the object participates in an integration loop. Integrators such as {@link
+   * RungeKuttaFehlbergIntegrator} typically allocate a single prototype interpolator and clone it
+   * for each run to minimize setup costs and to keep the interpolation strategy pluggable.
    */
   public DummyStepInterpolator() {
     super();
   }
 
   /**
-   * Simple constructor.
+   * Create an initialized interpolator bound to an existing state buffer.
    *
-   * @param y reference to the integrator array holding the state at the end of the step
-   * @param forward integration direction indicator
+   * <p>This constructor is typically used internally by integrators that manage their own state
+   * arrays. The interpolator stores only a reference to {@code y}; callers must ensure the array is
+   * populated with end-of-step values before interpolation is attempted and remains valid for the
+   * duration of the step processing.
+   *
+   * @param y reference to the mutable integrator state array holding end-of-step values
+   * @param forward {@code true} when integration time increases; {@code false} for backward steps
    */
   protected DummyStepInterpolator(double[] y, boolean forward) {
     super(y, forward);
   }
 
   /**
-   * Copy constructor.
+   * Create a deep copy of another dummy interpolator.
    *
-   * @param interpolator interpolator to copy from
+   * <p>The clone shares no mutable arrays with the source; it captures the current interpolated and
+   * current state so that subsequent updates to the original do not leak into the copy. This is
+   * used by integrators that follow the prototyping pattern to generate thread-local or step-local
+   * interpolators on demand.
+   *
+   * @param interpolator existing interpolator whose state and direction are replicated
    */
   protected DummyStepInterpolator(DummyStepInterpolator interpolator) {
     super(interpolator);
   }
 
+  /**
+   * Create a detached copy suitable for independent interpolation requests.
+   *
+   * <p>The returned instance preserves the current time, direction, and state snapshot of the
+   * source interpolator. Subsequent updates to either instance do not affect the other, making this
+   * method appropriate when the same integration step must be examined concurrently at different
+   * interpolated times or when caching a snapshot for later analysis.
+   *
+   * @return new {@code DummyStepInterpolator} containing the same state values and integration
+   *     direction as this instance
+   */
   @Override
   public DummyStepInterpolator copy() {
     return new DummyStepInterpolator(this);
   }
 
   /**
-   * Compute the state at the interpolated time. In this class, this method does nothing: the
-   * interpolated state is always the state at the end of the current step.
+   * Copy the end-of-step state into the interpolated slot without recomputation.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>Unlike rich interpolators, this implementation ignores {@code theta} and {@code
+   * oneMinusThetaH}. It simply mirrors the current state into the interpolated buffer so that calls
+   * to {@link AbstractStepInterpolator#getInterpolatedState()} yield the same values stored at the
+   * end of the step in {@link AbstractStepInterpolator#currentState}. The method preserves {@link
+   * AbstractStepInterpolator} invariants and relies on the caller to ensure the current state was
+   * freshly computed by the underlying integrator before invocation.
+   *
+   * @param theta normalized interpolation abscissa; zero is start of step, one is end of step
+   * @param oneMinusThetaH signed time gap from interpolated time to current grid point, in seconds
+   * @throws DerivativeException propagated if the base class requires derivative evaluation hooks
+   *     that fail during copying or validation
    */
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
     System.arraycopy(currentState, 0, interpolatedState, 0, currentState.length);
   }
 
+  /**
+   * Write the externalized form of the interpolator state.
+   *
+   * <p>Only the base class fields are serialized; no additional data is emitted because this
+   * implementation performs no interpolation-specific bookkeeping. The output stream is expected to
+   * remain open after the call so that callers can chain serialization of other objects.
+   *
+   * @param out destination stream that receives the normalized base interpolator fields
+   * @throws IOException if the underlying stream rejects the serialized form or closes prematurely
+   */
   public void writeExternal(ObjectOutput out) throws IOException {
     // save the state of the base class
     writeBaseExternal(out);
   }
 
+  /**
+   * Restore the interpolator from an externalized form and resynchronize its timeline.
+   *
+   * <p>The method delegates deserialization of core state to the base class, then sets the
+   * interpolated time so that subsequent {@link AbstractStepInterpolator#getInterpolatedState()}
+   * calls are immediately valid. Any {@link DerivativeException} encountered during reattachment is
+   * wrapped as an {@link IOException} to comply with the {@link java.io.Externalizable} contract.
+   *
+   * @param in source stream positioned at a serialized {@code DummyStepInterpolator} payload
+   * @throws IOException if the serialized form is corrupt or derivative recomputation fails
+   */
   public void readExternal(ObjectInput in) throws IOException {
 
     // read the base class
@@ -83,11 +147,9 @@ public class DummyStepInterpolator extends AbstractStepInterpolator implements S
       // we can now set the interpolated time and state
       setInterpolatedTime(t);
     } catch (DerivativeException e) {
-      IOException ioe = new IOException();
-      ioe.initCause(e);
-      throw ioe;
+      throw new IOException(e);
     }
   }
 
-  private static final long serialVersionUID = 1708010296707839488L;
+  @Serial private static final long serialVersionUID = 1708010296707839488L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/EulerStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/EulerStepInterpolator.java
@@ -1,58 +1,95 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
+
 /**
- * This class implements a linear interpolator for step.
+ * Linear dense-output helper tailored to explicit Euler steps.
  *
- * <p>This interpolator allow to compute dense output inside the last step computed. The
- * interpolation equation is consistent with the integration scheme :
+ * <p>An {@code EulerStepInterpolator} reconstructs intermediate states for the most recent step of
+ * an {@link EulerIntegrator} without re-evaluating user derivatives. It stores the terminal state
+ * and the single Euler slope {@code yDotK[0]} computed by the integrator, then answers
+ * interpolation queries using the scheme-consistent relation {@code y(t_n + theta*h) = y(t_n + h) -
+ * (1 - theta)*h * y'}. The instance is mutable and reused by the integrator across steps; callers
+ * should finalize and copy when they need to keep a snapshot beyond the current handler callback.
  *
- * <pre>
- *   y(t_n + theta h) = y (t_n + h) - (1-theta) h y'
- * </pre>
+ * <p>Lifecycle expectations:
  *
- * where theta belongs to [0 ; 1] and where y' is the evaluation of the derivatives already computed
- * during the step.
+ * <ul>
+ *   <li>Construct (or clone) an uninitialized prototype.
+ *   <li>{@link #reinitialize(FirstOrderDifferentialEquations, double[], double[][], boolean)}
+ *       supplies step data before storage.
+ *   <li>{@link #storeTime(double)} records the step end; {@link #setInterpolatedTime(double)}
+ *       answers dense-output queries.
+ *   <li>{@link #copy()} creates deep, independent snapshots once {@link #finalizeStep()} has been
+ *       executed.
+ * </ul>
+ *
+ * <p>The class is not thread-safe and assumes single-threaded integrator access. Interpolation is
+ * valid in either forward or backward integration direction; extrapolation outside the step is
+ * permitted but may reduce accuracy.
  *
  * @see EulerIntegrator
+ * @see RungeKuttaStepInterpolator
  * @version $Id: EulerStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
 class EulerStepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * AbstractStepInterpolator#reinitialize} method should be called before using the instance in
-   * order to initialize the internal arrays. This constructor is used only in order to delay the
-   * initialization in some cases. The {@link RungeKuttaIntegrator} class uses the prototyping
-   * design pattern to create the step interpolators by cloning an uninitialized model and latter
-   * initializing the copy.
+   * Create an uninitialized prototype ready for later reuse.
+   *
+   * <p>The instance contains no allocated state buffers until {@link
+   * AbstractStepInterpolator#reinitialize(double[], boolean)} or its Runge-Kutta specific overload
+   * is invoked. Integrators use this constructor when applying the prototype/clone pattern to limit
+   * allocation churn during long integrations.
    */
   public EulerStepInterpolator() {}
 
   /**
-   * Copy constructor.
+   * Copy constructor creating a deep, detached interpolator.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>Use this when an already finalized interpolator must be retained after the integrator moves
+   * to the next step. Arrays storing state and derivatives are duplicated so the new instance
+   * cannot be mutated by future integration activity, and references to the equations are
+   * intentionally cleared.
+   *
+   * @param interpolator source instance that has been finalized; its arrays are deep-copied and the
+   *     equations reference intentionally dropped.
    */
   public EulerStepInterpolator(EulerStepInterpolator interpolator) {
     super(interpolator);
   }
 
+  /**
+   * Create a deep copy preserving the finalized step data.
+   *
+   * <p>The returned interpolator shares no array references with the original, so subsequent
+   * integrator mutations or slope updates cannot affect the copy. Callers should ensure {@link
+   * #finalizeStep()} has run on the source before invoking this method so derivative data is
+   * complete when stored.
+   *
+   * @return a new {@code EulerStepInterpolator} holding identical step bounds, direction flags, and
+   *     cached interpolated state that are safe to keep beyond the current integration step.
+   */
   @Override
   public EulerStepInterpolator copy() {
     return new EulerStepInterpolator(this);
   }
 
   /**
-   * Compute the state at the interpolated time. This is the main processing method that should be
-   * implemented by the derived classes to perform the interpolation.
+   * Compute the interpolated state for a requested time inside or near the current step.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>This Euler-specific implementation applies linear reconstruction using the single stored
+   * slope. It writes results into {@link #interpolatedState} without allocating new arrays and does
+   * not modify {@link #currentState}. Callers may request times outside the nominal step bounds; in
+   * that case the same linear relation is used for extrapolation.
+   *
+   * @param theta normalized position in the step, where {@code 0} maps to the previous grid point
+   *     and {@code 1} to the current grid point; values outside [0, 1] request extrapolation.
+   * @param oneMinusThetaH signed time offset {@code currentTime - interpolatedTime}; positive when
+   *     integrating forward, negative when stepping backward.
+   * @throws DerivativeException propagated if underlying derivative computations deferred to
+   *     finalization fail before interpolation proceeds.
    */
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
@@ -62,5 +99,12 @@ class EulerStepInterpolator extends RungeKuttaStepInterpolator implements StepIn
     }
   }
 
-  private static final long serialVersionUID = -7179861704951334960L;
+  /**
+   * Serialization identifier preserving compatibility across releases of the interpolator class.
+   *
+   * <p>The value remains stable so dense-output snapshots stored by integrators can be safely
+   * deserialized in later runs without violating {@link java.io.Serializable} contracts. It does
+   * not influence interpolation logic or runtime behavior.
+   */
+  @Serial private static final long serialVersionUID = -7179861704951334960L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/EulerStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/EulerStepInterpolator.java
@@ -17,7 +17,7 @@ package org.spaceroots.mantissa.ode;
  * @version $Id: EulerStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
-class EulerStepInterpolator extends RungeKuttaStepInterpolator {
+class EulerStepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -39,13 +39,8 @@ class EulerStepInterpolator extends RungeKuttaStepInterpolator {
     super(interpolator);
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public EulerStepInterpolator copy() {
     return new EulerStepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/GillStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GillStepInterpolator.java
@@ -1,43 +1,58 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
+
 /**
- * This class implements a step interpolator for the Gill fourth order Runge-Kutta integrator.
+ * Step interpolator specialized for the Gill fourth-order Runge–Kutta scheme.
  *
- * <p>This interpolator allows to compute dense output inside the last step computed. The
- * interpolation equation is consistent with the integration scheme :
+ * <p>This interpolator reconstructs a continuous state estimate inside the most recently accepted
+ * integration step by reusing the four derivative evaluations produced by the Gill integrator. It
+ * is intended to be instantiated by {@link GillIntegrator}, passed to step handlers, and queried by
+ * callers that need values at arbitrary intermediate times without triggering extra derivative
+ * evaluations. The life cycle follows the pattern of this package: create an empty instance, {@link
+ * AbstractStepInterpolator#reinitialize reinitialize} it once step data is available, clone it when
+ * snapshots must be retained, and then interpolate repeatedly while the cached step remains valid.
  *
- * <pre>
- *   y(t_n + theta h) = y (t_n + h)
- *                    - (1 - theta) (h/6) [ (1 - theta) (1 - 4 theta) y'_1
- *                                        + (1 - theta) (1 + 2 theta) ((2-q) y'_2 + (2+q) y'_3)
- *                                        + (1 + theta + 4 theta^2) y'_4
- *                                        ]
- * </pre>
+ * <p>Instances are mutable and not thread-safe; each thread should work with its own copy to avoid
+ * races while reading and writing internal arrays. The interpolation formula preserves the Gill
+ * method invariants, assumes {@code theta} is within {@code [0, 1]}, and performs purely algebraic
+ * combinations of the stored stages, so performance is dominated by array arithmetic rather than
+ * additional function calls. Accuracy matches the parent integrator’s fourth-order dense output for
+ * interior points of the current step.
  *
- * where theta belongs to [0 ; 1], q = sqrt(2) and where y'_1 to y'_4 are the four evaluations of
- * the derivatives already computed during the step.
+ * <ul>
+ *   <li>Provides dense output aligned with the Gill Runge–Kutta tableau.
+ *   <li>Supports cloning so multiple consumers can safely hold step snapshots.
+ *   <li>Requires explicit reinitialization before any interpolation call.
+ * </ul>
  *
  * @see GillIntegrator
- * @version $Id: GillStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
+ * @see RungeKuttaStepInterpolator
  * @author L. Maisonobe
+ * @version $Id: GillStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  */
 class GillStepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * AbstractStepInterpolator#reinitialize} method should be called before using the instance in
-   * order to initialize the internal arrays. This constructor is used only in order to delay the
-   * initialization in some cases. The {@link RungeKuttaIntegrator} class uses the prototyping
-   * design pattern to create the step interpolators by cloning an uninitialized model and latter
-   * initializing the copy.
+   * Creates an uninitialized interpolator ready for deferred setup.
+   *
+   * <p>The instance does not yet contain step data or allocated buffers for the interpolated state.
+   * Callers must invoke {@link AbstractStepInterpolator#reinitialize} to bind the current step
+   * arrays, otherwise any attempt to interpolate will be invalid. {@link RungeKuttaIntegrator} uses
+   * this constructor to create a prototype that it clones and initializes lazily as steps are
+   * accepted.
    */
   public GillStepInterpolator() {}
 
   /**
    * Copy constructor.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>The new interpolator duplicates state, derivative stages, and timing metadata from the
+   * source so later mutations do not affect the original. Step handlers typically use this to cache
+   * a snapshot while the integrator advances.
+   *
+   * @param interpolator interpolator to copy from; should be initialized to capture meaningful
+   *     state.
    */
   public GillStepInterpolator(GillStepInterpolator interpolator) {
     super(interpolator);
@@ -49,14 +64,20 @@ class GillStepInterpolator extends RungeKuttaStepInterpolator implements StepInt
   }
 
   /**
-   * Compute the state at the interpolated time. This is the main processing method that should be
-   * implemented by the derived classes to perform the interpolation.
+   * Computes the interpolated state inside the current Gill step.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>This method applies the dense-output polynomial tied to the Gill RK4 tableau. It consumes
+   * the precomputed stage derivatives in {@code yDotK}, combines them with the normalized position
+   * {@code theta}, and writes the resulting coordinates into {@code interpolatedState} without
+   * altering the original step data. No additional derivative evaluations occur; the computation is
+   * deterministic given the stored stages and the supplied interpolation abscissa.
+   *
+   * @param theta normalized position in the step, {@code 0} at start and {@code 1} at end; callers
+   *     should keep it within the closed interval {@code [0, 1]}.
+   * @param oneMinusThetaH time offset from the interpolation instant to the step end, using the
+   *     same units as the integrator step size; typically {@code (1 - theta) * h}.
+   * @throws DerivativeException if previously computed derivatives could not be reused to form a
+   *     consistent interpolated state.
    */
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
@@ -66,8 +87,8 @@ class GillStepInterpolator extends RungeKuttaStepInterpolator implements StepInt
     double soMt = s * (1 - theta);
     double c23 = soMt * (1 + 2 * theta);
     double coeff1 = soMt * (1 - fourTheta);
-    double coeff2 = c23 * tMq;
-    double coeff3 = c23 * tPq;
+    double coeff2 = c23 * TMQ;
+    double coeff3 = c23 * TPQ;
     double coeff4 = s * (1 + theta * (1 + fourTheta));
 
     for (int i = 0; i < interpolatedState.length; ++i) {
@@ -81,10 +102,14 @@ class GillStepInterpolator extends RungeKuttaStepInterpolator implements StepInt
   }
 
   /** First Gill coefficient. */
-  private static final double tMq = 2 - Math.sqrt(2.0);
+  private static final double TMQ = 2 - Math.sqrt(2.0);
 
   /** Second Gill coefficient. */
-  private static final double tPq = 2 + Math.sqrt(2.0);
+  private static final double TPQ = 2 + Math.sqrt(2.0);
 
-  private static final long serialVersionUID = -107804074496313322L;
+  /**
+   * Serialization identifier ensuring compatible stream representation across versions of this
+   * interpolator implementation.
+   */
+  @Serial private static final long serialVersionUID = -107804074496313322L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/GillStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GillStepInterpolator.java
@@ -21,7 +21,7 @@ package org.spaceroots.mantissa.ode;
  * @version $Id: GillStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
-class GillStepInterpolator extends RungeKuttaStepInterpolator {
+class GillStepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -43,13 +43,8 @@ class GillStepInterpolator extends RungeKuttaStepInterpolator {
     super(interpolator);
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public GillStepInterpolator copy() {
     return new GillStepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerIntegrator.java
@@ -826,7 +826,7 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
           // Switching functions handling
           if (!reject) {
             interpolator.storeTime(stepStart + stepSize);
-            if (switchesHandler.evaluateStep(interpolator)) {
+            if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
               reject = true;
               hNew = Math.abs(switchesHandler.getEventTime() - stepStart);
             }
@@ -853,7 +853,7 @@ public class GraggBulirschStoerIntegrator extends AdaptiveStepsizeIntegrator {
 
         // provide the step data to the step handler
         interpolator.storeTime(stepStart);
-        handler.handleStep(interpolator, lastStep);
+        handler.handleStep((StepInterpolator) interpolator, lastStep);
 
         if (switchesHandler.reset(stepStart, y) && !lastStep) {
           // some switching function has triggered changes that

--- a/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerStepInterpolator.java
@@ -3,45 +3,36 @@ package org.spaceroots.mantissa.ode;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serial;
 
 /**
- * This class implements an interpolator for the Gragg-Bulirsch-Stoer integrator.
+ * Dense-output interpolator used by the Gragg-Bulirsch-Stoer integrator.
  *
- * <p>This interpolator compute dense output inside the last step produced by a Gragg-Bulirsch-Stoer
- * integrator.
+ * <p>The interpolator reconstructs states and derivatives anywhere inside the last accepted step
+ * produced by {@link GraggBulirschStoerIntegrator}. It evaluates Hermite-like polynomials whose
+ * coefficients are derived from step end-points and midpoint derivative estimates, allowing client
+ * code to query the solution with sub-step resolution without re-running the integrator. Typical
+ * usage is to call {@link #computeCoefficients(int, double)} once a step is accepted, then invoke
+ * {@link #setInterpolatedTime(double)} (inherited from the base class) repeatedly to obtain dense
+ * output through {@link #getInterpolatedState()}.
  *
- * <p>This implementation is basically a reimplementation in Java of the <a
- * href="http://www.unige.ch/math/folks/hairer/prog/nonstiff/odex.f">odex</a> fortran code by E.
- * Hairer and G. Wanner. The redistribution policy for this code is available <a
- * href="http://www.unige.ch/~hairer/prog/licence.txt">here</a>, for convenience, it is reproduced
- * below.
+ * <p>The class maintains no internal synchronization; instances are mutable and must be confined to
+ * a single integration thread. State remains valid only until the integrator advances past the
+ * buffered step. Polynomial degree grows with extrapolation order, trading accuracy for additional
+ * computation; {@link #estimateError(double[])} gives a normalized error hint for callers deciding
+ * whether dense evaluations are trustworthy at the chosen order.
  *
- * <table border="0" width="80%" cellpadding="10" align="center" bgcolor="#E0E0E0">
- * <tr><td>Copyright (c) 2004, Ernst Hairer</td></tr>
- *
- * <tr><td>Redistribution and use in source and binary forms, with or
- * without modification, are permitted provided that the following
- * conditions are met:
  * <ul>
- *  <li>Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.</li>
- *  <li>Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.</li>
- * </ul></td></tr>
+ *   <li>Computes and stores interpolation polynomials up to the requested degree.
+ *   <li>Supports serialization so checkpointed integrators can be restored mid-step.
+ *   <li>Mirrors the algorithms from the original Fortran <a
+ *       href="http://www.unige.ch/math/folks/hairer/prog/nonstiff/odex.f">odex</a> implementation,
+ *       retaining the same error-control heuristics.
+ * </ul>
  *
- * <tr><td><strong>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
- * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
- * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</strong></td></tr>
- * </table>
+ * <p>Redistribution and use in source and binary forms, with or without modification, are permitted
+ * under the terms reproduced from the original distribution notice available <a
+ * href="http://www.unige.ch/~hairer/prog/licence.txt">here</a>.
  *
  * @see GraggBulirschStoerIntegrator
  * @version $Id: GraggBulirschStoerStepInterpolator.java 1702 2006-09-10 19:52:58Z luc $
@@ -52,19 +43,19 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
     implements StepInterpolator {
 
   /** Slope at the beginning of the step. */
-  private double[] y0Dot;
+  private final double[] y0Dot;
 
   /** State at the end of the step. */
-  private double[] y1;
+  private final double[] y1;
 
   /** Slope at the end of the step. */
-  private double[] y1Dot;
+  private final double[] y1Dot;
 
   /**
    * Derivatives at the middle of the step. element 0 is state at midpoint, element 1 is first
    * derivative ...
    */
-  private double[][] yMidDots;
+  private final double[][] yMidDots;
 
   /** Interpolation polynoms. */
   private double[][] polynoms;
@@ -76,54 +67,68 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
   private int currentDegree;
 
   /**
-   * Reallocate the internal tables. Reallocate the internal tables in order to be able to handle
-   * interpolation polynoms up to the given degree
+   * Reallocate the internal tables in order to be able to handle interpolation polynoms up to the
+   * given degree.
    *
-   * @param maxDegree maximal degree to handle
+   * @param maxDegree maximal degree to handle when recomputing polynomial storage
    */
   private void resetTables(int maxDegree) {
 
     if (maxDegree < 0) {
-      polynoms = null;
-      errfac = null;
-      currentDegree = -1;
+      clearTables();
+      return;
+    }
+
+    initializePolynoms(maxDegree);
+    initializeErrorFactors(maxDegree);
+    currentDegree = 0;
+  }
+
+  private void clearTables() {
+    polynoms = null;
+    errfac = null;
+    currentDegree = -1;
+  }
+
+  private void initializePolynoms(int maxDegree) {
+    double[][] newPols = new double[maxDegree + 1][];
+    if (polynoms != null) {
+      System.arraycopy(polynoms, 0, newPols, 0, polynoms.length);
+      for (int i = polynoms.length; i < newPols.length; ++i) {
+        newPols[i] = new double[currentState.length];
+      }
     } else {
-
-      double[][] newPols = new double[maxDegree + 1][];
-      if (polynoms != null) {
-        System.arraycopy(polynoms, 0, newPols, 0, polynoms.length);
-        for (int i = polynoms.length; i < newPols.length; ++i) {
-          newPols[i] = new double[currentState.length];
-        }
-      } else {
-        for (int i = 0; i < newPols.length; ++i) {
-          newPols[i] = new double[currentState.length];
-        }
+      for (int i = 0; i < newPols.length; ++i) {
+        newPols[i] = new double[currentState.length];
       }
-      polynoms = newPols;
+    }
+    polynoms = newPols;
+  }
 
-      // initialize the error factors array for interpolation
-      if (maxDegree <= 4) {
-        errfac = null;
-      } else {
-        errfac = new double[maxDegree - 4];
-        for (int i = 0; i < errfac.length; ++i) {
-          int ip5 = i + 5;
-          errfac[i] = 1.0 / (ip5 * ip5);
-          double e = 0.5 * Math.sqrt(((double) (i + 1)) / ip5);
-          for (int j = 0; j <= i; ++j) {
-            errfac[i] *= e / (j + 1);
-          }
-        }
+  private void initializeErrorFactors(int maxDegree) {
+    if (maxDegree <= 4) {
+      errfac = null;
+      return;
+    }
+
+    errfac = new double[maxDegree - 4];
+    for (int i = 0; i < errfac.length; ++i) {
+      int ip5 = i + 5;
+      errfac[i] = 1.0 / (ip5 * ip5);
+      double e = 0.5 * Math.sqrt(((double) (i + 1)) / ip5);
+      for (int j = 0; j <= i; ++j) {
+        errfac[i] *= e / (j + 1);
       }
-
-      currentDegree = 0;
     }
   }
 
   /**
-   * Simple constructor. This constructor should not be used directly, it is only intended for the
-   * serialization process.
+   * Simple constructor intended only for the serialization framework.
+   *
+   * <p>Creates an uninitialized instance whose arrays are null and whose internal tables are sized
+   * for no interpolation degree. Regular callers should let the owning integrator build instances
+   * with the parameterized constructor so state vectors are immediately wired; this form exists so
+   * deserialization can populate fields manually before use.
    */
   public GraggBulirschStoerStepInterpolator() {
     y0Dot = null;
@@ -134,15 +139,20 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
   }
 
   /**
-   * Simple constructor.
+   * Constructor wiring the current step data produced by the integrator.
    *
-   * @param y reference to the integrator array holding the current state
-   * @param y0Dot reference to the integrator array holding the slope at the beginning of the step
-   * @param y1 reference to the integrator array holding the state at the end of the step
-   * @param y1Dot reference to the integrator array holding the slope at theend of the step
+   * @param y reference to the integrator array holding the current state values, reused by the
+   *     interpolator without copying
+   * @param y0Dot reference to the integrator array holding the slope at the beginning of the step;
+   *     same length and indexing as {@code y}
+   * @param y1 reference to the integrator array holding the state at the end of the step that will
+   *     be interpolated
+   * @param y1Dot reference to the integrator array holding the slope at the end of the step, used
+   *     for Hermite coefficients
    * @param yMidDots reference to the integrator array holding the derivatives at the middle point
-   *     of the step
-   * @param forward integration direction indicator
+   *     of the step for increasing interpolation orders
+   * @param forward integration direction indicator; {@code true} for forward time, {@code false}
+   *     for backward integration
    */
   public GraggBulirschStoerStepInterpolator(
       double[] y,
@@ -162,10 +172,14 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
   }
 
   /**
-   * Copy constructor.
+   * Copy constructor performing a deep copy of polynomial storage.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>Copies base interpolator state and duplicates all polynomial arrays up to the current degree
+   * so that dense evaluations on the new instance do not share mutable storage with the source.
+   * Temporary derivative buffers are deliberately left null to minimize memory footprint.
+   *
+   * @param interpolator interpolator to copy from; array contents are duplicated so the new
+   *     instance evolves independently of the source
    */
   public GraggBulirschStoerStepInterpolator(GraggBulirschStoerStepInterpolator interpolator) {
 
@@ -191,9 +205,23 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
         System.arraycopy(interpolator.polynoms[i], 0, polynoms[i], 0, dimension);
       }
       currentDegree = interpolator.currentDegree;
+      errfac = interpolator.errfac == null ? null : interpolator.errfac.clone();
+      return;
     }
+
+    errfac = null;
   }
 
+  /**
+   * Create a deep copy of this interpolator.
+   *
+   * <p>The returned instance preserves the same polynomial degree and coefficients so it can
+   * produce identical dense output for the current step, yet owns independent arrays to avoid
+   * accidental cross-thread mutation. Subsequent calls to {@link #computeCoefficients(int, double)}
+   * on either instance will diverge safely.
+   *
+   * @return a new interpolator carrying the same step data while owning separate mutable storage
+   */
   @Override
   public GraggBulirschStoerStepInterpolator copy() {
     return new GraggBulirschStoerStepInterpolator(this);
@@ -202,8 +230,14 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
   /**
    * Compute the interpolation coefficients for dense output.
    *
-   * @param mu degree of the interpolation polynom
-   * @param h current step
+   * <p>This method must be invoked once a trial step is accepted so that subsequent calls to {@link
+   * #setInterpolatedTime(double)} can evaluate intermediate states. It fills the polynomial arrays
+   * up to degree {@code mu + 4}, expanding storage if necessary. Callers should reuse the instance
+   * across steps to avoid allocations.
+   *
+   * @param mu degree of the interpolation polynom, typically derived from the extrapolation order
+   *     chosen by the integrator
+   * @param h current step size in integration units; sign matches the integration direction
    */
   public void computeCoefficients(int mu, double h) {
 
@@ -214,55 +248,77 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
     currentDegree = mu + 4;
 
     for (int i = 0; i < currentState.length; ++i) {
+      computeCoefficientsForIndex(mu, h, i);
+    }
+  }
 
-      double yp0 = h * y0Dot[i];
-      double yp1 = h * y1Dot[i];
-      double ydiff = y1[i] - currentState[i];
-      double aspl = ydiff - yp1;
-      double bspl = yp0 - ydiff;
+  private void computeCoefficientsForIndex(int mu, double h, int index) {
 
-      polynoms[0][i] = currentState[i];
-      polynoms[1][i] = ydiff;
-      polynoms[2][i] = aspl;
-      polynoms[3][i] = bspl;
+    double yp0 = h * y0Dot[index];
+    double yp1 = h * y1Dot[index];
+    double ydiff = y1[index] - currentState[index];
+    double aspl = ydiff - yp1;
+    double bspl = yp0 - ydiff;
 
-      if (mu < 0) {
-        return;
-      }
+    polynoms[0][index] = currentState[index];
+    polynoms[1][index] = ydiff;
+    polynoms[2][index] = aspl;
+    polynoms[3][index] = bspl;
 
-      // compute the remaining coefficients
-      double ph0 = 0.5 * (currentState[i] + y1[i]) + 0.125 * (aspl + bspl);
-      polynoms[4][i] = 16 * (yMidDots[0][i] - ph0);
+    if (mu < 0) {
+      return;
+    }
 
-      if (mu > 0) {
-        double ph1 = ydiff + 0.25 * (aspl - bspl);
-        polynoms[5][i] = 16 * (yMidDots[1][i] - ph1);
+    computeHigherDegreeCoefficients(mu, index, yp0, yp1, ydiff, aspl, bspl);
+  }
 
-        if (mu > 1) {
-          double ph2 = yp1 - yp0;
-          polynoms[6][i] = 16 * (yMidDots[2][i] - ph2 + polynoms[4][i]);
+  private void computeHigherDegreeCoefficients(
+      int mu, int index, double yp0, double yp1, double ydiff, double aspl, double bspl) {
 
-          if (mu > 2) {
-            double ph3 = 6 * (bspl - aspl);
-            polynoms[7][i] = 16 * (yMidDots[3][i] - ph3 + 3 * polynoms[5][i]);
+    double ph0 = 0.5 * (currentState[index] + y1[index]) + 0.125 * (aspl + bspl);
+    polynoms[4][index] = 16 * (yMidDots[0][index] - ph0);
 
-            for (int j = 4; j <= mu; ++j) {
-              double fac1 = 0.5 * j * (j - 1);
-              double fac2 = 2 * fac1 * (j - 2) * (j - 3);
-              polynoms[j + 4][i] =
-                  16 * (yMidDots[j][i] + fac1 * polynoms[j + 2][i] - fac2 * polynoms[j][i]);
-            }
-          }
-        }
-      }
+    if (mu == 0) {
+      return;
+    }
+
+    double ph1 = ydiff + 0.25 * (aspl - bspl);
+    polynoms[5][index] = 16 * (yMidDots[1][index] - ph1);
+
+    if (mu == 1) {
+      return;
+    }
+
+    double ph2 = yp1 - yp0;
+    polynoms[6][index] = 16 * (yMidDots[2][index] - ph2 + polynoms[4][index]);
+
+    if (mu == 2) {
+      return;
+    }
+
+    double ph3 = 6 * (bspl - aspl);
+    polynoms[7][index] = 16 * (yMidDots[3][index] - ph3 + 3 * polynoms[5][index]);
+
+    for (int j = 4; j <= mu; ++j) {
+      double fac1 = 0.5 * j * (j - 1);
+      double fac2 = 2 * fac1 * (j - 2) * (j - 3);
+      polynoms[j + 4][index] =
+          16 * (yMidDots[j][index] + fac1 * polynoms[j + 2][index] - fac2 * polynoms[j][index]);
     }
   }
 
   /**
    * Estimate interpolation error.
    *
-   * @param scale scaling array
-   * @return estimate of the interpolation error
+   * <p>The estimate uses the highest available polynomial degree and the precomputed error factors
+   * described in the original algorithm. It returns a weighted root-mean-square norm of the leading
+   * term scaled by {@code scale}, and falls back to zero when the degree is insufficient to form an
+   * error estimate.
+   *
+   * @param scale scaling array matching the state dimension; each entry must be non-zero to avoid
+   *     division errors and should reflect acceptable absolute or relative magnitudes
+   * @return estimate of the interpolation error; zero when degree is below five or scaling hides
+   *     the contribution
    */
   public double estimateError(double[] scale) {
     double error = 0;
@@ -277,14 +333,19 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
   }
 
   /**
-   * Compute the state at the interpolated time. This is the main processing method that should be
-   * implemented by the derived classes to perform the interpolation.
+   * Compute the state at the interpolated time.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>Uses the stored polynomial coefficients to build the dense solution corresponding to the
+   * current value of {@code theta}. The computation is side-effect free except for writing the
+   * inherited {@code interpolatedState} array. The method assumes coefficients have already been
+   * prepared by {@link #computeCoefficients(int, double)} for the current step.
+   *
+   * @param theta normalized interpolation abscissa within the step; {@code 0} targets the previous
+   *     step end, {@code 1} targets the current end, and intermediate values return dense output
+   * @param oneMinusThetaH time gap between the interpolated time and the current time; must match
+   *     the step direction so derived classes can reuse it consistently
+   * @throws DerivativeException propagated unchanged if the underlying user function signalled an
+   *     error while evaluating derivatives needed for interpolation
    */
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
@@ -298,26 +359,37 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
 
     for (int i = 0; i < dimension; ++i) {
       interpolatedState[i] =
-          polynoms[0][i]
-              + theta
-                  * (polynoms[1][i]
-                      + oneMinusTheta * (polynoms[2][i] * theta + polynoms[3][i] * oneMinusTheta));
+          baseInterpolatedValue(
+              theta, oneMinusTheta, polynoms[0][i], polynoms[1][i], polynoms[2][i], polynoms[3][i]);
 
       if (currentDegree > 3) {
-        double c = polynoms[currentDegree][i];
-        for (int j = currentDegree - 1; j > 3; --j) {
-          c = polynoms[j][i] + c * theta05 / (j - 3);
-        }
-        interpolatedState[i] += t4 * c;
+        interpolatedState[i] += t4 * interpolateHigherDegree(theta05, i);
       }
     }
+  }
+
+  private double baseInterpolatedValue(
+      double theta, double oneMinusTheta, double p0, double p1, double p2, double p3) {
+    return p0 + theta * (p1 + oneMinusTheta * (p2 * theta + p3 * oneMinusTheta));
+  }
+
+  private double interpolateHigherDegree(double theta05, int index) {
+    double c = polynoms[currentDegree][index];
+    for (int j = currentDegree - 1; j > 3; --j) {
+      c = polynoms[j][index] + c * theta05 / (j - 3);
+    }
+    return c;
   }
 
   /**
    * Save the state of the instance.
    *
-   * @param out stream where to save the state
-   * @exception IOException in case of write error
+   * <p>Serialization stores only the polynomial coefficients and degree for the current step; it
+   * does not persist transient work arrays. Callers must ensure the base interpolator state has
+   * already been prepared before invoking this method.
+   *
+   * @param out stream where to save the state; must remain open for the duration of the write
+   * @throws IOException in case of write error or if the target stream rejects data
    */
   public void writeExternal(ObjectOutput out) throws IOException {
 
@@ -338,8 +410,14 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
   /**
    * Read the state of the instance.
    *
-   * @param in stream where to read the state from
-   * @exception IOException in case of read error
+   * <p>Restores the base interpolator data and all polynomial coefficients for the pending step.
+   * After deserialization, the interpolator is ready to answer dense-output queries at the time
+   * supplied through {@link #setInterpolatedTime(double)} during this method.
+   *
+   * @param in stream where to read the state from; must supply the same structure written by {@link
+   *     #writeExternal(ObjectOutput)}
+   * @throws IOException in case of read error or when a derivative evaluation fails while restoring
+   *     the interpolated time
    */
   public void readExternal(ObjectInput in) throws IOException {
 
@@ -362,11 +440,9 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
       // we can now set the interpolated time and state
       setInterpolatedTime(t);
     } catch (DerivativeException e) {
-      IOException ioe = new IOException();
-      ioe.initCause(e);
-      throw ioe;
+      throw new IOException(e);
     }
   }
 
-  private static final long serialVersionUID = 7320613236731409847L;
+  @Serial private static final long serialVersionUID = 7320613236731409847L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GraggBulirschStoerStepInterpolator.java
@@ -48,7 +48,8 @@ import java.io.ObjectOutput;
  * @author E. Hairer and G. Wanner (fortran version)
  * @author L. Maisonobe (Java port)
  */
-class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator {
+class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator
+    implements StepInterpolator {
 
   /** Slope at the beginning of the step. */
   private double[] y0Dot;
@@ -193,13 +194,8 @@ class GraggBulirschStoerStepInterpolator extends AbstractStepInterpolator {
     }
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public GraggBulirschStoerStepInterpolator copy() {
     return new GraggBulirschStoerStepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/HighamHall54StepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/HighamHall54StepInterpolator.java
@@ -8,7 +8,7 @@ package org.spaceroots.mantissa.ode;
  * @version $Id: HighamHall54StepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
-class HighamHall54StepInterpolator extends RungeKuttaStepInterpolator {
+class HighamHall54StepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -32,13 +32,8 @@ class HighamHall54StepInterpolator extends RungeKuttaStepInterpolator {
     super(interpolator);
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public HighamHall54StepInterpolator copy() {
     return new HighamHall54StepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/HighamHall54StepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/HighamHall54StepInterpolator.java
@@ -1,50 +1,98 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
+
 /**
- * This class represents an interpolator over the last step during an ODE integration for the 5(4)
- * Higham and Hall integrator.
+ * Interpolates states inside the last accepted step of the 5(4) Higham and Hall Runge-Kutta scheme.
+ *
+ * <p>Instances are created by {@link HighamHall54Integrator} as part of the dense output mechanism.
+ * The interpolator stores the step derivatives produced by the integrator and rebuilds an
+ * intermediate state for any normalized abscissa {@code theta} in {@code [0, 1]} without
+ * re-evaluating user derivatives. Callers typically receive a fully initialized instance from the
+ * integrator and then query it repeatedly while {@link StepHandler} callbacks are executing. The
+ * interpolator is mutable during initialization and reuse, but once {@link
+ * org.spaceroots.mantissa.ode.AbstractStepInterpolator#finalizeStep finalizeStep} has been called
+ * for a step it can be safely read by a single thread until the next step replaces its buffers. It
+ * does not perform synchronization and should therefore not be shared across threads without
+ * external coordination.
+ *
+ * <p>Notable characteristics include:
+ *
+ * <ul>
+ *   <li>Uses a quintic polynomial tailored to the Higham–Hall tableau to achieve 4th order accuracy
+ *       between grid points.
+ *   <li>Avoids additional ODE function evaluations by reusing stored stage derivatives.
+ *   <li>Supports cloning via {@link #copy()} so integrators can prototype and duplicate instances
+ *       efficiently.
+ * </ul>
  *
  * @see HighamHall54Integrator
+ * @see RungeKuttaStepInterpolator
  * @version $Id: HighamHall54StepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
 class HighamHall54StepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * AbstractStepInterpolator#reinitialize} method should be called before using the instance in
-   * order to initialize the internal arrays. This constructor is used only in order to delay the
-   * initialization in some cases. The {@link RungeKuttaFehlbergIntegrator} uses the prototyping
-   * design pattern to create the step interpolators by cloning an uninitialized model and latter
-   * initializing the copy.
+   * Builds an uninitialized interpolator shell for later reuse.
+   *
+   * <p>The instance created by this constructor does not yet contain any step data. Callers must
+   * invoke {@link AbstractStepInterpolator#reinitialize(double[], boolean)} (indirectly through the
+   * owning integrator) before requesting interpolated states. This lazy construction is used by
+   * integrators that clone a prototype per step to avoid repeatedly allocating storage. Until
+   * reinitialized, accessing interpolation values is unsupported.
    */
   public HighamHall54StepInterpolator() {
     super();
   }
 
   /**
-   * Copy constructor.
+   * Creates a deep copy of another interpolator instance.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>All internal arrays are duplicated so that subsequent mutations of the source or the copy do
+   * not interfere. This constructor is primarily used by the prototype pattern inside Runge Kutta
+   * integrators when they need to supply a fresh interpolator for a new step while retaining
+   * previously computed data in the original.
+   *
+   * @param interpolator interpolator to copy from; must already be initialized for the step being
+   *     cloned so the new instance has consistent derivative buffers
    */
   public HighamHall54StepInterpolator(HighamHall54StepInterpolator interpolator) {
     super(interpolator);
   }
 
+  /**
+   * Returns a cloned interpolator carrying the same step data.
+   *
+   * <p>The returned instance owns its own arrays and can be mutated independently of the original.
+   * It is typically used by integrators when they need to preserve the state of the current step
+   * while preparing the next one.
+   *
+   * @return a new {@code HighamHall54StepInterpolator} with duplicated internal buffers and step
+   *     parameters
+   */
   @Override
   public HighamHall54StepInterpolator copy() {
     return new HighamHall54StepInterpolator(this);
   }
 
   /**
-   * Compute the state at the interpolated time.
+   * Compute the state vector at a normalized abscissa inside the current step.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>This method evaluates the Higham–Hall dense output polynomial using the stage derivatives
+   * from the last completed step. It assumes all interpolation arrays have already been set up by
+   * {@link org.spaceroots.mantissa.ode.AbstractStepInterpolator#reinitialize(double[], boolean)}
+   * and {@link org.spaceroots.mantissa.ode.AbstractStepInterpolator#finalizeStep()} before
+   * invocation. No additional derivative evaluations occur; only stored values are combined. The
+   * computation is linear in the dimension of the state vector and produces results consistent with
+   * a 4th order polynomial in {@code theta}.
+   *
+   * @param theta normalized abscissa in the current step; {@code 0} targets the start and {@code 1}
+   *     targets the end of the step, with intermediate values yielding interpolated states
+   * @param oneMinusThetaH current step size multiplied by {@code (1 - theta)}; retained for API
+   *     compatibility although not used by this implementation
+   * @throws DerivativeException if user-supplied derivative code raised an exception during step
+   *     preparation; propagated unchanged to preserve caller handling
    */
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
@@ -76,5 +124,9 @@ class HighamHall54StepInterpolator extends RungeKuttaStepInterpolator implements
     }
   }
 
-  private static final long serialVersionUID = -3583240427587318654L;
+  /**
+   * Serialization identifier preserving compatibility of interpolator instances across versions.
+   * The value is constant and does not participate in runtime interpolation behavior.
+   */
+  @Serial private static final long serialVersionUID = -3583240427587318654L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/MidpointStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/MidpointStepInterpolator.java
@@ -17,7 +17,7 @@ package org.spaceroots.mantissa.ode;
  * @version $Id: MidpointStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
-class MidpointStepInterpolator extends RungeKuttaStepInterpolator {
+class MidpointStepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -39,13 +39,8 @@ class MidpointStepInterpolator extends RungeKuttaStepInterpolator {
     super(interpolator);
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public MidpointStepInterpolator copy() {
     return new MidpointStepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/MidpointStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/MidpointStepInterpolator.java
@@ -1,58 +1,99 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
+
 /**
- * This class implements a step interpolator for second order Runge-Kutta integrator.
+ * Step interpolator dedicated to the explicit midpoint Runge-Kutta scheme.
  *
- * <p>This interpolator allow to compute dense output inside the last step computed. The
- * interpolation equation is consistent with the integration scheme :
+ * <p>The interpolator recreates a continuous approximation of the solution between the last two
+ * integration nodes computed by {@link MidpointIntegrator}. It relies on the two derivative
+ * evaluations already produced during the step and applies the scheme-consistent interpolation
+ * formula:
  *
  * <pre>
- *   y(t_n + theta h) = y (t_n + h) + (1-theta) h [theta y'_1 - (1+theta) y'_2]
+ *   y(t_n + θh) = y(t_n + h) + (1 - θ) h [ θ y'₁ - (1 + θ) y'₂ ]
  * </pre>
  *
- * where theta belongs to [0 ; 1] and where y'_1 and y'_2 are the two evaluations of the derivatives
- * already computed during the step.
+ * where {@code θ} is in the inclusive range {@code [0, 1]}. This makes it suitable for dense output
+ * generation, event detection logic that requires accurately located zero crossings, and clients
+ * that need intermediate values without re-evaluating derivatives. Instances are mutable and reused
+ * by the integrator; they are not thread-safe and should not be shared across concurrent
+ * integrations. Typical usage is internal: callers obtain an instance from the integrator callback,
+ * set the target time with {@link AbstractStepInterpolator#setInterpolatedTime}, and then read the
+ * state arrays that the base class exposes.
+ *
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> interpolate state values within the current step using
+ *       precomputed derivatives.
+ *   <li><strong>Notable behaviors:</strong> assumes a two-stage scheme; reuses cached arrays to
+ *       reduce allocations.
+ * </ul>
  *
  * @see MidpointIntegrator
+ * @see RungeKuttaStepInterpolator
+ * @see StepInterpolator
  * @version $Id: MidpointStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
 class MidpointStepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * AbstractStepInterpolator#reinitialize} method should be called before using the instance in
-   * order to initialize the internal arrays. This constructor is used only in order to delay the
-   * initialization in some cases. The {@link RungeKuttaIntegrator} class uses the prototyping
-   * design pattern to create the step interpolators by cloning an uninitialized model and latter
-   * initializing the copy.
+   * Simple constructor.
+   *
+   * <p>The instance created by this constructor intentionally starts uninitialized so that a {@link
+   * RungeKuttaIntegrator} can clone it as a prototype and defer array allocation until the actual
+   * problem size is known. Call {@link AbstractStepInterpolator#reinitialize} before first use to
+   * wire step data, derivatives, and the reference to the equations. This mirrors the design of
+   * other step interpolators in the library and helps avoid repeated allocations during long
+   * integrations.
    */
   public MidpointStepInterpolator() {}
 
   /**
-   * Copy constructor.
+   * Copy constructor used by the prototyping pattern.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>The newly built interpolator receives deep copies of the state and derivative arrays so that
+   * it can evolve independently of the original instance while keeping the same interpolation logic
+   * and current step metadata.
+   *
+   * @param interpolator source interpolator providing current step data to duplicate; must not be
+   *     {@code null}.
    */
   public MidpointStepInterpolator(MidpointStepInterpolator interpolator) {
     super(interpolator);
   }
 
+  /**
+   * Create an independent copy of this interpolator.
+   *
+   * <p>The returned instance carries cloned state and derivative arrays that capture the current
+   * interpolation context, making it safe to store beyond the lifetime of the original object
+   * managed by the integrator. Later updates to either instance do not affect the other.
+   *
+   * @return a deep copy containing the same step data and interpolation coefficients as this
+   *     instance.
+   */
   @Override
   public MidpointStepInterpolator copy() {
     return new MidpointStepInterpolator(this);
   }
 
   /**
-   * Compute the state at the interpolated time. This is the main processing method that should be
-   * implemented by the derived classes to perform the interpolation.
+   * Compute the state at the currently selected interpolated time.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>This method applies the midpoint-specific dense output formula using the normalized abscissa
+   * {@code theta} and the cached derivative evaluations. It populates the {@code interpolatedState}
+   * array provided by the base class without allocating new storage. Callers must have set the
+   * target time via {@link AbstractStepInterpolator#setInterpolatedTime} before this method is
+   * invoked. Input values are expected to be within the unit interval; values outside may still be
+   * processed but represent extrapolation beyond the current step.
+   *
+   * @param theta normalized interpolation abscissa within the step; {@code 0} is start and {@code
+   *     1} is end of the step; values outside perform extrapolation.
+   * @param oneMinusThetaH time gap {@code (1 - theta) * h} between the interpolated time and the
+   *     current step end; expressed in integration time units.
+   * @throws DerivativeException if user-supplied derivative computation signaled an error while
+   *     producing the stored stage values used for interpolation.
    */
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
@@ -65,5 +106,9 @@ class MidpointStepInterpolator extends RungeKuttaStepInterpolator implements Ste
     }
   }
 
-  private static final long serialVersionUID = -865524111506042509L;
+  /**
+   * Serialization version identifier ensuring compatibility across serialized interpolator
+   * instances created with the same class definition.
+   */
+  @Serial private static final long serialVersionUID = -865524111506042509L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaFehlbergIntegrator.java
@@ -181,7 +181,7 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
     // set up an interpolator sharing the integrator arrays
     AbstractStepInterpolator interpolator;
     if (handler.requiresDenseOutput() || (!switchesHandler.isEmpty())) {
-      RungeKuttaStepInterpolator rki = (RungeKuttaStepInterpolator) prototype.clone();
+      RungeKuttaStepInterpolator rki = (RungeKuttaStepInterpolator) prototype.copy();
       rki.reinitialize(equations, yTmp, yDotK, forward);
       interpolator = rki;
     } else {
@@ -258,7 +258,7 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
 
           // Switching functions handling
           interpolator.storeTime(stepStart + stepSize);
-          if (switchesHandler.evaluateStep(interpolator)) {
+          if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
             // reject the step to match exactly the next switch time
             hNew = switchesHandler.getEventTime() - stepStart;
           } else {
@@ -286,7 +286,7 @@ public abstract class RungeKuttaFehlbergIntegrator extends AdaptiveStepsizeInteg
 
       // provide the step data to the step handler
       interpolator.storeTime(stepStart);
-      handler.handleStep(interpolator, lastStep);
+      handler.handleStep((StepInterpolator) interpolator, lastStep);
 
       if (fsal) {
         // save the last evaluation for the next step

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
@@ -132,7 +132,7 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
     // set up an interpolator sharing the integrator arrays
     AbstractStepInterpolator interpolator;
     if (handler.requiresDenseOutput() || (!switchesHandler.isEmpty())) {
-      RungeKuttaStepInterpolator rki = (RungeKuttaStepInterpolator) prototype.clone();
+      RungeKuttaStepInterpolator rki = (RungeKuttaStepInterpolator) prototype.copy();
       rki.reinitialize(equations, yTmp, yDotK, forward);
       interpolator = rki;
     } else {
@@ -185,7 +185,7 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
 
         // Switching functions handling
         interpolator.storeTime(stepStart + stepSize);
-        if (switchesHandler.evaluateStep(interpolator)) {
+        if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
           needUpdate = true;
           stepSize = switchesHandler.getEventTime() - stepStart;
         } else {
@@ -205,7 +205,7 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
 
       // provide the step data to the step handler
       interpolator.storeTime(stepStart);
-      handler.handleStep(interpolator, lastStep);
+      handler.handleStep((StepInterpolator) interpolator, lastStep);
 
       if (fsal) {
         // save the last evaluation for the next step

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaStepInterpolator.java
@@ -72,7 +72,7 @@ abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
    * @param interpolator interpolator to copy from; must already be finalized for accurate
    *     interpolation results.
    */
-  public RungeKuttaStepInterpolator(RungeKuttaStepInterpolator interpolator) {
+  protected RungeKuttaStepInterpolator(RungeKuttaStepInterpolator interpolator) {
 
     super(interpolator);
 
@@ -142,9 +142,9 @@ abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
 
     // save the local attributes
     out.writeInt(yDotK.length);
-    for (int k = 0; k < yDotK.length; ++k) {
+    for (double[] doubles : yDotK) {
       for (int i = 0; i < currentState.length; ++i) {
-        out.writeDouble(yDotK[k][i]);
+        out.writeDouble(doubles[i]);
       }
     }
 
@@ -186,9 +186,7 @@ abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
       // we can now set the interpolated time and state
       setInterpolatedTime(t);
     } catch (DerivativeException e) {
-      IOException ioe = new IOException();
-      ioe.initCause(e);
-      throw ioe;
+      throw new IOException(e);
     }
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaStepInterpolator.java
@@ -5,8 +5,28 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 /**
- * This class represents an interpolator over the last step during an ODE integration for
- * Runge-Kutta and Runge-Kutta-Fehlberg integrators.
+ * Dense output helper for a single Runge-Kutta integration step.
+ *
+ * <p>The interpolator rebuilds the continuous state between two grid points after a Runge-Kutta or
+ * Runge-Kutta-Fehlberg step has been computed by an integrator. It stores the set of intermediate
+ * stage derivatives ({@code yDotK}) produced during the step and exposes a uniform {@link
+ * AbstractStepInterpolator} contract so step handlers can query any intermediate time without
+ * re-evaluating the differential equations. A new instance is created by integrators, reinitialized
+ * with step data, finalized lazily when interpolation is first requested, and then discarded or
+ * cloned for later reuse.
+ *
+ * <p>Instances are mutable and <strong>not</strong> thread-safe; each integration run must use a
+ * dedicated interpolator chain. Typical call flow is: construct (or clone a prototype), call {@link
+ * #reinitialize(FirstOrderDifferentialEquations, double[], double[][], boolean)}, let the
+ * integrator advance the step, and allow step handlers to interrogate interpolated states via the
+ * inherited API. Cloning is deep with respect to stored derivatives so callers may safely keep
+ * copies beyond the life of the original step.
+ *
+ * <ul>
+ *   <li>Responsibilities: carry Runge-Kutta stage slopes for dense output
+ *   <li>Lifecycle: constructed empty, reinitialized per step, optionally cloned
+ *   <li>Concurrency: no internal synchronization; use per-thread instances
+ * </ul>
  *
  * @see RungeKuttaIntegrator
  * @see RungeKuttaFehlbergIntegrator
@@ -16,12 +36,14 @@ import java.io.ObjectOutput;
 abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * #reinitialize} method should be called before using the instance in order to initialize the
-   * internal arrays. This constructor is used only in order to delay the initialization in some
-   * cases. The {@link RungeKuttaIntegrator} and {@link RungeKuttaFehlbergIntegrator} classes uses
-   * the prototyping design pattern to create the step interpolators by cloning an uninitialized
-   * model and latter initializing the copy.
+   * Simple constructor.
+   *
+   * <p>Builds an empty, non-finalized interpolator that must be initialized later with {@link
+   * #reinitialize(FirstOrderDifferentialEquations, double[], double[][], boolean)} before any
+   * interpolation attempt. Integrators rely on this constructor to create a prototype that can be
+   * cloned cheaply for every step, deferring array allocation until real step data is available.
+   * The resulting instance holds no references to equations or slopes until reinitialized and is
+   * therefore safe to reuse as a lightweight template.
    */
   protected RungeKuttaStepInterpolator() {
     super();
@@ -41,7 +63,14 @@ abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
    *
    * <p>The copy is a deep copy: its arrays are separated from the original arrays of the instance.
    *
-   * @param interpolator interpolator to copy from.
+   * <p>Use this constructor when a previously finalized interpolator must be retained independently
+   * of future steps (for example when a dense output model is stored). Arrays holding intermediate
+   * derivatives are deep-copied so modifications in one instance never leak into the other. The
+   * original interpolator state (current state, time, direction) is preserved, while references to
+   * the differential equations are intentionally dropped to avoid accidental reuse.
+   *
+   * @param interpolator interpolator to copy from; must already be finalized for accurate
+   *     interpolation results.
    */
   public RungeKuttaStepInterpolator(RungeKuttaStepInterpolator interpolator) {
 
@@ -66,22 +95,27 @@ abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
   }
 
   /**
-   * Reinitialize the instance
+   * Reinitialize the instance for a new Runge-Kutta step.
    *
-   * <p>Some Runge-Kutta integrators need fewer functions evaluations than their counterpart step
-   * interpolators. So the interpolator should perform the last evaluations they need by themselves.
-   * The {@link RungeKuttaIntegrator RungeKuttaIntegrator} and {@link RungeKuttaFehlbergIntegrator
-   * RungeKuttaFehlbergIntegrator} abstract classes call this method in order to let the step
-   * interpolator perform the evaluations it needs. These evaluations will be performed during the
-   * call to <code>doFinalize</code> if any, i.e. only if the step handler either calls the {@link
-   * AbstractStepInterpolator#finalizeStep finalizeStep} method or the {@link
-   * AbstractStepInterpolator#getInterpolatedState getInterpolatedState} method (for an interpolator
-   * which needs a finalization) or if it clones the step interpolator.
+   * <p>Integrators invoke this hook once per accepted step to supply the terminal state value, the
+   * ordered array of stage derivatives, and the integration direction. It resets internal caches
+   * inherited from {@link AbstractStepInterpolator} while retaining references to the provided
+   * arrays so that interpolation can be finalized lazily on demand. Callers must ensure the
+   * provided arrays remain valid and unmodified for the duration of interpolation of that step.
    *
-   * @param equations set of differential equations being integrated
-   * @param y reference to the integrator array holding the state at the end of the step
-   * @param yDotK reference to the integrator array holding all the intermediate slopes
-   * @param forward integration direction indicator
+   * <pre>{@code
+   * interpolator.reinitialize(equations, yEnd, kSlopes, forward);
+   * interpolator.storeTime(stepEnd);
+   * }</pre>
+   *
+   * @param equations set of first-order differential equations; never {@code null} and consistent
+   *     with the integrator producing the step.
+   * @param y reference to the state values at the end of the current step; contents are reused
+   *     until the interpolator is reinitialized again.
+   * @param yDotK reference to the intermediate Runge-Kutta slopes ordered by stage index; all inner
+   *     arrays must have the same dimension as {@code y}.
+   * @param forward {@code true} if integration advances toward increasing time, {@code false}
+   *     otherwise; preserved to honor interpolation direction.
    */
   public void reinitialize(
       FirstOrderDifferentialEquations equations, double[] y, double[][] yDotK, boolean forward) {
@@ -93,8 +127,13 @@ abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
   /**
    * Save the state of the instance.
    *
-   * @param out stream where to save the state
-   * @exception IOException in case of write error
+   * <p>Serializes the base interpolator data followed by every stored Runge-Kutta stage derivative
+   * for the current step. The referenced differential equations instance is deliberately excluded
+   * because it is not serializable and is expected to be supplied again on reinitialization.
+   *
+   * @param out stream where to save the state; must remain open for the duration of serialization
+   *     and is not closed by this method.
+   * @throws IOException if any element of the state cannot be written to the provided stream.
    */
   public void writeExternal(ObjectOutput out) throws IOException {
 
@@ -116,8 +155,15 @@ abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
   /**
    * Read the state of the instance.
    *
-   * @param in stream where to read the state from
-   * @exception IOException in case of read error
+   * <p>Restores the serialized interpolator content, including all intermediate derivatives, and
+   * resets the equations reference to {@code null}. After deserialization the caller must supply an
+   * equations instance via {@link #reinitialize(FirstOrderDifferentialEquations, double[],
+   * double[][], boolean)} before performing further interpolations.
+   *
+   * @param in stream where to read the state from; must deliver the data written by {@link
+   *     #writeExternal(ObjectOutput)} in the same order.
+   * @throws IOException if the serialized form is truncated, malformed, or cannot be processed due
+   *     to underlying I/O errors.
    */
   public void readExternal(ObjectInput in) throws IOException {
 
@@ -146,9 +192,22 @@ abstract class RungeKuttaStepInterpolator extends AbstractStepInterpolator {
     }
   }
 
-  /** Slopes at the intermediate points */
+  /**
+   * Slopes evaluated at each Runge-Kutta stage for the current step.
+   *
+   * <p>Each inner array has the same dimension as the state vector and is reused by the integrator
+   * across steps. The interpolator keeps a direct reference and assumes callers preserve these
+   * values until the next {@link #reinitialize(FirstOrderDifferentialEquations, double[],
+   * double[][], boolean)} invocation.
+   */
   protected double[][] yDotK;
 
-  /** Reference to the differential equations beeing integrated. */
+  /**
+   * Reference to the differential equations being integrated during the current step.
+   *
+   * <p>The reference is transient across serialization and is reset after reading external state.
+   * It is provided by {@link #reinitialize(FirstOrderDifferentialEquations, double[], double[][],
+   * boolean)} and is not owned by the interpolator.
+   */
   protected FirstOrderDifferentialEquations equations;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/StepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/StepInterpolator.java
@@ -3,12 +3,30 @@ package org.spaceroots.mantissa.ode;
 import java.io.Externalizable;
 
 /**
- * This interface represents an interpolator over the last step during an ODE integration.
+ * Interface for dense output interpolation across the most recently accepted integration step.
  *
- * <p>The various ODE integrators provide objects implementing this interface to the step handlers.
- * These objects are often custom objects tightly bound to the integrator internal algorithms. The
- * handlers can use these objects to retrieve the state vector at intermediate times between the
- * previous and the current grid points (this feature is often called dense output).
+ * <p>An integrator creates a fresh interpolator after each successful step and passes it to
+ * configured {@link StepHandler handlers}. Handlers can sample the numerical solution at any time
+ * within the step, obtaining a smoothly interpolated state without requesting smaller step sizes.
+ * Typical usage follows this pattern: a handler receives the interpolator, calls {@link
+ * #setInterpolatedTime(double)} with a target time between {@link #getPreviousTime()} and {@link
+ * #getCurrentTime()}, then reads {@link #getInterpolatedState()}. Implementations are usually
+ * lightweight views backed by the integrator’s internal state and may be reused between callbacks;
+ * they are therefore not guaranteed to be thread-safe.
+ *
+ * <p>Responsibilities include:
+ *
+ * <ul>
+ *   <li>Exposing the step bounds and natural integration direction.
+ *   <li>Allowing callers to pick an arbitrary interpolation time, even slightly outside the nominal
+ *       step interval, when exploratory searches are required.
+ *   <li>Providing the corresponding state vector with accuracy comparable to the underlying
+ *       integrator order within the step.
+ * </ul>
+ *
+ * <p>Implementations must preserve the numerical results produced by the integrator while
+ * minimizing additional allocations. Callers should treat returned arrays as read-only snapshots
+ * unless the concrete class explicitly documents a defensive copy.
  *
  * @see FirstOrderIntegrator
  * @see SecondOrderIntegrator
@@ -19,55 +37,93 @@ import java.io.Externalizable;
 public interface StepInterpolator extends Externalizable {
 
   /**
-   * Get the previous grid point time.
+   * Get the previous grid point time for the current interpolated step.
    *
-   * @return previous grid point time
+   * <p>The value corresponds to the start of the step accepted by the integrator. It is expressed
+   * in the integration variable units (typically seconds) and remains constant until the next step
+   * is accepted. Handlers can use it to bound interpolation requests or to detect step rejections
+   * when multiple callbacks occur.
+   *
+   * @return the time coordinate, in integration units, of the step starting point
    */
-  public double getPreviousTime();
+  double getPreviousTime();
 
   /**
-   * Get the current grid point time.
+   * Get the current grid point time for the active step.
    *
-   * @return current grid point time
+   * <p>This is the end time of the step that produced this interpolator. It may be greater or less
+   * than {@link #getPreviousTime()} depending on the integration direction. The value does not
+   * change while the interpolator instance is in use by handlers, even if subsequent steps are
+   * computed later on.
+   *
+   * @return the time coordinate, in integration units, of the step end point
    */
-  public double getCurrentTime();
+  double getCurrentTime();
 
   /**
    * Get the time of the interpolated point. If {@link #setInterpolatedTime} has not been called, it
    * returns the current grid point time.
    *
-   * @return interpolation point time
+   * <p>The interpolated time is mutable per interpolator instance and determines which state vector
+   * {@link #getInterpolatedState()} will expose. Values are typically constrained to the current
+   * step bounds, but implementations may support slight extrapolation for root-finding or event
+   * localization algorithms that probe near the boundaries.
+   *
+   * @return the time, in integration units, used for the next interpolated state retrieval
    */
-  public double getInterpolatedTime();
+  @SuppressWarnings("unused")
+  double getInterpolatedTime();
 
   /**
    * Set the time of the interpolated point.
    *
-   * <p>Setting the time outside of the current step is now allowed (it was not allowed up to
-   * version 5.4 of Mantissa), but should be used with care since the accuracy of the interpolator
-   * will probably be very poor far from this step. This allowance has been added to simplify
+   * <p>Setting the time outside the current step is now allowed (it was not allowed up to version
+   * 5.4 of Mantissa), but should be used with care since the accuracy of the interpolator will
+   * probably be very poor far from this step. This allowance has been added to simplify
    * implementation of search algorithms near the step endpoints.
    *
-   * @param time time of the interpolated point
-   * @throws DerivativeException if this call induces an automatic step finalization that throws one
+   * <p>Calling this method updates the internal interpolation model so the following call to {@link
+   * #getInterpolatedState()} returns a state consistent with the specified time. It is idempotent
+   * for identical input values and does not advance the integrator itself.
+   *
+   * <pre>{@code
+   * // Sample midway through the accepted step
+   * interpolator.setInterpolatedTime(
+   *     0.5 * (interpolator.getPreviousTime() + interpolator.getCurrentTime()));
+   * double[] midState = interpolator.getInterpolatedState();
+   * }</pre>
+   *
+   * @param time target time, in the integration variable units, for interpolation evaluation
+   * @throws DerivativeException if the interpolator must finalize or refresh step data and that
+   *     operation triggers a derivative computation failure
    */
-  public void setInterpolatedTime(double time) throws DerivativeException;
+  void setInterpolatedTime(double time) throws DerivativeException;
 
   /**
    * Get the state vector of the interpolated point.
    *
-   * @return state vector at time {@link #getInterpolatedTime}
+   * <p>The returned array contains one entry per state dimension, aligned with the integrator’s
+   * state ordering. Implementations may return an internal buffer for performance; callers should
+   * therefore read but not modify its contents unless documentation for the concrete class promises
+   * a defensive copy. The values reflect the time last provided to {@link
+   * #setInterpolatedTime(double)}.
+   *
+   * @return state vector matching the last set interpolated time, expressed in state units
    */
-  public double[] getInterpolatedState();
+  double[] getInterpolatedState();
 
   /**
-   * Check if the natural integration direction is forward.
+   * Check if the natural integration direction is forward (increasing time).
    *
    * <p>This method provides the integration direction as specified by the integrator itself, it
-   * avoid some nasty problems in degenerated cases like null steps due to cancellation at step
+   * avoids some nasty problems in degenerated cases like null steps due to cancellation at step
    * initialization, step control or switching function triggering.
    *
-   * @return true if the integration variable (time) increases during integration
+   * <p>The direction remains constant for a given integrator instance even if extrapolation is
+   * requested through {@link #setInterpolatedTime(double)}. Consumers can rely on it to select
+   * appropriate bracketing logic when scanning for events.
+   *
+   * @return {@code true} when time grows monotonically during integration; {@code false} otherwise
    */
-  public boolean isForward();
+  boolean isForward();
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/ThreeEighthesStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ThreeEighthesStepInterpolator.java
@@ -22,7 +22,7 @@ package org.spaceroots.mantissa.ode;
  * @version $Id: ThreeEighthesStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
  * @author L. Maisonobe
  */
-class ThreeEighthesStepInterpolator extends RungeKuttaStepInterpolator {
+class ThreeEighthesStepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
    * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
@@ -44,13 +44,8 @@ class ThreeEighthesStepInterpolator extends RungeKuttaStepInterpolator {
     super(interpolator);
   }
 
-  /**
-   * Clone the instance. the copy is a deep copy: its arrays are separated from the original arrays
-   * of the instance
-   *
-   * @return a copy of the instance
-   */
-  public Object clone() {
+  @Override
+  public ThreeEighthesStepInterpolator copy() {
     return new ThreeEighthesStepInterpolator(this);
   }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/ThreeEighthesStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ThreeEighthesStepInterpolator.java
@@ -1,22 +1,33 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
+
 /**
- * This class implements a step interpolator for the 3/8 fourth order Runge-Kutta integrator.
+ * Step interpolator for the classical 3/8 fourth-order Runge-Kutta scheme.
  *
- * <p>This interpolator allows to compute dense output inside the last step computed. The
- * interpolation equation is consistent with the integration scheme :
+ * <p>The interpolator computes a dense output over the last accepted integration step so callers
+ * can query intermediate states without re-integrating. It reconstructs the state using the same
+ * Butcher tableau as {@link ThreeEighthesIntegrator}, combining the four already-computed
+ * derivative evaluations and the normalized abscissa {@code theta} to achieve fourth-order accuracy
+ * between grid points.
  *
- * <pre>
- *   y(t_n + theta h) = y (t_n + h)
- *                    - (1 - theta) (h/8) [ (1 - 7 theta + 8 theta^2) y'_1
- *                                      + 3 (1 +   theta - 4 theta^2) y'_2
- *                                      + 3 (1 +   theta)             y'_3
- *                                      +   (1 +   theta + 4 theta^2) y'_4
- *                                        ]
- * </pre>
+ * <p>Typical usage is internal to the Runge-Kutta framework: the integrator clones a prototype of
+ * this class, initializes it with step data, and then delegates to it when a user requests an
+ * interpolated state. The instance is mutable between steps but not thread-safe; it is intended to
+ * be used by a single integration thread and discarded or reinitialized after each step. The
+ * interpolation preserves the integrator invariants—continuity of the state vector across the step
+ * and consistency with the discrete solution at {@code theta = 0} and {@code theta = 1}—while
+ * avoiding additional derivative evaluations, keeping the cost bounded to inexpensive linear
+ * combinations. The quality of the dense output matches the global order of the 3/8 method, which
+ * makes it suitable for event detection or output sampling that requires sub-step resolution.
  *
- * where theta belongs to [0 ; 1] and where y'_1 to y'_4 are the four evaluations of the derivatives
- * already computed during the step.
+ * <ul>
+ *   <li>Responsibility: provide {@link #computeInterpolatedState(double, double)} consistent with
+ *       the 3/8 tableau.
+ *   <li>Lifecycle: reinitialize from a base step, interpolate multiple times within that step, then
+ *       replace or reinitialize for the next step.
+ *   <li>Threading: no internal synchronization; callers must confine instances to one thread.
+ * </ul>
  *
  * @see ThreeEighthesIntegrator
  * @version $Id: ThreeEighthesStepInterpolator.java 1666 2005-12-15 16:37:55Z luc $
@@ -25,39 +36,72 @@ package org.spaceroots.mantissa.ode;
 class ThreeEighthesStepInterpolator extends RungeKuttaStepInterpolator implements StepInterpolator {
 
   /**
-   * Simple constructor. This constructor builds an instance that is not usable yet, the {@link
-   * AbstractStepInterpolator#reinitialize} method should be called before using the instance in
-   * order to initialize the internal arrays. This constructor is used only in order to delay the
-   * initialization in some cases. The {@link RungeKuttaIntegrator} class uses the prototyping
-   * design pattern to create the step interpolators by cloning an uninitialized model and latter
-   * initializing the copy.
+   * Simple constructor that creates a yet-to-be-initialized interpolator instance.
+   *
+   * <p>The newly created object does not contain step data until {@link
+   * AbstractStepInterpolator#reinitialize(double[], boolean)} is invoked by the owning integrator.
+   * This delayed initialization lets {@link RungeKuttaIntegrator} clone a lightweight prototype per
+   * step without allocating work arrays eagerly. Callers should treat the instance as unusable
+   * until after reinitialization has completed; thereafter it may be queried repeatedly within the
+   * same step for dense output and then discarded or reconfigured for subsequent steps.
    */
   public ThreeEighthesStepInterpolator() {}
 
   /**
-   * Copy constructor.
+   * Copy constructor producing an independent interpolator with the same step data.
    *
-   * @param interpolator interpolator to copy from. The copy is a deep copy: its arrays are
-   *     separated from the original arrays of the instance
+   * <p>The copy performs a deep duplication of the state vectors and derivative arrays so that the
+   * original and the clone can be used independently without shared mutable state. This is used by
+   * the integrator's prototype pattern when handing interpolators to user code while keeping an
+   * internal copy for continued integration.
+   *
+   * @param interpolator interpolator to copy from; its current step data and configuration are
+   *     replicated into the new instance while preserving value equality and separation of backing
+   *     arrays.
    */
   public ThreeEighthesStepInterpolator(ThreeEighthesStepInterpolator interpolator) {
     super(interpolator);
   }
 
+  /**
+   * Create a deep copy of this interpolator carrying the current step data.
+   *
+   * <p>The returned instance has the same interpolated time, state, derivatives, and direction, but
+   * all internal arrays are detached so mutations on one interpolator do not affect the other. This
+   * method is typically called by the integrator when it needs to expose the interpolator to user
+   * listeners while retaining an internal copy for continued computation.
+   *
+   * @return a new {@code ThreeEighthesStepInterpolator} initialized with identical data but backed
+   *     by independent arrays, suitable for concurrent read-only use during the same integration
+   *     step.
+   */
   @Override
   public ThreeEighthesStepInterpolator copy() {
     return new ThreeEighthesStepInterpolator(this);
   }
 
   /**
-   * Compute the state at the interpolated time. This is the main processing method that should be
-   * implemented by the derived classes to perform the interpolation.
+   * Compute the interpolated state vector for a normalized position inside the current step.
    *
-   * @param theta normalized interpolation abscissa within the step (theta is zero at the previous
-   *     time step and one at the current time step)
-   * @param oneMinusThetaH time gap between the interpolated time and the current time
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The method evaluates the dense output polynomial associated with the 3/8 Runge-Kutta tableau
+   * using the already-computed derivative stages {@code yDotK}. The parameter {@code theta}
+   * represents the normalized abscissa in {@code [0, 1]}, where {@code 0} returns the previous grid
+   * point, {@code 1} returns the current grid point, and intermediate values yield a smooth
+   * fourth-order approximation. No new derivative evaluations occur; the computation is a weighted
+   * linear combination of stored slopes and therefore inexpensive and deterministic.
+   *
+   * <pre>{@code
+   * // Example: interpolate halfway through the step
+   * interpolator.computeInterpolatedState(0.5, h * 0.5);
+   * var midState = interpolator.getInterpolatedState();
+   * }</pre>
+   *
+   * @param theta normalized interpolation abscissa within the step; values outside {@code [0, 1]}
+   *     yield an extrapolation consistent with the polynomial but may reduce accuracy.
+   * @param oneMinusThetaH signed time difference between the interpolated time and the current step
+   *     end; typically equals {@code (1 - theta) * h} and may be negative for backward integration.
+   * @throws DerivativeException propagated if user-provided derivative computation fails while
+   *     evaluating stored slopes for interpolation.
    */
   protected void computeInterpolatedState(double theta, double oneMinusThetaH)
       throws DerivativeException {
@@ -79,5 +123,9 @@ class ThreeEighthesStepInterpolator extends RungeKuttaStepInterpolator implement
     }
   }
 
-  private static final long serialVersionUID = -3345024435978721931L;
+  /**
+   * Serialization identifier preserving compatibility for serialized interpolators created with
+   * this implementation; remains stable across documentation-only changes.
+   */
+  @Serial private static final long serialVersionUID = -3345024435978721931L;
 }

--- a/src/test/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaStepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaStepInterpolatorTest.java
@@ -1,0 +1,148 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("java:S100")
+class ClassicalRungeKuttaStepInterpolatorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.0, 0.25, 0.5, 0.75, 1.0})
+  void setInterpolatedTime_withConstantDerivative_matchesAnalyticSolution(double theta)
+      throws DerivativeException {
+
+    double[] startState = new double[] {1.0, -2.0};
+    double[] constantDerivative = new double[] {0.5, -1.0};
+    double h = 2.0;
+
+    double[] endState =
+        new double[] {
+          startState[0] + constantDerivative[0] * h, startState[1] + constantDerivative[1] * h
+        };
+    double[][] slopes = constantSlopes(constantDerivative);
+
+    ClassicalRungeKuttaStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* startTime= */ 0.0, /* endTime= */ h, true);
+
+    double time = theta * h;
+    interpolator.setInterpolatedTime(time);
+
+    double[] expected =
+        new double[] {
+          startState[0] + constantDerivative[0] * theta * h,
+          startState[1] + constantDerivative[1] * theta * h
+        };
+
+    assertArrayEquals(expected, interpolator.getInterpolatedState(), EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_withDistinctSlopes_appliesRungeKuttaWeights()
+      throws DerivativeException {
+
+    double[] endState = new double[] {2.0};
+    double[][] slopes = new double[][] {{1.0}, {2.0}, {3.0}, {4.0}};
+
+    ClassicalRungeKuttaStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* startTime= */ 1.5, /* endTime= */ 2.5, true);
+
+    interpolator.setInterpolatedTime(1.8);
+
+    // Expected value computed analytically from the published RK4 dense output weights.
+    // For theta = 0.3 the coefficients give an adjustment of -13/200.
+    double[] interpolated = interpolator.getInterpolatedState();
+    assertEquals(-0.065, interpolated[0], EPS);
+  }
+
+  @Test
+  void copy_whenOriginalMutated_preservesDeepCopiedData() throws DerivativeException {
+
+    double[] startState = new double[] {1.0};
+    double[] constantDerivative = new double[] {0.2};
+    double h = 1.0;
+    double[] endState = new double[] {startState[0] + constantDerivative[0] * h};
+    double[][] slopes = constantSlopes(constantDerivative);
+
+    ClassicalRungeKuttaStepInterpolator original =
+        createInterpolator(endState, slopes, /* startTime= */ 0.0, /* endTime= */ h, true);
+    original.finalizeStep();
+
+    ClassicalRungeKuttaStepInterpolator copy = original.copy();
+
+    // Mutate the original after the copy to ensure deep copies are honored.
+    original.currentState[0] = 99.0;
+    original.yDotK[0][0] = 5.0;
+
+    double midpointTime = 0.5 * h;
+    copy.setInterpolatedTime(midpointTime);
+
+    double[] expected = new double[] {startState[0] + constantDerivative[0] * midpointTime};
+    assertArrayEquals(expected, copy.getInterpolatedState(), EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_backwardIntegration_usesNegativeStep() throws DerivativeException {
+
+    double startTime = 2.0;
+    double endTime = 0.0;
+    double h = endTime - startTime; // negative step
+
+    double[] startState = new double[] {5.0};
+    double[] derivative = new double[] {1.0};
+    double[] endState = new double[] {startState[0] + derivative[0] * h};
+    double[][] slopes = constantSlopes(derivative);
+
+    ClassicalRungeKuttaStepInterpolator interpolator =
+        createInterpolator(endState, slopes, startTime, endTime, false);
+
+    interpolator.setInterpolatedTime(1.0);
+
+    double expectedStateAtMidpoint = 4.0; // startState + derivative * (1.0 - startTime)
+    assertEquals(expectedStateAtMidpoint, interpolator.getInterpolatedState()[0], EPS);
+  }
+
+  private static ClassicalRungeKuttaStepInterpolator createInterpolator(
+      double[] endState, double[][] slopes, double startTime, double endTime, boolean forward) {
+
+    ClassicalRungeKuttaStepInterpolator interpolator = new ClassicalRungeKuttaStepInterpolator();
+    interpolator.reinitialize(new DummyEquations(endState.length), endState, slopes, forward);
+    interpolator.previousTime = startTime;
+    interpolator.storeTime(endTime);
+    return interpolator;
+  }
+
+  private static double[][] constantSlopes(double[] derivative) {
+    double[][] slopes = new double[4][];
+    for (int i = 0; i < slopes.length; i++) {
+      slopes[i] = derivative.clone();
+    }
+    return slopes;
+  }
+
+  private static final class DummyEquations implements FirstOrderDifferentialEquations {
+
+    private final int dimension;
+
+    DummyEquations(int dimension) {
+      this.dimension = dimension;
+    }
+
+    @Override
+    public int getDimension() {
+      return dimension;
+    }
+
+    @Override
+    @SuppressWarnings("RedundantThrows")
+    public void computeDerivatives(double t, double[] y, double[] yDot) throws DerivativeException {
+      Arrays.fill(yDot, 0.0);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/DormandPrince54StepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/DormandPrince54StepInterpolatorTest.java
@@ -1,0 +1,139 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@SuppressWarnings("java:S100")
+class DormandPrince54StepInterpolatorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  private DormandPrince54StepInterpolator interpolator;
+
+  @BeforeEach
+  void setUp() {
+    interpolator = createUnitSlopeInterpolator();
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0.0,0.0", "0.25,0.25", "0.5,0.5", "0.75,0.75", "1.0,1.0"})
+  @DisplayName("Interpolated state follows linear solution for constant slope")
+  void setInterpolatedTime_whenLinearDerivative_matchesAnalyticalSolution(
+      double time, double expected) throws DerivativeException {
+
+    // Act
+    interpolator.setInterpolatedTime(time);
+
+    // Assert
+    assertEquals(expected, interpolator.getInterpolatedState()[0], EPS);
+  }
+
+  @Test
+  @DisplayName("Cached interpolation vectors are reused within a step")
+  void setInterpolatedTime_whenSlopesMutateWithinStep_vectorsAreCached()
+      throws DerivativeException {
+
+    // Arrange
+    interpolator.setInterpolatedTime(0.5);
+    for (double[] stage : interpolator.yDotK) {
+      stage[0] = 5.0; // mutate slopes after vectors were initialized
+    }
+
+    // Act
+    interpolator.setInterpolatedTime(0.25);
+
+    // Assert
+    assertEquals(0.25, interpolator.getInterpolatedState()[0], EPS);
+  }
+
+  @Test
+  @DisplayName("Reinitialization resets cached vectors for the next step")
+  void reinitialize_whenNewStepUsesDifferentSlope_recomputesVectors() throws DerivativeException {
+
+    // Arrange: complete an initial interpolation to populate cached vectors
+    interpolator.setInterpolatedTime(0.5);
+
+    // Reinitialize for a new step with a different constant slope
+    double newSlope = 2.0;
+    double startTime = 1.0;
+    double endTime = 2.0;
+    double startValue = 1.0;
+    double endValue = startValue + newSlope * (endTime - startTime);
+
+    interpolator.reinitialize(
+        new ConstantEquation(newSlope), new double[] {endValue}, createSlopes(newSlope), true);
+    interpolator.previousTime = startTime;
+    interpolator.storeTime(endTime);
+
+    // Act
+    interpolator.setInterpolatedTime(1.5);
+
+    // Assert
+    assertEquals(2.0, interpolator.getInterpolatedState()[0], EPS);
+  }
+
+  @Test
+  @DisplayName("Copy provides deep clone independent from original state mutations")
+  void copy_whenOriginalMutates_preservesSnapshot() throws DerivativeException {
+
+    // Arrange
+    interpolator.setInterpolatedTime(0.5);
+    DormandPrince54StepInterpolator clone = interpolator.copy();
+
+    // mutate original after cloning
+    interpolator.currentState[0] = 10.0;
+    for (double[] stage : interpolator.yDotK) {
+      stage[0] = 5.0;
+    }
+
+    // Act
+    clone.setInterpolatedTime(0.25);
+
+    // Assert
+    assertEquals(0.25, clone.getInterpolatedState()[0], EPS);
+  }
+
+  private DormandPrince54StepInterpolator createUnitSlopeInterpolator() {
+    double startTime = 0.0;
+    double endTime = 1.0;
+    double slope = 1.0;
+    double[] endState = new double[] {slope * (endTime - startTime)};
+    DormandPrince54StepInterpolator stepInterpolator = new DormandPrince54StepInterpolator();
+    stepInterpolator.reinitialize(new ConstantEquation(slope), endState, createSlopes(slope), true);
+    stepInterpolator.previousTime = startTime;
+    stepInterpolator.storeTime(endTime);
+    return stepInterpolator;
+  }
+
+  private double[][] createSlopes(double slope) {
+    double[][] slopes = new double[7][1];
+    for (double[] stage : slopes) {
+      stage[0] = slope;
+    }
+    return slopes;
+  }
+
+  private static final class ConstantEquation implements FirstOrderDifferentialEquations {
+
+    private final double slope;
+
+    ConstantEquation(double slope) {
+      this.slope = slope;
+    }
+
+    @Override
+    public int getDimension() {
+      return 1;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      yDot[0] = slope;
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/DormandPrince853StepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/DormandPrince853StepInterpolatorTest.java
@@ -1,0 +1,172 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class DormandPrince853StepInterpolatorTest {
+
+  @Mock private FirstOrderDifferentialEquations equations;
+
+  @Test
+  void
+      setInterpolatedTime_whenCalledMultipleTimes_doesNotRecomputeDerivativesAfterFirstInitialization()
+          throws Exception {
+    double[] state = {1.0};
+    double[][] yDotK = createStageSlopes(1.0);
+
+    AtomicInteger derivativeValue = new AtomicInteger(14);
+    doAnswer(
+            invocation -> {
+              double[] target = invocation.getArgument(2);
+              Arrays.fill(target, derivativeValue.getAndIncrement());
+              return null;
+            })
+        .when(equations)
+        .computeDerivatives(anyDouble(), any(double[].class), any(double[].class));
+
+    DormandPrince853StepInterpolator interpolator = new DormandPrince853StepInterpolator();
+    interpolator.reinitialize(equations, state, yDotK, true);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+
+    interpolator.setInterpolatedTime(0.5);
+    double firstValue = interpolator.getInterpolatedState()[0];
+
+    interpolator.setInterpolatedTime(0.25);
+    double secondValue = interpolator.getInterpolatedState()[0];
+
+    verify(equations, times(3))
+        .computeDerivatives(anyDouble(), any(double[].class), any(double[].class));
+    assertNotEquals(firstValue, secondValue);
+  }
+
+  @Test
+  void setInterpolatedTime_afterStoreTime_recomputesDerivativesForNewStep() throws Exception {
+    double[] state = {1.0};
+    double[][] yDotK = createStageSlopes(2.0);
+
+    AtomicInteger derivativeValue = new AtomicInteger(20);
+    doAnswer(
+            invocation -> {
+              double[] target = invocation.getArgument(2);
+              Arrays.fill(target, derivativeValue.getAndIncrement());
+              return null;
+            })
+        .when(equations)
+        .computeDerivatives(anyDouble(), any(double[].class), any(double[].class));
+
+    DormandPrince853StepInterpolator interpolator = new DormandPrince853StepInterpolator();
+    interpolator.reinitialize(equations, state, yDotK, true);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+    interpolator.setInterpolatedTime(0.5);
+
+    verify(equations, times(3))
+        .computeDerivatives(anyDouble(), any(double[].class), any(double[].class));
+
+    clearInvocations(equations);
+    interpolator.shift();
+    interpolator.storeTime(2.0);
+    interpolator.setInterpolatedTime(1.5);
+
+    verify(equations, times(3))
+        .computeDerivatives(anyDouble(), any(double[].class), any(double[].class));
+  }
+
+  @Test
+  void doFinalize_whenCalled_usesExpectedEvaluationTimes() throws Exception {
+    double[] state = {2.0};
+    double[][] yDotK = createStageSlopes(3.0);
+
+    List<Double> evaluationTimes = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              evaluationTimes.add(invocation.getArgument(0));
+              double[] target = invocation.getArgument(2);
+              Arrays.fill(target, 1.0);
+              return null;
+            })
+        .when(equations)
+        .computeDerivatives(anyDouble(), any(double[].class), any(double[].class));
+
+    DormandPrince853StepInterpolator interpolator = new DormandPrince853StepInterpolator();
+    interpolator.reinitialize(equations, state, yDotK, true);
+    interpolator.previousTime = 2.0;
+    interpolator.storeTime(5.0);
+
+    interpolator.setInterpolatedTime(4.0);
+
+    assertEquals(3, evaluationTimes.size());
+    assertEquals(2.0 + (1.0 / 10.0) * 3.0, evaluationTimes.get(0), 1.0e-12);
+    assertEquals(2.0 + (1.0 / 5.0) * 3.0, evaluationTimes.get(1), 1.0e-12);
+    assertEquals(2.0 + (7.0 / 9.0) * 3.0, evaluationTimes.get(2), 1.0e-12);
+  }
+
+  @Test
+  void writeExternalAndReadExternal_whenRoundTripped_preservesInterpolationOutcome()
+      throws Exception {
+    double[] state = {2.5};
+    double[][] yDotK = createStageSlopes(1.0);
+
+    AtomicInteger derivativeValue = new AtomicInteger(30);
+    doAnswer(
+            invocation -> {
+              double[] target = invocation.getArgument(2);
+              Arrays.fill(target, derivativeValue.getAndIncrement());
+              return null;
+            })
+        .when(equations)
+        .computeDerivatives(anyDouble(), any(double[].class), any(double[].class));
+
+    DormandPrince853StepInterpolator original = new DormandPrince853StepInterpolator();
+    original.reinitialize(equations, state, yDotK, true);
+    original.previousTime = 1.0;
+    original.storeTime(1.5);
+    original.setInterpolatedTime(1.25);
+    double[] expected = original.getInterpolatedState();
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      original.writeExternal(oos);
+    }
+
+    DormandPrince853StepInterpolator copy = new DormandPrince853StepInterpolator();
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      copy.readExternal(ois);
+    }
+
+    copy.setInterpolatedTime(1.25);
+    assertArrayEquals(expected, copy.getInterpolatedState(), 1.0e-14);
+  }
+
+  private static double[][] createStageSlopes(double startValue) {
+    double[][] slopes = new double[13][1];
+    for (int k = 0; k < slopes.length; k++) {
+      slopes[k][0] = startValue + k;
+    }
+    return slopes;
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/DummyStepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/DummyStepInterpolatorTest.java
@@ -1,0 +1,100 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class DummyStepInterpolatorTest {
+
+  @Test
+  void setInterpolatedTime_whenStateMutated_expectCopiesLatestState() throws DerivativeException {
+    double[] state = {1.0, 2.0};
+    DummyStepInterpolator interpolator = new DummyStepInterpolator(state, true);
+
+    interpolator.storeTime(1.0);
+    interpolator.shift();
+    interpolator.storeTime(2.0);
+
+    state[0] = 5.0;
+    state[1] = 6.0;
+
+    interpolator.setInterpolatedTime(1.5);
+    double[] interpolated = interpolator.getInterpolatedState();
+
+    assertArrayEquals(new double[] {5.0, 6.0}, interpolated);
+  }
+
+  @Test
+  void getInterpolatedState_whenResultMutated_internalBufferUnaffected()
+      throws DerivativeException {
+    double[] state = {3.0, 4.0};
+    DummyStepInterpolator interpolator = new DummyStepInterpolator(state, true);
+
+    interpolator.storeTime(0.0);
+    interpolator.shift();
+    interpolator.storeTime(0.5);
+    interpolator.setInterpolatedTime(0.25);
+
+    double[] first = interpolator.getInterpolatedState();
+    first[0] = 99.0;
+
+    double[] second = interpolator.getInterpolatedState();
+    assertArrayEquals(new double[] {3.0, 4.0}, second);
+  }
+
+  @Test
+  void copy_whenOriginalChanges_copyRemainsIndependent() throws DerivativeException {
+    double[] state = {7.0, 8.0};
+    DummyStepInterpolator original = new DummyStepInterpolator(state, true);
+
+    original.storeTime(0.0);
+    original.shift();
+    original.storeTime(1.0);
+    original.setInterpolatedTime(0.75);
+    original.finalizeStep();
+
+    DummyStepInterpolator snapshot = original.copy();
+
+    state[0] = 11.0;
+    original.setInterpolatedTime(0.8);
+
+    assertArrayEquals(new double[] {7.0, 8.0}, snapshot.getInterpolatedState());
+    assertArrayEquals(new double[] {11.0, 8.0}, original.getInterpolatedState());
+  }
+
+  @Test
+  void serializationRoundTrip_whenUsingExternalizable_preservesStepData() throws Exception {
+    double[] state = {9.0, 8.0};
+    DummyStepInterpolator interpolator = new DummyStepInterpolator(state, false);
+
+    interpolator.storeTime(1.0);
+    interpolator.shift();
+    interpolator.storeTime(2.0);
+    interpolator.setInterpolatedTime(1.5);
+
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(bout)) {
+      oos.writeObject(interpolator);
+    }
+
+    DummyStepInterpolator restored;
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(bout.toByteArray()))) {
+      restored = (DummyStepInterpolator) ois.readObject();
+    }
+
+    assertEquals(1.0, restored.getPreviousTime());
+    assertEquals(2.0, restored.getCurrentTime());
+    assertEquals(1.5, restored.getInterpolatedTime());
+    assertArrayEquals(new double[] {9.0, 8.0}, restored.getInterpolatedState());
+    assertFalse(restored.isForward());
+    assertEquals(1.0, restored.h);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/EulerStepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/EulerStepInterpolatorTest.java
@@ -1,0 +1,76 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class EulerStepInterpolatorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Mock private FirstOrderDifferentialEquations equations;
+
+  @Test
+  void setInterpolatedTime_whenMidStep_returnsLinearlyInterpolatedState()
+      throws DerivativeException {
+    EulerStepInterpolator interpolator = new EulerStepInterpolator();
+    double[] endState = {1.0, -2.0};
+    double[][] slopes = {{0.5, -1.0}};
+
+    interpolator.reinitialize(equations, endState, slopes, true);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+
+    interpolator.setInterpolatedTime(0.5);
+
+    double[] interpolated = interpolator.getInterpolatedState();
+    assertEquals(0.75, interpolated[0], EPS);
+    assertEquals(-1.5, interpolated[1], EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_backwardIntegration_handlesNegativeStepSize()
+      throws DerivativeException {
+    EulerStepInterpolator interpolator = new EulerStepInterpolator();
+    double[] endState = {2.0, -4.0};
+    double[][] slopes = {{1.0, 3.0}};
+
+    interpolator.reinitialize(equations, endState, slopes, false);
+    interpolator.previousTime = 1.0;
+    interpolator.storeTime(0.0);
+
+    interpolator.setInterpolatedTime(0.5);
+
+    double[] interpolated = interpolator.getInterpolatedState();
+    assertEquals(2.5, interpolated[0], EPS);
+    assertEquals(-2.5, interpolated[1], EPS);
+  }
+
+  @Test
+  void copy_whenOriginalMutated_preservesIndependentState() throws DerivativeException {
+    EulerStepInterpolator interpolator = new EulerStepInterpolator();
+    double[] endState = {4.0};
+    double[][] slopes = {{2.0}};
+
+    interpolator.reinitialize(equations, endState, slopes, true);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+    interpolator.setInterpolatedTime(0.5);
+    interpolator.finalizeStep();
+
+    EulerStepInterpolator copy = interpolator.copy();
+
+    endState[0] = 99.0;
+    slopes[0][0] = 99.0;
+
+    copy.setInterpolatedTime(0.5);
+
+    double[] copiedState = copy.getInterpolatedState();
+    assertEquals(3.0, copiedState[0], EPS);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/GillStepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/GillStepInterpolatorTest.java
@@ -1,0 +1,162 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class GillStepInterpolatorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @Mock private FirstOrderDifferentialEquations equations;
+
+  @ParameterizedTest
+  @CsvSource({"0.0", "0.5", "1.0"})
+  void setInterpolatedTime_whenThetaMatchesGillFormula_returnsExpectedValue(double theta)
+      throws DerivativeException {
+
+    double[] endState = new double[] {1.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {10.0}, new double[] {20.0}, new double[] {30.0}, new double[] {40.0}
+        };
+
+    GillStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* previousTime= */ 0.0, /* currentTime= */ 1.0, true);
+
+    interpolator.setInterpolatedTime(theta);
+
+    double expected =
+        computeExpectedState(endState[0], slopes, theta, /* oneMinusThetaH= */ 1.0 - theta);
+
+    double[] interpolated = interpolator.getInterpolatedState();
+    assertEquals(expected, interpolated[0], EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_backwardIntegration_handlesNegativeStepSize()
+      throws DerivativeException {
+
+    double[] endState = new double[] {2.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {1.0}, new double[] {2.0}, new double[] {3.0}, new double[] {4.0}
+        };
+
+    double previousTime = 1.0;
+    double currentTime = 0.0;
+    GillStepInterpolator interpolator =
+        createInterpolator(endState, slopes, previousTime, currentTime, false);
+
+    double queryTime = 0.5;
+    interpolator.setInterpolatedTime(queryTime);
+
+    double h = currentTime - previousTime;
+    double oneMinusThetaH = currentTime - queryTime;
+    double theta = (h - oneMinusThetaH) / h;
+    double expected = computeExpectedState(endState[0], slopes, theta, oneMinusThetaH);
+
+    double[] interpolated = interpolator.getInterpolatedState();
+    assertEquals(expected, interpolated[0], EPS);
+  }
+
+  @Test
+  void copy_whenOriginalMutated_preservesIndependentData() throws DerivativeException {
+
+    double[] endState = new double[] {4.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {1.0}, new double[] {2.0}, new double[] {3.0}, new double[] {4.0}
+        };
+
+    GillStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* previousTime= */ 0.0, /* currentTime= */ 1.0, true);
+    interpolator.setInterpolatedTime(0.5);
+    interpolator.finalizeStep();
+
+    double[][] originalSlopes = new double[slopes.length][];
+    for (int i = 0; i < slopes.length; i++) {
+      originalSlopes[i] = slopes[i].clone();
+    }
+
+    GillStepInterpolator copy = interpolator.copy();
+
+    // mutate original references after the copy
+    endState[0] = 99.0;
+    slopes[0][0] = 99.0;
+
+    copy.setInterpolatedTime(0.5);
+
+    double expected =
+        computeExpectedState(
+            /* currentState= */ 4.0, originalSlopes, /* theta= */ 0.5, /* oneMinusThetaH= */ 0.5);
+
+    double[] copiedState = copy.getInterpolatedState();
+    assertEquals(expected, copiedState[0], EPS);
+    assertEquals(1.0, copy.yDotK[0][0], EPS);
+    assertEquals(4.0, copy.currentState[0], EPS);
+  }
+
+  @Test
+  void getInterpolatedState_returnsDefensiveCopy() throws DerivativeException {
+
+    double[] endState = new double[] {3.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {2.0}, new double[] {2.0}, new double[] {2.0}, new double[] {2.0}
+        };
+
+    GillStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* previousTime= */ 0.0, /* currentTime= */ 1.0, true);
+
+    interpolator.setInterpolatedTime(0.25);
+
+    double[] firstRead = interpolator.getInterpolatedState();
+    firstRead[0] = 100.0;
+
+    double[] secondRead = interpolator.getInterpolatedState();
+    double expected =
+        computeExpectedState(endState[0], slopes, /* theta= */ 0.25, /* oneMinusThetaH= */ 0.75);
+    assertEquals(expected, secondRead[0], EPS);
+  }
+
+  private GillStepInterpolator createInterpolator(
+      double[] endState,
+      double[][] slopes,
+      double previousTime,
+      double currentTime,
+      boolean forward) {
+
+    GillStepInterpolator interpolator = new GillStepInterpolator();
+    interpolator.reinitialize(equations, endState, slopes, forward);
+    interpolator.previousTime = previousTime;
+    interpolator.storeTime(currentTime);
+    return interpolator;
+  }
+
+  private double computeExpectedState(
+      double currentState, double[][] slopes, double theta, double oneMinusThetaH) {
+
+    double fourTheta = 4.0 * theta;
+    double s = oneMinusThetaH / 6.0;
+    double soMt = s * (1.0 - theta);
+    double c23 = soMt * (1.0 + 2.0 * theta);
+    double coeff1 = soMt * (1.0 - fourTheta);
+    double coeff2 = c23 * (2.0 - Math.sqrt(2.0));
+    double coeff3 = c23 * (2.0 + Math.sqrt(2.0));
+    double coeff4 = s * (1.0 + theta * (1.0 + fourTheta));
+
+    return currentState
+        - coeff1 * slopes[0][0]
+        - coeff2 * slopes[1][0]
+        - coeff3 * slopes[2][0]
+        - coeff4 * slopes[3][0];
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/GraggBulirschStoerStepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/GraggBulirschStoerStepInterpolatorTest.java
@@ -1,0 +1,187 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class GraggBulirschStoerStepInterpolatorTest {
+
+  @Test
+  void computeCoefficients_whenMuNegative_setsBaseCoefficientsOnly() {
+
+    double[] y = new double[] {1.0};
+    double[] y0Dot = new double[] {0.5};
+    double[] y1 = new double[] {3.0};
+    double[] y1Dot = new double[] {1.5};
+    double[][] yMidDots = new double[][] {new double[] {0.0}};
+
+    GraggBulirschStoerStepInterpolator interpolator =
+        new GraggBulirschStoerStepInterpolator(y, y0Dot, y1, y1Dot, yMidDots, true);
+
+    interpolator.computeCoefficients(-1, 2.0);
+
+    double[][] polynoms = polynomsOf(interpolator);
+    assertEquals(3, currentDegreeOf(interpolator));
+    assertArrayEquals(new double[] {1.0}, polynoms[0], 1.0e-15);
+    assertArrayEquals(new double[] {2.0}, polynoms[1], 1.0e-15);
+    assertArrayEquals(new double[] {-1.0}, polynoms[2], 1.0e-15);
+    assertArrayEquals(new double[] {-1.0}, polynoms[3], 1.0e-15);
+  }
+
+  @Test
+  void computeInterpolatedState_whenThetaHalf_matchesCubicPolynomial() throws DerivativeException {
+
+    double[] y = new double[] {1.0};
+    double[] y0Dot = new double[] {0.5};
+    double[] y1 = new double[] {3.0};
+    double[] y1Dot = new double[] {1.5};
+    double[][] yMidDots = new double[][] {new double[] {0.0}};
+
+    GraggBulirschStoerStepInterpolator interpolator =
+        new GraggBulirschStoerStepInterpolator(y, y0Dot, y1, y1Dot, yMidDots, true);
+
+    interpolator.computeCoefficients(-1, 1.0);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+
+    interpolator.setInterpolatedTime(0.5);
+    double[] state = interpolator.getInterpolatedState();
+
+    assertEquals(1.875, state[0], 1.0e-12);
+  }
+
+  @Test
+  void estimateError_whenDegreeBelowThreshold_returnsZero() {
+    double[] y = new double[] {0.0};
+    double[] y0Dot = new double[] {0.0};
+    double[] y1 = new double[] {1.0};
+    double[] y1Dot = new double[] {0.0};
+    double[][] yMidDots = new double[][] {new double[] {0.0}};
+
+    GraggBulirschStoerStepInterpolator interpolator =
+        new GraggBulirschStoerStepInterpolator(y, y0Dot, y1, y1Dot, yMidDots, true);
+
+    interpolator.computeCoefficients(-1, 1.0);
+
+    assertEquals(0.0, interpolator.estimateError(new double[] {1.0}), 0.0);
+  }
+
+  @Test
+  void estimateError_whenDegreeAtLeastFive_appliesErrfacScaling() {
+    double[] y = new double[] {1.0};
+    double[] y0Dot = new double[] {1.0};
+    double[] y1 = new double[] {2.0};
+    double[] y1Dot = new double[] {1.0};
+    double[][] yMidDots = new double[][] {new double[] {1.6}, new double[] {1.2}};
+
+    GraggBulirschStoerStepInterpolator interpolator =
+        new GraggBulirschStoerStepInterpolator(y, y0Dot, y1, y1Dot, yMidDots, true);
+
+    interpolator.computeCoefficients(1, 1.0);
+
+    double[][] polynoms = polynomsOf(interpolator);
+    assertEquals(3.2, polynoms[5][0], 1.0e-12);
+
+    double error = interpolator.estimateError(new double[] {1.0});
+
+    double expectedErrfac = 1.0 / 25.0;
+    expectedErrfac *= 0.5 * Math.sqrt(1.0 / 5.0);
+    double expected = 3.2 * expectedErrfac;
+
+    assertEquals(expected, error, 1.0e-14);
+  }
+
+  @Test
+  void copy_whenCalled_producesDeepIndependentPolynoms() {
+    double[] y = new double[] {2.0};
+    double[] y0Dot = new double[] {0.0};
+    double[] y1 = new double[] {4.0};
+    double[] y1Dot = new double[] {0.0};
+    double[][] yMidDots = new double[][] {new double[] {0.0}};
+
+    GraggBulirschStoerStepInterpolator original =
+        new GraggBulirschStoerStepInterpolator(y, y0Dot, y1, y1Dot, yMidDots, true);
+    original.computeCoefficients(0, 1.0);
+
+    GraggBulirschStoerStepInterpolator copy = original.copy();
+
+    double[][] originalPolynoms = polynomsOf(original);
+    double[][] copiedPolynoms = polynomsOf(copy);
+    assertEquals(currentDegreeOf(original), currentDegreeOf(copy));
+    assertNotSame(originalPolynoms, copiedPolynoms);
+    assertArrayEquals(originalPolynoms[0], copiedPolynoms[0], 0.0);
+
+    originalPolynoms[0][0] = 123.0;
+
+    assertEquals(2.0, copiedPolynoms[0][0], 0.0);
+  }
+
+  @Test
+  void serialization_roundTrip_preservesInterpolatedState()
+      throws IOException, DerivativeException {
+    double[] y = new double[] {0.0};
+    double[] y0Dot = new double[] {1.0};
+    double[] y1 = new double[] {1.0};
+    double[] y1Dot = new double[] {1.0};
+    double[][] yMidDots = new double[][] {new double[] {0.5}, new double[] {0.5}};
+
+    GraggBulirschStoerStepInterpolator original =
+        new GraggBulirschStoerStepInterpolator(y, y0Dot, y1, y1Dot, yMidDots, true);
+    original.computeCoefficients(1, 1.0);
+    original.previousTime = 2.0;
+    original.storeTime(3.0);
+    original.setInterpolatedTime(2.5);
+    double[] expectedState = original.getInterpolatedState();
+
+    byte[] serialized = serialize(original);
+
+    GraggBulirschStoerStepInterpolator restored = new GraggBulirschStoerStepInterpolator();
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restored.readExternal(ois);
+    }
+
+    assertEquals(original.getPreviousTime(), restored.getPreviousTime(), 0.0);
+    assertEquals(original.getCurrentTime(), restored.getCurrentTime(), 0.0);
+    assertEquals(currentDegreeOf(original), currentDegreeOf(restored));
+    assertArrayEquals(expectedState, restored.getInterpolatedState(), 1.0e-12);
+  }
+
+  private static double[][] polynomsOf(GraggBulirschStoerStepInterpolator interpolator) {
+    try {
+      Field field = GraggBulirschStoerStepInterpolator.class.getDeclaredField("polynoms");
+      field.setAccessible(true);
+      return (double[][]) field.get(interpolator);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static int currentDegreeOf(GraggBulirschStoerStepInterpolator interpolator) {
+    try {
+      Field field = GraggBulirschStoerStepInterpolator.class.getDeclaredField("currentDegree");
+      field.setAccessible(true);
+      return field.getInt(interpolator);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static byte[] serialize(GraggBulirschStoerStepInterpolator interpolator)
+      throws IOException {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      interpolator.writeExternal(oos);
+      oos.flush();
+      return bos.toByteArray();
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/HighamHall54StepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/HighamHall54StepInterpolatorTest.java
@@ -1,0 +1,113 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class HighamHall54StepInterpolatorTest {
+
+  private static final double TOLERANCE = 1.0e-13;
+
+  @Test
+  void setInterpolatedTime_atCurrentTime_returnsCurrentState() throws Exception {
+    double[] state = {1.0};
+    double[][] yDotK = createStageSlopes1D();
+
+    HighamHall54StepInterpolator interpolator = new HighamHall54StepInterpolator();
+    interpolator.reinitialize(null, state, yDotK, true);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+
+    interpolator.setInterpolatedTime(1.0);
+
+    assertArrayEquals(state, interpolator.getInterpolatedState(), TOLERANCE);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0.0, -2.5", "0.25, -2.0556640625", "0.5, -1.3906250000000016"})
+  void setInterpolatedTime_withinStep_matchesKnownValues(double time, double expected)
+      throws Exception {
+    double[] state = {1.0};
+    double[][] yDotK = createStageSlopes1D();
+
+    HighamHall54StepInterpolator interpolator = new HighamHall54StepInterpolator();
+    interpolator.reinitialize(null, state, yDotK, true);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+
+    interpolator.setInterpolatedTime(time);
+
+    assertEquals(expected, interpolator.getInterpolatedState()[0], TOLERANCE);
+  }
+
+  @Test
+  void setInterpolatedTime_withVectorState_updatesEachComponent() throws Exception {
+    double[] state = {10.0, -10.0};
+    double[][] yDotK = createSymmetricStageSlopes2D();
+
+    HighamHall54StepInterpolator interpolator = new HighamHall54StepInterpolator();
+    interpolator.reinitialize(null, state, yDotK, true);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+
+    interpolator.setInterpolatedTime(0.25);
+
+    double[] expected = {6.9443359375, -6.9443359375};
+    assertArrayEquals(expected, interpolator.getInterpolatedState(), TOLERANCE);
+  }
+
+  @Test
+  void copy_afterFinalization_isDeepAndIndependent() throws Exception {
+    double[] state = {1.0};
+    double[][] yDotK = createStageSlopes1D();
+
+    HighamHall54StepInterpolator interpolator = new HighamHall54StepInterpolator();
+    interpolator.reinitialize(null, state, yDotK, true);
+    interpolator.previousTime = 0.0;
+    interpolator.storeTime(1.0);
+    interpolator.setInterpolatedTime(0.5);
+    double originalValue = interpolator.getInterpolatedState()[0];
+    interpolator.finalizeStep();
+
+    HighamHall54StepInterpolator copy = interpolator.copy();
+
+    yDotK[0][0] = 10.0;
+    state[0] = 5.0;
+    interpolator.setInterpolatedTime(0.5);
+    double mutatedOriginalValue = interpolator.getInterpolatedState()[0];
+
+    copy.setInterpolatedTime(0.5);
+    double copiedValue = copy.getInterpolatedState()[0];
+
+    assertNotEquals(originalValue, mutatedOriginalValue, TOLERANCE);
+    assertEquals(originalValue, copiedValue, TOLERANCE);
+  }
+
+  private static double[][] createStageSlopes1D() {
+    double[][] slopes = new double[6][1];
+    slopes[0][0] = 1.0;
+    slopes[2][0] = 2.0;
+    slopes[3][0] = 3.0;
+    slopes[4][0] = 4.0;
+    slopes[5][0] = 5.0;
+    return slopes;
+  }
+
+  private static double[][] createSymmetricStageSlopes2D() {
+    double[][] slopes = new double[6][2];
+    slopes[0] = new double[] {1.0, -1.0};
+    slopes[2] = new double[] {2.0, -2.0};
+    slopes[3] = new double[] {3.0, -3.0};
+    slopes[4] = new double[] {4.0, -4.0};
+    slopes[5] = new double[] {5.0, -5.0};
+    return slopes;
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/MidpointStepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/MidpointStepInterpolatorTest.java
@@ -1,0 +1,159 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("java:S100")
+class MidpointStepInterpolatorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.0, 0.25, 0.5, 0.75, 1.0})
+  void setInterpolatedTime_withConstantDerivative_matchesLinearSolution(double theta)
+      throws DerivativeException {
+
+    double[] startState = new double[] {1.0, -2.0};
+    double[] derivative = new double[] {0.5, -1.5};
+    double h = 2.0;
+
+    double[] endState =
+        new double[] {
+          startState[0] + derivative[0] * h, startState[1] + derivative[1] * h,
+        };
+    double[][] slopes = constantSlopes(derivative);
+
+    MidpointStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* startTime= */ 0.0, /* endTime= */ h, true);
+
+    double time = theta * h;
+    interpolator.setInterpolatedTime(time);
+
+    double[] expected =
+        new double[] {
+          startState[0] + derivative[0] * time, startState[1] + derivative[1] * time,
+        };
+
+    assertArrayEquals(expected, interpolator.getInterpolatedState(), EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_withDistinctSlopes_usesMidpointWeights() throws DerivativeException {
+
+    double startTime = 0.0;
+    double endTime = 1.0;
+    double h = endTime - startTime;
+
+    double startState = 2.0;
+    double yDotStage0 = 1.0;
+    double yDotStage1 = 3.0;
+    double[] endState = new double[] {startState + h * yDotStage1};
+    double[][] slopes = new double[][] {{yDotStage0}, {yDotStage1}};
+
+    MidpointStepInterpolator interpolator =
+        createInterpolator(endState, slopes, startTime, endTime, true);
+
+    double theta = 0.3;
+    interpolator.setInterpolatedTime(startTime + theta * h);
+
+    double oneMinusThetaH = (1.0 - theta) * h;
+    double expected =
+        endState[0] + oneMinusThetaH * (theta * yDotStage0 - (1.0 + theta) * yDotStage1);
+
+    assertEquals(expected, interpolator.getInterpolatedState()[0], EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_backwardIntegration_producesStateInReverseStep()
+      throws DerivativeException {
+
+    double startTime = 1.0;
+    double endTime = 0.0;
+    double h = endTime - startTime; // negative
+
+    double startState = 5.0;
+    double derivative = 1.0;
+    double[] endState = new double[] {startState + h * derivative};
+    double[][] slopes = constantSlopes(new double[] {derivative});
+
+    MidpointStepInterpolator interpolator =
+        createInterpolator(endState, slopes, startTime, endTime, false);
+
+    double targetTime = 0.5;
+    interpolator.setInterpolatedTime(targetTime);
+
+    double expected = startState + derivative * (targetTime - startTime);
+    assertEquals(expected, interpolator.getInterpolatedState()[0], EPS);
+  }
+
+  @Test
+  void copy_whenOriginalMutated_keepsDeepClonedData() throws DerivativeException {
+
+    double[] startState = new double[] {1.0};
+    double[] derivative = new double[] {2.0};
+    double h = 1.0;
+
+    double[] endState = new double[] {startState[0] + derivative[0] * h};
+    double[][] slopes = constantSlopes(derivative);
+
+    MidpointStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* startTime= */ 0.0, /* endTime= */ h, true);
+    interpolator.setInterpolatedTime(0.5 * h);
+    interpolator.finalizeStep();
+
+    MidpointStepInterpolator copy = interpolator.copy();
+
+    endState[0] = 99.0;
+    slopes[0][0] = 99.0;
+    slopes[1][0] = 99.0;
+
+    double targetTime = 0.5 * h;
+    copy.setInterpolatedTime(targetTime);
+
+    double expected = startState[0] + derivative[0] * targetTime;
+    assertEquals(expected, copy.getInterpolatedState()[0], EPS);
+  }
+
+  private static MidpointStepInterpolator createInterpolator(
+      double[] endState, double[][] slopes, double startTime, double endTime, boolean forward) {
+
+    MidpointStepInterpolator interpolator = new MidpointStepInterpolator();
+    interpolator.reinitialize(new DummyEquations(endState.length), endState, slopes, forward);
+    interpolator.previousTime = startTime;
+    interpolator.storeTime(endTime);
+    return interpolator;
+  }
+
+  private static double[][] constantSlopes(double[] derivative) {
+    double[][] slopes = new double[2][];
+    for (int i = 0; i < slopes.length; i++) {
+      slopes[i] = derivative.clone();
+    }
+    return slopes;
+  }
+
+  private static final class DummyEquations implements FirstOrderDifferentialEquations {
+
+    private final int dimension;
+
+    DummyEquations(int dimension) {
+      this.dimension = dimension;
+    }
+
+    @Override
+    public int getDimension() {
+      return dimension;
+    }
+
+    @Override
+    @SuppressWarnings("RedundantThrows")
+    public void computeDerivatives(double t, double[] y, double[] yDot) throws DerivativeException {
+      Arrays.fill(yDot, 0.0);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/ThreeEighthesStepInterpolatorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/ThreeEighthesStepInterpolatorTest.java
@@ -1,0 +1,187 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ThreeEighthesStepInterpolatorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  private FirstOrderDifferentialEquations equations;
+
+  @BeforeEach
+  void setUp() {
+    equations = mock(FirstOrderDifferentialEquations.class);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0.0,2.0", "0.5,3.5", "1.0,5.0"})
+  void setInterpolatedTime_whenSlopeConstant_returnsLinearInterpolation(
+      double theta, double expectedValue) throws DerivativeException {
+
+    double[] endState = new double[] {5.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {3.0}, new double[] {3.0}, new double[] {3.0}, new double[] {3.0}
+        };
+
+    ThreeEighthesStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* previousTime= */ 0.0, /* currentTime= */ 1.0, true);
+
+    //noinspection PointlessArithmeticExpression
+    interpolator.setInterpolatedTime(0.0 + theta * 1.0);
+
+    double[] interpolated = interpolator.getInterpolatedState();
+    assertEquals(expectedValue, interpolated[0], EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_whenAtCurrentTime_returnsCurrentState() throws DerivativeException {
+    double[] endState = new double[] {10.0, -1.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {1.0, 2.0},
+          new double[] {3.0, 4.0},
+          new double[] {5.0, 6.0},
+          new double[] {7.0, 8.0}
+        };
+
+    ThreeEighthesStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* previousTime= */ 0.0, /* currentTime= */ 1.0, true);
+
+    interpolator.setInterpolatedTime(1.0);
+
+    assertArrayEquals(endState, interpolator.getInterpolatedState(), EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_whenMidStep_usesAllStageDerivatives() throws DerivativeException {
+    double[] endState = new double[] {10.0, -5.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {1.0, -1.0},
+          new double[] {0.5, 2.0},
+          new double[] {-1.0, 4.0},
+          new double[] {2.0, -0.5}
+        };
+
+    ThreeEighthesStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* previousTime= */ 1.0, /* currentTime= */ 3.0, true);
+
+    double theta = 0.25;
+    interpolator.setInterpolatedTime(1.0 + theta * 2.0);
+
+    double oneMinusThetaH = 3.0 - (1.0 + theta * 2.0);
+    double fourTheta2 = 4.0 * theta * theta;
+    double s = oneMinusThetaH / 8.0;
+    double coeff1 = s * (1.0 - 7.0 * theta + 2.0 * fourTheta2);
+    double coeff2 = 3.0 * s * (1.0 + theta - fourTheta2);
+    double coeff3 = 3.0 * s * (1.0 + theta);
+    double coeff4 = s * (1.0 + theta + fourTheta2);
+
+    double expected0 =
+        endState[0]
+            - coeff1 * slopes[0][0]
+            - coeff2 * slopes[1][0]
+            - coeff3 * slopes[2][0]
+            - coeff4 * slopes[3][0];
+    double expected1 =
+        endState[1]
+            - coeff1 * slopes[0][1]
+            - coeff2 * slopes[1][1]
+            - coeff3 * slopes[2][1]
+            - coeff4 * slopes[3][1];
+
+    double[] interpolated = interpolator.getInterpolatedState();
+    assertEquals(expected0, interpolated[0], EPS);
+    assertEquals(expected1, interpolated[1], EPS);
+  }
+
+  @Test
+  void setInterpolatedTime_whenBackwardIntegration_handlesNegativeStep()
+      throws DerivativeException {
+    double[] endState = new double[] {2.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {3.0}, new double[] {3.0}, new double[] {3.0}, new double[] {3.0}
+        };
+
+    ThreeEighthesStepInterpolator interpolator =
+        createInterpolator(
+            endState, slopes, /* previousTime= */ 2.0, /* currentTime= */ 1.0, false);
+
+    interpolator.setInterpolatedTime(1.5);
+
+    double[] interpolated = interpolator.getInterpolatedState();
+    assertEquals(3.5, interpolated[0], EPS);
+  }
+
+  @Test
+  void copy_whenModifiedOriginal_doesNotAffectCopy() throws DerivativeException {
+    double[] endState = new double[] {4.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {1.0}, new double[] {2.0}, new double[] {3.0}, new double[] {4.0}
+        };
+
+    ThreeEighthesStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* previousTime= */ 0.0, /* currentTime= */ 1.0, true);
+    interpolator.setInterpolatedTime(0.5);
+    interpolator.finalizeStep();
+
+    ThreeEighthesStepInterpolator copy = interpolator.copy();
+
+    slopes[0][0] = 99.0;
+    endState[0] = -10.0;
+
+    assertEquals(1.0, copy.yDotK[0][0], EPS);
+    assertEquals(4.0, copy.currentState[0], EPS);
+  }
+
+  @Test
+  void getInterpolatedState_returnsDefensiveCopy() throws DerivativeException {
+    double[] endState = new double[] {2.0, 3.0};
+    double[][] slopes =
+        new double[][] {
+          new double[] {1.0, 1.0},
+          new double[] {1.0, 1.0},
+          new double[] {1.0, 1.0},
+          new double[] {1.0, 1.0}
+        };
+
+    ThreeEighthesStepInterpolator interpolator =
+        createInterpolator(endState, slopes, /* previousTime= */ 0.0, /* currentTime= */ 1.0, true);
+
+    interpolator.setInterpolatedTime(0.25);
+
+    double[] firstRead = interpolator.getInterpolatedState();
+    firstRead[0] = 100.0;
+
+    double[] secondRead = interpolator.getInterpolatedState();
+    assertEquals(1.25, secondRead[0], EPS);
+  }
+
+  private ThreeEighthesStepInterpolator createInterpolator(
+      double[] endState,
+      double[][] slopes,
+      double previousTime,
+      double currentTime,
+      boolean forward) {
+
+    ThreeEighthesStepInterpolator interpolator = new ThreeEighthesStepInterpolator();
+    interpolator.reinitialize(equations, endState, slopes, forward);
+    interpolator.previousTime = previousTime;
+    interpolator.storeTime(currentTime);
+    return interpolator;
+  }
+}


### PR DESCRIPTION
## Summary
- replace clone-based state copying in the Runge–Kutta step interpolator hierarchy with explicit copy semantics and document the lifecycle
- refresh StepInterpolator/RungeKutta Javadoc and tighten several interpolator implementations (Dormand–Prince 5(4), Dormand–Prince 8(5,3), Higham–Hall 5(4), GBS, Euler, Midpoint, Gill, Three-Eighthes, classical RK4, dummy)
- add targeted unit tests for each interpolator to verify interpolation values, derivatives, and serialization/copy behavior

## Testing
- ./gradlew spotlessApply
- not run: ./gradlew test (not requested)
