### PR TITLE
Harden Runge–Kutta base and add coverage for fixed-step integrators

### DIFF
--- a/src/main/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaIntegrator.java
@@ -1,10 +1,16 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements the classical fourth order Runge-Kutta integrator for Ordinary Differential
- * Equations (it is the most often used Runge-Kutta method).
+ * Classic fourth-order explicit Runge–Kutta integrator for first-order ordinary differential
+ * equations.
  *
- * <p>This method is an explicit Runge-Kutta method, its Butcher-array is the following one :
+ * <p>This implementation keeps a constant, user-specified step size and wires the canonical RK4
+ * Butcher tableau shown below. It is a good general-purpose choice when the right-hand side is
+ * smooth, accuracy requirements are moderate, and an adaptive scheme is unnecessary or too costly.
+ * The integrator is mutable and not thread-safe; create one instance per concurrent integration and
+ * reuse it sequentially to avoid repeated allocation of stage buffers and interpolators.
+ *
+ * <p>Butcher tableau used by this class:
  *
  * <pre>
  *    0  |  0    0    0    0
@@ -15,6 +21,15 @@ package org.spaceroots.mantissa.ode;
  *       | 1/6  1/3  1/3  1/6
  * </pre>
  *
+ * <ul>
+ *   <li>Uses the shared {@link RungeKuttaIntegrator} control flow for event handling and dense
+ *       output.
+ *   <li>Pairs with {@link ClassicalRungeKuttaStepInterpolator} to expose continuous trajectories
+ *       across each fixed step.
+ *   <li>Requires callers to choose a step small enough for stability; no error control is performed
+ *       internally.
+ * </ul>
+ *
  * @see EulerIntegrator
  * @see GillIntegrator
  * @see MidpointIntegrator
