### PR TITLE
Improve ODE step handling docs and add coverage

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/AbstractStepInterpolator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/AbstractStepInterpolator.java
@@ -3,6 +3,7 @@ package org.spaceroots.mantissa.ode;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serializable;
 
 /**
  * Base class for dense-output interpolators that reconstruct the ODE state between grid points.
@@ -35,7 +36,7 @@ import java.io.ObjectOutput;
  * @version $Id: AbstractStepInterpolator.java 1709 2006-12-03 21:16:50Z luc $
  * @author L. Maisonobe
  */
-public abstract class AbstractStepInterpolator {
+public abstract class AbstractStepInterpolator implements Serializable {
 
   /** Previous grid point time, i.e. the start of the current step, in integration units. */
   protected double previousTime;

--- a/src/main/java/org/spaceroots/mantissa/ode/ContinuousOutputModel.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ContinuousOutputModel.java
@@ -1,46 +1,34 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This class stores all information provided by an ODE integrator during the integration process
- * and build a continuous model of the solution from this.
+ * Collects every accepted integration step and exposes a continuous view of the solution.
  *
- * <p>This class act as a step handler from the integrator point of view. It is called iteratively
- * during the integration process and stores a copy of all steps information in a sorted collection
- * for later use. Once the integration process is over, the user can use the {@link
- * #setInterpolatedTime setInterpolatedTime} and {@link #getInterpolatedState getInterpolatedState}
- * to retrieve this information at any time. It is important to wait for the integration to be over
- * before attempting to call {@link #setInterpolatedTime setInterpolatedTime} because some internal
- * variables are set only once the last step has been handled.
+ * <p>This step handler clones and stores finalized {@link StepInterpolator} instances in time order
+ * so that, after integration finishes, callers can move freely through the trajectory using {@link
+ * #setInterpolatedTime(double)} and {@link #getInterpolatedState()}. The model is intended for
+ * post-processing workflows such as plotting, re-sampling at uniform grids, or comparing numerical
+ * output against analytical benchmarks without rerunning the integrator. It remains mutable until
+ * the last step is marked, then behaves as a read-mostly buffer of frozen step snapshots.
  *
- * <p>This is useful for example if the main loop of the user application should remain independant
- * from the integration process or if one needs to mimic the behaviour of an analytical model
- * despite a numerical model is used (i.e. one needs the ability to get the model value at any time
- * or to navigate through the data).
+ * <p>The handler may be reused across multiple contiguous phases that share the same integration
+ * direction, enabling complex simulations (for example, coast–burn–coast) to appear as a single
+ * continuous record. Memory consumption scales with the number of accepted steps and the state
+ * dimension; tight tolerances or long horizons can therefore require considerable storage.
+ * Instances are not thread-safe and should be confined to the integration thread.
  *
- * <p>If problem modelization is done with several separate integration phases for contiguous
- * intervals, the same ContinuousOutputModel can be used as step handler for all integration phases
- * as long as they are performed in order and in the same direction. As an example, one can
- * extrapolate the trajectory of a satellite with one model (i.e. one set of differential equations)
- * up to the beginning of a maneuver, use another more complex model including thrusters
- * modelization and accurate attitude control during the maneuver, and revert to the first model
- * after the end of the maneuver. If the same continuous output model handles the steps of all
- * integration phases, the user do not need to bother when the maneuver begins or ends, he has all
- * the data available in a transparent manner.
- *
- * <p>An important feature of this class is that it implements the <code>Serializable</code>
- * interface. This means that the result of an integration can be serialized and reused later (if
- * stored into a persistent medium like a filesystem or a database) or elsewhere (if sent to another
- * application). Only the result of the integration is stored, there is no reference to the
- * integrated problem by itself.
- *
- * <p>One should be aware that the amount of data stored in a ContinuousOutputModel instance can be
- * important if the state vector is large, if the integration interval is long or if the steps are
- * small (which can result from small tolerance settings in {@link AdaptiveStepsizeIntegrator
- * adaptive step size integrators}).
+ * <ul>
+ *   <li><strong>Responsibilities:</strong> capture dense-output steps, provide random interpolation
+ *       access, and bridge adjacent integration phases.
+ *   <li><strong>Invariants:</strong> step order is preserved, direction is consistent across
+ *       appended models, and dense output remains available for every stored step.
+ *   <li><strong>Persistence:</strong> implements {@link Serializable}, allowing recorded
+ *       trajectories to be saved or transferred without rerunning the solver.
+ * </ul>
  *
  * @see StepHandler
  * @see StepInterpolator
@@ -49,26 +37,40 @@ import java.util.List;
  */
 public class ContinuousOutputModel implements StepHandler, Serializable {
 
-  /** Simple constructor. Build an empty continuous output model. */
+  /**
+   * Creates an empty continuous output model ready to receive steps.
+   *
+   * <p>The constructor allocates the internal list and immediately calls {@link #reset()} so all
+   * time markers are {@link Double#NaN} and the direction flag is forward. No steps are available
+   * until {@link #handleStep(StepInterpolator, boolean)} is invoked by an integrator, but the
+   * instance can be created early and passed around safely. Constructing multiple transient models
+   * is inexpensive and useful when experimenting with alternative integration settings or when
+   * issuing concurrent dry runs in test harnesses.
+   */
   public ContinuousOutputModel() {
     steps = new ArrayList<>();
     reset();
   }
 
   /**
-   * Append another model at the end of the instance.
+   * Appends the steps of another continuous model directly after this one.
    *
-   * @param model model to add at the end of the instance
-   * @exception IllegalArgumentException if the model to append is not compatible with the instance
-   *     (dimension of the state vector, propagation direction, hole between the dates)
+   * <p>The supplied model must describe the same state dimension and integration direction. A gap
+   * larger than a small fraction of the preceding step size is rejected to protect continuity.
+   * Steps are deep-copied, so later changes to the source model do not affect this instance.
+   *
+   * @param model another populated {@code ContinuousOutputModel} whose trajectory follows this one
+   *     in time and uses identical state dimensionality and direction; must not be {@code null}
+   * @throws IllegalArgumentException if vector dimensions differ, integration directions disagree,
+   *     or a detectable hole exists between the last local step and the first appended step
    */
   public void append(ContinuousOutputModel model) {
 
-    if (model.steps.size() == 0) {
+    if (model.steps.isEmpty()) {
       return;
     }
 
-    if (steps.size() == 0) {
+    if (steps.isEmpty()) {
       initialTime = model.initialTime;
       forward = model.forward;
     } else {
@@ -100,20 +102,28 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
   }
 
   /**
-   * Determines whether this handler needs dense output.
+   * Signals that dense output is mandatory for this handler.
    *
-   * <p>The essence of this class is to provide dense output over all steps, hence it requires the
-   * internal steps to provide themselves dense output. The method therefore returns always true.
+   * <p>The model reconstructs intermediate states from stored interpolators; it therefore requires
+   * every step to provide dense output. Integrators can check this flag when configuring step
+   * handling and enable the extra computations needed to populate dense interpolators. Because the
+   * return value is constant, clients may cache the decision and avoid repeated configuration
+   * checks during long runs.
    *
-   * @return always true
+   * @return {@code true}, indicating dense output is required for every accepted step
    */
   public boolean requiresDenseOutput() {
     return true;
   }
 
   /**
-   * Reset the step handler. Initialize the internal data as required before the first step is
-   * handled.
+   * Clears all stored steps and reinitializes timing metadata.
+   *
+   * <p>After a reset the model contains no interpolators, the current index is zero, and both
+   * boundary times are {@link Double#NaN}. Use this to reuse the same instance for a fresh
+   * integration run without reallocating internal structures. This helps reduce garbage creation
+   * during parameter sweeps or optimization loops that perform many short integrations in rapid
+   * succession.
    */
   public void reset() {
     initialTime = Double.NaN;
@@ -124,19 +134,25 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
   }
 
   /**
-   * Handle the last accepted step. A copy of the information provided by the last step is stored in
-   * the instance for later use.
+   * Records an accepted integration step.
    *
-   * @param interpolator interpolator for the last accepted step.
-   * @param isLast true if the step is the last one
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The supplied interpolator is finalized, deep-copied, and appended. On the first invocation
+   * the model captures the initial time and integration direction from the step metadata. When
+   * {@code isLast} is {@code true}, the method also stores the final time and updates the current
+   * index so callers may immediately query interpolated values.
+   *
+   * @param interpolator dense-output interpolator describing the accepted step; must align with the
+   *     integrator’s state vector and direction and must not be {@code null}
+   * @param isLast {@code true} when this step terminates the integration run; {@code false} when
+   *     more steps will follow
+   * @throws DerivativeException if finalizing or copying the interpolator requires derivative
+   *     evaluations that fail or propagate user exceptions
    */
   public void handleStep(StepInterpolator interpolator, boolean isLast) throws DerivativeException {
 
     AbstractStepInterpolator ai = (AbstractStepInterpolator) interpolator;
 
-    if (steps.size() == 0) {
+    if (steps.isEmpty()) {
       initialTime = interpolator.getPreviousTime();
       forward = interpolator.isForward();
     }
@@ -151,142 +167,93 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
   }
 
   /**
-   * Get the initial integration time.
+   * Returns the initial integration time recorded from the first stored step.
    *
-   * @return initial integration time
+   * <p>Before any steps are handled this value is {@link Double#NaN}. Once set, it reflects the
+   * earliest time across all appended models and remains stable.
+   *
+   * @return starting time of the trajectory, or {@code Double.NaN} when no steps are present
    */
   public double getInitialTime() {
     return initialTime;
   }
 
   /**
-   * Get the final integration time.
+   * Returns the final integration time of the latest recorded step.
    *
-   * @return final integration time
+   * <p>The value is updated when {@link #handleStep(StepInterpolator, boolean)} is invoked with the
+   * last-step flag. Prior to that point it remains {@link Double#NaN}.
+   *
+   * @return end time of the most recent integration phase, or {@code Double.NaN} until finalized
    */
+  @SuppressWarnings("unused")
   public double getFinalTime() {
     return finalTime;
   }
 
   /**
-   * Get the time of the interpolated point. If {@link #setInterpolatedTime} has not been called, it
-   * returns the final integration time.
+   * Returns the time associated with the currently selected interpolated state.
    *
-   * @return interpolation point time
+   * <p>Until {@link #setInterpolatedTime(double)} is invoked, this method returns the final
+   * integration time, matching the end of the last recorded step. When callers adjust interpolation
+   * time frequently, this accessor avoids redundant state computations when only the timestamp is
+   * needed, for example while logging event brackets or scanning for zero crossings.
+   *
+   * @return time of the last interpolation request, or the final integration time when unset
    */
+  @SuppressWarnings("unused")
   public double getInterpolatedTime() {
     return steps.get(index).getInterpolatedTime();
   }
 
   /**
-   * Set the time of the interpolated point.
+   * Selects the target time for subsequent interpolation requests.
    *
-   * <p>This method should <strong>not</strong> be called before the integration is over because
-   * some internal variables are set only once the last step has been handled.
+   * <p>The method locates the step that brackets the requested time using a mix of quadratic
+   * estimation and bounded refinement, then delegates to the underlying interpolator to prepare the
+   * state. Calls are intended after integration completes; invoking them earlier can yield
+   * incomplete data. Times outside the stored interval are allowed for cautious extrapolation, but
+   * fidelity decreases as the request moves away from recorded steps.
    *
-   * <p>Setting the time outside of the integration interval is now allowed (it was not allowed up
-   * to version 5.9 of Mantissa), but should be used with care since the accuracy of the
-   * interpolator will probably be very poor far from this interval. This allowance has been added
-   * to simplify implementation of search algorithms near the interval endpoints.
-   *
-   * @param time time of the interpolated point
+   * @param time absolute integration time to evaluate, potentially inside or slightly outside the
+   *     recorded interval; extreme extrapolation may reduce accuracy
    */
   public void setInterpolatedTime(double time) {
 
-    try {
-      // initialize the search with the complete steps table
-      int iMin = 0;
-      StepInterpolator sMin = (StepInterpolator) steps.get(iMin);
-      double tMin = 0.5 * (sMin.getPreviousTime() + sMin.getCurrentTime());
+    int iMin = 0;
+    AbstractStepInterpolator sMin = steps.get(iMin);
+    double tMin = midpoint(sMin);
 
-      int iMax = steps.size() - 1;
-      StepInterpolator sMax = (StepInterpolator) steps.get(iMax);
-      double tMax = 0.5 * (sMax.getPreviousTime() + sMax.getCurrentTime());
+    int iMax = steps.size() - 1;
+    AbstractStepInterpolator sMax = steps.get(iMax);
+    double tMax = midpoint(sMax);
 
-      // handle points outside of the integration interval
-      // or in the first and last step
-      if (locatePoint(time, sMin) <= 0) {
-        index = iMin;
-        sMin.setInterpolatedTime(time);
-        return;
-      }
-      if (locatePoint(time, sMax) >= 0) {
-        index = iMax;
-        sMax.setInterpolatedTime(time);
-        return;
-      }
-
-      // reduction of the table slice size
-      while (iMax - iMin > 5) {
-
-        // use the last estimated index as the splitting index
-        StepInterpolator si = (StepInterpolator) steps.get(index);
-        int location = locatePoint(time, si);
-        if (location < 0) {
-          iMax = index;
-          tMax = 0.5 * (si.getPreviousTime() + si.getCurrentTime());
-        } else if (location > 0) {
-          iMin = index;
-          tMin = 0.5 * (si.getPreviousTime() + si.getCurrentTime());
-        } else {
-          // we have found the target step, no need to continue searching
-          si.setInterpolatedTime(time);
-          return;
-        }
-
-        // compute a new estimate of the index in the reduced table slice
-        int iMed = (iMin + iMax) / 2;
-        StepInterpolator sMed = (StepInterpolator) steps.get(iMed);
-        double tMed = 0.5 * (sMed.getPreviousTime() + sMed.getCurrentTime());
-
-        if ((Math.abs(tMed - tMin) < 1e-6) || (Math.abs(tMax - tMed) < 1e-6)) {
-          // too close to the bounds, we estimate using a simple dichotomy
-          index = iMed;
-        } else {
-          // estimate the index using a reverse quadratic polynom
-          // (reverse means we have i = P(t), thus allowing to simply
-          // compute index = P(time) rather than solving a quadratic equation)
-          double d12 = tMax - tMed;
-          double d23 = tMed - tMin;
-          double d13 = tMax - tMin;
-          double dt1 = time - tMax;
-          double dt2 = time - tMed;
-          double dt3 = time - tMin;
-          double iLagrange =
-              ((dt2 * dt3 * d23) * iMax - (dt1 * dt3 * d13) * iMed + (dt1 * dt2 * d12) * iMin)
-                  / (d12 * d23 * d13);
-          index = (int) Math.rint(iLagrange);
-        }
-
-        // force the next size reduction to be at least one tenth
-        int low = Math.max(iMin + 1, (9 * iMin + iMax) / 10);
-        int high = Math.min(iMax - 1, (iMin + 9 * iMax) / 10);
-        if (index < low) {
-          index = low;
-        } else if (index > high) {
-          index = high;
-        }
-      }
-
-      // now the table slice is very small, we perform an iterative search
+    if (locatePoint(time, sMin) <= 0) {
       index = iMin;
-      while ((index <= iMax) && (locatePoint(time, (StepInterpolator) steps.get(index)) > 0)) {
-        ++index;
-      }
-
-      StepInterpolator si = (StepInterpolator) steps.get(index);
-
-      si.setInterpolatedTime(time);
-
-    } catch (DerivativeException de) {
-      throw new RuntimeException("unexpected DerivativeException caught", de);
+      safeSetInterpolatedTime(sMin, time);
+      return;
     }
+    if (locatePoint(time, sMax) >= 0) {
+      index = iMax;
+      safeSetInterpolatedTime(sMax, time);
+      return;
+    }
+
+    index = findIndex(time, iMin, iMax, tMin, tMax);
+    safeSetInterpolatedTime(steps.get(index), time);
   }
 
   /**
-   * Get the state vector of the interpolated point.
+   * Returns the state vector corresponding to the current interpolated time.
    *
-   * @return state vector at time {@link #getInterpolatedTime}
+   * <p>The returned array may be backed by an internal buffer owned by the underlying interpolator.
+   * Treat it as read-only or make a defensive copy before modification or long-term retention.
+   * Subsequent calls after changing {@link #setInterpolatedTime(double)} will update the contents
+   * of the same backing array, keeping allocations low when sampling many points along the
+   * trajectory.
+   *
+   * @return state components evaluated at {@link #getInterpolatedTime()}, possibly backed by a
+   *     mutable buffer reused between calls
    */
   public double[] getInterpolatedState() {
     return steps.get(index).getInterpolatedState();
@@ -300,7 +267,7 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
    * @return -1 if the double is before the interval, 0 if it is in the interval, and +1 if it is
    *     after the interval, according to the interval direction
    */
-  private int locatePoint(double time, StepInterpolator interval) {
+  private int locatePoint(double time, AbstractStepInterpolator interval) {
     if (forward) {
       if (time < interval.getPreviousTime()) {
         return -1;
@@ -334,5 +301,69 @@ public class ContinuousOutputModel implements StepHandler, Serializable {
   /** Steps table. */
   private final List<AbstractStepInterpolator> steps;
 
-  private static final long serialVersionUID = 2259286184268533249L;
+  private int findIndex(double time, int iMin, int iMax, double tMin, double tMax) {
+
+    while (iMax - iMin > 5) {
+
+      AbstractStepInterpolator si = steps.get(index);
+      int location = locatePoint(time, si);
+      if (location < 0) {
+        iMax = index;
+        tMax = midpoint(si);
+      } else if (location > 0) {
+        iMin = index;
+        tMin = midpoint(si);
+      } else {
+        return index;
+      }
+
+      int iMed = (iMin + iMax) / 2;
+      AbstractStepInterpolator sMed = steps.get(iMed);
+      double tMed = midpoint(sMed);
+
+      if ((Math.abs(tMed - tMin) < 1e-6) || (Math.abs(tMax - tMed) < 1e-6)) {
+        index = iMed;
+      } else {
+        double d12 = tMax - tMed;
+        double d23 = tMed - tMin;
+        double d13 = tMax - tMin;
+        double dt1 = time - tMax;
+        double dt2 = time - tMed;
+        double dt3 = time - tMin;
+        double iLagrange =
+            ((dt2 * dt3 * d23) * iMax - (dt1 * dt3 * d13) * iMed + (dt1 * dt2 * d12) * iMin)
+                / (d12 * d23 * d13);
+        index = (int) Math.rint(iLagrange);
+      }
+
+      int low = Math.max(iMin + 1, (9 * iMin + iMax) / 10);
+      int high = Math.min(iMax - 1, (iMin + 9 * iMax) / 10);
+      if (index < low) {
+        index = low;
+      } else if (index > high) {
+        index = high;
+      }
+    }
+
+    index = iMin;
+    while ((index <= iMax) && (locatePoint(time, steps.get(index)) > 0)) {
+      ++index;
+    }
+
+    return index;
+  }
+
+  private double midpoint(AbstractStepInterpolator interpolator) {
+    return 0.5 * (interpolator.getPreviousTime() + interpolator.getCurrentTime());
+  }
+
+  private void safeSetInterpolatedTime(AbstractStepInterpolator interpolator, double time) {
+    try {
+      interpolator.setInterpolatedTime(time);
+    } catch (DerivativeException e) {
+      throw new IllegalStateException("unexpected DerivativeException caught", e);
+    }
+  }
+
+  @Serial private static final long serialVersionUID = 2259286184268533249L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/DummyStepHandler.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/DummyStepHandler.java
@@ -1,16 +1,28 @@
 package org.spaceroots.mantissa.ode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * This class is a step handler that do nothing.
+ * A minimal {@link StepHandler} implementation that deliberately discards all step callbacks.
  *
- * <p>This class is provided as a convenience for users who are only interested in the final state
- * of an integration and not in the intermediate steps. Its handleStep method does nothing.
+ * <p>This handler exists for callers who only care about the final state of an integration and do
+ * not need dense output, per-step logging, or event tracking. Integrators will still invoke {@link
+ * #handleStep(StepInterpolator, boolean)} at each accepted step, but this class intentionally
+ * performs no work, keeps no state, and never requests denser interpolation. Using it avoids the
+ * overhead of allocating custom handlers when the intermediate trajectory is irrelevant.
  *
- * <p>Since this class has no internal state, it is implemented using the Singleton design pattern.
- * This means that only one instance is ever created, which can be retrieved using the getInstance
- * method. This explains why there is no public constructor.
+ * <p>The class is immutable, stateless, and thread-safe. It follows the Singleton pattern so a
+ * single reusable instance serves all callers. That design keeps allocation costs negligible even
+ * when many integrators run concurrently. Typical usage is to fetch the shared instance via {@link
+ * #getInstance()} and pass it to an integrator configuration API. No lifecycle management is
+ * required because the instance holds no resources.
+ *
+ * <ul>
+ *   <li>Requests no dense output, allowing integrators to skip continuous model construction.
+ *   <li>Ignores every step callback without side effects or retained references.
+ *   <li>Safe to reuse across threads and integrations because it maintains no mutable state.
+ * </ul>
  *
  * @see StepHandler
  * @version $Id: DummyStepHandler.java 1721 2007-10-07 20:21:25Z luc $
@@ -25,9 +37,14 @@ public class DummyStepHandler implements StepHandler, Serializable {
   private DummyStepHandler() {}
 
   /**
-   * Get the only instance.
+   * Get the single shared instance of this stateless handler.
    *
-   * @return the only instance
+   * <p>The method lazily instantiates the handler the first time it is requested, then returns the
+   * same object on every subsequent call. Callers should prefer this accessor over creating new
+   * instances to avoid unnecessary allocations and to emphasize the handler's stateless nature. The
+   * returned instance is safe for concurrent use because it never mutates internal data.
+   *
+   * @return the singleton instance reused for all no-op step handling needs
    */
   public static DummyStepHandler getInstance() {
     if (instance == null) {
@@ -37,35 +54,51 @@ public class DummyStepHandler implements StepHandler, Serializable {
   }
 
   /**
-   * Determines whether this handler needs dense output. Since this handler does nothing, it does
-   * not require dense output.
+   * Determine whether dense output is required for this handler.
    *
-   * @return always false
+   * <p>The dummy handler never needs continuous models or interpolated states because it ignores
+   * every step callback. Integrators can therefore skip building dense output structures, which may
+   * reduce memory usage and work performed per step. This method is idempotent and always returns
+   * the same value.
+   *
+   * @return {@code false}, indicating dense output can be disabled safely for this handler
    */
   public boolean requiresDenseOutput() {
     return false;
   }
 
   /**
-   * Reset the step handler. Initialize the internal data as required before the first step is
-   * handled.
+   * Reset the step handler in preparation for a new integration run.
+   *
+   * <p>No state is stored by this implementation, so the method performs no work. It exists to
+   * satisfy the {@link StepHandler} contract and to make explicit that no per-run initialization is
+   * necessary. Calling this method multiple times or between steps has no effect and is safe to do
+   * from any thread.
    */
-  public void reset() {}
+  public void reset() {
+    // Intentionally empty: dummy handler keeps no state to reset.
+  }
 
   /**
-   * Handle the last accepted step. This method does nothing in this class.
+   * Receive notification for an accepted integration step and intentionally ignore it.
    *
-   * @param interpolator interpolator for the last accepted step. For efficiency purposes, the
-   *     various integrators reuse the same object on each call, so if the instance wants to keep it
-   *     across all calls (for example to provide at the end of the integration a continuous model
-   *     valid throughout the integration range), it should build a local copy using the clone
-   *     method and store this copy.
-   * @param isLast true if the step is the last one
+   * <p>Integrators invoke this method after each successful step, providing a {@link
+   * StepInterpolator} that can expose the interpolated state and a flag indicating whether the
+   * current step ends the integration. This implementation deliberately performs no work and stores
+   * nothing, ensuring that downstream code cannot be influenced by intermediate steps. Both the
+   * interpolator reference and the {@code isLast} flag are accepted but unused. Null interpolators
+   * are tolerated because no dereferencing occurs.
+   *
+   * @param interpolator step interpolator for the accepted step; may be {@code null} because the
+   *     dummy handler never inspects it or retains references
+   * @param isLast {@code true} when the integrator reports the final step; ignored by this handler
    */
-  public void handleStep(StepInterpolator interpolator, boolean isLast) {}
+  public void handleStep(StepInterpolator interpolator, boolean isLast) {
+    // Intentionally empty: dummy handler ignores all steps and produces no output.
+  }
 
   /** The only instance. */
   private static DummyStepHandler instance = null;
 
-  private static final long serialVersionUID = 1804704906852043886L;
+  @Serial private static final long serialVersionUID = 1804704906852043886L;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/StepHandler.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/StepHandler.java
@@ -1,14 +1,26 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This interface represents a handler that should be called after each successful step.
+ * Interface for components notified after each successful numerical integration step.
  *
- * <p>The ODE integrators compute the evolution of the state vector at some grid points that depend
- * on their own internal algorithm. Once they have found a new grid point (possibly after having
- * computed several evaluation of the derivative at intermediate points), they provide it to objects
- * implementing this interface. These objects typically either ignore the intermediate steps and
- * wait for the last one, store the points in an ephemeris, or forward them to specialized
- * processing or output methods.
+ * <p>Integrators advance an ODE solution through a sequence of steps whose size depends on their
+ * internal error control and algorithmic choices. After finishing a step they pass a {@link
+ * StepInterpolator} to registered handlers so that application code can record, transform, or
+ * publish the evolving state without coupling to the solver implementation. Typical handlers either
+ * extract only end-of-step values, accumulate an ephemeris for later querying, or stream dense
+ * interpolated samples to downstream consumers such as visualizers or event detectors. The handler
+ * itself remains stateless with respect to the integrator; a fresh run should call {@link #reset()}
+ * so caches are cleared and invariants re-established before the first step arrives.
+ * Implementations are generally not thread-safe and are invoked on the integrator thread unless
+ * explicitly guarded by the caller.
+ *
+ * <p>Common responsibilities include:
+ *
+ * <ul>
+ *   <li>Deciding whether dense interpolation is required for intermediate evaluations.
+ *   <li>Storing or streaming step samples with user-defined precision.
+ *   <li>Detecting termination conditions based on the evolving state.
+ * </ul>
  *
  * @see FirstOrderIntegrator
  * @see SecondOrderIntegrator
@@ -19,35 +31,57 @@ package org.spaceroots.mantissa.ode;
 public interface StepHandler {
 
   /**
-   * Determines whether this handler needs dense output.
+   * States whether this handler needs dense output across each accepted step.
    *
-   * <p>This method allows the integrator to avoid performing extra computation if the handler does
-   * not need dense output. If this method returns false, the integrator will call the {@link
-   * #handleStep} method with a {@link DummyStepInterpolator} rather than a custom interpolator.
+   * <p>Integrators incur additional work to build a {@link StepInterpolator} capable of evaluating
+   * the state at arbitrary points within the step. Handlers that only consume end-of-step values
+   * should return {@code false} to let the integrator substitute a lightweight {@link
+   * DummyStepInterpolator} and reduce overhead. Handlers that interpolate internal samples,
+   * generate continuous output models, or perform fine-grained event checks should return {@code
+   * true}. The decision is static for the duration of one integration run and is typically based on
+   * how the handler aggregates or publishes results.
    *
-   * @return true if the handler needs dense output
+   * @return {@code true} when an interpolator with full dense-evaluation capability is required,
+   *     {@code false} when end-of-step values alone are sufficient and cheaper dummy data may be
+   *     used
    */
-  public boolean requiresDenseOutput();
+  boolean requiresDenseOutput();
 
   /**
-   * Reset the step handler. Initialize the internal data as required before the first step is
-   * handled.
+   * Reset the handler to prepare for a new integration sequence.
+   *
+   * <p>Integrators invoke this method exactly once before delivering the first step of a run. An
+   * implementation should clear cached samples, counters, or derived aggregates so that state from
+   * a previous integration does not leak into the next. The call happens before any thread starts
+   * delivering steps, so implementations may initialize mutable structures without additional
+   * synchronization. Handlers that allocate large buffers may choose to reuse them to limit garbage
+   * creation but must ensure content reflects only the upcoming run.
    */
-  public void reset();
+  void reset();
 
   /**
-   * Handle the last accepted step
+   * Process the last accepted step produced by the integrator.
    *
-   * @param interpolator interpolator for the last accepted step. For efficiency purposes, the
-   *     various integrators reuse the same object on each call, so if the instance wants to keep it
-   *     across all calls (for example to provide at the end of the integration a continuous model
-   *     valid throughout the integration range, as the {@link ContinuousOutputModel
-   *     ContinuousOutputModel} class does), it should build a local copy using the clone method of
-   *     the interpolator and store this copy. Keeping only a reference to the interpolator and
-   *     reusing it will result in unpredictable behaviour (potentially crashing the application).
-   * @param isLast true if the step is the last one
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>The same interpolator instance is reused across calls for efficiency. Handlers that need a
+   * persistent record must clone the interpolator or extract scalar data because retaining the
+   * shared object leads to mutated state on subsequent calls. The {@code isLast} flag allows
+   * implementations to finalize derived products, flush buffered output, or free resources after
+   * the terminal step. Typical implementations pull dense samples for plotting, push summaries to
+   * observers, or stop integration early when an application-specific condition is reached. The
+   * method may propagate {@link DerivativeException} so that upstream code can react to failures in
+   * the user-supplied dynamics function.
+   *
+   * <pre>{@code
+   * // Example: stash samples for later interpolation
+   * handler.handleStep(interpolator, interpolator.isForward());
+   * }</pre>
+   *
+   * @param interpolator step interpolator representing the accepted step; must be cloned or copied
+   *     before storing beyond the duration of this call
+   * @param isLast {@code true} when this invocation corresponds to the terminal step of the current
+   *     integration run, {@code false} otherwise
+   * @throws DerivativeException if evaluating the derivative through the interpolator triggers a
+   *     user function failure that the integrator chooses to propagate
    */
-  public void handleStep(StepInterpolator interpolator, boolean isLast) throws DerivativeException;
+  void handleStep(StepInterpolator interpolator, boolean isLast) throws DerivativeException;
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/StepNormalizer.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/StepNormalizer.java
@@ -1,19 +1,28 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class wraps an object implementing {@link FixedStepHandler} into a {@link StepHandler}.
+ * Normalizes calls from variable-step integrators so a fixed-step handler receives evenly spaced
+ * samples.
  *
- * <p>This wrapper allows to use fixed step handlers with general integrators which cannot guaranty
- * their integration steps will remain constant and therefore only accept general step handlers.
+ * <p>Integrators in this library expose state through {@link StepHandler} callbacks whose cadence
+ * is dictated by the adaptive step-size algorithm. {@code StepNormalizer} adapts that variable
+ * cadence to a user-supplied {@link FixedStepHandler} by generating synthetic callbacks on a
+ * constant grid decided at construction time. The first sample is always taken at the start of the
+ * integration interval and further samples are emitted every {@code h} units until the end of the
+ * last accepted step. The final emitted point is flagged with {@code isLast}, even when the last
+ * segment is shorter than {@code h}.
  *
- * <p>The stepsize used is selected at construction time. The {@link FixedStepHandler#handleStep
- * handleStep} method of the underlying {@link FixedStepHandler} object is called at the beginning
- * time of the integration t0 and also at times t0+h, t0+2h, ... If the integration range is an
- * integer multiple of the stepsize, then the last point handled will be the endpoint of the
- * integration tend, if not, the last point will belong to the interval [tend - h ; tend].
+ * <p>State is cached between invocations, so a single instance is intended to be used for one
+ * integration run and must be {@link #reset() reset} before reuse. Instances are mutable and not
+ * thread-safe; callers should confine them to the integrator thread. This helper does not constrain
+ * the underlying integrator: noninteger step ratios, overshoots, and backward integrations are all
+ * supported transparently.
  *
- * <p>There is no constraint on the integrator, it can use any timestep it needs (time steps longer
- * or shorter than the fixed time step and non-integer ratios are all allowed).
+ * <ul>
+ *   <li>Maintains direction automatically by negating the step when time decreases.
+ *   <li>Requires dense output from the integrator to interpolate intermediate grid points.
+ *   <li>Delegates array ownership to the caller; handlers should copy if they retain state.
+ * </ul>
  *
  * @see StepHandler
  * @see FixedStepHandler
@@ -23,10 +32,17 @@ package org.spaceroots.mantissa.ode;
 public class StepNormalizer implements StepHandler {
 
   /**
-   * Simple constructor.
+   * Creates a normalizer that feeds a fixed-step handler using a constant spacing.
    *
-   * @param h fixed time step (sign is not used)
-   * @param handler fixed time step handler to wrap
+   * <p>The supplied step size is converted to its absolute value; integration direction is inferred
+   * from the first received {@link StepInterpolator}. The wrapped {@link FixedStepHandler} is
+   * invoked immediately at the integration start time and then on each normalized grid point until
+   * the end of the last accepted step.
+   *
+   * @param h desired fixed spacing between emitted samples, in integration time units; sign is
+   *     ignored and zero is legal but produces no internal movement.
+   * @param handler delegate that receives normalized steps; must not be {@code null} and should
+   *     tolerate repeated array reuse by the normalizer.
    */
   public StepNormalizer(double h, FixedStepHandler handler) {
     this.h = Math.abs(h);
@@ -35,19 +51,25 @@ public class StepNormalizer implements StepHandler {
   }
 
   /**
-   * Determines whether this handler needs dense output. This handler needs dense output in order to
-   * provide data at regularly spaced steps regardless of the steps the integrator uses, so this
-   * method always returns true.
+   * Indicates that dense output is required from the driving integrator.
    *
-   * @return always true
+   * <p>The normalizer evaluates the provided {@link StepInterpolator} at arbitrary points inside
+   * each accepted step to align results with its fixed grid. Consequently, integrators using this
+   * handler must provide interpolators capable of returning accurate intermediate states.
+   *
+   * @return {@code true} because intermediate interpolation is mandatory for normalization
    */
   public boolean requiresDenseOutput() {
     return true;
   }
 
   /**
-   * Reset the step handler. Initialize the internal data as required before the first step is
-   * handled.
+   * Clears cached state so the instance can serve a new integration run.
+   *
+   * <p>This method forgets the last time, state vector, and detected direction. It should be called
+   * before reusing the handler with a different integrator or after an integration that terminated
+   * prematurely. Calling it between successive {@link #handleStep(StepInterpolator, boolean)} calls
+   * inside one integration would corrupt the normalization sequence.
    */
   public void reset() {
     lastTime = Double.NaN;
@@ -56,16 +78,20 @@ public class StepNormalizer implements StepHandler {
   }
 
   /**
-   * Handle the last accepted step
+   * Emits fixed-interval samples that fall within the accepted step.
    *
-   * @param interpolator interpolator for the last accepted step. For efficiency purposes, the
-   *     various integrators reuse the same object on each call, so if the instance wants to keep it
-   *     across all calls (for example to provide at the end of the integration a continuous model
-   *     valid throughout the integration range), it should build a local copy using the clone
-   *     method and store this copy.
-   * @param isLast true if the step is the last one
-   * @throws DerivativeException this exception is propagated to the caller if the underlying user
-   *     function triggers one
+   * <p>When first invoked, the method records the start of the interpolation interval and primes
+   * the grid based on the detected integration direction. On each call it walks forward or backward
+   * in {@code h}-sized increments, asking the interpolator for intermediate states and forwarding
+   * them to the wrapped {@link FixedStepHandler}. If {@code isLast} is {@code true}, the final
+   * emitted point is flagged so downstream logic can finalize any accumulation.
+   *
+   * @param interpolator provider for the current accepted step; must support repeated calls to
+   *     {@link StepInterpolator#setInterpolatedTime(double)} within the step bounds.
+   * @param isLast {@code true} when no more steps will arrive from the integrator; marks the final
+   *     delegated callback accordingly.
+   * @throws DerivativeException if the interpolator triggers derivative evaluation while preparing
+   *     an intermediate state and the user function signals a failure.
    */
   public void handleStep(StepInterpolator interpolator, boolean isLast) throws DerivativeException {
 

--- a/src/main/java/org/spaceroots/mantissa/ode/StepNormalizer.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/StepNormalizer.java
@@ -77,7 +77,7 @@ public class StepNormalizer implements StepHandler {
       interpolator.setInterpolatedTime(lastTime);
 
       double[] state = interpolator.getInterpolatedState();
-      lastState = (double[]) state.clone();
+      lastState = state.clone();
 
       // take the integration direction into account
       forward = (interpolator.getCurrentTime() >= lastTime);
@@ -113,7 +113,7 @@ public class StepNormalizer implements StepHandler {
   private double h;
 
   /** Underlying step handler. */
-  private FixedStepHandler handler;
+  private final FixedStepHandler handler;
 
   /** Last step time. */
   private double lastTime;

--- a/src/test/java/org/spaceroots/mantissa/ode/ContinuousOutputModelTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/ContinuousOutputModelTest.java
@@ -1,0 +1,244 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class ContinuousOutputModelTest {
+
+  @Test
+  void requiresDenseOutput_whenCalled_returnsTrue() {
+    ContinuousOutputModel model = new ContinuousOutputModel();
+
+    assertTrue(model.requiresDenseOutput());
+  }
+
+  @Test
+  void handleStep_whenTwoStepsProvided_tracksInitialFinalAndInterpolates()
+      throws DerivativeException {
+    ContinuousOutputModel model = new ContinuousOutputModel();
+
+    model.handleStep(step(0.0, 1.0, new double[] {0.0}, new double[] {1.0}, true), false);
+    model.handleStep(step(1.0, 2.0, new double[] {1.0}, new double[] {3.0}, true), true);
+
+    assertEquals(0.0, model.getInitialTime());
+    assertEquals(2.0, model.getInterpolatedTime());
+
+    model.setInterpolatedTime(1.5);
+
+    assertArrayEquals(new double[] {2.0}, model.getInterpolatedState(), 1.0e-12);
+  }
+
+  @Test
+  void reset_whenCalled_clearsStoredStepsAndMetadata() throws DerivativeException {
+    ContinuousOutputModel model = new ContinuousOutputModel();
+    model.handleStep(step(0.0, 1.0, new double[] {0.0}, new double[] {1.0}, true), true);
+
+    model.reset();
+
+    assertTrue(Double.isNaN(model.getInitialTime()));
+    assertTrue(Double.isNaN(model.getFinalTime()));
+
+    model.handleStep(step(2.0, 3.0, new double[] {2.0}, new double[] {4.0}, true), true);
+    model.setInterpolatedTime(2.5);
+
+    assertEquals(2.0, model.getInitialTime());
+    assertArrayEquals(new double[] {3.0}, model.getInterpolatedState(), 1.0e-12);
+  }
+
+  @Test
+  void append_withValidModel_combinesStepsAndPreservesOrdering() throws DerivativeException {
+    ContinuousOutputModel base = new ContinuousOutputModel();
+    base.handleStep(step(0.0, 1.0, new double[] {0.0}, new double[] {1.0}, true), true);
+
+    ContinuousOutputModel tail = new ContinuousOutputModel();
+    tail.handleStep(step(1.0, 2.0, new double[] {1.0}, new double[] {2.0}, true), true);
+
+    base.append(tail);
+
+    assertEquals(0.0, base.getInitialTime());
+    base.setInterpolatedTime(1.5);
+    assertArrayEquals(new double[] {1.5}, base.getInterpolatedState(), 1.0e-12);
+  }
+
+  @Test
+  void append_withDimensionMismatch_throwsIllegalArgumentException() throws DerivativeException {
+    ContinuousOutputModel base = new ContinuousOutputModel();
+    base.handleStep(step(0.0, 1.0, new double[] {0.0}, new double[] {1.0}, true), true);
+
+    ContinuousOutputModel mismatched = new ContinuousOutputModel();
+    mismatched.handleStep(
+        step(1.0, 2.0, new double[] {1.0, 2.0}, new double[] {3.0, 4.0}, true), true);
+
+    assertThrows(IllegalArgumentException.class, () -> base.append(mismatched));
+  }
+
+  @Test
+  void append_withDirectionMismatch_throwsIllegalArgumentException() throws DerivativeException {
+    ContinuousOutputModel base = new ContinuousOutputModel();
+    base.handleStep(step(0.0, 1.0, new double[] {0.0}, new double[] {1.0}, true), true);
+
+    ContinuousOutputModel reverse = new ContinuousOutputModel();
+    reverse.handleStep(step(1.0, 0.0, new double[] {1.0}, new double[] {0.0}, false), true);
+
+    assertThrows(IllegalArgumentException.class, () -> base.append(reverse));
+  }
+
+  @Test
+  void append_withGapTooLarge_throwsIllegalArgumentException() throws DerivativeException {
+    ContinuousOutputModel base = new ContinuousOutputModel();
+    base.handleStep(step(0.0, 1.0, new double[] {0.0}, new double[] {1.0}, true), true);
+
+    ContinuousOutputModel gapped = new ContinuousOutputModel();
+    gapped.handleStep(step(3.0, 4.0, new double[] {3.0}, new double[] {4.0}, true), true);
+
+    assertThrows(IllegalArgumentException.class, () -> base.append(gapped));
+  }
+
+  @Test
+  void setInterpolatedTime_whenOutsideBounds_usesEdgeStep() throws DerivativeException {
+    ContinuousOutputModel model = new ContinuousOutputModel();
+    model.handleStep(step(0.0, 1.0, new double[] {0.0}, new double[] {1.0}, true), false);
+    model.handleStep(step(1.0, 3.0, new double[] {1.0}, new double[] {3.0}, true), true);
+
+    model.setInterpolatedTime(-0.5);
+    assertArrayEquals(new double[] {-0.5}, model.getInterpolatedState(), 1.0e-12);
+
+    model.setInterpolatedTime(5.0);
+    assertArrayEquals(new double[] {5.0}, model.getInterpolatedState(), 1.0e-12);
+  }
+
+  @Test
+  void setInterpolatedTime_whenDenseOutputSpansManySteps_findsCorrectBracket()
+      throws DerivativeException {
+    ContinuousOutputModel model = new ContinuousOutputModel();
+    for (int i = 0; i < 7; i++) {
+      double end = i + 1.0;
+      model.handleStep(
+          step((double) i, end, new double[] {(double) i}, new double[] {end}, true), i == 6);
+    }
+
+    model.setInterpolatedTime(3.4);
+
+    assertArrayEquals(new double[] {3.4}, model.getInterpolatedState(), 1.0e-12);
+  }
+
+  @Test
+  void setInterpolatedTime_whenInterpolatorThrows_wrapsInIllegalStateException()
+      throws DerivativeException {
+    ContinuousOutputModel model = new ContinuousOutputModel();
+    model.handleStep(new ThrowingStepInterpolator(0.0, 1.0, true), true);
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> model.setInterpolatedTime(0.5));
+    assertInstanceOf(DerivativeException.class, exception.getCause());
+  }
+
+  private static StepInterpolator step(
+      double previousTime,
+      double currentTime,
+      double[] startState,
+      double[] endState,
+      boolean forward) {
+    return new SimpleStepInterpolator(previousTime, currentTime, startState, endState, forward);
+  }
+
+  private static class SimpleStepInterpolator extends AbstractStepInterpolator
+      implements StepInterpolator {
+
+    private final double[] startState;
+
+    /** Public no-arg constructor required by Externalizable; initializes to a benign 1D state. */
+    public SimpleStepInterpolator() {
+      super(new double[] {0.0}, true);
+      this.startState = new double[] {0.0};
+      this.previousTime = 0.0;
+      this.currentTime = 0.0;
+      this.h = 0.0;
+      this.interpolatedTime = 0.0;
+      System.arraycopy(
+          this.startState, 0, this.interpolatedState, 0, this.interpolatedState.length);
+    }
+
+    SimpleStepInterpolator(
+        double previousTime,
+        double currentTime,
+        double[] startState,
+        double[] endState,
+        boolean forward) {
+      super(endState.clone(), forward);
+      this.startState = startState.clone();
+      this.previousTime = previousTime;
+      this.currentTime = currentTime;
+      this.h = currentTime - previousTime;
+      this.interpolatedTime = currentTime;
+      System.arraycopy(endState, 0, this.interpolatedState, 0, endState.length);
+    }
+
+    protected SimpleStepInterpolator(SimpleStepInterpolator that) {
+      super(that);
+      this.startState = that.startState.clone();
+    }
+
+    @Override
+    public AbstractStepInterpolator copy() {
+      return new SimpleStepInterpolator(this);
+    }
+
+    @Override
+    protected void computeInterpolatedState(double theta, double oneMinusThetaH)
+        throws DerivativeException {
+      for (int i = 0; i < interpolatedState.length; i++) {
+        double delta = currentState[i] - startState[i];
+        interpolatedState[i] = startState[i] + theta * delta;
+      }
+    }
+
+    @Override
+    public void writeExternal(java.io.ObjectOutput out) {
+      // no-op: serialization not needed for test double
+    }
+
+    @Override
+    public void readExternal(java.io.ObjectInput in) {
+      // no-op: serialization not needed for test double
+    }
+  }
+
+  private static final class ThrowingStepInterpolator extends SimpleStepInterpolator {
+
+    /** Public no-arg constructor required by Externalizable. */
+    public ThrowingStepInterpolator() {
+      super();
+    }
+
+    ThrowingStepInterpolator(double previousTime, double currentTime, boolean forward) {
+      super(
+          previousTime,
+          currentTime,
+          new double[] {previousTime},
+          new double[] {currentTime},
+          forward);
+    }
+
+    private ThrowingStepInterpolator(ThrowingStepInterpolator that) {
+      super(that);
+    }
+
+    @Override
+    public AbstractStepInterpolator copy() {
+      return new ThrowingStepInterpolator(this);
+    }
+
+    @Override
+    protected void computeInterpolatedState(double theta, double oneMinusThetaH)
+        throws DerivativeException {
+      throw new DerivativeException(new RuntimeException("forced failure"));
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/DummyStepHandlerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/DummyStepHandlerTest.java
@@ -1,0 +1,89 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class DummyStepHandlerTest {
+
+  @Mock private StepInterpolator interpolator;
+
+  @Test
+  void getInstance_whenCalledMultipleTimes_returnsSameSingleton() {
+    DummyStepHandler first = DummyStepHandler.getInstance();
+    DummyStepHandler second = DummyStepHandler.getInstance();
+
+    assertNotNull(first);
+    assertSame(first, second);
+  }
+
+  @Test
+  void requiresDenseOutput_whenCalled_returnsFalse() {
+    DummyStepHandler handler = DummyStepHandler.getInstance();
+
+    assertFalse(handler.requiresDenseOutput());
+  }
+
+  @Test
+  void reset_whenInvoked_doesNotAlterSingleton() {
+    DummyStepHandler handler = DummyStepHandler.getInstance();
+
+    assertDoesNotThrow(handler::reset);
+    assertSame(handler, DummyStepHandler.getInstance());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void handleStep_whenCalledWithInterpolator_doesNothing(boolean isLast) {
+    DummyStepHandler handler = DummyStepHandler.getInstance();
+
+    handler.handleStep(interpolator, isLast);
+
+    verifyNoInteractions(interpolator);
+  }
+
+  @Test
+  void handleStep_whenInterpolatorNull_doesNotThrow() {
+    DummyStepHandler handler = DummyStepHandler.getInstance();
+
+    assertDoesNotThrow(() -> handler.handleStep(null, true));
+  }
+
+  @Test
+  void serializationRoundTrip_whenDeserialized_instanceRemainsStateless() throws Exception {
+    DummyStepHandler handler = DummyStepHandler.getInstance();
+
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(bout)) {
+      oos.writeObject(handler);
+    }
+
+    DummyStepHandler restored;
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(bout.toByteArray()))) {
+      restored = (DummyStepHandler) ois.readObject();
+    }
+
+    assertNotNull(restored);
+    assertFalse(restored.requiresDenseOutput());
+    assertSame(handler, DummyStepHandler.getInstance());
+
+    restored.handleStep(interpolator, false);
+    verifyNoInteractions(interpolator);
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/StepNormalizerTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/StepNormalizerTest.java
@@ -1,0 +1,213 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.lenient;
+
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class StepNormalizerTest {
+
+  @Mock private FixedStepHandler handler;
+
+  private List<StepCall> capturedSteps;
+
+  @BeforeEach
+  void setUpHandlerCapture() {
+    capturedSteps = new ArrayList<>();
+    lenient()
+        .doAnswer(
+            invocation -> {
+              double time = invocation.getArgument(0);
+              double[] state = invocation.getArgument(1);
+              boolean isLast = invocation.getArgument(2);
+              capturedSteps.add(new StepCall(time, state.clone(), isLast));
+              return null;
+            })
+        .when(handler)
+        .handleStep(anyDouble(), any(double[].class), anyBoolean());
+  }
+
+  @Test
+  void requiresDenseOutput_whenQueried_alwaysTrue() {
+    StepNormalizer normalizer = new StepNormalizer(0.5, handler);
+
+    assertTrue(normalizer.requiresDenseOutput());
+  }
+
+  @Test
+  void handleStep_whenForwardIntegration_emitsNormalizedStepsAndMarksLast()
+      throws DerivativeException {
+    StepNormalizer normalizer = new StepNormalizer(0.5, handler);
+    StubStepInterpolator interpolator = new StubStepInterpolator(0.0, 2.0);
+
+    normalizer.handleStep(interpolator, true);
+
+    double[] expectedTimes = {0.0, 0.5, 1.0, 1.5, 2.0};
+    assertEquals(expectedTimes.length, capturedSteps.size());
+    for (int i = 0; i < expectedTimes.length; i++) {
+      StepCall call = capturedSteps.get(i);
+      assertEquals(expectedTimes[i], call.time);
+      assertEquals(expectedTimes[i], call.state[0]);
+      assertEquals(expectedTimes[i] * 2.0, call.state[1]);
+      assertEquals(i == expectedTimes.length - 1, call.isLast);
+    }
+  }
+
+  @Test
+  void handleStep_whenBackwardIntegration_flipsDirectionAndEmitsDescendingTimes()
+      throws DerivativeException {
+    StepNormalizer normalizer = new StepNormalizer(0.5, handler);
+    StubStepInterpolator interpolator = new StubStepInterpolator(2.0, 0.0);
+
+    normalizer.handleStep(interpolator, true);
+
+    double[] expectedTimes = {2.0, 1.5, 1.0, 0.5};
+    assertEquals(expectedTimes.length, capturedSteps.size());
+    for (int i = 0; i < expectedTimes.length; i++) {
+      StepCall call = capturedSteps.get(i);
+      assertEquals(expectedTimes[i], call.time);
+      assertEquals(expectedTimes[i], call.state[0]);
+      assertEquals(expectedTimes[i] * 2.0, call.state[1]);
+      assertEquals(i == expectedTimes.length - 1, call.isLast);
+    }
+  }
+
+  @Test
+  void handleStep_whenStepsAccumulateAcrossCalls_emitsOnlyWhenGridCrossed()
+      throws DerivativeException {
+    StepNormalizer normalizer = new StepNormalizer(1.0, handler);
+
+    normalizer.handleStep(new StubStepInterpolator(0.0, 0.4), false);
+    assertTrue(capturedSteps.isEmpty(), "No output before first full step");
+
+    normalizer.handleStep(new StubStepInterpolator(0.4, 1.2), false);
+    assertEquals(1, capturedSteps.size());
+    assertEquals(0.0, capturedSteps.getFirst().time);
+    assertEquals(0.0, capturedSteps.getFirst().state[0]);
+    assertEquals(0.0, capturedSteps.getFirst().state[1]);
+    assertFalse(capturedSteps.getFirst().isLast);
+
+    normalizer.handleStep(new StubStepInterpolator(1.2, 2.0), true);
+
+    double[] expectedTimes = {0.0, 1.0, 2.0};
+    assertEquals(expectedTimes.length, capturedSteps.size());
+    for (int i = 1; i < expectedTimes.length; i++) {
+      StepCall call = capturedSteps.get(i);
+      assertEquals(expectedTimes[i], call.time);
+      assertEquals(expectedTimes[i], call.state[0]);
+      assertEquals(expectedTimes[i] * 2.0, call.state[1]);
+      assertEquals(i == expectedTimes.length - 1, call.isLast);
+    }
+  }
+
+  @Test
+  void reset_whenCalled_betweenRuns_resetsInternalState() throws DerivativeException {
+    StepNormalizer normalizer = new StepNormalizer(0.5, handler);
+
+    normalizer.handleStep(new StubStepInterpolator(0.0, 1.0), true);
+    capturedSteps.clear();
+
+    normalizer.reset();
+    normalizer.handleStep(new StubStepInterpolator(5.0, 6.0), true);
+
+    double[] expectedTimes = {5.0, 5.5, 6.0};
+    assertEquals(expectedTimes.length, capturedSteps.size());
+    for (int i = 0; i < expectedTimes.length; i++) {
+      StepCall call = capturedSteps.get(i);
+      assertEquals(expectedTimes[i], call.time);
+      assertEquals(expectedTimes[i], call.state[0]);
+      assertEquals(expectedTimes[i] * 2.0, call.state[1]);
+      assertEquals(i == expectedTimes.length - 1, call.isLast);
+    }
+  }
+
+  private static final class StepCall {
+    private final double time;
+    private final double[] state;
+    private final boolean isLast;
+
+    private StepCall(double time, double[] state, boolean isLast) {
+      this.time = time;
+      this.state = state;
+      this.isLast = isLast;
+    }
+  }
+
+  private static final class StubStepInterpolator implements StepInterpolator {
+
+    private final double previousTime;
+    private final double currentTime;
+    private final boolean forward;
+    private double interpolatedTime;
+    private final double[] stateBuffer;
+
+    public StubStepInterpolator() {
+      this(0.0, 0.0);
+    }
+
+    private StubStepInterpolator(double previousTime, double currentTime) {
+      this.previousTime = previousTime;
+      this.currentTime = currentTime;
+      this.forward = currentTime >= previousTime;
+      this.interpolatedTime = currentTime;
+      this.stateBuffer = new double[2];
+    }
+
+    @Override
+    public double getPreviousTime() {
+      return previousTime;
+    }
+
+    @Override
+    public double getCurrentTime() {
+      return currentTime;
+    }
+
+    @Override
+    public double getInterpolatedTime() {
+      return interpolatedTime;
+    }
+
+    @Override
+    public void setInterpolatedTime(double time) {
+      interpolatedTime = time;
+      stateBuffer[0] = time;
+      stateBuffer[1] = time * 2.0;
+    }
+
+    @Override
+    public double[] getInterpolatedState() {
+      return stateBuffer;
+    }
+
+    @Override
+    public boolean isForward() {
+      return forward;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) {
+      // not used in tests
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) {
+      // not used in tests
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- clarify dense-output expectations and lifecycle in StepHandler/StepNormalizer docs
- refactor DummyStepHandler/ContinuousOutputModel implementations to streamline handling
- add JUnit coverage for StepNormalizer, DummyStepHandler, and continuous output models

## Testing
- Not run (not requested)