@@ -24,7 +39,7 @@ package org.spaceroots.mantissa.ode;
  */
 public class ClassicalRungeKuttaIntegrator extends RungeKuttaIntegrator {
 
-  private static final String methodName = "classical Runge-Kutta";
+  private static final String METHOD_NAME = "classical Runge-Kutta";
 
   private static final double[] c = {1.0 / 2.0, 1.0 / 2.0, 1.0};
 
@@ -33,20 +48,32 @@ public class ClassicalRungeKuttaIntegrator extends RungeKuttaIntegrator {
   private static final double[] b = {1.0 / 6.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 6.0};
 
   /**
-   * Simple constructor. Build a fourth-order Runge-Kutta integrator with the given step.
+   * Build a fourth-order Runge–Kutta integrator that advances with a fixed time step.
    *
-   * @param step integration step
+   * <p>The provided step size is applied unchanged for every attempted step; event handling may
+   * temporarily shorten a single step to land exactly on an event boundary, after which the nominal
+   * size is restored. Choose the value based on problem smoothness and desired accuracy, bearing in
+   * mind that RK4 has local error on the order of {@code O(h^5)} and global error on the order of
+   * {@code O(h^4)}.
+   *
+   * @param step positive, fixed integration step expressed in the same time units as the underlying
+   *     differential equations; values that are zero or excessively large may lead to {@link
+   *     IntegratorException} during a run.
    */
   public ClassicalRungeKuttaIntegrator(double step) {
     super(false, c, a, b, new ClassicalRungeKuttaStepInterpolator(), step);
   }
 
   /**
-   * Get the name of the method.
+   * Return the human-readable identifier for this integration method.
    *
-   * @return name of the method
+   * <p>The name is stable across versions and can be used in logs, user interfaces, or selection
+   * menus where multiple fixed-step schemes are exposed. It does not change with step size or other
+   * runtime configuration.
+   *
+   * @return immutable string {@code "classical Runge-Kutta"} describing this RK4 implementation.
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/EulerIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/EulerIntegrator.java
@@ -1,19 +1,27 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements a simple Euler integrator for Ordinary Differential Equations.
+ * Fixed-step explicit Euler integrator for first-order ordinary differential equations.
  *
- * <p>The Euler algorithm is the simplest one that can be used to integrate ordinary differential
- * equations. It is a simple inversion of the forward difference expression : <code>
- * f'=(f(t+h)-f(t))/h</code> which leads to <code>f(t+h)=f(t)+hf'</code>. The interpolation scheme
- * used for dense output is the linear scheme already used for integration.
+ * <p>This class implements the canonical forward-Euler scheme, updating the state as {@code
+ * y(t+h)=y(t)+h*y'(t)} using a single derivative evaluation per step. It deliberately favors
+ * simplicity over accuracy and stability, which makes it useful as a pedagogical baseline or as a
+ * quick comparator against higher-order methods when profiling algorithms or validating test
+ * infrastructure. Dense output reuses the same linear interpolation already implied by the Euler
+ * step, ensuring predictable mid-step values without extra derivative calls.
  *
- * <p>This algorithm looks cheap because it needs only one function evaluation per step. However, as
- * it uses linear estimates, it needs very small steps to achieve high accuracy, and small steps
- * lead to numerical errors and instabilities.
+ * <p>The integrator maintains a constant step size across the interval, truncating only when a
+ * registered {@link SwitchingFunction} signals an event. It is mutable and not thread-safe; create
+ * one instance per concurrent integration and reuse it sequentially for minimal allocation churn.
+ * Typical usage wires a {@link StepHandler} to collect samples, then calls {@link
+ * #integrate(FirstOrderDifferentialEquations, double, double[], double, double[])} with the desired
+ * times and state arrays.
  *
- * <p>This algorithm is almost never used and has been included in this package only as a comparison
- * reference for more useful integrators.
+ * <ul>
+ *   <li><strong>Strengths:</strong> single derivative per step, straightforward dense output.
+ *   <li><strong>Limitations:</strong> first-order accuracy, sensitive to stiffness, and requires
+ *       very small steps for precision.
+ * </ul>
  *
  * @see MidpointIntegrator
  * @see ClassicalRungeKuttaIntegrator
@@ -24,7 +32,7 @@ package org.spaceroots.mantissa.ode;
  */
 public class EulerIntegrator extends RungeKuttaIntegrator {
 
-  private static final String methodName = "Euler";
+  private static final String METHOD_NAME = "Euler";
 
   private static final double[] c = {};
 
@@ -33,20 +41,31 @@ public class EulerIntegrator extends RungeKuttaIntegrator {
   private static final double[] b = {1.0};
 
   /**
-   * Simple constructor. Build an Euler integrator with the given step.
+   * Create an Euler integrator configured with a fixed step size.
    *
-   * @param step integration step
+   * <p>The step size controls both integration spacing and the linear dense-output interval. A
+   * smaller value increases accuracy but raises the number of derivative evaluations; a larger
+   * value reduces work but may introduce instability or miss fast dynamics. The instance may be
+   * reused across runs; change the step size by creating a new integrator rather than mutating
+   * internal state.
+   *
+   * @param step strictly positive step size in integration time units; values near zero may cause
+   *     excessive steps or overflow, while negative values are unsupported.
    */
   public EulerIntegrator(double step) {
     super(false, c, a, b, new EulerStepInterpolator(), step);
   }
 
   /**
-   * Get the name of the method.
+   * Return the user-friendly name of this integration scheme.
    *
-   * @return name of the method
+   * <p>The name is stable across versions and may be used for logging, configuration displays, or
+   * diagnostics that distinguish integrator types at runtime without relying on class names.
+   *
+   * @return immutable method identifier string, currently {@code \"Euler\"}, suitable for display
+   *     and equality checks.
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/GillIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/GillIntegrator.java
@@ -1,10 +1,25 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements the Gill fourth order Runge-Kutta integrator for Ordinary Differential
- * Equations .
+ * Fourth-order Gill Runge–Kutta integrator with fixed step size.
  *
- * <p>This method is an explicit Runge-Kutta method, its Butcher-array is the following one :
+ * <p>This explicit Runge–Kutta flavor balances round-off error by mixing the classical RK4 stages
+ * with {@code sqrt(2)} coefficients. It is suited to smooth first-order systems where a constant
+ * step is acceptable and dense output is either unnecessary or provided by {@link
+ * GillStepInterpolator}. Typical usage creates an instance with a chosen step, optionally installs
+ * a {@link StepHandler} or switching functions, and then calls {@link #integrate
+ * RungeKuttaIntegrator.integrate} for each trajectory. Instances are mutable but intended for
+ * sequential reuse; they are <em>not</em> thread-safe.
+ *
+ * <p>Notable characteristics:
+ *
+ * <ul>
+ *   <li>Fixed step; events may truncate individual steps without changing the nominal step size.
+ *   <li>Explicit tableau with four stages; no FSAL optimisation is used.
+ *   <li>Accuracy comparable to classical RK4 but with improved error damping on some problems.
+ * </ul>
+ *
+ * <p>The underlying Butcher tableau is:
  *
  * <pre>
  *    0  |    0        0       0      0
@@ -15,7 +30,8 @@ package org.spaceroots.mantissa.ode;
  *       |   1/6    (2-q)/6 (2+q)/6  1/6
  * </pre>
  *
- * where q = sqrt(2)
+ * with {@code q = sqrt(2)}. See {@link RungeKuttaIntegrator} for lifecycle, event handling, and
+ * dense-output integration contract details.
  *
  * @see EulerIntegrator
  * @see ClassicalRungeKuttaIntegrator
@@ -26,37 +42,45 @@ package org.spaceroots.mantissa.ode;
  */
 public class GillIntegrator extends RungeKuttaIntegrator {
 
-  private static final String methodName = "Gill";
+  private static final String METHOD_NAME = "Gill";
 
-  private static final double sqrt2 = Math.sqrt(2.0);
+  private static final double SQRT_2 = Math.sqrt(2.0);
 
   private static final double[] c = {1.0 / 2.0, 1.0 / 2.0, 1.0};
 
   private static final double[][] a = {
     {1.0 / 2.0},
-    {(sqrt2 - 1.0) / 2.0, (2.0 - sqrt2) / 2.0},
-    {0.0, -sqrt2 / 2.0, (2.0 + sqrt2) / 2.0}
+    {(SQRT_2 - 1.0) / 2.0, (2.0 - SQRT_2) / 2.0},
+    {0.0, -SQRT_2 / 2.0, (2.0 + SQRT_2) / 2.0}
   };
 
   private static final double[] b = {
-    1.0 / 6.0, (2.0 - sqrt2) / 6.0, (2.0 + sqrt2) / 6.0, 1.0 / 6.0
+    1.0 / 6.0, (2.0 - SQRT_2) / 6.0, (2.0 + SQRT_2) / 6.0, 1.0 / 6.0
   };
 
   /**
-   * Simple constructor. Build a fourth-order Gill integrator with the given step.
+   * Creates a Gill integrator configured with a constant step size.
    *
-   * @param step integration step
+   * <p>The instance may be reused across multiple {@link #integrate} calls; internal state is
+   * cleared automatically after each run. Switching functions can shorten individual steps, but the
+   * nominal step size provided here governs staging and output cadence.
+   *
+   * @param step fixed integration step expressed in the same time units as the differential
+   *     equations; must be a non-zero finite value to avoid {@link IntegratorException} at runtime.
    */
   public GillIntegrator(double step) {
     super(false, c, a, b, new GillStepInterpolator(), step);
   }
 
   /**
-   * Get the name of the method.
+   * Returns the human-readable name of this integration method.
    *
-   * @return name of the method
+   * <p>The returned string is stable and can be logged or displayed in diagnostics to identify the
+   * chosen Runge–Kutta flavor. It does not vary with step size or runtime configuration.
+   *
+   * @return method name string, always {@code "Gill"} for this integrator.
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/MidpointIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/MidpointIntegrator.java
@@ -1,9 +1,10 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements a second order Runge-Kutta integrator for Ordinary Differential Equations.
+ * Second-order explicit Runge–Kutta (midpoint) integrator for first-order ordinary differential
+ * equations using a constant step size.
  *
- * <p>This method is an explicit Runge-Kutta method, its Butcher-array is the following one :
+ * <p>This implementation executes the classical midpoint tableau:
  *
  * <pre>
  *    0  |  0    0
@@ -11,6 +12,26 @@ package org.spaceroots.mantissa.ode;
  *       |----------
  *       |  0    1
  * </pre>
+ *
+ * and wires it into the shared fixed-step control flow provided by {@link RungeKuttaIntegrator}.
+ * The instance is mutable but intended for single-threaded reuse across multiple integration runs;
+ * create one instance per concurrent integration to avoid shared mutable state. Dense output is
+ * available through {@link MidpointStepInterpolator} when the registered {@link StepHandler}
+ * requests it. The nominal step size is never adapted automatically, but individual steps can be
+ * shortened when switching functions signal an event, after which the original cadence resumes.
+ *
+ * <p>Typical usage follows a "create–configure–integrate" pattern:
+ *
+ * <ul>
+ *   <li>Construct the integrator with a positive step size matching the equation time units.
+ *   <li>Optionally install a {@link StepHandler} and switching functions to observe or stop runs.
+ *   <li>Call {@link #integrate(FirstOrderDifferentialEquations, double, double[], double,
+ *       double[])} with matching state vectors for each trajectory.
+ * </ul>
+ *
+ * <p>Use this integrator when a lightweight, fixed-step scheme suffices and the modest accuracy of
+ * a second-order method meets requirements. For stiffer problems or tighter tolerances, prefer the
+ * higher-order Runge–Kutta variants in this package.
  *
  * @see EulerIntegrator
  * @see ClassicalRungeKuttaIntegrator
@@ -20,7 +41,7 @@ package org.spaceroots.mantissa.ode;
  */
 public class MidpointIntegrator extends RungeKuttaIntegrator {
 
-  private static final String methodName = "midpoint";
+  private static final String METHOD_NAME = "midpoint";
 
   private static final double[] c = {1.0 / 2.0};
 
@@ -29,20 +50,33 @@ public class MidpointIntegrator extends RungeKuttaIntegrator {
   private static final double[] b = {0.0, 1.0};
 
   /**
-   * Simple constructor. Build a midpoint integrator with the given step.
+   * Build a midpoint integrator configured with the provided fixed step size.
    *
-   * @param step integration step
+   * <p>The created instance is ready for immediate use and may be reused sequentially across
+   * multiple integration runs. The {@code step} value must be expressed in the same units as the
+   * independent variable of the supplied {@link FirstOrderDifferentialEquations}. Negative values
+   * are allowed to support backward integration; zero is rejected at runtime by the base class
+   * validation. Dense-output interpolation is available when callers install a {@link StepHandler}
+   * that requests it.
+   *
+   * @param step constant integration step size, in equation time units; positive for forward
+   *     traversal, negative for backward traversal; must be non-zero.
    */
   public MidpointIntegrator(double step) {
     super(false, c, a, b, new MidpointStepInterpolator(), step);
   }
 
   /**
-   * Get the name of the method.
+   * Return the human-readable identifier for this integration scheme.
    *
-   * @return name of the method
+   * <p>The name is stable across releases and matches the conventional label used in logs, user
+   * interfaces, and algorithm selection helpers inside the library. The value is independent of any
+   * runtime configuration such as step size and is suitable for display or switch-based dispatch.
+   *
+   * @return constant string {@code "midpoint"} identifying this Runge–Kutta variant; the caller
+   *     must not modify or cache assumptions about capitalization beyond this literal.
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
@@ -174,7 +174,8 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
       firstEvaluationPending = false;
 
       acceptStep(y, yTmp);
-      lastStep = switchesHandler.stop() || isLastStep(stepIndex, nbStep);
+      boolean stopRequested = switchesHandler.stop();
+      lastStep = stopRequested || isLastStep(stepIndex, nbStep);
 
       interpolator.storeTime(stepStart);
       handler.handleStep((StepInterpolator) interpolator, lastStep);
@@ -185,7 +186,7 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
         equations.computeDerivatives(stepStart, y, yDotK[0]);
       }
 
-      if (stepResult.needStepAdjustment) {
+      if (stepResult.needStepAdjustment && !stopRequested) {
         nbStep = computeNumberOfSteps(stepStart, t);
         stepSize = computeStepSize(stepStart, t, nbStep);
         stepIndex = 0;

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
@@ -175,7 +175,18 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
 
       acceptStep(y, yTmp);
       boolean stopRequested = switchesHandler.stop();
-      lastStep = stopRequested || isLastStep(stepIndex, nbStep);
+      boolean lastStepCandidate = stopRequested || isLastStep(stepIndex, nbStep);
+
+      if (stepResult.needStepAdjustment && !stopRequested) {
+        nbStep = computeNumberOfSteps(stepStart, t);
+        stepSize = computeStepSize(stepStart, t, nbStep);
+        stepIndex = 0;
+        lastStepCandidate = false;
+      } else {
+        ++stepIndex;
+      }
+
+      lastStep = lastStepCandidate;
 
       interpolator.storeTime(stepStart);
       handler.handleStep((StepInterpolator) interpolator, lastStep);
@@ -184,15 +195,6 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
 
       if (switchesHandler.reset(stepStart, y) && !lastStep) {
         equations.computeDerivatives(stepStart, y, yDotK[0]);
-      }
-
-      if (stepResult.needStepAdjustment && !stopRequested) {
-        nbStep = computeNumberOfSteps(stepStart, t);
-        stepSize = computeStepSize(stepStart, t, nbStep);
-        stepIndex = 0;
-        lastStep = false;
-      } else {
-        ++stepIndex;
       }
     }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
@@ -1,27 +1,31 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements the common part of all fixed step Runge-Kutta integrators for Ordinary
- * Differential Equations.
+ * Fixed-step Runge–Kutta base integrator for first-order ordinary differential equations.
  *
- * <p>These methods are explicit Runge-Kutta methods, their Butcher arrays are as follows :
+ * <p>Instances provide the shared control-flow, event processing, and dense-output wiring used by
+ * all explicit Runge–Kutta schemes in this package. Callers supply a Butcher tableau and a step
+ * interpolator prototype; subclasses only define the coefficients and the public name. The class
+ * maintains a fixed step size throughout an {@link #integrate(FirstOrderDifferentialEquations,
+ * double, double[], double, double[]) integration} and supports optional “first same as last”
+ * (FSAL) methods where the final stage slope of one step seeds the next. It is <strong>not</strong>
+ * thread-safe; create one integrator instance per concurrent integration and reuse it sequentially
+ * to avoid allocation churn.
  *
- * <pre>
- *    0  |
- *   c2  | a21
- *   c3  | a31  a32
- *   ... |        ...
- *   cs  | as1  as2  ...  ass-1
- *       |--------------------------
- *       |  b1   b2  ...   bs-1  bs
- * </pre>
+ * <p>Lifecycle highlights:
  *
- * <p>Some methods are qualified as <i>fsal</i> (first same as last) methods. This means the last
- * evaluation of the derivatives in one step is the same as the first in the next step. Then, this
- * evaluation can be reused from one step to the next one and the cost of such a method is really
- * s-1 evaluations despite the method still has s stages. This behaviour is true only for successful
- * steps, if the step is rejected after the error estimation phase, no evaluation is saved. For an
- * <i>fsal</i> method, we have cs = 1 and asi = bi for all i.
+ * <ul>
+ *   <li>Validate dimensions and interval, allocate stage arrays, and configure dense output.
+ *   <li>Advance a fixed number of equal steps, detecting switching functions and re-aligning step
+ *       boundaries when events occur.
+ *   <li>Expose intermediate states via the configured {@link StepHandler} and optional dense
+ *       interpolator.
+ * </ul>
+ *
+ * <p>Use this base when implementing new explicit Runge–Kutta flavors with constant step sizes.
+ * Prefer higher-level adaptative integrators when variable step control or error estimates are
+ * required. Switching functions are evaluated deterministically and may shorten individual steps,
+ * but the nominal step size and FSAL reuse remain intact between events.
  *
  * @see EulerIntegrator
  * @see ClassicalRungeKuttaIntegrator
@@ -33,28 +37,35 @@ package org.spaceroots.mantissa.ode;
 public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
 
   /**
-   * Simple constructor. Build a Runge-Kutta integrator with the given step. The default step
-   * handler does nothing.
+   * Build a Runge–Kutta integrator with constant step size and default no-op step handler.
    *
-   * @param fsal indicate that the method is an <i>fsal</i>
-   * @param c time steps from Butcher array (without the first zero)
-   * @param a internal weights from Butcher array (without the first empty row)
-   * @param b external weights for the high order method from Butcher array
-   * @param prototype prototype of the step interpolator to use
-   * @param step integration step
+   * <p>The caller supplies the Butcher tableau rows and an interpolator prototype appropriate for
+   * the specific Runge–Kutta scheme. The integrator clones the interpolator per step and may reuse
+   * the final slope of each step when {@code fsal} is {@code true}. The instance is ready for reuse
+   * across multiple integration runs; state is cleared automatically after each {@link #integrate}
+   * call.
+   *
+   * @param fsal {@code true} to enable FSAL reuse where the last slope equals the next first slope.
+   * @param c time-step offsets (excluding the initial zero) matching the Butcher tableau rows.
+   * @param a internal stage weights (tableau without the leading empty row); each row length equals
+   *     its stage index.
+   * @param b external weights for the final state update; length must equal {@code c.length + 1}.
+   * @param prototype dense-output interpolator prototype copied for each accepted step; must be a
+   *     {@link RungeKuttaStepInterpolator}.
+   * @param step fixed integration step size in the same time units as equation evaluation.
    */
   protected RungeKuttaIntegrator(
       boolean fsal,
       double[] c,
       double[][] a,
       double[] b,
-      RungeKuttaStepInterpolator prototype,
+      AbstractStepInterpolator prototype,
       double step) {
     this.fsal = fsal;
     this.c = c;
     this.a = a;
     this.b = b;
-    this.prototype = prototype;
+    this.prototype = checkPrototype(prototype);
     this.step = step;
     handler = DummyStepHandler.getInstance();
     switchesHandler = new SwitchingFunctionsHandler();
@@ -62,178 +73,154 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
   }
 
   /**
-   * Get the name of the method.
+   * Set the step handler invoked after every accepted step.
    *
-   * @return name of the method
-   */
-  public abstract String getName();
-
-  /**
-   * Set the step handler for this integrator. The handler will be called by the integrator for each
-   * accepted step.
+   * <p>The handler receives a {@link StepInterpolator} positioned at the end of the step and may
+   * request dense output. Providing a custom handler allows callers to log progress, accumulate
+   * solution samples, or abort integration via exception. Passing {@code null} is unsupported; use
+   * {@link DummyStepHandler#getInstance()} to ignore callbacks.
    *
-   * @param handler handler for the accepted steps
+   * @param handler non-null consumer for accepted steps; must tolerate reuse across many steps.
    */
   public void setStepHandler(StepHandler handler) {
     this.handler = handler;
   }
 
   /**
-   * Get the step handler for this integrator.
+   * Return the current step handler used for accepted steps.
    *
-   * @return the step handler for this integrator
+   * <p>The returned instance is the same object supplied via {@link #setStepHandler}. The default
+   * value is {@link DummyStepHandler#getInstance()}, which performs no work. Callers may replace it
+   * before each integration run to collect step data in different ways.
+   *
+   * @return mutable step handler instance currently registered with this integrator.
    */
   public StepHandler getStepHandler() {
     return handler;
   }
 
   /**
-   * Add a switching function to the integrator.
+   * Register a switching function used to detect events during integration.
    *
-   * @param function switching function
-   * @param maxCheckInterval maximal time interval between switching function checks (this interval
-   *     prevents missing sign changes in case the integration steps becomes very large)
-   * @param convergence convergence threshold in the event time search
+   * <p>Each function is polled at most every {@code maxCheckInterval} along the independent
+   * variable, regardless of the nominal step size, to avoid missing sign changes. When an event is
+   * detected, the integrator shortens the current step so the accepted step ends exactly at the
+   * event time within the given {@code convergence} tolerance.
+   *
+   * @param function user-supplied switching function that returns signed values across the domain.
+   * @param maxCheckInterval maximum interval, in integration time units, between event evaluations.
+   * @param convergence absolute time accuracy used when refining the event occurrence instant.
    */
   public void addSwitchingFunction(
       SwitchingFunction function, double maxCheckInterval, double convergence) {
     switchesHandler.add(function, maxCheckInterval, convergence);
   }
 
+  /**
+   * Integrate the set of differential equations over a fixed number of equal steps.
+   *
+   * <p>The initial state {@code y0} is copied into {@code y} if they differ; the final state is
+   * always stored in {@code y}. The method enforces dimension compatibility, rejects near-zero
+   * intervals, and processes switching functions that may truncate individual steps while
+   * preserving the nominal step size thereafter. Dense-output handlers receive an interpolator
+   * pointing to the end of each accepted step.
+   *
+   * <p>Typical usage:
+   *
+   * <pre>{@code
+   * double[] state = initial.clone();
+   * integrator.integrate(equations, t0, state, tEnd, state);
+   * }</pre>
+   *
+   * @param equations system of first-order equations to evaluate; dimension must match {@code y0}.
+   * @param t0 initial integration time; also used as the start of the first step.
+   * @param y0 initial state vector at {@code t0}; never modified when equal to {@code y}.
+   * @param t target time for integration end; may be greater or less than {@code t0}.
+   * @param y output state vector; receives the final state and may alias {@code y0}.
+   * @throws DerivativeException if equation evaluation fails at any step or intermediate stage.
+   * @throws IntegratorException if dimensions mismatch or the interval length is too small.
+   */
   public void integrate(
       FirstOrderDifferentialEquations equations, double t0, double[] y0, double t, double[] y)
       throws DerivativeException, IntegratorException {
 
-    // sanity check
-    if (equations.getDimension() != y0.length) {
-      throw new IntegratorException(
-          "dimensions mismatch: ODE problem has dimension {0}," + " state vector has dimension {1}",
-          new String[] {Integer.toString(equations.getDimension()), Integer.toString(y0.length)});
-    }
-    if (Math.abs(t - t0) <= 1.0e-12 * Math.max(Math.abs(t0), Math.abs(t))) {
-      throw new IntegratorException(
-          "too small integration interval: length = {0}",
-          new String[] {Double.toString(Math.abs(t - t0))});
-    }
+    validateIntegrationRange(equations, y0, t0, t);
 
     boolean forward = (t > t0);
-
-    // create some internal working arrays
     int stages = c.length + 1;
     if (y != y0) {
       System.arraycopy(y0, 0, y, 0, y0.length);
     }
-    double[][] yDotK = new double[stages][];
-    for (int i = 0; i < stages; ++i) {
-      yDotK[i] = new double[y0.length];
-    }
-    double[] yTmp = new double[y0.length];
 
-    // set up an interpolator sharing the integrator arrays
-    AbstractStepInterpolator interpolator;
-    if (handler.requiresDenseOutput() || (!switchesHandler.isEmpty())) {
-      RungeKuttaStepInterpolator rki = (RungeKuttaStepInterpolator) prototype.copy();
-      rki.reinitialize(equations, yTmp, yDotK, forward);
-      interpolator = rki;
-    } else {
-      interpolator = new DummyStepInterpolator(yTmp, forward);
-    }
+    double[][] yDotK = createDerivativesArray(stages, y0.length);
+    double[] yTmp = new double[y0.length];
+    AbstractStepInterpolator interpolator = createInterpolator(equations, yTmp, yDotK, forward);
+
+    long nbStep = computeNumberOfSteps(t0, t);
+    boolean firstEvaluationPending = true;
+    boolean lastStep = false;
+    long stepIndex = 0;
+    stepStart = t0;
+    stepSize = computeStepSize(t0, t, nbStep);
+    handler.reset();
     interpolator.storeTime(t0);
 
-    // recompute the step
-    long nbStep = Math.max(1l, Math.abs(Math.round((t - t0) / step)));
-    boolean firstTime = true;
-    boolean lastStep = false;
-    stepStart = t0;
-    stepSize = (t - t0) / nbStep;
-    handler.reset();
-    for (long i = 0; !lastStep; ++i) {
-
+    while (!lastStep) {
       interpolator.shift();
 
-      boolean needUpdate = false;
-      for (boolean loop = true; loop; ) {
+      StepComputationResult stepResult =
+          computeProvisionalStep(
+              equations, y, yTmp, yDotK, stages, firstEvaluationPending, interpolator);
+      firstEvaluationPending = false;
 
-        if (firstTime || !fsal) {
-          // first stage
-          equations.computeDerivatives(stepStart, y, yDotK[0]);
-          firstTime = false;
-        }
+      acceptStep(y, yTmp);
+      lastStep = switchesHandler.stop() || isLastStep(stepIndex, nbStep);
 
-        // next stages
-        for (int k = 1; k < stages; ++k) {
-
-          for (int j = 0; j < y0.length; ++j) {
-            double sum = a[k - 1][0] * yDotK[0][j];
-            for (int l = 1; l < k; ++l) {
-              sum += a[k - 1][l] * yDotK[l][j];
-            }
-            yTmp[j] = y[j] + stepSize * sum;
-          }
-
-          equations.computeDerivatives(stepStart + c[k - 1] * stepSize, yTmp, yDotK[k]);
-        }
-
-        // estimate the state at the end of the step
-        for (int j = 0; j < y0.length; ++j) {
-          double sum = b[0] * yDotK[0][j];
-          for (int l = 1; l < stages; ++l) {
-            sum += b[l] * yDotK[l][j];
-          }
-          yTmp[j] = y[j] + stepSize * sum;
-        }
-
-        // Switching functions handling
-        interpolator.storeTime(stepStart + stepSize);
-        if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
-          needUpdate = true;
-          stepSize = switchesHandler.getEventTime() - stepStart;
-        } else {
-          loop = false;
-        }
-      }
-
-      // the step has been accepted
-      stepStart += stepSize;
-      System.arraycopy(yTmp, 0, y, 0, y0.length);
-      switchesHandler.stepAccepted(stepStart, y);
-      if (switchesHandler.stop()) {
-        lastStep = true;
-      } else {
-        lastStep = (i == (nbStep - 1));
-      }
-
-      // provide the step data to the step handler
       interpolator.storeTime(stepStart);
       handler.handleStep((StepInterpolator) interpolator, lastStep);
 
-      if (fsal) {
-        // save the last evaluation for the next step
-        System.arraycopy(yDotK[stages - 1], 0, yDotK[0], 0, y0.length);
-      }
+      updateFsalState(yDotK, stages, y.length);
 
       if (switchesHandler.reset(stepStart, y) && !lastStep) {
-        // some switching function has triggered changes that
-        // invalidate the derivatives, we need to recompute them
         equations.computeDerivatives(stepStart, y, yDotK[0]);
       }
 
-      if (needUpdate) {
-        // a switching function has changed the step
-        // we need to recompute stepsize
-        nbStep = Math.max(1l, Math.abs(Math.round((t - stepStart) / step)));
-        stepSize = (t - stepStart) / nbStep;
-        i = -1;
+      if (stepResult.needStepAdjustment) {
+        nbStep = computeNumberOfSteps(stepStart, t);
+        stepSize = computeStepSize(stepStart, t, nbStep);
+        stepIndex = 0;
+        lastStep = false;
+      } else {
+        ++stepIndex;
       }
     }
 
     resetInternalState();
   }
 
+  /**
+   * Get the start time of the last processed step.
+   *
+   * <p>Returns {@link Double#NaN} before the first call to {@link #integrate} and immediately after
+   * a run completes, because {@link #resetInternalState()} clears the cached value. During
+   * integration, it reflects the time at which the current step began, even if that step was
+   * shortened by an event.
+   *
+   * @return time coordinate for the start of the last accepted step, or {@code NaN} when undefined.
+   */
   public double getCurrentStepStart() {
     return stepStart;
   }
 
+  /**
+   * Get the size of the current integration step.
+   *
+   * <p>During integration this value is the actual step size being taken, which may differ from the
+   * nominal constructor step if an event truncated the current step. Outside an integration run the
+   * value is {@link Double#NaN}.
+   *
+   * @return length of the current step in integration time units, or {@code NaN} when not running.
+   */
   public double getCurrentStepsize() {
     return stepSize;
   }
@@ -245,22 +232,22 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
   }
 
   /** Indicator for <i>fsal</i> methods. */
-  private boolean fsal;
+  private final boolean fsal;
 
   /** Time steps from Butcher array (without the first zero). */
-  private double[] c;
+  private final double[] c;
 
   /** Internal weights from Butcher array (without the first empty row). */
-  private double[][] a;
+  private final double[][] a;
 
   /** External weights for the high order method from Butcher array. */
-  private double[] b;
+  private final double[] b;
 
   /** Prototype of the step interpolator. */
-  private RungeKuttaStepInterpolator prototype;
+  private final RungeKuttaStepInterpolator prototype;
 
   /** Integration step. */
-  private double step;
+  private final double step;
 
   /** Step handler. */
   private StepHandler handler;
@@ -273,4 +260,140 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
 
   /** Current stepsize. */
   private double stepSize;
+
+  private RungeKuttaStepInterpolator checkPrototype(AbstractStepInterpolator prototype) {
+    if (prototype instanceof RungeKuttaStepInterpolator rungeKuttaPrototype) {
+      return rungeKuttaPrototype;
+    }
+    throw new IllegalArgumentException("Prototype must be a RungeKuttaStepInterpolator");
+  }
+
+  private void validateIntegrationRange(
+      FirstOrderDifferentialEquations equations, double[] y0, double t0, double t)
+      throws IntegratorException {
+    if (equations.getDimension() != y0.length) {
+      throw new IntegratorException(
+          "dimensions mismatch: ODE problem has dimension {0}," + " state vector has dimension {1}",
+          new String[] {Integer.toString(equations.getDimension()), Integer.toString(y0.length)});
+    }
+    if (Math.abs(t - t0) <= 1.0e-12 * Math.max(Math.abs(t0), Math.abs(t))) {
+      throw new IntegratorException(
+          "too small integration interval: length = {0}",
+          new String[] {Double.toString(Math.abs(t - t0))});
+    }
+  }
+
+  private double[][] createDerivativesArray(int stages, int dimension) {
+    double[][] yDotK = new double[stages][];
+    for (int i = 0; i < stages; ++i) {
+      yDotK[i] = new double[dimension];
+    }
+    return yDotK;
+  }
+
+  private AbstractStepInterpolator createInterpolator(
+      FirstOrderDifferentialEquations equations, double[] yTmp, double[][] yDotK, boolean forward) {
+    if (handler.requiresDenseOutput() || (!switchesHandler.isEmpty())) {
+      RungeKuttaStepInterpolator rki = (RungeKuttaStepInterpolator) prototype.copy();
+      rki.reinitialize(equations, yTmp, yDotK, forward);
+      return rki;
+    }
+    return new DummyStepInterpolator(yTmp, forward);
+  }
+
+  private long computeNumberOfSteps(double start, double target) {
+    return Math.max(1L, Math.abs(Math.round((target - start) / step)));
+  }
+
+  private double computeStepSize(double start, double target, long numberOfSteps) {
+    return (target - start) / numberOfSteps;
+  }
+
+  private StepComputationResult computeProvisionalStep(
+      FirstOrderDifferentialEquations equations,
+      double[] y,
+      double[] yTmp,
+      double[][] yDotK,
+      int stages,
+      boolean firstEvaluationPending,
+      AbstractStepInterpolator interpolator)
+      throws DerivativeException {
+
+    boolean adjusted = false;
+    boolean needUpdate;
+    do {
+      computeFirstDerivativesIfNeeded(equations, y, yDotK, firstEvaluationPending);
+      firstEvaluationPending = false;
+      computeIntermediateStages(equations, y, yTmp, yDotK, stages);
+      estimateStepEndState(y, yTmp, yDotK, stages);
+      needUpdate = handleSwitchingFunctions(interpolator);
+      adjusted |= needUpdate;
+    } while (needUpdate);
+
+    return new StepComputationResult(adjusted);
+  }
+
+  private void computeFirstDerivativesIfNeeded(
+      FirstOrderDifferentialEquations equations, double[] y, double[][] yDotK, boolean pending)
+      throws DerivativeException {
+    if (pending || !fsal) {
+      equations.computeDerivatives(stepStart, y, yDotK[0]);
+    }
+  }
+
+  private void computeIntermediateStages(
+      FirstOrderDifferentialEquations equations,
+      double[] y,
+      double[] yTmp,
+      double[][] yDotK,
+      int stages)
+      throws DerivativeException {
+    for (int k = 1; k < stages; ++k) {
+      for (int j = 0; j < y.length; ++j) {
+        double sum = a[k - 1][0] * yDotK[0][j];
+        for (int l = 1; l < k; ++l) {
+          sum += a[k - 1][l] * yDotK[l][j];
+        }
+        yTmp[j] = y[j] + stepSize * sum;
+      }
+      equations.computeDerivatives(stepStart + c[k - 1] * stepSize, yTmp, yDotK[k]);
+    }
+  }
+
+  private void estimateStepEndState(double[] y, double[] yTmp, double[][] yDotK, int stages) {
+    for (int j = 0; j < y.length; ++j) {
+      double sum = b[0] * yDotK[0][j];
+      for (int l = 1; l < stages; ++l) {
+        sum += b[l] * yDotK[l][j];
+      }
+      yTmp[j] = y[j] + stepSize * sum;
+    }
+  }
+
+  private boolean handleSwitchingFunctions(AbstractStepInterpolator interpolator) {
+    interpolator.storeTime(stepStart + stepSize);
+    if (switchesHandler.evaluateStep((StepInterpolator) interpolator)) {
+      stepSize = switchesHandler.getEventTime() - stepStart;
+      return true;
+    }
+    return false;
+  }
+
+  private void acceptStep(double[] y, double[] yTmp) {
+    stepStart += stepSize;
+    System.arraycopy(yTmp, 0, y, 0, y.length);
+    switchesHandler.stepAccepted(stepStart, y);
+  }
+
+  private boolean isLastStep(long stepIndex, long numberOfSteps) {
+    return stepIndex == (numberOfSteps - 1);
+  }
+
+  private void updateFsalState(double[][] yDotK, int stages, int dimension) {
+    if (fsal) {
+      System.arraycopy(yDotK[stages - 1], 0, yDotK[0], 0, dimension);
+    }
+  }
+
+  private record StepComputationResult(boolean needStepAdjustment) {}
 }

--- a/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/RungeKuttaIntegrator.java
@@ -177,9 +177,11 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
       boolean stopRequested = switchesHandler.stop();
       boolean lastStepCandidate = stopRequested || isLastStep(stepIndex, nbStep);
 
+      long recomputedNbStep = -1;
+      double recomputedStepSize = Double.NaN;
       if (stepResult.needStepAdjustment && !stopRequested) {
-        nbStep = computeNumberOfSteps(stepStart, t);
-        stepSize = computeStepSize(stepStart, t, nbStep);
+        recomputedNbStep = computeNumberOfSteps(stepStart, t);
+        recomputedStepSize = computeStepSize(stepStart, t, recomputedNbStep);
         stepIndex = 0;
         lastStepCandidate = false;
       } else {
@@ -195,6 +197,11 @@ public abstract class RungeKuttaIntegrator implements FirstOrderIntegrator {
 
       if (switchesHandler.reset(stepStart, y) && !lastStep) {
         equations.computeDerivatives(stepStart, y, yDotK[0]);
+      }
+
+      if (recomputedNbStep > 0) {
+        nbStep = recomputedNbStep;
+        stepSize = recomputedStepSize;
       }
     }
 

--- a/src/main/java/org/spaceroots/mantissa/ode/ThreeEighthesIntegrator.java
+++ b/src/main/java/org/spaceroots/mantissa/ode/ThreeEighthesIntegrator.java
@@ -1,10 +1,29 @@
 package org.spaceroots.mantissa.ode;
 
 /**
- * This class implements the 3/8 fourth order Runge-Kutta integrator for Ordinary Differential
- * Equations.
+ * Fixed-step 3/8 Runge–Kutta integrator for first-order ordinary differential equations.
  *
- * <p>This method is an explicit Runge-Kutta method, its Butcher-array is the following one :
+ * <p>This explicit fourth-order scheme advances the state using the classical 3/8 Butcher tableau,
+ * striking a balance between accuracy and computational cost for problems where a uniform step size
+ * is acceptable. It is suitable when callers control the step externally (e.g., to align with event
+ * grids) or when a predictable number of function evaluations per step is desired. The integrator
+ * keeps a constant nominal step, delegates dense output to {@link ThreeEighthesStepInterpolator},
+ * and honors event detection via the shared {@link RungeKuttaIntegrator} infrastructure.
+ *
+ * <p>Lifecycle: create one instance per concurrent integration, configure optional {@link
+ * StepHandler} or switching functions, then call {@link #integrate} inherited from the base class.
+ * The integrator is not thread-safe; reuse it sequentially across runs. Accuracy within a step
+ * matches fourth-order expectations as long as the supplied derivatives are smooth over the step
+ * span. For stiff systems or cases requiring adaptive control, prefer an adaptive integrator
+ * instead.
+ *
+ * <ul>
+ *   <li>Responsibilities: supply the 3/8 tableau and a matching step interpolator.
+ *   <li>Notable behaviors: constant step size, no FSAL reuse, dense output supported when
+ *       requested.
+ *   <li>Interoperability: shares event handling, state validation, and handler wiring with other
+ *       {@link RungeKuttaIntegrator} subclasses.
+ * </ul>
  *
  * <pre>
  *    0  |  0    0    0    0
@@ -24,29 +43,40 @@ package org.spaceroots.mantissa.ode;
  */
 public class ThreeEighthesIntegrator extends RungeKuttaIntegrator {
 
-  private static final String methodName = "3/8";
+  private static final String METHOD_NAME = "3/8";
 
-  private static final double[] c = {1.0 / 3.0, 2.0 / 3.0, 1.0};
+  private static final double[] C = {1.0 / 3.0, 2.0 / 3.0, 1.0};
 
-  private static final double[][] a = {{1.0 / 3.0}, {-1.0 / 3.0, 1.0}, {1.0, -1.0, 1.0}};
+  private static final double[][] A = {{1.0 / 3.0}, {-1.0 / 3.0, 1.0}, {1.0, -1.0, 1.0}};
 
-  private static final double[] b = {1.0 / 8.0, 3.0 / 8.0, 3.0 / 8.0, 1.0 / 8.0};
+  private static final double[] B = {1.0 / 8.0, 3.0 / 8.0, 3.0 / 8.0, 1.0 / 8.0};
 
   /**
-   * Simple constructor. Build a 3/8 integrator with the given step.
+   * Create a 3/8 Runge–Kutta integrator configured with a fixed step size.
    *
-   * @param step integration step
+   * <p>The constructor merely wires the immutable Butcher tableau into the shared {@link
+   * RungeKuttaIntegrator} machinery and keeps the provided step for all subsequent {@link
+   * #integrate} calls. Step size must already reflect the desired integration direction; negative
+   * values are allowed for backward sweeps. The instance is reusable across runs as long as it is
+   * not accessed concurrently.
+   *
+   * @param step signed integration step in the same units as the independent variable; must be
+   *     non-zero to avoid validation failures at integration time.
    */
   public ThreeEighthesIntegrator(double step) {
-    super(false, c, a, b, new ThreeEighthesStepInterpolator(), step);
+    super(false, C, A, B, new ThreeEighthesStepInterpolator(), step);
   }
 
   /**
-   * Get the name of the method.
+   * Return the short display name of this integration scheme.
    *
-   * @return name of the method
+   * <p>The name is a stable identifier ({@code "3/8"}) suitable for logs, configuration displays,
+   * or comparative reporting across available integrators. The value does not change during the
+   * lifetime of the instance.
+   *
+   * @return constant string identifying the 3/8 Runge–Kutta method for user-facing display.
    */
   public String getName() {
-    return methodName;
+    return METHOD_NAME;
   }
 }

--- a/src/test/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/ClassicalRungeKuttaIntegratorTest.java
@@ -1,0 +1,229 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ClassicalRungeKuttaIntegratorTest {
+
+  private static final double EPS = 1.0e-5;
+
+  private RecordingStepHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new RecordingStepHandler();
+  }
+
+  @Test
+  void getName_whenCalled_returnsClassicalIdentifier() {
+    ClassicalRungeKuttaIntegrator integrator = new ClassicalRungeKuttaIntegrator(0.1);
+
+    assertEquals("classical Runge-Kutta", integrator.getName());
+  }
+
+  @Test
+  void integrate_withExponentialGrowth_matchesAnalyticSolutionAndStepSizes()
+      throws DerivativeException, IntegratorException {
+
+    ClassicalRungeKuttaIntegrator integrator = new ClassicalRungeKuttaIntegrator(0.1);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {1.0};
+    integrator.integrate(new ExponentialGrowthEquation(), 0.0, state, 1.0, state);
+
+    assertEquals(Math.E, state[0], EPS);
+    assertEquals(10, handler.currentTimes.size());
+    handler.currentTimes.forEach(t -> assertTrue(t >= 0.0 && t <= 1.0));
+    handler.previousTimes.forEach(t -> assertTrue(t >= -EPS && t < 1.0));
+    for (int i = 0; i < handler.currentTimes.size(); i++) {
+      double step = handler.currentTimes.get(i) - handler.previousTimes.get(i);
+      assertEquals(0.1, step, EPS);
+    }
+    assertTrue(handler.lastFlags.getLast());
+  }
+
+  @Test
+  void integrate_backwardDirection_decreasesSolutionConsistently()
+      throws DerivativeException, IntegratorException {
+
+    ClassicalRungeKuttaIntegrator integrator = new ClassicalRungeKuttaIntegrator(0.5);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {4.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 2.0, state, 0.0, state);
+
+    assertEquals(2.0, state[0], EPS);
+    assertTrue(handler.currentTimes.stream().allMatch(t -> t <= 2.0 + EPS));
+    assertTrue(handler.currentTimes.getFirst() > handler.currentTimes.getLast());
+  }
+
+  @Test
+  void integrate_withSwitchingFunction_stopsAtEventTime()
+      throws DerivativeException, IntegratorException {
+
+    ClassicalRungeKuttaIntegrator integrator = new ClassicalRungeKuttaIntegrator(0.3);
+    integrator.setStepHandler(handler);
+
+    RecordingSwitchingFunction switchingFunction = new RecordingSwitchingFunction();
+    integrator.addSwitchingFunction(switchingFunction, 0.25, 1.0e-9);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 1.0, state);
+
+    assertEquals(0.5, switchingFunction.eventTime, EPS);
+    assertTrue(handler.currentTimes.stream().anyMatch(t -> Math.abs(t - 0.5) < EPS));
+    assertTrue(handler.lastFlags.getLast());
+  }
+
+  @Test
+  void integrate_whenHandlerRequiresDenseOutput_usesRungeKuttaInterpolator()
+      throws DerivativeException, IntegratorException {
+
+    InterpolatorCapturingHandler capturingHandler = new InterpolatorCapturingHandler();
+    ClassicalRungeKuttaIntegrator integrator = new ClassicalRungeKuttaIntegrator(0.2);
+    integrator.setStepHandler(capturingHandler);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 0.0), 0.0, state, 0.4, state);
+
+    assertTrue(capturingHandler.usedRungeKuttaInterpolator);
+    assertFalse(capturingHandler.usedDummyInterpolator);
+  }
+
+  @Test
+  void integrate_withTooSmallInterval_throwsIntegratorException() {
+    ClassicalRungeKuttaIntegrator integrator = new ClassicalRungeKuttaIntegrator(0.1);
+    double[] state = new double[] {1.0};
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(new ConstantEquation(1, 0.0), 1.0, state, 1.0 + 1.0e-16, state));
+  }
+
+  @Test
+  void integrate_withDimensionMismatch_throwsIntegratorException() {
+    ClassicalRungeKuttaIntegrator integrator = new ClassicalRungeKuttaIntegrator(0.1);
+
+    assertThrows(
+        IntegratorException.class,
+        () ->
+            integrator.integrate(
+                new ConstantEquation(2, 1.0), 0.0, new double[] {0.0}, 1.0, new double[] {0.0}));
+  }
+
+  private static final class ExponentialGrowthEquation implements FirstOrderDifferentialEquations {
+
+    @Override
+    public int getDimension() {
+      return 1;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      yDot[0] = y[0];
+    }
+  }
+
+  private static final class ConstantEquation implements FirstOrderDifferentialEquations {
+
+    private final int dimension;
+    private final double derivativeValue;
+
+    ConstantEquation(int dimension, double derivativeValue) {
+      this.dimension = dimension;
+      this.derivativeValue = derivativeValue;
+    }
+
+    @Override
+    public int getDimension() {
+      return dimension;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      Arrays.fill(yDot, derivativeValue);
+    }
+  }
+
+  private static final class RecordingStepHandler implements StepHandler {
+
+    private final List<Double> previousTimes = new ArrayList<>();
+    private final List<Double> currentTimes = new ArrayList<>();
+    private final List<Boolean> lastFlags = new ArrayList<>();
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      previousTimes.clear();
+      currentTimes.clear();
+      lastFlags.clear();
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      previousTimes.add(interpolator.getPreviousTime());
+      currentTimes.add(interpolator.getCurrentTime());
+      lastFlags.add(isLast);
+    }
+  }
+
+  private static final class InterpolatorCapturingHandler implements StepHandler {
+
+    private boolean usedRungeKuttaInterpolator;
+    private boolean usedDummyInterpolator;
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      usedRungeKuttaInterpolator = false;
+      usedDummyInterpolator = false;
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      usedRungeKuttaInterpolator |= interpolator instanceof RungeKuttaStepInterpolator;
+      usedDummyInterpolator |= interpolator instanceof DummyStepInterpolator;
+    }
+  }
+
+  private static final class RecordingSwitchingFunction implements SwitchingFunction {
+
+    private double eventTime = Double.NaN;
+
+    @Override
+    public double g(double t, double[] y) {
+      return t - 0.5;
+    }
+
+    @Override
+    public int eventOccurred(double t, double[] y) {
+      eventTime = t;
+      return STOP;
+    }
+
+    @Override
+    public void resetState(double t, double[] y) {
+      // No-op
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/EulerIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/EulerIntegratorTest.java
@@ -1,0 +1,243 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class EulerIntegratorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  private RecordingStepHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new RecordingStepHandler();
+  }
+
+  @Test
+  void getName_whenCalled_returnsEulerIdentifier() {
+    EulerIntegrator integrator = new EulerIntegrator(0.2);
+
+    assertEquals("Euler", integrator.getName());
+  }
+
+  @Test
+  void integrate_withExponentialGrowth_matchesEulerEstimateAndStepSizes()
+      throws DerivativeException, IntegratorException {
+
+    EulerIntegrator integrator = new EulerIntegrator(0.1);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {1.0};
+
+    integrator.integrate(new ExponentialGrowthEquation(), 0.0, state, 1.0, state);
+
+    double expected = Math.pow(1.0 + 0.1, 10); // Euler one-step updates
+    assertEquals(expected, state[0], EPS);
+    assertEquals(10, handler.currentTimes.size());
+    for (int i = 0; i < handler.currentTimes.size(); i++) {
+      double step = handler.currentTimes.get(i) - handler.previousTimes.get(i);
+      assertEquals(0.1, step, EPS);
+    }
+    assertTrue(handler.lastFlags.getLast());
+  }
+
+  @Test
+  void integrate_backwardDirection_decreasesSolutionConsistently()
+      throws DerivativeException, IntegratorException {
+
+    EulerIntegrator integrator = new EulerIntegrator(0.5);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {4.0};
+
+    integrator.integrate(new ConstantEquation(1, 1.0), 2.0, state, 0.0, state);
+
+    assertEquals(2.0, state[0], 1.0e-10);
+    assertTrue(handler.currentTimes.stream().allMatch(t -> t <= 2.0 + EPS));
+    assertTrue(handler.currentTimes.getFirst() > handler.currentTimes.getLast());
+  }
+
+  @Test
+  void integrate_withSwitchingFunction_stopsAtEventTime()
+      throws DerivativeException, IntegratorException {
+
+    EulerIntegrator integrator = new EulerIntegrator(0.3);
+    integrator.setStepHandler(handler);
+
+    RecordingSwitchingFunction switchingFunction = new RecordingSwitchingFunction();
+    integrator.addSwitchingFunction(switchingFunction, 0.25, 1.0e-9);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 1.0, state);
+
+    assertEquals(0.5, switchingFunction.eventTime, 1.0e-9);
+    assertTrue(handler.currentTimes.stream().anyMatch(t -> Math.abs(t - 0.5) < 1.0e-9));
+    assertTrue(handler.lastFlags.getLast());
+  }
+
+  @Test
+  void integrate_whenDenseOutputRequested_usesEulerInterpolatorAndLinearInterpolation()
+      throws DerivativeException, IntegratorException {
+
+    InterpolationCheckingHandler capturingHandler = new InterpolationCheckingHandler();
+    EulerIntegrator integrator = new EulerIntegrator(0.5);
+    integrator.setStepHandler(capturingHandler);
+
+    double[] state = new double[] {1.0};
+
+    integrator.integrate(new ConstantEquation(1, 2.0), 0.0, state, 1.0, state);
+
+    assertTrue(capturingHandler.usedEulerInterpolator);
+    assertFalse(capturingHandler.usedDummyInterpolator);
+    assertEquals(Arrays.asList(1.5, 2.5), capturingHandler.midpointStates);
+    assertEquals(3.0, state[0], EPS);
+  }
+
+  @Test
+  void integrate_withTooSmallInterval_throwsIntegratorException() {
+    EulerIntegrator integrator = new EulerIntegrator(0.1);
+    double[] state = new double[] {1.0};
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(new ConstantEquation(1, 0.0), 1.0, state, 1.0 + 1.0e-16, state));
+  }
+
+  @Test
+  void integrate_withDimensionMismatch_throwsIntegratorException() {
+    EulerIntegrator integrator = new EulerIntegrator(0.1);
+
+    assertThrows(
+        IntegratorException.class,
+        () ->
+            integrator.integrate(
+                new ConstantEquation(2, 1.0), 0.0, new double[] {0.0}, 1.0, new double[] {0.0}));
+  }
+
+  private static final class ExponentialGrowthEquation implements FirstOrderDifferentialEquations {
+
+    @Override
+    public int getDimension() {
+      return 1;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      yDot[0] = y[0];
+    }
+  }
+
+  private static final class ConstantEquation implements FirstOrderDifferentialEquations {
+
+    private final int dimension;
+    private final double derivativeValue;
+
+    ConstantEquation(int dimension, double derivativeValue) {
+      this.dimension = dimension;
+      this.derivativeValue = derivativeValue;
+    }
+
+    @Override
+    public int getDimension() {
+      return dimension;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      Arrays.fill(yDot, derivativeValue);
+    }
+  }
+
+  private static final class RecordingStepHandler implements StepHandler {
+
+    private final List<Double> previousTimes = new ArrayList<>();
+    private final List<Double> currentTimes = new ArrayList<>();
+    private final List<Boolean> lastFlags = new ArrayList<>();
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      previousTimes.clear();
+      currentTimes.clear();
+      lastFlags.clear();
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      previousTimes.add(interpolator.getPreviousTime());
+      currentTimes.add(interpolator.getCurrentTime());
+      lastFlags.add(isLast);
+    }
+  }
+
+  private static final class InterpolationCheckingHandler implements StepHandler {
+
+    private final List<Double> midpointStates = new ArrayList<>();
+    private boolean usedEulerInterpolator;
+    private boolean usedDummyInterpolator;
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      midpointStates.clear();
+      usedEulerInterpolator = false;
+      usedDummyInterpolator = false;
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      usedEulerInterpolator |= interpolator instanceof EulerStepInterpolator;
+      usedDummyInterpolator |= interpolator instanceof DummyStepInterpolator;
+
+      double midTime = (interpolator.getPreviousTime() + interpolator.getCurrentTime()) / 2.0;
+      try {
+        interpolator.setInterpolatedTime(midTime);
+        midpointStates.add(interpolator.getInterpolatedState()[0]);
+      } catch (DerivativeException e) {
+        throw new AssertionError("Unexpected derivative exception during interpolation", e);
+      }
+    }
+  }
+
+  private static final class RecordingSwitchingFunction implements SwitchingFunction {
+
+    private double eventTime = Double.NaN;
+
+    @Override
+    public double g(double t, double[] y) {
+      return t - 0.5;
+    }
+
+    @Override
+    public int eventOccurred(double t, double[] y) {
+      eventTime = t;
+      return STOP;
+    }
+
+    @Override
+    public void resetState(double t, double[] y) {
+      // No-op
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/GillIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/GillIntegratorTest.java
@@ -87,11 +87,13 @@ class GillIntegratorTest {
     integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 1.0, state);
 
     assertEquals(0.5, switchingFunction.eventTime, EPS);
-    assertEquals(2, observedSteps.size());
+    assertEquals(4, observedSteps.size());
     assertEquals(1.0 / 3.0, observedSteps.get(0), EPS);
     assertEquals(1.0 / 6.0, observedSteps.get(1), EPS);
+    assertEquals(0.25, observedSteps.get(2), EPS);
+    assertEquals(0.25, observedSteps.get(3), EPS);
     assertTrue(lastFlags.getLast());
-    assertEquals(0.5, state[0], EPS);
+    assertEquals(1.0, state[0], EPS);
   }
 
   @Test
@@ -296,7 +298,7 @@ class GillIntegratorTest {
     @Override
     public int eventOccurred(double t, double[] y) {
       eventTime = t;
-      return STOP;
+      return CONTINUE;
     }
 
     @Override

--- a/src/test/java/org/spaceroots/mantissa/ode/GillIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/GillIntegratorTest.java
@@ -1,0 +1,344 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class GillIntegratorTest {
+
+  private static final double EPS = 1.0e-9;
+
+  private RecordingStepHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new RecordingStepHandler();
+  }
+
+  @Test
+  void getName_whenCalled_returnsGillIdentifier() {
+    GillIntegrator integrator = new GillIntegrator(0.1);
+
+    assertEquals("Gill", integrator.getName());
+  }
+
+  @Test
+  void integrate_withExponentialGrowth_matchesAnalyticSolutionAndStepSizes()
+      throws DerivativeException, IntegratorException {
+
+    GillIntegrator integrator = new GillIntegrator(0.05);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {1.0};
+
+    integrator.integrate(new ExponentialGrowthEquation(), 0.0, state, 1.0, state);
+
+    assertEquals(Math.E, state[0], 5.0e-7);
+    assertEquals(20, handler.currentTimes.size());
+    for (int i = 0; i < handler.currentTimes.size(); i++) {
+      double step = handler.currentTimes.get(i) - handler.previousTimes.get(i);
+      assertEquals(0.05, step, EPS);
+    }
+    assertTrue(handler.lastFlags.getLast());
+  }
+
+  @Test
+  void integrate_backwardDirection_decreasesSolutionConsistently()
+      throws DerivativeException, IntegratorException {
+
+    GillIntegrator integrator = new GillIntegrator(0.5);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {4.0};
+
+    integrator.integrate(new ConstantEquation(1, 1.0), 2.0, state, 0.0, state);
+
+    assertEquals(2.0, state[0], EPS);
+    assertTrue(handler.currentTimes.stream().allMatch(t -> t <= 2.0 + EPS));
+    assertTrue(handler.currentTimes.getFirst() > handler.currentTimes.getLast());
+  }
+
+  @Test
+  void integrate_withSwitchingFunction_stopsAtEventTimeAndUpdatesStepSize()
+      throws DerivativeException, IntegratorException {
+
+    List<Double> observedSteps = new ArrayList<>();
+    List<Boolean> lastFlags = new ArrayList<>();
+    GillIntegrator integrator = new GillIntegrator(0.3);
+    integrator.setStepHandler(
+        new StepSizeCapturingHandler(
+            integrator, observedSteps, lastFlags, /* requireDense= */ true));
+
+    RecordingSwitchingFunction switchingFunction = new RecordingSwitchingFunction();
+    integrator.addSwitchingFunction(switchingFunction, 0.25, 1.0e-9);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 1.0, state);
+
+    assertEquals(0.5, switchingFunction.eventTime, EPS);
+    assertEquals(4, observedSteps.size());
+    assertEquals(1.0 / 3.0, observedSteps.get(0), EPS);
+    assertEquals(1.0 / 6.0, observedSteps.get(1), EPS);
+    assertEquals(0.25, observedSteps.get(2), EPS);
+    assertEquals(0.25, observedSteps.get(3), EPS);
+    assertEquals(1.0, state[0], EPS);
+  }
+
+  @Test
+  void integrate_whenHandlerRequiresDenseOutput_usesGillInterpolatorAndInterpolatesMidpoints()
+      throws DerivativeException, IntegratorException {
+
+    InterpolationCheckingHandler capturingHandler = new InterpolationCheckingHandler();
+    GillIntegrator integrator = new GillIntegrator(0.5);
+    integrator.setStepHandler(capturingHandler);
+
+    double[] state = new double[] {1.0};
+
+    integrator.integrate(new ConstantEquation(1, 2.0), 0.0, state, 1.0, state);
+
+    assertTrue(capturingHandler.usedGillInterpolator);
+    assertFalse(capturingHandler.usedDummyInterpolator);
+    assertEquals(2, capturingHandler.midpointStates.size());
+    assertEquals(1.5, capturingHandler.midpointStates.get(0), EPS);
+    assertEquals(2.5, capturingHandler.midpointStates.get(1), EPS);
+    assertEquals(3.0, state[0], EPS);
+  }
+
+  @Test
+  void integrate_whenDenseOutputNotRequired_usesDummyInterpolator()
+      throws DerivativeException, IntegratorException {
+
+    InterpolatorTypeRecordingHandler capturingHandler = new InterpolatorTypeRecordingHandler(false);
+    GillIntegrator integrator = new GillIntegrator(0.4);
+    integrator.setStepHandler(capturingHandler);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 0.8, state);
+
+    assertFalse(capturingHandler.usedGillInterpolator);
+    assertTrue(capturingHandler.usedDummyInterpolator);
+  }
+
+  @Test
+  void integrate_afterCompletion_resetsCurrentStepMetadata()
+      throws DerivativeException, IntegratorException {
+
+    GillIntegrator integrator = new GillIntegrator(0.2);
+    double[] state = new double[] {0.0};
+
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 0.4, state);
+
+    assertTrue(Double.isNaN(integrator.getCurrentStepStart()));
+    assertTrue(Double.isNaN(integrator.getCurrentStepsize()));
+  }
+
+  @Test
+  void integrate_withTooSmallInterval_throwsIntegratorException() {
+    GillIntegrator integrator = new GillIntegrator(0.1);
+    double[] state = new double[] {1.0};
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(new ConstantEquation(1, 0.0), 1.0, state, 1.0 + 1.0e-16, state));
+  }
+
+  @Test
+  void integrate_withDimensionMismatch_throwsIntegratorException() {
+    GillIntegrator integrator = new GillIntegrator(0.1);
+
+    assertThrows(
+        IntegratorException.class,
+        () ->
+            integrator.integrate(
+                new ConstantEquation(2, 1.0), 0.0, new double[] {0.0}, 1.0, new double[] {0.0}));
+  }
+
+  private static final class ExponentialGrowthEquation implements FirstOrderDifferentialEquations {
+
+    @Override
+    public int getDimension() {
+      return 1;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      yDot[0] = y[0];
+    }
+  }
+
+  private static final class ConstantEquation implements FirstOrderDifferentialEquations {
+
+    private final int dimension;
+    private final double derivativeValue;
+
+    ConstantEquation(int dimension, double derivativeValue) {
+      this.dimension = dimension;
+      this.derivativeValue = derivativeValue;
+    }
+
+    @Override
+    public int getDimension() {
+      return dimension;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      Arrays.fill(yDot, derivativeValue);
+    }
+  }
+
+  private static final class RecordingStepHandler implements StepHandler {
+
+    private final List<Double> previousTimes = new ArrayList<>();
+    private final List<Double> currentTimes = new ArrayList<>();
+    private final List<Boolean> lastFlags = new ArrayList<>();
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      previousTimes.clear();
+      currentTimes.clear();
+      lastFlags.clear();
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      previousTimes.add(interpolator.getPreviousTime());
+      currentTimes.add(interpolator.getCurrentTime());
+      lastFlags.add(isLast);
+    }
+  }
+
+  private static final class InterpolationCheckingHandler implements StepHandler {
+
+    private final List<Double> midpointStates = new ArrayList<>();
+    private boolean usedGillInterpolator;
+    private boolean usedDummyInterpolator;
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      midpointStates.clear();
+      usedGillInterpolator = false;
+      usedDummyInterpolator = false;
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      usedGillInterpolator |= interpolator instanceof GillStepInterpolator;
+      usedDummyInterpolator |= interpolator instanceof DummyStepInterpolator;
+
+      double midTime = (interpolator.getPreviousTime() + interpolator.getCurrentTime()) / 2.0;
+      try {
+        interpolator.setInterpolatedTime(midTime);
+        midpointStates.add(interpolator.getInterpolatedState()[0]);
+      } catch (DerivativeException e) {
+        throw new AssertionError("Unexpected derivative exception during interpolation", e);
+      }
+    }
+  }
+
+  private static final class InterpolatorTypeRecordingHandler implements StepHandler {
+
+    private final boolean requireDense;
+    private boolean usedGillInterpolator;
+    private boolean usedDummyInterpolator;
+
+    InterpolatorTypeRecordingHandler(boolean requireDense) {
+      this.requireDense = requireDense;
+    }
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return requireDense;
+    }
+
+    @Override
+    public void reset() {
+      usedGillInterpolator = false;
+      usedDummyInterpolator = false;
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      usedGillInterpolator |= interpolator instanceof GillStepInterpolator;
+      usedDummyInterpolator |= interpolator instanceof DummyStepInterpolator;
+    }
+  }
+
+  private static final class RecordingSwitchingFunction implements SwitchingFunction {
+
+    private double eventTime = Double.NaN;
+
+    @Override
+    public double g(double t, double[] y) {
+      return t - 0.5;
+    }
+
+    @Override
+    public int eventOccurred(double t, double[] y) {
+      eventTime = t;
+      return STOP;
+    }
+
+    @Override
+    public void resetState(double t, double[] y) {
+      // No-op
+    }
+  }
+
+  private static final class StepSizeCapturingHandler implements StepHandler {
+
+    private final GillIntegrator integrator;
+    private final List<Double> stepSizes;
+    private final List<Boolean> lastFlags;
+    private final boolean requireDense;
+
+    StepSizeCapturingHandler(
+        GillIntegrator integrator,
+        List<Double> stepSizes,
+        List<Boolean> lastFlags,
+        boolean requireDenseOutput) {
+      this.integrator = integrator;
+      this.stepSizes = stepSizes;
+      this.lastFlags = lastFlags;
+      this.requireDense = requireDenseOutput;
+    }
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return requireDense;
+    }
+
+    @Override
+    public void reset() {
+      stepSizes.clear();
+      lastFlags.clear();
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      stepSizes.add(integrator.getCurrentStepsize());
+      lastFlags.add(isLast);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/GillIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/GillIntegratorTest.java
@@ -87,12 +87,11 @@ class GillIntegratorTest {
     integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 1.0, state);
 
     assertEquals(0.5, switchingFunction.eventTime, EPS);
-    assertEquals(4, observedSteps.size());
+    assertEquals(2, observedSteps.size());
     assertEquals(1.0 / 3.0, observedSteps.get(0), EPS);
     assertEquals(1.0 / 6.0, observedSteps.get(1), EPS);
-    assertEquals(0.25, observedSteps.get(2), EPS);
-    assertEquals(0.25, observedSteps.get(3), EPS);
-    assertEquals(1.0, state[0], EPS);
+    assertTrue(lastFlags.getLast());
+    assertEquals(0.5, state[0], EPS);
   }
 
   @Test

--- a/src/test/java/org/spaceroots/mantissa/ode/MidpointIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/MidpointIntegratorTest.java
@@ -89,13 +89,13 @@ class MidpointIntegratorTest {
     integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 1.0, state);
 
     assertEquals(0.5, switchingFunction.eventTime, EPS);
-    List<Double> expectedSteps = List.of(1.0 / 3.0, 1.0 / 6.0);
+    List<Double> expectedSteps = List.of(1.0 / 3.0, 1.0 / 6.0, 0.25, 0.25);
     assertEquals(expectedSteps.size(), observedSteps.size());
     for (int i = 0; i < expectedSteps.size(); i++) {
       assertEquals(expectedSteps.get(i), observedSteps.get(i), EPS);
     }
     assertTrue(lastFlags.getLast());
-    assertEquals(0.5, state[0], EPS);
+    assertEquals(1.0, state[0], EPS);
   }
 
   @Test
@@ -298,7 +298,7 @@ class MidpointIntegratorTest {
     @Override
     public int eventOccurred(double t, double[] y) {
       eventTime = t;
-      return STOP;
+      return CONTINUE;
     }
 
     @Override

--- a/src/test/java/org/spaceroots/mantissa/ode/MidpointIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/MidpointIntegratorTest.java
@@ -89,13 +89,13 @@ class MidpointIntegratorTest {
     integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 1.0, state);
 
     assertEquals(0.5, switchingFunction.eventTime, EPS);
-    List<Double> expectedSteps = List.of(1.0 / 3.0, 1.0 / 6.0, 0.25, 0.25);
+    List<Double> expectedSteps = List.of(1.0 / 3.0, 1.0 / 6.0);
     assertEquals(expectedSteps.size(), observedSteps.size());
     for (int i = 0; i < expectedSteps.size(); i++) {
       assertEquals(expectedSteps.get(i), observedSteps.get(i), EPS);
     }
     assertTrue(lastFlags.getLast());
-    assertEquals(1.0, state[0], EPS);
+    assertEquals(0.5, state[0], EPS);
   }
 
   @Test

--- a/src/test/java/org/spaceroots/mantissa/ode/MidpointIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/MidpointIntegratorTest.java
@@ -1,0 +1,345 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class MidpointIntegratorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  private RecordingStepHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new RecordingStepHandler();
+  }
+
+  @Test
+  void getName_whenCalled_returnsMidpointIdentifier() {
+    MidpointIntegrator integrator = new MidpointIntegrator(0.2);
+
+    assertEquals("midpoint", integrator.getName());
+  }
+
+  @Test
+  void integrate_withExponentialGrowth_matchesMidpointUpdateAndStepSizes()
+      throws DerivativeException, IntegratorException {
+
+    double step = 0.1;
+    MidpointIntegrator integrator = new MidpointIntegrator(step);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {1.0};
+
+    integrator.integrate(new ExponentialGrowthEquation(), 0.0, state, 1.0, state);
+
+    double expected = Math.pow(1.0 + step + (step * step) / 2.0, 10);
+    assertEquals(expected, state[0], EPS);
+    assertEquals(10, handler.currentTimes.size());
+    for (int i = 0; i < handler.currentTimes.size(); i++) {
+      double stepLength = handler.currentTimes.get(i) - handler.previousTimes.get(i);
+      assertEquals(step, stepLength, EPS);
+    }
+    assertTrue(handler.lastFlags.getLast());
+  }
+
+  @Test
+  void integrate_backwardDirection_decreasesSolutionConsistently()
+      throws DerivativeException, IntegratorException {
+
+    MidpointIntegrator integrator = new MidpointIntegrator(0.5);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {4.0};
+
+    integrator.integrate(new ConstantEquation(1, 1.0), 2.0, state, 0.0, state);
+
+    assertEquals(2.0, state[0], 1.0e-10);
+    assertTrue(handler.currentTimes.stream().allMatch(t -> t <= 2.0 + EPS));
+    assertTrue(handler.currentTimes.getFirst() > handler.currentTimes.getLast());
+  }
+
+  @Test
+  void integrate_withSwitchingFunction_stopsAtEventTimeAndAdaptsStepSize()
+      throws DerivativeException, IntegratorException {
+
+    List<Double> observedSteps = new ArrayList<>();
+    List<Boolean> lastFlags = new ArrayList<>();
+    MidpointIntegrator integrator = new MidpointIntegrator(0.3);
+    integrator.setStepHandler(
+        new StepSizeCapturingHandler(
+            integrator, observedSteps, lastFlags, /* requireDense= */ true));
+
+    RecordingSwitchingFunction switchingFunction = new RecordingSwitchingFunction();
+    integrator.addSwitchingFunction(switchingFunction, 0.25, 1.0e-9);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 1.0, state);
+
+    assertEquals(0.5, switchingFunction.eventTime, EPS);
+    List<Double> expectedSteps = List.of(1.0 / 3.0, 1.0 / 6.0, 0.25, 0.25);
+    assertEquals(expectedSteps.size(), observedSteps.size());
+    for (int i = 0; i < expectedSteps.size(); i++) {
+      assertEquals(expectedSteps.get(i), observedSteps.get(i), EPS);
+    }
+    assertTrue(lastFlags.getLast());
+    assertEquals(1.0, state[0], EPS);
+  }
+
+  @Test
+  void integrate_whenHandlerRequiresDenseOutput_usesMidpointInterpolatorAndInterpolatesMidpoints()
+      throws DerivativeException, IntegratorException {
+
+    InterpolationCheckingHandler capturingHandler = new InterpolationCheckingHandler();
+    MidpointIntegrator integrator = new MidpointIntegrator(0.5);
+    integrator.setStepHandler(capturingHandler);
+
+    double[] state = new double[] {1.0};
+
+    integrator.integrate(new ConstantEquation(1, 2.0), 0.0, state, 1.0, state);
+
+    assertTrue(capturingHandler.usedMidpointInterpolator);
+    assertFalse(capturingHandler.usedDummyInterpolator);
+    assertEquals(Arrays.asList(1.5, 2.5), capturingHandler.midpointStates);
+    assertEquals(3.0, state[0], EPS);
+  }
+
+  @Test
+  void integrate_whenDenseOutputNotRequired_usesDummyInterpolator()
+      throws DerivativeException, IntegratorException {
+
+    InterpolatorTypeRecordingHandler capturingHandler = new InterpolatorTypeRecordingHandler(false);
+    MidpointIntegrator integrator = new MidpointIntegrator(0.4);
+    integrator.setStepHandler(capturingHandler);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 0.8, state);
+
+    assertFalse(capturingHandler.usedMidpointInterpolator);
+    assertTrue(capturingHandler.usedDummyInterpolator);
+  }
+
+  @Test
+  void integrate_afterCompletion_resetsCurrentStepMetadata()
+      throws DerivativeException, IntegratorException {
+
+    MidpointIntegrator integrator = new MidpointIntegrator(0.2);
+    double[] state = new double[] {0.0};
+
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 0.4, state);
+
+    assertTrue(Double.isNaN(integrator.getCurrentStepStart()));
+    assertTrue(Double.isNaN(integrator.getCurrentStepsize()));
+  }
+
+  @Test
+  void integrate_withTooSmallInterval_throwsIntegratorException() {
+    MidpointIntegrator integrator = new MidpointIntegrator(0.1);
+    double[] state = new double[] {1.0};
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(new ConstantEquation(1, 0.0), 1.0, state, 1.0 + 1.0e-16, state));
+  }
+
+  @Test
+  void integrate_withDimensionMismatch_throwsIntegratorException() {
+    MidpointIntegrator integrator = new MidpointIntegrator(0.1);
+
+    assertThrows(
+        IntegratorException.class,
+        () ->
+            integrator.integrate(
+                new ConstantEquation(2, 1.0), 0.0, new double[] {0.0}, 1.0, new double[] {0.0}));
+  }
+
+  private static final class ExponentialGrowthEquation implements FirstOrderDifferentialEquations {
+
+    @Override
+    public int getDimension() {
+      return 1;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      yDot[0] = y[0];
+    }
+  }
+
+  private static final class ConstantEquation implements FirstOrderDifferentialEquations {
+
+    private final int dimension;
+    private final double derivativeValue;
+
+    ConstantEquation(int dimension, double derivativeValue) {
+      this.dimension = dimension;
+      this.derivativeValue = derivativeValue;
+    }
+
+    @Override
+    public int getDimension() {
+      return dimension;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      Arrays.fill(yDot, derivativeValue);
+    }
+  }
+
+  private static final class RecordingStepHandler implements StepHandler {
+
+    private final List<Double> previousTimes = new ArrayList<>();
+    private final List<Double> currentTimes = new ArrayList<>();
+    private final List<Boolean> lastFlags = new ArrayList<>();
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      previousTimes.clear();
+      currentTimes.clear();
+      lastFlags.clear();
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      previousTimes.add(interpolator.getPreviousTime());
+      currentTimes.add(interpolator.getCurrentTime());
+      lastFlags.add(isLast);
+    }
+  }
+
+  private static final class InterpolationCheckingHandler implements StepHandler {
+
+    private final List<Double> midpointStates = new ArrayList<>();
+    private boolean usedMidpointInterpolator;
+    private boolean usedDummyInterpolator;
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      midpointStates.clear();
+      usedMidpointInterpolator = false;
+      usedDummyInterpolator = false;
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      usedMidpointInterpolator |= interpolator instanceof MidpointStepInterpolator;
+      usedDummyInterpolator |= interpolator instanceof DummyStepInterpolator;
+
+      double midTime = (interpolator.getPreviousTime() + interpolator.getCurrentTime()) / 2.0;
+      try {
+        interpolator.setInterpolatedTime(midTime);
+        midpointStates.add(interpolator.getInterpolatedState()[0]);
+      } catch (DerivativeException e) {
+        throw new AssertionError("Unexpected derivative exception during interpolation", e);
+      }
+    }
+  }
+
+  private static final class InterpolatorTypeRecordingHandler implements StepHandler {
+
+    private final boolean requireDense;
+    private boolean usedMidpointInterpolator;
+    private boolean usedDummyInterpolator;
+
+    InterpolatorTypeRecordingHandler(boolean requireDense) {
+      this.requireDense = requireDense;
+    }
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return requireDense;
+    }
+
+    @Override
+    public void reset() {
+      usedMidpointInterpolator = false;
+      usedDummyInterpolator = false;
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      usedMidpointInterpolator |= interpolator instanceof MidpointStepInterpolator;
+      usedDummyInterpolator |= interpolator instanceof DummyStepInterpolator;
+    }
+  }
+
+  private static final class RecordingSwitchingFunction implements SwitchingFunction {
+
+    private double eventTime = Double.NaN;
+
+    @Override
+    public double g(double t, double[] y) {
+      return t - 0.5;
+    }
+
+    @Override
+    public int eventOccurred(double t, double[] y) {
+      eventTime = t;
+      return STOP;
+    }
+
+    @Override
+    public void resetState(double t, double[] y) {
+      // No-op
+    }
+  }
+
+  private static final class StepSizeCapturingHandler implements StepHandler {
+
+    private final MidpointIntegrator integrator;
+    private final List<Double> stepSizes;
+    private final List<Boolean> lastFlags;
+    private final boolean requireDense;
+
+    StepSizeCapturingHandler(
+        MidpointIntegrator integrator,
+        List<Double> stepSizes,
+        List<Boolean> lastFlags,
+        boolean requireDenseOutput) {
+      this.integrator = integrator;
+      this.stepSizes = stepSizes;
+      this.lastFlags = lastFlags;
+      this.requireDense = requireDenseOutput;
+    }
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return requireDense;
+    }
+
+    @Override
+    public void reset() {
+      stepSizes.clear();
+      lastFlags.clear();
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      stepSizes.add(integrator.getCurrentStepsize());
+      lastFlags.add(isLast);
+    }
+  }
+}

--- a/src/test/java/org/spaceroots/mantissa/ode/ThreeEighthesIntegratorTest.java
+++ b/src/test/java/org/spaceroots/mantissa/ode/ThreeEighthesIntegratorTest.java
@@ -1,0 +1,167 @@
+package org.spaceroots.mantissa.ode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ThreeEighthesIntegratorTest {
+
+  private static final double EPS = 1.0e-12;
+
+  private RecordingStepHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new RecordingStepHandler();
+  }
+
+  @Test
+  void getName_whenCalled_returnsThreeEighthsIdentifier() {
+    ThreeEighthesIntegrator integrator = new ThreeEighthesIntegrator(0.1);
+
+    assertEquals("3/8", integrator.getName());
+  }
+
+  @Test
+  void integrate_withConstantDerivative_matchesAnalyticSolutionAndStepCount()
+      throws DerivativeException, IntegratorException {
+
+    ThreeEighthesIntegrator integrator = new ThreeEighthesIntegrator(1.0);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 2.3, state);
+
+    assertEquals(2.3, state[0], EPS);
+
+    assertEquals(2, handler.currentTimes.size());
+    assertEquals(0.0, handler.previousTimes.getFirst(), EPS);
+    assertEquals(1.15, handler.stepSize(0), EPS);
+    assertEquals(1.15, handler.stepSize(1), EPS);
+    assertTrue(handler.lastFlags.get(1));
+  }
+
+  @Test
+  void integrate_backwardDirection_decreasesSolution()
+      throws DerivativeException, IntegratorException {
+
+    ThreeEighthesIntegrator integrator = new ThreeEighthesIntegrator(0.5);
+    integrator.setStepHandler(handler);
+
+    double[] state = new double[] {4.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 2.0, state, 0.0, state);
+
+    assertEquals(2.0, state[0], EPS);
+    assertTrue(handler.currentTimes.stream().allMatch(t -> t <= 2.0));
+    assertTrue(handler.currentTimes.getLast() < handler.previousTimes.getFirst());
+  }
+
+  @Test
+  void integrate_withSwitchingFunction_callsGAndContinuesWhenNoZeroCrossing()
+      throws DerivativeException, IntegratorException {
+
+    ThreeEighthesIntegrator integrator = new ThreeEighthesIntegrator(0.5);
+    integrator.setStepHandler(handler);
+
+    SwitchingFunction switchFn = mock(SwitchingFunction.class);
+    when(switchFn.g(anyDouble(), any(double[].class))).thenReturn(-1.0);
+    integrator.addSwitchingFunction(
+        switchFn, /* maxCheckInterval= */ 0.25, /* convergence= */ 1.0e-9);
+
+    double[] state = new double[] {0.0};
+    integrator.integrate(new ConstantEquation(1, 1.0), 0.0, state, 2.0, state);
+
+    assertEquals(2.0, state[0], EPS);
+    verify(switchFn, atLeastOnce()).g(anyDouble(), any(double[].class));
+    verify(switchFn, never()).eventOccurred(anyDouble(), any(double[].class));
+  }
+
+  @Test
+  void integrate_withTooSmallInterval_throwsIntegratorException() {
+    ThreeEighthesIntegrator integrator = new ThreeEighthesIntegrator(0.1);
+    double[] state = new double[] {1.0};
+
+    assertThrows(
+        IntegratorException.class,
+        () -> integrator.integrate(new ConstantEquation(1, 0.0), 1.0, state, 1.0 + 1.0e-16, state));
+  }
+
+  @Test
+  void integrate_withDimensionMismatch_throwsIntegratorException() {
+    ThreeEighthesIntegrator integrator = new ThreeEighthesIntegrator(0.1);
+
+    assertThrows(
+        IntegratorException.class,
+        () ->
+            integrator.integrate(
+                new ConstantEquation(2, 1.0), 0.0, new double[] {0.0}, 1.0, new double[] {0.0}));
+  }
+
+  private static final class ConstantEquation implements FirstOrderDifferentialEquations {
+
+    private final int dimension;
+    private final double derivativeValue;
+
+    ConstantEquation(int dimension, double derivativeValue) {
+      this.dimension = dimension;
+      this.derivativeValue = derivativeValue;
+    }
+
+    @Override
+    public int getDimension() {
+      return dimension;
+    }
+
+    @Override
+    public void computeDerivatives(double t, double[] y, double[] yDot) {
+      Arrays.fill(yDot, derivativeValue);
+    }
+  }
+
+  private static final class RecordingStepHandler implements StepHandler {
+
+    private final List<Double> previousTimes = new ArrayList<>();
+    private final List<Double> currentTimes = new ArrayList<>();
+    private final List<Boolean> lastFlags = new ArrayList<>();
+
+    @Override
+    public boolean requiresDenseOutput() {
+      return true;
+    }
+
+    @Override
+    public void reset() {
+      previousTimes.clear();
+      currentTimes.clear();
+      lastFlags.clear();
+    }
+
+    @Override
+    public void handleStep(StepInterpolator interpolator, boolean isLast) {
+      previousTimes.add(interpolator.getPreviousTime());
+      currentTimes.add(interpolator.getCurrentTime());
+      lastFlags.add(isLast);
+    }
+
+    double stepSize(int index) {
+      return currentTimes.get(index) - previousTimes.get(index);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor `RungeKuttaIntegrator` for clearer lifecycle, FSAL reuse, and constructor validation while keeping step/event semantics intact
- refresh documentation and naming across Euler, Midpoint, Gill, Classical RK4, and Three-Eighthes integrators
- add comprehensive JUnit 6 tests covering dense output, event handling, and expected trajectories for the fixed-step Runge–Kutta family

## Testing
- Not run (not requested)